### PR TITLE
Accept null or empty string for Forms

### DIFF
--- a/back/src/forms/validator.ts
+++ b/back/src/forms/validator.ts
@@ -17,12 +17,12 @@ export const formSchema = object().shape({
   id: string().required(),
   emitter: object().shape({
     type: string().matches(/(PRODUCER|OTHER|APPENDIX2)/),
-    pickupSite: string(),
+    pickupSite: string().nullable(true),
     company: companySchema
   }),
   recipient: object().shape({
     processingOperation: string().required(),
-    cap: string(),
+    cap: string().nullable(true),
     company: companySchema
   }),
   transporter: object().shape({
@@ -32,7 +32,7 @@ export const formSchema = object().shape({
     department: string().required(
       "Le département du transporteur est obligatoire"
     ),
-    validityLimit: date(),
+    validityLimit: date().nullable(true),
     numberPlate: string().nullable(true),
     company: companySchema
   }),
@@ -40,7 +40,7 @@ export const formSchema = object().shape({
     code: string().required("Code déchet manquant"),
     onuCode: string(),
     packagings: array().of(packagingSchema),
-    otherPackaging: string(),
+    otherPackaging: string().nullable(true),
     numberOfPackages: number()
       .integer()
       .min(1, "Le nombre de colis doit être supérieur à 0")

--- a/front/src/form/Emitter.tsx
+++ b/front/src/form/Emitter.tsx
@@ -9,7 +9,7 @@ type Values = {
 };
 export default connect<{}, Values>(function Emitter({ formik }) {
   const [pickupSite, setPickupSite] = useState(
-    formik.values.emitter.pickupSite != ""
+    !!formik.values.emitter.pickupSite
   );
 
   return (

--- a/front/src/form/Recipient.tsx
+++ b/front/src/form/Recipient.tsx
@@ -12,7 +12,7 @@ type Values = {
 
 export default connect<{}, Values>(function Recipient({ formik }) {
   const [hasTrader, setHasTrader] = useState(
-    formik.values.trader.company.siret != ""
+    !!formik.values.trader.company.siret
   );
   return (
     <React.Fragment>

--- a/front/src/form/schema.ts
+++ b/front/src/form/schema.ts
@@ -34,7 +34,7 @@ export const formSchema = object().shape({
   id: string().required(),
   emitter: object().shape({
     type: string().matches(/(PRODUCER|OTHER|APPENDIX2)/),
-    pickupSite: string(),
+    pickupSite: string().nullable(true),
     company: companySchema
   }),
   recipient: object().shape({
@@ -45,7 +45,7 @@ export const formSchema = object().shape({
         "Vous devez sélectionner une valeur",
         (v: string) => v != ""
       ),
-    cap: string(),
+    cap: string().nullable(true),
     company: companySchema
   }),
   transporter: object().shape({
@@ -55,7 +55,7 @@ export const formSchema = object().shape({
     department: string().required(
       "Le département du transporteur est obligatoire"
     ),
-    validityLimit: date(),
+    validityLimit: date().nullable(true),
     numberPlate: string().nullable(true),
     company: companySchema
   }),
@@ -64,7 +64,7 @@ export const formSchema = object().shape({
     name: string().required("Appelation du déchet manquante"),
     onuCode: string(),
     packagings: array().of(packagingSchema),
-    otherPackaging: string(),
+    otherPackaging: string().nullable(true),
     numberOfPackages: number()
       .integer()
       .min(1, "Le nombre de colis doit être supérieur à 0")


### PR DESCRIPTION
Le bug discuté ce matin avec toi @providenz 
- on accepte `null` pour les champs optionnels
- correction du front qui cherchait une empty string au lieu d'une falsy value (`!!null === !!"" === !!undefined`)

A terme il serait sans doute plus logique que toutes les valeurs nulles valent `null` et pas `""`. Donc modifier un peu le front pour ça.