### PR TITLE
Téléchargement de fichiers

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -5,6 +5,8 @@ DOC_HOST=doc-td.local
 ETL_HOST=etl-td.local
 METABASE_HOST=metabase-td.local
 
+URL_SCHEME=https
+
 EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr
 
 POSTGRES_HOST=12.345.67.89|postgres

--- a/back/src/common/__tests__/file-download.test.ts
+++ b/back/src/common/__tests__/file-download.test.ts
@@ -1,0 +1,81 @@
+import { downloadFileHandler, getFileDownloadToken } from "../file-download";
+
+const res: any = {};
+res.status = jest.fn().mockReturnValue(res);
+res.send = jest.fn().mockReturnValue(res);
+
+const redisGetMock: any = jest.fn(() => Promise.reject(null));
+const setInCacheMock = jest.fn(() => Promise.resolve());
+
+jest.mock("../redis", () => ({
+  redis: { get: () => redisGetMock() },
+  setInCache: () => setInCacheMock()
+}));
+
+describe("File download token", () => {
+  const handler = () => null;
+
+  it("should set token in cache", async () => {
+    await getFileDownloadToken({ type: "A_TYPE", params: null }, handler);
+
+    expect(setInCacheMock).toHaveBeenCalled();
+  });
+
+  it("should return token and link", async () => {
+    const res = await getFileDownloadToken(
+      { type: "A_TYPE", params: null },
+      handler
+    );
+
+    expect(res.token).not.toBeNull();
+    expect(res.downloadLink).not.toBeNull();
+  });
+
+  it("should return different tokens every time", async () => {
+    const res1 = await getFileDownloadToken(
+      { type: "A_TYPE", params: null },
+      handler
+    );
+    const res2 = await getFileDownloadToken(
+      { type: "A_TYPE", params: null },
+      handler
+    );
+
+    expect(res1.token).not.toBe(res2.token);
+  });
+});
+
+describe("File download handler", () => {
+  beforeEach(() => jest.restoreAllMocks());
+
+  test("should return an error when token does not exist", async () => {
+    await downloadFileHandler({ query: { token: "TOKEN" } } as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test("should return an error when token refer to an unknown type", async () => {
+    redisGetMock.mockResolvedValue(
+      JSON.stringify({ type: "UNKNOWN", params: null })
+    );
+
+    await downloadFileHandler({ query: { token: "TOKEN" } } as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  test("should work when token and type are known", async () => {
+    redisGetMock.mockResolvedValue(
+      JSON.stringify({ type: "EXISTS", params: null })
+    );
+    const fileDownloader = jest.fn();
+    await getFileDownloadToken(
+      { type: "EXISTS", params: null },
+      fileDownloader
+    );
+
+    await downloadFileHandler({ query: { token: "TOKEN" } } as any, res);
+
+    expect(fileDownloader).toHaveBeenCalled();
+  });
+});

--- a/back/src/common/__tests__/rules.test.ts
+++ b/back/src/common/__tests__/rules.test.ts
@@ -1,6 +1,6 @@
 import { Rule, RuleAnd } from "graphql-shield/dist/rules";
 
-import { isCompanyAdmin, isCompanyMember } from "../rules";
+import { isCompanyAdmin, isCompanyMember, isCompaniesUser } from "../rules";
 import { GraphQLResolveInfo } from "graphql";
 
 describe("isCompanyAdmin", () => {
@@ -87,6 +87,38 @@ describe("isCompanyMember", () => {
     const result = await testRule(isCompanyMember)(
       null,
       { siret: "85001946400013" },
+      { user: { id: "id" }, prisma }
+    );
+    expect(result).toBeInstanceOf(Error);
+  });
+});
+
+describe("isCompaniesUser", () => {
+  it("should return true if the user is user of the companies", async () => {
+    const prisma = {
+      companyAssociations: jest.fn()
+    };
+
+    prisma.companyAssociations.mockResolvedValueOnce([{ role: "ADMIN" }]);
+    prisma.companyAssociations.mockResolvedValueOnce([{ role: "MEMBER" }]);
+    const result = await testRule(isCompaniesUser)(
+      null,
+      { sirets: ["85001946400013", "85001946400014"] },
+      { user: { id: "id" }, prisma }
+    );
+    expect(result).toBe(true);
+  });
+
+  it("should return false if the user does not belong to one of the company", async () => {
+    const prisma = {
+      companyAssociations: jest.fn()
+    };
+
+    prisma.companyAssociations.mockResolvedValueOnce([{ role: "ADMIN" }]);
+    prisma.companyAssociations.mockResolvedValueOnce([]);
+    const result = await testRule(isCompaniesUser)(
+      null,
+      { sirets: ["85001946400013", "85001946400014"] },
       { user: { id: "id" }, prisma }
     );
     expect(result).toBeInstanceOf(Error);

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -34,7 +34,7 @@ export async function getFileDownloadToken(
   await setInCache(token, JSON.stringify({ type, params }), { EX: 10 });
   registerFileDownloader(type, downloadHandler);
 
-  return { token };
+  return { token, link: `https://${process.env.API_HOST}/download?token=${token}` };
 }
 
 /**
@@ -54,7 +54,7 @@ export async function downloadFileHandler(req: Request, res: Response) {
 
   const fileDownloader = fileDownloaders[type];
   if (!fileDownloader) {
-    return res.send(500).send("Type de fichier inconnu.");
+    return res.status(500).send("Type de fichier inconnu.");
   }
 
   return fileDownloader(res, params);

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -36,7 +36,7 @@ export async function getFileDownloadToken(
 
   return {
     token,
-    downloadLink: `${process.env.URL_SCHEME ?? "https"}://${
+    downloadLink: `${process.env.API_URL_SCHEME ?? "https"}://${
       process.env.API_HOST
     }/download?token=${token}`
   };

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { redis, setInCache } from "./redis";
-import { randomNumber } from "../utils";
+import { randomNumber, getAPIBaseURL } from "../utils";
 
 type DownloadInfos = { type: string; params: any };
 type DownloadHandler = (res: Response, params: any) => void | Promise<void>;
@@ -34,11 +34,10 @@ export async function getFileDownloadToken(
   await setInCache(token, JSON.stringify({ type, params }), { EX: 10 });
   registerFileDownloader(type, downloadHandler);
 
+  const API_BASE_URL = getAPIBaseURL()
   return {
     token,
-    downloadLink: `${process.env.API_URL_SCHEME ?? "https"}://${
-      process.env.API_HOST
-    }/download?token=${token}`
+    downloadLink: `${API_BASE_URL}/download?token=${token}`
   };
 }
 

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -36,7 +36,9 @@ export async function getFileDownloadToken(
 
   return {
     token,
-    downloadLink: `https://${process.env.API_HOST}/download?token=${token}`
+    downloadLink: `${process.env.URL_SCHEME ?? "https"}://${
+      process.env.API_HOST
+    }/download?token=${token}`
   };
 }
 

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -5,6 +5,7 @@ import { randomNumber, getAPIBaseURL } from "../utils";
 type DownloadInfos = { type: string; params: any };
 type DownloadHandler = (res: Response, params: any) => void | Promise<void>;
 
+// TODO register downloaders on server start if code is distributed on several machines
 const fileDownloaders = {};
 function registerFileDownloader(
   type: string,

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from "express";
+import { redis, setInCache } from "./redis";
+import { randomNumber } from "../utils";
+
+type DownloadInfos = { type: string; params: any };
+type DownloadHandler = (res: Response, params: any) => void | Promise<void>;
+
+const fileDownloaders = {};
+function registerFileDownloader(
+  type: string,
+  downloadHandler: DownloadHandler
+) {
+  if (type in fileDownloaders && fileDownloaders[type] !== downloadHandler) {
+    throw new Error(
+      `Type "${type}" is already registered as downloadable with an handler.`
+    );
+  }
+  fileDownloaders[type] = downloadHandler;
+}
+
+/**
+ * Basically the resolver implementation for Graphql downloadable types.
+ * It creates a token valid for 10 seconds and returns it.
+ * This token can then be used to download the desired file
+ * @param downloadInfos object `type` (must be unique) and some `params` passed to the handler
+ * @param downloadHandler the handler. Must output the file through the response object it receives
+ */
+export async function getFileDownloadToken(
+  { type, params }: DownloadInfos,
+  downloadHandler: DownloadHandler
+) {
+  const token = `${type}-${new Date().getTime()}-${randomNumber(4)}`;
+
+  await setInCache(token, JSON.stringify({ type, params }), { EX: 10 });
+  registerFileDownloader(type, downloadHandler);
+
+  return { token };
+}
+
+/**
+ * Handler for the /download route
+ * @param req
+ * @param res
+ */
+export async function downloadFileHandler(req: Request, res: Response) {
+  const { token } = req.query;
+  const redisValue = await redis.get(token).catch(_ => null);
+
+  if (redisValue == null) {
+    return res.status(403).send("Token invalide ou expiré.");
+  }
+
+  const { type, params }: DownloadInfos = JSON.parse(redisValue);
+
+  const fileDownloader = fileDownloaders[type];
+  if (!fileDownloader) {
+    return res.send(500).send("Type de fichier inconnu.");
+  }
+
+  return fileDownloader(res, params);
+}

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -34,7 +34,10 @@ export async function getFileDownloadToken(
   await setInCache(token, JSON.stringify({ type, params }), { EX: 10 });
   registerFileDownloader(type, downloadHandler);
 
-  return { token, link: `https://${process.env.API_HOST}/download?token=${token}` };
+  return {
+    token,
+    downloadLink: `https://${process.env.API_HOST}/download?token=${token}`
+  };
 }
 
 /**

--- a/back/src/common/redis.ts
+++ b/back/src/common/redis.ts
@@ -54,22 +54,30 @@ export async function cachedGet(
   try {
     const dbValue = await getter(itemKey);
 
-    const setOptions = Object.keys(options)
-      .map(key => {
-        const val = options[key];
-        // Some options don't have an associated value
-        if (isNaN(val)) {
-          return [key];
-        }
-        return [key, val];
-      })
-      .reduce((acc, val) => acc.concat(val), []);
-
     // No need to await the set, and it doesn't really matters if it fails
-    redis.set(cacheKey, parser.stringify(dbValue), setOptions).catch(_ => null);
+    setInCache(cacheKey, parser.stringify(dbValue), options).catch(_ => null);
 
     return dbValue;
   } catch (err) {
     throw err;
   }
+}
+
+export async function setInCache(
+  key: string,
+  value: any,
+  options: SetOptions = {}
+) {
+  const setOptions = Object.keys(options)
+    .map(key => {
+      const val = options[key];
+      // Some options don't have an associated value
+      if (isNaN(val)) {
+        return [key];
+      }
+      return [key, val];
+    })
+    .reduce((acc, val) => acc.concat(val), []);
+
+  return redis.set(key, value, setOptions);
 }

--- a/back/src/forms/exports/handler.ts
+++ b/back/src/forms/exports/handler.ts
@@ -19,7 +19,7 @@ export async function downloadCsvExport(res, { sirets, exportType }) {
     res.set("Content-Type", "text/csv");
     res.status(200).send(csv);
   } catch (e) {
-    res.status(500).send(e.message);
+    res.status(400).send(e.message);
   }
 }
 

--- a/back/src/forms/exports/handler.ts
+++ b/back/src/forms/exports/handler.ts
@@ -10,7 +10,7 @@ enum ExportType {
 
 export async function downloadCsvExport(res, { sirets, exportType }) {
   if (!sirets?.length || !exportType) {
-    return res.status(500).send("Paramètres invalides.");
+    return res.status(400).send("Paramètres invalides.");
   }
 
   try {
@@ -19,7 +19,7 @@ export async function downloadCsvExport(res, { sirets, exportType }) {
     res.set("Content-Type", "text/csv");
     res.status(200).send(csv);
   } catch (e) {
-    res.status(400).send(e.message);
+    res.status(500).send(e.message);
   }
 }
 

--- a/back/src/forms/exports/handler.ts
+++ b/back/src/forms/exports/handler.ts
@@ -8,18 +8,20 @@ enum ExportType {
   OUTGOING = "OUTGOING"
 }
 
-export const csvExportHandler = async (req, res) => {
-  const { siret, exportType } = req.query;
+export async function downloadCsvExport(res, { sirets, exportType }) {
+  if (!sirets?.length || !exportType) {
+    return res.status(500).send("Paramètres invalides.");
+  }
 
   try {
-    const csv = await getCsvExport(siret.split(","), exportType);
+    const csv = await getCsvExport(sirets, exportType);
     res.setHeader("Content-disposition", "attachment; filename=export.csv");
     res.set("Content-Type", "text/csv");
     res.status(200).send(csv);
   } catch (e) {
     res.status(500).send(e.message);
   }
-};
+}
 
 async function getCsvExport(sirets: string[], exportType: ExportType) {
   const data = await getExportData(sirets, exportType);

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -238,6 +238,7 @@ type Stat {
 
 type FileDownload {
   token: String
+  downloadLink: String
 }
 
 enum FormsRegisterExportType {

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -18,6 +18,16 @@ type Query {
   `wasteCode`: Code déchet pour affiner la recherche, optionnel
   """
   appendixForms(siret: String!, wasteCode: String): [Form]
+  """
+  Renvoie un token pour télécharger un pdf de bordereau
+  Ce token doit être transmis à la route /download pour obtenir le fichier.
+  Il est valable 10 secondes
+  """
+  formPdf(id: ID): FileDownload
+  formsRegister(
+    sirets: [String]
+    exportType: FormsRegisterExportType
+  ): FileDownload
 }
 
 type Mutation {
@@ -224,4 +234,13 @@ type Stat {
   wasteCode: String
   incoming: Float
   outgoing: Float
+}
+
+type FileDownload {
+  token: String
+}
+
+enum FormsRegisterExportType {
+  INCOMING
+  OUTGOING
 }

--- a/back/src/forms/pdf.ts
+++ b/back/src/forms/pdf.ts
@@ -37,8 +37,11 @@ const buildPdf = async (form, responseType: ResponseType) => {
 /**
  * Render a form pdf as an HTTP response
  */
-export const pdfHandler = async (req, res) => {
-  const { id } = req.query;
+export async function downloadPdf(res, { id }) {
+  if (!id) {
+    return res.status(500).send("Identifiant du bordereau manquant.");
+  }
+
   const form = await prisma.form({ id });
 
   return buildPdf(form, "stream")
@@ -53,7 +56,7 @@ export const pdfHandler = async (req, res) => {
       }
       res.status(500).send("Erreur lors de la génération du PDF");
     });
-};
+}
 
 /**
  * Render a pdf converted to base64 string to be sent via Mailjet API

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,4 +1,4 @@
-import { and, or } from "graphql-shield";
+import { or } from "graphql-shield";
 
 import {
   canAccessForm,
@@ -15,6 +15,7 @@ import {
 export default {
   Query: {
     form: canAccessForm,
+    formPdf: canAccessForm,
     forms: isAuthenticated,
     stats: isAuthenticated,
     appendixForms: or(isCompanyMember, isCompanyAdmin)

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -9,13 +9,15 @@ import {
 import {
   isAuthenticated,
   isCompanyMember,
-  isCompanyAdmin
+  isCompanyAdmin,
+  isCompaniesUser
 } from "../common/rules";
 
 export default {
   Query: {
     form: canAccessForm,
     formPdf: canAccessForm,
+    formsRegister: isCompaniesUser,
     forms: isAuthenticated,
     stats: isAuthenticated,
     appendixForms: or(isCompanyMember, isCompanyAdmin)

--- a/back/src/forms/queries/form-pdf.ts
+++ b/back/src/forms/queries/form-pdf.ts
@@ -1,0 +1,8 @@
+import { getFileDownloadToken } from "../../common/file-download";
+import { downloadPdf } from "../pdf";
+
+const TYPE = "form_pdf";
+
+export function formPdf(_, { id }) {
+  return getFileDownloadToken({ type: TYPE, params: { id } }, downloadPdf);
+}

--- a/back/src/forms/queries/forms-register.ts
+++ b/back/src/forms/queries/forms-register.ts
@@ -1,0 +1,11 @@
+import { getFileDownloadToken } from "../../common/file-download";
+import { downloadCsvExport } from "../exports/handler";
+
+const TYPE = "forms_register";
+
+export function formsRegister(_, { sirets, exportType }) {
+  return getFileDownloadToken(
+    { type: TYPE, params: { sirets, exportType } },
+    downloadCsvExport
+  );
+}

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -15,6 +15,8 @@ import { saveForm } from "./mutations/save-form";
 import { getReadableId } from "./readable-id";
 import { getUserCompanies } from "../companies/queries";
 import { DomainError, ErrorCode } from "../common/errors";
+import { formPdf } from "./queries/form-pdf";
+import { formsRegister } from "./queries/forms-register";
 
 export default {
   Form: {
@@ -119,7 +121,9 @@ export default {
       });
 
       return forms.map(f => unflattenObjectFromDb(f));
-    }
+    },
+    formPdf,
+    formsRegister
   },
   Mutation: {
     saveForm,

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -14,8 +14,7 @@ import { sentry } from "graphql-middleware-sentry";
 import { shield } from "graphql-shield";
 import { fileLoader, mergeResolvers, mergeTypes } from "merge-graphql-schemas";
 import { authRouter } from "./routers/auth-router";
-import { csvExportHandler } from "./forms/exports/handler";
-import { pdfHandler } from "./forms/pdf";
+import { downloadFileHandler } from "./common/file-download";
 import { prisma } from "./generated/prisma-client";
 import { healthRouter } from "./health";
 import { userActivationHandler } from "./users/activation";
@@ -157,8 +156,7 @@ app.use(authRouter);
 
 app.get("/ping", (_, res) => res.send("Pong!"));
 app.get("/userActivation", userActivationHandler);
-app.get("/pdf", pdfHandler);
-app.get("/exports", csvExportHandler);
+app.get("/download", downloadFileHandler);
 app.use("/health", healthRouter);
 
 // GraphQL endpoint

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -174,10 +174,10 @@ app.use(graphQLPath, passportBearerMiddleware, passportJwtMiddleware);
 
 // TODO Remove
 app.get("/pdf", (_, res) =>
-  res.send("Route dépréciée, utilisez la query GraphQL `formPdf`")
+  res.status(410).send("Route dépréciée, utilisez la query GraphQL `formPdf`")
 );
 app.get("/exports", (_, res) =>
-  res.send("Route dépréciée, utilisez la query GraphQL `formsRegister`")
+  res.status(410).send("Route dépréciée, utilisez la query GraphQL `formsRegister`")
 );
 
 server.applyMiddleware({

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -172,6 +172,14 @@ app.use(graphQLPath, passportBearerMiddleware, passportJwtMiddleware);
  * See https://developer.mozilla.org/fr/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
  */
 
+// TODO Remove
+app.get("/pdf", (_, res) =>
+  res.send("Route dépréciée, utilisez la query GraphQL `formPdf`")
+);
+app.get("/exports", (_, res) =>
+  res.send("Route dépréciée, utilisez la query GraphQL `formsRegister`")
+);
+
 server.applyMiddleware({
   app,
   cors: {

--- a/back/src/users/activation.ts
+++ b/back/src/users/activation.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../generated/prisma-client";
+import { getUIBaseURL } from "../utils";
 
 export const userActivationHandler = async (req, res) => {
   const { hash } = req.query;
@@ -18,5 +19,6 @@ export const userActivationHandler = async (req, res) => {
     data: { isActive: true }
   });
 
-  return res.redirect(`https://${process.env.UI_HOST}`);
+  const UI_BASE_URL = getUIBaseURL()
+  return res.redirect(UI_BASE_URL);
 };

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -49,6 +49,12 @@ export function getUIBaseURL() {
   return `${UI_URL_SCHEME}://${UI_HOST}`;
 }
 
+export function getAPIBaseURL() {
+  let { API_URL_SCHEME, API_HOST } = process.env;
+  API_URL_SCHEME = API_URL_SCHEME || "http";
+  return `${API_URL_SCHEME}://${API_HOST}`;
+}
+
 /**
  * Convert a date to midnight the same day
  * @param date

--- a/front/src/common/DownloadFileLink.tsx
+++ b/front/src/common/DownloadFileLink.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useLazyQuery } from "@apollo/react-hooks";
+import { DocumentNode } from "graphql";
+import { useEffect } from "react";
+
+type Props = {
+  query: DocumentNode;
+  params: any;
+  children?: any;
+};
+
+export default function DownloadFileLink({
+  query,
+  params,
+  children,
+  ...props
+}: Props & any) {
+  const [downloadFile, { data }] = useLazyQuery(query);
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    const key = Object.keys(data)[0];
+    if (data[key].downloadLink) {
+      window.open(data[key].downloadLink, "_blank");
+    }
+  }, [data]);
+
+  return (
+    <button
+      className="link"
+      {...props}
+      onClick={() => downloadFile({ variables: params })}
+    >
+      {children}
+    </button>
+  );
+}

--- a/front/src/common/DownloadFileLink.tsx
+++ b/front/src/common/DownloadFileLink.tsx
@@ -15,7 +15,9 @@ export default function DownloadFileLink({
   children,
   ...props
 }: Props & any) {
-  const [downloadFile, { data }] = useLazyQuery(query);
+  const [downloadFile, { data }] = useLazyQuery(query, {
+    fetchPolicy: "network-only"
+  });
 
   useEffect(() => {
     if (!data) {

--- a/front/src/dashboard/exports/exports.tsx
+++ b/front/src/dashboard/exports/exports.tsx
@@ -3,6 +3,7 @@ import { Me } from "../../login/model";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
 import Loader from "../../common/Loader";
+import DownloadFileLink from "../../common/DownloadFileLink";
 
 interface IProps {
   me: Me;
@@ -23,10 +24,16 @@ const GET_STATS = gql`
   }
 `;
 
+const FORMS_REGISTER = gql`
+  query FormsRegister($sirets: [String], $exportType: FormsRegisterExportType) {
+    formsRegister(sirets: $sirets, exportType: $exportType) {
+      downloadLink
+    }
+  }
+`;
+
 export default function Exports({ me }: IProps) {
-  const [sirets, setSirets] = useState(
-    me.companies.map(c => c.siret).join(",")
-  );
+  const [sirets, setSirets] = useState(me.companies.map(c => c.siret));
   const { loading, error, data } = useQuery(GET_STATS);
 
   return (
@@ -71,10 +78,8 @@ export default function Exports({ me }: IProps) {
       {me.companies.length > 1 && (
         <p>
           Pour quelle entreprise(s) souhaitez vous télécharger le registre ?{" "}
-          <select onChange={evt => setSirets(evt.target.value)}>
-            <option value={me.companies.map(c => c.siret).join(",")}>
-              Toutes
-            </option>
+          <select onChange={evt => setSirets([evt.target.value])}>
+            <option value={me.companies.map(c => c.siret)}>Toutes</option>
             {me.companies.map(c => (
               <option value={c.siret} key={c.siret}>
                 {c.name}
@@ -83,22 +88,20 @@ export default function Exports({ me }: IProps) {
           </select>
         </p>
       )}
-      <a
+      <DownloadFileLink
+        query={FORMS_REGISTER}
+        params={{ sirets, exportType: "OUTGOING" }}
         className="button"
-        target="_blank"
-        rel="noopener noreferrer"
-        href={`${process.env.REACT_APP_API_ENDPOINT}/exports?exportType=OUTGOING&siret=${sirets}`}
       >
         Registre de déchets sortants
-      </a>
-      <a
+      </DownloadFileLink>
+      <DownloadFileLink
+        query={FORMS_REGISTER}
+        params={{ sirets, exportType: "INCOMING" }}
         className="button"
-        target="_blank"
-        rel="noopener noreferrer"
-        href={`${process.env.REACT_APP_API_ENDPOINT}/exports?exportType=INCOMING&siret=${sirets}`}
       >
         Registre de déchets entrants
-      </a>
+      </DownloadFileLink>
     </div>
   );
 }

--- a/front/src/dashboard/slips/slips-actions/DownloadPdf.tsx
+++ b/front/src/dashboard/slips/slips-actions/DownloadPdf.tsx
@@ -1,18 +1,27 @@
 import React from "react";
 import { FaFilePdf } from "react-icons/fa";
+import DownloadFileLink from "../../../common/DownloadFileLink";
+import gql from "graphql-tag";
 
 type Props = { formId: string };
 
+export const FORMS_PDF = gql`
+  query FormPdf($id: ID) {
+    formPdf(id: $id) {
+      downloadLink
+      token
+    }
+  }
+`;
+
 export default function DownloadPdf({ formId }: Props) {
   return (
-    <a
-      className="icon"
-      href={`${process.env.REACT_APP_API_ENDPOINT}/pdf?id=${formId}`}
-      target="_blank"
-      rel="noopener noreferrer"
+    <DownloadFileLink
+      query={FORMS_PDF}
+      params={{ id: formId }}
       title="Télécharger le PDF"
     >
       <FaFilePdf />
-    </a>
+    </DownloadFileLink>
   );
 }

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -4,10 +4,12 @@ import gql from "graphql-tag";
 import { DateTime } from "luxon";
 import React, { useState } from "react";
 import { FaFileSignature } from "react-icons/fa";
+import DownloadFileLink from "../../common/DownloadFileLink";
 import RedErrorMessage from "../../common/RedErrorMessage";
 import { Form as FormModel } from "../../form/model";
 import Packagings from "../../form/packagings/Packagings";
 import { currentSiretService } from "../CompanySelector";
+import { FORMS_PDF } from "../slips/slips-actions/DownloadPdf";
 import { GET_TRANSPORT_SLIPS } from "./Transport";
 import "./TransportSignature.scss";
 import { Wizard } from "./Wizard";
@@ -165,13 +167,12 @@ export default function TransportSignature({ form }: Props) {
                       <p>
                         <small>
                           Si vous le désirez, vous pouvez accéder à{" "}
-                          <a
-                            href={`${process.env.REACT_APP_API_ENDPOINT}/pdf?id=${form.id}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          <DownloadFileLink
+                            query={FORMS_PDF}
+                            params={{ id: form.id }}
                           >
                             une vue CERFA du bordereau
-                          </a>
+                          </DownloadFileLink>
                         </small>
                       </p>
                     </>


### PR DESCRIPTION
Proposition pour les téléchargements de fichier.

- on a un problème actuellement car les routes ne sont pas sécurisées
- on ne peut pas sécuriser avec des shields comme le reste de l'app puisque ce ne sont pas des endpoints graphql
- mais graphql est vraiment fait pour retourner du JSON et non des fichiers. Retourner un base64encode est loin d'être idéal

Au lieu de doublonner la sécurité pour gérer les endpoints REST (complexite en +, risque de desynchro des règles...) je propose:
- de remplacer les endpoints REST par des endpoints GraphQL sécurisés (`/pdf` => `Query { formPdf }`, `/export` => `{ Query { formsRegister }`). Chaque endpoint renvoi un jeton de téléchargement 
- de créer un unique endpoint `/download?token=...` qui consumme ce jeton

Ce token, grace à Redis a une durée de vie de 10sec (arbitraire) et est aléatoire. Personne ne peut donc le deviner.

Coté front, on fait juste 2 requetes au lieu d'une. Example:

```
getFormPdf("form_id")
    .then(({ token, link }) => fetch(link))
``` 

Avec `getFormPdf(id)`:

```
{
formPdf(id: "form_id") { token link }
}
// Retourne {token: "a_token", link: "https://server/download?token=a_token"}
```

NB: nouvelle variable d'en `URL_SCHEME`, pour les liens en `http` en dev