### PR TITLE
Add typing to all resolvers

### DIFF
--- a/back/codegen.yml
+++ b/back/codegen.yml
@@ -1,9 +1,14 @@
 overwrite: true
-schema: "./src/**/*.graphql"
+schema: ./src/**/*.graphql
 generates:
-  src/generated/types.ts:
+  src/generated/graphql/types.ts:
     plugins:
-      - "typescript"
+      - typescript
+      - typescript-resolvers
+    config:
+      contextType: ../../types#GraphQLContext
+      enumsAsTypes: true
   documentation/api-reference.md:
     plugins:
       - graphql-markdown-plugin.js
+

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -2420,6 +2420,298 @@
         }
       }
     },
+    "@graphql-codegen/typescript-resolvers": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-resolvers/-/typescript-resolvers-1.13.3.tgz",
+      "integrity": "sha512-agojQF0q93ICehcAhC31rY7rBnWe18yLQloauXXe6ruXq/K9jVEsubK2Abxf1fqCcgpvK9JgNfD0OZNLuJgTIw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.13.3",
+        "@graphql-codegen/typescript": "1.13.3",
+        "@graphql-codegen/visitor-plugin-common": "1.13.3",
+        "@graphql-toolkit/common": "~0.10.4",
+        "auto-bind": "~4.0.0",
+        "tslib": "~1.11.1"
+      },
+      "dependencies": {
+        "@graphql-codegen/plugin-helpers": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.13.3.tgz",
+          "integrity": "sha512-ZBQFViP2KTpeIhFN69H4XlUYPnbTVFFdw0rZ8TMS50AvNoVd38B1OGlgXRTHuQBgs5digXdnkLH8mB6Gk2ElgA==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "~0.10.4",
+            "camel-case": "4.1.1",
+            "common-tags": "1.8.0",
+            "constant-case": "3.0.3",
+            "import-from": "3.0.0",
+            "lower-case": "2.0.1",
+            "param-case": "3.0.3",
+            "pascal-case": "3.1.1",
+            "tslib": "~1.11.1",
+            "upper-case": "2.0.1"
+          }
+        },
+        "@graphql-codegen/typescript": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-1.13.3.tgz",
+          "integrity": "sha512-8H95+wA/5RhcXKa/MtzC++jVtEfqMXQAH0LjJuMjbNalFAKfUIVoYLxnlPY669awxfBOP2XnQ0edjbhJLFP6tw==",
+          "dev": true,
+          "requires": {
+            "@graphql-codegen/plugin-helpers": "1.13.3",
+            "@graphql-codegen/visitor-plugin-common": "1.13.3",
+            "auto-bind": "~4.0.0",
+            "tslib": "~1.11.1"
+          }
+        },
+        "@graphql-codegen/visitor-plugin-common": {
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.13.3.tgz",
+          "integrity": "sha512-+NBJva/jW22t6FLWlnSWXWk13tPZMLf9BHuM/iXxwF830ANvpRfd3s6sE8AGaTGM1Y8ciy9LCd3sDEcwU4shoQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-codegen/plugin-helpers": "1.13.3",
+            "@graphql-toolkit/relay-operation-optimizer": "~0.10.4",
+            "array.prototype.flatmap": "1.2.3",
+            "auto-bind": "~4.0.0",
+            "dependency-graph": "0.9.0",
+            "graphql-tag": "2.10.3",
+            "parse-filepath": "1.0.2",
+            "pascal-case": "3.1.1",
+            "tslib": "~1.11.1"
+          }
+        },
+        "@graphql-toolkit/relay-operation-optimizer": {
+          "version": "0.10.6",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/relay-operation-optimizer/-/relay-operation-optimizer-0.10.6.tgz",
+          "integrity": "sha512-cbaVFJQc6xPRKBwz139RxwQgzrqEw0ggL+0Y7HkyjyiBScq+CzfqYjgwhaLYPGJiACwwjq6X6D6ESDtTS34HXQ==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "0.10.6",
+            "relay-compiler": "9.1.0"
+          },
+          "dependencies": {
+            "@graphql-toolkit/common": {
+              "version": "0.10.6",
+              "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.10.6.tgz",
+              "integrity": "sha512-rrH/KPheh/wCZzqUmNayBHd+aNWl/751C4iTL/327TzONdAVrV7ZQOyEkpGLW6YEFWPIlWxNkaBoEALIjCxTGg==",
+              "dev": true,
+              "requires": {
+                "aggregate-error": "3.0.1",
+                "camel-case": "4.1.1",
+                "graphql-tools": "5.0.0",
+                "lodash": "4.17.15"
+              }
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "apollo-link": {
+          "version": "1.2.14",
+          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+          "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+          "dev": true,
+          "requires": {
+            "apollo-utilities": "^1.3.0",
+            "ts-invariant": "^0.4.0",
+            "tslib": "^1.9.3",
+            "zen-observable-ts": "^0.8.21"
+          }
+        },
+        "camel-case": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+          "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
+          "dev": true,
+          "requires": {
+            "pascal-case": "^3.1.1",
+            "tslib": "^1.10.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "graphql-tag": {
+          "version": "2.10.3",
+          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
+          "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==",
+          "dev": true
+        },
+        "graphql-tools": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
+          "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
+          "dev": true,
+          "requires": {
+            "apollo-link": "^1.2.14",
+            "apollo-upload-client": "^13.0.0",
+            "deprecated-decorator": "^0.1.6",
+            "form-data": "^3.0.0",
+            "iterall": "^1.3.0",
+            "node-fetch": "^2.6.0",
+            "tslib": "^1.11.1",
+            "uuid": "^7.0.3"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "lower-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+          "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "relay-compiler": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-9.1.0.tgz",
+          "integrity": "sha512-jsJx0Ux5RoxM+JFm3M3xl7UfZAJ0kUTY/r6jqOpcYgVI3GLJthvNI4IoziFRlWbhizEzGFbpkdshZcu9IObJYA==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.0.0",
+            "@babel/generator": "^7.5.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/runtime": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "babel-preset-fbjs": "^3.3.0",
+            "chalk": "^2.4.1",
+            "fast-glob": "^2.2.2",
+            "fb-watchman": "^2.0.0",
+            "fbjs": "^1.0.0",
+            "immutable": "~3.7.6",
+            "nullthrows": "^1.1.1",
+            "relay-runtime": "9.1.0",
+            "signedsource": "^1.0.0",
+            "yargs": "^14.2.0"
+          }
+        },
+        "relay-runtime": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-9.1.0.tgz",
+          "integrity": "sha512-6FE5YlZpR/b3R/HzGly85V+c4MdtLJhFY/outQARgxXonomrwqEik0Cr34LnPK4DmGS36cMLUliqhCs/DZyPVw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "fbjs": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "tslib": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+          "dev": true
+        },
+        "upper-case": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
+          "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.10.0"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
+      }
+    },
     "@graphql-codegen/visitor-plugin-common": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.13.1.tgz",
@@ -7798,12 +8090,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7818,12 +8112,14 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -7945,7 +8241,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7957,6 +8254,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7971,6 +8269,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8091,7 +8390,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8224,6 +8524,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9193,6 +9494,16 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "dev": true,
+      "requires": {
+        "is-relative": "^1.0.0",
+        "is-windows": "^1.0.1"
+      }
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -9422,6 +9733,15 @@
         "has": "^1.0.1"
       }
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-retry-allowed": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
@@ -9446,6 +9766,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -11979,6 +12308,17 @@
         }
       }
     },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "dev": true,
+      "requires": {
+        "is-absolute": "^1.0.0",
+        "map-cache": "^0.2.0",
+        "path-root": "^0.1.1"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -12127,6 +12467,21 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "dev": true,
+      "requires": {
+        "path-root-regex": "^0.1.0"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-to-regexp": {
@@ -14730,6 +15085,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/back/package.json
+++ b/back/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^1.13.1",
     "@graphql-codegen/typescript": "1.13.1",
+    "@graphql-codegen/typescript-resolvers": "^1.13.3",
     "@types/bcrypt": "^3.0.0",
     "@types/body-parser": "^1.17.1",
     "@types/connect-redis": "0.0.13",

--- a/back/prisma/database/form.prisma
+++ b/back/prisma/database/form.prisma
@@ -21,7 +21,7 @@ type Form {
   # Workflow fields
   signedByTransporter: Boolean
 
-  status: String @default(value: "DRAFT")
+  status: Status @default(value: DRAFT)
   sentAt: DateTime
   sentBy: String
 

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -6,7 +6,8 @@ import {
   EmitterType,
   QuantityType,
   prisma,
-  UserRole
+  UserRole,
+  Status
 } from "../generated/prisma-client";
 
 /**
@@ -154,7 +155,7 @@ const formdata = {
   traderCompanyMail: "",
   emitterCompanyAddress: "20 Avenue de la 1ère Dfl 13000 Marseille",
   sentBy: "signe",
-  status: "SENT",
+  status: "SENT" as Status,
   wasteRefusalReason: "",
   recipientCompanySiret: "5678",
   transporterCompanyMail: "transporter@td.io",

--- a/back/src/companies/mutations/__tests__/create-company.test.ts
+++ b/back/src/companies/mutations/__tests__/create-company.test.ts
@@ -1,10 +1,9 @@
 import createCompany from "../create-company";
 import { ErrorCode } from "../../../common/errors";
 import { User, Company } from "../../../generated/prisma-client";
+import { GraphQLContext } from "../../../types";
 
-const context = {
-  user: { id: "USER_ID" } as User
-};
+const user = { id: "USER_ID" } as User;
 
 const mockExists = jest.fn();
 const mockCreateCompanyAssociation = jest.fn(() => ({
@@ -32,11 +31,11 @@ describe("Create company resolver", () => {
   it("should throw when company already exists", async () => {
     expect.assertions(1);
 
-    const companyInput = { siret: "a siret" } as Company;
+    const companyInput = { siret: "a siret" };
     mockExists.mockResolvedValueOnce(true);
 
     try {
-      await createCompany(null, { companyInput }, context as any);
+      await createCompany(user, { companyInput });
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.BAD_USER_INPUT);
     }
@@ -46,7 +45,7 @@ describe("Create company resolver", () => {
     const companyInput = { siret: "a siret" };
     mockExists.mockResolvedValueOnce(false);
 
-    await createCompany(null, { companyInput }, context as any);
+    await createCompany(user, { companyInput });
 
     expect(mockCreateCompanyAssociation).toHaveBeenCalledTimes(1);
   });

--- a/back/src/companies/mutations/__tests__/updateCompany.test.ts
+++ b/back/src/companies/mutations/__tests__/updateCompany.test.ts
@@ -1,4 +1,5 @@
-import updateCompany, { Payload } from "../updateCompany";
+import updateCompany from "../updateCompany";
+import { MutationUpdateCompanyArgs } from "../../../generated/graphql/types";
 
 const updateCompanyMock = jest.fn();
 jest.mock("../../../generated/prisma-client", () => ({
@@ -12,7 +13,7 @@ describe("updateCompany", () => {
     updateCompanyMock.mockReset();
   });
   it("should call prisma.updateCompany with proper data", async () => {
-    let payload: Payload = {
+    let payload: MutationUpdateCompanyArgs = {
       siret: "85001946400013",
       gerepId: "gerepId"
     };

--- a/back/src/companies/mutations/create-upload-link.ts
+++ b/back/src/companies/mutations/create-upload-link.ts
@@ -1,13 +1,12 @@
 import { getPutSignedUrl } from "../../common/s3";
-import { GraphQLContext } from "../../types";
+import { MutationCreateUploadLinkArgs } from "../../generated/graphql/types";
 
 export default async function createUploadLink(
-  _,
-  { fileName, fileType },
-  context: GraphQLContext
+  userId: string,
+  { fileName, fileType }: MutationCreateUploadLinkArgs
 ) {
   const timestamp = new Date().getTime();
-  const computedFileName = [context.user.id, timestamp, fileName].join("-");
+  const computedFileName = [userId, timestamp, fileName].join("-");
 
   const url = await getPutSignedUrl(computedFileName, fileType);
 

--- a/back/src/companies/mutations/renewSecurityCode.ts
+++ b/back/src/companies/mutations/renewSecurityCode.ts
@@ -4,6 +4,7 @@ import { companyMails } from "../mails";
 import { getCompanyActiveUsers } from "../queries/companyUsers";
 import { sendMail } from "../../common/mails.helper";
 import { UserInputError } from "apollo-server-express";
+import { CompanyPrivate } from "../../generated/graphql/types";
 
 /**
  * This function is used to renew the security code
@@ -11,7 +12,9 @@ import { UserInputError } from "apollo-server-express";
  * identical to the previous one, we generate a new one
  * @param siret
  */
-export default async function renewSecurityCode(siret: string) {
+export default async function renewSecurityCode(
+  siret: string
+): Promise<CompanyPrivate> {
   if (siret.length !== 14) {
     throw new UserInputError("Le siret doit faire 14 caractères", {
       invalidArgs: ["siret"]

--- a/back/src/companies/mutations/updateCompany.ts
+++ b/back/src/companies/mutations/updateCompany.ts
@@ -1,16 +1,10 @@
-import { prisma, CompanyType } from "../../generated/prisma-client";
+import { prisma } from "../../generated/prisma-client";
+import {
+  MutationUpdateCompanyArgs,
+  CompanyPrivate
+} from "../../generated/graphql/types";
 
-export type Payload = {
-  siret: string;
-  gerepId?: string;
-  contactEmail?: string;
-  contactPhone?: string;
-  website?: string;
-  companyTypes?: CompanyType[];
-  givenName?: string;
-};
-
-export default function updateCompany({
+export default async function updateCompany({
   siret,
   companyTypes,
   gerepId,
@@ -18,7 +12,7 @@ export default function updateCompany({
   contactPhone,
   website,
   givenName
-}: Payload) {
+}: MutationUpdateCompanyArgs): Promise<CompanyPrivate> {
   const data = {
     ...(companyTypes !== undefined
       ? { companyTypes: { set: companyTypes } }

--- a/back/src/companies/queries/companyInfos.ts
+++ b/back/src/companies/queries/companyInfos.ts
@@ -2,6 +2,7 @@ import { prisma, Company } from "../../generated/prisma-client";
 import { getInstallation } from "./installation";
 import { searchCompany } from "../sirene";
 import { UserInputError } from "apollo-server-express";
+import { CompanyPublic } from "../../generated/graphql/types";
 /**
  * This function is used to return public company
  * information for a specific siret. It merge info
@@ -10,7 +11,7 @@ import { UserInputError } from "apollo-server-express";
  *
  * @param siret
  */
-export async function getCompanyInfos(siret: string) {
+export async function getCompanyInfos(siret: string): Promise<CompanyPublic> {
   // retrieve cached info from SIRENE database
   const sireneCompanyInfo = await searchCompany(siret);
 

--- a/back/src/companies/resolvers.ts
+++ b/back/src/companies/resolvers.ts
@@ -1,5 +1,4 @@
 import { prisma } from "../generated/prisma-client";
-import { GraphQLContext } from "../types";
 import { searchCompany, searchCompanies } from "./sirene";
 import { renewSecurityCode, updateCompany } from "./mutations";
 import createCompany from "./mutations/create-company";
@@ -13,104 +12,115 @@ import {
   getUserRole,
   getInstallation
 } from "./queries";
+import {
+  QueryResolvers,
+  MutationResolvers,
+  CompanyPrivateResolvers,
+  CompanyMemberResolvers,
+  InstallationResolvers
+} from "../generated/graphql/types";
 
-type FavoriteType = "EMITTER" | "TRANSPORTER" | "RECIPIENT" | "TRADER";
+const queryResolvers: QueryResolvers = {
+  companyInfos: async (_, { siret }) => getCompanyInfos(siret),
+  searchCompanies: async (_, { clue, department }) => {
+    const companies = await searchCompanies(clue, department);
+    return companies.map(async company => {
+      return {
+        ...company,
+        installation: await getInstallation(company.siret)
+      };
+    });
+  },
+  favorites: async (_parent, { type }, context) => {
+    const lowerType = type.toLowerCase();
+    const userId = context.user.id;
+    const companies = await getUserCompanies(userId);
+
+    if (!companies.length) {
+      throw new Error(
+        `Vous n'appartenez à aucune entreprise, vous n'avez pas de favori.`
+      );
+    }
+
+    const forms = await prisma.forms({
+      where: {
+        OR: [
+          { owner: { id: userId } },
+          { recipientCompanySiret: companies[0].siret },
+          { emitterCompanySiret: companies[0].siret }
+        ],
+        isDeleted: false
+      },
+      orderBy: "createdAt_DESC",
+      first: 50
+    });
+
+    const favorites = forms
+      // Filter out forms with no data
+      .filter(f => f[`${lowerType}CompanySiret`])
+      .map(f => ({
+        name: f[`${lowerType}CompanyName`],
+        siret: f[`${lowerType}CompanySiret`],
+        address: f[`${lowerType}CompanyAddress`],
+        contact: f[`${lowerType}CompanyContact`],
+        phone: f[`${lowerType}CompanyPhone`],
+        mail: f[`${lowerType}CompanyMail`]
+      }))
+      // Remove duplicates (by company names)
+      .reduce((prev, cur) => {
+        if (prev.findIndex(el => el.name === cur.name) === -1) {
+          prev.push(cur);
+        }
+        return prev;
+      }, [])
+      .slice(0, 10);
+
+    // If there is no data yet, propose his own companies as favorites
+    // We won't have every props populated, but it's a start
+    if (!favorites.length) {
+      return Promise.all(companies.map(c => searchCompany(c.siret)));
+    }
+
+    return favorites;
+  },
+  ecoOrganismes: () => prisma.ecoOrganismes()
+};
+
+const mutationResolvers: MutationResolvers = {
+  renewSecurityCode: (_, { siret }) => renewSecurityCode(siret),
+  updateCompany: (_, args) => updateCompany(args),
+  createCompany: (_, args, context) => createCompany(context.user, args),
+  createUploadLink: (_, args, context) =>
+    createUploadLink(context.user.id, args)
+};
+
+const companyPrivateResolvers: CompanyPrivateResolvers = {
+  users: parent => {
+    return getCompanyUsers(parent.siret);
+  },
+  userRole: (parent, _, context) => {
+    const userId = context.user.id;
+    return getUserRole(userId, parent.siret);
+  }
+};
+
+const companyMemberResolvers: CompanyMemberResolvers = {
+  isMe: (parent, _, context) => {
+    return parent.id === context.user.id;
+  }
+};
+
+const installationResolvers: InstallationResolvers = {
+  urlFiche: parent =>
+    `https://www.georisques.gouv.fr/dossiers/installations/donnees/details/${parent.codeS3ic}#/`,
+  rubriques: async parent => getRubriques(parent.codeS3ic),
+  declarations: async parent => getDeclarations(parent.codeS3ic)
+};
 
 export default {
-  CompanyPrivate: {
-    users: parent => {
-      return getCompanyUsers(parent.siret);
-    },
-    userRole: (parent, _, context: GraphQLContext) => {
-      const userId = context.user.id;
-      return getUserRole(userId, parent.siret);
-    }
-  },
-  CompanyMember: {
-    isMe: (parent, _, context: GraphQLContext) => {
-      return parent.id === context.user.id;
-    }
-  },
-  Installation: {
-    urlFiche: parent =>
-      `https://www.georisques.gouv.fr/dossiers/installations/donnees/details/${parent.codeS3ic}#/`,
-    rubriques: async parent => getRubriques(parent.codeS3ic),
-    declarations: async parent => getDeclarations(parent.codeS3ic)
-  },
-  Query: {
-    companyInfos: async (_, { siret }) => getCompanyInfos(siret),
-    searchCompanies: async (_, { clue, department }) => {
-      const companies = await searchCompanies(clue, department);
-      return companies.map(async company => {
-        return {
-          ...company,
-          installation: await getInstallation(company.siret)
-        };
-      });
-    },
-    favorites: async (
-      parent,
-      { type }: { type: FavoriteType },
-      context: GraphQLContext
-    ) => {
-      const lowerType = type.toLowerCase();
-      const userId = context.user.id;
-      const companies = await getUserCompanies(userId);
-
-      if (!companies.length) {
-        throw new Error(
-          `Vous n'appartenez à aucune entreprise, vous n'avez pas de favori.`
-        );
-      }
-
-      const forms = await prisma.forms({
-        where: {
-          OR: [
-            { owner: { id: userId } },
-            { recipientCompanySiret: companies[0].siret },
-            { emitterCompanySiret: companies[0].siret }
-          ],
-          isDeleted: false
-        },
-        orderBy: "createdAt_DESC",
-        first: 50
-      });
-
-      const favorites = forms
-        // Filter out forms with no data
-        .filter(f => f[`${lowerType}CompanySiret`])
-        .map(f => ({
-          name: f[`${lowerType}CompanyName`],
-          siret: f[`${lowerType}CompanySiret`],
-          address: f[`${lowerType}CompanyAddress`],
-          contact: f[`${lowerType}CompanyContact`],
-          phone: f[`${lowerType}CompanyPhone`],
-          mail: f[`${lowerType}CompanyMail`]
-        }))
-        // Remove duplicates (by company names)
-        .reduce((prev, cur) => {
-          if (prev.findIndex(el => el.name === cur.name) === -1) {
-            prev.push(cur);
-          }
-          return prev;
-        }, [])
-        .slice(0, 10);
-
-      // If there is no data yet, propose his own companies as favorites
-      // We won't have every props populated, but it's a start
-      if (!favorites.length) {
-        return Promise.all(companies.map(c => searchCompany(c.siret)));
-      }
-
-      return favorites;
-    },
-    ecoOrganismes: (_, {}, context: GraphQLContext) =>
-      context.prisma.ecoOrganismes()
-  },
-  Mutation: {
-    renewSecurityCode: (_, { siret }) => renewSecurityCode(siret),
-    updateCompany: (_, payload) => updateCompany(payload),
-    createCompany,
-    createUploadLink
-  }
+  CompanyPrivate: companyPrivateResolvers,
+  CompanyMember: companyMemberResolvers,
+  Installation: installationResolvers,
+  Query: queryResolvers,
+  Mutation: mutationResolvers
 };

--- a/back/src/forms/mutations/__mocks__/data.ts
+++ b/back/src/forms/mutations/__mocks__/data.ts
@@ -1,3 +1,5 @@
+import { GraphQLContext } from "../../../types";
+
 export const getNewValidForm = () =>
   Object.assign(
     {},
@@ -154,4 +156,21 @@ const EMPTY_FORM = {
 // Instead, only pass deep clone
 export function getEmptyForm(): typeof EMPTY_FORM & { id?: string } {
   return JSON.parse(JSON.stringify(EMPTY_FORM));
+}
+/**
+ * return default context object
+ */
+export function getContext(): GraphQLContext {
+  return {
+    user: {
+      id: "userId",
+      name: "username",
+      email: "user@trackdechets.fr",
+      password: "pass",
+      createdAt: "",
+      updatedAt: ""
+    },
+    req: null,
+    res: null
+  };
 }

--- a/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
+++ b/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
@@ -9,6 +9,7 @@ import {
   Consistence,
   EmitterType,
   QuantityType,
+  Status,
   prisma
 } from "../../../generated/prisma-client";
 
@@ -64,7 +65,7 @@ const appendixFormData = {
   traderCompanyMail: "",
   emitterCompanyAddress: "20 Avenue de la 1ère Dfl 13000 Marseille",
   sentBy: "signe",
-  status: "GROUPED",
+  status: "GROUPED" as Status,
   wasteRefusalReason: "",
   recipientCompanySiret: "5678",
   transporterCompanyMail: "transporter@td.io",
@@ -139,7 +140,7 @@ const groupingFormData = {
   traderCompanyMail: "",
   emitterCompanyAddress: "20 Avenue de la 1ère Dfl 13000 Marseille",
   sentBy: "sender",
-  status: "SENT",
+  status: "SENT" as Status,
   wasteRefusalReason: "",
   recipientCompanySiret: "9999",
   transporterCompanyMail: "transporter@td.io",

--- a/back/src/forms/mutations/__tests__/mark-as-resent.test.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-resent.test.ts
@@ -1,36 +1,42 @@
-import { getNewValidForm } from "../__mocks__/data";
+import { getNewValidForm, getContext } from "../__mocks__/data";
 import { markAsResent } from "../mark-as";
 import * as companiesHelpers from "../../../companies/queries/userCompanies";
 import { ErrorCode } from "../../../common/errors";
 import { FormState } from "../../workflow/model";
 import { flattenObjectForDb } from "../../form-converter";
 
-describe("Forms -> markAsResent mutation", () => {
-  const formMock = jest.fn();
-  const temporaryStorageDetailMock = jest.fn(() => Promise.resolve(null));
-  const appendix2FormsMock = jest.fn(() => Promise.resolve([]));
-  function mockFormWith(value) {
-    const result: any = Promise.resolve(value);
-    result.temporaryStorageDetail = temporaryStorageDetailMock;
-    result.appendix2Forms = appendix2FormsMock;
-    formMock.mockReturnValue(result);
+const formMock = jest.fn();
+const temporaryStorageDetailMock = jest.fn(() => Promise.resolve(null));
+const appendix2FormsMock = jest.fn(() => Promise.resolve([]));
+function mockFormWith(value) {
+  const result: any = Promise.resolve(value);
+  result.temporaryStorageDetail = temporaryStorageDetailMock;
+  result.appendix2Forms = appendix2FormsMock;
+  formMock.mockReturnValue(result);
+}
+
+const prisma = {
+  form: formMock,
+  updateForm: jest.fn((...args) => Promise.resolve({})),
+  createForm: jest.fn((...args) => Promise.resolve({})),
+  createStatusLog: jest.fn((...args) => Promise.resolve({})),
+  updateManyForms: jest.fn((...args) => Promise.resolve({}))
+};
+
+jest.mock("../../../generated/prisma-client", () => ({
+  prisma: {
+    form: () => prisma.form(),
+    updateForm: (...args) => prisma.updateForm(...args),
+    createForm: (...args) => prisma.createForm(...args),
+    createStatusLog: (...args) => prisma.createStatusLog(...args),
+    updateManyForms: (...args) => prisma.updateManyForms(...args)
   }
+}));
 
-  const prisma = {
-    form: formMock,
-    updateForm: jest.fn(() => Promise.resolve({})),
-    createForm: jest.fn(() => Promise.resolve({})),
-    createStatusLog: jest.fn(() => Promise.resolve({})),
-    updateManyForms: jest.fn(() => Promise.resolve({}))
-  };
-
+describe("Forms -> markAsResent mutation", () => {
   const getUserCompaniesMock = jest.spyOn(companiesHelpers, "getUserCompanies");
 
-  const defaultContext = {
-    prisma,
-    user: { id: "userId" },
-    request: null
-  } as any;
+  const defaultContext = getContext();
 
   beforeEach(() => {
     getUserCompaniesMock.mockReset();
@@ -44,7 +50,7 @@ describe("Forms -> markAsResent mutation", () => {
       getUserCompaniesMock.mockResolvedValue([{ siret: "a siret" } as any]);
       mockFormWith({ id: 1, status: FormState.Draft });
 
-      await markAsResent(null, { id: 1, resentInfos: {} }, defaultContext);
+      await markAsResent({ id: "1", resentInfos: {} }, defaultContext);
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -61,7 +67,7 @@ describe("Forms -> markAsResent mutation", () => {
 
     mockFormWith(flattenObjectForDb(form));
 
-    await markAsResent(null, { id: 1, resentInfos: {} }, defaultContext);
+    await markAsResent({ id: "1", resentInfos: {} }, defaultContext);
 
     expect(prisma.updateForm).toHaveBeenCalledTimes(1);
     expect(prisma.updateForm).toHaveBeenCalledWith(

--- a/back/src/forms/mutations/__tests__/save-form.test.ts
+++ b/back/src/forms/mutations/__tests__/save-form.test.ts
@@ -1,28 +1,36 @@
 import { saveForm } from "../save-form";
 import { ErrorCode } from "../../../common/errors";
-
 import * as queries from "../../../companies/queries";
 
-describe("Forms -> saveForm mutation", () => {
-  const temporaryStorageDetailMock = jest.fn(() => Promise.resolve(null));
-  const ecoOrganismeMock = jest.fn(() => Promise.resolve(null));
-  const formMock = jest.fn(() => Promise.resolve({}));
-  function mockFormWith(value) {
-    const result: any = Promise.resolve(value);
-    result.temporaryStorageDetail = temporaryStorageDetailMock;
-    result.ecoOrganisme = ecoOrganismeMock;
-    formMock.mockReturnValue(result);
+const temporaryStorageDetailMock = jest.fn(() => Promise.resolve(null));
+const ecoOrganismeMock = jest.fn(() => Promise.resolve(null));
+const formMock = jest.fn(() => Promise.resolve({}));
+function mockFormWith(value) {
+  const result: any = Promise.resolve(value);
+  result.temporaryStorageDetail = temporaryStorageDetailMock;
+  result.ecoOrganisme = ecoOrganismeMock;
+  formMock.mockReturnValue(result);
+}
+
+const prisma = {
+  form: formMock,
+  forms: jest.fn((...args) => []),
+  updateForm: jest.fn((...args) => ({})),
+  createForm: jest.fn((...args) => ({}))
+};
+
+jest.mock("../../../generated/prisma-client", () => ({
+  prisma: {
+    form: () => prisma.form(),
+    forms: (...args) => prisma.forms(...args),
+    updateForm: (...args) => prisma.updateForm(...args),
+    createForm: (...args) => prisma.createForm(...args)
   }
+}));
 
-  const prisma = {
-    form: formMock,
-    forms: jest.fn(() => []),
-    updateForm: jest.fn(() => ({})),
-    createForm: jest.fn(() => ({}))
-  };
-
-  const getUserCompaniesMcock = jest.spyOn(queries, "getUserCompanies");
-  getUserCompaniesMcock.mockResolvedValue([
+describe("Forms -> saveForm mutation", () => {
+  const getUserCompaniesMock = jest.spyOn(queries, "getUserCompanies");
+  getUserCompaniesMock.mockResolvedValue([
     { id: "", securityCode: 123, companyTypes: [], siret: "user siret" }
   ]);
 
@@ -42,11 +50,7 @@ describe("Forms -> saveForm mutation", () => {
     };
 
     try {
-      await saveForm(null, { formInput }, {
-        prisma,
-        user: { id: "userId" },
-        request: null
-      } as any);
+      await saveForm("userId", { formInput } as any);
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -65,11 +69,7 @@ describe("Forms -> saveForm mutation", () => {
     };
 
     try {
-      await saveForm(null, { formInput }, {
-        prisma,
-        user: { id: "userId" },
-        request: null
-      } as any);
+      await saveForm("userId", { formInput } as any);
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -83,11 +83,7 @@ describe("Forms -> saveForm mutation", () => {
 
     mockFormWith({ emitterCompanySiret: "user siret" });
 
-    const result = await saveForm(null, { formInput }, {
-      prisma,
-      user: { id: "userId" },
-      request: null
-    } as any);
+    const result = await saveForm("userId", { formInput } as any);
 
     expect(result).not.toBeNull();
   });
@@ -101,11 +97,7 @@ describe("Forms -> saveForm mutation", () => {
     ecoOrganismeMock.mockResolvedValueOnce({ siret: "user siret" });
     mockFormWith({});
 
-    const result = await saveForm(null, { formInput }, {
-      prisma,
-      user: { id: "userId" },
-      request: null
-    } as any);
+    const result = await saveForm("userId", { formInput } as any);
 
     expect(result).not.toBeNull();
   });
@@ -122,11 +114,7 @@ describe("Forms -> saveForm mutation", () => {
     });
 
     try {
-      await saveForm(null, { formInput }, {
-        prisma,
-        user: { id: "userId" },
-        request: null
-      } as any);
+      await saveForm("userId", { formInput } as any);
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -142,11 +130,7 @@ describe("Forms -> saveForm mutation", () => {
     };
 
     try {
-      await saveForm(null, { formInput }, {
-        prisma,
-        user: { id: "userId" },
-        request: null
-      } as any);
+      await saveForm("userId", { formInput } as any);
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }

--- a/back/src/forms/mutations/duplicate-form.ts
+++ b/back/src/forms/mutations/duplicate-form.ts
@@ -4,6 +4,7 @@ import {
   unflattenObjectFromDb
 } from "../form-converter";
 import { getReadableId } from "../readable-id";
+import { MutationDuplicateFormArgs, Form } from "../../generated/graphql/types";
 
 /**
  * Duplicate the content of a form into a new DRAFT form
@@ -12,7 +13,10 @@ import { getReadableId } from "../readable-id";
  * @param formId
  * @param userId
  */
-export async function duplicateForm(formId: string, userId: string) {
+export async function duplicateForm(
+  userId: string,
+  { id: formId }: MutationDuplicateFormArgs
+): Promise<Form> {
   const existingForm = await prisma.form({
     id: formId
   });

--- a/back/src/forms/mutations/updateTransporterFields.ts
+++ b/back/src/forms/mutations/updateTransporterFields.ts
@@ -1,20 +1,20 @@
-import { GraphQLContext } from "../../types";
 import { unflattenObjectFromDb } from "../form-converter";
-
 import { ForbiddenError } from "apollo-server-express";
+import { MutationUpdateTransporterFieldsArgs } from "../../generated/graphql/types";
+import { prisma } from "../../generated/prisma-client";
 
-export async function updateTransporterFields(
-  _,
-  { id, transporterNumberPlate, transporterCustomInfo },
-  context: GraphQLContext
-) {
-  const form = await context.prisma.form({ id });
+export async function updateTransporterFields({
+  id,
+  transporterNumberPlate,
+  transporterCustomInfo
+}: MutationUpdateTransporterFieldsArgs) {
+  const form = await prisma.form({ id });
   if (form.status !== "SEALED") {
     throw new ForbiddenError(
       "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé"
     );
   }
-  const updatedForm = await context.prisma.updateForm({
+  const updatedForm = await prisma.updateForm({
     where: { id },
     data: { transporterNumberPlate, transporterCustomInfo }
   });

--- a/back/src/forms/pdf.ts
+++ b/back/src/forms/pdf.ts
@@ -28,7 +28,9 @@ const buildPdf = async (form, responseType: ResponseType) => {
 
   const appendix2Forms = await prisma.form({ id: form.id }).appendix2Forms();
   const ecoOrganisme = await prisma.form({ id: form.id }).ecoOrganisme();
-  const temporaryStorageDetail = await prisma.form({ id: form.id }).temporaryStorageDetail();
+  const temporaryStorageDetail = await prisma
+    .form({ id: form.id })
+    .temporaryStorageDetail();
   return axios.post(
     "http://td-pdf:3201/pdf",
     { ...form, appendix2Forms, ecoOrganisme, temporaryStorageDetail },

--- a/back/src/forms/queries/__tests__/forms.test.ts
+++ b/back/src/forms/queries/__tests__/forms.test.ts
@@ -1,32 +1,34 @@
 import forms from "../forms";
 import { ErrorCode } from "../../../common/errors";
+import { FormType } from "../../../generated/graphql/types";
 
 const prisma = {
-  forms: jest.fn(() => Promise.resolve([]))
+  forms: jest.fn((...args) => Promise.resolve([]))
 };
+
+jest.mock("../../../generated/prisma-client", () => ({
+  prisma: {
+    forms: (...args) => prisma.forms(...args)
+  }
+}));
 
 const getUserCompaniesMock = jest.fn();
 jest.mock("../../../companies/queries/userCompanies", () => ({
   getUserCompanies: () => getUserCompaniesMock()
 }));
 
-const defaultContext = {
-  prisma,
-  user: { id: "userId" },
-  request: null
-} as any;
-
 describe("Forms query", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
+  const ACTOR: FormType = "ACTOR";
   it("should fail if user doesnt belong to a company", async () => {
     expect.assertions(1);
     getUserCompaniesMock.mockResolvedValue([]);
 
     try {
-      await forms(null, { type: "", siret: null }, defaultContext);
+      await forms("userId", { type: ACTOR, siret: null });
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -35,9 +37,8 @@ describe("Forms query", () => {
   it("should fail if user ask for a siret he doesnt belong to", async () => {
     expect.assertions(1);
     getUserCompaniesMock.mockResolvedValue([{ siret: "a siret" }]);
-
     try {
-      await forms(null, { type: "", siret: "another siret" }, defaultContext);
+      await forms("userId", { type: ACTOR, siret: "another siret" });
     } catch (err) {
       expect(err.extensions.code).toBe(ErrorCode.FORBIDDEN);
     }
@@ -45,7 +46,7 @@ describe("Forms query", () => {
 
   it("should query forms when user belongs to company", async () => {
     getUserCompaniesMock.mockResolvedValue([{ siret: "a siret" }]);
-    await forms(null, { type: "", siret: "a siret" }, defaultContext);
+    await forms("userId", { type: ACTOR, siret: "a siret" });
 
     expect(prisma.forms).toHaveBeenCalled();
   });

--- a/back/src/forms/queries/form-pdf.ts
+++ b/back/src/forms/queries/form-pdf.ts
@@ -1,8 +1,9 @@
 import { getFileDownloadToken } from "../../common/file-download";
 import { downloadPdf } from "../pdf";
+import { QueryFormPdfArgs, FileDownload } from "../../generated/graphql/types";
 
 const TYPE = "form_pdf";
 
-export function formPdf(_, { id }) {
+export function formPdf({ id }: QueryFormPdfArgs): Promise<FileDownload> {
   return getFileDownloadToken({ type: TYPE, params: { id } }, downloadPdf);
 }

--- a/back/src/forms/queries/forms-register.ts
+++ b/back/src/forms/queries/forms-register.ts
@@ -1,9 +1,16 @@
 import { getFileDownloadToken } from "../../common/file-download";
 import { downloadCsvExport } from "../exports/handler";
+import {
+  QueryFormsRegisterArgs,
+  FileDownload
+} from "../../generated/graphql/types";
 
 const TYPE = "forms_register";
 
-export function formsRegister(_, { sirets, exportType }) {
+export function formsRegister({
+  sirets,
+  exportType
+}: QueryFormsRegisterArgs): Promise<FileDownload> {
   return getFileDownloadToken(
     { type: TYPE, params: { sirets, exportType } },
     downloadCsvExport

--- a/back/src/forms/resolvers.ts
+++ b/back/src/forms/resolvers.ts
@@ -2,9 +2,9 @@ import { getUserCompanies } from "../companies/queries";
 import {
   prisma,
   StatusLogConnection,
-  Company
+  Company,
+  Status
 } from "../generated/prisma-client";
-import { GraphQLContext } from "../types";
 import { unflattenObjectFromDb } from "./form-converter";
 import {
   markAsProcessed,
@@ -28,6 +28,12 @@ import {
   AuthenticationError
 } from "apollo-server-express";
 import { stateSummary } from "./queries/state-summary";
+import {
+  QueryResolvers,
+  MutationResolvers,
+  SubscriptionResolvers,
+  FormResolvers
+} from "../generated/graphql/types";
 
 // formsLifeCycle fragment
 const statusLogFragment = `
@@ -71,219 +77,225 @@ fragment Company on CompanyAssociation {
 
 const PAGINATE_BY = 100;
 
-export default {
-  Form: {
-    appendix2Forms: (parent, args, context: GraphQLContext) => {
-      return context.prisma.form({ id: parent.id }).appendix2Forms();
-    },
-    ecoOrganisme: (parent, _, context: GraphQLContext) => {
-      return context.prisma.form({ id: parent.id }).ecoOrganisme();
-    },
-    temporaryStorageDetail: async (parent, _, context: GraphQLContext) => {
-      const temporaryStorageDetail = await context.prisma
-        .form({ id: parent.id })
-        .temporaryStorageDetail();
+const queryResolvers: QueryResolvers = {
+  form: async (_, { id }) => {
+    if (!id) {
+      // On form creation, there is no id
+      return null;
+    }
 
-      return temporaryStorageDetail
-        ? unflattenObjectFromDb(temporaryStorageDetail)
-        : null;
-    },
-    // Somme contextual values, depending on the form status / type, mostly to ease the display
-    stateSummary
+    const dbForm = await prisma.form({ id });
+    return unflattenObjectFromDb(dbForm);
   },
-  Query: {
-    form: async (_, { id }, context: GraphQLContext) => {
-      if (!id) {
-        // On form creation, there is no id
-        return null;
-      }
+  forms: (_parent, args, context) => forms(context.user.id, args),
+  formsLifeCycle: async (
+    _parent,
+    { siret, loggedAfter, loggedBefore, cursorAfter, cursorBefore, formId },
+    context
+  ) => {
+    const userId = context.user.id;
 
-      const dbForm = await context.prisma.form({ id });
-      return unflattenObjectFromDb(dbForm);
-    },
-    forms,
-    formsLifeCycle: async (
-      _,
-      { siret, loggedAfter, loggedBefore, cursorAfter, cursorBefore, formId },
-      context: GraphQLContext
-    ) => {
-      const userId = context.user.id;
+    const userCompanies = await prisma
+      .companyAssociations({ where: { user: { id: userId } } })
+      .$fragment<{ company: Pick<Company, "id" | "siret"> }[]>(companyFragment)
+      .then(associations => associations.map(a => a.company));
 
-      const userCompanies = await prisma
-        .companyAssociations({ where: { user: { id: userId } } })
-        .$fragment<{ company: Company }[]>(companyFragment)
-        .then(associations => associations.map(a => a.company));
+    // User must be associated with a company
+    if (!userCompanies.length) {
+      throw new ForbiddenError(
+        "Vous n'êtes pas autorisé à consulter le cycle de vie des bordereaux."
+      );
+    }
+    // If user is associated with several companies, siret is mandatory
+    if (userCompanies.length > 1 && !siret) {
+      throw new UserInputError(
+        "Vous devez préciser pour quel siret vous souhaitez consulter",
+        {
+          invalidArgs: ["siret"]
+        }
+      );
+    }
+    // If requested siret does not belong to user, raise an error
+    if (!!siret && !userCompanies.map(c => c.siret).includes(siret)) {
+      throw new ForbiddenError(
+        "Vous n'avez pas le droit d'accéder au siret précisé"
+      );
+    }
+    // Select user company matching siret or get the first
+    const selectedCompany =
+      userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
 
-      // User must be associated with a company
-      if (!userCompanies.length) {
-        throw new ForbiddenError(
-          "Vous n'êtes pas autorisé à consulter le cycle de vie des bordereaux."
-        );
-      }
-      // If user is associated with several companies, siret is mandatory
-      if (userCompanies.length > 1 && !siret) {
-        throw new UserInputError(
-          "Vous devez préciser pour quel siret vous souhaitez consulter",
-          {
-            invalidArgs: ["siret"]
-          }
-        );
-      }
-      // If requested siret does not belong to user, raise an error
-      if (!!siret && !userCompanies.map(c => c.siret).includes(siret)) {
-        throw new ForbiddenError(
-          "Vous n'avez pas le droit d'accéder au siret précisé"
-        );
-      }
-      // Select user company matching siret or get the first
-      const selectedCompany =
-        userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
+    const SEALED: Status = "SEALED";
 
-      const formsFilter = {
-        OR: [
-          { owner: { id: userId } },
-          { recipientCompanySiret: selectedCompany.siret },
-          { emitterCompanySiret: selectedCompany.siret },
-          {
-            transporterCompanySiret: selectedCompany.siret,
-            status: "SEALED"
-          }
-        ]
-      };
-      const statusLogsCx = await context.prisma
-        .statusLogsConnection({
-          orderBy: "loggedAt_DESC",
-          first: PAGINATE_BY,
-          after: cursorAfter,
-          before: cursorBefore,
-          where: {
-            loggedAt_not: null,
-            loggedAt_gte: loggedAfter,
-            loggedAt_lte: loggedBefore,
-            form: { ...formsFilter, isDeleted: false, id: formId }
-          }
-        })
-        .$fragment<
-          StatusLogConnection & {
-            aggregate: { count: number };
-          }
-        >(statusLogFragment);
-
-      return {
-        statusLogs: statusLogsCx.edges.map(el => el.node),
-        ...statusLogsCx.pageInfo,
-        count: statusLogsCx.aggregate.count
-      };
-    },
-
-    stats: async (parent, args, context: GraphQLContext) => {
-      const userId = context.user.id;
-      const userCompanies = await getUserCompanies(userId);
-
-      return userCompanies.map(async userCompany => {
-        const queriedForms = await context.prisma.forms({
-          where: {
-            OR: [
-              { owner: { id: userId } },
-              { recipientCompanySiret: userCompany.siret },
-              { emitterCompanySiret: userCompany.siret }
-            ],
-            status: "PROCESSED",
-            isDeleted: false
-          }
-        });
-
-        const stats = queriedForms.reduce((prev, cur) => {
-          prev[cur.wasteDetailsCode] = prev[cur.wasteDetailsCode] || {
-            wasteCode: cur.wasteDetailsCode,
-            incoming: 0,
-            outgoing: 0
-          };
-          cur.recipientCompanySiret === userCompany.siret
-            ? (prev[cur.wasteDetailsCode].incoming += cur.quantityReceived)
-            : (prev[cur.wasteDetailsCode].outgoing += cur.quantityReceived);
-
-          prev[cur.wasteDetailsCode].incoming =
-            Math.round(prev[cur.wasteDetailsCode].incoming * 100) / 100;
-          prev[cur.wasteDetailsCode].outgoing =
-            Math.round(prev[cur.wasteDetailsCode].outgoing * 100) / 100;
-
-          return prev;
-        }, {});
-
-        return {
-          company: userCompany,
-          stats: Object.keys(stats).map(key => stats[key])
-        };
-      });
-    },
-    appendixForms: async (
-      parent,
-      { siret, wasteCode },
-      context: GraphQLContext
-    ) => {
-      const queriedForms = await context.prisma.forms({
+    const formsFilter = {
+      OR: [
+        { owner: { id: userId } },
+        { recipientCompanySiret: selectedCompany.siret },
+        { emitterCompanySiret: selectedCompany.siret },
+        {
+          transporterCompanySiret: selectedCompany.siret,
+          status: SEALED
+        }
+      ]
+    };
+    const statusLogsCx = await prisma
+      .statusLogsConnection({
+        orderBy: "loggedAt_DESC",
+        first: PAGINATE_BY,
+        after: cursorAfter,
+        before: cursorBefore,
         where: {
-          ...(wasteCode && { wasteDetailsCode: wasteCode }),
-          status: "AWAITING_GROUP",
-          recipientCompanySiret: siret,
+          loggedAt_not: null,
+          loggedAt_gte: loggedAfter,
+          loggedAt_lte: loggedBefore,
+          form: { ...formsFilter, isDeleted: false, id: formId }
+        }
+      })
+      .$fragment<
+        StatusLogConnection & {
+          aggregate: { count: number };
+        }
+      >(statusLogFragment);
+
+    return {
+      statusLogs: statusLogsCx.edges.map(el => el.node),
+      ...statusLogsCx.pageInfo,
+      count: statusLogsCx.aggregate.count
+    };
+  },
+  stats: async (_parent, _args, context) => {
+    const userId = context.user.id;
+    const userCompanies = await getUserCompanies(userId);
+
+    return userCompanies.map(async userCompany => {
+      const queriedForms = await prisma.forms({
+        where: {
+          OR: [
+            { owner: { id: userId } },
+            { recipientCompanySiret: userCompany.siret },
+            { emitterCompanySiret: userCompany.siret }
+          ],
+          status: "PROCESSED",
           isDeleted: false
         }
       });
 
-      return queriedForms.map(f => unflattenObjectFromDb(f));
-    },
-    formPdf,
-    formsRegister
+      const stats = queriedForms.reduce((prev, cur) => {
+        prev[cur.wasteDetailsCode] = prev[cur.wasteDetailsCode] || {
+          wasteCode: cur.wasteDetailsCode,
+          incoming: 0,
+          outgoing: 0
+        };
+        cur.recipientCompanySiret === userCompany.siret
+          ? (prev[cur.wasteDetailsCode].incoming += cur.quantityReceived)
+          : (prev[cur.wasteDetailsCode].outgoing += cur.quantityReceived);
+
+        prev[cur.wasteDetailsCode].incoming =
+          Math.round(prev[cur.wasteDetailsCode].incoming * 100) / 100;
+        prev[cur.wasteDetailsCode].outgoing =
+          Math.round(prev[cur.wasteDetailsCode].outgoing * 100) / 100;
+
+        return prev;
+      }, {});
+
+      return {
+        company: userCompany,
+        stats: Object.keys(stats).map(key => stats[key])
+      };
+    });
   },
-  Mutation: {
-    saveForm,
-    deleteForm: async (parent, { id }, context: GraphQLContext) => {
-      return context.prisma.updateForm({
-        where: { id },
-        data: { isDeleted: true }
+  appendixForms: async (_parent, { siret, wasteCode }) => {
+    const queriedForms = await prisma.forms({
+      where: {
+        ...(wasteCode && { wasteDetailsCode: wasteCode }),
+        status: "AWAITING_GROUP",
+        recipientCompanySiret: siret,
+        isDeleted: false
+      }
+    });
+
+    return queriedForms.map(f => unflattenObjectFromDb(f));
+  },
+  formPdf: (_parent, args) => formPdf(args),
+  formsRegister: (_parent, args) => formsRegister(args)
+};
+
+const mutationResolvers: MutationResolvers = {
+  saveForm: (_parent, args, context) => saveForm(context.user.id, args),
+  deleteForm: async (_parent, { id }) => {
+    const form = await prisma.updateForm({
+      where: { id },
+      data: { isDeleted: true }
+    });
+    return form;
+  },
+  duplicateForm: (_parent, args, { user }) => duplicateForm(user.id, args),
+  markAsSealed: (_parent, args, context) => markAsSealed(args, context),
+  markAsSent: (_parent, args, context) => markAsSent(args, context),
+  markAsReceived: (_parent, args, context) => markAsReceived(args, context),
+  markAsProcessed: (_parent, args, context) => markAsProcessed(args, context),
+  signedByTransporter: (_parent, args, context) =>
+    signedByTransporter(args, context),
+  updateTransporterFields: (_parent, args) => updateTransporterFields(args),
+  markAsTempStored: (_parent, args, context) => markAsTempStored(args, context),
+  markAsResealed: (_parent, args, context) => markAsResealed(args, context),
+  markAsResent: (_parent, args, context) => markAsResent(args, context)
+};
+
+const formResolvers: FormResolvers = {
+  appendix2Forms: parent => {
+    return prisma.form({ id: parent.id }).appendix2Forms();
+  },
+  ecoOrganisme: parent => {
+    return prisma.form({ id: parent.id }).ecoOrganisme();
+  },
+  temporaryStorageDetail: async parent => {
+    const temporaryStorageDetail = await prisma
+      .form({ id: parent.id })
+      .temporaryStorageDetail();
+
+    return temporaryStorageDetail
+      ? unflattenObjectFromDb(temporaryStorageDetail)
+      : null;
+  },
+  // Somme contextual values, depending on the form status / type, mostly to ease the display
+  stateSummary: parent => stateSummary(parent)
+};
+
+const subscriptionResolvers: SubscriptionResolvers = {
+  forms: {
+    subscribe: async (parent, { token }) => {
+      // Web socket has no headers so we pass the token as a param
+
+      const user = await prisma.accessToken({ token }).user();
+
+      if (!user) {
+        throw new AuthenticationError("Vous n'êtes pas connecté");
+      }
+
+      const userCompanies = await getUserCompanies(user.id);
+
+      return prisma.$subscribe.form({
+        OR: [
+          ...userCompanies.map(userCompany => ({
+            node: { emitterCompanySiret: userCompany.siret }
+          })),
+          ...userCompanies.map(userCompany => ({
+            node: { recipientCompanySiret: userCompany.siret }
+          })),
+          { node: { owner: { id: user.id } } }
+        ]
       });
     },
-    duplicateForm: (_parent, { id }, { user }: GraphQLContext) =>
-      duplicateForm(id, user.id),
-    markAsSealed,
-    markAsSent,
-    markAsReceived,
-    markAsProcessed,
-    signedByTransporter,
-    updateTransporterFields,
-    markAsTempStored,
-    markAsResealed,
-    markAsResent
-  },
-  Subscription: {
-    forms: {
-      subscribe: async (parent, { token }, context: GraphQLContext) => {
-        // Web socket has no headers so we pass the token as a param
-
-        const user = await prisma.accessToken({ token }).user();
-
-        if (!user) {
-          throw new AuthenticationError("Vous n'êtes pas connecté");
-        }
-
-        const userCompanies = await getUserCompanies(user.id);
-
-        return context.prisma.$subscribe.form({
-          OR: [
-            ...userCompanies.map(userCompany => ({
-              node: { emitterCompanySiret: userCompany.siret }
-            })),
-            ...userCompanies.map(userCompany => ({
-              node: { recipientCompanySiret: userCompany.siret }
-            })),
-            { node: { owner: { id: user.id } } }
-          ]
-        });
-      },
-      resolve: payload => {
-        return payload;
-      }
+    resolve: payload => {
+      return payload;
     }
   }
+};
+
+export default {
+  Form: formResolvers,
+  Query: queryResolvers,
+  Mutation: mutationResolvers,
+  Subscription: subscriptionResolvers
 };

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -136,8 +136,7 @@ export const formWorkflowMachine = Machine(
           src: (ctx, event) =>
             validateSecurityCode(
               ctx.form.emitterCompanySiret,
-              event.securityCode,
-              ctx.requestContext
+              event.securityCode
             ),
           onDone: {
             target: "pendingSentMarkFormAppendixAwaitingFormsAsGrouped"
@@ -150,8 +149,7 @@ export const formWorkflowMachine = Machine(
           src: (ctx, event) =>
             validateSecurityCode(
               ctx.form.recipientCompanySiret,
-              event.securityCode,
-              ctx.requestContext
+              event.securityCode
             ),
           onDone: {
             target: FormState.Resent
@@ -235,7 +233,7 @@ export const formWorkflowMachine = Machine(
   {
     services: {
       markFormAppendixAwaitingFormsAsGrouped: ctx =>
-        markFormAppendixAwaitingFormsAsGrouped(ctx.form.id, ctx.requestContext),
+        markFormAppendixAwaitingFormsAsGrouped(ctx.form.id),
       markFormAppendixGroupedsAsProcessed: ctx =>
         markFormAppendixGroupedsAsProcessed(ctx.form.id, ctx.requestContext)
     },

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1,4 +1,7 @@
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { GraphQLContext } from '../../types';
 export type Maybe<T> = T | null;
+export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -210,32 +213,30 @@ export type CompanyStat = {
 };
 
 /** Profil entreprise */
-export enum CompanyType {
+export type CompanyType = 
   /** Producteur de déchet */
-  Producer = 'PRODUCER',
+  'PRODUCER' |
   /** Installation de Transit, regroupement ou tri de déchets */
-  Collector = 'COLLECTOR',
+  'COLLECTOR' |
   /** Installation de traitement */
-  Wasteprocessor = 'WASTEPROCESSOR',
+  'WASTEPROCESSOR' |
   /** Transporteur */
-  Transporter = 'TRANSPORTER',
+  'TRANSPORTER' |
   /** Installation d'entreposage, dépollution, démontage, découpage de VHU */
-  WasteVehicles = 'WASTE_VEHICLES',
+  'WASTE_VEHICLES' |
   /** Installation de collecte de déchets apportés par le producteur initial */
-  WasteCenter = 'WASTE_CENTER',
+  'WASTE_CENTER' |
   /** Négociant */
-  Trader = 'TRADER'
-}
+  'TRADER';
 
 /** Consistance du déchet */
-export enum Consistence {
+export type Consistence = 
   /** Solide */
-  Solid = 'SOLID',
+  'SOLID' |
   /** Liquide */
-  Liquid = 'LIQUID',
+  'LIQUID' |
   /** Gazeux */
-  Gaseous = 'GASEOUS'
-}
+  'GASEOUS';
 
 
 /** Représente une ligne dans une déclaration GEREP */
@@ -324,27 +325,25 @@ export type EmitterInput = {
 };
 
 /** Types d'émetteur de déchet (choix multiple de la case 1) */
-export enum EmitterType {
+export type EmitterType = 
   /** Producetur de déchet */
-  Producer = 'PRODUCER',
+  'PRODUCER' |
   /** Autre détenteur */
-  Other = 'OTHER',
+  'OTHER' |
   /** Collecteur de petites quantités de déchets relevant de la même rubrique */
-  Appendix1 = 'APPENDIX1',
+  'APPENDIX1' |
   /** Personne ayant transformé ou réalisé un traitement dont la provenance des déchets reste identifiable */
-  Appendix2 = 'APPENDIX2'
-}
+  'APPENDIX2';
 
 /** Type d'établissement favoris */
-export enum FavoriteType {
-  Emitter = 'EMITTER',
-  Transporter = 'TRANSPORTER',
-  Recipient = 'RECIPIENT',
-  Trader = 'TRADER',
-  NextDestination = 'NEXT_DESTINATION',
-  TemporaryStorageDetail = 'TEMPORARY_STORAGE_DETAIL',
-  Destination = 'DESTINATION'
-}
+export type FavoriteType = 
+  'EMITTER' |
+  'TRANSPORTER' |
+  'RECIPIENT' |
+  'TRADER' |
+  'NEXT_DESTINATION' |
+  'TEMPORARY_STORAGE_DETAIL' |
+  'DESTINATION';
 
 /**
  * URL de téléchargement accompagné d'un token
@@ -495,46 +494,44 @@ export type FormsLifeCycleData = {
 };
 
 /** Type pour l'export du registre */
-export enum FormsRegisterExportType {
+export type FormsRegisterExportType = 
   /** Déchets entrants */
-  Incoming = 'INCOMING',
+  'INCOMING' |
   /** Déchets sortants */
-  Outgoing = 'OUTGOING'
-}
+  'OUTGOING';
 
 /** Différents statuts d'un BSD au cours de son cycle de vie */
-export enum FormStatus {
+export type FormStatus = 
   /**
    * BSD à l'état de brouillon
    * Des champs obligatoires peuvent manquer
    */
-  Draft = 'DRAFT',
+  'DRAFT' |
   /**
    * BSD finalisé
    * Les champs sont validés pour détecter des valeurs manquantes ou erronnées
    */
-  Sealed = 'SEALED',
+  'SEALED' |
   /** BSD envoyé vers l'établissement de destination */
-  Sent = 'SENT',
+  'SENT' |
   /** BSD reçu par l'établissement de destination */
-  Received = 'RECEIVED',
+  'RECEIVED' |
   /** BSD dont les déchets ont été traités */
-  Processed = 'PROCESSED',
+  'PROCESSED' |
   /** BSD en attente de regroupement */
-  AwaitingGroup = 'AWAITING_GROUP',
+  'AWAITING_GROUP' |
   /** Regroupement effectué */
-  Grouped = 'GROUPED',
+  'GROUPED' |
   /** Perte de traçabalité */
-  NoTraceability = 'NO_TRACEABILITY',
+  'NO_TRACEABILITY' |
   /** Déchet refusé */
-  Refused = 'REFUSED',
+  'REFUSED' |
   /** Déchet arrivé sur le site d'entreposage ou reconditionnement */
-  TempStored = 'TEMP_STORED',
+  'TEMP_STORED' |
   /** Déchet avec les cadres 14-19 complétées (si besoin), prêt à partir du site d'entreposage ou reconditionnement */
-  Resealed = 'RESEALED',
+  'RESEALED' |
   /** Déchet envoyé du site d'entreposage ou reconditionnement vers sa destination de traitement */
-  Resent = 'RESENT'
-}
+  'RESENT';
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
@@ -554,18 +551,16 @@ export type FormSubscription = {
 };
 
 /** Valeur possibles pour le filtre de la query `forms` */
-export enum FormType {
+export type FormType = 
   /** Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut) */
-  Actor = 'ACTOR',
+  'ACTOR' |
   /** Uniquement les BSD's dont je suis transporteur */
-  Transporter = 'TRANSPORTER'
-}
+  'TRANSPORTER';
 
 /** Type d'une déclaration GEREP */
-export enum GerepType {
-  Producteur = 'Producteur',
-  Traiteur = 'Traiteur'
-}
+export type GerepType = 
+  'Producteur' |
+  'Traiteur';
 
 /** Installation pour la protection de l'environnement (ICPE) */
 export type Installation = {
@@ -856,18 +851,17 @@ export type NextDestinationInput = {
 };
 
 /** Type de packaging du déchet */
-export enum Packagings {
+export type Packagings = 
   /** Fut */
-  Fut = 'FUT',
+  'FUT' |
   /** GRV */
-  Grv = 'GRV',
+  'GRV' |
   /** Citerne */
-  Citerne = 'CITERNE',
+  'CITERNE' |
   /** Benne */
-  Benne = 'BENNE',
+  'BENNE' |
   /** Autre */
-  Autre = 'AUTRE'
-}
+  'AUTRE';
 
 /** Payload permettant le rattachement d'un établissement à un utilisateur */
 export type PrivateCompanyInput = {
@@ -905,12 +899,11 @@ export type ProcessedFormInput = {
 };
 
 /** Type de quantité lors de l'émission */
-export enum QuantityType {
+export type QuantityType = 
   /** Quntité réelle */
-  Real = 'REAL',
+  'REAL' |
   /** Quantité estimée */
-  Estimated = 'ESTIMATED'
-}
+  'ESTIMATED';
 
 export type Query = {
    __typename?: 'Query';
@@ -1404,20 +1397,18 @@ export type User = {
  * * consulter/éditer les bordereaux
  * * consulter le reste des informations
  */
-export enum UserRole {
-  Member = 'MEMBER',
-  Admin = 'ADMIN'
-}
+export type UserRole = 
+  'MEMBER' |
+  'ADMIN';
 
 /** Statut d'acceptation d'un déchet */
-export enum WasteAcceptationStatusInput {
+export type WasteAcceptationStatusInput = 
   /** Accepté en totalité */
-  Accepted = 'ACCEPTED',
+  'ACCEPTED' |
   /** Refusé */
-  Refused = 'REFUSED',
+  'REFUSED' |
   /** Refus partiel */
-  PartiallyRefused = 'PARTIALLY_REFUSED'
-}
+  'PARTIALLY_REFUSED';
 
 /** Détails du déchet (case 3, 4, 5, 6) */
 export type WasteDetails = {
@@ -1465,14 +1456,13 @@ export type WasteDetailsInput = {
 };
 
 /** Type de déchets autorisé pour une rubrique */
-export enum WasteType {
+export type WasteType = 
   /** Déchet inerte */
-  Inerte = 'INERTE',
+  'INERTE' |
   /** Déchet non dangereux */
-  NotDangerous = 'NOT_DANGEROUS',
+  'NOT_DANGEROUS' |
   /** Déchet dangereux */
-  Dangerous = 'DANGEROUS'
-}
+  'DANGEROUS';
 
 /** Informations sur une adresse chantier */
 export type WorkSite = {
@@ -1492,3 +1482,682 @@ export type WorkSiteInput = {
   postalCode?: Maybe<Scalars['String']>;
   infos?: Maybe<Scalars['String']>;
 };
+
+
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type StitchingResolver<TResult, TParent, TContext, TArgs> = {
+  fragment: string;
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
+  | ResolverFn<TResult, TParent, TContext, TArgs>
+  | StitchingResolver<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterator<TResult> | Promise<AsyncIterator<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type isTypeOfResolverFn<T = {}> = (obj: T, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = {
+  Query: ResolverTypeWrapper<{}>,
+  String: ResolverTypeWrapper<Scalars['String']>,
+  Form: ResolverTypeWrapper<Form>,
+  ID: ResolverTypeWrapper<Scalars['ID']>,
+  Emitter: ResolverTypeWrapper<Emitter>,
+  EmitterType: EmitterType,
+  WorkSite: ResolverTypeWrapper<WorkSite>,
+  FormCompany: ResolverTypeWrapper<FormCompany>,
+  Recipient: ResolverTypeWrapper<Recipient>,
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>,
+  Transporter: ResolverTypeWrapper<Transporter>,
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']>,
+  WasteDetails: ResolverTypeWrapper<WasteDetails>,
+  Packagings: Packagings,
+  Int: ResolverTypeWrapper<Scalars['Int']>,
+  Float: ResolverTypeWrapper<Scalars['Float']>,
+  QuantityType: QuantityType,
+  Consistence: Consistence,
+  Trader: ResolverTypeWrapper<Trader>,
+  FormStatus: FormStatus,
+  NextDestination: ResolverTypeWrapper<NextDestination>,
+  EcoOrganisme: ResolverTypeWrapper<EcoOrganisme>,
+  TemporaryStorageDetail: ResolverTypeWrapper<TemporaryStorageDetail>,
+  TemporaryStorer: ResolverTypeWrapper<TemporaryStorer>,
+  Destination: ResolverTypeWrapper<Destination>,
+  StateSummary: ResolverTypeWrapper<StateSummary>,
+  CompanyPublic: ResolverTypeWrapper<CompanyPublic>,
+  Installation: ResolverTypeWrapper<Installation>,
+  Rubrique: ResolverTypeWrapper<Rubrique>,
+  WasteType: WasteType,
+  Declaration: ResolverTypeWrapper<Declaration>,
+  GerepType: GerepType,
+  FavoriteType: FavoriteType,
+  CompanyFavorite: ResolverTypeWrapper<CompanyFavorite>,
+  FileDownload: ResolverTypeWrapper<FileDownload>,
+  FormType: FormType,
+  formsLifeCycleData: ResolverTypeWrapper<FormsLifeCycleData>,
+  StatusLog: ResolverTypeWrapper<StatusLog>,
+  JSON: ResolverTypeWrapper<Scalars['JSON']>,
+  StatusLogForm: ResolverTypeWrapper<StatusLogForm>,
+  StatusLogUser: ResolverTypeWrapper<StatusLogUser>,
+  FormsRegisterExportType: FormsRegisterExportType,
+  User: ResolverTypeWrapper<User>,
+  CompanyPrivate: ResolverTypeWrapper<CompanyPrivate>,
+  CompanyType: CompanyType,
+  CompanyMember: ResolverTypeWrapper<CompanyMember>,
+  UserRole: UserRole,
+  CompanySearchResult: ResolverTypeWrapper<CompanySearchResult>,
+  CompanyStat: ResolverTypeWrapper<CompanyStat>,
+  Stat: ResolverTypeWrapper<Stat>,
+  Mutation: ResolverTypeWrapper<{}>,
+  PrivateCompanyInput: PrivateCompanyInput,
+  UploadLink: ResolverTypeWrapper<UploadLink>,
+  AuthPayload: ResolverTypeWrapper<AuthPayload>,
+  ProcessedFormInput: ProcessedFormInput,
+  NextDestinationInput: NextDestinationInput,
+  CompanyInput: CompanyInput,
+  ReceivedFormInput: ReceivedFormInput,
+  WasteAcceptationStatusInput: WasteAcceptationStatusInput,
+  ResealedFormInput: ResealedFormInput,
+  DestinationInput: DestinationInput,
+  WasteDetailsInput: WasteDetailsInput,
+  TransporterInput: TransporterInput,
+  ResentFormInput: ResentFormInput,
+  SentFormInput: SentFormInput,
+  TempStoredFormInput: TempStoredFormInput,
+  FormInput: FormInput,
+  EmitterInput: EmitterInput,
+  WorkSiteInput: WorkSiteInput,
+  RecipientInput: RecipientInput,
+  TraderInput: TraderInput,
+  AppendixFormInput: AppendixFormInput,
+  EcoOrganismeInput: EcoOrganismeInput,
+  TemporaryStorageDetailInput: TemporaryStorageDetailInput,
+  TransporterSignatureFormInput: TransporterSignatureFormInput,
+  SignupInput: SignupInput,
+  Subscription: ResolverTypeWrapper<{}>,
+  FormSubscription: ResolverTypeWrapper<FormSubscription>,
+};
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = {
+  Query: {},
+  String: Scalars['String'],
+  Form: Form,
+  ID: Scalars['ID'],
+  Emitter: Emitter,
+  EmitterType: EmitterType,
+  WorkSite: WorkSite,
+  FormCompany: FormCompany,
+  Recipient: Recipient,
+  Boolean: Scalars['Boolean'],
+  Transporter: Transporter,
+  DateTime: Scalars['DateTime'],
+  WasteDetails: WasteDetails,
+  Packagings: Packagings,
+  Int: Scalars['Int'],
+  Float: Scalars['Float'],
+  QuantityType: QuantityType,
+  Consistence: Consistence,
+  Trader: Trader,
+  FormStatus: FormStatus,
+  NextDestination: NextDestination,
+  EcoOrganisme: EcoOrganisme,
+  TemporaryStorageDetail: TemporaryStorageDetail,
+  TemporaryStorer: TemporaryStorer,
+  Destination: Destination,
+  StateSummary: StateSummary,
+  CompanyPublic: CompanyPublic,
+  Installation: Installation,
+  Rubrique: Rubrique,
+  WasteType: WasteType,
+  Declaration: Declaration,
+  GerepType: GerepType,
+  FavoriteType: FavoriteType,
+  CompanyFavorite: CompanyFavorite,
+  FileDownload: FileDownload,
+  FormType: FormType,
+  formsLifeCycleData: FormsLifeCycleData,
+  StatusLog: StatusLog,
+  JSON: Scalars['JSON'],
+  StatusLogForm: StatusLogForm,
+  StatusLogUser: StatusLogUser,
+  FormsRegisterExportType: FormsRegisterExportType,
+  User: User,
+  CompanyPrivate: CompanyPrivate,
+  CompanyType: CompanyType,
+  CompanyMember: CompanyMember,
+  UserRole: UserRole,
+  CompanySearchResult: CompanySearchResult,
+  CompanyStat: CompanyStat,
+  Stat: Stat,
+  Mutation: {},
+  PrivateCompanyInput: PrivateCompanyInput,
+  UploadLink: UploadLink,
+  AuthPayload: AuthPayload,
+  ProcessedFormInput: ProcessedFormInput,
+  NextDestinationInput: NextDestinationInput,
+  CompanyInput: CompanyInput,
+  ReceivedFormInput: ReceivedFormInput,
+  WasteAcceptationStatusInput: WasteAcceptationStatusInput,
+  ResealedFormInput: ResealedFormInput,
+  DestinationInput: DestinationInput,
+  WasteDetailsInput: WasteDetailsInput,
+  TransporterInput: TransporterInput,
+  ResentFormInput: ResentFormInput,
+  SentFormInput: SentFormInput,
+  TempStoredFormInput: TempStoredFormInput,
+  FormInput: FormInput,
+  EmitterInput: EmitterInput,
+  WorkSiteInput: WorkSiteInput,
+  RecipientInput: RecipientInput,
+  TraderInput: TraderInput,
+  AppendixFormInput: AppendixFormInput,
+  EcoOrganismeInput: EcoOrganismeInput,
+  TemporaryStorageDetailInput: TemporaryStorageDetailInput,
+  TransporterSignatureFormInput: TransporterSignatureFormInput,
+  SignupInput: SignupInput,
+  Subscription: {},
+  FormSubscription: FormSubscription,
+};
+
+export type AuthPayloadResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['AuthPayload'] = ResolversParentTypes['AuthPayload']> = {
+  token?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  user?: Resolver<ResolversTypes['User'], ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanyFavoriteResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanyFavorite'] = ResolversParentTypes['CompanyFavorite']> = {
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  contact?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  phone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  mail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanyMemberResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanyMember'] = ResolversParentTypes['CompanyMember']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  role?: Resolver<Maybe<ResolversTypes['UserRole']>, ParentType, ContextType>,
+  isActive?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  isPendingInvitation?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  isMe?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanyPrivateResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanyPrivate'] = ResolversParentTypes['CompanyPrivate']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+  companyTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyType']>>>, ParentType, ContextType>,
+  gerepId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  securityCode?: Resolver<ResolversTypes['Int'], ParentType, ContextType>,
+  contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  contactPhone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  website?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyMember']>>>, ParentType, ContextType>,
+  userRole?: Resolver<Maybe<ResolversTypes['UserRole']>, ParentType, ContextType>,
+  givenName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanyPublicResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanyPublic'] = ResolversParentTypes['CompanyPublic']> = {
+  contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  contactPhone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  website?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  etatAdministratif?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>,
+  isRegistered?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanySearchResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanySearchResult'] = ResolversParentTypes['CompanySearchResult']> = {
+  siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  companyTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyType']>>>, ParentType, ContextType>,
+  naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type CompanyStatResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanyStat'] = ResolversParentTypes['CompanyStat']> = {
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  stats?: Resolver<Maybe<Array<Maybe<ResolversTypes['Stat']>>>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime'
+}
+
+export type DeclarationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Declaration'] = ResolversParentTypes['Declaration']> = {
+  annee?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  codeDechet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  libDechet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  gerepType?: Resolver<Maybe<ResolversTypes['GerepType']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type DestinationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Destination'] = ResolversParentTypes['Destination']> = {
+  cap?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  processingOperation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  isFilledByEmitter?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type EcoOrganismeResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['EcoOrganisme'] = ResolversParentTypes['EcoOrganisme']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  siret?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  address?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type EmitterResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Emitter'] = ResolversParentTypes['Emitter']> = {
+  type?: Resolver<Maybe<ResolversTypes['EmitterType']>, ParentType, ContextType>,
+  workSite?: Resolver<Maybe<ResolversTypes['WorkSite']>, ParentType, ContextType>,
+  pickupSite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type FileDownloadResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['FileDownload'] = ResolversParentTypes['FileDownload']> = {
+  token?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  downloadLink?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type FormResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Form'] = ResolversParentTypes['Form']> = {
+  id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  readableId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  customId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  emitter?: Resolver<Maybe<ResolversTypes['Emitter']>, ParentType, ContextType>,
+  recipient?: Resolver<Maybe<ResolversTypes['Recipient']>, ParentType, ContextType>,
+  transporter?: Resolver<Maybe<ResolversTypes['Transporter']>, ParentType, ContextType>,
+  wasteDetails?: Resolver<Maybe<ResolversTypes['WasteDetails']>, ParentType, ContextType>,
+  trader?: Resolver<Maybe<ResolversTypes['Trader']>, ParentType, ContextType>,
+  createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  ownerId?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>,
+  status?: Resolver<Maybe<ResolversTypes['FormStatus']>, ParentType, ContextType>,
+  signedByTransporter?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  sentAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  sentBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  wasteAcceptationStatus?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  wasteRefusalReason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  receivedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  receivedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  quantityReceived?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  actualQuantity?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  processingOperationDone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  processingOperationDescription?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  processedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  processedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  noTraceability?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  nextDestination?: Resolver<Maybe<ResolversTypes['NextDestination']>, ParentType, ContextType>,
+  appendix2Forms?: Resolver<Maybe<Array<Maybe<ResolversTypes['Form']>>>, ParentType, ContextType>,
+  ecoOrganisme?: Resolver<Maybe<ResolversTypes['EcoOrganisme']>, ParentType, ContextType>,
+  temporaryStorageDetail?: Resolver<Maybe<ResolversTypes['TemporaryStorageDetail']>, ParentType, ContextType>,
+  stateSummary?: Resolver<Maybe<ResolversTypes['StateSummary']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type FormCompanyResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['FormCompany'] = ResolversParentTypes['FormCompany']> = {
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  contact?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  phone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  mail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type FormsLifeCycleDataResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['formsLifeCycleData'] = ResolversParentTypes['formsLifeCycleData']> = {
+  statusLogs?: Resolver<Maybe<Array<Maybe<ResolversTypes['StatusLog']>>>, ParentType, ContextType>,
+  hasNextPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  hasPreviousPage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  startCursor?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  endCursor?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type FormSubscriptionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['FormSubscription'] = ResolversParentTypes['FormSubscription']> = {
+  mutation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  node?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType>,
+  updatedFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>,
+  previousValues?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type InstallationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Installation'] = ResolversParentTypes['Installation']> = {
+  codeS3ic?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  urlFiche?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  rubriques?: Resolver<Maybe<Array<Maybe<ResolversTypes['Rubrique']>>>, ParentType, ContextType>,
+  declarations?: Resolver<Maybe<Array<Maybe<ResolversTypes['Declaration']>>>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
+  name: 'JSON'
+}
+
+export type MutationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  changePassword?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationChangePasswordArgs, 'oldPassword' | 'newPassword'>>,
+  createCompany?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationCreateCompanyArgs, 'companyInput'>>,
+  createUploadLink?: Resolver<Maybe<ResolversTypes['UploadLink']>, ParentType, ContextType, RequireFields<MutationCreateUploadLinkArgs, 'fileName' | 'fileType'>>,
+  deleteForm?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationDeleteFormArgs, 'id'>>,
+  deleteInvitation?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationDeleteInvitationArgs, 'email' | 'siret'>>,
+  duplicateForm?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationDuplicateFormArgs, 'id'>>,
+  editProfile?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationEditProfileArgs, never>>,
+  inviteUserToCompany?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationInviteUserToCompanyArgs, 'email' | 'siret' | 'role'>>,
+  joinWithInvite?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationJoinWithInviteArgs, 'inviteHash' | 'name' | 'password'>>,
+  login?: Resolver<ResolversTypes['AuthPayload'], ParentType, ContextType, RequireFields<MutationLoginArgs, 'email' | 'password'>>,
+  markAsProcessed?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsProcessedArgs, 'processedInfo'>>,
+  markAsReceived?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsReceivedArgs, 'receivedInfo'>>,
+  markAsResealed?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsResealedArgs, 'id' | 'resealedInfos'>>,
+  markAsResent?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsResentArgs, 'id' | 'resentInfos'>>,
+  markAsSealed?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsSealedArgs, never>>,
+  markAsSent?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsSentArgs, 'sentInfo'>>,
+  markAsTempStored?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationMarkAsTempStoredArgs, 'id' | 'tempStoredInfos'>>,
+  removeUserFromCompany?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationRemoveUserFromCompanyArgs, 'userId' | 'siret'>>,
+  renewSecurityCode?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationRenewSecurityCodeArgs, 'siret'>>,
+  resendInvitation?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationResendInvitationArgs, 'email' | 'siret'>>,
+  resetPassword?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, RequireFields<MutationResetPasswordArgs, 'email'>>,
+  saveForm?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationSaveFormArgs, 'formInput'>>,
+  signedByTransporter?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationSignedByTransporterArgs, 'id' | 'signingInfo'>>,
+  signup?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<MutationSignupArgs, 'userInfos'>>,
+  updateCompany?: Resolver<Maybe<ResolversTypes['CompanyPrivate']>, ParentType, ContextType, RequireFields<MutationUpdateCompanyArgs, 'siret'>>,
+  updateTransporterFields?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<MutationUpdateTransporterFieldsArgs, 'id'>>,
+};
+
+export type NextDestinationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['NextDestination'] = ResolversParentTypes['NextDestination']> = {
+  processingOperation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  apiKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  appendixForms?: Resolver<Maybe<Array<Maybe<ResolversTypes['Form']>>>, ParentType, ContextType, RequireFields<QueryAppendixFormsArgs, 'siret'>>,
+  companyInfos?: Resolver<Maybe<ResolversTypes['CompanyPublic']>, ParentType, ContextType, RequireFields<QueryCompanyInfosArgs, 'siret'>>,
+  ecoOrganismes?: Resolver<Maybe<Array<Maybe<ResolversTypes['EcoOrganisme']>>>, ParentType, ContextType>,
+  favorites?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyFavorite']>>>, ParentType, ContextType, RequireFields<QueryFavoritesArgs, 'type'>>,
+  form?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<QueryFormArgs, never>>,
+  formPdf?: Resolver<Maybe<ResolversTypes['FileDownload']>, ParentType, ContextType, RequireFields<QueryFormPdfArgs, never>>,
+  forms?: Resolver<Maybe<Array<Maybe<ResolversTypes['Form']>>>, ParentType, ContextType, RequireFields<QueryFormsArgs, 'type'>>,
+  formsLifeCycle?: Resolver<Maybe<ResolversTypes['formsLifeCycleData']>, ParentType, ContextType, RequireFields<QueryFormsLifeCycleArgs, never>>,
+  formsRegister?: Resolver<Maybe<ResolversTypes['FileDownload']>, ParentType, ContextType, RequireFields<QueryFormsRegisterArgs, never>>,
+  me?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>,
+  searchCompanies?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanySearchResult']>>>, ParentType, ContextType, RequireFields<QuerySearchCompaniesArgs, 'clue'>>,
+  stats?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyStat']>>>, ParentType, ContextType>,
+};
+
+export type RecipientResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Recipient'] = ResolversParentTypes['Recipient']> = {
+  cap?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  processingOperation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  isTempStorage?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type RubriqueResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Rubrique'] = ResolversParentTypes['Rubrique']> = {
+  rubrique?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  alinea?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  etatActivite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  regimeAutorise?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  activite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  category?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  volume?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  unite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  wasteType?: Resolver<Maybe<ResolversTypes['WasteType']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type StatResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Stat'] = ResolversParentTypes['Stat']> = {
+  wasteCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  incoming?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  outgoing?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type StateSummaryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['StateSummary'] = ResolversParentTypes['StateSummary']> = {
+  quantity?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  packagings?: Resolver<Maybe<Array<Maybe<ResolversTypes['Packagings']>>>, ParentType, ContextType>,
+  onuCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  transporter?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  transporterNumberPlate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  transporterCustomInfo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  recipient?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  emitter?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  lastActionOn?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type StatusLogResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['StatusLog'] = ResolversParentTypes['StatusLog']> = {
+  id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  status?: Resolver<Maybe<ResolversTypes['FormStatus']>, ParentType, ContextType>,
+  loggedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  updatedFields?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>,
+  form?: Resolver<Maybe<ResolversTypes['StatusLogForm']>, ParentType, ContextType>,
+  user?: Resolver<Maybe<ResolversTypes['StatusLogUser']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type StatusLogFormResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['StatusLogForm'] = ResolversParentTypes['StatusLogForm']> = {
+  id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  readableId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type StatusLogUserResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['StatusLogUser'] = ResolversParentTypes['StatusLogUser']> = {
+  id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>,
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type SubscriptionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = {
+  forms?: SubscriptionResolver<Maybe<ResolversTypes['FormSubscription']>, "forms", ParentType, ContextType, RequireFields<SubscriptionFormsArgs, 'token'>>,
+};
+
+export type TemporaryStorageDetailResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TemporaryStorageDetail'] = ResolversParentTypes['TemporaryStorageDetail']> = {
+  temporaryStorer?: Resolver<Maybe<ResolversTypes['TemporaryStorer']>, ParentType, ContextType>,
+  destination?: Resolver<Maybe<ResolversTypes['Destination']>, ParentType, ContextType>,
+  wasteDetails?: Resolver<Maybe<ResolversTypes['WasteDetails']>, ParentType, ContextType>,
+  transporter?: Resolver<Maybe<ResolversTypes['Transporter']>, ParentType, ContextType>,
+  signedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  signedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type TemporaryStorerResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TemporaryStorer'] = ResolversParentTypes['TemporaryStorer']> = {
+  quantityType?: Resolver<Maybe<ResolversTypes['QuantityType']>, ParentType, ContextType>,
+  quantityReceived?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  wasteAcceptationStatus?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  wasteRefusalReason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  receivedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  receivedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type TraderResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Trader'] = ResolversParentTypes['Trader']> = {
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  receipt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  department?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  validityLimit?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type TransporterResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Transporter'] = ResolversParentTypes['Transporter']> = {
+  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>,
+  isExemptedOfReceipt?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>,
+  receipt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  department?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  validityLimit?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>,
+  numberPlate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  customInfo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type UploadLinkResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['UploadLink'] = ResolversParentTypes['UploadLink']> = {
+  signedUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type UserResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  phone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  companies?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyPrivate']>>>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type WasteDetailsResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['WasteDetails'] = ResolversParentTypes['WasteDetails']> = {
+  code?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  onuCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  packagings?: Resolver<Maybe<Array<Maybe<ResolversTypes['Packagings']>>>, ParentType, ContextType>,
+  otherPackaging?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  numberOfPackages?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>,
+  quantity?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>,
+  quantityType?: Resolver<Maybe<ResolversTypes['QuantityType']>, ParentType, ContextType>,
+  consistence?: Resolver<Maybe<ResolversTypes['Consistence']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type WorkSiteResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['WorkSite'] = ResolversParentTypes['WorkSite']> = {
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  city?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  postalCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  infos?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>,
+  __isTypeOf?: isTypeOfResolverFn<ParentType>,
+};
+
+export type Resolvers<ContextType = GraphQLContext> = {
+  AuthPayload?: AuthPayloadResolvers<ContextType>,
+  CompanyFavorite?: CompanyFavoriteResolvers<ContextType>,
+  CompanyMember?: CompanyMemberResolvers<ContextType>,
+  CompanyPrivate?: CompanyPrivateResolvers<ContextType>,
+  CompanyPublic?: CompanyPublicResolvers<ContextType>,
+  CompanySearchResult?: CompanySearchResultResolvers<ContextType>,
+  CompanyStat?: CompanyStatResolvers<ContextType>,
+  DateTime?: GraphQLScalarType,
+  Declaration?: DeclarationResolvers<ContextType>,
+  Destination?: DestinationResolvers<ContextType>,
+  EcoOrganisme?: EcoOrganismeResolvers<ContextType>,
+  Emitter?: EmitterResolvers<ContextType>,
+  FileDownload?: FileDownloadResolvers<ContextType>,
+  Form?: FormResolvers<ContextType>,
+  FormCompany?: FormCompanyResolvers<ContextType>,
+  formsLifeCycleData?: FormsLifeCycleDataResolvers<ContextType>,
+  FormSubscription?: FormSubscriptionResolvers<ContextType>,
+  Installation?: InstallationResolvers<ContextType>,
+  JSON?: GraphQLScalarType,
+  Mutation?: MutationResolvers<ContextType>,
+  NextDestination?: NextDestinationResolvers<ContextType>,
+  Query?: QueryResolvers<ContextType>,
+  Recipient?: RecipientResolvers<ContextType>,
+  Rubrique?: RubriqueResolvers<ContextType>,
+  Stat?: StatResolvers<ContextType>,
+  StateSummary?: StateSummaryResolvers<ContextType>,
+  StatusLog?: StatusLogResolvers<ContextType>,
+  StatusLogForm?: StatusLogFormResolvers<ContextType>,
+  StatusLogUser?: StatusLogUserResolvers<ContextType>,
+  Subscription?: SubscriptionResolvers<ContextType>,
+  TemporaryStorageDetail?: TemporaryStorageDetailResolvers<ContextType>,
+  TemporaryStorer?: TemporaryStorerResolvers<ContextType>,
+  Trader?: TraderResolvers<ContextType>,
+  Transporter?: TransporterResolvers<ContextType>,
+  UploadLink?: UploadLinkResolvers<ContextType>,
+  User?: UserResolvers<ContextType>,
+  WasteDetails?: WasteDetailsResolvers<ContextType>,
+  WorkSite?: WorkSiteResolvers<ContextType>,
+};
+
+
+/**
+ * @deprecated
+ * Use "Resolvers" root object instead. If you wish to get "IResolvers", add "typesPrefix: I" to your config.
+*/
+export type IResolvers<ContextType = GraphQLContext> = Resolvers<ContextType>;

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -709,65 +709,6 @@ export interface ClientConstructor<T> {
  * Types
  */
 
-export type GrantOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC"
-  | "code_ASC"
-  | "code_DESC"
-  | "expires_ASC"
-  | "expires_DESC"
-  | "redirectUri_ASC"
-  | "redirectUri_DESC";
-
-export type CompanyOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "siret_ASC"
-  | "siret_DESC"
-  | "name_ASC"
-  | "name_DESC"
-  | "gerepId_ASC"
-  | "gerepId_DESC"
-  | "codeNaf_ASC"
-  | "codeNaf_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC"
-  | "securityCode_ASC"
-  | "securityCode_DESC"
-  | "givenName_ASC"
-  | "givenName_DESC"
-  | "contactEmail_ASC"
-  | "contactEmail_DESC"
-  | "contactPhone_ASC"
-  | "contactPhone_DESC"
-  | "website_ASC"
-  | "website_DESC";
-
-export type CompanyType =
-  | "PRODUCER"
-  | "COLLECTOR"
-  | "WASTEPROCESSOR"
-  | "TRANSPORTER"
-  | "WASTE_VEHICLES"
-  | "WASTE_CENTER"
-  | "TRADER";
-
-export type UserActivationHashOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "hash_ASC"
-  | "hash_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
-
 export type FormOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -930,6 +871,53 @@ export type FormOrderByInput =
   | "traderValidityLimit_ASC"
   | "traderValidityLimit_DESC";
 
+export type CompanyOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "siret_ASC"
+  | "siret_DESC"
+  | "name_ASC"
+  | "name_DESC"
+  | "gerepId_ASC"
+  | "gerepId_DESC"
+  | "codeNaf_ASC"
+  | "codeNaf_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "securityCode_ASC"
+  | "securityCode_DESC"
+  | "givenName_ASC"
+  | "givenName_DESC"
+  | "contactEmail_ASC"
+  | "contactEmail_DESC"
+  | "contactPhone_ASC"
+  | "contactPhone_DESC"
+  | "website_ASC"
+  | "website_DESC";
+
+export type CompanyType =
+  | "PRODUCER"
+  | "COLLECTOR"
+  | "WASTEPROCESSOR"
+  | "TRANSPORTER"
+  | "WASTE_VEHICLES"
+  | "WASTE_CENTER"
+  | "TRADER";
+
+export type UserActivationHashOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "hash_ASC"
+  | "hash_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC";
+
+export type Consistence = "SOLID" | "LIQUID" | "GASEOUS";
+
 export type TemporaryStorageDetailOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -1024,67 +1012,6 @@ export type UserOrderByInput =
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type Status =
-  | "DRAFT"
-  | "SEALED"
-  | "SENT"
-  | "RECEIVED"
-  | "PROCESSED"
-  | "AWAITING_GROUP"
-  | "GROUPED"
-  | "NO_TRACEABILITY"
-  | "REFUSED"
-  | "TEMP_STORED"
-  | "RESEALED"
-  | "RESENT";
-
-export type Consistence = "SOLID" | "LIQUID" | "GASEOUS";
-
-export type WasteType = "INERTE" | "NOT_DANGEROUS" | "DANGEROUS";
-
-export type QuantityType = "REAL" | "ESTIMATED";
-
-export type UserRole = "MEMBER" | "ADMIN";
-
-export type AccessTokenOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC"
-  | "token_ASC"
-  | "token_DESC"
-  | "isRevoked_ASC"
-  | "isRevoked_DESC"
-  | "lastUsed_ASC"
-  | "lastUsed_DESC";
-
-export type Seveso = "NS" | "SB" | "SH";
-
-export type EmitterType = "PRODUCER" | "OTHER" | "APPENDIX1" | "APPENDIX2";
-
-export type UserAccountHashOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "email_ASC"
-  | "email_DESC"
-  | "companySiret_ASC"
-  | "companySiret_DESC"
-  | "role_ASC"
-  | "role_DESC"
-  | "hash_ASC"
-  | "hash_DESC"
-  | "createdAt_ASC"
-  | "createdAt_DESC"
-  | "updatedAt_ASC"
-  | "updatedAt_DESC";
-
-export type WasteAcceptationStatus =
-  | "ACCEPTED"
-  | "REFUSED"
-  | "PARTIALLY_REFUSED";
-
 export type RubriqueOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -1110,6 +1037,105 @@ export type RubriqueOrderByInput =
   | "category_DESC"
   | "wasteType_ASC"
   | "wasteType_DESC";
+
+export type QuantityType = "REAL" | "ESTIMATED";
+
+export type InstallationOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "codeS3ic_ASC"
+  | "codeS3ic_DESC"
+  | "nomEts_ASC"
+  | "nomEts_DESC"
+  | "regime_ASC"
+  | "regime_DESC"
+  | "libRegime_ASC"
+  | "libRegime_DESC"
+  | "seveso_ASC"
+  | "seveso_DESC"
+  | "libSeveso_ASC"
+  | "libSeveso_DESC"
+  | "familleIc_ASC"
+  | "familleIc_DESC"
+  | "urlFiche_ASC"
+  | "urlFiche_DESC"
+  | "s3icNumeroSiret_ASC"
+  | "s3icNumeroSiret_DESC"
+  | "irepNumeroSiret_ASC"
+  | "irepNumeroSiret_DESC"
+  | "gerepNumeroSiret_ASC"
+  | "gerepNumeroSiret_DESC"
+  | "sireneNumeroSiret_ASC"
+  | "sireneNumeroSiret_DESC";
+
+export type EmitterType = "PRODUCER" | "OTHER" | "APPENDIX1" | "APPENDIX2";
+
+export type UserRole = "MEMBER" | "ADMIN";
+
+export type AccessTokenOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "token_ASC"
+  | "token_DESC"
+  | "isRevoked_ASC"
+  | "isRevoked_DESC"
+  | "lastUsed_ASC"
+  | "lastUsed_DESC";
+
+export type GrantOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "code_ASC"
+  | "code_DESC"
+  | "expires_ASC"
+  | "expires_DESC"
+  | "redirectUri_ASC"
+  | "redirectUri_DESC";
+
+export type WasteAcceptationStatus =
+  | "ACCEPTED"
+  | "REFUSED"
+  | "PARTIALLY_REFUSED";
+
+export type UserAccountHashOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "email_ASC"
+  | "email_DESC"
+  | "companySiret_ASC"
+  | "companySiret_DESC"
+  | "role_ASC"
+  | "role_DESC"
+  | "hash_ASC"
+  | "hash_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC";
+
+export type Status =
+  | "DRAFT"
+  | "SEALED"
+  | "SENT"
+  | "RECEIVED"
+  | "PROCESSED"
+  | "AWAITING_GROUP"
+  | "GROUPED"
+  | "NO_TRACEABILITY"
+  | "REFUSED"
+  | "TEMP_STORED"
+  | "RESEALED"
+  | "RESENT";
+
+export type WasteType = "INERTE" | "NOT_DANGEROUS" | "DANGEROUS";
 
 export type ApplicationOrderByInput =
   | "id_ASC"
@@ -1153,33 +1179,7 @@ export type EcoOrganismeOrderByInput =
   | "address_ASC"
   | "address_DESC";
 
-export type InstallationOrderByInput =
-  | "id_ASC"
-  | "id_DESC"
-  | "codeS3ic_ASC"
-  | "codeS3ic_DESC"
-  | "nomEts_ASC"
-  | "nomEts_DESC"
-  | "regime_ASC"
-  | "regime_DESC"
-  | "libRegime_ASC"
-  | "libRegime_DESC"
-  | "seveso_ASC"
-  | "seveso_DESC"
-  | "libSeveso_ASC"
-  | "libSeveso_DESC"
-  | "familleIc_ASC"
-  | "familleIc_DESC"
-  | "urlFiche_ASC"
-  | "urlFiche_DESC"
-  | "s3icNumeroSiret_ASC"
-  | "s3icNumeroSiret_DESC"
-  | "irepNumeroSiret_ASC"
-  | "irepNumeroSiret_DESC"
-  | "gerepNumeroSiret_ASC"
-  | "gerepNumeroSiret_DESC"
-  | "sireneNumeroSiret_ASC"
-  | "sireneNumeroSiret_DESC";
+export type Seveso = "NS" | "SB" | "SH";
 
 export type StatusLogOrderByInput =
   | "id_ASC"
@@ -1437,7 +1437,7 @@ export interface FormUpdateDataInput {
   isDeleted?: Maybe<Boolean>;
   owner?: Maybe<UserUpdateOneRequiredInput>;
   signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
+  status?: Maybe<Status>;
   sentAt?: Maybe<DateTimeInput>;
   sentBy?: Maybe<String>;
   isAccepted?: Maybe<Boolean>;
@@ -1749,7 +1749,7 @@ export interface FormUpdateInput {
   isDeleted?: Maybe<Boolean>;
   owner?: Maybe<UserUpdateOneRequiredInput>;
   signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
+  status?: Maybe<Status>;
   sentAt?: Maybe<DateTimeInput>;
   sentBy?: Maybe<String>;
   isAccepted?: Maybe<Boolean>;
@@ -1887,12 +1887,85 @@ export interface TemporaryStorageDetailCreateOneWithoutFormInput {
   connect?: Maybe<TemporaryStorageDetailWhereUniqueInput>;
 }
 
-export interface UserUpdateManyMutationInput {
-  isActive?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  password?: Maybe<String>;
+export interface ApplicationWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  clientSecret?: Maybe<String>;
+  clientSecret_not?: Maybe<String>;
+  clientSecret_in?: Maybe<String[] | String>;
+  clientSecret_not_in?: Maybe<String[] | String>;
+  clientSecret_lt?: Maybe<String>;
+  clientSecret_lte?: Maybe<String>;
+  clientSecret_gt?: Maybe<String>;
+  clientSecret_gte?: Maybe<String>;
+  clientSecret_contains?: Maybe<String>;
+  clientSecret_not_contains?: Maybe<String>;
+  clientSecret_starts_with?: Maybe<String>;
+  clientSecret_not_starts_with?: Maybe<String>;
+  clientSecret_ends_with?: Maybe<String>;
+  clientSecret_not_ends_with?: Maybe<String>;
   name?: Maybe<String>;
-  phone?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  admins_every?: Maybe<UserWhereInput>;
+  admins_some?: Maybe<UserWhereInput>;
+  admins_none?: Maybe<UserWhereInput>;
+  logoUrl?: Maybe<String>;
+  logoUrl_not?: Maybe<String>;
+  logoUrl_in?: Maybe<String[] | String>;
+  logoUrl_not_in?: Maybe<String[] | String>;
+  logoUrl_lt?: Maybe<String>;
+  logoUrl_lte?: Maybe<String>;
+  logoUrl_gt?: Maybe<String>;
+  logoUrl_gte?: Maybe<String>;
+  logoUrl_contains?: Maybe<String>;
+  logoUrl_not_contains?: Maybe<String>;
+  logoUrl_starts_with?: Maybe<String>;
+  logoUrl_not_starts_with?: Maybe<String>;
+  logoUrl_ends_with?: Maybe<String>;
+  logoUrl_not_ends_with?: Maybe<String>;
+  AND?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
+  OR?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
+  NOT?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
 }
 
 export interface AccessTokenWhereInput {
@@ -1955,6 +2028,2019 @@ export interface AccessTokenWhereInput {
   AND?: Maybe<AccessTokenWhereInput[] | AccessTokenWhereInput>;
   OR?: Maybe<AccessTokenWhereInput[] | AccessTokenWhereInput>;
   NOT?: Maybe<AccessTokenWhereInput[] | AccessTokenWhereInput>;
+}
+
+export interface FormWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  readableId?: Maybe<String>;
+  readableId_not?: Maybe<String>;
+  readableId_in?: Maybe<String[] | String>;
+  readableId_not_in?: Maybe<String[] | String>;
+  readableId_lt?: Maybe<String>;
+  readableId_lte?: Maybe<String>;
+  readableId_gt?: Maybe<String>;
+  readableId_gte?: Maybe<String>;
+  readableId_contains?: Maybe<String>;
+  readableId_not_contains?: Maybe<String>;
+  readableId_starts_with?: Maybe<String>;
+  readableId_not_starts_with?: Maybe<String>;
+  readableId_ends_with?: Maybe<String>;
+  readableId_not_ends_with?: Maybe<String>;
+  customId?: Maybe<String>;
+  customId_not?: Maybe<String>;
+  customId_in?: Maybe<String[] | String>;
+  customId_not_in?: Maybe<String[] | String>;
+  customId_lt?: Maybe<String>;
+  customId_lte?: Maybe<String>;
+  customId_gt?: Maybe<String>;
+  customId_gte?: Maybe<String>;
+  customId_contains?: Maybe<String>;
+  customId_not_contains?: Maybe<String>;
+  customId_starts_with?: Maybe<String>;
+  customId_not_starts_with?: Maybe<String>;
+  customId_ends_with?: Maybe<String>;
+  customId_not_ends_with?: Maybe<String>;
+  isDeleted?: Maybe<Boolean>;
+  isDeleted_not?: Maybe<Boolean>;
+  owner?: Maybe<UserWhereInput>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  signedByTransporter?: Maybe<Boolean>;
+  signedByTransporter_not?: Maybe<Boolean>;
+  status?: Maybe<Status>;
+  status_not?: Maybe<Status>;
+  status_in?: Maybe<Status[] | Status>;
+  status_not_in?: Maybe<Status[] | Status>;
+  sentAt?: Maybe<DateTimeInput>;
+  sentAt_not?: Maybe<DateTimeInput>;
+  sentAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  sentAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  sentAt_lt?: Maybe<DateTimeInput>;
+  sentAt_lte?: Maybe<DateTimeInput>;
+  sentAt_gt?: Maybe<DateTimeInput>;
+  sentAt_gte?: Maybe<DateTimeInput>;
+  sentBy?: Maybe<String>;
+  sentBy_not?: Maybe<String>;
+  sentBy_in?: Maybe<String[] | String>;
+  sentBy_not_in?: Maybe<String[] | String>;
+  sentBy_lt?: Maybe<String>;
+  sentBy_lte?: Maybe<String>;
+  sentBy_gt?: Maybe<String>;
+  sentBy_gte?: Maybe<String>;
+  sentBy_contains?: Maybe<String>;
+  sentBy_not_contains?: Maybe<String>;
+  sentBy_starts_with?: Maybe<String>;
+  sentBy_not_starts_with?: Maybe<String>;
+  sentBy_ends_with?: Maybe<String>;
+  sentBy_not_ends_with?: Maybe<String>;
+  isAccepted?: Maybe<Boolean>;
+  isAccepted_not?: Maybe<Boolean>;
+  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  wasteAcceptationStatus_not?: Maybe<WasteAcceptationStatus>;
+  wasteAcceptationStatus_in?: Maybe<
+    WasteAcceptationStatus[] | WasteAcceptationStatus
+  >;
+  wasteAcceptationStatus_not_in?: Maybe<
+    WasteAcceptationStatus[] | WasteAcceptationStatus
+  >;
+  wasteRefusalReason?: Maybe<String>;
+  wasteRefusalReason_not?: Maybe<String>;
+  wasteRefusalReason_in?: Maybe<String[] | String>;
+  wasteRefusalReason_not_in?: Maybe<String[] | String>;
+  wasteRefusalReason_lt?: Maybe<String>;
+  wasteRefusalReason_lte?: Maybe<String>;
+  wasteRefusalReason_gt?: Maybe<String>;
+  wasteRefusalReason_gte?: Maybe<String>;
+  wasteRefusalReason_contains?: Maybe<String>;
+  wasteRefusalReason_not_contains?: Maybe<String>;
+  wasteRefusalReason_starts_with?: Maybe<String>;
+  wasteRefusalReason_not_starts_with?: Maybe<String>;
+  wasteRefusalReason_ends_with?: Maybe<String>;
+  wasteRefusalReason_not_ends_with?: Maybe<String>;
+  receivedBy?: Maybe<String>;
+  receivedBy_not?: Maybe<String>;
+  receivedBy_in?: Maybe<String[] | String>;
+  receivedBy_not_in?: Maybe<String[] | String>;
+  receivedBy_lt?: Maybe<String>;
+  receivedBy_lte?: Maybe<String>;
+  receivedBy_gt?: Maybe<String>;
+  receivedBy_gte?: Maybe<String>;
+  receivedBy_contains?: Maybe<String>;
+  receivedBy_not_contains?: Maybe<String>;
+  receivedBy_starts_with?: Maybe<String>;
+  receivedBy_not_starts_with?: Maybe<String>;
+  receivedBy_ends_with?: Maybe<String>;
+  receivedBy_not_ends_with?: Maybe<String>;
+  receivedAt?: Maybe<DateTimeInput>;
+  receivedAt_not?: Maybe<DateTimeInput>;
+  receivedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  receivedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  receivedAt_lt?: Maybe<DateTimeInput>;
+  receivedAt_lte?: Maybe<DateTimeInput>;
+  receivedAt_gt?: Maybe<DateTimeInput>;
+  receivedAt_gte?: Maybe<DateTimeInput>;
+  quantityReceived?: Maybe<Float>;
+  quantityReceived_not?: Maybe<Float>;
+  quantityReceived_in?: Maybe<Float[] | Float>;
+  quantityReceived_not_in?: Maybe<Float[] | Float>;
+  quantityReceived_lt?: Maybe<Float>;
+  quantityReceived_lte?: Maybe<Float>;
+  quantityReceived_gt?: Maybe<Float>;
+  quantityReceived_gte?: Maybe<Float>;
+  processedBy?: Maybe<String>;
+  processedBy_not?: Maybe<String>;
+  processedBy_in?: Maybe<String[] | String>;
+  processedBy_not_in?: Maybe<String[] | String>;
+  processedBy_lt?: Maybe<String>;
+  processedBy_lte?: Maybe<String>;
+  processedBy_gt?: Maybe<String>;
+  processedBy_gte?: Maybe<String>;
+  processedBy_contains?: Maybe<String>;
+  processedBy_not_contains?: Maybe<String>;
+  processedBy_starts_with?: Maybe<String>;
+  processedBy_not_starts_with?: Maybe<String>;
+  processedBy_ends_with?: Maybe<String>;
+  processedBy_not_ends_with?: Maybe<String>;
+  processedAt?: Maybe<String>;
+  processedAt_not?: Maybe<String>;
+  processedAt_in?: Maybe<String[] | String>;
+  processedAt_not_in?: Maybe<String[] | String>;
+  processedAt_lt?: Maybe<String>;
+  processedAt_lte?: Maybe<String>;
+  processedAt_gt?: Maybe<String>;
+  processedAt_gte?: Maybe<String>;
+  processedAt_contains?: Maybe<String>;
+  processedAt_not_contains?: Maybe<String>;
+  processedAt_starts_with?: Maybe<String>;
+  processedAt_not_starts_with?: Maybe<String>;
+  processedAt_ends_with?: Maybe<String>;
+  processedAt_not_ends_with?: Maybe<String>;
+  processingOperationDone?: Maybe<String>;
+  processingOperationDone_not?: Maybe<String>;
+  processingOperationDone_in?: Maybe<String[] | String>;
+  processingOperationDone_not_in?: Maybe<String[] | String>;
+  processingOperationDone_lt?: Maybe<String>;
+  processingOperationDone_lte?: Maybe<String>;
+  processingOperationDone_gt?: Maybe<String>;
+  processingOperationDone_gte?: Maybe<String>;
+  processingOperationDone_contains?: Maybe<String>;
+  processingOperationDone_not_contains?: Maybe<String>;
+  processingOperationDone_starts_with?: Maybe<String>;
+  processingOperationDone_not_starts_with?: Maybe<String>;
+  processingOperationDone_ends_with?: Maybe<String>;
+  processingOperationDone_not_ends_with?: Maybe<String>;
+  processingOperationDescription?: Maybe<String>;
+  processingOperationDescription_not?: Maybe<String>;
+  processingOperationDescription_in?: Maybe<String[] | String>;
+  processingOperationDescription_not_in?: Maybe<String[] | String>;
+  processingOperationDescription_lt?: Maybe<String>;
+  processingOperationDescription_lte?: Maybe<String>;
+  processingOperationDescription_gt?: Maybe<String>;
+  processingOperationDescription_gte?: Maybe<String>;
+  processingOperationDescription_contains?: Maybe<String>;
+  processingOperationDescription_not_contains?: Maybe<String>;
+  processingOperationDescription_starts_with?: Maybe<String>;
+  processingOperationDescription_not_starts_with?: Maybe<String>;
+  processingOperationDescription_ends_with?: Maybe<String>;
+  processingOperationDescription_not_ends_with?: Maybe<String>;
+  noTraceability?: Maybe<Boolean>;
+  noTraceability_not?: Maybe<Boolean>;
+  nextDestinationProcessingOperation?: Maybe<String>;
+  nextDestinationProcessingOperation_not?: Maybe<String>;
+  nextDestinationProcessingOperation_in?: Maybe<String[] | String>;
+  nextDestinationProcessingOperation_not_in?: Maybe<String[] | String>;
+  nextDestinationProcessingOperation_lt?: Maybe<String>;
+  nextDestinationProcessingOperation_lte?: Maybe<String>;
+  nextDestinationProcessingOperation_gt?: Maybe<String>;
+  nextDestinationProcessingOperation_gte?: Maybe<String>;
+  nextDestinationProcessingOperation_contains?: Maybe<String>;
+  nextDestinationProcessingOperation_not_contains?: Maybe<String>;
+  nextDestinationProcessingOperation_starts_with?: Maybe<String>;
+  nextDestinationProcessingOperation_not_starts_with?: Maybe<String>;
+  nextDestinationProcessingOperation_ends_with?: Maybe<String>;
+  nextDestinationProcessingOperation_not_ends_with?: Maybe<String>;
+  nextDestinationCompanyName?: Maybe<String>;
+  nextDestinationCompanyName_not?: Maybe<String>;
+  nextDestinationCompanyName_in?: Maybe<String[] | String>;
+  nextDestinationCompanyName_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanyName_lt?: Maybe<String>;
+  nextDestinationCompanyName_lte?: Maybe<String>;
+  nextDestinationCompanyName_gt?: Maybe<String>;
+  nextDestinationCompanyName_gte?: Maybe<String>;
+  nextDestinationCompanyName_contains?: Maybe<String>;
+  nextDestinationCompanyName_not_contains?: Maybe<String>;
+  nextDestinationCompanyName_starts_with?: Maybe<String>;
+  nextDestinationCompanyName_not_starts_with?: Maybe<String>;
+  nextDestinationCompanyName_ends_with?: Maybe<String>;
+  nextDestinationCompanyName_not_ends_with?: Maybe<String>;
+  nextDestinationCompanySiret?: Maybe<String>;
+  nextDestinationCompanySiret_not?: Maybe<String>;
+  nextDestinationCompanySiret_in?: Maybe<String[] | String>;
+  nextDestinationCompanySiret_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanySiret_lt?: Maybe<String>;
+  nextDestinationCompanySiret_lte?: Maybe<String>;
+  nextDestinationCompanySiret_gt?: Maybe<String>;
+  nextDestinationCompanySiret_gte?: Maybe<String>;
+  nextDestinationCompanySiret_contains?: Maybe<String>;
+  nextDestinationCompanySiret_not_contains?: Maybe<String>;
+  nextDestinationCompanySiret_starts_with?: Maybe<String>;
+  nextDestinationCompanySiret_not_starts_with?: Maybe<String>;
+  nextDestinationCompanySiret_ends_with?: Maybe<String>;
+  nextDestinationCompanySiret_not_ends_with?: Maybe<String>;
+  nextDestinationCompanyAddress?: Maybe<String>;
+  nextDestinationCompanyAddress_not?: Maybe<String>;
+  nextDestinationCompanyAddress_in?: Maybe<String[] | String>;
+  nextDestinationCompanyAddress_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanyAddress_lt?: Maybe<String>;
+  nextDestinationCompanyAddress_lte?: Maybe<String>;
+  nextDestinationCompanyAddress_gt?: Maybe<String>;
+  nextDestinationCompanyAddress_gte?: Maybe<String>;
+  nextDestinationCompanyAddress_contains?: Maybe<String>;
+  nextDestinationCompanyAddress_not_contains?: Maybe<String>;
+  nextDestinationCompanyAddress_starts_with?: Maybe<String>;
+  nextDestinationCompanyAddress_not_starts_with?: Maybe<String>;
+  nextDestinationCompanyAddress_ends_with?: Maybe<String>;
+  nextDestinationCompanyAddress_not_ends_with?: Maybe<String>;
+  nextDestinationCompanyContact?: Maybe<String>;
+  nextDestinationCompanyContact_not?: Maybe<String>;
+  nextDestinationCompanyContact_in?: Maybe<String[] | String>;
+  nextDestinationCompanyContact_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanyContact_lt?: Maybe<String>;
+  nextDestinationCompanyContact_lte?: Maybe<String>;
+  nextDestinationCompanyContact_gt?: Maybe<String>;
+  nextDestinationCompanyContact_gte?: Maybe<String>;
+  nextDestinationCompanyContact_contains?: Maybe<String>;
+  nextDestinationCompanyContact_not_contains?: Maybe<String>;
+  nextDestinationCompanyContact_starts_with?: Maybe<String>;
+  nextDestinationCompanyContact_not_starts_with?: Maybe<String>;
+  nextDestinationCompanyContact_ends_with?: Maybe<String>;
+  nextDestinationCompanyContact_not_ends_with?: Maybe<String>;
+  nextDestinationCompanyPhone?: Maybe<String>;
+  nextDestinationCompanyPhone_not?: Maybe<String>;
+  nextDestinationCompanyPhone_in?: Maybe<String[] | String>;
+  nextDestinationCompanyPhone_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanyPhone_lt?: Maybe<String>;
+  nextDestinationCompanyPhone_lte?: Maybe<String>;
+  nextDestinationCompanyPhone_gt?: Maybe<String>;
+  nextDestinationCompanyPhone_gte?: Maybe<String>;
+  nextDestinationCompanyPhone_contains?: Maybe<String>;
+  nextDestinationCompanyPhone_not_contains?: Maybe<String>;
+  nextDestinationCompanyPhone_starts_with?: Maybe<String>;
+  nextDestinationCompanyPhone_not_starts_with?: Maybe<String>;
+  nextDestinationCompanyPhone_ends_with?: Maybe<String>;
+  nextDestinationCompanyPhone_not_ends_with?: Maybe<String>;
+  nextDestinationCompanyMail?: Maybe<String>;
+  nextDestinationCompanyMail_not?: Maybe<String>;
+  nextDestinationCompanyMail_in?: Maybe<String[] | String>;
+  nextDestinationCompanyMail_not_in?: Maybe<String[] | String>;
+  nextDestinationCompanyMail_lt?: Maybe<String>;
+  nextDestinationCompanyMail_lte?: Maybe<String>;
+  nextDestinationCompanyMail_gt?: Maybe<String>;
+  nextDestinationCompanyMail_gte?: Maybe<String>;
+  nextDestinationCompanyMail_contains?: Maybe<String>;
+  nextDestinationCompanyMail_not_contains?: Maybe<String>;
+  nextDestinationCompanyMail_starts_with?: Maybe<String>;
+  nextDestinationCompanyMail_not_starts_with?: Maybe<String>;
+  nextDestinationCompanyMail_ends_with?: Maybe<String>;
+  nextDestinationCompanyMail_not_ends_with?: Maybe<String>;
+  emitterType?: Maybe<EmitterType>;
+  emitterType_not?: Maybe<EmitterType>;
+  emitterType_in?: Maybe<EmitterType[] | EmitterType>;
+  emitterType_not_in?: Maybe<EmitterType[] | EmitterType>;
+  emitterPickupSite?: Maybe<String>;
+  emitterPickupSite_not?: Maybe<String>;
+  emitterPickupSite_in?: Maybe<String[] | String>;
+  emitterPickupSite_not_in?: Maybe<String[] | String>;
+  emitterPickupSite_lt?: Maybe<String>;
+  emitterPickupSite_lte?: Maybe<String>;
+  emitterPickupSite_gt?: Maybe<String>;
+  emitterPickupSite_gte?: Maybe<String>;
+  emitterPickupSite_contains?: Maybe<String>;
+  emitterPickupSite_not_contains?: Maybe<String>;
+  emitterPickupSite_starts_with?: Maybe<String>;
+  emitterPickupSite_not_starts_with?: Maybe<String>;
+  emitterPickupSite_ends_with?: Maybe<String>;
+  emitterPickupSite_not_ends_with?: Maybe<String>;
+  emitterWorkSiteName?: Maybe<String>;
+  emitterWorkSiteName_not?: Maybe<String>;
+  emitterWorkSiteName_in?: Maybe<String[] | String>;
+  emitterWorkSiteName_not_in?: Maybe<String[] | String>;
+  emitterWorkSiteName_lt?: Maybe<String>;
+  emitterWorkSiteName_lte?: Maybe<String>;
+  emitterWorkSiteName_gt?: Maybe<String>;
+  emitterWorkSiteName_gte?: Maybe<String>;
+  emitterWorkSiteName_contains?: Maybe<String>;
+  emitterWorkSiteName_not_contains?: Maybe<String>;
+  emitterWorkSiteName_starts_with?: Maybe<String>;
+  emitterWorkSiteName_not_starts_with?: Maybe<String>;
+  emitterWorkSiteName_ends_with?: Maybe<String>;
+  emitterWorkSiteName_not_ends_with?: Maybe<String>;
+  emitterWorkSiteAddress?: Maybe<String>;
+  emitterWorkSiteAddress_not?: Maybe<String>;
+  emitterWorkSiteAddress_in?: Maybe<String[] | String>;
+  emitterWorkSiteAddress_not_in?: Maybe<String[] | String>;
+  emitterWorkSiteAddress_lt?: Maybe<String>;
+  emitterWorkSiteAddress_lte?: Maybe<String>;
+  emitterWorkSiteAddress_gt?: Maybe<String>;
+  emitterWorkSiteAddress_gte?: Maybe<String>;
+  emitterWorkSiteAddress_contains?: Maybe<String>;
+  emitterWorkSiteAddress_not_contains?: Maybe<String>;
+  emitterWorkSiteAddress_starts_with?: Maybe<String>;
+  emitterWorkSiteAddress_not_starts_with?: Maybe<String>;
+  emitterWorkSiteAddress_ends_with?: Maybe<String>;
+  emitterWorkSiteAddress_not_ends_with?: Maybe<String>;
+  emitterWorkSiteCity?: Maybe<String>;
+  emitterWorkSiteCity_not?: Maybe<String>;
+  emitterWorkSiteCity_in?: Maybe<String[] | String>;
+  emitterWorkSiteCity_not_in?: Maybe<String[] | String>;
+  emitterWorkSiteCity_lt?: Maybe<String>;
+  emitterWorkSiteCity_lte?: Maybe<String>;
+  emitterWorkSiteCity_gt?: Maybe<String>;
+  emitterWorkSiteCity_gte?: Maybe<String>;
+  emitterWorkSiteCity_contains?: Maybe<String>;
+  emitterWorkSiteCity_not_contains?: Maybe<String>;
+  emitterWorkSiteCity_starts_with?: Maybe<String>;
+  emitterWorkSiteCity_not_starts_with?: Maybe<String>;
+  emitterWorkSiteCity_ends_with?: Maybe<String>;
+  emitterWorkSiteCity_not_ends_with?: Maybe<String>;
+  emitterWorkSitePostalCode?: Maybe<String>;
+  emitterWorkSitePostalCode_not?: Maybe<String>;
+  emitterWorkSitePostalCode_in?: Maybe<String[] | String>;
+  emitterWorkSitePostalCode_not_in?: Maybe<String[] | String>;
+  emitterWorkSitePostalCode_lt?: Maybe<String>;
+  emitterWorkSitePostalCode_lte?: Maybe<String>;
+  emitterWorkSitePostalCode_gt?: Maybe<String>;
+  emitterWorkSitePostalCode_gte?: Maybe<String>;
+  emitterWorkSitePostalCode_contains?: Maybe<String>;
+  emitterWorkSitePostalCode_not_contains?: Maybe<String>;
+  emitterWorkSitePostalCode_starts_with?: Maybe<String>;
+  emitterWorkSitePostalCode_not_starts_with?: Maybe<String>;
+  emitterWorkSitePostalCode_ends_with?: Maybe<String>;
+  emitterWorkSitePostalCode_not_ends_with?: Maybe<String>;
+  emitterWorkSiteInfos?: Maybe<String>;
+  emitterWorkSiteInfos_not?: Maybe<String>;
+  emitterWorkSiteInfos_in?: Maybe<String[] | String>;
+  emitterWorkSiteInfos_not_in?: Maybe<String[] | String>;
+  emitterWorkSiteInfos_lt?: Maybe<String>;
+  emitterWorkSiteInfos_lte?: Maybe<String>;
+  emitterWorkSiteInfos_gt?: Maybe<String>;
+  emitterWorkSiteInfos_gte?: Maybe<String>;
+  emitterWorkSiteInfos_contains?: Maybe<String>;
+  emitterWorkSiteInfos_not_contains?: Maybe<String>;
+  emitterWorkSiteInfos_starts_with?: Maybe<String>;
+  emitterWorkSiteInfos_not_starts_with?: Maybe<String>;
+  emitterWorkSiteInfos_ends_with?: Maybe<String>;
+  emitterWorkSiteInfos_not_ends_with?: Maybe<String>;
+  emitterCompanyName?: Maybe<String>;
+  emitterCompanyName_not?: Maybe<String>;
+  emitterCompanyName_in?: Maybe<String[] | String>;
+  emitterCompanyName_not_in?: Maybe<String[] | String>;
+  emitterCompanyName_lt?: Maybe<String>;
+  emitterCompanyName_lte?: Maybe<String>;
+  emitterCompanyName_gt?: Maybe<String>;
+  emitterCompanyName_gte?: Maybe<String>;
+  emitterCompanyName_contains?: Maybe<String>;
+  emitterCompanyName_not_contains?: Maybe<String>;
+  emitterCompanyName_starts_with?: Maybe<String>;
+  emitterCompanyName_not_starts_with?: Maybe<String>;
+  emitterCompanyName_ends_with?: Maybe<String>;
+  emitterCompanyName_not_ends_with?: Maybe<String>;
+  emitterCompanySiret?: Maybe<String>;
+  emitterCompanySiret_not?: Maybe<String>;
+  emitterCompanySiret_in?: Maybe<String[] | String>;
+  emitterCompanySiret_not_in?: Maybe<String[] | String>;
+  emitterCompanySiret_lt?: Maybe<String>;
+  emitterCompanySiret_lte?: Maybe<String>;
+  emitterCompanySiret_gt?: Maybe<String>;
+  emitterCompanySiret_gte?: Maybe<String>;
+  emitterCompanySiret_contains?: Maybe<String>;
+  emitterCompanySiret_not_contains?: Maybe<String>;
+  emitterCompanySiret_starts_with?: Maybe<String>;
+  emitterCompanySiret_not_starts_with?: Maybe<String>;
+  emitterCompanySiret_ends_with?: Maybe<String>;
+  emitterCompanySiret_not_ends_with?: Maybe<String>;
+  emitterCompanyAddress?: Maybe<String>;
+  emitterCompanyAddress_not?: Maybe<String>;
+  emitterCompanyAddress_in?: Maybe<String[] | String>;
+  emitterCompanyAddress_not_in?: Maybe<String[] | String>;
+  emitterCompanyAddress_lt?: Maybe<String>;
+  emitterCompanyAddress_lte?: Maybe<String>;
+  emitterCompanyAddress_gt?: Maybe<String>;
+  emitterCompanyAddress_gte?: Maybe<String>;
+  emitterCompanyAddress_contains?: Maybe<String>;
+  emitterCompanyAddress_not_contains?: Maybe<String>;
+  emitterCompanyAddress_starts_with?: Maybe<String>;
+  emitterCompanyAddress_not_starts_with?: Maybe<String>;
+  emitterCompanyAddress_ends_with?: Maybe<String>;
+  emitterCompanyAddress_not_ends_with?: Maybe<String>;
+  emitterCompanyContact?: Maybe<String>;
+  emitterCompanyContact_not?: Maybe<String>;
+  emitterCompanyContact_in?: Maybe<String[] | String>;
+  emitterCompanyContact_not_in?: Maybe<String[] | String>;
+  emitterCompanyContact_lt?: Maybe<String>;
+  emitterCompanyContact_lte?: Maybe<String>;
+  emitterCompanyContact_gt?: Maybe<String>;
+  emitterCompanyContact_gte?: Maybe<String>;
+  emitterCompanyContact_contains?: Maybe<String>;
+  emitterCompanyContact_not_contains?: Maybe<String>;
+  emitterCompanyContact_starts_with?: Maybe<String>;
+  emitterCompanyContact_not_starts_with?: Maybe<String>;
+  emitterCompanyContact_ends_with?: Maybe<String>;
+  emitterCompanyContact_not_ends_with?: Maybe<String>;
+  emitterCompanyPhone?: Maybe<String>;
+  emitterCompanyPhone_not?: Maybe<String>;
+  emitterCompanyPhone_in?: Maybe<String[] | String>;
+  emitterCompanyPhone_not_in?: Maybe<String[] | String>;
+  emitterCompanyPhone_lt?: Maybe<String>;
+  emitterCompanyPhone_lte?: Maybe<String>;
+  emitterCompanyPhone_gt?: Maybe<String>;
+  emitterCompanyPhone_gte?: Maybe<String>;
+  emitterCompanyPhone_contains?: Maybe<String>;
+  emitterCompanyPhone_not_contains?: Maybe<String>;
+  emitterCompanyPhone_starts_with?: Maybe<String>;
+  emitterCompanyPhone_not_starts_with?: Maybe<String>;
+  emitterCompanyPhone_ends_with?: Maybe<String>;
+  emitterCompanyPhone_not_ends_with?: Maybe<String>;
+  emitterCompanyMail?: Maybe<String>;
+  emitterCompanyMail_not?: Maybe<String>;
+  emitterCompanyMail_in?: Maybe<String[] | String>;
+  emitterCompanyMail_not_in?: Maybe<String[] | String>;
+  emitterCompanyMail_lt?: Maybe<String>;
+  emitterCompanyMail_lte?: Maybe<String>;
+  emitterCompanyMail_gt?: Maybe<String>;
+  emitterCompanyMail_gte?: Maybe<String>;
+  emitterCompanyMail_contains?: Maybe<String>;
+  emitterCompanyMail_not_contains?: Maybe<String>;
+  emitterCompanyMail_starts_with?: Maybe<String>;
+  emitterCompanyMail_not_starts_with?: Maybe<String>;
+  emitterCompanyMail_ends_with?: Maybe<String>;
+  emitterCompanyMail_not_ends_with?: Maybe<String>;
+  recipientCap?: Maybe<String>;
+  recipientCap_not?: Maybe<String>;
+  recipientCap_in?: Maybe<String[] | String>;
+  recipientCap_not_in?: Maybe<String[] | String>;
+  recipientCap_lt?: Maybe<String>;
+  recipientCap_lte?: Maybe<String>;
+  recipientCap_gt?: Maybe<String>;
+  recipientCap_gte?: Maybe<String>;
+  recipientCap_contains?: Maybe<String>;
+  recipientCap_not_contains?: Maybe<String>;
+  recipientCap_starts_with?: Maybe<String>;
+  recipientCap_not_starts_with?: Maybe<String>;
+  recipientCap_ends_with?: Maybe<String>;
+  recipientCap_not_ends_with?: Maybe<String>;
+  recipientProcessingOperation?: Maybe<String>;
+  recipientProcessingOperation_not?: Maybe<String>;
+  recipientProcessingOperation_in?: Maybe<String[] | String>;
+  recipientProcessingOperation_not_in?: Maybe<String[] | String>;
+  recipientProcessingOperation_lt?: Maybe<String>;
+  recipientProcessingOperation_lte?: Maybe<String>;
+  recipientProcessingOperation_gt?: Maybe<String>;
+  recipientProcessingOperation_gte?: Maybe<String>;
+  recipientProcessingOperation_contains?: Maybe<String>;
+  recipientProcessingOperation_not_contains?: Maybe<String>;
+  recipientProcessingOperation_starts_with?: Maybe<String>;
+  recipientProcessingOperation_not_starts_with?: Maybe<String>;
+  recipientProcessingOperation_ends_with?: Maybe<String>;
+  recipientProcessingOperation_not_ends_with?: Maybe<String>;
+  recipientIsTempStorage?: Maybe<Boolean>;
+  recipientIsTempStorage_not?: Maybe<Boolean>;
+  recipientCompanyName?: Maybe<String>;
+  recipientCompanyName_not?: Maybe<String>;
+  recipientCompanyName_in?: Maybe<String[] | String>;
+  recipientCompanyName_not_in?: Maybe<String[] | String>;
+  recipientCompanyName_lt?: Maybe<String>;
+  recipientCompanyName_lte?: Maybe<String>;
+  recipientCompanyName_gt?: Maybe<String>;
+  recipientCompanyName_gte?: Maybe<String>;
+  recipientCompanyName_contains?: Maybe<String>;
+  recipientCompanyName_not_contains?: Maybe<String>;
+  recipientCompanyName_starts_with?: Maybe<String>;
+  recipientCompanyName_not_starts_with?: Maybe<String>;
+  recipientCompanyName_ends_with?: Maybe<String>;
+  recipientCompanyName_not_ends_with?: Maybe<String>;
+  recipientCompanySiret?: Maybe<String>;
+  recipientCompanySiret_not?: Maybe<String>;
+  recipientCompanySiret_in?: Maybe<String[] | String>;
+  recipientCompanySiret_not_in?: Maybe<String[] | String>;
+  recipientCompanySiret_lt?: Maybe<String>;
+  recipientCompanySiret_lte?: Maybe<String>;
+  recipientCompanySiret_gt?: Maybe<String>;
+  recipientCompanySiret_gte?: Maybe<String>;
+  recipientCompanySiret_contains?: Maybe<String>;
+  recipientCompanySiret_not_contains?: Maybe<String>;
+  recipientCompanySiret_starts_with?: Maybe<String>;
+  recipientCompanySiret_not_starts_with?: Maybe<String>;
+  recipientCompanySiret_ends_with?: Maybe<String>;
+  recipientCompanySiret_not_ends_with?: Maybe<String>;
+  recipientCompanyAddress?: Maybe<String>;
+  recipientCompanyAddress_not?: Maybe<String>;
+  recipientCompanyAddress_in?: Maybe<String[] | String>;
+  recipientCompanyAddress_not_in?: Maybe<String[] | String>;
+  recipientCompanyAddress_lt?: Maybe<String>;
+  recipientCompanyAddress_lte?: Maybe<String>;
+  recipientCompanyAddress_gt?: Maybe<String>;
+  recipientCompanyAddress_gte?: Maybe<String>;
+  recipientCompanyAddress_contains?: Maybe<String>;
+  recipientCompanyAddress_not_contains?: Maybe<String>;
+  recipientCompanyAddress_starts_with?: Maybe<String>;
+  recipientCompanyAddress_not_starts_with?: Maybe<String>;
+  recipientCompanyAddress_ends_with?: Maybe<String>;
+  recipientCompanyAddress_not_ends_with?: Maybe<String>;
+  recipientCompanyContact?: Maybe<String>;
+  recipientCompanyContact_not?: Maybe<String>;
+  recipientCompanyContact_in?: Maybe<String[] | String>;
+  recipientCompanyContact_not_in?: Maybe<String[] | String>;
+  recipientCompanyContact_lt?: Maybe<String>;
+  recipientCompanyContact_lte?: Maybe<String>;
+  recipientCompanyContact_gt?: Maybe<String>;
+  recipientCompanyContact_gte?: Maybe<String>;
+  recipientCompanyContact_contains?: Maybe<String>;
+  recipientCompanyContact_not_contains?: Maybe<String>;
+  recipientCompanyContact_starts_with?: Maybe<String>;
+  recipientCompanyContact_not_starts_with?: Maybe<String>;
+  recipientCompanyContact_ends_with?: Maybe<String>;
+  recipientCompanyContact_not_ends_with?: Maybe<String>;
+  recipientCompanyPhone?: Maybe<String>;
+  recipientCompanyPhone_not?: Maybe<String>;
+  recipientCompanyPhone_in?: Maybe<String[] | String>;
+  recipientCompanyPhone_not_in?: Maybe<String[] | String>;
+  recipientCompanyPhone_lt?: Maybe<String>;
+  recipientCompanyPhone_lte?: Maybe<String>;
+  recipientCompanyPhone_gt?: Maybe<String>;
+  recipientCompanyPhone_gte?: Maybe<String>;
+  recipientCompanyPhone_contains?: Maybe<String>;
+  recipientCompanyPhone_not_contains?: Maybe<String>;
+  recipientCompanyPhone_starts_with?: Maybe<String>;
+  recipientCompanyPhone_not_starts_with?: Maybe<String>;
+  recipientCompanyPhone_ends_with?: Maybe<String>;
+  recipientCompanyPhone_not_ends_with?: Maybe<String>;
+  recipientCompanyMail?: Maybe<String>;
+  recipientCompanyMail_not?: Maybe<String>;
+  recipientCompanyMail_in?: Maybe<String[] | String>;
+  recipientCompanyMail_not_in?: Maybe<String[] | String>;
+  recipientCompanyMail_lt?: Maybe<String>;
+  recipientCompanyMail_lte?: Maybe<String>;
+  recipientCompanyMail_gt?: Maybe<String>;
+  recipientCompanyMail_gte?: Maybe<String>;
+  recipientCompanyMail_contains?: Maybe<String>;
+  recipientCompanyMail_not_contains?: Maybe<String>;
+  recipientCompanyMail_starts_with?: Maybe<String>;
+  recipientCompanyMail_not_starts_with?: Maybe<String>;
+  recipientCompanyMail_ends_with?: Maybe<String>;
+  recipientCompanyMail_not_ends_with?: Maybe<String>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanyName_not?: Maybe<String>;
+  transporterCompanyName_in?: Maybe<String[] | String>;
+  transporterCompanyName_not_in?: Maybe<String[] | String>;
+  transporterCompanyName_lt?: Maybe<String>;
+  transporterCompanyName_lte?: Maybe<String>;
+  transporterCompanyName_gt?: Maybe<String>;
+  transporterCompanyName_gte?: Maybe<String>;
+  transporterCompanyName_contains?: Maybe<String>;
+  transporterCompanyName_not_contains?: Maybe<String>;
+  transporterCompanyName_starts_with?: Maybe<String>;
+  transporterCompanyName_not_starts_with?: Maybe<String>;
+  transporterCompanyName_ends_with?: Maybe<String>;
+  transporterCompanyName_not_ends_with?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanySiret_not?: Maybe<String>;
+  transporterCompanySiret_in?: Maybe<String[] | String>;
+  transporterCompanySiret_not_in?: Maybe<String[] | String>;
+  transporterCompanySiret_lt?: Maybe<String>;
+  transporterCompanySiret_lte?: Maybe<String>;
+  transporterCompanySiret_gt?: Maybe<String>;
+  transporterCompanySiret_gte?: Maybe<String>;
+  transporterCompanySiret_contains?: Maybe<String>;
+  transporterCompanySiret_not_contains?: Maybe<String>;
+  transporterCompanySiret_starts_with?: Maybe<String>;
+  transporterCompanySiret_not_starts_with?: Maybe<String>;
+  transporterCompanySiret_ends_with?: Maybe<String>;
+  transporterCompanySiret_not_ends_with?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyAddress_not?: Maybe<String>;
+  transporterCompanyAddress_in?: Maybe<String[] | String>;
+  transporterCompanyAddress_not_in?: Maybe<String[] | String>;
+  transporterCompanyAddress_lt?: Maybe<String>;
+  transporterCompanyAddress_lte?: Maybe<String>;
+  transporterCompanyAddress_gt?: Maybe<String>;
+  transporterCompanyAddress_gte?: Maybe<String>;
+  transporterCompanyAddress_contains?: Maybe<String>;
+  transporterCompanyAddress_not_contains?: Maybe<String>;
+  transporterCompanyAddress_starts_with?: Maybe<String>;
+  transporterCompanyAddress_not_starts_with?: Maybe<String>;
+  transporterCompanyAddress_ends_with?: Maybe<String>;
+  transporterCompanyAddress_not_ends_with?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyContact_not?: Maybe<String>;
+  transporterCompanyContact_in?: Maybe<String[] | String>;
+  transporterCompanyContact_not_in?: Maybe<String[] | String>;
+  transporterCompanyContact_lt?: Maybe<String>;
+  transporterCompanyContact_lte?: Maybe<String>;
+  transporterCompanyContact_gt?: Maybe<String>;
+  transporterCompanyContact_gte?: Maybe<String>;
+  transporterCompanyContact_contains?: Maybe<String>;
+  transporterCompanyContact_not_contains?: Maybe<String>;
+  transporterCompanyContact_starts_with?: Maybe<String>;
+  transporterCompanyContact_not_starts_with?: Maybe<String>;
+  transporterCompanyContact_ends_with?: Maybe<String>;
+  transporterCompanyContact_not_ends_with?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyPhone_not?: Maybe<String>;
+  transporterCompanyPhone_in?: Maybe<String[] | String>;
+  transporterCompanyPhone_not_in?: Maybe<String[] | String>;
+  transporterCompanyPhone_lt?: Maybe<String>;
+  transporterCompanyPhone_lte?: Maybe<String>;
+  transporterCompanyPhone_gt?: Maybe<String>;
+  transporterCompanyPhone_gte?: Maybe<String>;
+  transporterCompanyPhone_contains?: Maybe<String>;
+  transporterCompanyPhone_not_contains?: Maybe<String>;
+  transporterCompanyPhone_starts_with?: Maybe<String>;
+  transporterCompanyPhone_not_starts_with?: Maybe<String>;
+  transporterCompanyPhone_ends_with?: Maybe<String>;
+  transporterCompanyPhone_not_ends_with?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterCompanyMail_not?: Maybe<String>;
+  transporterCompanyMail_in?: Maybe<String[] | String>;
+  transporterCompanyMail_not_in?: Maybe<String[] | String>;
+  transporterCompanyMail_lt?: Maybe<String>;
+  transporterCompanyMail_lte?: Maybe<String>;
+  transporterCompanyMail_gt?: Maybe<String>;
+  transporterCompanyMail_gte?: Maybe<String>;
+  transporterCompanyMail_contains?: Maybe<String>;
+  transporterCompanyMail_not_contains?: Maybe<String>;
+  transporterCompanyMail_starts_with?: Maybe<String>;
+  transporterCompanyMail_not_starts_with?: Maybe<String>;
+  transporterCompanyMail_ends_with?: Maybe<String>;
+  transporterCompanyMail_not_ends_with?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterIsExemptedOfReceipt_not?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterReceipt_not?: Maybe<String>;
+  transporterReceipt_in?: Maybe<String[] | String>;
+  transporterReceipt_not_in?: Maybe<String[] | String>;
+  transporterReceipt_lt?: Maybe<String>;
+  transporterReceipt_lte?: Maybe<String>;
+  transporterReceipt_gt?: Maybe<String>;
+  transporterReceipt_gte?: Maybe<String>;
+  transporterReceipt_contains?: Maybe<String>;
+  transporterReceipt_not_contains?: Maybe<String>;
+  transporterReceipt_starts_with?: Maybe<String>;
+  transporterReceipt_not_starts_with?: Maybe<String>;
+  transporterReceipt_ends_with?: Maybe<String>;
+  transporterReceipt_not_ends_with?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterDepartment_not?: Maybe<String>;
+  transporterDepartment_in?: Maybe<String[] | String>;
+  transporterDepartment_not_in?: Maybe<String[] | String>;
+  transporterDepartment_lt?: Maybe<String>;
+  transporterDepartment_lte?: Maybe<String>;
+  transporterDepartment_gt?: Maybe<String>;
+  transporterDepartment_gte?: Maybe<String>;
+  transporterDepartment_contains?: Maybe<String>;
+  transporterDepartment_not_contains?: Maybe<String>;
+  transporterDepartment_starts_with?: Maybe<String>;
+  transporterDepartment_not_starts_with?: Maybe<String>;
+  transporterDepartment_ends_with?: Maybe<String>;
+  transporterDepartment_not_ends_with?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterValidityLimit_not?: Maybe<DateTimeInput>;
+  transporterValidityLimit_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  transporterValidityLimit_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  transporterValidityLimit_lt?: Maybe<DateTimeInput>;
+  transporterValidityLimit_lte?: Maybe<DateTimeInput>;
+  transporterValidityLimit_gt?: Maybe<DateTimeInput>;
+  transporterValidityLimit_gte?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  transporterNumberPlate_not?: Maybe<String>;
+  transporterNumberPlate_in?: Maybe<String[] | String>;
+  transporterNumberPlate_not_in?: Maybe<String[] | String>;
+  transporterNumberPlate_lt?: Maybe<String>;
+  transporterNumberPlate_lte?: Maybe<String>;
+  transporterNumberPlate_gt?: Maybe<String>;
+  transporterNumberPlate_gte?: Maybe<String>;
+  transporterNumberPlate_contains?: Maybe<String>;
+  transporterNumberPlate_not_contains?: Maybe<String>;
+  transporterNumberPlate_starts_with?: Maybe<String>;
+  transporterNumberPlate_not_starts_with?: Maybe<String>;
+  transporterNumberPlate_ends_with?: Maybe<String>;
+  transporterNumberPlate_not_ends_with?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  transporterCustomInfo_not?: Maybe<String>;
+  transporterCustomInfo_in?: Maybe<String[] | String>;
+  transporterCustomInfo_not_in?: Maybe<String[] | String>;
+  transporterCustomInfo_lt?: Maybe<String>;
+  transporterCustomInfo_lte?: Maybe<String>;
+  transporterCustomInfo_gt?: Maybe<String>;
+  transporterCustomInfo_gte?: Maybe<String>;
+  transporterCustomInfo_contains?: Maybe<String>;
+  transporterCustomInfo_not_contains?: Maybe<String>;
+  transporterCustomInfo_starts_with?: Maybe<String>;
+  transporterCustomInfo_not_starts_with?: Maybe<String>;
+  transporterCustomInfo_ends_with?: Maybe<String>;
+  transporterCustomInfo_not_ends_with?: Maybe<String>;
+  wasteDetailsCode?: Maybe<String>;
+  wasteDetailsCode_not?: Maybe<String>;
+  wasteDetailsCode_in?: Maybe<String[] | String>;
+  wasteDetailsCode_not_in?: Maybe<String[] | String>;
+  wasteDetailsCode_lt?: Maybe<String>;
+  wasteDetailsCode_lte?: Maybe<String>;
+  wasteDetailsCode_gt?: Maybe<String>;
+  wasteDetailsCode_gte?: Maybe<String>;
+  wasteDetailsCode_contains?: Maybe<String>;
+  wasteDetailsCode_not_contains?: Maybe<String>;
+  wasteDetailsCode_starts_with?: Maybe<String>;
+  wasteDetailsCode_not_starts_with?: Maybe<String>;
+  wasteDetailsCode_ends_with?: Maybe<String>;
+  wasteDetailsCode_not_ends_with?: Maybe<String>;
+  wasteDetailsName?: Maybe<String>;
+  wasteDetailsName_not?: Maybe<String>;
+  wasteDetailsName_in?: Maybe<String[] | String>;
+  wasteDetailsName_not_in?: Maybe<String[] | String>;
+  wasteDetailsName_lt?: Maybe<String>;
+  wasteDetailsName_lte?: Maybe<String>;
+  wasteDetailsName_gt?: Maybe<String>;
+  wasteDetailsName_gte?: Maybe<String>;
+  wasteDetailsName_contains?: Maybe<String>;
+  wasteDetailsName_not_contains?: Maybe<String>;
+  wasteDetailsName_starts_with?: Maybe<String>;
+  wasteDetailsName_not_starts_with?: Maybe<String>;
+  wasteDetailsName_ends_with?: Maybe<String>;
+  wasteDetailsName_not_ends_with?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsOnuCode_not?: Maybe<String>;
+  wasteDetailsOnuCode_in?: Maybe<String[] | String>;
+  wasteDetailsOnuCode_not_in?: Maybe<String[] | String>;
+  wasteDetailsOnuCode_lt?: Maybe<String>;
+  wasteDetailsOnuCode_lte?: Maybe<String>;
+  wasteDetailsOnuCode_gt?: Maybe<String>;
+  wasteDetailsOnuCode_gte?: Maybe<String>;
+  wasteDetailsOnuCode_contains?: Maybe<String>;
+  wasteDetailsOnuCode_not_contains?: Maybe<String>;
+  wasteDetailsOnuCode_starts_with?: Maybe<String>;
+  wasteDetailsOnuCode_not_starts_with?: Maybe<String>;
+  wasteDetailsOnuCode_ends_with?: Maybe<String>;
+  wasteDetailsOnuCode_not_ends_with?: Maybe<String>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsOtherPackaging_not?: Maybe<String>;
+  wasteDetailsOtherPackaging_in?: Maybe<String[] | String>;
+  wasteDetailsOtherPackaging_not_in?: Maybe<String[] | String>;
+  wasteDetailsOtherPackaging_lt?: Maybe<String>;
+  wasteDetailsOtherPackaging_lte?: Maybe<String>;
+  wasteDetailsOtherPackaging_gt?: Maybe<String>;
+  wasteDetailsOtherPackaging_gte?: Maybe<String>;
+  wasteDetailsOtherPackaging_contains?: Maybe<String>;
+  wasteDetailsOtherPackaging_not_contains?: Maybe<String>;
+  wasteDetailsOtherPackaging_starts_with?: Maybe<String>;
+  wasteDetailsOtherPackaging_not_starts_with?: Maybe<String>;
+  wasteDetailsOtherPackaging_ends_with?: Maybe<String>;
+  wasteDetailsOtherPackaging_not_ends_with?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsNumberOfPackages_not?: Maybe<Int>;
+  wasteDetailsNumberOfPackages_in?: Maybe<Int[] | Int>;
+  wasteDetailsNumberOfPackages_not_in?: Maybe<Int[] | Int>;
+  wasteDetailsNumberOfPackages_lt?: Maybe<Int>;
+  wasteDetailsNumberOfPackages_lte?: Maybe<Int>;
+  wasteDetailsNumberOfPackages_gt?: Maybe<Int>;
+  wasteDetailsNumberOfPackages_gte?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantity_not?: Maybe<Float>;
+  wasteDetailsQuantity_in?: Maybe<Float[] | Float>;
+  wasteDetailsQuantity_not_in?: Maybe<Float[] | Float>;
+  wasteDetailsQuantity_lt?: Maybe<Float>;
+  wasteDetailsQuantity_lte?: Maybe<Float>;
+  wasteDetailsQuantity_gt?: Maybe<Float>;
+  wasteDetailsQuantity_gte?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  wasteDetailsQuantityType_not?: Maybe<QuantityType>;
+  wasteDetailsQuantityType_in?: Maybe<QuantityType[] | QuantityType>;
+  wasteDetailsQuantityType_not_in?: Maybe<QuantityType[] | QuantityType>;
+  wasteDetailsConsistence?: Maybe<Consistence>;
+  wasteDetailsConsistence_not?: Maybe<Consistence>;
+  wasteDetailsConsistence_in?: Maybe<Consistence[] | Consistence>;
+  wasteDetailsConsistence_not_in?: Maybe<Consistence[] | Consistence>;
+  traderCompanyName?: Maybe<String>;
+  traderCompanyName_not?: Maybe<String>;
+  traderCompanyName_in?: Maybe<String[] | String>;
+  traderCompanyName_not_in?: Maybe<String[] | String>;
+  traderCompanyName_lt?: Maybe<String>;
+  traderCompanyName_lte?: Maybe<String>;
+  traderCompanyName_gt?: Maybe<String>;
+  traderCompanyName_gte?: Maybe<String>;
+  traderCompanyName_contains?: Maybe<String>;
+  traderCompanyName_not_contains?: Maybe<String>;
+  traderCompanyName_starts_with?: Maybe<String>;
+  traderCompanyName_not_starts_with?: Maybe<String>;
+  traderCompanyName_ends_with?: Maybe<String>;
+  traderCompanyName_not_ends_with?: Maybe<String>;
+  traderCompanySiret?: Maybe<String>;
+  traderCompanySiret_not?: Maybe<String>;
+  traderCompanySiret_in?: Maybe<String[] | String>;
+  traderCompanySiret_not_in?: Maybe<String[] | String>;
+  traderCompanySiret_lt?: Maybe<String>;
+  traderCompanySiret_lte?: Maybe<String>;
+  traderCompanySiret_gt?: Maybe<String>;
+  traderCompanySiret_gte?: Maybe<String>;
+  traderCompanySiret_contains?: Maybe<String>;
+  traderCompanySiret_not_contains?: Maybe<String>;
+  traderCompanySiret_starts_with?: Maybe<String>;
+  traderCompanySiret_not_starts_with?: Maybe<String>;
+  traderCompanySiret_ends_with?: Maybe<String>;
+  traderCompanySiret_not_ends_with?: Maybe<String>;
+  traderCompanyAddress?: Maybe<String>;
+  traderCompanyAddress_not?: Maybe<String>;
+  traderCompanyAddress_in?: Maybe<String[] | String>;
+  traderCompanyAddress_not_in?: Maybe<String[] | String>;
+  traderCompanyAddress_lt?: Maybe<String>;
+  traderCompanyAddress_lte?: Maybe<String>;
+  traderCompanyAddress_gt?: Maybe<String>;
+  traderCompanyAddress_gte?: Maybe<String>;
+  traderCompanyAddress_contains?: Maybe<String>;
+  traderCompanyAddress_not_contains?: Maybe<String>;
+  traderCompanyAddress_starts_with?: Maybe<String>;
+  traderCompanyAddress_not_starts_with?: Maybe<String>;
+  traderCompanyAddress_ends_with?: Maybe<String>;
+  traderCompanyAddress_not_ends_with?: Maybe<String>;
+  traderCompanyContact?: Maybe<String>;
+  traderCompanyContact_not?: Maybe<String>;
+  traderCompanyContact_in?: Maybe<String[] | String>;
+  traderCompanyContact_not_in?: Maybe<String[] | String>;
+  traderCompanyContact_lt?: Maybe<String>;
+  traderCompanyContact_lte?: Maybe<String>;
+  traderCompanyContact_gt?: Maybe<String>;
+  traderCompanyContact_gte?: Maybe<String>;
+  traderCompanyContact_contains?: Maybe<String>;
+  traderCompanyContact_not_contains?: Maybe<String>;
+  traderCompanyContact_starts_with?: Maybe<String>;
+  traderCompanyContact_not_starts_with?: Maybe<String>;
+  traderCompanyContact_ends_with?: Maybe<String>;
+  traderCompanyContact_not_ends_with?: Maybe<String>;
+  traderCompanyPhone?: Maybe<String>;
+  traderCompanyPhone_not?: Maybe<String>;
+  traderCompanyPhone_in?: Maybe<String[] | String>;
+  traderCompanyPhone_not_in?: Maybe<String[] | String>;
+  traderCompanyPhone_lt?: Maybe<String>;
+  traderCompanyPhone_lte?: Maybe<String>;
+  traderCompanyPhone_gt?: Maybe<String>;
+  traderCompanyPhone_gte?: Maybe<String>;
+  traderCompanyPhone_contains?: Maybe<String>;
+  traderCompanyPhone_not_contains?: Maybe<String>;
+  traderCompanyPhone_starts_with?: Maybe<String>;
+  traderCompanyPhone_not_starts_with?: Maybe<String>;
+  traderCompanyPhone_ends_with?: Maybe<String>;
+  traderCompanyPhone_not_ends_with?: Maybe<String>;
+  traderCompanyMail?: Maybe<String>;
+  traderCompanyMail_not?: Maybe<String>;
+  traderCompanyMail_in?: Maybe<String[] | String>;
+  traderCompanyMail_not_in?: Maybe<String[] | String>;
+  traderCompanyMail_lt?: Maybe<String>;
+  traderCompanyMail_lte?: Maybe<String>;
+  traderCompanyMail_gt?: Maybe<String>;
+  traderCompanyMail_gte?: Maybe<String>;
+  traderCompanyMail_contains?: Maybe<String>;
+  traderCompanyMail_not_contains?: Maybe<String>;
+  traderCompanyMail_starts_with?: Maybe<String>;
+  traderCompanyMail_not_starts_with?: Maybe<String>;
+  traderCompanyMail_ends_with?: Maybe<String>;
+  traderCompanyMail_not_ends_with?: Maybe<String>;
+  traderReceipt?: Maybe<String>;
+  traderReceipt_not?: Maybe<String>;
+  traderReceipt_in?: Maybe<String[] | String>;
+  traderReceipt_not_in?: Maybe<String[] | String>;
+  traderReceipt_lt?: Maybe<String>;
+  traderReceipt_lte?: Maybe<String>;
+  traderReceipt_gt?: Maybe<String>;
+  traderReceipt_gte?: Maybe<String>;
+  traderReceipt_contains?: Maybe<String>;
+  traderReceipt_not_contains?: Maybe<String>;
+  traderReceipt_starts_with?: Maybe<String>;
+  traderReceipt_not_starts_with?: Maybe<String>;
+  traderReceipt_ends_with?: Maybe<String>;
+  traderReceipt_not_ends_with?: Maybe<String>;
+  traderDepartment?: Maybe<String>;
+  traderDepartment_not?: Maybe<String>;
+  traderDepartment_in?: Maybe<String[] | String>;
+  traderDepartment_not_in?: Maybe<String[] | String>;
+  traderDepartment_lt?: Maybe<String>;
+  traderDepartment_lte?: Maybe<String>;
+  traderDepartment_gt?: Maybe<String>;
+  traderDepartment_gte?: Maybe<String>;
+  traderDepartment_contains?: Maybe<String>;
+  traderDepartment_not_contains?: Maybe<String>;
+  traderDepartment_starts_with?: Maybe<String>;
+  traderDepartment_not_starts_with?: Maybe<String>;
+  traderDepartment_ends_with?: Maybe<String>;
+  traderDepartment_not_ends_with?: Maybe<String>;
+  traderValidityLimit?: Maybe<DateTimeInput>;
+  traderValidityLimit_not?: Maybe<DateTimeInput>;
+  traderValidityLimit_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  traderValidityLimit_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  traderValidityLimit_lt?: Maybe<DateTimeInput>;
+  traderValidityLimit_lte?: Maybe<DateTimeInput>;
+  traderValidityLimit_gt?: Maybe<DateTimeInput>;
+  traderValidityLimit_gte?: Maybe<DateTimeInput>;
+  ecoOrganisme?: Maybe<EcoOrganismeWhereInput>;
+  appendix2Forms_every?: Maybe<FormWhereInput>;
+  appendix2Forms_some?: Maybe<FormWhereInput>;
+  appendix2Forms_none?: Maybe<FormWhereInput>;
+  temporaryStorageDetail?: Maybe<TemporaryStorageDetailWhereInput>;
+  AND?: Maybe<FormWhereInput[] | FormWhereInput>;
+  OR?: Maybe<FormWhereInput[] | FormWhereInput>;
+  NOT?: Maybe<FormWhereInput[] | FormWhereInput>;
+}
+
+export interface AccessTokenCreateInput {
+  id?: Maybe<ID_Input>;
+  user: UserCreateOneInput;
+  application?: Maybe<ApplicationCreateOneInput>;
+  token: String;
+  isRevoked?: Maybe<Boolean>;
+  lastUsed?: Maybe<DateTimeInput>;
+}
+
+export interface TemporaryStorageDetailUpdateManyMutationInput {
+  tempStorerQuantityType?: Maybe<QuantityType>;
+  tempStorerQuantityReceived?: Maybe<Float>;
+  tempStorerWasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  tempStorerWasteRefusalReason?: Maybe<String>;
+  tempStorerReceivedAt?: Maybe<DateTimeInput>;
+  tempStorerReceivedBy?: Maybe<String>;
+  tempStorerSignedAt?: Maybe<DateTimeInput>;
+  destinationIsFilledByEmitter?: Maybe<Boolean>;
+  destinationCompanyName?: Maybe<String>;
+  destinationCompanySiret?: Maybe<String>;
+  destinationCompanyAddress?: Maybe<String>;
+  destinationCompanyContact?: Maybe<String>;
+  destinationCompanyPhone?: Maybe<String>;
+  destinationCompanyMail?: Maybe<String>;
+  destinationCap?: Maybe<String>;
+  destinationProcessingOperation?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsPackagings?: Maybe<Json>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  signedByTransporter?: Maybe<Boolean>;
+  signedBy?: Maybe<String>;
+  signedAt?: Maybe<DateTimeInput>;
+}
+
+export interface UserCreateOneInput {
+  create?: Maybe<UserCreateInput>;
+  connect?: Maybe<UserWhereUniqueInput>;
+}
+
+export interface FormUpdateWithoutTemporaryStorageDetailDataInput {
+  readableId?: Maybe<String>;
+  customId?: Maybe<String>;
+  isDeleted?: Maybe<Boolean>;
+  owner?: Maybe<UserUpdateOneRequiredInput>;
+  signedByTransporter?: Maybe<Boolean>;
+  status?: Maybe<Status>;
+  sentAt?: Maybe<DateTimeInput>;
+  sentBy?: Maybe<String>;
+  isAccepted?: Maybe<Boolean>;
+  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  wasteRefusalReason?: Maybe<String>;
+  receivedBy?: Maybe<String>;
+  receivedAt?: Maybe<DateTimeInput>;
+  quantityReceived?: Maybe<Float>;
+  processedBy?: Maybe<String>;
+  processedAt?: Maybe<String>;
+  processingOperationDone?: Maybe<String>;
+  processingOperationDescription?: Maybe<String>;
+  noTraceability?: Maybe<Boolean>;
+  nextDestinationProcessingOperation?: Maybe<String>;
+  nextDestinationCompanyName?: Maybe<String>;
+  nextDestinationCompanySiret?: Maybe<String>;
+  nextDestinationCompanyAddress?: Maybe<String>;
+  nextDestinationCompanyContact?: Maybe<String>;
+  nextDestinationCompanyPhone?: Maybe<String>;
+  nextDestinationCompanyMail?: Maybe<String>;
+  emitterType?: Maybe<EmitterType>;
+  emitterPickupSite?: Maybe<String>;
+  emitterWorkSiteName?: Maybe<String>;
+  emitterWorkSiteAddress?: Maybe<String>;
+  emitterWorkSiteCity?: Maybe<String>;
+  emitterWorkSitePostalCode?: Maybe<String>;
+  emitterWorkSiteInfos?: Maybe<String>;
+  emitterCompanyName?: Maybe<String>;
+  emitterCompanySiret?: Maybe<String>;
+  emitterCompanyAddress?: Maybe<String>;
+  emitterCompanyContact?: Maybe<String>;
+  emitterCompanyPhone?: Maybe<String>;
+  emitterCompanyMail?: Maybe<String>;
+  recipientCap?: Maybe<String>;
+  recipientProcessingOperation?: Maybe<String>;
+  recipientIsTempStorage?: Maybe<Boolean>;
+  recipientCompanyName?: Maybe<String>;
+  recipientCompanySiret?: Maybe<String>;
+  recipientCompanyAddress?: Maybe<String>;
+  recipientCompanyContact?: Maybe<String>;
+  recipientCompanyPhone?: Maybe<String>;
+  recipientCompanyMail?: Maybe<String>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  wasteDetailsCode?: Maybe<String>;
+  wasteDetailsName?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsPackagings?: Maybe<Json>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  wasteDetailsConsistence?: Maybe<Consistence>;
+  traderCompanyName?: Maybe<String>;
+  traderCompanySiret?: Maybe<String>;
+  traderCompanyAddress?: Maybe<String>;
+  traderCompanyContact?: Maybe<String>;
+  traderCompanyPhone?: Maybe<String>;
+  traderCompanyMail?: Maybe<String>;
+  traderReceipt?: Maybe<String>;
+  traderDepartment?: Maybe<String>;
+  traderValidityLimit?: Maybe<DateTimeInput>;
+  ecoOrganisme?: Maybe<EcoOrganismeUpdateOneInput>;
+  appendix2Forms?: Maybe<FormUpdateManyInput>;
+}
+
+export interface UserCreateInput {
+  id?: Maybe<ID_Input>;
+  isActive?: Maybe<Boolean>;
+  email: String;
+  password: String;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+  companyAssociations?: Maybe<CompanyAssociationCreateManyWithoutUserInput>;
+}
+
+export interface TemporaryStorageDetailUpdateInput {
+  form?: Maybe<FormUpdateOneWithoutTemporaryStorageDetailInput>;
+  tempStorerQuantityType?: Maybe<QuantityType>;
+  tempStorerQuantityReceived?: Maybe<Float>;
+  tempStorerWasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  tempStorerWasteRefusalReason?: Maybe<String>;
+  tempStorerReceivedAt?: Maybe<DateTimeInput>;
+  tempStorerReceivedBy?: Maybe<String>;
+  tempStorerSignedAt?: Maybe<DateTimeInput>;
+  destinationIsFilledByEmitter?: Maybe<Boolean>;
+  destinationCompanyName?: Maybe<String>;
+  destinationCompanySiret?: Maybe<String>;
+  destinationCompanyAddress?: Maybe<String>;
+  destinationCompanyContact?: Maybe<String>;
+  destinationCompanyPhone?: Maybe<String>;
+  destinationCompanyMail?: Maybe<String>;
+  destinationCap?: Maybe<String>;
+  destinationProcessingOperation?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsPackagings?: Maybe<Json>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  signedByTransporter?: Maybe<Boolean>;
+  signedBy?: Maybe<String>;
+  signedAt?: Maybe<DateTimeInput>;
+}
+
+export interface CompanyAssociationCreateManyWithoutUserInput {
+  create?: Maybe<
+    | CompanyAssociationCreateWithoutUserInput[]
+    | CompanyAssociationCreateWithoutUserInput
+  >;
+  connect?: Maybe<
+    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
+  >;
+}
+
+export interface FormCreateWithoutTemporaryStorageDetailInput {
+  id?: Maybe<ID_Input>;
+  readableId?: Maybe<String>;
+  customId?: Maybe<String>;
+  isDeleted?: Maybe<Boolean>;
+  owner: UserCreateOneInput;
+  signedByTransporter?: Maybe<Boolean>;
+  status?: Maybe<Status>;
+  sentAt?: Maybe<DateTimeInput>;
+  sentBy?: Maybe<String>;
+  isAccepted?: Maybe<Boolean>;
+  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  wasteRefusalReason?: Maybe<String>;
+  receivedBy?: Maybe<String>;
+  receivedAt?: Maybe<DateTimeInput>;
+  quantityReceived?: Maybe<Float>;
+  processedBy?: Maybe<String>;
+  processedAt?: Maybe<String>;
+  processingOperationDone?: Maybe<String>;
+  processingOperationDescription?: Maybe<String>;
+  noTraceability?: Maybe<Boolean>;
+  nextDestinationProcessingOperation?: Maybe<String>;
+  nextDestinationCompanyName?: Maybe<String>;
+  nextDestinationCompanySiret?: Maybe<String>;
+  nextDestinationCompanyAddress?: Maybe<String>;
+  nextDestinationCompanyContact?: Maybe<String>;
+  nextDestinationCompanyPhone?: Maybe<String>;
+  nextDestinationCompanyMail?: Maybe<String>;
+  emitterType?: Maybe<EmitterType>;
+  emitterPickupSite?: Maybe<String>;
+  emitterWorkSiteName?: Maybe<String>;
+  emitterWorkSiteAddress?: Maybe<String>;
+  emitterWorkSiteCity?: Maybe<String>;
+  emitterWorkSitePostalCode?: Maybe<String>;
+  emitterWorkSiteInfos?: Maybe<String>;
+  emitterCompanyName?: Maybe<String>;
+  emitterCompanySiret?: Maybe<String>;
+  emitterCompanyAddress?: Maybe<String>;
+  emitterCompanyContact?: Maybe<String>;
+  emitterCompanyPhone?: Maybe<String>;
+  emitterCompanyMail?: Maybe<String>;
+  recipientCap?: Maybe<String>;
+  recipientProcessingOperation?: Maybe<String>;
+  recipientIsTempStorage?: Maybe<Boolean>;
+  recipientCompanyName?: Maybe<String>;
+  recipientCompanySiret?: Maybe<String>;
+  recipientCompanyAddress?: Maybe<String>;
+  recipientCompanyContact?: Maybe<String>;
+  recipientCompanyPhone?: Maybe<String>;
+  recipientCompanyMail?: Maybe<String>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  wasteDetailsCode?: Maybe<String>;
+  wasteDetailsName?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsPackagings?: Maybe<Json>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  wasteDetailsConsistence?: Maybe<Consistence>;
+  traderCompanyName?: Maybe<String>;
+  traderCompanySiret?: Maybe<String>;
+  traderCompanyAddress?: Maybe<String>;
+  traderCompanyContact?: Maybe<String>;
+  traderCompanyPhone?: Maybe<String>;
+  traderCompanyMail?: Maybe<String>;
+  traderReceipt?: Maybe<String>;
+  traderDepartment?: Maybe<String>;
+  traderValidityLimit?: Maybe<DateTimeInput>;
+  ecoOrganisme?: Maybe<EcoOrganismeCreateOneInput>;
+  appendix2Forms?: Maybe<FormCreateManyInput>;
+}
+
+export interface CompanyAssociationCreateWithoutUserInput {
+  id?: Maybe<ID_Input>;
+  company: CompanyCreateOneInput;
+  role: UserRole;
+}
+
+export interface FormCreateOneWithoutTemporaryStorageDetailInput {
+  create?: Maybe<FormCreateWithoutTemporaryStorageDetailInput>;
+  connect?: Maybe<FormWhereUniqueInput>;
+}
+
+export interface CompanyCreateOneInput {
+  create?: Maybe<CompanyCreateInput>;
+  connect?: Maybe<CompanyWhereUniqueInput>;
+}
+
+export interface StatusLogUpdateManyMutationInput {
+  status?: Maybe<Status>;
+  loggedAt?: Maybe<DateTimeInput>;
+  updatedFields?: Maybe<Json>;
+}
+
+export interface CompanyCreateInput {
+  id?: Maybe<ID_Input>;
+  siret: String;
+  companyTypes?: Maybe<CompanyCreatecompanyTypesInput>;
+  name?: Maybe<String>;
+  gerepId?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  securityCode: Int;
+  givenName?: Maybe<String>;
+  contactEmail?: Maybe<String>;
+  contactPhone?: Maybe<String>;
+  website?: Maybe<String>;
+  documentKeys?: Maybe<CompanyCreatedocumentKeysInput>;
+}
+
+export type InstallationWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface CompanyCreatecompanyTypesInput {
+  set?: Maybe<CompanyType[] | CompanyType>;
+}
+
+export interface StatusLogUpdateInput {
+  user?: Maybe<UserUpdateOneRequiredInput>;
+  form?: Maybe<FormUpdateOneRequiredInput>;
+  status?: Maybe<Status>;
+  loggedAt?: Maybe<DateTimeInput>;
+  updatedFields?: Maybe<Json>;
+}
+
+export interface CompanyCreatedocumentKeysInput {
+  set?: Maybe<String[] | String>;
+}
+
+export interface CompanyWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  siret?: Maybe<String>;
+  siret_not?: Maybe<String>;
+  siret_in?: Maybe<String[] | String>;
+  siret_not_in?: Maybe<String[] | String>;
+  siret_lt?: Maybe<String>;
+  siret_lte?: Maybe<String>;
+  siret_gt?: Maybe<String>;
+  siret_gte?: Maybe<String>;
+  siret_contains?: Maybe<String>;
+  siret_not_contains?: Maybe<String>;
+  siret_starts_with?: Maybe<String>;
+  siret_not_starts_with?: Maybe<String>;
+  siret_ends_with?: Maybe<String>;
+  siret_not_ends_with?: Maybe<String>;
+  name?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  gerepId?: Maybe<String>;
+  gerepId_not?: Maybe<String>;
+  gerepId_in?: Maybe<String[] | String>;
+  gerepId_not_in?: Maybe<String[] | String>;
+  gerepId_lt?: Maybe<String>;
+  gerepId_lte?: Maybe<String>;
+  gerepId_gt?: Maybe<String>;
+  gerepId_gte?: Maybe<String>;
+  gerepId_contains?: Maybe<String>;
+  gerepId_not_contains?: Maybe<String>;
+  gerepId_starts_with?: Maybe<String>;
+  gerepId_not_starts_with?: Maybe<String>;
+  gerepId_ends_with?: Maybe<String>;
+  gerepId_not_ends_with?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  codeNaf_not?: Maybe<String>;
+  codeNaf_in?: Maybe<String[] | String>;
+  codeNaf_not_in?: Maybe<String[] | String>;
+  codeNaf_lt?: Maybe<String>;
+  codeNaf_lte?: Maybe<String>;
+  codeNaf_gt?: Maybe<String>;
+  codeNaf_gte?: Maybe<String>;
+  codeNaf_contains?: Maybe<String>;
+  codeNaf_not_contains?: Maybe<String>;
+  codeNaf_starts_with?: Maybe<String>;
+  codeNaf_not_starts_with?: Maybe<String>;
+  codeNaf_ends_with?: Maybe<String>;
+  codeNaf_not_ends_with?: Maybe<String>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  securityCode?: Maybe<Int>;
+  securityCode_not?: Maybe<Int>;
+  securityCode_in?: Maybe<Int[] | Int>;
+  securityCode_not_in?: Maybe<Int[] | Int>;
+  securityCode_lt?: Maybe<Int>;
+  securityCode_lte?: Maybe<Int>;
+  securityCode_gt?: Maybe<Int>;
+  securityCode_gte?: Maybe<Int>;
+  givenName?: Maybe<String>;
+  givenName_not?: Maybe<String>;
+  givenName_in?: Maybe<String[] | String>;
+  givenName_not_in?: Maybe<String[] | String>;
+  givenName_lt?: Maybe<String>;
+  givenName_lte?: Maybe<String>;
+  givenName_gt?: Maybe<String>;
+  givenName_gte?: Maybe<String>;
+  givenName_contains?: Maybe<String>;
+  givenName_not_contains?: Maybe<String>;
+  givenName_starts_with?: Maybe<String>;
+  givenName_not_starts_with?: Maybe<String>;
+  givenName_ends_with?: Maybe<String>;
+  givenName_not_ends_with?: Maybe<String>;
+  contactEmail?: Maybe<String>;
+  contactEmail_not?: Maybe<String>;
+  contactEmail_in?: Maybe<String[] | String>;
+  contactEmail_not_in?: Maybe<String[] | String>;
+  contactEmail_lt?: Maybe<String>;
+  contactEmail_lte?: Maybe<String>;
+  contactEmail_gt?: Maybe<String>;
+  contactEmail_gte?: Maybe<String>;
+  contactEmail_contains?: Maybe<String>;
+  contactEmail_not_contains?: Maybe<String>;
+  contactEmail_starts_with?: Maybe<String>;
+  contactEmail_not_starts_with?: Maybe<String>;
+  contactEmail_ends_with?: Maybe<String>;
+  contactEmail_not_ends_with?: Maybe<String>;
+  contactPhone?: Maybe<String>;
+  contactPhone_not?: Maybe<String>;
+  contactPhone_in?: Maybe<String[] | String>;
+  contactPhone_not_in?: Maybe<String[] | String>;
+  contactPhone_lt?: Maybe<String>;
+  contactPhone_lte?: Maybe<String>;
+  contactPhone_gt?: Maybe<String>;
+  contactPhone_gte?: Maybe<String>;
+  contactPhone_contains?: Maybe<String>;
+  contactPhone_not_contains?: Maybe<String>;
+  contactPhone_starts_with?: Maybe<String>;
+  contactPhone_not_starts_with?: Maybe<String>;
+  contactPhone_ends_with?: Maybe<String>;
+  contactPhone_not_ends_with?: Maybe<String>;
+  website?: Maybe<String>;
+  website_not?: Maybe<String>;
+  website_in?: Maybe<String[] | String>;
+  website_not_in?: Maybe<String[] | String>;
+  website_lt?: Maybe<String>;
+  website_lte?: Maybe<String>;
+  website_gt?: Maybe<String>;
+  website_gte?: Maybe<String>;
+  website_contains?: Maybe<String>;
+  website_not_contains?: Maybe<String>;
+  website_starts_with?: Maybe<String>;
+  website_not_starts_with?: Maybe<String>;
+  website_ends_with?: Maybe<String>;
+  website_not_ends_with?: Maybe<String>;
+  AND?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
+  OR?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
+  NOT?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
+}
+
+export interface ApplicationCreateOneInput {
+  create?: Maybe<ApplicationCreateInput>;
+  connect?: Maybe<ApplicationWhereUniqueInput>;
+}
+
+export interface StatusLogCreateInput {
+  id?: Maybe<ID_Input>;
+  user: UserCreateOneInput;
+  form: FormCreateOneInput;
+  status: Status;
+  loggedAt?: Maybe<DateTimeInput>;
+  updatedFields?: Maybe<Json>;
+}
+
+export interface ApplicationCreateInput {
+  id?: Maybe<ID_Input>;
+  clientSecret: String;
+  name: String;
+  admins?: Maybe<UserCreateManyInput>;
+  redirectUris?: Maybe<ApplicationCreateredirectUrisInput>;
+  logoUrl?: Maybe<String>;
+}
+
+export type RubriqueWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface UserCreateManyInput {
+  create?: Maybe<UserCreateInput[] | UserCreateInput>;
+  connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+}
+
+export interface UserWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  isActive?: Maybe<Boolean>;
+  isActive_not?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  email_not?: Maybe<String>;
+  email_in?: Maybe<String[] | String>;
+  email_not_in?: Maybe<String[] | String>;
+  email_lt?: Maybe<String>;
+  email_lte?: Maybe<String>;
+  email_gt?: Maybe<String>;
+  email_gte?: Maybe<String>;
+  email_contains?: Maybe<String>;
+  email_not_contains?: Maybe<String>;
+  email_starts_with?: Maybe<String>;
+  email_not_starts_with?: Maybe<String>;
+  email_ends_with?: Maybe<String>;
+  email_not_ends_with?: Maybe<String>;
+  password?: Maybe<String>;
+  password_not?: Maybe<String>;
+  password_in?: Maybe<String[] | String>;
+  password_not_in?: Maybe<String[] | String>;
+  password_lt?: Maybe<String>;
+  password_lte?: Maybe<String>;
+  password_gt?: Maybe<String>;
+  password_gte?: Maybe<String>;
+  password_contains?: Maybe<String>;
+  password_not_contains?: Maybe<String>;
+  password_starts_with?: Maybe<String>;
+  password_not_starts_with?: Maybe<String>;
+  password_ends_with?: Maybe<String>;
+  password_not_ends_with?: Maybe<String>;
+  name?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  phone?: Maybe<String>;
+  phone_not?: Maybe<String>;
+  phone_in?: Maybe<String[] | String>;
+  phone_not_in?: Maybe<String[] | String>;
+  phone_lt?: Maybe<String>;
+  phone_lte?: Maybe<String>;
+  phone_gt?: Maybe<String>;
+  phone_gte?: Maybe<String>;
+  phone_contains?: Maybe<String>;
+  phone_not_contains?: Maybe<String>;
+  phone_starts_with?: Maybe<String>;
+  phone_not_starts_with?: Maybe<String>;
+  phone_ends_with?: Maybe<String>;
+  phone_not_ends_with?: Maybe<String>;
+  companyAssociations_every?: Maybe<CompanyAssociationWhereInput>;
+  companyAssociations_some?: Maybe<CompanyAssociationWhereInput>;
+  companyAssociations_none?: Maybe<CompanyAssociationWhereInput>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  AND?: Maybe<UserWhereInput[] | UserWhereInput>;
+  OR?: Maybe<UserWhereInput[] | UserWhereInput>;
+  NOT?: Maybe<UserWhereInput[] | UserWhereInput>;
+}
+
+export interface ApplicationCreateredirectUrisInput {
+  set?: Maybe<String[] | String>;
+}
+
+export interface CompanyAssociationWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  user?: Maybe<UserWhereInput>;
+  company?: Maybe<CompanyWhereInput>;
+  role?: Maybe<UserRole>;
+  role_not?: Maybe<UserRole>;
+  role_in?: Maybe<UserRole[] | UserRole>;
+  role_not_in?: Maybe<UserRole[] | UserRole>;
+  AND?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
+  OR?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
+  NOT?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
+}
+
+export interface AccessTokenUpdateInput {
+  user?: Maybe<UserUpdateOneRequiredInput>;
+  application?: Maybe<ApplicationUpdateOneInput>;
+  token?: Maybe<String>;
+  isRevoked?: Maybe<Boolean>;
+  lastUsed?: Maybe<DateTimeInput>;
+}
+
+export interface InstallationUpdateManyMutationInput {
+  codeS3ic?: Maybe<String>;
+  nomEts?: Maybe<String>;
+  regime?: Maybe<String>;
+  libRegime?: Maybe<String>;
+  seveso?: Maybe<Seveso>;
+  libSeveso?: Maybe<String>;
+  familleIc?: Maybe<String>;
+  urlFiche?: Maybe<String>;
+  s3icNumeroSiret?: Maybe<String>;
+  irepNumeroSiret?: Maybe<String>;
+  gerepNumeroSiret?: Maybe<String>;
+  sireneNumeroSiret?: Maybe<String>;
+}
+
+export interface UserUpdateOneRequiredInput {
+  create?: Maybe<UserCreateInput>;
+  update?: Maybe<UserUpdateDataInput>;
+  upsert?: Maybe<UserUpsertNestedInput>;
+  connect?: Maybe<UserWhereUniqueInput>;
+}
+
+export type StatusLogWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface UserUpdateDataInput {
+  isActive?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  password?: Maybe<String>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+  companyAssociations?: Maybe<CompanyAssociationUpdateManyWithoutUserInput>;
+}
+
+export interface StatusLogWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  user?: Maybe<UserWhereInput>;
+  form?: Maybe<FormWhereInput>;
+  status?: Maybe<Status>;
+  status_not?: Maybe<Status>;
+  status_in?: Maybe<Status[] | Status>;
+  status_not_in?: Maybe<Status[] | Status>;
+  loggedAt?: Maybe<DateTimeInput>;
+  loggedAt_not?: Maybe<DateTimeInput>;
+  loggedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  loggedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  loggedAt_lt?: Maybe<DateTimeInput>;
+  loggedAt_lte?: Maybe<DateTimeInput>;
+  loggedAt_gt?: Maybe<DateTimeInput>;
+  loggedAt_gte?: Maybe<DateTimeInput>;
+  AND?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
+  OR?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
+  NOT?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
+}
+
+export interface CompanyAssociationUpdateManyWithoutUserInput {
+  create?: Maybe<
+    | CompanyAssociationCreateWithoutUserInput[]
+    | CompanyAssociationCreateWithoutUserInput
+  >;
+  delete?: Maybe<
+    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
+  >;
+  connect?: Maybe<
+    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
+  >;
+  set?: Maybe<
+    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
+  >;
+  disconnect?: Maybe<
+    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
+  >;
+  update?: Maybe<
+    | CompanyAssociationUpdateWithWhereUniqueWithoutUserInput[]
+    | CompanyAssociationUpdateWithWhereUniqueWithoutUserInput
+  >;
+  upsert?: Maybe<
+    | CompanyAssociationUpsertWithWhereUniqueWithoutUserInput[]
+    | CompanyAssociationUpsertWithWhereUniqueWithoutUserInput
+  >;
+  deleteMany?: Maybe<
+    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
+  >;
+  updateMany?: Maybe<
+    | CompanyAssociationUpdateManyWithWhereNestedInput[]
+    | CompanyAssociationUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface ApplicationUpdateOneRequiredInput {
+  create?: Maybe<ApplicationCreateInput>;
+  update?: Maybe<ApplicationUpdateDataInput>;
+  upsert?: Maybe<ApplicationUpsertNestedInput>;
+  connect?: Maybe<ApplicationWhereUniqueInput>;
+}
+
+export interface FormCreateManyInput {
+  create?: Maybe<FormCreateInput[] | FormCreateInput>;
+  connect?: Maybe<FormWhereUniqueInput[] | FormWhereUniqueInput>;
+}
+
+export interface GrantCreateInput {
+  id?: Maybe<ID_Input>;
+  user: UserCreateOneInput;
+  code: String;
+  application: ApplicationCreateOneInput;
+  expires: Int;
+  redirectUri: String;
+}
+
+export interface CompanyAssociationUpdateWithoutUserDataInput {
+  company?: Maybe<CompanyUpdateOneRequiredInput>;
+  role?: Maybe<UserRole>;
+}
+
+export interface FormUpdateManyMutationInput {
+  readableId?: Maybe<String>;
+  customId?: Maybe<String>;
+  isDeleted?: Maybe<Boolean>;
+  signedByTransporter?: Maybe<Boolean>;
+  status?: Maybe<Status>;
+  sentAt?: Maybe<DateTimeInput>;
+  sentBy?: Maybe<String>;
+  isAccepted?: Maybe<Boolean>;
+  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
+  wasteRefusalReason?: Maybe<String>;
+  receivedBy?: Maybe<String>;
+  receivedAt?: Maybe<DateTimeInput>;
+  quantityReceived?: Maybe<Float>;
+  processedBy?: Maybe<String>;
+  processedAt?: Maybe<String>;
+  processingOperationDone?: Maybe<String>;
+  processingOperationDescription?: Maybe<String>;
+  noTraceability?: Maybe<Boolean>;
+  nextDestinationProcessingOperation?: Maybe<String>;
+  nextDestinationCompanyName?: Maybe<String>;
+  nextDestinationCompanySiret?: Maybe<String>;
+  nextDestinationCompanyAddress?: Maybe<String>;
+  nextDestinationCompanyContact?: Maybe<String>;
+  nextDestinationCompanyPhone?: Maybe<String>;
+  nextDestinationCompanyMail?: Maybe<String>;
+  emitterType?: Maybe<EmitterType>;
+  emitterPickupSite?: Maybe<String>;
+  emitterWorkSiteName?: Maybe<String>;
+  emitterWorkSiteAddress?: Maybe<String>;
+  emitterWorkSiteCity?: Maybe<String>;
+  emitterWorkSitePostalCode?: Maybe<String>;
+  emitterWorkSiteInfos?: Maybe<String>;
+  emitterCompanyName?: Maybe<String>;
+  emitterCompanySiret?: Maybe<String>;
+  emitterCompanyAddress?: Maybe<String>;
+  emitterCompanyContact?: Maybe<String>;
+  emitterCompanyPhone?: Maybe<String>;
+  emitterCompanyMail?: Maybe<String>;
+  recipientCap?: Maybe<String>;
+  recipientProcessingOperation?: Maybe<String>;
+  recipientIsTempStorage?: Maybe<Boolean>;
+  recipientCompanyName?: Maybe<String>;
+  recipientCompanySiret?: Maybe<String>;
+  recipientCompanyAddress?: Maybe<String>;
+  recipientCompanyContact?: Maybe<String>;
+  recipientCompanyPhone?: Maybe<String>;
+  recipientCompanyMail?: Maybe<String>;
+  transporterCompanyName?: Maybe<String>;
+  transporterCompanySiret?: Maybe<String>;
+  transporterCompanyAddress?: Maybe<String>;
+  transporterCompanyContact?: Maybe<String>;
+  transporterCompanyPhone?: Maybe<String>;
+  transporterCompanyMail?: Maybe<String>;
+  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
+  transporterReceipt?: Maybe<String>;
+  transporterDepartment?: Maybe<String>;
+  transporterValidityLimit?: Maybe<DateTimeInput>;
+  transporterNumberPlate?: Maybe<String>;
+  transporterCustomInfo?: Maybe<String>;
+  wasteDetailsCode?: Maybe<String>;
+  wasteDetailsName?: Maybe<String>;
+  wasteDetailsOnuCode?: Maybe<String>;
+  wasteDetailsPackagings?: Maybe<Json>;
+  wasteDetailsOtherPackaging?: Maybe<String>;
+  wasteDetailsNumberOfPackages?: Maybe<Int>;
+  wasteDetailsQuantity?: Maybe<Float>;
+  wasteDetailsQuantityType?: Maybe<QuantityType>;
+  wasteDetailsConsistence?: Maybe<Consistence>;
+  traderCompanyName?: Maybe<String>;
+  traderCompanySiret?: Maybe<String>;
+  traderCompanyAddress?: Maybe<String>;
+  traderCompanyContact?: Maybe<String>;
+  traderCompanyPhone?: Maybe<String>;
+  traderCompanyMail?: Maybe<String>;
+  traderReceipt?: Maybe<String>;
+  traderDepartment?: Maybe<String>;
+  traderValidityLimit?: Maybe<DateTimeInput>;
+}
+
+export interface CompanyUpdateOneRequiredInput {
+  create?: Maybe<CompanyCreateInput>;
+  update?: Maybe<CompanyUpdateDataInput>;
+  upsert?: Maybe<CompanyUpsertNestedInput>;
+  connect?: Maybe<CompanyWhereUniqueInput>;
+}
+
+export interface FormUpdateManyWithWhereNestedInput {
+  where: FormScalarWhereInput;
+  data: FormUpdateManyDataInput;
+}
+
+export interface CompanyUpdateDataInput {
+  siret?: Maybe<String>;
+  companyTypes?: Maybe<CompanyUpdatecompanyTypesInput>;
+  name?: Maybe<String>;
+  gerepId?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  securityCode?: Maybe<Int>;
+  givenName?: Maybe<String>;
+  contactEmail?: Maybe<String>;
+  contactPhone?: Maybe<String>;
+  website?: Maybe<String>;
+  documentKeys?: Maybe<CompanyUpdatedocumentKeysInput>;
+}
+
+export type UserWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+  email?: Maybe<String>;
+}>;
+
+export interface CompanyUpdatecompanyTypesInput {
+  set?: Maybe<CompanyType[] | CompanyType>;
+}
+
+export interface UserAccountHashSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<UserAccountHashWhereInput>;
+  AND?: Maybe<
+    | UserAccountHashSubscriptionWhereInput[]
+    | UserAccountHashSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    | UserAccountHashSubscriptionWhereInput[]
+    | UserAccountHashSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    | UserAccountHashSubscriptionWhereInput[]
+    | UserAccountHashSubscriptionWhereInput
+  >;
+}
+
+export interface CompanyUpdatedocumentKeysInput {
+  set?: Maybe<String[] | String>;
+}
+
+export interface StatusLogSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<StatusLogWhereInput>;
+  AND?: Maybe<
+    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
+  >;
+}
+
+export interface CompanyUpsertNestedInput {
+  update: CompanyUpdateDataInput;
+  create: CompanyCreateInput;
+}
+
+export interface GrantSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<GrantWhereInput>;
+  AND?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
+  OR?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
+  NOT?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
+}
+
+export interface CompanyAssociationUpsertWithWhereUniqueWithoutUserInput {
+  where: CompanyAssociationWhereUniqueInput;
+  update: CompanyAssociationUpdateWithoutUserDataInput;
+  create: CompanyAssociationCreateWithoutUserInput;
+}
+
+export interface EcoOrganismeSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<EcoOrganismeWhereInput>;
+  AND?: Maybe<
+    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
+  >;
+}
+
+export interface CompanyAssociationScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  role?: Maybe<UserRole>;
+  role_not?: Maybe<UserRole>;
+  role_in?: Maybe<UserRole[] | UserRole>;
+  role_not_in?: Maybe<UserRole[] | UserRole>;
+  AND?: Maybe<
+    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
+  >;
+  OR?: Maybe<
+    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
+  >;
+  NOT?: Maybe<
+    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
+  >;
+}
+
+export interface CompanySubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<CompanyWhereInput>;
+  AND?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
+  OR?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
+  NOT?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
+}
+
+export interface CompanyAssociationUpdateManyWithWhereNestedInput {
+  where: CompanyAssociationScalarWhereInput;
+  data: CompanyAssociationUpdateManyDataInput;
+}
+
+export interface UserActivationHashUpdateManyMutationInput {
+  hash?: Maybe<String>;
+}
+
+export interface CompanyAssociationUpdateManyDataInput {
+  role?: Maybe<UserRole>;
+}
+
+export interface UserAccountHashUpdateManyMutationInput {
+  email?: Maybe<String>;
+  companySiret?: Maybe<ID_Input>;
+  role?: Maybe<UserRole>;
+  hash?: Maybe<String>;
+}
+
+export interface UserUpsertNestedInput {
+  update: UserUpdateDataInput;
+  create: UserCreateInput;
+}
+
+export interface UserUpdateManyMutationInput {
+  isActive?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  password?: Maybe<String>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+}
+
+export interface ApplicationUpdateOneInput {
+  create?: Maybe<ApplicationCreateInput>;
+  update?: Maybe<ApplicationUpdateDataInput>;
+  upsert?: Maybe<ApplicationUpsertNestedInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<ApplicationWhereUniqueInput>;
 }
 
 export interface TemporaryStorageDetailWhereInput {
@@ -2370,165 +4456,26 @@ export interface TemporaryStorageDetailWhereInput {
   >;
 }
 
-export interface AccessTokenCreateInput {
-  id?: Maybe<ID_Input>;
-  user: UserCreateOneInput;
-  application?: Maybe<ApplicationCreateOneInput>;
-  token: String;
-  isRevoked?: Maybe<Boolean>;
-  lastUsed?: Maybe<DateTimeInput>;
-}
-
-export interface TemporaryStorageDetailUpdateManyMutationInput {
-  tempStorerQuantityType?: Maybe<QuantityType>;
-  tempStorerQuantityReceived?: Maybe<Float>;
-  tempStorerWasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  tempStorerWasteRefusalReason?: Maybe<String>;
-  tempStorerReceivedAt?: Maybe<DateTimeInput>;
-  tempStorerReceivedBy?: Maybe<String>;
-  tempStorerSignedAt?: Maybe<DateTimeInput>;
-  destinationIsFilledByEmitter?: Maybe<Boolean>;
-  destinationCompanyName?: Maybe<String>;
-  destinationCompanySiret?: Maybe<String>;
-  destinationCompanyAddress?: Maybe<String>;
-  destinationCompanyContact?: Maybe<String>;
-  destinationCompanyPhone?: Maybe<String>;
-  destinationCompanyMail?: Maybe<String>;
-  destinationCap?: Maybe<String>;
-  destinationProcessingOperation?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsPackagings?: Maybe<Json>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  signedByTransporter?: Maybe<Boolean>;
-  signedBy?: Maybe<String>;
-  signedAt?: Maybe<DateTimeInput>;
-}
-
-export interface UserCreateOneInput {
-  create?: Maybe<UserCreateInput>;
-  connect?: Maybe<UserWhereUniqueInput>;
-}
-
-export interface FormUpdateWithoutTemporaryStorageDetailDataInput {
-  readableId?: Maybe<String>;
-  customId?: Maybe<String>;
-  isDeleted?: Maybe<Boolean>;
-  owner?: Maybe<UserUpdateOneRequiredInput>;
-  signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
-  sentAt?: Maybe<DateTimeInput>;
-  sentBy?: Maybe<String>;
-  isAccepted?: Maybe<Boolean>;
-  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  wasteRefusalReason?: Maybe<String>;
-  receivedBy?: Maybe<String>;
-  receivedAt?: Maybe<DateTimeInput>;
-  quantityReceived?: Maybe<Float>;
-  processedBy?: Maybe<String>;
-  processedAt?: Maybe<String>;
-  processingOperationDone?: Maybe<String>;
-  processingOperationDescription?: Maybe<String>;
-  noTraceability?: Maybe<Boolean>;
-  nextDestinationProcessingOperation?: Maybe<String>;
-  nextDestinationCompanyName?: Maybe<String>;
-  nextDestinationCompanySiret?: Maybe<String>;
-  nextDestinationCompanyAddress?: Maybe<String>;
-  nextDestinationCompanyContact?: Maybe<String>;
-  nextDestinationCompanyPhone?: Maybe<String>;
-  nextDestinationCompanyMail?: Maybe<String>;
-  emitterType?: Maybe<EmitterType>;
-  emitterPickupSite?: Maybe<String>;
-  emitterWorkSiteName?: Maybe<String>;
-  emitterWorkSiteAddress?: Maybe<String>;
-  emitterWorkSiteCity?: Maybe<String>;
-  emitterWorkSitePostalCode?: Maybe<String>;
-  emitterWorkSiteInfos?: Maybe<String>;
-  emitterCompanyName?: Maybe<String>;
-  emitterCompanySiret?: Maybe<String>;
-  emitterCompanyAddress?: Maybe<String>;
-  emitterCompanyContact?: Maybe<String>;
-  emitterCompanyPhone?: Maybe<String>;
-  emitterCompanyMail?: Maybe<String>;
-  recipientCap?: Maybe<String>;
-  recipientProcessingOperation?: Maybe<String>;
-  recipientIsTempStorage?: Maybe<Boolean>;
-  recipientCompanyName?: Maybe<String>;
-  recipientCompanySiret?: Maybe<String>;
-  recipientCompanyAddress?: Maybe<String>;
-  recipientCompanyContact?: Maybe<String>;
-  recipientCompanyPhone?: Maybe<String>;
-  recipientCompanyMail?: Maybe<String>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  transporterCustomInfo?: Maybe<String>;
-  wasteDetailsCode?: Maybe<String>;
-  wasteDetailsName?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsPackagings?: Maybe<Json>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  wasteDetailsConsistence?: Maybe<Consistence>;
-  traderCompanyName?: Maybe<String>;
-  traderCompanySiret?: Maybe<String>;
-  traderCompanyAddress?: Maybe<String>;
-  traderCompanyContact?: Maybe<String>;
-  traderCompanyPhone?: Maybe<String>;
-  traderCompanyMail?: Maybe<String>;
-  traderReceipt?: Maybe<String>;
-  traderDepartment?: Maybe<String>;
-  traderValidityLimit?: Maybe<DateTimeInput>;
-  ecoOrganisme?: Maybe<EcoOrganismeUpdateOneInput>;
-  appendix2Forms?: Maybe<FormUpdateManyInput>;
-}
-
-export interface UserCreateInput {
-  id?: Maybe<ID_Input>;
-  isActive?: Maybe<Boolean>;
-  email: String;
-  password: String;
+export interface ApplicationUpdateDataInput {
+  clientSecret?: Maybe<String>;
   name?: Maybe<String>;
-  phone?: Maybe<String>;
-  companyAssociations?: Maybe<CompanyAssociationCreateManyWithoutUserInput>;
+  admins?: Maybe<UserUpdateManyInput>;
+  redirectUris?: Maybe<ApplicationUpdateredirectUrisInput>;
+  logoUrl?: Maybe<String>;
 }
 
-export type GrantWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-  code?: Maybe<String>;
-}>;
+export interface FormUpdateOneWithoutTemporaryStorageDetailInput {
+  create?: Maybe<FormCreateWithoutTemporaryStorageDetailInput>;
+  update?: Maybe<FormUpdateWithoutTemporaryStorageDetailDataInput>;
+  upsert?: Maybe<FormUpsertWithoutTemporaryStorageDetailInput>;
+  delete?: Maybe<Boolean>;
+  disconnect?: Maybe<Boolean>;
+  connect?: Maybe<FormWhereUniqueInput>;
+}
 
-export interface CompanyAssociationCreateManyWithoutUserInput {
-  create?: Maybe<
-    | CompanyAssociationCreateWithoutUserInput[]
-    | CompanyAssociationCreateWithoutUserInput
-  >;
-  connect?: Maybe<
-    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
-  >;
+export interface EcoOrganismeCreateOneInput {
+  create?: Maybe<EcoOrganismeCreateInput>;
+  connect?: Maybe<EcoOrganismeWhereUniqueInput>;
 }
 
 export interface GrantWhereInput {
@@ -2605,41 +4552,9 @@ export interface GrantWhereInput {
   NOT?: Maybe<GrantWhereInput[] | GrantWhereInput>;
 }
 
-export interface CompanyAssociationCreateWithoutUserInput {
-  id?: Maybe<ID_Input>;
-  company: CompanyCreateOneInput;
-  role: UserRole;
-}
-
-export interface FormCreateOneWithoutTemporaryStorageDetailInput {
-  create?: Maybe<FormCreateWithoutTemporaryStorageDetailInput>;
-  connect?: Maybe<FormWhereUniqueInput>;
-}
-
-export interface CompanyCreateOneInput {
-  create?: Maybe<CompanyCreateInput>;
-  connect?: Maybe<CompanyWhereUniqueInput>;
-}
-
-export interface StatusLogUpdateManyMutationInput {
-  status?: Maybe<Status>;
-  loggedAt?: Maybe<DateTimeInput>;
-  updatedFields?: Maybe<Json>;
-}
-
-export interface CompanyCreateInput {
-  id?: Maybe<ID_Input>;
-  siret: String;
-  companyTypes?: Maybe<CompanyCreatecompanyTypesInput>;
-  name?: Maybe<String>;
-  gerepId?: Maybe<String>;
-  codeNaf?: Maybe<String>;
-  securityCode: Int;
-  givenName?: Maybe<String>;
-  contactEmail?: Maybe<String>;
-  contactPhone?: Maybe<String>;
-  website?: Maybe<String>;
-  documentKeys?: Maybe<CompanyCreatedocumentKeysInput>;
+export interface UserUpdateWithWhereUniqueNestedInput {
+  where: UserWhereUniqueInput;
+  data: UserUpdateDataInput;
 }
 
 export interface FormUpsertNestedInput {
@@ -2647,8 +4562,10 @@ export interface FormUpsertNestedInput {
   create: FormCreateInput;
 }
 
-export interface CompanyCreatecompanyTypesInput {
-  set?: Maybe<CompanyType[] | CompanyType>;
+export interface UserUpsertWithWhereUniqueNestedInput {
+  where: UserWhereUniqueInput;
+  update: UserUpdateDataInput;
+  create: UserCreateInput;
 }
 
 export interface InstallationWhereInput {
@@ -2829,18 +4746,98 @@ export interface InstallationWhereInput {
   NOT?: Maybe<InstallationWhereInput[] | InstallationWhereInput>;
 }
 
-export interface CompanyCreatedocumentKeysInput {
-  set?: Maybe<String[] | String>;
-}
-
-export interface FormCreateOneInput {
-  create?: Maybe<FormCreateInput>;
-  connect?: Maybe<FormWhereUniqueInput>;
-}
-
-export interface ApplicationCreateOneInput {
-  create?: Maybe<ApplicationCreateInput>;
-  connect?: Maybe<ApplicationWhereUniqueInput>;
+export interface UserScalarWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  isActive?: Maybe<Boolean>;
+  isActive_not?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  email_not?: Maybe<String>;
+  email_in?: Maybe<String[] | String>;
+  email_not_in?: Maybe<String[] | String>;
+  email_lt?: Maybe<String>;
+  email_lte?: Maybe<String>;
+  email_gt?: Maybe<String>;
+  email_gte?: Maybe<String>;
+  email_contains?: Maybe<String>;
+  email_not_contains?: Maybe<String>;
+  email_starts_with?: Maybe<String>;
+  email_not_starts_with?: Maybe<String>;
+  email_ends_with?: Maybe<String>;
+  email_not_ends_with?: Maybe<String>;
+  password?: Maybe<String>;
+  password_not?: Maybe<String>;
+  password_in?: Maybe<String[] | String>;
+  password_not_in?: Maybe<String[] | String>;
+  password_lt?: Maybe<String>;
+  password_lte?: Maybe<String>;
+  password_gt?: Maybe<String>;
+  password_gte?: Maybe<String>;
+  password_contains?: Maybe<String>;
+  password_not_contains?: Maybe<String>;
+  password_starts_with?: Maybe<String>;
+  password_not_starts_with?: Maybe<String>;
+  password_ends_with?: Maybe<String>;
+  password_not_ends_with?: Maybe<String>;
+  name?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  phone?: Maybe<String>;
+  phone_not?: Maybe<String>;
+  phone_in?: Maybe<String[] | String>;
+  phone_not_in?: Maybe<String[] | String>;
+  phone_lt?: Maybe<String>;
+  phone_lte?: Maybe<String>;
+  phone_gt?: Maybe<String>;
+  phone_gte?: Maybe<String>;
+  phone_contains?: Maybe<String>;
+  phone_not_contains?: Maybe<String>;
+  phone_starts_with?: Maybe<String>;
+  phone_not_starts_with?: Maybe<String>;
+  phone_ends_with?: Maybe<String>;
+  phone_not_ends_with?: Maybe<String>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  AND?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
+  OR?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
+  NOT?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
 }
 
 export interface RubriqueUpdateManyMutationInput {
@@ -2857,32 +4854,9 @@ export interface RubriqueUpdateManyMutationInput {
   wasteType?: Maybe<WasteType>;
 }
 
-export interface ApplicationCreateInput {
-  id?: Maybe<ID_Input>;
-  clientSecret: String;
-  name: String;
-  admins?: Maybe<UserCreateManyInput>;
-  redirectUris?: Maybe<ApplicationCreateredirectUrisInput>;
-  logoUrl?: Maybe<String>;
-}
-
-export interface RubriqueUpdateInput {
-  codeS3ic?: Maybe<String>;
-  rubrique?: Maybe<String>;
-  alinea?: Maybe<String>;
-  dateAutorisation?: Maybe<String>;
-  etatActivite?: Maybe<String>;
-  regimeAutorise?: Maybe<String>;
-  activite?: Maybe<String>;
-  volume?: Maybe<String>;
-  unite?: Maybe<String>;
-  category?: Maybe<String>;
-  wasteType?: Maybe<WasteType>;
-}
-
-export interface UserCreateManyInput {
-  create?: Maybe<UserCreateInput[] | UserCreateInput>;
-  connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+export interface UserUpdateManyWithWhereNestedInput {
+  where: UserScalarWhereInput;
+  data: UserUpdateManyDataInput;
 }
 
 export interface RubriqueWhereInput {
@@ -3049,31 +5023,12 @@ export interface RubriqueWhereInput {
   NOT?: Maybe<RubriqueWhereInput[] | RubriqueWhereInput>;
 }
 
-export interface ApplicationCreateredirectUrisInput {
-  set?: Maybe<String[] | String>;
-}
-
-export interface RubriqueCreateInput {
-  id?: Maybe<ID_Input>;
-  codeS3ic?: Maybe<String>;
-  rubrique?: Maybe<String>;
-  alinea?: Maybe<String>;
-  dateAutorisation?: Maybe<String>;
-  etatActivite?: Maybe<String>;
-  regimeAutorise?: Maybe<String>;
-  activite?: Maybe<String>;
-  volume?: Maybe<String>;
-  unite?: Maybe<String>;
-  category?: Maybe<String>;
-  wasteType?: Maybe<WasteType>;
-}
-
-export interface AccessTokenUpdateInput {
-  user?: Maybe<UserUpdateOneRequiredInput>;
-  application?: Maybe<ApplicationUpdateOneInput>;
-  token?: Maybe<String>;
-  isRevoked?: Maybe<Boolean>;
-  lastUsed?: Maybe<DateTimeInput>;
+export interface UserUpdateManyDataInput {
+  isActive?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  password?: Maybe<String>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
 }
 
 export interface InstallationUpdateInput {
@@ -3090,833 +5045,6 @@ export interface InstallationUpdateInput {
   gerepNumeroSiret?: Maybe<String>;
   sireneNumeroSiret?: Maybe<String>;
 }
-
-export interface UserUpdateOneRequiredInput {
-  create?: Maybe<UserCreateInput>;
-  update?: Maybe<UserUpdateDataInput>;
-  upsert?: Maybe<UserUpsertNestedInput>;
-  connect?: Maybe<UserWhereUniqueInput>;
-}
-
-export interface InstallationCreateInput {
-  id?: Maybe<ID_Input>;
-  codeS3ic?: Maybe<String>;
-  nomEts?: Maybe<String>;
-  regime?: Maybe<String>;
-  libRegime?: Maybe<String>;
-  seveso?: Maybe<Seveso>;
-  libSeveso?: Maybe<String>;
-  familleIc?: Maybe<String>;
-  urlFiche?: Maybe<String>;
-  s3icNumeroSiret?: Maybe<String>;
-  irepNumeroSiret?: Maybe<String>;
-  gerepNumeroSiret?: Maybe<String>;
-  sireneNumeroSiret?: Maybe<String>;
-}
-
-export interface UserUpdateDataInput {
-  isActive?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  password?: Maybe<String>;
-  name?: Maybe<String>;
-  phone?: Maybe<String>;
-  companyAssociations?: Maybe<CompanyAssociationUpdateManyWithoutUserInput>;
-}
-
-export interface StatusLogWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  user?: Maybe<UserWhereInput>;
-  form?: Maybe<FormWhereInput>;
-  status?: Maybe<Status>;
-  status_not?: Maybe<Status>;
-  status_in?: Maybe<Status[] | Status>;
-  status_not_in?: Maybe<Status[] | Status>;
-  loggedAt?: Maybe<DateTimeInput>;
-  loggedAt_not?: Maybe<DateTimeInput>;
-  loggedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  loggedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  loggedAt_lt?: Maybe<DateTimeInput>;
-  loggedAt_lte?: Maybe<DateTimeInput>;
-  loggedAt_gt?: Maybe<DateTimeInput>;
-  loggedAt_gte?: Maybe<DateTimeInput>;
-  AND?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
-  OR?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
-  NOT?: Maybe<StatusLogWhereInput[] | StatusLogWhereInput>;
-}
-
-export interface CompanyAssociationUpdateManyWithoutUserInput {
-  create?: Maybe<
-    | CompanyAssociationCreateWithoutUserInput[]
-    | CompanyAssociationCreateWithoutUserInput
-  >;
-  delete?: Maybe<
-    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
-  >;
-  connect?: Maybe<
-    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
-  >;
-  set?: Maybe<
-    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
-  >;
-  disconnect?: Maybe<
-    CompanyAssociationWhereUniqueInput[] | CompanyAssociationWhereUniqueInput
-  >;
-  update?: Maybe<
-    | CompanyAssociationUpdateWithWhereUniqueWithoutUserInput[]
-    | CompanyAssociationUpdateWithWhereUniqueWithoutUserInput
-  >;
-  upsert?: Maybe<
-    | CompanyAssociationUpsertWithWhereUniqueWithoutUserInput[]
-    | CompanyAssociationUpsertWithWhereUniqueWithoutUserInput
-  >;
-  deleteMany?: Maybe<
-    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
-  >;
-  updateMany?: Maybe<
-    | CompanyAssociationUpdateManyWithWhereNestedInput[]
-    | CompanyAssociationUpdateManyWithWhereNestedInput
-  >;
-}
-
-export interface ApplicationUpdateOneRequiredInput {
-  create?: Maybe<ApplicationCreateInput>;
-  update?: Maybe<ApplicationUpdateDataInput>;
-  upsert?: Maybe<ApplicationUpsertNestedInput>;
-  connect?: Maybe<ApplicationWhereUniqueInput>;
-}
-
-export interface FormCreateManyInput {
-  create?: Maybe<FormCreateInput[] | FormCreateInput>;
-  connect?: Maybe<FormWhereUniqueInput[] | FormWhereUniqueInput>;
-}
-
-export interface GrantCreateInput {
-  id?: Maybe<ID_Input>;
-  user: UserCreateOneInput;
-  code: String;
-  application: ApplicationCreateOneInput;
-  expires: Int;
-  redirectUri: String;
-}
-
-export interface CompanyAssociationUpdateWithoutUserDataInput {
-  company?: Maybe<CompanyUpdateOneRequiredInput>;
-  role?: Maybe<UserRole>;
-}
-
-export interface FormUpdateManyMutationInput {
-  readableId?: Maybe<String>;
-  customId?: Maybe<String>;
-  isDeleted?: Maybe<Boolean>;
-  signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
-  sentAt?: Maybe<DateTimeInput>;
-  sentBy?: Maybe<String>;
-  isAccepted?: Maybe<Boolean>;
-  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  wasteRefusalReason?: Maybe<String>;
-  receivedBy?: Maybe<String>;
-  receivedAt?: Maybe<DateTimeInput>;
-  quantityReceived?: Maybe<Float>;
-  processedBy?: Maybe<String>;
-  processedAt?: Maybe<String>;
-  processingOperationDone?: Maybe<String>;
-  processingOperationDescription?: Maybe<String>;
-  noTraceability?: Maybe<Boolean>;
-  nextDestinationProcessingOperation?: Maybe<String>;
-  nextDestinationCompanyName?: Maybe<String>;
-  nextDestinationCompanySiret?: Maybe<String>;
-  nextDestinationCompanyAddress?: Maybe<String>;
-  nextDestinationCompanyContact?: Maybe<String>;
-  nextDestinationCompanyPhone?: Maybe<String>;
-  nextDestinationCompanyMail?: Maybe<String>;
-  emitterType?: Maybe<EmitterType>;
-  emitterPickupSite?: Maybe<String>;
-  emitterWorkSiteName?: Maybe<String>;
-  emitterWorkSiteAddress?: Maybe<String>;
-  emitterWorkSiteCity?: Maybe<String>;
-  emitterWorkSitePostalCode?: Maybe<String>;
-  emitterWorkSiteInfos?: Maybe<String>;
-  emitterCompanyName?: Maybe<String>;
-  emitterCompanySiret?: Maybe<String>;
-  emitterCompanyAddress?: Maybe<String>;
-  emitterCompanyContact?: Maybe<String>;
-  emitterCompanyPhone?: Maybe<String>;
-  emitterCompanyMail?: Maybe<String>;
-  recipientCap?: Maybe<String>;
-  recipientProcessingOperation?: Maybe<String>;
-  recipientIsTempStorage?: Maybe<Boolean>;
-  recipientCompanyName?: Maybe<String>;
-  recipientCompanySiret?: Maybe<String>;
-  recipientCompanyAddress?: Maybe<String>;
-  recipientCompanyContact?: Maybe<String>;
-  recipientCompanyPhone?: Maybe<String>;
-  recipientCompanyMail?: Maybe<String>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  transporterCustomInfo?: Maybe<String>;
-  wasteDetailsCode?: Maybe<String>;
-  wasteDetailsName?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsPackagings?: Maybe<Json>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  wasteDetailsConsistence?: Maybe<Consistence>;
-  traderCompanyName?: Maybe<String>;
-  traderCompanySiret?: Maybe<String>;
-  traderCompanyAddress?: Maybe<String>;
-  traderCompanyContact?: Maybe<String>;
-  traderCompanyPhone?: Maybe<String>;
-  traderCompanyMail?: Maybe<String>;
-  traderReceipt?: Maybe<String>;
-  traderDepartment?: Maybe<String>;
-  traderValidityLimit?: Maybe<DateTimeInput>;
-}
-
-export interface CompanyUpdateOneRequiredInput {
-  create?: Maybe<CompanyCreateInput>;
-  update?: Maybe<CompanyUpdateDataInput>;
-  upsert?: Maybe<CompanyUpsertNestedInput>;
-  connect?: Maybe<CompanyWhereUniqueInput>;
-}
-
-export interface FormUpdateManyWithWhereNestedInput {
-  where: FormScalarWhereInput;
-  data: FormUpdateManyDataInput;
-}
-
-export interface CompanyUpdateDataInput {
-  siret?: Maybe<String>;
-  companyTypes?: Maybe<CompanyUpdatecompanyTypesInput>;
-  name?: Maybe<String>;
-  gerepId?: Maybe<String>;
-  codeNaf?: Maybe<String>;
-  securityCode?: Maybe<Int>;
-  givenName?: Maybe<String>;
-  contactEmail?: Maybe<String>;
-  contactPhone?: Maybe<String>;
-  website?: Maybe<String>;
-  documentKeys?: Maybe<CompanyUpdatedocumentKeysInput>;
-}
-
-export type UserWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-  email?: Maybe<String>;
-}>;
-
-export interface CompanyUpdatecompanyTypesInput {
-  set?: Maybe<CompanyType[] | CompanyType>;
-}
-
-export interface UserAccountHashSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<UserAccountHashWhereInput>;
-  AND?: Maybe<
-    | UserAccountHashSubscriptionWhereInput[]
-    | UserAccountHashSubscriptionWhereInput
-  >;
-  OR?: Maybe<
-    | UserAccountHashSubscriptionWhereInput[]
-    | UserAccountHashSubscriptionWhereInput
-  >;
-  NOT?: Maybe<
-    | UserAccountHashSubscriptionWhereInput[]
-    | UserAccountHashSubscriptionWhereInput
-  >;
-}
-
-export interface CompanyUpdatedocumentKeysInput {
-  set?: Maybe<String[] | String>;
-}
-
-export interface StatusLogSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<StatusLogWhereInput>;
-  AND?: Maybe<
-    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
-  >;
-  OR?: Maybe<
-    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
-  >;
-  NOT?: Maybe<
-    StatusLogSubscriptionWhereInput[] | StatusLogSubscriptionWhereInput
-  >;
-}
-
-export interface CompanyUpsertNestedInput {
-  update: CompanyUpdateDataInput;
-  create: CompanyCreateInput;
-}
-
-export interface GrantSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<GrantWhereInput>;
-  AND?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
-  OR?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
-  NOT?: Maybe<GrantSubscriptionWhereInput[] | GrantSubscriptionWhereInput>;
-}
-
-export interface CompanyAssociationUpsertWithWhereUniqueWithoutUserInput {
-  where: CompanyAssociationWhereUniqueInput;
-  update: CompanyAssociationUpdateWithoutUserDataInput;
-  create: CompanyAssociationCreateWithoutUserInput;
-}
-
-export interface EcoOrganismeSubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<EcoOrganismeWhereInput>;
-  AND?: Maybe<
-    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
-  >;
-  OR?: Maybe<
-    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
-  >;
-  NOT?: Maybe<
-    EcoOrganismeSubscriptionWhereInput[] | EcoOrganismeSubscriptionWhereInput
-  >;
-}
-
-export interface CompanyAssociationScalarWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  role?: Maybe<UserRole>;
-  role_not?: Maybe<UserRole>;
-  role_in?: Maybe<UserRole[] | UserRole>;
-  role_not_in?: Maybe<UserRole[] | UserRole>;
-  AND?: Maybe<
-    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
-  >;
-  OR?: Maybe<
-    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
-  >;
-  NOT?: Maybe<
-    CompanyAssociationScalarWhereInput[] | CompanyAssociationScalarWhereInput
-  >;
-}
-
-export interface CompanySubscriptionWhereInput {
-  mutation_in?: Maybe<MutationType[] | MutationType>;
-  updatedFields_contains?: Maybe<String>;
-  updatedFields_contains_every?: Maybe<String[] | String>;
-  updatedFields_contains_some?: Maybe<String[] | String>;
-  node?: Maybe<CompanyWhereInput>;
-  AND?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
-  OR?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
-  NOT?: Maybe<CompanySubscriptionWhereInput[] | CompanySubscriptionWhereInput>;
-}
-
-export interface CompanyAssociationUpdateManyWithWhereNestedInput {
-  where: CompanyAssociationScalarWhereInput;
-  data: CompanyAssociationUpdateManyDataInput;
-}
-
-export interface UserActivationHashUpdateManyMutationInput {
-  hash?: Maybe<String>;
-}
-
-export interface CompanyAssociationUpdateManyDataInput {
-  role?: Maybe<UserRole>;
-}
-
-export interface UserAccountHashUpdateManyMutationInput {
-  email?: Maybe<String>;
-  companySiret?: Maybe<ID_Input>;
-  role?: Maybe<UserRole>;
-  hash?: Maybe<String>;
-}
-
-export interface UserUpsertNestedInput {
-  update: UserUpdateDataInput;
-  create: UserCreateInput;
-}
-
-export interface ApplicationWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  clientSecret?: Maybe<String>;
-  clientSecret_not?: Maybe<String>;
-  clientSecret_in?: Maybe<String[] | String>;
-  clientSecret_not_in?: Maybe<String[] | String>;
-  clientSecret_lt?: Maybe<String>;
-  clientSecret_lte?: Maybe<String>;
-  clientSecret_gt?: Maybe<String>;
-  clientSecret_gte?: Maybe<String>;
-  clientSecret_contains?: Maybe<String>;
-  clientSecret_not_contains?: Maybe<String>;
-  clientSecret_starts_with?: Maybe<String>;
-  clientSecret_not_starts_with?: Maybe<String>;
-  clientSecret_ends_with?: Maybe<String>;
-  clientSecret_not_ends_with?: Maybe<String>;
-  name?: Maybe<String>;
-  name_not?: Maybe<String>;
-  name_in?: Maybe<String[] | String>;
-  name_not_in?: Maybe<String[] | String>;
-  name_lt?: Maybe<String>;
-  name_lte?: Maybe<String>;
-  name_gt?: Maybe<String>;
-  name_gte?: Maybe<String>;
-  name_contains?: Maybe<String>;
-  name_not_contains?: Maybe<String>;
-  name_starts_with?: Maybe<String>;
-  name_not_starts_with?: Maybe<String>;
-  name_ends_with?: Maybe<String>;
-  name_not_ends_with?: Maybe<String>;
-  admins_every?: Maybe<UserWhereInput>;
-  admins_some?: Maybe<UserWhereInput>;
-  admins_none?: Maybe<UserWhereInput>;
-  logoUrl?: Maybe<String>;
-  logoUrl_not?: Maybe<String>;
-  logoUrl_in?: Maybe<String[] | String>;
-  logoUrl_not_in?: Maybe<String[] | String>;
-  logoUrl_lt?: Maybe<String>;
-  logoUrl_lte?: Maybe<String>;
-  logoUrl_gt?: Maybe<String>;
-  logoUrl_gte?: Maybe<String>;
-  logoUrl_contains?: Maybe<String>;
-  logoUrl_not_contains?: Maybe<String>;
-  logoUrl_starts_with?: Maybe<String>;
-  logoUrl_not_starts_with?: Maybe<String>;
-  logoUrl_ends_with?: Maybe<String>;
-  logoUrl_not_ends_with?: Maybe<String>;
-  AND?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
-  OR?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
-  NOT?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
-}
-
-export interface ApplicationUpdateOneInput {
-  create?: Maybe<ApplicationCreateInput>;
-  update?: Maybe<ApplicationUpdateDataInput>;
-  upsert?: Maybe<ApplicationUpsertNestedInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<ApplicationWhereUniqueInput>;
-}
-
-export interface UserUpdateInput {
-  isActive?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  password?: Maybe<String>;
-  name?: Maybe<String>;
-  phone?: Maybe<String>;
-  companyAssociations?: Maybe<CompanyAssociationUpdateManyWithoutUserInput>;
-}
-
-export interface ApplicationUpdateDataInput {
-  clientSecret?: Maybe<String>;
-  name?: Maybe<String>;
-  admins?: Maybe<UserUpdateManyInput>;
-  redirectUris?: Maybe<ApplicationUpdateredirectUrisInput>;
-  logoUrl?: Maybe<String>;
-}
-
-export interface FormUpdateOneWithoutTemporaryStorageDetailInput {
-  create?: Maybe<FormCreateWithoutTemporaryStorageDetailInput>;
-  update?: Maybe<FormUpdateWithoutTemporaryStorageDetailDataInput>;
-  upsert?: Maybe<FormUpsertWithoutTemporaryStorageDetailInput>;
-  delete?: Maybe<Boolean>;
-  disconnect?: Maybe<Boolean>;
-  connect?: Maybe<FormWhereUniqueInput>;
-}
-
-export interface EcoOrganismeCreateOneInput {
-  create?: Maybe<EcoOrganismeCreateInput>;
-  connect?: Maybe<EcoOrganismeWhereUniqueInput>;
-}
-
-export interface FormCreateWithoutTemporaryStorageDetailInput {
-  id?: Maybe<ID_Input>;
-  readableId?: Maybe<String>;
-  customId?: Maybe<String>;
-  isDeleted?: Maybe<Boolean>;
-  owner: UserCreateOneInput;
-  signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
-  sentAt?: Maybe<DateTimeInput>;
-  sentBy?: Maybe<String>;
-  isAccepted?: Maybe<Boolean>;
-  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  wasteRefusalReason?: Maybe<String>;
-  receivedBy?: Maybe<String>;
-  receivedAt?: Maybe<DateTimeInput>;
-  quantityReceived?: Maybe<Float>;
-  processedBy?: Maybe<String>;
-  processedAt?: Maybe<String>;
-  processingOperationDone?: Maybe<String>;
-  processingOperationDescription?: Maybe<String>;
-  noTraceability?: Maybe<Boolean>;
-  nextDestinationProcessingOperation?: Maybe<String>;
-  nextDestinationCompanyName?: Maybe<String>;
-  nextDestinationCompanySiret?: Maybe<String>;
-  nextDestinationCompanyAddress?: Maybe<String>;
-  nextDestinationCompanyContact?: Maybe<String>;
-  nextDestinationCompanyPhone?: Maybe<String>;
-  nextDestinationCompanyMail?: Maybe<String>;
-  emitterType?: Maybe<EmitterType>;
-  emitterPickupSite?: Maybe<String>;
-  emitterWorkSiteName?: Maybe<String>;
-  emitterWorkSiteAddress?: Maybe<String>;
-  emitterWorkSiteCity?: Maybe<String>;
-  emitterWorkSitePostalCode?: Maybe<String>;
-  emitterWorkSiteInfos?: Maybe<String>;
-  emitterCompanyName?: Maybe<String>;
-  emitterCompanySiret?: Maybe<String>;
-  emitterCompanyAddress?: Maybe<String>;
-  emitterCompanyContact?: Maybe<String>;
-  emitterCompanyPhone?: Maybe<String>;
-  emitterCompanyMail?: Maybe<String>;
-  recipientCap?: Maybe<String>;
-  recipientProcessingOperation?: Maybe<String>;
-  recipientIsTempStorage?: Maybe<Boolean>;
-  recipientCompanyName?: Maybe<String>;
-  recipientCompanySiret?: Maybe<String>;
-  recipientCompanyAddress?: Maybe<String>;
-  recipientCompanyContact?: Maybe<String>;
-  recipientCompanyPhone?: Maybe<String>;
-  recipientCompanyMail?: Maybe<String>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  transporterCustomInfo?: Maybe<String>;
-  wasteDetailsCode?: Maybe<String>;
-  wasteDetailsName?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsPackagings?: Maybe<Json>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  wasteDetailsConsistence?: Maybe<Consistence>;
-  traderCompanyName?: Maybe<String>;
-  traderCompanySiret?: Maybe<String>;
-  traderCompanyAddress?: Maybe<String>;
-  traderCompanyContact?: Maybe<String>;
-  traderCompanyPhone?: Maybe<String>;
-  traderCompanyMail?: Maybe<String>;
-  traderReceipt?: Maybe<String>;
-  traderDepartment?: Maybe<String>;
-  traderValidityLimit?: Maybe<DateTimeInput>;
-  ecoOrganisme?: Maybe<EcoOrganismeCreateOneInput>;
-  appendix2Forms?: Maybe<FormCreateManyInput>;
-}
-
-export interface UserUpdateWithWhereUniqueNestedInput {
-  where: UserWhereUniqueInput;
-  data: UserUpdateDataInput;
-}
-
-export type InstallationWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
-
-export interface UserUpsertWithWhereUniqueNestedInput {
-  where: UserWhereUniqueInput;
-  update: UserUpdateDataInput;
-  create: UserCreateInput;
-}
-
-export interface StatusLogUpdateInput {
-  user?: Maybe<UserUpdateOneRequiredInput>;
-  form?: Maybe<FormUpdateOneRequiredInput>;
-  status?: Maybe<Status>;
-  loggedAt?: Maybe<DateTimeInput>;
-  updatedFields?: Maybe<Json>;
-}
-
-export interface UserScalarWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  isActive?: Maybe<Boolean>;
-  isActive_not?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  email_not?: Maybe<String>;
-  email_in?: Maybe<String[] | String>;
-  email_not_in?: Maybe<String[] | String>;
-  email_lt?: Maybe<String>;
-  email_lte?: Maybe<String>;
-  email_gt?: Maybe<String>;
-  email_gte?: Maybe<String>;
-  email_contains?: Maybe<String>;
-  email_not_contains?: Maybe<String>;
-  email_starts_with?: Maybe<String>;
-  email_not_starts_with?: Maybe<String>;
-  email_ends_with?: Maybe<String>;
-  email_not_ends_with?: Maybe<String>;
-  password?: Maybe<String>;
-  password_not?: Maybe<String>;
-  password_in?: Maybe<String[] | String>;
-  password_not_in?: Maybe<String[] | String>;
-  password_lt?: Maybe<String>;
-  password_lte?: Maybe<String>;
-  password_gt?: Maybe<String>;
-  password_gte?: Maybe<String>;
-  password_contains?: Maybe<String>;
-  password_not_contains?: Maybe<String>;
-  password_starts_with?: Maybe<String>;
-  password_not_starts_with?: Maybe<String>;
-  password_ends_with?: Maybe<String>;
-  password_not_ends_with?: Maybe<String>;
-  name?: Maybe<String>;
-  name_not?: Maybe<String>;
-  name_in?: Maybe<String[] | String>;
-  name_not_in?: Maybe<String[] | String>;
-  name_lt?: Maybe<String>;
-  name_lte?: Maybe<String>;
-  name_gt?: Maybe<String>;
-  name_gte?: Maybe<String>;
-  name_contains?: Maybe<String>;
-  name_not_contains?: Maybe<String>;
-  name_starts_with?: Maybe<String>;
-  name_not_starts_with?: Maybe<String>;
-  name_ends_with?: Maybe<String>;
-  name_not_ends_with?: Maybe<String>;
-  phone?: Maybe<String>;
-  phone_not?: Maybe<String>;
-  phone_in?: Maybe<String[] | String>;
-  phone_not_in?: Maybe<String[] | String>;
-  phone_lt?: Maybe<String>;
-  phone_lte?: Maybe<String>;
-  phone_gt?: Maybe<String>;
-  phone_gte?: Maybe<String>;
-  phone_contains?: Maybe<String>;
-  phone_not_contains?: Maybe<String>;
-  phone_starts_with?: Maybe<String>;
-  phone_not_starts_with?: Maybe<String>;
-  phone_ends_with?: Maybe<String>;
-  phone_not_ends_with?: Maybe<String>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  AND?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
-  OR?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
-  NOT?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
-}
-
-export type RubriqueWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
-
-export interface UserUpdateManyWithWhereNestedInput {
-  where: UserScalarWhereInput;
-  data: UserUpdateManyDataInput;
-}
-
-export interface UserWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  isActive?: Maybe<Boolean>;
-  isActive_not?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  email_not?: Maybe<String>;
-  email_in?: Maybe<String[] | String>;
-  email_not_in?: Maybe<String[] | String>;
-  email_lt?: Maybe<String>;
-  email_lte?: Maybe<String>;
-  email_gt?: Maybe<String>;
-  email_gte?: Maybe<String>;
-  email_contains?: Maybe<String>;
-  email_not_contains?: Maybe<String>;
-  email_starts_with?: Maybe<String>;
-  email_not_starts_with?: Maybe<String>;
-  email_ends_with?: Maybe<String>;
-  email_not_ends_with?: Maybe<String>;
-  password?: Maybe<String>;
-  password_not?: Maybe<String>;
-  password_in?: Maybe<String[] | String>;
-  password_not_in?: Maybe<String[] | String>;
-  password_lt?: Maybe<String>;
-  password_lte?: Maybe<String>;
-  password_gt?: Maybe<String>;
-  password_gte?: Maybe<String>;
-  password_contains?: Maybe<String>;
-  password_not_contains?: Maybe<String>;
-  password_starts_with?: Maybe<String>;
-  password_not_starts_with?: Maybe<String>;
-  password_ends_with?: Maybe<String>;
-  password_not_ends_with?: Maybe<String>;
-  name?: Maybe<String>;
-  name_not?: Maybe<String>;
-  name_in?: Maybe<String[] | String>;
-  name_not_in?: Maybe<String[] | String>;
-  name_lt?: Maybe<String>;
-  name_lte?: Maybe<String>;
-  name_gt?: Maybe<String>;
-  name_gte?: Maybe<String>;
-  name_contains?: Maybe<String>;
-  name_not_contains?: Maybe<String>;
-  name_starts_with?: Maybe<String>;
-  name_not_starts_with?: Maybe<String>;
-  name_ends_with?: Maybe<String>;
-  name_not_ends_with?: Maybe<String>;
-  phone?: Maybe<String>;
-  phone_not?: Maybe<String>;
-  phone_in?: Maybe<String[] | String>;
-  phone_not_in?: Maybe<String[] | String>;
-  phone_lt?: Maybe<String>;
-  phone_lte?: Maybe<String>;
-  phone_gt?: Maybe<String>;
-  phone_gte?: Maybe<String>;
-  phone_contains?: Maybe<String>;
-  phone_not_contains?: Maybe<String>;
-  phone_starts_with?: Maybe<String>;
-  phone_not_starts_with?: Maybe<String>;
-  phone_ends_with?: Maybe<String>;
-  phone_not_ends_with?: Maybe<String>;
-  companyAssociations_every?: Maybe<CompanyAssociationWhereInput>;
-  companyAssociations_some?: Maybe<CompanyAssociationWhereInput>;
-  companyAssociations_none?: Maybe<CompanyAssociationWhereInput>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  AND?: Maybe<UserWhereInput[] | UserWhereInput>;
-  OR?: Maybe<UserWhereInput[] | UserWhereInput>;
-  NOT?: Maybe<UserWhereInput[] | UserWhereInput>;
-}
-
-export interface UserUpdateManyDataInput {
-  isActive?: Maybe<Boolean>;
-  email?: Maybe<String>;
-  password?: Maybe<String>;
-  name?: Maybe<String>;
-  phone?: Maybe<String>;
-}
-
-export type StatusLogWhereUniqueInput = AtLeastOne<{
-  id: Maybe<ID_Input>;
-}>;
 
 export interface ApplicationUpdateredirectUrisInput {
   set?: Maybe<String[] | String>;
@@ -4006,20 +5134,10 @@ export interface FormScalarWhereInput {
   updatedAt_gte?: Maybe<DateTimeInput>;
   signedByTransporter?: Maybe<Boolean>;
   signedByTransporter_not?: Maybe<Boolean>;
-  status?: Maybe<String>;
-  status_not?: Maybe<String>;
-  status_in?: Maybe<String[] | String>;
-  status_not_in?: Maybe<String[] | String>;
-  status_lt?: Maybe<String>;
-  status_lte?: Maybe<String>;
-  status_gt?: Maybe<String>;
-  status_gte?: Maybe<String>;
-  status_contains?: Maybe<String>;
-  status_not_contains?: Maybe<String>;
-  status_starts_with?: Maybe<String>;
-  status_not_starts_with?: Maybe<String>;
-  status_ends_with?: Maybe<String>;
-  status_not_ends_with?: Maybe<String>;
+  status?: Maybe<Status>;
+  status_not?: Maybe<Status>;
+  status_in?: Maybe<Status[] | Status>;
+  status_not_in?: Maybe<Status[] | Status>;
   sentAt?: Maybe<DateTimeInput>;
   sentAt_not?: Maybe<DateTimeInput>;
   sentAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
@@ -4900,7 +6018,7 @@ export interface FormCreateInput {
   isDeleted?: Maybe<Boolean>;
   owner: UserCreateOneInput;
   signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
+  status?: Maybe<Status>;
   sentAt?: Maybe<DateTimeInput>;
   sentBy?: Maybe<String>;
   isAccepted?: Maybe<Boolean>;
@@ -5221,13 +6339,9 @@ export interface CompanyAssociationCreateInput {
   role: UserRole;
 }
 
-export interface StatusLogCreateInput {
-  id?: Maybe<ID_Input>;
-  user: UserCreateOneInput;
-  form: FormCreateOneInput;
-  status: Status;
-  loggedAt?: Maybe<DateTimeInput>;
-  updatedFields?: Maybe<Json>;
+export interface FormCreateOneInput {
+  create?: Maybe<FormCreateInput>;
+  connect?: Maybe<FormWhereUniqueInput>;
 }
 
 export interface UserCreateOneWithoutCompanyAssociationsInput {
@@ -5235,19 +6349,19 @@ export interface UserCreateOneWithoutCompanyAssociationsInput {
   connect?: Maybe<UserWhereUniqueInput>;
 }
 
-export interface InstallationUpdateManyMutationInput {
+export interface RubriqueCreateInput {
+  id?: Maybe<ID_Input>;
   codeS3ic?: Maybe<String>;
-  nomEts?: Maybe<String>;
-  regime?: Maybe<String>;
-  libRegime?: Maybe<String>;
-  seveso?: Maybe<Seveso>;
-  libSeveso?: Maybe<String>;
-  familleIc?: Maybe<String>;
-  urlFiche?: Maybe<String>;
-  s3icNumeroSiret?: Maybe<String>;
-  irepNumeroSiret?: Maybe<String>;
-  gerepNumeroSiret?: Maybe<String>;
-  sireneNumeroSiret?: Maybe<String>;
+  rubrique?: Maybe<String>;
+  alinea?: Maybe<String>;
+  dateAutorisation?: Maybe<String>;
+  etatActivite?: Maybe<String>;
+  regimeAutorise?: Maybe<String>;
+  activite?: Maybe<String>;
+  volume?: Maybe<String>;
+  unite?: Maybe<String>;
+  category?: Maybe<String>;
+  wasteType?: Maybe<WasteType>;
 }
 
 export interface UserCreateWithoutCompanyAssociationsInput {
@@ -5313,960 +6427,13 @@ export interface UserUpdateWithoutCompanyAssociationsDataInput {
   phone?: Maybe<String>;
 }
 
-export interface FormWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  readableId?: Maybe<String>;
-  readableId_not?: Maybe<String>;
-  readableId_in?: Maybe<String[] | String>;
-  readableId_not_in?: Maybe<String[] | String>;
-  readableId_lt?: Maybe<String>;
-  readableId_lte?: Maybe<String>;
-  readableId_gt?: Maybe<String>;
-  readableId_gte?: Maybe<String>;
-  readableId_contains?: Maybe<String>;
-  readableId_not_contains?: Maybe<String>;
-  readableId_starts_with?: Maybe<String>;
-  readableId_not_starts_with?: Maybe<String>;
-  readableId_ends_with?: Maybe<String>;
-  readableId_not_ends_with?: Maybe<String>;
-  customId?: Maybe<String>;
-  customId_not?: Maybe<String>;
-  customId_in?: Maybe<String[] | String>;
-  customId_not_in?: Maybe<String[] | String>;
-  customId_lt?: Maybe<String>;
-  customId_lte?: Maybe<String>;
-  customId_gt?: Maybe<String>;
-  customId_gte?: Maybe<String>;
-  customId_contains?: Maybe<String>;
-  customId_not_contains?: Maybe<String>;
-  customId_starts_with?: Maybe<String>;
-  customId_not_starts_with?: Maybe<String>;
-  customId_ends_with?: Maybe<String>;
-  customId_not_ends_with?: Maybe<String>;
-  isDeleted?: Maybe<Boolean>;
-  isDeleted_not?: Maybe<Boolean>;
-  owner?: Maybe<UserWhereInput>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  signedByTransporter?: Maybe<Boolean>;
-  signedByTransporter_not?: Maybe<Boolean>;
-  status?: Maybe<String>;
-  status_not?: Maybe<String>;
-  status_in?: Maybe<String[] | String>;
-  status_not_in?: Maybe<String[] | String>;
-  status_lt?: Maybe<String>;
-  status_lte?: Maybe<String>;
-  status_gt?: Maybe<String>;
-  status_gte?: Maybe<String>;
-  status_contains?: Maybe<String>;
-  status_not_contains?: Maybe<String>;
-  status_starts_with?: Maybe<String>;
-  status_not_starts_with?: Maybe<String>;
-  status_ends_with?: Maybe<String>;
-  status_not_ends_with?: Maybe<String>;
-  sentAt?: Maybe<DateTimeInput>;
-  sentAt_not?: Maybe<DateTimeInput>;
-  sentAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  sentAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  sentAt_lt?: Maybe<DateTimeInput>;
-  sentAt_lte?: Maybe<DateTimeInput>;
-  sentAt_gt?: Maybe<DateTimeInput>;
-  sentAt_gte?: Maybe<DateTimeInput>;
-  sentBy?: Maybe<String>;
-  sentBy_not?: Maybe<String>;
-  sentBy_in?: Maybe<String[] | String>;
-  sentBy_not_in?: Maybe<String[] | String>;
-  sentBy_lt?: Maybe<String>;
-  sentBy_lte?: Maybe<String>;
-  sentBy_gt?: Maybe<String>;
-  sentBy_gte?: Maybe<String>;
-  sentBy_contains?: Maybe<String>;
-  sentBy_not_contains?: Maybe<String>;
-  sentBy_starts_with?: Maybe<String>;
-  sentBy_not_starts_with?: Maybe<String>;
-  sentBy_ends_with?: Maybe<String>;
-  sentBy_not_ends_with?: Maybe<String>;
-  isAccepted?: Maybe<Boolean>;
-  isAccepted_not?: Maybe<Boolean>;
-  wasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  wasteAcceptationStatus_not?: Maybe<WasteAcceptationStatus>;
-  wasteAcceptationStatus_in?: Maybe<
-    WasteAcceptationStatus[] | WasteAcceptationStatus
-  >;
-  wasteAcceptationStatus_not_in?: Maybe<
-    WasteAcceptationStatus[] | WasteAcceptationStatus
-  >;
-  wasteRefusalReason?: Maybe<String>;
-  wasteRefusalReason_not?: Maybe<String>;
-  wasteRefusalReason_in?: Maybe<String[] | String>;
-  wasteRefusalReason_not_in?: Maybe<String[] | String>;
-  wasteRefusalReason_lt?: Maybe<String>;
-  wasteRefusalReason_lte?: Maybe<String>;
-  wasteRefusalReason_gt?: Maybe<String>;
-  wasteRefusalReason_gte?: Maybe<String>;
-  wasteRefusalReason_contains?: Maybe<String>;
-  wasteRefusalReason_not_contains?: Maybe<String>;
-  wasteRefusalReason_starts_with?: Maybe<String>;
-  wasteRefusalReason_not_starts_with?: Maybe<String>;
-  wasteRefusalReason_ends_with?: Maybe<String>;
-  wasteRefusalReason_not_ends_with?: Maybe<String>;
-  receivedBy?: Maybe<String>;
-  receivedBy_not?: Maybe<String>;
-  receivedBy_in?: Maybe<String[] | String>;
-  receivedBy_not_in?: Maybe<String[] | String>;
-  receivedBy_lt?: Maybe<String>;
-  receivedBy_lte?: Maybe<String>;
-  receivedBy_gt?: Maybe<String>;
-  receivedBy_gte?: Maybe<String>;
-  receivedBy_contains?: Maybe<String>;
-  receivedBy_not_contains?: Maybe<String>;
-  receivedBy_starts_with?: Maybe<String>;
-  receivedBy_not_starts_with?: Maybe<String>;
-  receivedBy_ends_with?: Maybe<String>;
-  receivedBy_not_ends_with?: Maybe<String>;
-  receivedAt?: Maybe<DateTimeInput>;
-  receivedAt_not?: Maybe<DateTimeInput>;
-  receivedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  receivedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  receivedAt_lt?: Maybe<DateTimeInput>;
-  receivedAt_lte?: Maybe<DateTimeInput>;
-  receivedAt_gt?: Maybe<DateTimeInput>;
-  receivedAt_gte?: Maybe<DateTimeInput>;
-  quantityReceived?: Maybe<Float>;
-  quantityReceived_not?: Maybe<Float>;
-  quantityReceived_in?: Maybe<Float[] | Float>;
-  quantityReceived_not_in?: Maybe<Float[] | Float>;
-  quantityReceived_lt?: Maybe<Float>;
-  quantityReceived_lte?: Maybe<Float>;
-  quantityReceived_gt?: Maybe<Float>;
-  quantityReceived_gte?: Maybe<Float>;
-  processedBy?: Maybe<String>;
-  processedBy_not?: Maybe<String>;
-  processedBy_in?: Maybe<String[] | String>;
-  processedBy_not_in?: Maybe<String[] | String>;
-  processedBy_lt?: Maybe<String>;
-  processedBy_lte?: Maybe<String>;
-  processedBy_gt?: Maybe<String>;
-  processedBy_gte?: Maybe<String>;
-  processedBy_contains?: Maybe<String>;
-  processedBy_not_contains?: Maybe<String>;
-  processedBy_starts_with?: Maybe<String>;
-  processedBy_not_starts_with?: Maybe<String>;
-  processedBy_ends_with?: Maybe<String>;
-  processedBy_not_ends_with?: Maybe<String>;
-  processedAt?: Maybe<String>;
-  processedAt_not?: Maybe<String>;
-  processedAt_in?: Maybe<String[] | String>;
-  processedAt_not_in?: Maybe<String[] | String>;
-  processedAt_lt?: Maybe<String>;
-  processedAt_lte?: Maybe<String>;
-  processedAt_gt?: Maybe<String>;
-  processedAt_gte?: Maybe<String>;
-  processedAt_contains?: Maybe<String>;
-  processedAt_not_contains?: Maybe<String>;
-  processedAt_starts_with?: Maybe<String>;
-  processedAt_not_starts_with?: Maybe<String>;
-  processedAt_ends_with?: Maybe<String>;
-  processedAt_not_ends_with?: Maybe<String>;
-  processingOperationDone?: Maybe<String>;
-  processingOperationDone_not?: Maybe<String>;
-  processingOperationDone_in?: Maybe<String[] | String>;
-  processingOperationDone_not_in?: Maybe<String[] | String>;
-  processingOperationDone_lt?: Maybe<String>;
-  processingOperationDone_lte?: Maybe<String>;
-  processingOperationDone_gt?: Maybe<String>;
-  processingOperationDone_gte?: Maybe<String>;
-  processingOperationDone_contains?: Maybe<String>;
-  processingOperationDone_not_contains?: Maybe<String>;
-  processingOperationDone_starts_with?: Maybe<String>;
-  processingOperationDone_not_starts_with?: Maybe<String>;
-  processingOperationDone_ends_with?: Maybe<String>;
-  processingOperationDone_not_ends_with?: Maybe<String>;
-  processingOperationDescription?: Maybe<String>;
-  processingOperationDescription_not?: Maybe<String>;
-  processingOperationDescription_in?: Maybe<String[] | String>;
-  processingOperationDescription_not_in?: Maybe<String[] | String>;
-  processingOperationDescription_lt?: Maybe<String>;
-  processingOperationDescription_lte?: Maybe<String>;
-  processingOperationDescription_gt?: Maybe<String>;
-  processingOperationDescription_gte?: Maybe<String>;
-  processingOperationDescription_contains?: Maybe<String>;
-  processingOperationDescription_not_contains?: Maybe<String>;
-  processingOperationDescription_starts_with?: Maybe<String>;
-  processingOperationDescription_not_starts_with?: Maybe<String>;
-  processingOperationDescription_ends_with?: Maybe<String>;
-  processingOperationDescription_not_ends_with?: Maybe<String>;
-  noTraceability?: Maybe<Boolean>;
-  noTraceability_not?: Maybe<Boolean>;
-  nextDestinationProcessingOperation?: Maybe<String>;
-  nextDestinationProcessingOperation_not?: Maybe<String>;
-  nextDestinationProcessingOperation_in?: Maybe<String[] | String>;
-  nextDestinationProcessingOperation_not_in?: Maybe<String[] | String>;
-  nextDestinationProcessingOperation_lt?: Maybe<String>;
-  nextDestinationProcessingOperation_lte?: Maybe<String>;
-  nextDestinationProcessingOperation_gt?: Maybe<String>;
-  nextDestinationProcessingOperation_gte?: Maybe<String>;
-  nextDestinationProcessingOperation_contains?: Maybe<String>;
-  nextDestinationProcessingOperation_not_contains?: Maybe<String>;
-  nextDestinationProcessingOperation_starts_with?: Maybe<String>;
-  nextDestinationProcessingOperation_not_starts_with?: Maybe<String>;
-  nextDestinationProcessingOperation_ends_with?: Maybe<String>;
-  nextDestinationProcessingOperation_not_ends_with?: Maybe<String>;
-  nextDestinationCompanyName?: Maybe<String>;
-  nextDestinationCompanyName_not?: Maybe<String>;
-  nextDestinationCompanyName_in?: Maybe<String[] | String>;
-  nextDestinationCompanyName_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanyName_lt?: Maybe<String>;
-  nextDestinationCompanyName_lte?: Maybe<String>;
-  nextDestinationCompanyName_gt?: Maybe<String>;
-  nextDestinationCompanyName_gte?: Maybe<String>;
-  nextDestinationCompanyName_contains?: Maybe<String>;
-  nextDestinationCompanyName_not_contains?: Maybe<String>;
-  nextDestinationCompanyName_starts_with?: Maybe<String>;
-  nextDestinationCompanyName_not_starts_with?: Maybe<String>;
-  nextDestinationCompanyName_ends_with?: Maybe<String>;
-  nextDestinationCompanyName_not_ends_with?: Maybe<String>;
-  nextDestinationCompanySiret?: Maybe<String>;
-  nextDestinationCompanySiret_not?: Maybe<String>;
-  nextDestinationCompanySiret_in?: Maybe<String[] | String>;
-  nextDestinationCompanySiret_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanySiret_lt?: Maybe<String>;
-  nextDestinationCompanySiret_lte?: Maybe<String>;
-  nextDestinationCompanySiret_gt?: Maybe<String>;
-  nextDestinationCompanySiret_gte?: Maybe<String>;
-  nextDestinationCompanySiret_contains?: Maybe<String>;
-  nextDestinationCompanySiret_not_contains?: Maybe<String>;
-  nextDestinationCompanySiret_starts_with?: Maybe<String>;
-  nextDestinationCompanySiret_not_starts_with?: Maybe<String>;
-  nextDestinationCompanySiret_ends_with?: Maybe<String>;
-  nextDestinationCompanySiret_not_ends_with?: Maybe<String>;
-  nextDestinationCompanyAddress?: Maybe<String>;
-  nextDestinationCompanyAddress_not?: Maybe<String>;
-  nextDestinationCompanyAddress_in?: Maybe<String[] | String>;
-  nextDestinationCompanyAddress_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanyAddress_lt?: Maybe<String>;
-  nextDestinationCompanyAddress_lte?: Maybe<String>;
-  nextDestinationCompanyAddress_gt?: Maybe<String>;
-  nextDestinationCompanyAddress_gte?: Maybe<String>;
-  nextDestinationCompanyAddress_contains?: Maybe<String>;
-  nextDestinationCompanyAddress_not_contains?: Maybe<String>;
-  nextDestinationCompanyAddress_starts_with?: Maybe<String>;
-  nextDestinationCompanyAddress_not_starts_with?: Maybe<String>;
-  nextDestinationCompanyAddress_ends_with?: Maybe<String>;
-  nextDestinationCompanyAddress_not_ends_with?: Maybe<String>;
-  nextDestinationCompanyContact?: Maybe<String>;
-  nextDestinationCompanyContact_not?: Maybe<String>;
-  nextDestinationCompanyContact_in?: Maybe<String[] | String>;
-  nextDestinationCompanyContact_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanyContact_lt?: Maybe<String>;
-  nextDestinationCompanyContact_lte?: Maybe<String>;
-  nextDestinationCompanyContact_gt?: Maybe<String>;
-  nextDestinationCompanyContact_gte?: Maybe<String>;
-  nextDestinationCompanyContact_contains?: Maybe<String>;
-  nextDestinationCompanyContact_not_contains?: Maybe<String>;
-  nextDestinationCompanyContact_starts_with?: Maybe<String>;
-  nextDestinationCompanyContact_not_starts_with?: Maybe<String>;
-  nextDestinationCompanyContact_ends_with?: Maybe<String>;
-  nextDestinationCompanyContact_not_ends_with?: Maybe<String>;
-  nextDestinationCompanyPhone?: Maybe<String>;
-  nextDestinationCompanyPhone_not?: Maybe<String>;
-  nextDestinationCompanyPhone_in?: Maybe<String[] | String>;
-  nextDestinationCompanyPhone_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanyPhone_lt?: Maybe<String>;
-  nextDestinationCompanyPhone_lte?: Maybe<String>;
-  nextDestinationCompanyPhone_gt?: Maybe<String>;
-  nextDestinationCompanyPhone_gte?: Maybe<String>;
-  nextDestinationCompanyPhone_contains?: Maybe<String>;
-  nextDestinationCompanyPhone_not_contains?: Maybe<String>;
-  nextDestinationCompanyPhone_starts_with?: Maybe<String>;
-  nextDestinationCompanyPhone_not_starts_with?: Maybe<String>;
-  nextDestinationCompanyPhone_ends_with?: Maybe<String>;
-  nextDestinationCompanyPhone_not_ends_with?: Maybe<String>;
-  nextDestinationCompanyMail?: Maybe<String>;
-  nextDestinationCompanyMail_not?: Maybe<String>;
-  nextDestinationCompanyMail_in?: Maybe<String[] | String>;
-  nextDestinationCompanyMail_not_in?: Maybe<String[] | String>;
-  nextDestinationCompanyMail_lt?: Maybe<String>;
-  nextDestinationCompanyMail_lte?: Maybe<String>;
-  nextDestinationCompanyMail_gt?: Maybe<String>;
-  nextDestinationCompanyMail_gte?: Maybe<String>;
-  nextDestinationCompanyMail_contains?: Maybe<String>;
-  nextDestinationCompanyMail_not_contains?: Maybe<String>;
-  nextDestinationCompanyMail_starts_with?: Maybe<String>;
-  nextDestinationCompanyMail_not_starts_with?: Maybe<String>;
-  nextDestinationCompanyMail_ends_with?: Maybe<String>;
-  nextDestinationCompanyMail_not_ends_with?: Maybe<String>;
-  emitterType?: Maybe<EmitterType>;
-  emitterType_not?: Maybe<EmitterType>;
-  emitterType_in?: Maybe<EmitterType[] | EmitterType>;
-  emitterType_not_in?: Maybe<EmitterType[] | EmitterType>;
-  emitterPickupSite?: Maybe<String>;
-  emitterPickupSite_not?: Maybe<String>;
-  emitterPickupSite_in?: Maybe<String[] | String>;
-  emitterPickupSite_not_in?: Maybe<String[] | String>;
-  emitterPickupSite_lt?: Maybe<String>;
-  emitterPickupSite_lte?: Maybe<String>;
-  emitterPickupSite_gt?: Maybe<String>;
-  emitterPickupSite_gte?: Maybe<String>;
-  emitterPickupSite_contains?: Maybe<String>;
-  emitterPickupSite_not_contains?: Maybe<String>;
-  emitterPickupSite_starts_with?: Maybe<String>;
-  emitterPickupSite_not_starts_with?: Maybe<String>;
-  emitterPickupSite_ends_with?: Maybe<String>;
-  emitterPickupSite_not_ends_with?: Maybe<String>;
-  emitterWorkSiteName?: Maybe<String>;
-  emitterWorkSiteName_not?: Maybe<String>;
-  emitterWorkSiteName_in?: Maybe<String[] | String>;
-  emitterWorkSiteName_not_in?: Maybe<String[] | String>;
-  emitterWorkSiteName_lt?: Maybe<String>;
-  emitterWorkSiteName_lte?: Maybe<String>;
-  emitterWorkSiteName_gt?: Maybe<String>;
-  emitterWorkSiteName_gte?: Maybe<String>;
-  emitterWorkSiteName_contains?: Maybe<String>;
-  emitterWorkSiteName_not_contains?: Maybe<String>;
-  emitterWorkSiteName_starts_with?: Maybe<String>;
-  emitterWorkSiteName_not_starts_with?: Maybe<String>;
-  emitterWorkSiteName_ends_with?: Maybe<String>;
-  emitterWorkSiteName_not_ends_with?: Maybe<String>;
-  emitterWorkSiteAddress?: Maybe<String>;
-  emitterWorkSiteAddress_not?: Maybe<String>;
-  emitterWorkSiteAddress_in?: Maybe<String[] | String>;
-  emitterWorkSiteAddress_not_in?: Maybe<String[] | String>;
-  emitterWorkSiteAddress_lt?: Maybe<String>;
-  emitterWorkSiteAddress_lte?: Maybe<String>;
-  emitterWorkSiteAddress_gt?: Maybe<String>;
-  emitterWorkSiteAddress_gte?: Maybe<String>;
-  emitterWorkSiteAddress_contains?: Maybe<String>;
-  emitterWorkSiteAddress_not_contains?: Maybe<String>;
-  emitterWorkSiteAddress_starts_with?: Maybe<String>;
-  emitterWorkSiteAddress_not_starts_with?: Maybe<String>;
-  emitterWorkSiteAddress_ends_with?: Maybe<String>;
-  emitterWorkSiteAddress_not_ends_with?: Maybe<String>;
-  emitterWorkSiteCity?: Maybe<String>;
-  emitterWorkSiteCity_not?: Maybe<String>;
-  emitterWorkSiteCity_in?: Maybe<String[] | String>;
-  emitterWorkSiteCity_not_in?: Maybe<String[] | String>;
-  emitterWorkSiteCity_lt?: Maybe<String>;
-  emitterWorkSiteCity_lte?: Maybe<String>;
-  emitterWorkSiteCity_gt?: Maybe<String>;
-  emitterWorkSiteCity_gte?: Maybe<String>;
-  emitterWorkSiteCity_contains?: Maybe<String>;
-  emitterWorkSiteCity_not_contains?: Maybe<String>;
-  emitterWorkSiteCity_starts_with?: Maybe<String>;
-  emitterWorkSiteCity_not_starts_with?: Maybe<String>;
-  emitterWorkSiteCity_ends_with?: Maybe<String>;
-  emitterWorkSiteCity_not_ends_with?: Maybe<String>;
-  emitterWorkSitePostalCode?: Maybe<String>;
-  emitterWorkSitePostalCode_not?: Maybe<String>;
-  emitterWorkSitePostalCode_in?: Maybe<String[] | String>;
-  emitterWorkSitePostalCode_not_in?: Maybe<String[] | String>;
-  emitterWorkSitePostalCode_lt?: Maybe<String>;
-  emitterWorkSitePostalCode_lte?: Maybe<String>;
-  emitterWorkSitePostalCode_gt?: Maybe<String>;
-  emitterWorkSitePostalCode_gte?: Maybe<String>;
-  emitterWorkSitePostalCode_contains?: Maybe<String>;
-  emitterWorkSitePostalCode_not_contains?: Maybe<String>;
-  emitterWorkSitePostalCode_starts_with?: Maybe<String>;
-  emitterWorkSitePostalCode_not_starts_with?: Maybe<String>;
-  emitterWorkSitePostalCode_ends_with?: Maybe<String>;
-  emitterWorkSitePostalCode_not_ends_with?: Maybe<String>;
-  emitterWorkSiteInfos?: Maybe<String>;
-  emitterWorkSiteInfos_not?: Maybe<String>;
-  emitterWorkSiteInfos_in?: Maybe<String[] | String>;
-  emitterWorkSiteInfos_not_in?: Maybe<String[] | String>;
-  emitterWorkSiteInfos_lt?: Maybe<String>;
-  emitterWorkSiteInfos_lte?: Maybe<String>;
-  emitterWorkSiteInfos_gt?: Maybe<String>;
-  emitterWorkSiteInfos_gte?: Maybe<String>;
-  emitterWorkSiteInfos_contains?: Maybe<String>;
-  emitterWorkSiteInfos_not_contains?: Maybe<String>;
-  emitterWorkSiteInfos_starts_with?: Maybe<String>;
-  emitterWorkSiteInfos_not_starts_with?: Maybe<String>;
-  emitterWorkSiteInfos_ends_with?: Maybe<String>;
-  emitterWorkSiteInfos_not_ends_with?: Maybe<String>;
-  emitterCompanyName?: Maybe<String>;
-  emitterCompanyName_not?: Maybe<String>;
-  emitterCompanyName_in?: Maybe<String[] | String>;
-  emitterCompanyName_not_in?: Maybe<String[] | String>;
-  emitterCompanyName_lt?: Maybe<String>;
-  emitterCompanyName_lte?: Maybe<String>;
-  emitterCompanyName_gt?: Maybe<String>;
-  emitterCompanyName_gte?: Maybe<String>;
-  emitterCompanyName_contains?: Maybe<String>;
-  emitterCompanyName_not_contains?: Maybe<String>;
-  emitterCompanyName_starts_with?: Maybe<String>;
-  emitterCompanyName_not_starts_with?: Maybe<String>;
-  emitterCompanyName_ends_with?: Maybe<String>;
-  emitterCompanyName_not_ends_with?: Maybe<String>;
-  emitterCompanySiret?: Maybe<String>;
-  emitterCompanySiret_not?: Maybe<String>;
-  emitterCompanySiret_in?: Maybe<String[] | String>;
-  emitterCompanySiret_not_in?: Maybe<String[] | String>;
-  emitterCompanySiret_lt?: Maybe<String>;
-  emitterCompanySiret_lte?: Maybe<String>;
-  emitterCompanySiret_gt?: Maybe<String>;
-  emitterCompanySiret_gte?: Maybe<String>;
-  emitterCompanySiret_contains?: Maybe<String>;
-  emitterCompanySiret_not_contains?: Maybe<String>;
-  emitterCompanySiret_starts_with?: Maybe<String>;
-  emitterCompanySiret_not_starts_with?: Maybe<String>;
-  emitterCompanySiret_ends_with?: Maybe<String>;
-  emitterCompanySiret_not_ends_with?: Maybe<String>;
-  emitterCompanyAddress?: Maybe<String>;
-  emitterCompanyAddress_not?: Maybe<String>;
-  emitterCompanyAddress_in?: Maybe<String[] | String>;
-  emitterCompanyAddress_not_in?: Maybe<String[] | String>;
-  emitterCompanyAddress_lt?: Maybe<String>;
-  emitterCompanyAddress_lte?: Maybe<String>;
-  emitterCompanyAddress_gt?: Maybe<String>;
-  emitterCompanyAddress_gte?: Maybe<String>;
-  emitterCompanyAddress_contains?: Maybe<String>;
-  emitterCompanyAddress_not_contains?: Maybe<String>;
-  emitterCompanyAddress_starts_with?: Maybe<String>;
-  emitterCompanyAddress_not_starts_with?: Maybe<String>;
-  emitterCompanyAddress_ends_with?: Maybe<String>;
-  emitterCompanyAddress_not_ends_with?: Maybe<String>;
-  emitterCompanyContact?: Maybe<String>;
-  emitterCompanyContact_not?: Maybe<String>;
-  emitterCompanyContact_in?: Maybe<String[] | String>;
-  emitterCompanyContact_not_in?: Maybe<String[] | String>;
-  emitterCompanyContact_lt?: Maybe<String>;
-  emitterCompanyContact_lte?: Maybe<String>;
-  emitterCompanyContact_gt?: Maybe<String>;
-  emitterCompanyContact_gte?: Maybe<String>;
-  emitterCompanyContact_contains?: Maybe<String>;
-  emitterCompanyContact_not_contains?: Maybe<String>;
-  emitterCompanyContact_starts_with?: Maybe<String>;
-  emitterCompanyContact_not_starts_with?: Maybe<String>;
-  emitterCompanyContact_ends_with?: Maybe<String>;
-  emitterCompanyContact_not_ends_with?: Maybe<String>;
-  emitterCompanyPhone?: Maybe<String>;
-  emitterCompanyPhone_not?: Maybe<String>;
-  emitterCompanyPhone_in?: Maybe<String[] | String>;
-  emitterCompanyPhone_not_in?: Maybe<String[] | String>;
-  emitterCompanyPhone_lt?: Maybe<String>;
-  emitterCompanyPhone_lte?: Maybe<String>;
-  emitterCompanyPhone_gt?: Maybe<String>;
-  emitterCompanyPhone_gte?: Maybe<String>;
-  emitterCompanyPhone_contains?: Maybe<String>;
-  emitterCompanyPhone_not_contains?: Maybe<String>;
-  emitterCompanyPhone_starts_with?: Maybe<String>;
-  emitterCompanyPhone_not_starts_with?: Maybe<String>;
-  emitterCompanyPhone_ends_with?: Maybe<String>;
-  emitterCompanyPhone_not_ends_with?: Maybe<String>;
-  emitterCompanyMail?: Maybe<String>;
-  emitterCompanyMail_not?: Maybe<String>;
-  emitterCompanyMail_in?: Maybe<String[] | String>;
-  emitterCompanyMail_not_in?: Maybe<String[] | String>;
-  emitterCompanyMail_lt?: Maybe<String>;
-  emitterCompanyMail_lte?: Maybe<String>;
-  emitterCompanyMail_gt?: Maybe<String>;
-  emitterCompanyMail_gte?: Maybe<String>;
-  emitterCompanyMail_contains?: Maybe<String>;
-  emitterCompanyMail_not_contains?: Maybe<String>;
-  emitterCompanyMail_starts_with?: Maybe<String>;
-  emitterCompanyMail_not_starts_with?: Maybe<String>;
-  emitterCompanyMail_ends_with?: Maybe<String>;
-  emitterCompanyMail_not_ends_with?: Maybe<String>;
-  recipientCap?: Maybe<String>;
-  recipientCap_not?: Maybe<String>;
-  recipientCap_in?: Maybe<String[] | String>;
-  recipientCap_not_in?: Maybe<String[] | String>;
-  recipientCap_lt?: Maybe<String>;
-  recipientCap_lte?: Maybe<String>;
-  recipientCap_gt?: Maybe<String>;
-  recipientCap_gte?: Maybe<String>;
-  recipientCap_contains?: Maybe<String>;
-  recipientCap_not_contains?: Maybe<String>;
-  recipientCap_starts_with?: Maybe<String>;
-  recipientCap_not_starts_with?: Maybe<String>;
-  recipientCap_ends_with?: Maybe<String>;
-  recipientCap_not_ends_with?: Maybe<String>;
-  recipientProcessingOperation?: Maybe<String>;
-  recipientProcessingOperation_not?: Maybe<String>;
-  recipientProcessingOperation_in?: Maybe<String[] | String>;
-  recipientProcessingOperation_not_in?: Maybe<String[] | String>;
-  recipientProcessingOperation_lt?: Maybe<String>;
-  recipientProcessingOperation_lte?: Maybe<String>;
-  recipientProcessingOperation_gt?: Maybe<String>;
-  recipientProcessingOperation_gte?: Maybe<String>;
-  recipientProcessingOperation_contains?: Maybe<String>;
-  recipientProcessingOperation_not_contains?: Maybe<String>;
-  recipientProcessingOperation_starts_with?: Maybe<String>;
-  recipientProcessingOperation_not_starts_with?: Maybe<String>;
-  recipientProcessingOperation_ends_with?: Maybe<String>;
-  recipientProcessingOperation_not_ends_with?: Maybe<String>;
-  recipientIsTempStorage?: Maybe<Boolean>;
-  recipientIsTempStorage_not?: Maybe<Boolean>;
-  recipientCompanyName?: Maybe<String>;
-  recipientCompanyName_not?: Maybe<String>;
-  recipientCompanyName_in?: Maybe<String[] | String>;
-  recipientCompanyName_not_in?: Maybe<String[] | String>;
-  recipientCompanyName_lt?: Maybe<String>;
-  recipientCompanyName_lte?: Maybe<String>;
-  recipientCompanyName_gt?: Maybe<String>;
-  recipientCompanyName_gte?: Maybe<String>;
-  recipientCompanyName_contains?: Maybe<String>;
-  recipientCompanyName_not_contains?: Maybe<String>;
-  recipientCompanyName_starts_with?: Maybe<String>;
-  recipientCompanyName_not_starts_with?: Maybe<String>;
-  recipientCompanyName_ends_with?: Maybe<String>;
-  recipientCompanyName_not_ends_with?: Maybe<String>;
-  recipientCompanySiret?: Maybe<String>;
-  recipientCompanySiret_not?: Maybe<String>;
-  recipientCompanySiret_in?: Maybe<String[] | String>;
-  recipientCompanySiret_not_in?: Maybe<String[] | String>;
-  recipientCompanySiret_lt?: Maybe<String>;
-  recipientCompanySiret_lte?: Maybe<String>;
-  recipientCompanySiret_gt?: Maybe<String>;
-  recipientCompanySiret_gte?: Maybe<String>;
-  recipientCompanySiret_contains?: Maybe<String>;
-  recipientCompanySiret_not_contains?: Maybe<String>;
-  recipientCompanySiret_starts_with?: Maybe<String>;
-  recipientCompanySiret_not_starts_with?: Maybe<String>;
-  recipientCompanySiret_ends_with?: Maybe<String>;
-  recipientCompanySiret_not_ends_with?: Maybe<String>;
-  recipientCompanyAddress?: Maybe<String>;
-  recipientCompanyAddress_not?: Maybe<String>;
-  recipientCompanyAddress_in?: Maybe<String[] | String>;
-  recipientCompanyAddress_not_in?: Maybe<String[] | String>;
-  recipientCompanyAddress_lt?: Maybe<String>;
-  recipientCompanyAddress_lte?: Maybe<String>;
-  recipientCompanyAddress_gt?: Maybe<String>;
-  recipientCompanyAddress_gte?: Maybe<String>;
-  recipientCompanyAddress_contains?: Maybe<String>;
-  recipientCompanyAddress_not_contains?: Maybe<String>;
-  recipientCompanyAddress_starts_with?: Maybe<String>;
-  recipientCompanyAddress_not_starts_with?: Maybe<String>;
-  recipientCompanyAddress_ends_with?: Maybe<String>;
-  recipientCompanyAddress_not_ends_with?: Maybe<String>;
-  recipientCompanyContact?: Maybe<String>;
-  recipientCompanyContact_not?: Maybe<String>;
-  recipientCompanyContact_in?: Maybe<String[] | String>;
-  recipientCompanyContact_not_in?: Maybe<String[] | String>;
-  recipientCompanyContact_lt?: Maybe<String>;
-  recipientCompanyContact_lte?: Maybe<String>;
-  recipientCompanyContact_gt?: Maybe<String>;
-  recipientCompanyContact_gte?: Maybe<String>;
-  recipientCompanyContact_contains?: Maybe<String>;
-  recipientCompanyContact_not_contains?: Maybe<String>;
-  recipientCompanyContact_starts_with?: Maybe<String>;
-  recipientCompanyContact_not_starts_with?: Maybe<String>;
-  recipientCompanyContact_ends_with?: Maybe<String>;
-  recipientCompanyContact_not_ends_with?: Maybe<String>;
-  recipientCompanyPhone?: Maybe<String>;
-  recipientCompanyPhone_not?: Maybe<String>;
-  recipientCompanyPhone_in?: Maybe<String[] | String>;
-  recipientCompanyPhone_not_in?: Maybe<String[] | String>;
-  recipientCompanyPhone_lt?: Maybe<String>;
-  recipientCompanyPhone_lte?: Maybe<String>;
-  recipientCompanyPhone_gt?: Maybe<String>;
-  recipientCompanyPhone_gte?: Maybe<String>;
-  recipientCompanyPhone_contains?: Maybe<String>;
-  recipientCompanyPhone_not_contains?: Maybe<String>;
-  recipientCompanyPhone_starts_with?: Maybe<String>;
-  recipientCompanyPhone_not_starts_with?: Maybe<String>;
-  recipientCompanyPhone_ends_with?: Maybe<String>;
-  recipientCompanyPhone_not_ends_with?: Maybe<String>;
-  recipientCompanyMail?: Maybe<String>;
-  recipientCompanyMail_not?: Maybe<String>;
-  recipientCompanyMail_in?: Maybe<String[] | String>;
-  recipientCompanyMail_not_in?: Maybe<String[] | String>;
-  recipientCompanyMail_lt?: Maybe<String>;
-  recipientCompanyMail_lte?: Maybe<String>;
-  recipientCompanyMail_gt?: Maybe<String>;
-  recipientCompanyMail_gte?: Maybe<String>;
-  recipientCompanyMail_contains?: Maybe<String>;
-  recipientCompanyMail_not_contains?: Maybe<String>;
-  recipientCompanyMail_starts_with?: Maybe<String>;
-  recipientCompanyMail_not_starts_with?: Maybe<String>;
-  recipientCompanyMail_ends_with?: Maybe<String>;
-  recipientCompanyMail_not_ends_with?: Maybe<String>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanyName_not?: Maybe<String>;
-  transporterCompanyName_in?: Maybe<String[] | String>;
-  transporterCompanyName_not_in?: Maybe<String[] | String>;
-  transporterCompanyName_lt?: Maybe<String>;
-  transporterCompanyName_lte?: Maybe<String>;
-  transporterCompanyName_gt?: Maybe<String>;
-  transporterCompanyName_gte?: Maybe<String>;
-  transporterCompanyName_contains?: Maybe<String>;
-  transporterCompanyName_not_contains?: Maybe<String>;
-  transporterCompanyName_starts_with?: Maybe<String>;
-  transporterCompanyName_not_starts_with?: Maybe<String>;
-  transporterCompanyName_ends_with?: Maybe<String>;
-  transporterCompanyName_not_ends_with?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanySiret_not?: Maybe<String>;
-  transporterCompanySiret_in?: Maybe<String[] | String>;
-  transporterCompanySiret_not_in?: Maybe<String[] | String>;
-  transporterCompanySiret_lt?: Maybe<String>;
-  transporterCompanySiret_lte?: Maybe<String>;
-  transporterCompanySiret_gt?: Maybe<String>;
-  transporterCompanySiret_gte?: Maybe<String>;
-  transporterCompanySiret_contains?: Maybe<String>;
-  transporterCompanySiret_not_contains?: Maybe<String>;
-  transporterCompanySiret_starts_with?: Maybe<String>;
-  transporterCompanySiret_not_starts_with?: Maybe<String>;
-  transporterCompanySiret_ends_with?: Maybe<String>;
-  transporterCompanySiret_not_ends_with?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyAddress_not?: Maybe<String>;
-  transporterCompanyAddress_in?: Maybe<String[] | String>;
-  transporterCompanyAddress_not_in?: Maybe<String[] | String>;
-  transporterCompanyAddress_lt?: Maybe<String>;
-  transporterCompanyAddress_lte?: Maybe<String>;
-  transporterCompanyAddress_gt?: Maybe<String>;
-  transporterCompanyAddress_gte?: Maybe<String>;
-  transporterCompanyAddress_contains?: Maybe<String>;
-  transporterCompanyAddress_not_contains?: Maybe<String>;
-  transporterCompanyAddress_starts_with?: Maybe<String>;
-  transporterCompanyAddress_not_starts_with?: Maybe<String>;
-  transporterCompanyAddress_ends_with?: Maybe<String>;
-  transporterCompanyAddress_not_ends_with?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyContact_not?: Maybe<String>;
-  transporterCompanyContact_in?: Maybe<String[] | String>;
-  transporterCompanyContact_not_in?: Maybe<String[] | String>;
-  transporterCompanyContact_lt?: Maybe<String>;
-  transporterCompanyContact_lte?: Maybe<String>;
-  transporterCompanyContact_gt?: Maybe<String>;
-  transporterCompanyContact_gte?: Maybe<String>;
-  transporterCompanyContact_contains?: Maybe<String>;
-  transporterCompanyContact_not_contains?: Maybe<String>;
-  transporterCompanyContact_starts_with?: Maybe<String>;
-  transporterCompanyContact_not_starts_with?: Maybe<String>;
-  transporterCompanyContact_ends_with?: Maybe<String>;
-  transporterCompanyContact_not_ends_with?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyPhone_not?: Maybe<String>;
-  transporterCompanyPhone_in?: Maybe<String[] | String>;
-  transporterCompanyPhone_not_in?: Maybe<String[] | String>;
-  transporterCompanyPhone_lt?: Maybe<String>;
-  transporterCompanyPhone_lte?: Maybe<String>;
-  transporterCompanyPhone_gt?: Maybe<String>;
-  transporterCompanyPhone_gte?: Maybe<String>;
-  transporterCompanyPhone_contains?: Maybe<String>;
-  transporterCompanyPhone_not_contains?: Maybe<String>;
-  transporterCompanyPhone_starts_with?: Maybe<String>;
-  transporterCompanyPhone_not_starts_with?: Maybe<String>;
-  transporterCompanyPhone_ends_with?: Maybe<String>;
-  transporterCompanyPhone_not_ends_with?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterCompanyMail_not?: Maybe<String>;
-  transporterCompanyMail_in?: Maybe<String[] | String>;
-  transporterCompanyMail_not_in?: Maybe<String[] | String>;
-  transporterCompanyMail_lt?: Maybe<String>;
-  transporterCompanyMail_lte?: Maybe<String>;
-  transporterCompanyMail_gt?: Maybe<String>;
-  transporterCompanyMail_gte?: Maybe<String>;
-  transporterCompanyMail_contains?: Maybe<String>;
-  transporterCompanyMail_not_contains?: Maybe<String>;
-  transporterCompanyMail_starts_with?: Maybe<String>;
-  transporterCompanyMail_not_starts_with?: Maybe<String>;
-  transporterCompanyMail_ends_with?: Maybe<String>;
-  transporterCompanyMail_not_ends_with?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterIsExemptedOfReceipt_not?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterReceipt_not?: Maybe<String>;
-  transporterReceipt_in?: Maybe<String[] | String>;
-  transporterReceipt_not_in?: Maybe<String[] | String>;
-  transporterReceipt_lt?: Maybe<String>;
-  transporterReceipt_lte?: Maybe<String>;
-  transporterReceipt_gt?: Maybe<String>;
-  transporterReceipt_gte?: Maybe<String>;
-  transporterReceipt_contains?: Maybe<String>;
-  transporterReceipt_not_contains?: Maybe<String>;
-  transporterReceipt_starts_with?: Maybe<String>;
-  transporterReceipt_not_starts_with?: Maybe<String>;
-  transporterReceipt_ends_with?: Maybe<String>;
-  transporterReceipt_not_ends_with?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterDepartment_not?: Maybe<String>;
-  transporterDepartment_in?: Maybe<String[] | String>;
-  transporterDepartment_not_in?: Maybe<String[] | String>;
-  transporterDepartment_lt?: Maybe<String>;
-  transporterDepartment_lte?: Maybe<String>;
-  transporterDepartment_gt?: Maybe<String>;
-  transporterDepartment_gte?: Maybe<String>;
-  transporterDepartment_contains?: Maybe<String>;
-  transporterDepartment_not_contains?: Maybe<String>;
-  transporterDepartment_starts_with?: Maybe<String>;
-  transporterDepartment_not_starts_with?: Maybe<String>;
-  transporterDepartment_ends_with?: Maybe<String>;
-  transporterDepartment_not_ends_with?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterValidityLimit_not?: Maybe<DateTimeInput>;
-  transporterValidityLimit_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  transporterValidityLimit_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  transporterValidityLimit_lt?: Maybe<DateTimeInput>;
-  transporterValidityLimit_lte?: Maybe<DateTimeInput>;
-  transporterValidityLimit_gt?: Maybe<DateTimeInput>;
-  transporterValidityLimit_gte?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  transporterNumberPlate_not?: Maybe<String>;
-  transporterNumberPlate_in?: Maybe<String[] | String>;
-  transporterNumberPlate_not_in?: Maybe<String[] | String>;
-  transporterNumberPlate_lt?: Maybe<String>;
-  transporterNumberPlate_lte?: Maybe<String>;
-  transporterNumberPlate_gt?: Maybe<String>;
-  transporterNumberPlate_gte?: Maybe<String>;
-  transporterNumberPlate_contains?: Maybe<String>;
-  transporterNumberPlate_not_contains?: Maybe<String>;
-  transporterNumberPlate_starts_with?: Maybe<String>;
-  transporterNumberPlate_not_starts_with?: Maybe<String>;
-  transporterNumberPlate_ends_with?: Maybe<String>;
-  transporterNumberPlate_not_ends_with?: Maybe<String>;
-  transporterCustomInfo?: Maybe<String>;
-  transporterCustomInfo_not?: Maybe<String>;
-  transporterCustomInfo_in?: Maybe<String[] | String>;
-  transporterCustomInfo_not_in?: Maybe<String[] | String>;
-  transporterCustomInfo_lt?: Maybe<String>;
-  transporterCustomInfo_lte?: Maybe<String>;
-  transporterCustomInfo_gt?: Maybe<String>;
-  transporterCustomInfo_gte?: Maybe<String>;
-  transporterCustomInfo_contains?: Maybe<String>;
-  transporterCustomInfo_not_contains?: Maybe<String>;
-  transporterCustomInfo_starts_with?: Maybe<String>;
-  transporterCustomInfo_not_starts_with?: Maybe<String>;
-  transporterCustomInfo_ends_with?: Maybe<String>;
-  transporterCustomInfo_not_ends_with?: Maybe<String>;
-  wasteDetailsCode?: Maybe<String>;
-  wasteDetailsCode_not?: Maybe<String>;
-  wasteDetailsCode_in?: Maybe<String[] | String>;
-  wasteDetailsCode_not_in?: Maybe<String[] | String>;
-  wasteDetailsCode_lt?: Maybe<String>;
-  wasteDetailsCode_lte?: Maybe<String>;
-  wasteDetailsCode_gt?: Maybe<String>;
-  wasteDetailsCode_gte?: Maybe<String>;
-  wasteDetailsCode_contains?: Maybe<String>;
-  wasteDetailsCode_not_contains?: Maybe<String>;
-  wasteDetailsCode_starts_with?: Maybe<String>;
-  wasteDetailsCode_not_starts_with?: Maybe<String>;
-  wasteDetailsCode_ends_with?: Maybe<String>;
-  wasteDetailsCode_not_ends_with?: Maybe<String>;
-  wasteDetailsName?: Maybe<String>;
-  wasteDetailsName_not?: Maybe<String>;
-  wasteDetailsName_in?: Maybe<String[] | String>;
-  wasteDetailsName_not_in?: Maybe<String[] | String>;
-  wasteDetailsName_lt?: Maybe<String>;
-  wasteDetailsName_lte?: Maybe<String>;
-  wasteDetailsName_gt?: Maybe<String>;
-  wasteDetailsName_gte?: Maybe<String>;
-  wasteDetailsName_contains?: Maybe<String>;
-  wasteDetailsName_not_contains?: Maybe<String>;
-  wasteDetailsName_starts_with?: Maybe<String>;
-  wasteDetailsName_not_starts_with?: Maybe<String>;
-  wasteDetailsName_ends_with?: Maybe<String>;
-  wasteDetailsName_not_ends_with?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsOnuCode_not?: Maybe<String>;
-  wasteDetailsOnuCode_in?: Maybe<String[] | String>;
-  wasteDetailsOnuCode_not_in?: Maybe<String[] | String>;
-  wasteDetailsOnuCode_lt?: Maybe<String>;
-  wasteDetailsOnuCode_lte?: Maybe<String>;
-  wasteDetailsOnuCode_gt?: Maybe<String>;
-  wasteDetailsOnuCode_gte?: Maybe<String>;
-  wasteDetailsOnuCode_contains?: Maybe<String>;
-  wasteDetailsOnuCode_not_contains?: Maybe<String>;
-  wasteDetailsOnuCode_starts_with?: Maybe<String>;
-  wasteDetailsOnuCode_not_starts_with?: Maybe<String>;
-  wasteDetailsOnuCode_ends_with?: Maybe<String>;
-  wasteDetailsOnuCode_not_ends_with?: Maybe<String>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsOtherPackaging_not?: Maybe<String>;
-  wasteDetailsOtherPackaging_in?: Maybe<String[] | String>;
-  wasteDetailsOtherPackaging_not_in?: Maybe<String[] | String>;
-  wasteDetailsOtherPackaging_lt?: Maybe<String>;
-  wasteDetailsOtherPackaging_lte?: Maybe<String>;
-  wasteDetailsOtherPackaging_gt?: Maybe<String>;
-  wasteDetailsOtherPackaging_gte?: Maybe<String>;
-  wasteDetailsOtherPackaging_contains?: Maybe<String>;
-  wasteDetailsOtherPackaging_not_contains?: Maybe<String>;
-  wasteDetailsOtherPackaging_starts_with?: Maybe<String>;
-  wasteDetailsOtherPackaging_not_starts_with?: Maybe<String>;
-  wasteDetailsOtherPackaging_ends_with?: Maybe<String>;
-  wasteDetailsOtherPackaging_not_ends_with?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsNumberOfPackages_not?: Maybe<Int>;
-  wasteDetailsNumberOfPackages_in?: Maybe<Int[] | Int>;
-  wasteDetailsNumberOfPackages_not_in?: Maybe<Int[] | Int>;
-  wasteDetailsNumberOfPackages_lt?: Maybe<Int>;
-  wasteDetailsNumberOfPackages_lte?: Maybe<Int>;
-  wasteDetailsNumberOfPackages_gt?: Maybe<Int>;
-  wasteDetailsNumberOfPackages_gte?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantity_not?: Maybe<Float>;
-  wasteDetailsQuantity_in?: Maybe<Float[] | Float>;
-  wasteDetailsQuantity_not_in?: Maybe<Float[] | Float>;
-  wasteDetailsQuantity_lt?: Maybe<Float>;
-  wasteDetailsQuantity_lte?: Maybe<Float>;
-  wasteDetailsQuantity_gt?: Maybe<Float>;
-  wasteDetailsQuantity_gte?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  wasteDetailsQuantityType_not?: Maybe<QuantityType>;
-  wasteDetailsQuantityType_in?: Maybe<QuantityType[] | QuantityType>;
-  wasteDetailsQuantityType_not_in?: Maybe<QuantityType[] | QuantityType>;
-  wasteDetailsConsistence?: Maybe<Consistence>;
-  wasteDetailsConsistence_not?: Maybe<Consistence>;
-  wasteDetailsConsistence_in?: Maybe<Consistence[] | Consistence>;
-  wasteDetailsConsistence_not_in?: Maybe<Consistence[] | Consistence>;
-  traderCompanyName?: Maybe<String>;
-  traderCompanyName_not?: Maybe<String>;
-  traderCompanyName_in?: Maybe<String[] | String>;
-  traderCompanyName_not_in?: Maybe<String[] | String>;
-  traderCompanyName_lt?: Maybe<String>;
-  traderCompanyName_lte?: Maybe<String>;
-  traderCompanyName_gt?: Maybe<String>;
-  traderCompanyName_gte?: Maybe<String>;
-  traderCompanyName_contains?: Maybe<String>;
-  traderCompanyName_not_contains?: Maybe<String>;
-  traderCompanyName_starts_with?: Maybe<String>;
-  traderCompanyName_not_starts_with?: Maybe<String>;
-  traderCompanyName_ends_with?: Maybe<String>;
-  traderCompanyName_not_ends_with?: Maybe<String>;
-  traderCompanySiret?: Maybe<String>;
-  traderCompanySiret_not?: Maybe<String>;
-  traderCompanySiret_in?: Maybe<String[] | String>;
-  traderCompanySiret_not_in?: Maybe<String[] | String>;
-  traderCompanySiret_lt?: Maybe<String>;
-  traderCompanySiret_lte?: Maybe<String>;
-  traderCompanySiret_gt?: Maybe<String>;
-  traderCompanySiret_gte?: Maybe<String>;
-  traderCompanySiret_contains?: Maybe<String>;
-  traderCompanySiret_not_contains?: Maybe<String>;
-  traderCompanySiret_starts_with?: Maybe<String>;
-  traderCompanySiret_not_starts_with?: Maybe<String>;
-  traderCompanySiret_ends_with?: Maybe<String>;
-  traderCompanySiret_not_ends_with?: Maybe<String>;
-  traderCompanyAddress?: Maybe<String>;
-  traderCompanyAddress_not?: Maybe<String>;
-  traderCompanyAddress_in?: Maybe<String[] | String>;
-  traderCompanyAddress_not_in?: Maybe<String[] | String>;
-  traderCompanyAddress_lt?: Maybe<String>;
-  traderCompanyAddress_lte?: Maybe<String>;
-  traderCompanyAddress_gt?: Maybe<String>;
-  traderCompanyAddress_gte?: Maybe<String>;
-  traderCompanyAddress_contains?: Maybe<String>;
-  traderCompanyAddress_not_contains?: Maybe<String>;
-  traderCompanyAddress_starts_with?: Maybe<String>;
-  traderCompanyAddress_not_starts_with?: Maybe<String>;
-  traderCompanyAddress_ends_with?: Maybe<String>;
-  traderCompanyAddress_not_ends_with?: Maybe<String>;
-  traderCompanyContact?: Maybe<String>;
-  traderCompanyContact_not?: Maybe<String>;
-  traderCompanyContact_in?: Maybe<String[] | String>;
-  traderCompanyContact_not_in?: Maybe<String[] | String>;
-  traderCompanyContact_lt?: Maybe<String>;
-  traderCompanyContact_lte?: Maybe<String>;
-  traderCompanyContact_gt?: Maybe<String>;
-  traderCompanyContact_gte?: Maybe<String>;
-  traderCompanyContact_contains?: Maybe<String>;
-  traderCompanyContact_not_contains?: Maybe<String>;
-  traderCompanyContact_starts_with?: Maybe<String>;
-  traderCompanyContact_not_starts_with?: Maybe<String>;
-  traderCompanyContact_ends_with?: Maybe<String>;
-  traderCompanyContact_not_ends_with?: Maybe<String>;
-  traderCompanyPhone?: Maybe<String>;
-  traderCompanyPhone_not?: Maybe<String>;
-  traderCompanyPhone_in?: Maybe<String[] | String>;
-  traderCompanyPhone_not_in?: Maybe<String[] | String>;
-  traderCompanyPhone_lt?: Maybe<String>;
-  traderCompanyPhone_lte?: Maybe<String>;
-  traderCompanyPhone_gt?: Maybe<String>;
-  traderCompanyPhone_gte?: Maybe<String>;
-  traderCompanyPhone_contains?: Maybe<String>;
-  traderCompanyPhone_not_contains?: Maybe<String>;
-  traderCompanyPhone_starts_with?: Maybe<String>;
-  traderCompanyPhone_not_starts_with?: Maybe<String>;
-  traderCompanyPhone_ends_with?: Maybe<String>;
-  traderCompanyPhone_not_ends_with?: Maybe<String>;
-  traderCompanyMail?: Maybe<String>;
-  traderCompanyMail_not?: Maybe<String>;
-  traderCompanyMail_in?: Maybe<String[] | String>;
-  traderCompanyMail_not_in?: Maybe<String[] | String>;
-  traderCompanyMail_lt?: Maybe<String>;
-  traderCompanyMail_lte?: Maybe<String>;
-  traderCompanyMail_gt?: Maybe<String>;
-  traderCompanyMail_gte?: Maybe<String>;
-  traderCompanyMail_contains?: Maybe<String>;
-  traderCompanyMail_not_contains?: Maybe<String>;
-  traderCompanyMail_starts_with?: Maybe<String>;
-  traderCompanyMail_not_starts_with?: Maybe<String>;
-  traderCompanyMail_ends_with?: Maybe<String>;
-  traderCompanyMail_not_ends_with?: Maybe<String>;
-  traderReceipt?: Maybe<String>;
-  traderReceipt_not?: Maybe<String>;
-  traderReceipt_in?: Maybe<String[] | String>;
-  traderReceipt_not_in?: Maybe<String[] | String>;
-  traderReceipt_lt?: Maybe<String>;
-  traderReceipt_lte?: Maybe<String>;
-  traderReceipt_gt?: Maybe<String>;
-  traderReceipt_gte?: Maybe<String>;
-  traderReceipt_contains?: Maybe<String>;
-  traderReceipt_not_contains?: Maybe<String>;
-  traderReceipt_starts_with?: Maybe<String>;
-  traderReceipt_not_starts_with?: Maybe<String>;
-  traderReceipt_ends_with?: Maybe<String>;
-  traderReceipt_not_ends_with?: Maybe<String>;
-  traderDepartment?: Maybe<String>;
-  traderDepartment_not?: Maybe<String>;
-  traderDepartment_in?: Maybe<String[] | String>;
-  traderDepartment_not_in?: Maybe<String[] | String>;
-  traderDepartment_lt?: Maybe<String>;
-  traderDepartment_lte?: Maybe<String>;
-  traderDepartment_gt?: Maybe<String>;
-  traderDepartment_gte?: Maybe<String>;
-  traderDepartment_contains?: Maybe<String>;
-  traderDepartment_not_contains?: Maybe<String>;
-  traderDepartment_starts_with?: Maybe<String>;
-  traderDepartment_not_starts_with?: Maybe<String>;
-  traderDepartment_ends_with?: Maybe<String>;
-  traderDepartment_not_ends_with?: Maybe<String>;
-  traderValidityLimit?: Maybe<DateTimeInput>;
-  traderValidityLimit_not?: Maybe<DateTimeInput>;
-  traderValidityLimit_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  traderValidityLimit_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  traderValidityLimit_lt?: Maybe<DateTimeInput>;
-  traderValidityLimit_lte?: Maybe<DateTimeInput>;
-  traderValidityLimit_gt?: Maybe<DateTimeInput>;
-  traderValidityLimit_gte?: Maybe<DateTimeInput>;
-  ecoOrganisme?: Maybe<EcoOrganismeWhereInput>;
-  appendix2Forms_every?: Maybe<FormWhereInput>;
-  appendix2Forms_some?: Maybe<FormWhereInput>;
-  appendix2Forms_none?: Maybe<FormWhereInput>;
-  temporaryStorageDetail?: Maybe<TemporaryStorageDetailWhereInput>;
-  AND?: Maybe<FormWhereInput[] | FormWhereInput>;
-  OR?: Maybe<FormWhereInput[] | FormWhereInput>;
-  NOT?: Maybe<FormWhereInput[] | FormWhereInput>;
+export interface UserUpdateInput {
+  isActive?: Maybe<Boolean>;
+  email?: Maybe<String>;
+  password?: Maybe<String>;
+  name?: Maybe<String>;
+  phone?: Maybe<String>;
+  companyAssociations?: Maybe<CompanyAssociationUpdateManyWithoutUserInput>;
 }
 
 export interface UserUpsertWithoutCompanyAssociationsInput {
@@ -6285,30 +6452,20 @@ export interface CompanyAssociationUpdateManyMutationInput {
   role?: Maybe<UserRole>;
 }
 
-export interface CompanyAssociationWhereInput {
+export interface InstallationCreateInput {
   id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  user?: Maybe<UserWhereInput>;
-  company?: Maybe<CompanyWhereInput>;
-  role?: Maybe<UserRole>;
-  role_not?: Maybe<UserRole>;
-  role_in?: Maybe<UserRole[] | UserRole>;
-  role_not_in?: Maybe<UserRole[] | UserRole>;
-  AND?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
-  OR?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
-  NOT?: Maybe<CompanyAssociationWhereInput[] | CompanyAssociationWhereInput>;
+  codeS3ic?: Maybe<String>;
+  nomEts?: Maybe<String>;
+  regime?: Maybe<String>;
+  libRegime?: Maybe<String>;
+  seveso?: Maybe<Seveso>;
+  libSeveso?: Maybe<String>;
+  familleIc?: Maybe<String>;
+  urlFiche?: Maybe<String>;
+  s3icNumeroSiret?: Maybe<String>;
+  irepNumeroSiret?: Maybe<String>;
+  gerepNumeroSiret?: Maybe<String>;
+  sireneNumeroSiret?: Maybe<String>;
 }
 
 export interface EcoOrganismeCreateInput {
@@ -6351,7 +6508,7 @@ export interface FormUpdateManyDataInput {
   customId?: Maybe<String>;
   isDeleted?: Maybe<Boolean>;
   signedByTransporter?: Maybe<Boolean>;
-  status?: Maybe<String>;
+  status?: Maybe<Status>;
   sentAt?: Maybe<DateTimeInput>;
   sentBy?: Maybe<String>;
   isAccepted?: Maybe<Boolean>;
@@ -6426,201 +6583,24 @@ export interface FormUpdateManyDataInput {
   traderValidityLimit?: Maybe<DateTimeInput>;
 }
 
-export interface CompanyWhereInput {
-  id?: Maybe<ID_Input>;
-  id_not?: Maybe<ID_Input>;
-  id_in?: Maybe<ID_Input[] | ID_Input>;
-  id_not_in?: Maybe<ID_Input[] | ID_Input>;
-  id_lt?: Maybe<ID_Input>;
-  id_lte?: Maybe<ID_Input>;
-  id_gt?: Maybe<ID_Input>;
-  id_gte?: Maybe<ID_Input>;
-  id_contains?: Maybe<ID_Input>;
-  id_not_contains?: Maybe<ID_Input>;
-  id_starts_with?: Maybe<ID_Input>;
-  id_not_starts_with?: Maybe<ID_Input>;
-  id_ends_with?: Maybe<ID_Input>;
-  id_not_ends_with?: Maybe<ID_Input>;
-  siret?: Maybe<String>;
-  siret_not?: Maybe<String>;
-  siret_in?: Maybe<String[] | String>;
-  siret_not_in?: Maybe<String[] | String>;
-  siret_lt?: Maybe<String>;
-  siret_lte?: Maybe<String>;
-  siret_gt?: Maybe<String>;
-  siret_gte?: Maybe<String>;
-  siret_contains?: Maybe<String>;
-  siret_not_contains?: Maybe<String>;
-  siret_starts_with?: Maybe<String>;
-  siret_not_starts_with?: Maybe<String>;
-  siret_ends_with?: Maybe<String>;
-  siret_not_ends_with?: Maybe<String>;
-  name?: Maybe<String>;
-  name_not?: Maybe<String>;
-  name_in?: Maybe<String[] | String>;
-  name_not_in?: Maybe<String[] | String>;
-  name_lt?: Maybe<String>;
-  name_lte?: Maybe<String>;
-  name_gt?: Maybe<String>;
-  name_gte?: Maybe<String>;
-  name_contains?: Maybe<String>;
-  name_not_contains?: Maybe<String>;
-  name_starts_with?: Maybe<String>;
-  name_not_starts_with?: Maybe<String>;
-  name_ends_with?: Maybe<String>;
-  name_not_ends_with?: Maybe<String>;
-  gerepId?: Maybe<String>;
-  gerepId_not?: Maybe<String>;
-  gerepId_in?: Maybe<String[] | String>;
-  gerepId_not_in?: Maybe<String[] | String>;
-  gerepId_lt?: Maybe<String>;
-  gerepId_lte?: Maybe<String>;
-  gerepId_gt?: Maybe<String>;
-  gerepId_gte?: Maybe<String>;
-  gerepId_contains?: Maybe<String>;
-  gerepId_not_contains?: Maybe<String>;
-  gerepId_starts_with?: Maybe<String>;
-  gerepId_not_starts_with?: Maybe<String>;
-  gerepId_ends_with?: Maybe<String>;
-  gerepId_not_ends_with?: Maybe<String>;
-  codeNaf?: Maybe<String>;
-  codeNaf_not?: Maybe<String>;
-  codeNaf_in?: Maybe<String[] | String>;
-  codeNaf_not_in?: Maybe<String[] | String>;
-  codeNaf_lt?: Maybe<String>;
-  codeNaf_lte?: Maybe<String>;
-  codeNaf_gt?: Maybe<String>;
-  codeNaf_gte?: Maybe<String>;
-  codeNaf_contains?: Maybe<String>;
-  codeNaf_not_contains?: Maybe<String>;
-  codeNaf_starts_with?: Maybe<String>;
-  codeNaf_not_starts_with?: Maybe<String>;
-  codeNaf_ends_with?: Maybe<String>;
-  codeNaf_not_ends_with?: Maybe<String>;
-  createdAt?: Maybe<DateTimeInput>;
-  createdAt_not?: Maybe<DateTimeInput>;
-  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  createdAt_lt?: Maybe<DateTimeInput>;
-  createdAt_lte?: Maybe<DateTimeInput>;
-  createdAt_gt?: Maybe<DateTimeInput>;
-  createdAt_gte?: Maybe<DateTimeInput>;
-  updatedAt?: Maybe<DateTimeInput>;
-  updatedAt_not?: Maybe<DateTimeInput>;
-  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
-  updatedAt_lt?: Maybe<DateTimeInput>;
-  updatedAt_lte?: Maybe<DateTimeInput>;
-  updatedAt_gt?: Maybe<DateTimeInput>;
-  updatedAt_gte?: Maybe<DateTimeInput>;
-  securityCode?: Maybe<Int>;
-  securityCode_not?: Maybe<Int>;
-  securityCode_in?: Maybe<Int[] | Int>;
-  securityCode_not_in?: Maybe<Int[] | Int>;
-  securityCode_lt?: Maybe<Int>;
-  securityCode_lte?: Maybe<Int>;
-  securityCode_gt?: Maybe<Int>;
-  securityCode_gte?: Maybe<Int>;
-  givenName?: Maybe<String>;
-  givenName_not?: Maybe<String>;
-  givenName_in?: Maybe<String[] | String>;
-  givenName_not_in?: Maybe<String[] | String>;
-  givenName_lt?: Maybe<String>;
-  givenName_lte?: Maybe<String>;
-  givenName_gt?: Maybe<String>;
-  givenName_gte?: Maybe<String>;
-  givenName_contains?: Maybe<String>;
-  givenName_not_contains?: Maybe<String>;
-  givenName_starts_with?: Maybe<String>;
-  givenName_not_starts_with?: Maybe<String>;
-  givenName_ends_with?: Maybe<String>;
-  givenName_not_ends_with?: Maybe<String>;
-  contactEmail?: Maybe<String>;
-  contactEmail_not?: Maybe<String>;
-  contactEmail_in?: Maybe<String[] | String>;
-  contactEmail_not_in?: Maybe<String[] | String>;
-  contactEmail_lt?: Maybe<String>;
-  contactEmail_lte?: Maybe<String>;
-  contactEmail_gt?: Maybe<String>;
-  contactEmail_gte?: Maybe<String>;
-  contactEmail_contains?: Maybe<String>;
-  contactEmail_not_contains?: Maybe<String>;
-  contactEmail_starts_with?: Maybe<String>;
-  contactEmail_not_starts_with?: Maybe<String>;
-  contactEmail_ends_with?: Maybe<String>;
-  contactEmail_not_ends_with?: Maybe<String>;
-  contactPhone?: Maybe<String>;
-  contactPhone_not?: Maybe<String>;
-  contactPhone_in?: Maybe<String[] | String>;
-  contactPhone_not_in?: Maybe<String[] | String>;
-  contactPhone_lt?: Maybe<String>;
-  contactPhone_lte?: Maybe<String>;
-  contactPhone_gt?: Maybe<String>;
-  contactPhone_gte?: Maybe<String>;
-  contactPhone_contains?: Maybe<String>;
-  contactPhone_not_contains?: Maybe<String>;
-  contactPhone_starts_with?: Maybe<String>;
-  contactPhone_not_starts_with?: Maybe<String>;
-  contactPhone_ends_with?: Maybe<String>;
-  contactPhone_not_ends_with?: Maybe<String>;
-  website?: Maybe<String>;
-  website_not?: Maybe<String>;
-  website_in?: Maybe<String[] | String>;
-  website_not_in?: Maybe<String[] | String>;
-  website_lt?: Maybe<String>;
-  website_lte?: Maybe<String>;
-  website_gt?: Maybe<String>;
-  website_gte?: Maybe<String>;
-  website_contains?: Maybe<String>;
-  website_not_contains?: Maybe<String>;
-  website_starts_with?: Maybe<String>;
-  website_not_starts_with?: Maybe<String>;
-  website_ends_with?: Maybe<String>;
-  website_not_ends_with?: Maybe<String>;
-  AND?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
-  OR?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
-  NOT?: Maybe<CompanyWhereInput[] | CompanyWhereInput>;
+export interface RubriqueUpdateInput {
+  codeS3ic?: Maybe<String>;
+  rubrique?: Maybe<String>;
+  alinea?: Maybe<String>;
+  dateAutorisation?: Maybe<String>;
+  etatActivite?: Maybe<String>;
+  regimeAutorise?: Maybe<String>;
+  activite?: Maybe<String>;
+  volume?: Maybe<String>;
+  unite?: Maybe<String>;
+  category?: Maybe<String>;
+  wasteType?: Maybe<WasteType>;
 }
 
-export interface TemporaryStorageDetailUpdateInput {
-  form?: Maybe<FormUpdateOneWithoutTemporaryStorageDetailInput>;
-  tempStorerQuantityType?: Maybe<QuantityType>;
-  tempStorerQuantityReceived?: Maybe<Float>;
-  tempStorerWasteAcceptationStatus?: Maybe<WasteAcceptationStatus>;
-  tempStorerWasteRefusalReason?: Maybe<String>;
-  tempStorerReceivedAt?: Maybe<DateTimeInput>;
-  tempStorerReceivedBy?: Maybe<String>;
-  tempStorerSignedAt?: Maybe<DateTimeInput>;
-  destinationIsFilledByEmitter?: Maybe<Boolean>;
-  destinationCompanyName?: Maybe<String>;
-  destinationCompanySiret?: Maybe<String>;
-  destinationCompanyAddress?: Maybe<String>;
-  destinationCompanyContact?: Maybe<String>;
-  destinationCompanyPhone?: Maybe<String>;
-  destinationCompanyMail?: Maybe<String>;
-  destinationCap?: Maybe<String>;
-  destinationProcessingOperation?: Maybe<String>;
-  wasteDetailsOnuCode?: Maybe<String>;
-  wasteDetailsPackagings?: Maybe<Json>;
-  wasteDetailsOtherPackaging?: Maybe<String>;
-  wasteDetailsNumberOfPackages?: Maybe<Int>;
-  wasteDetailsQuantity?: Maybe<Float>;
-  wasteDetailsQuantityType?: Maybe<QuantityType>;
-  transporterCompanyName?: Maybe<String>;
-  transporterCompanySiret?: Maybe<String>;
-  transporterCompanyAddress?: Maybe<String>;
-  transporterCompanyContact?: Maybe<String>;
-  transporterCompanyPhone?: Maybe<String>;
-  transporterCompanyMail?: Maybe<String>;
-  transporterIsExemptedOfReceipt?: Maybe<Boolean>;
-  transporterReceipt?: Maybe<String>;
-  transporterDepartment?: Maybe<String>;
-  transporterValidityLimit?: Maybe<DateTimeInput>;
-  transporterNumberPlate?: Maybe<String>;
-  signedByTransporter?: Maybe<Boolean>;
-  signedBy?: Maybe<String>;
-  signedAt?: Maybe<DateTimeInput>;
-}
+export type GrantWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+  code?: Maybe<String>;
+}>;
 
 export type FormWhereUniqueInput = AtLeastOne<{
   id: Maybe<ID_Input>;
@@ -6723,7 +6703,7 @@ export interface Form {
   createdAt: DateTimeOutput;
   updatedAt: DateTimeOutput;
   signedByTransporter?: Boolean;
-  status?: String;
+  status?: Status;
   sentAt?: DateTimeOutput;
   sentBy?: String;
   isAccepted?: Boolean;
@@ -6807,7 +6787,7 @@ export interface FormPromise extends Promise<Form>, Fragmentable {
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
   signedByTransporter: () => Promise<Boolean>;
-  status: () => Promise<String>;
+  status: () => Promise<Status>;
   sentAt: () => Promise<DateTimeOutput>;
   sentBy: () => Promise<String>;
   isAccepted: () => Promise<Boolean>;
@@ -6904,7 +6884,7 @@ export interface FormSubscription
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   signedByTransporter: () => Promise<AsyncIterator<Boolean>>;
-  status: () => Promise<AsyncIterator<String>>;
+  status: () => Promise<AsyncIterator<Status>>;
   sentAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   sentBy: () => Promise<AsyncIterator<String>>;
   isAccepted: () => Promise<AsyncIterator<Boolean>>;
@@ -7001,7 +6981,7 @@ export interface FormNullablePromise
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
   signedByTransporter: () => Promise<Boolean>;
-  status: () => Promise<String>;
+  status: () => Promise<Status>;
   sentAt: () => Promise<DateTimeOutput>;
   sentBy: () => Promise<String>;
   isAccepted: () => Promise<Boolean>;
@@ -7983,74 +7963,20 @@ export interface CompanyAssociationSubscriptionPayloadSubscription
   previousValues: <T = CompanyAssociationPreviousValuesSubscription>() => T;
 }
 
-export interface Installation {
-  id: ID_Output;
-  codeS3ic?: String;
-  nomEts?: String;
-  regime?: String;
-  libRegime?: String;
-  seveso?: Seveso;
-  libSeveso?: String;
-  familleIc?: String;
-  urlFiche?: String;
-  s3icNumeroSiret?: String;
-  irepNumeroSiret?: String;
-  gerepNumeroSiret?: String;
-  sireneNumeroSiret?: String;
+export interface AggregateGrant {
+  count: Int;
 }
 
-export interface InstallationPromise
-  extends Promise<Installation>,
+export interface AggregateGrantPromise
+  extends Promise<AggregateGrant>,
     Fragmentable {
-  id: () => Promise<ID_Output>;
-  codeS3ic: () => Promise<String>;
-  nomEts: () => Promise<String>;
-  regime: () => Promise<String>;
-  libRegime: () => Promise<String>;
-  seveso: () => Promise<Seveso>;
-  libSeveso: () => Promise<String>;
-  familleIc: () => Promise<String>;
-  urlFiche: () => Promise<String>;
-  s3icNumeroSiret: () => Promise<String>;
-  irepNumeroSiret: () => Promise<String>;
-  gerepNumeroSiret: () => Promise<String>;
-  sireneNumeroSiret: () => Promise<String>;
+  count: () => Promise<Int>;
 }
 
-export interface InstallationSubscription
-  extends Promise<AsyncIterator<Installation>>,
+export interface AggregateGrantSubscription
+  extends Promise<AsyncIterator<AggregateGrant>>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  codeS3ic: () => Promise<AsyncIterator<String>>;
-  nomEts: () => Promise<AsyncIterator<String>>;
-  regime: () => Promise<AsyncIterator<String>>;
-  libRegime: () => Promise<AsyncIterator<String>>;
-  seveso: () => Promise<AsyncIterator<Seveso>>;
-  libSeveso: () => Promise<AsyncIterator<String>>;
-  familleIc: () => Promise<AsyncIterator<String>>;
-  urlFiche: () => Promise<AsyncIterator<String>>;
-  s3icNumeroSiret: () => Promise<AsyncIterator<String>>;
-  irepNumeroSiret: () => Promise<AsyncIterator<String>>;
-  gerepNumeroSiret: () => Promise<AsyncIterator<String>>;
-  sireneNumeroSiret: () => Promise<AsyncIterator<String>>;
-}
-
-export interface InstallationNullablePromise
-  extends Promise<Installation | null>,
-    Fragmentable {
-  id: () => Promise<ID_Output>;
-  codeS3ic: () => Promise<String>;
-  nomEts: () => Promise<String>;
-  regime: () => Promise<String>;
-  libRegime: () => Promise<String>;
-  seveso: () => Promise<Seveso>;
-  libSeveso: () => Promise<String>;
-  familleIc: () => Promise<String>;
-  urlFiche: () => Promise<String>;
-  s3icNumeroSiret: () => Promise<String>;
-  irepNumeroSiret: () => Promise<String>;
-  gerepNumeroSiret: () => Promise<String>;
-  sireneNumeroSiret: () => Promise<String>;
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface CompanyAssociationPreviousValues {
@@ -8072,21 +7998,25 @@ export interface CompanyAssociationPreviousValuesSubscription
   role: () => Promise<AsyncIterator<UserRole>>;
 }
 
-export interface GrantEdge {
-  node: Grant;
-  cursor: String;
+export interface GrantConnection {
+  pageInfo: PageInfo;
+  edges: GrantEdge[];
 }
 
-export interface GrantEdgePromise extends Promise<GrantEdge>, Fragmentable {
-  node: <T = GrantPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface GrantEdgeSubscription
-  extends Promise<AsyncIterator<GrantEdge>>,
+export interface GrantConnectionPromise
+  extends Promise<GrantConnection>,
     Fragmentable {
-  node: <T = GrantSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<GrantEdge>>() => T;
+  aggregate: <T = AggregateGrantPromise>() => T;
+}
+
+export interface GrantConnectionSubscription
+  extends Promise<AsyncIterator<GrantConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<GrantEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateGrantSubscription>() => T;
 }
 
 export interface DeclarationEdge {
@@ -8108,76 +8038,50 @@ export interface DeclarationEdgeSubscription
   cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface Company {
+export interface Grant {
   id: ID_Output;
-  siret: String;
-  companyTypes: CompanyType[];
-  name?: String;
-  gerepId?: String;
-  codeNaf?: String;
   createdAt: DateTimeOutput;
   updatedAt: DateTimeOutput;
-  securityCode: Int;
-  givenName?: String;
-  contactEmail?: String;
-  contactPhone?: String;
-  website?: String;
-  documentKeys: String[];
+  code: String;
+  expires: Int;
+  redirectUri: String;
 }
 
-export interface CompanyPromise extends Promise<Company>, Fragmentable {
+export interface GrantPromise extends Promise<Grant>, Fragmentable {
   id: () => Promise<ID_Output>;
-  siret: () => Promise<String>;
-  companyTypes: () => Promise<CompanyType[]>;
-  name: () => Promise<String>;
-  gerepId: () => Promise<String>;
-  codeNaf: () => Promise<String>;
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
-  securityCode: () => Promise<Int>;
-  givenName: () => Promise<String>;
-  contactEmail: () => Promise<String>;
-  contactPhone: () => Promise<String>;
-  website: () => Promise<String>;
-  documentKeys: () => Promise<String[]>;
+  user: <T = UserPromise>() => T;
+  code: () => Promise<String>;
+  application: <T = ApplicationPromise>() => T;
+  expires: () => Promise<Int>;
+  redirectUri: () => Promise<String>;
 }
 
-export interface CompanySubscription
-  extends Promise<AsyncIterator<Company>>,
+export interface GrantSubscription
+  extends Promise<AsyncIterator<Grant>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  siret: () => Promise<AsyncIterator<String>>;
-  companyTypes: () => Promise<AsyncIterator<CompanyType[]>>;
-  name: () => Promise<AsyncIterator<String>>;
-  gerepId: () => Promise<AsyncIterator<String>>;
-  codeNaf: () => Promise<AsyncIterator<String>>;
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  securityCode: () => Promise<AsyncIterator<Int>>;
-  givenName: () => Promise<AsyncIterator<String>>;
-  contactEmail: () => Promise<AsyncIterator<String>>;
-  contactPhone: () => Promise<AsyncIterator<String>>;
-  website: () => Promise<AsyncIterator<String>>;
-  documentKeys: () => Promise<AsyncIterator<String[]>>;
+  user: <T = UserSubscription>() => T;
+  code: () => Promise<AsyncIterator<String>>;
+  application: <T = ApplicationSubscription>() => T;
+  expires: () => Promise<AsyncIterator<Int>>;
+  redirectUri: () => Promise<AsyncIterator<String>>;
 }
 
-export interface CompanyNullablePromise
-  extends Promise<Company | null>,
+export interface GrantNullablePromise
+  extends Promise<Grant | null>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  siret: () => Promise<String>;
-  companyTypes: () => Promise<CompanyType[]>;
-  name: () => Promise<String>;
-  gerepId: () => Promise<String>;
-  codeNaf: () => Promise<String>;
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
-  securityCode: () => Promise<Int>;
-  givenName: () => Promise<String>;
-  contactEmail: () => Promise<String>;
-  contactPhone: () => Promise<String>;
-  website: () => Promise<String>;
-  documentKeys: () => Promise<String[]>;
+  user: <T = UserPromise>() => T;
+  code: () => Promise<String>;
+  application: <T = ApplicationPromise>() => T;
+  expires: () => Promise<Int>;
+  redirectUri: () => Promise<String>;
 }
 
 export interface DeclarationSubscriptionPayload {
@@ -8205,20 +8109,21 @@ export interface DeclarationSubscriptionPayloadSubscription
   previousValues: <T = DeclarationPreviousValuesSubscription>() => T;
 }
 
-export interface AggregateForm {
-  count: Int;
+export interface FormEdge {
+  node: Form;
+  cursor: String;
 }
 
-export interface AggregateFormPromise
-  extends Promise<AggregateForm>,
-    Fragmentable {
-  count: () => Promise<Int>;
+export interface FormEdgePromise extends Promise<FormEdge>, Fragmentable {
+  node: <T = FormPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateFormSubscription
-  extends Promise<AsyncIterator<AggregateForm>>,
+export interface FormEdgeSubscription
+  extends Promise<AsyncIterator<FormEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = FormSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface DeclarationPreviousValues {
@@ -8255,25 +8160,175 @@ export interface DeclarationPreviousValuesSubscription
   gerepType: () => Promise<AsyncIterator<GerepType>>;
 }
 
-export interface FormConnection {
-  pageInfo: PageInfo;
-  edges: FormEdge[];
+export interface TemporaryStorageDetail {
+  id: ID_Output;
+  tempStorerQuantityType?: QuantityType;
+  tempStorerQuantityReceived?: Float;
+  tempStorerWasteAcceptationStatus?: WasteAcceptationStatus;
+  tempStorerWasteRefusalReason?: String;
+  tempStorerReceivedAt?: DateTimeOutput;
+  tempStorerReceivedBy?: String;
+  tempStorerSignedAt?: DateTimeOutput;
+  destinationIsFilledByEmitter?: Boolean;
+  destinationCompanyName?: String;
+  destinationCompanySiret?: String;
+  destinationCompanyAddress?: String;
+  destinationCompanyContact?: String;
+  destinationCompanyPhone?: String;
+  destinationCompanyMail?: String;
+  destinationCap?: String;
+  destinationProcessingOperation?: String;
+  wasteDetailsOnuCode?: String;
+  wasteDetailsPackagings?: Json;
+  wasteDetailsOtherPackaging?: String;
+  wasteDetailsNumberOfPackages?: Int;
+  wasteDetailsQuantity?: Float;
+  wasteDetailsQuantityType?: QuantityType;
+  transporterCompanyName?: String;
+  transporterCompanySiret?: String;
+  transporterCompanyAddress?: String;
+  transporterCompanyContact?: String;
+  transporterCompanyPhone?: String;
+  transporterCompanyMail?: String;
+  transporterIsExemptedOfReceipt?: Boolean;
+  transporterReceipt?: String;
+  transporterDepartment?: String;
+  transporterValidityLimit?: DateTimeOutput;
+  transporterNumberPlate?: String;
+  signedByTransporter?: Boolean;
+  signedBy?: String;
+  signedAt?: DateTimeOutput;
 }
 
-export interface FormConnectionPromise
-  extends Promise<FormConnection>,
+export interface TemporaryStorageDetailPromise
+  extends Promise<TemporaryStorageDetail>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<FormEdge>>() => T;
-  aggregate: <T = AggregateFormPromise>() => T;
+  id: () => Promise<ID_Output>;
+  form: <T = FormPromise>() => T;
+  tempStorerQuantityType: () => Promise<QuantityType>;
+  tempStorerQuantityReceived: () => Promise<Float>;
+  tempStorerWasteAcceptationStatus: () => Promise<WasteAcceptationStatus>;
+  tempStorerWasteRefusalReason: () => Promise<String>;
+  tempStorerReceivedAt: () => Promise<DateTimeOutput>;
+  tempStorerReceivedBy: () => Promise<String>;
+  tempStorerSignedAt: () => Promise<DateTimeOutput>;
+  destinationIsFilledByEmitter: () => Promise<Boolean>;
+  destinationCompanyName: () => Promise<String>;
+  destinationCompanySiret: () => Promise<String>;
+  destinationCompanyAddress: () => Promise<String>;
+  destinationCompanyContact: () => Promise<String>;
+  destinationCompanyPhone: () => Promise<String>;
+  destinationCompanyMail: () => Promise<String>;
+  destinationCap: () => Promise<String>;
+  destinationProcessingOperation: () => Promise<String>;
+  wasteDetailsOnuCode: () => Promise<String>;
+  wasteDetailsPackagings: () => Promise<Json>;
+  wasteDetailsOtherPackaging: () => Promise<String>;
+  wasteDetailsNumberOfPackages: () => Promise<Int>;
+  wasteDetailsQuantity: () => Promise<Float>;
+  wasteDetailsQuantityType: () => Promise<QuantityType>;
+  transporterCompanyName: () => Promise<String>;
+  transporterCompanySiret: () => Promise<String>;
+  transporterCompanyAddress: () => Promise<String>;
+  transporterCompanyContact: () => Promise<String>;
+  transporterCompanyPhone: () => Promise<String>;
+  transporterCompanyMail: () => Promise<String>;
+  transporterIsExemptedOfReceipt: () => Promise<Boolean>;
+  transporterReceipt: () => Promise<String>;
+  transporterDepartment: () => Promise<String>;
+  transporterValidityLimit: () => Promise<DateTimeOutput>;
+  transporterNumberPlate: () => Promise<String>;
+  signedByTransporter: () => Promise<Boolean>;
+  signedBy: () => Promise<String>;
+  signedAt: () => Promise<DateTimeOutput>;
 }
 
-export interface FormConnectionSubscription
-  extends Promise<AsyncIterator<FormConnection>>,
+export interface TemporaryStorageDetailSubscription
+  extends Promise<AsyncIterator<TemporaryStorageDetail>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<FormEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateFormSubscription>() => T;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  form: <T = FormSubscription>() => T;
+  tempStorerQuantityType: () => Promise<AsyncIterator<QuantityType>>;
+  tempStorerQuantityReceived: () => Promise<AsyncIterator<Float>>;
+  tempStorerWasteAcceptationStatus: () => Promise<
+    AsyncIterator<WasteAcceptationStatus>
+  >;
+  tempStorerWasteRefusalReason: () => Promise<AsyncIterator<String>>;
+  tempStorerReceivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  tempStorerReceivedBy: () => Promise<AsyncIterator<String>>;
+  tempStorerSignedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  destinationIsFilledByEmitter: () => Promise<AsyncIterator<Boolean>>;
+  destinationCompanyName: () => Promise<AsyncIterator<String>>;
+  destinationCompanySiret: () => Promise<AsyncIterator<String>>;
+  destinationCompanyAddress: () => Promise<AsyncIterator<String>>;
+  destinationCompanyContact: () => Promise<AsyncIterator<String>>;
+  destinationCompanyPhone: () => Promise<AsyncIterator<String>>;
+  destinationCompanyMail: () => Promise<AsyncIterator<String>>;
+  destinationCap: () => Promise<AsyncIterator<String>>;
+  destinationProcessingOperation: () => Promise<AsyncIterator<String>>;
+  wasteDetailsOnuCode: () => Promise<AsyncIterator<String>>;
+  wasteDetailsPackagings: () => Promise<AsyncIterator<Json>>;
+  wasteDetailsOtherPackaging: () => Promise<AsyncIterator<String>>;
+  wasteDetailsNumberOfPackages: () => Promise<AsyncIterator<Int>>;
+  wasteDetailsQuantity: () => Promise<AsyncIterator<Float>>;
+  wasteDetailsQuantityType: () => Promise<AsyncIterator<QuantityType>>;
+  transporterCompanyName: () => Promise<AsyncIterator<String>>;
+  transporterCompanySiret: () => Promise<AsyncIterator<String>>;
+  transporterCompanyAddress: () => Promise<AsyncIterator<String>>;
+  transporterCompanyContact: () => Promise<AsyncIterator<String>>;
+  transporterCompanyPhone: () => Promise<AsyncIterator<String>>;
+  transporterCompanyMail: () => Promise<AsyncIterator<String>>;
+  transporterIsExemptedOfReceipt: () => Promise<AsyncIterator<Boolean>>;
+  transporterReceipt: () => Promise<AsyncIterator<String>>;
+  transporterDepartment: () => Promise<AsyncIterator<String>>;
+  transporterValidityLimit: () => Promise<AsyncIterator<DateTimeOutput>>;
+  transporterNumberPlate: () => Promise<AsyncIterator<String>>;
+  signedByTransporter: () => Promise<AsyncIterator<Boolean>>;
+  signedBy: () => Promise<AsyncIterator<String>>;
+  signedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+}
+
+export interface TemporaryStorageDetailNullablePromise
+  extends Promise<TemporaryStorageDetail | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  form: <T = FormPromise>() => T;
+  tempStorerQuantityType: () => Promise<QuantityType>;
+  tempStorerQuantityReceived: () => Promise<Float>;
+  tempStorerWasteAcceptationStatus: () => Promise<WasteAcceptationStatus>;
+  tempStorerWasteRefusalReason: () => Promise<String>;
+  tempStorerReceivedAt: () => Promise<DateTimeOutput>;
+  tempStorerReceivedBy: () => Promise<String>;
+  tempStorerSignedAt: () => Promise<DateTimeOutput>;
+  destinationIsFilledByEmitter: () => Promise<Boolean>;
+  destinationCompanyName: () => Promise<String>;
+  destinationCompanySiret: () => Promise<String>;
+  destinationCompanyAddress: () => Promise<String>;
+  destinationCompanyContact: () => Promise<String>;
+  destinationCompanyPhone: () => Promise<String>;
+  destinationCompanyMail: () => Promise<String>;
+  destinationCap: () => Promise<String>;
+  destinationProcessingOperation: () => Promise<String>;
+  wasteDetailsOnuCode: () => Promise<String>;
+  wasteDetailsPackagings: () => Promise<Json>;
+  wasteDetailsOtherPackaging: () => Promise<String>;
+  wasteDetailsNumberOfPackages: () => Promise<Int>;
+  wasteDetailsQuantity: () => Promise<Float>;
+  wasteDetailsQuantityType: () => Promise<QuantityType>;
+  transporterCompanyName: () => Promise<String>;
+  transporterCompanySiret: () => Promise<String>;
+  transporterCompanyAddress: () => Promise<String>;
+  transporterCompanyContact: () => Promise<String>;
+  transporterCompanyPhone: () => Promise<String>;
+  transporterCompanyMail: () => Promise<String>;
+  transporterIsExemptedOfReceipt: () => Promise<Boolean>;
+  transporterReceipt: () => Promise<String>;
+  transporterDepartment: () => Promise<String>;
+  transporterValidityLimit: () => Promise<DateTimeOutput>;
+  transporterNumberPlate: () => Promise<String>;
+  signedByTransporter: () => Promise<Boolean>;
+  signedBy: () => Promise<String>;
+  signedAt: () => Promise<DateTimeOutput>;
 }
 
 export interface DeclarationConnection {
@@ -8393,25 +8448,25 @@ export interface EcoOrganismeSubscriptionPayloadSubscription
   previousValues: <T = EcoOrganismePreviousValuesSubscription>() => T;
 }
 
-export interface AccessTokenConnection {
+export interface CompanyConnection {
   pageInfo: PageInfo;
-  edges: AccessTokenEdge[];
+  edges: CompanyEdge[];
 }
 
-export interface AccessTokenConnectionPromise
-  extends Promise<AccessTokenConnection>,
+export interface CompanyConnectionPromise
+  extends Promise<CompanyConnection>,
     Fragmentable {
   pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<AccessTokenEdge>>() => T;
-  aggregate: <T = AggregateAccessTokenPromise>() => T;
+  edges: <T = FragmentableArray<CompanyEdge>>() => T;
+  aggregate: <T = AggregateCompanyPromise>() => T;
 }
 
-export interface AccessTokenConnectionSubscription
-  extends Promise<AsyncIterator<AccessTokenConnection>>,
+export interface CompanyConnectionSubscription
+  extends Promise<AsyncIterator<CompanyConnection>>,
     Fragmentable {
   pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<AccessTokenEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateAccessTokenSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<CompanyEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateCompanySubscription>() => T;
 }
 
 export interface EcoOrganismePreviousValues {
@@ -8550,7 +8605,7 @@ export interface FormPreviousValues {
   createdAt: DateTimeOutput;
   updatedAt: DateTimeOutput;
   signedByTransporter?: Boolean;
-  status?: String;
+  status?: Status;
   sentAt?: DateTimeOutput;
   sentBy?: String;
   isAccepted?: Boolean;
@@ -8635,7 +8690,7 @@ export interface FormPreviousValuesPromise
   createdAt: () => Promise<DateTimeOutput>;
   updatedAt: () => Promise<DateTimeOutput>;
   signedByTransporter: () => Promise<Boolean>;
-  status: () => Promise<String>;
+  status: () => Promise<Status>;
   sentAt: () => Promise<DateTimeOutput>;
   sentBy: () => Promise<String>;
   isAccepted: () => Promise<Boolean>;
@@ -8720,7 +8775,7 @@ export interface FormPreviousValuesSubscription
   createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   signedByTransporter: () => Promise<AsyncIterator<Boolean>>;
-  status: () => Promise<AsyncIterator<String>>;
+  status: () => Promise<AsyncIterator<Status>>;
   sentAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   sentBy: () => Promise<AsyncIterator<String>>;
   isAccepted: () => Promise<AsyncIterator<Boolean>>;
@@ -9051,20 +9106,21 @@ export interface AggregateCompanyAssociationSubscription
   count: () => Promise<AsyncIterator<Int>>;
 }
 
-export interface AggregateGrant {
-  count: Int;
+export interface GrantEdge {
+  node: Grant;
+  cursor: String;
 }
 
-export interface AggregateGrantPromise
-  extends Promise<AggregateGrant>,
-    Fragmentable {
-  count: () => Promise<Int>;
+export interface GrantEdgePromise extends Promise<GrantEdge>, Fragmentable {
+  node: <T = GrantPromise>() => T;
+  cursor: () => Promise<String>;
 }
 
-export interface AggregateGrantSubscription
-  extends Promise<AsyncIterator<AggregateGrant>>,
+export interface GrantEdgeSubscription
+  extends Promise<AsyncIterator<GrantEdge>>,
     Fragmentable {
-  count: () => Promise<AsyncIterator<Int>>;
+  node: <T = GrantSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
 }
 
 export interface InstallationSubscriptionPayload {
@@ -9092,50 +9148,20 @@ export interface InstallationSubscriptionPayloadSubscription
   previousValues: <T = InstallationPreviousValuesSubscription>() => T;
 }
 
-export interface Grant {
-  id: ID_Output;
-  createdAt: DateTimeOutput;
-  updatedAt: DateTimeOutput;
-  code: String;
-  expires: Int;
-  redirectUri: String;
+export interface AggregateForm {
+  count: Int;
 }
 
-export interface GrantPromise extends Promise<Grant>, Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  user: <T = UserPromise>() => T;
-  code: () => Promise<String>;
-  application: <T = ApplicationPromise>() => T;
-  expires: () => Promise<Int>;
-  redirectUri: () => Promise<String>;
-}
-
-export interface GrantSubscription
-  extends Promise<AsyncIterator<Grant>>,
+export interface AggregateFormPromise
+  extends Promise<AggregateForm>,
     Fragmentable {
-  id: () => Promise<AsyncIterator<ID_Output>>;
-  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  user: <T = UserSubscription>() => T;
-  code: () => Promise<AsyncIterator<String>>;
-  application: <T = ApplicationSubscription>() => T;
-  expires: () => Promise<AsyncIterator<Int>>;
-  redirectUri: () => Promise<AsyncIterator<String>>;
+  count: () => Promise<Int>;
 }
 
-export interface GrantNullablePromise
-  extends Promise<Grant | null>,
+export interface AggregateFormSubscription
+  extends Promise<AsyncIterator<AggregateForm>>,
     Fragmentable {
-  id: () => Promise<ID_Output>;
-  createdAt: () => Promise<DateTimeOutput>;
-  updatedAt: () => Promise<DateTimeOutput>;
-  user: <T = UserPromise>() => T;
-  code: () => Promise<String>;
-  application: <T = ApplicationPromise>() => T;
-  expires: () => Promise<Int>;
-  redirectUri: () => Promise<String>;
+  count: () => Promise<AsyncIterator<Int>>;
 }
 
 export interface InstallationPreviousValues {
@@ -9190,175 +9216,76 @@ export interface InstallationPreviousValuesSubscription
   sireneNumeroSiret: () => Promise<AsyncIterator<String>>;
 }
 
-export interface TemporaryStorageDetail {
+export interface Company {
   id: ID_Output;
-  tempStorerQuantityType?: QuantityType;
-  tempStorerQuantityReceived?: Float;
-  tempStorerWasteAcceptationStatus?: WasteAcceptationStatus;
-  tempStorerWasteRefusalReason?: String;
-  tempStorerReceivedAt?: DateTimeOutput;
-  tempStorerReceivedBy?: String;
-  tempStorerSignedAt?: DateTimeOutput;
-  destinationIsFilledByEmitter?: Boolean;
-  destinationCompanyName?: String;
-  destinationCompanySiret?: String;
-  destinationCompanyAddress?: String;
-  destinationCompanyContact?: String;
-  destinationCompanyPhone?: String;
-  destinationCompanyMail?: String;
-  destinationCap?: String;
-  destinationProcessingOperation?: String;
-  wasteDetailsOnuCode?: String;
-  wasteDetailsPackagings?: Json;
-  wasteDetailsOtherPackaging?: String;
-  wasteDetailsNumberOfPackages?: Int;
-  wasteDetailsQuantity?: Float;
-  wasteDetailsQuantityType?: QuantityType;
-  transporterCompanyName?: String;
-  transporterCompanySiret?: String;
-  transporterCompanyAddress?: String;
-  transporterCompanyContact?: String;
-  transporterCompanyPhone?: String;
-  transporterCompanyMail?: String;
-  transporterIsExemptedOfReceipt?: Boolean;
-  transporterReceipt?: String;
-  transporterDepartment?: String;
-  transporterValidityLimit?: DateTimeOutput;
-  transporterNumberPlate?: String;
-  signedByTransporter?: Boolean;
-  signedBy?: String;
-  signedAt?: DateTimeOutput;
+  siret: String;
+  companyTypes: CompanyType[];
+  name?: String;
+  gerepId?: String;
+  codeNaf?: String;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  securityCode: Int;
+  givenName?: String;
+  contactEmail?: String;
+  contactPhone?: String;
+  website?: String;
+  documentKeys: String[];
 }
 
-export interface TemporaryStorageDetailPromise
-  extends Promise<TemporaryStorageDetail>,
-    Fragmentable {
+export interface CompanyPromise extends Promise<Company>, Fragmentable {
   id: () => Promise<ID_Output>;
-  form: <T = FormPromise>() => T;
-  tempStorerQuantityType: () => Promise<QuantityType>;
-  tempStorerQuantityReceived: () => Promise<Float>;
-  tempStorerWasteAcceptationStatus: () => Promise<WasteAcceptationStatus>;
-  tempStorerWasteRefusalReason: () => Promise<String>;
-  tempStorerReceivedAt: () => Promise<DateTimeOutput>;
-  tempStorerReceivedBy: () => Promise<String>;
-  tempStorerSignedAt: () => Promise<DateTimeOutput>;
-  destinationIsFilledByEmitter: () => Promise<Boolean>;
-  destinationCompanyName: () => Promise<String>;
-  destinationCompanySiret: () => Promise<String>;
-  destinationCompanyAddress: () => Promise<String>;
-  destinationCompanyContact: () => Promise<String>;
-  destinationCompanyPhone: () => Promise<String>;
-  destinationCompanyMail: () => Promise<String>;
-  destinationCap: () => Promise<String>;
-  destinationProcessingOperation: () => Promise<String>;
-  wasteDetailsOnuCode: () => Promise<String>;
-  wasteDetailsPackagings: () => Promise<Json>;
-  wasteDetailsOtherPackaging: () => Promise<String>;
-  wasteDetailsNumberOfPackages: () => Promise<Int>;
-  wasteDetailsQuantity: () => Promise<Float>;
-  wasteDetailsQuantityType: () => Promise<QuantityType>;
-  transporterCompanyName: () => Promise<String>;
-  transporterCompanySiret: () => Promise<String>;
-  transporterCompanyAddress: () => Promise<String>;
-  transporterCompanyContact: () => Promise<String>;
-  transporterCompanyPhone: () => Promise<String>;
-  transporterCompanyMail: () => Promise<String>;
-  transporterIsExemptedOfReceipt: () => Promise<Boolean>;
-  transporterReceipt: () => Promise<String>;
-  transporterDepartment: () => Promise<String>;
-  transporterValidityLimit: () => Promise<DateTimeOutput>;
-  transporterNumberPlate: () => Promise<String>;
-  signedByTransporter: () => Promise<Boolean>;
-  signedBy: () => Promise<String>;
-  signedAt: () => Promise<DateTimeOutput>;
+  siret: () => Promise<String>;
+  companyTypes: () => Promise<CompanyType[]>;
+  name: () => Promise<String>;
+  gerepId: () => Promise<String>;
+  codeNaf: () => Promise<String>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  securityCode: () => Promise<Int>;
+  givenName: () => Promise<String>;
+  contactEmail: () => Promise<String>;
+  contactPhone: () => Promise<String>;
+  website: () => Promise<String>;
+  documentKeys: () => Promise<String[]>;
 }
 
-export interface TemporaryStorageDetailSubscription
-  extends Promise<AsyncIterator<TemporaryStorageDetail>>,
+export interface CompanySubscription
+  extends Promise<AsyncIterator<Company>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  form: <T = FormSubscription>() => T;
-  tempStorerQuantityType: () => Promise<AsyncIterator<QuantityType>>;
-  tempStorerQuantityReceived: () => Promise<AsyncIterator<Float>>;
-  tempStorerWasteAcceptationStatus: () => Promise<
-    AsyncIterator<WasteAcceptationStatus>
-  >;
-  tempStorerWasteRefusalReason: () => Promise<AsyncIterator<String>>;
-  tempStorerReceivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  tempStorerReceivedBy: () => Promise<AsyncIterator<String>>;
-  tempStorerSignedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
-  destinationIsFilledByEmitter: () => Promise<AsyncIterator<Boolean>>;
-  destinationCompanyName: () => Promise<AsyncIterator<String>>;
-  destinationCompanySiret: () => Promise<AsyncIterator<String>>;
-  destinationCompanyAddress: () => Promise<AsyncIterator<String>>;
-  destinationCompanyContact: () => Promise<AsyncIterator<String>>;
-  destinationCompanyPhone: () => Promise<AsyncIterator<String>>;
-  destinationCompanyMail: () => Promise<AsyncIterator<String>>;
-  destinationCap: () => Promise<AsyncIterator<String>>;
-  destinationProcessingOperation: () => Promise<AsyncIterator<String>>;
-  wasteDetailsOnuCode: () => Promise<AsyncIterator<String>>;
-  wasteDetailsPackagings: () => Promise<AsyncIterator<Json>>;
-  wasteDetailsOtherPackaging: () => Promise<AsyncIterator<String>>;
-  wasteDetailsNumberOfPackages: () => Promise<AsyncIterator<Int>>;
-  wasteDetailsQuantity: () => Promise<AsyncIterator<Float>>;
-  wasteDetailsQuantityType: () => Promise<AsyncIterator<QuantityType>>;
-  transporterCompanyName: () => Promise<AsyncIterator<String>>;
-  transporterCompanySiret: () => Promise<AsyncIterator<String>>;
-  transporterCompanyAddress: () => Promise<AsyncIterator<String>>;
-  transporterCompanyContact: () => Promise<AsyncIterator<String>>;
-  transporterCompanyPhone: () => Promise<AsyncIterator<String>>;
-  transporterCompanyMail: () => Promise<AsyncIterator<String>>;
-  transporterIsExemptedOfReceipt: () => Promise<AsyncIterator<Boolean>>;
-  transporterReceipt: () => Promise<AsyncIterator<String>>;
-  transporterDepartment: () => Promise<AsyncIterator<String>>;
-  transporterValidityLimit: () => Promise<AsyncIterator<DateTimeOutput>>;
-  transporterNumberPlate: () => Promise<AsyncIterator<String>>;
-  signedByTransporter: () => Promise<AsyncIterator<Boolean>>;
-  signedBy: () => Promise<AsyncIterator<String>>;
-  signedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  siret: () => Promise<AsyncIterator<String>>;
+  companyTypes: () => Promise<AsyncIterator<CompanyType[]>>;
+  name: () => Promise<AsyncIterator<String>>;
+  gerepId: () => Promise<AsyncIterator<String>>;
+  codeNaf: () => Promise<AsyncIterator<String>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  securityCode: () => Promise<AsyncIterator<Int>>;
+  givenName: () => Promise<AsyncIterator<String>>;
+  contactEmail: () => Promise<AsyncIterator<String>>;
+  contactPhone: () => Promise<AsyncIterator<String>>;
+  website: () => Promise<AsyncIterator<String>>;
+  documentKeys: () => Promise<AsyncIterator<String[]>>;
 }
 
-export interface TemporaryStorageDetailNullablePromise
-  extends Promise<TemporaryStorageDetail | null>,
+export interface CompanyNullablePromise
+  extends Promise<Company | null>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  form: <T = FormPromise>() => T;
-  tempStorerQuantityType: () => Promise<QuantityType>;
-  tempStorerQuantityReceived: () => Promise<Float>;
-  tempStorerWasteAcceptationStatus: () => Promise<WasteAcceptationStatus>;
-  tempStorerWasteRefusalReason: () => Promise<String>;
-  tempStorerReceivedAt: () => Promise<DateTimeOutput>;
-  tempStorerReceivedBy: () => Promise<String>;
-  tempStorerSignedAt: () => Promise<DateTimeOutput>;
-  destinationIsFilledByEmitter: () => Promise<Boolean>;
-  destinationCompanyName: () => Promise<String>;
-  destinationCompanySiret: () => Promise<String>;
-  destinationCompanyAddress: () => Promise<String>;
-  destinationCompanyContact: () => Promise<String>;
-  destinationCompanyPhone: () => Promise<String>;
-  destinationCompanyMail: () => Promise<String>;
-  destinationCap: () => Promise<String>;
-  destinationProcessingOperation: () => Promise<String>;
-  wasteDetailsOnuCode: () => Promise<String>;
-  wasteDetailsPackagings: () => Promise<Json>;
-  wasteDetailsOtherPackaging: () => Promise<String>;
-  wasteDetailsNumberOfPackages: () => Promise<Int>;
-  wasteDetailsQuantity: () => Promise<Float>;
-  wasteDetailsQuantityType: () => Promise<QuantityType>;
-  transporterCompanyName: () => Promise<String>;
-  transporterCompanySiret: () => Promise<String>;
-  transporterCompanyAddress: () => Promise<String>;
-  transporterCompanyContact: () => Promise<String>;
-  transporterCompanyPhone: () => Promise<String>;
-  transporterCompanyMail: () => Promise<String>;
-  transporterIsExemptedOfReceipt: () => Promise<Boolean>;
-  transporterReceipt: () => Promise<String>;
-  transporterDepartment: () => Promise<String>;
-  transporterValidityLimit: () => Promise<DateTimeOutput>;
-  transporterNumberPlate: () => Promise<String>;
-  signedByTransporter: () => Promise<Boolean>;
-  signedBy: () => Promise<String>;
-  signedAt: () => Promise<DateTimeOutput>;
+  siret: () => Promise<String>;
+  companyTypes: () => Promise<CompanyType[]>;
+  name: () => Promise<String>;
+  gerepId: () => Promise<String>;
+  codeNaf: () => Promise<String>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  securityCode: () => Promise<Int>;
+  givenName: () => Promise<String>;
+  contactEmail: () => Promise<String>;
+  contactPhone: () => Promise<String>;
+  website: () => Promise<String>;
+  documentKeys: () => Promise<String[]>;
 }
 
 export interface CompanyAssociationEdge {
@@ -9380,25 +9307,25 @@ export interface CompanyAssociationEdgeSubscription
   cursor: () => Promise<AsyncIterator<String>>;
 }
 
-export interface CompanyConnection {
+export interface AccessTokenConnection {
   pageInfo: PageInfo;
-  edges: CompanyEdge[];
+  edges: AccessTokenEdge[];
 }
 
-export interface CompanyConnectionPromise
-  extends Promise<CompanyConnection>,
+export interface AccessTokenConnectionPromise
+  extends Promise<AccessTokenConnection>,
     Fragmentable {
   pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<CompanyEdge>>() => T;
-  aggregate: <T = AggregateCompanyPromise>() => T;
+  edges: <T = FragmentableArray<AccessTokenEdge>>() => T;
+  aggregate: <T = AggregateAccessTokenPromise>() => T;
 }
 
-export interface CompanyConnectionSubscription
-  extends Promise<AsyncIterator<CompanyConnection>>,
+export interface AccessTokenConnectionSubscription
+  extends Promise<AsyncIterator<AccessTokenConnection>>,
     Fragmentable {
   pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<CompanyEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateCompanySubscription>() => T;
+  edges: <T = Promise<AsyncIterator<AccessTokenEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateAccessTokenSubscription>() => T;
 }
 
 export interface RubriqueSubscriptionPayload {
@@ -9574,25 +9501,36 @@ export interface StatusLogSubscriptionPayloadSubscription
   previousValues: <T = StatusLogPreviousValuesSubscription>() => T;
 }
 
-export interface GrantConnection {
-  pageInfo: PageInfo;
-  edges: GrantEdge[];
+export interface CompanyAssociation {
+  id: ID_Output;
+  role: UserRole;
 }
 
-export interface GrantConnectionPromise
-  extends Promise<GrantConnection>,
+export interface CompanyAssociationPromise
+  extends Promise<CompanyAssociation>,
     Fragmentable {
-  pageInfo: <T = PageInfoPromise>() => T;
-  edges: <T = FragmentableArray<GrantEdge>>() => T;
-  aggregate: <T = AggregateGrantPromise>() => T;
+  id: () => Promise<ID_Output>;
+  user: <T = UserPromise>() => T;
+  company: <T = CompanyPromise>() => T;
+  role: () => Promise<UserRole>;
 }
 
-export interface GrantConnectionSubscription
-  extends Promise<AsyncIterator<GrantConnection>>,
+export interface CompanyAssociationSubscription
+  extends Promise<AsyncIterator<CompanyAssociation>>,
     Fragmentable {
-  pageInfo: <T = PageInfoSubscription>() => T;
-  edges: <T = Promise<AsyncIterator<GrantEdgeSubscription>>>() => T;
-  aggregate: <T = AggregateGrantSubscription>() => T;
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  user: <T = UserSubscription>() => T;
+  company: <T = CompanySubscription>() => T;
+  role: () => Promise<AsyncIterator<UserRole>>;
+}
+
+export interface CompanyAssociationNullablePromise
+  extends Promise<CompanyAssociation | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  user: <T = UserPromise>() => T;
+  company: <T = CompanyPromise>() => T;
+  role: () => Promise<UserRole>;
 }
 
 export interface StatusLogPreviousValues {
@@ -9901,53 +9839,95 @@ export interface UserPreviousValuesSubscription
   updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
 }
 
-export interface FormEdge {
-  node: Form;
-  cursor: String;
+export interface FormConnection {
+  pageInfo: PageInfo;
+  edges: FormEdge[];
 }
 
-export interface FormEdgePromise extends Promise<FormEdge>, Fragmentable {
-  node: <T = FormPromise>() => T;
-  cursor: () => Promise<String>;
-}
-
-export interface FormEdgeSubscription
-  extends Promise<AsyncIterator<FormEdge>>,
+export interface FormConnectionPromise
+  extends Promise<FormConnection>,
     Fragmentable {
-  node: <T = FormSubscription>() => T;
-  cursor: () => Promise<AsyncIterator<String>>;
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<FormEdge>>() => T;
+  aggregate: <T = AggregateFormPromise>() => T;
 }
 
-export interface CompanyAssociation {
+export interface FormConnectionSubscription
+  extends Promise<AsyncIterator<FormConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<FormEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateFormSubscription>() => T;
+}
+
+export interface Installation {
   id: ID_Output;
-  role: UserRole;
+  codeS3ic?: String;
+  nomEts?: String;
+  regime?: String;
+  libRegime?: String;
+  seveso?: Seveso;
+  libSeveso?: String;
+  familleIc?: String;
+  urlFiche?: String;
+  s3icNumeroSiret?: String;
+  irepNumeroSiret?: String;
+  gerepNumeroSiret?: String;
+  sireneNumeroSiret?: String;
 }
 
-export interface CompanyAssociationPromise
-  extends Promise<CompanyAssociation>,
+export interface InstallationPromise
+  extends Promise<Installation>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  user: <T = UserPromise>() => T;
-  company: <T = CompanyPromise>() => T;
-  role: () => Promise<UserRole>;
+  codeS3ic: () => Promise<String>;
+  nomEts: () => Promise<String>;
+  regime: () => Promise<String>;
+  libRegime: () => Promise<String>;
+  seveso: () => Promise<Seveso>;
+  libSeveso: () => Promise<String>;
+  familleIc: () => Promise<String>;
+  urlFiche: () => Promise<String>;
+  s3icNumeroSiret: () => Promise<String>;
+  irepNumeroSiret: () => Promise<String>;
+  gerepNumeroSiret: () => Promise<String>;
+  sireneNumeroSiret: () => Promise<String>;
 }
 
-export interface CompanyAssociationSubscription
-  extends Promise<AsyncIterator<CompanyAssociation>>,
+export interface InstallationSubscription
+  extends Promise<AsyncIterator<Installation>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  user: <T = UserSubscription>() => T;
-  company: <T = CompanySubscription>() => T;
-  role: () => Promise<AsyncIterator<UserRole>>;
+  codeS3ic: () => Promise<AsyncIterator<String>>;
+  nomEts: () => Promise<AsyncIterator<String>>;
+  regime: () => Promise<AsyncIterator<String>>;
+  libRegime: () => Promise<AsyncIterator<String>>;
+  seveso: () => Promise<AsyncIterator<Seveso>>;
+  libSeveso: () => Promise<AsyncIterator<String>>;
+  familleIc: () => Promise<AsyncIterator<String>>;
+  urlFiche: () => Promise<AsyncIterator<String>>;
+  s3icNumeroSiret: () => Promise<AsyncIterator<String>>;
+  irepNumeroSiret: () => Promise<AsyncIterator<String>>;
+  gerepNumeroSiret: () => Promise<AsyncIterator<String>>;
+  sireneNumeroSiret: () => Promise<AsyncIterator<String>>;
 }
 
-export interface CompanyAssociationNullablePromise
-  extends Promise<CompanyAssociation | null>,
+export interface InstallationNullablePromise
+  extends Promise<Installation | null>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  user: <T = UserPromise>() => T;
-  company: <T = CompanyPromise>() => T;
-  role: () => Promise<UserRole>;
+  codeS3ic: () => Promise<String>;
+  nomEts: () => Promise<String>;
+  regime: () => Promise<String>;
+  libRegime: () => Promise<String>;
+  seveso: () => Promise<Seveso>;
+  libSeveso: () => Promise<String>;
+  familleIc: () => Promise<String>;
+  urlFiche: () => Promise<String>;
+  s3icNumeroSiret: () => Promise<String>;
+  irepNumeroSiret: () => Promise<String>;
+  gerepNumeroSiret: () => Promise<String>;
+  sireneNumeroSiret: () => Promise<String>;
 }
 
 /*

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -1335,7 +1335,7 @@ type Form {
   createdAt: DateTime!
   updatedAt: DateTime!
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -1426,7 +1426,7 @@ input FormCreateInput {
   isDeleted: Boolean
   owner: UserCreateOneInput!
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -1526,7 +1526,7 @@ input FormCreateWithoutTemporaryStorageDetailInput {
   isDeleted: Boolean
   owner: UserCreateOneInput!
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -1779,7 +1779,7 @@ type FormPreviousValues {
   createdAt: DateTime!
   updatedAt: DateTime!
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -1917,20 +1917,10 @@ input FormScalarWhereInput {
   updatedAt_gte: DateTime
   signedByTransporter: Boolean
   signedByTransporter_not: Boolean
-  status: String
-  status_not: String
-  status_in: [String!]
-  status_not_in: [String!]
-  status_lt: String
-  status_lte: String
-  status_gt: String
-  status_gte: String
-  status_contains: String
-  status_not_contains: String
-  status_starts_with: String
-  status_not_starts_with: String
-  status_ends_with: String
-  status_not_ends_with: String
+  status: Status
+  status_not: Status
+  status_in: [Status!]
+  status_not_in: [Status!]
   sentAt: DateTime
   sentAt_not: DateTime
   sentAt_in: [DateTime!]
@@ -2824,7 +2814,7 @@ input FormUpdateDataInput {
   isDeleted: Boolean
   owner: UserUpdateOneRequiredInput
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -2908,7 +2898,7 @@ input FormUpdateInput {
   isDeleted: Boolean
   owner: UserUpdateOneRequiredInput
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -2991,7 +2981,7 @@ input FormUpdateManyDataInput {
   customId: String
   isDeleted: Boolean
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -3083,7 +3073,7 @@ input FormUpdateManyMutationInput {
   customId: String
   isDeleted: Boolean
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -3185,7 +3175,7 @@ input FormUpdateWithoutTemporaryStorageDetailDataInput {
   isDeleted: Boolean
   owner: UserUpdateOneRequiredInput
   signedByTransporter: Boolean
-  status: String
+  status: Status
   sentAt: DateTime
   sentBy: String
   isAccepted: Boolean
@@ -3347,20 +3337,10 @@ input FormWhereInput {
   updatedAt_gte: DateTime
   signedByTransporter: Boolean
   signedByTransporter_not: Boolean
-  status: String
-  status_not: String
-  status_in: [String!]
-  status_not_in: [String!]
-  status_lt: String
-  status_lte: String
-  status_gt: String
-  status_gte: String
-  status_contains: String
-  status_not_contains: String
-  status_starts_with: String
-  status_not_starts_with: String
-  status_ends_with: String
-  status_not_ends_with: String
+  status: Status
+  status_not: Status
+  status_in: [Status!]
+  status_not_in: [Status!]
   sentAt: DateTime
   sentAt_not: DateTime
   sentAt_in: [DateTime!]

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -1,9 +1,7 @@
 import { ExpressContext } from "apollo-server-express/dist/ApolloServer";
 
-import { Prisma, User } from "./generated/prisma-client";
+import { User } from "./generated/prisma-client";
 
 export type GraphQLContext = ExpressContext & {
   user: User;
-  prisma: Prisma;
-  request: any;
 };

--- a/back/src/users/mutations/__tests__/changePassword.test.ts
+++ b/back/src/users/mutations/__tests__/changePassword.test.ts
@@ -24,7 +24,10 @@ describe("changePassword", () => {
     });
     expect.assertions(1);
     try {
-      await changePassword("userId", "badOldPassword", "newPassword");
+      await changePassword("userId", {
+        oldPassword: "badOldPassword",
+        newPassword: "newPassword"
+      });
     } catch (e) {
       expect(e.extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
     }
@@ -35,7 +38,10 @@ describe("changePassword", () => {
     userMock.mockResolvedValueOnce({
       password: hashedPassword
     });
-    await changePassword("userId", "oldPassword", "newPassword");
+    await changePassword("userId", {
+      oldPassword: "oldPassword",
+      newPassword: "newPassword"
+    });
     expect(updateUserMock).toHaveBeenCalled();
   });
 });

--- a/back/src/users/mutations/__tests__/inviteUserToCompany.test.ts
+++ b/back/src/users/mutations/__tests__/inviteUserToCompany.test.ts
@@ -50,12 +50,11 @@ describe("inviteUserToCompany", () => {
 
     const adminUser = { name: "John Snow" } as User;
 
-    await inviteUserToCompany(
-      adminUser,
-      "arya.stark@trackdechets.fr",
-      "85001946400013",
-      "MEMBER"
-    );
+    await inviteUserToCompany(adminUser, {
+      email: "arya.stark@trackdechets.fr",
+      siret: "85001946400013",
+      role: "MEMBER"
+    });
 
     expect(associateUserToCompanyMock).toBeCalledWith(
       "id",
@@ -87,12 +86,11 @@ describe("inviteUserToCompany", () => {
 
     const adminUser = { name: "John Snow" } as User;
 
-    await inviteUserToCompany(
-      adminUser,
-      "arya.stark@trackdechets.fr",
-      "85001946400013",
-      "MEMBER"
-    );
+    await inviteUserToCompany(adminUser, {
+      email: "arya.stark@trackdechets.fr",
+      siret: "85001946400013",
+      role: "MEMBER"
+    });
 
     expect(createUserAccountHashMock).toHaveBeenCalledWith(
       "arya.stark@trackdechets.fr",

--- a/back/src/users/mutations/__tests__/signup.integration.ts
+++ b/back/src/users/mutations/__tests__/signup.integration.ts
@@ -6,7 +6,6 @@ import { prisma } from "../../../generated/prisma-client";
 import { userMails } from "../../mails";
 import { userFactory, companyFactory } from "../../../__tests__/factories";
 import { ErrorCode } from "../../../common/errors";
-import { UserRole } from "../../../generated/types";
 
 // No mails
 const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
@@ -139,7 +138,7 @@ describe("{ mutation { signup } }", () => {
       email: user.email,
       companySiret: company.siret,
       hash: "hash",
-      role: UserRole.Member
+      role: "MEMBER"
     });
 
     const mutation = `

--- a/back/src/users/mutations/changePassword.ts
+++ b/back/src/users/mutations/changePassword.ts
@@ -1,14 +1,15 @@
 import { prisma } from "../../generated/prisma-client";
 import { hash, compare } from "bcrypt";
 import { UserInputError } from "apollo-server-express";
+import { MutationChangePasswordArgs } from "../../generated/graphql/types";
 
 /**
  * Change user password
- * @param userId
- * @param oldPassword
- * @param newPassword
  */
-export async function changePassword(userId, oldPassword, newPassword) {
+export async function changePassword(
+  userId: string,
+  { oldPassword, newPassword }: MutationChangePasswordArgs
+) {
   const user = await prisma.user({ id: userId });
   const passwordValid = await compare(oldPassword, user.password);
   if (!passwordValid) {

--- a/back/src/users/mutations/editProfile.ts
+++ b/back/src/users/mutations/editProfile.ts
@@ -1,10 +1,5 @@
 import { prisma } from "../../generated/prisma-client";
-
-type Payload = {
-  name?: string;
-  phone?: string;
-  email?: string;
-};
+import { MutationEditProfileArgs } from "../../generated/graphql/types";
 
 /**
  * Edit user profile
@@ -13,7 +8,7 @@ type Payload = {
  * @param userId
  * @param payload
  */
-export function editProfile(userId: string, payload: Payload) {
+export function editProfile(userId: string, payload: MutationEditProfileArgs) {
   const { name, phone, email } = payload;
 
   const data = {

--- a/back/src/users/mutations/inviteUserToCompany.ts
+++ b/back/src/users/mutations/inviteUserToCompany.ts
@@ -1,16 +1,19 @@
-import { prisma, User, UserRole } from "../../generated/prisma-client";
+import { prisma, User } from "../../generated/prisma-client";
 import { sendMail } from "../../common/mails.helper";
 import { userMails } from "../mails";
 import { associateUserToCompany } from "./associateUserToCompany";
 import { createUserAccountHash } from "./createUserAccountHash";
 import { UserInputError } from "apollo-server-express";
+import {
+  MutationInviteUserToCompanyArgs,
+  MutationResendInvitationArgs,
+  CompanyPrivate
+} from "../../generated/graphql/types";
 
 export async function inviteUserToCompany(
   adminUser: User,
-  email: string,
-  siret: string,
-  role: UserRole
-) {
+  { email, siret, role }: MutationInviteUserToCompanyArgs
+): Promise<CompanyPrivate> {
   const existingUser = await prisma.user({ email }).catch(_ => null);
 
   const company = await prisma.company({ siret });
@@ -44,13 +47,13 @@ export async function inviteUserToCompany(
       )
     );
   }
+
   return company;
 }
 
 export async function resendInvitation(
   adminUser: User,
-  email: string,
-  siret: string
+  { email, siret }: MutationResendInvitationArgs
 ) {
   const hashes = await prisma.userAccountHashes({
     where: { email, companySiret: siret }

--- a/back/src/users/mutations/joinWithInvite.ts
+++ b/back/src/users/mutations/joinWithInvite.ts
@@ -1,15 +1,19 @@
 import { prisma } from "../../generated/prisma-client";
+import {
+  MutationJoinWithInviteArgs,
+  User
+} from "../../generated/graphql/types";
 import { hashPassword } from "../utils";
 
-export async function joinWithInvite(
-  inviteHash: string,
-  name: string,
-  password: string
-) {
+export async function joinWithInvite({
+  inviteHash,
+  name,
+  password
+}: MutationJoinWithInviteArgs): Promise<User> {
   const existingHash = await prisma.userAccountHash({ hash: inviteHash });
 
   if (!existingHash) {
-    return new Error(
+    throw new Error(
       `Cette invitation n'est plus valable. Contactez le responsable de votre société.`
     );
   }

--- a/back/src/users/mutations/login.ts
+++ b/back/src/users/mutations/login.ts
@@ -2,6 +2,7 @@ import { prisma } from "../../generated/prisma-client";
 import { compare } from "bcrypt";
 import { apiKey } from "../queries";
 import { UserInputError, ForbiddenError } from "apollo-server-express";
+import { MutationLoginArgs } from "../../generated/graphql/types";
 
 /**
  * DEPRECATED
@@ -10,7 +11,7 @@ import { UserInputError, ForbiddenError } from "apollo-server-express";
  * @param email
  * @param password
  */
-export async function login(email: string, password: string) {
+export async function login({ email, password }: MutationLoginArgs) {
   const user = await prisma.user({ email: email.trim() });
   if (!user) {
     throw new UserInputError(`Aucun utilisateur trouvé avec l'email ${email}`, {

--- a/back/src/users/mutations/signup.ts
+++ b/back/src/users/mutations/signup.ts
@@ -4,7 +4,7 @@ import { User, prisma } from "../../generated/prisma-client";
 import { userMails } from "../mails";
 import { hashPassword } from "../utils";
 import { UserInputError } from "apollo-server-express";
-import { SignupInput } from "../../generated/types";
+import { SignupInput } from "../../generated/graphql/types";
 
 export default async function signup({
   name,

--- a/back/src/users/resolvers.ts
+++ b/back/src/users/resolvers.ts
@@ -1,7 +1,6 @@
 import { sendMail } from "../common/mails.helper";
 import { getUserCompanies } from "../companies/queries";
 import { prisma } from "../generated/prisma-client";
-import { GraphQLContext } from "../types";
 import { userMails } from "./mails";
 import {
   changePassword,
@@ -14,82 +13,83 @@ import {
 import signup from "./mutations/signup";
 import { hashPassword, generatePassword } from "./utils";
 import { apiKey } from "./queries";
+import {
+  QueryResolvers,
+  MutationResolvers,
+  UserResolvers
+} from "../generated/graphql/types";
 
-export default {
-  Mutation: {
-    signup: (_parent, { userInfos }) => signup(userInfos),
-    login: async (_parent, { email, password }) => login(email, password),
-    changePassword: async (_, { oldPassword, newPassword }, context) => {
-      const userId = context.user.id;
-      return changePassword(userId, oldPassword, newPassword);
-    },
-    resetPassword: async (_, { email }, context: GraphQLContext) => {
-      const user = await context.prisma.user({ email }).catch(__ => null);
+const queryResolvers: QueryResolvers = {
+  me: async (_parent, _args, context) => {
+    const userId = context.user.id;
+    return prisma.user({ id: userId });
+  },
+  apiKey: (_parent, _args, context) => apiKey(context.user)
+};
 
-      if (!user) {
-        throw new Error(`Cet email n'existe pas sur notre plateforme.`);
-      }
-
-      const newPassword = generatePassword();
-      const hashedPassword = await hashPassword(newPassword);
-      await prisma.updateUser({
-        where: { id: user.id },
-        data: { password: hashedPassword }
+const mutationResolvers: MutationResolvers = {
+  signup: (_parent, { userInfos }) => signup(userInfos),
+  login: async (_parent, args) => login(args),
+  changePassword: async (_, args, context) => {
+    const userId = context.user.id;
+    return changePassword(userId, args);
+  },
+  resetPassword: async (_, { email }) => {
+    const user = await prisma.user({ email }).catch(__ => null);
+    if (!user) {
+      throw new Error(`Cet email n'existe pas sur notre plateforme.`);
+    }
+    const newPassword = generatePassword();
+    const hashedPassword = await hashPassword(newPassword);
+    await prisma.updateUser({
+      where: { id: user.id },
+      data: { password: hashedPassword }
+    });
+    await sendMail(userMails.resetPassword(user.email, user.name, newPassword));
+    return true;
+  },
+  editProfile: (_, args, context) => {
+    const userId = context.user.id;
+    return editProfile(userId, args);
+  },
+  inviteUserToCompany: async (_, args, context) =>
+    inviteUserToCompany(context.user, args),
+  resendInvitation: async (_, args, context) =>
+    resendInvitation(context.user, args),
+  joinWithInvite: async (_, args) => joinWithInvite(args),
+  removeUserFromCompany: async (_, { userId, siret }) => {
+    await prisma
+      .deleteManyCompanyAssociations({
+        user: { id: userId },
+        company: { siret }
+      })
+      .catch(__ => {
+        throw new Error(
+          `Erreur, l'utilisateur n'a pas pu être retiré de l'entreprise`
+        );
       });
 
-      await sendMail(
-        userMails.resetPassword(user.email, user.name, newPassword)
-      );
-    },
-    editProfile: (_, payload, context) => {
-      const userId = context.user.id;
-      return editProfile(userId, payload);
-    },
-    inviteUserToCompany: async (
-      _,
-      { email, siret, role },
-      context: GraphQLContext
-    ) => inviteUserToCompany(context.user, email, siret, role),
-    resendInvitation: async (_, { email, siret }, context: GraphQLContext) =>
-      resendInvitation(context.user, email, siret),
-    joinWithInvite: async (_, { inviteHash, name, password }) =>
-      joinWithInvite(inviteHash, name, password),
-    removeUserFromCompany: async (_, { userId, siret }) => {
-      await prisma
-        .deleteManyCompanyAssociations({
-          user: { id: userId },
-          company: { siret }
-        })
-        .catch(__ => {
-          throw new Error(
-            `Erreur, l'utilisateur n'a pas pu être retiré de l'entreprise`
-          );
-        });
-
-      const company = await prisma.company({ siret });
-
-      return company;
-    },
-
-    deleteInvitation: async (_, { email, siret }) => {
-      const deletedAccountHash = await prisma
-        .deleteManyUserAccountHashes({ email, companySiret: siret })
-        .catch(err => {
-          throw new Error(`Erreur, l'invitation n'a pas pu être supprimée`);
-        });
-      return prisma.company({ siret });
-    }
+    return prisma.company({ siret });
   },
-  Query: {
-    me: async (parent, _, context) => {
-      const userId = context.user.id;
-      return context.prisma.user({ id: userId });
-    },
-    apiKey: (_parent, _args, context: GraphQLContext) => apiKey(context.user)
-  },
-  User: {
-    companies: async parent => {
-      return await getUserCompanies(parent.id);
+
+  deleteInvitation: async (_, { email, siret }) => {
+    try {
+      await prisma.deleteManyUserAccountHashes({ email, companySiret: siret });
+    } catch {
+      throw new Error(`Erreur, l'invitation n'a pas pu être supprimée`);
     }
+    return prisma.company({ siret });
   }
+};
+
+const userResolvers: UserResolvers = {
+  companies: async parent => {
+    return await getUserCompanies(parent.id);
+  }
+};
+
+export default {
+  Mutation: mutationResolvers,
+  Query: queryResolvers,
+  User: userResolvers
 };

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -3925,11 +3925,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3942,15 +3944,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4053,7 +4058,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4063,6 +4069,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4075,17 +4082,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4102,6 +4112,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4182,7 +4193,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4192,6 +4204,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4297,6 +4310,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8732,6 +8746,7 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8744,7 +8759,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -8753,7 +8769,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8856,7 +8873,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8866,6 +8884,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8878,17 +8897,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8905,6 +8927,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8985,7 +9008,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8995,6 +9019,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9100,6 +9125,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -2682,7 +2682,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
@@ -3069,7 +3069,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -3509,7 +3509,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3543,7 +3543,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -3803,7 +3803,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -3925,13 +3925,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3944,18 +3942,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4058,8 +4053,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4069,7 +4063,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4082,20 +4075,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4112,7 +4102,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4193,8 +4182,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4204,7 +4192,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4310,7 +4297,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4853,7 +4839,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4865,7 +4851,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4934,7 +4920,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
@@ -5355,7 +5341,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
             "array-union": "^1.0.1",
@@ -5367,7 +5353,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -5454,7 +5440,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -5595,7 +5581,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -6111,7 +6097,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
             "esutils": "^2.0.2",
@@ -6128,7 +6114,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6718,7 +6704,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -8037,7 +8023,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
@@ -8746,7 +8732,6 @@
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8759,8 +8744,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -8769,8 +8753,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8873,8 +8856,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8884,7 +8866,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8897,20 +8878,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8927,7 +8905,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9008,8 +8985,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9019,7 +8995,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9125,7 +9100,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10177,7 +10151,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -10452,7 +10426,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -10476,7 +10450,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -10493,7 +10467,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -10651,7 +10625,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -10747,7 +10721,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -10893,7 +10867,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -11347,7 +11321,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -11360,7 +11334,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -11531,7 +11505,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -11602,7 +11576,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -13629,7 +13603,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
@@ -13658,7 +13632,7 @@
       "dependencies": {
         "css-select": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
           "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
           "requires": {
             "boolbase": "~1.0.0",
@@ -13983,7 +13957,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -14284,7 +14258,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -14304,7 +14278,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -14896,7 +14870,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -14921,7 +14895,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -15315,7 +15289,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -16558,7 +16532,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",


### PR DESCRIPTION
:warning: Nécessite un `prisma deploy --force`

* Utilisation de `graphql-codegen` pour générer les types typescript des resolvers à partir du schéma GraphQL
* Typage de tous les resolvers à l'aide du fichier de types typescript ainsi généré. Comme les objets prisma sont déjà typés, on a un typage de bout en bout. 
* Suppression de la variable `prisma` du contexte GraphQL et simplification de la signature de certaines fonctions. Ça évite de passer le contexte dans toutes les fonctions imbriquées.
* Changement tu type de `Form.status`. Avant c'était un `string`, c'est désormais un `enum`