### PR TITLE
Don't leak error details in prod

### DIFF
--- a/back/src/__tests__/errors.integration.ts
+++ b/back/src/__tests__/errors.integration.ts
@@ -83,7 +83,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
+    expect(error.extensions).not.toBeDefined();
     expect(error.message).toEqual("Erreur serveur");
   });
 
@@ -98,7 +98,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
+    expect(error.extensions).not.toBeDefined();
     expect(error.message).toEqual("Erreur serveur");
   });
 
@@ -113,7 +113,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
+    expect(error.extensions).not.toBeDefined();
     expect(error.message).toEqual("Erreur serveur");
   });
 

--- a/back/src/__tests__/errors.integration.ts
+++ b/back/src/__tests__/errors.integration.ts
@@ -83,7 +83,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions).not.toBeDefined();
+    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
     expect(error.message).toEqual("Erreur serveur");
   });
 
@@ -98,7 +98,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions).not.toBeDefined();
+    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
     expect(error.message).toEqual("Erreur serveur");
   });
 
@@ -113,7 +113,7 @@ describe("Error handling", () => {
     expect(errors).toHaveLength(1);
 
     const error = errors[0];
-    expect(error.extensions).not.toBeDefined();
+    expect(error.extensions.code).toEqual("INTERNAL_SERVER_ERROR");
     expect(error.message).toEqual("Erreur serveur");
   });
 

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -117,8 +117,8 @@ export const server = new ApolloServer({
       err.extensions.code === ErrorCode.INTERNAL_SERVER_ERROR &&
       NODE_ENV !== "dev"
     ) {
-      // Do not leak error message for internal server error in production
-      err.message = "Erreur serveur";
+      // Do not leak error for internal server error in production
+      return new Error("Erreur serveur");
     }
     return err;
   }

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -1,5 +1,5 @@
 import { CaptureConsole } from "@sentry/integrations";
-import { ApolloServer, makeExecutableSchema } from "apollo-server-express";
+import { ApolloServer, makeExecutableSchema, ApolloError } from "apollo-server-express";
 import * as express from "express";
 import * as passport from "passport";
 import * as session from "express-session";
@@ -118,7 +118,7 @@ export const server = new ApolloServer({
       NODE_ENV !== "dev"
     ) {
       // Do not leak error for internal server error in production
-      return new Error("Erreur serveur");
+      return new ApolloError("Erreur serveur", ErrorCode.INTERNAL_SERVER_ERROR);
     }
     return err;
   }


### PR DESCRIPTION
Les erreurs `INTERNAL_SERVER_ERROR` exposaient le détail de l'erreur.
cf https://trello.com/c/0hZB7IT0/774-les-messages-des-erreurs-serveurs-sont-visibles-sur-sandbox

On modifiait bien le message d'erreur mais les prorpiétés supplémentaires sur l'objet restaient présentes (cf image plus bas). Pour éviter ca on recrée une erreur avec le bon message.

![image](https://user-images.githubusercontent.com/5145523/78522895-33d8c000-77cf-11ea-9e9c-2478638a7f74.png)
