### PR TITLE
Ajout d'un template pour la création de PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--
+  Décrivez brièvement l'objectif de votre pull request.
+  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
+  Pensez à ajouter le lien du ticket Trello correspondant.
+-->
+
+- [ ] Mettre à jour la documentation
+- [ ] Mettre à jour le change log
+- [ ] Documenter les breaking changes dans le change log
+
+---
+
+- [Ticket Trello]()


### PR DESCRIPTION
Cette PR ajoute un template qui pré-remplira la description des PR au moment de leur création. C'est surtout un moyen de ne pas oublier de documenter.

- [Creating a pull request template for your repository](https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)

---

- [Ticket Trello](https://trello.com/c/g5KdKhYR/1013-ajout-dun-template-de-pr-pour-ne-pas-oublier-de-documenter)