### PR TITLE
Utilisation systématique de graphql-shield

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -62,6 +62,96 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@sentry/core": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.8.0.tgz",
+      "integrity": "sha512-aAh2KLidIXJVGrxmHSVq2eVKbu7tZiYn5ylW6yzJXFetS5z4MA+JYaSBaG2inVYDEEqqMIkb17TyWxxziUDieg==",
+      "requires": {
+        "@sentry/hub": "5.8.0",
+        "@sentry/minimal": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.8.0.tgz",
+      "integrity": "sha512-VdApn1ZCNwH1wwQwoO6pu53PM/qgHG+DQege0hbByluImpLBhAj9w50nXnF/8KzV4UoMIVbzCb6jXzMRmqqp9A==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.8.0.tgz",
+      "integrity": "sha512-Obe3GqTtq63PAJ4opYEbeZ6Bm8uw+CND+7MywJLDguqnvIVRvxpcJIZ6wxcE/VjbU3OMkNmTMnM+ra8RB7Wj6w==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.8.0.tgz",
+      "integrity": "sha512-MIlFOgd+JvAUrBBmq7vr9ovRH1HvckhnwzHdoUPpKRBN+rQgTyZy1o6+kA2fASCbrRqFCP+Zk7EHMACKg8DpIw==",
+      "requires": {
+        "@sentry/hub": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.9.0.tgz",
+      "integrity": "sha512-1CWwSGhRfMr4Bvt1i0vIms+BBZd4dBzlDyWpyCboodCXF1rTJRci9roQ+Wh9XWwFEWvgDD2PzuKzfvu638v2Wg==",
+      "requires": {
+        "@sentry/core": "5.8.0",
+        "@sentry/hub": "5.8.0",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.8.0",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^3.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-KDxUvBSYi0/dHMdunbxAxD3389pcQioLtcO6CI6zt/nJXeVFolix66cRraeQvqupdLhvOk/el649W4fCPayTHw==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@types/bcrypt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-3.0.0.tgz",
@@ -78,9 +168,9 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.0.tgz",
-      "integrity": "sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
+      "integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -88,7 +178,7 @@
     },
     "@types/concat-stream": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
       "requires": {
         "@types/node": "*"
@@ -137,7 +227,7 @@
     },
     "@types/form-data": {
       "version": "0.0.33",
-      "resolved": "http://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
       "requires": {
         "@types/node": "*"
@@ -188,9 +278,9 @@
       "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/mongodb": {
-      "version": "3.1.26",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.26.tgz",
-      "integrity": "sha512-i7+l95IbqnGLRW+AJ6F2nzqosLUgU022lDuoHhbQquMV7tgek0vNUg9RwC2Fn7ImBSQSFdCWeU394ciPEwSeaQ==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.11.tgz",
+      "integrity": "sha512-i8mUMYzFYzUpH4a7IBbdOD/87/kyQHvOVAL8J8hvX+E6SQbPd83d+xkpPtRZlRELtjZFqyQMlEcxW+zfMw32vQ==",
       "dev": true,
       "requires": {
         "@types/bson": "*",
@@ -198,9 +288,9 @@
       }
     },
     "@types/mysql": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.6.tgz",
-      "integrity": "sha512-PJBY2R3jGJwGrmFgGAJ+1nj4S/PLkF6nT+HvUygniq9ZcVht0mTH1TLAjjyfIXf9FfrELs8mbqOrWa/Tn89NCA==",
+      "version": "2.15.8",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.8.tgz",
+      "integrity": "sha512-l0TUdg6KDEaLO75/yjdjksobJDRWv8iZlpRfv/WW1lQZCQDKdTDnKCkeH10oapzP/JTuKiTy6Cvq/sm/0GgcUw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -212,9 +302,9 @@
       "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w=="
     },
     "@types/prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-5Ksgx9H/Yjz6oamDbmDZstWlJGPTao7shNfambjf8o7OkHxDwAi0AJLQcFwS9pDKI4gQPdiKZXze3nT1eCOViQ=="
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.0.tgz",
+      "integrity": "sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A=="
     },
     "@types/range-parser": {
       "version": "1.2.2",
@@ -304,9 +394,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -316,7 +406,6 @@
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
       "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -325,9 +414,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true
     },
     "ansi-align": {
@@ -348,7 +437,8 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -570,7 +660,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -578,8 +667,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -653,14 +741,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
       "version": "0.18.0",
@@ -896,23 +982,6 @@
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
     "babel-preset-jest": {
       "version": "23.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
@@ -959,6 +1028,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -967,7 +1037,8 @@
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -1540,7 +1611,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1559,7 +1629,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -1568,9 +1638,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "body-parser": {
@@ -1700,9 +1770,9 @@
       }
     },
     "bson": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
       "dev": true
     },
     "buffer": {
@@ -1874,8 +1944,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.1",
@@ -1889,9 +1958,10 @@
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "charenc": {
       "version": "0.0.2",
@@ -1968,6 +2038,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -1984,7 +2055,8 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "clipboardy": {
       "version": "1.2.3",
@@ -2051,7 +2123,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -2180,9 +2252,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
           "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
@@ -2261,7 +2333,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2296,9 +2367,9 @@
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2518,7 +2589,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -2546,14 +2616,15 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -2604,14 +2675,12 @@
     "es6-promise": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
-      "dev": true
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2624,7 +2693,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.0",
@@ -2901,15 +2971,6 @@
         "url-join": "4.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -2917,9 +2978,9 @@
           "dev": true
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "dev": true,
           "requires": {
             "isarray": "0.0.1"
@@ -2930,8 +2991,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2955,13 +3015,25 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extglob": {
@@ -3032,19 +3104,17 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-      "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "dev": true,
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -3079,6 +3149,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -3216,8 +3287,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
@@ -3827,7 +3897,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4005,24 +4074,15 @@
             "json-schema-traverse": "^0.3.0"
           }
         },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "dotenv": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -4091,6 +4151,11 @@
         "graphql-tools": "^4.0.1"
       }
     },
+    "graphql-middleware-sentry": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/graphql-middleware-sentry/-/graphql-middleware-sentry-3.2.1.tgz",
+      "integrity": "sha512-lAwmHwsyey1db6scQg32javmqAFifabhqPIr0SUzx46O4kvjQlLZZn7KrRT12XDwgW7i6goAotdSPl9Fq+TBrQ=="
+    },
     "graphql-playground-html": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/graphql-playground-html/-/graphql-playground-html-1.6.4.tgz",
@@ -4124,12 +4189,33 @@
       }
     },
     "graphql-shield": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-shield/-/graphql-shield-4.1.0.tgz",
-      "integrity": "sha512-r3m5t7FpLDyJQIby0IKyNrtp8k62hP/syhPcrpdT67UVNKh0jjjl+zpjXh/3PXeNZHPEAiBQTHhFjnC7H2B4SA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/graphql-shield/-/graphql-shield-7.0.4.tgz",
+      "integrity": "sha512-+SEz/tKx2uJAbMKzS7X0hCUWsZo54J8SARhXb5jNDG/RKur44mjIGfBnuBRszw73+dUdBvTlLl1j1WKwm0ZhEA==",
       "requires": {
-        "object-hash": "^1.3.0",
-        "opencollective": "1.0.3"
+        "@types/yup": "0.26.26",
+        "object-hash": "^2.0.0",
+        "yup": "^0.27.0"
+      },
+      "dependencies": {
+        "@types/yup": {
+          "version": "0.26.26",
+          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.26.tgz",
+          "integrity": "sha512-5cLJLd8NIT7OfJLi7ScquRn/NWfmewBqJ92nT/FYfdpgKzyUNcR4n2BKEOQ7mOG8WuJXgomIvNl5P3sn9Akd4A=="
+        },
+        "yup": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
+          "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "fn-name": "~2.0.1",
+            "lodash": "^4.17.11",
+            "property-expr": "^1.5.0",
+            "synchronous-promise": "^2.0.6",
+            "toposort": "^2.0.2"
+          }
+        }
       }
     },
     "graphql-subscriptions": {
@@ -4206,14 +4292,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -4232,6 +4316,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -4239,7 +4324,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
     },
@@ -4364,7 +4450,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -4372,24 +4457,13 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -4460,9 +4534,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -4471,7 +4545,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
@@ -4503,31 +4577,11 @@
             "supports-color": "^5.3.0"
           }
         },
-        "chardet": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -4733,7 +4787,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -4824,7 +4879,8 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
@@ -4850,7 +4906,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -4864,8 +4921,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -4927,8 +4983,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.3.7",
@@ -5903,8 +5958,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "11.12.0",
@@ -5966,14 +6020,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -5987,8 +6039,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.5.1",
@@ -6031,7 +6082,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -6342,6 +6392,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -6395,9 +6450,9 @@
       "dev": true
     },
     "marked-terminal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.2.0.tgz",
-      "integrity": "sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.3.0.tgz",
+      "integrity": "sha512-+IUQJ5VlZoAFsM5MHNT7g3RHSkA3eETqhRCdXv4niUMAKHQ7lb1yvAcuGPmm4soxhmtX13u4Li6ZToXtvSEH+A==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.1.0",
@@ -6504,9 +6559,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
     },
     "methods": {
@@ -6556,7 +6611,8 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -6569,7 +6625,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -6610,19 +6667,9 @@
       }
     },
     "mongodb": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.3.tgz",
-      "integrity": "sha512-jw8UyPsq4QleZ9z+t/pIVy3L++51vKdaJ2Q/XXeYxk/3cnKioAH8H6f5tkkDivrQL4PUgUOHe9uZzkpRFH1XtQ==",
-      "dev": true,
-      "requires": {
-        "mongodb-core": "^3.2.3",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "mongodb-core": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.3.tgz",
-      "integrity": "sha512-UyI0rmvPPkjOJV8XGWa9VCTq7R4hBVipimhnAXeSXnuAPjuTqbyfA5Ec9RcYJ1Hhu+ISnc8bJ1KfGZd4ZkYARQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.5.tgz",
+      "integrity": "sha512-6NAv5gTFdwRyVfCz+O+KDszvjpyxmZw+VlmqmqKR2GmpkeKrKFRv/ZslgTtZba2dc9JYixIf99T5Gih7TIWv7Q==",
       "dev": true,
       "requires": {
         "bson": "^1.1.1",
@@ -6651,7 +6698,8 @@
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
     },
     "mysql": {
       "version": "2.17.1",
@@ -6864,8 +6912,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6904,9 +6951,9 @@
       }
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
+      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
     },
     "object-keys": {
       "version": "1.0.12",
@@ -6977,101 +7024,9 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "opencollective": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-      "requires": {
-        "babel-polyfill": "6.23.0",
-        "chalk": "1.1.3",
-        "inquirer": "3.0.6",
-        "minimist": "1.2.0",
-        "node-fetch": "1.6.3",
-        "opn": "4.0.2"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "inquirer": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.1",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "node-fetch": {
-          "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-          "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
       }
     },
     "opn": {
@@ -7160,7 +7115,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -7169,9 +7125,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -7317,27 +7273,26 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.10.0.tgz",
-      "integrity": "sha512-aE6FZomsyn3OeGv1oM50v7Xu5zR75c15LXdOCwA9GGrfjXsQjzwYpbcTS6OwEMhYfZQS6m/FVU/ilPLiPzJDCw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.14.0.tgz",
+      "integrity": "sha512-TLsdOWKFu44vHdejml4Uoo8h0EwCjdIj9Z9kpz7pA5i8iQxOTwVb1+Fy+X86kW5AXKxQpYpYDs4j/qPDbro/lg==",
       "dev": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "^2.0.4",
-        "pg-types": "~2.0.0",
+        "pg-pool": "^2.0.7",
+        "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       },
       "dependencies": {
         "semver": {
           "version": "4.3.2",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
           "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=",
           "dev": true
         }
@@ -7356,15 +7311,15 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.6.tgz",
-      "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw==",
       "dev": true
     },
     "pg-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.1.tgz",
-      "integrity": "sha512-b7y6QM1VF5nOeX9ukMQ0h8a9z89mojrBHXfJeSug4mhL0YpxNBm83ot2TROyoAmX/ZOX3UbwVO4EbH7i1ZZNiw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
       "dev": true,
       "requires": {
         "pg-int8": "1.0.1",
@@ -7392,12 +7347,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -7534,9 +7491,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg=="
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g=="
     },
     "pretty-format": {
       "version": "23.6.0",
@@ -7549,14 +7506,14 @@
       }
     },
     "prisma": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-1.29.1.tgz",
-      "integrity": "sha512-3kcBjan16LFTwtPS0w6iNUnXNzaS8aCOeck3tXpTbVgnnMyqfB3JCAHgB7IyMUtTLq01usxPCNcRi3SPx+Litg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-1.33.0.tgz",
+      "integrity": "sha512-sge6ozagrh3iMc+QIxU7Vu0fnjB7Gamwf/rwayctYk3EqkBsqLETXL7Gn328ZBhkPNeF2n70KLozvf89T12NaQ==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
-        "prisma-cli-core": "1.29.1",
-        "prisma-cli-engine": "1.29.1",
+        "prisma-cli-core": "1.33.0",
+        "prisma-cli-engine": "1.33.0",
         "semver": "^5.4.1",
         "source-map-support": "^0.4.18"
       },
@@ -7579,9 +7536,9 @@
       }
     },
     "prisma-cli-core": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-cli-core/-/prisma-cli-core-1.29.1.tgz",
-      "integrity": "sha512-b4FW/9as4uZu+D/NJGvLxVeETM2P//lTl3LEuLdYuyGlQKc4SsM8SGF/auzNDgS/ShtQDOmoJXxYI3beldNkZw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-cli-core/-/prisma-cli-core-1.33.0.tgz",
+      "integrity": "sha512-MTIiD5ie9w9UAYRoHpQBQKeRuTIRulk4eGNCH/lEJh+gp+9ukURaabuvMuQ1QbVMKbExdzYQAQK+8+mL1nW65A==",
       "dev": true,
       "requires": {
         "@types/express": "^4.16.1",
@@ -7610,11 +7567,11 @@
         "node-forge": "^0.7.1",
         "npm-run": "4.1.2",
         "opn": "^5.1.0",
-        "prisma-client-lib": "1.29.1",
-        "prisma-datamodel": "1.29.1",
-        "prisma-db-introspection": "1.29.1",
-        "prisma-generate-schema": "1.29.1",
-        "prisma-yml": "1.29.1",
+        "prisma-client-lib": "1.33.0",
+        "prisma-datamodel": "1.33.0",
+        "prisma-db-introspection": "1.33.0",
+        "prisma-generate-schema": "1.33.0",
+        "prisma-yml": "1.33.0",
         "scuid": "^1.0.2",
         "semver": "^5.6.0",
         "sillyname": "^0.1.0",
@@ -7623,9 +7580,9 @@
       },
       "dependencies": {
         "@types/express": {
-          "version": "4.16.1",
-          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-          "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+          "version": "4.17.2",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
+          "integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
           "dev": true,
           "requires": {
             "@types/body-parser": "*",
@@ -7651,9 +7608,9 @@
       }
     },
     "prisma-cli-engine": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-cli-engine/-/prisma-cli-engine-1.29.1.tgz",
-      "integrity": "sha512-w2SC+KgIL7/oiolvgDKXVRViBsTJauvQuPkEkj/3V+uT+X0wpPEWGr1pHYQHz3brhPz3DjtVk9hUTulDa2siNQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-cli-engine/-/prisma-cli-engine-1.33.0.tgz",
+      "integrity": "sha512-YzV9SJKpIs1WDK4QBBBk/i76yX5EI7TGdy0AX2pJRASbh5zg+SAgIczbDHcVaQdAg5KyZgoMZz7gpK0U43b2zQ==",
       "dev": true,
       "requires": {
         "@heroku/linewrap": "^1.0.0",
@@ -7690,7 +7647,7 @@
         "mkdirp": "^0.5.1",
         "opn": "^5.1.0",
         "prisma-json-schema": "0.1.3",
-        "prisma-yml": "1.29.1",
+        "prisma-yml": "1.33.0",
         "raven": "2.6.4",
         "rwlockfile": "^1.4.8",
         "scuid": "^1.0.2",
@@ -7703,15 +7660,6 @@
         "update-notifier": "^2.3.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -7745,9 +7693,9 @@
       }
     },
     "prisma-client-lib": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.29.1.tgz",
-      "integrity": "sha512-CbIYto+Bsk7QuGPoAJakOCR5ytjfx1eXgISgtuI5YIhgQdxMfixyr04cfHB4yVyF7vWkgyr7IbpOAiQhnPqYFA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-client-lib/-/prisma-client-lib-1.33.0.tgz",
+      "integrity": "sha512-jM2CrcgNH7WgwGBDyJebTcbG2JUQgHhuOw27Pn30KwGTJw8rqanIBhuVfhlWHPvOSSO30u/KV4hMPspiH4vyww==",
       "requires": {
         "@types/node": "^10.12.0",
         "@types/prettier": "^1.13.2",
@@ -7757,19 +7705,29 @@
         "http-link-dataloader": "^0.1.6",
         "jsonwebtoken": "^8.3.0",
         "lodash.flatten": "^4.4.0",
-        "prettier": "1.14.3",
-        "prisma-datamodel": "1.29.1",
-        "prisma-generate-schema": "1.29.1",
+        "prettier": "1.16.4",
+        "prisma-datamodel": "1.33.0",
+        "prisma-generate-schema": "1.33.0",
         "subscriptions-transport-ws": "^0.9.15",
         "uppercamelcase": "^3.0.0",
         "ws": "^6.1.0",
         "zen-observable": "^0.8.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "prisma-datamodel": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-datamodel/-/prisma-datamodel-1.29.1.tgz",
-      "integrity": "sha512-ryuzkQPND+U5Me77wv+HQfjTE9bn8sDk1hrI2OARtUkZDLtIh8TDLOTZkC8V12niy07APgGKhRRydP96kA+41g==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-datamodel/-/prisma-datamodel-1.33.0.tgz",
+      "integrity": "sha512-RjdxjSYAikEATQo1Oxtw7n1ySdXv1wnyI8BVTH+ffasdQ/iVHsW5qia6+3nLznc7pgTLpwBEmZVtmPPWNI/z1A==",
       "requires": {
         "graphql": "^14.0.2",
         "pluralize": "^7.0.0",
@@ -7777,9 +7735,9 @@
       }
     },
     "prisma-db-introspection": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-db-introspection/-/prisma-db-introspection-1.29.1.tgz",
-      "integrity": "sha512-wGptHcuydbzICsWgb1nXSFXlJIg6znjNIkP/G+LFJpIbnYsC7Npzhik19drr4A4DpgmfsHt7JUarNly98JHlSg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-db-introspection/-/prisma-db-introspection-1.33.0.tgz",
+      "integrity": "sha512-Cyn1t5rFw7Exm4nAdrfdy9v5V1ZxOzLw3hn3BtTiSkSr7hmASTG5dn6dQzPa/BMR5Fj10BQsumpYyEmcNoLlvg==",
       "dev": true,
       "requires": {
         "@types/mongodb": "^3.1.14",
@@ -7790,21 +7748,20 @@
         "mysql": "^2.16.0",
         "pg": "^7.4.1",
         "pluralize": "^7.0.0",
-        "prisma-datamodel": "1.29.1",
-        "prisma-yml": "1.29.1",
-        "scuid": "^1.0.2",
-        "uppercamelcase": "^3.0.0"
+        "prisma-datamodel": "1.33.0",
+        "prisma-yml": "1.33.0",
+        "scuid": "^1.0.2"
       }
     },
     "prisma-generate-schema": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-generate-schema/-/prisma-generate-schema-1.29.1.tgz",
-      "integrity": "sha512-SPv6zBVIwf2twCDQKDcErgYJbKsP6AFZu/vApwBhYk9V8HjNmDN09lWi8QUanrwjKcLevzFuC5K8Zof8paBFNg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-generate-schema/-/prisma-generate-schema-1.33.0.tgz",
+      "integrity": "sha512-ZGuFpzDOM2MHB3U33x7pckt3xsvR15C9ndP0SNsCxckRY7XDu3BRncTPXpbWKUR91RCpSH2ipyaPutd+0Bttvg==",
       "requires": {
         "graphql": "^14.0.2",
         "pluralize": "^7.0.0",
         "popsicle": "10",
-        "prisma-datamodel": "1.29.1"
+        "prisma-datamodel": "1.33.0"
       }
     },
     "prisma-json-schema": {
@@ -7814,9 +7771,9 @@
       "dev": true
     },
     "prisma-yml": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.29.1.tgz",
-      "integrity": "sha512-90DefhU7qSgdns+bExZQqeJDm2Wjkg4jBpzCj0yPf5zmkbbFio5pbcuUwc4oA4JxRt8gGmL5COyETL4jS1dumg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prisma-yml/-/prisma-yml-1.33.0.tgz",
+      "integrity": "sha512-qfz6gCApPMXPeFUtGfpYW52RpSJQT7qQOw9jt579+j6ysWkY4gwVlVPhEcwAfwj0dm0X0a14GyD5o5EEt411pQ==",
       "dev": true,
       "requires": {
         "ajv": "5",
@@ -7851,24 +7808,15 @@
             "json-schema-traverse": "^0.3.0"
           }
         },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "dotenv": {
           "version": "4.0.0",
-          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
           "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -8237,7 +8185,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -8264,14 +8211,12 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -8280,8 +8225,7 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -8373,6 +8317,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -8403,6 +8348,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
       }
@@ -8429,15 +8375,10 @@
         }
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-    },
     "rxjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -8639,7 +8580,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "sillyname": {
       "version": "0.1.0",
@@ -8913,7 +8855,6 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -9007,6 +8948,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -9024,6 +8966,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -9122,7 +9065,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -9287,8 +9230,9 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -9310,6 +9254,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
@@ -9474,14 +9419,12 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -9489,8 +9432,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -9710,7 +9652,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -9802,7 +9743,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -10013,9 +9953,9 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/back/package.json
+++ b/back/package.json
@@ -18,7 +18,7 @@
     "bcrypt": "^3.0.2",
     "dataloader": "^1.4.0",
     "graphql-middleware-sentry": "^3.2.1",
-    "graphql-shield": "^4.1.0",
+    "graphql-shield": "^7.0.4",
     "graphql-yoga": "^1.16.7",
     "ioredis": "^4.9.3",
     "jsonwebtoken": "^8.4.0",

--- a/back/src/commands/__tests__/sendmails.tests.ts
+++ b/back/src/commands/__tests__/sendmails.tests.ts
@@ -5,7 +5,6 @@ import {
   sendOnboardingFirstStepMails,
   sendOnboardingSecondStepMails
 } from "../onboarding.helpers";
-import { eventNames } from "cluster";
 
 // Let's mock prima DB
 jest.mock("../../generated/prisma-client", () => ({

--- a/back/src/commands/__tests__/sendmails.tests.ts
+++ b/back/src/commands/__tests__/sendmails.tests.ts
@@ -5,6 +5,7 @@ import {
   sendOnboardingFirstStepMails,
   sendOnboardingSecondStepMails
 } from "../onboarding.helpers";
+import { eventNames } from "cluster";
 
 // Let's mock prima DB
 jest.mock("../../generated/prisma-client", () => ({
@@ -30,8 +31,13 @@ describe("xDaysAgo", () => {
   });
 });
 
+const mockedAxiosPost = jest.spyOn(axios, "post"); // spy on axios.post method
+
+beforeEach(() => {
+  mockedAxiosPost.mockClear();
+});
+
 describe("sendOnboardingFirstStepMails", () => {
-  const mockedAxiosPost = jest.spyOn(axios, "post"); // spy on axios.post method
   it("should send a request to td mail service for onboarding first step", async () => {
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
@@ -45,19 +51,16 @@ describe("sendOnboardingFirstStepMails", () => {
     expect(mockedAxiosPost).toHaveBeenCalledWith("http://td-mail/send", {
       body: "_",
       subject: "Bienvenue sur Trackdéchets, démarrez dès aujourd’hui !",
-      templateId: 1006585, // hardcoded mailjet template ID, should match .env MJ_FIRST_ONBOARDING_TEMPLATE_ID
+      templateId: parseInt(process.env.MJ_FIRST_ONBOARDING_TEMPLATE_ID), // hardcoded mailjet template ID, should match .env MJ_FIRST_ONBOARDING_TEMPLATE_ID
       title: "Bienvenue sur Trackdéchets, démarrez dès aujourd’hui !",
       toEmail: "user@example.com",
       toName: "Rick Hunter",
-      baseUrl: "https://ui-td.local"
+      baseUrl: `https://${process.env.UI_HOST}`
     });
-    mockedAxiosPost.mockReset(); // removes calls, instances, returned values and implementations
   });
 });
 
 describe("sendOnboardingSecondStepMails", () => {
-  const mockedAxiosPost = jest.spyOn(axios, "post"); // spy on axios.post method
-
   it("should send a request to td mail service for onboarding second step", async () => {
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
@@ -71,12 +74,11 @@ describe("sendOnboardingSecondStepMails", () => {
     expect(mockedAxiosPost).toHaveBeenCalledWith("http://td-mail/send", {
       body: "_",
       subject: "Registre, FAQ, explorez tout ce que peut faire Trackdéchets !",
-      templateId: 1023698, // hardcoded mailjet template ID, should match .env MJ_SECOND_ONBOARDING_TEMPLATE_ID
+      templateId: parseInt(process.env.MJ_SECOND_ONBOARDING_TEMPLATE_ID), // hardcoded mailjet template ID, should match .env MJ_SECOND_ONBOARDING_TEMPLATE_ID
       title: "Registre, FAQ, explorez tout ce que peut faire Trackdéchets !",
       toEmail: "user@example.com",
       toName: "Rick Hunter",
-      baseUrl: "https://ui-td.local"
+      baseUrl: `https://${process.env.UI_HOST}`
     });
   });
-  mockedAxiosPost.mockReset(); // removes calls, instances, returned values and implementations
 });

--- a/back/src/commands/__tests__/sendmails.tests.ts
+++ b/back/src/commands/__tests__/sendmails.tests.ts
@@ -33,7 +33,7 @@ describe("xDaysAgo", () => {
 describe("sendOnboardingFirstStepMails", () => {
   const mockedAxiosPost = jest.spyOn(axios, "post"); // spy on axios.post method
   it("should send a request to td mail service for onboarding first step", async () => {
-    (mockedAxiosPost as jest.Mock).mockImplementationOnce(() =>
+    (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
         data: { results: "something" }
       })
@@ -41,7 +41,7 @@ describe("sendOnboardingFirstStepMails", () => {
 
     await sendOnboardingFirstStepMails();
 
-    expect(mockedAxiosPost as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost as jest.Mock<any>).toHaveBeenCalledTimes(1);
     expect(mockedAxiosPost).toHaveBeenCalledWith("http://td-mail/send", {
       body: "_",
       subject: "Bienvenue sur Trackdéchets, démarrez dès aujourd’hui !",
@@ -59,7 +59,7 @@ describe("sendOnboardingSecondStepMails", () => {
   const mockedAxiosPost = jest.spyOn(axios, "post"); // spy on axios.post method
 
   it("should send a request to td mail service for onboarding second step", async () => {
-    (mockedAxiosPost as jest.Mock).mockImplementationOnce(() =>
+    (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
       Promise.resolve({
         data: { results: "something" }
       })
@@ -67,7 +67,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
     await sendOnboardingSecondStepMails();
 
-    expect(mockedAxiosPost as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost as jest.Mock<any>).toHaveBeenCalledTimes(1);
     expect(mockedAxiosPost).toHaveBeenCalledWith("http://td-mail/send", {
       body: "_",
       subject: "Registre, FAQ, explorez tout ce que peut faire Trackdéchets !",

--- a/back/src/common/__tests__/rules.test.ts
+++ b/back/src/common/__tests__/rules.test.ts
@@ -1,6 +1,7 @@
-import { Rule } from "graphql-shield/dist/rules";
+import { Rule, RuleAnd } from "graphql-shield/dist/rules";
 
 import { isCompanyAdmin, isCompanyMember } from "../rules";
+import { GraphQLResolveInfo } from "graphql";
 
 describe("isCompanyAdmin", () => {
   it("should return true if the user is admin of the company", async () => {
@@ -29,7 +30,7 @@ describe("isCompanyAdmin", () => {
       { user: { id: "id" }, prisma }
     );
 
-    expect(result).toBe(false);
+    expect(result).toBeInstanceOf(Error);
   });
 
   it("should return false if the user does not belong to the company", async () => {
@@ -43,7 +44,7 @@ describe("isCompanyAdmin", () => {
       { siret: "85001946400013" },
       { user: { id: "id" }, prisma }
     );
-    expect(result).toBe(false);
+    expect(result).toBeInstanceOf(Error);
   });
 });
 
@@ -59,7 +60,7 @@ describe("isCompanyMember", () => {
       { siret: "85001946400013" },
       { user: { id: "id" }, prisma }
     );
-    expect(result).toBe(false);
+    expect(result).toBeInstanceOf(Error);
   });
 
   it("should return true if the user is member of the company", async () => {
@@ -88,11 +89,17 @@ describe("isCompanyMember", () => {
       { siret: "85001946400013" },
       { user: { id: "id" }, prisma }
     );
-    expect(result).toBe(false);
+    expect(result).toBeInstanceOf(Error);
   });
 });
 
-export function testRule(rule: Rule) {
+export function testRule(rule: Rule | RuleAnd) {
   return (parent, args, ctx) =>
-    rule.resolve(parent, args, ctx as any, null, {} as any);
+    rule.resolve(
+      parent,
+      args,
+      { _shield: { cache: {} }, ...ctx },
+      {} as GraphQLResolveInfo,
+      {} as any
+    );
 }

--- a/back/src/companies/permissions.ts
+++ b/back/src/companies/permissions.ts
@@ -3,7 +3,12 @@ import { and } from "graphql-shield";
 import { isCompanyAdmin, isAuthenticated } from "../common/rules";
 
 export default {
+  Query: {
+    companyUsers: and(isAuthenticated, isCompanyAdmin),
+    favorites: isAuthenticated
+  },
   Mutation: {
-    updateCompany: and(isAuthenticated, isCompanyAdmin)
+    updateCompany: and(isAuthenticated, isCompanyAdmin),
+    renewSecurityCode: and(isAuthenticated, isCompanyAdmin)
   }
 };

--- a/back/src/companies/permissions.ts
+++ b/back/src/companies/permissions.ts
@@ -4,11 +4,11 @@ import { isCompanyAdmin, isAuthenticated } from "../common/rules";
 
 export default {
   Query: {
-    companyUsers: and(isAuthenticated, isCompanyAdmin),
+    companyUsers: isCompanyAdmin,
     favorites: isAuthenticated
   },
   Mutation: {
-    updateCompany: and(isAuthenticated, isCompanyAdmin),
-    renewSecurityCode: and(isAuthenticated, isCompanyAdmin)
+    updateCompany: isCompanyAdmin,
+    renewSecurityCode: isCompanyAdmin
   }
 };

--- a/back/src/companies/resolvers.ts
+++ b/back/src/companies/resolvers.ts
@@ -1,10 +1,6 @@
 import axios from "axios";
 import { Context } from "../types";
-import {
-  getUserId,
-  currentUserBelongsToCompanyAdmins,
-  randomNumber
-} from "../utils";
+import { randomNumber } from "../utils";
 import {
   getCompanyAdmins,
   getUserCompanies,
@@ -53,7 +49,7 @@ export default {
       return memoizeRequest(siret);
     },
     companyUsers: async (_, { siret }, context: Context) => {
-      const currentUserId = getUserId(context);
+      const currentUserId = context.user.id;
 
       const invitedUsers = await context.prisma
         .userAccountHashes({ where: { companySiret: siret } })
@@ -107,7 +103,7 @@ export default {
       context: Context
     ) => {
       const lowerType = type.toLowerCase();
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
 
       if (!userCompanies.length) {

--- a/back/src/companies/resolvers.ts
+++ b/back/src/companies/resolvers.ts
@@ -53,12 +53,7 @@ export default {
       return memoizeRequest(siret);
     },
     companyUsers: async (_, { siret }, context: Context) => {
-      const companyAdmins = await getCompanyAdmins(siret);
-
       const currentUserId = getUserId(context);
-      if (!companyAdmins.find(a => a.id === currentUserId)) {
-        return [];
-      }
 
       const invitedUsers = await context.prisma
         .userAccountHashes({ where: { companySiret: siret } })
@@ -165,12 +160,6 @@ export default {
   },
   Mutation: {
     renewSecurityCode: async (_, { siret }, context: Context) => {
-      if (!currentUserBelongsToCompanyAdmins(context, siret)) {
-        throw new Error(
-          "Vous n'êtes pas autorisé à modifier ce code de sécurité."
-        );
-      }
-
       return context.prisma.updateCompany({
         where: { siret },
         data: {

--- a/back/src/forms/__tests__/rules.test.ts
+++ b/back/src/forms/__tests__/rules.test.ts
@@ -93,7 +93,7 @@ describe("canAccessForm", () => {
       { id: "12345" },
       { user: { id: "id" }, prisma }
     );
-    expect(result).toBe(false);
+    expect(result).toBeInstanceOf(Error);
   });
 });
 

--- a/back/src/forms/__tests__/rules.test.ts
+++ b/back/src/forms/__tests__/rules.test.ts
@@ -3,8 +3,8 @@ import { canAccessForm } from "../rules";
 
 describe("canAccessForm", () => {
   it("should be true if the user created the form", async () => {
-    const formFragment = jest.fn<any>();
-    const userFragment = jest.fn<any>();
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
     const prisma = {
       form: jest.fn(() => ({ $fragment: formFragment })),
       user: jest.fn(() => ({ $fragment: userFragment }))
@@ -99,8 +99,8 @@ describe("canAccessForm", () => {
 
 describe("isFormTransporter", () => {
   it("should be true if the user is the form transporter", async () => {
-    const formFragment = jest.fn<any>();
-    const userFragment = jest.fn<any>();
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
     const prisma = {
       form: jest.fn(() => ({ $fragment: formFragment })),
       user: jest.fn(() => ({ $fragment: userFragment }))
@@ -128,8 +128,8 @@ describe("isFormTransporter", () => {
 
 describe("isFormEmitter", () => {
   it("should be true if the user is the form emitter", async () => {
-    const formFragment = jest.fn<any>();
-    const userFragment = jest.fn<any>();
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
     const prisma = {
       form: jest.fn(() => ({ $fragment: formFragment })),
       user: jest.fn(() => ({ $fragment: userFragment }))
@@ -157,8 +157,8 @@ describe("isFormEmitter", () => {
 
 describe("isFormRecipient", () => {
   it("should be true if the user is the form emitter", async () => {
-    const formFragment = jest.fn<any>();
-    const userFragment = jest.fn<any>();
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
     const prisma = {
       form: jest.fn(() => ({ $fragment: formFragment })),
       user: jest.fn(() => ({ $fragment: userFragment }))

--- a/back/src/forms/__tests__/rules.test.ts
+++ b/back/src/forms/__tests__/rules.test.ts
@@ -1,0 +1,185 @@
+import { testRule } from "../../common/__tests__/rules.test";
+import { canAccessForm } from "../rules";
+
+describe("canAccessForm", () => {
+  it("should be true if the user created the form", async () => {
+    const formFragment = jest.fn<any>();
+    const userFragment = jest.fn<any>();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({ owner: { id: "current user id" } });
+    userFragment.mockResolvedValue({ companyAssociations: [] });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "current user id" }, prisma }
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("should be true if the user belongs to the company that emitted the form", async () => {
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: null },
+      emitterCompanySiret: "a siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "a siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "id" }, prisma }
+    );
+    expect(result).toBe(true);
+  });
+
+  it("should be true if the user belongs to the company that received the form", async () => {
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: null },
+      emitterCompanySiret: "other siret",
+      recipientCompanySiret: "a siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "a siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "id" }, prisma }
+    );
+    expect(result).toBe(true);
+  });
+
+  it("should be false if the user has nothing to do with the form", async () => {
+    const formFragment = jest.fn();
+    const userFragment = jest.fn();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: "an unkmown id" },
+      emitterCompanySiret: "other siret",
+      recipientCompanySiret: "yet another siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "a siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "id" }, prisma }
+    );
+    expect(result).toBe(false);
+  });
+});
+
+describe("isFormTransporter", () => {
+  it("should be true if the user is the form transporter", async () => {
+    const formFragment = jest.fn<any>();
+    const userFragment = jest.fn<any>();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: "current user id" },
+      emitterCompanySiret: "other siret",
+      recipientCompanySiret: "yet another siret",
+      transporterCompanySiret: "transporter siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "transporter siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "current user id" }, prisma }
+    );
+
+    expect(result).toBe(true);
+  });
+});
+
+describe("isFormEmitter", () => {
+  it("should be true if the user is the form emitter", async () => {
+    const formFragment = jest.fn<any>();
+    const userFragment = jest.fn<any>();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: "current user id" },
+      emitterCompanySiret: "emitter siret",
+      recipientCompanySiret: "recipient siret",
+      transporterCompanySiret: "transporter siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "emitter siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "current user id" }, prisma }
+    );
+
+    expect(result).toBe(true);
+  });
+});
+
+describe("isFormRecipient", () => {
+  it("should be true if the user is the form emitter", async () => {
+    const formFragment = jest.fn<any>();
+    const userFragment = jest.fn<any>();
+    const prisma = {
+      form: jest.fn(() => ({ $fragment: formFragment })),
+      user: jest.fn(() => ({ $fragment: userFragment }))
+    };
+
+    formFragment.mockResolvedValue({
+      owner: { id: "current user id" },
+      emitterCompanySiret: "emitter siret",
+      recipientCompanySiret: "recipient siret",
+      transporterCompanySiret: "transporter siret"
+    });
+    userFragment.mockResolvedValue({
+      companyAssociations: [{ company: { siret: "recipient siret" } }]
+    });
+
+    const result = await testRule(canAccessForm)(
+      null,
+      { id: "12345" },
+      { user: { id: "current user id" }, prisma }
+    );
+
+    expect(result).toBe(true);
+  });
+});

--- a/back/src/forms/exports/columns.ts
+++ b/back/src/forms/exports/columns.ts
@@ -1,5 +1,4 @@
 import { Form } from "../../generated/prisma-client";
-import { currentUserBelongsToCompany } from "../../utils";
 
 type ColumnDetail = {
   key: string;

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -17,7 +17,7 @@ type Query {
   `EmitterSiret`: Siret d'une des entreprises que j'administre
   `wasteCode`: Code déchet pour affiner la recherche, optionnel
   """
-  appendixForms(emitterSiret: String!, wasteCode: String): [Form]
+  appendixForms(siret: String!, wasteCode: String): [Form]
 }
 
 type Mutation {

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -14,7 +14,7 @@ type Query {
   stats: [CompanyStat]
   """
   Renvoie des BSD candidats à un regroupement dans une annexe 2
-  `EmitterSiret`: Siret d'une des entreprises que j'administre
+  `siret`: Siret d'une des entreprises que j'administre
   `wasteCode`: Code déchet pour affiner la recherche, optionnel
   """
   appendixForms(siret: String!, wasteCode: String): [Form]

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -13,7 +13,7 @@ export default {
     form: canAccessForm,
     forms: isAuthenticated,
     stats: isAuthenticated,
-    appendixForms: and(isAuthenticated, isCompanyMember) // TODO emitterSiret and not siret
+    appendixForms: and(isAuthenticated, isCompanyMember)
   },
   Mutation: {
     saveForm: isAuthenticated,

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,0 +1,22 @@
+import { and, or } from "graphql-shield";
+
+import { canAccessForm, isFormRecipient, isFormEmitter } from "./rules";
+import { isAuthenticated, isCompanyMember } from "../common/rules";
+
+export default {
+  Query: {
+    form: canAccessForm,
+    forms: isAuthenticated,
+    stats: isAuthenticated,
+    appendixForms: and(isAuthenticated, isCompanyMember) // TODO emitterSiret and not siret
+  },
+  Mutation: {
+    saveForm: isAuthenticated,
+    deleteForm: canAccessForm,
+    duplicateForm: canAccessForm,
+    markAsSealed: canAccessForm,
+    markAsSent: or(isFormRecipient, isFormEmitter),
+    markAsReceived: canAccessForm,
+    markAsProcessed: canAccessForm
+  }
+};

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,6 +1,11 @@
 import { and, or } from "graphql-shield";
 
-import { canAccessForm, isFormRecipient, isFormEmitter } from "./rules";
+import {
+  canAccessForm,
+  isFormRecipient,
+  isFormEmitter,
+  isFormTransporter
+} from "./rules";
 import { isAuthenticated, isCompanyMember } from "../common/rules";
 
 export default {
@@ -17,6 +22,7 @@ export default {
     markAsSealed: canAccessForm,
     markAsSent: or(isFormRecipient, isFormEmitter),
     markAsReceived: canAccessForm,
-    markAsProcessed: canAccessForm
+    markAsProcessed: canAccessForm,
+    signedByTransporter: isFormTransporter
   }
 };

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -13,7 +13,7 @@ export default {
     form: canAccessForm,
     forms: isAuthenticated,
     stats: isAuthenticated,
-    appendixForms: and(isAuthenticated, isCompanyMember)
+    appendixForms: isCompanyMember
   },
   Mutation: {
     saveForm: isAuthenticated,

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -104,14 +104,14 @@ export default {
     },
     appendixForms: async (
       parent,
-      { emitterSiret, wasteCode },
+      { siret, wasteCode },
       context: Context
     ) => {
       const forms = await context.prisma.forms({
         where: {
           ...(wasteCode && { wasteDetailsCode: wasteCode }),
           status: "AWAITING_GROUP",
-          recipientCompanySiret: emitterSiret,
+          recipientCompanySiret: siret,
           isDeleted: false
         }
       });

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -1,4 +1,4 @@
-import { getUserId, getUserIdFromToken } from "../utils";
+import { getUserIdFromToken } from "../utils";
 import { Context } from "../types";
 import {
   flattenObjectForDb,
@@ -27,7 +27,7 @@ export default {
       return unflattenObjectFromDb(dbForm);
     },
     forms: async (_, { siret, type }, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
 
       if (!userCompanies.length) {
@@ -62,7 +62,7 @@ export default {
       return forms.map(f => unflattenObjectFromDb(f));
     },
     stats: async (parent, args, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
 
       return userCompanies.map(async userCompany => {
@@ -121,7 +121,7 @@ export default {
   },
   Mutation: {
     saveForm: async (parent, { formInput }, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
 
       const { id, ...formContent } = formInput;
       if (id) {
@@ -152,7 +152,7 @@ export default {
       });
     },
     duplicateForm: async (parent, { id }, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
 
       const existingForm = await context.prisma.form({
         id
@@ -183,7 +183,7 @@ export default {
         );
       }
 
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
       const sirets = userCompanies.map(c => c.siret);
 
@@ -197,7 +197,7 @@ export default {
       });
     },
     markAsSent: async (_, { id, sentInfo }, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const form = await context.prisma.form({ id });
 
       if (!["DRAFT", "SEALED"].includes(form.status)) {
@@ -216,7 +216,7 @@ export default {
     markAsReceived: async (parent, { id, receivedInfo }, context: Context) => {
       const form = await context.prisma.form({ id });
 
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
       const sirets = userCompanies.map(c => c.siret);
 
@@ -236,7 +236,7 @@ export default {
     ) => {
       const form = await context.prisma.form({ id });
 
-      const userId = getUserId(context);
+      const userId = context.user.id;
       const userCompanies = await getUserCompanies(userId);
       const sirets = userCompanies.map(c => c.siret);
 
@@ -285,7 +285,7 @@ export default {
         );
       }
 
-      const userId = getUserId(context);
+      const userId = context.user.id;
       logStatusChange(id, userId, status, context);
 
       return context.prisma.updateForm({

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -266,16 +266,6 @@ export default {
     signedByTransporter: async (_, { id, signingInfo }, context: Context) => {
       const form = await context.prisma.form({ id });
 
-      const userId = getUserId(context);
-      const userCompanies = await getUserCompanies(userId);
-      const sirets = userCompanies.map(c => c.siret);
-
-      if (!sirets.includes(form.transporterCompanySiret)) {
-        throw new Error(
-          "Vous n'êtes pas transporteur de ce bordereau. Vous ne pouvez pas réaliser cette action"
-        );
-      }
-
       if (signingInfo.signedByProducer) {
         const emitterCompany = await context.prisma.company({
           siret: form.emitterCompanySiret
@@ -294,6 +284,8 @@ export default {
           "Vous ne pouvez plus signer ce bordereau, il a dékà été marqué comme envoyé."
         );
       }
+
+      const userId = getUserId(context);
       logStatusChange(id, userId, status, context);
 
       return context.prisma.updateForm({

--- a/back/src/forms/rules.ts
+++ b/back/src/forms/rules.ts
@@ -1,0 +1,97 @@
+import { rule } from "graphql-shield";
+import { Prisma } from "../generated/prisma-client";
+
+type FormSiretsAndOwner = {
+  recipientCompanySiret: string;
+  emitterCompanySiret: string;
+  transporterCompanySiret: string;
+  owner: { id: string };
+};
+
+export const canAccessForm = rule()(async (_, { id }, ctx) => {
+  if (!ctx.user || !id) {
+    return false;
+  }
+  const { formInfos, currentUserSirets } = await getFormAccessInfos(
+    id,
+    ctx.user.id,
+    ctx.prisma
+  );
+
+  return (
+    formInfos.owner.id === ctx.user.id ||
+    currentUserSirets.includes(formInfos.emitterCompanySiret) ||
+    currentUserSirets.includes(formInfos.recipientCompanySiret)
+  );
+});
+
+export const isFormRecipient = rule()(async (_, { id }, ctx) => {
+  if (!ctx.user || !id) {
+    return false;
+  }
+  const { formInfos, currentUserSirets } = await getFormAccessInfos(
+    id,
+    ctx.user.id,
+    ctx.prisma
+  );
+
+  return currentUserSirets.includes(formInfos.recipientCompanySiret);
+});
+
+export const isFormEmitter = rule()(async (_, { id }, ctx) => {
+  if (!ctx.user || !id) {
+    return false;
+  }
+  const { formInfos, currentUserSirets } = await getFormAccessInfos(
+    id,
+    ctx.user.id,
+    ctx.prisma
+  );
+
+  return currentUserSirets.includes(formInfos.emitterCompanySiret);
+});
+
+export const isFormTransporter = rule()(async (_, { id }, ctx) => {
+  if (!ctx.user || !id) {
+    return false;
+  }
+  const { formInfos, currentUserSirets } = await getFormAccessInfos(
+    id,
+    ctx.user.id,
+    ctx.prisma
+  );
+
+  return currentUserSirets.includes(formInfos.transporterCompanySiret);
+});
+
+async function getFormAccessInfos(
+  formId: string,
+  userId: string,
+  prisma: Prisma
+) {
+  const formInfos = await prisma.form({ id: formId }).$fragment<
+    FormSiretsAndOwner
+  >(`
+  fragment FormWithOwner on Form {
+    recipientCompanySiret
+    emitterCompanySiret
+    transporterCompanySiret
+    owner { id }}
+  }
+`);
+
+  const user = await prisma.user({ id: userId }).$fragment<{
+    companyAssociations: { company: { siret: string } }[];
+  }>(`
+  fragment UserSirets on User {
+    companyAssociations {
+      company {
+        siret
+      }
+    }
+  }
+`);
+  const currentUserSirets = user.companyAssociations.map(a => a.company.siret);
+
+  return { formInfos, currentUserSirets };
+}

--- a/back/src/subscriptions/__tests__/rejected-form.test.ts
+++ b/back/src/subscriptions/__tests__/rejected-form.test.ts
@@ -162,7 +162,7 @@ describe("mailWhenFormIsDeclined", () => {
     // spies on axios get and post methods
     const mockedAxiosGet = jest.spyOn(axios, "get");
     const mockedAxiosPost = jest.spyOn(axios, "post");
-    (mockedAxiosGet as jest.Mock)
+    (mockedAxiosGet as jest.Mock<any>)
       .mockImplementationOnce(() =>
         Promise.resolve({
           data: insee1
@@ -173,7 +173,7 @@ describe("mailWhenFormIsDeclined", () => {
           data: insee2
         })
       );
-    (mockedAxiosPost as jest.Mock).mockImplementation(() =>
+    (mockedAxiosPost as jest.Mock<any>).mockImplementation(() =>
       Promise.resolve({
         data: { result: "ok" }
       })
@@ -182,10 +182,10 @@ describe("mailWhenFormIsDeclined", () => {
     await mailWhenFormIsDeclined(formPayload);
 
     // get called twice for td-insee
-    expect(mockedAxiosGet as jest.Mock).toHaveBeenCalledTimes(2);
+    expect(mockedAxiosGet as jest.Mock<any>).toHaveBeenCalledTimes(2);
 
     // post called 3 times for mail sending
-    expect(mockedAxiosPost as jest.Mock).toHaveBeenCalledTimes(3);
+    expect(mockedAxiosPost as jest.Mock<any>).toHaveBeenCalledTimes(3);
 
     const args = mockedAxiosPost.mock.calls;
     // right service was calleds

--- a/back/src/users/permissions.ts
+++ b/back/src/users/permissions.ts
@@ -1,10 +1,16 @@
-import { isAuthenticated } from "../common/rules";
+import { and } from "graphql-shield";
+
+import { isAuthenticated, isCompanyAdmin } from "../common/rules";
 
 export default {
   Query: {
-    me: isAuthenticated
+    me: isAuthenticated,
+    apiKey: isAuthenticated
   },
   Mutation: {
-    changePassword: isAuthenticated
+    changePassword: isAuthenticated,
+    editProfile: isAuthenticated,
+    inviteUserToCompany: and(isAuthenticated, isCompanyAdmin),
+    removeUserFromCompany: and(isAuthenticated, isCompanyAdmin)
   }
 };

--- a/back/src/users/permissions.ts
+++ b/back/src/users/permissions.ts
@@ -10,7 +10,7 @@ export default {
   Mutation: {
     changePassword: isAuthenticated,
     editProfile: isAuthenticated,
-    inviteUserToCompany: and(isAuthenticated, isCompanyAdmin),
-    removeUserFromCompany: and(isAuthenticated, isCompanyAdmin)
+    inviteUserToCompany: isCompanyAdmin,
+    removeUserFromCompany: isCompanyAdmin
   }
 };

--- a/back/src/users/resolvers.ts
+++ b/back/src/users/resolvers.ts
@@ -190,12 +190,6 @@ export default {
       const admins = await getCompanyAdmins(siret);
       const admin = admins.find(a => a.id === userId);
 
-      if (!admin) {
-        throw new Error(
-          "Vous ne pouvez pas inviter un utilisateur dans cette entreprise."
-        );
-      }
-
       const existingUser = await context.prisma
         .user({ email })
         .catch(_ => null);
@@ -284,16 +278,7 @@ export default {
         user
       };
     },
-    removeUserFromCompany: async (_, { userId, siret }, context: Context) => {
-      const currentUserId = getUserId(context);
-      const admins = await getCompanyAdmins(siret);
-
-      if (!admins || !admins.find(a => a.id === currentUserId)) {
-        throw new Error(
-          "Vous ne pouvez pas retirer un utilisateur dans cette entreprise."
-        );
-      }
-
+    removeUserFromCompany: async (_, { userId, siret }) => {
       await prisma
         .deleteManyCompanyAssociations({
           user: { id: userId },

--- a/back/src/users/resolvers.ts
+++ b/back/src/users/resolvers.ts
@@ -187,8 +187,8 @@ export default {
       context: Context
     ) => {
       const userId = getUserId(context);
-      const admins = await getCompanyAdmins(siret);
-      const admin = admins.find(a => a.id === userId);
+      // Current user is necessarely admin, otherwise he can't invite another user (rule set in permissions file)
+      const admin = await context.prisma.user({ id: userId });
 
       const existingUser = await context.prisma
         .user({ email })

--- a/back/src/users/resolvers.ts
+++ b/back/src/users/resolvers.ts
@@ -1,12 +1,12 @@
 import { hash, compare } from "bcrypt";
 import { sign } from "jsonwebtoken";
-import { getUserId, randomNumber } from "../utils";
+import { randomNumber } from "../utils";
 import { Context } from "../types";
 import { prisma } from "../generated/prisma-client";
 import { sendMail } from "../common/mails.helper";
 import { userMails } from "./mails";
 import companyResolver from "../companies/resolvers";
-import { getCompanyAdmins, getUserCompanies } from "../companies/helper";
+import { getUserCompanies } from "../companies/helper";
 import { DomainError, ErrorCode } from "../common/errors";
 
 const { JWT_SECRET } = process.env;
@@ -124,7 +124,7 @@ export default {
       };
     },
     changePassword: async (_, { oldPassword, newPassword }, context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
 
       const user = await context.prisma.user({ id: userId });
       const passwordValid = await compare(oldPassword, user.password);
@@ -164,7 +164,7 @@ export default {
       );
     },
     editProfile: (_, { name, phone, email }, context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
 
       return prisma
         .updateUser({
@@ -186,7 +186,7 @@ export default {
       { email, siret, role },
       context: Context
     ) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       // Current user is necessarely admin, otherwise he can't invite another user (rule set in permissions file)
       const admin = await context.prisma.user({ id: userId });
 
@@ -295,11 +295,11 @@ export default {
   },
   Query: {
     me: async (parent, _, context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       return context.prisma.user({ id: userId });
     },
     apiKey: (parent, args, context: Context) => {
-      const userId = getUserId(context);
+      const userId = context.user.id;
       return sign({ userId: userId }, JWT_SECRET);
     }
   },

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -1,5 +1,4 @@
 import { verify } from "jsonwebtoken";
-import { getCompanyUsers, getCompanyAdmins } from "./companies/helper";
 
 const { JWT_SECRET } = process.env;
 
@@ -7,47 +6,9 @@ interface Token {
   userId: string;
 }
 
-interface Context {
-  request: any;
-}
-
-/** DEPRECATED !
- * We should get userId directly from the context
- * => const userId = context.user.id
- * To be used in conjunction with permission isAuthenticated
- * to ensure user is not null
- */
-export function getUserId(context: Context) {
-  const Authorization = context.request.get("Authorization");
-  if (Authorization) {
-    const token = Authorization.replace("Bearer ", "");
-    return getUserIdFromToken(token);
-  }
-}
-
 export function getUserIdFromToken(token: string) {
   const verifiedToken = verify(token, JWT_SECRET) as Token;
   return verifiedToken && verifiedToken.userId;
-}
-
-export async function currentUserBelongsToCompany(
-  context: Context,
-  siret: string
-) {
-  const companyUsers = await getCompanyUsers(siret);
-
-  const currentUserId = getUserId(context);
-  return !!companyUsers.find(a => a.id === currentUserId);
-}
-
-export async function currentUserBelongsToCompanyAdmins(
-  context: Context,
-  siret: string
-) {
-  const companyAdmins = await getCompanyAdmins(siret);
-
-  const currentUserId = getUserId(context);
-  return !!companyAdmins.find(a => a.id === currentUserId);
 }
 
 export function randomNumber(length: number = 4) {

--- a/front/src/form/appendix/FormsSelector.tsx
+++ b/front/src/form/appendix/FormsSelector.tsx
@@ -10,7 +10,7 @@ import useDidUpdateEffect from "../../utils/use-did-update";
 
 const GET_APPENDIX_FORMS = gql`
   query AppendixForms($emitterSiret: String!, $wasteCode: String) {
-    appendixForms(emitterSiret: $emitterSiret, wasteCode: $wasteCode) {
+    appendixForms(siret: $emitterSiret, wasteCode: $wasteCode) {
       readableId
       emitter {
         company {


### PR DESCRIPTION
⚠ Ca touche à tous les droits !
⚒ Je n'ai pas terminé de recetter en local

Utilisation systématique de `graphql-shield`, qui donne plusieurs avantages:

- la logique de gestion des droits est séparée de la logique métier
- les resolvers peuvent donc partir du principe que si l'utilisateur est là, c'est qu'il a le droit. cOn gagne en lisibilité
- on peut en un clin d'oeil voir pour chaque `query` et `mutation` les conditions d'autorisation
- pas de rule en revanche pour les subscriptions => ce n'est pas supporté par la librairie pour le moment

------

Remarque annexe, j'ai du modifier quelque peu 2 fichiers de tests qui refusaient de passer chez moi.
- `jest.Mock` me causait des erreurs de typage, j'ai du remplacé par `jest.Mock<any>`. Je n'ai pas trop fouillé pourquoi mais j'ai pourtant refait un `npm i` et je devrais avoir la meme version de TS que vous
- dans l'environnement dans lequel je fais passer mes tests je n'ai pas le `.env` chargé, ca posait problème pour certaines valeurs hardcodées. J'ai donc modifier le test pour ne pas tester ces valeurs Ca me semble plus safe vu qu'on va rapidement les faire tourner sur l'IC et qu'il risque d'y avoir le meme problème
- certains mocks ne senblaient pas correctement reset sur mon environnement. J'ai du réarranger un peu pour m'assurer qu'ils etaient bien clean entre chaque test. Sinon j'avais un `toHaveBeenCalledTimes(1)` qui renvoyait 2.

Tout ca est peut etre lié au fait que j'ai fait tourner les tests en local et pas dans le container => possible qu'il y ait une petite diff dans la version de node
