### PR TITLE
Fix error messages on mark as sealed mutation

### DIFF
--- a/back/src/forms/workflow/errors.ts
+++ b/back/src/forms/workflow/errors.ts
@@ -5,7 +5,7 @@ import {
   ForbiddenError,
   ApolloError
 } from "apollo-server-express";
-
+import { unflattenObjectFromDb } from "../form-converter";
 export enum WorkflowError {
   InvalidForm,
   InvalidTransition,
@@ -18,7 +18,7 @@ export async function getError(error: WorkflowError, form: Form) {
   switch (error) {
     case WorkflowError.InvalidForm:
       const errors: string[] = await formSchema
-        .validate(form, { abortEarly: false })
+        .validate(unflattenObjectFromDb(form), { abortEarly: false })
         .catch(err => err.errors);
       return new UserInputError(
         `Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.\nErreur(s): ${errors.join(


### PR DESCRIPTION
Les messages d'erreurs renvoyés par l'api sur la mutation mark as sealed ne correspondaient pas aux erreurs rencontrées.
Par ailleurs les tests unitaires ne vérifiaient pas que seuls les messages d'erreurs voulus étaient renvoyés.