### PR TITLE
Add pre-push git hook

### DIFF
--- a/.githooks/install-hooks.sh
+++ b/.githooks/install-hooks.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+GIT_DIR=$(git rev-parse --git-dir)
+
+echo "Installing hooks..."
+# this command creates symlink to our pre-push script
+ln -s ../../.githooks/pre-push.sh $GIT_DIR/hooks/pre-push
+echo "Done!"

--- a/.githooks/pre-push.sh
+++ b/.githooks/pre-push.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Exit and return error if any command fails
+set -e
+
+# Run backend tests
+echo "Running td-api tests"
+docker exec $(docker ps -aqf "name=td-api") npm test
+echo "......................"
+
+
+# Run frontend tests
+echo "Running td-front tests"
+docker exec -e CI=true $(docker ps -aqf "name=td-ui") npm test
+echo "......................."

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Il faut alors se connecter à l'image postgre et y restaurer ce dump. Par exempl
 
 6. C'est prêt ! Rendez-vous sur l'URL `UI_HOST` configurée dans votre fichier `.env` pour commencer à utiliser l'application.
 
+7. [Linux/MacOS uniquement] Avant de pousser votre premier commit, il est recommandé d'installer un hook Github permettant de faire tourner les tests avant chaque push. Le script `~/.githooks/install-hooks.sh` se chargera de l'installation. Si vous avez besoin de forcer un push sans faire passer les tests, il est toujours possible de faire `git push --no-verify`.
+
 ## Technologies
 
 - [React](https://reactjs.org/)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,6 +64,7 @@ services:
 
   td-ui:
     image: node:10.14-alpine
+    container_name: td-ui
     working_dir: /usr/src/front
     command: sh -c "npm install && npm start"
     expose:


### PR DESCRIPTION
Ajout d'un pre-push hook Github qui fait tourner les tests (front + back) avant de pousser. Le hook peut être installé (de manière complètement optionnel) grâce au script `.githooks/install-hooks.sh`. Une fois le hook installé, il est toujours possible de pousser sans faire tourner les tests avec la commande `git push --no-verify`. L'usage des hooks Github pourra être étendu pour faire d'autres vérifications, par exemple vérifier qu'il n'y a pas de `console.log` qui traine dans le code.  