### PR TITLE
Hotfix to prevent hitting API Sirene rate limit while bulk creating a…

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -14,7 +14,8 @@
     "build": "tsc && copyfiles src/**/*.graphql dist/ && copyfiles -e '**/*.ts' prisma/*.yml prisma/**/* dist/",
     "lint": "eslint -c .eslintrc.js --ext .ts ./src",
     "lint:fix": "eslint -c .eslintrc.js --fix --ext .ts ./src",
-    "bulk-create-account": "ts-node src/users/bulk-creation/index.ts",
+    "bulk-create-account:dev": "ts-node src/users/bulk-creation/index.ts",
+    "bulk-create-account": "node src/users/bulk-creation/index.js",
     "graphql-codegen": "graphql-codegen --config codegen.yml"
   },
   "keywords": [],

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -12,12 +12,8 @@ sendMailSpy.mockImplementation(() => Promise.resolve());
 jest.mock("../sirene", () => ({
   getCompanyThrottled: jest.fn(() =>
     Promise.resolve({
-      etablissement: {
-        unite_legale: {
-          denomination: "NAME FROM SIRENE"
-        },
-        activite_principale: "62.01Z"
-      }
+      naf: "62.01Z",
+      name: "NAME FROM SIRENE"
     })
   ),
   sirenify: jest.fn(company =>
@@ -105,7 +101,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(codeEnStock.website).toEqual("https://codeenstock.trackdechets.fr");
     expect(codeEnStock.gerepId).toEqual("1234");
     expect(codeEnStock.contactPhone).toEqual("0600000000");
-  });
+  }, 10000);
 
   test("already existing company", async () => {
     // assume Code en Stock was already created
@@ -119,7 +115,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(await prisma.company({ siret: "85001946400013" })).toEqual(
       codeEnStock
     );
-  });
+  }, 10000);
 
   test("already existing user", async () => {
     // assume a user with this email already exists
@@ -140,7 +136,7 @@ describe("bulk create users and companies from csv files", () => {
     });
     expect(associations).toHaveLength(1);
     expect(associations[0].role).toEqual("ADMIN");
-  });
+  }, 10000);
 
   test("already existing user with existing role in company", async () => {
     // John Snow and Code en Stock already exist
@@ -169,7 +165,7 @@ describe("bulk create users and companies from csv files", () => {
     });
     expect(associations).toHaveLength(1);
     expect(associations[0]).toEqual(role);
-  });
+  }, 10000);
 
   test("user with pending invitation", async () => {
     const company = await companyFactory({ siret: "51212357100022" });
@@ -199,7 +195,7 @@ describe("bulk create users and companies from csv files", () => {
 
     // invitation should be deleted
     expect(await prisma.userAccountHashes()).toHaveLength(0);
-  });
+  }, 10000);
 
   test("role in csv already in pending invitation", async () => {
     // assume John Snow was already invited to Trackdéchets
@@ -225,5 +221,5 @@ describe("bulk create users and companies from csv files", () => {
 
     // invitation should be deleted
     expect(await prisma.userAccountHashes()).toHaveLength(0);
-  });
+  }, 10000);
 });

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -69,14 +69,17 @@ export async function bulkCreate(opts: Opts): Promise<void> {
 
   let isValid = true;
 
-  // validate companies
-  const companiesPromises = companiesRows.map(company =>
-    validateCompany(company).catch(err => {
+  const companies = [];
+
+  // perform validation
+  for (const company of companiesRows) {
+    console.log(`Validate company ${company.siret}`);
+    const validCompany = await validateCompany(company).catch(err => {
       isValid = false;
       console.error(err);
-    })
-  );
-  let companies = await Promise.all(companiesPromises);
+    });
+    companies.push(validCompany);
+  }
 
   // validate roles
   const validateRole = validateRoleGenerator(companies);
@@ -102,93 +105,94 @@ export async function bulkCreate(opts: Opts): Promise<void> {
     process.exit(1);
   }
 
-  // add name and codeNaf to companies
-  companies = await Promise.all(
-    companies.map(c => {
-      return sirenify(c);
-    })
-  ).catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  const sirenifiedCompanies = [];
+
+  // add sirene information
+  for (const c of companies) {
+    try {
+      console.log(`Add sirene info for company ${c.siret}`);
+      const sirenified = await sirenify(c);
+      sirenifiedCompanies.push(sirenified);
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+  }
 
   // create companies in Trackdéchets
 
-  await Promise.all(
-    companies.map(async company => {
-      const existingCompany = await prisma.company({ siret: company.siret });
-      if (!existingCompany) {
-        return prisma.createCompany({
-          siret: company.siret,
-          codeNaf: company.codeNaf,
-          gerepId: company.gerepId,
-          name: company.name,
-          companyTypes: { set: company.companyTypes },
-          securityCode: randomNumber(4),
-          givenName: company.givenName,
-          contactEmail: company.contactEmail,
-          contactPhone: company.contactPhone,
-          website: company.website
-        });
-      }
-    })
-  );
+  for (const company of sirenifiedCompanies) {
+    const existingCompany = await prisma.company({ siret: company.siret });
+    if (!existingCompany) {
+      console.log(`Create company ${company.siret}`);
+      await prisma.createCompany({
+        siret: company.siret,
+        codeNaf: company.codeNaf,
+        gerepId: company.gerepId,
+        name: company.name,
+        companyTypes: { set: company.companyTypes },
+        securityCode: randomNumber(4),
+        givenName: company.givenName,
+        contactEmail: company.contactEmail,
+        contactPhone: company.contactPhone,
+        website: company.website
+      });
+    }
+  }
 
   // group roles by email
   const usersWithRoles = groupBy("email", roles);
 
-  await Promise.all(
-    Object.keys(usersWithRoles).map(async email => {
-      // check for existing user
-      let user = await prisma.user({ email });
+  for (const email of Object.keys(usersWithRoles)) {
+    // check for existing user
+    let user = await prisma.user({ email });
 
-      let newUser = null;
+    let newUser = null;
 
-      if (!user) {
-        // No user matches this email. Creates a new one
-        const password = Math.random()
-          .toString(36)
-          .slice(-10);
+    if (!user) {
+      // No user matches this email. Creates a new one
+      const password = Math.random().toString(36).slice(-10);
 
-        const hashedPassword = await hashPassword(password);
+      const hashedPassword = await hashPassword(password);
 
-        user = await prisma.createUser({
-          name: email,
-          email,
-          password: hashedPassword,
-          isActive: true
-        });
+      console.log(`Create user ${email} / ${password}`);
+      user = await prisma.createUser({
+        name: email,
+        email,
+        password: hashedPassword,
+        isActive: true
+      });
 
-        await acceptNewUserCompanyInvitations(user);
+      await acceptNewUserCompanyInvitations(user);
 
-        newUser = { password };
-      }
+      newUser = { password };
+    }
 
-      const associations = await Promise.all(
-        usersWithRoles[email].map(async ({ role, siret }) => {
-          try {
-            return await associateUserToCompany(user.id, siret, role);
-          } catch (err) {
-            if (err instanceof UserInputError) {
-              // association already exist, return it
-              const existingAssociations = await prisma.companyAssociations({
-                where: { company: { siret }, user: { id: user.id } }
-              });
-              return existingAssociations[0];
-            }
-
-            console.error(err);
+    await Promise.all(
+      usersWithRoles[email].map(async ({ role, siret }) => {
+        try {
+          return await associateUserToCompany(user.id, siret, role);
+        } catch (err) {
+          if (err instanceof UserInputError) {
+            // association already exist, return it
+            const existingAssociations = await prisma.companyAssociations({
+              where: { company: { siret }, user: { id: user.id } }
+            });
+            return existingAssociations[0];
           }
-        })
-      );
 
-      if (newUser) {
-        // send welcome email to new user
-        const mail = {
-          to: [{ name: email, email }],
-          subject: "Bienvenue sur Trackdéchets",
-          title: "Bienvenue sur Trackdéchets",
-          body: `
+          console.error(err);
+        }
+      })
+    );
+
+    if (newUser) {
+      // send welcome email to new user
+      const mail = {
+        to: [{ name: email, email }],
+        subject: "Bienvenue sur Trackdéchets",
+        title: "Bienvenue sur Trackdéchets",
+        body: `
           Bonjour,
           <br/>
           Vous avez été invité à rejoindre Trackdéchets: la plateforme de dématérialisation
@@ -200,18 +204,15 @@ export async function bulkCreate(opts: Opts): Promise<void> {
           <br/>
           mot de passe provisoire: ${newUser.password}
         `
-        };
+      };
 
-        try {
-          await sendMail(mail);
-        } catch (err) {
-          console.error("Error while sending invitation email");
-        }
+      try {
+        await sendMail(mail);
+      } catch (err) {
+        console.error("Error while sending invitation email");
       }
-
-      return associations;
-    })
-  );
+    }
+  }
 }
 
 if (require.main === module) {

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -73,7 +73,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
 
   // perform validation
   for (const company of companiesRows) {
-    console.log(`Validate company ${company.siret}`);
+    console.info(`Validate company ${company.siret}`);
     const validCompany = await validateCompany(company).catch(err => {
       isValid = false;
       console.error(err);
@@ -110,7 +110,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
   // add sirene information
   for (const c of companies) {
     try {
-      console.log(`Add sirene info for company ${c.siret}`);
+      console.info(`Add sirene info for company ${c.siret}`);
       const sirenified = await sirenify(c);
       sirenifiedCompanies.push(sirenified);
     } catch (err) {
@@ -124,7 +124,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
   for (const company of sirenifiedCompanies) {
     const existingCompany = await prisma.company({ siret: company.siret });
     if (!existingCompany) {
-      console.log(`Create company ${company.siret}`);
+      console.info(`Create company ${company.siret}`);
       await prisma.createCompany({
         siret: company.siret,
         codeNaf: company.codeNaf,
@@ -155,7 +155,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
 
       const hashedPassword = await hashPassword(password);
 
-      console.log(`Create user ${email} / ${password}`);
+      console.info(`Create user ${email} / ${password}`);
       user = await prisma.createUser({
         name: email,
         email,

--- a/back/src/users/bulk-creation/types.ts
+++ b/back/src/users/bulk-creation/types.ts
@@ -8,10 +8,6 @@ export type RoleRow = InferType<typeof r>;
 
 // Company info from SIRENE API
 export interface CompanyInfo {
-  etablissement: {
-    unite_legale: {
-      denomination: string;
-    };
-    activite_principale: string;
-  };
+  name: string;
+  codeNaf: string;
 }

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -61,10 +61,7 @@ export const companyValidationSchema = yup.object().shape({
       return isCompanyType;
     }),
   givenName: yup.string().notRequired(),
-  contactEmail: yup
-    .string()
-    .notRequired()
-    .email(),
+  contactEmail: yup.string().notRequired().email(),
   contactPhone: yup
     .string()
     .notRequired()
@@ -73,12 +70,7 @@ export const companyValidationSchema = yup.object().shape({
       message: "Le numéro de téléphone de contact est invalide",
       excludeEmptyString: true
     }),
-  website: yup
-    .string()
-    .notRequired()
-    .url(),
-  name: yup.string().notRequired(),
-  codeNaf: yup.string().notRequired()
+  website: yup.string().notRequired().url()
 });
 
 /**
@@ -117,10 +109,7 @@ export const roleValidationSchema = (companies: CompanyRow[]) =>
           return true;
         }
       ),
-    role: yup
-      .string()
-      .required()
-      .oneOf(ROLES)
+    role: yup.string().required().oneOf(ROLES)
   });
 
 /** Generates a validateRole function */


### PR DESCRIPTION
* Utilisation de `for of await getCompanyThrottled` plutôt que `Promise.all(getCompanyThrottled)` pour que les appels à l'API Sirene s'execute séquentiellement avec un setTimeout de 500ms (rate limit à 7r/s) 
* Utilisation de `node` à la place de `ts-node` pour exécuter le script en prod
* Ajout d'information de debug pour suivre l'avancée du script 

Testé sur les comptes https://trello.com/c/vPpvzUx3 en local avec une copie de la base de prod