### PR TITLE
Customize session cookie name

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -25,6 +25,7 @@ JWT_SECRET=*********
 
 # Session configuration
 SESSION_SECRET=*********
+SESSION_NAME=connect.sid
 SESSION_COOKIE_HOST=trackdechets.fr
 SESSION_COOKIE_SECURE=false
 

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -2,6 +2,7 @@ import * as express from "express";
 import * as passport from "passport";
 import * as querystring from "querystring";
 import { getUIBaseURL } from "../utils";
+import { sess } from "../server";
 
 const { UI_HOST } = process.env;
 
@@ -37,7 +38,7 @@ authRouter.get("/isAuthenticated", (req, res) => {
 authRouter.post("/logout", (req, res) => {
   req.logout();
   res
-    .clearCookie("connect.sid", { domain: UI_HOST, path: "/" })
+    .clearCookie(sess.name, { domain: UI_HOST, path: "/" })
     .redirect(`${UI_BASE_URL}`);
 });
 

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -29,6 +29,7 @@ const {
   SESSION_SECRET,
   SESSION_COOKIE_HOST,
   SESSION_COOKIE_SECURE,
+  SESSION_NAME,
   UI_HOST,
   NODE_ENV
 } = process.env;
@@ -150,8 +151,9 @@ app.use(
 const RedisStore = redisStore(session);
 const redisClient = new Redis({ host: "redis" });
 
-const sess = {
+export const sess = {
   store: new RedisStore({ client: redisClient }),
+  name: SESSION_NAME || "trackdechets.connect.sid",
   secret: SESSION_SECRET,
   resave: false,
   saveUninitialized: false,


### PR DESCRIPTION
Cf https://trello.com/c/Em9OJUQi 

Le cookie de session de production sur `trackdechets.beta.gouv.fr` est également présent sur `sandbox.trackdechets.beta.gouv.fr`. Le navigateur envoie donc à l'API `Cookie: connect.sid={prod_cookie};connect.sid={sandbox_cookie}`. Si le cookie de prod est en premier, c'est lui qui est parsé par l'API et la session n'est pas reconnue. 

On ne peut malheureusement pas appliquer un `sameSite: strict` pour éviter que le cookie de prod s'applique sur sandbox car ça l'empêcherait d'être envoyé à l'API. D'après https://github.com/expressjs/session#name la solution est de spécifier un nom de cookie différent.