### PR TITLE
Normalisation de l'adresse email lors de la connexion / inscription

### DIFF
--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -60,6 +60,19 @@ describe("POST /login", () => {
     expect(login.header["set-cookie"]).toHaveLength(1);
   });
 
+  it("should authenticate user with their legacy account if any", async () => {
+    const user = await userFactory({
+      email: "USER_WITH_LEGACY_EMAIL@DOMAIN.COM"
+    });
+
+    const login = await request
+      .post("/login")
+      .send(`email=${user.email}`)
+      .send(`password=pass`);
+
+    expect(login.header["set-cookie"]).toHaveLength(1);
+  });
+
   it("should not authenticate an unknown user", async () => {
     const login = await request
       .post("/login")

--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -60,19 +60,6 @@ describe("POST /login", () => {
     expect(login.header["set-cookie"]).toHaveLength(1);
   });
 
-  it("should authenticate user with their legacy account if any", async () => {
-    const user = await userFactory({
-      email: "USER_WITH_LEGACY_EMAIL@DOMAIN.COM"
-    });
-
-    const login = await request
-      .post("/login")
-      .send(`email=${user.email}`)
-      .send(`password=pass`);
-
-    expect(login.header["set-cookie"]).toHaveLength(1);
-  });
-
   it("should not authenticate an unknown user", async () => {
     const login = await request
       .post("/login")

--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -49,6 +49,17 @@ describe("POST /login", () => {
     });
   });
 
+  it("should authenticate user regarldess of their email's casing", async () => {
+    const user = await userFactory();
+
+    const login = await request
+      .post("/login")
+      .send(`email=${user.email.toUpperCase()}`)
+      .send(`password=pass`);
+
+    expect(login.header["set-cookie"]).toHaveLength(1);
+  });
+
   it("should not authenticate an unknown user", async () => {
     const login = await request
       .post("/login")

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -10,15 +10,14 @@ import {
   UserRole,
   Status,
   CompanyCreateInput,
-  FormCreateInput,
-  UserCreateInput
+  FormCreateInput
 } from "../generated/prisma-client";
 
 /**
  * Create a user with name and email
  * @param opt: extra parameters
  */
-export const userFactory = async (opt: Partial<UserCreateInput> = {}) => {
+export const userFactory = async (opt = {}) => {
   const defaultPassword = await hash("pass", 10);
   const userIndex = (await prisma.usersConnection().aggregate().count()) + 1;
   const data = {

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -10,14 +10,15 @@ import {
   UserRole,
   Status,
   CompanyCreateInput,
-  FormCreateInput
+  FormCreateInput,
+  UserCreateInput
 } from "../generated/prisma-client";
 
 /**
  * Create a user with name and email
  * @param opt: extra parameters
  */
-export const userFactory = async (opt = {}) => {
+export const userFactory = async (opt: Partial<UserCreateInput> = {}) => {
   const defaultPassword = await hash("pass", 10);
   const userIndex = (await prisma.usersConnection().aggregate().count()) + 1;
   const data = {

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -16,7 +16,7 @@ import {
   User as PrismaUser
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
-import { sameDayMidnight, daysBetween } from "./utils";
+import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
 
 const { JWT_SECRET } = process.env;
 
@@ -60,7 +60,7 @@ passport.use(
   new LocalStrategy(
     { usernameField: "email" },
     async (username, password, done) => {
-      const user = await prisma.user({ email: username.trim() });
+      const user = await prisma.user({ email: sanitizeEmail(username) });
       if (!user) {
         return done(null, false, {
           ...getLoginError(username).UNKNOWN_USER

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -56,31 +56,11 @@ export const getLoginError = (username: string) => ({
   }
 });
 
-function legacySanitizeEmail(email: string): string {
-  return email.trim();
-}
-
-function isLegacyEmail(email: string): boolean {
-  return sanitizeEmail(email) !== legacySanitizeEmail(email);
-}
-
 passport.use(
   new LocalStrategy(
     { usernameField: "email" },
     async (username, password, done) => {
-      let user = null;
-
-      if (isLegacyEmail(username)) {
-        // Some users were created before email sanitization was introduced
-        // so we need to look up a potential legacy account before resotring to the new sanitization
-        // We'll be able to get rid of this code once legacy emails have been sanitized
-        user = await prisma.user({ email: legacySanitizeEmail(username) });
-      }
-
-      if (!user) {
-        user = await prisma.user({ email: sanitizeEmail(username) });
-      }
-
+      const user = await prisma.user({ email: sanitizeEmail(username) });
       if (!user) {
         return done(null, false, {
           ...getLoginError(username).UNKNOWN_USER

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -16,7 +16,12 @@ import {
   User as PrismaUser
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
-import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
+import {
+  sameDayMidnight,
+  daysBetween,
+  legacySanitizeEmail,
+  sanitizeEmail
+} from "./utils";
 
 const { JWT_SECRET } = process.env;
 
@@ -56,21 +61,13 @@ export const getLoginError = (username: string) => ({
   }
 });
 
-function legacySanitizeEmail(email: string): string {
-  return email.trim();
-}
-
-function isLegacyEmail(email: string): boolean {
-  return sanitizeEmail(email) !== legacySanitizeEmail(email);
-}
-
 passport.use(
   new LocalStrategy(
     { usernameField: "email" },
     async (username, password, done) => {
       let user = null;
 
-      if (isLegacyEmail(username)) {
+      if (legacySanitizeEmail(username) !== sanitizeEmail(username)) {
         // Some users were created before email sanitization was introduced
         // so we need to look up a potential legacy account before resotring to the new sanitization
         // We'll be able to get rid of this code once legacy emails have been sanitized

--- a/back/src/users/mutations/signup.ts
+++ b/back/src/users/mutations/signup.ts
@@ -3,15 +3,18 @@ import { sendMail } from "../../common/mails.helper";
 import { User, prisma } from "../../generated/prisma-client";
 import { userMails } from "../mails";
 import { hashPassword } from "../utils";
+import { sanitizeEmail } from "../../utils";
 import { UserInputError } from "apollo-server-express";
 import { SignupInput } from "../../generated/graphql/types";
 
 export default async function signup({
   name,
-  email,
   password,
-  phone
+  phone,
+  ...rest
 }: SignupInput) {
+  const email = sanitizeEmail(rest.email);
+
   // check user does not exist
   const userExists = await prisma.$exists.user({ email });
 

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -72,6 +72,10 @@ export function daysBetween(date1: Date, date2: Date): number {
   return numberOfdays;
 }
 
+export function legacySanitizeEmail(email: string): string {
+  return email.trim();
+}
+
 export function sanitizeEmail(email: string): string {
   return email.toLowerCase().trim();
 }

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -71,3 +71,7 @@ export function daysBetween(date1: Date, date2: Date): number {
   const numberOfdays = Math.trunc((millis1 - millis2) / dayMillis);
   return numberOfdays;
 }
+
+export function sanitizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}

--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -115,7 +115,7 @@ export default function Signup() {
             <div className="form__group">
               <label>Email*</label>
               <div className="search__group">
-                <Field type="text" name="email" />
+                <Field type="email" name="email" />
                 <button
                   type="button"
                   className="overlay-button"


### PR DESCRIPTION
Actuellement, il est possible de s'inscrire avec la même adresse email mais deux casses différentes, par exemple :

1. user@email.com
2. USER@EMAIL.COM

Avec cette PR, les adresses emails seront désormais normalisées avant insertion en base de donnée. La même normalisation est appliquée aux adresses emails soumises au moment de la connexion.

Je n'ai pas touché à la mutation `login` qui est marquée comme dépréciée, je ne sais pas si ça vaut le coup de la mettre à jour ainsi que ses tests ?

---

* [Ticket Trello](https://trello.com/c/AKwK3EhS/898-connexion-et-probl%C3%A9matique-des-emails)