### PR TITLE
Permissions des opérations de l'API  "privée"

### DIFF
--- a/back/src/__tests__/testClient.ts
+++ b/back/src/__tests__/testClient.ts
@@ -14,8 +14,10 @@ function makeClient(user?: User, authType?: AuthType) {
   if (user) {
     setOptions({
       request: {
-        user,
-        ...(authType ? { auth: authType } : {})
+        user: {
+          ...user,
+          ...(authType ? { auth: authType } : {})
+        }
       }
     });
   }

--- a/back/src/__tests__/testClient.ts
+++ b/back/src/__tests__/testClient.ts
@@ -1,12 +1,10 @@
 import { createTestClient } from "apollo-server-integration-testing";
 import { server } from "../server";
-import { User } from "../generated/prisma-client";
-import { AuthType } from "../auth";
 
 /**
  * Instantiate test client
  */
-function makeClient(user?: User, authType?: AuthType) {
+function makeClient(user?: Express.User) {
   const { mutate, query, setOptions } = createTestClient({
     apolloServer: server
   });
@@ -14,10 +12,7 @@ function makeClient(user?: User, authType?: AuthType) {
   if (user) {
     setOptions({
       request: {
-        user: {
-          ...user,
-          ...(authType ? { auth: authType } : {})
-        }
+        user
       }
     });
   }

--- a/back/src/__tests__/testClient.ts
+++ b/back/src/__tests__/testClient.ts
@@ -1,11 +1,12 @@
 import { createTestClient } from "apollo-server-integration-testing";
 import { server } from "../server";
 import { User } from "../generated/prisma-client";
+import { AuthType } from "../auth";
 
 /**
  * Instantiate test client
  */
-function makeClient(user?: User) {
+function makeClient(user?: User, authType?: AuthType) {
   const { mutate, query, setOptions } = createTestClient({
     apolloServer: server
   });
@@ -13,7 +14,8 @@ function makeClient(user?: User) {
   if (user) {
     setOptions({
       request: {
-        user
+        user,
+        ...(authType ? { auth: authType } : {})
       }
     });
   }

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -25,9 +25,15 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface User extends PrismaUser {
-      auth?: string;
+      auth?: AuthType;
     }
   }
+}
+
+export enum AuthType {
+  SESSION,
+  JWT,
+  BEARER
 }
 
 // verbose error message and related errored field
@@ -83,7 +89,7 @@ passport.serializeUser((user: User, done) => {
 passport.deserializeUser((id: string, done) => {
   prisma
     .user({ id })
-    .then(user => done(null, { ...user, auth: "session" }))
+    .then(user => done(null, { ...user, auth: AuthType.SESSION }))
     .catch(err => done(err));
 });
 
@@ -107,7 +113,7 @@ passport.use(
           if (accessToken && accessToken.isRevoked) {
             return done(null, false);
           }
-          return done(null, { ...user, auth: "jwt" }, { token });
+          return done(null, { ...user, auth: AuthType.JWT }, { token });
         } else {
           return done(null, false);
         }
@@ -165,7 +171,7 @@ passport.use(
       if (accessToken && !accessToken.isRevoked) {
         const user = accessToken.user;
         await updateAccessTokenLastUsed(accessToken);
-        return done(null, { ...user, auth: "bearer" });
+        return done(null, { ...user, auth: AuthType.BEARER });
       } else {
         return done(null, false);
       }

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -31,9 +31,9 @@ declare global {
 }
 
 export enum AuthType {
-  SESSION,
-  JWT,
-  BEARER
+  Session = "session",
+  JWT = "jwt",
+  Bearer = "bearer"
 }
 
 // verbose error message and related errored field
@@ -89,7 +89,7 @@ passport.serializeUser((user: User, done) => {
 passport.deserializeUser((id: string, done) => {
   prisma
     .user({ id })
-    .then(user => done(null, { ...user, auth: AuthType.SESSION }))
+    .then(user => done(null, { ...user, auth: AuthType.Session }))
     .catch(err => done(err));
 });
 
@@ -171,7 +171,7 @@ passport.use(
       if (accessToken && !accessToken.isRevoked) {
         const user = accessToken.user;
         await updateAccessTokenLastUsed(accessToken);
-        return done(null, { ...user, auth: AuthType.BEARER });
+        return done(null, { ...user, auth: AuthType.Bearer });
       } else {
         return done(null, false);
       }

--- a/back/src/common/__tests__/rules.test.ts
+++ b/back/src/common/__tests__/rules.test.ts
@@ -33,7 +33,7 @@ describe("isAuthenticatedFromUI", () => {
   });
 
   it("should return ForbiddenError if a user is authenticated with Bearer token", async () => {
-    const context = { user: { id: "id", auth: AuthType.BEARER } };
+    const context = { user: { id: "id", auth: AuthType.Bearer } };
     const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
     expect(result).toBeInstanceOf(ForbiddenError);
   });
@@ -45,7 +45,7 @@ describe("isAuthenticatedFromUI", () => {
   });
 
   it("should return true if a user is authenticated with a session cookie", async () => {
-    const context = { user: { id: "id", auth: AuthType.SESSION } };
+    const context = { user: { id: "id", auth: AuthType.Session } };
     const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
     expect(result).toEqual(true);
   });

--- a/back/src/common/__tests__/rules.test.ts
+++ b/back/src/common/__tests__/rules.test.ts
@@ -1,7 +1,55 @@
 import { Rule, RuleAnd } from "graphql-shield/dist/rules";
 
-import { isCompanyAdmin, isCompanyMember, isCompaniesUser } from "../rules";
+import {
+  isAuthenticated,
+  isCompanyAdmin,
+  isCompanyMember,
+  isCompaniesUser,
+  isAuthenticatedFromUI
+} from "../rules";
 import { GraphQLResolveInfo } from "graphql";
+import { AuthenticationError, ForbiddenError } from "apollo-server-express";
+import { AuthType } from "../../auth";
+
+describe("isAuthenticated", () => {
+  it("should return AuthenticationError if there is no user in context", async () => {
+    const context = {};
+    const result = await testRule(isAuthenticated)(null, {}, context);
+    expect(result).toBeInstanceOf(AuthenticationError);
+  });
+
+  it("should return true if there a user in context", async () => {
+    const context = { user: { id: "id" } };
+    const result = await testRule(isAuthenticated)(null, {}, context);
+    expect(result).toEqual(true);
+  });
+});
+
+describe("isAuthenticatedFromUI", () => {
+  it("should return AuthenticationError if there is no user in context", async () => {
+    const context = {};
+    const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
+    expect(result).toBeInstanceOf(AuthenticationError);
+  });
+
+  it("should return ForbiddenError if a user is authenticated with Bearer token", async () => {
+    const context = { user: { id: "id", auth: AuthType.BEARER } };
+    const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
+    expect(result).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("should return ForbiddenError if a user is authenticated with JWT token", async () => {
+    const context = { user: { id: "id", auth: AuthType.JWT } };
+    const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
+    expect(result).toBeInstanceOf(ForbiddenError);
+  });
+
+  it("should return true if a user is authenticated with a session cookie", async () => {
+    const context = { user: { id: "id", auth: AuthType.SESSION } };
+    const result = await testRule(isAuthenticatedFromUI)(null, {}, context);
+    expect(result).toEqual(true);
+  });
+});
 
 describe("isCompanyAdmin", () => {
   it("should return true if the user is admin of the company", async () => {

--- a/back/src/common/rules.ts
+++ b/back/src/common/rules.ts
@@ -20,7 +20,7 @@ export const isAuthenticatedFromUI = chain(
   isAuthenticated,
   rule({ cache: "contextual" })(async (_1, _2, ctx: GraphQLContext) => {
     return (
-      ctx.user?.auth === AuthType.SESSION ||
+      ctx.user?.auth === AuthType.Session ||
       new ForbiddenError(
         "Cette opération n'est accessible que depuis l'interface graphique Trackdéchets"
       )

--- a/back/src/companies/mutations/__tests__/create-company.integration.ts
+++ b/back/src/companies/mutations/__tests__/create-company.integration.ts
@@ -4,6 +4,7 @@ import * as mailsHelper from "../../../common/mails.helper";
 import { prisma } from "../../../generated/prisma-client";
 import makeClient from "../../../__tests__/testClient";
 import { ErrorCode } from "../../../common/errors";
+import { AuthType } from "../../../auth";
 
 // No mails
 const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
@@ -35,7 +36,7 @@ describe("Create company endpoint", () => {
     }
   `;
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 
@@ -91,7 +92,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 
@@ -131,7 +132,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 
@@ -160,7 +161,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     await mutate(mutation);
 
@@ -186,7 +187,7 @@ describe("Create company endpoint", () => {
         ) { siret, gerepId, name, companyTypes }
       }
       `;
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { errors, data } = await mutate(mutation);
 
@@ -196,7 +197,7 @@ describe("Create company endpoint", () => {
 
   test("should alert when a user creates too many companies", async () => {
     const user = await userFactory();
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     async function createCompany(siret) {
       const mutation = `

--- a/back/src/companies/mutations/__tests__/create-company.integration.ts
+++ b/back/src/companies/mutations/__tests__/create-company.integration.ts
@@ -36,7 +36,7 @@ describe("Create company endpoint", () => {
     }
   `;
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 
@@ -92,7 +92,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 
@@ -132,7 +132,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 
@@ -161,7 +161,7 @@ describe("Create company endpoint", () => {
           }
       }`;
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     await mutate(mutation);
 
@@ -187,7 +187,7 @@ describe("Create company endpoint", () => {
         ) { siret, gerepId, name, companyTypes }
       }
       `;
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { errors, data } = await mutate(mutation);
 
@@ -197,7 +197,7 @@ describe("Create company endpoint", () => {
 
   test("should alert when a user creates too many companies", async () => {
     const user = await userFactory();
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     async function createCompany(siret) {
       const mutation = `

--- a/back/src/companies/mutations/traderReceipt/__tests__/createTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/createTraderReceipt.integration.ts
@@ -26,7 +26,7 @@ describe("{ mutation { createTraderReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/traderReceipt/__tests__/createTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/createTraderReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { prisma } from "../../../../generated/prisma-client";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { createTraderReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -25,7 +26,7 @@ describe("{ mutation { createTraderReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/traderReceipt/__tests__/deleteTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/deleteTraderReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { prisma } from "../../../../generated/prisma-client";
 import { resetDatabase } from "../../../../../integration-tests/helper";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { deleteTraderReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -21,7 +22,7 @@ describe("{ mutation { deleteTraderReceipt } }", () => {
       where: { id: company.id }
     });
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const mutation = `
       mutation {

--- a/back/src/companies/mutations/traderReceipt/__tests__/deleteTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/deleteTraderReceipt.integration.ts
@@ -22,7 +22,7 @@ describe("{ mutation { deleteTraderReceipt } }", () => {
       where: { id: company.id }
     });
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const mutation = `
       mutation {

--- a/back/src/companies/mutations/traderReceipt/__tests__/updateTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/updateTraderReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { prisma } from "../../../../generated/prisma-client";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { updateTraderReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -37,7 +38,7 @@ describe("{ mutation { updateTraderReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/traderReceipt/__tests__/updateTraderReceipt.integration.ts
+++ b/back/src/companies/mutations/traderReceipt/__tests__/updateTraderReceipt.integration.ts
@@ -38,7 +38,7 @@ describe("{ mutation { updateTraderReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/transporterReceipt/__tests__/createTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/createTransporterReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { prisma } from "../../../../generated/prisma-client";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { createTransporterReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -25,7 +26,7 @@ describe("{ mutation { createTransporterReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/transporterReceipt/__tests__/createTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/createTransporterReceipt.integration.ts
@@ -26,7 +26,7 @@ describe("{ mutation { createTransporterReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/transporterReceipt/__tests__/deleteTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/deleteTransporterReceipt.integration.ts
@@ -22,7 +22,7 @@ describe("{ mutation { deleteTransporterReceipt } }", () => {
       where: { id: company.id }
     });
 
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const mutation = `
       mutation {

--- a/back/src/companies/mutations/transporterReceipt/__tests__/deleteTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/deleteTransporterReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { prisma } from "../../../../generated/prisma-client";
 import { resetDatabase } from "../../../../../integration-tests/helper";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { deleteTransporterReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -21,7 +22,7 @@ describe("{ mutation { deleteTransporterReceipt } }", () => {
       where: { id: company.id }
     });
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const mutation = `
       mutation {

--- a/back/src/companies/mutations/transporterReceipt/__tests__/updateTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/updateTransporterReceipt.integration.ts
@@ -38,7 +38,7 @@ describe("{ mutation { updateTransporterReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user, AuthType.Session);
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/mutations/transporterReceipt/__tests__/updateTransporterReceipt.integration.ts
+++ b/back/src/companies/mutations/transporterReceipt/__tests__/updateTransporterReceipt.integration.ts
@@ -2,6 +2,7 @@ import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { prisma } from "../../../../generated/prisma-client";
+import { AuthType } from "../../../../auth";
 
 describe("{ mutation { updateTransporterReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -37,7 +38,7 @@ describe("{ mutation { updateTransporterReceipt } }", () => {
           }
           ) { receiptNumber, validityLimit, department }
         }`;
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(user, AuthType.Session);
 
     const { data } = await mutate(mutation);
 

--- a/back/src/companies/rules/permissions.ts
+++ b/back/src/companies/rules/permissions.ts
@@ -2,11 +2,11 @@ import {
   isAuthenticated,
   isUserInCompaniesWithRoles
 } from "../../common/rules";
-import { rule, and } from "graphql-shield";
+import { rule, chain } from "graphql-shield";
 import { prisma } from "../../generated/prisma-client";
 import { UserInputError, ForbiddenError } from "apollo-server-express";
 
-export const canUpdateDeleteTransporterReceipt = and(
+export const canUpdateDeleteTransporterReceipt = chain(
   isAuthenticated,
   rule()(async (_, { input }, ctx) => {
     const { id } = input;
@@ -42,7 +42,7 @@ export const canUpdateDeleteTransporterReceipt = and(
   })
 );
 
-export const canUpdateDeleteTraderReceipt = and(
+export const canUpdateDeleteTraderReceipt = chain(
   isAuthenticated,
   rule()(async (_, { input }, ctx) => {
     const { id } = input;

--- a/back/src/companies/shield-tree.ts
+++ b/back/src/companies/shield-tree.ts
@@ -1,5 +1,5 @@
 import { chain } from "graphql-shield";
-import { isAuthenticated, isCompanyAdmin } from "../common/rules";
+import { isCompanyAdmin, isAuthenticatedFromUI } from "../common/rules";
 import {
   createCompanySchema,
   createUploadLinkSchema,
@@ -17,32 +17,39 @@ import {
 
 export default {
   Query: {
-    favorites: isAuthenticated
+    favorites: isAuthenticatedFromUI
   },
   Mutation: {
-    updateCompany: isCompanyAdmin,
-    renewSecurityCode: isCompanyAdmin,
-    createCompany: chain(createCompanySchema, isAuthenticated),
-    createUploadLink: chain(createUploadLinkSchema, isAuthenticated),
+    updateCompany: chain(isAuthenticatedFromUI, isCompanyAdmin),
+    renewSecurityCode: chain(isAuthenticatedFromUI, isCompanyAdmin),
+    createCompany: chain(createCompanySchema, isAuthenticatedFromUI),
+    createUploadLink: chain(createUploadLinkSchema, isAuthenticatedFromUI),
     createTransporterReceipt: chain(
       createTransporterReceiptSchema,
-      isAuthenticated
+      isAuthenticatedFromUI
     ),
     updateTransporterReceipt: chain(
       updateTransporterReceiptSchema,
+      isAuthenticatedFromUI,
       canUpdateDeleteTransporterReceipt
     ),
     deleteTransporterReceipt: chain(
       deleteTransporterReceiptSchema,
+      isAuthenticatedFromUI,
       canUpdateDeleteTransporterReceipt
     ),
-    createTraderReceipt: chain(createTraderReceiptSchema, isAuthenticated),
+    createTraderReceipt: chain(
+      createTraderReceiptSchema,
+      isAuthenticatedFromUI
+    ),
     updateTraderReceipt: chain(
       updateTraderReceiptSchema,
+      isAuthenticatedFromUI,
       canUpdateDeleteTraderReceipt
     ),
     deleteTraderReceipt: chain(
       deleteTraderReceiptSchema,
+      isAuthenticatedFromUI,
       canUpdateDeleteTraderReceipt
     )
   }

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1,6 +1,7 @@
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { GraphQLContext } from '../../types';
 export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -29,7 +30,7 @@ export type AppendixFormInput = {
 
 /** Cet objet est renvoyé par la mutation login qui est dépréciée */
 export type AuthPayload = {
-   __typename?: 'AuthPayload';
+  __typename?: 'AuthPayload';
   /**
    * Bearer token à durée illimité permettant de s'authentifier
    * à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
@@ -46,7 +47,7 @@ export type AuthPayload = {
  * BSD édités
  */
 export type CompanyFavorite = {
-   __typename?: 'CompanyFavorite';
+  __typename?: 'CompanyFavorite';
   /** Nom de l'établissement */
   name?: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -83,7 +84,7 @@ export type CompanyInput = {
 
 /** Information sur utilisateur au sein d'un établissement */
 export type CompanyMember = {
-   __typename?: 'CompanyMember';
+  __typename?: 'CompanyMember';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email */
@@ -102,7 +103,7 @@ export type CompanyMember = {
 
 /** Information sur un établissement accessible par un utilisateur membre */
 export type CompanyPrivate = {
-   __typename?: 'CompanyPrivate';
+  __typename?: 'CompanyPrivate';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Profil de l'établissement */
@@ -149,7 +150,7 @@ export type CompanyPrivate = {
 
 /** Information sur un établissement accessible publiquement */
 export type CompanyPublic = {
-   __typename?: 'CompanyPublic';
+  __typename?: 'CompanyPublic';
   /** Email de contact */
   contactEmail?: Maybe<Scalars['String']>;
   /** Numéro de téléphone de contact */
@@ -183,7 +184,7 @@ export type CompanyPublic = {
 
 /** Information sur un établissement accessible publiquement en recherche */
 export type CompanySearchResult = {
-   __typename?: 'CompanySearchResult';
+  __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret?: Maybe<Scalars['String']>;
   /** État administratif de l'établissement. A = Actif, F = Fermé */
@@ -213,7 +214,7 @@ export type CompanySearchResult = {
 
 /** Statistiques d'un établissement */
 export type CompanyStat = {
-   __typename?: 'CompanyStat';
+  __typename?: 'CompanyStat';
   /** Établissement */
   company?: Maybe<FormCompany>;
   /** Liste des statistiques */
@@ -223,28 +224,28 @@ export type CompanyStat = {
 /** Profil entreprise */
 export type CompanyType = 
   /** Producteur de déchet */
-  'PRODUCER' |
+  | 'PRODUCER'
   /** Installation de Transit, regroupement ou tri de déchets */
-  'COLLECTOR' |
+  | 'COLLECTOR'
   /** Installation de traitement */
-  'WASTEPROCESSOR' |
+  | 'WASTEPROCESSOR'
   /** Transporteur */
-  'TRANSPORTER' |
+  | 'TRANSPORTER'
   /** Installation d'entreposage, dépollution, démontage, découpage de VHU */
-  'WASTE_VEHICLES' |
+  | 'WASTE_VEHICLES'
   /** Installation de collecte de déchets apportés par le producteur initial */
-  'WASTE_CENTER' |
+  | 'WASTE_CENTER'
   /** Négociant */
-  'TRADER';
+  | 'TRADER';
 
 /** Consistance du déchet */
 export type Consistence = 
   /** Solide */
-  'SOLID' |
+  | 'SOLID'
   /** Liquide */
-  'LIQUID' |
+  | 'LIQUID'
   /** Gazeux */
-  'GASEOUS';
+  | 'GASEOUS';
 
 /** Payload de création d'un bordereau */
 export type CreateFormInput = {
@@ -292,7 +293,7 @@ export type CreateTransporterReceiptInput = {
 
 /** Représente une ligne dans une déclaration GEREP */
 export type Declaration = {
-   __typename?: 'Declaration';
+  __typename?: 'Declaration';
   /** Année de la déclaration */
   annee?: Maybe<Scalars['String']>;
   /** Code du déchet */
@@ -316,7 +317,7 @@ export type DeleteTransporterReceiptInput = {
 };
 
 export type Destination = {
-   __typename?: 'Destination';
+  __typename?: 'Destination';
   /** N° de CAP (le cas échéant) */
   cap?: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -344,7 +345,7 @@ export type DestinationInput = {
  * Seul un éco-organisme enregistré dans Trackdéchet peut être associé.
  */
 export type EcoOrganisme = {
-   __typename?: 'EcoOrganisme';
+  __typename?: 'EcoOrganisme';
   id: Scalars['ID'];
   /** Nom de l'éco-organisme */
   name: Scalars['String'];
@@ -361,7 +362,7 @@ export type EcoOrganismeInput = {
 
 /** Émetteur du BSD (case 1) */
 export type Emitter = {
-   __typename?: 'Emitter';
+  __typename?: 'Emitter';
   /** Type d'émetteur */
   type?: Maybe<EmitterType>;
   /** Adresse du chantier */
@@ -390,30 +391,30 @@ export type EmitterInput = {
 /** Types d'émetteur de déchet (choix multiple de la case 1) */
 export type EmitterType = 
   /** Producetur de déchet */
-  'PRODUCER' |
+  | 'PRODUCER'
   /** Autre détenteur */
-  'OTHER' |
+  | 'OTHER'
   /** Collecteur de petites quantités de déchets relevant de la même rubrique */
-  'APPENDIX1' |
+  | 'APPENDIX1'
   /** Personne ayant transformé ou réalisé un traitement dont la provenance des déchets reste identifiable */
-  'APPENDIX2';
+  | 'APPENDIX2';
 
 /** Type d'établissement favoris */
 export type FavoriteType = 
-  'EMITTER' |
-  'TRANSPORTER' |
-  'RECIPIENT' |
-  'TRADER' |
-  'NEXT_DESTINATION' |
-  'TEMPORARY_STORAGE_DETAIL' |
-  'DESTINATION';
+  | 'EMITTER'
+  | 'TRANSPORTER'
+  | 'RECIPIENT'
+  | 'TRADER'
+  | 'NEXT_DESTINATION'
+  | 'TEMPORARY_STORAGE_DETAIL'
+  | 'DESTINATION';
 
 /**
  * URL de téléchargement accompagné d'un token
  * permettant de valider le téléchargement.
  */
 export type FileDownload = {
-   __typename?: 'FileDownload';
+  __typename?: 'FileDownload';
   /** Token ayant une durée de validité de 10s */
   token?: Maybe<Scalars['String']>;
   /** Lien de téléchargement */
@@ -425,7 +426,7 @@ export type FileDownload = {
  * Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
  */
 export type Form = {
-   __typename?: 'Form';
+  __typename?: 'Form';
   /** Identifiant interne du BSD */
   id: Scalars['ID'];
   /** Identifiant utilisé dans la case 'Bordereau n° ****' */
@@ -502,7 +503,7 @@ export type Form = {
 
 /** Information sur un établissement dans un BSD */
 export type FormCompany = {
-   __typename?: 'FormCompany';
+  __typename?: 'FormCompany';
   /** Nom de l'établissement */
   name?: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -544,19 +545,19 @@ export type FormInput = {
 
 export type FormRole = 
   /** Les BSD's dont je suis transporteur */
-  'TRANSPORTER' |
+  | 'TRANSPORTER'
   /** Les BSD's dont je suis la destination de traitement */
-  'RECIPIENT' |
+  | 'RECIPIENT'
   /** Les BSD's dont je suis l'émetteur */
-  'EMITTER' |
+  | 'EMITTER'
   /** Les BSD's dont je suis le négociant */
-  'TRADER' |
+  | 'TRADER'
   /** Les BSD's dont je suis éco-organisme */
-  'ECO_ORGANISME';
+  | 'ECO_ORGANISME';
 
 /** Informations du cycle de vie des bordereaux */
 export type FormsLifeCycleData = {
-   __typename?: 'formsLifeCycleData';
+  __typename?: 'formsLifeCycleData';
   /** Liste des changements de statuts */
   statusLogs: Array<StatusLog>;
   /** pagination, indique si d'autres pages existent après */
@@ -574,9 +575,9 @@ export type FormsLifeCycleData = {
 /** Format de l'export du registre */
 export type FormsRegisterExportFormat = 
   /** Fichier csv */
-  'CSV' |
+  | 'CSV'
   /** Fichier Excel */
-  'XLSX';
+  | 'XLSX';
 
 /**
  * Modèle de registre réglementaire tels que décrits dans l'arrêté du 29 février 2012 fixant
@@ -585,31 +586,31 @@ export type FormsRegisterExportFormat =
  */
 export type FormsRegisterExportType = 
   /** Registre exhaustif, déchets entrants et sortants */
-  'ALL' |
+  | 'ALL'
   /**
    * Registre producteur, déchets sortants
    * Art 1: Les exploitants des établissements produisant ou expédiant des déchets tiennent à jour
    * un registre chronologique où sont consignés tous les déchets sortants.
    */
-  'OUTGOING' |
+  | 'OUTGOING'
   /**
    * Registre traiteur, TTR
    * Art 2: Les exploitants des installations de transit, de regroupement ou de traitement de déchets,
    * notamment de tri, établissent et tiennent à jour un registre chronologique où sont consignés
    * tous les déchets entrants.
    */
-  'INCOMING' |
+  | 'INCOMING'
   /**
    * Registre transporteur
    * Art 3: Les transporteurs et les collecteurs de déchets tiennent à jour un registre chronologique
    * des déchets transportés ou collectés.
    */
-  'TRANSPORTED' |
+  | 'TRANSPORTED'
   /**
    * Registre négociants
    * Art 4: Les négociants tiennent à jour un registre chronologique des déchets détenus.
    */
-  'TRADED';
+  | 'TRADED';
 
 /** Différents statuts d'un BSD au cours de son cycle de vie */
 export type FormStatus = 
@@ -617,32 +618,32 @@ export type FormStatus =
    * BSD à l'état de brouillon
    * Des champs obligatoires peuvent manquer
    */
-  'DRAFT' |
+  | 'DRAFT'
   /**
    * BSD finalisé
    * Les champs sont validés pour détecter des valeurs manquantes ou erronnées
    */
-  'SEALED' |
+  | 'SEALED'
   /** BSD envoyé vers l'établissement de destination */
-  'SENT' |
+  | 'SENT'
   /** BSD reçu par l'établissement de destination */
-  'RECEIVED' |
+  | 'RECEIVED'
   /** BSD dont les déchets ont été traités */
-  'PROCESSED' |
+  | 'PROCESSED'
   /** BSD en attente de regroupement */
-  'AWAITING_GROUP' |
+  | 'AWAITING_GROUP'
   /** Regroupement effectué */
-  'GROUPED' |
+  | 'GROUPED'
   /** Perte de traçabalité */
-  'NO_TRACEABILITY' |
+  | 'NO_TRACEABILITY'
   /** Déchet refusé */
-  'REFUSED' |
+  | 'REFUSED'
   /** Déchet arrivé sur le site d'entreposage ou reconditionnement */
-  'TEMP_STORED' |
+  | 'TEMP_STORED'
   /** Déchet avec les cadres 14-19 complétées (si besoin), prêt à partir du site d'entreposage ou reconditionnement */
-  'RESEALED' |
+  | 'RESEALED'
   /** Déchet envoyé du site d'entreposage ou reconditionnement vers sa destination de traitement */
-  'RESENT';
+  | 'RESENT';
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
@@ -650,7 +651,7 @@ export type FormStatus =
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
-   __typename?: 'FormSubscription';
+  __typename?: 'FormSubscription';
   /** Type de mutation */
   mutation?: Maybe<Scalars['String']>;
   /** BSD concerné */
@@ -664,18 +665,18 @@ export type FormSubscription = {
 /** Valeur possibles pour le filtre de la query `forms` */
 export type FormType = 
   /** DEPRECATED - Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut) */
-  'ACTOR' |
+  | 'ACTOR'
   /** Uniquement les BSD's dont je suis transporteur */
-  'TRANSPORTER';
+  | 'TRANSPORTER';
 
 /** Type d'une déclaration GEREP */
 export type GerepType = 
-  'Producteur' |
-  'Traiteur';
+  | 'Producteur'
+  | 'Traiteur';
 
 /** Installation pour la protection de l'environnement (ICPE) */
 export type Installation = {
-   __typename?: 'Installation';
+  __typename?: 'Installation';
   /** Identifiant S3IC */
   codeS3ic?: Maybe<Scalars['String']>;
   /** URL de la fiche ICPE sur Géorisques */
@@ -688,7 +689,7 @@ export type Installation = {
 
 
 export type MultimodalTransporter = {
-   __typename?: 'MultimodalTransporter';
+  __typename?: 'MultimodalTransporter';
   /** Établissement transporteur */
   company?: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -706,7 +707,7 @@ export type MultimodalTransporter = {
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /**
    * USAGE INTERNE
    * Modifie le mot de passe d'un utilisateur
@@ -1147,7 +1148,7 @@ export type MutationUpdateTransporterReceiptArgs = {
 
 /** Destination ultérieure prévue (case 12) */
 export type NextDestination = {
-   __typename?: 'NextDestination';
+  __typename?: 'NextDestination';
   /** Traitement prévue (code D/R) */
   processingOperation?: Maybe<Scalars['String']>;
   /** Établissement ultérieure */
@@ -1201,15 +1202,15 @@ export type NextSegmentTransporterInput = {
 /** Type de packaging du déchet */
 export type Packagings = 
   /** Fut */
-  'FUT' |
+  | 'FUT'
   /** GRV */
-  'GRV' |
+  | 'GRV'
   /** Citerne */
-  'CITERNE' |
+  | 'CITERNE'
   /** Benne */
-  'BENNE' |
+  | 'BENNE'
   /** Autre */
-  'AUTRE';
+  | 'AUTRE';
 
 /** Payload permettant le rattachement d'un établissement à un utilisateur */
 export type PrivateCompanyInput = {
@@ -1256,12 +1257,12 @@ export type ProcessedFormInput = {
 /** Type de quantité lors de l'émission */
 export type QuantityType = 
   /** Quntité réelle */
-  'REAL' |
+  | 'REAL'
   /** Quantité estimée */
-  'ESTIMATED';
+  | 'ESTIMATED';
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /**
    * USAGE INTERNE > Mon Compte > Générer un token
    * Renvoie un token permettant de s'authentifier à l'API Trackdéchets
@@ -1406,7 +1407,7 @@ export type ReceivedFormInput = {
  * ou de reconditionnement prévue (case 2)
  */
 export type Recipient = {
-   __typename?: 'Recipient';
+  __typename?: 'Recipient';
   /** N° de CAP (le cas échéant) */
   cap?: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -1462,7 +1463,7 @@ export type ResentFormInput = {
  * [nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
  */
 export type Rubrique = {
-   __typename?: 'Rubrique';
+  __typename?: 'Rubrique';
   /**
    * Numéro de rubrique tel que défini dans la nomenclature des ICPE
    * Ex: 2710
@@ -1510,7 +1511,7 @@ export type SignupInput = {
 
 /** Statistiques */
 export type Stat = {
-   __typename?: 'Stat';
+  __typename?: 'Stat';
   /** Code déchet */
   wasteCode: Scalars['String'];
   /** Quantité entrante */
@@ -1529,7 +1530,7 @@ export type Stat = {
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
-   __typename?: 'StateSummary';
+  __typename?: 'StateSummary';
   /** Quantité la plus à jour */
   quantity?: Maybe<Scalars['Float']>;
   /** Packaging le plus à jour */
@@ -1552,7 +1553,7 @@ export type StateSummary = {
 
 /** Changement de statut d'un bordereau */
 export type StatusLog = {
-   __typename?: 'StatusLog';
+  __typename?: 'StatusLog';
   /** Identifiant du log */
   id?: Maybe<Scalars['ID']>;
   /** Statut du bordereau après le changement de statut */
@@ -1569,7 +1570,7 @@ export type StatusLog = {
 
 /** Information sur un BSD dans les logs de modifications de statuts */
 export type StatusLogForm = {
-   __typename?: 'StatusLogForm';
+  __typename?: 'StatusLogForm';
   /** Identifiant du BSD */
   id?: Maybe<Scalars['ID']>;
   /** N° du bordereau */
@@ -1578,13 +1579,13 @@ export type StatusLogForm = {
 
 /** Utilisateur ayant modifié le BSD */
 export type StatusLogUser = {
-   __typename?: 'StatusLogUser';
+  __typename?: 'StatusLogUser';
   id?: Maybe<Scalars['ID']>;
   email?: Maybe<Scalars['String']>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
    * 
@@ -1606,7 +1607,7 @@ export type TakeOverInput = {
 
 /** Données du BSD suite sur la partie entreposage provisoire ou reconditionnement, rattachées à un BSD existant */
 export type TemporaryStorageDetail = {
-   __typename?: 'TemporaryStorageDetail';
+  __typename?: 'TemporaryStorageDetail';
   /** Établissement qui sotcke temporairement le déchet (case 13) */
   temporaryStorer?: Maybe<TemporaryStorer>;
   /**
@@ -1629,7 +1630,7 @@ export type TemporaryStorageDetailInput = {
 };
 
 export type TemporaryStorer = {
-   __typename?: 'TemporaryStorer';
+  __typename?: 'TemporaryStorer';
   quantityType?: Maybe<QuantityType>;
   quantityReceived?: Maybe<Scalars['Float']>;
   wasteAcceptationStatus?: Maybe<Scalars['String']>;
@@ -1657,7 +1658,7 @@ export type TempStoredFormInput = {
 
 /** Négociant (case 7) */
 export type Trader = {
-   __typename?: 'Trader';
+  __typename?: 'Trader';
   /** Établissement négociant */
   company?: Maybe<FormCompany>;
   /** N° de récipissé */
@@ -1682,7 +1683,7 @@ export type TraderInput = {
 
 /** Récépissé négociant */
 export type TraderReceipt = {
-   __typename?: 'TraderReceipt';
+  __typename?: 'TraderReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars['String'];
@@ -1694,7 +1695,7 @@ export type TraderReceipt = {
 
 /** Collecteur - transporteur (case 8) */
 export type Transporter = {
-   __typename?: 'Transporter';
+  __typename?: 'Transporter';
   /** Établissement collecteur - transporteur */
   company?: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -1729,7 +1730,7 @@ export type TransporterInput = {
 
 /** Récépissé transporteur */
 export type TransporterReceipt = {
-   __typename?: 'TransporterReceipt';
+  __typename?: 'TransporterReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars['String'];
@@ -1760,14 +1761,14 @@ export type TransporterSignatureFormInput = {
 };
 
 export type TransportMode = 
-  'ROAD' |
-  'RAIL' |
-  'AIR' |
-  'RIVER' |
-  'SEA';
+  | 'ROAD'
+  | 'RAIL'
+  | 'AIR'
+  | 'RIVER'
+  | 'SEA';
 
 export type TransportSegment = {
-   __typename?: 'TransportSegment';
+  __typename?: 'TransportSegment';
   id: Scalars['ID'];
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret?: Maybe<Scalars['String']>;
@@ -1836,7 +1837,7 @@ export type UpdateTransporterReceiptInput = {
 
 /** Lien d'upload */
 export type UploadLink = {
-   __typename?: 'UploadLink';
+  __typename?: 'UploadLink';
   /** URL signé permettant d'uploader un fichier */
   signedUrl?: Maybe<Scalars['String']>;
   /** Clé permettant l'upload du fichier */
@@ -1845,7 +1846,7 @@ export type UploadLink = {
 
 /** Représente un utilisateur sur la plateforme Trackdéchets */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email de l'utiliateur */
@@ -1874,21 +1875,21 @@ export type User = {
  * * consulter le reste des informations
  */
 export type UserRole = 
-  'MEMBER' |
-  'ADMIN';
+  | 'MEMBER'
+  | 'ADMIN';
 
 /** Statut d'acceptation d'un déchet */
 export type WasteAcceptationStatusInput = 
   /** Accepté en totalité */
-  'ACCEPTED' |
+  | 'ACCEPTED'
   /** Refusé */
-  'REFUSED' |
+  | 'REFUSED'
   /** Refus partiel */
-  'PARTIALLY_REFUSED';
+  | 'PARTIALLY_REFUSED';
 
 /** Détails du déchet (case 3, 4, 5, 6) */
 export type WasteDetails = {
-   __typename?: 'WasteDetails';
+  __typename?: 'WasteDetails';
   /** Rubrique déchet au format |_|_| |_|_| |_|_| (*) */
   code?: Maybe<Scalars['String']>;
   /** Dénomination usuelle */
@@ -1951,15 +1952,15 @@ export type WasteDetailsInput = {
 /** Type de déchets autorisé pour une rubrique */
 export type WasteType = 
   /** Déchet inerte */
-  'INERTE' |
+  | 'INERTE'
   /** Déchet non dangereux */
-  'NOT_DANGEROUS' |
+  | 'NOT_DANGEROUS'
   /** Déchet dangereux */
-  'DANGEROUS';
+  | 'DANGEROUS';
 
 /** Informations sur une adresse chantier */
 export type WorkSite = {
-   __typename?: 'WorkSite';
+  __typename?: 'WorkSite';
   name?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
@@ -2755,6 +2756,13 @@ export type Resolvers<ContextType = GraphQLContext> = {
  */
 export type IResolvers<ContextType = GraphQLContext> = Resolvers<ContextType>;
 
+export function createAppendixFormInputMock(props: Partial<AppendixFormInput>): AppendixFormInput {
+  return {
+    readableId: null,
+    ...props,
+  };
+}
+
 export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload {
   return {
     __typename: "AuthPayload",
@@ -2762,7 +2770,7 @@ export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload 
     user: createUserMock({}),
     ...props,
   };
-};
+}
 
 export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): CompanyFavorite {
   return {
@@ -2777,7 +2785,19 @@ export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): Comp
     traderReceipt: null,
     ...props,
   };
-};
+}
+
+export function createCompanyInputMock(props: Partial<CompanyInput>): CompanyInput {
+  return {
+    siret: null,
+    name: null,
+    address: null,
+    contact: null,
+    mail: null,
+    phone: null,
+    ...props,
+  };
+}
 
 export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyMember {
   return {
@@ -2791,7 +2811,7 @@ export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyM
     isMe: null,
     ...props,
   };
-};
+}
 
 export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): CompanyPrivate {
   return {
@@ -2816,7 +2836,7 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyPublic {
   return {
@@ -2836,7 +2856,7 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanySearchResultMock(props: Partial<CompanySearchResult>): CompanySearchResult {
   return {
@@ -2854,7 +2874,7 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat {
   return {
@@ -2863,7 +2883,40 @@ export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat 
     stats: [],
     ...props,
   };
-};
+}
+
+export function createCreateFormInputMock(props: Partial<CreateFormInput>): CreateFormInput {
+  return {
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
+
+export function createCreateTraderReceiptInputMock(props: Partial<CreateTraderReceiptInput>): CreateTraderReceiptInput {
+  return {
+    receiptNumber: "",
+    validityLimit: new Date(),
+    department: "",
+    ...props,
+  };
+}
+
+export function createCreateTransporterReceiptInputMock(props: Partial<CreateTransporterReceiptInput>): CreateTransporterReceiptInput {
+  return {
+    receiptNumber: "",
+    validityLimit: new Date(),
+    department: "",
+    ...props,
+  };
+}
 
 export function createDeclarationMock(props: Partial<Declaration>): Declaration {
   return {
@@ -2874,7 +2927,21 @@ export function createDeclarationMock(props: Partial<Declaration>): Declaration 
     gerepType: null,
     ...props,
   };
-};
+}
+
+export function createDeleteTraderReceiptInputMock(props: Partial<DeleteTraderReceiptInput>): DeleteTraderReceiptInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
+
+export function createDeleteTransporterReceiptInputMock(props: Partial<DeleteTransporterReceiptInput>): DeleteTransporterReceiptInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
 
 export function createDestinationMock(props: Partial<Destination>): Destination {
   return {
@@ -2885,7 +2952,16 @@ export function createDestinationMock(props: Partial<Destination>): Destination 
     isFilledByEmitter: null,
     ...props,
   };
-};
+}
+
+export function createDestinationInputMock(props: Partial<DestinationInput>): DestinationInput {
+  return {
+    company: null,
+    cap: null,
+    processingOperation: null,
+    ...props,
+  };
+}
 
 export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganisme {
   return {
@@ -2896,7 +2972,14 @@ export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganis
     address: "",
     ...props,
   };
-};
+}
+
+export function createEcoOrganismeInputMock(props: Partial<EcoOrganismeInput>): EcoOrganismeInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
 
 export function createEmitterMock(props: Partial<Emitter>): Emitter {
   return {
@@ -2907,7 +2990,17 @@ export function createEmitterMock(props: Partial<Emitter>): Emitter {
     company: null,
     ...props,
   };
-};
+}
+
+export function createEmitterInputMock(props: Partial<EmitterInput>): EmitterInput {
+  return {
+    type: null,
+    workSite: null,
+    pickupSite: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createFileDownloadMock(props: Partial<FileDownload>): FileDownload {
   return {
@@ -2916,7 +3009,7 @@ export function createFileDownloadMock(props: Partial<FileDownload>): FileDownlo
     downloadLink: null,
     ...props,
   };
-};
+}
 
 export function createFormMock(props: Partial<Form>): Form {
   return {
@@ -2957,7 +3050,7 @@ export function createFormMock(props: Partial<Form>): Form {
     nextTransporterSiret: null,
     ...props,
   };
-};
+}
 
 export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany {
   return {
@@ -2970,7 +3063,23 @@ export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany 
     mail: null,
     ...props,
   };
-};
+}
+
+export function createFormInputMock(props: Partial<FormInput>): FormInput {
+  return {
+    id: null,
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
 
 export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>): FormsLifeCycleData {
   return {
@@ -2983,7 +3092,7 @@ export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>)
     count: null,
     ...props,
   };
-};
+}
 
 export function createFormSubscriptionMock(props: Partial<FormSubscription>): FormSubscription {
   return {
@@ -2994,7 +3103,7 @@ export function createFormSubscriptionMock(props: Partial<FormSubscription>): Fo
     previousValues: null,
     ...props,
   };
-};
+}
 
 export function createInstallationMock(props: Partial<Installation>): Installation {
   return {
@@ -3005,7 +3114,7 @@ export function createInstallationMock(props: Partial<Installation>): Installati
     declarations: null,
     ...props,
   };
-};
+}
 
 export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
   return {
@@ -3019,7 +3128,7 @@ export function createMultimodalTransporterMock(props: Partial<MultimodalTranspo
     customInfo: null,
     ...props,
   };
-};
+}
 
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
@@ -3028,7 +3137,85 @@ export function createNextDestinationMock(props: Partial<NextDestination>): Next
     company: null,
     ...props,
   };
-};
+}
+
+export function createNextDestinationInputMock(props: Partial<NextDestinationInput>): NextDestinationInput {
+  return {
+    processingOperation: null,
+    company: null,
+    ...props,
+  };
+}
+
+export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
+  return {
+    siret: null,
+    name: null,
+    address: null,
+    contact: null,
+    mail: null,
+    phone: null,
+    ...props,
+  };
+}
+
+export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
+  return {
+    transporter: null,
+    mode: "ROAD",
+    ...props,
+  };
+}
+
+export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
+  return {
+    isExemptedOfReceipt: null,
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    numberPlate: null,
+    company: null,
+    ...props,
+  };
+}
+
+export function createPrivateCompanyInputMock(props: Partial<PrivateCompanyInput>): PrivateCompanyInput {
+  return {
+    siret: "",
+    gerepId: null,
+    companyTypes: null,
+    codeNaf: null,
+    companyName: null,
+    documentKeys: null,
+    transporterReceiptId: null,
+    traderReceiptId: null,
+    ...props,
+  };
+}
+
+export function createProcessedFormInputMock(props: Partial<ProcessedFormInput>): ProcessedFormInput {
+  return {
+    processingOperationDone: "",
+    processingOperationDescription: null,
+    processedBy: "",
+    processedAt: new Date(),
+    nextDestination: null,
+    noTraceability: null,
+    ...props,
+  };
+}
+
+export function createReceivedFormInputMock(props: Partial<ReceivedFormInput>): ReceivedFormInput {
+  return {
+    wasteAcceptationStatus: "ACCEPTED",
+    wasteRefusalReason: null,
+    receivedBy: "",
+    receivedAt: new Date(),
+    signedAt: null,
+    quantityReceived: 0,
+    ...props,
+  };
+}
 
 export function createRecipientMock(props: Partial<Recipient>): Recipient {
   return {
@@ -3039,7 +3226,37 @@ export function createRecipientMock(props: Partial<Recipient>): Recipient {
     isTempStorage: null,
     ...props,
   };
-};
+}
+
+export function createRecipientInputMock(props: Partial<RecipientInput>): RecipientInput {
+  return {
+    cap: null,
+    processingOperation: null,
+    company: null,
+    isTempStorage: null,
+    ...props,
+  };
+}
+
+export function createResealedFormInputMock(props: Partial<ResealedFormInput>): ResealedFormInput {
+  return {
+    destination: null,
+    wasteDetails: null,
+    transporter: null,
+    ...props,
+  };
+}
+
+export function createResentFormInputMock(props: Partial<ResentFormInput>): ResentFormInput {
+  return {
+    destination: null,
+    wasteDetails: null,
+    transporter: null,
+    signedBy: null,
+    signedAt: null,
+    ...props,
+  };
+}
 
 export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
   return {
@@ -3055,7 +3272,25 @@ export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
     wasteType: null,
     ...props,
   };
-};
+}
+
+export function createSentFormInputMock(props: Partial<SentFormInput>): SentFormInput {
+  return {
+    sentAt: null,
+    sentBy: null,
+    ...props,
+  };
+}
+
+export function createSignupInputMock(props: Partial<SignupInput>): SignupInput {
+  return {
+    email: "",
+    password: "",
+    name: "",
+    phone: null,
+    ...props,
+  };
+}
 
 export function createStatMock(props: Partial<Stat>): Stat {
   return {
@@ -3065,7 +3300,7 @@ export function createStatMock(props: Partial<Stat>): Stat {
     outgoing: 0,
     ...props,
   };
-};
+}
 
 export function createStateSummaryMock(props: Partial<StateSummary>): StateSummary {
   return {
@@ -3081,7 +3316,7 @@ export function createStateSummaryMock(props: Partial<StateSummary>): StateSumma
     lastActionOn: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
   return {
@@ -3094,7 +3329,7 @@ export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
     user: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLogForm {
   return {
@@ -3103,7 +3338,7 @@ export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLo
     readableId: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLogUser {
   return {
@@ -3112,7 +3347,7 @@ export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLo
     email: null,
     ...props,
   };
-};
+}
 
 export function createSubscriptionMock(props: Partial<Subscription>): Subscription {
   return {
@@ -3120,7 +3355,15 @@ export function createSubscriptionMock(props: Partial<Subscription>): Subscripti
     forms: null,
     ...props,
   };
-};
+}
+
+export function createTakeOverInputMock(props: Partial<TakeOverInput>): TakeOverInput {
+  return {
+    takenOverAt: new Date(),
+    takenOverBy: "",
+    ...props,
+  };
+}
 
 export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorageDetail>): TemporaryStorageDetail {
   return {
@@ -3133,7 +3376,14 @@ export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorage
     signedAt: null,
     ...props,
   };
-};
+}
+
+export function createTemporaryStorageDetailInputMock(props: Partial<TemporaryStorageDetailInput>): TemporaryStorageDetailInput {
+  return {
+    destination: null,
+    ...props,
+  };
+}
 
 export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): TemporaryStorer {
   return {
@@ -3146,7 +3396,20 @@ export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): Temp
     receivedBy: null,
     ...props,
   };
-};
+}
+
+export function createTempStoredFormInputMock(props: Partial<TempStoredFormInput>): TempStoredFormInput {
+  return {
+    wasteAcceptationStatus: "ACCEPTED",
+    wasteRefusalReason: null,
+    receivedBy: "",
+    receivedAt: new Date(),
+    signedAt: null,
+    quantityReceived: 0,
+    quantityType: "REAL",
+    ...props,
+  };
+}
 
 export function createTraderMock(props: Partial<Trader>): Trader {
   return {
@@ -3157,7 +3420,17 @@ export function createTraderMock(props: Partial<Trader>): Trader {
     validityLimit: null,
     ...props,
   };
-};
+}
+
+export function createTraderInputMock(props: Partial<TraderInput>): TraderInput {
+  return {
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderReceipt {
   return {
@@ -3168,7 +3441,7 @@ export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderRe
     department: "",
     ...props,
   };
-};
+}
 
 export function createTransporterMock(props: Partial<Transporter>): Transporter {
   return {
@@ -3182,7 +3455,19 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
     customInfo: null,
     ...props,
   };
-};
+}
+
+export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
+  return {
+    isExemptedOfReceipt: null,
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    numberPlate: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createTransporterReceiptMock(props: Partial<TransporterReceipt>): TransporterReceipt {
   return {
@@ -3193,7 +3478,21 @@ export function createTransporterReceiptMock(props: Partial<TransporterReceipt>)
     department: "",
     ...props,
   };
-};
+}
+
+export function createTransporterSignatureFormInputMock(props: Partial<TransporterSignatureFormInput>): TransporterSignatureFormInput {
+  return {
+    sentAt: new Date(),
+    signedByTransporter: false,
+    securityCode: null,
+    sentBy: null,
+    signedByProducer: false,
+    packagings: [],
+    quantity: 0,
+    onuCode: null,
+    ...props,
+  };
+}
 
 export function createTransportSegmentMock(props: Partial<TransportSegment>): TransportSegment {
   return {
@@ -3208,7 +3507,43 @@ export function createTransportSegmentMock(props: Partial<TransportSegment>): Tr
     segmentNumber: null,
     ...props,
   };
-};
+}
+
+export function createUpdateFormInputMock(props: Partial<UpdateFormInput>): UpdateFormInput {
+  return {
+    id: "",
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
+
+export function createUpdateTraderReceiptInputMock(props: Partial<UpdateTraderReceiptInput>): UpdateTraderReceiptInput {
+  return {
+    id: "",
+    receiptNumber: null,
+    validityLimit: null,
+    department: null,
+    ...props,
+  };
+}
+
+export function createUpdateTransporterReceiptInputMock(props: Partial<UpdateTransporterReceiptInput>): UpdateTransporterReceiptInput {
+  return {
+    id: "",
+    receiptNumber: null,
+    validityLimit: null,
+    department: null,
+    ...props,
+  };
+}
 
 export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
   return {
@@ -3217,7 +3552,7 @@ export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
     key: null,
     ...props,
   };
-};
+}
 
 export function createUserMock(props: Partial<User>): User {
   return {
@@ -3229,7 +3564,7 @@ export function createUserMock(props: Partial<User>): User {
     companies: null,
     ...props,
   };
-};
+}
 
 export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetails {
   return {
@@ -3245,7 +3580,22 @@ export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetai
     consistence: null,
     ...props,
   };
-};
+}
+
+export function createWasteDetailsInputMock(props: Partial<WasteDetailsInput>): WasteDetailsInput {
+  return {
+    code: null,
+    name: null,
+    onuCode: null,
+    packagings: null,
+    otherPackaging: null,
+    numberOfPackages: null,
+    quantity: null,
+    quantityType: null,
+    consistence: null,
+    ...props,
+  };
+}
 
 export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
   return {
@@ -3257,4 +3607,15 @@ export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
     infos: null,
     ...props,
   };
-};
+}
+
+export function createWorkSiteInputMock(props: Partial<WorkSiteInput>): WorkSiteInput {
+  return {
+    name: null,
+    address: null,
+    city: null,
+    postalCode: null,
+    infos: null,
+    ...props,
+  };
+}

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1,7 +1,6 @@
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { GraphQLContext } from '../../types';
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -30,7 +29,7 @@ export type AppendixFormInput = {
 
 /** Cet objet est renvoyé par la mutation login qui est dépréciée */
 export type AuthPayload = {
-  __typename?: 'AuthPayload';
+   __typename?: 'AuthPayload';
   /**
    * Bearer token à durée illimité permettant de s'authentifier
    * à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
@@ -47,7 +46,7 @@ export type AuthPayload = {
  * BSD édités
  */
 export type CompanyFavorite = {
-  __typename?: 'CompanyFavorite';
+   __typename?: 'CompanyFavorite';
   /** Nom de l'établissement */
   name?: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -84,7 +83,7 @@ export type CompanyInput = {
 
 /** Information sur utilisateur au sein d'un établissement */
 export type CompanyMember = {
-  __typename?: 'CompanyMember';
+   __typename?: 'CompanyMember';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email */
@@ -103,7 +102,7 @@ export type CompanyMember = {
 
 /** Information sur un établissement accessible par un utilisateur membre */
 export type CompanyPrivate = {
-  __typename?: 'CompanyPrivate';
+   __typename?: 'CompanyPrivate';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Profil de l'établissement */
@@ -150,7 +149,7 @@ export type CompanyPrivate = {
 
 /** Information sur un établissement accessible publiquement */
 export type CompanyPublic = {
-  __typename?: 'CompanyPublic';
+   __typename?: 'CompanyPublic';
   /** Email de contact */
   contactEmail?: Maybe<Scalars['String']>;
   /** Numéro de téléphone de contact */
@@ -184,7 +183,7 @@ export type CompanyPublic = {
 
 /** Information sur un établissement accessible publiquement en recherche */
 export type CompanySearchResult = {
-  __typename?: 'CompanySearchResult';
+   __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret?: Maybe<Scalars['String']>;
   /** État administratif de l'établissement. A = Actif, F = Fermé */
@@ -214,7 +213,7 @@ export type CompanySearchResult = {
 
 /** Statistiques d'un établissement */
 export type CompanyStat = {
-  __typename?: 'CompanyStat';
+   __typename?: 'CompanyStat';
   /** Établissement */
   company?: Maybe<FormCompany>;
   /** Liste des statistiques */
@@ -224,28 +223,28 @@ export type CompanyStat = {
 /** Profil entreprise */
 export type CompanyType = 
   /** Producteur de déchet */
-  | 'PRODUCER'
+  'PRODUCER' |
   /** Installation de Transit, regroupement ou tri de déchets */
-  | 'COLLECTOR'
+  'COLLECTOR' |
   /** Installation de traitement */
-  | 'WASTEPROCESSOR'
+  'WASTEPROCESSOR' |
   /** Transporteur */
-  | 'TRANSPORTER'
+  'TRANSPORTER' |
   /** Installation d'entreposage, dépollution, démontage, découpage de VHU */
-  | 'WASTE_VEHICLES'
+  'WASTE_VEHICLES' |
   /** Installation de collecte de déchets apportés par le producteur initial */
-  | 'WASTE_CENTER'
+  'WASTE_CENTER' |
   /** Négociant */
-  | 'TRADER';
+  'TRADER';
 
 /** Consistance du déchet */
 export type Consistence = 
   /** Solide */
-  | 'SOLID'
+  'SOLID' |
   /** Liquide */
-  | 'LIQUID'
+  'LIQUID' |
   /** Gazeux */
-  | 'GASEOUS';
+  'GASEOUS';
 
 /** Payload de création d'un bordereau */
 export type CreateFormInput = {
@@ -293,7 +292,7 @@ export type CreateTransporterReceiptInput = {
 
 /** Représente une ligne dans une déclaration GEREP */
 export type Declaration = {
-  __typename?: 'Declaration';
+   __typename?: 'Declaration';
   /** Année de la déclaration */
   annee?: Maybe<Scalars['String']>;
   /** Code du déchet */
@@ -317,7 +316,7 @@ export type DeleteTransporterReceiptInput = {
 };
 
 export type Destination = {
-  __typename?: 'Destination';
+   __typename?: 'Destination';
   /** N° de CAP (le cas échéant) */
   cap?: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -345,7 +344,7 @@ export type DestinationInput = {
  * Seul un éco-organisme enregistré dans Trackdéchet peut être associé.
  */
 export type EcoOrganisme = {
-  __typename?: 'EcoOrganisme';
+   __typename?: 'EcoOrganisme';
   id: Scalars['ID'];
   /** Nom de l'éco-organisme */
   name: Scalars['String'];
@@ -362,7 +361,7 @@ export type EcoOrganismeInput = {
 
 /** Émetteur du BSD (case 1) */
 export type Emitter = {
-  __typename?: 'Emitter';
+   __typename?: 'Emitter';
   /** Type d'émetteur */
   type?: Maybe<EmitterType>;
   /** Adresse du chantier */
@@ -391,30 +390,30 @@ export type EmitterInput = {
 /** Types d'émetteur de déchet (choix multiple de la case 1) */
 export type EmitterType = 
   /** Producetur de déchet */
-  | 'PRODUCER'
+  'PRODUCER' |
   /** Autre détenteur */
-  | 'OTHER'
+  'OTHER' |
   /** Collecteur de petites quantités de déchets relevant de la même rubrique */
-  | 'APPENDIX1'
+  'APPENDIX1' |
   /** Personne ayant transformé ou réalisé un traitement dont la provenance des déchets reste identifiable */
-  | 'APPENDIX2';
+  'APPENDIX2';
 
 /** Type d'établissement favoris */
 export type FavoriteType = 
-  | 'EMITTER'
-  | 'TRANSPORTER'
-  | 'RECIPIENT'
-  | 'TRADER'
-  | 'NEXT_DESTINATION'
-  | 'TEMPORARY_STORAGE_DETAIL'
-  | 'DESTINATION';
+  'EMITTER' |
+  'TRANSPORTER' |
+  'RECIPIENT' |
+  'TRADER' |
+  'NEXT_DESTINATION' |
+  'TEMPORARY_STORAGE_DETAIL' |
+  'DESTINATION';
 
 /**
  * URL de téléchargement accompagné d'un token
  * permettant de valider le téléchargement.
  */
 export type FileDownload = {
-  __typename?: 'FileDownload';
+   __typename?: 'FileDownload';
   /** Token ayant une durée de validité de 10s */
   token?: Maybe<Scalars['String']>;
   /** Lien de téléchargement */
@@ -426,7 +425,7 @@ export type FileDownload = {
  * Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
  */
 export type Form = {
-  __typename?: 'Form';
+   __typename?: 'Form';
   /** Identifiant interne du BSD */
   id: Scalars['ID'];
   /** Identifiant utilisé dans la case 'Bordereau n° ****' */
@@ -503,7 +502,7 @@ export type Form = {
 
 /** Information sur un établissement dans un BSD */
 export type FormCompany = {
-  __typename?: 'FormCompany';
+   __typename?: 'FormCompany';
   /** Nom de l'établissement */
   name?: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -545,19 +544,19 @@ export type FormInput = {
 
 export type FormRole = 
   /** Les BSD's dont je suis transporteur */
-  | 'TRANSPORTER'
+  'TRANSPORTER' |
   /** Les BSD's dont je suis la destination de traitement */
-  | 'RECIPIENT'
+  'RECIPIENT' |
   /** Les BSD's dont je suis l'émetteur */
-  | 'EMITTER'
+  'EMITTER' |
   /** Les BSD's dont je suis le négociant */
-  | 'TRADER'
+  'TRADER' |
   /** Les BSD's dont je suis éco-organisme */
-  | 'ECO_ORGANISME';
+  'ECO_ORGANISME';
 
 /** Informations du cycle de vie des bordereaux */
 export type FormsLifeCycleData = {
-  __typename?: 'formsLifeCycleData';
+   __typename?: 'formsLifeCycleData';
   /** Liste des changements de statuts */
   statusLogs: Array<StatusLog>;
   /** pagination, indique si d'autres pages existent après */
@@ -575,9 +574,9 @@ export type FormsLifeCycleData = {
 /** Format de l'export du registre */
 export type FormsRegisterExportFormat = 
   /** Fichier csv */
-  | 'CSV'
+  'CSV' |
   /** Fichier Excel */
-  | 'XLSX';
+  'XLSX';
 
 /**
  * Modèle de registre réglementaire tels que décrits dans l'arrêté du 29 février 2012 fixant
@@ -586,31 +585,31 @@ export type FormsRegisterExportFormat =
  */
 export type FormsRegisterExportType = 
   /** Registre exhaustif, déchets entrants et sortants */
-  | 'ALL'
+  'ALL' |
   /**
    * Registre producteur, déchets sortants
    * Art 1: Les exploitants des établissements produisant ou expédiant des déchets tiennent à jour
    * un registre chronologique où sont consignés tous les déchets sortants.
    */
-  | 'OUTGOING'
+  'OUTGOING' |
   /**
    * Registre traiteur, TTR
    * Art 2: Les exploitants des installations de transit, de regroupement ou de traitement de déchets,
    * notamment de tri, établissent et tiennent à jour un registre chronologique où sont consignés
    * tous les déchets entrants.
    */
-  | 'INCOMING'
+  'INCOMING' |
   /**
    * Registre transporteur
    * Art 3: Les transporteurs et les collecteurs de déchets tiennent à jour un registre chronologique
    * des déchets transportés ou collectés.
    */
-  | 'TRANSPORTED'
+  'TRANSPORTED' |
   /**
    * Registre négociants
    * Art 4: Les négociants tiennent à jour un registre chronologique des déchets détenus.
    */
-  | 'TRADED';
+  'TRADED';
 
 /** Différents statuts d'un BSD au cours de son cycle de vie */
 export type FormStatus = 
@@ -618,32 +617,32 @@ export type FormStatus =
    * BSD à l'état de brouillon
    * Des champs obligatoires peuvent manquer
    */
-  | 'DRAFT'
+  'DRAFT' |
   /**
    * BSD finalisé
    * Les champs sont validés pour détecter des valeurs manquantes ou erronnées
    */
-  | 'SEALED'
+  'SEALED' |
   /** BSD envoyé vers l'établissement de destination */
-  | 'SENT'
+  'SENT' |
   /** BSD reçu par l'établissement de destination */
-  | 'RECEIVED'
+  'RECEIVED' |
   /** BSD dont les déchets ont été traités */
-  | 'PROCESSED'
+  'PROCESSED' |
   /** BSD en attente de regroupement */
-  | 'AWAITING_GROUP'
+  'AWAITING_GROUP' |
   /** Regroupement effectué */
-  | 'GROUPED'
+  'GROUPED' |
   /** Perte de traçabalité */
-  | 'NO_TRACEABILITY'
+  'NO_TRACEABILITY' |
   /** Déchet refusé */
-  | 'REFUSED'
+  'REFUSED' |
   /** Déchet arrivé sur le site d'entreposage ou reconditionnement */
-  | 'TEMP_STORED'
+  'TEMP_STORED' |
   /** Déchet avec les cadres 14-19 complétées (si besoin), prêt à partir du site d'entreposage ou reconditionnement */
-  | 'RESEALED'
+  'RESEALED' |
   /** Déchet envoyé du site d'entreposage ou reconditionnement vers sa destination de traitement */
-  | 'RESENT';
+  'RESENT';
 
 /**
  * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
@@ -651,7 +650,7 @@ export type FormStatus =
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
-  __typename?: 'FormSubscription';
+   __typename?: 'FormSubscription';
   /** Type de mutation */
   mutation?: Maybe<Scalars['String']>;
   /** BSD concerné */
@@ -665,18 +664,18 @@ export type FormSubscription = {
 /** Valeur possibles pour le filtre de la query `forms` */
 export type FormType = 
   /** DEPRECATED - Uniquement les BSD's dont je suis émetteur ou destinataire (cas par défaut) */
-  | 'ACTOR'
+  'ACTOR' |
   /** Uniquement les BSD's dont je suis transporteur */
-  | 'TRANSPORTER';
+  'TRANSPORTER';
 
 /** Type d'une déclaration GEREP */
 export type GerepType = 
-  | 'Producteur'
-  | 'Traiteur';
+  'Producteur' |
+  'Traiteur';
 
 /** Installation pour la protection de l'environnement (ICPE) */
 export type Installation = {
-  __typename?: 'Installation';
+   __typename?: 'Installation';
   /** Identifiant S3IC */
   codeS3ic?: Maybe<Scalars['String']>;
   /** URL de la fiche ICPE sur Géorisques */
@@ -689,7 +688,7 @@ export type Installation = {
 
 
 export type MultimodalTransporter = {
-  __typename?: 'MultimodalTransporter';
+   __typename?: 'MultimodalTransporter';
   /** Établissement transporteur */
   company?: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -707,7 +706,7 @@ export type MultimodalTransporter = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+   __typename?: 'Mutation';
   /**
    * USAGE INTERNE
    * Modifie le mot de passe d'un utilisateur
@@ -1148,7 +1147,7 @@ export type MutationUpdateTransporterReceiptArgs = {
 
 /** Destination ultérieure prévue (case 12) */
 export type NextDestination = {
-  __typename?: 'NextDestination';
+   __typename?: 'NextDestination';
   /** Traitement prévue (code D/R) */
   processingOperation?: Maybe<Scalars['String']>;
   /** Établissement ultérieure */
@@ -1202,15 +1201,15 @@ export type NextSegmentTransporterInput = {
 /** Type de packaging du déchet */
 export type Packagings = 
   /** Fut */
-  | 'FUT'
+  'FUT' |
   /** GRV */
-  | 'GRV'
+  'GRV' |
   /** Citerne */
-  | 'CITERNE'
+  'CITERNE' |
   /** Benne */
-  | 'BENNE'
+  'BENNE' |
   /** Autre */
-  | 'AUTRE';
+  'AUTRE';
 
 /** Payload permettant le rattachement d'un établissement à un utilisateur */
 export type PrivateCompanyInput = {
@@ -1257,12 +1256,12 @@ export type ProcessedFormInput = {
 /** Type de quantité lors de l'émission */
 export type QuantityType = 
   /** Quntité réelle */
-  | 'REAL'
+  'REAL' |
   /** Quantité estimée */
-  | 'ESTIMATED';
+  'ESTIMATED';
 
 export type Query = {
-  __typename?: 'Query';
+   __typename?: 'Query';
   /**
    * USAGE INTERNE > Mon Compte > Générer un token
    * Renvoie un token permettant de s'authentifier à l'API Trackdéchets
@@ -1407,7 +1406,7 @@ export type ReceivedFormInput = {
  * ou de reconditionnement prévue (case 2)
  */
 export type Recipient = {
-  __typename?: 'Recipient';
+   __typename?: 'Recipient';
   /** N° de CAP (le cas échéant) */
   cap?: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -1463,7 +1462,7 @@ export type ResentFormInput = {
  * [nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
  */
 export type Rubrique = {
-  __typename?: 'Rubrique';
+   __typename?: 'Rubrique';
   /**
    * Numéro de rubrique tel que défini dans la nomenclature des ICPE
    * Ex: 2710
@@ -1511,7 +1510,7 @@ export type SignupInput = {
 
 /** Statistiques */
 export type Stat = {
-  __typename?: 'Stat';
+   __typename?: 'Stat';
   /** Code déchet */
   wasteCode: Scalars['String'];
   /** Quantité entrante */
@@ -1530,7 +1529,7 @@ export type Stat = {
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
-  __typename?: 'StateSummary';
+   __typename?: 'StateSummary';
   /** Quantité la plus à jour */
   quantity?: Maybe<Scalars['Float']>;
   /** Packaging le plus à jour */
@@ -1553,7 +1552,7 @@ export type StateSummary = {
 
 /** Changement de statut d'un bordereau */
 export type StatusLog = {
-  __typename?: 'StatusLog';
+   __typename?: 'StatusLog';
   /** Identifiant du log */
   id?: Maybe<Scalars['ID']>;
   /** Statut du bordereau après le changement de statut */
@@ -1570,7 +1569,7 @@ export type StatusLog = {
 
 /** Information sur un BSD dans les logs de modifications de statuts */
 export type StatusLogForm = {
-  __typename?: 'StatusLogForm';
+   __typename?: 'StatusLogForm';
   /** Identifiant du BSD */
   id?: Maybe<Scalars['ID']>;
   /** N° du bordereau */
@@ -1579,13 +1578,13 @@ export type StatusLogForm = {
 
 /** Utilisateur ayant modifié le BSD */
 export type StatusLogUser = {
-  __typename?: 'StatusLogUser';
+   __typename?: 'StatusLogUser';
   id?: Maybe<Scalars['ID']>;
   email?: Maybe<Scalars['String']>;
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
+   __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
    * 
@@ -1607,7 +1606,7 @@ export type TakeOverInput = {
 
 /** Données du BSD suite sur la partie entreposage provisoire ou reconditionnement, rattachées à un BSD existant */
 export type TemporaryStorageDetail = {
-  __typename?: 'TemporaryStorageDetail';
+   __typename?: 'TemporaryStorageDetail';
   /** Établissement qui sotcke temporairement le déchet (case 13) */
   temporaryStorer?: Maybe<TemporaryStorer>;
   /**
@@ -1630,7 +1629,7 @@ export type TemporaryStorageDetailInput = {
 };
 
 export type TemporaryStorer = {
-  __typename?: 'TemporaryStorer';
+   __typename?: 'TemporaryStorer';
   quantityType?: Maybe<QuantityType>;
   quantityReceived?: Maybe<Scalars['Float']>;
   wasteAcceptationStatus?: Maybe<Scalars['String']>;
@@ -1658,7 +1657,7 @@ export type TempStoredFormInput = {
 
 /** Négociant (case 7) */
 export type Trader = {
-  __typename?: 'Trader';
+   __typename?: 'Trader';
   /** Établissement négociant */
   company?: Maybe<FormCompany>;
   /** N° de récipissé */
@@ -1683,7 +1682,7 @@ export type TraderInput = {
 
 /** Récépissé négociant */
 export type TraderReceipt = {
-  __typename?: 'TraderReceipt';
+   __typename?: 'TraderReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars['String'];
@@ -1695,7 +1694,7 @@ export type TraderReceipt = {
 
 /** Collecteur - transporteur (case 8) */
 export type Transporter = {
-  __typename?: 'Transporter';
+   __typename?: 'Transporter';
   /** Établissement collecteur - transporteur */
   company?: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -1730,7 +1729,7 @@ export type TransporterInput = {
 
 /** Récépissé transporteur */
 export type TransporterReceipt = {
-  __typename?: 'TransporterReceipt';
+   __typename?: 'TransporterReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars['String'];
@@ -1761,14 +1760,14 @@ export type TransporterSignatureFormInput = {
 };
 
 export type TransportMode = 
-  | 'ROAD'
-  | 'RAIL'
-  | 'AIR'
-  | 'RIVER'
-  | 'SEA';
+  'ROAD' |
+  'RAIL' |
+  'AIR' |
+  'RIVER' |
+  'SEA';
 
 export type TransportSegment = {
-  __typename?: 'TransportSegment';
+   __typename?: 'TransportSegment';
   id: Scalars['ID'];
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret?: Maybe<Scalars['String']>;
@@ -1837,7 +1836,7 @@ export type UpdateTransporterReceiptInput = {
 
 /** Lien d'upload */
 export type UploadLink = {
-  __typename?: 'UploadLink';
+   __typename?: 'UploadLink';
   /** URL signé permettant d'uploader un fichier */
   signedUrl?: Maybe<Scalars['String']>;
   /** Clé permettant l'upload du fichier */
@@ -1846,7 +1845,7 @@ export type UploadLink = {
 
 /** Représente un utilisateur sur la plateforme Trackdéchets */
 export type User = {
-  __typename?: 'User';
+   __typename?: 'User';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email de l'utiliateur */
@@ -1875,21 +1874,21 @@ export type User = {
  * * consulter le reste des informations
  */
 export type UserRole = 
-  | 'MEMBER'
-  | 'ADMIN';
+  'MEMBER' |
+  'ADMIN';
 
 /** Statut d'acceptation d'un déchet */
 export type WasteAcceptationStatusInput = 
   /** Accepté en totalité */
-  | 'ACCEPTED'
+  'ACCEPTED' |
   /** Refusé */
-  | 'REFUSED'
+  'REFUSED' |
   /** Refus partiel */
-  | 'PARTIALLY_REFUSED';
+  'PARTIALLY_REFUSED';
 
 /** Détails du déchet (case 3, 4, 5, 6) */
 export type WasteDetails = {
-  __typename?: 'WasteDetails';
+   __typename?: 'WasteDetails';
   /** Rubrique déchet au format |_|_| |_|_| |_|_| (*) */
   code?: Maybe<Scalars['String']>;
   /** Dénomination usuelle */
@@ -1952,15 +1951,15 @@ export type WasteDetailsInput = {
 /** Type de déchets autorisé pour une rubrique */
 export type WasteType = 
   /** Déchet inerte */
-  | 'INERTE'
+  'INERTE' |
   /** Déchet non dangereux */
-  | 'NOT_DANGEROUS'
+  'NOT_DANGEROUS' |
   /** Déchet dangereux */
-  | 'DANGEROUS';
+  'DANGEROUS';
 
 /** Informations sur une adresse chantier */
 export type WorkSite = {
-  __typename?: 'WorkSite';
+   __typename?: 'WorkSite';
   name?: Maybe<Scalars['String']>;
   address?: Maybe<Scalars['String']>;
   city?: Maybe<Scalars['String']>;
@@ -2756,13 +2755,6 @@ export type Resolvers<ContextType = GraphQLContext> = {
  */
 export type IResolvers<ContextType = GraphQLContext> = Resolvers<ContextType>;
 
-export function createAppendixFormInputMock(props: Partial<AppendixFormInput>): AppendixFormInput {
-  return {
-    readableId: null,
-    ...props,
-  };
-}
-
 export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload {
   return {
     __typename: "AuthPayload",
@@ -2770,7 +2762,7 @@ export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload 
     user: createUserMock({}),
     ...props,
   };
-}
+};
 
 export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): CompanyFavorite {
   return {
@@ -2785,19 +2777,7 @@ export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): Comp
     traderReceipt: null,
     ...props,
   };
-}
-
-export function createCompanyInputMock(props: Partial<CompanyInput>): CompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
+};
 
 export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyMember {
   return {
@@ -2811,7 +2791,7 @@ export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyM
     isMe: null,
     ...props,
   };
-}
+};
 
 export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): CompanyPrivate {
   return {
@@ -2836,7 +2816,7 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyPublic {
   return {
@@ -2856,7 +2836,7 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanySearchResultMock(props: Partial<CompanySearchResult>): CompanySearchResult {
   return {
@@ -2874,7 +2854,7 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat {
   return {
@@ -2883,25 +2863,7 @@ export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat 
     stats: [],
     ...props,
   };
-}
-
-export function createCreateTraderReceiptInputMock(props: Partial<CreateTraderReceiptInput>): CreateTraderReceiptInput {
-  return {
-    receiptNumber: "",
-    validityLimit: new Date(),
-    department: "",
-    ...props,
-  };
-}
-
-export function createCreateTransporterReceiptInputMock(props: Partial<CreateTransporterReceiptInput>): CreateTransporterReceiptInput {
-  return {
-    receiptNumber: "",
-    validityLimit: new Date(),
-    department: "",
-    ...props,
-  };
-}
+};
 
 export function createDeclarationMock(props: Partial<Declaration>): Declaration {
   return {
@@ -2912,21 +2874,7 @@ export function createDeclarationMock(props: Partial<Declaration>): Declaration 
     gerepType: null,
     ...props,
   };
-}
-
-export function createDeleteTraderReceiptInputMock(props: Partial<DeleteTraderReceiptInput>): DeleteTraderReceiptInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
-
-export function createDeleteTransporterReceiptInputMock(props: Partial<DeleteTransporterReceiptInput>): DeleteTransporterReceiptInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
+};
 
 export function createDestinationMock(props: Partial<Destination>): Destination {
   return {
@@ -2937,16 +2885,7 @@ export function createDestinationMock(props: Partial<Destination>): Destination 
     isFilledByEmitter: null,
     ...props,
   };
-}
-
-export function createDestinationInputMock(props: Partial<DestinationInput>): DestinationInput {
-  return {
-    company: null,
-    cap: null,
-    processingOperation: null,
-    ...props,
-  };
-}
+};
 
 export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganisme {
   return {
@@ -2957,14 +2896,7 @@ export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganis
     address: "",
     ...props,
   };
-}
-
-export function createEcoOrganismeInputMock(props: Partial<EcoOrganismeInput>): EcoOrganismeInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
+};
 
 export function createEmitterMock(props: Partial<Emitter>): Emitter {
   return {
@@ -2975,17 +2907,7 @@ export function createEmitterMock(props: Partial<Emitter>): Emitter {
     company: null,
     ...props,
   };
-}
-
-export function createEmitterInputMock(props: Partial<EmitterInput>): EmitterInput {
-  return {
-    type: null,
-    workSite: null,
-    pickupSite: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createFileDownloadMock(props: Partial<FileDownload>): FileDownload {
   return {
@@ -2994,7 +2916,7 @@ export function createFileDownloadMock(props: Partial<FileDownload>): FileDownlo
     downloadLink: null,
     ...props,
   };
-}
+};
 
 export function createFormMock(props: Partial<Form>): Form {
   return {
@@ -3035,7 +2957,7 @@ export function createFormMock(props: Partial<Form>): Form {
     nextTransporterSiret: null,
     ...props,
   };
-}
+};
 
 export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany {
   return {
@@ -3048,23 +2970,7 @@ export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany 
     mail: null,
     ...props,
   };
-}
-
-export function createFormInputMock(props: Partial<FormInput>): FormInput {
-  return {
-    id: null,
-    customId: null,
-    emitter: null,
-    recipient: null,
-    transporter: null,
-    wasteDetails: null,
-    trader: null,
-    appendix2Forms: null,
-    ecoOrganisme: null,
-    temporaryStorageDetail: null,
-    ...props,
-  };
-}
+};
 
 export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>): FormsLifeCycleData {
   return {
@@ -3077,7 +2983,7 @@ export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>)
     count: null,
     ...props,
   };
-}
+};
 
 export function createFormSubscriptionMock(props: Partial<FormSubscription>): FormSubscription {
   return {
@@ -3088,7 +2994,7 @@ export function createFormSubscriptionMock(props: Partial<FormSubscription>): Fo
     previousValues: null,
     ...props,
   };
-}
+};
 
 export function createInstallationMock(props: Partial<Installation>): Installation {
   return {
@@ -3099,7 +3005,7 @@ export function createInstallationMock(props: Partial<Installation>): Installati
     declarations: null,
     ...props,
   };
-}
+};
 
 export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
   return {
@@ -3113,7 +3019,7 @@ export function createMultimodalTransporterMock(props: Partial<MultimodalTranspo
     customInfo: null,
     ...props,
   };
-}
+};
 
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
@@ -3122,85 +3028,7 @@ export function createNextDestinationMock(props: Partial<NextDestination>): Next
     company: null,
     ...props,
   };
-}
-
-export function createNextDestinationInputMock(props: Partial<NextDestinationInput>): NextDestinationInput {
-  return {
-    processingOperation: null,
-    company: null,
-    ...props,
-  };
-}
-
-export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
-
-export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
-  return {
-    transporter: null,
-    mode: "ROAD",
-    ...props,
-  };
-}
-
-export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
-    ...props,
-  };
-}
-
-export function createPrivateCompanyInputMock(props: Partial<PrivateCompanyInput>): PrivateCompanyInput {
-  return {
-    siret: "",
-    gerepId: null,
-    companyTypes: null,
-    codeNaf: null,
-    companyName: null,
-    documentKeys: null,
-    transporterReceiptId: null,
-    traderReceiptId: null,
-    ...props,
-  };
-}
-
-export function createProcessedFormInputMock(props: Partial<ProcessedFormInput>): ProcessedFormInput {
-  return {
-    processingOperationDone: "",
-    processingOperationDescription: null,
-    processedBy: "",
-    processedAt: new Date(),
-    nextDestination: null,
-    noTraceability: null,
-    ...props,
-  };
-}
-
-export function createReceivedFormInputMock(props: Partial<ReceivedFormInput>): ReceivedFormInput {
-  return {
-    wasteAcceptationStatus: "ACCEPTED",
-    wasteRefusalReason: null,
-    receivedBy: "",
-    receivedAt: new Date(),
-    signedAt: null,
-    quantityReceived: 0,
-    ...props,
-  };
-}
+};
 
 export function createRecipientMock(props: Partial<Recipient>): Recipient {
   return {
@@ -3211,37 +3039,7 @@ export function createRecipientMock(props: Partial<Recipient>): Recipient {
     isTempStorage: null,
     ...props,
   };
-}
-
-export function createRecipientInputMock(props: Partial<RecipientInput>): RecipientInput {
-  return {
-    cap: null,
-    processingOperation: null,
-    company: null,
-    isTempStorage: null,
-    ...props,
-  };
-}
-
-export function createResealedFormInputMock(props: Partial<ResealedFormInput>): ResealedFormInput {
-  return {
-    destination: null,
-    wasteDetails: null,
-    transporter: null,
-    ...props,
-  };
-}
-
-export function createResentFormInputMock(props: Partial<ResentFormInput>): ResentFormInput {
-  return {
-    destination: null,
-    wasteDetails: null,
-    transporter: null,
-    signedBy: null,
-    signedAt: null,
-    ...props,
-  };
-}
+};
 
 export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
   return {
@@ -3257,25 +3055,7 @@ export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
     wasteType: null,
     ...props,
   };
-}
-
-export function createSentFormInputMock(props: Partial<SentFormInput>): SentFormInput {
-  return {
-    sentAt: null,
-    sentBy: null,
-    ...props,
-  };
-}
-
-export function createSignupInputMock(props: Partial<SignupInput>): SignupInput {
-  return {
-    email: "",
-    password: "",
-    name: "",
-    phone: null,
-    ...props,
-  };
-}
+};
 
 export function createStatMock(props: Partial<Stat>): Stat {
   return {
@@ -3285,7 +3065,7 @@ export function createStatMock(props: Partial<Stat>): Stat {
     outgoing: 0,
     ...props,
   };
-}
+};
 
 export function createStateSummaryMock(props: Partial<StateSummary>): StateSummary {
   return {
@@ -3301,7 +3081,7 @@ export function createStateSummaryMock(props: Partial<StateSummary>): StateSumma
     lastActionOn: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
   return {
@@ -3314,7 +3094,7 @@ export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
     user: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLogForm {
   return {
@@ -3323,7 +3103,7 @@ export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLo
     readableId: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLogUser {
   return {
@@ -3332,7 +3112,7 @@ export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLo
     email: null,
     ...props,
   };
-}
+};
 
 export function createSubscriptionMock(props: Partial<Subscription>): Subscription {
   return {
@@ -3340,15 +3120,7 @@ export function createSubscriptionMock(props: Partial<Subscription>): Subscripti
     forms: null,
     ...props,
   };
-}
-
-export function createTakeOverInputMock(props: Partial<TakeOverInput>): TakeOverInput {
-  return {
-    takenOverAt: new Date(),
-    takenOverBy: "",
-    ...props,
-  };
-}
+};
 
 export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorageDetail>): TemporaryStorageDetail {
   return {
@@ -3361,14 +3133,7 @@ export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorage
     signedAt: null,
     ...props,
   };
-}
-
-export function createTemporaryStorageDetailInputMock(props: Partial<TemporaryStorageDetailInput>): TemporaryStorageDetailInput {
-  return {
-    destination: null,
-    ...props,
-  };
-}
+};
 
 export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): TemporaryStorer {
   return {
@@ -3381,20 +3146,7 @@ export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): Temp
     receivedBy: null,
     ...props,
   };
-}
-
-export function createTempStoredFormInputMock(props: Partial<TempStoredFormInput>): TempStoredFormInput {
-  return {
-    wasteAcceptationStatus: "ACCEPTED",
-    wasteRefusalReason: null,
-    receivedBy: "",
-    receivedAt: new Date(),
-    signedAt: null,
-    quantityReceived: 0,
-    quantityType: "REAL",
-    ...props,
-  };
-}
+};
 
 export function createTraderMock(props: Partial<Trader>): Trader {
   return {
@@ -3405,17 +3157,7 @@ export function createTraderMock(props: Partial<Trader>): Trader {
     validityLimit: null,
     ...props,
   };
-}
-
-export function createTraderInputMock(props: Partial<TraderInput>): TraderInput {
-  return {
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderReceipt {
   return {
@@ -3426,7 +3168,7 @@ export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderRe
     department: "",
     ...props,
   };
-}
+};
 
 export function createTransporterMock(props: Partial<Transporter>): Transporter {
   return {
@@ -3440,19 +3182,7 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
     customInfo: null,
     ...props,
   };
-}
-
-export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createTransporterReceiptMock(props: Partial<TransporterReceipt>): TransporterReceipt {
   return {
@@ -3463,21 +3193,7 @@ export function createTransporterReceiptMock(props: Partial<TransporterReceipt>)
     department: "",
     ...props,
   };
-}
-
-export function createTransporterSignatureFormInputMock(props: Partial<TransporterSignatureFormInput>): TransporterSignatureFormInput {
-  return {
-    sentAt: new Date(),
-    signedByTransporter: false,
-    securityCode: null,
-    sentBy: null,
-    signedByProducer: false,
-    packagings: [],
-    quantity: 0,
-    onuCode: null,
-    ...props,
-  };
-}
+};
 
 export function createTransportSegmentMock(props: Partial<TransportSegment>): TransportSegment {
   return {
@@ -3492,27 +3208,7 @@ export function createTransportSegmentMock(props: Partial<TransportSegment>): Tr
     segmentNumber: null,
     ...props,
   };
-}
-
-export function createUpdateTraderReceiptInputMock(props: Partial<UpdateTraderReceiptInput>): UpdateTraderReceiptInput {
-  return {
-    id: "",
-    receiptNumber: null,
-    validityLimit: null,
-    department: null,
-    ...props,
-  };
-}
-
-export function createUpdateTransporterReceiptInputMock(props: Partial<UpdateTransporterReceiptInput>): UpdateTransporterReceiptInput {
-  return {
-    id: "",
-    receiptNumber: null,
-    validityLimit: null,
-    department: null,
-    ...props,
-  };
-}
+};
 
 export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
   return {
@@ -3521,7 +3217,7 @@ export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
     key: null,
     ...props,
   };
-}
+};
 
 export function createUserMock(props: Partial<User>): User {
   return {
@@ -3533,7 +3229,7 @@ export function createUserMock(props: Partial<User>): User {
     companies: null,
     ...props,
   };
-}
+};
 
 export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetails {
   return {
@@ -3549,22 +3245,7 @@ export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetai
     consistence: null,
     ...props,
   };
-}
-
-export function createWasteDetailsInputMock(props: Partial<WasteDetailsInput>): WasteDetailsInput {
-  return {
-    code: null,
-    name: null,
-    onuCode: null,
-    packagings: null,
-    otherPackaging: null,
-    numberOfPackages: null,
-    quantity: null,
-    quantityType: null,
-    consistence: null,
-    ...props,
-  };
-}
+};
 
 export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
   return {
@@ -3576,15 +3257,4 @@ export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
     infos: null,
     ...props,
   };
-}
-
-export function createWorkSiteInputMock(props: Partial<WorkSiteInput>): WorkSiteInput {
-  return {
-    name: null,
-    address: null,
-    city: null,
-    postalCode: null,
-    infos: null,
-    ...props,
-  };
-}
+};

--- a/back/src/users/__tests__/invite.integration.ts
+++ b/back/src/users/__tests__/invite.integration.ts
@@ -32,7 +32,7 @@ describe("Invitation removal", () => {
       company.siret
     );
 
-    const { mutate } = makeClient(admin, AuthType.Session);
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     // Call the mutation to delete the invitation
     // We pass company siret to allow permission to check requiring user is one admin of this company
@@ -64,7 +64,7 @@ describe("Invitation resend", () => {
     const usrToInvite = await userFactory();
     await createUserAccountHash(usrToInvite.email, "MEMBER", company.siret);
 
-    const { mutate } = makeClient(admin, AuthType.Session);
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     // Call the mutation to resend the invitation
 
@@ -104,7 +104,7 @@ describe("Invitation sending", () => {
     // set up an user, a company, its admin and an invitation (UserAccountHash)
     const { user: admin, company } = await userWithCompanyFactory("ADMIN");
 
-    const { mutate } = makeClient(admin, AuthType.Session);
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     // Call the mutation to send an invitation
     const invitedUserEmail = "newuser@example.test";

--- a/back/src/users/__tests__/invite.integration.ts
+++ b/back/src/users/__tests__/invite.integration.ts
@@ -7,6 +7,7 @@ import axios from "axios";
 
 import makeClient from "../../__tests__/testClient";
 import { resetDatabase } from "../../../integration-tests/helper";
+import { AuthType } from "../../auth";
 
 // Intercept mail calls
 const mockedAxiosPost = jest.spyOn(axios, "post");
@@ -31,7 +32,7 @@ describe("Invitation removal", () => {
       company.siret
     );
 
-    const { mutate } = makeClient(admin);
+    const { mutate } = makeClient(admin, AuthType.Session);
 
     // Call the mutation to delete the invitation
     // We pass company siret to allow permission to check requiring user is one admin of this company
@@ -63,7 +64,7 @@ describe("Invitation resend", () => {
     const usrToInvite = await userFactory();
     await createUserAccountHash(usrToInvite.email, "MEMBER", company.siret);
 
-    const { mutate } = makeClient(admin);
+    const { mutate } = makeClient(admin, AuthType.Session);
 
     // Call the mutation to resend the invitation
 
@@ -103,7 +104,7 @@ describe("Invitation sending", () => {
     // set up an user, a company, its admin and an invitation (UserAccountHash)
     const { user: admin, company } = await userWithCompanyFactory("ADMIN");
 
-    const { mutate } = makeClient(admin);
+    const { mutate } = makeClient(admin, AuthType.Session);
 
     // Call the mutation to send an invitation
     const invitedUserEmail = "newuser@example.test";

--- a/back/src/users/queries/__tests__/apiKey.integration.ts
+++ b/back/src/users/queries/__tests__/apiKey.integration.ts
@@ -2,13 +2,14 @@ import { userFactory } from "../../../__tests__/factories";
 import makeClient from "../../../__tests__/testClient";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import { prisma } from "../../../generated/prisma-client";
+import { AuthType } from "../../../auth";
 
 describe("{ query { apiKey } }", () => {
   afterAll(() => resetDatabase());
 
   it("should return an api key", async () => {
     const user = await userFactory();
-    const { query } = makeClient(user);
+    const { query } = makeClient(user, AuthType.Session);
     const { data } = await query("query { apiKey }");
     expect(data.apiKey).toHaveLength(40);
     // should have created an accessToken in db

--- a/back/src/users/queries/__tests__/apiKey.integration.ts
+++ b/back/src/users/queries/__tests__/apiKey.integration.ts
@@ -9,7 +9,7 @@ describe("{ query { apiKey } }", () => {
 
   it("should return an api key", async () => {
     const user = await userFactory();
-    const { query } = makeClient(user, AuthType.Session);
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
     const { data } = await query("query { apiKey }");
     expect(data.apiKey).toHaveLength(40);
     // should have created an accessToken in db

--- a/back/src/users/shield-tree.ts
+++ b/back/src/users/shield-tree.ts
@@ -1,18 +1,23 @@
-import { isAuthenticated, isCompanyAdmin } from "../common/rules";
+import {
+  isAuthenticated,
+  isAuthenticatedFromUI,
+  isCompanyAdmin
+} from "../common/rules";
 import { signupSchema } from "./rules/schema";
+import { chain } from "graphql-shield";
 
 export default {
   Query: {
     me: isAuthenticated,
-    apiKey: isAuthenticated
+    apiKey: isAuthenticatedFromUI
   },
   Mutation: {
-    changePassword: isAuthenticated,
-    editProfile: isAuthenticated,
-    inviteUserToCompany: isCompanyAdmin,
-    resendInvitation: isCompanyAdmin,
-    removeUserFromCompany: isCompanyAdmin,
-    deleteInvitation: isCompanyAdmin,
+    changePassword: isAuthenticatedFromUI,
+    editProfile: isAuthenticatedFromUI,
+    inviteUserToCompany: chain(isAuthenticatedFromUI, isCompanyAdmin),
+    resendInvitation: chain(isAuthenticatedFromUI, isCompanyAdmin),
+    removeUserFromCompany: chain(isAuthenticatedFromUI, isCompanyAdmin),
+    deleteInvitation: chain(isAuthenticatedFromUI, isCompanyAdmin),
     signup: signupSchema
   }
 };

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1,5 +1,4 @@
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -27,7 +26,7 @@ export type AppendixFormInput = {
 
 /** Cet objet est renvoyé par la mutation login qui est dépréciée */
 export type AuthPayload = {
-  __typename?: 'AuthPayload';
+   __typename?: 'AuthPayload';
   /**
    * Bearer token à durée illimité permettant de s'authentifier
    * à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
@@ -44,7 +43,7 @@ export type AuthPayload = {
  * BSD édités
  */
 export type CompanyFavorite = {
-  __typename?: 'CompanyFavorite';
+   __typename?: 'CompanyFavorite';
   /** Nom de l'établissement */
   name: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -81,7 +80,7 @@ export type CompanyInput = {
 
 /** Information sur utilisateur au sein d'un établissement */
 export type CompanyMember = {
-  __typename?: 'CompanyMember';
+   __typename?: 'CompanyMember';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email */
@@ -100,7 +99,7 @@ export type CompanyMember = {
 
 /** Information sur un établissement accessible par un utilisateur membre */
 export type CompanyPrivate = {
-  __typename?: 'CompanyPrivate';
+   __typename?: 'CompanyPrivate';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Profil de l'établissement */
@@ -147,7 +146,7 @@ export type CompanyPrivate = {
 
 /** Information sur un établissement accessible publiquement */
 export type CompanyPublic = {
-  __typename?: 'CompanyPublic';
+   __typename?: 'CompanyPublic';
   /** Email de contact */
   contactEmail: Maybe<Scalars['String']>;
   /** Numéro de téléphone de contact */
@@ -181,7 +180,7 @@ export type CompanyPublic = {
 
 /** Information sur un établissement accessible publiquement en recherche */
 export type CompanySearchResult = {
-  __typename?: 'CompanySearchResult';
+   __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret: Maybe<Scalars['String']>;
   /** État administratif de l'établissement. A = Actif, F = Fermé */
@@ -211,7 +210,7 @@ export type CompanySearchResult = {
 
 /** Statistiques d'un établissement */
 export type CompanyStat = {
-  __typename?: 'CompanyStat';
+   __typename?: 'CompanyStat';
   /** Établissement */
   company: Maybe<FormCompany>;
   /** Liste des statistiques */
@@ -292,7 +291,7 @@ export type CreateTransporterReceiptInput = {
 
 /** Représente une ligne dans une déclaration GEREP */
 export type Declaration = {
-  __typename?: 'Declaration';
+   __typename?: 'Declaration';
   /** Année de la déclaration */
   annee: Maybe<Scalars['String']>;
   /** Code du déchet */
@@ -316,7 +315,7 @@ export type DeleteTransporterReceiptInput = {
 };
 
 export type Destination = {
-  __typename?: 'Destination';
+   __typename?: 'Destination';
   /** N° de CAP (le cas échéant) */
   cap: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -344,7 +343,7 @@ export type DestinationInput = {
  * Seul un éco-organisme enregistré dans Trackdéchet peut être associé.
  */
 export type EcoOrganisme = {
-  __typename?: 'EcoOrganisme';
+   __typename?: 'EcoOrganisme';
   id: Scalars['ID'];
   /** Nom de l'éco-organisme */
   name: Scalars['String'];
@@ -361,7 +360,7 @@ export type EcoOrganismeInput = {
 
 /** Émetteur du BSD (case 1) */
 export type Emitter = {
-  __typename?: 'Emitter';
+   __typename?: 'Emitter';
   /** Type d'émetteur */
   type: Maybe<EmitterType>;
   /** Adresse du chantier */
@@ -415,7 +414,7 @@ export enum FavoriteType {
  * permettant de valider le téléchargement.
  */
 export type FileDownload = {
-  __typename?: 'FileDownload';
+   __typename?: 'FileDownload';
   /** Token ayant une durée de validité de 10s */
   token: Maybe<Scalars['String']>;
   /** Lien de téléchargement */
@@ -427,7 +426,7 @@ export type FileDownload = {
  * Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
  */
 export type Form = {
-  __typename?: 'Form';
+   __typename?: 'Form';
   /** Identifiant interne du BSD */
   id: Scalars['ID'];
   /** Identifiant utilisé dans la case 'Bordereau n° ****' */
@@ -504,7 +503,7 @@ export type Form = {
 
 /** Information sur un établissement dans un BSD */
 export type FormCompany = {
-  __typename?: 'FormCompany';
+   __typename?: 'FormCompany';
   /** Nom de l'établissement */
   name: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -559,7 +558,7 @@ export enum FormRole {
 
 /** Informations du cycle de vie des bordereaux */
 export type FormsLifeCycleData = {
-  __typename?: 'formsLifeCycleData';
+   __typename?: 'formsLifeCycleData';
   /** Liste des changements de statuts */
   statusLogs: Array<StatusLog>;
   /** pagination, indique si d'autres pages existent après */
@@ -656,7 +655,7 @@ export enum FormStatus {
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
-  __typename?: 'FormSubscription';
+   __typename?: 'FormSubscription';
   /** Type de mutation */
   mutation: Maybe<Scalars['String']>;
   /** BSD concerné */
@@ -683,7 +682,7 @@ export enum GerepType {
 
 /** Installation pour la protection de l'environnement (ICPE) */
 export type Installation = {
-  __typename?: 'Installation';
+   __typename?: 'Installation';
   /** Identifiant S3IC */
   codeS3ic: Maybe<Scalars['String']>;
   /** URL de la fiche ICPE sur Géorisques */
@@ -696,7 +695,7 @@ export type Installation = {
 
 
 export type MultimodalTransporter = {
-  __typename?: 'MultimodalTransporter';
+   __typename?: 'MultimodalTransporter';
   /** Établissement transporteur */
   company: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -714,7 +713,7 @@ export type MultimodalTransporter = {
 };
 
 export type Mutation = {
-  __typename?: 'Mutation';
+   __typename?: 'Mutation';
   /**
    * USAGE INTERNE
    * Modifie le mot de passe d'un utilisateur
@@ -1155,7 +1154,7 @@ export type MutationUpdateTransporterReceiptArgs = {
 
 /** Destination ultérieure prévue (case 12) */
 export type NextDestination = {
-  __typename?: 'NextDestination';
+   __typename?: 'NextDestination';
   /** Traitement prévue (code D/R) */
   processingOperation: Maybe<Scalars['String']>;
   /** Établissement ultérieure */
@@ -1271,7 +1270,7 @@ export enum QuantityType {
 }
 
 export type Query = {
-  __typename?: 'Query';
+   __typename?: 'Query';
   /**
    * USAGE INTERNE > Mon Compte > Générer un token
    * Renvoie un token permettant de s'authentifier à l'API Trackdéchets
@@ -1416,7 +1415,7 @@ export type ReceivedFormInput = {
  * ou de reconditionnement prévue (case 2)
  */
 export type Recipient = {
-  __typename?: 'Recipient';
+   __typename?: 'Recipient';
   /** N° de CAP (le cas échéant) */
   cap: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -1472,7 +1471,7 @@ export type ResentFormInput = {
  * [nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
  */
 export type Rubrique = {
-  __typename?: 'Rubrique';
+   __typename?: 'Rubrique';
   /**
    * Numéro de rubrique tel que défini dans la nomenclature des ICPE
    * Ex: 2710
@@ -1520,7 +1519,7 @@ export type SignupInput = {
 
 /** Statistiques */
 export type Stat = {
-  __typename?: 'Stat';
+   __typename?: 'Stat';
   /** Code déchet */
   wasteCode: Scalars['String'];
   /** Quantité entrante */
@@ -1539,7 +1538,7 @@ export type Stat = {
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
-  __typename?: 'StateSummary';
+   __typename?: 'StateSummary';
   /** Quantité la plus à jour */
   quantity: Maybe<Scalars['Float']>;
   /** Packaging le plus à jour */
@@ -1562,7 +1561,7 @@ export type StateSummary = {
 
 /** Changement de statut d'un bordereau */
 export type StatusLog = {
-  __typename?: 'StatusLog';
+   __typename?: 'StatusLog';
   /** Identifiant du log */
   id: Maybe<Scalars['ID']>;
   /** Statut du bordereau après le changement de statut */
@@ -1579,7 +1578,7 @@ export type StatusLog = {
 
 /** Information sur un BSD dans les logs de modifications de statuts */
 export type StatusLogForm = {
-  __typename?: 'StatusLogForm';
+   __typename?: 'StatusLogForm';
   /** Identifiant du BSD */
   id: Maybe<Scalars['ID']>;
   /** N° du bordereau */
@@ -1588,13 +1587,13 @@ export type StatusLogForm = {
 
 /** Utilisateur ayant modifié le BSD */
 export type StatusLogUser = {
-  __typename?: 'StatusLogUser';
+   __typename?: 'StatusLogUser';
   id: Maybe<Scalars['ID']>;
   email: Maybe<Scalars['String']>;
 };
 
 export type Subscription = {
-  __typename?: 'Subscription';
+   __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
    * 
@@ -1616,7 +1615,7 @@ export type TakeOverInput = {
 
 /** Données du BSD suite sur la partie entreposage provisoire ou reconditionnement, rattachées à un BSD existant */
 export type TemporaryStorageDetail = {
-  __typename?: 'TemporaryStorageDetail';
+   __typename?: 'TemporaryStorageDetail';
   /** Établissement qui sotcke temporairement le déchet (case 13) */
   temporaryStorer: Maybe<TemporaryStorer>;
   /**
@@ -1639,7 +1638,7 @@ export type TemporaryStorageDetailInput = {
 };
 
 export type TemporaryStorer = {
-  __typename?: 'TemporaryStorer';
+   __typename?: 'TemporaryStorer';
   quantityType: Maybe<QuantityType>;
   quantityReceived: Maybe<Scalars['Float']>;
   wasteAcceptationStatus: Maybe<Scalars['String']>;
@@ -1667,7 +1666,7 @@ export type TempStoredFormInput = {
 
 /** Négociant (case 7) */
 export type Trader = {
-  __typename?: 'Trader';
+   __typename?: 'Trader';
   /** Établissement négociant */
   company: Maybe<FormCompany>;
   /** N° de récipissé */
@@ -1692,7 +1691,7 @@ export type TraderInput = {
 
 /** Récépissé négociant */
 export type TraderReceipt = {
-  __typename?: 'TraderReceipt';
+   __typename?: 'TraderReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars['String'];
@@ -1704,7 +1703,7 @@ export type TraderReceipt = {
 
 /** Collecteur - transporteur (case 8) */
 export type Transporter = {
-  __typename?: 'Transporter';
+   __typename?: 'Transporter';
   /** Établissement collecteur - transporteur */
   company: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -1739,7 +1738,7 @@ export type TransporterInput = {
 
 /** Récépissé transporteur */
 export type TransporterReceipt = {
-  __typename?: 'TransporterReceipt';
+   __typename?: 'TransporterReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars['String'];
@@ -1778,7 +1777,7 @@ export enum TransportMode {
 }
 
 export type TransportSegment = {
-  __typename?: 'TransportSegment';
+   __typename?: 'TransportSegment';
   id: Scalars['ID'];
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret: Maybe<Scalars['String']>;
@@ -1847,7 +1846,7 @@ export type UpdateTransporterReceiptInput = {
 
 /** Lien d'upload */
 export type UploadLink = {
-  __typename?: 'UploadLink';
+   __typename?: 'UploadLink';
   /** URL signé permettant d'uploader un fichier */
   signedUrl: Maybe<Scalars['String']>;
   /** Clé permettant l'upload du fichier */
@@ -1856,7 +1855,7 @@ export type UploadLink = {
 
 /** Représente un utilisateur sur la plateforme Trackdéchets */
 export type User = {
-  __typename?: 'User';
+   __typename?: 'User';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email de l'utiliateur */
@@ -1901,7 +1900,7 @@ export enum WasteAcceptationStatusInput {
 
 /** Détails du déchet (case 3, 4, 5, 6) */
 export type WasteDetails = {
-  __typename?: 'WasteDetails';
+   __typename?: 'WasteDetails';
   /** Rubrique déchet au format |_|_| |_|_| |_|_| (*) */
   code: Maybe<Scalars['String']>;
   /** Dénomination usuelle */
@@ -1973,7 +1972,7 @@ export enum WasteType {
 
 /** Informations sur une adresse chantier */
 export type WorkSite = {
-  __typename?: 'WorkSite';
+   __typename?: 'WorkSite';
   name: Maybe<Scalars['String']>;
   address: Maybe<Scalars['String']>;
   city: Maybe<Scalars['String']>;
@@ -1991,13 +1990,6 @@ export type WorkSiteInput = {
 };
 
 
-export function createAppendixFormInputMock(props: Partial<AppendixFormInput>): AppendixFormInput {
-  return {
-    readableId: null,
-    ...props,
-  };
-}
-
 export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload {
   return {
     __typename: "AuthPayload",
@@ -2005,7 +1997,7 @@ export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload 
     user: createUserMock({}),
     ...props,
   };
-}
+};
 
 export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): CompanyFavorite {
   return {
@@ -2020,19 +2012,7 @@ export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): Comp
     traderReceipt: null,
     ...props,
   };
-}
-
-export function createCompanyInputMock(props: Partial<CompanyInput>): CompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
+};
 
 export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyMember {
   return {
@@ -2046,7 +2026,7 @@ export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyM
     isMe: null,
     ...props,
   };
-}
+};
 
 export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): CompanyPrivate {
   return {
@@ -2071,7 +2051,7 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyPublic {
   return {
@@ -2091,7 +2071,7 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanySearchResultMock(props: Partial<CompanySearchResult>): CompanySearchResult {
   return {
@@ -2109,7 +2089,7 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
     traderReceipt: null,
     ...props,
   };
-}
+};
 
 export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat {
   return {
@@ -2118,25 +2098,7 @@ export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat 
     stats: [],
     ...props,
   };
-}
-
-export function createCreateTraderReceiptInputMock(props: Partial<CreateTraderReceiptInput>): CreateTraderReceiptInput {
-  return {
-    receiptNumber: "",
-    validityLimit: new Date(),
-    department: "",
-    ...props,
-  };
-}
-
-export function createCreateTransporterReceiptInputMock(props: Partial<CreateTransporterReceiptInput>): CreateTransporterReceiptInput {
-  return {
-    receiptNumber: "",
-    validityLimit: new Date(),
-    department: "",
-    ...props,
-  };
-}
+};
 
 export function createDeclarationMock(props: Partial<Declaration>): Declaration {
   return {
@@ -2147,21 +2109,7 @@ export function createDeclarationMock(props: Partial<Declaration>): Declaration 
     gerepType: null,
     ...props,
   };
-}
-
-export function createDeleteTraderReceiptInputMock(props: Partial<DeleteTraderReceiptInput>): DeleteTraderReceiptInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
-
-export function createDeleteTransporterReceiptInputMock(props: Partial<DeleteTransporterReceiptInput>): DeleteTransporterReceiptInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
+};
 
 export function createDestinationMock(props: Partial<Destination>): Destination {
   return {
@@ -2172,16 +2120,7 @@ export function createDestinationMock(props: Partial<Destination>): Destination 
     isFilledByEmitter: null,
     ...props,
   };
-}
-
-export function createDestinationInputMock(props: Partial<DestinationInput>): DestinationInput {
-  return {
-    company: null,
-    cap: null,
-    processingOperation: null,
-    ...props,
-  };
-}
+};
 
 export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganisme {
   return {
@@ -2192,14 +2131,7 @@ export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganis
     address: "",
     ...props,
   };
-}
-
-export function createEcoOrganismeInputMock(props: Partial<EcoOrganismeInput>): EcoOrganismeInput {
-  return {
-    id: "",
-    ...props,
-  };
-}
+};
 
 export function createEmitterMock(props: Partial<Emitter>): Emitter {
   return {
@@ -2210,17 +2142,7 @@ export function createEmitterMock(props: Partial<Emitter>): Emitter {
     company: null,
     ...props,
   };
-}
-
-export function createEmitterInputMock(props: Partial<EmitterInput>): EmitterInput {
-  return {
-    type: null,
-    workSite: null,
-    pickupSite: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createFileDownloadMock(props: Partial<FileDownload>): FileDownload {
   return {
@@ -2229,7 +2151,7 @@ export function createFileDownloadMock(props: Partial<FileDownload>): FileDownlo
     downloadLink: null,
     ...props,
   };
-}
+};
 
 export function createFormMock(props: Partial<Form>): Form {
   return {
@@ -2270,7 +2192,7 @@ export function createFormMock(props: Partial<Form>): Form {
     nextTransporterSiret: null,
     ...props,
   };
-}
+};
 
 export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany {
   return {
@@ -2283,23 +2205,7 @@ export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany 
     mail: null,
     ...props,
   };
-}
-
-export function createFormInputMock(props: Partial<FormInput>): FormInput {
-  return {
-    id: null,
-    customId: null,
-    emitter: null,
-    recipient: null,
-    transporter: null,
-    wasteDetails: null,
-    trader: null,
-    appendix2Forms: null,
-    ecoOrganisme: null,
-    temporaryStorageDetail: null,
-    ...props,
-  };
-}
+};
 
 export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>): FormsLifeCycleData {
   return {
@@ -2312,7 +2218,7 @@ export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>)
     count: null,
     ...props,
   };
-}
+};
 
 export function createFormSubscriptionMock(props: Partial<FormSubscription>): FormSubscription {
   return {
@@ -2323,7 +2229,7 @@ export function createFormSubscriptionMock(props: Partial<FormSubscription>): Fo
     previousValues: null,
     ...props,
   };
-}
+};
 
 export function createInstallationMock(props: Partial<Installation>): Installation {
   return {
@@ -2334,7 +2240,7 @@ export function createInstallationMock(props: Partial<Installation>): Installati
     declarations: null,
     ...props,
   };
-}
+};
 
 export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
   return {
@@ -2348,7 +2254,7 @@ export function createMultimodalTransporterMock(props: Partial<MultimodalTranspo
     customInfo: null,
     ...props,
   };
-}
+};
 
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
@@ -2357,85 +2263,7 @@ export function createNextDestinationMock(props: Partial<NextDestination>): Next
     company: null,
     ...props,
   };
-}
-
-export function createNextDestinationInputMock(props: Partial<NextDestinationInput>): NextDestinationInput {
-  return {
-    processingOperation: null,
-    company: null,
-    ...props,
-  };
-}
-
-export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
-
-export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
-  return {
-    transporter: null,
-    mode: TransportMode.Road,
-    ...props,
-  };
-}
-
-export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
-    ...props,
-  };
-}
-
-export function createPrivateCompanyInputMock(props: Partial<PrivateCompanyInput>): PrivateCompanyInput {
-  return {
-    siret: "",
-    gerepId: null,
-    companyTypes: null,
-    codeNaf: null,
-    companyName: null,
-    documentKeys: null,
-    transporterReceiptId: null,
-    traderReceiptId: null,
-    ...props,
-  };
-}
-
-export function createProcessedFormInputMock(props: Partial<ProcessedFormInput>): ProcessedFormInput {
-  return {
-    processingOperationDone: "",
-    processingOperationDescription: null,
-    processedBy: "",
-    processedAt: new Date(),
-    nextDestination: null,
-    noTraceability: null,
-    ...props,
-  };
-}
-
-export function createReceivedFormInputMock(props: Partial<ReceivedFormInput>): ReceivedFormInput {
-  return {
-    wasteAcceptationStatus: WasteAcceptationStatusInput.Accepted,
-    wasteRefusalReason: null,
-    receivedBy: "",
-    receivedAt: new Date(),
-    signedAt: null,
-    quantityReceived: 0,
-    ...props,
-  };
-}
+};
 
 export function createRecipientMock(props: Partial<Recipient>): Recipient {
   return {
@@ -2446,37 +2274,7 @@ export function createRecipientMock(props: Partial<Recipient>): Recipient {
     isTempStorage: null,
     ...props,
   };
-}
-
-export function createRecipientInputMock(props: Partial<RecipientInput>): RecipientInput {
-  return {
-    cap: null,
-    processingOperation: null,
-    company: null,
-    isTempStorage: null,
-    ...props,
-  };
-}
-
-export function createResealedFormInputMock(props: Partial<ResealedFormInput>): ResealedFormInput {
-  return {
-    destination: null,
-    wasteDetails: null,
-    transporter: null,
-    ...props,
-  };
-}
-
-export function createResentFormInputMock(props: Partial<ResentFormInput>): ResentFormInput {
-  return {
-    destination: null,
-    wasteDetails: null,
-    transporter: null,
-    signedBy: null,
-    signedAt: null,
-    ...props,
-  };
-}
+};
 
 export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
   return {
@@ -2492,25 +2290,7 @@ export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
     wasteType: null,
     ...props,
   };
-}
-
-export function createSentFormInputMock(props: Partial<SentFormInput>): SentFormInput {
-  return {
-    sentAt: null,
-    sentBy: null,
-    ...props,
-  };
-}
-
-export function createSignupInputMock(props: Partial<SignupInput>): SignupInput {
-  return {
-    email: "",
-    password: "",
-    name: "",
-    phone: null,
-    ...props,
-  };
-}
+};
 
 export function createStatMock(props: Partial<Stat>): Stat {
   return {
@@ -2520,7 +2300,7 @@ export function createStatMock(props: Partial<Stat>): Stat {
     outgoing: 0,
     ...props,
   };
-}
+};
 
 export function createStateSummaryMock(props: Partial<StateSummary>): StateSummary {
   return {
@@ -2536,7 +2316,7 @@ export function createStateSummaryMock(props: Partial<StateSummary>): StateSumma
     lastActionOn: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
   return {
@@ -2549,7 +2329,7 @@ export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
     user: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLogForm {
   return {
@@ -2558,7 +2338,7 @@ export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLo
     readableId: null,
     ...props,
   };
-}
+};
 
 export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLogUser {
   return {
@@ -2567,7 +2347,7 @@ export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLo
     email: null,
     ...props,
   };
-}
+};
 
 export function createSubscriptionMock(props: Partial<Subscription>): Subscription {
   return {
@@ -2575,15 +2355,7 @@ export function createSubscriptionMock(props: Partial<Subscription>): Subscripti
     forms: null,
     ...props,
   };
-}
-
-export function createTakeOverInputMock(props: Partial<TakeOverInput>): TakeOverInput {
-  return {
-    takenOverAt: new Date(),
-    takenOverBy: "",
-    ...props,
-  };
-}
+};
 
 export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorageDetail>): TemporaryStorageDetail {
   return {
@@ -2596,14 +2368,7 @@ export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorage
     signedAt: null,
     ...props,
   };
-}
-
-export function createTemporaryStorageDetailInputMock(props: Partial<TemporaryStorageDetailInput>): TemporaryStorageDetailInput {
-  return {
-    destination: null,
-    ...props,
-  };
-}
+};
 
 export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): TemporaryStorer {
   return {
@@ -2616,20 +2381,7 @@ export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): Temp
     receivedBy: null,
     ...props,
   };
-}
-
-export function createTempStoredFormInputMock(props: Partial<TempStoredFormInput>): TempStoredFormInput {
-  return {
-    wasteAcceptationStatus: WasteAcceptationStatusInput.Accepted,
-    wasteRefusalReason: null,
-    receivedBy: "",
-    receivedAt: new Date(),
-    signedAt: null,
-    quantityReceived: 0,
-    quantityType: QuantityType.Real,
-    ...props,
-  };
-}
+};
 
 export function createTraderMock(props: Partial<Trader>): Trader {
   return {
@@ -2640,17 +2392,7 @@ export function createTraderMock(props: Partial<Trader>): Trader {
     validityLimit: null,
     ...props,
   };
-}
-
-export function createTraderInputMock(props: Partial<TraderInput>): TraderInput {
-  return {
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderReceipt {
   return {
@@ -2661,7 +2403,7 @@ export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderRe
     department: "",
     ...props,
   };
-}
+};
 
 export function createTransporterMock(props: Partial<Transporter>): Transporter {
   return {
@@ -2675,19 +2417,7 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
     customInfo: null,
     ...props,
   };
-}
-
-export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
-    ...props,
-  };
-}
+};
 
 export function createTransporterReceiptMock(props: Partial<TransporterReceipt>): TransporterReceipt {
   return {
@@ -2698,21 +2428,7 @@ export function createTransporterReceiptMock(props: Partial<TransporterReceipt>)
     department: "",
     ...props,
   };
-}
-
-export function createTransporterSignatureFormInputMock(props: Partial<TransporterSignatureFormInput>): TransporterSignatureFormInput {
-  return {
-    sentAt: new Date(),
-    signedByTransporter: false,
-    securityCode: null,
-    sentBy: null,
-    signedByProducer: false,
-    packagings: [],
-    quantity: 0,
-    onuCode: null,
-    ...props,
-  };
-}
+};
 
 export function createTransportSegmentMock(props: Partial<TransportSegment>): TransportSegment {
   return {
@@ -2727,27 +2443,7 @@ export function createTransportSegmentMock(props: Partial<TransportSegment>): Tr
     segmentNumber: null,
     ...props,
   };
-}
-
-export function createUpdateTraderReceiptInputMock(props: Partial<UpdateTraderReceiptInput>): UpdateTraderReceiptInput {
-  return {
-    id: "",
-    receiptNumber: null,
-    validityLimit: null,
-    department: null,
-    ...props,
-  };
-}
-
-export function createUpdateTransporterReceiptInputMock(props: Partial<UpdateTransporterReceiptInput>): UpdateTransporterReceiptInput {
-  return {
-    id: "",
-    receiptNumber: null,
-    validityLimit: null,
-    department: null,
-    ...props,
-  };
-}
+};
 
 export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
   return {
@@ -2756,7 +2452,7 @@ export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
     key: null,
     ...props,
   };
-}
+};
 
 export function createUserMock(props: Partial<User>): User {
   return {
@@ -2768,7 +2464,7 @@ export function createUserMock(props: Partial<User>): User {
     companies: null,
     ...props,
   };
-}
+};
 
 export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetails {
   return {
@@ -2784,22 +2480,7 @@ export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetai
     consistence: null,
     ...props,
   };
-}
-
-export function createWasteDetailsInputMock(props: Partial<WasteDetailsInput>): WasteDetailsInput {
-  return {
-    code: null,
-    name: null,
-    onuCode: null,
-    packagings: null,
-    otherPackaging: null,
-    numberOfPackages: null,
-    quantity: null,
-    quantityType: null,
-    consistence: null,
-    ...props,
-  };
-}
+};
 
 export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
   return {
@@ -2811,15 +2492,4 @@ export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
     infos: null,
     ...props,
   };
-}
-
-export function createWorkSiteInputMock(props: Partial<WorkSiteInput>): WorkSiteInput {
-  return {
-    name: null,
-    address: null,
-    city: null,
-    postalCode: null,
-    infos: null,
-    ...props,
-  };
-}
+};

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1,4 +1,5 @@
 export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: any }> = { [K in keyof T]: T[K] };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -26,7 +27,7 @@ export type AppendixFormInput = {
 
 /** Cet objet est renvoyé par la mutation login qui est dépréciée */
 export type AuthPayload = {
-   __typename?: 'AuthPayload';
+  __typename?: 'AuthPayload';
   /**
    * Bearer token à durée illimité permettant de s'authentifier
    * à l'API Trackdéchets. Pour ce faire, il doit être passé dans le
@@ -43,7 +44,7 @@ export type AuthPayload = {
  * BSD édités
  */
 export type CompanyFavorite = {
-   __typename?: 'CompanyFavorite';
+  __typename?: 'CompanyFavorite';
   /** Nom de l'établissement */
   name: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -80,7 +81,7 @@ export type CompanyInput = {
 
 /** Information sur utilisateur au sein d'un établissement */
 export type CompanyMember = {
-   __typename?: 'CompanyMember';
+  __typename?: 'CompanyMember';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email */
@@ -99,7 +100,7 @@ export type CompanyMember = {
 
 /** Information sur un établissement accessible par un utilisateur membre */
 export type CompanyPrivate = {
-   __typename?: 'CompanyPrivate';
+  __typename?: 'CompanyPrivate';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Profil de l'établissement */
@@ -146,7 +147,7 @@ export type CompanyPrivate = {
 
 /** Information sur un établissement accessible publiquement */
 export type CompanyPublic = {
-   __typename?: 'CompanyPublic';
+  __typename?: 'CompanyPublic';
   /** Email de contact */
   contactEmail: Maybe<Scalars['String']>;
   /** Numéro de téléphone de contact */
@@ -180,7 +181,7 @@ export type CompanyPublic = {
 
 /** Information sur un établissement accessible publiquement en recherche */
 export type CompanySearchResult = {
-   __typename?: 'CompanySearchResult';
+  __typename?: 'CompanySearchResult';
   /** SIRET de l'établissement */
   siret: Maybe<Scalars['String']>;
   /** État administratif de l'établissement. A = Actif, F = Fermé */
@@ -210,7 +211,7 @@ export type CompanySearchResult = {
 
 /** Statistiques d'un établissement */
 export type CompanyStat = {
-   __typename?: 'CompanyStat';
+  __typename?: 'CompanyStat';
   /** Établissement */
   company: Maybe<FormCompany>;
   /** Liste des statistiques */
@@ -291,7 +292,7 @@ export type CreateTransporterReceiptInput = {
 
 /** Représente une ligne dans une déclaration GEREP */
 export type Declaration = {
-   __typename?: 'Declaration';
+  __typename?: 'Declaration';
   /** Année de la déclaration */
   annee: Maybe<Scalars['String']>;
   /** Code du déchet */
@@ -315,7 +316,7 @@ export type DeleteTransporterReceiptInput = {
 };
 
 export type Destination = {
-   __typename?: 'Destination';
+  __typename?: 'Destination';
   /** N° de CAP (le cas échéant) */
   cap: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -343,7 +344,7 @@ export type DestinationInput = {
  * Seul un éco-organisme enregistré dans Trackdéchet peut être associé.
  */
 export type EcoOrganisme = {
-   __typename?: 'EcoOrganisme';
+  __typename?: 'EcoOrganisme';
   id: Scalars['ID'];
   /** Nom de l'éco-organisme */
   name: Scalars['String'];
@@ -360,7 +361,7 @@ export type EcoOrganismeInput = {
 
 /** Émetteur du BSD (case 1) */
 export type Emitter = {
-   __typename?: 'Emitter';
+  __typename?: 'Emitter';
   /** Type d'émetteur */
   type: Maybe<EmitterType>;
   /** Adresse du chantier */
@@ -414,7 +415,7 @@ export enum FavoriteType {
  * permettant de valider le téléchargement.
  */
 export type FileDownload = {
-   __typename?: 'FileDownload';
+  __typename?: 'FileDownload';
   /** Token ayant une durée de validité de 10s */
   token: Maybe<Scalars['String']>;
   /** Lien de téléchargement */
@@ -426,7 +427,7 @@ export type FileDownload = {
  * Version dématérialisée du [CERFA n°12571*01](https://www.service-public.fr/professionnels-entreprises/vosdroits/R14334)
  */
 export type Form = {
-   __typename?: 'Form';
+  __typename?: 'Form';
   /** Identifiant interne du BSD */
   id: Scalars['ID'];
   /** Identifiant utilisé dans la case 'Bordereau n° ****' */
@@ -503,7 +504,7 @@ export type Form = {
 
 /** Information sur un établissement dans un BSD */
 export type FormCompany = {
-   __typename?: 'FormCompany';
+  __typename?: 'FormCompany';
   /** Nom de l'établissement */
   name: Maybe<Scalars['String']>;
   /** SIRET de l'établissement */
@@ -558,7 +559,7 @@ export enum FormRole {
 
 /** Informations du cycle de vie des bordereaux */
 export type FormsLifeCycleData = {
-   __typename?: 'formsLifeCycleData';
+  __typename?: 'formsLifeCycleData';
   /** Liste des changements de statuts */
   statusLogs: Array<StatusLog>;
   /** pagination, indique si d'autres pages existent après */
@@ -655,7 +656,7 @@ export enum FormStatus {
  * Mise à jour d'un BSD
  */
 export type FormSubscription = {
-   __typename?: 'FormSubscription';
+  __typename?: 'FormSubscription';
   /** Type de mutation */
   mutation: Maybe<Scalars['String']>;
   /** BSD concerné */
@@ -682,7 +683,7 @@ export enum GerepType {
 
 /** Installation pour la protection de l'environnement (ICPE) */
 export type Installation = {
-   __typename?: 'Installation';
+  __typename?: 'Installation';
   /** Identifiant S3IC */
   codeS3ic: Maybe<Scalars['String']>;
   /** URL de la fiche ICPE sur Géorisques */
@@ -695,7 +696,7 @@ export type Installation = {
 
 
 export type MultimodalTransporter = {
-   __typename?: 'MultimodalTransporter';
+  __typename?: 'MultimodalTransporter';
   /** Établissement transporteur */
   company: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -713,7 +714,7 @@ export type MultimodalTransporter = {
 };
 
 export type Mutation = {
-   __typename?: 'Mutation';
+  __typename?: 'Mutation';
   /**
    * USAGE INTERNE
    * Modifie le mot de passe d'un utilisateur
@@ -1154,7 +1155,7 @@ export type MutationUpdateTransporterReceiptArgs = {
 
 /** Destination ultérieure prévue (case 12) */
 export type NextDestination = {
-   __typename?: 'NextDestination';
+  __typename?: 'NextDestination';
   /** Traitement prévue (code D/R) */
   processingOperation: Maybe<Scalars['String']>;
   /** Établissement ultérieure */
@@ -1270,7 +1271,7 @@ export enum QuantityType {
 }
 
 export type Query = {
-   __typename?: 'Query';
+  __typename?: 'Query';
   /**
    * USAGE INTERNE > Mon Compte > Générer un token
    * Renvoie un token permettant de s'authentifier à l'API Trackdéchets
@@ -1415,7 +1416,7 @@ export type ReceivedFormInput = {
  * ou de reconditionnement prévue (case 2)
  */
 export type Recipient = {
-   __typename?: 'Recipient';
+  __typename?: 'Recipient';
   /** N° de CAP (le cas échéant) */
   cap: Maybe<Scalars['String']>;
   /** Opération d'élimination / valorisation prévue (code D/R) */
@@ -1471,7 +1472,7 @@ export type ResentFormInput = {
  * [nomenclature des ICPE](https://www.georisques.gouv.fr/dossiers/installations/nomenclature-ic)
  */
 export type Rubrique = {
-   __typename?: 'Rubrique';
+  __typename?: 'Rubrique';
   /**
    * Numéro de rubrique tel que défini dans la nomenclature des ICPE
    * Ex: 2710
@@ -1519,7 +1520,7 @@ export type SignupInput = {
 
 /** Statistiques */
 export type Stat = {
-   __typename?: 'Stat';
+  __typename?: 'Stat';
   /** Code déchet */
   wasteCode: Scalars['String'];
   /** Quantité entrante */
@@ -1538,7 +1539,7 @@ export type Stat = {
  * Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours la valeur pour un instant T donné.
  */
 export type StateSummary = {
-   __typename?: 'StateSummary';
+  __typename?: 'StateSummary';
   /** Quantité la plus à jour */
   quantity: Maybe<Scalars['Float']>;
   /** Packaging le plus à jour */
@@ -1561,7 +1562,7 @@ export type StateSummary = {
 
 /** Changement de statut d'un bordereau */
 export type StatusLog = {
-   __typename?: 'StatusLog';
+  __typename?: 'StatusLog';
   /** Identifiant du log */
   id: Maybe<Scalars['ID']>;
   /** Statut du bordereau après le changement de statut */
@@ -1578,7 +1579,7 @@ export type StatusLog = {
 
 /** Information sur un BSD dans les logs de modifications de statuts */
 export type StatusLogForm = {
-   __typename?: 'StatusLogForm';
+  __typename?: 'StatusLogForm';
   /** Identifiant du BSD */
   id: Maybe<Scalars['ID']>;
   /** N° du bordereau */
@@ -1587,13 +1588,13 @@ export type StatusLogForm = {
 
 /** Utilisateur ayant modifié le BSD */
 export type StatusLogUser = {
-   __typename?: 'StatusLogUser';
+  __typename?: 'StatusLogUser';
   id: Maybe<Scalars['ID']>;
   email: Maybe<Scalars['String']>;
 };
 
 export type Subscription = {
-   __typename?: 'Subscription';
+  __typename?: 'Subscription';
   /**
    * DEPRECATED - Privilégier l'utilisation d'un polling régulier sur la query `formsLifeCycle`
    * 
@@ -1615,7 +1616,7 @@ export type TakeOverInput = {
 
 /** Données du BSD suite sur la partie entreposage provisoire ou reconditionnement, rattachées à un BSD existant */
 export type TemporaryStorageDetail = {
-   __typename?: 'TemporaryStorageDetail';
+  __typename?: 'TemporaryStorageDetail';
   /** Établissement qui sotcke temporairement le déchet (case 13) */
   temporaryStorer: Maybe<TemporaryStorer>;
   /**
@@ -1638,7 +1639,7 @@ export type TemporaryStorageDetailInput = {
 };
 
 export type TemporaryStorer = {
-   __typename?: 'TemporaryStorer';
+  __typename?: 'TemporaryStorer';
   quantityType: Maybe<QuantityType>;
   quantityReceived: Maybe<Scalars['Float']>;
   wasteAcceptationStatus: Maybe<Scalars['String']>;
@@ -1666,7 +1667,7 @@ export type TempStoredFormInput = {
 
 /** Négociant (case 7) */
 export type Trader = {
-   __typename?: 'Trader';
+  __typename?: 'Trader';
   /** Établissement négociant */
   company: Maybe<FormCompany>;
   /** N° de récipissé */
@@ -1691,7 +1692,7 @@ export type TraderInput = {
 
 /** Récépissé négociant */
 export type TraderReceipt = {
-   __typename?: 'TraderReceipt';
+  __typename?: 'TraderReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars['String'];
@@ -1703,7 +1704,7 @@ export type TraderReceipt = {
 
 /** Collecteur - transporteur (case 8) */
 export type Transporter = {
-   __typename?: 'Transporter';
+  __typename?: 'Transporter';
   /** Établissement collecteur - transporteur */
   company: Maybe<FormCompany>;
   /** Exemption de récipissé */
@@ -1738,7 +1739,7 @@ export type TransporterInput = {
 
 /** Récépissé transporteur */
 export type TransporterReceipt = {
-   __typename?: 'TransporterReceipt';
+  __typename?: 'TransporterReceipt';
   id: Scalars['ID'];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars['String'];
@@ -1777,7 +1778,7 @@ export enum TransportMode {
 }
 
 export type TransportSegment = {
-   __typename?: 'TransportSegment';
+  __typename?: 'TransportSegment';
   id: Scalars['ID'];
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret: Maybe<Scalars['String']>;
@@ -1846,7 +1847,7 @@ export type UpdateTransporterReceiptInput = {
 
 /** Lien d'upload */
 export type UploadLink = {
-   __typename?: 'UploadLink';
+  __typename?: 'UploadLink';
   /** URL signé permettant d'uploader un fichier */
   signedUrl: Maybe<Scalars['String']>;
   /** Clé permettant l'upload du fichier */
@@ -1855,7 +1856,7 @@ export type UploadLink = {
 
 /** Représente un utilisateur sur la plateforme Trackdéchets */
 export type User = {
-   __typename?: 'User';
+  __typename?: 'User';
   /** Identifiant opaque */
   id: Scalars['ID'];
   /** Email de l'utiliateur */
@@ -1900,7 +1901,7 @@ export enum WasteAcceptationStatusInput {
 
 /** Détails du déchet (case 3, 4, 5, 6) */
 export type WasteDetails = {
-   __typename?: 'WasteDetails';
+  __typename?: 'WasteDetails';
   /** Rubrique déchet au format |_|_| |_|_| |_|_| (*) */
   code: Maybe<Scalars['String']>;
   /** Dénomination usuelle */
@@ -1972,7 +1973,7 @@ export enum WasteType {
 
 /** Informations sur une adresse chantier */
 export type WorkSite = {
-   __typename?: 'WorkSite';
+  __typename?: 'WorkSite';
   name: Maybe<Scalars['String']>;
   address: Maybe<Scalars['String']>;
   city: Maybe<Scalars['String']>;
@@ -1990,6 +1991,13 @@ export type WorkSiteInput = {
 };
 
 
+export function createAppendixFormInputMock(props: Partial<AppendixFormInput>): AppendixFormInput {
+  return {
+    readableId: null,
+    ...props,
+  };
+}
+
 export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload {
   return {
     __typename: "AuthPayload",
@@ -1997,7 +2005,7 @@ export function createAuthPayloadMock(props: Partial<AuthPayload>): AuthPayload 
     user: createUserMock({}),
     ...props,
   };
-};
+}
 
 export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): CompanyFavorite {
   return {
@@ -2012,7 +2020,19 @@ export function createCompanyFavoriteMock(props: Partial<CompanyFavorite>): Comp
     traderReceipt: null,
     ...props,
   };
-};
+}
+
+export function createCompanyInputMock(props: Partial<CompanyInput>): CompanyInput {
+  return {
+    siret: null,
+    name: null,
+    address: null,
+    contact: null,
+    mail: null,
+    phone: null,
+    ...props,
+  };
+}
 
 export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyMember {
   return {
@@ -2026,7 +2046,7 @@ export function createCompanyMemberMock(props: Partial<CompanyMember>): CompanyM
     isMe: null,
     ...props,
   };
-};
+}
 
 export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): CompanyPrivate {
   return {
@@ -2051,7 +2071,7 @@ export function createCompanyPrivateMock(props: Partial<CompanyPrivate>): Compan
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyPublic {
   return {
@@ -2071,7 +2091,7 @@ export function createCompanyPublicMock(props: Partial<CompanyPublic>): CompanyP
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanySearchResultMock(props: Partial<CompanySearchResult>): CompanySearchResult {
   return {
@@ -2089,7 +2109,7 @@ export function createCompanySearchResultMock(props: Partial<CompanySearchResult
     traderReceipt: null,
     ...props,
   };
-};
+}
 
 export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat {
   return {
@@ -2098,7 +2118,40 @@ export function createCompanyStatMock(props: Partial<CompanyStat>): CompanyStat 
     stats: [],
     ...props,
   };
-};
+}
+
+export function createCreateFormInputMock(props: Partial<CreateFormInput>): CreateFormInput {
+  return {
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
+
+export function createCreateTraderReceiptInputMock(props: Partial<CreateTraderReceiptInput>): CreateTraderReceiptInput {
+  return {
+    receiptNumber: "",
+    validityLimit: new Date(),
+    department: "",
+    ...props,
+  };
+}
+
+export function createCreateTransporterReceiptInputMock(props: Partial<CreateTransporterReceiptInput>): CreateTransporterReceiptInput {
+  return {
+    receiptNumber: "",
+    validityLimit: new Date(),
+    department: "",
+    ...props,
+  };
+}
 
 export function createDeclarationMock(props: Partial<Declaration>): Declaration {
   return {
@@ -2109,7 +2162,21 @@ export function createDeclarationMock(props: Partial<Declaration>): Declaration 
     gerepType: null,
     ...props,
   };
-};
+}
+
+export function createDeleteTraderReceiptInputMock(props: Partial<DeleteTraderReceiptInput>): DeleteTraderReceiptInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
+
+export function createDeleteTransporterReceiptInputMock(props: Partial<DeleteTransporterReceiptInput>): DeleteTransporterReceiptInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
 
 export function createDestinationMock(props: Partial<Destination>): Destination {
   return {
@@ -2120,7 +2187,16 @@ export function createDestinationMock(props: Partial<Destination>): Destination 
     isFilledByEmitter: null,
     ...props,
   };
-};
+}
+
+export function createDestinationInputMock(props: Partial<DestinationInput>): DestinationInput {
+  return {
+    company: null,
+    cap: null,
+    processingOperation: null,
+    ...props,
+  };
+}
 
 export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganisme {
   return {
@@ -2131,7 +2207,14 @@ export function createEcoOrganismeMock(props: Partial<EcoOrganisme>): EcoOrganis
     address: "",
     ...props,
   };
-};
+}
+
+export function createEcoOrganismeInputMock(props: Partial<EcoOrganismeInput>): EcoOrganismeInput {
+  return {
+    id: "",
+    ...props,
+  };
+}
 
 export function createEmitterMock(props: Partial<Emitter>): Emitter {
   return {
@@ -2142,7 +2225,17 @@ export function createEmitterMock(props: Partial<Emitter>): Emitter {
     company: null,
     ...props,
   };
-};
+}
+
+export function createEmitterInputMock(props: Partial<EmitterInput>): EmitterInput {
+  return {
+    type: null,
+    workSite: null,
+    pickupSite: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createFileDownloadMock(props: Partial<FileDownload>): FileDownload {
   return {
@@ -2151,7 +2244,7 @@ export function createFileDownloadMock(props: Partial<FileDownload>): FileDownlo
     downloadLink: null,
     ...props,
   };
-};
+}
 
 export function createFormMock(props: Partial<Form>): Form {
   return {
@@ -2192,7 +2285,7 @@ export function createFormMock(props: Partial<Form>): Form {
     nextTransporterSiret: null,
     ...props,
   };
-};
+}
 
 export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany {
   return {
@@ -2205,7 +2298,23 @@ export function createFormCompanyMock(props: Partial<FormCompany>): FormCompany 
     mail: null,
     ...props,
   };
-};
+}
+
+export function createFormInputMock(props: Partial<FormInput>): FormInput {
+  return {
+    id: null,
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
 
 export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>): FormsLifeCycleData {
   return {
@@ -2218,7 +2327,7 @@ export function createFormsLifeCycleDataMock(props: Partial<FormsLifeCycleData>)
     count: null,
     ...props,
   };
-};
+}
 
 export function createFormSubscriptionMock(props: Partial<FormSubscription>): FormSubscription {
   return {
@@ -2229,7 +2338,7 @@ export function createFormSubscriptionMock(props: Partial<FormSubscription>): Fo
     previousValues: null,
     ...props,
   };
-};
+}
 
 export function createInstallationMock(props: Partial<Installation>): Installation {
   return {
@@ -2240,7 +2349,7 @@ export function createInstallationMock(props: Partial<Installation>): Installati
     declarations: null,
     ...props,
   };
-};
+}
 
 export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
   return {
@@ -2254,7 +2363,7 @@ export function createMultimodalTransporterMock(props: Partial<MultimodalTranspo
     customInfo: null,
     ...props,
   };
-};
+}
 
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
@@ -2263,7 +2372,85 @@ export function createNextDestinationMock(props: Partial<NextDestination>): Next
     company: null,
     ...props,
   };
-};
+}
+
+export function createNextDestinationInputMock(props: Partial<NextDestinationInput>): NextDestinationInput {
+  return {
+    processingOperation: null,
+    company: null,
+    ...props,
+  };
+}
+
+export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
+  return {
+    siret: null,
+    name: null,
+    address: null,
+    contact: null,
+    mail: null,
+    phone: null,
+    ...props,
+  };
+}
+
+export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
+  return {
+    transporter: null,
+    mode: TransportMode.Road,
+    ...props,
+  };
+}
+
+export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
+  return {
+    isExemptedOfReceipt: null,
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    numberPlate: null,
+    company: null,
+    ...props,
+  };
+}
+
+export function createPrivateCompanyInputMock(props: Partial<PrivateCompanyInput>): PrivateCompanyInput {
+  return {
+    siret: "",
+    gerepId: null,
+    companyTypes: null,
+    codeNaf: null,
+    companyName: null,
+    documentKeys: null,
+    transporterReceiptId: null,
+    traderReceiptId: null,
+    ...props,
+  };
+}
+
+export function createProcessedFormInputMock(props: Partial<ProcessedFormInput>): ProcessedFormInput {
+  return {
+    processingOperationDone: "",
+    processingOperationDescription: null,
+    processedBy: "",
+    processedAt: new Date(),
+    nextDestination: null,
+    noTraceability: null,
+    ...props,
+  };
+}
+
+export function createReceivedFormInputMock(props: Partial<ReceivedFormInput>): ReceivedFormInput {
+  return {
+    wasteAcceptationStatus: WasteAcceptationStatusInput.Accepted,
+    wasteRefusalReason: null,
+    receivedBy: "",
+    receivedAt: new Date(),
+    signedAt: null,
+    quantityReceived: 0,
+    ...props,
+  };
+}
 
 export function createRecipientMock(props: Partial<Recipient>): Recipient {
   return {
@@ -2274,7 +2461,37 @@ export function createRecipientMock(props: Partial<Recipient>): Recipient {
     isTempStorage: null,
     ...props,
   };
-};
+}
+
+export function createRecipientInputMock(props: Partial<RecipientInput>): RecipientInput {
+  return {
+    cap: null,
+    processingOperation: null,
+    company: null,
+    isTempStorage: null,
+    ...props,
+  };
+}
+
+export function createResealedFormInputMock(props: Partial<ResealedFormInput>): ResealedFormInput {
+  return {
+    destination: null,
+    wasteDetails: null,
+    transporter: null,
+    ...props,
+  };
+}
+
+export function createResentFormInputMock(props: Partial<ResentFormInput>): ResentFormInput {
+  return {
+    destination: null,
+    wasteDetails: null,
+    transporter: null,
+    signedBy: null,
+    signedAt: null,
+    ...props,
+  };
+}
 
 export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
   return {
@@ -2290,7 +2507,25 @@ export function createRubriqueMock(props: Partial<Rubrique>): Rubrique {
     wasteType: null,
     ...props,
   };
-};
+}
+
+export function createSentFormInputMock(props: Partial<SentFormInput>): SentFormInput {
+  return {
+    sentAt: null,
+    sentBy: null,
+    ...props,
+  };
+}
+
+export function createSignupInputMock(props: Partial<SignupInput>): SignupInput {
+  return {
+    email: "",
+    password: "",
+    name: "",
+    phone: null,
+    ...props,
+  };
+}
 
 export function createStatMock(props: Partial<Stat>): Stat {
   return {
@@ -2300,7 +2535,7 @@ export function createStatMock(props: Partial<Stat>): Stat {
     outgoing: 0,
     ...props,
   };
-};
+}
 
 export function createStateSummaryMock(props: Partial<StateSummary>): StateSummary {
   return {
@@ -2316,7 +2551,7 @@ export function createStateSummaryMock(props: Partial<StateSummary>): StateSumma
     lastActionOn: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
   return {
@@ -2329,7 +2564,7 @@ export function createStatusLogMock(props: Partial<StatusLog>): StatusLog {
     user: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLogForm {
   return {
@@ -2338,7 +2573,7 @@ export function createStatusLogFormMock(props: Partial<StatusLogForm>): StatusLo
     readableId: null,
     ...props,
   };
-};
+}
 
 export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLogUser {
   return {
@@ -2347,7 +2582,7 @@ export function createStatusLogUserMock(props: Partial<StatusLogUser>): StatusLo
     email: null,
     ...props,
   };
-};
+}
 
 export function createSubscriptionMock(props: Partial<Subscription>): Subscription {
   return {
@@ -2355,7 +2590,15 @@ export function createSubscriptionMock(props: Partial<Subscription>): Subscripti
     forms: null,
     ...props,
   };
-};
+}
+
+export function createTakeOverInputMock(props: Partial<TakeOverInput>): TakeOverInput {
+  return {
+    takenOverAt: new Date(),
+    takenOverBy: "",
+    ...props,
+  };
+}
 
 export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorageDetail>): TemporaryStorageDetail {
   return {
@@ -2368,7 +2611,14 @@ export function createTemporaryStorageDetailMock(props: Partial<TemporaryStorage
     signedAt: null,
     ...props,
   };
-};
+}
+
+export function createTemporaryStorageDetailInputMock(props: Partial<TemporaryStorageDetailInput>): TemporaryStorageDetailInput {
+  return {
+    destination: null,
+    ...props,
+  };
+}
 
 export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): TemporaryStorer {
   return {
@@ -2381,7 +2631,20 @@ export function createTemporaryStorerMock(props: Partial<TemporaryStorer>): Temp
     receivedBy: null,
     ...props,
   };
-};
+}
+
+export function createTempStoredFormInputMock(props: Partial<TempStoredFormInput>): TempStoredFormInput {
+  return {
+    wasteAcceptationStatus: WasteAcceptationStatusInput.Accepted,
+    wasteRefusalReason: null,
+    receivedBy: "",
+    receivedAt: new Date(),
+    signedAt: null,
+    quantityReceived: 0,
+    quantityType: QuantityType.Real,
+    ...props,
+  };
+}
 
 export function createTraderMock(props: Partial<Trader>): Trader {
   return {
@@ -2392,7 +2655,17 @@ export function createTraderMock(props: Partial<Trader>): Trader {
     validityLimit: null,
     ...props,
   };
-};
+}
+
+export function createTraderInputMock(props: Partial<TraderInput>): TraderInput {
+  return {
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderReceipt {
   return {
@@ -2403,7 +2676,7 @@ export function createTraderReceiptMock(props: Partial<TraderReceipt>): TraderRe
     department: "",
     ...props,
   };
-};
+}
 
 export function createTransporterMock(props: Partial<Transporter>): Transporter {
   return {
@@ -2417,7 +2690,19 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
     customInfo: null,
     ...props,
   };
-};
+}
+
+export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
+  return {
+    isExemptedOfReceipt: null,
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    numberPlate: null,
+    company: null,
+    ...props,
+  };
+}
 
 export function createTransporterReceiptMock(props: Partial<TransporterReceipt>): TransporterReceipt {
   return {
@@ -2428,7 +2713,21 @@ export function createTransporterReceiptMock(props: Partial<TransporterReceipt>)
     department: "",
     ...props,
   };
-};
+}
+
+export function createTransporterSignatureFormInputMock(props: Partial<TransporterSignatureFormInput>): TransporterSignatureFormInput {
+  return {
+    sentAt: new Date(),
+    signedByTransporter: false,
+    securityCode: null,
+    sentBy: null,
+    signedByProducer: false,
+    packagings: [],
+    quantity: 0,
+    onuCode: null,
+    ...props,
+  };
+}
 
 export function createTransportSegmentMock(props: Partial<TransportSegment>): TransportSegment {
   return {
@@ -2443,7 +2742,43 @@ export function createTransportSegmentMock(props: Partial<TransportSegment>): Tr
     segmentNumber: null,
     ...props,
   };
-};
+}
+
+export function createUpdateFormInputMock(props: Partial<UpdateFormInput>): UpdateFormInput {
+  return {
+    id: "",
+    customId: null,
+    emitter: null,
+    recipient: null,
+    transporter: null,
+    wasteDetails: null,
+    trader: null,
+    appendix2Forms: null,
+    ecoOrganisme: null,
+    temporaryStorageDetail: null,
+    ...props,
+  };
+}
+
+export function createUpdateTraderReceiptInputMock(props: Partial<UpdateTraderReceiptInput>): UpdateTraderReceiptInput {
+  return {
+    id: "",
+    receiptNumber: null,
+    validityLimit: null,
+    department: null,
+    ...props,
+  };
+}
+
+export function createUpdateTransporterReceiptInputMock(props: Partial<UpdateTransporterReceiptInput>): UpdateTransporterReceiptInput {
+  return {
+    id: "",
+    receiptNumber: null,
+    validityLimit: null,
+    department: null,
+    ...props,
+  };
+}
 
 export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
   return {
@@ -2452,7 +2787,7 @@ export function createUploadLinkMock(props: Partial<UploadLink>): UploadLink {
     key: null,
     ...props,
   };
-};
+}
 
 export function createUserMock(props: Partial<User>): User {
   return {
@@ -2464,7 +2799,7 @@ export function createUserMock(props: Partial<User>): User {
     companies: null,
     ...props,
   };
-};
+}
 
 export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetails {
   return {
@@ -2480,7 +2815,22 @@ export function createWasteDetailsMock(props: Partial<WasteDetails>): WasteDetai
     consistence: null,
     ...props,
   };
-};
+}
+
+export function createWasteDetailsInputMock(props: Partial<WasteDetailsInput>): WasteDetailsInput {
+  return {
+    code: null,
+    name: null,
+    onuCode: null,
+    packagings: null,
+    otherPackaging: null,
+    numberOfPackages: null,
+    quantity: null,
+    quantityType: null,
+    consistence: null,
+    ...props,
+  };
+}
 
 export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
   return {
@@ -2492,4 +2842,15 @@ export function createWorkSiteMock(props: Partial<WorkSite>): WorkSite {
     infos: null,
     ...props,
   };
-};
+}
+
+export function createWorkSiteInputMock(props: Partial<WorkSiteInput>): WorkSiteInput {
+  return {
+    name: null,
+    address: null,
+    city: null,
+    postalCode: null,
+    infos: null,
+    ...props,
+  };
+}


### PR DESCRIPTION
Ajout d'une règle `graphql-shield` `isAuthenticatedFromUI` permettant de vérifier qu'une opération est effectuée depuis l'interface Trackdéchets. On utilise pour cela le champ `auth` de l'objet `GraphQLContext.user` pour savoir si un utilisateur est authentifié avec un cookie de session plutôt qu'un token Bearer ou JWT.