### PR TITLE
Security fix

### DIFF
--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -45,6 +45,10 @@ export default {
       const userId = getUserId(context);
       const userCompanies = await getUserCompanies(userId);
 
+      if (!userCompanies.length) {
+        throw new Error("Vous n'êtes pas autorisé à consulter les bordereaux.");
+      }
+
       // Find on userCompanies to make sure that the siret belongs to the current user
       const selectedCompany =
         userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();


### PR DESCRIPTION
For whatever reason, `await prisma.companyAssociations({ where: { user: { id: userId } } })` returns all companyAssociations if `userId == undefined`....

And if you are not logged in, the userId is indeed undefined. Which allowed you to see forms you should not see.
I'm gonna check if it's a known bug on prisma and if upgrading the library would help avoid this kind of problems.

For now we just return an empty array if `userId == undefined`.