### PR TITLE
Correction du lien vers la liste des installations classées

### DIFF
--- a/front/src/form/Recipient.tsx
+++ b/front/src/form/Recipient.tsx
@@ -42,7 +42,7 @@ export default function Recipient() {
           Pour vous assurer que l'entreprise de destination est autorisée à
           recevoir le déchet, vous pouvez consulter{" "}
           <a
-            href="https://www.georisques.gouv.fr/dossiers/installations/donnees#/"
+            href="https://www.georisques.gouv.fr/risques/installations/donnees#/"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Cette PR met à jour l'URL pointant vers la liste des installations classées.

---

- [Ticket Trello](https://trello.com/c/irHy8SP7/960-le-lien-vers-la-liste-des-installations-class%C3%A9es-ne-fonctionne-plus)