### PR TITLE
Nettoyage d'un champ inutile

### DIFF
--- a/back/prisma/datamodel.prisma
+++ b/back/prisma/datamodel.prisma
@@ -7,7 +7,6 @@ type User {
   phone: String
   userType: Json
 
-  companies: [Company] @relation(name: "UserCompanies")
   companyAssociations: [CompanyAssociation]
 
   createdAt: DateTime! @createdAt


### PR DESCRIPTION
`companyAssociations` a remplacé `companies`, qui était resté en place le temps de la migration. Il aurait du sauter juste après.
On le  supprime pour éviter les erreurs dans l'avenir et les confusions.

J'ai vérifié, il ne semble plus y a voir d'usage. Tout semble passé via les `companyAssociations`, comme prévu.
J'en parlais ici: https://trello.com/c/XFjqQv40/506-questions-pour-orion-retour-vacances

⚠Demande de jouer un `prisma deploy` sur les serveurs