### PR TITLE
Enforce date validation

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -30,6 +30,7 @@
     "cors": "^2.8.5",
     "csv-parser": "^2.3.2",
     "dataloader": "^1.4.0",
+    "date-fns": "^2.12.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
     "graphql": "^14.5.8",

--- a/back/src/forms/__tests__/validationHelpers.test.ts
+++ b/back/src/forms/__tests__/validationHelpers.test.ts
@@ -1,0 +1,39 @@
+import { object } from "yup";
+
+import { validDate } from "../validation-helpers";
+
+const dummySchema = object({
+  someDate: validDate({ verboseFieldName: "date de test", required: true })
+});
+
+describe("Test validDate helper", () => {
+  test.each([
+    "2020-12-30",
+    "2020-12-30T23:45:55",
+    "2020-12-30T23:45:55Z",
+    "2020-12-30T23:45:55+08",
+    "2020-12-30T23:45:55.987"
+  ])("validDate is valid with date formatted as %p", async dateStr => {
+    const isValid = await dummySchema.isValid({ someDate: dateStr });
+    expect(isValid).toEqual(true);
+  });
+
+  test.each([
+    "20201230",
+    "2020-12-30 23:45:55",
+    "2020-12-30T23 45 55",
+    33,
+    "junk"
+  ])("validDate is invalid with date formatted as %p", async dateStr => {
+    const isValid = await dummySchema.isValid({ someDate: dateStr });
+    expect(isValid).toEqual(false);
+  });
+
+  test.each([{ someDate: null }, {}])(
+    "validDate is invalid with empty or null value",
+    async params => {
+      const isValid = await dummySchema.isValid(params);
+      expect(isValid).toEqual(false);
+    }
+  );
+});

--- a/back/src/forms/__tests__/validationHelpers.test.ts
+++ b/back/src/forms/__tests__/validationHelpers.test.ts
@@ -1,19 +1,19 @@
 import { object } from "yup";
 
-import { validDate } from "../validation-helpers";
+import { validDatetime } from "../validation-helpers";
 
 const dummySchema = object({
-  someDate: validDate({ verboseFieldName: "date de test", required: true })
+  someDate: validDatetime({ verboseFieldName: "date de test", required: true })
 });
 
-describe("Test validDate helper", () => {
+describe("Test validDatetime helper", () => {
   test.each([
     "2020-12-30",
     "2020-12-30T23:45:55",
     "2020-12-30T23:45:55Z",
     "2020-12-30T23:45:55+08",
     "2020-12-30T23:45:55.987"
-  ])("validDate is valid with date formatted as %p", async dateStr => {
+  ])("validDatetime is valid with date formatted as %p", async dateStr => {
     const isValid = await dummySchema.isValid({ someDate: dateStr });
     expect(isValid).toEqual(true);
   });
@@ -24,13 +24,13 @@ describe("Test validDate helper", () => {
     "2020-12-30T23 45 55",
     33,
     "junk"
-  ])("validDate is invalid with date formatted as %p", async dateStr => {
+  ])("validDatetime is invalid with date formatted as %p", async dateStr => {
     const isValid = await dummySchema.isValid({ someDate: dateStr });
     expect(isValid).toEqual(false);
   });
 
   test.each([{ someDate: null }, {}])(
-    "validDate is invalid with empty or null value",
+    "validDatetime is invalid with empty or null value",
     async params => {
       const isValid = await dummySchema.isValid(params);
       expect(isValid).toEqual(false);

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -1,4 +1,13 @@
+"""The `DateTime` scalar expects a date-formatted string matching one of the following formats:
+  - "yyyy-MM-dd" (eg. 2020-11-23)
+  - "yyyy-MM-ddTHH:mm:ss" (eg. 2020-11-23T13:34:55)
+  - "yyyy-MM-ddTHH:mm:ssX" (eg. 2020-11-23T13:34:55Z)
+  - "yyyy-MM-dd'T'HH:mm:ss.SSS" (eg. 2020-11-23T13:34:55.987)
+  - "yyyy-MM-dd'T'HH:mm:ss.SSSX" (eg. 2020-11-23T13:34:55.987Z)
+"""
 scalar DateTime
+
+
 scalar JSON
 
 type Query {

--- a/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
@@ -212,6 +212,50 @@ describe("{ mutation { markAsSent } }", () => {
       );
 
       const emitterCompany = await companyFactory();
+
+      let form = await formFactory({
+        ownerId: user.id,
+        opt: {
+          status: "SEALED",
+          emitterCompanySiret: emitterCompany.siret,
+          recipientCompanySiret: recipientCompany.siret,
+          wasteDetailsCode: wrongWasteCode
+        }
+      });
+
+      const { mutate } = makeClient(user);
+
+      const mutation = `
+    mutation   {
+      markAsSent(id: "${form.id}", sentInfo: { sentAt: "2018-12-11T00:00:00.000Z", sentBy: "John Doe"}) {
+        id
+      }
+    }
+  `;
+
+      const { errors } = await mutate(mutation);
+
+      expect(errors[0].message).toEqual(
+        expect.stringContaining(
+          "Le code déchet est obligatoire et doit appartenir à la liste  du code"
+        )
+      );
+      form = await prisma.form({ id: form.id });
+
+      expect(form.status).toEqual("SEALED");
+
+      // check no SEALED statusLog is created
+      const statusLogs = await prisma.statusLogs({
+        where: {
+          form: { id: form.id },
+          user: { id: user.id },
+          status: "SEALED"
+        }
+      });
+      expect(statusLogs.length).toEqual(0);
+    }
+  );
+
   test.each(["20201211", "junk", "2020 12 11", "2020-12-33"])(
     "sentAt must be a valid date, %p is not valid",
     async dateStr => {
@@ -226,33 +270,27 @@ describe("{ mutation { markAsSent } }", () => {
         opt: {
           status: "SEALED",
           emitterCompanySiret: emitterCompany.siret,
- 
-          recipientCompanySiret: recipientCompany.siret,
-          wasteDetailsCode: wrongWasteCode
- 
+          recipientCompanySiret: recipientCompany.siret
         }
       });
 
       const { mutate } = makeClient(user);
 
       const mutation = `
- 
-      mutation   {
-        markAsSent(id: "${form.id}", sentInfo: { sentAt: "${dateStr}", sentBy: "John Doe"}) {
-          id
+        mutation   {
+          markAsSent(id: "${form.id}", sentInfo: { sentAt: "${dateStr}", sentBy: "John Doe"}) {
+            id
+          }
         }
-      }
-    `;
+      `;
 
       const { errors } = await mutate(mutation);
       expect(errors[0].message).toEqual(
         "La date d'envoi n'est pas formatée correctement"
- 
       );
       form = await prisma.form({ id: form.id });
 
       expect(form.status).toEqual("SEALED");
- 
 
       // check no SEALED statusLog is created
       const statusLogs = await prisma.statusLogs({
@@ -263,7 +301,6 @@ describe("{ mutation { markAsSent } }", () => {
         }
       });
       expect(statusLogs.length).toEqual(0);
- Use date validation helper on existing schemas
     }
   );
 });

--- a/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-sent.integration.ts
@@ -6,7 +6,6 @@ import {
 import makeClient from "../../../__tests__/testClient";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import { prisma } from "../../../generated/prisma-client";
-import { isExpired } from "../../../oauth2";
 
 jest.mock("axios", () => ({
   default: {

--- a/back/src/forms/schema-validation.ts
+++ b/back/src/forms/schema-validation.ts
@@ -1,6 +1,7 @@
-import { object, date, string, boolean, number, array, mixed } from "yup";
+import { object, string, boolean, number, array, mixed } from "yup";
 import { companySchema } from "./validator";
 import { GROUP_CODES } from "./workflow/machine";
+import { validDate } from "./validation-helpers";
 
 const PROCESSING_OPERATION_CODES = [
   "D 1",
@@ -41,7 +42,10 @@ export const receivedInfoSchema = object({
   receivedBy: string().required(
     "Vous devez saisir un responsable de la réception."
   ),
-  receivedAt: date().required("Vous devez saisir une date de réception."),
+  receivedAt: validDate({
+    verboseFieldName: "date de réception",
+    required: true
+  }),
 
   quantityReceived: number()
     .required()
@@ -82,7 +86,7 @@ export default {
   Mutation: {
     markAsSent: object().shape({
       sentInfo: object({
-        sentAt: date().required("Vous devez saisir une date d'envoi."),
+        sentAt: validDate({ verboseFieldName: "date d'envoi", required: true }),
         sentBy: string().required(
           "Vous devez saisir un responsable de l'envoi."
         )
@@ -103,9 +107,10 @@ export default {
         processedBy: string().required(
           "Vous devez saisir un responsable de traitement."
         ),
-        processedAt: date().required(
-          "Vous devez saisir la date de traitement."
-        ),
+        processedAt: validDate({
+          verboseFieldName: "date de traitement",
+          required: true
+        }),
         nextDestination: object().when("processingOperationDone", {
           is: val => GROUP_CODES.includes(val),
           then: object({
@@ -118,7 +123,7 @@ export default {
     }),
     signedByTransporter: object().shape({
       signingInfo: object({
-        sentAt: date().required("Vous devez saisir une date d'envoi."),
+        sentAt: validDate({ verboseFieldName: "date d'envoi", required: true }),
         signedByTransporter: boolean()
           .required("Vous devez indiquer si le transporteur a signé.")
           .oneOf(
@@ -166,7 +171,10 @@ export default {
         receivedBy: string().required(
           "Vous devez saisir un responsable de la réception."
         ),
-        receivedAt: date().required("Vous devez saisir une date de réception."),
+        receivedAt: validDate({
+          verboseFieldName: "date de réception",
+          required: true
+        }),
         quantityReceived: number()
           .required()
           // if waste is refused, quantityReceived must be 0
@@ -226,7 +234,7 @@ export default {
                     "Le département du transporteur est obligatoire"
                   )
           ),
-          validityLimit: date().nullable(true),
+          validityLimit: validDate({ verboseFieldName: "date de validité" }),
           numberPlate: string().nullable(true),
           company: companySchema("Transporteur")
         })
@@ -263,14 +271,17 @@ export default {
                     "Le département du transporteur est obligatoire"
                   )
           ),
-          validityLimit: date().nullable(true),
+          validityLimit: validDate({ verboseFieldName: "date de validité" }),
           numberPlate: string().nullable(true),
           company: companySchema("Transporteur")
         }),
         signedBy: string().required(
           "Vous devez saisir un responsable de l'envoi."
         ),
-        signedAt: date().required("Vous devez saisir une date de l'envoi.")
+        signedAt: validDate({
+          verboseFieldName: "une date d'envoi",
+          required: true
+        })
       })
     })
   }

--- a/back/src/forms/schema-validation.ts
+++ b/back/src/forms/schema-validation.ts
@@ -1,7 +1,7 @@
 import { object, string, boolean, number, array, mixed } from "yup";
 import { companySchema } from "./validator";
 import { GROUP_CODES } from "./workflow/machine";
-import { validDate } from "./validation-helpers";
+import { validDatetime } from "./validation-helpers";
 
 const PROCESSING_OPERATION_CODES = [
   "D 1",
@@ -42,7 +42,7 @@ export const receivedInfoSchema = object({
   receivedBy: string().required(
     "Vous devez saisir un responsable de la réception."
   ),
-  receivedAt: validDate({
+  receivedAt: validDatetime({
     verboseFieldName: "date de réception",
     required: true
   }),
@@ -86,7 +86,7 @@ export default {
   Mutation: {
     markAsSent: object().shape({
       sentInfo: object({
-        sentAt: validDate({ verboseFieldName: "date d'envoi", required: true }),
+        sentAt: validDatetime({ verboseFieldName: "date d'envoi", required: true }),
         sentBy: string().required(
           "Vous devez saisir un responsable de l'envoi."
         )
@@ -107,7 +107,7 @@ export default {
         processedBy: string().required(
           "Vous devez saisir un responsable de traitement."
         ),
-        processedAt: validDate({
+        processedAt: validDatetime({
           verboseFieldName: "date de traitement",
           required: true
         }),
@@ -123,7 +123,7 @@ export default {
     }),
     signedByTransporter: object().shape({
       signingInfo: object({
-        sentAt: validDate({ verboseFieldName: "date d'envoi", required: true }),
+        sentAt: validDatetime({ verboseFieldName: "date d'envoi", required: true }),
         signedByTransporter: boolean()
           .required("Vous devez indiquer si le transporteur a signé.")
           .oneOf(
@@ -171,7 +171,7 @@ export default {
         receivedBy: string().required(
           "Vous devez saisir un responsable de la réception."
         ),
-        receivedAt: validDate({
+        receivedAt: validDatetime({
           verboseFieldName: "date de réception",
           required: true
         }),
@@ -234,7 +234,7 @@ export default {
                     "Le département du transporteur est obligatoire"
                   )
           ),
-          validityLimit: validDate({ verboseFieldName: "date de validité" }),
+          validityLimit: validDatetime({ verboseFieldName: "date de validité" }),
           numberPlate: string().nullable(true),
           company: companySchema("Transporteur")
         })
@@ -271,14 +271,14 @@ export default {
                     "Le département du transporteur est obligatoire"
                   )
           ),
-          validityLimit: validDate({ verboseFieldName: "date de validité" }),
+          validityLimit: validDatetime({ verboseFieldName: "date de validité" }),
           numberPlate: string().nullable(true),
           company: companySchema("Transporteur")
         }),
         signedBy: string().required(
           "Vous devez saisir un responsable de l'envoi."
         ),
-        signedAt: validDate({
+        signedAt: validDatetime({
           verboseFieldName: "une date d'envoi",
           required: true
         })

--- a/back/src/forms/validation-helpers.ts
+++ b/back/src/forms/validation-helpers.ts
@@ -13,7 +13,7 @@ const allowed_formats = [
  * Check an incoming string is a date formatted according to allowed_formats
  * "2020-11-23", "2020-11-23T13:34:55","2020-11-23T13:34:55Z", "2020-11-23T13:34:55.987", "2020-11-23T13:34:55.987Z"
  */
-const isValidDate = str => {
+const isValidDatetime = str => {
   if (!str) {
     return true;
   }
@@ -31,8 +31,11 @@ const isValidDate = str => {
  *
  * The validation is built upon string(), because date() passes an already processed value to chained method, thus allowing
  * some formatted dates we don't want to accept.
+ * 
+ * @param verboseFieldName - human readable field name, for error messages
+ * @param required - is this field required ?
  */
-export function validDate({ verboseFieldName, required = false }) {
+export function validDatetime({ verboseFieldName, required = false }) {
   let validator = string();
   if (!!required) {
     validator = validator.required(`Vous devez saisir une ${verboseFieldName}`);
@@ -44,7 +47,7 @@ export function validDate({ verboseFieldName, required = false }) {
     "valid-required-date",
     `La ${verboseFieldName} n'est pas formatée correctement`,
     v => {
-      return isValidDate(v);
+      return isValidDatetime(v);
     }
   );
 }

--- a/back/src/forms/validation-helpers.ts
+++ b/back/src/forms/validation-helpers.ts
@@ -1,0 +1,50 @@
+import { parse } from "date-fns";
+import { string } from "yup";
+
+const allowed_formats = [
+  "yyyy-MM-dd",
+  "yyyy-MM-dd'T'HH:mm:ss",
+  "yyyy-MM-dd'T'HH:mm:ssX",
+  "yyyy-MM-dd'T'HH:mm:ss.SSS",
+  "yyyy-MM-dd'T'HH:mm:ss.SSSX"
+];
+
+/**
+ * Check an incoming string is a date formatted according to allowed_formats
+ * "2020-11-23", "2020-11-23T13:34:55","2020-11-23T13:34:55Z", "2020-11-23T13:34:55.987", "2020-11-23T13:34:55.987Z"
+ */
+const isValidDate = str => {
+  if (!str) {
+    return true;
+  }
+  for (let fmt of allowed_formats) {
+    if (!!parse(str, fmt, new Date()).getDate()) {
+      return true;
+    }
+  }
+};
+
+/**
+ * Check a provided string is parsable as a valid date
+ * We can't rely solely on yup, because strings like "20200120" are accepted but are passed unformatted to prisma/postgres which
+ * causes server errors.
+ *
+ * The validation is built upon string(), because date() passes an already processed value to chained method, thus allowing
+ * some formatted dates we don't want to accept.
+ */
+export function validDate({ verboseFieldName, required = false }) {
+  let validator = string();
+  if (!!required) {
+    validator = validator.required(`Vous devez saisir une ${verboseFieldName}`);
+  } else {
+    validator = validator.nullable();
+  }
+
+  return validator.test(
+    "valid-required-date",
+    `La ${verboseFieldName} n'est pas formatée correctement`,
+    v => {
+      return isValidDate(v);
+    }
+  );
+}

--- a/back/src/forms/validation-helpers.ts
+++ b/back/src/forms/validation-helpers.ts
@@ -1,7 +1,7 @@
 import { parse } from "date-fns";
 import { string } from "yup";
 
-const allowed_formats = [
+const allowedFormats = [
   "yyyy-MM-dd",
   "yyyy-MM-dd'T'HH:mm:ss",
   "yyyy-MM-dd'T'HH:mm:ssX",
@@ -17,9 +17,9 @@ const isValidDatetime = str => {
   if (!str) {
     return true;
   }
-  for (let fmt of allowed_formats) {
+  for (const fmt of allowedFormats) {
     // to know if a given string is correctly formatted date, we use date-fns parse
-    // if format is correct, getDate() will return a nice Date object, 
+    // if format is correct, getDate() will return a nice Date object,
     // else parse will return an Invalid Date, i.e Date, whose time value is NaN
     if (!!parse(str, fmt, new Date()).getDate()) {
       return true;
@@ -34,7 +34,7 @@ const isValidDatetime = str => {
  *
  * The validation is built upon string(), because date() passes an already processed value to chained method, thus allowing
  * some formatted dates we don't want to accept.
- * 
+ *
  * @param verboseFieldName - human readable field name, for error messages
  * @param required - is this field required ?
  */

--- a/back/src/forms/validation-helpers.ts
+++ b/back/src/forms/validation-helpers.ts
@@ -18,6 +18,9 @@ const isValidDatetime = str => {
     return true;
   }
   for (let fmt of allowed_formats) {
+    // to know if a given string is correctly formatted date, we use date-fns parse
+    // if format is correct, getDate() will return a nice Date object, 
+    // else parse will return an Invalid Date, i.e Date, whose time value is NaN
     if (!!parse(str, fmt, new Date()).getDate()) {
       return true;
     }

--- a/back/src/forms/validator.ts
+++ b/back/src/forms/validator.ts
@@ -1,7 +1,6 @@
 import {
   string,
   object,
-  date,
   number,
   array,
   boolean,
@@ -9,7 +8,11 @@ import {
   LocaleObject
 } from "yup";
 import { prisma } from "../generated/prisma-client";
+
 import wasteCodes from "./wasteCodes";
+
+import { validDate } from "./validation-helpers";
+
 setLocale({
   mixed: {
     default: "${path} est invalide",
@@ -79,7 +82,7 @@ export const formSchema = object<any>().shape({
           ? schema.nullable(true)
           : schema.required("Le département du transporteur est obligatoire")
     ),
-    validityLimit: date().nullable(true),
+    validityLimit: validDate({ verboseFieldName: "date de validité" }),
     numberPlate: string().nullable(true),
     company: companySchema("Transporteur")
   }),

--- a/back/src/forms/validator.ts
+++ b/back/src/forms/validator.ts
@@ -12,6 +12,7 @@ import { prisma } from "../generated/prisma-client";
 import wasteCodes from "./wasteCodes";
 
 import { validDate } from "./validation-helpers";
+import { validDatetime } from "./validation-helpers";
 
 setLocale({
   mixed: {
@@ -82,7 +83,7 @@ export const formSchema = object<any>().shape({
           ? schema.nullable(true)
           : schema.required("Le département du transporteur est obligatoire")
     ),
-    validityLimit: validDate({ verboseFieldName: "date de validité" }),
+    validityLimit: validDatetime({ verboseFieldName: "date de validité" }),
     numberPlate: string().nullable(true),
     company: companySchema("Transporteur")
   }),

--- a/back/src/forms/validator.ts
+++ b/back/src/forms/validator.ts
@@ -11,7 +11,6 @@ import { prisma } from "../generated/prisma-client";
 
 import wasteCodes from "./wasteCodes";
 
-import { validDate } from "./validation-helpers";
 import { validDatetime } from "./validation-helpers";
 
 setLocale({

--- a/back/src/generated/types.ts
+++ b/back/src/generated/types.ts
@@ -6,6 +6,14 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /**
+   * The `DateTime` scalar expects a date-formatted string matching one of the following formats:
+   * - "yyyy-MM-dd" (eg. 2020-11-23)
+   * - "yyyy-MM-ddTHH:mm:ss" (eg. 2020-11-23T13:34:55)
+   * - "yyyy-MM-ddTHH:mm:ssX" (eg. 2020-11-23T13:34:55Z)
+   * - "yyyy-MM-dd'T'HH:mm:ss.SSS" (eg. 2020-11-23T13:34:55.987)
+   * - "yyyy-MM-dd'T'HH:mm:ss.SSSX" (eg. 2020-11-23T13:34:55.987Z)
+   */
   DateTime: any;
   JSON: any;
 };

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -5062,6 +5062,13 @@ The `Boolean` scalar type represents `true` or `false`.
 
 ### DateTime
 
+The `DateTime` scalar expects a date-formatted string matching one of the following formats:
+- "yyyy-MM-dd" (eg. 2020-11-23)
+- "yyyy-MM-ddTHH:mm:ss" (eg. 2020-11-23T13:34:55)
+- "yyyy-MM-ddTHH:mm:ssX" (eg. 2020-11-23T13:34:55Z)
+- "yyyy-MM-dd'T'HH:mm:ss.SSS" (eg. 2020-11-23T13:34:55.987)
+- "yyyy-MM-dd'T'HH:mm:ss.SSSX" (eg. 2020-11-23T13:34:55.987Z)
+
 ### Float
 
 The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).


### PR DESCRIPTION
Yup laissait passer des dates sous un format incompatible avec prisma/postgres (eg "20200422") ce qui aboutissait à des erreurs serveurs. Cette PR utilise un helper pour valider le format des dates( "yyyy-MM-dd",  "yyyy-MM-dd'T'HH:mm:ss",  "yyyy-MM-dd'T'HH:mm:ssX",  "yyyy-MM-dd'T'HH:mm:ss.SSS",  "yyyy-MM-dd'T'HH:mm:ss.SSSX"). La liste des formats est basée sur ce que j'ai pu rencontrer dans les tests et les db.
La doc est mise à jour pour expliciter les formats.