### PR TITLE
Fix appendix2 permission rule

### DIFF
--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -6,14 +6,18 @@ import {
   isFormEmitter,
   isFormTransporter
 } from "./rules";
-import { isAuthenticated, isCompanyMember } from "../common/rules";
+import {
+  isAuthenticated,
+  isCompanyMember,
+  isCompanyAdmin
+} from "../common/rules";
 
 export default {
   Query: {
     form: canAccessForm,
     forms: isAuthenticated,
     stats: isAuthenticated,
-    appendixForms: isCompanyMember
+    appendixForms: or(isCompanyMember, isCompanyAdmin)
   },
   Mutation: {
     saveForm: isAuthenticated,


### PR DESCRIPTION
FIX: on peut éditer une annexe 2 si on est member OU admin

cf https://trello.com/c/7SEmyL8f/576-on-maffiche-une-info-derreur-et-pas-de-bsd-quand-je-veux-g%C3%A9n%C3%A9rer-1-annexe-2