### PR TITLE
Update integration-tests/run.sh

### DIFF
--- a/back/integration-tests/run.sh
+++ b/back/integration-tests/run.sh
@@ -19,8 +19,8 @@ startcontainers(){
 }
 
 stopcontainers(){
-    echo ">> Stopping containers 🛏️ ..."
-    docker-compose stop
+    echo ">> Removing containers 🛏️ ..."
+    docker-compose rm --stop -v --force
 }
 
 runtest(){


### PR DESCRIPTION
## Problème

* Je travaille sur une branche `feat/magic` et je modifie les modèles prisma par rapport à `dev`
* Je fais tourner les tests d'intégration. La base de données d'intégration se synchronise avec les nouveaux modèles prisma. 
* À la fin du run des tests, les containers sont bien arrêtés mais les volumes anonymes associés sont conservés. 
* Je retourne sur `dev` et je fais tourner les tests d'intégration. Ma base de données de test est toujours synchronisée avec les modèles de `feat/magic`. `prisma deploy` applique donc une migration mais qui va dans le sens inverse de l'évolution des modèles et peut demander de force. J'ai même eu un soucis de base complètement corrompue. 

## Solution 
On peut donc envisager de supprimer les containers après les avoir stoppé pour être sur de repartir d'une base de données complètement vierge.
