### PR TITLE
Sauvegarder des userTypes saisis au signup

### DIFF
--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -306,7 +306,7 @@ export default withRouter(function Signup(routerProps: RouteComponentProps) {
                               onBlur={async ev => {
                                 ev.persist();
 
-                                const siret = ev.target.value;
+                                const siret = ev.target.value.replace(/\s/g, '');
 
                                 if (siret.length == 14) {
                                   let company_ = null;
@@ -347,9 +347,8 @@ export default withRouter(function Signup(routerProps: RouteComponentProps) {
                                         return self.indexOf(value) === index;
                                       }
                                     );
-                                    form.setFieldValue("userType", userType);
-                                  } else {
-                                    form.setFieldValue("userType", []);
+                                    const currentValue = form.values.userType
+                                    form.setFieldValue("userType", [...currentValue, ...userType]);
                                   }
                                 }
 


### PR DESCRIPTION
https://trello.com/c/vYf4iQHB/445-lors-de-linscription-la-s%C3%A9lection-dune-entreprise-efface-les-champs-situ%C3%A9s-apr%C3%A8s-cat%C3%A9gories

J'ai fait le choix de merger sélection utilisateur et sélection  automatique pour le moment. Et ne pas effacer la sélection utilisateur si on n'a aucune suggestion à proposer. Ca peut potentiellement bouger si discussions sur la carte, mais ça me semble le plus logique.

Et j'en ai profité pour trimer automatiquement les espaces dans les sirets saisis. Un siret saisi avec espace (classique sur infogreffe par ex) ne déclenchait pas de recherche