### PR TITLE
Split action columns and improve action buttons

### DIFF
--- a/front/src/dashboard/slips/SlipActions.scss
+++ b/front/src/dashboard/slips/SlipActions.scss
@@ -1,11 +1,10 @@
 .SlipActions {
   display: flex;
-  margin-top: 5px;
 
+  align-items: center;
   .icon {
     font-size: larger;
     margin: 0 5px;
-    text-decoration: underline;
     cursor: pointer;
     background: none;
     border: none;
@@ -15,5 +14,16 @@
 
   .action-error {
     white-space: pre-line;
+  }
+}
+
+.dynamic-action {
+  display: flex;
+  align-items: center;
+
+  &__text {
+    margin-left: 6px;
+    font-size: 12px;
+    font-weight: bold;
   }
 }

--- a/front/src/dashboard/slips/SlipActions.tsx
+++ b/front/src/dashboard/slips/SlipActions.tsx
@@ -1,12 +1,14 @@
 import { useMutation } from "@apollo/react-hooks";
 import React, { useState, useEffect } from "react";
 import {
-  FaCheck,
-  FaCog,
+  FaTruckMoving,
+  FaCogs,
   FaEdit,
-  FaEnvelope,
-  FaEnvelopeOpen
+  FaIndustry,
+  FaFileSignature
 } from "react-icons/fa";
+import { IconContext } from "react-icons";
+
 import { Link } from "react-router-dom";
 import { Form } from "../../form/model";
 import "./SlipActions.scss";
@@ -26,11 +28,10 @@ export type SlipActionProps = {
   form: Form;
 };
 
-interface IProps {
+interface SlipActionsProps {
   form: Form;
-  siret: string;
 }
-export default function SlipActions({ form, siret }: IProps) {
+export function SlipActions({ form }: SlipActionsProps) {
   return (
     <div className="SlipActions">
       {form.status === "DRAFT" ? (
@@ -44,12 +45,14 @@ export default function SlipActions({ form, siret }: IProps) {
         <DownloadPdf formId={form.id} />
       )}
       <Duplicate formId={form.id} />
-      <DynamicActions form={form} siret={siret} />
     </div>
   );
 }
 
-function DynamicActions({ form, siret }) {
+interface DynamicActionsProps extends SlipActionsProps {
+  siret: string;
+}
+export function DynamicActions({ form, siret }: DynamicActionsProps) {
   const nextStep = getNextStep(form, siret);
   // This dynamic mutation must have a value, otherwise the `useMutation` hook throws.
   // And hooks should not be conditionally called (cf rules of hooks)
@@ -73,14 +76,22 @@ function DynamicActions({ form, siret }) {
   }
 
   return (
-    <>
+    <div className="SlipActions">
       <button
-        className="icon"
+        className="button small"
         onClick={() => setIsOpen(true)}
         title={buttons[nextStep].title}
       >
-        {buttons[nextStep].icon({})}
+        <span className="dynamic-action">
+          <IconContext.Provider value={{ size: "2em" }}>
+            {buttons[nextStep].icon({})}
+          </IconContext.Provider>
+          <span className="dynamic-action__text">
+            {buttons[nextStep].title}
+          </span>
+        </span>
       </button>
+
       <div
         className="modal__backdrop"
         id="modal"
@@ -97,7 +108,6 @@ function DynamicActions({ form, siret }) {
               form={form}
             />
           )}
-
           {error && (
             <div
               className="notification error action-error"
@@ -108,21 +118,25 @@ function DynamicActions({ form, siret }) {
           )}
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
 const buttons = {
-  SEALED: { title: "Finaliser", icon: FaCheck, component: Sealed },
-  SENT: { title: "Marquer comme envoyé", icon: FaEnvelope, component: Sent },
+  SEALED: {
+    title: "Finaliser le bordereau",
+    icon: FaFileSignature,
+    component: Sealed
+  },
+  SENT: { title: "Valider l'enlèvement", icon: FaTruckMoving, component: Sent },
   RECEIVED: {
-    title: "Réception du déchet",
-    icon: FaEnvelopeOpen,
+    title: "Valider la réception",
+    icon: FaIndustry,
     component: Received
   },
   PROCESSED: {
-    title: "Marquer comme traité",
-    icon: FaCog,
+    title: "Valider le traitement",
+    icon: FaCogs,
     component: Processed
   }
 };

--- a/front/src/dashboard/slips/Slips.tsx
+++ b/front/src/dashboard/slips/Slips.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DateTime } from "luxon";
-import SlipActions from "./SlipActions";
+import { SlipActions, DynamicActions } from "./SlipActions";
 import { Form } from "../../form/model";
 import { useFormsTable } from "./use-forms-table";
 import { FaSort } from "react-icons/fa";
@@ -18,8 +18,18 @@ const statusLabels: { [key: string]: string } = {
   REFUSED: "Refusé"
 };
 
-type Props = { forms: Form[]; siret: string; hiddenFields?: string[] };
-export default function Slips({ forms, siret, hiddenFields = [] }: Props) {
+type Props = {
+  forms: Form[];
+  siret: string;
+  hiddenFields?: string[];
+  dynamicActions?: boolean;
+};
+export default function Slips({
+  forms,
+  siret,
+  hiddenFields = [],
+  dynamicActions = false
+}: Props) {
   const [sortedForms, sortBy, filter] = useFormsTable(forms);
 
   return (
@@ -66,7 +76,8 @@ export default function Slips({ forms, siret, hiddenFields = [] }: Props) {
               </small>
             </th>
           )}
-          <th>Actions</th>
+          {dynamicActions && <th>Mes actions</th>}
+          <th></th>
         </tr>
         <tr>
           {hiddenFields.indexOf("readableId") === -1 && (
@@ -103,6 +114,7 @@ export default function Slips({ forms, siret, hiddenFields = [] }: Props) {
           <th />
           {hiddenFields.indexOf("status") === -1 && <th />}
           <th />
+          {dynamicActions && <th></th>}
         </tr>
       </thead>
       <tbody>
@@ -128,8 +140,13 @@ export default function Slips({ forms, siret, hiddenFields = [] }: Props) {
             {hiddenFields.indexOf("status") === -1 && (
               <td>{statusLabels[s.status]}</td>
             )}
+            {dynamicActions && (
+              <td>
+                <DynamicActions siret={siret} form={s} />
+              </td>
+            )}
             <td>
-              <SlipActions siret={siret} form={s} />
+              <SlipActions form={s} />
             </td>
           </tr>
         ))}

--- a/front/src/dashboard/slips/SlipsTabs.tsx
+++ b/front/src/dashboard/slips/SlipsTabs.tsx
@@ -40,6 +40,7 @@ export default function SlipsTabs({ me, siret }: Props) {
             siret={siret}
             forms={drafts}
             hiddenFields={["status", "readableId"]}
+            dynamicActions={true}
           />
         ) : (
           <div className="empty-tab">
@@ -60,7 +61,7 @@ export default function SlipsTabs({ me, siret }: Props) {
       </TabPanel>
       <TabPanel>
         {toSign.length ? (
-          <Slips siret={siret} forms={toSign} />
+          <Slips siret={siret} forms={toSign} dynamicActions={true}/>
         ) : (
           <div className="empty-tab">
             <img src="/illu/illu_sent.svg" alt="" />
@@ -76,7 +77,7 @@ export default function SlipsTabs({ me, siret }: Props) {
       </TabPanel>
       <TabPanel>
         {status.length ? (
-          <Slips siret={siret} forms={status} />
+          <Slips siret={siret} forms={status}  />
         ) : (
           <div className="empty-tab">
             <img src="/illu/illu_transfer.svg" alt="" />


### PR DESCRIPTION


Cf. https://trello.com/c/qRE0LiAy/691-etq-utilisateur-je-vois-2-colonnes-daction-dans-le-dashboard

Pour réduire la confusion chez les nouveaux utilisateurs, suite à l'atelier de février:
- split de la colonne action en actions métier(sceller, recevoir, traiter etc)  et actions administratives (dupliquer, voir un pdf, supprimer) et renommage de la colonne action métier en "mes actions"
- rewording des actions
- remplacement des icones jugées les plus confusantes™

On reste sur les icones fontawesome, on verra avec le ou la futur UX designer si c'est pertinent de changer.

----

<img width="552" alt="Capture d’écran 2020-02-26 à 16 52 26" src="https://user-images.githubusercontent.com/878396/75362006-6af6b000-58b8-11ea-80c2-e4dfc8087beb.png">

----
<img width="203" alt="Capture d’écran 2020-02-26 à 16 52 19" src="https://user-images.githubusercontent.com/878396/75362011-6cc07380-58b8-11ea-8555-92c5b111c7f1.png">