### PR TITLE
[Front] Prevent deceptive behaviour on search icon clicks

### DIFF
--- a/front/src/form/company/CompanySelector.scss
+++ b/front/src/form/company/CompanySelector.scss
@@ -40,4 +40,9 @@
       background-color: #daf5e7;
     }
   }
+
+  .search-icon {
+    cursor: text;
+  }
 }
+

--- a/front/src/form/company/CompanySelector.tsx
+++ b/front/src/form/company/CompanySelector.tsx
@@ -116,7 +116,7 @@ export default connect<FieldProps>(function CompanySelector(props) {
                   setSearchTerm({ ...searchTerm, clue: e.target.value })
                 }
               />
-              <button className="overlay-button" aria-label="Recherche">
+              <button className="overlay-button search-icon" aria-label="Recherche" disabled={true}>
                 <FaSearch />
               </button>
             </div>


### PR DESCRIPTION
A search icon click used to redirect user to an unwanted page.
This behavior was deceptive, icon is now inactive and greyed, and mouse
cursor is not changed when hovering.