### PR TITLE
Feat/edit form checks

### DIFF
--- a/back/src/companies/helper.ts
+++ b/back/src/companies/helper.ts
@@ -55,7 +55,14 @@ function getUsersThroughCompanyAssociations(params: object) {
     .then(association => association.map(a => a.user));
 }
 
-export async function getUserCompanies(userId: string) {
+type CompanyFragment = Pick<
+  Company,
+  "id" | "siret" | "securityCode" | "companyTypes"
+>;
+
+export async function getUserCompanies(
+  userId: string
+): Promise<CompanyFragment[]> {
   if (!userId) {
     return Promise.resolve([]);
   }

--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -1,8 +1,10 @@
+import { Form } from "../generated/prisma-client";
+
 export function flattenObjectForDb(
   input,
   previousKeys = [],
   dbObject = {}
-) {
+): Partial<Form> {
   Object.keys(input).forEach(key => {
     if (
       input[key] &&

--- a/back/src/forms/mutations/__tests__/save-form.test.ts
+++ b/back/src/forms/mutations/__tests__/save-form.test.ts
@@ -50,7 +50,6 @@ describe("Forms -> saveForm mutation", () => {
 
       expect("Should throw").toBe("Error");
     } catch (err) {
-      console.log(err);
       expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
     }
   });

--- a/back/src/forms/mutations/__tests__/save-form.test.ts
+++ b/back/src/forms/mutations/__tests__/save-form.test.ts
@@ -4,12 +4,19 @@ import { ErrorCode } from "../../../common/errors";
 import * as helpers from "../../../companies/helper";
 
 describe("Forms -> saveForm mutation", () => {
+  const formMock = jest.fn();
   const prisma = {
-    form: jest.fn()
+    form: formMock,
+    updateForm: jest.fn(() => ({})),
+    createForm: jest.fn(() => ({}))
   };
 
   const getUserCompaniesMcock = jest.spyOn(helpers, "getUserCompanies");
   getUserCompaniesMcock.mockResolvedValue([{ siret: "user siret" }]);
+
+  beforeEach(() => {
+    formMock.mockReset();
+  });
 
   it("should fail when creating a form the current user is not part of", async () => {
     const formInput = {
@@ -39,6 +46,65 @@ describe("Forms -> saveForm mutation", () => {
       traderCompanySiret: "an unknown siret",
       recipientCompanySiret: "an unknown siret",
       transporterCompanySiret: "an unknown siret"
+    };
+
+    try {
+      await saveForm(null, { formInput }, {
+        prisma,
+        user: { id: "userId" },
+        request: null
+      } as any);
+
+      expect("Should throw").toBe("Error");
+    } catch (err) {
+      expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+
+  it("should work when editing a form the current user is part of, with partial input", async () => {
+    const formInput = {
+      id: "existing id"
+      // No siret infos
+    };
+
+    formMock.mockResolvedValue({ emitterCompanySiret: "user siret" });
+
+    const result = await saveForm(null, { formInput }, {
+      prisma,
+      user: { id: "userId" },
+      request: null
+    } as any);
+
+    expect(result).not.toBeNull();
+  });
+
+  it("should fail when editing a form the current user is not part of, with partial input", async () => {
+    const formInput = {
+      id: "existing id"
+      // No siret infos
+    };
+
+    formMock.mockResolvedValue({
+      emitterCompanySiret: "unknown resolved siret"
+    });
+
+    try {
+      await saveForm(null, { formInput }, {
+        prisma,
+        user: { id: "userId" },
+        request: null
+      } as any);
+
+      expect("Should throw").toBe("Error");
+    } catch (err) {
+      expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+
+  it("should fail when creating a form the current user is not part of, with partial input", async () => {
+    const formInput = {
+      // No id
+      // No siret infos
     };
 
     try {

--- a/back/src/forms/mutations/__tests__/save-form.test.ts
+++ b/back/src/forms/mutations/__tests__/save-form.test.ts
@@ -1,0 +1,57 @@
+import { saveForm } from "../save-form";
+import { ErrorCode } from "../../../common/errors";
+
+import * as helpers from "../../../companies/helper";
+
+describe("Forms -> saveForm mutation", () => {
+  const prisma = {
+    form: jest.fn()
+  };
+
+  const getUserCompaniesMcock = jest.spyOn(helpers, "getUserCompanies");
+  getUserCompaniesMcock.mockResolvedValue([{ siret: "user siret" }]);
+
+  it("should fail when creating a form the current user is not part of", async () => {
+    const formInput = {
+      emitterCompanySiret: "an unknown siret",
+      traderCompanySiret: "an unknown siret",
+      recipientCompanySiret: "an unknown siret",
+      transporterCompanySiret: "an unknown siret"
+    };
+
+    try {
+      await saveForm(null, { formInput }, {
+        prisma,
+        user: { id: "userId" },
+        request: null
+      } as any);
+
+      expect("Should throw").toBe("Error");
+    } catch (err) {
+      expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+
+  it("should fail when editing a form the current user is not part of", async () => {
+    const formInput = {
+      id: "existing id",
+      emitterCompanySiret: "an unknown siret",
+      traderCompanySiret: "an unknown siret",
+      recipientCompanySiret: "an unknown siret",
+      transporterCompanySiret: "an unknown siret"
+    };
+
+    try {
+      await saveForm(null, { formInput }, {
+        prisma,
+        user: { id: "userId" },
+        request: null
+      } as any);
+
+      expect("Should throw").toBe("Error");
+    } catch (err) {
+      console.log(err);
+      expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+});

--- a/back/src/forms/mutations/save-form.ts
+++ b/back/src/forms/mutations/save-form.ts
@@ -15,7 +15,7 @@ export async function saveForm(_, { formInput }, context: Context) {
   const { id, ...formContent } = formInput;
   const form = flattenObjectForDb(formContent);
 
-  await checkThatUserIsPartOftheForm(userId, form, context);
+  await checkThatUserIsPartOftheForm(userId, { ...form, id }, context);
 
   if (id) {
     const updatedForm = await context.prisma.updateForm({
@@ -53,9 +53,9 @@ async function checkThatUserIsPartOftheForm(
 ) {
   const isEdition = form.id != null;
   const formSirets = formSiretsGetter(form);
-  const hasMissingFormInfo = formSirets.some(siret => siret == null);
+  const hasPartialFormInput = formSirets.some(siret => siret == null);
 
-  if (isEdition && hasMissingFormInfo) {
+  if (isEdition && hasPartialFormInput) {
     const savedForm = await context.prisma.form({ id: form.id });
     const savedFormSirets = formSiretsGetter(savedForm);
     formSirets.push(...savedFormSirets);

--- a/back/src/forms/mutations/save-form.ts
+++ b/back/src/forms/mutations/save-form.ts
@@ -1,0 +1,69 @@
+import { Context } from "../../types";
+import { flattenObjectForDb, unflattenObjectFromDb } from "../form-converter";
+import { DomainError, ErrorCode } from "../../common/errors";
+import { getReadableId } from "../readable-id";
+import { Form } from "../../generated/prisma-client";
+import { getUserCompanies } from "../../companies/helper";
+
+export async function saveForm(_, { formInput }, context: Context) {
+  const userId = context.user.id;
+
+  const { id, ...formContent } = formInput;
+  const form = flattenObjectForDb(formContent);
+
+  await checkThatUserIsPartOftheForm(userId, form, context);
+
+  if (id) {
+    const updatedForm = await context.prisma.updateForm({
+      where: { id },
+      data: {
+        ...form,
+        appendix2Forms: { connect: formContent.appendix2Forms }
+      }
+    });
+
+    return unflattenObjectFromDb(updatedForm);
+  }
+
+  const newForm = await context.prisma.createForm({
+    ...form,
+    appendix2Forms: { connect: formContent.appendix2Forms },
+    readableId: await getReadableId(context),
+    owner: { connect: { id: userId } }
+  });
+
+  return unflattenObjectFromDb(newForm);
+}
+
+const formSiretsGetter = (form: Partial<Form>) => [
+  form.emitterCompanySiret,
+  form.traderCompanySiret,
+  form.recipientCompanySiret,
+  form.transporterCompanySiret
+];
+
+async function checkThatUserIsPartOftheForm(
+  userId: string,
+  form: Partial<Form>,
+  context: Context
+) {
+  const isEdition = form.id != null;
+  const formSirets = formSiretsGetter(form);
+  const hasMissingFormInfo = formSirets.some(siret => siret == null);
+
+  if (isEdition && hasMissingFormInfo) {
+    const savedForm = await context.prisma.form({ id: form.id });
+    const savedFormSirets = formSiretsGetter(savedForm);
+    formSirets.push(...savedFormSirets);
+  }
+
+  const userCompanies = await getUserCompanies(userId);
+  const userSirets = userCompanies.map(c => c.siret);
+
+  if (formSirets.some(siret => userSirets.includes(siret))) {
+    throw new DomainError(
+      "Vous ne pouvez pas créer ou modifier un bordereau sur lequel votre entreprise n'apparait pas.",
+      ErrorCode.BAD_USER_INPUT
+    );
+  }
+}

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -1,7 +1,6 @@
 import { getUserIdFromToken } from "../utils";
 import { Context } from "../types";
 import {
-  flattenObjectForDb,
   unflattenObjectFromDb,
   cleanUpNotDuplicatableFieldsInForm
 } from "./form-converter";
@@ -9,6 +8,7 @@ import { formSchema } from "./validator";
 import { getNextStep } from "./workflow";
 import { getReadableId } from "./readable-id";
 import { getUserCompanies } from "../companies/helper";
+import { saveForm } from "./mutations/save-form";
 
 export default {
   Form: {
@@ -120,31 +120,7 @@ export default {
     }
   },
   Mutation: {
-    saveForm: async (parent, { formInput }, context: Context) => {
-      const userId = context.user.id;
-
-      const { id, ...formContent } = formInput;
-      if (id) {
-        const updatedForm = await context.prisma.updateForm({
-          where: { id },
-          data: {
-            ...flattenObjectForDb(formContent),
-            appendix2Forms: { connect: formContent.appendix2Forms }
-          }
-        });
-
-        return unflattenObjectFromDb(updatedForm);
-      }
-
-      const newForm = await context.prisma.createForm({
-        ...flattenObjectForDb(formContent),
-        appendix2Forms: { connect: formContent.appendix2Forms },
-        readableId: await getReadableId(context),
-        owner: { connect: { id: userId } }
-      });
-
-      return unflattenObjectFromDb(newForm);
-    },
+    saveForm,
     deleteForm: async (parent, { id }, context: Context) => {
       return context.prisma.updateForm({
         where: { id },

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -3764,6 +3764,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "cogo-toast": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cogo-toast/-/cogo-toast-4.1.1.tgz",
+      "integrity": "sha512-PZ16evCEtkcb43ycKubxpmjEb5ZFzSRqjKccJDJ1wbdhfQVdZreOFpJCo1q3xkGDghwXtNse/xsoG854k5pSmg=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
     "apollo-link-context": "^1.0.19",
     "apollo-link-http": "^1.5.16",
     "apollo-utilities": "^1.3.2",
+    "cogo-toast": "^4.1.1",
     "env-cmd": "^10.0.1",
     "formik": "^1.3.2",
     "graphql": "^14.0.2",

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -1,14 +1,17 @@
-import React, { useState, ReactElement, useEffect, useRef } from "react";
-import { Step, IStepContainerProps } from "./Step";
-import "./StepList.scss";
+import { Mutation, Query } from "@apollo/react-components";
+import cogoToast from "cogo-toast";
 import { Formik, FormikActions, setNestedObjectValues } from "formik";
-import initialState from "../initial-state";
-import { Query, Mutation } from "@apollo/react-components";
-import { withRouter, RouteComponentProps } from "react-router";
-import { GET_FORM, SAVE_FORM } from "./queries";
-import { GET_SLIPS } from "../../dashboard/slips/query";
-import { formSchema } from "../schema";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
+import { RouteComponentProps, withRouter } from "react-router";
+
 import { currentSiretService } from "../../dashboard/CompanySelector";
+import { GET_SLIPS } from "../../dashboard/slips/query";
+import initialState from "../initial-state";
+import { formSchema } from "../schema";
+import { GET_FORM, SAVE_FORM } from "./queries";
+import { IStepContainerProps, Step } from "./Step";
+
+import "./StepList.scss";
 
 interface IProps {
   children: ReactElement<IStepContainerProps>[];
@@ -120,9 +123,11 @@ export default withRouter(function StepList(
                             // and don't use the classic Formik mechanism
                             saveForm({
                               variables: { formInput: values }
-                            }).then(_ =>
-                              props.history.push("/dashboard/slips")
-                            );
+                            })
+                              .then(_ => props.history.push("/dashboard/slips"))
+                              .catch(err => {
+                                cogoToast.error(err.message, { hideAfter: 7 });
+                              });
                             return false;
                           }}
                         >


### PR DESCRIPTION
cf https://trello.com/c/riLUlE1z/558-changer-les-droits-d%C3%A9dition-de-bsd-en-mode-brouillon

On autorise la création et la modification de bordereaux uniquement pour les acteurs qui font partie de ce bordereau (emitter, recipient, trader ou recipient)