### PR TITLE
Correction de la configuration de dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/back"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+  - package-ecosystem: "npm"
+    directory: "/front"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+  - package-ecosystem: "pdf"
+    directory: "/back"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"


### PR DESCRIPTION
Cette PR ajoute un fichier de configuration pour que les PR corrigeant des problèmes de sécurité soient ouverte à destination de `dev` et non `master`.

De cette façon on pourra réagir aux PR créés automatiquement en vérifiant que les nouvelles versions n'introduisent pas de breaking change et en les mergeant dans `dev`.

- [Configuration options for dependency updates](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)

---

- [Ticket Trello](https://trello.com/c/MY4rGlcH/1012-corriger-la-configuration-de-la-d%C3%A9tection-automatique-des-vuln%C3%A9rabilit%C3%A9s-dans-les-d%C3%A9pendances)