### PR TITLE
Correction du `stateSummary` avec un `form` minimal

### DIFF
--- a/back/src/forms/queries/state-summary.ts
+++ b/back/src/forms/queries/state-summary.ts
@@ -9,15 +9,16 @@ export const stateSummary = async (form: Form): Promise<StateSummary> => {
     quantity: getQuantity(form, temporaryStorageDetail),
     packagings:
       temporaryStorageDetail?.wasteDetailsPackagings ??
-      form.wasteDetails.packagings,
+      form.wasteDetails?.packagings ??
+      [],
     onuCode:
-      temporaryStorageDetail?.wasteDetailsOnuCode ?? form.wasteDetails.onuCode,
-    transporterNumberPlate: temporaryStorageDetail
-      ? temporaryStorageDetail.transporterNumberPlate
-      : form.transporter.numberPlate,
-    transporterCustomInfo: temporaryStorageDetail
-      ? temporaryStorageDetail.transporterNumberPlate
-      : form.transporter.customInfo,
+      temporaryStorageDetail?.wasteDetailsOnuCode ?? form.wasteDetails?.onuCode,
+    transporterNumberPlate:
+      temporaryStorageDetail?.transporterNumberPlate ??
+      form.transporter?.numberPlate,
+    transporterCustomInfo:
+      temporaryStorageDetail?.transporterNumberPlate ??
+      form.transporter?.customInfo,
     transporter: getTransporter(form, temporaryStorageDetail),
     recipient: getRecipient(form, temporaryStorageDetail),
     emitter: getEmitter(form, temporaryStorageDetail),

--- a/back/tsconfig.json
+++ b/back/tsconfig.json
@@ -8,8 +8,14 @@
     "target": "es6",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+
     "strict": false,
-    "noImplicitAny": false
+    "noImplicitThis": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": false,
+    "strictNullChecks": false,
+    "strictPropertyInitialization": false
   },
   "include": ["src/**/*", "prisma/**/*"]
 }


### PR DESCRIPTION
Cette PR corrige les différents problèmes sur `stateSummary` lorsqu'un `form` contient peu d'informations.

---

- [Ticket Trello](https://trello.com/c/OGxNCMlg/961-lapi-retourne-une-erreur-lorsquun-bsd-contient-tr%C3%A8s-peu-dinformations)