### PR TITLE
Allow mail sender name & address to be configured

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -49,6 +49,8 @@ MJ_MAIN_TEMPLATE_ID=*********
 MJ_FIRST_ONBOARDING_TEMPLATE_ID=*********
 MJ_SECOND_ONBOARDING_TEMPLATE_ID=*********
 MJ_SECURITY_CODE_RENEWAL_TEMPLATE_ID=*********
+MJ_SENDER_EMAIL_ADDRESS=*********
+MJ_SENDER_NAME=*********
 
 # Whether or not to notify DREAL UD when
 # a waste is refused. Should be activated in prod only

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -102,6 +102,8 @@ services:
     environment:
       MJ_APIKEY_PUBLIC: $MJ_APIKEY_PUBLIC
       MJ_APIKEY_PRIVATE: $MJ_APIKEY_PRIVATE
+      MJ_SENDER_EMAIL_ADDRESS: $MJ_SENDER_EMAIL_ADDRESS
+      MJ_SENDER_NAME: $MJ_SENDER_NAME
 
   td-etl:
     image: td-etl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
     environment:
       MJ_APIKEY_PUBLIC: $MJ_APIKEY_PUBLIC
       MJ_APIKEY_PRIVATE: $MJ_APIKEY_PRIVATE
+      MJ_SENDER_EMAIL_ADDRESS: $MJ_SENDER_EMAIL_ADDRESS
+      MJ_SENDER_NAME: $MJ_SENDER_NAME
 
   td-doc:
     image: betagouv/trackdechets-doc:master

--- a/mail/src/mail.go
+++ b/mail/src/mail.go
@@ -37,6 +37,9 @@ var mailjetClient = mailjet.NewMailjetClient(
 	mustGetenv("MJ_APIKEY_PRIVATE"),
 )
 
+var senderAddress = mustGetenv("MJ_SENDER_EMAIL_ADDRESS")
+var senderName = mustGetenv("MJ_SENDER_NAME")
+
 func mustGetenv(k string) string {
 	v := os.Getenv(k)
 	if v == "" {
@@ -92,8 +95,8 @@ func sendEmail(w http.ResponseWriter, r *http.Request) {
 
 	messagesInfoParams := mailjet.InfoMessagesV31{
 		From: &mailjet.RecipientV31{
-			Email: "noreply@trackdechets.fr",
-			Name:  "Noreply Trackdéchets",
+			Email: senderAddress,
+			Name:  senderName,
 		},
 		To:               getAsMailjetRecipients(data.To),
 		Cc:               getAsMailjetRecipients(data.Cc),


### PR DESCRIPTION
Dans le but de consolider l'envoi d'email, se débarrasser du no-reply au profit d'une adresse en trackdechets.beta.gouv

NB: nécessite d'ajouter de nouveaux settings (MJ_SENDER_EMAIL_ADDRESS & MJ_SENDER_NAME)