### PR TITLE
Correction du lancement du service PDF

### DIFF
--- a/front/src/dashboard/slips/SlipActions.tsx
+++ b/front/src/dashboard/slips/SlipActions.tsx
@@ -148,7 +148,7 @@ const buttons = {
     component: Resealed,
   },
   RESENT: {
-    title: "Valider l'envement",
+    title: "Valider l'enlèvement",
     icon: FaTruckMoving,
     component: Resent,
   },

--- a/pdf/src/app.ts
+++ b/pdf/src/app.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { json } from "body-parser";
-import Sentry from "@sentry/node";
+import * as Sentry from "@sentry/node";
 import buildPdf from "./generator";
 
 const sentryDsn = process.env.SENTRY_DSN;


### PR DESCRIPTION
Suite au passage du service PDF en Typescript, une erreur est levée à l'exécution : 

```
node_1.default.init({
               ^
TypeError: Cannot read property 'init' of undefined
/usr/src/app/dist/app.js:21
```

Le problème vient de l'import de Sentry (`node_1` correspond à `@sentry/node`).

cf https://www.npmjs.com/package/@sentry/node#usage