### PR TITLE
Fixes: dashboard & compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     environment:
       POSTGRES_USER: $POSTGRES_USER
       POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      AIRFLOW_POSTGRES_USER: $AIRFLOW_POSTGRES_USER
+      AIRFLOW_POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
     volumes:
       - postgres:/var/lib/postgresql/data
 

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/react-hooks";
 import gql from "graphql-tag";
 import React, { useState } from "react";
-import { Route, useHistory } from "react-router";
+import { Route, Redirect } from "react-router";
 import Loader from "../common/Loader";
 import { Me } from "../login/model";
 import { currentSiretService } from "./CompanySelector";
@@ -50,14 +50,13 @@ export default function Dashboard() {
     }
   });
   const match = useRouteMatch();
-  const history = useHistory();
 
   if (loading || !activeSiret) return <Loader />;
   if (error || !data) return <p>{`Erreur ! ${error?.message}`}</p>;
 
   // As long as you don't belong to a company, you can't access the dashnoard
   if (data.me.companies.length === 0) {
-    history.push("/account/companies");
+    return <Redirect to="/account/companies" />
   }
 
   return (

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -51,13 +51,15 @@ export default function Dashboard() {
   });
   const match = useRouteMatch();
 
-  if (loading || !activeSiret) return <Loader />;
+  if (loading) return <Loader />;
   if (error || !data) return <p>{`Erreur ! ${error?.message}`}</p>;
 
   // As long as you don't belong to a company, you can't access the dashnoard
   if (data.me.companies.length === 0) {
-    return <Redirect to="/account/companies" />
+    return <Redirect to="/account/companies" />;
   }
+
+  if (!activeSiret) return null;
 
   return (
     <div id="dashboard" className="dashboard">


### PR DESCRIPTION
2 minis fixs:
- ne pas render le dashboard tant qu'on a pas de company [cf trello](https://trello.com/c/YpIt3x5E/700-etq-utilisateur-nayant-pas-encore-d%C3%A9tablissement-la-page-dashboard-slips-plante)
- ENV manquante pour postgres. Tu confirmes @benoitguigal ? J'ai eu des erreurs en restorant la recette, et j'ai l'impression que c'est nécessaire [à ce script](https://github.com/MTES-MCT/trackdechets/blob/master/postgres/scripts/init-airflow-user-db.sh)
