### PR TITLE
Mise à jour des liens vers les fiche ICPE

### DIFF
--- a/back/src/companies/resolvers.ts
+++ b/back/src/companies/resolvers.ts
@@ -42,6 +42,8 @@ export default {
     }
   },
   Installation: {
+    urlFiche: parent =>
+      `https://www.georisques.gouv.fr/dossiers/installations/donnees/details/${parent.codeS3ic}#/`,
     rubriques: async parent => getRubriques(parent.codeS3ic),
     declarations: async parent => getDeclarations(parent.codeS3ic)
   },

--- a/front/src/form/Recipient.tsx
+++ b/front/src/form/Recipient.tsx
@@ -23,7 +23,7 @@ export default connect<{}, Values>(function Recipient({ formik }) {
           Pour vous assurer que l'entreprise de destination est autorisée à
           recevoir le déchet, vous pouvez consulter{" "}
           <a
-            href="http://www.installationsclassees.developpement-durable.gouv.fr/rechercheICForm.php"
+            href="https://www.georisques.gouv.fr/dossiers/installations/donnees#/"
             target="_blank"
           >
             la liste des installation classées.


### PR DESCRIPTION
[https://trello.com/c/4TqD6y8B](https://trello.com/c/4TqD6y8B)

Mise à jour des liens vers les fiches détail ICPE suite à la fermeture du site [http://www.installationsclassees.developpement-durable.gouv.fr/](http://www.installationsclassees.developpement-durable.gouv.fr/)