### PR TITLE
Correction du formatage des informations de transport multimodal sur le PDF

### DIFF
--- a/pdf/src/__tests__/helpers.test.js
+++ b/pdf/src/__tests__/helpers.test.js
@@ -55,6 +55,7 @@ describe("processSegment", () => {
     };
 
     expect(processSegment(params)).toMatchObject({
+      transporterCompanySiren: params.transporterCompanySiret.slice(0, 9),
       transporterValidityLimit: dateFmt(params.transporterValidityLimit)
     });
   });

--- a/pdf/src/__tests__/helpers.test.js
+++ b/pdf/src/__tests__/helpers.test.js
@@ -1,4 +1,8 @@
-const { processMainFormParams, dateFmt } = require("../helpers");
+const {
+  processMainFormParams,
+  processSegment,
+  dateFmt
+} = require("../helpers");
 
 describe("processMainFormParams", () => {
   it("should format the fields", () => {
@@ -39,6 +43,19 @@ describe("processMainFormParams", () => {
       processedAt: dateFmt(params.processedAt),
       signedAt: dateFmt(params.signedAt),
       tempStoredFormSignedAt: dateFmt(params.signedAt)
+    });
+  });
+});
+
+describe("processSegment", () => {
+  it("should format the fields", () => {
+    const params = {
+      transporterCompanySiret: "0".repeat(14),
+      transporterValidityLimit: new Date("01/01/2020").toISOString()
+    };
+
+    expect(processSegment(params)).toMatchObject({
+      transporterValidityLimit: dateFmt(params.transporterValidityLimit)
     });
   });
 });

--- a/pdf/src/helpers.js
+++ b/pdf/src/helpers.js
@@ -367,7 +367,7 @@ function verboseMode(mode) {
   return transportModeLabels[mode];
 }
 function processSegment(segment) {
-  const data = stringifyNumberFields(segment);
+  const data = processMainFormParams(stringifyNumberFields(segment));
   return {
     ...data,
     takenOverAt: dateFmt(data.takenOverAt),

--- a/pdf/src/helpers.js
+++ b/pdf/src/helpers.js
@@ -371,8 +371,7 @@ function processSegment(segment) {
   return {
     ...data,
     takenOverAt: dateFmt(data.takenOverAt),
-    mode: verboseMode(data.mode),
-    transporterCompanySiren: siretToSiren(data.transporterCompanySiret)
+    mode: verboseMode(data.mode)
   };
 }
 

--- a/pdf/src/settings.js
+++ b/pdf/src/settings.js
@@ -230,8 +230,14 @@ const appendixYOffsets = [0, 104, 208, 313, 418];
 const transportSegmentSettings = {
   segmentNumber: { x: 162, y: 628, fontSize: 10 },
   transporterCompanySiren: { x: 90, y: 640, fontSize: 10 },
-  transporterCompanyName: { x: 71, y: 650, fontSize: 10 },
-  transporterCompanyAddress: { x: 77, y: 660, fontSize: 10 },
+  transporterCompanyName: { x: 71, y: 650, fontSize: 10, maxLength: 50 },
+  transporterCompanyAddress: {
+    x: 77,
+    y: 660,
+    fontSize: 10,
+    lineBreakAt: 55,
+    maxLength: 110
+  },
   transporterCompanyPhone: { x: 62, y: 680, fontSize: 10 },
   transporterCompanyMail: { x: 63, y: 691, fontSize: 10 },
   transporterCompanyContact: { x: 122, y: 702, fontSize: 10 },


### PR DESCRIPTION
Cette PR corrige les problèmes de formatage identifiés dans le PDF attaché à ce [ticket Trello](https://trello.com/c/GWVxLtMm/923-bugs-tests-du-17-juin) au niveau du transport multimodal.

- [x] Correction du formatage de la date de limite de validité du récépissé transporteur
- [x] Limitation de la longueur du nom du transporteur

---

* [Ticket Trello](https://trello.com/c/GWVxLtMm/923-bugs-tests-du-17-juin)