### PR TITLE
Restart puppeteer si fail

### DIFF
--- a/pdf/src/generator.js
+++ b/pdf/src/generator.js
@@ -12,36 +12,52 @@ const toDate = string => {
   return `${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`;
 };
 
-const browserLaunch = puppeteer.launch({
-  args: [
-    "--no-sandbox",
-    "--disable-setuid-sandbox",
-    // This will write shared memory files into /tmp instead of /dev/shm,
-    // because Docker’s default for /dev/shm is 64MB
-    "--disable-dev-shm-usage"
-  ]
-});
+let browserInstance = null;
+async function getBrowser() {
+  try {
+    browserInstance =
+      browserInstance ||
+      (await puppeteer.launch({
+        args: [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          // This will write shared memory files into /tmp instead of /dev/shm,
+          // because Docker’s default for /dev/shm is 64MB
+          "--disable-dev-shm-usage"
+        ]
+      }));
+  } catch (err) {
+    return Promise.reject(err);
+  }
+
+  return browserInstance;
+}
 
 async function write(params) {
-  const browser = await browserLaunch.catch(err =>
-    console.error("Cannot launch puppeteer", err)
+  const browser = await getBrowser().catch(err =>
+    logAndRethrow("Cannot launch puppeteer", err)
   );
 
   const pageContent = tempFn({ toDate, ...params });
 
   const page = await browser
     .newPage()
-    .catch(err => console.error("Error while starting new page", err));
+    .catch(err => logAndRethrow("Error while starting new page", err));
   await page.setContent(pageContent);
 
   const buffer = await page
     .pdf({ format: "A4" })
-    .catch(err => console.error("Error while generating PDF", err));
+    .catch(err => logAndRethrow("Error while generating PDF", err));
 
   await page
     .close()
-    .catch(err => console.error("Error while closing buffer", err));
+    .catch(err => logAndRethrow("Error while closing buffer", err));
   return buffer;
+}
+
+function logAndRethrow(message, err) {
+  console.error(message, err);
+  throw err;
 }
 
 module.exports = write;

--- a/pdf/src/index.js
+++ b/pdf/src/index.js
@@ -9,20 +9,25 @@ const app = polka().use(json());
 app.get("ping", (_, res) => res.end("pong"));
 
 app.post("/pdf", async (req, res) => {
-  const bufferPdf = await write(req.body);
+  try {
+    const bufferPdf = await write(req.body);
 
-  const date = new Date();
-  const fileName = `BSD_${Math.round(
-    Math.random() * 1000
-  )}_${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
+    const date = new Date();
+    const fileName = `BSD_${Math.round(
+      Math.random() * 1000
+    )}_${date.getDate()}-${date.getMonth() + 1}-${date.getFullYear()}`;
 
-  res.writeHead(200, {
-    "Content-Type": "application/pdf",
-    "Content-disposition": `attachment;filename=${fileName}.pdf`,
-    "Content-Length": bufferPdf.length
-  });
+    res.writeHead(200, {
+      "Content-Type": "application/pdf",
+      "Content-disposition": `attachment;filename=${fileName}.pdf`,
+      "Content-Length": bufferPdf.length
+    });
 
-  res.end(bufferPdf);
+    res.end(bufferPdf);
+  } catch (err) {
+    res.statusCode = 501;
+    res.end("Une erreur est survenue lors de la génération du PDF.");
+  }
 });
 
 app.listen(PORT, err => {


### PR DESCRIPTION
Suite au bug que tu as constaté. L'idée est qu'on ne s'arrête pas au premier bug de lancement de Chrome mais qu'on essaie de le relancer dans les appels qui suivent si le premier coup n'a pas marché.