### PR TITLE
Nettoyage des champs à la duplication

### DIFF
--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -1,19 +1,11 @@
-export function flattenObjectForDb(
-  input,
-  previousKeys = [],
-  dbObject = {}
-) {
+export function flattenObjectForDb(input, previousKeys = [], dbObject = {}) {
   Object.keys(input).forEach(key => {
     if (
       input[key] &&
       !Array.isArray(input[key]) &&
       typeof input[key] === "object"
     ) {
-      return flattenObjectForDb(
-        input[key],
-        [...previousKeys, key],
-        dbObject
-      );
+      return flattenObjectForDb(input[key], [...previousKeys, key], dbObject);
     }
 
     const objectKey = [...previousKeys, key]
@@ -67,13 +59,20 @@ export function unflattenObjectFromDb(input, apiObject = {}) {
 
 export function cleanUpNotDuplicatableFieldsInForm(form) {
   const {
+    // Identifying fields
     id,
     createdAt,
     updatedAt,
     readableId,
 
+    // Fields we explicitly want to cleanup
     transporterNumberPlate,
+    wasteDetailsNumberOfPackages,
+    wasteDetailsQuantity,
+    wasteDetailsQuantityType,
+    wasteDetailsConsistence,
 
+    // Workflow fields
     status,
     sentAt,
     sentBy,


### PR DESCRIPTION
Je néttoie en plus avec cette PR:
- quantité
- type de quantité (réelle ou estimée)
- nombre de colis
- consistance

On peut moduler les champs à nettoyer si besoin !

cf https://trello.com/c/tKbblctR/440-etq-user-quand-je-duplique-1-bsd-il-devrait-%C3%AAtre-copi%C3%A9-coll%C3%A9-%C3%A0-lidentique-mais-sans-la-consistance-et-la-quantit%C3%A9