### PR TITLE
Ajout d'éléments de documentation

### DIFF
--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -143,7 +143,60 @@ type Mutation {
   "Duplique un BSD"
   duplicateForm("ID d'un BSD" id: ID!): Form
 
-  "Scelle un BSD"
+  """
+  Scelle un BSD
+  Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+  doivent avoir été renseignés grâce à la mutation `saveForm`
+
+  ```
+  emitter: {
+    type
+    company: {
+      siret
+      name
+      address
+      contact
+      phone
+      mail
+    }
+  }
+  recipient: {
+    processingOperation
+    company: {
+      siret
+      name
+      address
+      contact
+      phone
+      mail
+    }
+  }
+  transporter: {
+    company: {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+    receipt
+    department
+    validityLimit
+    numberPlate
+  }
+  wasteDetails: {
+    code
+    onuCode
+    name
+    packagings
+    numberOfPackages
+    quantity
+    quantityType
+    consistence
+  }
+  ```
+  """
   markAsSealed("ID d'un BSD" id: ID): Form
 
   "Valide l'envoi d'un BSD"

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -736,7 +736,60 @@ export type Mutation = {
   markAsResealed?: Maybe<Form>;
   /** Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement */
   markAsResent?: Maybe<Form>;
-  /** Scelle un BSD */
+  /**
+   * Scelle un BSD
+   * Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+   * doivent avoir été renseignés grâce à la mutation `saveForm`
+   * 
+   * ```
+   * emitter: {
+   *   type
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     phone
+   *     mail
+   *   }
+   * }
+   * recipient: {
+   *   processingOperation
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     phone
+   *     mail
+   *   }
+   * }
+   * transporter: {
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     mail
+   *     phone
+   *   }
+   *   receipt
+   *   department
+   *   validityLimit
+   *   numberPlate
+   * }
+   * wasteDetails: {
+   *   code
+   *   onuCode
+   *   name
+   *   packagings
+   *   numberOfPackages
+   *   quantity
+   *   quantityType
+   *   consistence
+   * }
+   * ```
+   */
   markAsSealed?: Maybe<Form>;
   /** Valide l'envoi d'un BSD */
   markAsSent?: Maybe<Form>;

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -786,6 +786,57 @@ Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement
 <td>
 
 Scelle un BSD
+Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+doivent avoir été renseignés grâce à la mutation `saveForm`
+
+```
+emitter: {
+  type
+  company: {
+    siret
+    name
+    address
+    contact
+    phone
+    mail
+  }
+}
+recipient: {
+  processingOperation
+  company: {
+    siret
+    name
+    address
+    contact
+    phone
+    mail
+  }
+}
+transporter: {
+  company: {
+    siret
+    name
+    address
+    contact
+    mail
+    phone
+  }
+  receipt
+  department
+  validityLimit
+  numberPlate
+}
+wasteDetails: {
+  code
+  onuCode
+  name
+  packagings
+  numberOfPackages
+  quantity
+  quantityType
+  consistence
+}
+```
 
 </td>
 </tr>

--- a/doc/docs/sirene.md
+++ b/doc/docs/sirene.md
@@ -1,0 +1,40 @@
+---
+id: sirene
+title: API Sirene enrichie
+sidebar_label: API Sirene enrichie
+---
+
+### Rechercher un établissement par son SIRET
+
+Nous exposons une query `companyInfos` qui interroge la base SIRENE (via [https://entreprise.data.gouv.fr](https://entreprise.data.gouv.fr)), la base des installations classées pour la protection de l'environnement (ICPE) et la base Trackdéchets pour obtenir des informations sur un établissement à partir de son numéro SIRET.
+
+La query renvoie un objet de type [`CompanyPublic`](https://developers.trackdechets.beta.gouv.fr/docs/api-reference/#companypublic) et permet notamment de savoir si un établissement est inscrit sur Trackdéchets grâce au champ `isRegistered`.
+
+Exemple d'utilisation:
+
+```graphql
+query {
+  companyInfos(siret: "13001045700013"){
+    name
+    naf
+    address
+    isRegistered
+  }
+}
+```
+
+```
+{
+  "data": {
+    "companyInfos": {
+      "name": "DIRECTION REGIONALE DE L'ENVIRONNEMENT DE L'AMENAGEMENT ET DU LOGEMENT NOUVELLE-AQUITAINE",
+      "naf": "84.13Z",
+      "address": "15 Rue Arthur Ranc 86000 Poitiers",
+      "isRegistered": true
+    }
+  }
+}
+```
+
+:::note
+Nous avons crée une **fiche entreprise** pour chaque établissement sur l'interface graphique Trackdéchets qui illustre l'utilisation de cette query. Exemple avec la DREAL Nouvelle Aquitaine: [https://trackdechets.beta.gouv.fr/company/13001045700013](https://trackdechets.beta.gouv.fr/company/13001045700013)

--- a/doc/website/sidebars.json
+++ b/doc/website/sidebars.json
@@ -9,7 +9,8 @@
       "environments",
       "access-token",
       "playground",
-      "multimodal"
+      "multimodal",
+      "sirene"
     ],
     "Référence de l'API": ["api-reference", "changelog"]
   }

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -742,7 +742,60 @@ export type Mutation = {
   markAsResealed: Maybe<Form>;
   /** Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement */
   markAsResent: Maybe<Form>;
-  /** Scelle un BSD */
+  /**
+   * Scelle un BSD
+   * Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+   * doivent avoir été renseignés grâce à la mutation `saveForm`
+   * 
+   * ```
+   * emitter: {
+   *   type
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     phone
+   *     mail
+   *   }
+   * }
+   * recipient: {
+   *   processingOperation
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     phone
+   *     mail
+   *   }
+   * }
+   * transporter: {
+   *   company: {
+   *     siret
+   *     name
+   *     address
+   *     contact
+   *     mail
+   *     phone
+   *   }
+   *   receipt
+   *   department
+   *   validityLimit
+   *   numberPlate
+   * }
+   * wasteDetails: {
+   *   code
+   *   onuCode
+   *   name
+   *   packagings
+   *   numberOfPackages
+   *   quantity
+   *   quantityType
+   *   consistence
+   * }
+   * ```
+   */
   markAsSealed: Maybe<Form>;
   /** Valide l'envoi d'un BSD */
   markAsSent: Maybe<Form>;


### PR DESCRIPTION
Suite à des questions de support récurrentes

* Documentation de la query `companyInfos` dans une section "API sirene enrichie" de la documentation
* Ajout des champs obligatoires du BSD lors de la mutation `markAsSealed` dans le docstring GraphQL de la mutation