### PR TITLE
Date d'acceptation ou refus du déchet

### DIFF
--- a/back/prisma/database/form.prisma
+++ b/back/prisma/database/form.prisma
@@ -30,7 +30,7 @@ type Form {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
-  acceptedAt: DateTime
+  signedAt: DateTime
   quantityReceived: Float
 
   processedBy: String
@@ -134,7 +134,6 @@ type TemporaryStorageDetail {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
-  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
 
   # Frame 14

--- a/back/prisma/database/form.prisma
+++ b/back/prisma/database/form.prisma
@@ -30,6 +30,7 @@ type Form {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
 
   processedBy: String
@@ -133,6 +134,7 @@ type TemporaryStorageDetail {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
 
   # Frame 14

--- a/back/src/forms/__tests__/wasteReceive.integration.ts
+++ b/back/src/forms/__tests__/wasteReceive.integration.ts
@@ -167,6 +167,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Holden",
             receivedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: REFUSED,
             wasteRefusalReason: "Lorem ipsum",
             quantityReceived: 0
@@ -215,6 +216,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Holden",
             receivedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: REFUSED,
             wasteRefusalReason: "Lorem ipsum",
             quantityReceived: 21

--- a/back/src/forms/__tests__/wasteReceive.integration.ts
+++ b/back/src/forms/__tests__/wasteReceive.integration.ts
@@ -43,6 +43,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 11
       }
@@ -89,6 +90,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: -2
       }
@@ -128,6 +130,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 0
       }
@@ -256,6 +259,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Carol",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: PARTIALLY_REFUSED,
             wasteRefusalReason: "Dolor sit amet",
             quantityReceived: 12.5
@@ -314,6 +318,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Sandy",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: PARTIALLY_REFUSED,
             wasteRefusalReason: "Dolor sit amet",
             quantityReceived: 19
@@ -357,6 +362,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
+            acceptedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 11
       }

--- a/back/src/forms/__tests__/wasteReceive.integration.ts
+++ b/back/src/forms/__tests__/wasteReceive.integration.ts
@@ -43,7 +43,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 11
       }
@@ -90,7 +90,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: -2
       }
@@ -130,7 +130,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 0
       }
@@ -259,7 +259,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Carol",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: PARTIALLY_REFUSED,
             wasteRefusalReason: "Dolor sit amet",
             quantityReceived: 12.5
@@ -318,7 +318,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Sandy",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: PARTIALLY_REFUSED,
             wasteRefusalReason: "Dolor sit amet",
             quantityReceived: 19
@@ -362,7 +362,7 @@ describe("Test Form reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
-            acceptedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 11
       }

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -297,7 +297,7 @@ input TempStoredFormInput {
   "Date à laquelle le déchet a été reçu (case 13)"
   receivedAt: DateTime!
 
-  "Date à laquelle le déchet a été accepté ou refusé (case 13)"
+  "Date à laquelle le déchet a été accepté ou refusé (case 13). Défaut à la date d'aujourd'hui."
   signedAt: DateTime
 
   "Quantité réelle présentée (case 13)"
@@ -321,7 +321,7 @@ input ResentFormInput {
   "Nom du signataire du BSD suite  (case 19)"
   signedBy: String
 
-  "Date de signature du BSD suite (case 19)"
+  "Date de signature du BSD suite (case 19). Défaut à la date d'aujourd'hui."
   signedAt: DateTime
 }
 

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -60,8 +60,8 @@ input ReceivedFormInput {
   "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime!
 
-  "Date à laquelle le déchet a été accepté (case 10)"
-  acceptedAt: DateTime
+  "Date à laquelle le déchet a été accepté ou refusé (case 10)"
+  signedAt: DateTime
 
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float!
@@ -285,22 +285,22 @@ input WasteDetailsInput {
 }
 
 input TempStoredFormInput {
-  "Statut d'acceptation du déchet (case 10)"
+  "Statut d'acceptation du déchet (case 13)"
   wasteAcceptationStatus: WasteAcceptationStatusInput!
 
-  "Raison du refus (case 10)"
+  "Raison du refus (case 13)"
   wasteRefusalReason: String
 
-  "Nom de la personne en charge de la réception du déchet (case 10)"
+  "Nom de la personne en charge de la réception du déchet (case 13)"
   receivedBy: String!
 
-  "Date à laquelle le déchet a été reçu (case 10)"
+  "Date à laquelle le déchet a été reçu (case 13)"
   receivedAt: DateTime!
 
-  "Date à laquelle le déchet a été accepté (case 10)"
-  acceptedAt: DateTime
+  "Date à laquelle le déchet a été accepté ou refusé (case 13)"
+  signedAt: DateTime
 
-  "Quantité réelle présentée (case 10)"
+  "Quantité réelle présentée (case 13)"
   quantityReceived: Float!
 
   "Réelle ou estimée"

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -60,6 +60,9 @@ input ReceivedFormInput {
   "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime!
 
+  "Date à laquelle le déchet a été accepté (case 10)"
+  acceptedAt: DateTime!
+
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float!
 }
@@ -293,6 +296,9 @@ input TempStoredFormInput {
 
   "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime!
+
+  "Date à laquelle le déchet a été accepté (case 10)"
+  acceptedAt: DateTime!
 
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float!

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -61,7 +61,7 @@ input ReceivedFormInput {
   receivedAt: DateTime!
 
   "Date à laquelle le déchet a été accepté (case 10)"
-  acceptedAt: DateTime!
+  acceptedAt: DateTime
 
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float!
@@ -298,7 +298,7 @@ input TempStoredFormInput {
   receivedAt: DateTime!
 
   "Date à laquelle le déchet a été accepté (case 10)"
-  acceptedAt: DateTime!
+  acceptedAt: DateTime
 
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float!

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -351,6 +351,9 @@ type Form {
   "Date à laquelle le déchet a été reçu (case 10)"
   receivedAt: DateTime
 
+  "Date à laquelle le déchet a été accepté ou refusé (case 10)"
+  signedAt: DateTime
+
   "Quantité réelle présentée (case 10)"
   quantityReceived: Float
 

--- a/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
+++ b/back/src/forms/mutations/__tests__/appendix2-mark-as-received-processed.integration.ts
@@ -219,6 +219,7 @@ describe("Test Form with appendix reception", () => {
             receivedInfo: {
             receivedBy: "Bill",
             receivedAt :"2019-01-17T10:22:00+0100",
+            signedAt :"2019-01-17T10:22:00+0100",
             wasteAcceptationStatus: ACCEPTED,
             quantityReceived: 11
       }

--- a/back/src/forms/mutations/__tests__/mark-as-temp-stored.integration.ts
+++ b/back/src/forms/mutations/__tests__/mark-as-temp-stored.integration.ts
@@ -43,6 +43,7 @@ describe("{ mutation { markAsTempStored } }", () => {
           wasteRefusalReason: ""
           receivedBy: "John Doe",
           receivedAt: "2018-12-11T00:00:00.000Z",
+          signedAt: "2018-12-11T00:00:00.000Z",
           quantityReceived: 2.4
           quantityType: REAL
         }) {
@@ -95,6 +96,7 @@ describe("{ mutation { markAsTempStored } }", () => {
           wasteRefusalReason: "Thats isn't what I was expecting man !"
           receivedBy: "John Doe",
           receivedAt: "2018-12-11T00:00:00.000Z",
+          signedAt: "2018-12-11T00:00:00.000Z",
           quantityReceived: 0
           quantityType: REAL
         }) {

--- a/back/src/forms/mutations/mark-as.ts
+++ b/back/src/forms/mutations/mark-as.ts
@@ -127,8 +127,7 @@ export function markAsTempStored(
         ...Object.keys(infos).reduce((prev, cur) => {
           prev[`tempStorer${capitalize(cur)}`] = infos[cur];
           return prev;
-        }, {}),
-        tempStorerSignedAt: new Date()
+        }, {})
       }
     }
   });
@@ -260,7 +259,7 @@ const fieldsToLog = {
     "quantity",
     "onuCode"
   ],
-  MARK_RECEIVED: ["receivedBy", "receivedAt", "acceptedAt", "quantityReceived"],
+  MARK_RECEIVED: ["receivedBy", "receivedAt", "signedAt", "quantityReceived"],
   MARK_PROCESSED: [
     "processedBy",
     "processedAt",
@@ -279,7 +278,7 @@ const fieldsToLog = {
   MARK_TEMP_STORED: [
     "receivedBy",
     "receivedAt",
-    "acceptedAt",
+    "signedAt",
     "quantityReceived",
     "quantityType"
   ],

--- a/back/src/forms/mutations/mark-as.ts
+++ b/back/src/forms/mutations/mark-as.ts
@@ -43,7 +43,10 @@ export function markAsReceived(
 ): Promise<Form> {
   return transitionForm(
     id,
-    { eventType: "MARK_RECEIVED", eventParams: receivedInfo },
+    {
+      eventType: "MARK_RECEIVED",
+      eventParams: { signedAt: new Date(), ...receivedInfo }
+    },
     context
   );
 }
@@ -124,6 +127,7 @@ export function markAsTempStored(
   const transformEventToFormParams = infos => ({
     temporaryStorageDetail: {
       update: {
+        tempStorerSignedAt: new Date(), // Default value to now
         ...Object.keys(infos).reduce((prev, cur) => {
           prev[`tempStorer${capitalize(cur)}`] = infos[cur];
           return prev;

--- a/back/src/forms/mutations/mark-as.ts
+++ b/back/src/forms/mutations/mark-as.ts
@@ -260,7 +260,7 @@ const fieldsToLog = {
     "quantity",
     "onuCode"
   ],
-  MARK_RECEIVED: ["receivedBy", "receivedAt", "quantityReceived"],
+  MARK_RECEIVED: ["receivedBy", "receivedAt", "acceptedAt", "quantityReceived"],
   MARK_PROCESSED: [
     "processedBy",
     "processedAt",
@@ -279,6 +279,7 @@ const fieldsToLog = {
   MARK_TEMP_STORED: [
     "receivedBy",
     "receivedAt",
+    "acceptedAt",
     "quantityReceived",
     "quantityType"
   ],

--- a/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
+++ b/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
@@ -7,7 +7,7 @@ const acceptedInfo = {
   wasteRefusalReason: "",
   receivedBy: "Jim",
   receivedAt: "2020-01-17T10:12:00+0100",
-  acceptedAt: "2020-01-17T10:12:00+0100"
+  signedAt: "2020-01-17T10:12:00+0100"
 };
 
 const receivedInfoSchema = getReceivedInfoSchema(Yup);

--- a/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
+++ b/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
@@ -6,7 +6,8 @@ const acceptedInfo = {
   quantityReceived: 12.5,
   wasteRefusalReason: "",
   receivedBy: "Jim",
-  receivedAt: "2020-01-17T10:12:00+0100"
+  receivedAt: "2020-01-17T10:12:00+0100",
+  acceptedAt: "2020-01-17T10:12:00+0100"
 };
 
 const receivedInfoSchema = getReceivedInfoSchema(Yup);

--- a/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
+++ b/back/src/forms/rules/__tests__/wasteReceptionValidator.test.ts
@@ -53,7 +53,8 @@ const refusedInfo = {
   quantityReceived: 0,
   wasteRefusalReason: "non conformity",
   receivedBy: "Joe",
-  receivedAt: "2020-01-17T10:12:00+0100"
+  receivedAt: "2020-01-17T10:12:00+0100",
+  signedAt: "2020-01-17T10:12:00+0100"
 };
 
 describe("waste is refused", () => {
@@ -93,7 +94,8 @@ const partiallyRefusedInfo = {
   quantityReceived: 11,
   wasteRefusalReason: "mixed waste",
   receivedBy: "Bill",
-  receivedAt: "2020-01-17T10:12:00+0100"
+  receivedAt: "2020-01-17T10:12:00+0100",
+  signedAt: "2020-01-17T10:12:00+0100"
 };
 describe("waste is partially accepted", () => {
   const { wasteAcceptationStatus, quantityReceived } = partiallyRefusedInfo;

--- a/back/src/forms/rules/schema.ts
+++ b/back/src/forms/rules/schema.ts
@@ -2,17 +2,17 @@ import { validDatetime, validCompany } from "./validation-helpers";
 import { inputRule } from "graphql-shield";
 import {
   PROCESSING_OPERATION_CODES,
-  GROUP_CODES
+  GROUP_CODES,
 } from "../../common/constants";
 import { number } from "yup";
 
-export const getReceivedInfoSchema = yup =>
+export const getReceivedInfoSchema = (yup) =>
   yup.object({
     wasteAcceptationStatus: yup
       .string()
       .required()
       .matches(/(ACCEPTED|REFUSED|PARTIALLY_REFUSED)/, {
-        message: "Vous devez préciser si vous acceptez ou non le déchet."
+        message: "Vous devez préciser si vous acceptez ou non le déchet.",
       }),
     receivedBy: yup
       .string()
@@ -20,27 +20,17 @@ export const getReceivedInfoSchema = yup =>
     receivedAt: validDatetime(
       {
         verboseFieldName: "date de réception",
-        required: true
+        required: true,
       },
       yup
     ),
-    acceptedAt: yup
-      .string()
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.test(
-              "is-not-set",
-              "Vous ne devez pas saisir de date d'acceptation du déchet lors d'un refus.",
-              v => !v
-            )
-          : validDatetime(
-              {
-                verboseFieldName: "date d'acceptation",
-                required: true
-              },
-              yup
-            )
-      ),
+    signedAt: validDatetime(
+      {
+        verboseFieldName: "date d'acceptation",
+        required: true,
+      },
+      yup
+    ),
 
     quantityReceived: yup
       .number()
@@ -51,7 +41,7 @@ export const getReceivedInfoSchema = yup =>
           ? schema.test(
               "is-zero",
               "Vous devez saisir une quantité reçue égale à 0.",
-              v => v === 0
+              (v) => v === 0
             )
           : schema
       )
@@ -61,7 +51,7 @@ export const getReceivedInfoSchema = yup =>
           ? schema.test(
               "is-strictly-positive",
               "Vous devez saisir une quantité reçue supérieure à 0.",
-              v => v > 0
+              (v) => v > 0
             )
           : schema
       ),
@@ -73,44 +63,44 @@ export const getReceivedInfoSchema = yup =>
           : schema.test(
               "is-empty",
               "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-              v => !v
+              (v) => !v
             )
-      )
+      ),
   });
 
 export const markAsSentSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
       sentInfo: yup.object({
         sentAt: validDatetime(
           {
             verboseFieldName: "date d'envoi",
-            required: true
+            required: true,
           },
           yup
         ),
         sentBy: yup
           .string()
-          .required("Vous devez saisir un responsable de l'envoi.")
-      })
+          .required("Vous devez saisir un responsable de l'envoi."),
+      }),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
 export const markAsReceivedSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
-      receivedInfo: getReceivedInfoSchema(yup)
+      receivedInfo: getReceivedInfoSchema(yup),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
 export const markAsProcessedSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
       processedInfo: yup.object({
         processingOperationDone: yup
@@ -128,36 +118,36 @@ export const markAsProcessedSchema = inputRule()(
         processedAt: validDatetime(
           {
             verboseFieldName: "date de traitement",
-            required: true
+            required: true,
           },
           yup
         ),
         nextDestination: yup.object().when("processingOperationDone", {
-          is: val => GROUP_CODES.includes(val),
+          is: (val) => GROUP_CODES.includes(val),
           then: yup.object({
             processingOperation: yup.string(),
             company: validCompany(
               { verboseFieldName: "Destination ultérieure prévue" },
               yup
-            )
-          })
+            ),
+          }),
         }),
-        noTraceability: yup.boolean().nullable(true)
-      })
+        noTraceability: yup.boolean().nullable(true),
+      }),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
 export const signedByTransporterSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
       signingInfo: yup.object({
         sentAt: validDatetime(
           {
             verboseFieldName: "date d'envoi",
-            required: true
+            required: true,
           },
           yup
         ),
@@ -186,26 +176,26 @@ export const signedByTransporterSchema = inputRule()(
         quantity: yup
           .number()
           .positive("Vous devez saisir une quantité envoyée supérieure à 0."),
-        onuCode: yup.string().nullable(true)
-      })
+        onuCode: yup.string().nullable(true),
+      }),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
 export const markAsTempStoredSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
-      tempStoredInfos: getReceivedInfoSchema(yup)
+      tempStoredInfos: getReceivedInfoSchema(yup),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
 export const markAsResealedSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
       resealedInfos: yup.object({
         wasteDetails: yup.object({}),
@@ -231,17 +221,17 @@ export const markAsResealedSchema = inputRule()(
             ),
           validityLimit: validDatetime(
             {
-              verboseFieldName: "date de validité"
+              verboseFieldName: "date de validité",
             },
             yup
           ),
           numberPlate: yup.string().nullable(true),
-          company: validCompany({ verboseFieldName: "Transporteur" }, yup)
-        })
-      })
+          company: validCompany({ verboseFieldName: "Transporteur" }, yup),
+        }),
+      }),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 
@@ -266,7 +256,7 @@ export const temporaryStorageDestinationSchema = inputRule()(yup =>
 );
 
 export const markAsResentSchema = inputRule()(
-  yup =>
+  (yup) =>
     yup.object().shape({
       resentInfos: yup.object({
         wasteDetails: yup.object({}),
@@ -292,12 +282,12 @@ export const markAsResentSchema = inputRule()(
             ),
           validityLimit: validDatetime(
             {
-              verboseFieldName: "date de validité"
+              verboseFieldName: "date de validité",
             },
             yup
           ),
           numberPlate: yup.string().nullable(true),
-          company: validCompany({ verboseFieldName: "Transporteur" }, yup)
+          company: validCompany({ verboseFieldName: "Transporteur" }, yup),
         }),
         signedBy: yup
           .string()
@@ -305,14 +295,14 @@ export const markAsResentSchema = inputRule()(
         signedAt: validDatetime(
           {
             verboseFieldName: "une date d'envoi",
-            required: true
+            required: true,
           },
           yup
-        )
-      })
+        ),
+      }),
     }),
   {
-    abortEarly: false
+    abortEarly: false,
   }
 );
 

--- a/back/src/forms/rules/schema.ts
+++ b/back/src/forms/rules/schema.ts
@@ -2,17 +2,17 @@ import { validDatetime, validCompany } from "./validation-helpers";
 import { inputRule } from "graphql-shield";
 import {
   PROCESSING_OPERATION_CODES,
-  GROUP_CODES,
+  GROUP_CODES
 } from "../../common/constants";
 import { number } from "yup";
 
-export const getReceivedInfoSchema = (yup) =>
+export const getReceivedInfoSchema = yup =>
   yup.object({
     wasteAcceptationStatus: yup
       .string()
       .required()
       .matches(/(ACCEPTED|REFUSED|PARTIALLY_REFUSED)/, {
-        message: "Vous devez préciser si vous acceptez ou non le déchet.",
+        message: "Vous devez préciser si vous acceptez ou non le déchet."
       }),
     receivedBy: yup
       .string()
@@ -20,14 +20,13 @@ export const getReceivedInfoSchema = (yup) =>
     receivedAt: validDatetime(
       {
         verboseFieldName: "date de réception",
-        required: true,
+        required: true
       },
       yup
     ),
     signedAt: validDatetime(
       {
-        verboseFieldName: "date d'acceptation",
-        required: true,
+        verboseFieldName: "date d'acceptation"
       },
       yup
     ),
@@ -41,7 +40,7 @@ export const getReceivedInfoSchema = (yup) =>
           ? schema.test(
               "is-zero",
               "Vous devez saisir une quantité reçue égale à 0.",
-              (v) => v === 0
+              v => v === 0
             )
           : schema
       )
@@ -51,7 +50,7 @@ export const getReceivedInfoSchema = (yup) =>
           ? schema.test(
               "is-strictly-positive",
               "Vous devez saisir une quantité reçue supérieure à 0.",
-              (v) => v > 0
+              v => v > 0
             )
           : schema
       ),
@@ -63,44 +62,44 @@ export const getReceivedInfoSchema = (yup) =>
           : schema.test(
               "is-empty",
               "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-              (v) => !v
+              v => !v
             )
-      ),
+      )
   });
 
 export const markAsSentSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
       sentInfo: yup.object({
         sentAt: validDatetime(
           {
             verboseFieldName: "date d'envoi",
-            required: true,
+            required: true
           },
           yup
         ),
         sentBy: yup
           .string()
-          .required("Vous devez saisir un responsable de l'envoi."),
-      }),
+          .required("Vous devez saisir un responsable de l'envoi.")
+      })
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const markAsReceivedSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
-      receivedInfo: getReceivedInfoSchema(yup),
+      receivedInfo: getReceivedInfoSchema(yup)
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const markAsProcessedSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
       processedInfo: yup.object({
         processingOperationDone: yup
@@ -118,36 +117,36 @@ export const markAsProcessedSchema = inputRule()(
         processedAt: validDatetime(
           {
             verboseFieldName: "date de traitement",
-            required: true,
+            required: true
           },
           yup
         ),
         nextDestination: yup.object().when("processingOperationDone", {
-          is: (val) => GROUP_CODES.includes(val),
+          is: val => GROUP_CODES.includes(val),
           then: yup.object({
             processingOperation: yup.string(),
             company: validCompany(
               { verboseFieldName: "Destination ultérieure prévue" },
               yup
-            ),
-          }),
+            )
+          })
         }),
-        noTraceability: yup.boolean().nullable(true),
-      }),
+        noTraceability: yup.boolean().nullable(true)
+      })
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const signedByTransporterSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
       signingInfo: yup.object({
         sentAt: validDatetime(
           {
             verboseFieldName: "date d'envoi",
-            required: true,
+            required: true
           },
           yup
         ),
@@ -176,26 +175,26 @@ export const signedByTransporterSchema = inputRule()(
         quantity: yup
           .number()
           .positive("Vous devez saisir une quantité envoyée supérieure à 0."),
-        onuCode: yup.string().nullable(true),
-      }),
+        onuCode: yup.string().nullable(true)
+      })
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const markAsTempStoredSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
-      tempStoredInfos: getReceivedInfoSchema(yup),
+      tempStoredInfos: getReceivedInfoSchema(yup)
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const markAsResealedSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
       resealedInfos: yup.object({
         wasteDetails: yup.object({}),
@@ -221,17 +220,17 @@ export const markAsResealedSchema = inputRule()(
             ),
           validityLimit: validDatetime(
             {
-              verboseFieldName: "date de validité",
+              verboseFieldName: "date de validité"
             },
             yup
           ),
           numberPlate: yup.string().nullable(true),
-          company: validCompany({ verboseFieldName: "Transporteur" }, yup),
-        }),
-      }),
+          company: validCompany({ verboseFieldName: "Transporteur" }, yup)
+        })
+      })
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
@@ -256,7 +255,7 @@ export const temporaryStorageDestinationSchema = inputRule()(yup =>
 );
 
 export const markAsResentSchema = inputRule()(
-  (yup) =>
+  yup =>
     yup.object().shape({
       resentInfos: yup.object({
         wasteDetails: yup.object({}),
@@ -282,12 +281,12 @@ export const markAsResentSchema = inputRule()(
             ),
           validityLimit: validDatetime(
             {
-              verboseFieldName: "date de validité",
+              verboseFieldName: "date de validité"
             },
             yup
           ),
           numberPlate: yup.string().nullable(true),
-          company: validCompany({ verboseFieldName: "Transporteur" }, yup),
+          company: validCompany({ verboseFieldName: "Transporteur" }, yup)
         }),
         signedBy: yup
           .string()
@@ -295,33 +294,23 @@ export const markAsResentSchema = inputRule()(
         signedAt: validDatetime(
           {
             verboseFieldName: "une date d'envoi",
-            required: true,
+            required: true
           },
           yup
-        ),
-      }),
+        )
+      })
     }),
   {
-    abortEarly: false,
+    abortEarly: false
   }
 );
 
 export const formsSchema = inputRule()(yup =>
   yup.object({
     siret: yup.string().nullable(),
-    first: yup
-      .number()
-      .lessThan(501)
-      .moreThan(0)
-      .nullable(),
-    skip: yup
-      .number()
-      .moreThan(0)
-      .nullable(),
-    status: yup
-      .array()
-      .of(yup.string())
-      .nullable(),
+    first: yup.number().lessThan(501).moreThan(0).nullable(),
+    skip: yup.number().moreThan(0).nullable(),
+    status: yup.array().of(yup.string()).nullable(),
     roles: yup
       .array()
       .of(

--- a/back/src/forms/workflow/__tests__/workflow.integration.ts
+++ b/back/src/forms/workflow/__tests__/workflow.integration.ts
@@ -276,6 +276,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
             wasteAcceptationStatus: ACCEPTED
             receivedBy: "Antoine Derieux"
             receivedAt: "2020-04-05T11:18:00"
+            acceptedAt: "2020-04-05T11:18:00"
             quantityReceived: 1
           }
         ){
@@ -364,6 +365,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
         updatedFields: {
           receivedBy: "Antoine Derieux",
           receivedAt: "2020-04-05T11:18:00",
+          acceptedAt: "2020-04-05T11:18:00",
           quantityReceived: 1
         }
       },

--- a/back/src/forms/workflow/__tests__/workflow.integration.ts
+++ b/back/src/forms/workflow/__tests__/workflow.integration.ts
@@ -751,6 +751,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
             wasteAcceptationStatus: ACCEPTED
             receivedBy: "Antoine Derieux"
             receivedAt: "2020-04-05T11:18:00"
+            signedAt: "2020-04-05T11:18:00"
             quantityReceived: 1
           }
         ){
@@ -838,6 +839,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
         updatedFields: {
           receivedBy: "Antoine Derieux",
           receivedAt: "2020-04-05T11:18:00",
+          signedAt: "2020-04-05T11:18:00",
           quantityReceived: 1
         }
       },

--- a/back/src/forms/workflow/__tests__/workflow.integration.ts
+++ b/back/src/forms/workflow/__tests__/workflow.integration.ts
@@ -832,7 +832,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
           processedBy: "Alfred Dujardin",
           processedAt: "2020-04-15T10:22:00",
           processingOperationDone: "D 10",
-          processingOperationDescription: "Incinération"
+          processingOperationDescription: "Incinération",
         }
       },
       {
@@ -862,6 +862,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
         updatedFields: {
           receivedBy: "Mr Provisoire",
           receivedAt: "2020-05-03T09:00:00",
+          signedAt: "2020-05-03T09:00:00",
           quantityReceived: 1,
           quantityType: "REAL"
         }

--- a/back/src/forms/workflow/__tests__/workflow.integration.ts
+++ b/back/src/forms/workflow/__tests__/workflow.integration.ts
@@ -638,6 +638,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
             wasteAcceptationStatus: ACCEPTED
             receivedBy: "Mr Provisoire",
             receivedAt: "2020-05-03T09:00:00"
+            signedAt: "2020-05-03T09:00:00"
             quantityReceived: 1
             quantityType: REAL
           }) {

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1163,7 +1163,7 @@ export type ReceivedFormInput = {
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
   /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt: Scalars['DateTime'];
+  acceptedAt?: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
 };
@@ -1409,7 +1409,7 @@ export type TempStoredFormInput = {
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
   /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt: Scalars['DateTime'];
+  acceptedAt?: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
   /** Réelle ou estimée */

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -229,7 +229,7 @@ export type CompanyStat = {
 };
 
 /** Profil entreprise */
-export type CompanyType =
+export type CompanyType = 
   /** Producteur de déchet */
   'PRODUCER' |
   /** Installation de Transit, regroupement ou tri de déchets */
@@ -246,7 +246,7 @@ export type CompanyType =
   'TRADER';
 
 /** Consistance du déchet */
-export type Consistence =
+export type Consistence = 
   /** Solide */
   'SOLID' |
   /** Liquide */
@@ -373,7 +373,7 @@ export type EmitterInput = {
 };
 
 /** Types d'émetteur de déchet (choix multiple de la case 1) */
-export type EmitterType =
+export type EmitterType = 
   /** Producetur de déchet */
   'PRODUCER' |
   /** Autre détenteur */
@@ -384,7 +384,7 @@ export type EmitterType =
   'APPENDIX2';
 
 /** Type d'établissement favoris */
-export type FavoriteType =
+export type FavoriteType = 
   'EMITTER' |
   'TRANSPORTER' |
   'RECIPIENT' |
@@ -526,7 +526,7 @@ export type FormInput = {
   temporaryStorageDetail?: Maybe<TemporaryStorageDetailInput>;
 };
 
-export type FormRole =
+export type FormRole = 
   /** Les BSD's dont je suis transporteur */
   'TRANSPORTER' |
   /** Les BSD's dont je suis la destination de traitement */
@@ -556,14 +556,14 @@ export type FormsLifeCycleData = {
 };
 
 /** Type pour l'export du registre */
-export type FormsRegisterExportType =
+export type FormsRegisterExportType = 
   /** Déchets entrants */
   'INCOMING' |
   /** Déchets sortants */
   'OUTGOING';
 
 /** Différents statuts d'un BSD au cours de son cycle de vie */
-export type FormStatus =
+export type FormStatus = 
   /**
    * BSD à l'état de brouillon
    * Des champs obligatoires peuvent manquer
@@ -597,7 +597,7 @@ export type FormStatus =
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
- *
+ * 
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
@@ -613,14 +613,14 @@ export type FormSubscription = {
 };
 
 /** Valeur possibles pour le filtre de la query `forms` */
-export type FormType =
+export type FormType = 
   /** DEPRECATED - Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut) */
   'ACTOR' |
   /** Uniquement les BSD's dont je suis transporteur */
   'TRANSPORTER';
 
 /** Type d'une déclaration GEREP */
-export type GerepType =
+export type GerepType = 
   'Producteur' |
   'Traiteur';
 
@@ -702,7 +702,7 @@ export type Mutation = {
   /**
    * DEPRECATED - La récupération de token pour le compte de tiers
    * doit s'effectuer avec le protocole OAuth2
-   *
+   * 
    * Récupére un token à partir de l'email et du mot de passe
    * d'un utilisateur.
    */
@@ -975,7 +975,7 @@ export type NextDestinationInput = {
 };
 
 /** Type de packaging du déchet */
-export type Packagings =
+export type Packagings = 
   /** Fut */
   'FUT' |
   /** GRV */
@@ -1027,7 +1027,7 @@ export type ProcessedFormInput = {
 };
 
 /** Type de quantité lors de l'émission */
-export type QuantityType =
+export type QuantityType = 
   /** Quntité réelle */
   'REAL' |
   /** Quantité estimée */
@@ -1221,7 +1221,7 @@ export type ResentFormInput = {
   transporter?: Maybe<TransporterInput>;
   /** Nom du signataire du BSD suite  (case 19) */
   signedBy?: Maybe<Scalars['String']>;
-  /** Date de signature du BSD suite (case 19) */
+  /** Date de signature du BSD suite (case 19). Défaut à la date d'aujourd'hui. */
   signedAt?: Maybe<Scalars['DateTime']>;
 };
 
@@ -1294,7 +1294,7 @@ export type Stat = {
  * - le bordereau peut naviguer entre plusieurs entreprises.
  * - quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
  * - si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
- *
+ * 
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
@@ -1356,7 +1356,7 @@ export type Subscription = {
    __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
-   *
+   * 
    * Permet de s'abonner aux changements de statuts d'un BSD
    */
   forms?: Maybe<FormSubscription>;
@@ -1410,7 +1410,7 @@ export type TempStoredFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 13) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté ou refusé (case 13) */
+  /** Date à laquelle le déchet a été accepté ou refusé (case 13). Défaut à la date d'aujourd'hui. */
   signedAt?: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 13) */
   quantityReceived: Scalars['Float'];
@@ -1573,24 +1573,24 @@ export type User = {
 /**
  * Liste les différents rôles d'un utilisateur au sein
  * d'un établissement.
- *
+ * 
  * Les admins peuvent:
  * * consulter/éditer les bordereaux
  * * gérer les utilisateurs de l'établissement
  * * éditer les informations de la fiche entreprise
  * * demander le renouvellement du code de sécurité
  * * Éditer les informations de la fiche entreprise
- *
+ * 
  * Les membres peuvent:
  * * consulter/éditer les bordereaux
  * * consulter le reste des informations
  */
-export type UserRole =
+export type UserRole = 
   'MEMBER' |
   'ADMIN';
 
 /** Statut d'acceptation d'un déchet */
-export type WasteAcceptationStatusInput =
+export type WasteAcceptationStatusInput = 
   /** Accepté en totalité */
   'ACCEPTED' |
   /** Refusé */
@@ -1644,7 +1644,7 @@ export type WasteDetailsInput = {
 };
 
 /** Type de déchets autorisé pour une rubrique */
-export type WasteType =
+export type WasteType = 
   /** Déchet inerte */
   'INERTE' |
   /** Déchet non dangereux */

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -229,7 +229,7 @@ export type CompanyStat = {
 };
 
 /** Profil entreprise */
-export type CompanyType = 
+export type CompanyType =
   /** Producteur de déchet */
   'PRODUCER' |
   /** Installation de Transit, regroupement ou tri de déchets */
@@ -246,7 +246,7 @@ export type CompanyType =
   'TRADER';
 
 /** Consistance du déchet */
-export type Consistence = 
+export type Consistence =
   /** Solide */
   'SOLID' |
   /** Liquide */
@@ -373,7 +373,7 @@ export type EmitterInput = {
 };
 
 /** Types d'émetteur de déchet (choix multiple de la case 1) */
-export type EmitterType = 
+export type EmitterType =
   /** Producetur de déchet */
   'PRODUCER' |
   /** Autre détenteur */
@@ -384,7 +384,7 @@ export type EmitterType =
   'APPENDIX2';
 
 /** Type d'établissement favoris */
-export type FavoriteType = 
+export type FavoriteType =
   'EMITTER' |
   'TRANSPORTER' |
   'RECIPIENT' |
@@ -452,6 +452,8 @@ export type Form = {
   receivedBy?: Maybe<Scalars['String']>;
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt?: Maybe<Scalars['DateTime']>;
+  /** Date à laquelle le déchet a été accepté ou refusé (case 10) */
+  signedAt?: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived?: Maybe<Scalars['Float']>;
   /**
@@ -524,7 +526,7 @@ export type FormInput = {
   temporaryStorageDetail?: Maybe<TemporaryStorageDetailInput>;
 };
 
-export type FormRole = 
+export type FormRole =
   /** Les BSD's dont je suis transporteur */
   'TRANSPORTER' |
   /** Les BSD's dont je suis la destination de traitement */
@@ -554,14 +556,14 @@ export type FormsLifeCycleData = {
 };
 
 /** Type pour l'export du registre */
-export type FormsRegisterExportType = 
+export type FormsRegisterExportType =
   /** Déchets entrants */
   'INCOMING' |
   /** Déchets sortants */
   'OUTGOING';
 
 /** Différents statuts d'un BSD au cours de son cycle de vie */
-export type FormStatus = 
+export type FormStatus =
   /**
    * BSD à l'état de brouillon
    * Des champs obligatoires peuvent manquer
@@ -595,7 +597,7 @@ export type FormStatus =
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
- * 
+ *
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
@@ -611,14 +613,14 @@ export type FormSubscription = {
 };
 
 /** Valeur possibles pour le filtre de la query `forms` */
-export type FormType = 
+export type FormType =
   /** DEPRECATED - Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut) */
   'ACTOR' |
   /** Uniquement les BSD's dont je suis transporteur */
   'TRANSPORTER';
 
 /** Type d'une déclaration GEREP */
-export type GerepType = 
+export type GerepType =
   'Producteur' |
   'Traiteur';
 
@@ -700,7 +702,7 @@ export type Mutation = {
   /**
    * DEPRECATED - La récupération de token pour le compte de tiers
    * doit s'effectuer avec le protocole OAuth2
-   * 
+   *
    * Récupére un token à partir de l'email et du mot de passe
    * d'un utilisateur.
    */
@@ -973,7 +975,7 @@ export type NextDestinationInput = {
 };
 
 /** Type de packaging du déchet */
-export type Packagings = 
+export type Packagings =
   /** Fut */
   'FUT' |
   /** GRV */
@@ -1025,7 +1027,7 @@ export type ProcessedFormInput = {
 };
 
 /** Type de quantité lors de l'émission */
-export type QuantityType = 
+export type QuantityType =
   /** Quntité réelle */
   'REAL' |
   /** Quantité estimée */
@@ -1162,8 +1164,8 @@ export type ReceivedFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt?: Maybe<Scalars['DateTime']>;
+  /** Date à laquelle le déchet a été accepté ou refusé (case 10) */
+  signedAt?: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
 };
@@ -1292,7 +1294,7 @@ export type Stat = {
  * - le bordereau peut naviguer entre plusieurs entreprises.
  * - quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
  * - si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
- * 
+ *
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
@@ -1354,7 +1356,7 @@ export type Subscription = {
    __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
-   * 
+   *
    * Permet de s'abonner aux changements de statuts d'un BSD
    */
   forms?: Maybe<FormSubscription>;
@@ -1400,17 +1402,17 @@ export type TemporaryStorer = {
 };
 
 export type TempStoredFormInput = {
-  /** Statut d'acceptation du déchet (case 10) */
+  /** Statut d'acceptation du déchet (case 13) */
   wasteAcceptationStatus: WasteAcceptationStatusInput;
-  /** Raison du refus (case 10) */
+  /** Raison du refus (case 13) */
   wasteRefusalReason?: Maybe<Scalars['String']>;
-  /** Nom de la personne en charge de la réception du déchet (case 10) */
+  /** Nom de la personne en charge de la réception du déchet (case 13) */
   receivedBy: Scalars['String'];
-  /** Date à laquelle le déchet a été reçu (case 10) */
+  /** Date à laquelle le déchet a été reçu (case 13) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt?: Maybe<Scalars['DateTime']>;
-  /** Quantité réelle présentée (case 10) */
+  /** Date à laquelle le déchet a été accepté ou refusé (case 13) */
+  signedAt?: Maybe<Scalars['DateTime']>;
+  /** Quantité réelle présentée (case 13) */
   quantityReceived: Scalars['Float'];
   /** Réelle ou estimée */
   quantityType: QuantityType;
@@ -1571,24 +1573,24 @@ export type User = {
 /**
  * Liste les différents rôles d'un utilisateur au sein
  * d'un établissement.
- * 
+ *
  * Les admins peuvent:
  * * consulter/éditer les bordereaux
  * * gérer les utilisateurs de l'établissement
  * * éditer les informations de la fiche entreprise
  * * demander le renouvellement du code de sécurité
  * * Éditer les informations de la fiche entreprise
- * 
+ *
  * Les membres peuvent:
  * * consulter/éditer les bordereaux
  * * consulter le reste des informations
  */
-export type UserRole = 
+export type UserRole =
   'MEMBER' |
   'ADMIN';
 
 /** Statut d'acceptation d'un déchet */
-export type WasteAcceptationStatusInput = 
+export type WasteAcceptationStatusInput =
   /** Accepté en totalité */
   'ACCEPTED' |
   /** Refusé */
@@ -1642,7 +1644,7 @@ export type WasteDetailsInput = {
 };
 
 /** Type de déchets autorisé pour une rubrique */
-export type WasteType = 
+export type WasteType =
   /** Déchet inerte */
   'INERTE' |
   /** Déchet non dangereux */
@@ -2077,6 +2079,7 @@ export type FormResolvers<ContextType = GraphQLContext, ParentType extends Resol
   wasteRefusalReason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receivedBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   receivedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  signedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   quantityReceived?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   actualQuantity?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   processingOperationDone?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1162,6 +1162,8 @@ export type ReceivedFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
+  /** Date à laquelle le déchet a été accepté (case 10) */
+  acceptedAt: Scalars['DateTime'];
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
 };
@@ -1406,6 +1408,8 @@ export type TempStoredFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
+  /** Date à laquelle le déchet a été accepté (case 10) */
+  acceptedAt: Scalars['DateTime'];
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
   /** Réelle ou estimée */

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -893,6 +893,8 @@ export type FormOrderByInput =
   | "receivedBy_DESC"
   | "receivedAt_ASC"
   | "receivedAt_DESC"
+  | "acceptedAt_ASC"
+  | "acceptedAt_DESC"
   | "quantityReceived_ASC"
   | "quantityReceived_DESC"
   | "processedBy_ASC"
@@ -1039,6 +1041,8 @@ export type TemporaryStorageDetailOrderByInput =
   | "tempStorerReceivedAt_DESC"
   | "tempStorerReceivedBy_ASC"
   | "tempStorerReceivedBy_DESC"
+  | "tempStorerAccepteddAt_ASC"
+  | "tempStorerAccepteddAt_DESC"
   | "tempStorerSignedAt_ASC"
   | "tempStorerSignedAt_DESC"
   | "destinationIsFilledByEmitter_ASC"
@@ -1417,6 +1421,7 @@ export interface TemporaryStorageDetailUpdateWithoutFormDataInput {
   tempStorerWasteRefusalReason?: Maybe<String>;
   tempStorerReceivedAt?: Maybe<DateTimeInput>;
   tempStorerReceivedBy?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   destinationIsFilledByEmitter?: Maybe<Boolean>;
   destinationCompanyName?: Maybe<String>;
@@ -1512,6 +1517,7 @@ export interface FormUpdateDataInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -1938,6 +1944,7 @@ export interface FormUpdateInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -2023,6 +2030,7 @@ export interface TemporaryStorageDetailCreateWithoutFormInput {
   tempStorerWasteRefusalReason?: Maybe<String>;
   tempStorerReceivedAt?: Maybe<DateTimeInput>;
   tempStorerReceivedBy?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   destinationIsFilledByEmitter?: Maybe<Boolean>;
   destinationCompanyName?: Maybe<String>;
@@ -2158,6 +2166,14 @@ export interface TemporaryStorageDetailWhereInput {
   tempStorerReceivedBy_not_starts_with?: Maybe<String>;
   tempStorerReceivedBy_ends_with?: Maybe<String>;
   tempStorerReceivedBy_not_ends_with?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
+  tempStorerAccepteddAt_not?: Maybe<DateTimeInput>;
+  tempStorerAccepteddAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  tempStorerAccepteddAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  tempStorerAccepteddAt_lt?: Maybe<DateTimeInput>;
+  tempStorerAccepteddAt_lte?: Maybe<DateTimeInput>;
+  tempStorerAccepteddAt_gt?: Maybe<DateTimeInput>;
+  tempStorerAccepteddAt_gte?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt_not?: Maybe<DateTimeInput>;
   tempStorerSignedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
@@ -2660,6 +2676,7 @@ export interface TemporaryStorageDetailUpdateInput {
   tempStorerWasteRefusalReason?: Maybe<String>;
   tempStorerReceivedAt?: Maybe<DateTimeInput>;
   tempStorerReceivedBy?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   destinationIsFilledByEmitter?: Maybe<Boolean>;
   destinationCompanyName?: Maybe<String>;
@@ -3317,6 +3334,7 @@ export interface FormUpdateManyMutationInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -3402,6 +3420,7 @@ export interface FormUpdateManyDataInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -3621,6 +3640,14 @@ export interface FormScalarWhereInput {
   receivedAt_lte?: Maybe<DateTimeInput>;
   receivedAt_gt?: Maybe<DateTimeInput>;
   receivedAt_gte?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
+  acceptedAt_not?: Maybe<DateTimeInput>;
+  acceptedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  acceptedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  acceptedAt_lt?: Maybe<DateTimeInput>;
+  acceptedAt_lte?: Maybe<DateTimeInput>;
+  acceptedAt_gt?: Maybe<DateTimeInput>;
+  acceptedAt_gte?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   quantityReceived_not?: Maybe<Float>;
   quantityReceived_in?: Maybe<Float[] | Float>;
@@ -4867,6 +4894,14 @@ export interface FormWhereInput {
   receivedAt_lte?: Maybe<DateTimeInput>;
   receivedAt_gt?: Maybe<DateTimeInput>;
   receivedAt_gte?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
+  acceptedAt_not?: Maybe<DateTimeInput>;
+  acceptedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  acceptedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  acceptedAt_lt?: Maybe<DateTimeInput>;
+  acceptedAt_lte?: Maybe<DateTimeInput>;
+  acceptedAt_gt?: Maybe<DateTimeInput>;
+  acceptedAt_gte?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   quantityReceived_not?: Maybe<Float>;
   quantityReceived_in?: Maybe<Float[] | Float>;
@@ -5715,6 +5750,7 @@ export interface FormCreateInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -5801,6 +5837,7 @@ export interface FormUpdateWithoutTemporaryStorageDetailDataInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -5891,6 +5928,7 @@ export interface FormCreateWithoutTemporaryStorageDetailInput {
   wasteRefusalReason?: Maybe<String>;
   receivedBy?: Maybe<String>;
   receivedAt?: Maybe<DateTimeInput>;
+  acceptedAt?: Maybe<DateTimeInput>;
   quantityReceived?: Maybe<Float>;
   processedBy?: Maybe<String>;
   processedAt?: Maybe<String>;
@@ -5973,6 +6011,7 @@ export interface TemporaryStorageDetailCreateInput {
   tempStorerWasteRefusalReason?: Maybe<String>;
   tempStorerReceivedAt?: Maybe<DateTimeInput>;
   tempStorerReceivedBy?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   destinationIsFilledByEmitter?: Maybe<Boolean>;
   destinationCompanyName?: Maybe<String>;
@@ -6898,6 +6937,7 @@ export interface TemporaryStorageDetailUpdateManyMutationInput {
   tempStorerWasteRefusalReason?: Maybe<String>;
   tempStorerReceivedAt?: Maybe<DateTimeInput>;
   tempStorerReceivedBy?: Maybe<String>;
+  tempStorerAccepteddAt?: Maybe<DateTimeInput>;
   tempStorerSignedAt?: Maybe<DateTimeInput>;
   destinationIsFilledByEmitter?: Maybe<Boolean>;
   destinationCompanyName?: Maybe<String>;
@@ -7336,6 +7376,7 @@ export interface Form {
   wasteRefusalReason?: String;
   receivedBy?: String;
   receivedAt?: DateTimeOutput;
+  acceptedAt?: DateTimeOutput;
   quantityReceived?: Float;
   processedBy?: String;
   processedAt?: String;
@@ -7420,6 +7461,7 @@ export interface FormPromise extends Promise<Form>, Fragmentable {
   wasteRefusalReason: () => Promise<String>;
   receivedBy: () => Promise<String>;
   receivedAt: () => Promise<DateTimeOutput>;
+  acceptedAt: () => Promise<DateTimeOutput>;
   quantityReceived: () => Promise<Float>;
   processedBy: () => Promise<String>;
   processedAt: () => Promise<String>;
@@ -7517,6 +7559,7 @@ export interface FormSubscription
   wasteRefusalReason: () => Promise<AsyncIterator<String>>;
   receivedBy: () => Promise<AsyncIterator<String>>;
   receivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  acceptedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   quantityReceived: () => Promise<AsyncIterator<Float>>;
   processedBy: () => Promise<AsyncIterator<String>>;
   processedAt: () => Promise<AsyncIterator<String>>;
@@ -7614,6 +7657,7 @@ export interface FormNullablePromise
   wasteRefusalReason: () => Promise<String>;
   receivedBy: () => Promise<String>;
   receivedAt: () => Promise<DateTimeOutput>;
+  acceptedAt: () => Promise<DateTimeOutput>;
   quantityReceived: () => Promise<Float>;
   processedBy: () => Promise<String>;
   processedAt: () => Promise<String>;
@@ -8818,6 +8862,7 @@ export interface TemporaryStorageDetail {
   tempStorerWasteRefusalReason?: String;
   tempStorerReceivedAt?: DateTimeOutput;
   tempStorerReceivedBy?: String;
+  tempStorerAccepteddAt?: DateTimeOutput;
   tempStorerSignedAt?: DateTimeOutput;
   destinationIsFilledByEmitter?: Boolean;
   destinationCompanyName?: String;
@@ -8861,6 +8906,7 @@ export interface TemporaryStorageDetailPromise
   tempStorerWasteRefusalReason: () => Promise<String>;
   tempStorerReceivedAt: () => Promise<DateTimeOutput>;
   tempStorerReceivedBy: () => Promise<String>;
+  tempStorerAccepteddAt: () => Promise<DateTimeOutput>;
   tempStorerSignedAt: () => Promise<DateTimeOutput>;
   destinationIsFilledByEmitter: () => Promise<Boolean>;
   destinationCompanyName: () => Promise<String>;
@@ -8906,6 +8952,7 @@ export interface TemporaryStorageDetailSubscription
   tempStorerWasteRefusalReason: () => Promise<AsyncIterator<String>>;
   tempStorerReceivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   tempStorerReceivedBy: () => Promise<AsyncIterator<String>>;
+  tempStorerAccepteddAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   tempStorerSignedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   destinationIsFilledByEmitter: () => Promise<AsyncIterator<Boolean>>;
   destinationCompanyName: () => Promise<AsyncIterator<String>>;
@@ -8949,6 +8996,7 @@ export interface TemporaryStorageDetailNullablePromise
   tempStorerWasteRefusalReason: () => Promise<String>;
   tempStorerReceivedAt: () => Promise<DateTimeOutput>;
   tempStorerReceivedBy: () => Promise<String>;
+  tempStorerAccepteddAt: () => Promise<DateTimeOutput>;
   tempStorerSignedAt: () => Promise<DateTimeOutput>;
   destinationIsFilledByEmitter: () => Promise<Boolean>;
   destinationCompanyName: () => Promise<String>;
@@ -9047,6 +9095,7 @@ export interface FormPreviousValues {
   wasteRefusalReason?: String;
   receivedBy?: String;
   receivedAt?: DateTimeOutput;
+  acceptedAt?: DateTimeOutput;
   quantityReceived?: Float;
   processedBy?: String;
   processedAt?: String;
@@ -9132,6 +9181,7 @@ export interface FormPreviousValuesPromise
   wasteRefusalReason: () => Promise<String>;
   receivedBy: () => Promise<String>;
   receivedAt: () => Promise<DateTimeOutput>;
+  acceptedAt: () => Promise<DateTimeOutput>;
   quantityReceived: () => Promise<Float>;
   processedBy: () => Promise<String>;
   processedAt: () => Promise<String>;
@@ -9217,6 +9267,7 @@ export interface FormPreviousValuesSubscription
   wasteRefusalReason: () => Promise<AsyncIterator<String>>;
   receivedBy: () => Promise<AsyncIterator<String>>;
   receivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  acceptedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   quantityReceived: () => Promise<AsyncIterator<Float>>;
   processedBy: () => Promise<AsyncIterator<String>>;
   processedAt: () => Promise<AsyncIterator<String>>;
@@ -10027,6 +10078,7 @@ export interface TemporaryStorageDetailPreviousValues {
   tempStorerWasteRefusalReason?: String;
   tempStorerReceivedAt?: DateTimeOutput;
   tempStorerReceivedBy?: String;
+  tempStorerAccepteddAt?: DateTimeOutput;
   tempStorerSignedAt?: DateTimeOutput;
   destinationIsFilledByEmitter?: Boolean;
   destinationCompanyName?: String;
@@ -10069,6 +10121,7 @@ export interface TemporaryStorageDetailPreviousValuesPromise
   tempStorerWasteRefusalReason: () => Promise<String>;
   tempStorerReceivedAt: () => Promise<DateTimeOutput>;
   tempStorerReceivedBy: () => Promise<String>;
+  tempStorerAccepteddAt: () => Promise<DateTimeOutput>;
   tempStorerSignedAt: () => Promise<DateTimeOutput>;
   destinationIsFilledByEmitter: () => Promise<Boolean>;
   destinationCompanyName: () => Promise<String>;
@@ -10113,6 +10166,7 @@ export interface TemporaryStorageDetailPreviousValuesSubscription
   tempStorerWasteRefusalReason: () => Promise<AsyncIterator<String>>;
   tempStorerReceivedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   tempStorerReceivedBy: () => Promise<AsyncIterator<String>>;
+  tempStorerAccepteddAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   tempStorerSignedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   destinationIsFilledByEmitter: () => Promise<AsyncIterator<Boolean>>;
   destinationCompanyName: () => Promise<AsyncIterator<String>>;

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -1361,6 +1361,7 @@ type Form {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -1452,6 +1453,7 @@ input FormCreateInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -1552,6 +1554,7 @@ input FormCreateWithoutTemporaryStorageDetailInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -1657,6 +1660,8 @@ enum FormOrderByInput {
   receivedBy_DESC
   receivedAt_ASC
   receivedAt_DESC
+  acceptedAt_ASC
+  acceptedAt_DESC
   quantityReceived_ASC
   quantityReceived_DESC
   processedBy_ASC
@@ -1805,6 +1810,7 @@ type FormPreviousValues {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -2013,6 +2019,14 @@ input FormScalarWhereInput {
   receivedAt_lte: DateTime
   receivedAt_gt: DateTime
   receivedAt_gte: DateTime
+  acceptedAt: DateTime
+  acceptedAt_not: DateTime
+  acceptedAt_in: [DateTime!]
+  acceptedAt_not_in: [DateTime!]
+  acceptedAt_lt: DateTime
+  acceptedAt_lte: DateTime
+  acceptedAt_gt: DateTime
+  acceptedAt_gte: DateTime
   quantityReceived: Float
   quantityReceived_not: Float
   quantityReceived_in: [Float!]
@@ -2850,6 +2864,7 @@ input FormUpdateDataInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -2934,6 +2949,7 @@ input FormUpdateInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -3017,6 +3033,7 @@ input FormUpdateManyDataInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -3109,6 +3126,7 @@ input FormUpdateManyMutationInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -3211,6 +3229,7 @@ input FormUpdateWithoutTemporaryStorageDetailDataInput {
   wasteRefusalReason: String
   receivedBy: String
   receivedAt: DateTime
+  acceptedAt: DateTime
   quantityReceived: Float
   processedBy: String
   processedAt: String
@@ -3443,6 +3462,14 @@ input FormWhereInput {
   receivedAt_lte: DateTime
   receivedAt_gt: DateTime
   receivedAt_gte: DateTime
+  acceptedAt: DateTime
+  acceptedAt_not: DateTime
+  acceptedAt_in: [DateTime!]
+  acceptedAt_not_in: [DateTime!]
+  acceptedAt_lt: DateTime
+  acceptedAt_lte: DateTime
+  acceptedAt_gt: DateTime
+  acceptedAt_gte: DateTime
   quantityReceived: Float
   quantityReceived_not: Float
   quantityReceived_in: [Float!]
@@ -5397,6 +5424,7 @@ type TemporaryStorageDetail {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5444,6 +5472,7 @@ input TemporaryStorageDetailCreateInput {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5489,6 +5518,7 @@ input TemporaryStorageDetailCreateWithoutFormInput {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5541,6 +5571,8 @@ enum TemporaryStorageDetailOrderByInput {
   tempStorerReceivedAt_DESC
   tempStorerReceivedBy_ASC
   tempStorerReceivedBy_DESC
+  tempStorerAccepteddAt_ASC
+  tempStorerAccepteddAt_DESC
   tempStorerSignedAt_ASC
   tempStorerSignedAt_DESC
   destinationIsFilledByEmitter_ASC
@@ -5611,6 +5643,7 @@ type TemporaryStorageDetailPreviousValues {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5669,6 +5702,7 @@ input TemporaryStorageDetailUpdateInput {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5708,6 +5742,7 @@ input TemporaryStorageDetailUpdateManyMutationInput {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5756,6 +5791,7 @@ input TemporaryStorageDetailUpdateWithoutFormDataInput {
   tempStorerWasteRefusalReason: String
   tempStorerReceivedAt: DateTime
   tempStorerReceivedBy: String
+  tempStorerAccepteddAt: DateTime
   tempStorerSignedAt: DateTime
   destinationIsFilledByEmitter: Boolean
   destinationCompanyName: String
@@ -5861,6 +5897,14 @@ input TemporaryStorageDetailWhereInput {
   tempStorerReceivedBy_not_starts_with: String
   tempStorerReceivedBy_ends_with: String
   tempStorerReceivedBy_not_ends_with: String
+  tempStorerAccepteddAt: DateTime
+  tempStorerAccepteddAt_not: DateTime
+  tempStorerAccepteddAt_in: [DateTime!]
+  tempStorerAccepteddAt_not_in: [DateTime!]
+  tempStorerAccepteddAt_lt: DateTime
+  tempStorerAccepteddAt_lte: DateTime
+  tempStorerAccepteddAt_gt: DateTime
+  tempStorerAccepteddAt_gte: DateTime
   tempStorerSignedAt: DateTime
   tempStorerSignedAt_not: DateTime
   tempStorerSignedAt_in: [DateTime!]

--- a/back/src/subscriptions/__tests__/rejected-form.test.ts
+++ b/back/src/subscriptions/__tests__/rejected-form.test.ts
@@ -58,6 +58,7 @@ const mockedForm = {
   traderDepartment: "",
   recipientCompanyContact: "jean",
   receivedAt: "2019-10-16T00:00:00.000Z",
+  acceptedAt: "2019-10-16T00:00:00.000Z",
   transporterIsExemptedOfReceipt: false,
   sentAt: "2019-10-16T00:00:00.000Z",
   traderCompanySiret: "",

--- a/back/src/subscriptions/__tests__/rejected-form.test.ts
+++ b/back/src/subscriptions/__tests__/rejected-form.test.ts
@@ -58,7 +58,7 @@ const mockedForm = {
   traderDepartment: "",
   recipientCompanyContact: "jean",
   receivedAt: "2019-10-16T00:00:00.000Z",
-  acceptedAt: "2019-10-16T00:00:00.000Z",
+  signedAt: "2019-10-16T00:00:00.000Z",
   transporterIsExemptedOfReceipt: false,
   sentAt: "2019-10-16T00:00:00.000Z",
   traderCompanySiret: "",

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -4401,6 +4401,15 @@ Date à laquelle le déchet a été reçu (case 10)
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>acceptedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td>
+
+Date à laquelle le déchet a été accepté (case 10)
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>quantityReceived</strong></td>
 <td valign="top"><a href="#float">Float</a>!</td>
 <td>
@@ -4697,6 +4706,15 @@ Nom de la personne en charge de la réception du déchet (case 10)
 <td>
 
 Date à laquelle le déchet a été reçu (case 10)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>acceptedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td>
+
+Date à laquelle le déchet a été accepté (case 10)
 
 </td>
 </tr>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -4580,7 +4580,7 @@ Nom du signataire du BSD suite  (case 19)
 <td valign="top"><a href="#datetime">DateTime</a></td>
 <td>
 
-Date de signature du BSD suite (case 19)
+Date de signature du BSD suite (case 19). Défaut à la date d'aujourd'hui.
 
 </td>
 </tr>
@@ -4723,7 +4723,7 @@ Date à laquelle le déchet a été reçu (case 13)
 <td valign="top"><a href="#datetime">DateTime</a></td>
 <td>
 
-Date à laquelle le déchet a été accepté ou refusé (case 13)
+Date à laquelle le déchet a été accepté ou refusé (case 13). Défaut à la date d'aujourd'hui.
 
 </td>
 </tr>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2264,6 +2264,15 @@ Date à laquelle le déchet a été reçu (case 10)
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>signedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td>
+
+Date à laquelle le déchet a été accepté ou refusé (case 10)
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>quantityReceived</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
@@ -4401,11 +4410,11 @@ Date à laquelle le déchet a été reçu (case 10)
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>acceptedAt</strong></td>
-<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td colspan="2" valign="top"><strong>signedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
 <td>
 
-Date à laquelle le déchet a été accepté (case 10)
+Date à laquelle le déchet a été accepté ou refusé (case 10)
 
 </td>
 </tr>
@@ -4678,7 +4687,7 @@ Numéro de téléphone de l'utilisateur
 <td valign="top"><a href="#wasteacceptationstatusinput">WasteAcceptationStatusInput</a>!</td>
 <td>
 
-Statut d'acceptation du déchet (case 10)
+Statut d'acceptation du déchet (case 13)
 
 </td>
 </tr>
@@ -4687,7 +4696,7 @@ Statut d'acceptation du déchet (case 10)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Raison du refus (case 10)
+Raison du refus (case 13)
 
 </td>
 </tr>
@@ -4696,7 +4705,7 @@ Raison du refus (case 10)
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-Nom de la personne en charge de la réception du déchet (case 10)
+Nom de la personne en charge de la réception du déchet (case 13)
 
 </td>
 </tr>
@@ -4705,16 +4714,16 @@ Nom de la personne en charge de la réception du déchet (case 10)
 <td valign="top"><a href="#datetime">DateTime</a>!</td>
 <td>
 
-Date à laquelle le déchet a été reçu (case 10)
+Date à laquelle le déchet a été reçu (case 13)
 
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>acceptedAt</strong></td>
-<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td colspan="2" valign="top"><strong>signedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
 <td>
 
-Date à laquelle le déchet a été accepté (case 10)
+Date à laquelle le déchet a été accepté ou refusé (case 13)
 
 </td>
 </tr>
@@ -4723,7 +4732,7 @@ Date à laquelle le déchet a été accepté (case 10)
 <td valign="top"><a href="#float">Float</a>!</td>
 <td>
 
-Quantité réelle présentée (case 10)
+Quantité réelle présentée (case 13)
 
 </td>
 </tr>

--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -39,6 +39,7 @@ export default function Received(props: SlipActionProps) {
         initialValues={{
           receivedBy: "",
           receivedAt: DateTime.local().toISODate(),
+          acceptedAt: DateTime.local().toISODate(),
           quantityReceived: "",
           wasteAcceptationStatus: "",
           wasteRefusalReason: "",
@@ -53,6 +54,12 @@ export default function Received(props: SlipActionProps) {
 
           return (
             <Form>
+              <label>
+                Date d'arrivée
+                <Field component={DateInput} name="receivedAt" />
+                <FieldError fieldError={errors.receivedAt} />
+              </label>
+
               <div className="form__group">
                 <fieldset>
                   <div style={{ display: "flex" }}>
@@ -95,16 +102,6 @@ export default function Received(props: SlipActionProps) {
               </div>
 
               <label>
-                Nom du responsable
-                <Field type="text" name="receivedBy" placeholder="NOM Prénom" />
-                <FieldError fieldError={errors.receivedBy} />
-              </label>
-              <label>
-                Date de réception
-                <Field component={DateInput} name="receivedAt" />
-                <FieldError fieldError={errors.receivedAt} />
-              </label>
-              <label>
                 Poids à l'arrivée
                 <Field
                   component={NumberInput}
@@ -121,6 +118,7 @@ export default function Received(props: SlipActionProps) {
                   tonnes
                 </span>
               </label>
+
               {props.form.recipient?.isTempStorage &&
                 props.form.status === FormStatus.Sent && (
                   <fieldset>
@@ -150,6 +148,19 @@ export default function Received(props: SlipActionProps) {
                   <FieldError fieldError={errors.wasteRefusalReason} />
                 </label>
               )}
+
+              <label>
+                Nom du responsable
+                <Field type="text" name="receivedBy" placeholder="NOM Prénom" />
+                <FieldError fieldError={errors.receivedBy} />
+              </label>
+
+              <label>
+                Date d'acceptation
+                <Field component={DateInput} name="acceptedAt" />
+                <FieldError fieldError={errors.acceptedAt} />
+              </label>
+
               <p>
                 {values.wasteAcceptationStatus &&
                   textConfig[values.wasteAcceptationStatus].validationText}

--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -39,7 +39,7 @@ export default function Received(props: SlipActionProps) {
         initialValues={{
           receivedBy: "",
           receivedAt: DateTime.local().toISODate(),
-          acceptedAt: DateTime.local().toISODate(),
+          signedAt: DateTime.local().toISODate(),
           quantityReceived: "",
           wasteAcceptationStatus: "",
           wasteRefusalReason: "",
@@ -157,8 +157,8 @@ export default function Received(props: SlipActionProps) {
 
               <label>
                 Date d'acceptation
-                <Field component={DateInput} name="acceptedAt" />
-                <FieldError fieldError={errors.acceptedAt} />
+                <Field component={DateInput} name="signedAt" />
+                <FieldError fieldError={errors.signedAt} />
               </label>
 
               <p>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1170,6 +1170,8 @@ export type ReceivedFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
+  /** Date à laquelle le déchet a été accepté (case 10) */
+  acceptedAt: Scalars['DateTime'];
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
 };
@@ -1414,6 +1416,8 @@ export type TempStoredFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
+  /** Date à laquelle le déchet a été accepté (case 10) */
+  acceptedAt: Scalars['DateTime'];
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
   /** Réelle ou estimée */

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1229,7 +1229,7 @@ export type ResentFormInput = {
   transporter: Maybe<TransporterInput>;
   /** Nom du signataire du BSD suite  (case 19) */
   signedBy: Maybe<Scalars['String']>;
-  /** Date de signature du BSD suite (case 19) */
+  /** Date de signature du BSD suite (case 19). Défaut à la date d'aujourd'hui. */
   signedAt: Maybe<Scalars['DateTime']>;
 };
 
@@ -1418,7 +1418,7 @@ export type TempStoredFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 13) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté ou refusé (case 13) */
+  /** Date à laquelle le déchet a été accepté ou refusé (case 13). Défaut à la date d'aujourd'hui. */
   signedAt: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 13) */
   quantityReceived: Scalars['Float'];

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -453,6 +453,8 @@ export type Form = {
   receivedBy: Maybe<Scalars['String']>;
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Maybe<Scalars['DateTime']>;
+  /** Date à laquelle le déchet a été accepté ou refusé (case 10) */
+  signedAt: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Maybe<Scalars['Float']>;
   /**
@@ -1170,8 +1172,8 @@ export type ReceivedFormInput = {
   receivedBy: Scalars['String'];
   /** Date à laquelle le déchet a été reçu (case 10) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt: Scalars['DateTime'];
+  /** Date à laquelle le déchet a été accepté ou refusé (case 10) */
+  signedAt: Maybe<Scalars['DateTime']>;
   /** Quantité réelle présentée (case 10) */
   quantityReceived: Scalars['Float'];
 };
@@ -1408,17 +1410,17 @@ export type TemporaryStorer = {
 };
 
 export type TempStoredFormInput = {
-  /** Statut d'acceptation du déchet (case 10) */
+  /** Statut d'acceptation du déchet (case 13) */
   wasteAcceptationStatus: WasteAcceptationStatusInput;
-  /** Raison du refus (case 10) */
+  /** Raison du refus (case 13) */
   wasteRefusalReason: Maybe<Scalars['String']>;
-  /** Nom de la personne en charge de la réception du déchet (case 10) */
+  /** Nom de la personne en charge de la réception du déchet (case 13) */
   receivedBy: Scalars['String'];
-  /** Date à laquelle le déchet a été reçu (case 10) */
+  /** Date à laquelle le déchet a été reçu (case 13) */
   receivedAt: Scalars['DateTime'];
-  /** Date à laquelle le déchet a été accepté (case 10) */
-  acceptedAt: Scalars['DateTime'];
-  /** Quantité réelle présentée (case 10) */
+  /** Date à laquelle le déchet a été accepté ou refusé (case 13) */
+  signedAt: Maybe<Scalars['DateTime']>;
+  /** Quantité réelle présentée (case 13) */
   quantityReceived: Scalars['Float'];
   /** Réelle ou estimée */
   quantityType: QuantityType;

--- a/pdf/src/helpers.js
+++ b/pdf/src/helpers.js
@@ -198,7 +198,7 @@ const getTempStorerWasteDetailsType = (params) => {
 /**
  * Format date fields to french fmt and copy some fields values to other fields
  * @param params
- * @returns {{traderValidityLimit: *, senderSentAt: *, transporterSentAt: *, recipientCompanyName10: *, transporterValidityLimit: *, recipientCompanySiret10: *, receivedAt2: *, recipientCompanyContact10: *, receivedAt1: *, recipientCompanyAddress10: *}}
+ * @returns {{traderValidityLimit: *, senderSentAt: *, transporterSentAt: *, recipientCompanyName10: *, transporterValidityLimit: *, recipientCompanySiret10: *, signedAt: *, recipientCompanyContact10: *, receivedAt: *, recipientCompanyAddress10: *}}
  */
 const renameAndFormatMainFormFields = (params) => ({
   transporterValidityLimit: dateFmt(params.transporterValidityLimit),
@@ -210,13 +210,14 @@ const renameAndFormatMainFormFields = (params) => ({
   transporterSentAt: dateFmt(params.sentAt),
   senderSentBy: params.sentBy,
   senderSentAt: dateFmt(params.sentAt),
-  receivedAt1: dateFmt(params.receivedAt),
-  receivedAt2: dateFmt(params.receivedAt),
+  receivedAt: dateFmt(params.receivedAt),
+  signedAt: dateFmt(params.signedAt),
   receivedBy10: params.receivedBy,
   processedAt: dateFmt(params.processedAt),
-  signedAt: dateFmt(params.signedAt),
   tempStorerReceivedAt: dateFmt(params.tempStorerReceivedAt),
   tempStorerSignedAt: dateFmt(params.tempStorerSignedAt),
+  tempStoredFormSignedAt: dateFmt(params.signedAt),
+  tempStoredFormSignedBy: dateFmt(params.signedBy),
 });
 
 /**

--- a/pdf/src/settings.js
+++ b/pdf/src/settings.js
@@ -88,10 +88,10 @@ const mainFormFieldSettings = {
   recipientPhoneContact10: { x: 124, y: 662 },
   quantityReceived: { x: 198, y: 673, rightAlign: true },
   receivedBy10: { x: 85, y: 735 },
-  receivedAt1: { x: 122, y: 683 },
+  receivedAt: { x: 122, y: 683 },
   wasteRefusalReason: { x: 100, y: 704, lineBreakAt: 50 },
 
-  receivedAt2: { x: 66, y: 746 },
+  signedAt: { x: 66, y: 746 },
 
   wasteAccepted: { x: 116, y: 696, fontSize: 12 },
   wasteNotAccepted: { x: 161, y: 696, fontSize: 12 },
@@ -187,8 +187,8 @@ const temporaryStorageDetailsFieldSettings = {
   transporterValidityLimit: { x: 366, y: 425 },
   transporterSentAt: { x: 388, y: 455 },
 
-  signedBy: { x: 75, y: 562 },
-  signedAt: { x: 215, y: 562 },
+  tempStoredFormSignedBy: { x: 75, y: 562 },
+  tempStoredFormSignedAt: { x: 215, y: 562 },
 };
 
 // appendix2 header field settings


### PR DESCRIPTION
Ajout d'un champ `signedAt` dans les mutations  `markedAsReceived` et `markAsTempStored`. Ce champ permet d'indiquer la date d'acceptation (ou de refus) du déchet. Auparavant, cette date se voyait automatiquement assigner la valeur de la date de réception du déchet. Elles sont désormais bien distinctes.
Le champ prend par défaut la valeur `Date.now()`.

Mini quickwin visuel dans le même temps pour faciliter le remplissage de ces mutations dans l'interface.

cf [carte trello](https://trello.com/c/uVDbsy8p/846-date-arriv%C3%A9edate-acceptation).