### PR TITLE
Correction de la configuration dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "dev"
-  - package-ecosystem: "pdf"
-    directory: "/back"
+  - package-ecosystem: "npm"
+    directory: "/pdf"
     schedule:
       interval: "daily"
     target-branch: "dev"


### PR DESCRIPTION
J'ai fait une boulette dans la configuration de dependabot 🙃 C'est un peu chiant à tester, ce n'est prit en compte qu'à partir du moment où le fichier de config est sur la branche par défaut (master).