### PR TITLE
Fix bugs PDF generation and add integration test for duplicateForm mutation

### DIFF
--- a/back/integration-tests/wait-for-prisma.sh
+++ b/back/integration-tests/wait-for-prisma.sh
@@ -1,5 +1,5 @@
 attempt_counter=0
-max_attempts=10
+max_attempts=30
 
 until [ $(curl -s -o /dev/null -w '%{http_code}' http://prisma:4467) -eq 200 ]; do
     if [ ${attempt_counter} -eq ${max_attempts} ];then

--- a/back/src/forms/__tests__/readable-id.test.ts
+++ b/back/src/forms/__tests__/readable-id.test.ts
@@ -1,47 +1,42 @@
 import { getReadableId } from "../readable-id";
-import { GraphQLContext } from "../../types";
+
+const formsMock = jest.fn();
+
+jest.mock("../../generated/prisma-client", () => ({
+  prisma: {
+    forms: jest.fn((...args) => formsMock(...args))
+  }
+}));
 
 describe("getReadableId", () => {
+  afterEach(() => {
+    formsMock.mockReset();
+  });
+
   const currentYearDigits = `${new Date().getFullYear()}`.slice(2, 4);
 
   test("should return first ID when there is no form", async () => {
-    const context = {
-      prisma: {
-        forms: jest.fn(() => [])
-      } as any,
-      user: null,
-      request: null
-    } as GraphQLContext;
+    formsMock.mockResolvedValueOnce([]);
 
-    const result = await getReadableId(context);
+    const result = await getReadableId();
 
     expect(result).toBe(`TD-${currentYearDigits}-AAA00001`);
   });
 
   test("should return next ID when there is existing forms on the current year", async () => {
-    const context = {
-      prisma: {
-        forms: jest.fn(() => [{ readableId: `TD-${currentYearDigits}-ABC12345` }])
-      } as any,
-      user: null,
-      request: null
-    } as GraphQLContext;
+    formsMock.mockResolvedValueOnce([
+      { readableId: `TD-${currentYearDigits}-ABC12345` }
+    ]);
 
-    const result = await getReadableId(context);
+    const result = await getReadableId();
 
     expect(result).toBe(`TD-${currentYearDigits}-ABC12346`);
   });
 
   test("should return first year number when there is no existing forms on the current year", async () => {
-    const context = {
-      prisma: {
-        forms: jest.fn(() => [{ readableId: "TD-00-AAA99999" }])
-      } as any,
-      user: null,
-      request: null
-    } as GraphQLContext;
+    formsMock.mockResolvedValueOnce([{ readableId: "TD-00-AAA99999" }]);
 
-    const result = await getReadableId(context);
+    const result = await getReadableId();
 
     expect(result).toBe(`TD-${currentYearDigits}-AAA00001`);
   });

--- a/back/src/forms/mutations/__tests__/duplicate-form.integration.ts
+++ b/back/src/forms/mutations/__tests__/duplicate-form.integration.ts
@@ -1,0 +1,38 @@
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+import { prisma } from "../../../generated/prisma-client";
+import { cleanUpNotDuplicatableFieldsInForm } from "../../form-converter";
+import { resetDatabase } from "../../../../integration-tests/helper";
+
+describe("{ mutation { duplicateForm } }", () => {
+  afterAll(() => resetDatabase());
+
+  it("should duplicate an existing form", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const mutation = `
+      mutation {
+        duplicateForm(id: "${form.id}") {
+          id
+        }
+      }
+    `;
+
+    const { data } = await mutate(mutation);
+
+    const duplicateForm = await prisma.form({ id: data.duplicateForm.id });
+
+    expect(cleanUpNotDuplicatableFieldsInForm(form)).toEqual(
+      cleanUpNotDuplicatableFieldsInForm(duplicateForm)
+    );
+  });
+});

--- a/back/src/forms/mutations/duplicate-form.ts
+++ b/back/src/forms/mutations/duplicate-form.ts
@@ -13,11 +13,11 @@ import { getReadableId } from "../readable-id";
  * @param userId
  */
 export async function duplicateForm(formId: string, userId: string) {
-  const existingForm = prisma.form({
+  const existingForm = await prisma.form({
     id: formId
   });
 
-  const newForm = prisma.createForm({
+  const newForm = await prisma.createForm({
     ...cleanUpNotDuplicatableFieldsInForm(existingForm),
     readableId: await getReadableId(),
     status: "DRAFT",

--- a/back/src/forms/mutations/duplicate-form.ts
+++ b/back/src/forms/mutations/duplicate-form.ts
@@ -1,0 +1,28 @@
+import { prisma } from "../../generated/prisma-client";
+import {
+  cleanUpNotDuplicatableFieldsInForm,
+  unflattenObjectFromDb
+} from "../form-converter";
+import { getReadableId } from "../readable-id";
+
+/**
+ * Duplicate the content of a form into a new DRAFT form
+ * A new readable ID is generated and some fields which
+ * are not duplicable are omitted
+ * @param formId
+ * @param userId
+ */
+export async function duplicateForm(formId: string, userId: string) {
+  const existingForm = prisma.form({
+    id: formId
+  });
+
+  const newForm = prisma.createForm({
+    ...cleanUpNotDuplicatableFieldsInForm(existingForm),
+    readableId: await getReadableId(),
+    status: "DRAFT",
+    owner: { connect: { id: userId } }
+  });
+
+  return unflattenObjectFromDb(newForm);
+}

--- a/back/src/forms/mutations/index.ts
+++ b/back/src/forms/mutations/index.ts
@@ -1,0 +1,3 @@
+import { duplicateForm } from "./duplicate-form";
+
+export { duplicateForm };

--- a/back/src/forms/mutations/save-form.ts
+++ b/back/src/forms/mutations/save-form.ts
@@ -33,7 +33,7 @@ export async function saveForm(_, { formInput }, context: GraphQLContext) {
   const newForm = await context.prisma.createForm({
     ...(form as FormCreateInput),
     appendix2Forms: { connect: formContent.appendix2Forms },
-    readableId: await getReadableId(context),
+    readableId: await getReadableId(),
     owner: { connect: { id: userId } }
   });
   await context.prisma.createStatusLog({

--- a/back/src/forms/readable-id.ts
+++ b/back/src/forms/readable-id.ts
@@ -1,13 +1,13 @@
-import { GraphQLContext } from "../types";
+import { prisma } from "../generated/prisma-client";
 
-export async function getReadableId(context: GraphQLContext) {
+export async function getReadableId() {
   const beginningOfYear = new Date(new Date().getFullYear(), 0, 1);
   const shortYear = beginningOfYear
     .getFullYear()
     .toString()
     .slice(-2);
 
-  const mostRecentForms = await context.prisma.forms({
+  const mostRecentForms = await prisma.forms({
     orderBy: "readableId_DESC",
     first: 10
   });

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -210,7 +210,7 @@ export default {
 
       const newForm = await context.prisma.createForm({
         ...cleanUpNotDuplicatableFieldsInForm(existingForm),
-        readableId: await getReadableId(context),
+        readableId: await getReadableId(),
         status: "DRAFT",
         owner: { connect: { id: userId } }
       });

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -2,10 +2,7 @@ import { DomainError, ErrorCode } from "../common/errors";
 import { getUserCompanies } from "../companies/queries";
 import { prisma, StatusLogConnection } from "../generated/prisma-client";
 import { GraphQLContext } from "../types";
-import {
-  cleanUpNotDuplicatableFieldsInForm,
-  unflattenObjectFromDb
-} from "./form-converter";
+import { unflattenObjectFromDb } from "./form-converter";
 import {
   markAsProcessed,
   markAsReceived,
@@ -13,11 +10,11 @@ import {
   markAsSent,
   signedByTransporter
 } from "./mutations/mark-as";
+import { duplicateForm } from "./mutations";
 import { saveForm } from "./mutations/save-form";
 import { formPdf } from "./queries/form-pdf";
 import forms from "./queries/forms";
 import { formsRegister } from "./queries/forms-register";
-import { getReadableId } from "./readable-id";
 
 // formsLifeCycle fragment
 const statusLogFragment = `
@@ -201,22 +198,8 @@ export default {
         data: { isDeleted: true }
       });
     },
-    duplicateForm: async (parent, { id }, context: GraphQLContext) => {
-      const userId = context.user.id;
-
-      const existingForm = await context.prisma.form({
-        id
-      });
-
-      const newForm = await context.prisma.createForm({
-        ...cleanUpNotDuplicatableFieldsInForm(existingForm),
-        readableId: await getReadableId(),
-        status: "DRAFT",
-        owner: { connect: { id: userId } }
-      });
-
-      return unflattenObjectFromDb(newForm);
-    },
+    duplicateForm: (_parent, { id }, { user }: GraphQLContext) =>
+      duplicateForm(id, user.id),
     markAsSealed,
     markAsSent,
     markAsReceived,

--- a/pdf/src/generator.js
+++ b/pdf/src/generator.js
@@ -301,10 +301,12 @@ const renameAndFormatFields = params => ({
   recipientCompanyAddress10: params.recipientCompanyAddress,
   recipientCompanyContact10: params.recipientCompanyContact,
   transporterSentAt: dateFmt(params.sentAt),
+  senderSentBy: params.sentBy,
   senderSentAt: dateFmt(params.sentAt),
   receivedAt1: dateFmt(params.receivedAt),
   receivedAt2: dateFmt(params.receivedAt),
-  receivedBy10: params.receivedBy
+  receivedBy10: params.receivedBy,
+  processedAt: dateFmt(params.processedAt)
 });
 
 /**
@@ -318,7 +320,7 @@ const getWasteDetailsPackagings = params => {
   if (!params.wasteDetailsPackagings) {
     return {};
   }
-  return params.wasteDetailsPackagings.reduce(function (acc, elem) {
+  return params.wasteDetailsPackagings.reduce(function(acc, elem) {
     let key = `wasteDetailsPackagings${capitalize(elem)}`;
     return {
       ...acc,
@@ -373,13 +375,13 @@ const getWasteQuantityRefused = (wasteDetailsQuantity, quantityReceived) =>
 const getWasteRefusalreason = params =>
   params.wasteAcceptationStatus === "PARTIALLY_REFUSED"
     ? {
-      wasteRefusalReason: `Refus partiel: ${
-        params.wasteRefusalReason
+        wasteRefusalReason: `Refus partiel: ${
+          params.wasteRefusalReason
         } - Tonnage estimé de refus : ${getWasteQuantityRefused(
           params.wasteDetailsQuantity,
           params.quantityReceived
         )} tonnes`
-    }
+      }
     : {};
 
 /**


### PR DESCRIPTION
Cf https://trello.com/c/HhNur5V0

* Correction du générateur de pdf
  * le champ `sentBy` n'était pas visible
  * la date `processedAt` n'était pas formatée
* Ajout d'un test d'intégration pour la mutation `duplicateForm`. Au passage déplacement du code dans un fichier séparé et modification de `getReadableId` pour ne pas utiliser la variable `prisma` globale.
* Augmentation du nombre d'essai de connexion à prisma dans les tests d'inté pour laisser du temps à mon vieux Macbook