### PR TITLE
Prise en compte des retours sur l'optionalité du code ONU

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -243,7 +243,7 @@ describe("Mutation.markAsSealed", () => {
       expect.objectContaining({
         message: [
           "Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.",
-          "Erreur(s): Le code ONU est obligatoire pour les déchets dangereux"
+          `Erreur(s): La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
         ].join("\n")
       })
     ]);

--- a/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
@@ -95,7 +95,7 @@ describe("Mutation.signedByTransporter", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: "Le code ONU est obligatoire pour les déchets dangereux",
+        message: `La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`,
         extensions: expect.objectContaining({
           code: ErrorCode.BAD_USER_INPUT
         })

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -290,7 +290,9 @@ export const wasteDetailsSchema: yup.ObjectSchema<WasteDetails> = yup
         yup
           .string()
           .ensure()
-          .required("Le code ONU est obligatoire pour les déchets dangereux"),
+          .required(
+            `La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
+          ),
       otherwise: () => yup.string().nullable(),
       wasteDetailsPackagings: yup.array().ensure().required(),
       wasteDetailsNumberOfPackages: yup

--- a/front/src/form/WasteInfo.tsx
+++ b/front/src/form/WasteInfo.tsx
@@ -133,16 +133,14 @@ export default connect<{}, Values>(function WasteInfo(props) {
 
         <RedErrorMessage name="wasteDetails.quantityType" />
       </div>
-      {values.wasteDetails.code.includes("*") && (
-        <div className="form__group">
-          <label>
-            Mentions au titre des règlements ADR, RID, ADNR, IMDG
-            <Field type="text" name="wasteDetails.onuCode" />
-          </label>
+      <div className="form__group">
+        <label>
+          Mentions au titre des règlements ADR, RID, ADNR, IMDG
+          <Field type="text" name="wasteDetails.onuCode" />
+        </label>
 
-          <RedErrorMessage name="wasteDetails.onuCode" />
-        </div>
-      )}
+        <RedErrorMessage name="wasteDetails.onuCode" />
+      </div>
     </>
   );
 });

--- a/front/src/form/WasteInfo.tsx
+++ b/front/src/form/WasteInfo.tsx
@@ -10,6 +10,7 @@ import FormsSelector from "./appendix/FormsSelector";
 import AppendixInfo from "./appendix/AppendixInfo";
 import Tooltip from "../common/Tooltip";
 import "./WasteInfo.scss";
+import { isDangerous } from "../generated/constants";
 
 type Values = {
   wasteDetails: { code: string; packagings: string[] };
@@ -135,7 +136,8 @@ export default connect<{}, Values>(function WasteInfo(props) {
       </div>
       <div className="form__group">
         <label>
-          Mentions au titre des règlements ADR, RID, ADNR, IMDG
+          Mentions au titre des règlements ADR, RID, ADNR, IMDG{" "}
+          {!isDangerous(values.wasteDetails.code) && "(optionnel)"}
           <Field type="text" name="wasteDetails.onuCode" />
         </label>
 

--- a/front/src/form/schema.ts
+++ b/front/src/form/schema.ts
@@ -99,7 +99,9 @@ export const formSchema = object().shape({
       then: () =>
         string()
           .ensure()
-          .required("Le code ONU est obligatoire pour les déchets dangereux"),
+          .required(
+            `La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
+          ),
       otherwise: () => string().nullable(),
     }),
     packagings: array().of(packagingSchema),


### PR DESCRIPTION
Cette PR intègre les remarques partagées sur l'optionalité du code ONU. À savoir :

- [x] Le champ code ONU doit rester visible, même pour les déchets non-dangereux.
- [x] Le message d'erreur est à améliorer.

---

- [Ticket Trello](https://trello.com/c/T5Un4no8/974-rendre-le-code-onu-optionnel-pour-les-d%C3%A9chets-non-dangereux)