### PR TITLE
Fix company name was not set at company creation

### DIFF
--- a/back/prisma/scripts/set-company-name.ts
+++ b/back/prisma/scripts/set-company-name.ts
@@ -1,0 +1,20 @@
+import { Updater, registerUpdater } from ".";
+import { setCompanyName } from "../../src/scripts/prisma/set-company-name";
+
+@registerUpdater(
+  "Set company name for records where it was not set at creation",
+  `Populate field name`,
+  true
+)
+export class SetCompanyNameUpdater implements Updater {
+  async run() {
+    console.info("Starting script to populate names");
+    try {
+      await setCompanyName();
+      console.log("Done updating");
+    } catch (err) {
+      console.error("☠ Something went wrong during the update", err);
+      throw new Error();
+    }
+  }
+}

--- a/back/prisma/scripts/set-wasteacceptationstatus.ts
+++ b/back/prisma/scripts/set-wasteacceptationstatus.ts
@@ -7,7 +7,7 @@ import {
 @registerUpdater(
   "Set wasteAcceptationStatus",
   `The wasteAcceptationStatus properties was added to replace isAccepted`,
-  true
+  false
 )
 export class SetFormUpdater implements Updater {
   async run() {

--- a/back/src/companies/mutations/__tests__/create-company.integration.ts
+++ b/back/src/companies/mutations/__tests__/create-company.integration.ts
@@ -18,15 +18,21 @@ describe("Create company endpoint", () => {
     const user = await userFactory();
 
     const siret = "12345678912345";
+    const gerepId = "1234";
+    const name = "Acme";
+    const companyTypes = ["PRODUCER"];
+    const naf = "456";
 
     const mutation = `
     mutation {
       createCompany(
         companyInput: {
           siret: "${siret}"
-          gerepId: "1234"
+          gerepId: "${gerepId}"
+          companyName: "${name}"
+          companyTypes: [${companyTypes}]
         }
-      ) { id }
+      ) { siret, gerepId, name, companyTypes }
     }
   `;
 
@@ -34,8 +40,13 @@ describe("Create company endpoint", () => {
 
     const { data } = await mutate(mutation);
 
-    expect(data.createCompany.id).toBeDefined();
-    expect(data.createCompany.id).not.toBeNull();
+    const expected = {
+      siret,
+      gerepId,
+      name,
+      companyTypes
+    };
+    expect(data.createCompany).toEqual(expected);
 
     const newCompanyExists = await prisma.$exists.company({ siret });
     expect(newCompanyExists).toBe(true);

--- a/back/src/scripts/prisma/__tests__/set-company-name.integration.ts
+++ b/back/src/scripts/prisma/__tests__/set-company-name.integration.ts
@@ -1,0 +1,73 @@
+import axios from "axios";
+import { setCompanyName } from "../set-company-name";
+import { prisma } from "../../../generated/prisma-client";
+import { resetDatabase } from "../../../../integration-tests/helper";
+
+jest.mock("axios");
+
+// Skip this test in a normal test run because it targets a function
+// that should be run only once in "npm run update"
+
+describe.skip("setCompanyName", () => {
+  afterAll(async () => {
+    await resetDatabase();
+    jest.resetAllMocks();
+  });
+
+  it("should set company name where it was not previously set", async () => {
+    // Frontier, name is set
+    const frontier = await prisma.createCompany({
+      siret: "81343950200028",
+      name: "Frontier SAS",
+      securityCode: 1234
+    });
+
+    // LP, name is not set
+    const lp = await prisma.createCompany({
+      siret: "51212357100022",
+      securityCode: 2345
+    });
+    const resp1 = { status: 200, data: { name: "LP" } };
+    (axios.get as jest.Mock).mockResolvedValueOnce(resp1);
+
+    // Code en stock, name is not set
+    const codeEnStock = await prisma.createCompany({
+      siret: "85001946400013",
+      securityCode: 2345
+    });
+    const resp2 = { status: 200, data: { name: "CODE EN STOCK" } };
+    (axios.get as jest.Mock).mockResolvedValueOnce(resp2);
+
+    // Unknown SIRET, name is not set
+    const unknown = await prisma.createCompany({
+      siret: "xxxxxxxxxxxxxx",
+      securityCode: 3456
+    });
+
+    // expect insee service to retunr 404
+    const resp3 = { status: 404 };
+    (axios.get as jest.Mock).mockResolvedValueOnce(resp3);
+
+    await setCompanyName();
+
+    // Frontier name was already set, it should be unchanged
+    const frontierUpdated = await prisma.company({ siret: frontier.siret });
+    expect(frontierUpdated.name).toEqual(frontier.name);
+
+    // LP name should be set
+    const lpUpdated = await prisma.company({ siret: lp.siret });
+    expect(lpUpdated.name).toEqual("LP");
+
+    // Code en Stock name should be set
+    const codeEnStockUpdated = await prisma.company({
+      siret: codeEnStock.siret
+    });
+    expect(codeEnStockUpdated.name).toEqual("CODE EN STOCK");
+
+    // Unknown company name should not be set
+    const unknownUpdated = await prisma.company({
+      siret: unknown.siret
+    });
+    expect(unknownUpdated.name).toBeNull();
+  });
+});

--- a/back/src/scripts/prisma/set-company-name.ts
+++ b/back/src/scripts/prisma/set-company-name.ts
@@ -1,0 +1,41 @@
+import { prisma } from "../../generated/prisma-client";
+import axios from "axios";
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function setCompanyName() {
+  // filter companies where name field is not set
+  const companies = await prisma.companies({ where: { name: null } });
+
+  for (const company of companies) {
+    console.log(`Setting name for company ${company.siret}`);
+
+    try {
+      const response = await axios.get(
+        `http://td-insee:81/siret/${company.siret}`
+      );
+
+      if (response.status === 200) {
+        const companyInfo = response.data;
+
+        await prisma.updateCompany({
+          data: {
+            name: companyInfo.name
+          },
+          where: {
+            id: company.id
+          }
+        });
+      } else {
+        console.log(`Received status code ${response.status}`, response);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+
+    // Wait some time to avoid 429 Too many requests
+    await sleep(1000);
+  }
+}

--- a/front/src/account/AccountCompanyAdd.tsx
+++ b/front/src/account/AccountCompanyAdd.tsx
@@ -138,7 +138,10 @@ export default function AccountCompanyAdd() {
         }}
         onSubmit={values => {
           const { isAllowed, ...companyInput } = values;
-          createCompany({ variables: { companyInput } }).then(_ => {
+          const companyName = companyInfos ? companyInfos.name || "" : "";
+          createCompany({
+            variables: { companyInput: { ...companyInput, companyName } }
+          }).then(_ => {
             history.push("/dashboard/slips");
           });
         }}


### PR DESCRIPTION
⚠️ nécessite un `npm run update`

Cf https://trello.com/c/bZXxwHwV

Le nom de l'entreprise n'était plus sauvegardé en base depuis les changements relatifs au rattachement entreprise. Ce n'est pas problématique pour le fonctionnement de l'application puisque cette info est récupérée dynamiquement dans la base SIRENE mais ça empêche Judith et Claire de suivre les nouvelles inscriptions dans metabase. 

* Modification de `createCompany.integration.ts` pour vérifier que `createCompany` sauvegarde  bien le nom en base lorsqu'on lui passe.
* Correction du composant `AccountCompanyAdd` pour inclure le nom de l'entreprise dans le payload 
* Ajout d'un script permettant de définir le nom de l'entreprise pour tous les enregistrements en base qui n'en ont pas.

