### PR TITLE
Amélioration du client sirene

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -36,6 +36,9 @@ PRISMA_ENDPOINT=http://prisma:4466
 # Secret used for encoding JSON web tokens
 JWT_SECRET=*********
 
+# Secret for INSEE SIRENE API
+INSEE_SECRET=*********
+
 # Session configuration
 SESSION_SECRET=*********
 SESSION_NAME=connect.sid

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -64,7 +64,9 @@ passport.use(
       }
       const passwordValid = await compare(password, user.password);
       if (!passwordValid) {
-        return done(null, false, { ...getLoginError(username).INVALID_PASSWORD });
+        return done(null, false, {
+          ...getLoginError(username).INVALID_PASSWORD
+        });
       }
       return done(null, user);
     }

--- a/back/src/common/__tests__/redis.test.ts
+++ b/back/src/common/__tests__/redis.test.ts
@@ -47,7 +47,9 @@ describe("cachedGet", () => {
 
   test("should be able to get json in cache", async () => {
     const foo = () => null;
-    const res = await cachedGet(foo, "foo", "2000", { parser: JSON });
+    const res = await cachedGet<{ name: string }>(foo, "foo", "2000", {
+      parser: JSON
+    });
 
     expect(res.name).toBe("foo");
   });

--- a/back/src/common/errors.ts
+++ b/back/src/common/errors.ts
@@ -1,3 +1,5 @@
+import { ApolloError } from "apollo-server-express";
+
 /**
  * Apollo built-in error code
  * See https://www.apollographql.com/docs/apollo-server/data/errors/
@@ -9,5 +11,13 @@ export enum ErrorCode {
   UNAUTHENTICATED = "UNAUTHENTICATED",
   FORBIDDEN = "FORBIDDEN",
   BAD_USER_INPUT = "BAD_USER_INPUT",
+  TOO_MANY_REQUESTS = "TOO_MANY_REQUESTS",
   INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
+}
+
+export class TooManyRequestsError extends ApolloError {
+  constructor(message: string, properties?: Record<string, any>) {
+    super(message, "TOO_MANY_REQUESTS", properties);
+    Object.defineProperty(this, "name", { value: "TooManyRequestsError" });
+  }
 }

--- a/back/src/common/redis.ts
+++ b/back/src/common/redis.ts
@@ -36,12 +36,12 @@ type SetOptions = {
   XX?: boolean; // XX -- Only set the key if it already exist.
 };
 
-export async function cachedGet(
-  getter: (itemKey) => Promise<any>,
+export async function cachedGet<T>(
+  getter: (itemKey: string | number) => Promise<T>,
   objectType: string,
   itemKey: string | number,
   settings: { parser?: Parser; options?: SetOptions } = {}
-) {
+): Promise<T> {
   const { parser = defaultParser, options = {} } = settings;
   const cacheKey = generateKey(objectType, itemKey);
 

--- a/back/src/companies/__tests__/verif.integration.ts
+++ b/back/src/companies/__tests__/verif.integration.ts
@@ -17,9 +17,7 @@ const company = {
   codeCommune: "13201",
   name: "CODE EN STOCK",
   naf: "62.01Z",
-  libelleNaf: "Programmation informatique",
-  longitude: 5.387141,
-  latitude: 43.300746
+  libelleNaf: "Programmation informatique"
 };
 
 describe("verifyPrestataire", () => {

--- a/back/src/companies/companies.graphql
+++ b/back/src/companies/companies.graphql
@@ -199,12 +199,6 @@ type CompanyPrivate {
   "Libellé NAF de l'établissement"
   libelleNaf: String
 
-  "Longitude de l'établissement (info géographique)"
-  longitude: Float
-
-  "Latitude de l'établissement (info géographique)"
-  latitude: Float
-
   """
   Installation classée pour la protection de l'environnement (ICPE)
   associé à cet établissement (le cas échéant)
@@ -251,12 +245,6 @@ type CompanyPublic {
   "Libellé NAF"
   libelleNaf: String
 
-  "Longitude de l'établissement (info géographique)"
-  longitude: Float
-
-  "Latitude de l'établissement (info géographique)"
-  latitude: Float
-
   """
   Installation classée pour la protection de l'environnement (ICPE)
   associé à cet établissement
@@ -284,8 +272,14 @@ type CompanySearchResult {
   "SIRET de l'établissement"
   siret: String
 
+  "État administratif de l'établissement. A = Actif, F = Fermé"
+  etatAdministratif: String
+
   "Adresse de l'établissement"
   address: String
+
+  "Code commune de l'établissement"
+  codeCommune: String
 
   "Nom de l'établissement"
   name: String
@@ -298,12 +292,6 @@ type CompanySearchResult {
 
   "Libellé NAF"
   libelleNaf: String
-
-  "Longitude de l'établissement (info géographique)"
-  longitude: Float
-
-  "Latitude de l'établissement (info géographique)"
-  latitude: Float
 
   """
   Installation classée pour la protection de l'environnement (ICPE)

--- a/back/src/companies/queries/__tests__/companyInfos.integration.ts
+++ b/back/src/companies/queries/__tests__/companyInfos.integration.ts
@@ -21,9 +21,7 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       codeCommune: "13201",
       naf: "62.01Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     });
 
     const gqlquery = `
@@ -35,8 +33,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
           address
           naf
           libelleNaf
-          longitude
-          latitude
           isRegistered
           contactEmail
           contactPhone
@@ -55,8 +51,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       naf: "62.01Z",
       libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746,
       isRegistered: false,
       contactEmail: null,
       contactPhone: null,
@@ -73,9 +67,7 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       codeCommune: "13201",
       naf: "62.01Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     });
 
     await prisma.createCompany({
@@ -100,8 +92,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
           address
           naf
           libelleNaf
-          longitude
-          latitude
           isRegistered
           contactEmail
           contactPhone
@@ -120,8 +110,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       naf: "62.01Z",
       libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746,
       isRegistered: true,
       contactEmail: "john.snow@trackdechets.fr",
       contactPhone: "0600000000",
@@ -140,9 +128,7 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       codeCommune: "13201",
       naf: "62.01Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     });
 
     const receipt = {
@@ -183,9 +169,7 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       codeCommune: "13201",
       naf: "62.01Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     });
 
     const receipt = {
@@ -233,8 +217,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
         address
         naf
         libelleNaf
-        longitude
-        latitude
         isRegistered
         contactEmail
         contactPhone
@@ -253,8 +235,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "49 Rue de la République 18220 Les Aix-d'Angillon",
       naf: "52.4T",
       libelleNaf: "",
-      longitude: 2.574108,
-      latitude: 47.199802,
       isRegistered: false,
       contactEmail: null,
       contactPhone: null,
@@ -278,8 +258,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
           address
           naf
           libelleNaf
-          longitude
-          latitude
           isRegistered
           contactEmail
           contactPhone
@@ -298,8 +276,6 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
       address: "",
       naf: null,
       libelleNaf: "",
-      longitude: null,
-      latitude: null,
       isRegistered: false,
       contactEmail: null,
       contactPhone: null,

--- a/back/src/companies/queries/__tests__/searchCompanies.integration.ts
+++ b/back/src/companies/queries/__tests__/searchCompanies.integration.ts
@@ -19,9 +19,7 @@ describe("query { searchCompanies(clue, department) }", () => {
         address: "4 Boulevard Longchamp 13001 Marseille",
         name: "CODE EN STOCK",
         naf: "6201Z",
-        libelleNaf: "Programmation informatique",
-        longitude: 5.387141,
-        latitude: 43.300746
+        libelleNaf: "Programmation informatique"
       }
     ]);
 
@@ -34,8 +32,6 @@ describe("query { searchCompanies(clue, department) }", () => {
           companyTypes
           naf
           libelleNaf
-          longitude
-          latitude
           installation {
             codeS3ic
           }
@@ -54,9 +50,7 @@ describe("query { searchCompanies(clue, department) }", () => {
         address: "4 Boulevard Longchamp 13001 Marseille",
         name: "CODE EN STOCK",
         naf: "6201Z",
-        libelleNaf: "Programmation informatique",
-        longitude: 5.387141,
-        latitude: 43.300746
+        libelleNaf: "Programmation informatique"
       }
     ]);
 
@@ -69,8 +63,6 @@ describe("query { searchCompanies(clue, department) }", () => {
           companyTypes
           naf
           libelleNaf
-          longitude
-          latitude
           installation {
             codeS3ic
           }
@@ -97,9 +89,7 @@ describe("query { searchCompanies(clue, department) }", () => {
         address: "4 Boulevard Longchamp 13001 Marseille",
         name: "CODE EN STOCK",
         naf: "6201Z",
-        libelleNaf: "Programmation informatique",
-        longitude: 5.387141,
-        latitude: 43.300746
+        libelleNaf: "Programmation informatique"
       }
     ]);
 

--- a/back/src/companies/queries/companyInfos.ts
+++ b/back/src/companies/queries/companyInfos.ts
@@ -13,7 +13,7 @@ import { CompanyPublic } from "../../generated/graphql/types";
  */
 export async function getCompanyInfos(siret: string): Promise<CompanyPublic> {
   // retrieve cached info from SIRENE database
-  const sireneCompanyInfo = await searchCompany(siret);
+  const { __typename, ...sireneCompanyInfo } = await searchCompany(siret);
 
   // sireneCompanyInfo default to { siret: '', ...} if the siret is
   // not recognized. Handle this edge case by throwing a NOT_FOUND

--- a/back/src/companies/sirene/__tests__/cache.integration.ts
+++ b/back/src/companies/sirene/__tests__/cache.integration.ts
@@ -1,5 +1,4 @@
-import { searchCompanyCached } from "../cache";
-import * as client from "../client";
+import { cache } from "../cache";
 import { resetCache } from "../../../../integration-tests/helper";
 
 const company = {
@@ -7,19 +6,17 @@ const company = {
   address: "4 Boulevard Longchamp 13001 Marseille",
   name: "CODE EN STOCK",
   naf: "62.01Z",
-  libelleNaf: "Programmation informatique",
-  longitude: 5.387141,
-  latitude: 43.300746
+  libelleNaf: "Programmation informatique"
 };
-
-const searchCompanySpy = jest
-  .spyOn(client, "searchCompany")
-  .mockResolvedValue(company);
 
 describe("searchCompany cached", () => {
   afterAll(() => resetCache());
 
   it("should cache company information", async () => {
+    const searchCompany = jest.fn();
+    searchCompany.mockResolvedValueOnce(company);
+    const searchCompanyCached = cache(searchCompany);
+
     // call the function twice on the same siret
     const company1 = await searchCompanyCached("85001946400013");
     const company2 = await searchCompanyCached("85001946400013");
@@ -27,6 +24,6 @@ describe("searchCompany cached", () => {
     expect(company2).toEqual(company);
 
     // check searchCompany has been called only once
-    expect(searchCompanySpy).toHaveBeenCalledTimes(1);
+    expect(searchCompany).toHaveBeenCalledTimes(1);
   });
 });

--- a/back/src/companies/sirene/__tests__/ratelimit.integration.ts
+++ b/back/src/companies/sirene/__tests__/ratelimit.integration.ts
@@ -1,0 +1,59 @@
+import { throttle } from "../ratelimit";
+import { resetCache } from "../../../../integration-tests/helper";
+import { redisClient, setInCache } from "../../../common/redis";
+
+describe("throttled decorator", () => {
+  afterEach(() => resetCache());
+
+  it("should throttle API call when hitting 429", async () => {
+    expect.assertions(6);
+
+    // function to be throttled
+    const fn = jest.fn();
+    const cacheKey = "throttle_test";
+    const errorMessage = "Out of quotas";
+
+    // check throttle key is not set in redis initially
+    const isThrottledInitially = await redisClient.get(cacheKey);
+    expect(isThrottledInitially).toBeNull();
+
+    fn.mockRejectedValueOnce({ response: { status: 429 } });
+
+    // decorates function
+    const throttled = throttle<{ status: number }>(fn, {
+      cacheKey,
+      errorMessage
+    });
+
+    try {
+      await throttled("siret");
+    } catch (err) {
+      expect(err.message).toEqual(errorMessage);
+    }
+
+    // check throttle key is set in redis
+    const isThrottled = await redisClient.get(cacheKey);
+    expect(isThrottled).toEqual("true");
+
+    // subsequent calls should fail fast and not hit fn
+    fn.mockClear();
+    try {
+      await throttled("siret");
+    } catch (err) {
+      expect(err.message).toEqual(errorMessage);
+    }
+    expect(fn).not.toHaveBeenCalled();
+
+    // expires throttle key after 1 second
+    await setInCache(cacheKey, "true", { EX: 1 });
+
+    // wait for the throttle period to expires
+    await new Promise(resolve => setTimeout(() => resolve(), 1500));
+
+    fn.mockResolvedValueOnce({ status: 200 });
+
+    // it should make request normally after the throttled period
+    const response = await throttled("siret");
+    expect(response.status).toEqual(200);
+  });
+});

--- a/back/src/companies/sirene/__tests__/redundancy.test.ts
+++ b/back/src/companies/sirene/__tests__/redundancy.test.ts
@@ -1,0 +1,78 @@
+import { redundant } from "../redundancy";
+import { ErrorCode } from "../../../common/errors";
+
+const fn1 = jest.fn();
+const fn2 = jest.fn();
+
+describe("redundant", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not call fallback function when the first function succeeds", async () => {
+    const fn = redundant<string>(fn1, fn2);
+
+    // test fn1 returns something
+    fn1.mockResolvedValueOnce("bar");
+
+    const response = await fn("foo");
+    expect(response).toEqual("bar");
+
+    // fn2 should not be called
+    expect(fn1).toHaveBeenCalled();
+    expect(fn2).not.toHaveBeenCalled();
+  });
+
+  it("should call fallback function when the first function returns 5xx", async () => {
+    // test fn1 throw 5xx
+    fn1.mockRejectedValueOnce({ response: { status: 502 } });
+    fn2.mockResolvedValueOnce("bar");
+
+    const fn = redundant<string>(fn1, fn2);
+    const response = await fn("foo");
+    expect(response).toEqual("bar");
+    // fn2 should have been called
+    expect(fn1).toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalled();
+  });
+
+  it("should call fallback function when the first function returns TOO_MANY_REQUESTS", async () => {
+    const fn = redundant<string>(fn1, fn2);
+
+    // test fn1 throw TooManyRequests
+    fn1.mockRejectedValueOnce({
+      extensions: { code: ErrorCode.TOO_MANY_REQUESTS }
+    });
+    fn2.mockResolvedValueOnce("bar");
+
+    const response = await fn("foo");
+    expect(response).toEqual("bar");
+    // fn2 should have been called
+    expect(fn1).toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalled();
+  });
+
+  it("should throw first error when both functions fail", async () => {
+    expect.assertions(1);
+
+    const fn1BadGateway = "fn1 Bad Gateway";
+    const fn2BadGateway = "fn2 Bad Gateway";
+
+    // test both fn1 and fn2 throws 5xx
+    fn1.mockRejectedValueOnce({
+      response: { status: 502, message: fn1BadGateway }
+    });
+    fn2.mockRejectedValueOnce({
+      response: { status: 502, message: fn2BadGateway }
+    });
+
+    const fn = redundant<string>(fn1, fn2);
+
+    try {
+      await fn("foo");
+    } catch (err) {
+      // in case both failed, return first err message
+      expect(err.response.message).toEqual(fn1BadGateway);
+    }
+  });
+});

--- a/back/src/companies/sirene/__tests__/sirene.test.ts
+++ b/back/src/companies/sirene/__tests__/sirene.test.ts
@@ -1,0 +1,14 @@
+import { searchCompany } from "..";
+import { ErrorCode } from "../../../common/errors";
+
+describe("searchCompany", () => {
+  it(`should throw BAD_USER_INPUT error if
+    the siret is not 14 character length`, async () => {
+    expect.assertions(1);
+    try {
+      await searchCompany("invalide");
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+});

--- a/back/src/companies/sirene/cache.ts
+++ b/back/src/companies/sirene/cache.ts
@@ -1,27 +1,15 @@
-import { UserInputError } from "apollo-server-express";
 import { cachedGet } from "../../common/redis";
-import { searchCompany } from "./client";
-import { CompanySearchResult } from "./types";
 
 export const COMPANY_INFOS_CACHE_KEY = "CompanyInfos";
 const EXPIRY_TIME = 60 * 60 * 24;
 
-/**
- * Wrap calls to searchCompany
- * It performs validation and return from cache if key is present
- * @param siret
- */
-export function searchCompanyCached(
-  siret: string
-): Promise<CompanySearchResult> {
-  if (siret.length !== 14) {
-    throw new UserInputError("Le siret doit faire 14 caractères", {
-      invalidArgs: ["siret"]
+export function cache<U>(fn: (v: string) => Promise<U>) {
+  const cached = (v: string) => {
+    return cachedGet<U>(fn, COMPANY_INFOS_CACHE_KEY, v, {
+      parser: JSON,
+      options: { EX: EXPIRY_TIME }
     });
-  }
+  };
 
-  return cachedGet(searchCompany, COMPANY_INFOS_CACHE_KEY, siret, {
-    parser: JSON,
-    options: { EX: EXPIRY_TIME }
-  });
+  return cached;
 }

--- a/back/src/companies/sirene/entreprise.data.gouv.fr/__tests__/client.test.ts
+++ b/back/src/companies/sirene/entreprise.data.gouv.fr/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { searchCompany, searchCompanies } from "../client";
-import { ErrorCode } from "../../../common/errors";
+import { ErrorCode } from "../../../../common/errors";
 import axios from "axios";
 
 jest.mock("axios");
@@ -22,8 +22,6 @@ describe("searchCompany", () => {
           code_postal: "13001",
           code_commune: "13201",
           libelle_commune: "MARSEILLE",
-          longitude: "5.387141",
-          latitude: "43.300746",
           geo_adresse: "4 Boulevard Longchamp 13001 Marseille",
           unite_legale: {
             denomination: "CODE EN STOCK",
@@ -40,9 +38,7 @@ describe("searchCompany", () => {
       codeCommune: "13201",
       name: "CODE EN STOCK",
       naf: "62.01Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     };
     expect(company).toEqual(expected);
   });
@@ -61,8 +57,6 @@ describe("searchCompany", () => {
           code_postal: "13001",
           code_commune: "13201",
           libelle_commune: "MARSEILLE",
-          longitude: "5.387141",
-          latitude: "43.300746",
           geo_adresse: "4 RUE DES ROSIERS 13001 Marseille",
           unite_legale: {
             denomination: null,
@@ -126,8 +120,6 @@ describe("searchCompanies", () => {
             libelle_commune: "MARSEILLE",
             activite_principale: "6201Z",
             libelle_activite_principale: "Programmation informatique",
-            longitude: "5.387141",
-            latitude: "43.300746",
             geo_adresse: "4 Boulevard Longchamp 13001 Marseille"
           }
         ]
@@ -140,9 +132,7 @@ describe("searchCompanies", () => {
       address: "4 Boulevard Longchamp 13001 Marseille",
       name: "CODE EN STOCK",
       naf: "6201Z",
-      libelleNaf: "Programmation informatique",
-      longitude: 5.387141,
-      latitude: 43.300746
+      libelleNaf: "Programmation informatique"
     };
     expect(companies[0]).toEqual(expected);
   });
@@ -163,8 +153,6 @@ describe("searchCompanies", () => {
             activite_principale: "1071C",
             libelle_activite_principale:
               "Boulangerie et boulangerie-pâtisserie",
-            longitude: "5.38641",
-            latitude: "43.300208",
             geo_adresse: "18 Cours Joseph Thierry 13001 Marseille"
           }
         ]
@@ -218,8 +206,6 @@ describe("searchCompanies", () => {
             activite_principale: "4724Z",
             libelle_activite_principale:
               "Commerce de détail de pain, pâtisserie et confiserie en magasin spécialisé",
-            longitude: "4.693487",
-            latitude: "45.258127",
             geo_adresse: "1 route des blés 07100 ANNONAY"
           }
         ]
@@ -234,9 +220,7 @@ describe("searchCompanies", () => {
       name: "BOULANGERIE",
       naf: "4724Z",
       libelleNaf:
-        "Commerce de détail de pain, pâtisserie et confiserie en magasin spécialisé",
-      longitude: 4.693487,
-      latitude: 45.258127
+        "Commerce de détail de pain, pâtisserie et confiserie en magasin spécialisé"
     };
     expect(companies[0]).toEqual(expected);
     expect(
@@ -258,8 +242,6 @@ describe("searchCompanies", () => {
           libelle_voie: "LONGCHAMP",
           code_postal: "13001",
           libelle_commune: "MARSEILLE",
-          longitude: "5.387141",
-          latitude: "43.300746",
           geo_adresse: "4 Boulevard Longchamp 13001 Marseille",
           unite_legale: {
             denomination: "CODE EN STOCK",

--- a/back/src/companies/sirene/index.ts
+++ b/back/src/companies/sirene/index.ts
@@ -1,4 +1,69 @@
-import { searchCompanies } from "./client";
-import { searchCompanyCached as searchCompany } from "./cache";
+import {
+  searchCompany as searchCompanyInsee,
+  searchCompanies as searchCompaniesInsee
+} from "./insee/client";
+import {
+  searchCompany as searchCompanyDataGouv,
+  searchCompanies as searchCompaniesDataGouv
+} from "./entreprise.data.gouv.fr/client";
+import { CompanySearchResult } from "../../generated/graphql/types";
+import { throttle } from "./ratelimit";
+import { redundant } from "./redundancy";
+import { cache } from "./cache";
+import { UserInputError } from "apollo-server-express";
 
-export { searchCompanies, searchCompany };
+const INSEE_THROTTLE_KEY = "insee_throttle";
+const DATA_GOUV_THROTTLE_KEY = "data_gouv_throttle";
+
+function throttleErrorMessage(apiType: string) {
+  return `Trop de requêtes sur l'API Sirene ${apiType}`;
+}
+
+/**
+ * Apply throttle, redundant and cache decorators to searchCompany functions
+ * We use INSEE API in priority and fall back to entreprise.data.gouv.fr
+ */
+const decoratedSearchCompany = cache(
+  redundant(
+    throttle(searchCompanyInsee, {
+      cacheKey: INSEE_THROTTLE_KEY,
+      errorMessage: throttleErrorMessage("INSEE")
+    }),
+    throttle(searchCompanyDataGouv, {
+      cacheKey: DATA_GOUV_THROTTLE_KEY,
+      errorMessage: throttleErrorMessage("entreprise.data.gouv.fr")
+    })
+  )
+);
+
+export function searchCompany(siret: string): Promise<CompanySearchResult> {
+  if (siret.length !== 14) {
+    throw new UserInputError("Le siret doit faire 14 caractères", {
+      invalidArgs: ["siret"]
+    });
+  }
+  return decoratedSearchCompany(siret);
+}
+
+/**
+ * Apply throttle and redundant decorator to searchCompanies functions
+ * We use entreprise.data.gouv.fr API in priority and fallback to INSEE
+ * because fuzzy search is way better in entreprise.data.gouv.fr
+ */
+const decoratedSearchCompanies = redundant(
+  throttle(searchCompaniesDataGouv, {
+    cacheKey: DATA_GOUV_THROTTLE_KEY,
+    errorMessage: throttleErrorMessage("entreprise.data.gouv.fr")
+  }),
+  throttle(searchCompaniesInsee, {
+    cacheKey: INSEE_THROTTLE_KEY,
+    errorMessage: throttleErrorMessage("INSEE")
+  })
+);
+
+export function searchCompanies(
+  clue: string,
+  department?: string
+): Promise<CompanySearchResult[]> {
+  return decoratedSearchCompanies(clue, department);
+}

--- a/back/src/companies/sirene/insee/__tests__/client.test.ts
+++ b/back/src/companies/sirene/insee/__tests__/client.test.ts
@@ -1,0 +1,232 @@
+import { searchCompany, searchCompanies } from "../client";
+import { ErrorCode } from "../../../../common/errors";
+import * as token from "../token";
+
+const axiosGet = jest.spyOn(token, "authorizedAxiosGet");
+
+const axiosResponseDefault = {
+  statusText: "",
+  config: null,
+  headers: null
+};
+
+describe("searchCompany", () => {
+  afterEach(() => {
+    axiosGet.mockReset();
+  });
+
+  it("should retrieve a company by siret", async () => {
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissement: {
+          siret: "85001946400013",
+          uniteLegale: {
+            denominationUniteLegale: "CODE EN STOCK",
+            categorieJuridiqueUniteLegale: "",
+            etatAdministratifUniteLegale: "A",
+            prenom1UniteLegale: "",
+            nomUniteLegale: "",
+            activitePrincipaleUniteLegale: "62.01Z"
+          },
+          adresseEtablissement: {
+            numeroVoieEtablissement: "4",
+            typeVoieEtablissement: "BD",
+            libelleVoieEtablissement: "LONGCHAMP",
+            codePostalEtablissement: "13001",
+            libelleCommuneEtablissement: "Marseille",
+            codeCommuneEtablissement: "13201"
+          }
+        }
+      }
+    });
+
+    const company = await searchCompany("85001946400013");
+    const expected = {
+      siret: "85001946400013",
+      etatAdministratif: "A",
+      address: "4 BD LONGCHAMP 13001 Marseille",
+      codeCommune: "13201",
+      name: "CODE EN STOCK",
+      naf: "62.01Z",
+      libelleNaf: "Programmation informatique"
+    };
+    expect(company).toEqual(expected);
+  });
+
+  it(`should set name for an individual enterprise
+      by concatenating first and last name`, async () => {
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissement: {
+          siret: "34393738900041",
+          uniteLegale: {
+            denominationUniteLegale: "",
+            categorieJuridiqueUniteLegale: "1000",
+            etatAdministratifUniteLegale: "A",
+            prenom1UniteLegale: "JOHN",
+            nomUniteLegale: "SNOW",
+            activitePrincipaleUniteLegale: "62.01Z"
+          },
+          adresseEtablissement: {
+            numeroVoieEtablissement: "4",
+            typeVoieEtablissement: "RUE",
+            libelleVoieEtablissement: "DES ROSIERS",
+            codePostalEtablissement: "13001",
+            libelleCommuneEtablissement: "Marseille",
+            codeCommuneEtablissement: "13201"
+          }
+        }
+      }
+    });
+    const company = await searchCompany("34393738900041");
+    expect(company.name).toEqual("JOHN SNOW");
+  });
+
+  it("should raise BAD_USER_INPUT if error 404 (siret not found)", async () => {
+    axiosGet.mockRejectedValueOnce({
+      response: {
+        status: 404
+      }
+    });
+    expect.assertions(1);
+    try {
+      await searchCompany("xxxxxxxxxxxxxx");
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+
+  it(`should escalate other types of errors
+          (network, internal server error, etc)`, async () => {
+    axiosGet.mockRejectedValueOnce({
+      message: "Erreur inconnue"
+    });
+    expect.assertions(1);
+    try {
+      await searchCompany("85001946400013");
+    } catch (e) {
+      expect(e.message).toEqual("Erreur inconnue");
+    }
+  });
+});
+
+describe("searchCompanies", () => {
+  afterEach(() => {
+    axiosGet.mockReset();
+  });
+
+  it("perform a full text search based on a clue", async () => {
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissements: [
+          {
+            siret: "85001946400013",
+            uniteLegale: {
+              denominationUniteLegale: "CODE EN STOCK",
+              categorieJuridiqueUniteLegale: "",
+              etatAdministratifUniteLegale: "A",
+              prenom1UniteLegale: "",
+              nomUniteLegale: "",
+              activitePrincipaleUniteLegale: "62.01Z"
+            },
+            adresseEtablissement: {
+              numeroVoieEtablissement: "4",
+              typeVoieEtablissement: "BD",
+              libelleVoieEtablissement: "LONGCHAMP",
+              codePostalEtablissement: "13001",
+              libelleCommuneEtablissement: "Marseille",
+              codeCommuneEtablissement: "13201"
+            }
+          }
+        ]
+      }
+    });
+    const companies = await searchCompanies("code en stock");
+    expect(companies).toHaveLength(1);
+    const expected = {
+      siret: "85001946400013",
+      address: "4 BD LONGCHAMP 13001 Marseille",
+      codeCommune: "13201",
+      etatAdministratif: "A",
+      name: "CODE EN STOCK",
+      naf: "62.01Z",
+      libelleNaf: "Programmation informatique"
+    };
+    expect(companies[0]).toEqual(expected);
+  });
+
+  it("should return empty array if no results", async () => {
+    axiosGet.mockRejectedValueOnce({
+      response: {
+        status: 404
+      }
+    });
+    const companies = await searchCompanies("sdsdhuu876gbshdsdsd");
+    expect(companies).toHaveLength(0);
+  });
+
+  it(`should escalate other types of errors
+      (network, internal server error, etc)`, async () => {
+    axiosGet.mockRejectedValueOnce({
+      message: "Erreur inconnue"
+    });
+    expect.assertions(1);
+    try {
+      await searchCompanies("boulangerie");
+    } catch (e) {
+      expect(e.message).toEqual("Erreur inconnue");
+    }
+  });
+
+  it("should filter results by departement", async () => {
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissements: [
+          {
+            siret: "xxxxxxxxxxxxxx",
+            uniteLegale: {
+              denominationUniteLegale: "BOULANGERIE",
+              categorieJuridiqueUniteLegale: "",
+              etatAdministratifUniteLegale: "A",
+              prenom1UniteLegale: "",
+              nomUniteLegale: "",
+              activitePrincipaleUniteLegale: "4724Z"
+            },
+            adresseEtablissement: {
+              numeroVoieEtablissement: "1",
+              typeVoieEtablissement: "ROUTE",
+              libelleVoieEtablissement: "DES BLÉS",
+              codePostalEtablissement: "07100",
+              libelleCommuneEtablissement: "ANNONAY",
+              codeCommuneEtablissement: "07110"
+            }
+          }
+        ]
+      }
+    });
+
+    const companies = await searchCompanies("boulangerie", "07");
+    expect(companies).toHaveLength(1);
+    const expected = {
+      siret: "xxxxxxxxxxxxxx",
+      address: "1 ROUTE DES BLÉS 07100 ANNONAY",
+      codeCommune: "07110",
+      etatAdministratif: "A",
+      name: "BOULANGERIE",
+      naf: "4724Z",
+      libelleNaf:
+        "Commerce de détail de pain, pâtisserie et confiserie en magasin spécialisé"
+    };
+    expect(companies[0]).toEqual(expected);
+    const callUrl = axiosGet.mock.calls[0][0];
+    expect(callUrl).toContain("codePostalEtablissement:07*");
+  });
+});

--- a/back/src/companies/sirene/insee/__tests__/token.integration.ts
+++ b/back/src/companies/sirene/insee/__tests__/token.integration.ts
@@ -1,0 +1,109 @@
+import axios from "axios";
+import { authorizedAxiosGet, getToken, INSEE_TOKEN_KEY } from "../token";
+import { resetCache } from "../../../../../integration-tests/helper";
+import { setInCache } from "../../../../common/redis";
+
+jest.mock("axios");
+
+describe("authorizedAxiosGet", () => {
+  afterEach(async () => {
+    (axios.get as jest.Mock).mockReset();
+    await resetCache();
+  });
+
+  it("should renew token when no initial token is set", async () => {
+    // check there is no initial token saved
+    const initialToken = await getToken();
+    expect(initialToken).toBeNull();
+
+    const siret = "11111111111111";
+    const url = `/siret/${siret}`;
+    const validToken = "valid_token";
+
+    // mock POST /token
+    (axios.post as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        access_token: validToken
+      }
+    });
+
+    // mock GET url
+    (axios.get as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        siret
+      }
+    });
+
+    // patched will retrieve a token
+    // before making the actual call
+    const response = await authorizedAxiosGet<{ siret: string }>(url);
+
+    // check it returns the data
+    expect(response.data.siret).toEqual(siret);
+
+    // check the token has been saved to redis
+    const token = await getToken();
+    expect(token).toEqual(validToken);
+
+    // check axios has been called with authorization header
+    expect(axios.get as jest.Mock).toHaveBeenCalledWith(url, {
+      headers: { Authorization: `Bearer ${validToken}` }
+    });
+  });
+
+  it("should renew token when an expired token is set", async () => {
+    const invalidToken = "invalid_token";
+    await setInCache(INSEE_TOKEN_KEY, invalidToken);
+
+    // check initial token is invalid
+    const initialToken = await getToken();
+    expect(initialToken).toEqual(invalidToken);
+
+    const siret = "11111111111111";
+    const url = `/siret/${siret}`;
+    const validToken = "valid_token";
+
+    // mock GET url returns 401
+    (axios.get as jest.Mock).mockRejectedValueOnce({
+      response: {
+        status: 401
+      }
+    });
+
+    // mock POST /token
+    (axios.post as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        access_token: validToken
+      }
+    });
+
+    // mock GET url return 200 and data
+    (axios.get as jest.Mock).mockResolvedValueOnce({
+      status: 200,
+      data: {
+        siret
+      }
+    });
+
+    // patched axios get should try a first time and get 401
+    // then renew the token, then retry and get 200
+    const response = await authorizedAxiosGet<{ siret: string }>(url);
+
+    // check it returns the data
+    expect(response.data.siret).toEqual(siret);
+
+    // check the token has been saved to redis
+    const token = await getToken();
+    expect(token).toEqual(validToken);
+
+    // check axios has been called first with invalidToken and
+    // then with validToken
+    expect((axios.get as jest.Mock).mock.calls).toEqual([
+      [url, { headers: { Authorization: `Bearer ${invalidToken}` } }],
+      [url, { headers: { Authorization: `Bearer ${validToken}` } }]
+    ]);
+  });
+});

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -1,0 +1,133 @@
+import {
+  SearchResponseInsee,
+  CompanySearchResult,
+  FullTextSearchResponseInsee
+} from "../types";
+import { libelleFromCodeNaf, buildAddress } from "../utils";
+import { UserInputError } from "apollo-server-express";
+import { authorizedAxiosGet } from "./token";
+
+const SIRENE_API_BASE_URL = "https://api.insee.fr/entreprises/sirene/V3";
+
+/**
+ * Build a company object from a search response
+ * @param data etablissement response object
+ */
+function searchResponseToCompany({
+  etablissement
+}: SearchResponseInsee): CompanySearchResult {
+  const address = buildAddress(
+    etablissement.adresseEtablissement.numeroVoieEtablissement,
+    etablissement.adresseEtablissement.typeVoieEtablissement,
+    etablissement.adresseEtablissement.libelleVoieEtablissement,
+    etablissement.adresseEtablissement.codePostalEtablissement,
+    etablissement.adresseEtablissement.libelleCommuneEtablissement
+  );
+
+  const company = {
+    siret: etablissement.siret,
+    etatAdministratif: etablissement.uniteLegale.etatAdministratifUniteLegale,
+    address,
+    codeCommune: etablissement.adresseEtablissement.codeCommuneEtablissement,
+    name: etablissement.uniteLegale.denominationUniteLegale,
+    naf: etablissement.uniteLegale.activitePrincipaleUniteLegale,
+    libelleNaf: ""
+  };
+
+  if (company.naf) {
+    company.libelleNaf = libelleFromCodeNaf(company.naf);
+  }
+
+  const isEntrepreneurIndividuel =
+    etablissement.uniteLegale.categorieJuridiqueUniteLegale === "1000";
+
+  if (isEntrepreneurIndividuel) {
+    // concatenate prénom et nom
+    company.name = [
+      etablissement.uniteLegale.prenom1UniteLegale,
+      etablissement.uniteLegale.nomUniteLegale
+    ]
+      .join(" ")
+      .trim();
+  }
+
+  return company;
+}
+
+/**
+ * Search a company by SIRET
+ * @param siret
+ */
+export function searchCompany(siret: string): Promise<CompanySearchResult> {
+  const searchUrl = `${SIRENE_API_BASE_URL}/siret/${siret}`;
+
+  return authorizedAxiosGet<SearchResponseInsee>(searchUrl)
+    .then(r => searchResponseToCompany(r.data))
+    .catch(error => {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+      if (error.response?.status === 404) {
+        // 404 "no results found"
+        throw new UserInputError("Aucun établissement trouvé avec ce SIRET", {
+          invalidArgs: ["siret"]
+        });
+      }
+      throw error;
+    });
+}
+
+/**
+ * Build a list of company objects from a full text search response
+ * @param data etablissement response object
+ */
+function fullTextSearchResponseToCompanies(
+  r: FullTextSearchResponseInsee
+): CompanySearchResult[] {
+  return r.etablissements.map(etablissement =>
+    searchResponseToCompany({ etablissement })
+  );
+}
+
+/**
+ * Full text search in SIRENE database
+ *
+ * @param clue search string
+ * @param department department filter
+ */
+export function searchCompanies(
+  clue: string,
+  department?: string
+): Promise<CompanySearchResult[]> {
+  // list of filters to pass as "q" arguments
+  const filters = [];
+
+  // exclude closed companies
+  filters.push(`etatAdministratifUniteLegale:A`);
+
+  if (/[0-9]{14}/.test(clue)) {
+    // clue is formatted like a SIRET
+    filters.push(`siret:${clue}`);
+  } else {
+    filters.push(`denominationUniteLegale:"*${clue}*"~`);
+  }
+
+  if (department) {
+    filters.push(`codePostalEtablissement:${department}*`);
+  }
+
+  const searchUrl = `${SIRENE_API_BASE_URL}/siret?q=${filters.join(" AND ")}`;
+
+  return authorizedAxiosGet<FullTextSearchResponseInsee>(searchUrl)
+    .then(r => {
+      return fullTextSearchResponseToCompanies(r.data);
+    })
+    .catch(error => {
+      // The request was made and the server responded with a status code
+      // that falls out of the range of 2xx
+      if (error.response?.status === 404) {
+        // 404 "no results found"
+        return [];
+      }
+      throw error;
+    });
+}

--- a/back/src/companies/sirene/insee/token.ts
+++ b/back/src/companies/sirene/insee/token.ts
@@ -1,0 +1,78 @@
+import axios, { AxiosResponse, AxiosRequestConfig } from "axios";
+import { redisClient, setInCache } from "../../../common/redis";
+
+const SIRENE_API_TOKEN_URL = "https://api.insee.fr/token";
+export const INSEE_TOKEN_KEY = "insee_token";
+const { INSEE_SECRET } = process.env;
+
+/**
+ * Generates INSEE Sirene API token
+ */
+async function generateToken(): Promise<string> {
+  const headers = {
+    Authorization: `Basic ${INSEE_SECRET}`,
+    "Content-Type": "application/x-www-form-urlencoded"
+  };
+
+  const response = await axios.post(
+    SIRENE_API_TOKEN_URL,
+    "grant_type=client_credentials",
+    { headers }
+  );
+
+  return response.data.access_token;
+}
+
+/**
+ * Generates a token and save it to redis cache
+ */
+async function renewToken(): Promise<void> {
+  const token = await generateToken();
+  await setInCache(INSEE_TOKEN_KEY, token);
+}
+
+/**
+ * Retrives token from redis cache
+ */
+export async function getToken(): Promise<string> {
+  return redisClient.get(INSEE_TOKEN_KEY);
+}
+
+/**
+ * Patched version of axios.get that handles
+ * authorization to INSEE API and token renewal
+ */
+export async function authorizedAxiosGet<T>(
+  url: string,
+  config?: AxiosRequestConfig
+): Promise<AxiosResponse<T>> {
+  // inner function that add authorization header
+  async function get() {
+    let token = await getToken();
+    if (token === null) {
+      // token has never been set, renew it
+      await renewToken();
+      token = await getToken();
+    }
+    const authHeader = {
+      Authorization: `Bearer ${token}`
+    };
+    return axios.get<T>(url, {
+      ...config,
+      headers: { ...(config?.headers ? config.headers : {}), ...authHeader }
+    });
+  }
+  try {
+    const response = await get();
+    return response;
+  } catch (err) {
+    if (err.response?.status === 401) {
+      // Token has expired, renew it
+      await renewToken();
+      // Retry request after renewal
+      return get();
+    } else {
+      throw err;
+    }
+  }
+}

--- a/back/src/companies/sirene/ratelimit.ts
+++ b/back/src/companies/sirene/ratelimit.ts
@@ -1,0 +1,38 @@
+import { redisClient, setInCache } from "../../common/redis";
+import { TooManyRequestsError } from "../../common/errors";
+
+type ThrottledDecoratorOpts = {
+  cacheKey: string;
+  errorMessage: string;
+  expiry?: number;
+};
+
+/**
+ * Throttle API calls in case we hit rate limit
+ */
+export function throttle<T>(
+  fn: (...args) => Promise<T>,
+  { cacheKey, errorMessage, expiry }: ThrottledDecoratorOpts
+) {
+  const rateLimited = async (...args) => {
+    const isRateLimited = await redisClient.get(cacheKey);
+    if (isRateLimited) {
+      // fail fast if we know we are being rate limited
+      // to prevent our API from being blacklisted
+      throw new TooManyRequestsError(errorMessage);
+    }
+    try {
+      const response = await fn(...args);
+      return response;
+    } catch (err) {
+      if (err.response?.status === 429) {
+        // server responded with a 429 TOO MANY REQUESTS
+        // activate rate limiting cache key for a specific amout of time
+        await setInCache(cacheKey, "true", { EX: expiry ?? 60 });
+        throw new TooManyRequestsError(errorMessage);
+      }
+      throw err;
+    }
+  };
+  return rateLimited;
+}

--- a/back/src/companies/sirene/redundancy.ts
+++ b/back/src/companies/sirene/redundancy.ts
@@ -1,0 +1,36 @@
+import { ErrorCode } from "../../common/errors";
+
+/**
+ * fallback to fn2 if fn1 fails
+ */
+export function redundant<T>(
+  fn1: (...args) => Promise<T>,
+  fn2: (...args) => Promise<T>
+) {
+  const redundantFn = async (...args) => {
+    try {
+      // try fn1
+      const response1 = await fn1(...args);
+      return response1;
+    } catch (err1) {
+      if (
+        // fn1 has failed
+        err1.response?.status >= 500 ||
+        err1.extensions?.code === ErrorCode.TOO_MANY_REQUESTS
+      ) {
+        try {
+          // try fn2
+          const response2 = await fn2(...args);
+          return response2;
+        } catch (err2) {
+          // fn2 has also fails, throw err1
+          throw err1;
+        }
+      } else {
+        throw err1;
+      }
+    }
+  };
+
+  return redundantFn;
+}

--- a/back/src/companies/sirene/types.ts
+++ b/back/src/companies/sirene/types.ts
@@ -1,5 +1,5 @@
-// Response from /api/sirene/v3/etablissements/<VOTRE_SIRET>
-export interface SearchResponse {
+// Response from https://api.entreprise.data.gouv.fr/api/sirene/v3/etablissements/<VOTRE_SIRET>
+export interface SearchResponseDataGouv {
   etablissement: {
     siret: string;
     etat_administratif: string;
@@ -9,8 +9,6 @@ export interface SearchResponse {
     code_postal: string;
     code_commune: string;
     libelle_commune: string;
-    longitude: string;
-    latitude: string;
     geo_adresse: string;
     unite_legale: {
       denomination: string;
@@ -22,8 +20,33 @@ export interface SearchResponse {
   };
 }
 
-// Response from /api/sirene/v1/full_text/<CLUE>
-export interface FullTextSearchResponse {
+interface EtablissementInsee {
+  siret: string;
+  uniteLegale: {
+    denominationUniteLegale: string;
+    categorieJuridiqueUniteLegale: string;
+    etatAdministratifUniteLegale: string;
+    prenom1UniteLegale: string;
+    nomUniteLegale: string;
+    activitePrincipaleUniteLegale: string;
+  };
+  adresseEtablissement: {
+    numeroVoieEtablissement: string;
+    typeVoieEtablissement: string;
+    libelleVoieEtablissement: string;
+    codePostalEtablissement: string;
+    libelleCommuneEtablissement: string;
+    codeCommuneEtablissement: string;
+  };
+}
+
+// Response from https://api.insee.fr/entreprises/siret/V3/siret/<VOTRE_SIRET>
+export interface SearchResponseInsee {
+  etablissement: EtablissementInsee;
+}
+
+// Response from https://api.entreprise.data.gouv.fr/api/sirene/v1/full_text/<CLUE>
+export interface FullTextSearchResponseDataGouv {
   etablissement: {
     siret: string;
     nom_raison_sociale: string;
@@ -35,10 +58,13 @@ export interface FullTextSearchResponse {
     libelle_commune: string;
     activite_principale: string;
     libelle_activite_principale: string;
-    longitude: string;
-    latitude: string;
     geo_adresse: string;
   }[];
+}
+
+// Response from https://api.insee.fr/entreprises/siret/V3/siret/
+export interface FullTextSearchResponseInsee {
+  etablissements: EtablissementInsee[];
 }
 
 // return type for functions searchCompany and searchCompanies
@@ -50,6 +76,4 @@ export interface CompanySearchResult {
   name: string;
   naf: string;
   libelleNaf: string;
-  longitude: number;
-  latitude: number;
 }

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -136,10 +136,6 @@ export type CompanyPrivate = {
   naf?: Maybe<Scalars['String']>;
   /** Libellé NAF de l'établissement */
   libelleNaf?: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude?: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude?: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement (le cas échéant)
@@ -172,10 +168,6 @@ export type CompanyPublic = {
   naf?: Maybe<Scalars['String']>;
   /** Libellé NAF */
   libelleNaf?: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude?: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude?: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement
@@ -194,8 +186,12 @@ export type CompanySearchResult = {
    __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret?: Maybe<Scalars['String']>;
+  /** État administratif de l'établissement. A = Actif, F = Fermé */
+  etatAdministratif?: Maybe<Scalars['String']>;
   /** Adresse de l'établissement */
   address?: Maybe<Scalars['String']>;
+  /** Code commune de l'établissement */
+  codeCommune?: Maybe<Scalars['String']>;
   /** Nom de l'établissement */
   name?: Maybe<Scalars['String']>;
   /** Profil de l'établissement */
@@ -204,10 +200,6 @@ export type CompanySearchResult = {
   naf?: Maybe<Scalars['String']>;
   /** Libellé NAF */
   libelleNaf?: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude?: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude?: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement
@@ -2199,8 +2191,6 @@ export type CompanyPrivateResolvers<ContextType = GraphQLContext, ParentType ext
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>;
   transporterReceipt?: Resolver<Maybe<ResolversTypes['TransporterReceipt']>, ParentType, ContextType>;
   traderReceipt?: Resolver<Maybe<ResolversTypes['TraderReceipt']>, ParentType, ContextType>;
@@ -2217,8 +2207,6 @@ export type CompanyPublicResolvers<ContextType = GraphQLContext, ParentType exte
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>;
   isRegistered?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   transporterReceipt?: Resolver<Maybe<ResolversTypes['TransporterReceipt']>, ParentType, ContextType>;
@@ -2228,13 +2216,13 @@ export type CompanyPublicResolvers<ContextType = GraphQLContext, ParentType exte
 
 export type CompanySearchResultResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['CompanySearchResult'] = ResolversParentTypes['CompanySearchResult']> = {
   siret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  etatAdministratif?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  codeCommune?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   companyTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['CompanyType']>>>, ParentType, ContextType>;
   naf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   libelleNaf?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  latitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   installation?: Resolver<Maybe<ResolversTypes['Installation']>, ParentType, ContextType>;
   transporterReceipt?: Resolver<Maybe<ResolversTypes['TransporterReceipt']>, ParentType, ContextType>;
   traderReceipt?: Resolver<Maybe<ResolversTypes['TraderReceipt']>, ParentType, ContextType>;
@@ -2718,8 +2706,6 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     name: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     transporterReceipt: null,
     traderReceipt: null,
@@ -2739,8 +2725,6 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     name: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     isRegistered: null,
     transporterReceipt: null,
@@ -2753,13 +2737,13 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
   return {
     __typename: "CompanySearchResult",
     siret: null,
+    etatAdministratif: null,
     address: null,
+    codeCommune: null,
     name: null,
     companyTypes: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     transporterReceipt: null,
     traderReceipt: null,

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -15,10 +15,14 @@ authRouter.post("/login", (req, res, next) => {
     }
     if (!user) {
       const queries = {
-        ...{ error: info.message , errorField: info.errorField, username:info.username},
+        ...{
+          error: info.message,
+          errorField: info.errorField,
+          username: info.username
+        },
         ...(req.body.returnTo ? { returnTo: req.body.returnTo } : {})
       };
- 
+
       return res.redirect(
         `${UI_BASE_URL}/login?${querystring.stringify(queries)}`
       );

--- a/back/src/subscriptions/__tests__/rejected-form.test.ts
+++ b/back/src/subscriptions/__tests__/rejected-form.test.ts
@@ -136,8 +136,6 @@ const insee1: CompanySearchResult = {
   naf: "123",
   libelleNaf: "Fabricant de déchets",
   address: "01 Rue Marie Curie 66480 Laville",
-  longitude: 1.0,
-  latitude: 1.0,
   codeCommune: "66001"
 };
 const insee2: CompanySearchResult = {
@@ -146,8 +144,6 @@ const insee2: CompanySearchResult = {
   naf: "345",
   libelleNaf: "Traitement de déchets",
   address: "rue de la Paix, 77760 Une ville",
-  longitude: 2.0,
-  latitude: 2.0,
   codeCommune: "77001"
 };
 

--- a/back/src/users/bulk-creation/sirene.ts
+++ b/back/src/users/bulk-creation/sirene.ts
@@ -1,6 +1,6 @@
 import { CompanyRow } from "./types";
 import { CompanyInfo } from "./types";
-import { searchCompany } from "../../companies/sirene/client";
+import { searchCompany } from "../../companies/sirene/entreprise.data.gouv.fr/client";
 import { CompanySearchResult } from "../../generated/graphql/types";
 
 /**

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -1644,24 +1644,6 @@ Libellé NAF de l'établissement
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Longitude de l'établissement (info géographique)
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Latitude de l'établissement (info géographique)
-
-</td>
-</tr>
-<tr>
 <td colspan="2" valign="top"><strong>installation</strong></td>
 <td valign="top"><a href="#installation">Installation</a></td>
 <td>
@@ -1788,24 +1770,6 @@ Libellé NAF
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Longitude de l'établissement (info géographique)
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Latitude de l'établissement (info géographique)
-
-</td>
-</tr>
-<tr>
 <td colspan="2" valign="top"><strong>installation</strong></td>
 <td valign="top"><a href="#installation">Installation</a></td>
 <td>
@@ -1869,11 +1833,29 @@ SIRET de l'établissement
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>etatAdministratif</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+État administratif de l'établissement. A = Actif, F = Fermé
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>address</strong></td>
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
 Adresse de l'établissement
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>codeCommune</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Code commune de l'établissement
 
 </td>
 </tr>
@@ -1910,24 +1892,6 @@ Code NAF
 <td>
 
 Libellé NAF
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>longitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Longitude de l'établissement (info géographique)
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>latitude</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
-<td>
-
-Latitude de l'établissement (info géographique)
 
 </td>
 </tr>

--- a/front/src/dashboard/slips/slips-actions/Delete.tsx
+++ b/front/src/dashboard/slips/slips-actions/Delete.tsx
@@ -55,7 +55,10 @@ export default function Delete({ formId }: Props) {
           <h3>Confirmer la suppression ?</h3>
           <p>Cette action est irréversible.</p>
           <div className="form__actions">
-            <button className="button-outline primary" onClick={() => setIsOpen(false)}>
+            <button
+              className="button-outline primary"
+              onClick={() => setIsOpen(false)}
+            >
               Annuler
             </button>
             <button className="button no-margin" onClick={() => deleteForm()}>

--- a/front/src/form/waste-code/WasteCode.tsx
+++ b/front/src/form/waste-code/WasteCode.tsx
@@ -45,9 +45,9 @@ export default function WasteCode(props) {
             type="text"
             name={field.name}
             value={wasteCode}
-            className={`waste-code__input ${meta.touched &&
-              meta.error &&
-              "input-error"}`}
+            className={`waste-code__input ${
+              meta.touched && meta.error && "input-error"
+            }`}
             onBlur={field.onBlur}
             onChange={e => setWasteCode(e.target.value)}
           />

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -133,10 +133,6 @@ export type CompanyPrivate = {
   naf: Maybe<Scalars['String']>;
   /** Libellé NAF de l'établissement */
   libelleNaf: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement (le cas échéant)
@@ -169,10 +165,6 @@ export type CompanyPublic = {
   naf: Maybe<Scalars['String']>;
   /** Libellé NAF */
   libelleNaf: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement
@@ -191,8 +183,12 @@ export type CompanySearchResult = {
    __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret: Maybe<Scalars['String']>;
+  /** État administratif de l'établissement. A = Actif, F = Fermé */
+  etatAdministratif: Maybe<Scalars['String']>;
   /** Adresse de l'établissement */
   address: Maybe<Scalars['String']>;
+  /** Code commune de l'établissement */
+  codeCommune: Maybe<Scalars['String']>;
   /** Nom de l'établissement */
   name: Maybe<Scalars['String']>;
   /** Profil de l'établissement */
@@ -201,10 +197,6 @@ export type CompanySearchResult = {
   naf: Maybe<Scalars['String']>;
   /** Libellé NAF */
   libelleNaf: Maybe<Scalars['String']>;
-  /** Longitude de l'établissement (info géographique) */
-  longitude: Maybe<Scalars['Float']>;
-  /** Latitude de l'établissement (info géographique) */
-  latitude: Maybe<Scalars['Float']>;
   /**
    * Installation classée pour la protection de l'environnement (ICPE)
    * associé à cet établissement
@@ -1955,8 +1947,6 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     name: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     transporterReceipt: null,
     traderReceipt: null,
@@ -1976,8 +1966,6 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     name: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     isRegistered: null,
     transporterReceipt: null,
@@ -1990,13 +1978,13 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
   return {
     __typename: "CompanySearchResult",
     siret: null,
+    etatAdministratif: null,
     address: null,
+    codeCommune: null,
     name: null,
     companyTypes: null,
     naf: null,
     libelleNaf: null,
-    longitude: null,
-    latitude: null,
     installation: null,
     transporterReceipt: null,
     traderReceipt: null,

--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -35,13 +35,13 @@ export default function Signup() {
             const { cgu, ...userInfos } = values;
 
             signup({ variables: { userInfos } })
-              .then((_) =>
+              .then(_ =>
                 history.push({
                   pathname: "/signup/activation",
                   state: { signupEmail: userInfos.email },
                 })
               )
-              .catch((_) => {
+              .catch(_ => {
                 setSubmitting(false);
               });
           }}


### PR DESCRIPTION
* Implémentation du client de l'API Sirene de l'INSEE
* Ajout d'un mécanisme de "throttling" client pour éviter de se retrouver banni: dès réception d'une `429: Too Many Requests` on met un flag redis avec une durée d'expiration qui permet de ne pas refaire de requête avant la fin de la période.   
* Ajout d'un mécanisme de "redondance" entre l'API de l'INSEE et l'API de entreprise.data.gouv.fr: on essaye d'abord avec l'API 1 et si on prend 5xx ou 429 on bascule sur l'API 2. À noter que l'ordre de priorité n'est pas le même entre la recherche par SIRET et la recherche par nom car la recherche full text de l'API INSEE ne fonctionne pas bien sur le champ `denominationUniteLegale`.
* Suppression des champs `latitude` et `longitude` des objets `CompanyPublic`, `CompanyPrivate`, `CompanySearchResult`. Ces champs ne sont en effet pas retournés par l'API de l'INSEE.