### PR TITLE
Do not open prisma port to the outside world

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: prismagraphql/prisma:1.34.10
     restart: always
     ports:
-      - "4466:4466"
+      - "127.0.0.1:4466:4466"
     environment:
       PRISMA_CONFIG: |
         port: 4466


### PR DESCRIPTION
Utilisation d'un tunnel SSH à la place. Exemple avec `autossh`

`autossh -M9044 -N -L 4466:127.0.0.1:4466 user@host -i ~/path/to/ssh/key`