### PR TITLE
Fix company title width

### DIFF
--- a/front/src/dashboard/DashboardMenu.scss
+++ b/front/src/dashboard/DashboardMenu.scss
@@ -3,6 +3,9 @@
   .company-title {
     margin: 30px 30px;
     font-weight: bold;
+    @media (min-width: 749px) {
+      max-width: 200px;
+    }
   }
 
   .company-select {


### PR DESCRIPTION
Bug remonté par Emmanuel en recette métier de [Modification de la nav](https://trello.com/c/6galtRFZ). Lorsque le nom de la société est très long, le menu de gauche (qui est flex) s'étend 
jusqu'à la moitié de l'écran. 

![affichage](https://user-images.githubusercontent.com/2269165/69232150-c2370700-0b8a-11ea-8127-8a41d31497a0.PNG)

Ajout d'un max-width sur desktop pour résoudre le problème