### PR TITLE
Fix - As a recipient of a BSD, I cannot seal it

### DIFF
--- a/back/src/companies/queries/userCompanies.ts
+++ b/back/src/companies/queries/userCompanies.ts
@@ -36,7 +36,9 @@ export async function getUserCompanies(userId: string) {
 
   return Promise.all(
     companies.map(async company => {
-      const companySireneInfo = await getCachedCompanySireneInfo(company.siret);
+      const companySireneInfo = await getCachedCompanySireneInfo(
+        company.siret
+      ).catch(_ => ({}));
       const companyIcpeInfo = {
         installation: await getInstallation(company.siret)
       };

--- a/back/src/forms/mutations/__tests__/mark-as-processed.test.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-processed.test.ts
@@ -28,21 +28,6 @@ describe("Forms -> markAsProcessed mutation", () => {
     jest.clearAllMocks();
   });
 
-  it("fail if current user is not recipient", async () => {
-    expect.assertions(1);
-    try {
-      const form = getNewValidForm();
-      form.status = "RECEIVED";
-
-      prisma.form.mockResolvedValue({ id: 1, status: FormState.Received });
-      getUserCompaniesMock.mockResolvedValue([{ siret: "any siret" } as any]);
-
-      await markAsProcessed(null, { id: 1, processedInfo: {} }, defaultContext);
-    } catch (err) {
-      expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
-    }
-  });
-
   it("set status to NoTraceability if actor is exempt of traceability", async () => {
     const form = getNewValidForm();
     form.status = "RECEIVED";

--- a/back/src/forms/mutations/__tests__/mark-as-sealed.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sealed.integration.ts
@@ -3,9 +3,8 @@ import {
   formFactory,
   companyFactory
 } from "../../../__tests__/factories";
-import { createTestClient } from "apollo-server-integration-testing";
+import makeClient from "../../../__tests__/testClient";
 import { resetDatabase } from "../../../../integration-tests/helper";
-import { server } from "../../../server";
 import { prisma } from "../../../generated/prisma-client";
 
 jest.mock("axios", () => ({
@@ -35,13 +34,7 @@ describe("{ mutation { markAsSealed } }", () => {
       }
     });
 
-    const { mutate, setOptions } = createTestClient({ apolloServer: server });
-
-    setOptions({
-      request: {
-        user
-      }
-    });
+    const { mutate } = makeClient(user);
 
     const mutation = `
       mutation   {
@@ -56,6 +49,13 @@ describe("{ mutation { markAsSealed } }", () => {
     form = await prisma.form({ id: form.id });
 
     expect(form.status).toEqual("SEALED");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: {id: user.id}, status:"SEALED"  }
+    });
+    expect(statusLogs.length).toEqual(1);
+ 
   });
 
   test("the recipient of the BSD can seal it", async () => {
@@ -74,13 +74,7 @@ describe("{ mutation { markAsSealed } }", () => {
       }
     });
 
-    const { mutate, setOptions } = createTestClient({ apolloServer: server });
-
-    setOptions({
-      request: {
-        user
-      }
-    });
+    const { mutate } = makeClient(user);
 
     const mutation = `
       mutation   {
@@ -95,5 +89,12 @@ describe("{ mutation { markAsSealed } }", () => {
     form = await prisma.form({ id: form.id });
 
     expect(form.status).toEqual("SEALED");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: {id: user.id}, status:"SEALED"  }
+    });
+    expect(statusLogs.length).toEqual(1);
+ 
   });
 });

--- a/back/src/forms/mutations/__tests__/mark-as-sealed.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sealed.integration.ts
@@ -1,0 +1,99 @@
+import {
+  userWithCompanyFactory,
+  formFactory,
+  companyFactory
+} from "../../../__tests__/factories";
+import { createTestClient } from "apollo-server-integration-testing";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { server } from "../../../server";
+import { prisma } from "../../../generated/prisma-client";
+
+jest.mock("axios", () => ({
+  default: {
+    get: jest.fn(() => Promise.resolve({ data: {} }))
+  }
+}));
+
+describe("{ mutation { markAsSealed } }", () => {
+  afterAll(() => {
+    resetDatabase();
+  });
+
+  test("the emitter of the BSD can seal it", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const recipientCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate, setOptions } = createTestClient({ apolloServer: server });
+
+    setOptions({
+      request: {
+        user
+      }
+    });
+
+    const mutation = `
+      mutation   {
+        markAsSealed(id: "${form.id}") {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SEALED");
+  });
+
+  test("the recipient of the BSD can seal it", async () => {
+    const { user, company: recipientCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const emitterCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate, setOptions } = createTestClient({ apolloServer: server });
+
+    setOptions({
+      request: {
+        user
+      }
+    });
+
+    const mutation = `
+      mutation   {
+        markAsSealed(id: "${form.id}") {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SEALED");
+  });
+});

--- a/back/src/forms/mutations/__tests__/mark-as-sealed.test.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sealed.test.ts
@@ -87,18 +87,6 @@ describe("Forms -> markAsSealed mutation", () => {
     }
   });
 
-  it("should fail when current user cannot do the transition", async () => {
-    expect.assertions(1);
-    try {
-      getUserCompaniesMock.mockResolvedValue([{ siret: "any siret" } as any]);
-      prisma.form.mockResolvedValue({ id: 1, status: "DRAFT" });
-
-      await markAsSealed(null, { id: 1 }, defaultContext);
-    } catch (err) {
-      expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
-    }
-  });
-
   it("should fail when SEALED is not a possible next step", async () => {
     expect.assertions(1);
     try {

--- a/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
@@ -1,0 +1,207 @@
+import {
+  userWithCompanyFactory,
+  formFactory,
+  companyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { prisma } from "../../../generated/prisma-client";
+
+jest.mock("axios", () => ({
+  default: {
+    get: jest.fn(() => Promise.resolve({ data: {} }))
+  }
+}));
+
+describe("{ mutation { markAsSent } }", () => {
+  afterAll(() => {
+    resetDatabase();
+  });
+
+  test("the emitter of the BSD can send it when it's sealed", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const recipientCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SEALED",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation   {
+        markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SENT");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: { id: user.id }, status: "SENT" }
+    });
+    expect(statusLogs.length).toEqual(1);
+  });
+
+  test("the recipient of the BSD can send it when it's sealed", async () => {
+    const { user, company: recipientCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const emitterCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SEALED",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation   {
+        markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SENT");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: { id: user.id }, status: "SENT" }
+    });
+    expect(statusLogs.length).toEqual(1);
+  });
+
+  test("the emitter of the BSD can send it when it's a draft", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const recipientCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation   {
+        markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SENT");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: { id: user.id }, status: "SENT" }
+    });
+    expect(statusLogs.length).toEqual(1);
+  });
+
+  test("the recipient of the BSD can send it when it's a draft", async () => {
+    const { user, company: recipientCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const emitterCompany = await companyFactory();
+
+    let form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation   {
+        markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+          id
+        }
+      }
+    `;
+
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.status).toEqual("SENT");
+
+    // check relevant statusLog is created
+    const statusLogs = await prisma.statusLogs({
+      where: { form: { id: form.id }, user: { id: user.id }, status: "SENT" }
+    });
+    expect(statusLogs.length).toEqual(1);
+  });
+
+  test("should fail if user is neither emitter or recipient", async () => {
+    const { user } = await userWithCompanyFactory("MEMBER");
+
+    const emitterCompany = await companyFactory();
+
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SEALED",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: emitterCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation   {
+        markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+          id
+        }
+      }
+    `;
+
+    const { errors } = await mutate(mutation);
+    expect(errors[0].extensions.code).toBe("FORBIDDEN");
+
+    const resultingForm = await prisma.form({ id: form.id });
+    expect(resultingForm.status).toEqual("SEALED");
+  });
+});

--- a/back/src/forms/mutations/__tests__/marked-as-send.test.ts
+++ b/back/src/forms/mutations/__tests__/marked-as-send.test.ts
@@ -32,7 +32,7 @@ describe("Forms -> markAsSealed mutation", () => {
     expect.assertions(1);
     try {
       getUserCompaniesMock.mockResolvedValue([{ siret: "a siret" } as any]);
-      prisma.form.mockResolvedValue({ id: 1, status: FormState.Sealed });
+      prisma.form.mockResolvedValue({ id: 1, status: FormState.Sent });
 
       await markAsSent(null, { id: 1, sentInfo: {} }, defaultContext);
     } catch (err) {

--- a/back/src/forms/mutations/mark-as.ts
+++ b/back/src/forms/mutations/mark-as.ts
@@ -74,12 +74,8 @@ async function transitionForm(
   const form = await context.prisma.form({ id: formId });
   const formPropsFromEvent = transformEventToFormProps(eventParams);
 
-  const userCompanies = await getUserCompanies(context.user.id);
-  const actorSirets = userCompanies.map(c => c.siret);
-
   const startingState = State.from(form.status, {
     form: { ...form, ...formPropsFromEvent },
-    actorSirets,
     requestContext: context,
     isStableState: true
   });
@@ -111,7 +107,7 @@ async function transitionForm(
 
       // `done` means we reached a final state (xstate concept)
       // `context.isStableState` is a concept introduced to differentiate form state with transient states (validation or side effects)
-      // If we reached one of those, we konow the transition is over and we can safely update the form and return
+      // If we reached one of those, we know the transition is over and we can safely update the form and return
       if (state.done || state.context.isStableState) {
         const newStatus = state.value;
         await logStatusChange(formId, newStatus, context);

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -26,10 +26,10 @@ export default {
     saveForm: isAuthenticated,
     deleteForm: canAccessForm,
     duplicateForm: canAccessForm,
-    markAsSealed: canAccessForm,
+    markAsSealed: or(isFormRecipient, isFormEmitter),
     markAsSent: or(isFormRecipient, isFormEmitter),
-    markAsReceived: canAccessForm,
-    markAsProcessed: canAccessForm,
+    markAsReceived: isFormRecipient,
+    markAsProcessed: isFormRecipient,
     signedByTransporter: isFormTransporter
   }
 };

--- a/back/src/forms/schema-validation.ts
+++ b/back/src/forms/schema-validation.ts
@@ -89,16 +89,22 @@ export default {
     signedByTransporter: object().shape({
       signingInfo: object({
         sentAt: date().required("Vous devez saisir une date d'envoi."),
-        signedByTransporter: boolean().required(
-          "Voud devez indiquer si le transporteur a signé."
-        ),
+        signedByTransporter: boolean()
+          .required("Vous devez indiquer si le transporteur a signé.")
+          .oneOf(
+            [true],
+            "Le transporteur doit signer pour valider l'enlèvement."
+          ),
         securityCode: number().nullable(true),
         sentBy: string().required(
           "Vous devez saisir un responsable de l'envoi."
         ),
-        signedByProducer: boolean().required(
-          "Voud devez indiquer si le producteur a signé."
-        ),
+        signedByProducer: boolean()
+          .required("Vous devez indiquer si le producteur a signé.")
+          .oneOf(
+            [true],
+            "Le producteur doit signer pour valider l'enlèvement."
+          ),
 
         packagings: array().of(
           string().matches(/(FUT|GRV|CITERNE|BENNE|AUTRE)/)

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -28,7 +28,7 @@ export const formWorkflowMachine = Machine(
           MARK_SEALED: [
             {
               target: "error.invalidTransition",
-              cond: "isNotEmitter"
+              cond: "isNeitherEmitterOrRecipient"
             },
             { target: "pendingSealedValidation" }
           ],
@@ -197,6 +197,9 @@ export const formWorkflowMachine = Machine(
       isNeitherEmitterOrTransporter: ctx =>
         !ctx.actorSirets.includes(ctx.form.emitterCompanySiret) &&
         !ctx.actorSirets.includes(ctx.form.transporterCompanySiret),
+      isNeitherEmitterOrRecipient: ctx =>
+        !ctx.actorSirets.includes(ctx.form.emitterCompanySiret) &&
+        !ctx.actorSirets.includes(ctx.form.recipientCompanySiret),
       isMissingSignature: (_, event: any) =>
         !event.signedByTransporter || !event.signedByProducer,
       isNotRecipient: ctx =>

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -16,7 +16,6 @@ export const formWorkflowMachine = Machine(
     initial: FormState.Draft,
     context: {
       form: null,
-      actorSirets: [],
       requestContext: null,
       isStableState: true
     },
@@ -25,33 +24,15 @@ export const formWorkflowMachine = Machine(
         entry: "setStable",
         exit: "setUnStable",
         on: {
-          MARK_SEALED: [
-            {
-              target: "error.invalidTransition",
-              cond: "isNeitherEmitterOrRecipient"
-            },
-            { target: "pendingSealedValidation" }
-          ],
-          MARK_SENT: [
-            {
-              target: "error.invalidTransition",
-              cond: "isNotEmitter"
-            },
-            { target: "pendingSentValidation" }
-          ]
+          MARK_SEALED: [{ target: "pendingSealedValidation" }],
+          MARK_SENT: [{ target: "pendingSentValidation" }]
         }
       },
       [FormState.Sealed]: {
         entry: "setStable",
         exit: "setUnStable",
         on: {
-          MARK_SENT: [
-            {
-              target: "error.invalidTransition",
-              cond: "isNeitherEmitterOrTransporter"
-            },
-            { target: "pendingSentValidation" }
-          ],
+          MARK_SENT: [{ target: "pendingSentValidation" }],
           MARK_SIGNED_BY_TRANSPORTER: [
             {
               target: "error.missingSignature",
@@ -69,10 +50,6 @@ export const formWorkflowMachine = Machine(
         on: {
           MARK_RECEIVED: [
             {
-              target: "error.invalidTransition",
-              cond: "isNotRecipient"
-            },
-            {
               target: "pendingReceivedMarkFormAppendixGroupedsAsProcessed",
               cond: "isFormAccepted"
             },
@@ -88,10 +65,6 @@ export const formWorkflowMachine = Machine(
         exit: "setUnStable",
         on: {
           MARK_PROCESSED: [
-            {
-              target: "error.invalidTransition",
-              cond: "isNotRecipient"
-            },
             {
               target: FormState.NoTraceability,
               cond: "isExemptOfTraceability"
@@ -192,18 +165,8 @@ export const formWorkflowMachine = Machine(
       setUnStable: assign({ isStableState: false }) as any
     },
     guards: {
-      isNotEmitter: ctx =>
-        !ctx.actorSirets.includes(ctx.form.emitterCompanySiret),
-      isNeitherEmitterOrTransporter: ctx =>
-        !ctx.actorSirets.includes(ctx.form.emitterCompanySiret) &&
-        !ctx.actorSirets.includes(ctx.form.transporterCompanySiret),
-      isNeitherEmitterOrRecipient: ctx =>
-        !ctx.actorSirets.includes(ctx.form.emitterCompanySiret) &&
-        !ctx.actorSirets.includes(ctx.form.recipientCompanySiret),
       isMissingSignature: (_, event: any) =>
         !event.signedByTransporter || !event.signedByProducer,
-      isNotRecipient: ctx =>
-        !ctx.actorSirets.includes(ctx.form.recipientCompanySiret),
       isExemptOfTraceability: ctx => ctx.form.noTraceability,
       awaitsGroup: ctx =>
         GROUP_CODES.includes(ctx.form.processingOperationDone),


### PR DESCRIPTION
https://trello.com/c/C9a0JNbm

:warning: c'est une PR de hotfix sur master. À merger sur `dev` ensuite

@Riron je crois que tu avais commencé à bosser dessus donc je te laisse faire des modifications et merger sur master cette nuit. Le test n°2 de`mark-as-sealed.integration.ts` permet de reproduire le bug rencontré. 

Est-ce qu'à l'avenir on ne devrait pas centraliser toutes les histoires de permissions dans le fichier `permissions` (plutôt que d'utiliser les guards xstate) ?


