### PR TITLE
Update compose configuration and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: |
             ssh ${<< parameters.user >>}@${<< parameters.host >>} "cd /srv/trackdechets/
                 docker-compose pull
-                docker-compose up -d
+                docker-compose up -d && docker-compose stop td-etl
                 docker exec \$(docker ps -qf 'name=td-api') npx prisma deploy"
 
   integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,10 @@ jobs:
           command: |
             ssh ${<< parameters.user >>}@${<< parameters.host >>} "cd /srv/trackdechets/
                 docker-compose pull
-                docker-compose up -d && docker-compose stop td-etl
+                if [ "${CIRCLE_BRANCH}" == "dev" ]; then
+                  docker-compose up -d postgres
+                fi
+                docker-compose up -d prisma redis td-api td-ui td-insee td-pdf td-mail td-doc metabase
                 docker exec \$(docker ps -qf 'name=td-api') npx prisma deploy"
 
   integration-tests:

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -1,8 +1,5 @@
 version: "3"
 services:
-  postgres:
-    image: betagouv/trackdechets-postgres:sandbox
-
   td-api:
     image: betagouv/trackdechets-api:sandbox
 

--- a/docker-compose.val.yml
+++ b/docker-compose.val.yml
@@ -1,7 +1,16 @@
 version: "3"
 services:
+
   postgres:
     image: betagouv/trackdechets-postgres:dev
+    restart: always
+    environment:
+      POSTGRES_USER: $POSTGRES_USER
+      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      AIRFLOW_POSTGRES_USER: $AIRFLOW_POSTGRES_USER
+      AIRFLOW_POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
+    volumes:
+      - postgres:/var/lib/postgresql/data
 
   td-api:
     image: betagouv/trackdechets-api:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,18 +16,6 @@ services:
             user: $POSTGRES_USER
             password: $POSTGRES_PASSWORD
             migrations: true
-
-  postgres:
-    image: betagouv/trackdechets-postgres:master
-    restart: always
-    environment:
-      POSTGRES_USER: $POSTGRES_USER
-      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
-      AIRFLOW_POSTGRES_USER: $AIRFLOW_POSTGRES_USER
-      AIRFLOW_POSTGRES_PASSWORD: $AIRFLOW_POSTGRES_PASSWORD
-    volumes:
-      - postgres:/var/lib/postgresql/data
-
   redis:
     image: redis:5.0-alpine
     restart: always


### PR DESCRIPTION
* Modification compose 
  * suppression du service postgres en prod et sandbox (db managée). Les images postgres:master et postgres:sandbox seront quand même buildée et pushées pour rien mais c'est un moindre mal et ça évite de faire plusieurs fichiers de build
* Modification CI 
  * démarrage de postgres si `CIRCLE_BRANCH == dev`
  * démarrage explicite de l'ensemble des autres services pour exclure `td-etl` 

À terme on pourra peut-être passer recette sur une db managée pour homogénéiser les configs.