### PR TITLE
Ajout du SIRET au mail `contentAwaitsGuest`

### DIFF
--- a/back/src/subscriptions/forms.ts
+++ b/back/src/subscriptions/forms.ts
@@ -66,6 +66,7 @@ async function mailToInexistantRecipient(payload: FormSubscriptionPayload) {
       recipientMail,
       recipientName,
       payload.node.recipientCompanyName,
+      payload.node.recipientCompanySiret,
       payload.node.emitterCompanyName
     )
   );
@@ -100,6 +101,7 @@ async function mailToInexistantEmitter(payload: FormSubscriptionPayload) {
       emitterMail,
       emitterName,
       payload.node.emitterCompanyName,
+      payload.node.emitterCompanySiret,
       payload.node.recipientCompanyName
     )
   );

--- a/back/src/users/mails.ts
+++ b/back/src/users/mails.ts
@@ -27,7 +27,13 @@ export const userMails = {
     <br>
     Si vous avez la moindre interrogation, n’hésitez pas à nous contacter à l'email <a href="mailto:emmanuel.flahaut@developpement-durable.gouv.fr">emmanuel.flahaut@developpement-durable.gouv.fr</a>.`
   }),
-  contentAwaitsGuest: (toEmail, toName, toCompanyName, fromCompanyName) => ({
+  contentAwaitsGuest: (
+    toEmail,
+    toName,
+    toCompanyName,
+    toCompanySiret,
+    fromCompanyName
+  ) => ({
     toEmail,
     toName,
     subject:
@@ -36,7 +42,7 @@ export const userMails = {
       "Un BSD numérique vous attend sur Trackdéchets : créez votre compte pour y accéder !",
     body: `Bonjour ${toName},
     <br><br>
-    L'entreprise ${fromCompanyName} vient de créer un BSD dématérialisé disponible sur <a href="https://${UI_HOST}/">https://trackdechets.beta.gouv.fr</a> qui concerne votre entreprise ${toCompanyName}.
+    L'entreprise ${fromCompanyName} vient de créer un BSD dématérialisé disponible sur <a href="https://${UI_HOST}/">https://trackdechets.beta.gouv.fr</a> qui concerne votre entreprise ${toCompanyName} (SIRET: ${toCompanySiret}).
     <br><br>
     <strong>Qu’est-ce que Trackdéchets ?</strong>
     <br>
@@ -116,7 +122,7 @@ export const userMails = {
       new Date(form.receivedAt)
     )}, le déchet de la société suivante :
     <br><br>
-   
+
     <ul>
     <li>${cleanupSpecialChars(form.emitterCompanyName)} - ${
       form.emitterCompanyAddress


### PR DESCRIPTION
On ajoute le siret de l'entreprise dans le mail `contentAwaitsGuest`

Micro correction suite à https://trello.com/c/iArZ4UuI/568-etq-user-je-ne-peux-pas-acc%C3%A9der-%C3%A0-mon-compte-et-voir-mon-bsd-num%C3%A9rique