### PR TITLE
Add fallback address

### DIFF
--- a/insee/src/insee.go
+++ b/insee/src/insee.go
@@ -131,12 +131,18 @@ func buildSearchURI(query url.Values) string {
 }
 
 func etablissementToResponse(item Etablissement) Response {
+	address := item.GeoAdresse
+
+	if address == "" {
+		address = item.LibelleVoie + " " + item.LibelleCommune
+	}
+
 	return Response{item.Siret,
 		item.Siren,
 		item.NomRaisonSociale,
 		item.ActivitePrincipale,
 		item.LibelleActivitePrincipale,
-		item.GeoAdresse,
+		address,
 		item.Longitude,
 		item.Latitude,
 		item.Departement}

--- a/insee/src/structs.go
+++ b/insee/src/structs.go
@@ -23,6 +23,8 @@ type Etablissement struct {
 	ActivitePrincipale        string `json:"activite_principale"`
 	LibelleActivitePrincipale string `json:"libelle_activite_principale"`
 	GeoAdresse                string `json:"geo_adresse"`
+	LibelleCommune            string `json:"libelle_commune"`
+	LibelleVoie               string `json:"libelle_voie"`
 	Longitude                 string `json:"longitude"`
 	Latitude                  string `json:"latitude"`
 	Departement               string `json:"departement"`


### PR DESCRIPTION
Pour les entreprises qui n'ont pas d'adresse précise, on rajoute un fallback sur les champs LibelleVoie & LibelleCommune