### PR TITLE
Correction du champ poids pour supporter les virgules à la signature transporteur

### DIFF
--- a/front/src/dashboard/transport/TransportSignature.tsx
+++ b/front/src/dashboard/transport/TransportSignature.tsx
@@ -176,6 +176,7 @@ export default function TransportSignature({ form, userSiret }: Props) {
                           type="number"
                           name="quantity"
                           className="field__weight field__block"
+                          step="0.001"
                         />
                       </label>
                     </p>


### PR DESCRIPTION
Cette PR corrige un bug empêchant de saisir des nombres à virgules pour le poids au moment de la signature transporteur.

---

- [Ticket Trello](https://trello.com/c/PUfczrcV/1020-impossible-de-saisir-un-nombre-%C3%A0-virgule-pour-le-poids-%C3%A0-la-signature-transporteur)