### PR TITLE
Display awaiting_group forms in follow up tab

### DIFF
--- a/front/src/dashboard/slips/tabs/FollowTab.tsx
+++ b/front/src/dashboard/slips/tabs/FollowTab.tsx
@@ -27,6 +27,7 @@ export default function FollowTab() {
         FormStatus.TempStored,
         FormStatus.Resealed,
         FormStatus.Resent,
+        FormStatus.AwaitingGroup,
       ],
       hasNextStep: false,
     },


### PR DESCRIPTION
Correction d'un bug masquant l'affichage des bsds en attente de regroupement dans les onglets de l'UI.