### PR TITLE
Composants génériques d'erreur

### DIFF
--- a/front/src/account/Account.tsx
+++ b/front/src/account/Account.tsx
@@ -30,7 +30,7 @@ export default withRouter(function Account({ match }: RouteComponentProps) {
 
   if (loading) return <Loader />;
 
-  if (error) return <Error message={error.message} />;
+  if (error) return <Error apolloError={error} />;
 
   return (
     <div id="account" className="account dashboard">

--- a/front/src/account/Account.tsx
+++ b/front/src/account/Account.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@apollo/react-hooks";
 import AccountMenu from "./AccountMenu";
 import { Route, withRouter, RouteComponentProps } from "react-router";
 import Loader from "../common/Loader";
-import Error from "../common/Error";
+import { InlineError } from "../common/Error";
 import AccountInfo from "./AccountInfo";
 import AccountIntegrationApi from "./AccountIntegrationApi";
 import AccountCompanyList from "./AccountCompanyList";
@@ -30,7 +30,7 @@ export default withRouter(function Account({ match }: RouteComponentProps) {
 
   if (loading) return <Loader />;
 
-  if (error) return <Error apolloError={error} />;
+  if (error) return <InlineError apolloError={error} />;
 
   return (
     <div id="account" className="account dashboard">

--- a/front/src/account/AccountCompanyAdd.tsx
+++ b/front/src/account/AccountCompanyAdd.tsx
@@ -5,6 +5,7 @@ import gql from "graphql-tag";
 import React, { useEffect, useRef, useState } from "react";
 import { FaHourglassHalf } from "react-icons/fa";
 import { useHistory } from "react-router-dom";
+import { NotificationError } from "../common/Error";
 import Loader from "../common/Loader";
 import RedErrorMessage from "../common/RedErrorMessage";
 import { GET_ME } from "../dashboard/Dashboard";
@@ -110,9 +111,7 @@ export default function AccountCompanyAdd() {
 
   return (
     <div className="panel">
-      {savingError && (
-        <div className="notification error">{savingError.message}</div>
-      )}
+      {savingError && <NotificationError apolloError={savingError} />}
 
       <Formik
         initialValues={{
@@ -174,7 +173,7 @@ export default function AccountCompanyAdd() {
               </div>
             </div>
 
-            {error && <div className="notification error">{error.message}</div>}
+            {error && <NotificationError apolloError={error} />}
             {data && (
               <>
                 <AccountFieldNotEditable

--- a/front/src/account/fields/forms/AccountFormCompanyTypes.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyTypes.tsx
@@ -5,6 +5,7 @@ import { Formik, Field, Form, FormikProps } from "formik";
 import CompanyTypes from "../../../login/CompanyType";
 import RedErrorMessage from "../../../common/RedErrorMessage";
 import styles from "./AccountForm.module.scss";
+import { InlineError } from "../../../common/Error";
 
 type Props = {
   name: string;
@@ -67,7 +68,7 @@ export default function AccountFormCompanyTypes({
           {props.errors[name] && (
             <RedErrorMessage name="phone">{props.errors[name]}</RedErrorMessage>
           )}
-          {error && <div>{error.message}</div>}
+          {error && <InlineError apolloError={error} />}
 
           <button
             className="button"

--- a/front/src/common/Error.module.scss
+++ b/front/src/common/Error.module.scss
@@ -1,0 +1,3 @@
+.lineBreak {
+  white-space: pre-line;
+}

--- a/front/src/common/Error.tsx
+++ b/front/src/common/Error.tsx
@@ -25,7 +25,7 @@ export const ErrorProvider: FunctionComponent<Props> = ({
   return <>{errors.map((error, idx) => children({ error, idx }))}</>;
 };
 
-export default function Error({ apolloError }: Props) {
+export function InlineError({ apolloError }: Props) {
   return (
     <ErrorProvider apolloError={apolloError}>
       {({ error, idx }) => (

--- a/front/src/common/Error.tsx
+++ b/front/src/common/Error.tsx
@@ -1,9 +1,52 @@
-import React from "react";
+import { ApolloError } from "apollo-client";
+import React, { FunctionComponent } from "react";
+import styles from "./Error.module.scss";
 
 type Props = {
-  message: string;
+  apolloError: ApolloError;
+  className?: string;
 };
 
-export default function Error({ message }: Props) {
-  return <p>{`Erreur ! ${message}`}</p>;
+export const isFunction = (obj: any): obj is Function =>
+  typeof obj === "function";
+
+export const ErrorProvider: FunctionComponent<Props> = ({
+  apolloError,
+  children
+}) => {
+  if (!children || !isFunction(children)) {
+    console.info("ErrorProvider only accepts a function as a child.");
+    return null;
+  }
+
+  const errors = apolloError.graphQLErrors ??
+    apolloError.networkError ?? [apolloError];
+
+  return <>{errors.map((error, idx) => children({ error, idx }))}</>;
+};
+
+export default function Error({ apolloError }: Props) {
+  return (
+    <ErrorProvider apolloError={apolloError}>
+      {({ error, idx }) => (
+        <p key={`${idx}-${error.message}`}>{`Erreur ! ${error.message}`}</p>
+      )}
+    </ErrorProvider>
+  );
+}
+
+export function NotificationError({ apolloError, className }: Props) {
+  return (
+    <ErrorProvider apolloError={apolloError}>
+      {({ error, idx }) => (
+        <div
+          key={`${idx}-${error.message}`}
+          className={`notification error ${styles.lineBreak} ${className ??
+            ""}`}
+        >
+          {error.message}
+        </div>
+      )}
+    </ErrorProvider>
+  );
 }

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -1,5 +1,6 @@
 import { DocumentNode } from "graphql";
 import { DataProxy } from "apollo-cache";
+import { ApolloError } from "apollo-client";
 
 /**
  * converts `aString` to `A_STRING`
@@ -42,4 +43,8 @@ export function updateApolloCache<T>(
   } catch (_) {
     console.info(`Cache miss, skipping update.`);
   }
+}
+
+export function getErrorMessages(err: ApolloError) {
+  return err.graphQLErrors.map(error => error.message);
 }

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from "@apollo/react-hooks";
 import gql from "graphql-tag";
 import React, { useState } from "react";
-import { Route, Redirect } from "react-router";
+import { Redirect, Route } from "react-router";
+import { useRouteMatch } from "react-router-dom";
+import { InlineError } from "../common/Error";
 import Loader from "../common/Loader";
 import { Me } from "../login/model";
 import { currentSiretService } from "./CompanySelector";
@@ -10,7 +12,6 @@ import DashboardMenu from "./DashboardMenu";
 import Exports from "./exports/exports";
 import SlipsContainer from "./slips/SlipsContainer";
 import Transport from "./transport/Transport";
-import { useRouteMatch } from "react-router-dom";
 
 export const GET_ME = gql`
   {
@@ -52,7 +53,8 @@ export default function Dashboard() {
   const match = useRouteMatch();
 
   if (loading) return <Loader />;
-  if (error || !data) return <p>{`Erreur ! ${error?.message}`}</p>;
+  if (error) return <InlineError apolloError={error} />;
+  if (!data) return <p>Aucune donnée à afficher</p>;
 
   // As long as you don't belong to a company, you can't access the dashnoard
   if (data.me.companies.length === 0) {

--- a/front/src/dashboard/exports/exports.tsx
+++ b/front/src/dashboard/exports/exports.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
-import { Me } from "../../login/model";
-import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
-import Loader from "../../common/Loader";
+import gql from "graphql-tag";
+import React, { useState } from "react";
 import DownloadFileLink from "../../common/DownloadFileLink";
+import { InlineError } from "../../common/Error";
+import Loader from "../../common/Loader";
+import { Me } from "../../login/model";
 
 interface IProps {
   me: Me;
@@ -40,7 +41,8 @@ export default function Exports({ me }: IProps) {
     <div className="main">
       <h2>Statistiques</h2>
       {loading && <Loader />}
-      {(error || !data) && <p>"Erreur..."</p>}
+      {error && <InlineError apolloError={error} />}
+      {!data && <p>Aucune donnée à afficher.</p>}
       {data && (
         <table className="table">
           <thead>

--- a/front/src/dashboard/slips/SlipActions.tsx
+++ b/front/src/dashboard/slips/SlipActions.tsx
@@ -19,6 +19,7 @@ import Received from "./slips-actions/Received";
 import Sealed from "./slips-actions/Sealed";
 import Sent from "./slips-actions/Sent";
 import mutations from "./slips-actions/slip-actions.mutations";
+import { NotificationError } from "../../common/Error";
 
 export type SlipActionProps = {
   onSubmit: (vars: any) => any;
@@ -99,12 +100,7 @@ function DynamicActions({ form, siret }) {
           )}
 
           {error && (
-            <div
-              className="notification error action-error"
-              dangerouslySetInnerHTML={{
-                __html: error.graphQLErrors[0].message
-              }}
-            />
+            <NotificationError className="action-error" apolloError={error} />
           )}
         </div>
       </div>

--- a/front/src/dashboard/slips/SlipsTabs.tsx
+++ b/front/src/dashboard/slips/SlipsTabs.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { FaClone } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+import { InlineError } from "../../common/Error";
 import Loader from "../../common/Loader";
 import { Me } from "../../login/model";
 import { GET_SLIPS } from "./query";
@@ -18,7 +19,8 @@ export default function SlipsTabs({ me, siret }: Props) {
   });
 
   if (loading) return <Loader />;
-  if (error || !data) return <p>Erreur...</p>;
+  if (error) return <InlineError apolloError={error} />;
+  if (!data) return <p>Aucune donnée à afficher</p>;
 
   const drafts = getTabForms(SlipTabs.DRAFTS, data.forms, siret);
   const toSign = getTabForms(SlipTabs.TO_SIGN, data.forms, siret);

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -1,8 +1,9 @@
-import React from "react";
-import { Me } from "../../login/model";
-import "./Transport.scss";
 import { Query } from "@apollo/react-components";
 import gql from "graphql-tag";
+import React from "react";
+import { InlineError } from "../../common/Error";
+import { Me } from "../../login/model";
+import "./Transport.scss";
 import TransportSignature from "./TransportSignature";
 
 type Props = {
@@ -62,7 +63,8 @@ export default function Transport({ me, siret }: Props) {
         >
           {({ loading, error, data }) => {
             if (loading) return <p>Chargement...</p>;
-            if (error || !data) return <p>"Erreur..."</p>;
+            if (error) return <InlineError apolloError={error} />;
+            if (!data) return <p>Aucune donnée à afficher</p>;
 
             return (
               <table className="table">

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -5,6 +5,8 @@ import { DateTime } from "luxon";
 import React, { useState } from "react";
 import { FaFileSignature } from "react-icons/fa";
 import DownloadFileLink from "../../common/DownloadFileLink";
+import { NotificationError } from "../../common/Error";
+import { updateApolloCache } from "../../common/helper";
 import RedErrorMessage from "../../common/RedErrorMessage";
 import { Form, Form as FormModel } from "../../form/model";
 import Packagings from "../../form/packagings/Packagings";
@@ -13,7 +15,6 @@ import { FORMS_PDF } from "../slips/slips-actions/DownloadPdf";
 import { GET_TRANSPORT_SLIPS } from "./Transport";
 import "./TransportSignature.scss";
 import { Wizard } from "./Wizard";
-import { updateApolloCache } from "../../common/helper";
 
 export const SIGNED_BY_TRANSPORTER = gql`
   mutation SignedByTransporter(
@@ -241,9 +242,7 @@ export default function TransportSignature({ form }: Props) {
                         <Field type="text" name="sentBy" />
                       </label>
                     </p>
-                    {error && (
-                      <div className="notification error">{error.message}</div>
-                    )}
+                    {error && <NotificationError apolloError={error} />}
                   </div>
                 </>
               )}

--- a/front/src/form/appendix/FormsTable.tsx
+++ b/front/src/form/appendix/FormsTable.tsx
@@ -1,9 +1,10 @@
-import React from "react";
 import { useQuery } from "@apollo/react-hooks";
-import gql from "graphql-tag";
 import { useFormikContext } from "formik";
-import { Form } from "../model";
+import gql from "graphql-tag";
 import { DateTime } from "luxon";
+import React from "react";
+import { InlineError } from "../../common/Error";
+import { Form } from "../model";
 
 const GET_APPENDIX_FORMS = gql`
   query AppendixForms($emitterSiret: String!, $wasteCode: String) {
@@ -36,7 +37,8 @@ export default function FormsTable({ wasteCode, selectedItems, onToggle }) {
   });
 
   if (loading) return <p>Chargement...</p>;
-  if (error || !data) return <p>{`Erreur! ${error && error.message}`}</p>;
+  if (error) return <InlineError apolloError={error} />;
+  if (!data) return <p>Aucune donnée à afficher</p>;
 
   const forms = data.appendixForms;
 

--- a/front/src/form/company/CompanySelector.tsx
+++ b/front/src/form/company/CompanySelector.tsx
@@ -1,11 +1,12 @@
-import { useQuery, useLazyQuery } from "@apollo/react-hooks";
+import { useLazyQuery, useQuery } from "@apollo/react-hooks";
 import { Field, useField, useFormikContext } from "formik";
 import React, { useEffect, useReducer } from "react";
 import { FaCheck, FaRegCircle, FaSearch } from "react-icons/fa";
+import { InlineError } from "../../common/Error";
+import { toMacroCase } from "../../common/helper";
 import RedErrorMessage from "../../common/RedErrorMessage";
 import "./CompanySelector.scss";
 import { FAVORITES, SEARCH_COMPANIES } from "./query";
-import { toMacroCase } from "../../common/helper";
 
 export type Rubrique = {
   rubrique: string;
@@ -132,7 +133,7 @@ export default function CompanySelector(props) {
   });
 
   if (loading) return <p>Chargement...</p>;
-  if (error) return <p>Erreur :(</p>;
+  if (error) return <InlineError apolloError={error} />;
 
   return (
     <div className="CompanySelector">

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -115,9 +115,8 @@ export default withRouter(function StepList(
                   })
                     .then(_ => props.history.push("/dashboard/slips"))
                     .catch(err => {
-                      cogoToast.error(
-                        err.message.replace("GraphQL error:", ""),
-                        { hideAfter: 7 }
+                      err.graphQLErrors.map(err =>
+                        cogoToast.error(err.message, { hideAfter: 7 })
                       );
                     });
                   return false;

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -3,6 +3,7 @@ import cogoToast from "cogo-toast";
 import { Formik, setNestedObjectValues } from "formik";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { RouteComponentProps, withRouter } from "react-router";
+import { InlineError } from "../../common/Error";
 import { updateApolloCache } from "../../common/helper";
 import { currentSiretService } from "../../dashboard/CompanySelector";
 import { GET_SLIPS } from "../../dashboard/slips/query";
@@ -75,7 +76,7 @@ export default withRouter(function StepList(
   });
 
   if (loading) return <p>Chargement...</p>;
-  if (error) return <p>Erreur :(</p>;
+  if (error) return <InlineError apolloError={error} />;
 
   const state = { ...initialState, ...data.form };
   return (

--- a/front/src/login/ResetPassword.tsx
+++ b/front/src/login/ResetPassword.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from "react";
-import { Mutation } from "@apollo/react-components";
+import { useMutation } from "@apollo/react-hooks";
 import gql from "graphql-tag";
+import React, { useState } from "react";
+import { NotificationError } from "../common/Error";
 
 const RESET_PASSWORD = gql`
   mutation ResetPassword($email: String!) {
@@ -9,56 +10,47 @@ const RESET_PASSWORD = gql`
 `;
 export default function ResetPassword() {
   const [email, setEmail] = useState("");
-  const [error, setError] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
+  const [resetPassword, { error }] = useMutation(RESET_PASSWORD);
   return (
     <section className="section section-white">
       <div className="container">
-        <Mutation mutation={RESET_PASSWORD}>
-          {(resetPassword, { data, error }) => (
-            <form
-              onSubmit={e => {
-                e.preventDefault();
-                resetPassword({ variables: { email } })
-                  .then(_ => setShowSuccess(true))
-                  .catch(err => setError(err.message));
-                setError("");
-                setShowSuccess(false);
-                setEmail("");
-              }}
-            >
-              <h1>Réinitialisation de votre mot de passe</h1>
-              <p>
-                Afin de réinitialiser votre mot de passe, merci de saisir votre
-                email. Un nouveau mot de passe vous sera transmis.
-              </p>
-              <div className="form__group">
-                <label>
-                  <input
-                    type="text"
-                    placeholder="Saisissez votre email"
-                    value={email}
-                    onChange={e => setEmail(e.target.value)}
-                  />
-                </label>
-              </div>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            resetPassword({ variables: { email } }).then(_ =>
+              setShowSuccess(true)
+            );
+            setShowSuccess(false);
+            setEmail("");
+          }}
+        >
+          <h1>Réinitialisation de votre mot de passe</h1>
+          <p>
+            Afin de réinitialiser votre mot de passe, merci de saisir votre
+            email. Un nouveau mot de passe vous sera transmis.
+          </p>
+          <div className="form__group">
+            <label>
+              <input
+                type="text"
+                placeholder="Saisissez votre email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+              />
+            </label>
+          </div>
 
-              <button className="button" type="submit">
-                Réinitialiser
-              </button>
-            </form>
-          )}
-        </Mutation>
+          <button className="button" type="submit">
+            Réinitialiser
+          </button>
+        </form>
         {showSuccess && (
           <div className="notification success">
             Un email avec votre nouveau mot de passe vient de vous être envoyé.
           </div>
         )}
-        {error && (
-          <div className="notification error">
-            Une erreur est survenue: {error}
-          </div>
-        )}
+        {error && <NotificationError apolloError={error} />}
       </div>
     </section>
   );

--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -3,6 +3,7 @@ import { Field } from "formik";
 import React, { useState } from "react";
 import { FaEnvelope, FaEye, FaIdCard, FaLock, FaPhone } from "react-icons/fa";
 import { Link, useHistory } from "react-router-dom";
+import { NotificationError } from "../common/Error";
 import PasswordMeter from "../common/PasswordMeter";
 import RedErrorMessage from "../common/RedErrorMessage";
 import { SIGNUP } from "./mutations";
@@ -28,7 +29,7 @@ export default function Signup() {
             passwordConfirmation: "",
             cgu: false
           }}
-          onSubmit={(values: any, { setStatus, setSubmitting }) => {
+          onSubmit={(values: any, { setSubmitting }) => {
             const {
               passwordConfirmation,
               emailConfirmation,
@@ -38,13 +39,7 @@ export default function Signup() {
 
             signup({ variables: { userInfos } })
               .then(_ => history.push("/signup/activation"))
-              .catch(errors => {
-                // graphQLErrors are returned as an array of objects, we map and join  them to a string
-
-                let errorMessages = (errors.graphQLErrors || [])
-                  .map(({ message }: { message: string }) => message)
-                  .join("\n");
-                setStatus(errorMessages);
+              .catch(_ => {
                 setSubmitting(false);
               });
           }}
@@ -224,9 +219,7 @@ export default function Signup() {
 
             <RedErrorMessage name="cgu" />
 
-            {signupError && (
-              <div className="notification error">{signupError.message}</div>
-            )}
+            {signupError && <NotificationError apolloError={signupError} />}
           </Wizard.Page>
         </Wizard>
       </div>


### PR DESCRIPTION
Utilisation systématique de composants génériques pour les erreurs.
- on ne se base plus sur `error.message`
- on va chercher l'erreur détaillée pour éviter  les prefixes `GraphQL Error` / `NetworkError`.
- on fallback sur l'erreur de base si on a pas d'info plus précise