### PR TITLE
Enhance transporter page

### DIFF
--- a/back/prisma/datamodel.prisma
+++ b/back/prisma/datamodel.prisma
@@ -252,6 +252,8 @@ type Form {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  # Free field, used to easily retrieve transporter tours
+  transporterCustomInfo: String
 
   # Waste details fields
   wasteDetailsCode: String
@@ -280,6 +282,8 @@ type Form {
   ecoOrganisme: EcoOrganisme
 
   appendix2Forms: [Form]
+
+
 }
 
 enum EmitterType {

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -25,6 +25,7 @@ type Query {
     type: FormType = ACTOR
     ): [Form]
 
+
   "Renvoie des statistiques sur le volume de déchets entrant et sortant"
   stats: [CompanyStat]
 
@@ -88,6 +89,16 @@ type Mutation {
   saveForm(
     "Payload du BSD"
     formInput: FormInput!
+    ): Form
+
+ "Met à jour la plaque d'immatriculation ou le champ libre du transporteur"
+  updateTransporterFields(
+    "ID d'un BSD"
+    id: ID!
+    "Plaque d'immatriculation du transporteur"
+    transporterNumberPlate: String
+    "Champ libre, utilisable par exemple pour noter les tournées des transporteurs"
+     transporterCustomInfo: String
     ): Form
 
   "Supprime un BSD"
@@ -308,7 +319,9 @@ type Form {
 
   "Annexe 2"
   appendix2Forms: [Form]
+
   ecoOrganisme: EcoOrganisme
+
 }
 
 "Information sur un établissement dans un BSD"
@@ -410,6 +423,9 @@ type Transporter {
 
   "Numéro de plaque d'immatriculation"
   numberPlate: String
+
+  "Information libre, destinée aux transporteurs"
+  customInfo: String
 }
 
 "Destination ultérieure prévue (case 12)"

--- a/back/src/forms/mutations/__tests__/updateTransporterFields.integration.ts
+++ b/back/src/forms/mutations/__tests__/updateTransporterFields.integration.ts
@@ -1,0 +1,146 @@
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { prisma } from "../../../generated/prisma-client";
+
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+
+jest.mock("axios", () => ({
+  default: {
+    get: jest.fn(() => Promise.resolve({ data: {} }))
+  }
+}));
+
+describe("Forms -> updateTransporterFields mutation", () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+  afterAll(async () => {
+    await resetDatabase();
+  });
+
+  it("should update transporter plate", async () => {
+    const { user: emitter } = await userWithCompanyFactory("MEMBER");
+    const {
+      user: transporter,
+      company: transporterCompany
+    } = await userWithCompanyFactory("MEMBER");
+
+    let form = await formFactory({
+      ownerId: emitter.id,
+      opt: {
+        status: "SEALED",
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+    const { mutate } = makeClient(transporter);
+    const mutation = `
+    mutation {
+      updateTransporterFields(id: "${form.id}", transporterNumberPlate: "ZBLOP 83") {
+        id
+      }
+    }
+  `;
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.transporterNumberPlate).toEqual("ZBLOP 83");
+  });
+
+  it("should update transporter custom info", async () => {
+    const { user: emitter } = await userWithCompanyFactory("MEMBER");
+    const {
+      user: transporter,
+      company: transporterCompany
+    } = await userWithCompanyFactory("MEMBER");
+
+    let form = await formFactory({
+      ownerId: emitter.id,
+      opt: {
+        status: "SEALED",
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+    const { mutate } = makeClient(transporter);
+    const mutation = `
+    mutation {
+      updateTransporterFields(id: "${form.id}", transporterCustomInfo: "tournée 493") {
+        id
+      }
+    }
+  `;
+    await mutate(mutation);
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.transporterCustomInfo).toEqual("tournée 493");
+  });
+
+  it("should not update not SEALED forms", async () => {
+    const { user: emitter } = await userWithCompanyFactory("MEMBER");
+    const {
+      user: transporter,
+      company: transporterCompany
+    } = await userWithCompanyFactory("MEMBER");
+
+    let form = await formFactory({
+      ownerId: emitter.id,
+      opt: {
+        status: "SENT",
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+    const { mutate } = makeClient(transporter);
+    const mutation = `
+    mutation {
+      updateTransporterFields(id: "${form.id}", transporterCustomInfo: "tournée 493") {
+        id
+      }
+    }
+  `;
+    const { errors } = await mutate(mutation);
+    expect(errors[0].message).toEqual(
+      "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé"
+    );
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.transporterCustomInfo).toEqual(null);
+  });
+
+  it("should not update form if user is not made by a transporter", async () => {
+    const { user: emitter } = await userWithCompanyFactory("MEMBER");
+    const {
+      user: transporter,
+      company: transporterCompany
+    } = await userWithCompanyFactory("MEMBER");
+
+    let form = await formFactory({
+      ownerId: emitter.id,
+      opt: {
+        status: "SEALED",
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+    const { mutate } = makeClient(emitter); // not a transporter
+    const mutation = `
+    mutation {
+      updateTransporterFields(id: "${form.id}", transporterCustomInfo: "tournée 493") {
+        id
+      }
+    }
+  `;
+    const { errors } = await mutate(mutation);
+
+    expect(errors[0].message).toEqual(
+      "Vous n'êtes pas transporteur de ce bordereau."
+    );
+
+    form = await prisma.form({ id: form.id });
+
+    expect(form.transporterCustomInfo).toEqual(null);
+  });
+});

--- a/back/src/forms/mutations/updateTransporterFields.ts
+++ b/back/src/forms/mutations/updateTransporterFields.ts
@@ -1,0 +1,21 @@
+import { GraphQLContext } from "../../types";
+import { unflattenObjectFromDb } from "../form-converter";
+
+import { ForbiddenError } from "apollo-server-express";
+
+export async function updateTransporterFields(
+  _,
+  { id, transporterNumberPlate, transporterCustomInfo },
+  context: GraphQLContext
+) {
+  const form = await context.prisma.form({ id });
+  if (form.status !== "SEALED") {
+    throw new ForbiddenError("Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé");
+  }
+  const updatedForm = await context.prisma.updateForm({
+    where: { id },
+    data: { transporterNumberPlate, transporterCustomInfo }
+  });
+
+  return unflattenObjectFromDb(updatedForm);
+}

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -32,6 +32,7 @@ export default {
     markAsSent: or(isFormRecipient, isFormEmitter),
     markAsReceived: isFormRecipient,
     markAsProcessed: isFormRecipient,
-    signedByTransporter: isFormTransporter
+    signedByTransporter: isFormTransporter,
+    updateTransporterFields: isFormTransporter
   }
 };

--- a/back/src/forms/queries/forms.ts
+++ b/back/src/forms/queries/forms.ts
@@ -31,7 +31,7 @@ export default async function forms(
     },
     TRANSPORTER: {
       transporterCompanySiret: selectedCompany.siret,
-      status: "SEALED"
+      status_in: ["SEALED", "SENT"]
     }
   };
 

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -15,6 +15,7 @@ import {
 } from "./mutations/mark-as";
 import { duplicateForm } from "./mutations";
 import { saveForm } from "./mutations/save-form";
+import { updateTransporterFields } from "./mutations/updateTransporterFields";
 import { formPdf } from "./queries/form-pdf";
 import forms from "./queries/forms";
 import { formsRegister } from "./queries/forms-register";
@@ -234,7 +235,8 @@ export default {
     markAsSent,
     markAsReceived,
     markAsProcessed,
-    signedByTransporter
+    signedByTransporter,
+    updateTransporterFields
   },
   Subscription: {
     forms: {

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -781,6 +781,8 @@ export type FormOrderByInput =
   | "transporterValidityLimit_DESC"
   | "transporterNumberPlate_ASC"
   | "transporterNumberPlate_DESC"
+  | "transporterCustomInfo_ASC"
+  | "transporterCustomInfo_DESC"
   | "wasteDetailsCode_ASC"
   | "wasteDetailsCode_DESC"
   | "wasteDetailsName_ASC"
@@ -1199,6 +1201,7 @@ export interface FormUpdateInput {
   transporterDepartment?: Maybe<String>;
   transporterValidityLimit?: Maybe<DateTimeInput>;
   transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsName?: Maybe<String>;
   wasteDetailsOnuCode?: Maybe<String>;
@@ -1526,6 +1529,7 @@ export interface FormCreateInput {
   transporterDepartment?: Maybe<String>;
   transporterValidityLimit?: Maybe<DateTimeInput>;
   transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsName?: Maybe<String>;
   wasteDetailsOnuCode?: Maybe<String>;
@@ -2605,6 +2609,20 @@ export interface FormWhereInput {
   transporterNumberPlate_not_starts_with?: Maybe<String>;
   transporterNumberPlate_ends_with?: Maybe<String>;
   transporterNumberPlate_not_ends_with?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  transporterCustomInfo_not?: Maybe<String>;
+  transporterCustomInfo_in?: Maybe<String[] | String>;
+  transporterCustomInfo_not_in?: Maybe<String[] | String>;
+  transporterCustomInfo_lt?: Maybe<String>;
+  transporterCustomInfo_lte?: Maybe<String>;
+  transporterCustomInfo_gt?: Maybe<String>;
+  transporterCustomInfo_gte?: Maybe<String>;
+  transporterCustomInfo_contains?: Maybe<String>;
+  transporterCustomInfo_not_contains?: Maybe<String>;
+  transporterCustomInfo_starts_with?: Maybe<String>;
+  transporterCustomInfo_not_starts_with?: Maybe<String>;
+  transporterCustomInfo_ends_with?: Maybe<String>;
+  transporterCustomInfo_not_ends_with?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsCode_not?: Maybe<String>;
   wasteDetailsCode_in?: Maybe<String[] | String>;
@@ -3314,6 +3332,7 @@ export interface FormUpdateManyDataInput {
   transporterDepartment?: Maybe<String>;
   transporterValidityLimit?: Maybe<DateTimeInput>;
   transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsName?: Maybe<String>;
   wasteDetailsOnuCode?: Maybe<String>;
@@ -3421,6 +3440,7 @@ export interface FormUpdateDataInput {
   transporterDepartment?: Maybe<String>;
   transporterValidityLimit?: Maybe<DateTimeInput>;
   transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsName?: Maybe<String>;
   wasteDetailsOnuCode?: Maybe<String>;
@@ -3786,6 +3806,7 @@ export interface FormUpdateManyMutationInput {
   transporterDepartment?: Maybe<String>;
   transporterValidityLimit?: Maybe<DateTimeInput>;
   transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsName?: Maybe<String>;
   wasteDetailsOnuCode?: Maybe<String>;
@@ -4543,6 +4564,20 @@ export interface FormScalarWhereInput {
   transporterNumberPlate_not_starts_with?: Maybe<String>;
   transporterNumberPlate_ends_with?: Maybe<String>;
   transporterNumberPlate_not_ends_with?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  transporterCustomInfo_not?: Maybe<String>;
+  transporterCustomInfo_in?: Maybe<String[] | String>;
+  transporterCustomInfo_not_in?: Maybe<String[] | String>;
+  transporterCustomInfo_lt?: Maybe<String>;
+  transporterCustomInfo_lte?: Maybe<String>;
+  transporterCustomInfo_gt?: Maybe<String>;
+  transporterCustomInfo_gte?: Maybe<String>;
+  transporterCustomInfo_contains?: Maybe<String>;
+  transporterCustomInfo_not_contains?: Maybe<String>;
+  transporterCustomInfo_starts_with?: Maybe<String>;
+  transporterCustomInfo_not_starts_with?: Maybe<String>;
+  transporterCustomInfo_ends_with?: Maybe<String>;
+  transporterCustomInfo_not_ends_with?: Maybe<String>;
   wasteDetailsCode?: Maybe<String>;
   wasteDetailsCode_not?: Maybe<String>;
   wasteDetailsCode_in?: Maybe<String[] | String>;
@@ -6911,6 +6946,7 @@ export interface Form {
   transporterDepartment?: String;
   transporterValidityLimit?: DateTimeOutput;
   transporterNumberPlate?: String;
+  transporterCustomInfo?: String;
   wasteDetailsCode?: String;
   wasteDetailsName?: String;
   wasteDetailsOnuCode?: String;
@@ -6993,6 +7029,7 @@ export interface FormPromise extends Promise<Form>, Fragmentable {
   transporterDepartment: () => Promise<String>;
   transporterValidityLimit: () => Promise<DateTimeOutput>;
   transporterNumberPlate: () => Promise<String>;
+  transporterCustomInfo: () => Promise<String>;
   wasteDetailsCode: () => Promise<String>;
   wasteDetailsName: () => Promise<String>;
   wasteDetailsOnuCode: () => Promise<String>;
@@ -7087,6 +7124,7 @@ export interface FormSubscription
   transporterDepartment: () => Promise<AsyncIterator<String>>;
   transporterValidityLimit: () => Promise<AsyncIterator<DateTimeOutput>>;
   transporterNumberPlate: () => Promise<AsyncIterator<String>>;
+  transporterCustomInfo: () => Promise<AsyncIterator<String>>;
   wasteDetailsCode: () => Promise<AsyncIterator<String>>;
   wasteDetailsName: () => Promise<AsyncIterator<String>>;
   wasteDetailsOnuCode: () => Promise<AsyncIterator<String>>;
@@ -7181,6 +7219,7 @@ export interface FormNullablePromise
   transporterDepartment: () => Promise<String>;
   transporterValidityLimit: () => Promise<DateTimeOutput>;
   transporterNumberPlate: () => Promise<String>;
+  transporterCustomInfo: () => Promise<String>;
   wasteDetailsCode: () => Promise<String>;
   wasteDetailsName: () => Promise<String>;
   wasteDetailsOnuCode: () => Promise<String>;
@@ -7501,6 +7540,7 @@ export interface FormPreviousValues {
   transporterDepartment?: String;
   transporterValidityLimit?: DateTimeOutput;
   transporterNumberPlate?: String;
+  transporterCustomInfo?: String;
   wasteDetailsCode?: String;
   wasteDetailsName?: String;
   wasteDetailsOnuCode?: String;
@@ -7584,6 +7624,7 @@ export interface FormPreviousValuesPromise
   transporterDepartment: () => Promise<String>;
   transporterValidityLimit: () => Promise<DateTimeOutput>;
   transporterNumberPlate: () => Promise<String>;
+  transporterCustomInfo: () => Promise<String>;
   wasteDetailsCode: () => Promise<String>;
   wasteDetailsName: () => Promise<String>;
   wasteDetailsOnuCode: () => Promise<String>;
@@ -7667,6 +7708,7 @@ export interface FormPreviousValuesSubscription
   transporterDepartment: () => Promise<AsyncIterator<String>>;
   transporterValidityLimit: () => Promise<AsyncIterator<DateTimeOutput>>;
   transporterNumberPlate: () => Promise<AsyncIterator<String>>;
+  transporterCustomInfo: () => Promise<AsyncIterator<String>>;
   wasteDetailsCode: () => Promise<AsyncIterator<String>>;
   wasteDetailsName: () => Promise<AsyncIterator<String>>;
   wasteDetailsOnuCode: () => Promise<AsyncIterator<String>>;

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -1384,6 +1384,7 @@ type Form {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -1472,6 +1473,7 @@ input FormCreateInput {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -1630,6 +1632,8 @@ enum FormOrderByInput {
   transporterValidityLimit_DESC
   transporterNumberPlate_ASC
   transporterNumberPlate_DESC
+  transporterCustomInfo_ASC
+  transporterCustomInfo_DESC
   wasteDetailsCode_ASC
   wasteDetailsCode_DESC
   wasteDetailsName_ASC
@@ -1729,6 +1733,7 @@ type FormPreviousValues {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -2474,6 +2479,20 @@ input FormScalarWhereInput {
   transporterNumberPlate_not_starts_with: String
   transporterNumberPlate_ends_with: String
   transporterNumberPlate_not_ends_with: String
+  transporterCustomInfo: String
+  transporterCustomInfo_not: String
+  transporterCustomInfo_in: [String!]
+  transporterCustomInfo_not_in: [String!]
+  transporterCustomInfo_lt: String
+  transporterCustomInfo_lte: String
+  transporterCustomInfo_gt: String
+  transporterCustomInfo_gte: String
+  transporterCustomInfo_contains: String
+  transporterCustomInfo_not_contains: String
+  transporterCustomInfo_starts_with: String
+  transporterCustomInfo_not_starts_with: String
+  transporterCustomInfo_ends_with: String
+  transporterCustomInfo_not_ends_with: String
   wasteDetailsCode: String
   wasteDetailsCode_not: String
   wasteDetailsCode_in: [String!]
@@ -2756,6 +2775,7 @@ input FormUpdateDataInput {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -2837,6 +2857,7 @@ input FormUpdateInput {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -2917,6 +2938,7 @@ input FormUpdateManyDataInput {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -3007,6 +3029,7 @@ input FormUpdateManyMutationInput {
   transporterDepartment: String
   transporterValidityLimit: DateTime
   transporterNumberPlate: String
+  transporterCustomInfo: String
   wasteDetailsCode: String
   wasteDetailsName: String
   wasteDetailsOnuCode: String
@@ -3781,6 +3804,20 @@ input FormWhereInput {
   transporterNumberPlate_not_starts_with: String
   transporterNumberPlate_ends_with: String
   transporterNumberPlate_not_ends_with: String
+  transporterCustomInfo: String
+  transporterCustomInfo_not: String
+  transporterCustomInfo_in: [String!]
+  transporterCustomInfo_not_in: [String!]
+  transporterCustomInfo_lt: String
+  transporterCustomInfo_lte: String
+  transporterCustomInfo_gt: String
+  transporterCustomInfo_gte: String
+  transporterCustomInfo_contains: String
+  transporterCustomInfo_not_contains: String
+  transporterCustomInfo_starts_with: String
+  transporterCustomInfo_not_starts_with: String
+  transporterCustomInfo_ends_with: String
+  transporterCustomInfo_not_ends_with: String
   wasteDetailsCode: String
   wasteDetailsCode_not: String
   wasteDetailsCode_in: [String!]

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -477,6 +477,42 @@ Payload du BSD
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>updateTransporterFields</strong></td>
+<td valign="top"><a href="#form">Form</a></td>
+<td>
+
+Met à jour la plaque d'immatriculation ou le champ libre du transporteur
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID d'un BSD
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">transporterNumberPlate</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Plaque d'immatriculation du transporteur
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">transporterCustomInfo</td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Champ libre, utilisable par exemple pour noter les tournées des transporteurs
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>deleteForm</strong></td>
 <td valign="top"><a href="#form">Form</a></td>
 <td>
@@ -2641,6 +2677,15 @@ Limite de validité du récipissé
 <td>
 
 Numéro de plaque d'immatriculation
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>customInfo</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Information libre, destinée aux transporteurs
 
 </td>
 </tr>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8893,8 +8893,7 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -8915,8 +8914,7 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/front/src/common/SideMenu.scss
+++ b/front/src/common/SideMenu.scss
@@ -1,9 +1,14 @@
-
 .dashboard-menu.side-menu {
   background-color: #ebeff3;
   flex: 0 1 auto;
   padding: 0 20px 10px 0;
-  min-width: 240px;
+
+  @media (min-width: 748px) and(max-width: 1110px) {
+    max-width: 140px;
+  }
+  @media (min-width: 1111px) {
+    min-width: 240px;
+  }
 
   .side-menu__mobile-trigger {
     display: flex;
@@ -13,5 +18,3 @@
     cursor: pointer;
   }
 }
-
-

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -2,6 +2,9 @@ import { DocumentNode } from "graphql";
 import { DataProxy } from "apollo-cache";
 import { ApolloError } from "apollo-client";
 
+export const capitalize = (str: string) =>
+  str.charAt(0).toUpperCase() + str.slice(1);
+
 /**
  * converts `aString` to `A_STRING`
  * @param string

--- a/front/src/dashboard/DashboardMenu.scss
+++ b/front/src/dashboard/DashboardMenu.scss
@@ -3,6 +3,7 @@
   .company-title {
     margin: 30px 30px;
     font-weight: bold;
+    overflow-wrap: break-word;
     @media (min-width: 749px) {
       max-width: 200px;
     }

--- a/front/src/dashboard/constants.tsx
+++ b/front/src/dashboard/constants.tsx
@@ -1,0 +1,11 @@
+export const statusLabels: { [key: string]: string } = {
+    DRAFT: "Brouillon",
+    SEALED: "En attente d'envoi",
+    SENT: "En attente de réception",
+    RECEIVED: "Reçu, en attente de traitement",
+    PROCESSED: "Traité",
+    AWAITING_GROUP: "Traité, en attente de regroupement",
+    GROUPED: "Traité, annexé à un bordereau de regroupement",
+    NO_TRACEABILITY: "Regroupé, avec autorisation de perte de traçabilité",
+    REFUSED: "Refusé"
+  };

--- a/front/src/dashboard/slips/Slips.tsx
+++ b/front/src/dashboard/slips/Slips.tsx
@@ -3,20 +3,9 @@ import { DateTime } from "luxon";
 import { SlipActions, DynamicActions } from "./SlipActions";
 import { Form } from "../../form/model";
 import { useFormsTable } from "./use-forms-table";
+import { statusLabels } from "../constants";
 import { FaSort } from "react-icons/fa";
 import "./Slips.scss";
-
-const statusLabels: { [key: string]: string } = {
-  DRAFT: "Brouillon",
-  SEALED: "En attente d'envoi",
-  SENT: "En attente de réception",
-  RECEIVED: "Reçu, en attente de traitement",
-  PROCESSED: "Traité",
-  AWAITING_GROUP: "Traité, en attente de regroupement",
-  GROUPED: "Traité, annexé à un bordereau de regroupement",
-  NO_TRACEABILITY: "Regroupé, avec autorisation de perte de traçabilité",
-  REFUSED: "Refusé"
-};
 
 type Props = {
   forms: Form[];

--- a/front/src/dashboard/slips/use-forms-table.ts
+++ b/front/src/dashboard/slips/use-forms-table.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 
 function getKey(object: any, key: string) {
   const splittedKey = key.split(".");
-  return splittedKey.reduce((prev, curr) => prev && prev[curr], object);
+  return splittedKey.reduce((prev, curr) => prev && prev[curr], object) || "";
 }
 
 function compareBy(key: string) {
@@ -18,7 +18,6 @@ export function useFormsTable(
   inputForms: Form[]
 ): [Form[], (k: string) => void, (k: string, v: string) => void] {
   const [forms, setForms] = useState(inputForms);
-
   const [sortKey, setSortKey] = useState("");
   const [filters, setFilters] = useState<{ key: string; value: string }[]>([]);
 

--- a/front/src/dashboard/transport/Transport.scss
+++ b/front/src/dashboard/transport/Transport.scss
@@ -9,3 +9,40 @@ table .icon {
 .transport-table {
   overflow-y: auto;
 }
+
+.transport-menu {
+  display: flex;
+  margin: 1em;
+
+  .link {
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--theme-dark-text);
+    margin-right: 1.5em;
+  }
+
+  .link:hover {
+    background: none;
+    color: var(--blue);
+  }
+
+  .link.active {
+    color: var(--blue);
+    border-bottom: var(--blue) solid 2px;
+    cursor: default;
+  }
+  .transport-refresh {
+    margin-left: auto;
+    &:hover {
+      margin-left: auto; //prevent button default rules to be applied on click
+    }
+  }
+}
+.transporter-permanent-filter{
+  display: flex;
+  margin: 1em;
+  input{
+    max-width: 300px;
+    margin-right: 1em;
+  }
+}

--- a/front/src/dashboard/transport/Transport.scss
+++ b/front/src/dashboard/transport/Transport.scss
@@ -9,7 +9,16 @@ table .icon {
 .transport-table {
   overflow-y: auto;
 }
-
+@media all and (max-width: 768px) {
+  td.hide-on-mobile,
+  th.hide-on-mobile {
+    display: none;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    visibility: collapse;
+  }
+}
 .transport-menu {
   display: flex;
   margin: 1em;
@@ -38,10 +47,10 @@ table .icon {
     }
   }
 }
-.transporter-permanent-filter{
+.transporter-permanent-filter {
   display: flex;
   margin: 1em;
-  input{
+  input {
     max-width: 300px;
     margin-right: 1em;
   }

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -1,20 +1,25 @@
-import { Query } from "@apollo/react-components";
 import gql from "graphql-tag";
 import React from "react";
-import { InlineError } from "../../common/Error";
+
 import { Me } from "../../login/model";
 import "./Transport.scss";
 import TransportSignature from "./TransportSignature";
+import TransporterInfoEdit from "./TransporterInfoEdit";
+import { useQuery } from "@apollo/react-hooks";
+import { useFormsTable } from "../slips/use-forms-table";
+import { FaSync, FaSort } from "react-icons/fa";
+import { useState } from "react";
+import useLocalStorage from "./hooks";
 
 type Props = {
   me: Me;
   siret: string;
 };
-
 export const GET_TRANSPORT_SLIPS = gql`
   query GetSlips($siret: String, $type: FormType) {
     forms(siret: $siret, type: $type) {
       id
+      status
       readableId
       createdAt
       emitter {
@@ -37,6 +42,8 @@ export const GET_TRANSPORT_SLIPS = gql`
           siret
           address
         }
+        numberPlate
+        customInfo
       }
       wasteDetails {
         code
@@ -48,58 +55,203 @@ export const GET_TRANSPORT_SLIPS = gql`
     }
   }
 `;
+const Table = ({ forms, displayActions }) => {
+  const [sortedForms, sortBy, filter] = useFormsTable(forms);
 
-export default function Transport({ me, siret }: Props) {
   return (
-    <>
+    <table className="table transport-table">
+      <thead>
+        <tr>
+          <th className="sortable" onClick={() => sortBy("readableId")}>
+            Numéro{" "}
+            <small>
+              <FaSort />
+            </small>
+          </th>
+          <th
+            className="sortable"
+            onClick={() => sortBy("emitter.company.name")}
+          >
+            Emetteur{" "}
+            <small>
+              <FaSort />
+            </small>
+          </th>
+          <th
+            className="sortable"
+            onClick={() => sortBy("recipient.company.name")}
+          >
+            Destinataire{" "}
+            <small>
+              <FaSort />
+            </small>
+          </th>
+
+          <th>Déchet</th>
+          <th>Quantité estimée</th>
+          <th colSpan={2}>Champ libre</th>
+          <th colSpan={2}>Plaque d'immatriculation</th>
+
+          {displayActions ? <th>Action</th> : null}
+        </tr>
+        <tr>
+          <th>
+            <input
+              type="text"
+              onChange={e => filter("readableId", e.target.value)}
+              placeholder="Filtrer..."
+            />
+          </th>
+          <th>
+            <input
+              type="text"
+              onChange={e => filter("emitter.company.name", e.target.value)}
+              placeholder="Filtrer..."
+            />
+          </th>
+          <th>
+            <input
+              type="text"
+              onChange={e => filter("recipient.company.name", e.target.value)}
+              placeholder="Filtrer..."
+            />
+          </th>
+          <th>
+            <input
+              type="text"
+              onChange={e => filter("wasteDetails.name", e.target.value)}
+              placeholder="Filtrer..."
+            />
+          </th>
+          <th></th>
+          <th colSpan={2}></th>
+          <th colSpan={2}></th>
+          {displayActions ? <th></th> : null}
+        </tr>
+      </thead>
+      <tbody>
+        {sortedForms.map(form => (
+          <tr key={form.id}>
+            <td>{form.readableId}</td>
+            <td>{form.emitter.company && form.emitter.company.name}</td>
+            <td>{form.recipient.company && form.recipient.company.name}</td>
+            <td>
+              <div>{form.wasteDetails.name}</div>
+            </td>
+            <td>{form.wasteDetails.quantity} tonnes</td>
+
+            <td>{form.transporter.customInfo}</td>
+            <td style={{ paddingLeft: 0, paddingRight: 0 }}>
+              {
+                <TransporterInfoEdit
+                  form={form}
+                  fieldName="customInfo"
+                  title={"Modifier le champ libre"}
+                />
+              }
+            </td>
+            <td>{form.transporter.numberPlate}</td>
+            <td style={{ paddingLeft: 0 }}>
+              {
+                <TransporterInfoEdit
+                  form={form}
+                  fieldName="numberPlate"
+                  title={"Modifier la plaque d'immatriculation"}
+                />
+              }
+            </td>
+            {displayActions ? (
+              <td>{<TransportSignature form={form} />}</td>
+            ) : null}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+const TRANSPORTER_FILTER_STORAGE_KEY = "TRANSPORTER_FILTER_STORAGE_KEY";
+export default function Transport({ siret }: Props & any) {
+  const [filterStatus, setFilterStatus] = useState("SEALED");
+  const [persistentFilter, setPersistentFilter] = useLocalStorage(
+    TRANSPORTER_FILTER_STORAGE_KEY
+  );
+  const { loading, error, data, refetch } = useQuery(GET_TRANSPORT_SLIPS, {
+    variables: { siret, type: "TRANSPORTER" }
+  });
+  if (loading) return <div>loading</div>;
+  if (error) return <div>error</div>;
+
+  const filterAgainstPersistenFilter = (field, filterParam, filterStatus) => {
+    field = !field ? "" : field;
+    return field.toLowerCase().indexOf(filterParam.toLowerCase()) > -1;
+  };
+
+  // filter forms by status and concatenate waste code and name to ease searching
+  const filteredForms = data
+    ? data.forms
+        .filter(
+          f =>
+            f.status === filterStatus &&
+            filterAgainstPersistenFilter(
+              f.transporter.customInfo,
+              persistentFilter,
+              filterStatus
+            )
+        )
+        .map(f => ({
+          ...f,
+          wasteDetails: {
+            ...f.wasteDetails,
+            name: `${f.wasteDetails.code} ${f.wasteDetails.name} `
+          }
+        }))
+    : [];
+  return (
+    <div>
       <div className="header-content">
-        <h2>Mes bordereaux à transporter</h2>
+        <h2>Déchets à transporter</h2>
       </div>
 
-      <div className="transport-table">
-        <Query
-          query={GET_TRANSPORT_SLIPS}
-          variables={{ siret, type: "TRANSPORTER" }}
+      <div className="transport-menu">
+        <button
+          onClick={() => setFilterStatus("SEALED")}
+          className={`link ${filterStatus === "SEALED" ? "active" : ""}`}
         >
-          {({ loading, error, data }) => {
-            if (loading) return <p>Chargement...</p>;
-            if (error) return <InlineError apolloError={error} />;
-            if (!data) return <p>Aucune donnée à afficher</p>;
-
-            return (
-              <table className="table">
-                <thead>
-                  <tr>
-                    <th>Numéro</th>
-                    <th>Emetteur</th>
-                    <th>Déchet</th>
-                    <th>Quantité estimée</th>
-                    <th>Action</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.forms.map(form => (
-                    <tr key={form.id}>
-                      <td>{form.readableId}</td>
-                      <td>
-                        {form.emitter.company && form.emitter.company.name}
-                      </td>
-                      <td>
-                        <div>{form.wasteDetails.code}</div>
-                        <div>{form.wasteDetails.name}</div>
-                      </td>
-                      <td>{form.wasteDetails.quantity} tonnes</td>
-                      <td>
-                        <TransportSignature form={form} />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            );
-          }}
-        </Query>
+          Déchets à collecter
+        </button>
+        <button
+          onClick={() => setFilterStatus("SENT")}
+          className={`link ${filterStatus === "SENT" ? "active" : ""}`}
+        >
+          Déchets en attente de traitement
+        </button>
+        <button
+          className="button button-primary transport-refresh"
+          onClick={() => refetch({ siret, type: "TRANSPORTER" })}
+        >
+          <FaSync /> Rafraîchir
+        </button>
       </div>
-    </>
+
+      <div className="transporter-permanent-filter form__group">
+        <input
+          type="text"
+          placeholder="Filtre champ libre…"
+          value={persistentFilter}
+          onChange={e => setPersistentFilter(e.target.value)}
+        />
+
+        {persistentFilter && (
+          <button
+            className="button-outline warning"
+            onClick={e => setPersistentFilter("")}
+          >
+            Afficher tous les bordereaux
+          </button>
+        )}
+      </div>
+
+      <Table forms={filteredForms} displayActions={filterStatus === "SEALED"} />
+    </div>
   );
 }

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -78,7 +78,7 @@ const Table = ({ forms, displayActions }) => {
             </small>
           </th>
           <th
-            className="sortable"
+            className="sortable hide-on-mobile"
             onClick={() => sortBy("recipient.company.name")}
           >
             Destinataire{" "}
@@ -88,7 +88,7 @@ const Table = ({ forms, displayActions }) => {
           </th>
 
           <th>Déchet</th>
-          <th>Quantité estimée</th>
+          <th className="hide-on-mobile">Quantité estimée</th>
           <th colSpan={2}>Champ libre</th>
           <th colSpan={2}>Plaque d'immatriculation</th>
 
@@ -109,7 +109,7 @@ const Table = ({ forms, displayActions }) => {
               placeholder="Filtrer..."
             />
           </th>
-          <th>
+          <th className="hide-on-mobile">
             <input
               type="text"
               onChange={e => filter("recipient.company.name", e.target.value)}
@@ -123,7 +123,7 @@ const Table = ({ forms, displayActions }) => {
               placeholder="Filtrer..."
             />
           </th>
-          <th></th>
+          <th className="hide-on-mobile"></th>
           <th colSpan={2}></th>
           <th colSpan={2}></th>
           {displayActions ? <th></th> : null}
@@ -134,11 +134,15 @@ const Table = ({ forms, displayActions }) => {
           <tr key={form.id}>
             <td>{form.readableId}</td>
             <td>{form.emitter.company && form.emitter.company.name}</td>
-            <td>{form.recipient.company && form.recipient.company.name}</td>
+            <td className="hide-on-mobile">
+              {form.recipient.company && form.recipient.company.name}
+            </td>
             <td>
               <div>{form.wasteDetails.name}</div>
             </td>
-            <td>{form.wasteDetails.quantity} tonnes</td>
+            <td className="hide-on-mobile">
+              {form.wasteDetails.quantity} tonnes
+            </td>
 
             <td>{form.transporter.customInfo}</td>
             <td style={{ paddingLeft: 0, paddingRight: 0 }}>

--- a/front/src/dashboard/transport/TransportSignature.scss
+++ b/front/src/dashboard/transport/TransportSignature.scss
@@ -19,3 +19,15 @@
     }
   }
 }
+
+// hide number input spinner
+input.no-spinner::-webkit-outer-spin-button,
+input.no-spinner::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input.no-spinner[type=number] {
+  -moz-appearance: textfield;
+}

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -233,7 +233,11 @@ export default function TransportSignature({ form }: Props) {
                     <p>
                       <label>
                         Code de sécurité entreprise
-                        <Field type="number" name="securityCode" />
+                        <Field
+                          name="securityCode"
+                          type="number"
+                          className="no-spinner"
+                        />
                       </label>
                     </p>
                     <p>

--- a/front/src/dashboard/transport/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/transport/TransporterInfoEdit.tsx
@@ -1,0 +1,105 @@
+import { useMutation } from "@apollo/react-hooks";
+import { useFormik } from "formik";
+
+import gql from "graphql-tag";
+
+import React, { useState } from "react";
+import { FaEdit } from "react-icons/fa";
+
+import { Form as FormModel } from "../../form/model";
+import { NotificationError } from "../../common/Error";
+import { capitalize } from "../../common/helper";
+import "./TransportSignature.scss";
+
+export const UPDATE_PLATE = gql`
+  mutation updateTransporterFields(
+    $id: ID!
+    $transporterNumberPlate: String
+    $transporterCustomInfo: String
+  ) {
+    updateTransporterFields(
+      id: $id
+      transporterNumberPlate: $transporterNumberPlate
+      transporterCustomInfo: $transporterCustomInfo
+    ) {
+      id
+
+      transporter {
+        numberPlate
+        customInfo
+      }
+    }
+  }
+`;
+
+type Props = { form: FormModel; fieldName: string; title: string };
+
+export default function TransporterInfoEdit({ form, fieldName, title }: Props) {
+  const mutationFieldName = `transporter${capitalize(fieldName)}`;
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [updateTransporterPlate, { error }] = useMutation(UPDATE_PLATE, {
+    onCompleted: () => setIsOpen(false)
+  });
+  const formik = useFormik({
+    initialValues: {
+      [fieldName]: form.transporter[fieldName]
+    },
+    onSubmit: values => {
+      updateTransporterPlate({
+        variables: { id: form.id, [mutationFieldName]: values[fieldName] }
+      });
+    }
+  });
+
+  if (form.status !== "SEALED") {
+    return null;
+  }
+  return (
+    <>
+      <button
+        className="link icon"
+        onClick={() => setIsOpen(true)}
+        title={title}
+      >
+        <FaEdit />
+      </button>
+      <div
+        className="modal__backdrop"
+        id="modal"
+        style={{
+          display: isOpen ? "flex" : "none"
+        }}
+      >
+        <div className="modal">
+          <h2>{title}</h2>
+          <form onSubmit={formik.handleSubmit}>
+            <label htmlFor={`id_${fieldName}`}>Nouvelle valeur</label>
+            <input
+              id={`id_${fieldName}`}
+              name={fieldName}
+              type="text"
+              onChange={formik.handleChange}
+              value={formik.values[fieldName]}
+            />
+            {error && <NotificationError apolloError={error} />}
+
+            <div className="buttons">
+              <button
+                className="button warning"
+                type="button"
+                onClick={() => setIsOpen(false)}
+              >
+                Annuler
+              </button>
+              <button className="button" type="submit">
+                Valider
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/front/src/dashboard/transport/hooks.tsx
+++ b/front/src/dashboard/transport/hooks.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+function useLocalStorage(key) {
+  // State to store  value
+
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      // Get from local storage
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return ""
+      return item ? JSON.parse(item) : "";
+    } catch (error) {
+      // If error return ""
+      return "";
+    }
+  });
+
+  // Wrap useState's setter function that persists the new value to localStorage
+  const setValue = value => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToPersist =
+        value instanceof Function ? value(storedValue) : value;
+      // Set react state
+      setStoredValue(valueToPersist);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToPersist));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}
+
+export default useLocalStorage;

--- a/front/src/form/model.ts
+++ b/front/src/form/model.ts
@@ -26,6 +26,8 @@ export type Form = {
   };
   transporter: {
     company: FormCompany;
+    numberPlate: string;
+    customInfo: string;
   };
   wasteDetails: {
     quantity: number;


### PR DESCRIPTION
Modifie la page transporteur (https://trello.com/c/SWD2XdpU/727-am%C3%A9lioration-de-la-page-transporteur) :
- ajout d'un champ transporterCustominfo destiné à stocker des infos de type numéro de tournée
- ajout d'une mutation pour modifier tranposrterNumberPlate et transporterCustominfo (uniqt pour les transporter et les bsd SEALED)
- récupère les bsd SEALED et SENT en les répartissant dans 2 onglets (utilse pour les transporteurs pour savoir ce qui a été enlevé et en cours de transport)
- ajoute des champs de recherche et permet de trier les colonnes
- ajoute un champ de recherche persistant(localstorage) sur customInfo
- permet de modifier la plaque et custoInfo depuis l'UI (page rtansporteur, bsd SAELED)
- retire le spinner du champ securityCode (https://trello.com/c/0MGlJqmL/767-le-code-de-s%C3%A9curit%C3%A9-na-pas-besoin-de-curseur-pour-augmenter-ou-r%C3%A9duire) 