### PR TITLE
Status page

### DIFF
--- a/back/src/health.ts
+++ b/back/src/health.ts
@@ -1,0 +1,101 @@
+import * as express from "express";
+import axios from "axios";
+import { resolve } from "url";
+
+export const healthRouter = express.Router();
+
+const TIMEOUT = 5000;
+const services = [
+  { name: "td-pdf", port: 3201, check: pingCheck },
+  { name: "td-insee", port: 81, check: pingCheck },
+  { name: "td-mail", port: 80, check: pingCheck },
+  { name: "td-etl", port: 80, check: etlCheck }
+];
+
+type HealthCheck = {
+  name: string;
+  ok: boolean;
+  requestTime?: number;
+  status?: number;
+  message?: string;
+};
+
+services.map(service => {
+  healthRouter.get(`/${service.name}`, async (_, res) => {
+    try {
+      const health = await service.check();
+      res.json(health);
+    } catch (error) {
+      res.json({
+        name: service.name,
+        ok: false,
+        message: "Unknown error"
+      });
+    }
+  });
+});
+
+async function pingCheck() {
+  return httpCheck(
+    this.name,
+    this.port,
+    "/ping",
+    data => typeof data === "string" && data.toLowerCase() === "pong"
+  );
+}
+
+async function etlCheck() {
+  return httpCheck(
+    this.name,
+    this.port,
+    "/health",
+    data =>
+      data.metadatabase.status === "healthy" &&
+      data.scheduler.status === "healthy"
+  );
+}
+
+async function httpCheck(
+  name: string,
+  port: number,
+  uri: string,
+  isOk: (data: any) => boolean
+): Promise<HealthCheck> {
+  const instance = axios.create();
+  instance.interceptors.request.use(
+    (config: any) => {
+      config.requestStartTime = Date.now();
+      return config;
+    },
+    error => Promise.reject(error)
+  );
+  instance.interceptors.response.use(
+    (response: any) => {
+      response.config.requestTime =
+        Date.now() - response.config.requestStartTime;
+      return response;
+    },
+    error => Promise.reject(error)
+  );
+
+  try {
+    const { status, data, config } = await instance.get(
+      resolve(`http://${name}:${port}`, uri),
+      { timeout: TIMEOUT }
+    );
+
+    return {
+      name,
+      ok: isOk(data),
+      status,
+      requestTime: (config as any).requestTime
+    };
+  } catch (error) {
+    return {
+      name,
+      ok: false,
+      ...(error.response && { status: error.response.status }),
+      ...(error.message && { message: error.message })
+    };
+  }
+}

--- a/back/src/health.ts
+++ b/back/src/health.ts
@@ -24,9 +24,9 @@ services.map(service => {
   healthRouter.get(`/${service.name}`, async (_, res) => {
     try {
       const health = await service.check();
-      res.json(health);
+      res.status(health.ok ? 200 : 503).json(health);
     } catch (error) {
-      res.json({
+      res.status(503).json({
         name: service.name,
         ok: false,
         message: "Unknown error"

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -11,6 +11,7 @@ import { getUser } from "./auth";
 import { csvExportHandler } from "./forms/exports/handler";
 import { pdfHandler } from "./forms/pdf";
 import { prisma } from "./generated/prisma-client";
+import { healthRouter } from "./health";
 import { userActivationHandler } from "./users/activation";
 import { mergePermissions } from "./utils";
 
@@ -71,6 +72,7 @@ app.get("/ping", (_, res) => res.send("Pong!"));
 app.get("/userActivation", userActivationHandler);
 app.get("/pdf", pdfHandler);
 app.get("/exports", csvExportHandler);
+app.use("/health", healthRouter);
 
 server.applyMiddleware({
   app,

--- a/mail/src/mail.go
+++ b/mail/src/mail.go
@@ -40,10 +40,15 @@ func mustGetenv(k string) string {
 }
 
 func main() {
+	http.HandleFunc("/ping", pong)
 	http.HandleFunc("/send", sendEmail)
 	http.HandleFunc("/contact/", singleContactHandler)
 	http.HandleFunc("/contact", contactsHandler)
 	log.Fatal(http.ListenAndServe(":80", nil))
+}
+
+func pong(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Pong"))
 }
 
 func sendEmail(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +65,6 @@ func sendEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Impossible de déséréaliser l'entrée.", http.StatusBadRequest)
 		return
 	}
-
 
 	if data.Body == "" || data.Subject == "" || data.Title == "" || data.ToEmail == "" || data.ToName == "" || data.TemplateID == 0 {
 		msg := fmt.Sprintf("Données manquantes: %v", data)

--- a/status/.env.model
+++ b/status/.env.model
@@ -1,0 +1,10 @@
+DB_DRIVER=pgsql
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=postgres
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_PREFIX=chq_
+APP_KEY=base64:csTGQw6a3ukPnGkAg2Ny1uklCduDm684EczDHNgv/14=
+APP_LOG=errorlog
+DEBUG=false

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,6 @@
+# Status
+
+- Basé sur [Cachet](https://docs.cachethq.io/docs/welcome) & [Cachet-monitor](https://github.com/CastawayLabs/cachet-monitor)
+- Doit etre déployé sur un serveur **différent du serveur de production**. Puis accessbile à une adresse du type `status.trackdechets.fr`
+- Le monitor fait des pings réguliers sur les services définis dans le fichier `monitor/config.json` et crée des incidents automatiquement en cas de problème
+- Il est également possible de créer et résoudre des incidents à la main dans Cachet

--- a/status/docker-compose.yml
+++ b/status/docker-compose.yml
@@ -2,19 +2,18 @@ version: "3"
 
 services:
   postgres:
-    image: postgres:9.5
+    image: postgres:10.5
     volumes:
       - /var/lib/postgresql/data
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     restart: always
+
   cachet:
-    image: docker pull cachethq/docker:2.3.12
+    image: cachethq/docker:2.3.12
     ports:
       - 80:8000
-    links:
-      - postgres:postgres
     environment:
       - DB_DRIVER=pgsql
       - DB_HOST=postgres
@@ -23,14 +22,18 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=postgres
       - DB_PREFIX=chq_
-      - APP_KEY=${APP_KEY:-null}
+      - APP_KEY=base64:csTGQw6a3ukPnGkAg2Ny1uklCduDm684EczDHNgv/14=
       - APP_LOG=errorlog
       - DEBUG=false
     depends_on:
       - postgres
     restart: on-failure
+
   monitor:
     build:
-      context: ./cachet-monitor
+      context: ./monitor
     volumes:
-      - ./cachet-monitor/config.json:/etc/cachet-monitor.config.json
+      - ./monitor/config.json:/etc/cachet-monitor.config.json
+    depends_on:
+      - cachet
+    restart: on-failure

--- a/status/docker-compose.yml
+++ b/status/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:9.5
+    volumes:
+      - /var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    restart: always
+  cachet:
+    image: docker pull cachethq/docker:2.3.12
+    ports:
+      - 80:8000
+    links:
+      - postgres:postgres
+    environment:
+      - DB_DRIVER=pgsql
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_DATABASE=postgres
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=postgres
+      - DB_PREFIX=chq_
+      - APP_KEY=${APP_KEY:-null}
+      - APP_LOG=errorlog
+      - DEBUG=false
+    depends_on:
+      - postgres
+    restart: on-failure
+  monitor:
+    build:
+      context: ./cachet-monitor
+    volumes:
+      - ./cachet-monitor/config.json:/etc/cachet-monitor.config.json

--- a/status/docker-compose.yml
+++ b/status/docker-compose.yml
@@ -6,25 +6,16 @@ services:
     volumes:
       - /var/lib/postgresql/data
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=$DB_USERNAME
+      - POSTGRES_PASSWORD=$DB_PASSWORD
     restart: always
 
   cachet:
     image: cachethq/docker:2.3.12
     ports:
-      - 80:8000
-    environment:
-      - DB_DRIVER=pgsql
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_DATABASE=postgres
-      - DB_USERNAME=postgres
-      - DB_PASSWORD=postgres
-      - DB_PREFIX=chq_
-      - APP_KEY=base64:csTGQw6a3ukPnGkAg2Ny1uklCduDm684EczDHNgv/14=
-      - APP_LOG=errorlog
-      - DEBUG=false
+      - 81:8000
+    env_file:
+      - .env
     depends_on:
       - postgres
     restart: on-failure

--- a/status/monitor/Dockerfile
+++ b/status/monitor/Dockerfile
@@ -1,0 +1,8 @@
+
+FROM golang
+
+RUN mkdir -p /cachet-monitor/
+RUN cd /cachet-monitor && wget https://github.com/CastawayLabs/cachet-monitor/releases/download/v3.0/cachet_monitor_linux_amd64
+RUN cd /cachet-monitor && chmod +x ./cachet_monitor_linux_amd64 && mv cachet_monitor_linux_amd64 /bin/cachet-monitor
+
+ENTRYPOINT cachet-monitor -c /etc/cachet-monitor.config.json

--- a/status/monitor/Dockerfile
+++ b/status/monitor/Dockerfile
@@ -5,4 +5,4 @@ RUN mkdir -p /cachet-monitor/
 RUN cd /cachet-monitor && wget https://github.com/CastawayLabs/cachet-monitor/releases/download/v3.0/cachet_monitor_linux_amd64
 RUN cd /cachet-monitor && chmod +x ./cachet_monitor_linux_amd64 && mv cachet_monitor_linux_amd64 /bin/cachet-monitor
 
-ENTRYPOINT cachet-monitor -c /etc/cachet-monitor.config.json
+ENTRYPOINT sleep 3 && cachet-monitor -c /etc/cachet-monitor.config.json

--- a/status/monitor/config.json
+++ b/status/monitor/config.json
@@ -1,0 +1,49 @@
+{
+  "api": {
+    "url": "https://demo.cachethq.io/api/v1",
+    "token": "9yMHsdioQosnyVK4iCVR",
+    "insecure": false
+  },
+  "date_format": "02/01/2006 15:04:05 MST",
+  "monitors": [
+    {
+      "name": "td-pdf",
+      "target": "https://api.trackdechets.beta.gouv.fr/health/td-pdf",
+      "strict": true,
+      "method": "GET",
+      "component_id": 1,
+      "metric_id": 1,
+      "interval": 5,
+      "timeout": 5,
+      "threshold": 80,
+      "expected_status_code": 200,
+      "expected_body": "ok: true"
+    },
+    {
+      "name": "td-insee",
+      "target": "https://api.trackdechets.beta.gouv.fr/health/td-insee",
+      "strict": true,
+      "method": "GET",
+      "component_id": 1,
+      "metric_id": 1,
+      "interval": 5,
+      "timeout": 5,
+      "threshold": 80,
+      "expected_status_code": 200,
+      "expected_body": "ok: true"
+    },
+    {
+      "name": "td-mail",
+      "target": "https://api.trackdechets.beta.gouv.fr/health/td-mail",
+      "strict": true,
+      "method": "GET",
+      "component_id": 1,
+      "metric_id": 1,
+      "interval": 5,
+      "timeout": 5,
+      "threshold": 80,
+      "expected_status_code": 200,
+      "expected_body": "ok: true"
+    }
+  ]
+}

--- a/status/monitor/config.json
+++ b/status/monitor/config.json
@@ -7,8 +7,8 @@
   "date_format": "02/01/2006 15:04:05 MST",
   "monitors": [
     {
-      "name": "td-pdf",
-      "target": "https://api.trackdechets.beta.gouv.fr/health/td-pdf",
+      "name": "td-api",
+      "target": "https://api.trackdechets.beta.gouv.fr/health",
       "strict": true,
       "method": "GET",
       "component_id": 1,
@@ -19,12 +19,22 @@
       "expected_status_code": 200
     },
     {
+      "name": "td-pdf",
+      "target": "https://api.trackdechets.beta.gouv.fr/health/td-pdf",
+      "strict": true,
+      "method": "GET",
+      "component_id": 2,
+      "interval": 5,
+      "timeout": 5,
+      "threshold": 80,
+      "expected_status_code": 200
+    },
+    {
       "name": "td-insee",
       "target": "https://api.trackdechets.beta.gouv.fr/health/td-insee",
       "strict": true,
       "method": "GET",
-      "component_id": 2,
-      "metric_id": 2,
+      "component_id": 4,
       "interval": 5,
       "timeout": 5,
       "threshold": 80,
@@ -36,7 +46,6 @@
       "strict": true,
       "method": "GET",
       "component_id": 3,
-      "metric_id": 3,
       "interval": 5,
       "timeout": 5,
       "threshold": 80,

--- a/status/monitor/config.json
+++ b/status/monitor/config.json
@@ -1,8 +1,8 @@
 {
   "api": {
-    "url": "https://demo.cachethq.io/api/v1",
-    "token": "9yMHsdioQosnyVK4iCVR",
-    "insecure": false
+    "url": "http://cachet:8000/api/v1",
+    "token": "5LWYCXWaUbLcgefjoNXh",
+    "insecure": true
   },
   "date_format": "02/01/2006 15:04:05 MST",
   "monitors": [
@@ -16,34 +16,31 @@
       "interval": 5,
       "timeout": 5,
       "threshold": 80,
-      "expected_status_code": 200,
-      "expected_body": "ok: true"
+      "expected_status_code": 200
     },
     {
       "name": "td-insee",
       "target": "https://api.trackdechets.beta.gouv.fr/health/td-insee",
       "strict": true,
       "method": "GET",
-      "component_id": 1,
-      "metric_id": 1,
+      "component_id": 2,
+      "metric_id": 2,
       "interval": 5,
       "timeout": 5,
       "threshold": 80,
-      "expected_status_code": 200,
-      "expected_body": "ok: true"
+      "expected_status_code": 200
     },
     {
       "name": "td-mail",
       "target": "https://api.trackdechets.beta.gouv.fr/health/td-mail",
       "strict": true,
       "method": "GET",
-      "component_id": 1,
-      "metric_id": 1,
+      "component_id": 3,
+      "metric_id": 3,
       "interval": 5,
       "timeout": 5,
       "threshold": 80,
-      "expected_status_code": 200,
-      "expected_body": "ok: true"
+      "expected_status_code": 200
     }
   ]
 }


### PR DESCRIPTION
- ajout de routes `/health/*` pour pouvoir monitorer la santé des différents services. On renvoi une 200 si le service est up, une 503 sinon (Service Unavailable). On ajoute également un temps de réponse quand le service est up, afin de pouvoir dessiner si besoin sur un graph les temps de réponse dans le temps de nos services.
- ajout d'un dossier `status` avec tout ce qu'il faut pour runner un [cachet](https://cachethq.io/). C'est les docker qui vont bien et la config du plugin [cachet-monitor](https://github.com/castawaylabs/cachet-monitor) qui permet de monitorer automatiquement les services. Le cachet permet également d'ajouter des incidents à la main si besoin.

Il reste à finaliser la configuration du `cachet-monitor`, mais tant que les routes `/health` ne sont pas en place c'est difficile à tester. Je pense qu'on pourrait donc merger en checkant surtout ces routes là, et je referai une PR pour amender la config du monitor dans `/status/monitor/config.json`

Le cachet a commencé à etre deployé sur le serveur discourse, les informations de connexion sont dans le Trello.