### PR TITLE
Correction de la validation du traitement

### DIFF
--- a/back/prisma/scripts/update-next-destination-country.ts
+++ b/back/prisma/scripts/update-next-destination-country.ts
@@ -1,0 +1,21 @@
+import { Updater, registerUpdater } from "./helper/helper";
+import { prisma } from "../../src/generated/prisma-client";
+
+@registerUpdater(
+  "Set default value of FR for next destination company country",
+  "Set default value of FR for next destination company country",
+  true
+)
+export class UpdateNextDestinationCountry implements Updater {
+  async run() {
+    await prisma.updateManyForms({
+      data: {
+        nextDestinationCompanyCountry: "FR"
+      },
+      where: {
+        nextDestinationCompanySiret_not: null,
+        nextDestinationCompanyCountry: null
+      }
+    });
+  }
+}

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -244,7 +244,7 @@ describe("mutation.markAsProcessed", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Destination ultérieure prévue: L'opération de traitement renseignée ne permet pas de destination ultérieure"
+          "L'opération de traitement renseignée ne permet pas de destination ultérieure"
       })
     ]);
   });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -1,13 +1,12 @@
-import { createTestClient } from "apollo-server-integration-testing";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { prisma } from "../../../../generated/prisma-client";
-import { server } from "../../../../server";
 import {
   formFactory,
   userWithCompanyFactory,
   companyFactory
 } from "../../../../__tests__/factories";
 import { PROCESSING_OPERATIONS } from "../../../../common/constants";
+import makeClient from "../../../../__tests__/testClient";
 
 jest.mock("axios", () => ({
   default: {
@@ -24,37 +23,11 @@ const MARK_AS_PROCESSED = `
   }
 `;
 
-describe("Integration / Mark as processed mutation", () => {
-  let user;
-  let company;
-  let mutate;
-
-  beforeAll(async () => {
-    const userAndCompany = await userWithCompanyFactory("ADMIN");
-    user = userAndCompany.user;
-    company = userAndCompany.company;
-  });
-
-  beforeEach(() => {
-    // instantiate test client
-    const { mutate: m, setOptions } = createTestClient({
-      apolloServer: server
-    });
-
-    setOptions({
-      request: {
-        user
-      }
-    });
-
-    mutate = m;
-  });
-
-  afterAll(async () => {
-    await resetDatabase();
-  });
+describe("mutation.markAsProcessed", () => {
+  afterAll(() => resetDatabase());
 
   it("should fail if current user is not recipient", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
     const recipientCompany = await companyFactory();
 
     const form = await formFactory({
@@ -66,6 +39,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     const { errors } = await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -81,6 +55,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should mark a form as processed", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -90,6 +65,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -118,6 +94,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should fill the description with the operation's", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -130,6 +107,7 @@ describe("Integration / Mark as processed mutation", () => {
     const processingOperation = PROCESSING_OPERATIONS.find(
       operation => operation.code === "D 1"
     );
+    const { mutate } = makeClient(user);
     const {
       data: {
         markAsProcessed: { processingOperationDescription }
@@ -150,6 +128,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should not mark a form as processed when operation code is not valid", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -159,6 +138,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     const { errors } = await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -188,6 +168,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should mark a form as AWAITING_GROUP when operation implies so", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -197,6 +178,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -224,7 +206,8 @@ describe("Integration / Mark as processed mutation", () => {
     expect(resultingForm.status).toBe("AWAITING_GROUP");
   });
 
-  it("should mark a form as NO_TRACEABILITY when user declares it", async () => {
+  it("should return an error when providing a next destination for a non-grouping waste code", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -234,6 +217,50 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: "R 1",
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z",
+          nextDestination: {
+            processingOperation: "D 1",
+            company: {
+              mail: "m@m.fr",
+              siret: "97874512984578",
+              name: "company",
+              phone: "0101010101",
+              contact: "The famous bot",
+              address: "A beautiful place..."
+            }
+          }
+        }
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Destination ultérieure prévue: L'opération de traitement renseignée ne permet pas de destination ultérieure"
+      })
+    ]);
+  });
+
+  it("should mark a form as NO_TRACEABILITY when user declares it", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "RECEIVED",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
     await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -252,6 +279,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should add a foreign next destination", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -261,6 +289,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,
@@ -291,6 +320,7 @@ describe("Integration / Mark as processed mutation", () => {
   });
 
   it("should disallow a missing siret for a french next destination", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -300,6 +330,7 @@ describe("Integration / Mark as processed mutation", () => {
       }
     });
 
+    const { mutate } = makeClient(user);
     const { errors } = await mutate(MARK_AS_PROCESSED, {
       variables: {
         id: form.id,

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -34,6 +34,8 @@ export async function markAsProcessedFn(
     formUpdateInput.nextDestinationCompanySiret &&
     !formUpdateInput.nextDestinationCompanyCountry
   ) {
+    // only default to "FR" if there's an actual nextDestination
+    // otherwise keep it empty to avoid filling a field for an object that doesn't exist
     formUpdateInput.nextDestinationCompanyCountry = "FR";
   }
 

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -30,6 +30,13 @@ export async function markAsProcessedFn(
   formUpdateInput.processingOperationDescription =
     processedInfo.processingOperationDescription || operation?.description;
 
+  if (
+    formUpdateInput.nextDestinationCompanySiret &&
+    !formUpdateInput.nextDestinationCompanyCountry
+  ) {
+    formUpdateInput.nextDestinationCompanyCountry = "FR";
+  }
+
   return transitionForm(
     form,
     { eventType: "MARK_PROCESSED", eventParams: processedInfo },

--- a/front/src/dashboard/slips/slips-actions/Processed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Processed.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Formik, Field, Form } from "formik";
+import React, { useEffect } from "react";
+import { Formik, Field, Form, useFormikContext } from "formik";
 import { DateTime } from "luxon";
 import {
   PROCESSING_OPERATIONS,
@@ -8,8 +8,121 @@ import {
 import DateInput from "../../../form/custom-inputs/DateInput";
 import CompanySelector from "../../../form/company/CompanySelector";
 import { SlipActionProps } from "../SlipActions";
+import { MutationMarkAsProcessedArgs } from "../../../generated/graphql/types";
 
-export default function Processed(props: SlipActionProps) {
+function Processed(props: SlipActionProps) {
+  const {
+    values: { processingOperationDone, nextDestination },
+    setFieldValue,
+  } = useFormikContext<MutationMarkAsProcessedArgs["processedInfo"]>();
+
+  useEffect(() => {
+    if (
+      PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(processingOperationDone)
+    ) {
+      if (nextDestination == null) {
+        setFieldValue("nextDestination", {
+          processingOperation: "",
+          company: {
+            siret: "",
+            name: "",
+            address: "",
+            contact: "",
+            mail: "",
+            phone: "",
+          },
+        });
+      }
+    } else {
+      setFieldValue("nextDestination", null);
+    }
+  }, [processingOperationDone, nextDestination, setFieldValue]);
+
+  return (
+    <Form>
+      <div className="form__group">
+        <label>
+          Nom du responsable
+          <Field type="text" name="processedBy" placeholder="NOM Prénom" />
+        </label>
+      </div>
+      <div className="form__group">
+        <label>
+          Date de traitement
+          <Field component={DateInput} name="processedAt" />
+        </label>
+      </div>
+      <div className="form__group">
+        <label>Opération d’élimination / valorisation effectuée</label>
+        <Field component="select" name="processingOperationDone">
+          <option value="">Choisissez...</option>
+          {PROCESSING_OPERATIONS.map(operation => (
+            <option key={operation.code} value={operation.code}>
+              {operation.code} - {operation.description.substr(0, 50)}
+              {operation.description.length > 50 ? "..." : ""}
+            </option>
+          ))}
+        </Field>
+        <div>
+          Code de traitement initialement prévu par le producteur:{" "}
+          {props.form.recipient?.processingOperation}
+        </div>
+      </div>
+      <div className="form__group">
+        <label>
+          Description de l'Opération
+          <Field component="textarea" name="processingOperationDescription" />
+        </label>
+      </div>
+      <div className="form__group">
+        <label>
+          <Field type="checkbox" name="noTraceability" />
+          Rupture de traçabilité autorisée par arrêté préfectoral pour ce déchet
+          - la responsabilité du producteur du déchet est transférée
+        </label>
+      </div>
+      {nextDestination && (
+        <div className="form__group">
+          <h4>Destination ultérieure prévue</h4>
+          <CompanySelector
+            name="nextDestination.company"
+            allowForeignCompanies
+          />
+
+          <div className="form__group">
+            <label>Opération d’élimination / valorisation (code D/R)</label>
+            <Field
+              component="select"
+              name="nextDestination.processingOperation"
+            >
+              <option value="">Choisissez...</option>
+              {PROCESSING_OPERATIONS.map(operation => (
+                <option key={operation.code} value={operation.code}>
+                  {operation.code} - {operation.description.substr(0, 50)}
+                  {operation.description.length > 50 ? "..." : ""}
+                </option>
+              ))}
+            </Field>
+          </div>
+        </div>
+      )}
+      <div className="form__group button__group">
+        <button
+          type="button"
+          className="button secondary"
+          onClick={props.onCancel}
+        >
+          Annuler
+        </button>
+        <button type="submit" className="button">
+          Je valide
+        </button>
+      </div>
+    </Form>
+  );
+}
+
+export default function ProcessedWrapper(props: SlipActionProps) {
   return (
     <div>
       <Formik
@@ -18,115 +131,12 @@ export default function Processed(props: SlipActionProps) {
           processingOperationDescription: "",
           processedBy: "",
           processedAt: DateTime.local().toISODate(),
-          nextDestination: {
-            processingOperation: "",
-            company: {
-              siret: "",
-              name: "",
-              address: "",
-              contact: "",
-              mail: "",
-              phone: "",
-            },
-          },
+          nextDestination: null,
           noTraceability: false,
         }}
         onSubmit={values => props.onSubmit({ info: values })}
       >
-        {({ values }) => (
-          <Form>
-            <div className="form__group">
-              <label>
-                Nom du responsable
-                <Field
-                  type="text"
-                  name="processedBy"
-                  placeholder="NOM Prénom"
-                />
-              </label>
-            </div>
-            <div className="form__group">
-              <label>
-                Date de traitement
-                <Field component={DateInput} name="processedAt" />
-              </label>
-            </div>
-            <div className="form__group">
-              <label>Opération d’élimination / valorisation effectuée</label>
-              <Field component="select" name="processingOperationDone">
-                <option value="">Choisissez...</option>
-                {PROCESSING_OPERATIONS.map(operation => (
-                  <option key={operation.code} value={operation.code}>
-                    {operation.code} - {operation.description.substr(0, 50)}
-                    {operation.description.length > 50 ? "..." : ""}
-                  </option>
-                ))}
-              </Field>
-              <div>
-                Code de traitement initialement prévu par le producteur:{" "}
-                {props.form.recipient?.processingOperation}
-              </div>
-            </div>
-            <div className="form__group">
-              <label>
-                Description de l'Opération
-                <Field
-                  component="textarea"
-                  name="processingOperationDescription"
-                />
-              </label>
-            </div>
-            <div className="form__group">
-              <label>
-                <Field type="checkbox" name="noTraceability" />
-                Rupture de traçabilité autorisée par arrêté préfectoral pour ce
-                déchet - la responsabilité du producteur du déchet est
-                transférée
-              </label>
-            </div>
-            {PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
-              values.processingOperationDone
-            ) && (
-              <div className="form__group">
-                <h4>Destination ultérieure prévue</h4>
-                <CompanySelector
-                  name="nextDestination.company"
-                  allowForeignCompanies
-                />
-
-                <div className="form__group">
-                  <label>
-                    Opération d’élimination / valorisation (code D/R)
-                  </label>
-                  <Field
-                    component="select"
-                    name="nextDestination.processingOperation"
-                  >
-                    <option value="">Choisissez...</option>
-                    {PROCESSING_OPERATIONS.map(operation => (
-                      <option key={operation.code} value={operation.code}>
-                        {operation.code} - {operation.description.substr(0, 50)}
-                        {operation.description.length > 50 ? "..." : ""}
-                      </option>
-                    ))}
-                  </Field>
-                </div>
-              </div>
-            )}
-            <div className="form__group button__group">
-              <button
-                type="button"
-                className="button secondary"
-                onClick={props.onCancel}
-              >
-                Annuler
-              </button>
-              <button type="submit" className="button">
-                Je valide
-              </button>
-            </div>
-          </Form>
-        )}
+        <Processed {...props} />
       </Formik>
     </div>
   );


### PR DESCRIPTION
Actuellement, l'application front envoit en permanence un objet `nextDestination` (qui est vide pour les opérations qui ne sont pas concernées par le regroupement). Ça passait jusqu'à ce qu'on améliore la validation qui maintenant refuse la mutation en précisant que le `contact` de la `nextDestination` ne peut pas être vide.

Dans cette PR, je fais en sorte de ne pas envoyer d'objet vide lorsqu'il n'y a pas de mutation. J'en ai également profité pour améliorer la validation/message d'erreur lorsqu'une `nextDestination` est passée pour un code déchet qui n'est pas lié à un regroupement.

---

- [Ticket Trello](https://trello.com/c/IkuY8hxu/995-impossible-de-valider-le-traitement)