### PR TITLE
Don't expose the owner id

### DIFF
--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -269,9 +269,6 @@ type Form {
   "Date de la dernière modification du BSD"
   updatedAt: DateTime
 
-  "ID de l'utilisateur ayant crée le BSD"
-  ownerId: Int
-
   "Statut du BSD (brouillon, envoyé, reçu, traité, etc)"
   status: FormStatus
 

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -1826,15 +1826,6 @@ Date de la dernière modification du BSD
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>ownerId</strong></td>
-<td valign="top"><a href="#int">Int</a></td>
-<td>
-
-ID de l'utilisateur ayant crée le BSD
-
-</td>
-</tr>
-<tr>
 <td colspan="2" valign="top"><strong>status</strong></td>
 <td valign="top"><a href="#formstatus">FormStatus</a></td>
 <td>


### PR DESCRIPTION
⚠ Breaking change ?

On arrete d'exposer `ownerId` sur le type `Form`.
cf https://trello.com/c/mhyAs4tj/771-le-champ-ownerid-nest-pas-retourn%C3%A9

`OwnerId` a toujours été exposé par l'api GraphQL mais n'a jamais eu d'implémentation: il a toujours retourné `null`. On en a donc jamais eu besoin et je ne pense pas qu'on doive l'exposer, ca pourrait meme peut-être être une leak d'information...

S'il n'a jamais eu de valeur, il est quand meme possible que certains demandent le champ dans leur query. Supprimer le champ casserait donc leur requête. Il faut donc qu'on prévienne dans la NL tech.