### PR TITLE
Fix formsLifeCycle query

### DIFF
--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -114,6 +114,7 @@ export default {
           after: cursorAfter,
           before: cursorBefore,
           where: {
+            loggedAt_not: null,
             loggedAt_gte: loggedAfter,
             loggedAt_lte: loggedBefore,
             form: { ...formsFilter, isDeleted: false, id: formId }


### PR DESCRIPTION
Ne renvoie plus les statuslogs dont le champ loggedAt est null