### PR TITLE
Mise à jour de la documentation du cycle de vie du BSD

### DIFF
--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -249,6 +249,9 @@ type Mutation {
     "Informations liées à l'envoi"
     sentInfo: SentFormInput!
   ): Form
+    @deprecated(
+      reason: "Utiliser la mutation signedByTransporter permettant d'apposer les signatures collecteur-transporteur (case 8) et émetteur (case 9)"
+    )
 
   "Valide la réception d'un BSD"
   markAsReceived(
@@ -266,11 +269,20 @@ type Mutation {
     processedInfo: ProcessedFormInput!
   ): Form
 
-  "Valide la prise en charge par le transporteur, et peut valider l'envoi"
+  """
+  Permet de transférer le déchet à un transporteur lors de la collecte initiale (signatures en case 8 et 9)
+  ou après une étape d'entreposage provisoire ou de reconditionnement (signatures en case 18 et 19).
+  Cette mutation doit être appelée avec le token du collecteur-transporteur.
+  L'établissement émetteur (resp. d'entreposage provisoire ou de reconditionnement) est authentifié quant à lui grâce à son code de sécurité
+  disponible sur le tableau de bord Trackdéchets
+  Mon Compte > Établissements > Sécurité.
+  D'un point de vue pratique, cela implique qu'un responsable de l'établissement
+  émetteur (resp. d'entreposage provisoire ou de reconditionnement) renseigne le code de sécurité sur le terminal du collecteur-transporteur.
+  """
   signedByTransporter(
     "ID d'un BSD"
     id: ID!
-    "Informations liées à la signature transporteur"
+    "Informations liées aux signatures transporteur et émetteur (case 8 et 9)"
     signingInfo: TransporterSignatureFormInput!
   ): Form
 
@@ -282,6 +294,9 @@ type Mutation {
 
   "Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement"
   markAsResent(id: ID!, resentInfos: ResentFormInput!): Form
+    @deprecated(
+      reason: "Utiliser la mutation signedByTransporter permettant d'apposer les signatures du collecteur-transporteur (case 18) et de l'exploitant du site d'entreposage provisoire ou de reconditionnement (case 19)"
+    )
 
   "Prépare un nouveau segment de transport multimodal"
   prepareSegment(

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -784,7 +784,10 @@ export type Mutation = {
   markAsReceived?: Maybe<Form>;
   /** Valide la complétion des cadres 14 à 19 lors d'un entreposage provisoire ou reconditionnement */
   markAsResealed?: Maybe<Form>;
-  /** Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement */
+  /**
+   * Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement
+   * @deprecated Utiliser la mutation signedByTransporter permettant d'apposer les signatures du collecteur-transporteur (case 18) et de l'exploitant du site d'entreposage provisoire ou de reconditionnement (case 19)
+   */
   markAsResent?: Maybe<Form>;
   /**
    * Scelle un BSD
@@ -841,7 +844,10 @@ export type Mutation = {
    * ```
    */
   markAsSealed?: Maybe<Form>;
-  /** Valide l'envoi d'un BSD */
+  /**
+   * Valide l'envoi d'un BSD
+   * @deprecated Utiliser la mutation signedByTransporter permettant d'apposer les signatures collecteur-transporteur (case 8) et émetteur (case 9)
+   */
   markAsSent?: Maybe<Form>;
   /** Valide la réception d'un BSD d'un entreposage provisoire ou reconditionnement */
   markAsTempStored?: Maybe<Form>;
@@ -874,7 +880,18 @@ export type Mutation = {
    * @deprecated Utiliser createForm / updateForm selon le besoin
    */
   saveForm?: Maybe<Form>;
-  /** Valide la prise en charge par le transporteur, et peut valider l'envoi */
+  /**
+   * Permet de transférer le déchet à un transporteur lors de la collecte initiale (signatures en case 8 et 9)
+   * ou après une étape d'entreposage provisoire ou de reconditionnement (signatures en case 18 et 19).
+   * Cette mutation doit être appelée avec le token du collecteur-transporteur.
+   * L'établissement émetteur (resp. d'entreposage provisoire ou de
+   * reconditionnement) est authentifié quant à lui grâce à son code de sécurité
+   * disponible sur le tableau de bord Trackdéchets
+   * Mon Compte > Établissements > Sécurité.
+   * D'un point de vue pratique, cela implique qu'un responsable de l'établissement
+   * émetteur (resp. d'entreposage provisoire ou de reconditionnement) renseigne le
+   * code de sécurité sur le terminal du collecteur-transporteur.
+   */
   signedByTransporter?: Maybe<Form>;
   /**
    * USAGE INTERNE

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -821,12 +821,18 @@ Valide la complétion des cadres 14 à 19 lors d'un entreposage provisoire ou re
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>markAsResent</strong></td>
+<td colspan="2" valign="top"><strong>markAsResent</strong> ⚠️</td>
 <td valign="top"><a href="#form">Form</a></td>
 <td>
 
 Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement
 
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+Utiliser la mutation signedByTransporter permettant d'apposer les signatures du collecteur-transporteur (case 18) et de l'exploitant du site d'entreposage provisoire ou de reconditionnement (case 19)
+
+</blockquote>
 </td>
 </tr>
 <tr>
@@ -909,12 +915,18 @@ ID d'un BSD
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>markAsSent</strong></td>
+<td colspan="2" valign="top"><strong>markAsSent</strong> ⚠️</td>
 <td valign="top"><a href="#form">Form</a></td>
 <td>
 
 Valide l'envoi d'un BSD
 
+<p>⚠️ <strong>DEPRECATED</strong></p>
+<blockquote>
+
+Utiliser la mutation signedByTransporter permettant d'apposer les signatures collecteur-transporteur (case 8) et émetteur (case 9)
+
+</blockquote>
 </td>
 </tr>
 <tr>
@@ -1091,7 +1103,14 @@ Payload du BSD
 <td valign="top"><a href="#form">Form</a></td>
 <td>
 
-Valide la prise en charge par le transporteur, et peut valider l'envoi
+Permet de transférer le déchet à un transporteur lors de la collecte initiale (signatures en case 8 et 9)
+ou après une étape d'entreposage provisoire ou de reconditionnement (signatures en case 18 et 19).
+Cette mutation doit être appelée avec le token du collecteur-transporteur.
+L'établissement émetteur (resp. d'entreposage provisoire ou de reconditionnement) est authentifié quant à lui grâce à son code de sécurité
+disponible sur le tableau de bord Trackdéchets
+Mon Compte > Établissements > Sécurité.
+D'un point de vue pratique, cela implique qu'un responsable de l'établissement
+émetteur (resp. d'entreposage provisoire ou de reconditionnement) renseigne le code de sécurité sur le terminal du collecteur-transporteur.
 
 </td>
 </tr>
@@ -1109,7 +1128,7 @@ ID d'un BSD
 <td valign="top"><a href="#transportersignatureforminput">TransporterSignatureFormInput</a>!</td>
 <td>
 
-Informations liées à la signature transporteur
+Informations liées aux signatures transporteur et émetteur (case 8 et 9)
 
 </td>
 </tr>

--- a/doc/docs/workflow.md
+++ b/doc/docs/workflow.md
@@ -46,42 +46,46 @@ Chaque changement d'état s'effectue grâce à une mutation.
 
 | Mutation              | Transition                                                                                       | Données                                                                           | Permissions                                                         |
 | --------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `saveForm`            | `-> DRAFT` <br />                                                                                | [FormInput](api-reference.md#forminput)                                           | N'importe quel utilisateur connecté                                 |
-| `markAsSealed`        | `DRAFT -> SEALED`                                                                                |                                                                                   | L'émetteur ou le destinataire du BSD                                |
-| `markAsSent`          | `SEALED -> SENT`                                                                                 | [SentFormInput](api-reference.md#sentforminput)                                   | Uniquement l'émetteur du BSD                                        |
-| `signedByTransporter` | `SEALED -> SENT` <br/> `RESEALED -> RESEALED`                                                    | [TransporterSignatureFormInput](api-reference.md#s#transportersignatureforminput) | Uniquement le transporteur                                          |
-| `markAsReceived`      | `SENT -> RECEIVED` <br/> `SENT -> REFUSED`                                                       | [ReceivedFormInput](api-reference.md#receivedforminput)                           | Uniquement le destinataire du BSD                                   |
-| `markAsProcessed`     | `RECEIVED -> PROCESSED` <br /> `RECEIVED -> NO_TRACEABILITY` <br /> `RECEIVED -> AWAITING_GROUP` | [ProcessedFormInput](api-reference.md#processedforminput)                         | Uniquement le destinataire du BSD                                   |
-| `markAsTempStored`    | `SENT -> TEMP_STORED` <br/> `SENT -> REFUSED`                                                    | [TempStoredFormInput](api-reference.md#tempstoredforminput)                       | Uniquement le site d'entreposage temporaire ou de reconditionnement |
+| `createForm`            | `-> DRAFT` <br />  | [FormInput](api-reference.md#forminput) | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>|
+| `updateForm`            | `DRAFT -> DRAFT` <br />  | [FormInput](api-reference.md#forminput) | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>|
+| `markAsSealed`        | `DRAFT -> SEALED`                                                                                |                                                                                   | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>                               |
+| `signedByTransporter` | <div><ul><li>`SEALED -> SENT`</li><li>`RESEALED -> RESENT`</li></ul></div>                                                    | [TransporterSignatureFormInput](api-reference.md#s#transportersignatureforminput) | Uniquement le collecteur-transporteur, l'émetteur ou le site d'entreposage provisoire/reconditionnement étant authentifié grâce au code de sécurité présent en paramètre de la mutation  |
+| `markAsReceived`      | <div><ul><li>`SENT -> RECEIVED`</li><li>`SENT -> REFUSED`</li></ul></div>                                                         | [ReceivedFormInput](api-reference.md#receivedforminput)                           | Uniquement le destinataire du BSD                                   |
+| `markAsProcessed`     | <div><ul><li>`RECEIVED -> PROCESSED`</li><li>`RECEIVED -> NO_TRACEABILITY`</li><li>`RECEIVED -> AWAITING_GROUP`</li></ul></div>| [ProcessedFormInput](api-reference.md#processedforminput)                         | Uniquement le destinataire du BSD                                   |
+| `markAsTempStored`    | <div><ul><li>`SENT -> TEMP_STORED`</li><li>`SENT -> REFUSED`</li></ul></div>                                                    | [TempStoredFormInput](api-reference.md#tempstoredforminput)                       | Uniquement le site d'entreposage temporaire ou de reconditionnement |
 | `markAsResealed`      | `TEMP_STORED -> RESEALED`                                                                        | [ResealedFormInput](api-reference.md#resealedtoredforminput)                      | Uniquement le site d'entreposage temporaire ou de reconditionnement |
-| `markAsResent`        | `RESEALED -> RESENT`                                                                             | [ResentFormInput](api-reference.md#resenttoredforminput)                          | Uniquement le site d'entreposage temporaire ou de reconditionnement |
 
-<script src="https://unpkg.com/mermaid@8.0.0/dist/mermaid.min.js"></script>
+
+<script src="https://unpkg.com/mermaid@8.1.0/dist/mermaid.min.js"></script>
 <script>mermaid.initialize({startOnLoad:true});</script>
 
 Le diagramme ci dessous retrace le cycle de vie d'un BSD dans Trackdéchets:
 
 <div class="mermaid">
 graph TD
-A[DRAFT] -->|Optionnel| B(SEALED)
-B --> |Par l'émetteur| C(SENT)
-A --> |Par l'émetteur| C
-C -->|Par le receveur| D(RECEIVED)
-D -- Cas classique -->E(PROCESSED)
-D -- Regroupement et perte de traçabilite -->G(NO_TRACEABILITY)
-D -- Regroupement -->F(AWAITING_GROUP)
-C -- Refus de déchets --> I(REFUSED)
-F-. Rempli une annexe2 .->A
-F-. Rempli une annexe2 .->A
-F-. Rempli une annexe2 .->A
-F--Fait partie d'une annexe2 -->H[GROUPED]
-H--BSD avec annexe devient Processed -->E
-C -- Par le site provisoire / BSD suite -->J(TEMP_STORED)
-J -- Optionnel via API --> K(RESEALED)
-J --> L
-K -- Entreposage terminé --> L(RESENT)
+AO(NO STATE) -->|createForm| A
+A -->|updateForm| A
+A[DRAFT] -->|markAsSealed| B(SEALED)
+B -->|signedByTransporter| C(SENT)
+C -->|markAsReceived| D(RECEIVED)
+D -->|markAsProcessed| E(PROCESSED)
+D -->|markAsProcessed - avec rupture de traçabalité |G(NO_TRACEABILITY)
+D -->|markAsProcessed - avec opération de regroupement | F(AWAITING_GROUP)
+C -->|markAsReceived - avec refus| I(REFUSED)
+C -->|markAsTempStored - avec refus| I
+F.->|createForm - appendix2Forms |A
+F-->|Lors de la création d'un nouveau BSD avec annexe 2|H[GROUPED]
+H-->|Lorsque markAsProcessed est appelé sur le BSD avec annexe 2|E
+C -->|markAsTempStored|J(TEMP_STORED)
+J -->|markAsResealed| K(RESEALED)
+K -->|signedByTransporter| L(RESENT)
 L --> D
 </div>
+
+## Exemples
+
+Vous pouvez consulter [ce test d'intégration](https://github.com/MTES-MCT/trackdechets/blob/master/back/src/forms/workflow/__tests__/workflow.integration.ts) écrit en Node.js pour voir des exemples concrets d'utilisation de l'API pour différents cas d'usage (acheminement direct du producteur à l'installation de traitement, entreposage provisoire, multi-modal, etc)
+
 
 ## BSD au format pdf
 

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -791,7 +791,10 @@ export type Mutation = {
   markAsReceived: Maybe<Form>;
   /** Valide la complétion des cadres 14 à 19 lors d'un entreposage provisoire ou reconditionnement */
   markAsResealed: Maybe<Form>;
-  /** Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement */
+  /**
+   * Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement
+   * @deprecated Utiliser la mutation signedByTransporter permettant d'apposer les signatures du collecteur-transporteur (case 18) et de l'exploitant du site d'entreposage provisoire ou de reconditionnement (case 19)
+   */
   markAsResent: Maybe<Form>;
   /**
    * Scelle un BSD
@@ -848,7 +851,10 @@ export type Mutation = {
    * ```
    */
   markAsSealed: Maybe<Form>;
-  /** Valide l'envoi d'un BSD */
+  /**
+   * Valide l'envoi d'un BSD
+   * @deprecated Utiliser la mutation signedByTransporter permettant d'apposer les signatures collecteur-transporteur (case 8) et émetteur (case 9)
+   */
   markAsSent: Maybe<Form>;
   /** Valide la réception d'un BSD d'un entreposage provisoire ou reconditionnement */
   markAsTempStored: Maybe<Form>;
@@ -881,7 +887,18 @@ export type Mutation = {
    * @deprecated Utiliser createForm / updateForm selon le besoin
    */
   saveForm: Maybe<Form>;
-  /** Valide la prise en charge par le transporteur, et peut valider l'envoi */
+  /**
+   * Permet de transférer le déchet à un transporteur lors de la collecte initiale (signatures en case 8 et 9)
+   * ou après une étape d'entreposage provisoire ou de reconditionnement (signatures en case 18 et 19).
+   * Cette mutation doit être appelée avec le token du collecteur-transporteur.
+   * L'établissement émetteur (resp. d'entreposage provisoire ou de
+   * reconditionnement) est authentifié quant à lui grâce à son code de sécurité
+   * disponible sur le tableau de bord Trackdéchets
+   * Mon Compte > Établissements > Sécurité.
+   * D'un point de vue pratique, cela implique qu'un responsable de l'établissement
+   * émetteur (resp. d'entreposage provisoire ou de reconditionnement) renseigne le
+   * code de sécurité sur le terminal du collecteur-transporteur.
+   */
   signedByTransporter: Maybe<Form>;
   /**
    * USAGE INTERNE


### PR DESCRIPTION
* Mise à jour de la documentation du cycle de vie du BSD 
* Deprecation warning pour les mutations `markAsSent` et `markAsResent`

![Capture d’écran 2020-07-29 à 10 34 12](https://user-images.githubusercontent.com/2269165/88778776-3483d080-d189-11ea-8ada-5f132ae65136.png)
