### PR TITLE
Enable API playground in production

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -59,6 +59,8 @@ const schemaWithMiddleware = applyMiddleware(
 
 export const server = new ApolloServer({
   schema: schemaWithMiddleware,
+  introspection: true, // used to enable the playground in production
+  playground: true, // used to enable the playground in production
   context: async ctx => ({
     ...ctx,
     user: await getUser(ctx.req),


### PR DESCRIPTION
Effet de bord suite à [https://github.com/MTES-MCT/trackdechets/pull/102](https://github.com/MTES-MCT/trackdechets/pull/102) et au remplacement de `graphql-yoga`

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/2269165/72165983-b3214800-33c8-11ea-8447-2ab495bd3721.png">

https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/#enabling-graphql-playground-in-production 