### PR TITLE
back - Add some unit tests to module company

### DIFF
--- a/back/src/companies/__tests__/cache.test.ts
+++ b/back/src/companies/__tests__/cache.test.ts
@@ -1,0 +1,38 @@
+import { memoizeRequest } from "../cache";
+import axios from "axios";
+
+jest.mock("axios");
+
+const companyInfo = {
+  siret: "85001946400013",
+  siren: "850019464",
+  name: "CODE EN STOCK",
+  naf: "6201Z",
+  libelleNaf: "Programmation informatique",
+  address: "4 Boulevard Longchamp 13001 Marseille",
+  longitude: "5.387147",
+  latitude: "43.300749"
+};
+
+// https://stackoverflow.com/questions/51495473/typescript-and-jest-avoiding-type-errors-on-mocked-functions
+
+describe("memoizeRequest", () => {
+  it("should cache value based on siret key", async () => {
+    (axios.get as jest.Mock).mockResolvedValueOnce({ data: companyInfo });
+    let c = await memoizeRequest("85001946400013");
+    expect(c).toEqual(companyInfo);
+    expect(axios.get as jest.Mock).toHaveBeenCalledTimes(1);
+
+    // Call the function another time and check it is called only once
+    await memoizeRequest("85001946400013");
+    expect(axios.get as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not cache value if an error is raised", async () => {
+    (axios.get as jest.Mock).mockResolvedValueOnce(
+      new Error("something went wrong")
+    );
+    let c = await memoizeRequest("bad siret");
+    expect(c).toBeUndefined();
+  });
+});

--- a/back/src/companies/__tests__/helper.test.ts
+++ b/back/src/companies/__tests__/helper.test.ts
@@ -1,0 +1,65 @@
+import { getUserCompanies } from "../helper";
+
+const mockCompanyAssociations = jest.fn();
+
+jest.mock("../../generated/prisma-client", () => ({
+  prisma: {
+    companyAssociations: jest.fn(() => ({
+      $fragment: mockCompanyAssociations
+    }))
+  }
+}));
+
+jest.mock("../cache", () => ({
+  memoizeRequest: jest.fn()
+}));
+
+import { memoizeRequest } from "../cache";
+
+const mockMemoizeRequest = memoizeRequest as jest.Mock;
+
+describe("getUserCompanies", () => {
+  it("should return an empty array if the userId is not specified", async () => {
+    const companies = await getUserCompanies(null);
+    expect(companies).toEqual([]);
+  });
+  it("should merge info from SIRENE and TD", async () => {
+    mockCompanyAssociations.mockResolvedValueOnce([
+      { company: { id: "id", siret: "85001946400013", securityCode: "2317" } }
+    ]);
+    mockMemoizeRequest.mockResolvedValueOnce({
+      siret: "85001946400013",
+      name: "Code en Stock",
+      naf: "701Z",
+      address: "4 boulevard Longchamp 13001 Marseille"
+    });
+
+    const companies = await getUserCompanies("id");
+    const expected = [
+      {
+        id: "id",
+        siret: "85001946400013",
+        securityCode: "2317",
+        name: "Code en Stock",
+        naf: "701Z",
+        address: "4 boulevard Longchamp 13001 Marseille"
+      }
+    ];
+    expect(companies).toEqual(expected);
+  });
+  it("should not set siret to empty string", async () => {
+    mockCompanyAssociations.mockResolvedValueOnce([
+      { company: { id: "id", siret: "85001946400013", securityCode: "2317" } }
+    ]);
+    mockMemoizeRequest.mockReturnValueOnce(
+      Promise.resolve({
+        siret: "",
+        name: "",
+        naf: "",
+        address: ""
+      })
+    );
+    const companies = await getUserCompanies("id");
+    expect(companies[0].siret).toEqual("85001946400013");
+  });
+});

--- a/back/src/companies/__tests__/verif.test.ts
+++ b/back/src/companies/__tests__/verif.test.ts
@@ -1,0 +1,41 @@
+import { checkIsCompatible } from "../verif";
+import { getInstallationRubriques } from "../helper";
+
+jest.mock("../helper", () => ({
+  getInstallationRubriques: jest.fn()
+}));
+
+describe("checkIsCompatible", () => {
+  it("should return false if the waste is dangerous and no rubrique is compatible", async () => {
+    const rubriques = [{ wasteType: "NOT_DANGEROUS" }];
+    (getInstallationRubriques as jest.Mock).mockResolvedValueOnce(rubriques);
+
+    const isCompatible = await checkIsCompatible(
+      { codeS3ic: "0056.0987" },
+      "*78 98 78"
+    );
+
+    expect(isCompatible).toBe(false);
+  });
+
+  it("should return true if the waste is not dangerous", async () => {
+    const isCompatible = await checkIsCompatible(
+      { codeS3ic: "0056.0987" },
+      "78 98 78"
+    );
+
+    expect(isCompatible).toBe(true);
+  });
+
+  it("should return true if the waste is dangerous and there is a rubrique compatible", async () => {
+    const rubriques = [{ wasteType: "DANGEROUS" }];
+    (getInstallationRubriques as jest.Mock).mockResolvedValueOnce(rubriques);
+
+    const isCompatible = await checkIsCompatible(
+      { codeS3ic: "0056.0987" },
+      "*78 98 78"
+    );
+
+    expect(isCompatible).toBe(true);
+  });
+});


### PR DESCRIPTION
WIP 

Je me suis amusé à ajouté quelques tests pour voir comment fonctionne `jest`. 

Dans `helper.test.ts`, je mock les appels à prisma ce qui me permet de tester uniquement la logique de la fonction et d'avoir des tests qui tournent rapidement.