### PR TITLE
MAJ documentation technique

### DIFF
--- a/documentation/docs/glossary.md
+++ b/documentation/docs/glossary.md
@@ -87,3 +87,73 @@ type Form {
   appendix2Forms: [Form]
 }
 ```
+
+## Champs obligatoires
+
+Lors de la création d'un bordereau aucun champ n'est obligatoire. En revanche, si on souhaite le faire rentrer dans le workflow de validation, c'est à dire lui faire quitter l'état `DRAFT`, la plupart des champs sont obligatoires. Le détail pour chaque champ du type `FormInput`, type attendu lors de la création d'un bordereau, est présenté ci-dessous.
+
+```bash
+input FormInput {
+  id: ID # Obligatoire ⚠ quand modification, non présent si création
+  emitter: EmitterInput # Obligatoire ⚠
+  recipient: RecipientInput # Obligatoire ⚠
+  transporter: TransporterInput # Obligatoire ⚠
+  wasteDetails: WasteDetailsInput # Obligatoire ⚠
+  trader: TraderInput # Optionnel ✔. Tous les bordereaux ne passent pas par un négociant
+
+  appendix2Forms: [AppendixFormInput] # Optionnel ✔. Utile uniquement lors de la création d'annexes 2
+}
+
+input EmitterInput {
+  type: EmitterType # Obligatoire ⚠, peut prendre les valeurs PRODUCER|OTHER|APPENDIX2
+  pickupSite: String # Optionnel ✔
+  company: CompanyInput # Obligatoire ⚠
+}
+
+input RecipientInput {
+  cap: String # Optionnel ✔
+  processingOperation: String # Obligatoire ⚠
+  company: CompanyInput # Obligatoire ⚠
+}
+
+input TransporterInput {
+  receipt: String # Obligatoire ⚠
+  department: String # Obligatoire ⚠
+  validityLimit: DateTime # Optionnel ✔
+  numberPlate: String # Optionnel ✔
+  company: CompanyInput # Obligatoire ⚠
+}
+
+input TraderInput {
+  receipt: String # Optionnel ✔
+  department: String # Optionnel ✔
+  validityLimit: DateTime # Optionnel ✔
+  company: CompanyInput # Optionnel ✔
+}
+
+input WasteDetailsInput {
+  code: String # Obligatoire ⚠
+  name: String # Obligatoire ⚠
+  onuCode: String # Obligatoire ⚠
+  packagings: [Packagings] # Obligatoire ⚠
+  otherPackaging: String # Optionnel ✔
+  numberOfPackages: Int # Obligatoire ⚠
+  quantity: Float # Obligatoire ⚠
+  quantityType: QuantityType # Obligatoire ⚠, peut prendre les valeurs REAL|ESTIMATED
+  consistence: Consistence # Obligatoire ⚠, peut prendre les valeurs SOLID|LIQUID|GASEOUS
+}
+
+input AppendixFormInput {
+  emitterSiret: String # Optionnel ✔
+  readableId: ID # Optionnel ✔
+}
+
+input CompanyInput {
+  siret: String # Obligatoire ⚠
+  name: String # Obligatoire ⚠
+  address: String # Obligatoire ⚠
+  contact: String # Obligatoire ⚠
+  mail: String # Obligatoire ⚠
+  phone: String # Obligatoire ⚠
+}
+```

--- a/documentation/docs/workflow.md
+++ b/documentation/docs/workflow.md
@@ -37,8 +37,8 @@ Chaque bordereau commence sa vie par l'état `DRAFT`. Le brouillons signifie plu
 Une fois que le brouillon est prêt on le "scelle". Il a alors les caractéristiques suivantes:
 
 - dans l'interface de Trackdéchets, il apparait dans
-  - l'onglet "En attente de signature" pour le producteur du déchet
-  - l'onglet "Statut du déchet" celui qui reçoit le déchet
+    - l'onglet "En attente de signature" pour le producteur du déchet
+    - l'onglet "Statut du déchet" celui qui reçoit le déchet
 - on ne peut plus le modifier
 - un BSD ne peut pas passer à l'état scellé s'il n'est pas valide (champs vides / manquants / incorrects)
 - on peut imprimer un PDF

--- a/documentation/docs/workflow.md
+++ b/documentation/docs/workflow.md
@@ -7,8 +7,9 @@ Le diagramme ci dessous retrace le cycle de vie d'un BSD dans Trackdéchets:
 
 <div class="mermaid">
 graph TD
-A[DRAFT] -->B(SEALED)
+A[DRAFT] -->|Optionnel| B(SEALED)
 B --> |Par l'émetteur| C(SENT)
+A --> |Par l'émetteur| C
 C -->|Par le receveur| D{RECEIVED}
 D -- Cas classique -->E(PROCESSED)
 D -- Regroupement et perte de traçabilite -->G(NO_TRACEABILITY)
@@ -36,8 +37,8 @@ Chaque bordereau commence sa vie par l'état `DRAFT`. Le brouillons signifie plu
 Une fois que le brouillon est prêt on le "scelle". Il a alors les caractéristiques suivantes:
 
 - dans l'interface de Trackdéchets, il apparait dans
-    - l'onglet "En attente de signature" pour le producteur du déchet
-    - l'onglet "Statut du déchet" celui qui reçoit le déchet
+  - l'onglet "En attente de signature" pour le producteur du déchet
+  - l'onglet "Statut du déchet" celui qui reçoit le déchet
 - on ne peut plus le modifier
 - un BSD ne peut pas passer à l'état scellé s'il n'est pas valide (champs vides / manquants / incorrects)
 - on peut imprimer un PDF
@@ -70,4 +71,3 @@ Celui qui reçoit le déchet va ensuite pouvoir déclarer le traitement effectu�
 - le cas échant la prochaine opération prévue
 - le cas échant la description du prochain centre de traitement (nom, adresse, contact...) dans un champ de texte libre
 - le cas échant préciser s'il y a perte de traçabilité pour ce BSD
-


### PR DESCRIPTION
Evos pour la doc.
- Listing des champs obligatoires / optionnels pour `FormInput`
- MAJ du schéma de workflow maintenant que l'état `SEALED` est optionnel

cf https://trello.com/c/dVqnxemo/429-documenter-la-liste-des-champs-bloquants-dans-le-workflow-du-bsd