### PR TITLE
Correction du label "date de traitement"

### DIFF
--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -463,7 +463,7 @@ export type Form = {
   actualQuantity?: Maybe<Scalars['Float']>;
   /** Traitement réalisé (code D/R) */
   processingOperationDone?: Maybe<Scalars['String']>;
-  /** Description de l'opération de traitement (case 11) */
+  /** Description de l'opération d’élimination / valorisation (case 11) */
   processingOperationDescription?: Maybe<Scalars['String']>;
   /** Personne en charge du traitement */
   processedBy?: Maybe<Scalars['String']>;
@@ -1012,7 +1012,7 @@ export type PrivateCompanyInput = {
 export type ProcessedFormInput = {
   /** Traitement réalisé (code D/R) */
   processingOperationDone: Scalars['String'];
-  /** Description de l'opération de traitement (case 11) */
+  /** Description de l'opération d’élimination / valorisation (case 11) */
   processingOperationDescription?: Maybe<Scalars['String']>;
   /** Personne en charge du traitement */
   processedBy: Scalars['String'];

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2297,7 +2297,7 @@ Traitement réalisé (code D/R)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Description de l'opération de traitement (case 11)
+Description de l'opération d’élimination / valorisation (case 11)
 
 </td>
 </tr>
@@ -4308,7 +4308,7 @@ Traitement réalisé (code D/R)
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-Description de l'opération de traitement (case 11)
+Description de l'opération d’élimination / valorisation (case 11)
 
 </td>
 </tr>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8831,7 +8831,8 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -8852,7 +8853,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/front/src/dashboard/slips/slips-actions/Processed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Processed.tsx
@@ -44,7 +44,7 @@ export default function Processed(props: SlipActionProps) {
             </div>
             <div className="form__group">
               <label>
-                Date de réception
+                Date de traitement
                 <Field component={DateInput} name="processedAt" />
               </label>
             </div>
@@ -89,7 +89,9 @@ export default function Processed(props: SlipActionProps) {
                 <CompanySelector name="nextDestination.company" />
 
                 <div className="form__group">
-                  <label>Opération d’élimination / valorisation (code D/R)</label>
+                  <label>
+                    Opération d’élimination / valorisation (code D/R)
+                  </label>
                   <Field
                     component="select"
                     name="nextDestination.processingOperation"

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -464,7 +464,7 @@ export type Form = {
   actualQuantity: Maybe<Scalars['Float']>;
   /** Traitement réalisé (code D/R) */
   processingOperationDone: Maybe<Scalars['String']>;
-  /** Description de l'Opération d’élimination / valorisation prévue (code D/R) (case 11) */
+  /** Description de l'opération d’élimination / valorisation (case 11) */
   processingOperationDescription: Maybe<Scalars['String']>;
   /** Personne en charge du traitement */
   processedBy: Maybe<Scalars['String']>;
@@ -599,7 +599,7 @@ export enum FormStatus {
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
- *
+ * 
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
@@ -706,7 +706,7 @@ export type Mutation = {
   /**
    * DEPRECATED - La récupération de token pour le compte de tiers
    * doit s'effectuer avec le protocole OAuth2
-   *
+   * 
    * Récupére un token à partir de l'email et du mot de passe
    * d'un utilisateur.
    */
@@ -1019,7 +1019,7 @@ export type PrivateCompanyInput = {
 export type ProcessedFormInput = {
   /** Traitement réalisé (code D/R) */
   processingOperationDone: Scalars['String'];
-  /** Description de l'opération de traitement (case 11) */
+  /** Description de l'opération d’élimination / valorisation (case 11) */
   processingOperationDescription: Maybe<Scalars['String']>;
   /** Personne en charge du traitement */
   processedBy: Scalars['String'];
@@ -1300,7 +1300,7 @@ export type Stat = {
  * - le bordereau peut naviguer entre plusieurs entreprises.
  * - quand le bordereau a-t-il été modifié pour la dernière fois ? (création, signature, traitement... ?)
  * - si c'est un bordereau avec conditionnement et qu'on attend un transporteur, quel est-il ?
- *
+ * 
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
@@ -1362,7 +1362,7 @@ export type Subscription = {
    __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
-   *
+   * 
    * Permet de s'abonner aux changements de statuts d'un BSD
    */
   forms: Maybe<FormSubscription>;
@@ -1579,14 +1579,14 @@ export type User = {
 /**
  * Liste les différents rôles d'un utilisateur au sein
  * d'un établissement.
- *
+ * 
  * Les admins peuvent:
  * * consulter/éditer les bordereaux
  * * gérer les utilisateurs de l'établissement
  * * éditer les informations de la fiche entreprise
  * * demander le renouvellement du code de sécurité
  * * Éditer les informations de la fiche entreprise
- *
+ * 
  * Les membres peuvent:
  * * consulter/éditer les bordereaux
  * * consulter le reste des informations


### PR DESCRIPTION
Le label du champ de la date de traitement est actuellement "Date de réception", cette PR le corrige pour "Date de traitement".

* [Ticket Trello](https://trello.com/c/HgNzEWGG/905-probl%C3%A8me-label-date-de-traitement)

Le premier commit contient la mise à jour de fichiers générés qui sont le résultat du démarrage des applis.