### PR TITLE
Suppression du code de normalisation déprécié des emails

### DIFF
--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -60,19 +60,6 @@ describe("POST /login", () => {
     expect(login.header["set-cookie"]).toHaveLength(1);
   });
 
-  it("should authenticate user with their legacy account if any", async () => {
-    const user = await userFactory({
-      email: "USER_WITH_LEGACY_EMAIL@DOMAIN.COM"
-    });
-
-    const login = await request
-      .post("/login")
-      .send(`email=${user.email}`)
-      .send(`password=pass`);
-
-    expect(login.header["set-cookie"]).toHaveLength(1);
-  });
-
   it("should not authenticate an unknown user", async () => {
     const login = await request
       .post("/login")

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -16,13 +16,7 @@ import {
   User as PrismaUser
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
-import {
-  sameDayMidnight,
-  daysBetween,
-  legacySanitizeEmail,
-  sanitizeEmail
-} from "./utils";
-import { GraphQLContext } from "./types";
+import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
 
 const { JWT_SECRET } = process.env;
 
@@ -66,18 +60,7 @@ passport.use(
   new LocalStrategy(
     { usernameField: "email" },
     async (username, password, done) => {
-      let user = null;
-
-      if (legacySanitizeEmail(username) !== sanitizeEmail(username)) {
-        // Some users were created before email sanitization was introduced
-        // so we need to look up a potential legacy account before resotring to the new sanitization
-        // We'll be able to get rid of this code once legacy emails have been sanitized
-        user = await prisma.user({ email: legacySanitizeEmail(username) });
-      }
-
-      if (!user) {
-        user = await prisma.user({ email: sanitizeEmail(username) });
-      }
+      const user = await prisma.user({ email: sanitizeEmail(username) });
 
       if (!user) {
         return done(null, false, {

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -17,6 +17,7 @@ import {
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
 import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
+import { GraphQLContext } from "./types";
 
 const { JWT_SECRET } = process.env;
 

--- a/back/src/scripts/bin/deleteUser.ts
+++ b/back/src/scripts/bin/deleteUser.ts
@@ -3,9 +3,25 @@ import { prisma } from "../../generated/prisma-client";
 import deleteUser from "../prisma/deleteUser";
 
 (async () => {
-  const userID = process.argv[3];
+  const [userID] = process.argv.slice(2);
 
-  const user = userID ? await prisma.user({ id: userID }) : null;
+  if (!userID) {
+    console.log(
+      [
+        `Ce script permet de supprimer 1 compte utilisateur et ses objets liés.`,
+        `Il accepte un seul argument :`,
+        `- userID : id de l'utilisateur à supprimer`,
+        `Avant d'enclencher la suppression, des vérifications sont faites pour s'assurer de ne pas supprimer des informations importantes.`,
+        `Il est par exemple impossible de supprimer un utilisateur qui est seul administrateur d'une entreprise.`,
+        ``,
+        `Exemple :`,
+        `node ./src/scripts/bin/mergeUsersAndDelete.js 1234`
+      ].join("\n")
+    );
+    return;
+  }
+
+  const user = await prisma.user({ id: userID });
 
   if (!user) {
     console.log(

--- a/back/src/scripts/bin/mergeUsersAndDelete.ts
+++ b/back/src/scripts/bin/mergeUsersAndDelete.ts
@@ -4,11 +4,25 @@ import mergeUsers from "../prisma/mergeUsers";
 import deleteUser from "../prisma/deleteUser";
 
 (async () => {
-  const userID = process.argv[3];
-  const heirUserID = process.argv[4];
+  const [userID, heirUserID] = process.argv.slice(2);
 
-  const user = userID ? await prisma.user({ id: userID }) : null;
-  const heir = heirUserID ? await prisma.user({ id: heirUserID }) : null;
+  if (!userID || !heirUserID) {
+    console.log(
+      [
+        `Ce script permet de fusionner 2 comptes utilisateurs et d'en supprimer un.`,
+        `Il accepte deux arguments :`,
+        `- userID : id de l'utilisateur à supprimer, il cède tous ses objets liés à l'héritier`,
+        `- heirUserID : id de l'utilisateur héritier, il obtient tous les objets liés`,
+        ``,
+        `Exemple :`,
+        `node ./src/scripts/bin/mergeUsersAndDelete.js 1234 5678`
+      ].join("\n")
+    );
+    return;
+  }
+
+  const user = await prisma.user({ id: userID });
+  const heir = await prisma.user({ id: heirUserID });
 
   if (!user) {
     console.log(

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -13,7 +13,7 @@ import {
 import { FullUser } from "./types";
 import { UserInputError } from "apollo-server-express";
 import { hash } from "bcrypt";
-import { getUid, legacySanitizeEmail, sanitizeEmail } from "../utils";
+import { getUid, sanitizeEmail } from "../utils";
 
 export async function getUserCompanies(userId: string): Promise<Company[]> {
   const companyAssociations = await prisma
@@ -142,7 +142,7 @@ export async function createAccessToken(user: User) {
 
 export function userExists(unsafeEmail: string) {
   return prisma.$exists.user({
-    email_in: [legacySanitizeEmail(unsafeEmail), sanitizeEmail(unsafeEmail)]
+    email: sanitizeEmail(unsafeEmail)
   });
 }
 

--- a/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
@@ -95,24 +95,6 @@ describe("Mutation.signup", () => {
     expect(errors[0].extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
   });
 
-  it("should throw BAD_USER_INPUT if email already exist with the same casing", async () => {
-    const alreadyExistingUser = await userFactory({
-      email: "JOHNdoe@gmail.COM"
-    });
-
-    const { errors } = await mutate(SIGNUP, {
-      variables: {
-        userInfos: {
-          email: alreadyExistingUser.email,
-          password: "newUserPassword",
-          name: alreadyExistingUser.name,
-          phone: alreadyExistingUser.phone
-        }
-      }
-    });
-    expect(errors[0].extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
-  });
-
   it("should throw BAD_USER_INPUT if email is not valid", async () => {
     const user = {
       email: "bademail",

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -57,10 +57,6 @@ export function daysBetween(date1: Date, date2: Date): number {
   return numberOfdays;
 }
 
-export function legacySanitizeEmail(email: string): string {
-  return email.trim();
-}
-
 export function sanitizeEmail(email: string): string {
   return email.toLowerCase().trim();
 }


### PR DESCRIPTION
Cette PR fait suite à #334. L'objectif est de supprimer le code qui gère la phase transitoire entre emails non normalisés et emails normalisés.

Je corrige les données en base de donnée avant de mettre cette PR en ready to review.

---

- [Ticket Trello](https://trello.com/c/osEivvWb/967-supprimer-le-code-g%C3%A9rant-les-emails-non-normalis%C3%A9s)