### PR TITLE
Documentation de l'utilisation d'un backup de base de donnée

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@
   - [Installation](#installation)
   - [Conventions](#conventions)
 - [Tests unitaires](#tests-unitaires)
-- [Tests d'intégration](#tests-d-intégration)
+- [Tests d'intégration](#tests-dintégration)
 - [Créer une PR](#créer-une-pr)
 - [Déploiement](#déploiement)
 - [Guides](#guides)
-  - [Mettre à jour le changelog](#mettre-a-jour-le-changelog)
-  - [Mettre à jour la documentation](#mettre-a-jour-la-documentation)
+  - [Mettre à jour le changelog](#mettre-à-jour-le-changelog)
+  - [Mettre à jour la documentation](#mettre-à-jour-la-documentation)
   - [Utiliser un backup de base de donnée](#utiliser-un-backup-de-base-de-donnée)
 
 ## Mise en route

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ cd back/integration-tests
 3. Une fois la PR complète, passer la branche de "draft" à "ready to review" et demander la revue à au moins 1 autre développeur de l'équipe (idéalement 2). Si possible faire un rebase (éviter le merge autant que possible) de la branche `dev` pour être bien à jour et la CI au vert avant la revue.
 4. Une fois que la PR est approuvée et que les changements demandées ont été apportées, l'auteur de la PR peut la merger dans `dev`.
 
-Note : l'équipe n'a pas de conventions strict concernant le nom des branches et les messages de commit mais compte sur le bon sens de chacun.
+Note : l'équipe n'a pas de conventions strictes concernant le nom des branches et les messages de commit mais compte sur le bon sens de chacun.
 
 ## Déploiement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
   - [Mettre à jour le changelog](#mettre-à-jour-le-changelog)
   - [Mettre à jour la documentation](#mettre-à-jour-la-documentation)
   - [Utiliser un backup de base de donnée](#utiliser-un-backup-de-base-de-donnée)
+  - [Créer un tampon de signature pour la génération PDF](#créer-un-tampon-de-signature-pour-la-génération-pdf)
 
 ## Mise en route
 
@@ -222,3 +223,8 @@ La procédure qui suit aura pour effet de remplacer vos données en local par le
    # exemple :
    pg_restore -U trackdechets -d prisma --clean /var/backups/backup
    ```
+
+### Créer un tampon de signature pour la génération PDF
+
+Il est possible de créer de nouveaux tampons à partir du fichier [stamp.drawio.png](./pdf/src/medias/stamp.drawio.png).
+C'est un fichier PNG valide que l'on peut éditer directement dans Visual Code avec l'extension [Draw.io VS Code Integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 - [Guides](#guides)
   - [Mettre à jour le changelog](#mettre-a-jour-le-changelog)
   - [Mettre à jour la documentation](#mettre-a-jour-la-documentation)
+  - [Utiliser un backup de base de donnée](#utiliser-un-backup-de-base-de-donnée)
 
 ## Mise en route
 
@@ -194,3 +195,30 @@ Il est possible de documenter les changements à venir en ajoutant une section "
 ### Mettre à jour la documentation
 
 Les nouvelles fonctionnalités impactant l'API doivent être documentées dans la documentation technique `./doc` en même temps que leur développement. Si possible faire également un post sur le [forum technique](https://forum.trackdechets.beta.gouv.fr/).
+
+### Utiliser un backup de base de donnée
+
+Il est possible d'importer un backup d'une base de donnée d'un environnement afin de le tester en local.
+La procédure qui suit aura pour effet de remplacer vos données en local par les données du backup.
+
+1. Télécharger un backup de la base de donnée `prisma` depuis Scaleway
+2. Démarrer le container Postgres
+   ```
+   docker-compose -f docker-compose.dev.yml up --build postgres
+   ```
+3. Copier le fichier de backup à l'intérieur du container
+   ```
+   # docker cp <fichier backup> <nom du container postgres>:<chemin où copier>
+   # exemple :
+   docker cp backup trackdechets_postgres_1:/var/backups
+   ```
+4. Accéder au container Postgres
+   ```
+   docker exec -it $(docker ps -aqf "name=trackdechets_td-api") bash
+   ```
+5. Restaurer le backup
+   ```
+   # pg_restore -U trackdechets -d prisma --clean <fichier backup>
+   # exemple :
+   pg_restore -U trackdechets -d prisma --clean /var/backups/backup
+   ```

--- a/README.md
+++ b/README.md
@@ -9,38 +9,37 @@
 
 Dépôt de code de la startup d'état **Trackdéchets** incubée à la Fabrique Numérique du Ministère de la Transition Écologique et Solidaire.
 
-Ce `README` s'adresse aux intervenant·es  techniques sur le projet. Pour plus d'infos en tant qu'utilisateur.ice du produit ou de l'API, vous pouvez consulter les liens suivants:
+Ce `README` s'adresse aux intervenant·es techniques sur le projet. Pour plus d'infos en tant qu'utilisateur.ice du produit ou de l'API, vous pouvez consulter les liens suivants:
 
-* [Site web](https://trackdechets.beta.gouv.fr)
-* [FAQ](https://faq.trackdechets.fr/)
-* [Documentation technique de l'API](https://developers.trackdechets.beta.gouv.fr)
-* [Forum technique](https://forum.trackdechets.beta.gouv.fr)
+- [Site web](https://trackdechets.beta.gouv.fr)
+- [FAQ](https://faq.trackdechets.fr/)
+- [Documentation technique de l'API](https://developers.trackdechets.beta.gouv.fr)
+- [Forum technique](https://forum.trackdechets.beta.gouv.fr)
 
 ## Architecture logicielle
 
 Le projet utilise `docker-compose` avec les différents services suivants:
 
-* `td-api` (`./back`) Serveur Express.js avec une API GraphQL (Node.js)
-* `td-ui` (`./front`) Single Page App pour la page d'accueil et le dashboard (React.js)
-* `td-pdf` (`./pdf`) Service interne de génération de BSD au format PDF (Node.js)
-* `td-mail` (`./mail`) Service interne d'envoi de courriels via Mailjet (Golang)
-* `td-etl` (`./etl`) Service interne de préparation des données de la base des ICPE (Python, Airflow)
-* `td-doc` (`./doc`) Documentation technique du projet (Docusaurus)
+- `td-api` (`./back`) Serveur Express.js avec une API GraphQL (Node.js)
+- `td-ui` (`./front`) Single Page App pour la page d'accueil et le dashboard (React.js)
+- `td-pdf` (`./pdf`) Service interne de génération de BSD au format PDF (Node.js)
+- `td-mail` (`./mail`) Service interne d'envoi de courriels via Mailjet (Golang)
+- `td-etl` (`./etl`) Service interne de préparation des données de la base des ICPE (Python, Airflow)
+- `td-doc` (`./doc`) Documentation technique du projet (Docusaurus)
 
 La config `nginx` pour chaque container exposé est créee de façon automatique grâce à [jwilder/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)
 
 ![stack](./stack.png)
 
-
 ## Environnements
 
 Plusieurs environnements sont configurés via les différents fichiers compose.
 
-* **dev** pour le développement en local
-* **test** pour faire tourner les tests, en local ou sur CircleCI
-* **recette**: environnement de validation fonctionnelle, synchronisé avec la branche `dev`.
-* **sandbox**: environnement "bac à sable" pour les personnes souhaitant s'interfacer avec l'API Trackdéchets, synchronisé avec la branche `master`
-* **prod**: environnement de production, synchronisé avec la branche `master`
+- **dev** pour le développement en local
+- **test** pour faire tourner les tests, en local ou sur CircleCI
+- **recette**: environnement de validation fonctionnelle, synchronisé avec la branche `dev`.
+- **sandbox**: environnement "bac à sable" pour les personnes souhaitant s'interfacer avec l'API Trackdéchets, synchronisé avec la branche `master`
+- **prod**: environnement de production, synchronisé avec la branche `master`
 
 ## Infrastructure
 
@@ -48,191 +47,17 @@ Les différentes instances sont hébérgées chez OVH et Scaleway. Le détail es
 
 ## Outillage
 
-* [CircleCI](https://circleci.com/) pour l'intégration continue et le déploiement
-* [Sentry](https://sentry.io) pour le reporting des erreurs
-* [Graylog](https://www.graylog.org/) pour l'indexation des logs
-* [Metabase](https://www.metabase.com/) pour l'analyse et la visualisation des données Trackdéchets
-* [Matomo](https://fr.matomo.org/) pour l'analyse du traffic web
-* [Cachet](http://cachethq.io/) pour la page de statuts et les alertes
-* [graphql-codegen](https://graphql-code-generator.com/) pour générer la référence de l'API et le typage Typescript à partir des fichiers de définition GraphQL.
-
-## Mise en route
-
-### Pré-requis
-
-* Installer `docker` et `docker-compose`
-
-### Nginx-proxy
-
-[jwilder/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) permet d'accéder aux différents services exposées au travers d'URLs de type `http://trackdechets.local`, `http://api.trackdechets.local`, etc sur le port 80 plutôt que de mapper chaque service sur différents ports de `localhost`.
-
-
-* Créer un répertoire `nginx-proxy` sur votre espace de travail et y ajouter le fichier `docker-compose.yml` suivant:
-
-  ```docker
-  version: "3.1"
-
-  services:
-    nginx-proxy:
-      image: jwilder/nginx-proxy:alpine
-      ports:
-        - "80:80"
-      volumes:
-        - /var/run/docker.sock:/tmp/docker.sock:ro
-      restart: unless-stopped
-
-  networks:
-    default:
-      external:
-        name: nginx-proxy
-  ```
-
-* Créer le `network` docker `nginx-proxy`
-
-  ```
-  docker network create nginx-proxy
-  ```
-
-* Mapper les différentes URLs sur localhost dans votre fichier `host`
-
-  ```
-  127.0.0.1 api.trackdechets.local
-  127.0.0.1 trackdechets.local
-  127.0.0.1 etl.trackdechets.local
-  127.0.0.1 metabase.trackdechets.local
-  127.0.0.1 doc.trackdechets.local
-  127.0.0.1 developers.trackdechets.local
-  ```
-
-  > Pour rappel, le fichier host est dans `C:\Windows\System32\drivers\etc` sous windows, `/etc/hosts` ou `/private/etc/hosts` sous Linux et Mac
-
-* Démarrer le proxy nginx
-
-  ```
-  docker-compose up
-  ```
-
-Pour plus de détails, se référer au post ["Set a local web development environement with custom urls and https"](https://medium.com/@francoisromain/set-a-local-web-development-environment-with-custom-urls-and-https-3fbe91d2eaf0) par @francoisromain
-
-
-### Configurer les variables d'environnements
-
-* Renommer le ficher `.env.model` en `.env` et le compléter en demandant les infos à un développeur de l'équipe
-* Créer un fichier `.env` dans `front/` en s'inspirant du fichier `.env.recette`
-
-### Démarrer les containers
-
-
-```bash
-git clone git@github.com:MTES-MCT/trackdechets.git
-cd trackdechets
-git checkout --track origin/dev
-git checkout -b feat/my-awesome-feature
-docker-compose -f docker-compose.dev.yml up postgres redis prisma td-api td-pdf td-ui
-```
-
-Le démarrage du service `td-mail` est déconseillé en développement pour éviter des envois de courriels intempestifs mais vous pouvez l'activer pour le bon fonctionnement de certaines fonctionnalités (ex: validation de l'inscription, invitation à rejoindre un établissement, etc)
-
-Vous pouvez également démarrer les services `td-doc`, `td-etl` et `metabase` au cas par cas mais ceux-ci  ne sont pas essentiels au fonctionnement de l'API ou de l'interface utilisateur.
-
-
-### Synchroniser la base de données avec le schéma prisma
-
-Les modèles de données sont définis dans les fichiers `back/prisma/database/*.prisma`.
-Afin de synchroniser les tables PostgreSQL, il faut lancer une déploiement prisma
-
-
-```bash
-docker exec -it $(docker ps -aqf "name=trackdechets_td-api") bash
-npx prisma deploy
-```
-
-### Accéder aux différents services
-
-C'est prêt ! Rendez-vous sur l'URL `UI_HOST` configurée dans votre fichier `.env` (par ex: `http://trackdechets.local`) pour commencer à utiliser l'application ou sur `API_HOST` (par ex `http://api.trackdechets.local`) pour accéder au playground GraphQL.
-
-Il existe également un playground prisma exposant directement les fonctionnalités de l'ORM accessible sur `http://localhost:4466`.
-
-### Appliquer les conventions de style
-
-[Linux/MacOS uniquement] Avant de pousser votre premier commit, il est recommandé d'installer un hook Github permettant de faire tourner eslint et prettier sur le code source back et front. `~/.githooks/install-hooks.sh` se chargera de l'installation. Si vous avez besoin de forcer un push sans vérifier les conventions de style, il est toujours possible de faire git push --no-verify.
-
-
-## Tests
-
-### Tests unitaires (back et front)
-
-#### Faire tourner tous les tests
-
-```
-docker-compose -f docker-compose.test.yml up
-```
-
-#### Faire tourner uniquement certains tests
-
-Il est également possible de faire tourner les tests unitaires sur l'environnement de `dev` en se connectant à chacun des containers
-
-* Démarrer les différents services
-
-  ```
-  docker-compose -f docker-compose.dev.yml up postgres prisma redis td-pdf td-api td-ui
-  ```
-
-* Faire tourner les tests back
-
-  ```bash
-  docker exec -it $(docker ps -aqf "name=trackdechets_td-api") bash
-  npm run test # run all the tests
-  npx jest path src/path/to/my-function.test.ts # run only one test
-  ```
-
-* Faire tourner les tests front
-
-  ```bash
-  docker exec -it $(docker ps -aqf "name=td-ui") sh
-  npm run test # run tests in watch mode
-  ```
-
-
-### Tests d'intégration back
-
-Ce sont tous les tests ayant l'extension `.integration.ts` et nécessitant le setup d'une base de données de test.
-
-```bash
-cd back/integration-tests
-./run.sh # run all the tests at once and exit
-```
-
-Il est également possible de faire tourner chaque test de façon indépendante:
-
-```bash
-cd back/integration-tests
-./run.sh -u # start the containers
-./run.sh -r workflow.integration.ts
-./run.sh -d # remove the containers
-```
+- [CircleCI](https://circleci.com/) pour l'intégration continue et le déploiement
+- [Sentry](https://sentry.io) pour le reporting des erreurs
+- [Graylog](https://www.graylog.org/) pour l'indexation des logs
+- [Metabase](https://www.metabase.com/) pour l'analyse et la visualisation des données Trackdéchets
+- [Matomo](https://fr.matomo.org/) pour l'analyse du traffic web
+- [Cachet](http://cachethq.io/) pour la page de statuts et les alertes
+- [graphql-codegen](https://graphql-code-generator.com/) pour générer la référence de l'API et le typage Typescript à partir des fichiers de définition GraphQL.
 
 ## Compatibilité navigateur
 
 Le support des navigateurs est configuré dans le fichier [`./front/.browserslistrc`](./front/.browserslistrc). La liste des navigateurs correspondant à cette config est [la suivante](https://browserl.ist/?q=%3E+0.1%25%2C+not+dead%2C+not+op_mini+all%2C+ie+11)
-
-
-## Déploiement
-
-Le déploiement est géré par CircleCI à l'aide du fichier [./circle/config.yml](.circleci/config.yml).
-Chaque update de la branche `dev` déclenche un déploiement sur l'environnement de recette. Chaque update de la branche `master` déclenche un déploiement sur les environnements sandbox et prod. Le déroulement dans le détails d'une mise en production est le suivant:
-
-* Balayer la colonne Trello "Recette Métier" pour vérifier que l'étiquette "OK PASSAGE EN PROD" a bien été ajouté sur toutes les cartes.
-* Faire le cahier de recette pour vérifier qu'il n'y a pas eu de régression sur les fonctionnalités critiques de l'application (login, signup, rattachement établissement, invitation collaborateur, création BSD)
-* Mettre à jour le Changelog avec un nouveau numéro de version (versionnage calendaire)
-* Créer une PR `dev` -> `master`
-* Au besoin résoudre les conflits entre `master` et `dev` en fusionnant `master` dans `dev`
-* Faire une relecture des différents changements apportés aux modèles de données et scripts de migration.
-* Si possible faire tourner les migrations sur une copie de la base de prod en local.
-* S'assurer que les nouvelles variables d'environnement (Cf `.env.model`) ont bien été ajoutée sur sandbox et prod
-* Merger la PR et suivre l'avancement du déploiement sur le CI
-* Se connecter à l'instance de prod et faire tourner le script `npm run update` dans le container `td-api`. Faire de même sur l'instance sandbox.
-
 
 ## Contribuer
 
@@ -245,5 +70,3 @@ La liste des contributeurs au projet est disponible sur [AUTHORS.md](./AUTHORS.m
 ## Licence
 
 [GNU Affero General Public License v3.0 ou plus récent](https://spdx.org/licenses/AGPL-3.0-or-later.html)
-
-

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -1,4 +1,0 @@
-## Génération des tampons de signature
-
-Il est possible de créer de nouveaux tampons à partir du fichier [stamp.drawio.png](./src/medias/stamp.drawio.png).
-C'est un fichier PNG valide que l'on peut éditer directement dans Visual Code avec l'extension [Draw.io VS Code Integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio)


### PR DESCRIPTION
Cette PR documente le processus pour utiliser un backup de base de donnée en local.

Je ne savais pas trop où le mettre, le README est déjà bien remplit. Du coup j'ai restructuré un peu en déplaçant tout ce qui concerne les contributeurs du projet dans le fichier `CONTRIBUTING.md`. J'ai ajouté une section "guides" où on pourra ajouter ce genre de choses.

J'ai l'impression que c'est plus digeste comme ça mais vous me direz ce que vous en pensez.

---

- [Ticket Trello](https://trello.com/c/7pTNKwIc/983-documentation-de-lutilisation-dun-backup-de-base-de-donn%C3%A9e)