### PR TITLE
appendixforms.integration.ts échoue de façon aléatoire

### DIFF
--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -9,7 +9,7 @@ import {
   UserRole,
   Status
 } from "../generated/prisma-client";
-import { getReadableId } from "../forms/readable-id";
+import * as crypto from "crypto";
 
 /**
  * Create a user with name and email
@@ -185,10 +185,18 @@ const formdata = {
   recipientCompanyName: "WASTE COMPANY"
 };
 
+/**
+ * Thread-safe version of getReadableId for tests
+ */
+export function getReadableId() {
+  const uid = crypto.randomBytes(16).toString("hex");
+  return `TD-${uid}`;
+}
+
 export const formFactory = async ({ ownerId, opt = {} }) => {
   const formParams = { ...formdata, ...opt };
   return prisma.createForm({
-    readableId: await getReadableId(),
+    readableId: getReadableId(),
     ...formParams,
     owner: { connect: { id: ownerId } }
   });

--- a/back/src/forms/__tests__/appendixforms.integration.ts
+++ b/back/src/forms/__tests__/appendixforms.integration.ts
@@ -1,9 +1,6 @@
 import * as mailsHelper from "../../common/mails.helper";
-
 import makeClient from "../../__tests__/testClient";
-import { prepareDB } from "./helpers";
-
-import { formFactory } from "../../__tests__/factories";
+import { formFactory, userWithCompanyFactory } from "../../__tests__/factories";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { ErrorCode } from "../../common/errors";
 
@@ -19,11 +16,13 @@ describe("Test appendixForms", () => {
   });
   it("should return appendixForms data", async () => {
     const {
-      emitter,
-      emitterCompany,
-      recipient,
-      recipientCompany
-    } = await prepareDB();
+      user: emitter,
+      company: emitterCompany
+    } = await userWithCompanyFactory("ADMIN");
+    const {
+      user: recipient,
+      company: recipientCompany
+    } = await userWithCompanyFactory("ADMIN");
 
     // This form is in AWAITING_GROUP and should be returned
     const form = await formFactory({
@@ -32,8 +31,7 @@ describe("Test appendixForms", () => {
         emitterCompanyName: emitterCompany.name,
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
-        status: "AWAITING_GROUP",
-        readableId: "TD-1"
+        status: "AWAITING_GROUP"
       }
     });
     // other forms should not be returned
@@ -43,8 +41,7 @@ describe("Test appendixForms", () => {
         emitterCompanyName: emitterCompany.name,
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
-        status: "PROCESSED",
-        readableId: "TD-2"
+        status: "PROCESSED"
       }
     });
     await formFactory({
@@ -53,8 +50,7 @@ describe("Test appendixForms", () => {
         emitterCompanyName: emitterCompany.name,
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
-        status: "RECEIVED",
-        readableId: "TD-3"
+        status: "RECEIVED"
       }
     });
 
@@ -69,11 +65,14 @@ describe("Test appendixForms", () => {
 
   it("should not return appendixForms data", async () => {
     const {
-      emitter,
-      emitterCompany,
-      recipient,
-      recipientCompany
-    } = await prepareDB();
+      user: emitter,
+      company: emitterCompany
+    } = await userWithCompanyFactory("ADMIN");
+
+    const {
+      user: recipient,
+      company: recipientCompany
+    } = await userWithCompanyFactory("ADMIN");
 
     await formFactory({
       ownerId: emitter.id,
@@ -81,8 +80,7 @@ describe("Test appendixForms", () => {
         emitterCompanyName: emitterCompany.name,
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
-        status: "AWAITING_GROUP",
-        readableId: "TD-4"
+        status: "AWAITING_GROUP"
       }
     });
     // the queried siret is not recipientCompanySiret, result should be null

--- a/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
+++ b/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../generated/prisma-client";
 
 import { resetDatabase } from "../../../../integration-tests/helper";
-import { getReadableId } from "../../readable-id";
+import { getReadableId } from "../../../__tests__/factories";
 
 // No mails
 const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
@@ -190,19 +190,19 @@ describe("Test Form with appendix reception", () => {
     // these forms are in "GROUPED" state
     let initialForm1 = await prisma.createForm({
       ...appendixFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       owner: { connect: { id: emitter.id } }
     });
     let initialForm2 = await prisma.createForm({
       ...appendixFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       owner: { connect: { id: emitter.id } }
     });
 
     // this form regroups both initialForms
     let formWithAppendix2 = await prisma.createForm({
       ...groupingFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       recipientCompanySiret: lastRecipientCompany.siret,
       owner: { connect: { id: emitter.id } },
       appendix2Forms: {
@@ -265,13 +265,13 @@ describe("Test Form with appendix processing", () => {
     // these forms are in "GROUPED" state
     let initialForm1 = await prisma.createForm({
       ...appendixFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       status: "PROCESSED",
       owner: { connect: { id: emitter.id } }
     });
     let initialForm2 = await prisma.createForm({
       ...appendixFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       status: "PROCESSED",
       owner: { connect: { id: emitter.id } }
     });
@@ -279,7 +279,7 @@ describe("Test Form with appendix processing", () => {
     // this form regroups both initialForms
     let formWithAppendix2 = await prisma.createForm({
       ...groupingFormData,
-      readableId: await getReadableId(),
+      readableId: getReadableId(),
       recipientCompanySiret: lastRecipientCompany.siret,
       status: "RECEIVED",
       owner: { connect: { id: emitter.id } },

--- a/back/src/forms/queries/__tests__/forms.integration.ts
+++ b/back/src/forms/queries/__tests__/forms.integration.ts
@@ -10,10 +10,10 @@ import {
 
 function createForms(userId: string, params: any[]) {
   return Promise.all(
-    params.map((p, i) => {
+    params.map(p => {
       return formFactory({
         ownerId: userId,
-        opt: { ...p, readableId: `TD-${i}` }
+        opt: p
       });
     })
   );


### PR DESCRIPTION
Le test `appendixforms.integration.ts` échoue de façon aléatoire en ce moment avec l'erreur `"Whoops. Looks like an internal server error"`. Voir par exemple [ce build](
https://app.circleci.com/pipelines/github/MTES-MCT/trackdechets/1531/workflows/cc16ff91-2980-4b96-94ec-f5b6bce34a98/jobs/2438). 
Je n'ai pas réussi à reproduire en local mais une possibilité est que ce soit du à un changement que j'ai fait rendant le champ `Form.readableId` obligatoire dans prisma ce qui m'a amené à ajouter des `getReadableId` un peu partout dans les tests d'intégration lors de la création de BSD. Or on a vu que cette méthode n'est pas thread safe et peu donc amener à des collisions,  . J'ai donc remplacé les appels à `getReadableId` dans les tests par une version "thread safe".   
Pas certain que ça vienne de là mais ça ne peut pas faire de mal en tout cas
