### PR TITLE
Docstring du schéma GraphQL et génération d'une référence de l'API

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -1734,7 +1734,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -2923,6 +2923,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -3093,7 +3099,7 @@
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -3184,7 +3190,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -3892,12 +3898,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3917,7 +3925,8 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4065,6 +4074,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4528,7 +4538,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -4660,6 +4670,20 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "graphql-markdown": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-markdown/-/graphql-markdown-5.2.0.tgz",
+      "integrity": "sha512-4y/H/m7sjr+IIpAcLutGdOq+cYEApCdS9RFXfheTUFqjS7EzuaD1SDl6mMJ1hppbuq+9DNMy2Nu2QXnX0JA5xA==",
+      "dev": true,
+      "requires": {
+        "deep-diff": "^1.0.2",
+        "graphql": "^14.0.2",
+        "lodash.isplainobject": "^4.0.6",
+        "minimist": "^1.2.0",
+        "node-fetch": "^2.2.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "graphql-middleware": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-4.0.2.tgz",
@@ -4695,36 +4719,6 @@
       "dev": true,
       "requires": {
         "cross-fetch": "2.2.2"
-      }
-    },
-    "graphql-shield": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-shield/-/graphql-shield-7.0.4.tgz",
-      "integrity": "sha512-+SEz/tKx2uJAbMKzS7X0hCUWsZo54J8SARhXb5jNDG/RKur44mjIGfBnuBRszw73+dUdBvTlLl1j1WKwm0ZhEA==",
-      "requires": {
-        "@types/yup": "0.26.26",
-        "object-hash": "^2.0.0",
-        "yup": "^0.27.0"
-      },
-      "dependencies": {
-        "@types/yup": {
-          "version": "0.26.26",
-          "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.26.tgz",
-          "integrity": "sha512-5cLJLd8NIT7OfJLi7ScquRn/NWfmewBqJ92nT/FYfdpgKzyUNcR4n2BKEOQ7mOG8WuJXgomIvNl5P3sn9Akd4A=="
-        },
-        "yup": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
-          "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "fn-name": "~2.0.1",
-            "lodash": "^4.17.11",
-            "property-expr": "^1.5.0",
-            "synchronous-promise": "^2.0.6",
-            "toposort": "^2.0.2"
-          }
-        }
       }
     },
     "graphql-tag": {
@@ -5301,7 +5295,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6259,7 +6253,7 @@
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -6269,7 +6263,7 @@
     "jws": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -6656,7 +6650,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memory-pager": {
@@ -6810,7 +6804,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -7270,11 +7264,6 @@
         }
       }
     },
-    "object-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
-      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
-    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -7390,12 +7379,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -7566,7 +7555,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -8666,7 +8655,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9315,7 +9304,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10093,7 +10082,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "whatwg-mimetype": {

--- a/back/package.json
+++ b/back/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "ts-node src/index.ts",
     "update": "ts-node prisma/scripts/index.ts",
+    "graphql-markdown": "ts-node src/scripts/graphql-markdown.ts",
     "test": "jest"
   },
   "keywords": [],
@@ -62,6 +63,7 @@
     "@types/yup": "^0.26.27",
     "apollo-server-integration-testing": "^2.3.0",
     "apollo-server-testing": "^2.9.13",
+    "graphql-markdown": "^5.2.0",
     "jest": "^24.9.0",
     "jsonwebtoken": "^8.5.1",
     "nodemon": "^2.0.2",

--- a/back/src/companies/companies.graphql
+++ b/back/src/companies/companies.graphql
@@ -1,42 +1,90 @@
-type Rubrique {
-  rubrique: String
-  alinea: String
-  etatActivite: String
-  regimeAutorise: String
-  activite: String
-  category: String
-  volume: String
-  unite: String
-  wasteType: WasteType
+
+type Query {
+
+  """
+  Renvoie des informations publiques sur un établissement
+  extrait de la base SIRENE et de la base des installations
+  classées pour la protection de l'environnement (ICPE)
+  """
+  companyInfos(
+    "SIRET de l'établissement"
+    siret: String!
+    ): CompanyPublic
+
+  """
+  Effectue une recherche floue sur la base SIRENE et enrichit
+  les résultats avec des informations provenant de Trackdéchets
+  """
+  searchCompanies(
+    """
+    Champ utilisé pour faire une recherche floue
+    sur la nom de l'établissement, ex: 'Boulangerie Dupont'
+    """
+    clue: String!,
+    "(Optionnel) Filtre les résultats par numéro de département"
+    department: Int
+    ): [CompanySearchResult]
+
+  """
+  Renvoie les établissements favoris de l'utilisateur. C'est à dire les
+  établissements qui font souvent partis des BSD édités
+  """
+  favorites(
+    "type de favoris"
+    type: FavoriteType!
+    ): [CompanyFavorite]
 }
 
-enum GerepType {
-  Producteur
-  Traiteur
+type Mutation {
+
+  """
+  USAGE INTERNE
+  Renouvelle le code de sécurité de l'établissement
+  """
+  renewSecurityCode(siret: String!): CompanyPrivate
+
+  """
+  USAGE INTERNE
+  Édite les informations d'un établissement
+  """
+  updateCompany(
+    "SIRET de l'établissement"
+    siret: String!
+    "(Optionnel) Identifiant GEREP"
+    gerepId: String
+    "(Optionnel) Email de contact"
+    contactEmail: String
+    "(Optionnel) Numéro de téléphone de contact"
+    contactPhone: String
+    "(Optionnel) Site web"
+    website: String
+    "(Optionnel) Profil de l'établissement"
+    companyTypes: [CompanyType]
+    "(Optionnel) Nom d'usage de l'établissement"
+    givenName: String
+  ): CompanyPrivate
+
+  """
+  USAGE INTERNE
+  Rattache un établissement à l'utilisateur authentifié
+  """
+  createCompany(companyInput: PrivateCompanyInput!): CompanyPrivate
+
+  """
+  USAGE INTERNE
+  Récupère une URL signé pour l'upload d'un fichier
+  """
+  createUploadLink(
+    "nom du fichier"
+    fileName: String!,
+    "type de fichier"
+    fileType: String!
+    ): UploadLink
 }
 
-enum WasteType {
-  INERTE
-  NOT_DANGEROUS
-  DANGEROUS
-}
-
-type Declaration {
-  annee: String
-  codeDechet: String
-  libDechet: String
-  gerepType: GerepType
-}
-
-type Installation {
-  codeS3ic: String
-  urlFiche: String
-  rubriques: [Rubrique]
-  declarations: [Declaration]
-}
-
-"Liste des profils entreprise"
+"Profil entreprise"
 enum CompanyType {
+
   "Producteur de déchet"
   PRODUCER
 
@@ -59,16 +107,11 @@ enum CompanyType {
   TRADER
 }
 
-# Private company type accessed by a user
-# who is member of the company. Is is typically
-# accessed through `query { user { companies } }`
 
-"""
-Information sur un établissement accessible par un utilisateur membre
-"""
+"Information sur un établissement accessible par un utilisateur membre"
 type CompanyPrivate {
 
-  "Identifiant unique"
+  "Identifiant opaque"
   id: ID!
 
   "Profil de l'établissement"
@@ -77,7 +120,7 @@ type CompanyPrivate {
   "Identifiant GEREP"
   gerepId: String
 
-  "Code de sécurité"
+  "Code de sécurité permettant de signer les BSD"
   securityCode: Int!
 
   "Email de contact (visible sur la fiche entreprise)"
@@ -97,7 +140,8 @@ type CompanyPrivate {
 
   """
   Nom d'usage de l'entreprise qui permet de différencier
-  différents établissements ayant le même nom"""
+  différents établissements ayant le même nom
+  """
   givenName: String
 
   "SIRET de l'établissement"
@@ -123,7 +167,7 @@ type CompanyPrivate {
 
   """
   Installation classée pour la protection de l'environnement (ICPE)
-  associé à cet établissement
+  associé à cet établissement (le cas échéant)
   """
   installation: Installation
 }
@@ -169,12 +213,12 @@ type CompanyPublic {
   installation: Installation
 
   """
-  Si oui on non cet établissement est rattaché à un
-  utilisateur sur la plateforme Trackdéchets"""
+  Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets
+  """
   isRegistered: Boolean
 }
 
-"Information sur un établissement accessible en recherche"
+"Information sur un établissement accessible publiquement en recherche"
 type CompanySearchResult {
 
   "SIRET de l'établissement"
@@ -214,6 +258,7 @@ La liste des favoris est constituée à partir de l'historique des
 BSD édités
 """
 type CompanyFavorite {
+
   "Nom de l'établissement"
   name: String
 
@@ -233,67 +278,13 @@ type CompanyFavorite {
   mail: String
 }
 
-type Query {
-  """
-  Renvoie des informations publiques sur un établissement
-  extrait de la base SIRENE et de la base des installations
-  classées pour la protection de l'environnement (ICPE)
-  """
-  companyInfos(siret: String!): CompanyPublic
-
-  """
-  Effectue une recherche floue sur la base SIRENE et enrichit
-  les résultats avec des informations provenant de Trackdéchets
-  """
-  searchCompanies(clue: String!, department: Int): [CompanySearchResult]
-
-  """
-  Liste les établissements favoris de l'utilisateur. C'est à dire les
-  établissements qui font souvent partis des BSD édités
-  """
-  favorites(type: FavoriteType!): [CompanyFavorite]
-}
-
-type Mutation {
-
-  "Renouvelle le code de sécurité de l'établissement"
-  renewSecurityCode(siret: String!): CompanyPrivate
-
-  "Édite les informations d'un établissement"
-  updateCompany(
-    "SIRET de l'établissement"
-    siret: String!
-    "Identifiant GEREP"
-    gerepId: String
-    "Email de contact"
-    contactEmail: String
-    "Numéro de téléphone de contact"
-    contactPhone: String
-    "Site web"
-    website: String
-    "Profil de l'établissement"
-    companyTypes: [CompanyType]
-    "Nom d'usage de l'établissement"
-    givenName: String
-  ): CompanyPrivate
-
-  "Rattache un établissement à l'utilisateur authentifié"
-  createCompany(companyInput: PrivateCompanyInput!): CompanyPrivate
-
-  """
-  Renvoie une URL permettant de télécharger un fichier
-  Le fichier peut être par exemple un BSD au format .pdf
-  ou un registre au format .csv
-  """
-  createUploadLink(fileName: String!, fileType: String!): UploadLink
-}
-
+"Lien d'upload"
 type UploadLink {
 
-  "URL permettant de télécharger un fichier, protégée par une clé"
+  "URL signé permettant d'uploader un fichier"
   signedUrl: String
 
-  "Clé unique permettant le téléchargement de fichier. La clé expire au bout de 10 secondes"
+  "Clé permettant l'upload du fichier"
   key: String
 }
 
@@ -317,14 +308,15 @@ input PrivateCompanyInput {
 
   """
   Liste de documents permettant de démontrer l'appartenance
-  de l'utilisateur à l'établissement"""
+  de l'utilisateur à l'établissement
+  """
   documentKeys: [String]
 }
 
 "Information sur utilisateur au sein d'un établissement"
 type CompanyMember {
 
-  "Identifiant unique"
+  "Identifiant opaque"
   id: ID!
 
   "Email"
@@ -333,7 +325,7 @@ type CompanyMember {
   "Nom de l'utilisateur"
   name: String
 
-  "Rôle de l'utilisateur dans l'établissement (ADMIN or MEMBER)"
+  "Rôle de l'utilisateur dans l'établissement (admin ou membre)"
   role: UserRole
 
   "Si oui ou non l'email de l'utilisateur a été confirmé"
@@ -353,4 +345,96 @@ enum FavoriteType {
   RECIPIENT
   TRADER
   NEXT_DESTINATION
+}
+
+"""
+Rubrique ICPE d'un établissement avec les autorisations associées
+Pour plus de détails, se référer à la
+[nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
+"""
+type Rubrique {
+
+  """
+  Numéro de rubrique tel que défini dans la nomenclature des ICPE
+  Ex: 2710
+  """
+  rubrique: String
+
+  "Alinéa pour la rubrique concerné"
+  alinea: String
+
+  "État de l'activité, ex: 'En fonct', 'À l'arrêt'"
+  etatActivite: String
+
+  "Régime autorisé pour la rubrique: déclaratif, autorisation, seveso, etc"
+  regimeAutorise: String
+
+  """
+  Description de l'activité:
+  Ex: traitement thermique de déchets dangereux
+  """
+  activite: String
+
+  "Catégorie d'établissement associé: TTR, VHU, Traitement"
+  category: String
+
+  "Volume autorisé"
+  volume: String
+
+  "Unité utilisé pour le volume autorisé"
+  unite: String
+
+  "Type de déchets autorisé"
+  wasteType: WasteType
+}
+
+"Type d'une déclaration GEREP"
+enum GerepType {
+  Producteur
+  Traiteur
+}
+
+"Type de déchets autorisé pour une rubrique"
+enum WasteType {
+
+  "Déchet inerte"
+  INERTE
+
+  "Déchet non dangereux"
+  NOT_DANGEROUS
+
+  "Déchet dangereux"
+  DANGEROUS
+}
+
+"Représente une ligne dans une déclaration GEREP"
+type Declaration {
+
+  "Année de la déclaration"
+  annee: String
+
+  "Code du déchet"
+  codeDechet: String
+
+  "Description du déchet"
+  libDechet: String
+
+  "Type de déclaration GEREP: producteur ou traiteur"
+  gerepType: GerepType
+}
+
+"Installation pour la protection de l'environnement (ICPE)"
+type Installation {
+
+  "Identifiant S3IC"
+  codeS3ic: String
+
+  "URL de la fiche ICPE sur Géorisques"
+  urlFiche: String
+
+  "Liste des rubriques associées"
+  rubriques: [Rubrique]
+
+  "Liste des déclarations GEREP"
+  declarations: [Declaration]
 }

--- a/back/src/companies/companies.graphql
+++ b/back/src/companies/companies.graphql
@@ -35,153 +35,318 @@ type Installation {
   declarations: [Declaration]
 }
 
+"Liste des profils entreprise"
 enum CompanyType {
+  "Producteur de déchet"
   PRODUCER
+
+  "Installation de Transit, regroupement ou tri de déchets"
   COLLECTOR
+
+  "Installation de traitement"
   WASTEPROCESSOR
+
+  "Transporteur"
   TRANSPORTER
+
+  "Installation d'entreposage, dépollution, démontage, découpage de VHU"
   WASTE_VEHICLES
+
+  "Installation de collecte de déchets apportés par le producteur initial"
   WASTE_CENTER
+
+  "Négociant"
   TRADER
 }
 
 # Private company type accessed by a user
 # who is member of the company. Is is typically
 # accessed through `query { user { companies } }`
+
+"""
+Information sur un établissement accessible par un utilisateur membre
+"""
 type CompanyPrivate {
-  # Company info in Prisma
-  ########################
+
+  "Identifiant unique"
   id: ID!
+
+  "Profil de l'établissement"
   companyTypes: [CompanyType]
+
+  "Identifiant GEREP"
   gerepId: String
+
+  "Code de sécurité"
   securityCode: Int!
 
-  # Contact info (from prisma)
-  ###########################
+  "Email de contact (visible sur la fiche entreprise)"
   contactEmail: String
+
+  "Numéro de téléphone de contact (visible sur la fiche entreprise)"
   contactPhone: String
+
+  "Site web (visible sur la fiche entreprise)"
   website: String
 
-  # List of company members
+  "Liste des utilisateurs appartenant à cet établissement"
   users: [CompanyMember]
 
-  # Role of the logged in user in the company
+  "Rôle de l'utilisateur authentifié cau sein de cet établissement"
   userRole: UserRole
 
-  # Given name used in company selector
+  """
+  Nom d'usage de l'entreprise qui permet de différencier
+  différents établissements ayant le même nom"""
   givenName: String
 
-  # Company info from SIRENE
-  ##########################
+  "SIRET de l'établissement"
   siret: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom de l'établissement"
   name: String
+
+  "Code NAF de l'établissement"
   naf: String
+
+  "Libellé NAF de l'établissement"
   libelleNaf: String
+
+  "Longitude de l'établissement (info géographique)"
   longitude: Float
+
+  "Latitude de l'établissement (info géographique)"
   latitude: Float
 
-  # Company info from ICPE database
-  #################################
+  """
+  Installation classée pour la protection de l'environnement (ICPE)
+  associé à cet établissement
+  """
   installation: Installation
 }
 
-# Public company type that can be accessed
-# by a user who is not member of the company
-# (for example in the fiche entreprise)
+
+"Information sur un établissement accessible publiquement"
 type CompanyPublic {
-  # Contact info (from prisma)
-  ###########################
+
+  "Email de contact"
   contactEmail: String
+
+  "Numéro de téléphone de contact"
   contactPhone: String
+
+  "Site web"
   website: String
 
-  # Company info from SIRENE
-  ##########################
+  "SIRET de l'établissement"
   siret: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom de l'établissement"
   name: String
+
+  "Code NAF"
   naf: String
+
+  "Libellé NAF"
   libelleNaf: String
+
+  "Longitude de l'établissement (info géographique)"
   longitude: Float
+
+  "Latitude de l'établissement (info géographique)"
   latitude: Float
 
-  # Company info from ICPE database
+  """
+  Installation classée pour la protection de l'environnement (ICPE)
+  associé à cet établissement
+  """
   installation: Installation
 
-  # Whether or not this company is registered in TD
+  """
+  Si oui on non cet établissement est rattaché à un
+  utilisateur sur la plateforme Trackdéchets"""
   isRegistered: Boolean
 }
 
+"Information sur un établissement accessible en recherche"
 type CompanySearchResult {
-  # company info from SIRENE
+
+  "SIRET de l'établissement"
   siret: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom de l'établissement"
   name: String
+
+  "Profil de l'établissement"
   companyTypes: [CompanyType]
+
+  "Code NAF"
   naf: String
+
+  "Libellé NAF"
   libelleNaf: String
+
+  "Longitude de l'établissement (info géographique)"
   longitude: Float
+
+  "Latitude de l'établissement (info géographique)"
   latitude: Float
 
-  # company info from ICPE database
+  """
+  Installation classée pour la protection de l'environnement (ICPE)
+  associé à cet établissement
+  """
   installation: Installation
 }
 
+"""
+Information sur établissement accessible dans la liste des favoris
+La liste des favoris est constituée à partir de l'historique des
+BSD édités
+"""
 type CompanyFavorite {
+  "Nom de l'établissement"
   name: String
+
+  "SIRET de l'établissement"
   siret: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom du contact"
   contact: String
+
+  "Numéro de téléphone"
   phone: String
+
+  "Email de contact"
   mail: String
 }
 
 type Query {
+  """
+  Renvoie des informations publiques sur un établissement
+  extrait de la base SIRENE et de la base des installations
+  classées pour la protection de l'environnement (ICPE)
+  """
   companyInfos(siret: String!): CompanyPublic
+
+  """
+  Effectue une recherche floue sur la base SIRENE et enrichit
+  les résultats avec des informations provenant de Trackdéchets
+  """
   searchCompanies(clue: String!, department: Int): [CompanySearchResult]
+
+  """
+  Liste les établissements favoris de l'utilisateur. C'est à dire les
+  établissements qui font souvent partis des BSD édités
+  """
   favorites(type: FavoriteType!): [CompanyFavorite]
 }
 
 type Mutation {
+
+  "Renouvelle le code de sécurité de l'établissement"
   renewSecurityCode(siret: String!): CompanyPrivate
+
+  "Édite les informations d'un établissement"
   updateCompany(
+    "SIRET de l'établissement"
     siret: String!
+    "Identifiant GEREP"
     gerepId: String
+    "Email de contact"
     contactEmail: String
+    "Numéro de téléphone de contact"
     contactPhone: String
+    "Site web"
     website: String
+    "Profil de l'établissement"
     companyTypes: [CompanyType]
+    "Nom d'usage de l'établissement"
     givenName: String
   ): CompanyPrivate
+
+  "Rattache un établissement à l'utilisateur authentifié"
   createCompany(companyInput: PrivateCompanyInput!): CompanyPrivate
+
+  """
+  Renvoie une URL permettant de télécharger un fichier
+  Le fichier peut être par exemple un BSD au format .pdf
+  ou un registre au format .csv
+  """
   createUploadLink(fileName: String!, fileType: String!): UploadLink
 }
 
 type UploadLink {
+
+  "URL permettant de télécharger un fichier, protégée par une clé"
   signedUrl: String
+
+  "Clé unique permettant le téléchargement de fichier. La clé expire au bout de 10 secondes"
   key: String
 }
 
+"Payload permettant le rattachement d'un établissement à un utilisateur"
 input PrivateCompanyInput {
+
+  "SIRET de l'établissement"
   siret: String!
+
+  "Identifiant GEREP de l'établissement"
   gerepId: String
+
+  "Profil de l'établissement"
   companyTypes: [CompanyType]
+
+  "Code NAF"
   codeNaf: String
+
+  "Nom de l'établissement"
   companyName: String
+
+  """
+  Liste de documents permettant de démontrer l'appartenance
+  de l'utilisateur à l'établissement"""
   documentKeys: [String]
 }
 
+"Information sur utilisateur au sein d'un établissement"
 type CompanyMember {
+
+  "Identifiant unique"
   id: ID!
+
+  "Email"
   email: String!
+
+  "Nom de l'utilisateur"
   name: String
+
+  "Rôle de l'utilisateur dans l'établissement (ADMIN or MEMBER)"
   role: UserRole
+
+  "Si oui ou non l'email de l'utilisateur a été confirmé"
   isActive: Boolean
+
+  "Si oui ou non une une invitation à joindre l'établissement est en attente"
   isPendingInvitation: Boolean
+
+  "Si oui ou non cet utilisateur correspond à l'utilisateur authentifié"
   isMe: Boolean
 }
 
+"Type d'établissement favoris"
 enum FavoriteType {
   EMITTER
   TRANSPORTER

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -233,7 +233,7 @@ input TraderInput {
 "Payload lié au détails du déchet (case 3, 4, 5, 6)"
 input WasteDetailsInput {
 
-  "rubrique déchet au format |_|_| |_|_| |_|_| (*)"
+  "Rubrique déchet au format |_|_| |_|_| |_|_| (*)"
   code: String
 
   "Dénomination usuelle"

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -1,110 +1,262 @@
+"Payload de signature d'un BSD"
 input SentFormInput {
+
+  "Date de l'envoi du déchet par l'émetteur (case 9)"
   sentAt: DateTime
+
+  "Nom de la personne responsable de l'envoi du déchet (case 9)"
   sentBy: String
 }
 
+"Payload de signature d'un BSD par un transporteur"
 input TransporterSignatureFormInput {
+
+  "Date de l'envoi du déchet par l'émetteur (case 9)"
   sentAt: DateTime!
+
+  "Si oui ou non le BSD a été signé par un transporteur"
   signedByTransporter: Boolean!
+
+  "Code de sécurité permettant d'authentifier l'émetteur"
   securityCode: Int
+
+  "Nom de la personne responsable de l'envoi du déchet (case 9)"
   sentBy: String
+
+  "Si oui on non le BSD a été signé par l'émetteur"
   signedByProducer: Boolean!
 
+  "Conditionnement"
   packagings: [Packagings]!
+
+  "Quantité en tonnes"
   quantity: Float!
+
+  "Code ONU"
   onuCode: String!
 }
 
+"Statut d'acceptation d'un déchet"
 enum WasteAcceptationStatusInput {
+
+  "Accepté en totalité"
   ACCEPTED
+
+  "Refusé"
   REFUSED
+
+  "Refus partiel"
   PARTIALLY_REFUSED
 }
 
+"Payload de réception d'un BSD"
 input ReceivedFormInput {
+
+  "Statut d'acceptation du déchet (case 10)"
   wasteAcceptationStatus: WasteAcceptationStatusInput!
+
+  "Raison du refus (case 10)"
   wasteRefusalReason: String
+
+  "Nom de la personne en charge de la réception du déchet (case 10)"
   receivedBy: String!
+
+  "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime!
+
+  "Quantité réelle présentée (case 10)"
   quantityReceived: Float!
 }
 
+"Payload de traitement d'un BSD"
 input ProcessedFormInput {
+
+  "Traitement réalisé (code D/R)"
   processingOperationDone: String!
+
+  "Description de l'opération de traitement (case 11)"
   processingOperationDescription: String
+
+  "Personne en charge du traitement"
   processedBy: String!
+
+  "Date à laquelle le déchet a été traité"
   processedAt: DateTime!
+
+  "Destination ultérieure prévue (case 12)"
   nextDestination: NextDestinationInput
+
+  "Si oui ou non il y a eu perte de traçabalité"
   noTraceability: Boolean
 }
 
 input NextDestinationInput {
+
+  "Traitement prévue (code D/R)"
   processingOperation: String
+
+  "Établissement de destination ultérieur"
   company: CompanyInput
 }
 
+
+"Payload de création d'un BSD"
 input FormInput {
+
+  "Identifiant opaque"
   id: ID
+
+  """
+  Identifiant personnalisé permettant de faire le lien avec un
+  objet un système d'information tierce
+  """
   customId: String
+
+  "Établissement émetteur/producteur du déchet (case 1)"
   emitter: EmitterInput
+
+  "Établissement qui reçoit le déchet (case 2)"
   recipient: RecipientInput
+
+  "Transporteur du déchet (case 8)"
   transporter: TransporterInput
+
+  "Détails du déchet (case 3)"
   wasteDetails: WasteDetailsInput
+
+  "Négociant (case 7)"
   trader: TraderInput
 
+  "Annexe 2"
   appendix2Forms: [AppendixFormInput]
 }
 
+"Payload de création d'une annexe 2"
 input AppendixFormInput {
+
+  "SIRET de l'établissement émetteur"
   emitterSiret: String
+
+  "N° de bordereau"
   readableId: ID
 }
 
+"Payload d'un établissement"
 input CompanyInput {
+
+  "SIRET de l'établissement"
   siret: String
+
+  "Nom de l'établissement"
   name: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom du contact dans l'établissement"
   contact: String
+
+  "Email du contact dans l'établissement"
   mail: String
+
+  "Numéro de téléphone de contact dans l'établissement"
   phone: String
 }
 
+"Payload lié à un l'émetteur du BSD (case 1)"
 input EmitterInput {
+
+  "Type d'émetteur"
   type: EmitterType
+
+  "Adresse du chantier"
   pickupSite: String
+
+  "Établissement émetteur"
   company: CompanyInput
 }
 
+"""
+Payload lié à l'installation de destination ou d'entreprosage
+ou de reconditionnement prévue (case 2)
+"""
 input RecipientInput {
+
+  "N° de CAP (le cas échéant)"
   cap: String
+
+  "Opération d'élimination / valorisation prévue (code D/R)"
   processingOperation: String
+
+  "Établissement de destination"
   company: CompanyInput
 }
 
+"Collecteur - transporteur (case 8)"
 input TransporterInput {
+
+  "Exemption de récipissé"
   isExemptedOfReceipt: Boolean
+
+  "N° de récipissé"
   receipt: String
+
+  "Département"
   department: String
+
+  "Limite de validité du récipissé"
   validityLimit: DateTime
+
+  "Numéro de plaque d'immatriculation"
   numberPlate: String
+
+  "Établissement collecteur - transporteur"
   company: CompanyInput
 }
 
+"Payload lié au négociant"
 input TraderInput {
+
+  "N° de récipissé"
   receipt: String
+
+  "Département"
   department: String
+
+  "Limite de validité"
   validityLimit: DateTime
+
+  "Établissement négociant"
   company: CompanyInput
 }
 
+"Payload lié au détails du déchet (case 3, 4, 5, 6)"
 input WasteDetailsInput {
+
+  "rubrique déchet au format |_|_| |_|_| |_|_| (*)"
   code: String
+
+  "Dénomination usuelle"
   name: String
+
+  "Code ONU"
   onuCode: String
+
+  "Conditionnement"
   packagings: [Packagings]
+
+  "Autre packaging (préciser)"
   otherPackaging: String
+
+  "Nombre de colis"
   numberOfPackages: Int
+
+  "Quantité en tonnes"
   quantity: Float
+
+  "Réelle ou estimée"
   quantityType: QuantityType
+
+  "Consistance"
   consistence: Consistence
 }

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -2,325 +2,604 @@ scalar DateTime
 scalar JSON
 
 type Query {
+
+  "Renvoie un BSD, sélectionné par ID"
+  form(
+    "Identifiant opaque du BSD"
+    id: ID
+    ): Form
+
   """
-  Renvoie un BSD, sélectionné par ID
-  """
-  form(id: ID): Form
-  """
-  Renvoie les BSDs de la compagnie sélectionnée (la première par défaut)
+  Renvoie les BSDs de l'établissement sélectionné (le premier par défaut)
   Par défaut, renvoie les BSDs dont on est producteur ou destinataire.
   On peut également demander les bordereaux pour lesquels on est transporteur
   """
-  forms(siret: String, type: FormType = ACTOR): [Form]
+  forms(
+    "SIRET d'un établissement dont je suis membre"
+    siret: String,
+    """
+    (Optionnel) Type de BSD renvoyés
+    ACTOR = BSD's dont on est producteur ou destinataire
+    TRANSPORTER = BSD's dont on est transporteur
+    """
+    type: FormType = ACTOR
+    ): [Form]
+
+  "Renvoie des statistiques sur le volume de déchets entrant et sortant"
   stats: [CompanyStat]
-  """
-  Renvoie des BSD candidats à un regroupement dans une annexe 2
-  `siret`: Siret d'une des entreprises que j'administre
-  `wasteCode`: Code déchet pour affiner la recherche, optionnel
-  """
-  appendixForms(siret: String!, wasteCode: String): [Form]
+
+  "Renvoie des BSD candidats à un regroupement dans une annexe 2"
+  appendixForms(
+    "Siret d'un des établissements dont je suis membre"
+    siret: String!,
+    "(Optionnel) Code déchet pour affiner la recherche"
+    wasteCode: String
+    ): [Form]
 
   """
-  Renvoie un token pour télécharger un pdf de bordereau
+  Renvoie un token pour télécharger un pdf de BSD
   Ce token doit être transmis à la route /download pour obtenir le fichier.
   Il est valable 10 secondes
   """
-  formPdf(id: ID): FileDownload
+  formPdf(
+    "ID d'un BSD"
+    id: ID):
+  FileDownload
+
+  """
+  Renvoie un token pour télécharger un csv du regsitre
+  Ce token doit être transmis à la route /download pour obtenir le fichier.
+  Il est valable 10 secondes
+  """
   formsRegister(
+    "Liste de SIRET d'établissements dont je suis membre"
     sirets: [String]
+    "Type d'export"
     exportType: FormsRegisterExportType
   ): FileDownload
 
-  
-"""
-Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée. 
-La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
-Seuls les changements de statuts disposant d'un champ `created` non nul sont retournés
-  
-Filtres:
 
-  `siret`: Siret d'une des entreprises que j'administre, optionnel
-
-  `loggedAfter`: date formatée après laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
-
-  `loggedBefore`: date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
-  
-  `formId`: id d'un bordereau, optionnel
-  
-Pagination:
-
-  `cursorAfter`: cursor après lequel les changements de statut doivent être retournés, optionnel
-
-  `cursorBefore`: cursor avant lequel les changements de statut doivent être retournés, optionnel
- 
   """
-  formsLifeCycle(siret: String, loggedBefore: String, loggedAfter: String, cursorAfter:String, cursorBefore:String, formId: ID):formsLifeCycleData
+  Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
+  La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
+  Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
+  """
+  formsLifeCycle(
+    "(Optionnel) SIRET d'un établissement dont je suis membre"
+    siret: String,
+    "(Optionnel) Date formatée après laquelle les changements de statut doivent être retournés (YYYY-MM-DD)"
+    loggedBefore: String,
+    "(Optionnel) Date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel"
+    loggedAfter: String,
+    "(Optionnel) PAGINATION - Curseur après lequel les changements de statut doivent être retournés"
+    cursorAfter: String,
+    "(Optionnel) PAGINATION - Curseur avant lequel les changements de statut doivent être retournés"
+    cursorBefore: String,
+    "(Optionnel) ID d'un BSD en particulier"
+    formId: ID
+    ):formsLifeCycleData
 
 }
 
 
 type Mutation {
-  """
-  Sauvegarde un BSD (création ou modification, si `FormInput` contient un ID)
-  """
-  saveForm(formInput: FormInput!): Form
-  """
-  Supprime un BSD
-  """
-  deleteForm(id: ID!): Form
-  """
-  Duplique un BSD
-  """
-  duplicateForm(id: ID!): Form
 
-  """
-  Scelle un BSD
-  """
-  markAsSealed(id: ID): Form
-  """
-  Valide l'envoi d'un BSD
-  """
-  markAsSent(id: ID, sentInfo: SentFormInput!): Form
-  """
-  Valide la réception d'un BSD
-  """
-  markAsReceived(id: ID, receivedInfo: ReceivedFormInput!): Form
-  """
-  Valide le traitement d'un BSD
-  """
-  markAsProcessed(id: ID, processedInfo: ProcessedFormInput!): Form
+  "Sauvegarde un BSD (création ou modification, si `FormInput` contient un ID)"
+  saveForm(
+    "Payload du BSD"
+    formInput: FormInput!
+    ): Form
 
-  """
-  Valide la prise en charge par le transporteur, et peut valider l'envoi
-  """
-  signedByTransporter(
+  "Supprime un BSD"
+  deleteForm(
+    "ID d'un BSD"
     id: ID!
+    ): Form
+
+  "Duplique un BSD"
+  duplicateForm(
+    "ID d'un BSD"
+    id: ID!
+    ): Form
+
+  "Scelle un BSD"
+  markAsSealed(
+    "ID d'un BSD"
+    id: ID
+    ): Form
+
+  "Valide l'envoi d'un BSD"
+  markAsSent(
+    "ID d'un BSD"
+    id: ID,
+    "Informations liées à l'envoi"
+    sentInfo: SentFormInput!
+    ): Form
+
+  "Valide la réception d'un BSD"
+  markAsReceived(
+    "ID d'un BSD"
+    id: ID,
+    "Informations liées à la réception"
+    receivedInfo: ReceivedFormInput!): Form
+
+  "Valide le traitement d'un BSD"
+  markAsProcessed(
+    "ID d'un BSD"
+    id: ID,
+    "Informations liées au traitement"
+    processedInfo: ProcessedFormInput!
+    ): Form
+
+  "Valide la prise en charge par le transporteur, et peut valider l'envoi"
+  signedByTransporter(
+    "ID d'un BSD"
+    id: ID!
+    "Informations liées à la signature transporteur"
     signingInfo: TransporterSignatureFormInput!
   ): Form
 }
 
 type Subscription {
-  forms(token: String!): FormSubscription
+  """
+  DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
+
+  Permet de s'abonner aux changements de statuts d'un BSD
+  """
+  forms(
+    "Token permettant de s'authentifier à l'API"
+    token: String!
+    ): FormSubscription
 }
 
+"""
+DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
+
+Mise à jour d'un BSD
+"""
 type FormSubscription {
+
+  "Type de mutation"
   mutation: String
+
+  "BSD concerné"
   node: Form
+
+  "Liste des champs mis à jour"
   updatedFields: [String]
+
+  "Ancienne valeurs"
   previousValues: Form
 }
 
+"Différents statuts d'un BSD au cours de son cycle de vie"
 enum FormStatus {
+
+  """
+  BSD à l'état de brouillon
+  Des champs obligatoires peuvent manquer
+  """
   DRAFT
+
+  """
+  BSD finalisé
+  Les champs sont validés pour détecter des valeurs manquantes ou erronnées
+  """
   SEALED
+
+  "BSD envoyé vers l'établissement de destination"
   SENT
+
+  "BSD reçu par l'établissement de destination"
   RECEIVED
+
+  "BSD dont les déchets ont été traités"
   PROCESSED
+
+  "BSD en attente de regroupement"
   AWAITING_GROUP
+
+  "Regroupement effectué"
   GROUPED
+
+  "Perte de traçabalité"
   NO_TRACEABILITY
+
+  "Déchet refusé"
   REFUSED
 }
 
-"""
-On peut récupérer les BSD par type:
-- ACTOR: on est acteur du BSD, c'est à dire émetteur ou destinataire (cas par défaut)
-- TRANSPORTER: on est uniquement transporteur du déchet
-"""
+"Valeur possibles pour le filtre de la query `forms`"
 enum FormType {
+
+  "Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut)"
   ACTOR
+
+  "Uniquement les BSD's dont je suis transporteur"
   TRANSPORTER
 }
 
 """
-Représente un BSD
+Bordereau de suivi de déchets (BSD)
+Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
 """
 type Form {
+
+  "Identifiant interne du BSD"
   id: ID
+
+  "Identifiant utilisé dans la case 'Bordereau n° ****'"
   readableId: String
+
+  """
+  Identifiant personnalisé permettant de faire le lien avec un
+  objet un système d'information tierce
+  """
   customId: String
 
+  "Établissement émetteur/producteur du déchet (case 1)"
   emitter: Emitter
+
+  "Établissement qui reçoit le déchet (case 2)"
   recipient: Recipient
+
+  "Transporteur du déchet (case 8)"
   transporter: Transporter
+
+  "Détails du déchet (case 3)"
   wasteDetails: WasteDetails
+
+  "Négociant (case 7)"
   trader: Trader
 
+  "Date de création du BSD"
   createdAt: DateTime
+
+  "Date de la dernière modification du BSD"
   updatedAt: DateTime
 
+  "ID de l'utilisateur ayant crée le BSD"
   ownerId: Int
+
+  "Statut du BSD (brouillon, envoyé, reçu, traité, etc)"
   status: FormStatus
 
+  "Si oui ou non le BSD a été signé par un transporteur"
   signedByTransporter: Boolean
 
+  "Date de l'envoi du déchet par l'émetteur (case 9)"
   sentAt: DateTime
+
+  "Nom de la personne responsable de l'envoi du déchet (case 9)"
   sentBy: String
 
+  "Statut d'acceptation du déchet (case 10)"
   wasteAcceptationStatus: String
+
+  "Raison du refus (case 10)"
   wasteRefusalReason: String
+
+  "Nom de la personne en charge de la réception du déchet (case 10)"
   receivedBy: String
+
+  "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime
+
+  "Quantité réelle présentée (case 10)"
   quantityReceived: Float
 
+  "Si oui ou non le traitement a été effectué"
   processingOperationDone: String
+
+  "Description de l'opération de traitement (case 11)"
   processingOperationDescription: String
+
+  "Personne en charge du traitement"
   processedBy: String
+
+  "Date à laquelle le déchet a été traité"
   processedAt: DateTime
+
+  "Si oui ou non il y a eu perte de traçabalité"
   noTraceability: Boolean
+
+  "Destination ultérieure prévue (case 12)"
   nextDestination: NextDestination
 
+  "Annexe 2"
   appendix2Forms: [Form]
 }
 
+"Information sur un établissement dans un BSD"
 type FormCompany {
+
+  "Nom de l'établissement"
   name: String
+
+  "SIRET de l'établissement"
   siret: String
+
+  "Adresse de l'établissement"
   address: String
+
+  "Nom du contact dans l'établissement"
   contact: String
+
+  "Numéro de téléphone de contact dans l'établissement"
   phone: String
+
+  "Email du contact dans l'établissement"
   mail: String
 }
 
+"Types d'émetteur de déchet (choix multiple de la case 1)"
 enum EmitterType {
+
+  "Producetur de déchet"
   PRODUCER
+
+  "Autre détenteur"
   OTHER
+
+  "Collecteur de petites quantités de déchets relevant de la même rubrique"
   APPENDIX1
+
+  "Personne ayant transformé ou réalisé un traitement dont la provenance des déchets reste identifiable"
   APPENDIX2
 }
 
+"Émetteur du BSD (case 1)"
 type Emitter {
+
+  "Type d'émetteur"
   type: EmitterType
+
+  "Adresse du chantier"
   pickupSite: String
 
+  "Établissement émetteur"
   company: FormCompany
 }
 
+"""
+Installation de destination ou d'entreprosage
+ou de reconditionnement prévue (case 2)
+"""
 type Recipient {
+
+  "N° de CAP (le cas échéant)"
   cap: String
+
+  "Opération d'élimination / valorisation prévue (code D/R)"
   processingOperation: String
 
+  "Établissement de destination"
   company: FormCompany
 }
 
+"Collecteur - transporteur (case 8)"
 type Transporter {
+
+  "Établissement collecteur - transporteur"
   company: FormCompany
 
+  "Exemption de récipissé"
   isExemptedOfReceipt: Boolean
 
+  "N° de récipissé"
   receipt: String
+
+  "Département"
   department: String
+
+  "Limite de validité du récipissé"
   validityLimit: DateTime
+
+  "Numéro de plaque d'immatriculation"
   numberPlate: String
 }
 
+"Destination ultérieure prévue (case 12)"
 type NextDestination {
+
+  "Traitement prévue (code D/R)"
   processingOperation: String
+
+  "Établissement ultérieure"
   company: FormCompany
 }
 
+"Type de quantité lors de l'émission"
 enum QuantityType {
+
+  "Quntité réelle"
   REAL
+
+  "Quantité estimée"
   ESTIMATED
 }
 
+"Type de packaging du déchet"
 enum Packagings {
+
+  "Fut"
   FUT
+
+  "GRV"
   GRV
+
+  "Citerne"
   CITERNE
+
+  "Benne"
   BENNE
+
+  "Autre"
   AUTRE
 }
 
+"Consistance du déchet"
 enum Consistence {
+
+  "Solide"
   SOLID
+
+  "Liquide"
   LIQUID
+
+  "Gazeux"
   GASEOUS
 }
 
+"Détails du déchet (case 3, 4, 5, 6)"
 type WasteDetails {
+
+  "rubrique déchet au format |_|_| |_|_| |_|_| (*)"
   code: String
+
+  "Dénomination usuelle"
   name: String
+
+  "Code ONU"
   onuCode: String
+
+  "Conditionnement"
   packagings: [Packagings]
   otherPackaging: String
+
+  "Nombre de colis"
   numberOfPackages: Int
+
+  "Quantité en tonnes"
   quantity: Float
+
+  "Réelle ou estimée"
   quantityType: QuantityType
+
+  "Consistance"
   consistence: Consistence
 }
 
+"Négociant (case 7)"
 type Trader {
+
+  "Établissement négociant"
   company: FormCompany
 
+  "N° de récipissé"
   receipt: String
+
+  "Département"
   department: String
+
+  "Limite de validité"
   validityLimit: DateTime
 }
 
+"Statistiques d'un établissement"
 type CompanyStat {
+
+  "Établissement"
   company: FormCompany
+
+  "Liste des statistiques"
   stats: [Stat]
 }
 
+"Statistiques"
 type Stat {
+
+  "Code déchet"
   wasteCode: String
+
+  "Quantité entrante"
   incoming: Float
+
+  "Qantité sortante"
   outgoing: Float
 }
 
+"""
+URL de téléchargement accompagné d'un token
+permettant de valider le téléchargement.
+"""
 type FileDownload {
+
+  "Token ayant une durée de validité de 10s"
   token: String
+
+  "Lien de téléchargement"
   downloadLink: String
 }
 
+"Type pour l'export du registre"
 enum FormsRegisterExportType {
+
+  "Déchets entrants"
   INCOMING
+
+  "Déchets sortants"
   OUTGOING
 }
- 
+
+"Information sur un BSD dans les logs de modifications de statuts"
 type StatusLogForm {
+
+  "Identifiant du BSD"
   id: ID
+
+  "N° du bordereau"
   readableId: String
 }
 
+"Utilisateur ayant modifié le BSD"
 type StatusLogUser {
   id: ID
   email: String
 }
 
-"""
-Changement de statut d'un bordereau
-
-  `status`: statut du bordereau après le changement de statut
-
-  `updatedFields`: valeur des champs transmis lors du changement de statut (eg. receivedBY, processingOperationDescription)
-"""
+"Changement de statut d'un bordereau"
 type StatusLog{
+
+  "Identifiant du log"
   id: ID
+
+  "Statut du bordereau après le changement de statut"
   status: FormStatus
+
+  "Date à laquelle le changement de statut a été effectué"
   loggedAt: DateTime
+
+  "Valeur des champs transmis lors du changement de statut (eg. receivedBY, processingOperationDescription)"
   updatedFields: JSON
+
+  "BSD concerné"
   form: StatusLogForm
+
+  "Utilisateur à l'origine de la modification"
   user: StatusLogUser
 }
 
-"""
-Informations du cycle de vie des bordereaux
 
-Pagination
-
-  `hasNextPage` et `hasPreviousPage`: pagination, indique si d'autres pages existent avant ou après
-
-  `startCursor`et `endCursor`: premier et dernier ID de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle
-
-"""
+"Informations du cycle de vie des bordereaux"
 type formsLifeCycleData{
+
+  "Liste des changements de statuts"
   statusLogs: [StatusLog]
+
+  "pagination, indique si d'autres pages existent après"
   hasNextPage: Boolean
+
+  "pagination, indique si d'autres pages existent avant"
   hasPreviousPage: Boolean
+
+  "Premier id de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle"
   startCursor: ID
+
+  "Dernier ID de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle"
   endCursor: ID
+
+  "Nombre de changements de statuts renvoyés"
   count: Int
 }
 

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -288,7 +288,7 @@ type Form {
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float
 
-  "Si oui ou non le traitement a été effectué"
+  "Traitement réalisé (code D/R)"
   processingOperationDone: String
 
   "Description de l'opération de traitement (case 11)"
@@ -454,7 +454,7 @@ enum Consistence {
 "Détails du déchet (case 3, 4, 5, 6)"
 type WasteDetails {
 
-  "rubrique déchet au format |_|_| |_|_| |_|_| (*)"
+  "Rubrique déchet au format |_|_| |_|_| |_|_| (*)"
   code: String
 
   "Dénomination usuelle"
@@ -465,6 +465,8 @@ type WasteDetails {
 
   "Conditionnement"
   packagings: [Packagings]
+
+  "Autre packaging (préciser)"
   otherPackaging: String
 
   "Nombre de colis"

--- a/back/src/scripts/graphql-markdown.ts
+++ b/back/src/scripts/graphql-markdown.ts
@@ -9,6 +9,8 @@ import * as fs from "fs";
 const content = [];
 
 const options = {
+  title: "Référence de l'API GraphQL",
+  skipTableOfContents: true,
   printer: (txt: string) => content.push(txt)
 };
 

--- a/back/src/scripts/graphql-markdown.ts
+++ b/back/src/scripts/graphql-markdown.ts
@@ -1,0 +1,21 @@
+import { renderSchema, schemaToJSON } from "graphql-markdown";
+import { schema } from "../server";
+import * as graphql from "graphql";
+import * as fs from "fs";
+
+// Render GraphQL schema to markdown
+// and save as a page in the documentation folder
+
+const content = [];
+
+const options = {
+  printer: (txt: string) => content.push(txt)
+};
+
+const filePath = "documentation/api-reference.md";
+
+schemaToJSON(schema, { graphql }).then(s => {
+  renderSchema(s, options);
+  fs.writeFileSync(filePath, content.join("\n"));
+  process.exit(0);
+});

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -83,7 +83,7 @@ const sentryMiddleware = () =>
     }
   });
 
-const schema = makeExecutableSchema({ typeDefs, resolvers });
+export const schema = makeExecutableSchema({ typeDefs, resolvers });
 export const schemaWithMiddleware = applyMiddleware(
   schema,
   ...[

--- a/back/src/users/users.graphql
+++ b/back/src/users/users.graphql
@@ -1,61 +1,111 @@
 type Query {
+  "Renvoie les informations sur l'utilisateur authentifié"
   me: User
+  "Renvoie un token permettant de faire des requêtes sur l'API Trackdéchets"
   apiKey: String
 }
 
 input SignupInput {
+  "Email de l'utilisateur"
   email: String!
+  "mot de passe de l'utilisateur"
   password: String!
+  "Nom de l'utilisateur"
   name: String!
+  "Numéro de téléphone de l'utilisateur"
   phone: String
 }
 
 type Mutation {
+  "Permet de créer un nouvel utilisateur"
   signup(userInfos: SignupInput!): User
+
+  """
+  DEPRECATED - La récupération de token doit s'effectuer avec
+  le protocole OAuth2
+
+  Récupére un token à partir de l'email et du mot de passe
+  d'un utilisateur.
+  """
   login(email: String!, password: String!): AuthPayload!
+
+  "Modifie le mot de passe d'un utilisateur"
   changePassword(oldPassword: String!, newPassword: String!): User!
+
+  "Envoie un email pour la réinitialisation du mot de passe"
   resetPassword(email: String!): Boolean
+
+  "Met à jour les informations de l'utilisateur"
   editProfile(name: String, phone: String, email: String): User
+
+  "Invite un nouvel utilisateur à un établissement"
   inviteUserToCompany(email: String!, siret: String!, role: UserRole!): CompanyPrivate
+
+  "Renvoie l'email d'invitation à un établissement"
   resendInvitation(email: String!, siret: String!): Boolean
+
+  "Active le compte d'un utilisateur invité"
   joinWithInvite(
     inviteHash: String!
     name: String!
     password: String!
   ): User!
+
+  "Supprime les droits d'un utilisateurs sur un établissement"
   removeUserFromCompany(userId: ID!, siret: String!):  CompanyPrivate
+
+  "Supprime une invitation à un établissement"
   deleteInvitation(email: String!, siret: String!):  CompanyPrivate
 }
 
+
+"Cet objet est renvoyé par la mutation login qui est dépréciée"
 type AuthPayload {
+  """
+  Bearer token à durée illimité permettant de s'authentifier
+  à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
+  header d'autorisation `Authorization: Bearer ******`
+  """
   token: String!
+
+  "Utilisateur lié au token"
   user: User!
 }
 
-enum UserType {
-  PRODUCER
-  COLLECTOR
-  WASTEPROCESSOR
-  TRANSPORTER
-  WASTE_VEHICLES
-  WASTE_CENTER
-  TRADER
-}
+"""
+Liste les différents rôles d'un utilisateur au sein
+d'un établissement.
 
+Les admins peuvent:
+* consulter/éditer les bordereaux
+* gérer les utilisateurs de l'établissement
+* éditer les informations de la fiche entreprise
+* demander le renouvellement du code de sécurité
+* Éditer les informations de la fiche entreprise
+
+Les membres peuvent:
+* consulter/éditer les bordereaux
+* consulter le reste des informations
+"""
 enum UserRole {
   MEMBER
   ADMIN
 }
 
+"Représente un utilisateur sur la plateforme Trackdéchets"
 type User {
+  "Identifiant unique"
   id: ID!
+
+  "Email de l'utiliateur"
   email: String!
+
+  "Nom de l'utilisateur"
   name: String
+
+  "Numéro de téléphone de l'utilisateur"
   phone: String
 
+  "Liste des établissements dont fait partie l'utilisateur"
   companies: [CompanyPrivate]
-}
-
-type AccessToken {
-  token: String!
 }

--- a/back/src/users/users.graphql
+++ b/back/src/users/users.graphql
@@ -1,61 +1,100 @@
 type Query {
+
   "Renvoie les informations sur l'utilisateur authentifié"
   me: User
-  "Renvoie un token permettant de faire des requêtes sur l'API Trackdéchets"
+
+  """
+  USAGE INTERNE > Mon Compte > Générer un token
+  Renvoie un token permettant de s'authentifier à l'API Trackdéchets
+  """
   apiKey: String
 }
 
-input SignupInput {
-  "Email de l'utilisateur"
-  email: String!
-  "mot de passe de l'utilisateur"
-  password: String!
-  "Nom de l'utilisateur"
-  name: String!
-  "Numéro de téléphone de l'utilisateur"
-  phone: String
-}
+
 
 type Mutation {
-  "Permet de créer un nouvel utilisateur"
+
+  """
+  USAGE INTERNE
+  Permet de créer un nouvel utilisateur
+  """
   signup(userInfos: SignupInput!): User
 
   """
-  DEPRECATED - La récupération de token doit s'effectuer avec
-  le protocole OAuth2
+  DEPRECATED - La récupération de token pour le compte de tiers
+  doit s'effectuer avec le protocole OAuth2
 
   Récupére un token à partir de l'email et du mot de passe
   d'un utilisateur.
   """
   login(email: String!, password: String!): AuthPayload!
 
-  "Modifie le mot de passe d'un utilisateur"
+  """
+  USAGE INTERNE
+  Modifie le mot de passe d'un utilisateur
+  """
   changePassword(oldPassword: String!, newPassword: String!): User!
 
-  "Envoie un email pour la réinitialisation du mot de passe"
+  """
+  USAGE INTERNE
+  Envoie un email pour la réinitialisation du mot de passe
+  """
   resetPassword(email: String!): Boolean
 
-  "Met à jour les informations de l'utilisateur"
+  """
+  USAGE INTERNE
+  Met à jour les informations de l'utilisateur
+  """
   editProfile(name: String, phone: String, email: String): User
 
-  "Invite un nouvel utilisateur à un établissement"
+  """
+  USAGE INTERNE
+  Invite un nouvel utilisateur à un établissement
+  """
   inviteUserToCompany(email: String!, siret: String!, role: UserRole!): CompanyPrivate
 
-  "Renvoie l'email d'invitation à un établissement"
+  """
+  USAGE INTERNE
+  Renvoie l'email d'invitation à un établissement
+  """
   resendInvitation(email: String!, siret: String!): Boolean
 
-  "Active le compte d'un utilisateur invité"
+  """
+  USAGE INTERNE
+  Active le compte d'un utilisateur invité
+  """
   joinWithInvite(
     inviteHash: String!
     name: String!
     password: String!
   ): User!
 
-  "Supprime les droits d'un utilisateurs sur un établissement"
+  """
+  USAGE INTERNE
+  Supprime les droits d'un utilisateurs sur un établissement
+  """
   removeUserFromCompany(userId: ID!, siret: String!):  CompanyPrivate
 
-  "Supprime une invitation à un établissement"
+  """
+  USAGE INTERNE
+  Supprime une invitation à un établissement
+  """
   deleteInvitation(email: String!, siret: String!):  CompanyPrivate
+}
+
+input SignupInput {
+
+  "Email de l'utilisateur"
+  email: String!
+
+  "Mot de passe de l'utilisateur"
+  password: String!
+
+  "Nom de l'utilisateur"
+  name: String!
+
+  "Numéro de téléphone de l'utilisateur"
+  phone: String
 }
 
 
@@ -94,7 +133,8 @@ enum UserRole {
 
 "Représente un utilisateur sur la plateforme Trackdéchets"
 type User {
-  "Identifiant unique"
+
+  "Identifiant opaque"
   id: ID!
 
   "Email de l'utiliateur"
@@ -106,6 +146,6 @@ type User {
   "Numéro de téléphone de l'utilisateur"
   phone: String
 
-  "Liste des établissements dont fait partie l'utilisateur"
+  "Liste des établissements dont l'utilisateur est membre"
   companies: [CompanyPrivate]
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,6 +47,7 @@ services:
     command: npx nodemon -L --watch src --exec "ts-node" src/index.ts
     volumes:
       - ./back/src:/usr/src/app/src
+      - ./documentation/docs/api-reference:/usr/src/app/documentation
     env_file:
       - .env
     environment:

--- a/documentation/docs/api-reference/api-reference.md
+++ b/documentation/docs/api-reference/api-reference.md
@@ -26,7 +26,11 @@ classées pour la protection de l'environnement (ICPE)
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>searchCompanies</strong></td>
@@ -41,19 +45,28 @@ les résultats avec des informations provenant de Trackdéchets
 <tr>
 <td colspan="2" align="right" valign="top">clue</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Champ utilisé pour faire une recherche floue
+sur la nom de l'établissement, ex: 'Boulangerie Dupont'
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">department</td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+(Optionnel) Filtre les résultats par numéro de département
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>favorites</strong></td>
 <td valign="top">[<a href="#companyfavorite">CompanyFavorite</a>]</td>
 <td>
 
-Liste les établissements favoris de l'utilisateur. C'est à dire les
+Renvoie les établissements favoris de l'utilisateur. C'est à dire les
 établissements qui font souvent partis des BSD édités
 
 </td>
@@ -61,7 +74,11 @@ Liste les établissements favoris de l'utilisateur. C'est à dire les
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#favoritetype">FavoriteType</a>!</td>
-<td></td>
+<td>
+
+type de favoris
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>form</strong></td>
@@ -75,14 +92,18 @@ Renvoie un BSD, sélectionné par ID
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Identifiant opaque du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>forms</strong></td>
 <td valign="top">[<a href="#form">Form</a>]</td>
 <td>
 
-Renvoie les BSDs de la compagnie sélectionnée (la première par défaut)
+Renvoie les BSDs de l'établissement sélectionné (le premier par défaut)
 Par défaut, renvoie les BSDs dont on est producteur ou destinataire.
 On peut également demander les bordereaux pour lesquels on est transporteur
 
@@ -91,17 +112,31 @@ On peut également demander les bordereaux pour lesquels on est transporteur
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+SIRET d'un établissement dont je suis membre
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
 <td valign="top"><a href="#formtype">FormType</a></td>
-<td></td>
+<td>
+
+(Optionnel) Type de BSD renvoyés
+ACTOR = BSD's dont on est producteur ou destinataire
+TRANSPORTER = BSD's dont on est transporteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>stats</strong></td>
 <td valign="top">[<a href="#companystat">CompanyStat</a>]</td>
-<td></td>
+<td>
+
+Renvoie des statistiques sur le volume de déchets entrant et sortant
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendixForms</strong></td>
@@ -109,27 +144,33 @@ On peut également demander les bordereaux pour lesquels on est transporteur
 <td>
 
 Renvoie des BSD candidats à un regroupement dans une annexe 2
-`siret`: Siret d'une des entreprises que j'administre
-`wasteCode`: Code déchet pour affiner la recherche, optionnel
 
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Siret d'un des établissements dont je suis membre
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">wasteCode</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) Code déchet pour affiner la recherche
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formPdf</strong></td>
 <td valign="top"><a href="#filedownload">FileDownload</a></td>
 <td>
 
-Renvoie un token pour télécharger un pdf de bordereau
+Renvoie un token pour télécharger un pdf de BSD
 Ce token doit être transmis à la route /download pour obtenir le fichier.
 Il est valable 10 secondes
 
@@ -138,79 +179,105 @@ Il est valable 10 secondes
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formsRegister</strong></td>
 <td valign="top"><a href="#filedownload">FileDownload</a></td>
-<td></td>
+<td>
+
+Renvoie un token pour télécharger un csv du regsitre
+Ce token doit être transmis à la route /download pour obtenir le fichier.
+Il est valable 10 secondes
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">sirets</td>
 <td valign="top">[<a href="#string">String</a>]</td>
-<td></td>
+<td>
+
+Liste de SIRET d'établissements dont je suis membre
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">exportType</td>
 <td valign="top"><a href="#formsregisterexporttype">FormsRegisterExportType</a></td>
-<td></td>
+<td>
+
+Type d'export
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>formsLifeCycle</strong></td>
 <td valign="top"><a href="#formslifecycledata">formsLifeCycleData</a></td>
 <td>
 
-Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée. 
-La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `created`)
-Seuls les changements de statuts disposant d'un champ `created` non nul sont retournés
-  
-Filtres:
-
-  `siret`: Siret d'une des entreprises que j'administre, optionnel
-
-  `createdAfter`: date formatée après laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
-
-  `createdBefore`: date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
-  
-  `formId`: id d'un bordereau, optionnel
-  
-Pagination:
-
-  `cursorAfter`: cursor après lequel les changements de statut doivent être retournés, optionnel
-
-  `cursorBefore`: cursor avant lequel les changements de statut doivent être retournés, optionnel
+Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
+La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
+Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
 
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) SIRET d'un établissement dont je suis membre
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">loggedBefore</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) Date formatée après laquelle les changements de statut doivent être retournés (YYYY-MM-DD)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">loggedAfter</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) Date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">cursorAfter</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) PAGINATION - Curseur après lequel les changements de statut doivent être retournés
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">cursorBefore</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+(Optionnel) PAGINATION - Curseur avant lequel les changements de statut doivent être retournés
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">formId</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+(Optionnel) ID d'un BSD en particulier
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>me</strong></td>
@@ -226,7 +293,8 @@ Renvoie les informations sur l'utilisateur authentifié
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Renvoie un token permettant de faire des requêtes sur l'API Trackdéchets
+USAGE INTERNE > Mon Compte > Générer un token
+Renvoie un token permettant de s'authentifier à l'API Trackdéchets
 
 </td>
 </tr>
@@ -249,6 +317,7 @@ Renvoie un token permettant de faire des requêtes sur l'API Trackdéchets
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Renouvelle le code de sécurité de l'établissement
 
 </td>
@@ -263,6 +332,7 @@ Renouvelle le code de sécurité de l'établissement
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Édite les informations d'un établissement
 
 </td>
@@ -281,7 +351,7 @@ SIRET de l'établissement
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Identifiant GEREP
+(Optionnel) Identifiant GEREP
 
 </td>
 </tr>
@@ -290,7 +360,7 @@ Identifiant GEREP
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Email de contact
+(Optionnel) Email de contact
 
 </td>
 </tr>
@@ -299,7 +369,7 @@ Email de contact
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Numéro de téléphone de contact
+(Optionnel) Numéro de téléphone de contact
 
 </td>
 </tr>
@@ -308,7 +378,7 @@ Numéro de téléphone de contact
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Site web
+(Optionnel) Site web
 
 </td>
 </tr>
@@ -317,7 +387,7 @@ Site web
 <td valign="top">[<a href="#companytype">CompanyType</a>]</td>
 <td>
 
-Profil de l'établissement
+(Optionnel) Profil de l'établissement
 
 </td>
 </tr>
@@ -326,7 +396,7 @@ Profil de l'établissement
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Nom d'usage de l'établissement
+(Optionnel) Nom d'usage de l'établissement
 
 </td>
 </tr>
@@ -335,6 +405,7 @@ Nom d'usage de l'établissement
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Rattache un établissement à l'utilisateur authentifié
 
 </td>
@@ -349,21 +420,28 @@ Rattache un établissement à l'utilisateur authentifié
 <td valign="top"><a href="#uploadlink">UploadLink</a></td>
 <td>
 
-Renvoie une URL permettant de télécharger un fichier
-Le fichier peut être par exemple un BSD au format .pdf
-ou un registre au format .csv
+USAGE INTERNE
+Récupère une URL signé pour l'upload d'un fichier
 
 </td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">fileName</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+nom du fichier
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">fileType</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+type de fichier
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>saveForm</strong></td>
@@ -377,7 +455,11 @@ Sauvegarde un BSD (création ou modification, si `FormInput` contient un ID)
 <tr>
 <td colspan="2" align="right" valign="top">formInput</td>
 <td valign="top"><a href="#forminput">FormInput</a>!</td>
-<td></td>
+<td>
+
+Payload du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>deleteForm</strong></td>
@@ -391,7 +473,11 @@ Supprime un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>duplicateForm</strong></td>
@@ -405,7 +491,11 @@ Duplique un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>markAsSealed</strong></td>
@@ -419,7 +509,11 @@ Scelle un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>markAsSent</strong></td>
@@ -433,12 +527,20 @@ Valide l'envoi d'un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">sentInfo</td>
 <td valign="top"><a href="#sentforminput">SentFormInput</a>!</td>
-<td></td>
+<td>
+
+Informations liées à l'envoi
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>markAsReceived</strong></td>
@@ -452,12 +554,20 @@ Valide la réception d'un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">receivedInfo</td>
 <td valign="top"><a href="#receivedforminput">ReceivedFormInput</a>!</td>
-<td></td>
+<td>
+
+Informations liées à la réception
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>markAsProcessed</strong></td>
@@ -471,12 +581,20 @@ Valide le traitement d'un BSD
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">processedInfo</td>
 <td valign="top"><a href="#processedforminput">ProcessedFormInput</a>!</td>
-<td></td>
+<td>
+
+Informations liées au traitement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
@@ -490,18 +608,27 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" align="right" valign="top">id</td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+ID d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">signingInfo</td>
 <td valign="top"><a href="#transportersignatureforminput">TransporterSignatureFormInput</a>!</td>
-<td></td>
+<td>
+
+Informations liées à la signature transporteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signup</strong></td>
 <td valign="top"><a href="#user">User</a></td>
 <td>
 
+USAGE INTERNE
 Permet de créer un nouvel utilisateur
 
 </td>
@@ -516,8 +643,8 @@ Permet de créer un nouvel utilisateur
 <td valign="top"><a href="#authpayload">AuthPayload</a>!</td>
 <td>
 
-DEPRECATED - La récupération de token doit s'effectuer avec
-le protocole OAuth2
+DEPRECATED - La récupération de token pour le compte de tiers
+doit s'effectuer avec le protocole OAuth2
 
 Récupére un token à partir de l'email et du mot de passe
 d'un utilisateur.
@@ -539,6 +666,7 @@ d'un utilisateur.
 <td valign="top"><a href="#user">User</a>!</td>
 <td>
 
+USAGE INTERNE
 Modifie le mot de passe d'un utilisateur
 
 </td>
@@ -558,6 +686,7 @@ Modifie le mot de passe d'un utilisateur
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
+USAGE INTERNE
 Envoie un email pour la réinitialisation du mot de passe
 
 </td>
@@ -572,6 +701,7 @@ Envoie un email pour la réinitialisation du mot de passe
 <td valign="top"><a href="#user">User</a></td>
 <td>
 
+USAGE INTERNE
 Met à jour les informations de l'utilisateur
 
 </td>
@@ -596,6 +726,7 @@ Met à jour les informations de l'utilisateur
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Invite un nouvel utilisateur à un établissement
 
 </td>
@@ -620,6 +751,7 @@ Invite un nouvel utilisateur à un établissement
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
+USAGE INTERNE
 Renvoie l'email d'invitation à un établissement
 
 </td>
@@ -639,6 +771,7 @@ Renvoie l'email d'invitation à un établissement
 <td valign="top"><a href="#user">User</a>!</td>
 <td>
 
+USAGE INTERNE
 Active le compte d'un utilisateur invité
 
 </td>
@@ -663,6 +796,7 @@ Active le compte d'un utilisateur invité
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Supprime les droits d'un utilisateurs sur un établissement
 
 </td>
@@ -682,6 +816,7 @@ Supprime les droits d'un utilisateurs sur un établissement
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
 <td>
 
+USAGE INTERNE
 Supprime une invitation à un établissement
 
 </td>
@@ -830,7 +965,7 @@ Information sur utilisateur au sein d'un établissement
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
-Identifiant unique
+Identifiant opaque
 
 </td>
 </tr>
@@ -857,7 +992,7 @@ Nom de l'utilisateur
 <td valign="top"><a href="#userrole">UserRole</a></td>
 <td>
 
-Rôle de l'utilisateur dans l'établissement (ADMIN or MEMBER)
+Rôle de l'utilisateur dans l'établissement (admin ou membre)
 
 </td>
 </tr>
@@ -910,7 +1045,7 @@ Information sur un établissement accessible par un utilisateur membre
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
-Identifiant unique
+Identifiant opaque
 
 </td>
 </tr>
@@ -937,7 +1072,7 @@ Identifiant GEREP
 <td valign="top"><a href="#int">Int</a>!</td>
 <td>
 
-Code de sécurité
+Code de sécurité permettant de signer les BSD
 
 </td>
 </tr>
@@ -1065,7 +1200,7 @@ Latitude de l'établissement (info géographique)
 <td>
 
 Installation classée pour la protection de l'environnement (ICPE)
-associé à cet établissement
+associé à cet établissement (le cas échéant)
 
 </td>
 </tr>
@@ -1191,8 +1326,7 @@ associé à cet établissement
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
-Si oui on non cet établissement est rattaché à un
-utilisateur sur la plateforme Trackdéchets
+Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets
 
 </td>
 </tr>
@@ -1201,7 +1335,7 @@ utilisateur sur la plateforme Trackdéchets
 
 ### CompanySearchResult
 
-Information sur un établissement accessible en recherche
+Information sur un établissement accessible publiquement en recherche
 
 <table>
 <thead>
@@ -1300,6 +1434,8 @@ associé à cet établissement
 
 ### CompanyStat
 
+Statistiques d'un établissement
+
 <table>
 <thead>
 <tr>
@@ -1313,17 +1449,27 @@ associé à cet établissement
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>stats</strong></td>
 <td valign="top">[<a href="#stat">Stat</a>]</td>
-<td></td>
+<td>
+
+Liste des statistiques
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Declaration
+
+Représente une ligne dans une déclaration GEREP
 
 <table>
 <thead>
@@ -1338,27 +1484,45 @@ associé à cet établissement
 <tr>
 <td colspan="2" valign="top"><strong>annee</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Année de la déclaration
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>codeDechet</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code du déchet
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>libDechet</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Description du déchet
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gerepType</strong></td>
 <td valign="top"><a href="#gereptype">GerepType</a></td>
-<td></td>
+<td>
+
+Type de déclaration GEREP: producteur ou traiteur
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Emitter
+
+Émetteur du BSD (case 1)
 
 <table>
 <thead>
@@ -1373,22 +1537,37 @@ associé à cet établissement
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#emittertype">EmitterType</a></td>
-<td></td>
+<td>
+
+Type d'émetteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>pickupSite</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse du chantier
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement émetteur
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FileDownload
+
+URL de téléchargement accompagné d'un token
+permettant de valider le téléchargement.
 
 <table>
 <thead>
@@ -1403,19 +1582,28 @@ associé à cet établissement
 <tr>
 <td colspan="2" valign="top"><strong>token</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Token ayant une durée de validité de 10s
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>downloadLink</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Lien de téléchargement
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Form
 
-Représente un BSD
+Bordereau de suivi de déchets (BSD)
+Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
 
 <table>
 <thead>
@@ -1430,142 +1618,253 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Identifiant interne du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant utilisé dans la case 'Bordereau n° ****'
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>customId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant personnalisé permettant de faire le lien avec un
+objet un système d'information tierce
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>emitter</strong></td>
 <td valign="top"><a href="#emitter">Emitter</a></td>
-<td></td>
+<td>
+
+Établissement émetteur/producteur du déchet (case 1)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recipient</strong></td>
 <td valign="top"><a href="#recipient">Recipient</a></td>
-<td></td>
+<td>
+
+Établissement qui reçoit le déchet (case 2)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>transporter</strong></td>
 <td valign="top"><a href="#transporter">Transporter</a></td>
-<td></td>
+<td>
+
+Transporteur du déchet (case 8)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteDetails</strong></td>
 <td valign="top"><a href="#wastedetails">WasteDetails</a></td>
-<td></td>
+<td>
+
+Détails du déchet (case 3)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>trader</strong></td>
 <td valign="top"><a href="#trader">Trader</a></td>
-<td></td>
+<td>
+
+Négociant (case 7)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>createdAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date de création du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>updatedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date de la dernière modification du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>ownerId</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+ID de l'utilisateur ayant crée le BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#formstatus">FormStatus</a></td>
-<td></td>
+<td>
+
+Statut du BSD (brouillon, envoyé, reçu, traité, etc)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non le BSD a été signé par un transporteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sentAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date de l'envoi du déchet par l'émetteur (case 9)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sentBy</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de la personne responsable de l'envoi du déchet (case 9)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteAcceptationStatus</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Statut d'acceptation du déchet (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteRefusalReason</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Raison du refus (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receivedBy</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de la personne en charge de la réception du déchet (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receivedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date à laquelle le déchet a été reçu (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantityReceived</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité réelle présentée (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Si oui ou non le traitement a été effectué
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperationDescription</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Description de l'opération de traitement (case 11)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processedBy</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Personne en charge du traitement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date à laquelle le déchet a été traité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>noTraceability</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non il y a eu perte de traçabalité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nextDestination</strong></td>
 <td valign="top"><a href="#nextdestination">NextDestination</a></td>
-<td></td>
+<td>
+
+Destination ultérieure prévue (case 12)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
 <td valign="top">[<a href="#form">Form</a>]</td>
-<td></td>
+<td>
+
+Annexe 2
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FormCompany
+
+Information sur un établissement dans un BSD
 
 <table>
 <thead>
@@ -1580,37 +1879,65 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>siret</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contact</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom du contact dans l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>phone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de contact dans l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mail</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Email du contact dans l'établissement
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FormSubscription
+
+DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
+
+Mise à jour d'un BSD
 
 <table>
 <thead>
@@ -1625,27 +1952,45 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>mutation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Type de mutation
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>node</strong></td>
 <td valign="top"><a href="#form">Form</a></td>
-<td></td>
+<td>
+
+BSD concerné
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>updatedFields</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
-<td></td>
+<td>
+
+Liste des champs mis à jour
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>previousValues</strong></td>
 <td valign="top"><a href="#form">Form</a></td>
-<td></td>
+<td>
+
+Ancienne valeurs
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Installation
+
+Installation pour la protection de l'environnement (ICPE)
 
 <table>
 <thead>
@@ -1660,27 +2005,45 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>codeS3ic</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant S3IC
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>urlFiche</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+URL de la fiche ICPE sur Géorisques
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>rubriques</strong></td>
 <td valign="top">[<a href="#rubrique">Rubrique</a>]</td>
-<td></td>
+<td>
+
+Liste des rubriques associées
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>declarations</strong></td>
 <td valign="top">[<a href="#declaration">Declaration</a>]</td>
-<td></td>
+<td>
+
+Liste des déclarations GEREP
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### NextDestination
+
+Destination ultérieure prévue (case 12)
 
 <table>
 <thead>
@@ -1695,17 +2058,28 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>processingOperation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Traitement prévue (code D/R)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement ultérieure
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Recipient
+
+Installation de destination ou d'entreprosage
+ou de reconditionnement prévue (case 2)
 
 <table>
 <thead>
@@ -1720,22 +2094,38 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>cap</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de CAP (le cas échéant)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Opération d'élimination / valorisation prévue (code D/R)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement de destination
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Rubrique
+
+Rubrique ICPE d'un établissement avec les autorisations associées
+Pour plus de détails, se référer à la
+[nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
 
 <table>
 <thead>
@@ -1750,52 +2140,92 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>rubrique</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de rubrique tel que défini dans la nomenclature des ICPE
+Ex: 2710
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>alinea</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Alinéa pour la rubrique concerné
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>etatActivite</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+État de l'activité, ex: 'En fonct', 'À l'arrêt'
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>regimeAutorise</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Régime autorisé pour la rubrique: déclaratif, autorisation, seveso, etc
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>activite</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Description de l'activité:
+Ex: traitement thermique de déchets dangereux
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>category</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Catégorie d'établissement associé: TTR, VHU, Traitement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>volume</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Volume autorisé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>unite</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Unité utilisé pour le volume autorisé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteType</strong></td>
 <td valign="top"><a href="#wastetype">WasteType</a></td>
-<td></td>
+<td>
+
+Type de déchets autorisé
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Stat
+
+Statistiques
 
 <table>
 <thead>
@@ -1810,17 +2240,29 @@ Représente un BSD
 <tr>
 <td colspan="2" valign="top"><strong>wasteCode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code déchet
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>incoming</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité entrante
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>outgoing</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Qantité sortante
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -1829,10 +2271,6 @@ Représente un BSD
 
 Changement de statut d'un bordereau
 
-  `status`: statut du bordereau après le changement de statut
-
-  `updatedFields`: valeur des champs transmis lors du changement de statut (eg. receivedBY, processingOperationDescription)
-
 <table>
 <thead>
 <tr>
@@ -1846,38 +2284,64 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Identifiant du log
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#formstatus">FormStatus</a></td>
-<td></td>
+<td>
+
+Statut du bordereau après le changement de statut
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>loggedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date à laquelle le changement de statut a été effectué
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>updatedFields</strong></td>
 <td valign="top"><a href="#json">JSON</a></td>
-<td></td>
+<td>
+
+Valeur des champs transmis lors du changement de statut (eg. receivedBY, processingOperationDescription)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>form</strong></td>
 <td valign="top"><a href="#statuslogform">StatusLogForm</a></td>
-<td></td>
+<td>
+
+BSD concerné
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>user</strong></td>
 <td valign="top"><a href="#statusloguser">StatusLogUser</a></td>
-<td></td>
+<td>
+
+Utilisateur à l'origine de la modification
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### StatusLogForm
 
+Information sur un BSD dans les logs de modifications de statuts
+
 <table>
 <thead>
 <tr>
@@ -1891,17 +2355,27 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Identifiant du BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° du bordereau
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### StatusLogUser
+
+Utilisateur ayant modifié le BSD
 
 <table>
 <thead>
@@ -1941,18 +2415,30 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>forms</strong></td>
 <td valign="top"><a href="#formsubscription">FormSubscription</a></td>
-<td></td>
+<td>
+
+DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
+
+Permet de s'abonner aux changements de statuts d'un BSD
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">token</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Token permettant de s'authentifier à l'API
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Trader
 
+Négociant (case 7)
+
 <table>
 <thead>
 <tr>
@@ -1966,28 +2452,46 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement négociant
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receipt</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>department</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Département
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>validityLimit</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Limite de validité
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### Transporter
 
+Collecteur - transporteur (case 8)
+
 <table>
 <thead>
 <tr>
@@ -2001,37 +2505,63 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Établissement collecteur - transporteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Exemption de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receipt</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>department</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Département
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>validityLimit</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Limite de validité du récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>numberPlate</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de plaque d'immatriculation
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### UploadLink
+
+Lien d'upload
 
 <table>
 <thead>
@@ -2048,7 +2578,7 @@ Changement de statut d'un bordereau
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-URL permettant de télécharger un fichier, protégée par une clé
+URL signé permettant d'uploader un fichier
 
 </td>
 </tr>
@@ -2057,7 +2587,7 @@ URL permettant de télécharger un fichier, protégée par une clé
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Clé unique permettant le téléchargement de fichier. La clé expire au bout de 10 secondes
+Clé permettant l'upload du fichier
 
 </td>
 </tr>
@@ -2083,7 +2613,7 @@ Représente un utilisateur sur la plateforme Trackdéchets
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
-Identifiant unique
+Identifiant opaque
 
 </td>
 </tr>
@@ -2119,7 +2649,7 @@ Numéro de téléphone de l'utilisateur
 <td valign="top">[<a href="#companyprivate">CompanyPrivate</a>]</td>
 <td>
 
-Liste des établissements dont fait partie l'utilisateur
+Liste des établissements dont l'utilisateur est membre
 
 </td>
 </tr>
@@ -2127,6 +2657,8 @@ Liste des établissements dont fait partie l'utilisateur
 </table>
 
 ### WasteDetails
+
+Détails du déchet (case 3, 4, 5, 6)
 
 <table>
 <thead>
@@ -2141,22 +2673,38 @@ Liste des établissements dont fait partie l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>code</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+rubrique déchet au format |_|_| |_|_| |_|_| (*)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Dénomination usuelle
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>onuCode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code ONU
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagings</strong></td>
 <td valign="top">[<a href="#packagings">Packagings</a>]</td>
-<td></td>
+<td>
+
+Conditionnement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>otherPackaging</strong></td>
@@ -2166,22 +2714,38 @@ Liste des établissements dont fait partie l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>numberOfPackages</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+Nombre de colis
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantity</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité en tonnes
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantityType</strong></td>
 <td valign="top"><a href="#quantitytype">QuantityType</a></td>
-<td></td>
+<td>
+
+Réelle ou estimée
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>consistence</strong></td>
 <td valign="top"><a href="#consistence">Consistence</a></td>
-<td></td>
+<td>
+
+Consistance
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2189,12 +2753,6 @@ Liste des établissements dont fait partie l'utilisateur
 ### formsLifeCycleData
 
 Informations du cycle de vie des bordereaux
-
-Pagination
-
-  `hasNextPage` et `hasPreviousPage`: pagination, indique si d'autres pages existent avant ou après
-
-  `startCursor`et `endCursor`: premier et dernier ID de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle
 
 <table>
 <thead>
@@ -2209,32 +2767,56 @@ Pagination
 <tr>
 <td colspan="2" valign="top"><strong>statusLogs</strong></td>
 <td valign="top">[<a href="#statuslog">StatusLog</a>]</td>
-<td></td>
+<td>
+
+Liste des changements de statuts
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>hasNextPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+pagination, indique si d'autres pages existent après
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+pagination, indique si d'autres pages existent avant
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>startCursor</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Premier id de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>endCursor</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Dernier ID de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>count</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+Nombre de changements de statuts renvoyés
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2648,7 +3230,7 @@ Email de l'utilisateur
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-mot de passe de l'utilisateur
+Mot de passe de l'utilisateur
 
 </td>
 </tr>
@@ -2868,7 +3450,7 @@ Numéro de téléphone de l'utilisateur
 
 ### CompanyType
 
-Liste des profils entreprise
+Profil entreprise
 
 <table>
 <thead>
@@ -2937,6 +3519,8 @@ Négociant
 
 ### Consistence
 
+Consistance du déchet
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -2945,20 +3529,34 @@ Négociant
 <tbody>
 <tr>
 <td valign="top"><strong>SOLID</strong></td>
-<td></td>
+<td>
+
+Solide
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>LIQUID</strong></td>
-<td></td>
+<td>
+
+Liquide
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>GASEOUS</strong></td>
-<td></td>
+<td>
+
+Gazeux
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### EmitterType
+
+Types d'émetteur de déchet (choix multiple de la case 1)
 
 <table>
 <thead>
@@ -2968,19 +3566,35 @@ Négociant
 <tbody>
 <tr>
 <td valign="top"><strong>PRODUCER</strong></td>
-<td></td>
+<td>
+
+Producetur de déchet
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>OTHER</strong></td>
-<td></td>
+<td>
+
+Autre détenteur
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>APPENDIX1</strong></td>
-<td></td>
+<td>
+
+Collecteur de petites quantités de déchets relevant de la même rubrique
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>APPENDIX2</strong></td>
-<td></td>
+<td>
+
+Personne ayant transformé ou réalisé un traitement dont la provenance des déchets reste identifiable
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -3020,6 +3634,8 @@ Type d'établissement favoris
 
 ### FormStatus
 
+Différents statuts d'un BSD au cours de son cycle de vie
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -3028,48 +3644,84 @@ Type d'établissement favoris
 <tbody>
 <tr>
 <td valign="top"><strong>DRAFT</strong></td>
-<td></td>
+<td>
+
+BSD à l'état de brouillon
+Des champs obligatoires peuvent manquer
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>SEALED</strong></td>
-<td></td>
+<td>
+
+BSD finalisé
+Les champs sont validés pour détecter des valeurs manquantes ou erronnées
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>SENT</strong></td>
-<td></td>
+<td>
+
+BSD envoyé vers l'établissement de destination
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>RECEIVED</strong></td>
-<td></td>
+<td>
+
+BSD reçu par l'établissement de destination
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>PROCESSED</strong></td>
-<td></td>
+<td>
+
+BSD dont les déchets ont été traités
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>AWAITING_GROUP</strong></td>
-<td></td>
+<td>
+
+BSD en attente de regroupement
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>GROUPED</strong></td>
-<td></td>
+<td>
+
+Regroupement effectué
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>NO_TRACEABILITY</strong></td>
-<td></td>
+<td>
+
+Perte de traçabalité
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>REFUSED</strong></td>
-<td></td>
+<td>
+
+Déchet refusé
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FormType
 
-On peut récupérer les BSD par type:
-- ACTOR: on est acteur du BSD, c'est à dire émetteur ou destinataire (cas par défaut)
-- TRANSPORTER: on est uniquement transporteur du déchet
+Valeur possibles pour le filtre de la query `forms`
 
 <table>
 <thead>
@@ -3079,16 +3731,26 @@ On peut récupérer les BSD par type:
 <tbody>
 <tr>
 <td valign="top"><strong>ACTOR</strong></td>
-<td></td>
+<td>
+
+Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut)
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>TRANSPORTER</strong></td>
-<td></td>
+<td>
+
+Uniquement les BSD's dont je suis transporteur
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FormsRegisterExportType
+
+Type pour l'export du registre
 
 <table>
 <thead>
@@ -3098,16 +3760,26 @@ On peut récupérer les BSD par type:
 <tbody>
 <tr>
 <td valign="top"><strong>INCOMING</strong></td>
-<td></td>
+<td>
+
+Déchets entrants
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>OUTGOING</strong></td>
-<td></td>
+<td>
+
+Déchets sortants
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### GerepType
+
+Type d'une déclaration GEREP
 
 <table>
 <thead>
@@ -3128,6 +3800,8 @@ On peut récupérer les BSD par type:
 
 ### Packagings
 
+Type de packaging du déchet
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -3136,28 +3810,50 @@ On peut récupérer les BSD par type:
 <tbody>
 <tr>
 <td valign="top"><strong>FUT</strong></td>
-<td></td>
+<td>
+
+Fut
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>GRV</strong></td>
-<td></td>
+<td>
+
+GRV
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>CITERNE</strong></td>
-<td></td>
+<td>
+
+Citerne
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>BENNE</strong></td>
-<td></td>
+<td>
+
+Benne
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>AUTRE</strong></td>
-<td></td>
+<td>
+
+Autre
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### QuantityType
+
+Type de quantité lors de l'émission
 
 <table>
 <thead>
@@ -3167,11 +3863,19 @@ On peut récupérer les BSD par type:
 <tbody>
 <tr>
 <td valign="top"><strong>REAL</strong></td>
-<td></td>
+<td>
+
+Quntité réelle
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>ESTIMATED</strong></td>
-<td></td>
+<td>
+
+Quantité estimée
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -3234,6 +3938,8 @@ Les membres peuvent:
 
 ### WasteType
 
+Type de déchets autorisé pour une rubrique
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -3242,15 +3948,27 @@ Les membres peuvent:
 <tbody>
 <tr>
 <td valign="top"><strong>INERTE</strong></td>
-<td></td>
+<td>
+
+Déchet inerte
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>NOT_DANGEROUS</strong></td>
-<td></td>
+<td>
+
+Déchet non dangereux
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>DANGEROUS</strong></td>
-<td></td>
+<td>
+
+Déchet dangereux
+
+</td>
 </tr>
 </tbody>
 </table>

--- a/documentation/docs/api-reference/api-reference.md
+++ b/documentation/docs/api-reference/api-reference.md
@@ -1801,7 +1801,7 @@ Quantité réelle présentée (case 10)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Si oui ou non le traitement a été effectué
+Traitement réalisé (code D/R)
 
 </td>
 </tr>
@@ -2675,7 +2675,7 @@ Détails du déchet (case 3, 4, 5, 6)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-rubrique déchet au format |_|_| |_|_| |_|_| (*)
+Rubrique déchet au format |_|_| |_|_| |_|_| (*)
 
 </td>
 </tr>
@@ -2709,7 +2709,11 @@ Conditionnement
 <tr>
 <td colspan="2" valign="top"><strong>otherPackaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Autre packaging (préciser)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>numberOfPackages</strong></td>
@@ -2825,6 +2829,8 @@ Nombre de changements de statuts renvoyés
 
 ### AppendixFormInput
 
+Payload de création d'une annexe 2
+
 <table>
 <thead>
 <tr>
@@ -2837,17 +2843,27 @@ Nombre de changements de statuts renvoyés
 <tr>
 <td colspan="2" valign="top"><strong>emitterSiret</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+SIRET de l'établissement émetteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+N° de bordereau
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### CompanyInput
+
+Payload d'un établissement
 
 <table>
 <thead>
@@ -2861,37 +2877,63 @@ Nombre de changements de statuts renvoyés
 <tr>
 <td colspan="2" valign="top"><strong>siret</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contact</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom du contact dans l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mail</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Email du contact dans l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>phone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de contact dans l'établissement
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### EmitterInput
+
+Payload lié à un l'émetteur du BSD (case 1)
 
 <table>
 <thead>
@@ -2905,22 +2947,36 @@ Nombre de changements de statuts renvoyés
 <tr>
 <td colspan="2" valign="top"><strong>type</strong></td>
 <td valign="top"><a href="#emittertype">EmitterType</a></td>
-<td></td>
+<td>
+
+Type d'émetteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>pickupSite</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse du chantier
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#companyinput">CompanyInput</a></td>
-<td></td>
+<td>
+
+Établissement émetteur
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### FormInput
+
+Payload de création d'un BSD
 
 <table>
 <thead>
@@ -2934,42 +2990,75 @@ Nombre de changements de statuts renvoyés
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
-<td></td>
+<td>
+
+Identifiant opaque
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>customId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant personnalisé permettant de faire le lien avec un
+objet un système d'information tierce
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>emitter</strong></td>
 <td valign="top"><a href="#emitterinput">EmitterInput</a></td>
-<td></td>
+<td>
+
+Établissement émetteur/producteur du déchet (case 1)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recipient</strong></td>
 <td valign="top"><a href="#recipientinput">RecipientInput</a></td>
-<td></td>
+<td>
+
+Établissement qui reçoit le déchet (case 2)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>transporter</strong></td>
 <td valign="top"><a href="#transporterinput">TransporterInput</a></td>
-<td></td>
+<td>
+
+Transporteur du déchet (case 8)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteDetails</strong></td>
 <td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
-<td></td>
+<td>
+
+Détails du déchet (case 3)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>trader</strong></td>
 <td valign="top"><a href="#traderinput">TraderInput</a></td>
-<td></td>
+<td>
+
+Négociant (case 7)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
 <td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>]</td>
-<td></td>
+<td>
+
+Annexe 2
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2988,12 +3077,20 @@ Nombre de changements de statuts renvoyés
 <tr>
 <td colspan="2" valign="top"><strong>processingOperation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Traitement prévue (code D/R)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#companyinput">CompanyInput</a></td>
-<td></td>
+<td>
+
+Établissement de destination ultérieur
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -3071,6 +3168,8 @@ de l'utilisateur à l'établissement
 
 ### ProcessedFormInput
 
+Payload de traitement d'un BSD
+
 <table>
 <thead>
 <tr>
@@ -3083,37 +3182,63 @@ de l'utilisateur à l'établissement
 <tr>
 <td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Traitement réalisé (code D/R)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperationDescription</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Description de l'opération de traitement (case 11)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processedBy</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Personne en charge du traitement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a>!</td>
-<td></td>
+<td>
+
+Date à laquelle le déchet a été traité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>nextDestination</strong></td>
 <td valign="top"><a href="#nextdestinationinput">NextDestinationInput</a></td>
-<td></td>
+<td>
+
+Destination ultérieure prévue (case 12)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>noTraceability</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non il y a eu perte de traçabalité
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### ReceivedFormInput
+
+Payload de réception d'un BSD
 
 <table>
 <thead>
@@ -3127,32 +3252,55 @@ de l'utilisateur à l'établissement
 <tr>
 <td colspan="2" valign="top"><strong>wasteAcceptationStatus</strong></td>
 <td valign="top"><a href="#wasteacceptationstatusinput">WasteAcceptationStatusInput</a>!</td>
-<td></td>
+<td>
+
+Statut d'acceptation du déchet (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteRefusalReason</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Raison du refus (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receivedBy</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Nom de la personne en charge de la réception du déchet (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receivedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a>!</td>
-<td></td>
+<td>
+
+Date à laquelle le déchet a été reçu (case 10)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantityReceived</strong></td>
 <td valign="top"><a href="#float">Float</a>!</td>
-<td></td>
+<td>
+
+Quantité réelle présentée (case 10)
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### RecipientInput
+
+Payload lié à l'installation de destination ou d'entreprosage
+ou de reconditionnement prévue (case 2)
 
 <table>
 <thead>
@@ -3166,22 +3314,36 @@ de l'utilisateur à l'établissement
 <tr>
 <td colspan="2" valign="top"><strong>cap</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de CAP (le cas échéant)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperation</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Opération d'élimination / valorisation prévue (code D/R)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#companyinput">CompanyInput</a></td>
-<td></td>
+<td>
+
+Établissement de destination
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### SentFormInput
+
+Payload de signature d'un BSD
 
 <table>
 <thead>
@@ -3195,12 +3357,20 @@ de l'utilisateur à l'établissement
 <tr>
 <td colspan="2" valign="top"><strong>sentAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date de l'envoi du déchet par l'émetteur (case 9)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sentBy</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de la personne responsable de l'envoi du déchet (case 9)
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -3257,6 +3427,8 @@ Numéro de téléphone de l'utilisateur
 
 ### TraderInput
 
+Payload lié au négociant
+
 <table>
 <thead>
 <tr>
@@ -3269,27 +3441,45 @@ Numéro de téléphone de l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>receipt</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>department</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Département
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>validityLimit</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Limite de validité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#companyinput">CompanyInput</a></td>
-<td></td>
+<td>
+
+Établissement négociant
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### TransporterInput
+
+Collecteur - transporteur (case 8)
 
 <table>
 <thead>
@@ -3303,37 +3493,63 @@ Numéro de téléphone de l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Exemption de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>receipt</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+N° de récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>department</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Département
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>validityLimit</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Limite de validité du récipissé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>numberPlate</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de plaque d'immatriculation
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>company</strong></td>
 <td valign="top"><a href="#companyinput">CompanyInput</a></td>
-<td></td>
+<td>
+
+Établissement collecteur - transporteur
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### TransporterSignatureFormInput
+
+Payload de signature d'un BSD par un transporteur
 
 <table>
 <thead>
@@ -3347,47 +3563,81 @@ Numéro de téléphone de l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>sentAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a>!</td>
-<td></td>
+<td>
+
+Date de l'envoi du déchet par l'émetteur (case 9)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
-<td></td>
+<td>
+
+Si oui ou non le BSD a été signé par un transporteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>securityCode</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+Code de sécurité permettant d'authentifier l'émetteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>sentBy</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de la personne responsable de l'envoi du déchet (case 9)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signedByProducer</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a>!</td>
-<td></td>
+<td>
+
+Si oui on non le BSD a été signé par l'émetteur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagings</strong></td>
 <td valign="top">[<a href="#packagings">Packagings</a>]!</td>
-<td></td>
+<td>
+
+Conditionnement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantity</strong></td>
 <td valign="top"><a href="#float">Float</a>!</td>
-<td></td>
+<td>
+
+Quantité en tonnes
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>onuCode</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Code ONU
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### WasteDetailsInput
+
+Payload lié au détails du déchet (case 3, 4, 5, 6)
 
 <table>
 <thead>
@@ -3401,47 +3651,83 @@ Numéro de téléphone de l'utilisateur
 <tr>
 <td colspan="2" valign="top"><strong>code</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+rubrique déchet au format |_|_| |_|_| |_|_| (*)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Dénomination usuelle
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>onuCode</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code ONU
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>packagings</strong></td>
 <td valign="top">[<a href="#packagings">Packagings</a>]</td>
-<td></td>
+<td>
+
+Conditionnement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>otherPackaging</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Autre packaging (préciser)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>numberOfPackages</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+Nombre de colis
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantity</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité en tonnes
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantityType</strong></td>
 <td valign="top"><a href="#quantitytype">QuantityType</a></td>
-<td></td>
+<td>
+
+Réelle ou estimée
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>consistence</strong></td>
 <td valign="top"><a href="#consistence">Consistence</a></td>
-<td></td>
+<td>
+
+Consistance
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -3915,6 +4201,8 @@ Les membres peuvent:
 
 ### WasteAcceptationStatusInput
 
+Statut d'acceptation d'un déchet
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -3923,15 +4211,27 @@ Les membres peuvent:
 <tbody>
 <tr>
 <td valign="top"><strong>ACCEPTED</strong></td>
-<td></td>
+<td>
+
+Accepté en totalité
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>REFUSED</strong></td>
-<td></td>
+<td>
+
+Refusé
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>PARTIALLY_REFUSED</strong></td>
-<td></td>
+<td>
+
+Refus partiel
+
+</td>
 </tr>
 </tbody>
 </table>

--- a/documentation/docs/api-reference/api-reference.md
+++ b/documentation/docs/api-reference/api-reference.md
@@ -1,81 +1,5 @@
-# Schema Types
+# Référence de l'API GraphQL
 
-<details>
-  <summary><strong>Table of Contents</strong></summary>
-
-  * [Query](#query)
-  * [Mutation](#mutation)
-  * [Objects](#objects)
-    * [AccessToken](#accesstoken)
-    * [AuthPayload](#authpayload)
-    * [CompanyFavorite](#companyfavorite)
-    * [CompanyMember](#companymember)
-    * [CompanyPrivate](#companyprivate)
-    * [CompanyPublic](#companypublic)
-    * [CompanySearchResult](#companysearchresult)
-    * [CompanyStat](#companystat)
-    * [Declaration](#declaration)
-    * [Emitter](#emitter)
-    * [FileDownload](#filedownload)
-    * [Form](#form)
-    * [FormCompany](#formcompany)
-    * [FormSubscription](#formsubscription)
-    * [Installation](#installation)
-    * [NextDestination](#nextdestination)
-    * [Recipient](#recipient)
-    * [Rubrique](#rubrique)
-    * [Stat](#stat)
-    * [StatusLog](#statuslog)
-    * [StatusLogForm](#statuslogform)
-    * [StatusLogUser](#statusloguser)
-    * [Subscription](#subscription)
-    * [Trader](#trader)
-    * [Transporter](#transporter)
-    * [UploadLink](#uploadlink)
-    * [User](#user)
-    * [WasteDetails](#wastedetails)
-    * [formsLifeCycleData](#formslifecycledata)
-  * [Inputs](#inputs)
-    * [AppendixFormInput](#appendixforminput)
-    * [CompanyInput](#companyinput)
-    * [EmitterInput](#emitterinput)
-    * [FormInput](#forminput)
-    * [NextDestinationInput](#nextdestinationinput)
-    * [PrivateCompanyInput](#privatecompanyinput)
-    * [ProcessedFormInput](#processedforminput)
-    * [ReceivedFormInput](#receivedforminput)
-    * [RecipientInput](#recipientinput)
-    * [SentFormInput](#sentforminput)
-    * [SignupInput](#signupinput)
-    * [TraderInput](#traderinput)
-    * [TransporterInput](#transporterinput)
-    * [TransporterSignatureFormInput](#transportersignatureforminput)
-    * [WasteDetailsInput](#wastedetailsinput)
-  * [Enums](#enums)
-    * [CompanyType](#companytype)
-    * [Consistence](#consistence)
-    * [EmitterType](#emittertype)
-    * [FavoriteType](#favoritetype)
-    * [FormStatus](#formstatus)
-    * [FormType](#formtype)
-    * [FormsRegisterExportType](#formsregisterexporttype)
-    * [GerepType](#gereptype)
-    * [Packagings](#packagings)
-    * [QuantityType](#quantitytype)
-    * [UserRole](#userrole)
-    * [UserType](#usertype)
-    * [WasteAcceptationStatusInput](#wasteacceptationstatusinput)
-    * [WasteType](#wastetype)
-  * [Scalars](#scalars)
-    * [Boolean](#boolean)
-    * [DateTime](#datetime)
-    * [Float](#float)
-    * [ID](#id)
-    * [Int](#int)
-    * [JSON](#json)
-    * [String](#string)
-
-</details>
 
 ## Query
 <table>
@@ -91,7 +15,13 @@
 <tr>
 <td colspan="2" valign="top"><strong>companyInfos</strong></td>
 <td valign="top"><a href="#companypublic">CompanyPublic</a></td>
-<td></td>
+<td>
+
+Renvoie des informations publiques sur un établissement
+extrait de la base SIRENE et de la base des installations
+classées pour la protection de l'environnement (ICPE)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
@@ -101,7 +31,12 @@
 <tr>
 <td colspan="2" valign="top"><strong>searchCompanies</strong></td>
 <td valign="top">[<a href="#companysearchresult">CompanySearchResult</a>]</td>
-<td></td>
+<td>
+
+Effectue une recherche floue sur la base SIRENE et enrichit
+les résultats avec des informations provenant de Trackdéchets
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">clue</td>
@@ -116,7 +51,12 @@
 <tr>
 <td colspan="2" valign="top"><strong>favorites</strong></td>
 <td valign="top">[<a href="#companyfavorite">CompanyFavorite</a>]</td>
-<td></td>
+<td>
+
+Liste les établissements favoris de l'utilisateur. C'est à dire les
+établissements qui font souvent partis des BSD édités
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">type</td>
@@ -275,12 +215,20 @@ Pagination:
 <tr>
 <td colspan="2" valign="top"><strong>me</strong></td>
 <td valign="top"><a href="#user">User</a></td>
-<td></td>
+<td>
+
+Renvoie les informations sur l'utilisateur authentifié
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>apiKey</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Renvoie un token permettant de faire des requêtes sur l'API Trackdéchets
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -299,7 +247,11 @@ Pagination:
 <tr>
 <td colspan="2" valign="top"><strong>renewSecurityCode</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Renouvelle le code de sécurité de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
@@ -309,47 +261,83 @@ Pagination:
 <tr>
 <td colspan="2" valign="top"><strong>updateCompany</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Édite les informations d'un établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">siret</td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">gerepId</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant GEREP
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">contactEmail</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Email de contact
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">contactPhone</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de contact
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">website</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Site web
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">companyTypes</td>
 <td valign="top">[<a href="#companytype">CompanyType</a>]</td>
-<td></td>
+<td>
+
+Profil de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">givenName</td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom d'usage de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>createCompany</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Rattache un établissement à l'utilisateur authentifié
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">companyInput</td>
@@ -359,7 +347,13 @@ Pagination:
 <tr>
 <td colspan="2" valign="top"><strong>createUploadLink</strong></td>
 <td valign="top"><a href="#uploadlink">UploadLink</a></td>
-<td></td>
+<td>
+
+Renvoie une URL permettant de télécharger un fichier
+Le fichier peut être par exemple un BSD au format .pdf
+ou un registre au format .csv
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">fileName</td>
@@ -506,7 +500,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>signup</strong></td>
 <td valign="top"><a href="#user">User</a></td>
-<td></td>
+<td>
+
+Permet de créer un nouvel utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">userInfos</td>
@@ -516,7 +514,15 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>login</strong></td>
 <td valign="top"><a href="#authpayload">AuthPayload</a>!</td>
-<td></td>
+<td>
+
+DEPRECATED - La récupération de token doit s'effectuer avec
+le protocole OAuth2
+
+Récupére un token à partir de l'email et du mot de passe
+d'un utilisateur.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">email</td>
@@ -531,7 +537,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>changePassword</strong></td>
 <td valign="top"><a href="#user">User</a>!</td>
-<td></td>
+<td>
+
+Modifie le mot de passe d'un utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">oldPassword</td>
@@ -546,7 +556,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>resetPassword</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Envoie un email pour la réinitialisation du mot de passe
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">email</td>
@@ -556,7 +570,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>editProfile</strong></td>
 <td valign="top"><a href="#user">User</a></td>
-<td></td>
+<td>
+
+Met à jour les informations de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">name</td>
@@ -576,7 +594,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>inviteUserToCompany</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Invite un nouvel utilisateur à un établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">email</td>
@@ -596,7 +618,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>resendInvitation</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Renvoie l'email d'invitation à un établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">email</td>
@@ -611,7 +637,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>joinWithInvite</strong></td>
 <td valign="top"><a href="#user">User</a>!</td>
-<td></td>
+<td>
+
+Active le compte d'un utilisateur invité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">inviteHash</td>
@@ -631,7 +661,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>removeUserFromCompany</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Supprime les droits d'un utilisateurs sur un établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">userId</td>
@@ -646,7 +680,11 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>deleteInvitation</strong></td>
 <td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
-<td></td>
+<td>
+
+Supprime une invitation à un établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" align="right" valign="top">email</td>
@@ -663,28 +701,10 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 
 ## Objects
 
-### AccessToken
-
-<table>
-<thead>
-<tr>
-<th align="left">Field</th>
-<th align="right">Argument</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>token</strong></td>
-<td valign="top"><a href="#string">String</a>!</td>
-<td></td>
-</tr>
-</tbody>
-</table>
-
 ### AuthPayload
 
+Cet objet est renvoyé par la mutation login qui est dépréciée
+
 <table>
 <thead>
 <tr>
@@ -698,18 +718,32 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>token</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Bearer token à durée illimité permettant de s'authentifier
+à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
+header d'autorisation `Authorization: Bearer ******`
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>user</strong></td>
 <td valign="top"><a href="#user">User</a>!</td>
-<td></td>
+<td>
+
+Utilisateur lié au token
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### CompanyFavorite
 
+Information sur établissement accessible dans la liste des favoris
+La liste des favoris est constituée à partir de l'historique des
+BSD édités
+
 <table>
 <thead>
 <tr>
@@ -723,38 +757,64 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>siret</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contact</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom du contact
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>phone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mail</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Email de contact
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### CompanyMember
 
+Information sur utilisateur au sein d'un établissement
+
 <table>
 <thead>
 <tr>
@@ -768,46 +828,72 @@ Valide la prise en charge par le transporteur, et peut valider l'envoi
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+Identifiant unique
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>email</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Email
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>role</strong></td>
 <td valign="top"><a href="#userrole">UserRole</a></td>
-<td></td>
+<td>
+
+Rôle de l'utilisateur dans l'établissement (ADMIN or MEMBER)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isActive</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non l'email de l'utilisateur a été confirmé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isPendingInvitation</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non une une invitation à joindre l'établissement est en attente
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>isMe</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
+<td>
+
+Si oui ou non cet utilisateur correspond à l'utilisateur authentifié
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### CompanyPrivate
 
-Private company type accessed by a user
-who is member of the company. Is is typically
-accessed through `query { user { companies } }`
+Information sur un établissement accessible par un utilisateur membre
 
 <table>
 <thead>
@@ -824,52 +910,70 @@ accessed through `query { user { companies } }`
 <td valign="top"><a href="#id">ID</a>!</td>
 <td>
 
- Company info in Prisma
-#######################
+Identifiant unique
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>companyTypes</strong></td>
 <td valign="top">[<a href="#companytype">CompanyType</a>]</td>
-<td></td>
+<td>
+
+Profil de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gerepId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant GEREP
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>securityCode</strong></td>
 <td valign="top"><a href="#int">Int</a>!</td>
-<td></td>
+<td>
+
+Code de sécurité
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contactEmail</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
- Contact info (from prisma)
-##########################
+Email de contact (visible sur la fiche entreprise)
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contactPhone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de contact (visible sur la fiche entreprise)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>website</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Site web (visible sur la fiche entreprise)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>users</strong></td>
 <td valign="top">[<a href="#companymember">CompanyMember</a>]</td>
 <td>
 
-List of company members
+Liste des utilisateurs appartenant à cet établissement
 
 </td>
 </tr>
@@ -878,7 +982,7 @@ List of company members
 <td valign="top"><a href="#userrole">UserRole</a></td>
 <td>
 
-Role of the logged in user in the company
+Rôle de l'utilisateur authentifié cau sein de cet établissement
 
 </td>
 </tr>
@@ -887,7 +991,8 @@ Role of the logged in user in the company
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Given name used in company selector
+Nom d'usage de l'entreprise qui permet de différencier
+différents établissements ayant le même nom
 
 </td>
 </tr>
@@ -896,48 +1001,71 @@ Given name used in company selector
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
- Company info from SIRENE
-#########################
+SIRET de l'établissement
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>naf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code NAF de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>libelleNaf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Libellé NAF de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Longitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Latitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>installation</strong></td>
 <td valign="top"><a href="#installation">Installation</a></td>
 <td>
 
- Company info from ICPE database
-################################
+Installation classée pour la protection de l'environnement (ICPE)
+associé à cet établissement
 
 </td>
 </tr>
@@ -946,9 +1074,7 @@ Given name used in company selector
 
 ### CompanyPublic
 
-Public company type that can be accessed
-by a user who is not member of the company
-(for example in the fiche entreprise)
+Information sur un établissement accessible publiquement
 
 <table>
 <thead>
@@ -965,67 +1091,98 @@ by a user who is not member of the company
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
- Contact info (from prisma)
-##########################
+Email de contact
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>contactPhone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de contact
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>website</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Site web
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>siret</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
- Company info from SIRENE
-#########################
+SIRET de l'établissement
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>naf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code NAF
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>libelleNaf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Libellé NAF
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Longitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Latitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>installation</strong></td>
 <td valign="top"><a href="#installation">Installation</a></td>
 <td>
 
-Company info from ICPE database
+Installation classée pour la protection de l'environnement (ICPE)
+associé à cet établissement
 
 </td>
 </tr>
@@ -1034,7 +1191,8 @@ Company info from ICPE database
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
-Whether or not this company is registered in TD
+Si oui on non cet établissement est rattaché à un
+utilisateur sur la plateforme Trackdéchets
 
 </td>
 </tr>
@@ -1042,6 +1200,8 @@ Whether or not this company is registered in TD
 </table>
 
 ### CompanySearchResult
+
+Information sur un établissement accessible en recherche
 
 <table>
 <thead>
@@ -1058,51 +1218,80 @@ Whether or not this company is registered in TD
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-company info from SIRENE
+SIRET de l'établissement
 
 </td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Adresse de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>companyTypes</strong></td>
 <td valign="top">[<a href="#companytype">CompanyType</a>]</td>
-<td></td>
+<td>
+
+Profil de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>naf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code NAF
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>libelleNaf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Libellé NAF
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>longitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Longitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>latitude</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Latitude de l'établissement (info géographique)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>installation</strong></td>
 <td valign="top"><a href="#installation">Installation</a></td>
 <td>
 
-company info from ICPE database
+Installation classée pour la protection de l'environnement (ICPE)
+associé à cet établissement
 
 </td>
 </tr>
@@ -1857,17 +2046,27 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>signedUrl</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+URL permettant de télécharger un fichier, protégée par une clé
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>key</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Clé unique permettant le téléchargement de fichier. La clé expire au bout de 10 secondes
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### User
+
+Représente un utilisateur sur la plateforme Trackdéchets
 
 <table>
 <thead>
@@ -1882,27 +2081,47 @@ Changement de statut d'un bordereau
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+Identifiant unique
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>email</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Email de l'utiliateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>phone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>companies</strong></td>
 <td valign="top">[<a href="#companyprivate">CompanyPrivate</a>]</td>
-<td></td>
+<td>
+
+Liste des établissements dont fait partie l'utilisateur
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2199,6 +2418,8 @@ Pagination
 
 ### PrivateCompanyInput
 
+Payload permettant le rattachement d'un établissement à un utilisateur
+
 <table>
 <thead>
 <tr>
@@ -2211,32 +2432,57 @@ Pagination
 <tr>
 <td colspan="2" valign="top"><strong>siret</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+SIRET de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>gerepId</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Identifiant GEREP de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>companyTypes</strong></td>
 <td valign="top">[<a href="#companytype">CompanyType</a>]</td>
-<td></td>
+<td>
+
+Profil de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>codeNaf</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Code NAF
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>companyName</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Nom de l'établissement
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>documentKeys</strong></td>
 <td valign="top">[<a href="#string">String</a>]</td>
-<td></td>
+<td>
+
+Liste de documents permettant de démontrer l'appartenance
+de l'utilisateur à l'établissement
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2391,22 +2637,38 @@ Pagination
 <tr>
 <td colspan="2" valign="top"><strong>email</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Email de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>password</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+mot de passe de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Nom de l'utilisateur
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>phone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Numéro de téléphone de l'utilisateur
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2606,6 +2868,8 @@ Pagination
 
 ### CompanyType
 
+Liste des profils entreprise
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -2614,31 +2878,59 @@ Pagination
 <tbody>
 <tr>
 <td valign="top"><strong>PRODUCER</strong></td>
-<td></td>
+<td>
+
+Producteur de déchet
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>COLLECTOR</strong></td>
-<td></td>
+<td>
+
+Installation de Transit, regroupement ou tri de déchets
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>WASTEPROCESSOR</strong></td>
-<td></td>
+<td>
+
+Installation de traitement
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>TRANSPORTER</strong></td>
-<td></td>
+<td>
+
+Transporteur
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>WASTE_VEHICLES</strong></td>
-<td></td>
+<td>
+
+Installation d'entreposage, dépollution, démontage, découpage de VHU
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>WASTE_CENTER</strong></td>
-<td></td>
+<td>
+
+Installation de collecte de déchets apportés par le producteur initial
+
+</td>
 </tr>
 <tr>
 <td valign="top"><strong>TRADER</strong></td>
-<td></td>
+<td>
+
+Négociant
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -2694,6 +2986,8 @@ Pagination
 </table>
 
 ### FavoriteType
+
+Type d'établissement favoris
 
 <table>
 <thead>
@@ -2884,6 +3178,20 @@ On peut récupérer les BSD par type:
 
 ### UserRole
 
+Liste les différents rôles d'un utilisateur au sein
+d'un établissement.
+
+Les admins peuvent:
+* consulter/éditer les bordereaux
+* gérer les utilisateurs de l'établissement
+* éditer les informations de la fiche entreprise
+* demander le renouvellement du code de sécurité
+* Éditer les informations de la fiche entreprise
+
+Les membres peuvent:
+* consulter/éditer les bordereaux
+* consulter le reste des informations
+
 <table>
 <thead>
 <th align="left">Value</th>
@@ -2896,45 +3204,6 @@ On peut récupérer les BSD par type:
 </tr>
 <tr>
 <td valign="top"><strong>ADMIN</strong></td>
-<td></td>
-</tr>
-</tbody>
-</table>
-
-### UserType
-
-<table>
-<thead>
-<th align="left">Value</th>
-<th align="left">Description</th>
-</thead>
-<tbody>
-<tr>
-<td valign="top"><strong>PRODUCER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>COLLECTOR</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>WASTEPROCESSOR</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>TRANSPORTER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>WASTE_VEHICLES</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>WASTE_CENTER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>TRADER</strong></td>
 <td></td>
 </tr>
 </tbody>

--- a/documentation/docs/api-reference/api-reference.md
+++ b/documentation/docs/api-reference/api-reference.md
@@ -1,0 +1,3013 @@
+# Schema Types
+
+<details>
+  <summary><strong>Table of Contents</strong></summary>
+
+  * [Query](#query)
+  * [Mutation](#mutation)
+  * [Objects](#objects)
+    * [AccessToken](#accesstoken)
+    * [AuthPayload](#authpayload)
+    * [CompanyFavorite](#companyfavorite)
+    * [CompanyMember](#companymember)
+    * [CompanyPrivate](#companyprivate)
+    * [CompanyPublic](#companypublic)
+    * [CompanySearchResult](#companysearchresult)
+    * [CompanyStat](#companystat)
+    * [Declaration](#declaration)
+    * [Emitter](#emitter)
+    * [FileDownload](#filedownload)
+    * [Form](#form)
+    * [FormCompany](#formcompany)
+    * [FormSubscription](#formsubscription)
+    * [Installation](#installation)
+    * [NextDestination](#nextdestination)
+    * [Recipient](#recipient)
+    * [Rubrique](#rubrique)
+    * [Stat](#stat)
+    * [StatusLog](#statuslog)
+    * [StatusLogForm](#statuslogform)
+    * [StatusLogUser](#statusloguser)
+    * [Subscription](#subscription)
+    * [Trader](#trader)
+    * [Transporter](#transporter)
+    * [UploadLink](#uploadlink)
+    * [User](#user)
+    * [WasteDetails](#wastedetails)
+    * [formsLifeCycleData](#formslifecycledata)
+  * [Inputs](#inputs)
+    * [AppendixFormInput](#appendixforminput)
+    * [CompanyInput](#companyinput)
+    * [EmitterInput](#emitterinput)
+    * [FormInput](#forminput)
+    * [NextDestinationInput](#nextdestinationinput)
+    * [PrivateCompanyInput](#privatecompanyinput)
+    * [ProcessedFormInput](#processedforminput)
+    * [ReceivedFormInput](#receivedforminput)
+    * [RecipientInput](#recipientinput)
+    * [SentFormInput](#sentforminput)
+    * [SignupInput](#signupinput)
+    * [TraderInput](#traderinput)
+    * [TransporterInput](#transporterinput)
+    * [TransporterSignatureFormInput](#transportersignatureforminput)
+    * [WasteDetailsInput](#wastedetailsinput)
+  * [Enums](#enums)
+    * [CompanyType](#companytype)
+    * [Consistence](#consistence)
+    * [EmitterType](#emittertype)
+    * [FavoriteType](#favoritetype)
+    * [FormStatus](#formstatus)
+    * [FormType](#formtype)
+    * [FormsRegisterExportType](#formsregisterexporttype)
+    * [GerepType](#gereptype)
+    * [Packagings](#packagings)
+    * [QuantityType](#quantitytype)
+    * [UserRole](#userrole)
+    * [UserType](#usertype)
+    * [WasteAcceptationStatusInput](#wasteacceptationstatusinput)
+    * [WasteType](#wastetype)
+  * [Scalars](#scalars)
+    * [Boolean](#boolean)
+    * [DateTime](#datetime)
+    * [Float](#float)
+    * [ID](#id)
+    * [Int](#int)
+    * [JSON](#json)
+    * [String](#string)
+
+</details>
+
+## Query
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>companyInfos</strong></td>
+<td valign="top"><a href="#companypublic">CompanyPublic</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>searchCompanies</strong></td>
+<td valign="top">[<a href="#companysearchresult">CompanySearchResult</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">clue</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">department</td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>favorites</strong></td>
+<td valign="top">[<a href="#companyfavorite">CompanyFavorite</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#favoritetype">FavoriteType</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>form</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Renvoie un BSD, sélectionné par ID
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>forms</strong></td>
+<td valign="top">[<a href="#form">Form</a>]</td>
+<td>
+
+Renvoie les BSDs de la compagnie sélectionnée (la première par défaut)
+Par défaut, renvoie les BSDs dont on est producteur ou destinataire.
+On peut également demander les bordereaux pour lesquels on est transporteur
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">type</td>
+<td valign="top"><a href="#formtype">FormType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stats</strong></td>
+<td valign="top">[<a href="#companystat">CompanyStat</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>appendixForms</strong></td>
+<td valign="top">[<a href="#form">Form</a>]</td>
+<td>
+
+Renvoie des BSD candidats à un regroupement dans une annexe 2
+`siret`: Siret d'une des entreprises que j'administre
+`wasteCode`: Code déchet pour affiner la recherche, optionnel
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">wasteCode</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>formPdf</strong></td>
+<td valign="top"><a href="#filedownload">FileDownload</a></td>
+<td>
+
+Renvoie un token pour télécharger un pdf de bordereau
+Ce token doit être transmis à la route /download pour obtenir le fichier.
+Il est valable 10 secondes
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>formsRegister</strong></td>
+<td valign="top"><a href="#filedownload">FileDownload</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sirets</td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">exportType</td>
+<td valign="top"><a href="#formsregisterexporttype">FormsRegisterExportType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>formsLifeCycle</strong></td>
+<td valign="top"><a href="#formslifecycledata">formsLifeCycleData</a></td>
+<td>
+
+Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée. 
+La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `created`)
+Seuls les changements de statuts disposant d'un champ `created` non nul sont retournés
+  
+Filtres:
+
+  `siret`: Siret d'une des entreprises que j'administre, optionnel
+
+  `createdAfter`: date formatée après laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
+
+  `createdBefore`: date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel
+  
+  `formId`: id d'un bordereau, optionnel
+  
+Pagination:
+
+  `cursorAfter`: cursor après lequel les changements de statut doivent être retournés, optionnel
+
+  `cursorBefore`: cursor avant lequel les changements de statut doivent être retournés, optionnel
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">loggedBefore</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">loggedAfter</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">cursorAfter</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">cursorBefore</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">formId</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>me</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>apiKey</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Mutation
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>renewSecurityCode</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updateCompany</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">gerepId</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">contactEmail</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">contactPhone</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">website</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">companyTypes</td>
+<td valign="top">[<a href="#companytype">CompanyType</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">givenName</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createCompany</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">companyInput</td>
+<td valign="top"><a href="#privatecompanyinput">PrivateCompanyInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createUploadLink</strong></td>
+<td valign="top"><a href="#uploadlink">UploadLink</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">fileName</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">fileType</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saveForm</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Sauvegarde un BSD (création ou modification, si `FormInput` contient un ID)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">formInput</td>
+<td valign="top"><a href="#forminput">FormInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deleteForm</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Supprime un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>duplicateForm</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Duplique un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>markAsSealed</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Scelle un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>markAsSent</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Valide l'envoi d'un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">sentInfo</td>
+<td valign="top"><a href="#sentforminput">SentFormInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>markAsReceived</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Valide la réception d'un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">receivedInfo</td>
+<td valign="top"><a href="#receivedforminput">ReceivedFormInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>markAsProcessed</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Valide le traitement d'un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">processedInfo</td>
+<td valign="top"><a href="#processedforminput">ProcessedFormInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Valide la prise en charge par le transporteur, et peut valider l'envoi
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">signingInfo</td>
+<td valign="top"><a href="#transportersignatureforminput">TransporterSignatureFormInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signup</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">userInfos</td>
+<td valign="top"><a href="#signupinput">SignupInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>login</strong></td>
+<td valign="top"><a href="#authpayload">AuthPayload</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">password</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>changePassword</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">oldPassword</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">newPassword</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>resetPassword</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>editProfile</strong></td>
+<td valign="top"><a href="#user">User</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">name</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">phone</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>inviteUserToCompany</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">role</td>
+<td valign="top"><a href="#userrole">UserRole</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>resendInvitation</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>joinWithInvite</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">inviteHash</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">name</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">password</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>removeUserFromCompany</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">userId</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>deleteInvitation</strong></td>
+<td valign="top"><a href="#companyprivate">CompanyPrivate</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">email</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Objects
+
+### AccessToken
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### AuthPayload
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#user">User</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CompanyFavorite
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contact</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>mail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CompanyMember
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>role</strong></td>
+<td valign="top"><a href="#userrole">UserRole</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isActive</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isPendingInvitation</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isMe</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CompanyPrivate
+
+Private company type accessed by a user
+who is member of the company. Is is typically
+accessed through `query { user { companies } }`
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ Company info in Prisma
+#######################
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyTypes</strong></td>
+<td valign="top">[<a href="#companytype">CompanyType</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gerepId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>securityCode</strong></td>
+<td valign="top"><a href="#int">Int</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contactEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+ Contact info (from prisma)
+##########################
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contactPhone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>website</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>users</strong></td>
+<td valign="top">[<a href="#companymember">CompanyMember</a>]</td>
+<td>
+
+List of company members
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>userRole</strong></td>
+<td valign="top"><a href="#userrole">UserRole</a></td>
+<td>
+
+Role of the logged in user in the company
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>givenName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Given name used in company selector
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+ Company info from SIRENE
+#########################
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>naf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>libelleNaf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>installation</strong></td>
+<td valign="top"><a href="#installation">Installation</a></td>
+<td>
+
+ Company info from ICPE database
+################################
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CompanyPublic
+
+Public company type that can be accessed
+by a user who is not member of the company
+(for example in the fiche entreprise)
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>contactEmail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+ Contact info (from prisma)
+##########################
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contactPhone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>website</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+ Company info from SIRENE
+#########################
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>naf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>libelleNaf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>installation</strong></td>
+<td valign="top"><a href="#installation">Installation</a></td>
+<td>
+
+Company info from ICPE database
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isRegistered</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td>
+
+Whether or not this company is registered in TD
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CompanySearchResult
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+company info from SIRENE
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyTypes</strong></td>
+<td valign="top">[<a href="#companytype">CompanyType</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>naf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>libelleNaf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>longitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>latitude</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>installation</strong></td>
+<td valign="top"><a href="#installation">Installation</a></td>
+<td>
+
+company info from ICPE database
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### CompanyStat
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>stats</strong></td>
+<td valign="top">[<a href="#stat">Stat</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Declaration
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>annee</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>codeDechet</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>libDechet</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gerepType</strong></td>
+<td valign="top"><a href="#gereptype">GerepType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Emitter
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#emittertype">EmitterType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pickupSite</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FileDownload
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>token</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>downloadLink</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Form
+
+Représente un BSD
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>readableId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>emitter</strong></td>
+<td valign="top"><a href="#emitter">Emitter</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>recipient</strong></td>
+<td valign="top"><a href="#recipient">Recipient</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>transporter</strong></td>
+<td valign="top"><a href="#transporter">Transporter</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteDetails</strong></td>
+<td valign="top"><a href="#wastedetails">WasteDetails</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trader</strong></td>
+<td valign="top"><a href="#trader">Trader</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>createdAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>ownerId</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#formstatus">FormStatus</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sentAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sentBy</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteAcceptationStatus</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteRefusalReason</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receivedBy</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receivedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityReceived</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperationDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processedBy</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>noTraceability</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>nextDestination</strong></td>
+<td valign="top"><a href="#nextdestination">NextDestination</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
+<td valign="top">[<a href="#form">Form</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormCompany
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contact</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>mail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormSubscription
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>mutation</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>node</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedFields</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>previousValues</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Installation
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>codeS3ic</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>urlFiche</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>rubriques</strong></td>
+<td valign="top">[<a href="#rubrique">Rubrique</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>declarations</strong></td>
+<td valign="top">[<a href="#declaration">Declaration</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### NextDestination
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperation</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Recipient
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>cap</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperation</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Rubrique
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>rubrique</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>alinea</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>etatActivite</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>regimeAutorise</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>activite</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>category</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>volume</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>unite</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteType</strong></td>
+<td valign="top"><a href="#wastetype">WasteType</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Stat
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>wasteCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>incoming</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>outgoing</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StatusLog
+
+Changement de statut d'un bordereau
+
+  `status`: statut du bordereau après le changement de statut
+
+  `updatedFields`: valeur des champs transmis lors du changement de statut (eg. receivedBY, processingOperationDescription)
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#formstatus">FormStatus</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>loggedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>updatedFields</strong></td>
+<td valign="top"><a href="#json">JSON</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>form</strong></td>
+<td valign="top"><a href="#statuslogform">StatusLogForm</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>user</strong></td>
+<td valign="top"><a href="#statusloguser">StatusLogUser</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StatusLogForm
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>readableId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### StatusLogUser
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Subscription
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>forms</strong></td>
+<td valign="top"><a href="#formsubscription">FormSubscription</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">token</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Trader
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receipt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>department</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>validityLimit</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Transporter
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receipt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>department</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>validityLimit</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>numberPlate</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UploadLink
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>signedUrl</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>key</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### User
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companies</strong></td>
+<td valign="top">[<a href="#companyprivate">CompanyPrivate</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### WasteDetails
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>onuCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>packagings</strong></td>
+<td valign="top">[<a href="#packagings">Packagings</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>otherPackaging</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>numberOfPackages</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityType</strong></td>
+<td valign="top"><a href="#quantitytype">QuantityType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>consistence</strong></td>
+<td valign="top"><a href="#consistence">Consistence</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### formsLifeCycleData
+
+Informations du cycle de vie des bordereaux
+
+Pagination
+
+  `hasNextPage` et `hasPreviousPage`: pagination, indique si d'autres pages existent avant ou après
+
+  `startCursor`et `endCursor`: premier et dernier ID de la page, à passer dans cursorAfter ou cursorBefore de la query formsLifeCycle
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>statusLogs</strong></td>
+<td valign="top">[<a href="#statuslog">StatusLog</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>hasNextPage</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>hasPreviousPage</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startCursor</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endCursor</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>count</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Inputs
+
+### AppendixFormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>emitterSiret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>readableId</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### CompanyInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>address</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>contact</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>mail</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### EmitterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>type</strong></td>
+<td valign="top"><a href="#emittertype">EmitterType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>pickupSite</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>emitter</strong></td>
+<td valign="top"><a href="#emitterinput">EmitterInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>recipient</strong></td>
+<td valign="top"><a href="#recipientinput">RecipientInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>transporter</strong></td>
+<td valign="top"><a href="#transporterinput">TransporterInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteDetails</strong></td>
+<td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>trader</strong></td>
+<td valign="top"><a href="#traderinput">TraderInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
+<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### NextDestinationInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperation</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### PrivateCompanyInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>gerepId</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyTypes</strong></td>
+<td valign="top">[<a href="#companytype">CompanyType</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>codeNaf</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>companyName</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>documentKeys</strong></td>
+<td valign="top">[<a href="#string">String</a>]</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ProcessedFormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperationDescription</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processedBy</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>nextDestination</strong></td>
+<td valign="top"><a href="#nextdestinationinput">NextDestinationInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>noTraceability</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### ReceivedFormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>wasteAcceptationStatus</strong></td>
+<td valign="top"><a href="#wasteacceptationstatusinput">WasteAcceptationStatusInput</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteRefusalReason</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receivedBy</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receivedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityReceived</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### RecipientInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>cap</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperation</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SentFormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>sentAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sentBy</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### SignupInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>password</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>phone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TraderInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>receipt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>department</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>validityLimit</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TransporterInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receipt</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>department</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>validityLimit</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>numberPlate</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### TransporterSignatureFormInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>sentAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>securityCode</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sentBy</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signedByProducer</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>packagings</strong></td>
+<td valign="top">[<a href="#packagings">Packagings</a>]!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>onuCode</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### WasteDetailsInput
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>code</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>onuCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>packagings</strong></td>
+<td valign="top">[<a href="#packagings">Packagings</a>]</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>otherPackaging</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>numberOfPackages</strong></td>
+<td valign="top"><a href="#int">Int</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityType</strong></td>
+<td valign="top"><a href="#quantitytype">QuantityType</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>consistence</strong></td>
+<td valign="top"><a href="#consistence">Consistence</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Enums
+
+### CompanyType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PRODUCER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>COLLECTOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTEPROCESSOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSPORTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTE_VEHICLES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTE_CENTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRADER</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Consistence
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>SOLID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>LIQUID</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GASEOUS</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### EmitterType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PRODUCER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OTHER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>APPENDIX1</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>APPENDIX2</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FavoriteType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>EMITTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSPORTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RECIPIENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRADER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NEXT_DESTINATION</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormStatus
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>DRAFT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SEALED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>SENT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>RECEIVED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PROCESSED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AWAITING_GROUP</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GROUPED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NO_TRACEABILITY</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REFUSED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormType
+
+On peut récupérer les BSD par type:
+- ACTOR: on est acteur du BSD, c'est à dire émetteur ou destinataire (cas par défaut)
+- TRANSPORTER: on est uniquement transporteur du déchet
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACTOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSPORTER</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### FormsRegisterExportType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>INCOMING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>OUTGOING</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### GerepType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>Producteur</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>Traiteur</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### Packagings
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>FUT</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>GRV</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>CITERNE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>BENNE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>AUTRE</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### QuantityType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>REAL</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ESTIMATED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserRole
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>MEMBER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ADMIN</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### UserType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PRODUCER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>COLLECTOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTEPROCESSOR</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRANSPORTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTE_VEHICLES</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>WASTE_CENTER</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>TRADER</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### WasteAcceptationStatusInput
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>ACCEPTED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REFUSED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>PARTIALLY_REFUSED</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### WasteType
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>INERTE</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>NOT_DANGEROUS</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>DANGEROUS</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+## Scalars
+
+### Boolean
+
+The `Boolean` scalar type represents `true` or `false`.
+
+### DateTime
+
+### Float
+
+The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+
+### ID
+
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
+
+### Int
+
+The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+
+### JSON
+
+### String
+
+The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.

--- a/documentation/docs/api-reference/api-reference.md
+++ b/documentation/docs/api-reference/api-reference.md
@@ -3653,7 +3653,7 @@ Payload lié au détails du déchet (case 3, 4, 5, 6)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-rubrique déchet au format |_|_| |_|_| |_|_| (*)
+Rubrique déchet au format |_|_| |_|_| |_|_| (*)
 
 </td>
 </tr>

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -12,3 +12,4 @@ nav:
   - "Cycle de vie d'un BSD": "workflow.md"
   - "Cas d'usages": "use-cases.md"
   - "Lexique": "glossary.md"
+  - "Référence de l'API": "api-reference/api-reference.md"


### PR DESCRIPTION
J'ai documenté l'ensemble des Query, Mutation, Type et arguments avec des strings de documentation (Cf https://www.apollographql.com/docs/apollo-server/schema/schema/#documentation-strings).

Cela permet d'avoir de la documentation précise pour l'ensemble des champs et arguments sur le playground.

J'ai également ajouté un script permettant de générer une [référence de l'API](https://github.com/MTES-MCT/trackdechets/blob/e50f935d620892f1a6c7fbf9f6dafc5457dd3630/documentation/docs/api-reference/api-reference.md) au format Markdown qui s'ajoute à la documentation.

J'en ai profité pour mettre un drapeau sur les `query`et `mutation` que je pense réservé pour un usage interne. Ça représente une bonne partie de l'API. Ce serait pas mal de voir comment on peut restreindre l'accès pour un usage uniquement depuis l'UI TD et comment les cacher de la documentation.
 