### PR TITLE
Allow application/graphql headers

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -16,6 +16,7 @@
     "@sentry/node": "^5.8.0",
     "apollo-server-express": "^2.9.13",
     "axios": "^0.18.1",
+    "body-parser-graphql": "^1.1.0",
     "bcrypt": "^3.0.7",
     "dataloader": "^1.4.0",
     "express": "^4.17.1",

--- a/back/src/__tests__/api-requests.integration.ts
+++ b/back/src/__tests__/api-requests.integration.ts
@@ -1,0 +1,53 @@
+import { sign } from "jsonwebtoken";
+import axios from "axios";
+
+import { resetDatabase } from "../../integration-tests/helper";
+import { server } from "../server";
+import { createTestClient } from "apollo-server-testing";
+import { userFactory } from "./factories";
+
+const { JWT_SECRET } = process.env;
+
+describe("Perform api requests", () => {
+  afterAll(async () => {
+    await resetDatabase();
+  });
+
+  test("query request with application/json header", async () => {
+    const user = await userFactory();
+
+    const token = sign({ userId: user.id }, JWT_SECRET, { expiresIn: "1d" });
+
+    const res = await axios({
+      method: "POST",
+      url: "http://td-api/account/api",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      data: {
+        query: "{   me {    id   email } } "
+      }
+    });
+
+    expect(res.data.data.me.email).toEqual(user.email);
+  });
+
+  test("query request with application/graphql header", async () => {
+    const user2 = await userFactory();
+
+    const token = sign({ userId: user2.id }, JWT_SECRET, { expiresIn: "1d" });
+
+    const res = await axios({
+      method: "POST",
+      url: "http://td-api/account/api",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/graphql"
+      },
+      data: "{   me {     id   email  } } "
+    });
+
+    expect(res.data.data.me.email).toEqual(user2.email);
+  });
+});

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -6,6 +6,7 @@ import { applyMiddleware } from "graphql-middleware";
 import { sentry } from "graphql-middleware-sentry";
 import { shield } from "graphql-shield";
 import { fileLoader, mergeResolvers, mergeTypes } from "merge-graphql-schemas";
+import * as bodyParser from "body-parser-graphql";
 
 import { getUser } from "./auth";
 import { csvExportHandler } from "./forms/exports/handler";
@@ -68,16 +69,15 @@ export const server = new ApolloServer({
   })
 });
 
-
-
 export const app = express();
+app.use(bodyParser.graphql()); // allow application/graphql header
 
 app.get("/ping", (_, res) => res.send("Pong!"));
 app.get("/userActivation", userActivationHandler);
 app.get("/pdf", pdfHandler);
 app.get("/exports", csvExportHandler);
 app.use("/health", healthRouter);
-
+ app.use(bodyParser.graphql());
 server.applyMiddleware({
   app,
   cors: {


### PR DESCRIPTION
Ce header était géré nativement par yoga, ce n'est pas le cas par apollo-server.