### PR TITLE
Display awaiting_group forms in follow up tab

### DIFF
--- a/front/src/dashboard/slips/tabs/FollowTab.tsx
+++ b/front/src/dashboard/slips/tabs/FollowTab.tsx
@@ -5,7 +5,7 @@ import Loader from "../../../common/Loader";
 import {
   FormStatus,
   Query,
-  QueryFormsArgs,
+  QueryFormsArgs
 } from "../../../generated/graphql/types";
 import { SiretContext } from "../../Dashboard";
 import { GET_SLIPS } from "../query";
@@ -27,9 +27,10 @@ export default function FollowTab() {
         FormStatus.TempStored,
         FormStatus.Resealed,
         FormStatus.Resent,
+        FormStatus.AwaitingGroup
       ],
-      hasNextStep: false,
-    },
+      hasNextStep: false
+    }
   });
 
   if (loading) return <Loader />;


### PR DESCRIPTION
Correction d'un bug masquant l'affichage des bsds en attente de regroupement dans les onglets de l'UI.