### PR TITLE
accept multi associations

### DIFF
--- a/back/src/common/rules.ts
+++ b/back/src/common/rules.ts
@@ -97,8 +97,6 @@ async function isUserInCompanyWithRole(
   if (associations.length == 0) {
     return false;
   } else {
-    // there should not be more than one association
-    const { role } = associations[0];
-    return role === expectedRole;
+    return associations.some(({ role }) => role === expectedRole);
   }
 }

--- a/back/src/common/rules.ts
+++ b/back/src/common/rules.ts
@@ -94,9 +94,5 @@ async function isUserInCompanyWithRole(
     }
   });
 
-  if (associations.length == 0) {
-    return false;
-  } else {
-    return associations.some(({ role }) => role === expectedRole);
-  }
+  return associations.some(({ role }) => role === expectedRole);
 }


### PR DESCRIPTION
Il est possible d'avoir plusieurs associations avec une entreprise dans le modèle actuel.
On va revoir ca, mais autant checker toutes les associations dans tous les cas.

Modif suite au problème remonté par Sarpi