### PR TITLE
Upgrade metabase version

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -141,7 +141,7 @@ services:
       - ./etl/code/tests:/usr/local/airflow/tests
 
   metabase:
-    image: metabase/metabase
+    image: metabase/metabase:v0.34.2
     volumes:
       - metabase:/metabase-data
     environment:

--- a/docker-compose.val.yml
+++ b/docker-compose.val.yml
@@ -140,7 +140,7 @@ services:
       AIRFLOW_CONN_POSTGRES_PRISMA: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/prisma
 
   metabase:
-    image: metabase/metabase
+    image: metabase/metabase:v0.34.2
     volumes:
       - metabase:/metabase-data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,7 @@ services:
       AIRFLOW_CONN_POSTGRES_PRISMA: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/prisma
 
   metabase:
-    image: metabase/metabase
+    image: metabase/metabase:v0.34.2
     volumes:
       - metabase:/metabase-data
     environment:


### PR DESCRIPTION
La dernière version de metabase présents des features intéressantes. 
On pourrait mettre `metabase:latest` mais cela peut conduire à des surprises lors de mise en prod. Du coup je pense qu'il vaut mieux spécifier la version explicitement et faire des mises à jour à la main.