### PR TITLE
Fix & retours - BSD suite

### DIFF
--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -322,6 +322,25 @@ type Form {
 
   "BSD suite - détail des champs de la partie entreposage provisoire ou reconditionnement"
   temporaryStorageDetail: TemporaryStorageDetail
+
+  "Résumé des valeurs clés du bordereau à l'instant T"
+  stateSummary: StateSummary
+}
+
+"""
+En fonction du statut du bordereau, différentes informations sont à lire pour connaitre vraiment l'étast du bordereau:
+- la quantité peut changer entre émission, réception, entreposage provisoire...
+- le bordereau peut naviguer entre plusieurs entreprises.
+- quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
+- si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
+
+Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
+"""
+type StateSummary {
+  quantity: Float
+  transporter: FormCompany
+  recipient: FormCompany
+  lastActionOn: DateTime
 }
 
 "Données du BSD suite sur la partie entreposage provisoire ou reconditionnement, rattachées à un BSD existant"

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -337,9 +337,19 @@ En fonction du statut du bordereau, différentes informations sont à lire pour 
 Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
 """
 type StateSummary {
+  "Quantité la plus à jour"
   quantity: Float
+
+  "Prochaine entreprise à transporter le déchet (entreprise en case 8 ou 18)"
   transporter: FormCompany
+
+  "Prochaine entreprise à recevoir le déchet (entreprise en case 2 ou 14)"
   recipient: FormCompany
+
+  "Prochaine entreprise à émettre le déchet (entreprise en case 1 ou 13)"
+  emitter: FormCompany
+
+  "Date de la dernière action sur le bordereau"
   lastActionOn: DateTime
 }
 

--- a/back/src/forms/queries/state-summary.ts
+++ b/back/src/forms/queries/state-summary.ts
@@ -1,0 +1,115 @@
+import { GraphQLContext } from "../../types";
+import { TemporaryStorageDetail } from "../../generated/prisma-client";
+import { Form, FormStatus } from "../../generated/types";
+
+export const stateSummary = async (
+  parent: Form,
+  _,
+  context: GraphQLContext
+) => {
+  const temporaryStorageDetail = await context.prisma
+    .form({ id: parent.id })
+    .temporaryStorageDetail();
+
+  return {
+    actualQuantity: getActualQuantity(parent, temporaryStorageDetail),
+    transporter: getTransporter(parent, temporaryStorageDetail),
+    recipient: getRecipient(parent, temporaryStorageDetail),
+    lastActionOn: getLastActionOn(parent, temporaryStorageDetail)
+  };
+};
+
+function getTransporter(
+  form: Form,
+  temporaryStorageDetail: TemporaryStorageDetail
+) {
+  if ([FormStatus.Sealed, FormStatus.Draft].includes(form.status)) {
+    return form.transporter?.company;
+  }
+
+  if (
+    temporaryStorageDetail &&
+    [FormStatus.Resealed, FormStatus.TempStored].includes(form.status)
+  ) {
+    return {
+      name: temporaryStorageDetail.transporterCompanyName,
+      siret: temporaryStorageDetail.transporterCompanySiret,
+      address: temporaryStorageDetail.transporterCompanyAddress,
+      contact: temporaryStorageDetail.transporterCompanyContact,
+      phone: temporaryStorageDetail.transporterCompanyPhone,
+      mail: temporaryStorageDetail.transporterCompanyMail
+    };
+  }
+
+  return null;
+}
+
+function getRecipient(
+  form: Form,
+  temporaryStorageDetail: TemporaryStorageDetail
+) {
+  if (
+    temporaryStorageDetail &&
+    ![FormStatus.Draft, FormStatus.Sent].includes(form.status)
+  ) {
+    return {
+      name: temporaryStorageDetail.destinationCompanyName,
+      siret: temporaryStorageDetail.destinationCompanySiret,
+      address: temporaryStorageDetail.destinationCompanyAddress,
+      contact: temporaryStorageDetail.destinationCompanyContact,
+      phone: temporaryStorageDetail.destinationCompanyPhone,
+      mail: temporaryStorageDetail.destinationCompanyMail
+    };
+  }
+
+  return form.recipient?.company;
+}
+
+function getLastActionOn(
+  form: Form,
+  temporaryStorageDetail: TemporaryStorageDetail
+): string {
+  switch (form.status) {
+    case FormStatus.Sent:
+      return form.sentAt;
+    case FormStatus.Received:
+      return form.receivedAt;
+    case FormStatus.Processed:
+      return form.processedAt;
+    case FormStatus.TempStored:
+    case FormStatus.Resealed:
+      return temporaryStorageDetail.tempStorerReceivedAt;
+    case FormStatus.Resent:
+      return temporaryStorageDetail.signedAt;
+    default:
+      return form.createdAt;
+  }
+}
+
+function getActualQuantity(
+  form: Form,
+  temporaryStorageDetail: TemporaryStorageDetail
+): number | null {
+  // When the form is received we have the definitive quantity
+  if (form.quantityReceived != null) {
+    return form.quantityReceived;
+  }
+  // When form is temp stored the quantity is reported on arrival and might be changed
+  if (form.recipient?.isTempStorage) {
+    // Repackaging
+    if (temporaryStorageDetail?.wasteDetailsQuantity) {
+      return temporaryStorageDetail.wasteDetailsQuantity;
+    }
+
+    // Arrival
+    if (temporaryStorageDetail?.tempStorerQuantityReceived != null) {
+      return temporaryStorageDetail.tempStorerQuantityReceived;
+    }
+  }
+  // Not a lot happened yet, use the quantity input
+  if (form.wasteDetails?.quantity) {
+    return form.wasteDetails.quantity;
+  }
+  // For drafts, we might not have a quantity yet
+  return null;
+}

--- a/back/src/forms/queries/state-summary.ts
+++ b/back/src/forms/queries/state-summary.ts
@@ -12,7 +12,7 @@ export const stateSummary = async (
     .temporaryStorageDetail();
 
   return {
-    actualQuantity: getActualQuantity(parent, temporaryStorageDetail),
+    quantity: getQuantity(parent, temporaryStorageDetail),
     transporter: getTransporter(parent, temporaryStorageDetail),
     recipient: getRecipient(parent, temporaryStorageDetail),
     lastActionOn: getLastActionOn(parent, temporaryStorageDetail)
@@ -86,7 +86,7 @@ function getLastActionOn(
   }
 }
 
-function getActualQuantity(
+function getQuantity(
   form: Form,
   temporaryStorageDetail: TemporaryStorageDetail
 ): number | null {

--- a/back/src/forms/queries/state-summary.ts
+++ b/back/src/forms/queries/state-summary.ts
@@ -15,6 +15,7 @@ export const stateSummary = async (
     quantity: getQuantity(parent, temporaryStorageDetail),
     transporter: getTransporter(parent, temporaryStorageDetail),
     recipient: getRecipient(parent, temporaryStorageDetail),
+    emitter: getEmitter(parent, temporaryStorageDetail),
     lastActionOn: getLastActionOn(parent, temporaryStorageDetail)
   };
 };
@@ -63,6 +64,20 @@ function getRecipient(
   }
 
   return form.recipient?.company;
+}
+
+function getEmitter(
+  form: Form,
+  temporaryStorageDetail: TemporaryStorageDetail
+) {
+  if (
+    temporaryStorageDetail &&
+    [FormStatus.TempStored, FormStatus.Resealed].includes(form.status)
+  ) {
+    return form.recipient?.company;
+  }
+
+  return form.emitter?.company;
 }
 
 function getLastActionOn(

--- a/back/src/generated/types.ts
+++ b/back/src/generated/types.ts
@@ -423,6 +423,8 @@ export type Form = {
   ecoOrganisme?: Maybe<EcoOrganisme>;
   /** BSD suite - détail des champs de la partie entreposage provisoire ou reconditionnement */
   temporaryStorageDetail?: Maybe<TemporaryStorageDetail>;
+  /** Résumé des valeurs clés du bordereau à l'instant T */
+  stateSummary?: Maybe<StateSummary>;
 };
 
 /** Information sur un établissement dans un BSD */
@@ -1148,6 +1150,23 @@ export type Stat = {
   incoming?: Maybe<Scalars['Float']>;
   /** Qantité sortante */
   outgoing?: Maybe<Scalars['Float']>;
+};
+
+/**
+ * En fonction du statut du bordereau, différentes informations sont à lire pour connaitre vraiment l'étast du bordereau:
+ * - la quantité peut changer entre émission, réception, entreposage provisoire...
+ * - le bordereau peut naviguer entre plusieurs entreprises.
+ * - quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
+ * - si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
+ * 
+ * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
+ */
+export type StateSummary = {
+   __typename?: 'StateSummary';
+  quantity?: Maybe<Scalars['Float']>;
+  transporter?: Maybe<FormCompany>;
+  recipient?: Maybe<FormCompany>;
+  lastActionOn?: Maybe<Scalars['DateTime']>;
 };
 
 /** Changement de statut d'un bordereau */

--- a/back/src/generated/types.ts
+++ b/back/src/generated/types.ts
@@ -1163,9 +1163,15 @@ export type Stat = {
  */
 export type StateSummary = {
    __typename?: 'StateSummary';
+  /** Quantité la plus à jour */
   quantity?: Maybe<Scalars['Float']>;
+  /** Prochaine entreprise à transporter le déchet (entreprise en case 8 ou 18) */
   transporter?: Maybe<FormCompany>;
+  /** Prochaine entreprise à recevoir le déchet (entreprise en case 2 ou 14) */
   recipient?: Maybe<FormCompany>;
+  /** Prochaine entreprise à émettre le déchet (entreprise en case 1 ou 13) */
+  emitter?: Maybe<FormCompany>;
+  /** Date de la dernière action sur le bordereau */
   lastActionOn?: Maybe<Scalars['DateTime']>;
 };
 

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2559,22 +2559,47 @@ Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours 
 <tr>
 <td colspan="2" valign="top"><strong>quantity</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité la plus à jour
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>transporter</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Prochaine entreprise à transporter le déchet (entreprise en case 8 ou 18)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>recipient</strong></td>
 <td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td></td>
+<td>
+
+Prochaine entreprise à recevoir le déchet (entreprise en case 2 ou 14)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>emitter</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td>
+
+Prochaine entreprise à émettre le déchet (entreprise en case 1 ou 13)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>lastActionOn</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date de la dernière action sur le bordereau
+
+</td>
 </tr>
 </tbody>
 </table>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2110,6 +2110,15 @@ BSD suite - détail des champs de la partie entreposage provisoire ou reconditio
 
 </td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>stateSummary</strong></td>
+<td valign="top"><a href="#statesummary">StateSummary</a></td>
+<td>
+
+Résumé des valeurs clés du bordereau à l'instant T
+
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -2523,6 +2532,49 @@ Quantité entrante
 Qantité sortante
 
 </td>
+</tr>
+</tbody>
+</table>
+
+### StateSummary
+
+En fonction du statut du bordereau, différentes informations sont à lire pour connaitre vraiment l'étast du bordereau:
+- la quantité peut changer entre émission, réception, entreposage provisoire...
+- le bordereau peut naviguer entre plusieurs entreprises.
+- quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
+- si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
+
+Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>transporter</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>recipient</strong></td>
+<td valign="top"><a href="#formcompany">FormCompany</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>lastActionOn</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
 </tr>
 </tbody>
 </table>

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -121,7 +121,20 @@ const staticFieldsFragment = gql`
     readableId
     createdAt
     status
-    actualQuantity
+    stateSummary {
+      quantity
+      transporter {
+        name
+        siret
+        address
+      }
+      recipient {
+        name
+        siret
+        address
+      }
+      lastActionOn
+    }
   }
 `;
 

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -133,6 +133,11 @@ const staticFieldsFragment = gql`
         siret
         address
       }
+      emitter {
+        name
+        siret
+        address
+      }
       lastActionOn
     }
   }

--- a/front/src/dashboard/slips/Slips.tsx
+++ b/front/src/dashboard/slips/Slips.tsx
@@ -17,7 +17,7 @@ export default function Slips({
   forms,
   siret,
   hiddenFields = [],
-  dynamicActions = false
+  dynamicActions = false,
 }: Props) {
   const [sortedForms, sortBy, filter] = useFormsTable(forms);
 
@@ -43,7 +43,7 @@ export default function Slips({
           </th>
           <th
             className="sortable"
-            onClick={() => sortBy("recipient.company.name")}
+            onClick={() => sortBy("stateSummary.recipient.name")}
           >
             Destinataire{" "}
             <small>
@@ -73,7 +73,7 @@ export default function Slips({
             <th>
               <input
                 type="text"
-                onChange={e => filter("readableId", e.target.value)}
+                onChange={(e) => filter("readableId", e.target.value)}
                 placeholder="Filtrer..."
               />
             </th>
@@ -82,21 +82,21 @@ export default function Slips({
           <th>
             <input
               type="text"
-              onChange={e => filter("emitter.company.name", e.target.value)}
+              onChange={(e) => filter("emitter.company.name", e.target.value)}
               placeholder="Filtrer..."
             />
           </th>
           <th>
             <input
               type="text"
-              onChange={e => filter("recipient.company.name", e.target.value)}
+              onChange={(e) => filter("stateSummary.recipient.name", e.target.value)}
               placeholder="Filtrer..."
             />
           </th>
           <th>
             <input
               type="text"
-              onChange={e => filter("wasteDetails.code", e.target.value)}
+              onChange={(e) => filter("wasteDetails.code", e.target.value)}
               placeholder="Filtrer..."
             />
           </th>
@@ -115,8 +115,8 @@ export default function Slips({
               </td>
             )}
             <td>{DateTime.fromISO(s.createdAt).toLocaleString()}</td>
-            <td>{s.emitter.company && s.emitter.company.name}</td>
-            <td>{s.recipient.company && s.recipient.company.name}</td>
+            <td>{s.emitter.company?.name}</td>
+            <td>{s.stateSummary.recipient?.name}</td>
             <td>
               {s.wasteDetails && (
                 <React.Fragment>
@@ -125,7 +125,7 @@ export default function Slips({
                 </React.Fragment>
               )}
             </td>
-            <td>{s.actualQuantity ?? "?"} t</td>
+            <td>{s.stateSummary.quantity ?? "?"} t</td>
             {hiddenFields.indexOf("status") === -1 && (
               <td>{statusLabels[s.status]}</td>
             )}

--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -6,25 +6,25 @@ import DateInput from "../../../form/custom-inputs/DateInput";
 import { SlipActionProps } from "../SlipActions";
 import {
   InlineRadioButton,
-  RadioButton
+  RadioButton,
 } from "../../../form/custom-inputs/RadioButton";
 import { WasteAcceptationStatus, FormStatus } from "../../../Constants";
 
 const textConfig = {
   [WasteAcceptationStatus.ACCEPTED]: {
     validationText:
-      "En validant, je confirme la réception des déchets indiqués dans ce bordereau."
+      "En validant, je confirme la réception des déchets indiqués dans ce bordereau.",
   },
   [WasteAcceptationStatus.REFUSED]: {
     validationText:
       "En refusant ce déchet, je le retourne à son producteur. Un mail automatique Trackdéchets, informera le producteur de ce refus, accompagné du BSD en pdf. L'inspection des ICPE et ma société en recevront une copie",
-    refusalReasonText: "Motif du refus"
+    refusalReasonText: "Motif du refus",
   },
   [WasteAcceptationStatus.PARTIALLY_REFUSED]: {
     validationText:
       "En validant, je confirme la réception des déchets pour la quantité indiquée dans ce bordereau. Un mail automatique Trackdéchets, informera le producteur de ce refus partiel, accompagné du BSD en pdf. L'inspection des ICPE et ma société en recevront une copie",
-    refusalReasonText: "Motif du refus partiel"
-  }
+    refusalReasonText: "Motif du refus partiel",
+  },
 };
 const FieldError = ({ fieldError }) =>
   !!fieldError ? <p className="text-red mt-0 mb-0">{fieldError}</p> : null;
@@ -40,9 +40,9 @@ export default function Received(props: SlipActionProps) {
           wasteAcceptationStatus: "",
           wasteRefusalReason: "",
           ...(props.form.recipient.isTempStorage &&
-            props.form.status === FormStatus.SENT && { quantityType: "REAL" })
+            props.form.status === FormStatus.SENT && { quantityType: "REAL" }),
         }}
-        onSubmit={values => props.onSubmit({ info: values })}
+        onSubmit={(values) => props.onSubmit({ info: values })}
       >
         {({ values, errors, touched, handleReset, setFieldValue }) => {
           const hasErrors = !!Object.keys(errors).length;
@@ -114,7 +114,8 @@ export default function Received(props: SlipActionProps) {
                 />
                 <FieldError fieldError={errors.quantityReceived} />
                 <span>
-                  Poids indicatif émis: {props.form.actualQuantity} tonnes
+                  Poids indicatif émis: {props.form.stateSummary.quantity}{" "}
+                  tonnes
                 </span>
               </label>
               {props.form.recipient.isTempStorage &&
@@ -138,7 +139,7 @@ export default function Received(props: SlipActionProps) {
               {/* Display wasteRefusalReason field if waste is refused or partially refused*/}
               {[
                 WasteAcceptationStatus.REFUSED.toString(),
-                WasteAcceptationStatus.PARTIALLY_REFUSED.toString()
+                WasteAcceptationStatus.PARTIALLY_REFUSED.toString(),
               ].includes(values.wasteAcceptationStatus) && (
                 <label>
                   {textConfig[values.wasteAcceptationStatus].refusalReasonText}

--- a/front/src/dashboard/slips/slips-actions/Resealed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Resealed.tsx
@@ -1,6 +1,6 @@
 import merge from "deepmerge";
 import { Field, Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { removeNulls } from "../../../common/helper";
 import RedErrorMessage from "../../../common/RedErrorMessage";
 import CompanySelector from "../../../form/company/CompanySelector";
@@ -21,6 +21,10 @@ export default function Resealed({
   const initialValues = merge(
     emptyState,
     removeNulls(form.temporaryStorageDetail)
+  );
+
+  const [isRefurbished, setIsRefurbished] = useState(
+    !!form.temporaryStorageDetail.wasteDetails.quantity
   );
 
   return (
@@ -58,71 +62,86 @@ export default function Resealed({
               </Field>
             </div>
 
-            <h5>Détails du déchet</h5>
-            <div className="notification info">
-              Les champs concernant le détail du déchet sont à remplir en cas de
-              reconditionnement uniquement.
-            </div>
-
-            <h4>Conditionnement</h4>
-            <div className="form__group">
-              <Field name="wasteDetails.packagings" component={Packagings} />
-
-              {values.wasteDetails.packagings.indexOf("AUTRE") > -1 && (
-                <label>
-                  <Field
-                    name="wasteDetails.otherPackaging"
-                    type="text"
-                    placeholder="Détail de l'autre conditionnement"
-                  />
-                </label>
-              )}
-
-              <Field
-                component={NumberInput}
-                name="wasteDetails.numberOfPackages"
-                label="Nombre de colis"
-              />
-              <RedErrorMessage name="wasteDetails.numberOfPackages" />
-            </div>
-
-            <h4>Quantité en tonnes</h4>
-            <div className="form__group">
-              <Field
-                component={NumberInput}
-                name="wasteDetails.quantity"
-                placeholder="En tonnes"
-                min="0"
-                step="0.001"
-              />
-
-              <RedErrorMessage name="wasteDetails.quantity" />
-
-              <fieldset>
-                <legend>Cette quantité est</legend>
-                <Field
-                  name="wasteDetails.quantityType"
-                  id="REAL"
-                  label="Réelle"
-                  component={RadioButton}
-                />
-                <Field
-                  name="wasteDetails.quantityType"
-                  id="ESTIMATED"
-                  label="Estimée"
-                  component={RadioButton}
-                />
-              </fieldset>
-
-              <RedErrorMessage name="wasteDetails.quantityType" />
-            </div>
             <div className="form__group">
               <label>
-                Mentions au titre des règlements ADR, RID, ADNR, IMDG (le cas
-                échéant)
-                <Field type="text" name="wasteDetails.onuCode" />
+                <input
+                  type="checkbox"
+                  checked={isRefurbished}
+                  onChange={() => setIsRefurbished(!isRefurbished)}
+                />
+                Les déchets ont subi un reconditionnement, je dois saisir les
+                détails
               </label>
             </div>
+
+            {isRefurbished && (
+              <>
+                <h5>Détails du déchet</h5>
+
+                <h4>Conditionnement</h4>
+                <div className="form__group">
+                  <Field
+                    name="wasteDetails.packagings"
+                    component={Packagings}
+                  />
+
+                  {values.wasteDetails.packagings.indexOf("AUTRE") > -1 && (
+                    <label>
+                      <Field
+                        name="wasteDetails.otherPackaging"
+                        type="text"
+                        placeholder="Détail de l'autre conditionnement"
+                      />
+                    </label>
+                  )}
+
+                  <Field
+                    component={NumberInput}
+                    name="wasteDetails.numberOfPackages"
+                    label="Nombre de colis"
+                  />
+                  <RedErrorMessage name="wasteDetails.numberOfPackages" />
+                </div>
+
+                <h4>Quantité en tonnes</h4>
+                <div className="form__group">
+                  <Field
+                    component={NumberInput}
+                    name="wasteDetails.quantity"
+                    placeholder="En tonnes"
+                    min="0"
+                    step="0.001"
+                  />
+
+                  <RedErrorMessage name="wasteDetails.quantity" />
+
+                  <fieldset>
+                    <legend>Cette quantité est</legend>
+                    <Field
+                      name="wasteDetails.quantityType"
+                      id="REAL"
+                      label="Réelle"
+                      component={RadioButton}
+                    />
+                    <Field
+                      name="wasteDetails.quantityType"
+                      id="ESTIMATED"
+                      label="Estimée"
+                      component={RadioButton}
+                    />
+                  </fieldset>
+
+                  <RedErrorMessage name="wasteDetails.quantityType" />
+                </div>
+                <div className="form__group">
+                  <label>
+                    Mentions au titre des règlements ADR, RID, ADNR, IMDG (le
+                    cas échéant)
+                    <Field type="text" name="wasteDetails.onuCode" />
+                  </label>
+                </div>
+              </>
+            )}
 
             <h5>
               Collecteur-transporteur après entreposage ou reconditionnement

--- a/front/src/dashboard/slips/slips-actions/Resent.tsx
+++ b/front/src/dashboard/slips/slips-actions/Resent.tsx
@@ -1,6 +1,6 @@
 import merge from "deepmerge";
 import { Field, Form, Formik } from "formik";
-import React from "react";
+import React, { useState } from "react";
 import { removeNulls } from "../../../common/helper";
 import RedErrorMessage from "../../../common/RedErrorMessage";
 import CompanySelector from "../../../form/company/CompanySelector";
@@ -17,6 +17,10 @@ export default function Resent({ form, onSubmit, onCancel }: SlipActionProps) {
   const initialValues = merge(
     emptyState,
     removeNulls(form.temporaryStorageDetail)
+  );
+
+  const [isRefurbished, setIsRefurbished] = useState(
+    !!form.temporaryStorageDetail.wasteDetails.quantity
   );
 
   return (
@@ -53,72 +57,86 @@ export default function Resent({ form, onSubmit, onCancel }: SlipActionProps) {
                 ))}
               </Field>
             </div>
-
-            <h5>Détails du déchet</h5>
-            <div className="notification info">
-              Les champs concernant le détail du déchet sont à remplir en cas de
-              reconditionnement uniquement.
-            </div>
-
-            <h4>Conditionnement</h4>
-            <div className="form__group">
-              <Field name="wasteDetails.packagings" component={Packagings} />
-
-              {values.wasteDetails.packagings.indexOf("AUTRE") > -1 && (
-                <label>
-                  <Field
-                    name="wasteDetails.otherPackaging"
-                    type="text"
-                    placeholder="Détail de l'autre conditionnement"
-                  />
-                </label>
-              )}
-
-              <Field
-                component={NumberInput}
-                name="wasteDetails.numberOfPackages"
-                label="Nombre de colis"
-              />
-              <RedErrorMessage name="wasteDetails.numberOfPackages" />
-            </div>
-
-            <h4>Quantité en tonnes</h4>
-            <div className="form__group">
-              <Field
-                component={NumberInput}
-                name="wasteDetails.quantity"
-                placeholder="En tonnes"
-                min="0"
-                step="0.001"
-              />
-
-              <RedErrorMessage name="wasteDetails.quantity" />
-
-              <fieldset>
-                <legend>Cette quantité est</legend>
-                <Field
-                  name="wasteDetails.quantityType"
-                  id="REAL"
-                  label="Réelle"
-                  component={RadioButton}
-                />
-                <Field
-                  name="wasteDetails.quantityType"
-                  id="ESTIMATED"
-                  label="Estimée"
-                  component={RadioButton}
-                />
-              </fieldset>
-
-              <RedErrorMessage name="wasteDetails.quantityType" />
-            </div>
             <div className="form__group">
               <label>
-                Mentions au titre des règlements ADR, RID, ADNR, IMDG (le cas
-                échéant)
-                <Field type="text" name="wasteDetails.onuCode" />
+                <input
+                  type="checkbox"
+                  checked={isRefurbished}
+                  onChange={() => setIsRefurbished(!isRefurbished)}
+                />
+                Les déchets ont subi un reconditionnement, je dois saisir les
+                détails
               </label>
             </div>
+
+            {isRefurbished && (
+              <>
+                <h5>Détails du déchet</h5>
+
+                <h4>Conditionnement</h4>
+                <div className="form__group">
+                  <Field
+                    name="wasteDetails.packagings"
+                    component={Packagings}
+                  />
+
+                  {values.wasteDetails.packagings.indexOf("AUTRE") > -1 && (
+                    <label>
+                      <Field
+                        name="wasteDetails.otherPackaging"
+                        type="text"
+                        placeholder="Détail de l'autre conditionnement"
+                      />
+                    </label>
+                  )}
+
+                  <Field
+                    component={NumberInput}
+                    name="wasteDetails.numberOfPackages"
+                    label="Nombre de colis"
+                  />
+                  <RedErrorMessage name="wasteDetails.numberOfPackages" />
+                </div>
+
+                <h4>Quantité en tonnes</h4>
+                <div className="form__group">
+                  <Field
+                    component={NumberInput}
+                    name="wasteDetails.quantity"
+                    placeholder="En tonnes"
+                    min="0"
+                    step="0.001"
+                  />
+
+                  <RedErrorMessage name="wasteDetails.quantity" />
+
+                  <fieldset>
+                    <legend>Cette quantité est</legend>
+                    <Field
+                      name="wasteDetails.quantityType"
+                      id="REAL"
+                      label="Réelle"
+                      component={RadioButton}
+                    />
+                    <Field
+                      name="wasteDetails.quantityType"
+                      id="ESTIMATED"
+                      label="Estimée"
+                      component={RadioButton}
+                    />
+                  </fieldset>
+
+                  <RedErrorMessage name="wasteDetails.quantityType" />
+                </div>
+                <div className="form__group">
+                  <label>
+                    Mentions au titre des règlements ADR, RID, ADNR, IMDG (le
+                    cas échéant)
+                    <Field type="text" name="wasteDetails.onuCode" />
+                  </label>
+                </div>
+              </>
+            )}
 
             <h5>
               Collecteur-transporteur après entreposage ou reconditionnement

--- a/front/src/dashboard/slips/slips-actions/next-step.ts
+++ b/front/src/dashboard/slips/slips-actions/next-step.ts
@@ -73,6 +73,7 @@ export function getNextStep(form: Form, currentSiret: string) {
 
   if (currentUserIsDestination) {
     if (form.status === FormStatus.RESENT) return FormStatus.RECEIVED;
+    if (form.status === FormStatus.RECEIVED) return FormStatus.PROCESSED;
   }
 
   if (currentUserIsTempStorer) {

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -23,8 +23,8 @@ export const GET_TRANSPORT_SLIPS = gql`
     forms(siret: $siret, type: $type) {
       ...FullForm
     }
-    ${fullFormFragment}
   }
+  ${fullFormFragment}
 `;
 const Table = ({ forms, displayActions }) => {
   const [sortedForms, sortBy, filter] = useFormsTable(forms);
@@ -50,7 +50,7 @@ const Table = ({ forms, displayActions }) => {
           </th>
           <th
             className="sortable hide-on-mobile"
-            onClick={() => sortBy("recipient.company.name")}
+            onClick={() => sortBy("stateSummary.recipient.name")}
           >
             Destinataire{" "}
             <small>
@@ -83,7 +83,9 @@ const Table = ({ forms, displayActions }) => {
           <th className="hide-on-mobile">
             <input
               type="text"
-              onChange={(e) => filter("recipient.company.name", e.target.value)}
+              onChange={(e) =>
+                filter("stateSummary.recipient.name", e.target.value)
+              }
               placeholder="Filtrer..."
             />
           </th>
@@ -109,7 +111,7 @@ const Table = ({ forms, displayActions }) => {
             </td>
             <td>{form.emitter.company && form.emitter.company.name}</td>
             <td className="hide-on-mobile">
-              {form.recipient.company && form.recipient.company.name}
+              {form.stateSummary.recipient?.name}
             </td>
             <td>
               <div>{form.wasteDetails.name}</div>

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -109,7 +109,7 @@ const Table = ({ forms, displayActions }) => {
               {form.readableId}
               <DownloadPdf formId={form.id} />
             </td>
-            <td>{form.emitter.company && form.emitter.company.name}</td>
+            <td>{form.stateSummary.emitter?.name}</td>
             <td className="hide-on-mobile">
               {form.stateSummary.recipient?.name}
             </td>

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -40,18 +40,18 @@ export default function TransportSignature({ form }: Props) {
   const [signedByTransporter, { error }] = useMutation(SIGNED_BY_TRANSPORTER, {
     onCompleted: () => setIsOpen(false),
     refetchQueries: [],
-    update: store => {
+    update: (store) => {
       updateApolloCache<{ forms: Form[] }>(store, {
         query: GET_TRANSPORT_SLIPS,
         variables: {
           siret: currentSiretService.getSiret(),
-          type: "TRANSPORTER"
+          type: "TRANSPORTER",
         },
-        getNewData: data => ({
-          forms: data.forms.filter(f => f.id !== form.id)
-        })
+        getNewData: (data) => ({
+          forms: data.forms.filter((f) => f.id !== form.id),
+        }),
       });
-    }
+    },
   });
 
   return (
@@ -67,7 +67,7 @@ export default function TransportSignature({ form }: Props) {
         className="modal__backdrop"
         id="modal"
         style={{
-          display: isOpen ? "flex" : "none"
+          display: isOpen ? "flex" : "none",
         }}
       >
         <div className="modal">
@@ -82,11 +82,11 @@ export default function TransportSignature({ form }: Props) {
               signedByProducer: false,
               packagings: form.wasteDetails.packagings,
               quantity: form.wasteDetails.quantity,
-              onuCode: form.wasteDetails.onuCode
+              onuCode: form.wasteDetails.onuCode,
             }}
             onSubmit={(values: any) =>
               signedByTransporter({
-                variables: { id: form.id, signingInfo: values }
+                variables: { id: form.id, signingInfo: values },
               })
             }
             onCancel={() => setIsOpen(false)}
@@ -135,9 +135,9 @@ export default function TransportSignature({ form }: Props) {
 
                   <h3>Destination du déchet</h3>
                   <address>
-                    {form.recipient.company.name} (
-                    {form.recipient.company.siret})
-                    <br /> {form.recipient.company.address}
+                    {form.stateSummary.recipient?.name} (
+                    {form.stateSummary.recipient?.siret})
+                    <br /> {form.stateSummary.recipient?.address}
                   </address>
 
                   <h3>Validation</h3>
@@ -205,16 +205,16 @@ export default function TransportSignature({ form }: Props) {
 
                     <h3>Transporteur</h3>
                     <address>
-                      {form.transporter.company.name} (
-                      {form.transporter.company.siret})
-                      <br /> {form.transporter.company.address}
+                      {form.stateSummary.transporter.name} (
+                      {form.stateSummary.transporter.siret})
+                      <br /> {form.stateSummary.transporter.address}
                     </address>
 
                     <h3>Destination du déchet</h3>
                     <address>
-                      {form.recipient.company.name} (
-                      {form.recipient.company.siret})
-                      <br /> {form.recipient.company.address}
+                      {form.stateSummary.recipient?.name} (
+                      {form.stateSummary.recipient?.siret})
+                      <br /> {form.stateSummary.recipient?.address}
                     </address>
 
                     <p>

--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -187,8 +187,9 @@ export default function TransportSignature({ form }: Props) {
 
                     <h3>Lieu de collecte</h3>
                     <address>
-                      {form.emitter.company.name} ({form.emitter.company.siret})
-                      <br /> {form.emitter.company.address}
+                      {form.stateSummary.emitter?.name} (
+                      {form.stateSummary.emitter?.siret})
+                      <br /> {form.stateSummary.emitter?.address}
                     </address>
 
                     <h3>Mes déchets</h3>

--- a/front/src/form/Recipient.tsx
+++ b/front/src/form/Recipient.tsx
@@ -22,10 +22,6 @@ export default function Recipient() {
 
   return (
     <>
-      <h4>
-        Installation de destination ou d’entreposage ou de reconditionnement
-      </h4>
-
       <div className="form__group">
         <label>
           <Field type="checkbox" name="recipient.isTempStorage" />
@@ -33,6 +29,13 @@ export default function Recipient() {
           reconditionnement
         </label>
       </div>
+
+      <h4 className="required">
+        Installation{" "}
+        {values.recipient.isTempStorage
+          ? "d'entreposage ou de reconditionnement"
+          : "de destination"}
+      </h4>
 
       <div className="text-quote recipient">
         <p>

--- a/front/src/form/model.ts
+++ b/front/src/form/model.ts
@@ -7,6 +7,7 @@ export type Form = {
     quantity: number;
     transporter: FormCompany;
     recipient: FormCompany;
+    emitter: FormCompany;
     lastActionOn: string;
   };
   ecoOrganisme: {

--- a/front/src/form/model.ts
+++ b/front/src/form/model.ts
@@ -3,6 +3,12 @@ export type Form = {
   customId: string;
   readableId: string;
   status: string;
+  stateSummary: {
+    quantity: number;
+    transporter: FormCompany;
+    recipient: FormCompany;
+    lastActionOn: string;
+  };
   ecoOrganisme: {
     id: string;
   };
@@ -29,7 +35,6 @@ export type Form = {
   wasteDetails: WasteDetails;
 
   receivedAt: string;
-  actualQuantity: number;
   quantityReceived: number;
   processingOperationDone: string;
   temporaryStorageDetail: {

--- a/front/src/form/model.ts
+++ b/front/src/form/model.ts
@@ -50,6 +50,7 @@ export type Form = {
     };
     destination: {
       company: FormCompany;
+      processingOperation: string;
     };
     transporter: Transporter;
     wasteDetails: WasteDetails;

--- a/front/src/form/temporaryStorage/TemporaryStorage.tsx
+++ b/front/src/form/temporaryStorage/TemporaryStorage.tsx
@@ -15,6 +15,17 @@ export default function TemporaryStorage(props) {
         initialState.temporaryStorageDetail
       );
     }
+
+    if (
+      values.recipient.processingOperation &&
+      values.temporaryStorageDetail &&
+      !values.temporaryStorageDetail.destination.processingOperation
+    ) {
+      setFieldValue(
+        "temporaryStorageDetail.destination.processingOperation",
+        values.recipient.processingOperation
+      );
+    }
   }, [values, setFieldValue]);
 
   if (!values.recipient?.isTempStorage || !values.temporaryStorageDetail) {
@@ -41,7 +52,7 @@ export default function TemporaryStorage(props) {
           name={`${props.name}.destination.processingOperation`}
         >
           <option value="">Choisissez...</option>
-          {Operations.map(o => (
+          {Operations.map((o) => (
             <option key={o.code} value={o.code}>
               {o.code} - {o.description.substr(0, 50)}
               {o.description.length > 50 ? "..." : ""}


### PR DESCRIPTION
Modifications sur le BSD Suite grace aux retours d'Emmanuel.

- [x] adapter les titres dans le formulaire si on coche "entreposage provisoire"
- [x] précompléter code DR de la destination finale avec celui de l'entreposage provisoire
- [x] transporteur: mauvais lieu de collecte / destination affiché quand reconditionnement
- [x] lors de la complétion des infos de reconditionnement: y a t il eu un reconditionnement ? si non cacher les champs de détail du déchet inutiles
- [x] transport / dashboard => second destinataire n'est pas affiché. C'est l'entreprise en charge du reconditionnement qui s'affiche à la place
- [x] traitement => je suis la destination finale mais je ne vois pas s'afficher le bordereau dans mon dahsboard (la derniere etape du bsd donc)

Techniquement il y a un "changement". J'ai introduit un objet `statusSummary` sur l'objet `Form` (je n'aime pas ce nom, je suis preneur de bonnes idées++). Le role de cet objet est d'avoir des infos calculées valable à l'instant T. Ex:
- quel est la prochaine entreprise qui doit recevoir le BSD ? (avec le BSD suite ca dépend de ou en est le bordereau)
- quelle est la dernière quantité connue du BSD ? (il y a celle du producteur, la pesée à l'arrivée, la pesée en reconditionnement, etc etc)
- quand a été modifié le BSD pourla dernière fois ? (création, modification, signature 1, signature 2... ca peut permettre de voir si c'est un BSD "vivant" ou mort)

C'est bien pratique en front, ca évite de se casser la tête dans pas mal de cas.