### PR TITLE
apollo-client 2.6

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -67,6 +67,25 @@
         }
       }
     },
+    "@apollo/react-testing": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-testing/-/react-testing-3.1.3.tgz",
+      "integrity": "sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==",
+      "dev": true,
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "fast-json-stable-stringify": "^2.0.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -2115,11 +2134,14 @@
       }
     },
     "apollo-utilities": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.26.tgz",
-      "integrity": "sha512-URw7o3phymliqYCYatcird2YRPUU2eWCNvip64U9gQrX56mEfK4m99yBIDCMTpmcvOFsKLii1sIEZsHIs/bvnw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "append-transform": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4,6 +4,69 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollo/react-common": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.3.tgz",
+      "integrity": "sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==",
+      "requires": {
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@apollo/react-components": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-components/-/react-components-3.1.3.tgz",
+      "integrity": "sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@apollo/react-hooks": "^3.1.3",
+        "prop-types": "^15.7.2",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
+    "@apollo/react-hooks": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.3.tgz",
+      "integrity": "sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==",
+      "requires": {
+        "@apollo/react-common": "^3.1.3",
+        "@wry/equality": "^0.1.9",
+        "ts-invariant": "^0.4.4",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -1138,12 +1201,6 @@
         "webfontloader": "^1.6.27"
       }
     },
-    "@types/async": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.50.tgz",
-      "integrity": "sha512-VMhZMMQgV1zsR+lX/0IBfAk+8Eb7dPVMWiQGFAt3qjo5x7Ml6b77jUo0e1C3ToD+XRDXqtrfw+6AB0uUsPEr3Q==",
-      "optional": true
-    },
     "@types/geojson": {
       "version": "7946.0.7",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
@@ -1213,9 +1270,9 @@
       }
     },
     "@types/node": {
-      "version": "10.12.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
+      "version": "10.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
+      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -1518,6 +1575,14 @@
         "@webassemblyjs/ast": "1.7.6",
         "@webassemblyjs/wast-parser": "1.7.6",
         "@xtuc/long": "4.2.1"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "@xtuc/ieee754": {
@@ -1960,68 +2025,103 @@
       }
     },
     "apollo-client": {
-      "version": "2.4.7",
-      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.4.7.tgz",
-      "integrity": "sha512-6aAm+16AFBYZhJF8eKxrup6AbYni01InDiwTfZhMMTP2xaXQWjsQnfaHbI2oE+hd3+AZFy1drkse8RZKghR/WQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/apollo-client/-/apollo-client-2.6.4.tgz",
+      "integrity": "sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==",
       "requires": {
-        "@types/async": "2.0.50",
         "@types/zen-observable": "^0.8.0",
-        "apollo-cache": "1.1.21",
+        "apollo-cache": "1.3.2",
         "apollo-link": "^1.0.0",
-        "apollo-link-dedup": "^1.0.0",
-        "apollo-utilities": "1.0.26",
+        "apollo-utilities": "1.3.2",
         "symbol-observable": "^1.0.2",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
+      },
+      "dependencies": {
+        "apollo-cache": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+          "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
+          "requires": {
+            "apollo-utilities": "^1.3.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "apollo-link": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.4.tgz",
-      "integrity": "sha512-B1z+9H2nTyWEhMXRFSnoZ1vSuAYP+V/EdUJvRx9uZ8yuIBZMm6reyVtr1n0BWlKeSFyPieKJy2RLzmITAAQAMQ==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
       "requires": {
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.11"
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.20"
+      },
+      "dependencies": {
+        "apollo-utilities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+          "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+          "requires": {
+            "@wry/equality": "^0.1.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "apollo-link-context": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.10.tgz",
-      "integrity": "sha512-HX3BEmkANs2A8AcYCy92SFJrW+0SbGrhDTSHV6ZwKIJ9ZrsOtly8cMrRLzEw1emjHIz5SP7XJEn3ko7BwhBBSw==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.19.tgz",
+      "integrity": "sha512-TUi5TyufU84hEiGkpt+5gdH5HkB3Gx46npNfoxR4of3DKBCMuItGERt36RCaryGcU/C3u2zsICU3tJ+Z9LjFoQ==",
       "requires": {
-        "apollo-link": "^1.2.4"
-      }
-    },
-    "apollo-link-dedup": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.11.tgz",
-      "integrity": "sha512-RcvkXR0CNbQcsw6LdrPksGa+9YjZ1ghk0k2PKal6rSBCyyqzokcBawXOtoMN8q+0FLR1dGs5GnAQVeucQuY28g==",
-      "requires": {
-        "apollo-link": "^1.2.4"
+        "apollo-link": "^1.2.13",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-error": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.2.tgz",
-      "integrity": "sha512-zlEZiqQ42E49+BeX3mIKPkMTSlOPrYNEwzSi1MubUiP/Bi6QRP7tzdJXNBnUpkW6MjZJQpfSNZNxK/xwvPiJIw==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.12.tgz",
+      "integrity": "sha512-psNmHyuy3valGikt/XHJfe0pKJnRX19tLLs6P6EHRxg+6q6JMXNVLYPaQBkL0FkwdTCB0cbFJAGRYCBviG8TDA==",
       "requires": {
-        "apollo-link": "^1.2.4"
+        "apollo-link": "^1.2.13",
+        "apollo-link-http-common": "^0.2.15",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.7.tgz",
-      "integrity": "sha512-EZ9nynHjwYCpGYP5IsRrZGTWidUVpshk7MuSG4joqGtJMwpFCgMQz+y3BHdUhowHtfAd9z60XmeOTG9FJolb8A==",
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz",
+      "integrity": "sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==",
       "requires": {
-        "apollo-link": "^1.2.4",
-        "apollo-link-http-common": "^0.2.6"
+        "apollo-link": "^1.2.13",
+        "apollo-link-http-common": "^0.2.15",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-link-http-common": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.6.tgz",
-      "integrity": "sha512-LUOMWvrZuBP1hyWLBXyaW0KyFeKo79j+k3N+Q4HSkXKbLibnllXQ+JxxoSKGhm0bhREygiLtJAG9JnGlhxGO/Q==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz",
+      "integrity": "sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==",
       "requires": {
-        "apollo-link": "^1.2.4"
+        "apollo-link": "^1.2.13",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-utilities": {
@@ -5994,11 +6094,6 @@
         }
       }
     },
-    "fbjs-css-vars": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.1.tgz",
-      "integrity": "sha512-IM+v/C40MNZWqsLErc32e0TyIk/NhkkQZL0QmjBh6zi1eXv0/GeVKmKmueQX7nn9SXQBQbTUcB8zuexIF3/88w=="
-    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -9062,11 +9157,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.flowright": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flowright/-/lodash.flowright-3.5.0.tgz",
-      "integrity": "sha1-K1//OZcW1+fcVyT+k0n2cGUYTWc="
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -9076,11 +9166,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -14249,52 +14334,6 @@
         "scheduler": "^0.12.0-alpha.2"
       }
     },
-    "react-apollo": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/react-apollo/-/react-apollo-2.3.2.tgz",
-      "integrity": "sha512-3lU9iqmj4KMIZvlWWSuLihxMGLEAL6oNmnSTWrb3/mRP36Zy0zJD4rdaonDx4WzqFYQAnUPaOiFnHGp0UQUTwA==",
-      "requires": {
-        "fbjs": "^1.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "invariant": "^2.2.2",
-        "lodash.flowright": "^3.5.0",
-        "lodash.isequal": "^4.5.0",
-        "prop-types": "^15.6.0"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
-          "integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
-          "requires": {
-            "react-is": "^16.3.2"
-          }
-        },
-        "promise": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-          "requires": {
-            "asap": "~2.0.3"
-          }
-        }
-      }
-    },
     "react-app-polyfill": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-0.2.0.tgz",
@@ -14468,9 +14507,9 @@
       "integrity": "sha512-0DiXTcECUNoMvze2zcFwYYrHAFgQ2rBM0+HIHfaECKRfE1NZYwfuUSbwyg9s1uVPuy7o/KqQKSwBGMWQFvdrhQ=="
     },
     "react-is": {
-      "version": "16.6.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
-      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
     "react-lazyload": {
       "version": "2.5.0",
@@ -17752,6 +17791,14 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -17798,9 +17845,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "ua-parser-js": {
@@ -19213,15 +19260,16 @@
       }
     },
     "zen-observable": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
-      "integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ=="
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g=="
     },
     "zen-observable-ts": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.11.tgz",
-      "integrity": "sha512-8bs7rgGV4kz5iTb9isudkuQjtWwPnQ8lXq6/T76vrepYZVMsDEv6BXaEA+DHdJSK3KVLduagi9jSpSAJ5NgKHw==",
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
       "requires": {
+        "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
     },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1291,8 +1291,7 @@
     "@types/node": {
       "version": "10.17.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.5.tgz",
-      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==",
-      "dev": true
+      "integrity": "sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA=="
     },
     "@types/node-fetch": {
       "version": "2.1.4",
@@ -1594,6 +1593,15 @@
         "@webassemblyjs/ast": "1.7.6",
         "@webassemblyjs/wast-parser": "1.7.6",
         "@xtuc/long": "4.2.1"
+      }
+    },
+    "@wry/context": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.4.4.tgz",
+      "integrity": "sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==",
+      "requires": {
+        "@types/node": ">=6",
+        "tslib": "^1.9.3"
       }
     },
     "@wry/equality": {
@@ -2026,21 +2034,24 @@
       }
     },
     "apollo-cache": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.1.21.tgz",
-      "integrity": "sha512-5ErNb78KHtrJNimkDBTEigcvHkIqUmS7QJIk4lpZZ+XLVVgvk2fD+GhD1PLP+s8vHfAKVbO6vdbRxCCjGGrh5w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-cache/-/apollo-cache-1.3.2.tgz",
+      "integrity": "sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==",
       "requires": {
-        "apollo-utilities": "^1.0.26"
+        "apollo-utilities": "^1.3.2",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-cache-inmemory": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.11.tgz",
-      "integrity": "sha512-fSoyjBV5RV57J3i/VHDDB74ZgXc0PFiogheNFHEhC0mL6rg5e/DjTx0Vg+csIBk23gvlzTvV+eypx7Q2NJ+dYg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz",
+      "integrity": "sha512-S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==",
       "requires": {
-        "apollo-cache": "^1.1.21",
-        "apollo-utilities": "^1.0.26",
-        "optimism": "^0.6.6"
+        "apollo-cache": "^1.3.2",
+        "apollo-utilities": "^1.3.2",
+        "optimism": "^0.10.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "apollo-client": {
@@ -8198,11 +8209,6 @@
         "invariant": "^2.2.0"
       }
     },
-    "immutable-tuple": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/immutable-tuple/-/immutable-tuple-0.4.9.tgz",
-      "integrity": "sha512-LWbJPZnidF8eczu7XmcnLBsumuyRBkpwIRPCZxlojouhBo5jEBO4toj6n7hMy6IxHU/c+MqDSWkvaTpPlMQcyA=="
-    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -10133,11 +10139,11 @@
       }
     },
     "optimism": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.6.8.tgz",
-      "integrity": "sha512-bN5n1KCxSqwBDnmgDnzMtQTHdL+uea2HYFx1smvtE+w2AMl0Uy31g0aXnP/Nt85OINnMJPRpJyfRQLTCqn5Weg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.10.3.tgz",
+      "integrity": "sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==",
       "requires": {
-        "immutable-tuple": "^0.4.9"
+        "@wry/context": "^0.4.0"
       }
     },
     "optimist": {

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -2094,16 +2094,6 @@
         "tslib": "^1.9.3"
       }
     },
-    "apollo-link-error": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.12.tgz",
-      "integrity": "sha512-psNmHyuy3valGikt/XHJfe0pKJnRX19tLLs6P6EHRxg+6q6JMXNVLYPaQBkL0FkwdTCB0cbFJAGRYCBviG8TDA==",
-      "requires": {
-        "apollo-link": "^1.2.13",
-        "apollo-link-http-common": "^0.2.15",
-        "tslib": "^1.9.3"
-      }
-    },
     "apollo-link-http": {
       "version": "1.5.16",
       "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.16.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -3,14 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@apollo/react-components": "^3.1.3",
+    "@apollo/react-hooks": "^3.1.3",
     "@typeform/embed": "^0.6.1",
     "@types/mapbox-gl": "^0.54.3",
     "apollo-cache-inmemory": "^1.3.11",
-    "apollo-client": "^2.4.7",
-    "apollo-link": "^1.2.4",
-    "apollo-link-context": "^1.0.10",
-    "apollo-link-error": "^1.1.2",
-    "apollo-link-http": "^1.5.7",
+    "apollo-client": "^2.6.4",
+    "apollo-link": "^1.2.13",
+    "apollo-link-context": "^1.0.19",
+    "apollo-link-error": "^1.1.12",
+    "apollo-link-http": "^1.5.16",
     "env-cmd": "^10.0.1",
     "formik": "^1.3.2",
     "graphql": "^14.0.2",
@@ -21,7 +23,6 @@
     "node-sass": "^4.10.0",
     "rc-tree": "^1.14.8",
     "react": "^16.7.0-alpha",
-    "react-apollo": "^2.3.2",
     "react-app-polyfill": "^0.2.0",
     "react-dom": "^16.7.0-alpha",
     "react-icons": "^3.2.2",
@@ -67,7 +68,7 @@
     "@types/jest": "^23.3.9",
     "@types/jwt-decode": "^2.2.1",
     "@types/luxon": "^1.4.1",
-    "@types/node": "^10.12.9",
+    "@types/node": "^10.17.5",
     "@types/node-fetch": "^2.1.4",
     "@types/rc-tree": "^1.11.2",
     "@types/react": "^16.9.5",
@@ -78,6 +79,6 @@
     "@types/yup": "^0.26.4",
     "@types/zxcvbn": "^4.4.0",
     "react-snap": "^1.23.0",
-    "typescript": "^3.1.6"
+    "typescript": "^3.7.2"
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
     "apollo-link": "^1.2.13",
     "apollo-link-context": "^1.0.19",
     "apollo-link-http": "^1.5.16",
+    "apollo-utilities": "^1.3.2",
     "env-cmd": "^10.0.1",
     "formik": "^1.3.2",
     "graphql": "^14.0.2",
@@ -60,6 +61,7 @@
     "inlineCss": true
   },
   "devDependencies": {
+    "@apollo/react-testing": "^3.1.3",
     "@testing-library/dom": "^6.6.0",
     "@testing-library/jest-dom": "^4.1.1",
     "@testing-library/react": "^9.3.0",

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,7 @@
     "@apollo/react-hooks": "^3.1.3",
     "@typeform/embed": "^0.6.1",
     "@types/mapbox-gl": "^0.54.3",
-    "apollo-cache-inmemory": "^1.3.11",
+    "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "apollo-link": "^1.2.13",
     "apollo-link-context": "^1.0.19",

--- a/front/package.json
+++ b/front/package.json
@@ -11,7 +11,6 @@
     "apollo-client": "^2.6.4",
     "apollo-link": "^1.2.13",
     "apollo-link-context": "^1.0.19",
-    "apollo-link-error": "^1.1.12",
     "apollo-link-http": "^1.5.16",
     "env-cmd": "^10.0.1",
     "formik": "^1.3.2",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ApolloProvider } from "react-apollo";
+import { ApolloProvider } from "@apollo/react-hooks";
 import { BrowserRouter as Router } from "react-router-dom";
 import "./App.css";
 import client from "./graphql-client";

--- a/front/src/company/Company.tsx
+++ b/front/src/company/Company.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import gql from "graphql-tag";
-import { Query } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import { RouteComponentProps } from "react-router";
 import CompanyHeader from "./CompanyHeader";
 import CompanyMap from "./CompanyMap";
@@ -55,13 +55,13 @@ export default function CompanyInfo({
       fetchPolicy="no-cache"
     >
       {({ loading, error, data }) => {
-        if (loading) return "Loading...";
-        if (error) return `Error!: ${error}`;
+        if (loading) return <p>"Loading..."</p>;
+        if (error) return <p>{`Error!: ${error}`}</p>;
 
         const company: Company = data.companyInfos;
 
         if (!company.siret) {
-          return "Entreprise inconnue";
+          return <p>"Entreprise inconnue"</p>;
         }
 
         return (

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import React from "react";
-import { Query } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import { Route, RouteComponentProps } from "react-router";
 import Account from "./account/Account";
 import "./Dashboard.scss";
@@ -67,8 +67,8 @@ export default class Dashboard extends React.Component<RouteComponentProps, S> {
     return (
       <Query<MeData> query={GET_ME}>
         {({ loading, error, data }) => {
-          if (loading) return "Chargement...";
-          if (error) return `Erreur ! ${error.message}`;
+          if (loading) return <p>Chargement...</p>;
+          if (error) return <p>{`Erreur ! ${error.message}`}</p>;
 
           if (data) {
             // default to first company siret if it is not set
@@ -109,6 +109,8 @@ export default class Dashboard extends React.Component<RouteComponentProps, S> {
               </div>
             );
           }
+
+          return null;
         }}
       </Query>
     );

--- a/front/src/dashboard/account/Account.tsx
+++ b/front/src/dashboard/account/Account.tsx
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import React, { useRef, useState } from "react";
-import { ApolloConsumer } from "react-apollo";
+import { ApolloConsumer } from "@apollo/react-components";
 import { FaCopy } from "react-icons/fa";
 import { RouteComponentProps, withRouter } from "react-router";
 import { localAuthService } from "../../login/auth.service";

--- a/front/src/dashboard/account/EditCompany.tsx
+++ b/front/src/dashboard/account/EditCompany.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import CompanyType from "../../login/CompanyType";
-import { Mutation, MutationFn, MutationResult } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import gql from "graphql-tag";
 
 export const UPDATE_COMPANY = gql`
@@ -20,7 +20,7 @@ export default function EditCompany({ siret, companyTypes, onSubmit }: Props) {
   return (
     <div className="account__form">
       <Mutation mutation={UPDATE_COMPANY}>
-        {(updateCompany: MutationFn, { loading }: MutationResult) => {
+        {(updateCompany, { loading }) => {
           return (
             <Formik
               initialValues={{ companyTypes }}

--- a/front/src/dashboard/account/EditCompany.tsx
+++ b/front/src/dashboard/account/EditCompany.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import CompanyType from "../../login/CompanyType";
-import { Mutation } from "@apollo/react-components";
+import { useMutation } from "@apollo/react-hooks";
 import gql from "graphql-tag";
 
 export const UPDATE_COMPANY = gql`
@@ -17,49 +17,41 @@ export const UPDATE_COMPANY = gql`
 type Props = { siret: string; companyTypes: string[]; onSubmit: () => void };
 
 export default function EditCompany({ siret, companyTypes, onSubmit }: Props) {
+  const [updateCompany, { loading }] = useMutation(UPDATE_COMPANY);
+
   return (
     <div className="account__form">
-      <Mutation mutation={UPDATE_COMPANY}>
-        {(updateCompany, { loading }) => {
-          return (
-            <Formik
-              initialValues={{ companyTypes }}
-              onSubmit={(values, { setSubmitting, setFieldError }) => {
-                updateCompany({ variables: { siret, ...values } })
-                  .then(_ => {
-                    setSubmitting(false);
-                    onSubmit();
-                  })
-                  .catch(_ => {
-                    setFieldError(
-                      "companyTypes",
-                      "Une erreur est survenue. Veuillez réessayer"
-                    );
-                  });
-              }}
-            >
-              {({ isSubmitting }) => (
-                <Form>
-                  <label>Profil de l'entreprise</label>
-                  <Field name="companyTypes" component={CompanyType} />
-                  <ErrorMessage
-                    name="companyTypes"
-                    render={msg => <div>{msg}</div>}
-                  />
-                  {loading && <div>Envoi en cours...</div>}
-                  <button
-                    type="submit"
-                    className="button"
-                    disabled={isSubmitting}
-                  >
-                    Enregistrer
-                  </button>
-                </Form>
-              )}
-            </Formik>
-          );
+      <Formik
+        initialValues={{ companyTypes }}
+        onSubmit={(values, { setSubmitting, setFieldError }) => {
+          updateCompany({ variables: { siret, ...values } })
+            .then(_ => {
+              setSubmitting(false);
+              onSubmit();
+            })
+            .catch(_ => {
+              setFieldError(
+                "companyTypes",
+                "Une erreur est survenue. Veuillez réessayer"
+              );
+            });
         }}
-      </Mutation>
+      >
+        {({ isSubmitting }) => (
+          <Form>
+            <label>Profil de l'entreprise</label>
+            <Field name="companyTypes" component={CompanyType} />
+            <ErrorMessage
+              name="companyTypes"
+              render={msg => <div>{msg}</div>}
+            />
+            {loading && <div>Envoi en cours...</div>}
+            <button type="submit" className="button" disabled={isSubmitting}>
+              Enregistrer
+            </button>
+          </Form>
+        )}
+      </Formik>
     </div>
   );
 }

--- a/front/src/dashboard/account/EditProfile.tsx
+++ b/front/src/dashboard/account/EditProfile.tsx
@@ -1,7 +1,7 @@
 import { Field, Form, Formik } from "formik";
 import React from "react";
 import { Me } from "../../login/model";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import gql from "graphql-tag";
 import { GET_ME } from "../Dashboard";
 
@@ -22,7 +22,7 @@ export default function EditProfile({ me, onSubmit }: Props) {
       <Mutation
         mutation={EDIT_PROFILE}
         update={(cache, { data: { editProfile } }) => {
-          const query = cache.readQuery<{ me: Me }>({ query: GET_ME });
+          const query = cache.readQuery({ query: GET_ME });
           if (!query || !query.me) {
             return;
           }

--- a/front/src/dashboard/account/InviteNewUser.tsx
+++ b/front/src/dashboard/account/InviteNewUser.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Formik, Form, Field } from "formik";
 import "./InviteNewUser.scss";
-import { Mutation, Query } from "react-apollo";
+import { Mutation, Query } from "@apollo/react-components";
 import gql from "graphql-tag";
 import RedErrorMessage from "../../form/RedErrorMessage";
 import { FaTimes } from "react-icons/fa";
@@ -97,9 +97,8 @@ export default function InviteNewUser({ siret }: Props) {
       )}
       <Query query={COMPANY_USERS} variables={{ siret }}>
         {({ loading, error, data }) => {
-          if (loading) return "Chargement...";
-          if (error) return `Erreur ! ${error.message}`;
-
+          if (loading) return <p>Chargement...</p>;
+          if (error) return <p>{`Erreur ! ${error.message}`}</p>;
           return (
             <div>
               <h5>Membres de l'équipe ({data.companyUsers.length})</h5>
@@ -115,9 +114,9 @@ export default function InviteNewUser({ siret }: Props) {
                           <Mutation
                             mutation={REMOVE_USER}
                             update={proxy => {
-                              const data = proxy.readQuery<{
-                                companyUsers: any[];
-                              }>({ query: COMPANY_USERS });
+                              const data = proxy.readQuery({
+                                query: COMPANY_USERS
+                              });
                               if (!data || !data.companyUsers) {
                                 return;
                               }

--- a/front/src/dashboard/exports/exports.tsx
+++ b/front/src/dashboard/exports/exports.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Me } from "../../login/model";
-import { Query, QueryResult } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import gql from "graphql-tag";
 
 interface IProps {
@@ -41,9 +41,9 @@ export default function Exports({ me }: IProps) {
     <div className="main">
       <h2>Statistiques</h2>
       <Query query={GET_STATS}>
-        {({ loading, error, data }: QueryResult<{ stats: Stats[] }>) => {
-          if (loading) return "Chargement...";
-          if (error || !data) return "Erreur...";
+        {({ loading, error, data }) => {
+          if (loading) return <p>Chargement...</p>;
+          if (error || !data) return <p>"Erreur..."</p>;
           return (
             <table className="table">
               <thead>
@@ -98,18 +98,14 @@ export default function Exports({ me }: IProps) {
       <a
         className="button"
         target="_blank"
-        href={`${
-          process.env.REACT_APP_API_ENDPOINT
-        }/exports?exportType=OUTGOING&siret=${sirets}`}
+        href={`${process.env.REACT_APP_API_ENDPOINT}/exports?exportType=OUTGOING&siret=${sirets}`}
       >
         Registre de déchets sortants
       </a>
       <a
         className="button"
         target="_blank"
-        href={`${
-          process.env.REACT_APP_API_ENDPOINT
-        }/exports?exportType=INCOMING&siret=${sirets}`}
+        href={`${process.env.REACT_APP_API_ENDPOINT}/exports?exportType=INCOMING&siret=${sirets}`}
       >
         Registre de déchets entrants
       </a>

--- a/front/src/dashboard/slips/SlipActions.tsx
+++ b/front/src/dashboard/slips/SlipActions.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import {
   FaCheck,
   FaCog,

--- a/front/src/dashboard/slips/SlipsTabs.tsx
+++ b/front/src/dashboard/slips/SlipsTabs.tsx
@@ -3,20 +3,19 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import "./SlipsTabs.scss";
 import Slips from "./Slips";
 import { GET_SLIPS } from "./query";
-import { Query, QueryResult } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import { Me } from "../../login/model";
-import { Form } from "../../form/model";
-import { getNextStep, getTabForms, SlipTabs } from "./slips-actions/next-step";
+import { getTabForms, SlipTabs } from "./slips-actions/next-step";
 import { FaClone } from "react-icons/fa";
 import { Link } from "react-router-dom";
 
-type Props = { me: Me, siret?: string };
+type Props = { me: Me; siret?: string };
 export default function SlipsTabs({ me, siret }: Props) {
   return (
     <Query query={GET_SLIPS} variables={{ siret }}>
-      {({ loading, error, data }: QueryResult<{ forms: Form[] }>) => {
-        if (loading) return "Chargement...";
-        if (error || !data) return "Erreur...";
+      {({ loading, error, data }) => {
+        if (loading) return <p>"..."</p>;
+        if (error || !data) return <p>"Erreur..."</p>;
 
         const drafts = getTabForms(SlipTabs.DRAFTS, data.forms, me);
         const toSign = getTabForms(SlipTabs.TO_SIGN, data.forms, me);

--- a/front/src/dashboard/slips/slips-actions/Delete.tsx
+++ b/front/src/dashboard/slips/slips-actions/Delete.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import { FaTrash } from "react-icons/fa";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import mutations from "./slip-actions.mutations";
 import { GET_SLIPS } from "../query";
-import { Form } from "../../../form/model";
 import { currentSiretService } from "../../CompanySelector";
 
 type Props = { formId: string };
@@ -42,7 +41,7 @@ export default function Delete({ formId }: Props) {
                   deleteForm({
                     variables: { id: formId },
                     update: (store, { data: { deleteForm } }) => {
-                      const data = store.readQuery<{ forms: Form[] }>({
+                      const data = store.readQuery({
                         query: GET_SLIPS,
                         variables: { siret: currentSiretService.getSiret() }
                       });

--- a/front/src/dashboard/slips/slips-actions/Duplicate.tsx
+++ b/front/src/dashboard/slips/slips-actions/Duplicate.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { FaClone } from "react-icons/fa";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import mutations from "./slip-actions.mutations";
 import { GET_SLIPS } from "../query";
-import { Form } from "../../../form/model";
 import { currentSiretService } from "../../CompanySelector";
 
 type Props = { formId: string };
@@ -19,7 +18,7 @@ export default function Duplicate({ formId }: Props) {
             duplicate({
               variables: { id: formId },
               update: (store, { data: { duplicateForm } }) => {
-                const data = store.readQuery<{ forms: Form[] }>({
+                const data = store.readQuery({
                   query: GET_SLIPS,
                   variables: { siret: currentSiretService.getSiret() }
                 });

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import { Me } from "../../login/model";
 import "./Transport.scss";
-import { Query, QueryResult } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import gql from "graphql-tag";
-import { Form } from "../../form/model";
 import TransportSignature from "./TransportSignature";
 
 type Props = {
@@ -61,9 +60,9 @@ export default function Transport({ me, siret }: Props) {
           query={GET_TRANSPORT_SLIPS}
           variables={{ siret, type: "TRANSPORTER" }}
         >
-          {({ loading, error, data }: QueryResult<{ forms: Form[] }>) => {
-            if (loading) return "Chargement...";
-            if (error || !data) return "Erreur...";
+          {({ loading, error, data }) => {
+            if (loading) return <p>Chargement...</p>;
+            if (error || !data) return <p>"Erreur..."</p>;
 
             return (
               <table className="table">

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { Form as FormModel, Form } from "../../form/model";
 import { FaFileSignature } from "react-icons/fa";
-import { Formik, Field } from "formik";
+import { Field } from "formik";
 import { DateTime } from "luxon";
 import gql from "graphql-tag";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import Packagings from "../../form/packagings/Packagings";
 import { Wizard } from "./Wizard";
 import "./TransportSignature.scss";
@@ -67,7 +67,7 @@ export default function TransportSignature({ form }: Props) {
                   signedByTransporter({
                     variables: { id: form.id, signingInfo: values },
                     update: (store, { data: { signedByTransporter } }) => {
-                      const data = store.readQuery<{ forms: Form[] }>({
+                      const data = store.readQuery({
                         query: GET_TRANSPORT_SLIPS,
                         variables: {
                           siret: currentSiretService.getSiret(),
@@ -166,9 +166,7 @@ export default function TransportSignature({ form }: Props) {
                         <small>
                           Si vous le désirez, vous pouvez accéder à{" "}
                           <a
-                            href={`${
-                              process.env.REACT_APP_API_ENDPOINT
-                            }/pdf?id=${form.id}`}
+                            href={`${process.env.REACT_APP_API_ENDPOINT}/pdf?id=${form.id}`}
                             target="_blank"
                           >
                             une vue CERFA du bordereau

--- a/front/src/form/appendix/FormsSelector.tsx
+++ b/front/src/form/appendix/FormsSelector.tsx
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 import React, { useState, useEffect, useReducer } from "react";
-import { Query, QueryResult } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import { Form } from "../model";
 import { DateTime } from "luxon";
 import { connect, getIn, setIn } from "formik";
@@ -124,9 +124,10 @@ export default connect<Props>(function FormsSelector(props) {
           emitterSiret: props.emitterSiret
         }}
       >
-        {({ loading, error, data }: QueryResult<{ appendixForms: Form[] }>) => {
-          if (loading) return "Chargement...";
-          if (error || !data) return `Erreur! ${error && error.message}`;
+        {({ loading, error, data }) => {
+          if (loading) return <p>Chargement...</p>;
+          if (error || !data)
+            return <p>{`Erreur! ${error && error.message}`}</p>;
 
           const values = data.appendixForms;
 
@@ -181,7 +182,9 @@ export default connect<Props>(function FormsSelector(props) {
                       />
                     </td>
                     <td>{v.readableId}</td>
-                    <td>{v.wasteDetails.code} - {v.wasteDetails.name}</td>
+                    <td>
+                      {v.wasteDetails.code} - {v.wasteDetails.name}
+                    </td>
                     <td>{v.emitter.company.name}</td>
                     <td>{DateTime.fromISO(v.receivedAt).toLocaleString()}</td>
                     <td>{v.quantityReceived} tonnes</td>

--- a/front/src/form/company/CompanySelector.tsx
+++ b/front/src/form/company/CompanySelector.tsx
@@ -1,6 +1,6 @@
 import { connect, Field, FieldProps } from "formik";
 import React, { useEffect, useState } from "react";
-import { Query } from "react-apollo";
+import { Query } from "@apollo/react-components";
 import { FaSearch, FaCheck, FaRegCircle } from "react-icons/fa";
 import "./CompanySelector.scss";
 import { FAVORITES, SEARCH_COMPANIES } from "./query";
@@ -39,8 +39,9 @@ export default connect<FieldProps>(function CompanySelector(props) {
   const [isLoading, setIsLoading] = useState(false);
   const [displayDepartment, setDisplayDepartment] = useState(false);
 
-  const [selectedCompany, setSelectedCompany] = useState<Company>(props.field
-    .value as Company);
+  const [selectedCompany, setSelectedCompany] = useState<Company>(
+    props.field.value as Company
+  );
 
   useEffect(() => {
     if (!debouncedSearchTerm || debouncedSearchTerm.clue.length < 1) {

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -3,11 +3,10 @@ import { Step, IStepContainerProps } from "./Step";
 import "./StepList.scss";
 import { Formik, FormikActions, setNestedObjectValues } from "formik";
 import initialState from "../initial-state";
-import { Query, Mutation } from "react-apollo";
+import { Query, Mutation } from "@apollo/react-components";
 import { withRouter, RouteComponentProps } from "react-router";
 import { GET_FORM, SAVE_FORM } from "./queries";
 import { GET_SLIPS } from "../../dashboard/slips/query";
-import { Form } from "../model";
 import { formSchema } from "../schema";
 import { currentSiretService } from "../../dashboard/CompanySelector";
 
@@ -88,7 +87,7 @@ export default withRouter(function StepList(
               <Mutation
                 mutation={SAVE_FORM}
                 update={(store, { data: { saveForm } }) => {
-                  const data = store.readQuery<{ forms: Form[] }>({
+                  const data = store.readQuery({
                     query: GET_SLIPS,
                     variables: { siret: currentSiretService.getSiret() }
                   });
@@ -119,8 +118,10 @@ export default withRouter(function StepList(
                             e.preventDefault();
                             // As wer want to be able to save draft, we skip validation on submit
                             // and don't use the classic Formik mechanism
-                            saveForm({ variables: { formInput: values } }).then(
-                              _ => props.history.push("/dashboard/slips")
+                            saveForm({
+                              variables: { formInput: values }
+                            }).then(_ =>
+                              props.history.push("/dashboard/slips")
                             );
                             return false;
                           }}

--- a/front/src/login/ChangePassword.tsx
+++ b/front/src/login/ChangePassword.tsx
@@ -1,6 +1,6 @@
 import { Field, Form, Formik, FormikActions } from "formik";
 import React from "react";
-import { Mutation, MutationFn } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import RedErrorMessage from "../form/RedErrorMessage";
 import { CHANGEPASSWORD } from "./mutations";
@@ -10,12 +10,15 @@ type Values = {
   newPassword: string;
   newPasswordConfirmation: string;
 };
-const handleSubmit = (
-  payload: Values,
+const handleSubmit = ({
+  payload,
+  props
+}: {
+  payload: Values;
   props: FormikActions<Values> & {
-    changePassword: MutationFn;
-  } & RouteComponentProps
-) => {
+    changePassword;
+  } & RouteComponentProps;
+}) => {
   const { oldPassword, newPassword } = payload;
   props
     .changePassword({ variables: { oldPassword, newPassword } })
@@ -41,10 +44,13 @@ export default withRouter(function Login(
             newPasswordConfirmation: ""
           }}
           onSubmit={(values, formikActions) => {
-            handleSubmit(values, {
-              changePassword,
-              ...formikActions,
-              ...routeComponentProps
+            handleSubmit({
+              payload: values,
+              props: {
+                changePassword,
+                ...formikActions,
+                ...routeComponentProps
+              }
             });
           }}
           validate={values => {

--- a/front/src/login/Invite.tsx
+++ b/front/src/login/Invite.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import { Formik, Form, Field, ErrorMessage } from "formik";
 import gql from "graphql-tag";
 import { withRouter, RouteComponentProps } from "react-router";

--- a/front/src/login/Login.tsx
+++ b/front/src/login/Login.tsx
@@ -1,6 +1,6 @@
 import { ErrorMessage, Field, Form, Formik, FormikActions } from "formik";
 import React from "react";
-import { Mutation, MutationFn } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import { LOGIN } from "./mutations";
 import { localAuthService } from "./auth.service";
@@ -8,7 +8,7 @@ import { localAuthService } from "./auth.service";
 type Values = { email: string; password: string; form: string };
 const handleSubmit = (
   payload: Values,
-  props: FormikActions<Values> & { login: MutationFn } & RouteComponentProps
+  props: FormikActions<Values> & { login } & RouteComponentProps
 ) => {
   const { email, password } = payload;
   props
@@ -32,7 +32,7 @@ export default withRouter(function Login(
 ) {
   return (
     <Mutation mutation={LOGIN}>
-      {(login, { data }) => (
+      {login => (
         <Formik
           initialValues={{ email: "", password: "", form: "" }}
           onSubmit={(values, formikActions) => {

--- a/front/src/login/ResetPassword.tsx
+++ b/front/src/login/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Mutation } from "react-apollo";
+import { Mutation } from "@apollo/react-components";
 import gql from "graphql-tag";
 
 const RESET_PASSWORD = gql`

--- a/front/src/tracker.ts
+++ b/front/src/tracker.ts
@@ -32,14 +32,14 @@ function loadTracker() {
 }
 
 export function getTracker() {
-  let tracker = null;
   if (typeof Piwik !== "undefined") {
-    tracker = Piwik.getAsyncTracker(
+    const tracker = Piwik.getAsyncTracker(
       `${process.env.REACT_APP_MATOMO_TRACKER_URL}piwik.php`,
       process.env.REACT_APP_MATOMO_TRACKER_SITE_ID
     );
+    return tracker;
   }
-  return tracker;
+  return null;
 }
 
 export function trackPageView(pageTitle: string) {
@@ -49,7 +49,12 @@ export function trackPageView(pageTitle: string) {
   }
 }
 
-export function trackEvent(category: string, action: string, name?: string, value?: number) {
+export function trackEvent(
+  category: string,
+  action: string,
+  name?: string,
+  value?: number
+) {
   const tracker = getTracker();
   if (tracker) {
     tracker.trackEvent(category, action);

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "noImplicitAny": false,
     "jsx": "preserve",
     "lib": [
       "dom",


### PR DESCRIPTION
https://trello.com/c/ThZj4Bvx 

* Upgrade des librairies suivantes:
  * `apollo-client`
  * `apollo-link`
  * `apollo-link-context`
  *  `apollo-link-http`
  * `apollo-cache-inmemory`
* La librairie "parapluie" `react-apollo` est remplacée par deux librairies distinctes: `@apollo/react-components` et `@apollo/react-hooks`. L'idée est de remplacer les composants `<Query />` et `<Mutation />` par les hooks `useQuery` et `useMutation`petit à petit [Guide de migration](https://www.apollographql.com/docs/react/migrating/hooks-migration/) et in fine de supprimer la dépendance à `@apollo/react-components`. Un exemple utilisant les hooks se trouve dans `dashboard/account/EditCompany.tsx`
* Suppression de la lib `apollo-link-error` (non utilisée)
* Upgrade de typescript (requis par les nouveaux types de apollo-client) et de @types/node (requis par le nouvelle version de typescript)
* Ajout de `"noImplicitAny": false` dans `tsconfig.json` (voir les [options du compilateur](https://www.typescriptlang.org/docs/handbook/compiler-options.html)), cela permet d'éviter toutes les erreurs de type "Parameter type xxx has an any type" dans les render props des composants `<Query />` et `<Mutation />`. On pourra changer ce paramètre lorsqu'on utilise les hooks pour lesquels le type est correctement inféré
* Ajout de @apollo/react-testing pour pouvoir mocker facilement les appels GraphQL. Voir un exemple dans `dashboard/account/__tests__/EditCompany.test.tsx`
* Ajout de `apollo-utilities": "^1.3.2` à cause d'une erreur `[TypeError: (0 , _apolloUtilities.removeClientSetsFromDocument) is not a function]` obtenu en utilisant `<MockedProvider>` de `@apollo/react-testing` [Voir cette issue](https://github.com/apollographql/apollo-client/issues/4325)