### PR TITLE
Fix IE login / logout 

### DIFF
--- a/back/src/common/middlewares/nocache.ts
+++ b/back/src/common/middlewares/nocache.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Express middleware to prevent response
+ * from being cached by the browser
+ */
+export default (_req: Request, res: Response, next: NextFunction) => {
+  res.header("Cache-Control", "private, no-cache, no-store, must-revalidate");
+  res.header("Expires", "-1");
+  res.header("Pragma", "no-cache");
+  next();
+};

--- a/back/src/forms/mutations/__tests__/save-form.integration.ts
+++ b/back/src/forms/mutations/__tests__/save-form.integration.ts
@@ -172,7 +172,7 @@ describe("{ mutation { saveForm } }", () => {
     // update its waste name
     const updatePayload = {
       ...createPayload,
-      id: id,
+      id,
       wasteDetails: { name: "things" }
     };
 

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -39,7 +39,7 @@ authRouter.post("/logout", (req, res) => {
   req.logout();
   res
     .clearCookie(sess.name, {
-      domain: SESSION_COOKIE_HOST || UI_HOST,
+      domain: sess.cookie.domain,
       path: "/"
     })
     .redirect(`${UI_BASE_URL}`);

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -3,13 +3,13 @@ import * as passport from "passport";
 import * as querystring from "querystring";
 import { getUIBaseURL } from "../utils";
 import { sess } from "../server";
+import nocache from "../common/middlewares/nocache";
 
-const { UI_HOST } = process.env;
+const { UI_HOST, SESSION_COOKIE_HOST } = process.env;
 
 const UI_BASE_URL = getUIBaseURL();
 
 const authRouter = express.Router();
-
 authRouter.post("/login", (req, res, next) => {
   passport.authenticate("local", (err, user, info) => {
     if (err) {
@@ -31,14 +31,17 @@ authRouter.post("/login", (req, res, next) => {
   })(req, res, next);
 });
 
-authRouter.get("/isAuthenticated", (req, res) => {
+authRouter.get("/isAuthenticated", nocache, (req, res) => {
   return res.json({ isAuthenticated: req.isAuthenticated() });
 });
 
 authRouter.post("/logout", (req, res) => {
   req.logout();
   res
-    .clearCookie(sess.name, { domain: UI_HOST, path: "/" })
+    .clearCookie(sess.name, {
+      domain: SESSION_COOKIE_HOST || UI_HOST,
+      path: "/"
+    })
     .redirect(`${UI_BASE_URL}`);
 });
 

--- a/front/package.json
+++ b/front/package.json
@@ -33,7 +33,6 @@
     "react-scripts": "3.3.0",
     "react-tabs": "3.1.0",
     "template.data.gouv.fr": "^1.3.2",
-    "whatwg-fetch": "^3.0.0",
     "yup": "^0.26.6",
     "zxcvbn": "^4.4.2"
   },

--- a/front/src/use-auth.tsx
+++ b/front/src/use-auth.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import "whatwg-fetch";
 
 export function useAuth() {
   const [loading, setIsLoading] = useState(true);


### PR DESCRIPTION
Le bug provenait du fait que IE cachait l'appel à `GET /isAuthenticated`. 
Résolu en appliquant les bons headers dans la réponse 
Par ailleurs on avait un problème de `domain` sur la route `POST /logout`

Autres modifs mineures non liées au bug:
* suppression de la dépendance à `whatwg-fetch`, le polyfill est déjà géré par `react-app-polyfill`.
* Fix d'une erreur TSLint