### PR TITLE
Ajout du champ "customInfo" à "TransporterInput"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Unreleased
+
+- Ajout du champ `customInfo` à `TransporterInput`, ce qui permet de renseigner cette information via les mutations `createForm`, `updateForm`, `markAsResent`, `markAsResealed`, [PR 417](https://github.com/MTES-MCT/trackdechets/pull/417)
+
 # [2020.10.1] 05/10/2020
 
 - Ajout d'une limitation de 1000 requêtes possible par une même adresse IP dans une fenêtre de 1 minute, [PR 407](https://github.com/MTES-MCT/trackdechets/pull/407)

--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -190,7 +190,8 @@ function flattenTransporterInput(input: { transporter?: TransporterInput }) {
     transporterReceipt: chain(input.transporter, t => t.receipt),
     transporterDepartment: chain(input.transporter, t => t.department),
     transporterValidityLimit: chain(input.transporter, t => t.validityLimit),
-    transporterNumberPlate: chain(input.transporter, t => t.numberPlate)
+    transporterNumberPlate: chain(input.transporter, t => t.numberPlate),
+    transporterCustomInfo: chain(input.transporter, t => t.customInfo)
   };
 }
 

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -468,50 +468,9 @@ input ResealedFormInput {
   transporter: TransporterInput
 }
 
-"Payload d'un segment de transport"
-input NextSegmentCompanyInput {
-  "SIRET de l'établissement"
-  siret: String
-
-  "Nom de l'établissement"
-  name: String
-
-  "Adresse de l'établissement"
-  address: String
-
-  "Nom du contact dans l'établissement"
-  contact: String
-
-  "Email du contact dans l'établissement"
-  mail: String
-
-  "Numéro de téléphone de contact dans l'établissement"
-  phone: String
-}
-
-input NextSegmentTransporterInput {
-  "Exemption de récipissé"
-  isExemptedOfReceipt: Boolean
-
-  "N° de récipissé"
-  receipt: String
-
-  "Département"
-  department: String
-
-  "Limite de validité du récipissé"
-  validityLimit: DateTime
-
-  "Numéro de plaque d'immatriculation"
-  numberPlate: String
-
-  "Établissement collecteur - transporteur"
-  company: NextSegmentCompanyInput
-}
-
 "Payload lié à l'ajout de segment de transport multimodal (case 20 à 21)"
 input NextSegmentInfoInput {
-  transporter: NextSegmentTransporterInput
+  transporter: TransporterInput
   mode: TransportMode!
 }
 

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -334,6 +334,9 @@ input RecipientInput {
 
 "Collecteur - transporteur (case 8)"
 input TransporterInput {
+  "Établissement collecteur - transporteur"
+  company: CompanyInput
+
   "Exemption de récipissé"
   isExemptedOfReceipt: Boolean
 
@@ -349,8 +352,8 @@ input TransporterInput {
   "Numéro de plaque d'immatriculation"
   numberPlate: String
 
-  "Établissement collecteur - transporteur"
-  company: CompanyInput
+  "Information libre, destinée aux transporteurs"
+  customInfo: String
 }
 
 "Payload lié au négociant"

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -983,29 +983,6 @@ enum TransportMode {
   SEA
 }
 
-type MultimodalTransporter {
-  "Établissement transporteur"
-  company: FormCompany
-
-  "Exemption de récipissé"
-  isExemptedOfReceipt: Boolean
-
-  "N° de récipissé"
-  receipt: String
-
-  "Département"
-  department: String
-
-  "Limite de validité du récipissé"
-  validityLimit: DateTime
-
-  "Numéro de plaque d'immatriculation"
-  numberPlate: String
-
-  "Information libre, destinée aux transporteurs"
-  customInfo: String
-}
-
 type TransportSegment {
   id: ID!
 
@@ -1013,7 +990,7 @@ type TransportSegment {
   previousTransporterCompanySiret: String
 
   "Transporteur du segment"
-  transporter: MultimodalTransporter
+  transporter: Transporter
 
   "Mode de transport"
   mode: TransportMode

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -37,6 +37,22 @@ const CREATE_FORM = `
           }
         }
       }
+      transporter {
+        company {
+          siret
+          name
+          address
+          contact
+          mail
+          phone
+        }
+        isExemptedOfReceipt
+        receipt
+        department
+        validityLimit
+        numberPlate
+        customInfo
+      }
     }
   }
 `;
@@ -333,4 +349,43 @@ describe("Mutation.createForm", () => {
       ]);
     }
   );
+
+  it("should create a form with a transporter", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      transporter: {
+        company: {
+          siret: "12345678901234",
+          name: "Transporter",
+          address: "123 whatever street, Somewhere",
+          contact: "Jane Doe",
+          mail: "janedoe@transporter.com",
+          phone: "06"
+        },
+        isExemptedOfReceipt: false,
+        receipt: "8043",
+        department: "69",
+        validityLimit: "2040-01-01T00:00:00.000Z",
+        numberPlate: "AX-123-69",
+        customInfo: "T-456"
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { data, errors } = await mutate(CREATE_FORM, {
+      variables: {
+        createFormInput
+      }
+    });
+
+    expect(errors).toEqual(undefined);
+    expect(data.createForm.transporter).toMatchObject(
+      createFormInput.transporter
+    );
+  });
 });

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -784,24 +784,6 @@ export type Invitation = {
 };
 
 
-export type MultimodalTransporter = {
-  __typename?: 'MultimodalTransporter';
-  /** Établissement transporteur */
-  company?: Maybe<FormCompany>;
-  /** Exemption de récipissé */
-  isExemptedOfReceipt?: Maybe<Scalars['Boolean']>;
-  /** N° de récipissé */
-  receipt?: Maybe<Scalars['String']>;
-  /** Département */
-  department?: Maybe<Scalars['String']>;
-  /** Limite de validité du récipissé */
-  validityLimit?: Maybe<Scalars['DateTime']>;
-  /** Numéro de plaque d'immatriculation */
-  numberPlate?: Maybe<Scalars['String']>;
-  /** Information libre, destinée aux transporteurs */
-  customInfo?: Maybe<Scalars['String']>;
-};
-
 export type Mutation = {
   __typename?: 'Mutation';
   /**
@@ -1271,41 +1253,10 @@ export type NextDestinationInput = {
   company: InternationalCompanyInput;
 };
 
-/** Payload d'un segment de transport */
-export type NextSegmentCompanyInput = {
-  /** SIRET de l'établissement */
-  siret?: Maybe<Scalars['String']>;
-  /** Nom de l'établissement */
-  name?: Maybe<Scalars['String']>;
-  /** Adresse de l'établissement */
-  address?: Maybe<Scalars['String']>;
-  /** Nom du contact dans l'établissement */
-  contact?: Maybe<Scalars['String']>;
-  /** Email du contact dans l'établissement */
-  mail?: Maybe<Scalars['String']>;
-  /** Numéro de téléphone de contact dans l'établissement */
-  phone?: Maybe<Scalars['String']>;
-};
-
 /** Payload lié à l'ajout de segment de transport multimodal (case 20 à 21) */
 export type NextSegmentInfoInput = {
-  transporter?: Maybe<NextSegmentTransporterInput>;
+  transporter?: Maybe<TransporterInput>;
   mode: TransportMode;
-};
-
-export type NextSegmentTransporterInput = {
-  /** Exemption de récipissé */
-  isExemptedOfReceipt?: Maybe<Scalars['Boolean']>;
-  /** N° de récipissé */
-  receipt?: Maybe<Scalars['String']>;
-  /** Département */
-  department?: Maybe<Scalars['String']>;
-  /** Limite de validité du récipissé */
-  validityLimit?: Maybe<Scalars['DateTime']>;
-  /** Numéro de plaque d'immatriculation */
-  numberPlate?: Maybe<Scalars['String']>;
-  /** Établissement collecteur - transporteur */
-  company?: Maybe<NextSegmentCompanyInput>;
 };
 
 /** Type de packaging du déchet */
@@ -1906,7 +1857,7 @@ export type TransportSegment = {
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret?: Maybe<Scalars['String']>;
   /** Transporteur du segment */
-  transporter?: Maybe<MultimodalTransporter>;
+  transporter?: Maybe<Transporter>;
   /** Mode de transport */
   mode?: Maybe<TransportMode>;
   /** Date de prise en charge */
@@ -2213,7 +2164,6 @@ export type ResolversTypes = {
   Destination: ResolverTypeWrapper<Destination>;
   StateSummary: ResolverTypeWrapper<StateSummary>;
   TransportSegment: ResolverTypeWrapper<TransportSegment>;
-  MultimodalTransporter: ResolverTypeWrapper<MultimodalTransporter>;
   TransportMode: TransportMode;
   CompanyPublic: ResolverTypeWrapper<CompanyPublic>;
   Installation: ResolverTypeWrapper<Installation>;
@@ -2263,8 +2213,6 @@ export type ResolversTypes = {
   DeleteTraderReceiptInput: DeleteTraderReceiptInput;
   DeleteTransporterReceiptInput: DeleteTransporterReceiptInput;
   NextSegmentInfoInput: NextSegmentInfoInput;
-  NextSegmentTransporterInput: NextSegmentTransporterInput;
-  NextSegmentCompanyInput: NextSegmentCompanyInput;
   ImportPaperFormInput: ImportPaperFormInput;
   SignatureFormInput: SignatureFormInput;
   ReceivedFormInput: ReceivedFormInput;
@@ -2317,7 +2265,6 @@ export type ResolversParentTypes = {
   Destination: Destination;
   StateSummary: StateSummary;
   TransportSegment: TransportSegment;
-  MultimodalTransporter: MultimodalTransporter;
   TransportMode: TransportMode;
   CompanyPublic: CompanyPublic;
   Installation: Installation;
@@ -2367,8 +2314,6 @@ export type ResolversParentTypes = {
   DeleteTraderReceiptInput: DeleteTraderReceiptInput;
   DeleteTransporterReceiptInput: DeleteTransporterReceiptInput;
   NextSegmentInfoInput: NextSegmentInfoInput;
-  NextSegmentTransporterInput: NextSegmentTransporterInput;
-  NextSegmentCompanyInput: NextSegmentCompanyInput;
   ImportPaperFormInput: ImportPaperFormInput;
   SignatureFormInput: SignatureFormInput;
   ReceivedFormInput: ReceivedFormInput;
@@ -2613,17 +2558,6 @@ export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
   name: 'JSON';
 }
 
-export type MultimodalTransporterResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['MultimodalTransporter'] = ResolversParentTypes['MultimodalTransporter']> = {
-  company?: Resolver<Maybe<ResolversTypes['FormCompany']>, ParentType, ContextType>;
-  isExemptedOfReceipt?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  receipt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  department?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  validityLimit?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
-  numberPlate?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  customInfo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: isTypeOfResolverFn<ParentType>;
-};
-
 export type MutationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   changePassword?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationChangePasswordArgs, 'oldPassword' | 'newPassword'>>;
   createCompany?: Resolver<ResolversTypes['CompanyPrivate'], ParentType, ContextType, RequireFields<MutationCreateCompanyArgs, 'companyInput'>>;
@@ -2814,7 +2748,7 @@ export type TransporterReceiptResolvers<ContextType = GraphQLContext, ParentType
 export type TransportSegmentResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TransportSegment'] = ResolversParentTypes['TransportSegment']> = {
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   previousTransporterCompanySiret?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  transporter?: Resolver<Maybe<ResolversTypes['MultimodalTransporter']>, ParentType, ContextType>;
+  transporter?: Resolver<Maybe<ResolversTypes['Transporter']>, ParentType, ContextType>;
   mode?: Resolver<Maybe<ResolversTypes['TransportMode']>, ParentType, ContextType>;
   takenOverAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   takenOverBy?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -2881,7 +2815,6 @@ export type Resolvers<ContextType = GraphQLContext> = {
   Installation?: InstallationResolvers<ContextType>;
   Invitation?: InvitationResolvers<ContextType>;
   JSON?: GraphQLScalarType;
-  MultimodalTransporter?: MultimodalTransporterResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   NextDestination?: NextDestinationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
@@ -3319,20 +3252,6 @@ export function createInvitationMock(props: Partial<Invitation>): Invitation {
   };
 }
 
-export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
-  return {
-    __typename: "MultimodalTransporter",
-    company: null,
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    customInfo: null,
-    ...props,
-  };
-}
-
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
     __typename: "NextDestination",
@@ -3350,34 +3269,10 @@ export function createNextDestinationInputMock(props: Partial<NextDestinationInp
   };
 }
 
-export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
-
 export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
   return {
     transporter: null,
     mode: "ROAD",
-    ...props,
-  };
-}
-
-export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
     ...props,
   };
 }

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1798,6 +1798,8 @@ export type Transporter = {
 
 /** Collecteur - transporteur (case 8) */
 export type TransporterInput = {
+  /** Établissement collecteur - transporteur */
+  company?: Maybe<CompanyInput>;
   /** Exemption de récipissé */
   isExemptedOfReceipt?: Maybe<Scalars['Boolean']>;
   /** N° de récipissé */
@@ -1808,8 +1810,8 @@ export type TransporterInput = {
   validityLimit?: Maybe<Scalars['DateTime']>;
   /** Numéro de plaque d'immatriculation */
   numberPlate?: Maybe<Scalars['String']>;
-  /** Établissement collecteur - transporteur */
-  company?: Maybe<CompanyInput>;
+  /** Information libre, destinée aux transporteurs */
+  customInfo?: Maybe<Scalars['String']>;
 };
 
 /** Récépissé transporteur */
@@ -3565,12 +3567,13 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
 
 export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
   return {
+    company: null,
     isExemptedOfReceipt: null,
     receipt: null,
     department: null,
     validityLimit: null,
     numberPlate: null,
-    company: null,
+    customInfo: null,
     ...props,
   };
 }

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -4705,6 +4705,15 @@ Collecteur - transporteur (case 8)
 </thead>
 <tbody>
 <tr>
+<td colspan="2" valign="top"><strong>company</strong></td>
+<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td>
+
+Établissement collecteur - transporteur
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
@@ -4750,11 +4759,11 @@ Numéro de plaque d'immatriculation
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>company</strong></td>
-<td valign="top"><a href="#companyinput">CompanyInput</a></td>
+<td colspan="2" valign="top"><strong>customInfo</strong></td>
+<td valign="top"><a href="#string">String</a></td>
 <td>
 
-Établissement collecteur - transporteur
+Information libre, destinée aux transporteurs
 
 </td>
 </tr>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2263,84 +2263,6 @@ Liste des déclarations GEREP
 </tbody>
 </table>
 
-### MultimodalTransporter
-
-<table>
-<thead>
-<tr>
-<th align="left">Field</th>
-<th align="right">Argument</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>company</strong></td>
-<td valign="top"><a href="#formcompany">FormCompany</a></td>
-<td>
-
-Établissement transporteur
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td>
-
-Exemption de récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>receipt</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-N° de récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>department</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Département
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>validityLimit</strong></td>
-<td valign="top"><a href="#datetime">DateTime</a></td>
-<td>
-
-Limite de validité du récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>numberPlate</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Numéro de plaque d'immatriculation
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>customInfo</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Information libre, destinée aux transporteurs
-
-</td>
-</tr>
-</tbody>
-</table>
-
 ### NextDestination
 
 Destination ultérieure prévue (case 12)
@@ -3101,7 +3023,7 @@ Siret du transporteur précédent
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>transporter</strong></td>
-<td valign="top"><a href="#multimodaltransporter">MultimodalTransporter</a></td>
+<td valign="top"><a href="#transporter">Transporter</a></td>
 <td>
 
 Transporteur du segment
@@ -4203,76 +4125,6 @@ Traitement prévue (code D/R)
 </tbody>
 </table>
 
-### NextSegmentCompanyInput
-
-Payload d'un segment de transport
-
-<table>
-<thead>
-<tr>
-<th colspan="2" align="left">Field</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>siret</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-SIRET de l'établissement
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>name</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Nom de l'établissement
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>address</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Adresse de l'établissement
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>contact</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Nom du contact dans l'établissement
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>mail</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Email du contact dans l'établissement
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>phone</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Numéro de téléphone de contact dans l'établissement
-
-</td>
-</tr>
-</tbody>
-</table>
-
 ### NextSegmentInfoInput
 
 Payload lié à l'ajout de segment de transport multimodal (case 20 à 21)
@@ -4288,81 +4140,13 @@ Payload lié à l'ajout de segment de transport multimodal (case 20 à 21)
 <tbody>
 <tr>
 <td colspan="2" valign="top"><strong>transporter</strong></td>
-<td valign="top"><a href="#nextsegmenttransporterinput">NextSegmentTransporterInput</a></td>
+<td valign="top"><a href="#transporterinput">TransporterInput</a></td>
 <td></td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>mode</strong></td>
 <td valign="top"><a href="#transportmode">TransportMode</a>!</td>
 <td></td>
-</tr>
-</tbody>
-</table>
-
-### NextSegmentTransporterInput
-
-<table>
-<thead>
-<tr>
-<th colspan="2" align="left">Field</th>
-<th align="left">Type</th>
-<th align="left">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td colspan="2" valign="top"><strong>isExemptedOfReceipt</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td>
-
-Exemption de récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>receipt</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-N° de récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>department</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Département
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>validityLimit</strong></td>
-<td valign="top"><a href="#datetime">DateTime</a></td>
-<td>
-
-Limite de validité du récipissé
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>numberPlate</strong></td>
-<td valign="top"><a href="#string">String</a></td>
-<td>
-
-Numéro de plaque d'immatriculation
-
-</td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>company</strong></td>
-<td valign="top"><a href="#nextsegmentcompanyinput">NextSegmentCompanyInput</a></td>
-<td>
-
-Établissement collecteur - transporteur
-
-</td>
 </tr>
 </tbody>
 </table>

--- a/front/src/dashboard/transport/PrepareSegment.tsx
+++ b/front/src/dashboard/transport/PrepareSegment.tsx
@@ -146,6 +146,7 @@ export default function PrepareSegment({ form, userSiret }: Props) {
                     nextSegmentInfo: {
                       transporter: {
                         ...transporter,
+                        customInfo: null,
                         validityLimit: validityLimit || null,
                       },
                       ...rst,

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1806,6 +1806,8 @@ export type Transporter = {
 
 /** Collecteur - transporteur (case 8) */
 export type TransporterInput = {
+  /** Établissement collecteur - transporteur */
+  company: Maybe<CompanyInput>;
   /** Exemption de récipissé */
   isExemptedOfReceipt: Maybe<Scalars['Boolean']>;
   /** N° de récipissé */
@@ -1816,8 +1818,8 @@ export type TransporterInput = {
   validityLimit: Maybe<Scalars['DateTime']>;
   /** Numéro de plaque d'immatriculation */
   numberPlate: Maybe<Scalars['String']>;
-  /** Établissement collecteur - transporteur */
-  company: Maybe<CompanyInput>;
+  /** Information libre, destinée aux transporteurs */
+  customInfo: Maybe<Scalars['String']>;
 };
 
 /** Récépissé transporteur */
@@ -2796,12 +2798,13 @@ export function createTransporterMock(props: Partial<Transporter>): Transporter 
 
 export function createTransporterInputMock(props: Partial<TransporterInput>): TransporterInput {
   return {
+    company: null,
     isExemptedOfReceipt: null,
     receipt: null,
     department: null,
     validityLimit: null,
     numberPlate: null,
-    company: null,
+    customInfo: null,
     ...props,
   };
 }

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -790,24 +790,6 @@ export type Invitation = {
 };
 
 
-export type MultimodalTransporter = {
-  __typename?: 'MultimodalTransporter';
-  /** Établissement transporteur */
-  company: Maybe<FormCompany>;
-  /** Exemption de récipissé */
-  isExemptedOfReceipt: Maybe<Scalars['Boolean']>;
-  /** N° de récipissé */
-  receipt: Maybe<Scalars['String']>;
-  /** Département */
-  department: Maybe<Scalars['String']>;
-  /** Limite de validité du récipissé */
-  validityLimit: Maybe<Scalars['DateTime']>;
-  /** Numéro de plaque d'immatriculation */
-  numberPlate: Maybe<Scalars['String']>;
-  /** Information libre, destinée aux transporteurs */
-  customInfo: Maybe<Scalars['String']>;
-};
-
 export type Mutation = {
   __typename?: 'Mutation';
   /**
@@ -1277,41 +1259,10 @@ export type NextDestinationInput = {
   company: InternationalCompanyInput;
 };
 
-/** Payload d'un segment de transport */
-export type NextSegmentCompanyInput = {
-  /** SIRET de l'établissement */
-  siret: Maybe<Scalars['String']>;
-  /** Nom de l'établissement */
-  name: Maybe<Scalars['String']>;
-  /** Adresse de l'établissement */
-  address: Maybe<Scalars['String']>;
-  /** Nom du contact dans l'établissement */
-  contact: Maybe<Scalars['String']>;
-  /** Email du contact dans l'établissement */
-  mail: Maybe<Scalars['String']>;
-  /** Numéro de téléphone de contact dans l'établissement */
-  phone: Maybe<Scalars['String']>;
-};
-
 /** Payload lié à l'ajout de segment de transport multimodal (case 20 à 21) */
 export type NextSegmentInfoInput = {
-  transporter: Maybe<NextSegmentTransporterInput>;
+  transporter: Maybe<TransporterInput>;
   mode: TransportMode;
-};
-
-export type NextSegmentTransporterInput = {
-  /** Exemption de récipissé */
-  isExemptedOfReceipt: Maybe<Scalars['Boolean']>;
-  /** N° de récipissé */
-  receipt: Maybe<Scalars['String']>;
-  /** Département */
-  department: Maybe<Scalars['String']>;
-  /** Limite de validité du récipissé */
-  validityLimit: Maybe<Scalars['DateTime']>;
-  /** Numéro de plaque d'immatriculation */
-  numberPlate: Maybe<Scalars['String']>;
-  /** Établissement collecteur - transporteur */
-  company: Maybe<NextSegmentCompanyInput>;
 };
 
 /** Type de packaging du déchet */
@@ -1915,7 +1866,7 @@ export type TransportSegment = {
   /** Siret du transporteur précédent */
   previousTransporterCompanySiret: Maybe<Scalars['String']>;
   /** Transporteur du segment */
-  transporter: Maybe<MultimodalTransporter>;
+  transporter: Maybe<Transporter>;
   /** Mode de transport */
   mode: Maybe<TransportMode>;
   /** Date de prise en charge */
@@ -2532,20 +2483,6 @@ export function createInvitationMock(props: Partial<Invitation>): Invitation {
   };
 }
 
-export function createMultimodalTransporterMock(props: Partial<MultimodalTransporter>): MultimodalTransporter {
-  return {
-    __typename: "MultimodalTransporter",
-    company: null,
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    customInfo: null,
-    ...props,
-  };
-}
-
 export function createNextDestinationMock(props: Partial<NextDestination>): NextDestination {
   return {
     __typename: "NextDestination",
@@ -2563,34 +2500,10 @@ export function createNextDestinationInputMock(props: Partial<NextDestinationInp
   };
 }
 
-export function createNextSegmentCompanyInputMock(props: Partial<NextSegmentCompanyInput>): NextSegmentCompanyInput {
-  return {
-    siret: null,
-    name: null,
-    address: null,
-    contact: null,
-    mail: null,
-    phone: null,
-    ...props,
-  };
-}
-
 export function createNextSegmentInfoInputMock(props: Partial<NextSegmentInfoInput>): NextSegmentInfoInput {
   return {
     transporter: null,
     mode: TransportMode.Road,
-    ...props,
-  };
-}
-
-export function createNextSegmentTransporterInputMock(props: Partial<NextSegmentTransporterInput>): NextSegmentTransporterInput {
-  return {
-    isExemptedOfReceipt: null,
-    receipt: null,
-    department: null,
-    validityLimit: null,
-    numberPlate: null,
-    company: null,
     ...props,
   };
 }


### PR DESCRIPTION
Cette PR ajoute le seul champ transporteur absent de `TransporterInput` : `customInfo`. Il s'agit d'un besoin remonté par un utilisateur de l'API.

---

- [Ticket Trello](https://trello.com/c/wSUXhBHY/979-ajouter-custominfo-%C3%A0-transporterinput)