### PR TITLE
Script de remplissage du champ currentTransporterSiret

### DIFF
--- a/back/prisma/scripts/index.ts
+++ b/back/prisma/scripts/index.ts
@@ -3,7 +3,9 @@ import { updaters, Updater } from "./helper/helper";
 
 async function loadUpdaters() {
   console.info("⌛ Loading updaters...");
-  const loaded = await loadFiles(`${__dirname}/**`);
+
+  const loaded = await loadFiles(`${__dirname}/*.ts`);
+
   console.info(`✅ [${loaded.length}] updaters have been loaded.`);
   console.info(`🔢 [${updaters.length}] updaters are active.`);
 }
@@ -11,7 +13,7 @@ async function loadUpdaters() {
 async function run() {
   await loadUpdaters();
 
-  // Run them one by one
+  //Run them one by one
   for (const updater of updaters) {
     console.info(`=== About to start "${updater.name}" script ===`);
     console.info(`Description: ${updater.description}`);

--- a/back/prisma/scripts/set-currentTransporterSiret.ts
+++ b/back/prisma/scripts/set-currentTransporterSiret.ts
@@ -1,0 +1,48 @@
+import { Updater, registerUpdater } from "./helper/helper";
+import { prisma } from "../../src/generated/prisma-client";
+
+async function setCurrentTransporterSiret() {
+  try {
+    const forms = await prisma.forms({
+      where: {
+        AND: [
+          {
+            OR: [
+              { currentTransporterSiret: "" },
+              { currentTransporterSiret: null }
+            ]
+          },
+          { status: "SENT" }
+        ]
+      }
+    });
+    const updates = [];
+
+    for (const form of forms) {
+      const update = prisma.updateForm({
+        data: { currentTransporterSiret: form.transporterCompanySiret },
+        where: { id: form.id }
+      });
+      updates.push(update);
+    }
+    return await Promise.all(updates);
+  } catch (err) {
+    console.error("☠ Something went wrong during the update", err);
+    throw new Error();
+  }
+}
+
+@registerUpdater(
+  "Set current transporter siret field",
+  `New column currentTransporterSiret filled with transporter company siret on SENT forms`,
+  true
+)
+export class SetCurrentTransporterSiret implements Updater {
+  run() {
+    console.info(
+      "Starting script to set currentTransporterSiret for existing forms..."
+    );
+
+    return setCurrentTransporterSiret();
+  }
+}


### PR DESCRIPTION
A la suite de l'ajout du multimodal, les bsd déjà en statut SENT n'avaient pas de champ currentTransporterSiret renseigné.