### PR TITLE
Config sentry to forward errors to front

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -36,6 +36,7 @@ const sentryMiddleware = () =>
       environment: process.env.NODE_ENV,
       integrations: [new CaptureConsole({ levels: ["error"] })]
     },
+    forwardErrors: true,
     withScope: (scope, error, context: any) => {
       scope.setExtra("body", context.request.body);
       scope.setExtra("origin", context.request.headers.origin);


### PR DESCRIPTION
Sentry Graphql middleware blocks errors by default., hiding useful error messages from end users.
This PR configures Sentry client to forward errors to client (front).