### PR TITLE
Fix / schéma formulaire et annexe 2 + droits annexe 2

### DIFF
--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -128,9 +128,6 @@ input FormInput {
 
 "Payload de création d'une annexe 2"
 input AppendixFormInput {
-  "SIRET de l'établissement émetteur"
-  emitterSiret: String
-
   "N° de bordereau"
   readableId: ID
 }

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,4 +1,4 @@
-import { or } from "graphql-shield";
+import { or, and } from "graphql-shield";
 
 import {
   canAccessForm,
@@ -6,7 +6,8 @@ import {
   isFormEmitter,
   isFormTransporter,
   isFormTrader,
-  isFormTempStorer
+  isFormTempStorer,
+  isAllowedToUseAppendix2Forms
 } from "./rules";
 import {
   isAuthenticated,
@@ -26,7 +27,7 @@ export default {
     appendixForms: or(isCompanyMember, isCompanyAdmin)
   },
   Mutation: {
-    saveForm: isAuthenticated,
+    saveForm: and(isAuthenticated, isAllowedToUseAppendix2Forms),
     deleteForm: canAccessForm,
     duplicateForm: canAccessForm,
     markAsSealed: or(isFormRecipient, isFormEmitter, isFormTrader),

--- a/back/src/generated/types.ts
+++ b/back/src/generated/types.ts
@@ -20,8 +20,6 @@ export type Scalars = {
 
 /** Payload de création d'une annexe 2 */
 export type AppendixFormInput = {
-  /** SIRET de l'établissement émetteur */
-  emitterSiret?: Maybe<Scalars['String']>;
   /** N° de bordereau */
   readableId?: Maybe<Scalars['ID']>;
 };

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -3277,15 +3277,6 @@ Payload de création d'une annexe 2
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>emitterSiret</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-SIRET de l'établissement émetteur
-
-</td>
-</tr>
-<tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#id">ID</a></td>
 <td>

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -163,13 +163,6 @@ const mutableFieldsFragment = gql`
   ${recipientFragment}
 `;
 
-export const editableFormFragment = gql`
-  fragment EditableForm on Form {
-    ...MutableFieldsFragment
-  }
-  ${mutableFieldsFragment}
-`;
-
 export const fullFormFragment = gql`
   fragment FullForm on Form {
     ...MutableFieldsFragment

--- a/front/src/form/stepper/queries.ts
+++ b/front/src/form/stepper/queries.ts
@@ -1,13 +1,13 @@
 import gql from "graphql-tag";
-import { fullFormFragment, editableFormFragment } from "../../common/fragments";
+import { fullFormFragment } from "../../common/fragments";
 
 export const GET_FORM = gql`
   query Form($formId: ID) {
     form(id: $formId) {
-      ...EditableForm
+      ...FullForm
     }
   }
-  ${editableFormFragment}
+  ${fullFormFragment}
 `;
 
 export const SAVE_FORM = gql`


### PR DESCRIPTION
- `emitterSiret` n'est plus attendu en input pour une ennexe 2 ([carte trello](https://trello.com/c/4UlBV0ub/821-dans-la-mutation-saveform-appendix2forms-attend-un-emittersiret-qui-fait-%C3%A9chouer-la-requete))
- on vérifie qu'on a bien les droits sur les bordereaux qu'on ajoute en annexe 2
- meilleure gestion du state form en front: on gère le fait que les props non attendues par l'input ne soient pas envoyées meme si elles ont été chargées dans l'objet `Form` ([carte Trello](https://trello.com/c/iscLLBYE/822-erreur-lors-de-la-modification-dun-bsd-suite))
