### PR TITLE
Make transporter onu code optional

### DIFF
--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -31,7 +31,7 @@ input TransporterSignatureFormInput {
   quantity: Float!
 
   "Code ONU"
-  onuCode: String!
+  onuCode: String
 }
 
 "Statut d'acceptation d'un déchet"

--- a/back/src/forms/schema-validation.ts
+++ b/back/src/forms/schema-validation.ts
@@ -142,7 +142,7 @@ export default {
         quantity: number().positive(
           "Vous devez saisir une quantité envoyée supérieure à 0."
         ),
-        onuCode: string().required("Vous devez saisir un code ONU.")
+        onuCode: string().nullable(true)
       })
     }),
     markAsTempStored: object().shape({

--- a/back/src/generated/types.ts
+++ b/back/src/generated/types.ts
@@ -1321,7 +1321,7 @@ export type TransporterSignatureFormInput = {
   /** Quantité en tonnes */
   quantity: Scalars['Float'];
   /** Code ONU */
-  onuCode: Scalars['String'];
+  onuCode?: Maybe<Scalars['String']>;
 };
 
 /** Lien d'upload */

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -4333,7 +4333,7 @@ Quantité en tonnes
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>onuCode</strong></td>
-<td valign="top"><a href="#string">String</a>!</td>
+<td valign="top"><a href="#string">String</a></td>
 <td>
 
 Code ONU

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -127,7 +127,8 @@ export default function TransportSignature({ form }: Props) {
 
                   <p>
                     <label>
-                      Code ADR
+                      Code ADR (ONU) - Champ à renseigner selon le déchet
+                      transporté, sous votre responsabilité
                       <Field type="text" name="onuCode" />
                     </label>
                   </p>


### PR DESCRIPTION
Rend le code onu (adr) non obligatoire lors de la signature transporteur et ajoute une mention.

cf. https://trello.com/c/p69XxlU3/807-dans-signature-transporteur-le-message-erreur-absence-code-onu-apparait-sur-ecran-signature-producteur