### PR TITLE
Suppression du warning Crisp

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -34,9 +34,11 @@
   </head>
   <body>
     <noscript>
-      Pour accéder à toutes les fonctionnalités de ce site, vous devez activer JavaScript.
-      Voici les <a href="https://www.enable-javascript.com/fr/">
-      instructions pour activer JavaScript dans votre navigateur Web</a>.
+      Pour accéder à toutes les fonctionnalités de ce site, vous devez activer
+      JavaScript. Voici les
+      <a href="https://www.enable-javascript.com/fr/">
+        instructions pour activer JavaScript dans votre navigateur Web</a
+      >.
     </noscript>
     <div id="root"></div>
     <!--
@@ -52,16 +54,16 @@
 
     <!-- CRISP -->
     <script type="text/javascript">
-        // CRISP
-        window.$crisp = [];
-        window.CRISP_WEBSITE_ID = "11231caa-e6f1-436b-addc-eec1e0ddf040";
-        (function() {
-          d = document;
-          s = d.createElement("script");
-          s.src = "https://client.crisp.chat/l.js";
-          s.async = 1;
-          d.getElementsByTagName("head")[0].appendChild(s);
-        })();
+      // CRISP
+      window.$crisp = ["safe", true];
+      window.CRISP_WEBSITE_ID = "11231caa-e6f1-436b-addc-eec1e0ddf040";
+      (function () {
+        d = document;
+        s = d.createElement("script");
+        s.src = "https://client.crisp.chat/l.js";
+        s.async = 1;
+        d.getElementsByTagName("head")[0].appendChild(s);
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Micro modif pour supprimer le warning console en prod
![image](https://user-images.githubusercontent.com/5145523/79832405-a211ab00-83a9-11ea-8059-27763a70eced.png)

J'ai juste rajouté le `safe true` comme suggéré.