### PR TITLE
back - make sure TD info takes precedence over insee info

### DIFF
--- a/back/src/companies/helper.ts
+++ b/back/src/companies/helper.ts
@@ -68,7 +68,7 @@ export async function getUserCompanies(userId: string) {
   return Promise.all(
     companies.map(company => {
       return memoizeRequest(company.siret).then(companyInfo => {
-        return { ...company, ...companyInfo };
+        return { ...companyInfo, ...company };
       });
     })
   );


### PR DESCRIPTION
J'ai fait ce mini fix en vue de la mise en prod de demain. Si jamais le service `td-insee` renvoie `{siret: ""}` comme c'était le cas, on est sûr que le siret de l'objet `company` (obtenu depuis prisma) prendra l'avantage.

Je ferai un meilleur refacto ensuite en ajoutant des tests