### PR TITLE
Pass more config options to allow distant dbs

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -6,6 +6,8 @@ METABASE_HOST=metabase-td.local
 
 EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr
 
+POSTGRES_HOST=12.345.67.89|postgres
+POSTGRES_PORT=5432
 POSTGRES_USER=trackdechets
 POSTGRES_PASSWORD=*********
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,8 +11,8 @@ services:
         databases:
           default:
             connector: postgres
-            host: postgres
-            port: 5432
+            host: $POSTGRES_HOST
+            port: $POSTGRES_PORT
             user: $POSTGRES_USER
             password: $POSTGRES_PASSWORD
             migrations: true
@@ -122,6 +122,8 @@ services:
       VIRTUAL_HOST: $ETL_HOST
       VIRTUAL_PORT: 8080
       LOAD_EX: n
+      POSTGRES_HOST: $POSTGRES_HOST
+      POSTGRES_PORT: $POSTGRES_PORT
       POSTGRES_USER: $AIRFLOW_POSTGRES_USER
       POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
       AIRFLOW__CORE__FERNET_KEY: $AIRFLOW_FERNET_KEY

--- a/docker-compose.val.yml
+++ b/docker-compose.val.yml
@@ -11,8 +11,8 @@ services:
         databases:
           default:
             connector: postgres
-            host: postgres
-            port: 5432
+            host: $POSTGRES_HOST
+            port: $POSTGRES_PORT
             user: $POSTGRES_USER
             password: $POSTGRES_PASSWORD
             migrations: true
@@ -122,6 +122,8 @@ services:
     environment:
       POSTGRES_USER: $AIRFLOW_POSTGRES_USER
       POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
+      POSTGRES_HOST: $POSTGRES_HOST
+      POSTGRES_PORT: $POSTGRES_PORT
       AIRFLOW__CORE__FERNET_KEY: $AIRFLOW_FERNET_KEY
       AIRFLOW__CORE__LOGGING_LEVEL: ERROR
       AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
         databases:
           default:
             connector: postgres
-            host: postgres
-            port: 5432
+            host: $POSTGRES_HOST
+            port: $POSTGRES_PORT
             user: $POSTGRES_USER
             password: $POSTGRES_PASSWORD
             migrations: true
@@ -90,6 +90,8 @@ services:
     environment:
       POSTGRES_USER: $AIRFLOW_POSTGRES_USER
       POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
+      POSTGRES_HOST: $POSTGRES_HOST
+      POSTGRES_PORT: $POSTGRES_PORT
       AIRFLOW__CORE__FERNET_KEY: $AIRFLOW_FERNET_KEY
       AIRFLOW__CORE__LOGGING_LEVEL: ERROR
       AIRFLOW__CORE__EXECUTOR: LocalExecutor


### PR DESCRIPTION
# Do not merge, .env files need to be updated.

Some yaml tweaks to be able to use a distant postgres instance.
For now, postgres section is kept to be able to dump db and switch back to docker instances if needed.