### PR TITLE
Amélioration du service INSEE

### DIFF
--- a/back/src/companies/insee.ts
+++ b/back/src/companies/insee.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { cachedGet } from "../common/redis";
+import { DomainError, ErrorCode } from "../common/errors";
 
 const COMPANY_INFOS_CACHE_KEY = "CompanyInfos";
 const INSEE_URI = "http://td-insee:81";
@@ -10,14 +11,24 @@ function getCompanySireneInfo(siret: string) {
 }
 
 export function getCachedCompanySireneInfo(siret) {
+  if (siret.length != 14) {
+    throw new DomainError(
+      "Le siret doit faire 14 caractères",
+      ErrorCode.BAD_USER_INPUT
+    );
+  }
+
   return cachedGet(getCompanySireneInfo, COMPANY_INFOS_CACHE_KEY, siret, {
     parser: JSON,
     options: { EX: EXPIRY_TIME }
+  }).catch(_ => {
+    throw new Error("Erreur technique, merci de réessayer");
   });
 }
 
 export function searchCompanies(clue: string, department: string = "") {
   return axios
     .get(`${INSEE_URI}/search?clue=${clue}&department=${department}`)
-    .then(r => r.data);
+    .then(r => r.data)
+    .catch(_ => []); // Silently fail
 }

--- a/back/src/companies/queries/companyInfos.ts
+++ b/back/src/companies/queries/companyInfos.ts
@@ -11,13 +11,6 @@ import { getCachedCompanySireneInfo } from "../insee";
  * @param siret
  */
 export async function getCompanyInfos(siret: string) {
-  if (siret.length != 14) {
-    throw new DomainError(
-      "Le siret doit faire 14 caractères",
-      ErrorCode.BAD_USER_INPUT
-    );
-  }
-
   // retrieve cached info from SIRENE database
   const sireneCompanyInfo = await getCachedCompanySireneInfo(siret);
 

--- a/insee/Dockerfile
+++ b/insee/Dockerfile
@@ -6,6 +6,7 @@ RUN go get && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/insee
 
 # final stage
 FROM alpine
+RUN apk update && apk add ca-certificates
 WORKDIR /app
 COPY --from=build-env /go/src/app/build/ .
 EXPOSE 81

--- a/insee/src/client.go
+++ b/insee/src/client.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"time"
+	"io/ioutil"
+	"net/http/httputil"
+	"log"
+	"net/http"
+)
+
+const (
+	baseSireneURL = "https://entreprise.data.gouv.fr/api/sirene/v1"
+)
+
+// Client Http client to entreprise.data.gouv.fr
+type Client struct {
+	httpClient  *http.Client
+}
+
+func (client *Client) queryAPI(uri string) ([]byte, error) {
+	req, err := http.NewRequest("GET", baseSireneURL+uri, nil)
+
+	req.Header.Add("Accept", `application/json`)
+
+  resp, err := client.httpClient.Do(req)
+
+	if err != nil {
+    log.Println("Technical error while querying API", err)
+		return nil, errors.New("Request failed - Technical error")
+	}
+
+	if resp.StatusCode != 200 {
+		log.Println("Error while querying SIRENE API, received status code", resp.StatusCode, http.StatusText(resp.StatusCode))
+
+		requestDump, _ := httputil.DumpRequest(req, true)
+    log.Println("Dumping error content...", string(requestDump))
+
+    responseData, _ := ioutil.ReadAll(resp.Body)
+    return nil, errors.New(string(responseData))
+	}
+
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+    log.Println("Technical error while reading API result", err)
+		return nil, errors.New("Request failed - Could not read response")
+	}
+
+	return responseData, nil
+}
+
+
+
+func newClient(options ...func(*Client)) *Client {
+	cli := Client{
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+
+	for i := range options {
+		options[i](&cli)
+	}
+
+	return &cli
+}

--- a/insee/src/client.go
+++ b/insee/src/client.go
@@ -2,20 +2,20 @@ package main
 
 import (
 	"errors"
-	"time"
 	"io/ioutil"
-	"net/http/httputil"
 	"log"
 	"net/http"
+	"net/http/httputil"
+	"time"
 )
 
 const (
 	baseSireneURL = "https://entreprise.data.gouv.fr/api/sirene/v1"
 )
 
-// Client Http client to entreprise.data.gouv.fr
+// Client - Http client to entreprise.data.gouv.fr
 type Client struct {
-	httpClient  *http.Client
+	httpClient *http.Client
 }
 
 func (client *Client) queryAPI(uri string) ([]byte, error) {
@@ -23,10 +23,10 @@ func (client *Client) queryAPI(uri string) ([]byte, error) {
 
 	req.Header.Add("Accept", `application/json`)
 
-  resp, err := client.httpClient.Do(req)
+	resp, err := client.httpClient.Do(req)
 
 	if err != nil {
-    log.Println("Technical error while querying API", err)
+		log.Println("Technical error while querying API", err)
 		return nil, errors.New("Request failed - Technical error")
 	}
 
@@ -34,22 +34,20 @@ func (client *Client) queryAPI(uri string) ([]byte, error) {
 		log.Println("Error while querying SIRENE API, received status code", resp.StatusCode, http.StatusText(resp.StatusCode))
 
 		requestDump, _ := httputil.DumpRequest(req, true)
-    log.Println("Dumping error content...", string(requestDump))
+		log.Println("Dumping error content...", string(requestDump))
 
-    responseData, _ := ioutil.ReadAll(resp.Body)
-    return nil, errors.New(string(responseData))
+		responseData, _ := ioutil.ReadAll(resp.Body)
+		return nil, errors.New(string(responseData))
 	}
 
 	responseData, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-    log.Println("Technical error while reading API result", err)
+		log.Println("Technical error while reading API result", err)
 		return nil, errors.New("Request failed - Could not read response")
 	}
 
 	return responseData, nil
 }
-
-
 
 func newClient(options ...func(*Client)) *Client {
 	cli := Client{

--- a/insee/src/client_test.go
+++ b/insee/src/client_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+const (
+	okResponse = `{
+		"response": "Anything here"
+  }`
+	koResponse = `{
+    "message": "no results found"
+  }`
+)
+
+func TestQueryApi(t *testing.T) {
+	getCli := func(response *http.Response) *Client {
+		httpClient := NewTestClient(func(req *http.Request) *http.Response {
+			return response
+		})
+		cli := newClient()
+		cli.httpClient = httpClient
+		return cli
+	}
+
+	t.Run("returns 404 when SIRET does not exist", func(t *testing.T) {
+    cli := getCli(&http.Response{
+      StatusCode: http.StatusNotFound,
+      Body:       ioutil.NopCloser(bytes.NewBufferString(koResponse)),
+      Header: make(http.Header),
+    })
+
+		_, got := cli.queryAPI("not a SIRET")
+		want := koResponse
+
+		if got.Error() != want {
+			t.Errorf("got %v want %v", got, want)
+		}
+	})
+
+	t.Run("returns response when SIRET exists", func(t *testing.T) {
+    cli := getCli(&http.Response{
+      StatusCode: 200,
+      Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+      Header: make(http.Header),
+    })
+
+		gotAsBytes, _ := cli.queryAPI("not a SIRET")
+    got := string(gotAsBytes[:])
+    want := okResponse
+
+		if got != want {
+			t.Errorf("got %v want %v", got, want)
+		}
+	})
+}
+
+// RoundTripFunc .
+type RoundTripFunc func(req *http.Request) *http.Response
+
+// RoundTrip .
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+//NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}

--- a/insee/src/client_test.go
+++ b/insee/src/client_test.go
@@ -27,11 +27,11 @@ func TestQueryApi(t *testing.T) {
 	}
 
 	t.Run("returns 404 when SIRET does not exist", func(t *testing.T) {
-    cli := getCli(&http.Response{
-      StatusCode: http.StatusNotFound,
-      Body:       ioutil.NopCloser(bytes.NewBufferString(koResponse)),
-      Header: make(http.Header),
-    })
+		cli := getCli(&http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(koResponse)),
+			Header:     make(http.Header),
+		})
 
 		_, got := cli.queryAPI("not a SIRET")
 		want := koResponse
@@ -42,15 +42,15 @@ func TestQueryApi(t *testing.T) {
 	})
 
 	t.Run("returns response when SIRET exists", func(t *testing.T) {
-    cli := getCli(&http.Response{
-      StatusCode: 200,
-      Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
-      Header: make(http.Header),
-    })
+		cli := getCli(&http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(okResponse)),
+			Header:     make(http.Header),
+		})
 
 		gotAsBytes, _ := cli.queryAPI("not a SIRET")
-    got := string(gotAsBytes[:])
-    want := okResponse
+		got := string(gotAsBytes[:])
+		want := okResponse
 
 		if got != want {
 			t.Errorf("got %v want %v", got, want)

--- a/insee/src/insee.go
+++ b/insee/src/insee.go
@@ -56,13 +56,12 @@ func Siret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
-  responseData, err := gouvAPIClient.queryAPI("/siret/" + strippedSiret)
+	responseData, err := gouvAPIClient.queryAPI("/siret/" + strippedSiret)
 	if err != nil {
-    w.WriteHeader(http.StatusInternalServerError)
-    w.Write([]byte(err.Error()))
-    return
-  }
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(err.Error()))
+		return
+	}
 
 	var fullResponseObject APIResponse
 	json.Unmarshal(responseData, &fullResponseObject)
@@ -85,12 +84,12 @@ func Search(w http.ResponseWriter, r *http.Request) {
 
 	uri := buildSearchURI(r.URL.Query())
 
-  res, err := gouvAPIClient.queryAPI(uri)
-  if err != nil {
-    w.Write([]byte(err.Error()))
-    w.WriteHeader(http.StatusInternalServerError)
-    return
-  }
+	res, err := gouvAPIClient.queryAPI(uri)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	var fullResponseObject APIMultiResponse
 	json.Unmarshal(res, &fullResponseObject)


### PR DESCRIPTION
On s'assure que si le webservice renvoie une erreur, le service back ait également bien une erreur. ll faut éviter des objets vides renvoyés par le service INSEE qui sont sources de bugs