### PR TITLE
Remove mtes logo link

### DIFF
--- a/front/src/Header.scss
+++ b/front/src/Header.scss
@@ -40,4 +40,7 @@
       background-color: var(--white);
     }
   }
+  &__brand {
+    display: flex;
+  }
 }

--- a/front/src/Header.tsx
+++ b/front/src/Header.tsx
@@ -22,19 +22,20 @@ export default withRouter(function Header({
   return (
     <header className="navbar" role="navigation">
       <div className="navbar__container">
-        <Link className="navbar__home" to="/">
+        <div className="navbar__brand">
           <img
             className="navbar__logo"
             src="/mtes.png"
             alt="Ministère de la Transition écologique et solidaire"
           />
-          <img
-            className="navbar__logo"
-            src="/trackdechets.png"
-            alt="trackdechets.data.gouv.fr"
-          />
-        </Link>
-
+          <Link className="navbar__home" to="/">
+            <img
+              className="navbar__logo"
+              src="/trackdechets.png"
+              alt="trackdechets.data.gouv.fr"
+            />
+          </Link>
+        </div>
         <nav>
           <ul className="nav__links">
             <li className="nav__item">


### PR DESCRIPTION
Il s'avère qu'avoir 2 logos différents pointant sur la home n'est pas une bonne pratique UX, le lien sur la Marianne est retiré.