### PR TITLE
Conservation de l'entreprise sélectionné après la création/édition d'un BSD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout d'une limitation de 1000 requêtes possible par une même adresse IP dans une fenêtre de 1 minute, [PR 407](https://github.com/MTES-MCT/trackdechets/pull/407)
 - Amélioration de la machine à état permettant de calculer les états possibles du BSD [PR 411](https://github.com/MTES-MCT/trackdechets/pull/411)
 - Ajout de la possibilité de pouvoir importer un BSD papier signé, [PR 404](https://github.com/MTES-MCT/trackdechets/pull/404)
+- Préservation de la sélection d'entreprise après la création d'un BSD, [PR 410](https://github.com/MTES-MCT/trackdechets/pull/410)
 
 # [2020.09.1] 28/09/2020
 

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -81,7 +81,7 @@ export default function Dashboard() {
               <Redirect to={`${match.url}/slips`} />
             </Route>
 
-            <Route path={`${match.url}/slips`}>
+            <Route path={`${match.path}/slips`}>
               <SlipsContainer />
             </Route>
 

--- a/front/src/dashboard/slips/SlipActions.tsx
+++ b/front/src/dashboard/slips/SlipActions.tsx
@@ -9,7 +9,7 @@ import {
   FaPencilAlt,
 } from "react-icons/fa";
 import { IconContext } from "react-icons";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import "./SlipActions.scss";
 import Delete from "./slips-actions/Delete";
 import DownloadPdf from "./slips-actions/DownloadPdf";
@@ -35,11 +35,17 @@ interface SlipActionsProps {
   form: Form;
 }
 export function SlipActions({ form }: SlipActionsProps) {
+  const { siret } = useParams<{ siret: string }>();
+
   return (
     <div className="SlipActions">
       {form.status === "DRAFT" ? (
         <>
-          <Link to={`/form/${form.id}`} className="icon" title="Editer">
+          <Link
+            to={`/form/${form.id}?redirectTo=${siret}`}
+            className="icon"
+            title="Editer"
+          >
             <FaEdit />
           </Link>
           <Delete formId={form.id} />

--- a/front/src/dashboard/slips/SlipsHeader.tsx
+++ b/front/src/dashboard/slips/SlipsHeader.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import "./SlipsHeader.scss";
 import { FaTimesCircle } from "react-icons/fa";
 
 export default function SlipsHeader() {
+  const { siret } = useParams<{ siret: string }>();
   const [isOpen, setIsOpen] = useState(false);
   useEffect(() => {
     const warningBannerShown = window.localStorage.getItem("td-warningbanner");
@@ -19,7 +20,7 @@ export default function SlipsHeader() {
         </div>
 
         <div className="buttons">
-          <Link to="/form">
+          <Link to={`/form?redirectTo=${siret}`}>
             <button className="button primary">Créer un bordereau</button>
           </Link>
         </div>

--- a/front/src/dashboard/slips/tabs/DraftsTab.tsx
+++ b/front/src/dashboard/slips/tabs/DraftsTab.tsx
@@ -32,7 +32,7 @@ export default function DraftsTab() {
         <h4>Il n'y a aucun bordereau en brouillon</h4>
         <p>
           Si vous le souhaitez, vous pouvez{" "}
-          <Link to="/form">
+          <Link to={`/form?redirectTo=${siret}`}>
             <button className="button-outline small primary">
               créer un bordereau
             </button>

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -8,7 +8,8 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import { RouteComponentProps, withRouter, useLocation } from "react-router";
+import { useLocation, useHistory } from "react-router";
+import queryString from "query-string";
 import { InlineError } from "../../common/Error";
 import { updateApolloCache } from "../../common/helper";
 import { currentSiretService } from "../../dashboard/CompanySelector";
@@ -31,13 +32,12 @@ interface IProps {
   children: ReactElement<IStepContainerProps>[];
   formId?: string;
 }
-export default withRouter(function StepList(
-  props: IProps & RouteComponentProps
-) {
+export default function StepList(props: IProps) {
   const [currentStep, setCurrentStep] = useState(0);
   const totalSteps = props.children.length - 1;
+  const history = useHistory();
   const { search } = useLocation();
-  const searchParams = new URLSearchParams(search);
+  const searchParams = queryString.parse(search);
 
   const { loading, error, data } = useQuery<Pick<Query, "form">, QueryFormArgs>(
     GET_FORM,
@@ -165,8 +165,8 @@ export default withRouter(function StepList(
                     variables: { formInput },
                   })
                     .then(_ =>
-                      props.history.push(
-                        `/dashboard/${searchParams.get("redirectTo") ?? ""}`
+                      history.push(
+                        `/dashboard/${searchParams.redirectTo ?? ""}`
                       )
                     )
                     .catch(err => {
@@ -195,7 +195,7 @@ export default withRouter(function StepList(
       </div>
     </div>
   );
-});
+}
 
 /**
  * Construct the form state by merging initialState and the actual form.

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import { RouteComponentProps, withRouter } from "react-router";
+import { RouteComponentProps, withRouter, useLocation } from "react-router";
 import { InlineError } from "../../common/Error";
 import { updateApolloCache } from "../../common/helper";
 import { currentSiretService } from "../../dashboard/CompanySelector";
@@ -36,6 +36,8 @@ export default withRouter(function StepList(
 ) {
   const [currentStep, setCurrentStep] = useState(0);
   const totalSteps = props.children.length - 1;
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
 
   const { loading, error, data } = useQuery<Pick<Query, "form">, QueryFormArgs>(
     GET_FORM,
@@ -162,7 +164,11 @@ export default withRouter(function StepList(
                   saveForm({
                     variables: { formInput },
                   })
-                    .then(_ => props.history.push("/dashboard/"))
+                    .then(_ =>
+                      props.history.push(
+                        `/dashboard/${searchParams.get("redirectTo") ?? ""}`
+                      )
+                    )
                     .catch(err => {
                       err.graphQLErrors.map(err =>
                         cogoToast.error(err.message, { hideAfter: 7 })


### PR DESCRIPTION
Cette PR permet de conserver la sélection de l'entreprise courante lors de la création/édition d'un BSD. En me penchant sur ce correctif j'ai identifié quelques points d'amélioration :

- Il serait intéressant de regrouper les routes dans un fichier `ROUTES.ts` pour en faciliter la maintenance :
  ```typescript
  const ROUTES = {
    dashboard: "/:siret/dashboard",
    login: "/login",
    // ...
  };

  // import { generatePath } from "react-router-dom";
  <Link to={generatePath(ROUTES.dashboard, { siret: "1234" })}>dashboard</Link>
  ```
- Le siret courant est assez central et on se rend compte qu'on souhaite le conserver partout. Je pense qu'il faudrait passer de `/dashboard/:siret`, `/form` à `/:siret/dashboard`, `/:siret/form`. Ce qui permettrait également de fluidifier la navigation au niveau de "mon compte" qui liste tous les établissements plutôt que celui actuellement sélectionné. Le sélecteur d'entreprise devrait probablement se situer au niveau du header.
- Le siret courant est propagé de différentes façon : un service qui lit/écrit dans le `localStorage`, un contexte React et dans l'URL. L'URL est en soit déjà une information contextuelle, on pourrait simplement utiliser `useParams()`.
- Les récentes versions de `react-router-dom` simplifie la gestion des routes imbriquées. Il pourrait être intéressant de mettre la librairie à jour.

C'est des choses qui demandent un peu de boulot et qui compliquerait la tâche de refonte UX en cours. Au final, je pense que ça devrait attendre et il y a des points UX dont il faudrait discuter. C'est pour ça que dans cette PR j'ai fait au plus simple.

---

- [Ticket Trello](https://trello.com/c/etZcHSPk/1016-conserver-la-s%C3%A9lection-de-lentreprise-lors-de-la-navigation)