### PR TITLE
Permettre aux utilisateurs de demander à rejoindre une entreprise

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Suppression du service metabase suite au basculement vers une instance metabase dédiée [PR 453](https://github.com/MTES-MCT/trackdechets/pull/453)
 - Ajout du profil d'entreprise "éco-organisme". Ce type d'entreprise peut renseigner ses agréments et signer un BSD à la place du détenteur lorsqu'il est responsable des déchets. [PR 400](https://github.com/MTES-MCT/trackdechets/pull/400)
 - Dépréciation des arguments `first` et `skip` sur la query `forms`. A la place, pour paginer utiliser `cursorAfter` et `first` ou `cursorBefore` et `last`. Côté filtres, ajout des arguments `updatedAfter` et `sentAfter` sur la query `forms` pour filtrer par date, `wasteCode` pour filtrer par code déchet, et de `siretPresentOnForm` pour sélectionner des bordereaux ou le SIRET passé apparait [PR 455](https://github.com/MTES-MCT/trackdechets/pull/455)
+- Ajout d'un mécanisme de demande de rattachement à un établissement [PR 418](https://github.com/MTES-MCT/trackdechets/pull/418)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/prisma/database/user.prisma
+++ b/back/prisma/database/user.prisma
@@ -40,6 +40,30 @@ type UserAccountHash {
   acceptedAt: DateTime
 }
 
+enum MembershipRequestStatus {
+  PENDING
+  ACCEPTED
+  REFUSED
+}
+
+type MembershipRequest {
+  id: ID! @id
+
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
+
+  status: MembershipRequestStatus! @default(value: PENDING)
+
+  # Email of the admin who has accepted or refused the request
+  statusUpdatedBy: String
+
+  user: User! @relation(link: INLINE, name: "InvitationRequest_user_User")
+  company: Company! @relation(link: INLINE)
+
+  # List of emails the invitation was sent to
+  sentTo: [String!]! @scalarList(strategy: RELATION)
+}
+
 """
 OAuth2 - Access token to a user resource
 https://tools.ietf.org/html/rfc6749#section-5

--- a/back/prisma/database/user.prisma
+++ b/back/prisma/database/user.prisma
@@ -57,10 +57,10 @@ type MembershipRequest {
   # Email of the admin who has accepted or refused the request
   statusUpdatedBy: String
 
-  user: User! @relation(link: INLINE, name: "InvitationRequest_user_User")
+  user: User! @relation(link: INLINE, name: "MembershipRequest_user_User")
   company: Company! @relation(link: INLINE)
 
-  # List of emails the invitation was sent to
+  # List of emails the request was sent to
   sentTo: [String!]! @scalarList(strategy: RELATION)
 }
 

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -8,7 +8,8 @@ import {
   User,
   UserRole,
   TraderReceiptWhereUniqueInput,
-  TransporterReceiptWhereUniqueInput
+  TransporterReceiptWhereUniqueInput,
+  Company
 } from "../generated/prisma-client";
 import {
   CompanyNotFound,
@@ -100,6 +101,18 @@ export async function getUserRole(userId: string, siret: string) {
     return associations[0].role;
   }
   return null;
+}
+
+/**
+ * Returns true if user belongs to company with either
+ * MEMBER or ADMIN role, false otherwise
+ * @param user
+ */
+export function isCompanyMember(user: User, company: Company) {
+  return prisma.$exists.companyAssociation({
+    user: { id: user.id },
+    company: { id: company.id }
+  });
 }
 
 /**

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -813,11 +813,11 @@ export type MembershipRequest = {
   siret: Scalars['String'];
   /** Nom de l'établissement */
   name: Scalars['String'];
-  /** Statut de la demande d'invitation */
+  /** Statut de la demande de rattachement */
   status: MembershipRequestStatus;
   /**
    * Liste des adresses email correspondant aux comptes administrateurs à qui la demande
-   * d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+   * de rattachement a été envoyée. Les adresses emails sont partiellement masquées de la
    * façon suivante j********w@trackdechets.fr
    */
   sentTo: Array<Scalars['String']>;
@@ -1482,7 +1482,7 @@ export type Query = {
    * à partir de l'identifiant de cette demande ou du SIRET de l'établissement
    * auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
    * paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
-   * permet notamment de suivre l'état d'avancement de la demande d'invitation
+   * permet notamment de suivre l'état d'avancement de la demande de rattachement
    * (en attente, accepté, refusé)
    */
   membershipRequest?: Maybe<MembershipRequest>;

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -27,6 +27,7 @@ export interface Exists {
   form: (where?: FormWhereInput) => Promise<boolean>;
   grant: (where?: GrantWhereInput) => Promise<boolean>;
   installation: (where?: InstallationWhereInput) => Promise<boolean>;
+  membershipRequest: (where?: MembershipRequestWhereInput) => Promise<boolean>;
   rubrique: (where?: RubriqueWhereInput) => Promise<boolean>;
   statusLog: (where?: StatusLogWhereInput) => Promise<boolean>;
   temporaryStorageDetail: (
@@ -246,6 +247,27 @@ export interface Prisma {
     first?: Int;
     last?: Int;
   }) => InstallationConnectionPromise;
+  membershipRequest: (
+    where: MembershipRequestWhereUniqueInput
+  ) => MembershipRequestNullablePromise;
+  membershipRequests: (args?: {
+    where?: MembershipRequestWhereInput;
+    orderBy?: MembershipRequestOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => FragmentableArray<MembershipRequest>;
+  membershipRequestsConnection: (args?: {
+    where?: MembershipRequestWhereInput;
+    orderBy?: MembershipRequestOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => MembershipRequestConnectionPromise;
   rubrique: (where: RubriqueWhereUniqueInput) => RubriqueNullablePromise;
   rubriques: (args?: {
     where?: RubriqueWhereInput;
@@ -599,6 +621,28 @@ export interface Prisma {
   deleteManyInstallations: (
     where?: InstallationWhereInput
   ) => BatchPayloadPromise;
+  createMembershipRequest: (
+    data: MembershipRequestCreateInput
+  ) => MembershipRequestPromise;
+  updateMembershipRequest: (args: {
+    data: MembershipRequestUpdateInput;
+    where: MembershipRequestWhereUniqueInput;
+  }) => MembershipRequestPromise;
+  updateManyMembershipRequests: (args: {
+    data: MembershipRequestUpdateManyMutationInput;
+    where?: MembershipRequestWhereInput;
+  }) => BatchPayloadPromise;
+  upsertMembershipRequest: (args: {
+    where: MembershipRequestWhereUniqueInput;
+    create: MembershipRequestCreateInput;
+    update: MembershipRequestUpdateInput;
+  }) => MembershipRequestPromise;
+  deleteMembershipRequest: (
+    where: MembershipRequestWhereUniqueInput
+  ) => MembershipRequestPromise;
+  deleteManyMembershipRequests: (
+    where?: MembershipRequestWhereInput
+  ) => BatchPayloadPromise;
   createRubrique: (data: RubriqueCreateInput) => RubriquePromise;
   updateRubrique: (args: {
     data: RubriqueUpdateInput;
@@ -813,6 +857,9 @@ export interface Subscription {
   installation: (
     where?: InstallationSubscriptionWhereInput
   ) => InstallationSubscriptionPayloadSubscription;
+  membershipRequest: (
+    where?: MembershipRequestSubscriptionWhereInput
+  ) => MembershipRequestSubscriptionPayloadSubscription;
   rubrique: (
     where?: RubriqueSubscriptionWhereInput
   ) => RubriqueSubscriptionPayloadSubscription;
@@ -1242,6 +1289,20 @@ export type InstallationOrderByInput =
   | "gerepNumeroSiret_DESC"
   | "sireneNumeroSiret_ASC"
   | "sireneNumeroSiret_DESC";
+
+export type MembershipRequestStatus = "PENDING" | "ACCEPTED" | "REFUSED";
+
+export type MembershipRequestOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "createdAt_ASC"
+  | "createdAt_DESC"
+  | "updatedAt_ASC"
+  | "updatedAt_DESC"
+  | "status_ASC"
+  | "status_DESC"
+  | "statusUpdatedBy_ASC"
+  | "statusUpdatedBy_DESC";
 
 export type WasteType = "INERTE" | "NOT_DANGEROUS" | "DANGEROUS";
 
@@ -4079,6 +4140,66 @@ export interface InstallationWhereInput {
   AND?: Maybe<InstallationWhereInput[] | InstallationWhereInput>;
   OR?: Maybe<InstallationWhereInput[] | InstallationWhereInput>;
   NOT?: Maybe<InstallationWhereInput[] | InstallationWhereInput>;
+}
+
+export type MembershipRequestWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+}>;
+
+export interface MembershipRequestWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  createdAt?: Maybe<DateTimeInput>;
+  createdAt_not?: Maybe<DateTimeInput>;
+  createdAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  createdAt_lt?: Maybe<DateTimeInput>;
+  createdAt_lte?: Maybe<DateTimeInput>;
+  createdAt_gt?: Maybe<DateTimeInput>;
+  createdAt_gte?: Maybe<DateTimeInput>;
+  updatedAt?: Maybe<DateTimeInput>;
+  updatedAt_not?: Maybe<DateTimeInput>;
+  updatedAt_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_not_in?: Maybe<DateTimeInput[] | DateTimeInput>;
+  updatedAt_lt?: Maybe<DateTimeInput>;
+  updatedAt_lte?: Maybe<DateTimeInput>;
+  updatedAt_gt?: Maybe<DateTimeInput>;
+  updatedAt_gte?: Maybe<DateTimeInput>;
+  status?: Maybe<MembershipRequestStatus>;
+  status_not?: Maybe<MembershipRequestStatus>;
+  status_in?: Maybe<MembershipRequestStatus[] | MembershipRequestStatus>;
+  status_not_in?: Maybe<MembershipRequestStatus[] | MembershipRequestStatus>;
+  statusUpdatedBy?: Maybe<String>;
+  statusUpdatedBy_not?: Maybe<String>;
+  statusUpdatedBy_in?: Maybe<String[] | String>;
+  statusUpdatedBy_not_in?: Maybe<String[] | String>;
+  statusUpdatedBy_lt?: Maybe<String>;
+  statusUpdatedBy_lte?: Maybe<String>;
+  statusUpdatedBy_gt?: Maybe<String>;
+  statusUpdatedBy_gte?: Maybe<String>;
+  statusUpdatedBy_contains?: Maybe<String>;
+  statusUpdatedBy_not_contains?: Maybe<String>;
+  statusUpdatedBy_starts_with?: Maybe<String>;
+  statusUpdatedBy_not_starts_with?: Maybe<String>;
+  statusUpdatedBy_ends_with?: Maybe<String>;
+  statusUpdatedBy_not_ends_with?: Maybe<String>;
+  user?: Maybe<UserWhereInput>;
+  company?: Maybe<CompanyWhereInput>;
+  AND?: Maybe<MembershipRequestWhereInput[] | MembershipRequestWhereInput>;
+  OR?: Maybe<MembershipRequestWhereInput[] | MembershipRequestWhereInput>;
+  NOT?: Maybe<MembershipRequestWhereInput[] | MembershipRequestWhereInput>;
 }
 
 export type RubriqueWhereUniqueInput = AtLeastOne<{
@@ -7171,6 +7292,37 @@ export interface InstallationUpdateManyMutationInput {
   sireneNumeroSiret?: Maybe<String>;
 }
 
+export interface MembershipRequestCreateInput {
+  id?: Maybe<ID_Input>;
+  status?: Maybe<MembershipRequestStatus>;
+  statusUpdatedBy?: Maybe<String>;
+  user: UserCreateOneInput;
+  company: CompanyCreateOneInput;
+  sentTo?: Maybe<MembershipRequestCreatesentToInput>;
+}
+
+export interface MembershipRequestCreatesentToInput {
+  set?: Maybe<String[] | String>;
+}
+
+export interface MembershipRequestUpdateInput {
+  status?: Maybe<MembershipRequestStatus>;
+  statusUpdatedBy?: Maybe<String>;
+  user?: Maybe<UserUpdateOneRequiredInput>;
+  company?: Maybe<CompanyUpdateOneRequiredInput>;
+  sentTo?: Maybe<MembershipRequestUpdatesentToInput>;
+}
+
+export interface MembershipRequestUpdatesentToInput {
+  set?: Maybe<String[] | String>;
+}
+
+export interface MembershipRequestUpdateManyMutationInput {
+  status?: Maybe<MembershipRequestStatus>;
+  statusUpdatedBy?: Maybe<String>;
+  sentTo?: Maybe<MembershipRequestUpdatesentToInput>;
+}
+
 export interface RubriqueCreateInput {
   id?: Maybe<ID_Input>;
   codeS3ic?: Maybe<String>;
@@ -8059,6 +8211,26 @@ export interface InstallationSubscriptionWhereInput {
   >;
   NOT?: Maybe<
     InstallationSubscriptionWhereInput[] | InstallationSubscriptionWhereInput
+  >;
+}
+
+export interface MembershipRequestSubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<MembershipRequestWhereInput>;
+  AND?: Maybe<
+    | MembershipRequestSubscriptionWhereInput[]
+    | MembershipRequestSubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    | MembershipRequestSubscriptionWhereInput[]
+    | MembershipRequestSubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    | MembershipRequestSubscriptionWhereInput[]
+    | MembershipRequestSubscriptionWhereInput
   >;
 }
 
@@ -10020,6 +10192,110 @@ export interface AggregateInstallationSubscription
   count: () => Promise<AsyncIterator<Int>>;
 }
 
+export interface MembershipRequest {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  status: MembershipRequestStatus;
+  statusUpdatedBy?: String;
+  sentTo: String[];
+}
+
+export interface MembershipRequestPromise
+  extends Promise<MembershipRequest>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  status: () => Promise<MembershipRequestStatus>;
+  statusUpdatedBy: () => Promise<String>;
+  user: <T = UserPromise>() => T;
+  company: <T = CompanyPromise>() => T;
+  sentTo: () => Promise<String[]>;
+}
+
+export interface MembershipRequestSubscription
+  extends Promise<AsyncIterator<MembershipRequest>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  status: () => Promise<AsyncIterator<MembershipRequestStatus>>;
+  statusUpdatedBy: () => Promise<AsyncIterator<String>>;
+  user: <T = UserSubscription>() => T;
+  company: <T = CompanySubscription>() => T;
+  sentTo: () => Promise<AsyncIterator<String[]>>;
+}
+
+export interface MembershipRequestNullablePromise
+  extends Promise<MembershipRequest | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  status: () => Promise<MembershipRequestStatus>;
+  statusUpdatedBy: () => Promise<String>;
+  user: <T = UserPromise>() => T;
+  company: <T = CompanyPromise>() => T;
+  sentTo: () => Promise<String[]>;
+}
+
+export interface MembershipRequestConnection {
+  pageInfo: PageInfo;
+  edges: MembershipRequestEdge[];
+}
+
+export interface MembershipRequestConnectionPromise
+  extends Promise<MembershipRequestConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<MembershipRequestEdge>>() => T;
+  aggregate: <T = AggregateMembershipRequestPromise>() => T;
+}
+
+export interface MembershipRequestConnectionSubscription
+  extends Promise<AsyncIterator<MembershipRequestConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<MembershipRequestEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateMembershipRequestSubscription>() => T;
+}
+
+export interface MembershipRequestEdge {
+  node: MembershipRequest;
+  cursor: String;
+}
+
+export interface MembershipRequestEdgePromise
+  extends Promise<MembershipRequestEdge>,
+    Fragmentable {
+  node: <T = MembershipRequestPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface MembershipRequestEdgeSubscription
+  extends Promise<AsyncIterator<MembershipRequestEdge>>,
+    Fragmentable {
+  node: <T = MembershipRequestSubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateMembershipRequest {
+  count: Int;
+}
+
+export interface AggregateMembershipRequestPromise
+  extends Promise<AggregateMembershipRequest>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateMembershipRequestSubscription
+  extends Promise<AsyncIterator<AggregateMembershipRequest>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
 export interface Rubrique {
   id: ID_Output;
   codeS3ic?: String;
@@ -11516,6 +11792,62 @@ export interface InstallationPreviousValuesSubscription
   sireneNumeroSiret: () => Promise<AsyncIterator<String>>;
 }
 
+export interface MembershipRequestSubscriptionPayload {
+  mutation: MutationType;
+  node: MembershipRequest;
+  updatedFields: String[];
+  previousValues: MembershipRequestPreviousValues;
+}
+
+export interface MembershipRequestSubscriptionPayloadPromise
+  extends Promise<MembershipRequestSubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = MembershipRequestPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = MembershipRequestPreviousValuesPromise>() => T;
+}
+
+export interface MembershipRequestSubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<MembershipRequestSubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = MembershipRequestSubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = MembershipRequestPreviousValuesSubscription>() => T;
+}
+
+export interface MembershipRequestPreviousValues {
+  id: ID_Output;
+  createdAt: DateTimeOutput;
+  updatedAt: DateTimeOutput;
+  status: MembershipRequestStatus;
+  statusUpdatedBy?: String;
+  sentTo: String[];
+}
+
+export interface MembershipRequestPreviousValuesPromise
+  extends Promise<MembershipRequestPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  createdAt: () => Promise<DateTimeOutput>;
+  updatedAt: () => Promise<DateTimeOutput>;
+  status: () => Promise<MembershipRequestStatus>;
+  statusUpdatedBy: () => Promise<String>;
+  sentTo: () => Promise<String[]>;
+}
+
+export interface MembershipRequestPreviousValuesSubscription
+  extends Promise<AsyncIterator<MembershipRequestPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  createdAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  updatedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
+  status: () => Promise<AsyncIterator<MembershipRequestStatus>>;
+  statusUpdatedBy: () => Promise<AsyncIterator<String>>;
+  sentTo: () => Promise<AsyncIterator<String[]>>;
+}
+
 export interface RubriqueSubscriptionPayload {
   mutation: MutationType;
   node: Rubrique;
@@ -12266,6 +12598,14 @@ export const models: Model[] = [
   },
   {
     name: "UserAccountHash",
+    embedded: false
+  },
+  {
+    name: "MembershipRequestStatus",
+    embedded: false
+  },
+  {
+    name: "MembershipRequest",
     embedded: false
   },
   {

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -192,6 +192,10 @@ type AggregateInstallation {
   count: Int!
 }
 
+type AggregateMembershipRequest {
+  count: Int!
+}
+
 type AggregateRubrique {
   count: Int!
 }
@@ -5216,6 +5220,165 @@ scalar Json
 
 scalar Long
 
+type MembershipRequest {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  status: MembershipRequestStatus!
+  statusUpdatedBy: String
+  user: User!
+  company: Company!
+  sentTo: [String!]!
+}
+
+type MembershipRequestConnection {
+  pageInfo: PageInfo!
+  edges: [MembershipRequestEdge]!
+  aggregate: AggregateMembershipRequest!
+}
+
+input MembershipRequestCreateInput {
+  id: ID
+  status: MembershipRequestStatus
+  statusUpdatedBy: String
+  user: UserCreateOneInput!
+  company: CompanyCreateOneInput!
+  sentTo: MembershipRequestCreatesentToInput
+}
+
+input MembershipRequestCreatesentToInput {
+  set: [String!]
+}
+
+type MembershipRequestEdge {
+  node: MembershipRequest!
+  cursor: String!
+}
+
+enum MembershipRequestOrderByInput {
+  id_ASC
+  id_DESC
+  createdAt_ASC
+  createdAt_DESC
+  updatedAt_ASC
+  updatedAt_DESC
+  status_ASC
+  status_DESC
+  statusUpdatedBy_ASC
+  statusUpdatedBy_DESC
+}
+
+type MembershipRequestPreviousValues {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  status: MembershipRequestStatus!
+  statusUpdatedBy: String
+  sentTo: [String!]!
+}
+
+enum MembershipRequestStatus {
+  PENDING
+  ACCEPTED
+  REFUSED
+}
+
+type MembershipRequestSubscriptionPayload {
+  mutation: MutationType!
+  node: MembershipRequest
+  updatedFields: [String!]
+  previousValues: MembershipRequestPreviousValues
+}
+
+input MembershipRequestSubscriptionWhereInput {
+  mutation_in: [MutationType!]
+  updatedFields_contains: String
+  updatedFields_contains_every: [String!]
+  updatedFields_contains_some: [String!]
+  node: MembershipRequestWhereInput
+  AND: [MembershipRequestSubscriptionWhereInput!]
+  OR: [MembershipRequestSubscriptionWhereInput!]
+  NOT: [MembershipRequestSubscriptionWhereInput!]
+}
+
+input MembershipRequestUpdateInput {
+  status: MembershipRequestStatus
+  statusUpdatedBy: String
+  user: UserUpdateOneRequiredInput
+  company: CompanyUpdateOneRequiredInput
+  sentTo: MembershipRequestUpdatesentToInput
+}
+
+input MembershipRequestUpdateManyMutationInput {
+  status: MembershipRequestStatus
+  statusUpdatedBy: String
+  sentTo: MembershipRequestUpdatesentToInput
+}
+
+input MembershipRequestUpdatesentToInput {
+  set: [String!]
+}
+
+input MembershipRequestWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  createdAt: DateTime
+  createdAt_not: DateTime
+  createdAt_in: [DateTime!]
+  createdAt_not_in: [DateTime!]
+  createdAt_lt: DateTime
+  createdAt_lte: DateTime
+  createdAt_gt: DateTime
+  createdAt_gte: DateTime
+  updatedAt: DateTime
+  updatedAt_not: DateTime
+  updatedAt_in: [DateTime!]
+  updatedAt_not_in: [DateTime!]
+  updatedAt_lt: DateTime
+  updatedAt_lte: DateTime
+  updatedAt_gt: DateTime
+  updatedAt_gte: DateTime
+  status: MembershipRequestStatus
+  status_not: MembershipRequestStatus
+  status_in: [MembershipRequestStatus!]
+  status_not_in: [MembershipRequestStatus!]
+  statusUpdatedBy: String
+  statusUpdatedBy_not: String
+  statusUpdatedBy_in: [String!]
+  statusUpdatedBy_not_in: [String!]
+  statusUpdatedBy_lt: String
+  statusUpdatedBy_lte: String
+  statusUpdatedBy_gt: String
+  statusUpdatedBy_gte: String
+  statusUpdatedBy_contains: String
+  statusUpdatedBy_not_contains: String
+  statusUpdatedBy_starts_with: String
+  statusUpdatedBy_not_starts_with: String
+  statusUpdatedBy_ends_with: String
+  statusUpdatedBy_not_ends_with: String
+  user: UserWhereInput
+  company: CompanyWhereInput
+  AND: [MembershipRequestWhereInput!]
+  OR: [MembershipRequestWhereInput!]
+  NOT: [MembershipRequestWhereInput!]
+}
+
+input MembershipRequestWhereUniqueInput {
+  id: ID
+}
+
 type Mutation {
   createAccessToken(data: AccessTokenCreateInput!): AccessToken!
   updateAccessToken(data: AccessTokenUpdateInput!, where: AccessTokenWhereUniqueInput!): AccessToken
@@ -5271,6 +5434,12 @@ type Mutation {
   upsertInstallation(where: InstallationWhereUniqueInput!, create: InstallationCreateInput!, update: InstallationUpdateInput!): Installation!
   deleteInstallation(where: InstallationWhereUniqueInput!): Installation
   deleteManyInstallations(where: InstallationWhereInput): BatchPayload!
+  createMembershipRequest(data: MembershipRequestCreateInput!): MembershipRequest!
+  updateMembershipRequest(data: MembershipRequestUpdateInput!, where: MembershipRequestWhereUniqueInput!): MembershipRequest
+  updateManyMembershipRequests(data: MembershipRequestUpdateManyMutationInput!, where: MembershipRequestWhereInput): BatchPayload!
+  upsertMembershipRequest(where: MembershipRequestWhereUniqueInput!, create: MembershipRequestCreateInput!, update: MembershipRequestUpdateInput!): MembershipRequest!
+  deleteMembershipRequest(where: MembershipRequestWhereUniqueInput!): MembershipRequest
+  deleteManyMembershipRequests(where: MembershipRequestWhereInput): BatchPayload!
   createRubrique(data: RubriqueCreateInput!): Rubrique!
   updateRubrique(data: RubriqueUpdateInput!, where: RubriqueWhereUniqueInput!): Rubrique
   updateManyRubriques(data: RubriqueUpdateManyMutationInput!, where: RubriqueWhereInput): BatchPayload!
@@ -5377,6 +5546,9 @@ type Query {
   installation(where: InstallationWhereUniqueInput!): Installation
   installations(where: InstallationWhereInput, orderBy: InstallationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Installation]!
   installationsConnection(where: InstallationWhereInput, orderBy: InstallationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): InstallationConnection!
+  membershipRequest(where: MembershipRequestWhereUniqueInput!): MembershipRequest
+  membershipRequests(where: MembershipRequestWhereInput, orderBy: MembershipRequestOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [MembershipRequest]!
+  membershipRequestsConnection(where: MembershipRequestWhereInput, orderBy: MembershipRequestOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): MembershipRequestConnection!
   rubrique(where: RubriqueWhereUniqueInput!): Rubrique
   rubriques(where: RubriqueWhereInput, orderBy: RubriqueOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Rubrique]!
   rubriquesConnection(where: RubriqueWhereInput, orderBy: RubriqueOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): RubriqueConnection!
@@ -5852,6 +6024,7 @@ type Subscription {
   form(where: FormSubscriptionWhereInput): FormSubscriptionPayload
   grant(where: GrantSubscriptionWhereInput): GrantSubscriptionPayload
   installation(where: InstallationSubscriptionWhereInput): InstallationSubscriptionPayload
+  membershipRequest(where: MembershipRequestSubscriptionWhereInput): MembershipRequestSubscriptionPayload
   rubrique(where: RubriqueSubscriptionWhereInput): RubriqueSubscriptionPayload
   statusLog(where: StatusLogSubscriptionWhereInput): StatusLogSubscriptionPayload
   temporaryStorageDetail(where: TemporaryStorageDetailSubscriptionWhereInput): TemporaryStorageDetailSubscriptionPayload

--- a/back/src/users/__tests__/utils.test.ts
+++ b/back/src/users/__tests__/utils.test.ts
@@ -1,0 +1,22 @@
+import { partiallyHideEmail } from "../utils";
+
+describe("partiallyHideEmail", () => {
+  it("should partially hide a well formatted email address", () => {
+    const hidden = partiallyHideEmail("john.snow@trackdechets.fr");
+    expect(hidden).toEqual("jo****@trackdechets.fr");
+  });
+
+  it("should partially hide email with short user part", () => {
+    let hidden = partiallyHideEmail("a@trackdechets.fr");
+    expect(hidden).toEqual("a****@trackdechets.fr");
+    hidden = partiallyHideEmail("aa@trackdechets.fr");
+    expect(hidden).toEqual("aa****@trackdechets.fr");
+    hidden = partiallyHideEmail("aaa@trackdechets.fr");
+    expect(hidden).toEqual("aa****@trackdechets.fr");
+  });
+
+  it("should throw an error if string is not an email", () => {
+    const t = () => partiallyHideEmail("this is not an email");
+    expect(t).toThrowError("this must be a valid email");
+  });
+});

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -181,9 +181,9 @@ export async function acceptNewUserCompanyInvitations(user: User) {
 export async function getMembershipRequestOrNotFoundError(
   where: MembershipRequestWhereUniqueInput
 ) {
-  const invitationRequest = await prisma.membershipRequest(where);
-  if (!invitationRequest) {
+  const membershipRequest = await prisma.membershipRequest(where);
+  if (!membershipRequest) {
     throw new UserInputError("Cette demande de rattachement n'existe pas");
   }
-  return invitationRequest;
+  return membershipRequest;
 }

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -8,7 +8,8 @@ import {
   UserRole,
   UserAccountHashWhereInput,
   CompanyAssociationWhereInput,
-  Company
+  Company,
+  MembershipRequestWhereUniqueInput
 } from "../generated/prisma-client";
 import { FullUser } from "./types";
 import { UserInputError } from "apollo-server-express";
@@ -175,4 +176,14 @@ export async function acceptNewUserCompanyInvitations(user: User) {
     },
     data: { acceptedAt: new Date().toISOString() }
   });
+}
+
+export async function getMembershipRequestOrNotFoundError(
+  where: MembershipRequestWhereUniqueInput
+) {
+  const invitationRequest = await prisma.membershipRequest(where);
+  if (!invitationRequest) {
+    throw new UserInputError("Cette demande de rattachement n'existe pas");
+  }
+  return invitationRequest;
 }

--- a/back/src/users/errors.ts
+++ b/back/src/users/errors.ts
@@ -1,6 +1,6 @@
 import { UserInputError } from "apollo-server-express";
 
-export class InvitationRequestAlreadyAccepted extends UserInputError {
+export class MembershipRequestAlreadyAccepted extends UserInputError {
   constructor() {
     super(
       "Cette demande de rattachement a déjà été acceptée par un autre administrateur"
@@ -8,7 +8,7 @@ export class InvitationRequestAlreadyAccepted extends UserInputError {
   }
 }
 
-export class InvitationRequestAlreadyRefused extends UserInputError {
+export class MembershipRequestAlreadyRefused extends UserInputError {
   constructor() {
     super(
       "Cette demande de rattachement a déjà été refusée par un autre administrateur"

--- a/back/src/users/errors.ts
+++ b/back/src/users/errors.ts
@@ -1,0 +1,17 @@
+import { UserInputError } from "apollo-server-express";
+
+export class InvitationRequestAlreadyAccepted extends UserInputError {
+  constructor() {
+    super(
+      "Cette demande de rattachement a déjà été acceptée par un autre administrateur"
+    );
+  }
+}
+
+export class InvitationRequestAlreadyRefused extends UserInputError {
+  constructor() {
+    super(
+      "Cette demande de rattachement a déjà été refusée par un autre administrateur"
+    );
+  }
+}

--- a/back/src/users/mails.ts
+++ b/back/src/users/mails.ts
@@ -245,7 +245,7 @@ export const userMails = {
   }),
   membershipRequest: (
     recipients,
-    invitationRequestLink: string,
+    membershipRequestLink: string,
     user: User,
     company: Company
   ) => ({
@@ -258,7 +258,7 @@ export const userMails = {
     dont vous êtes administrateur.
 
     Pour valider ou refuser sa demande, cliquer sur
-    <a href="${invitationRequestLink}">ce lien</a>
+    <a href="${membershipRequestLink}">ce lien</a>
     `
   }),
   membershipRequestAccepted: (user: User, company: Company) => ({

--- a/back/src/users/mails.ts
+++ b/back/src/users/mails.ts
@@ -1,5 +1,5 @@
 import { escape } from "querystring";
-import { Form } from "../generated/prisma-client";
+import { Company, Form, User } from "../generated/prisma-client";
 import { cleanupSpecialChars, toFrFormat } from "../common/mails.helper";
 
 const {
@@ -231,5 +231,58 @@ export const userMails = {
     Aussi, je vous informe que le BSD est désormais disponible sur votre compte Trackdéchets, dans l'onglet "archives" et le restera durant 5 ans. Il n'est donc pas utile de l'imprimer.
     <br><br>
     Quelles conséquences pour vous? La responsabilité du déchet (au sens de l'article L541-2 du code de l'Env.) est transférée à la société ${form.recipientCompanyName}, votre registre est renseigné.`
+  }),
+  membershipRequestConfirmation: (user: User, company: Company) => ({
+    to: [{ email: user.email, name: user.name }],
+    subject: "Votre demande de rattachement a été transmise à l'administrateur",
+    title: "Votre demande de rattachement a été transmise à l'administrateur",
+    body: `Bonjour,
+    <br/><br/>
+    Votre demande de rattachement à l’entreprise ${company.name} (${company.siret}) a été transmise à l'administrateur de l’établissement.
+
+    Si votre demande est acceptée, vous serez informé(e) par email.
+    `
+  }),
+  membershipRequest: (
+    recipients,
+    invitationRequestLink: string,
+    user: User,
+    company: Company
+  ) => ({
+    to: recipients,
+    subject: "Un utilisateur souhaite rejoindre votre établissement",
+    title: "Un utilisateur souhaite rejoindre votre établissement",
+    body: `Bonjour
+    <br/><br/>
+    L'utilisateur ${user.email} a demandé à rejoindre l'établissement ${company.name} (${company.siret})
+    dont vous êtes administrateur.
+
+    Pour valider ou refuser sa demande, cliquer sur
+    <a href="${invitationRequestLink}">ce lien</a>
+    `
+  }),
+  membershipRequestAccepted: (user: User, company: Company) => ({
+    to: [{ email: user.email, name: user.name }],
+    subject: `Vous êtes à présent membre de l’établissement ${company.name} (${company.siret}) 🔔`,
+    title: `Vous êtes à présent membre de l’établissement ${company.name} (${company.siret}) 🔔`,
+    body: `Bonjour,
+    <br/><br/>
+    Votre demande de rattachement à l’entreprise ${company.name} (${company.siret}) a été acceptée par l'administrateur de l’établissement.
+
+    Vous pourrez à présent effectuer des actions pour le compte de l’entreprise
+    (créer / signer / suivre des BSD, accéder au registre, consulter les fiches entreprise, consulter le code de sécurité).
+    `
+  }),
+  membershipRequestRefused: (user: User, company: Company) => ({
+    to: [{ email: user.email, name: user.name }],
+    subject:
+      "Votre demande de rattachement a été refusée par l'administrateur de l’établissement",
+    title:
+      "Votre demande de rattachement a été refusée par l'administrateur de l’établissement",
+    body: `Bonjour,
+    <br/><br/>
+    Votre demande de rattachement à l’entreprise ${company.name} (${company.siret}) a été refusée par l'administrateur de l’établissement.
+    Vous ne pouvez donc pas effectuer d’action pour le compte de cette entreprise.
+    `
   })
 };

--- a/back/src/users/resolvers/MembershipRequest.ts
+++ b/back/src/users/resolvers/MembershipRequest.ts
@@ -1,0 +1,8 @@
+import { MembershipRequestResolvers } from "../../generated/graphql/types";
+import { partiallyHideEmail } from "../utils";
+
+const membershipRequestResolvers: MembershipRequestResolvers = {
+  sentTo: parent => parent.sentTo.map(email => partiallyHideEmail(email))
+};
+
+export default membershipRequestResolvers;

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -9,6 +9,9 @@ import deleteInvitation from "./mutations/deleteInvitation";
 import resendInvitation from "./mutations/resendInvitation";
 import joinWithInvite from "./mutations/joinWithInvite";
 import removeUserFromCompany from "./mutations/removeUserFromCompany";
+import sendMembershipRequest from "./mutations/sendMembershipRequest";
+import acceptMembershipRequest from "./mutations/acceptMembershipRequest";
+import refuseMembershipRequest from "./mutations/refuseMembershipRequest";
 
 const Mutation: MutationResolvers = {
   signup,
@@ -20,7 +23,10 @@ const Mutation: MutationResolvers = {
   deleteInvitation,
   resendInvitation,
   joinWithInvite,
-  removeUserFromCompany
+  removeUserFromCompany,
+  sendMembershipRequest,
+  acceptMembershipRequest,
+  refuseMembershipRequest
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/Query.ts
+++ b/back/src/users/resolvers/Query.ts
@@ -2,11 +2,13 @@ import { QueryResolvers } from "../../generated/graphql/types";
 import me from "./queries/me";
 import apiKey from "./queries/apiKey";
 import invitation from "./queries/invitation";
+import membershipRequest from "./queries/membershipRequest";
 
 const Query: QueryResolvers = {
   me,
   apiKey,
-  invitation
+  invitation,
+  membershipRequest
 };
 
 export default Query;

--- a/back/src/users/resolvers/index.ts
+++ b/back/src/users/resolvers/index.ts
@@ -1,9 +1,11 @@
 import Query from "./Query";
 import Mutation from "./Mutation";
 import User from "./User";
+import MembershipRequest from "./MembershipRequest";
 
 export default {
   Query,
   Mutation,
-  User
+  User,
+  MembershipRequest
 };

--- a/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
@@ -122,12 +122,12 @@ describe("mutation acceptMembershipRequest", () => {
       const members = data.acceptMembershipRequest.users.map(u => u.email);
       expect(members).toContain(user.email);
 
-      const acceptedInvitationRequest = await prisma.membershipRequest({
+      const acceptedMembershipRequest = await prisma.membershipRequest({
         id: membershipRequest.id
       });
 
-      expect(acceptedInvitationRequest.status).toEqual("ACCEPTED");
-      expect(acceptedInvitationRequest.statusUpdatedBy).toEqual(user.email);
+      expect(acceptedMembershipRequest.status).toEqual("ACCEPTED");
+      expect(acceptedMembershipRequest.statusUpdatedBy).toEqual(user.email);
 
       const companyAssociations = await prisma.companyAssociations({
         where: { user: { id: requester.id }, company: { id: company.id } }

--- a/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
@@ -1,0 +1,144 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { prisma } from "../../../../generated/prisma-client";
+import {
+  userFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import * as mailsHelper from "../../../../common/mails.helper";
+import { userMails } from "../../../mails";
+import { AuthType } from "../../../../auth";
+
+// No mails
+const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
+sendMailSpy.mockImplementation(() => Promise.resolve());
+
+const ACCEPT_MEMBERSHIP_REQUEST = `
+  mutation AcceptMembershipRequest($id: ID!, $role: UserRole!){
+    acceptMembershipRequest(id: $id, role: $role){
+      siret
+      users {
+        email
+        role
+      }
+    }
+  }
+`;
+
+describe("mutation acceptMembershipRequest", () => {
+  afterAll(resetDatabase);
+  afterEach(sendMailSpy.mockClear);
+
+  it("should deny access to unauthenticated users", async () => {
+    const { mutate } = makeClient();
+    const { errors } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+      variables: { id: "id", role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual("Vous n'êtes pas connecté.");
+  });
+
+  it("should return error if the request does not exist", async () => {
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+      variables: { id: "does_not_exist", role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement n'existe pas"
+    );
+  });
+
+  it("should return an error if user is not admin of the company", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      `Vous n'êtes pas administrateur de l'entreprise portant le siret "${company.siret}".`
+    );
+  });
+
+  it("should return an error if the request is already accepted", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } },
+      status: "ACCEPTED",
+      statusUpdatedBy: "john.snow@trackdechets.fr"
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement a déjà été acceptée par un autre administrateur"
+    );
+  });
+
+  it("should return an error if the request is already refused", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } },
+      status: "REFUSED",
+      statusUpdatedBy: "john.snow@trackdechets.fr"
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement a déjà été refusée par un autre administrateur"
+    );
+  });
+
+  it.each(["MEMBER", "ADMIN"])(
+    "should associate requesting user to company with role %p",
+    async role => {
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+      const requester = await userFactory();
+      const membershipRequest = await prisma.createMembershipRequest({
+        user: { connect: { id: requester.id } },
+        company: { connect: { id: company.id } }
+      });
+      const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+      const { data } = await mutate(ACCEPT_MEMBERSHIP_REQUEST, {
+        variables: { id: membershipRequest.id, role }
+      });
+      expect(data.acceptMembershipRequest.users).toHaveLength(2);
+      const members = data.acceptMembershipRequest.users.map(u => u.email);
+      expect(members).toContain(user.email);
+
+      const acceptedInvitationRequest = await prisma.membershipRequest({
+        id: membershipRequest.id
+      });
+
+      expect(acceptedInvitationRequest.status).toEqual("ACCEPTED");
+      expect(acceptedInvitationRequest.statusUpdatedBy).toEqual(user.email);
+
+      const companyAssociations = await prisma.companyAssociations({
+        where: { user: { id: requester.id }, company: { id: company.id } }
+      });
+
+      expect(companyAssociations).toHaveLength(1);
+      expect(companyAssociations[0].role).toEqual(role);
+
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        userMails.membershipRequestAccepted(requester, company)
+      );
+    }
+  );
+});

--- a/back/src/users/resolvers/mutations/__tests__/refuseMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/refuseMembershipRequest.integration.ts
@@ -1,0 +1,135 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { prisma } from "../../../../generated/prisma-client";
+import {
+  userFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import * as mailsHelper from "../../../../common/mails.helper";
+import { userMails } from "../../../mails";
+import { AuthType } from "../../../../auth";
+
+// No mails
+const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
+sendMailSpy.mockImplementation(() => Promise.resolve());
+
+const REFUSE_MEMBERSHIP_REQUEST = `
+  mutation RefuseMembershipRequest($id: ID!){
+    refuseMembershipRequest(id: $id){
+      siret
+      users {
+        email
+        role
+      }
+    }
+  }
+`;
+
+describe("mutation refuseMembershipRequest", () => {
+  afterAll(resetDatabase);
+
+  afterEach(sendMailSpy.mockClear);
+
+  it("should deny access to unauthenticated users", async () => {
+    const { mutate } = makeClient();
+    const { errors } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: "id" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual("Vous n'êtes pas connecté.");
+  });
+
+  it("should return error if the request does not exist", async () => {
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: "does_not_exist" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement n'existe pas"
+    );
+  });
+
+  it("should return an error if user is not admin of the company", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      `Vous n'êtes pas administrateur de l'entreprise portant le siret "${company.siret}".`
+    );
+  });
+
+  it("should return an error if the request is already accepted", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } },
+      status: "ACCEPTED",
+      statusUpdatedBy: "john.snow@trackdechets.fr"
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement a déjà été acceptée par un autre administrateur"
+    );
+  });
+
+  it("should return an error if the request is already refused", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } },
+      status: "REFUSED",
+      statusUpdatedBy: "john.snow@trackdechets.fr"
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id, role: "MEMBER" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement a déjà été refusée par un autre administrateur"
+    );
+  });
+
+  it("should refuse a membership request", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await mutate(REFUSE_MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id }
+    });
+    expect(data.refuseMembershipRequest.users).toHaveLength(1);
+    const refusedMembershipRequest = await prisma.membershipRequest({
+      id: membershipRequest.id
+    });
+    expect(refusedMembershipRequest.status).toEqual("REFUSED");
+    expect(refusedMembershipRequest.statusUpdatedBy).toEqual(user.email);
+    const associationExists = await prisma.$exists.companyAssociation({
+      user: { id: requester.id },
+      company: { id: company.id }
+    });
+    expect(associationExists).toEqual(false);
+    expect(sendMailSpy).toHaveBeenCalledWith(
+      userMails.membershipRequestRefused(requester, company)
+    );
+  });
+});

--- a/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
@@ -26,7 +26,7 @@ const SEND_MEMBERSHIP_REQUEST = `
   }
 `;
 
-describe("mutation send invitation request", () => {
+describe("mutation sendMembershipRequest", () => {
   afterAll(resetDatabase);
 
   afterEach(sendMailSpy.mockClear);

--- a/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
@@ -1,0 +1,132 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { prisma } from "../../../../generated/prisma-client";
+import {
+  companyFactory,
+  userFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { associateUserToCompany } from "../../../database";
+import * as mailsHelper from "../../../../common/mails.helper";
+import { userMails } from "../../../mails";
+
+// No mails
+const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
+sendMailSpy.mockImplementation(() => Promise.resolve());
+
+const SEND_MEMBERSHIP_REQUEST = `
+  mutation SendMembershipRequest($siret: String!){
+    sendMembershipRequest(siret: $siret){
+      id
+      email
+      siret
+      sentTo
+      status
+    }
+  }
+`;
+
+describe("mutation send invitation request", () => {
+  afterAll(resetDatabase);
+
+  afterEach(sendMailSpy.mockClear);
+
+  it("should deny access to unauthenticated users", async () => {
+    const { mutate } = makeClient();
+    const { company } = await userWithCompanyFactory("ADMIN");
+    const { errors } = await mutate(SEND_MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual("Vous n'êtes pas connecté.");
+  });
+
+  it("should send a request to all admins of the company and create a MembershipRequest record", async () => {
+    const requester = await userFactory();
+    const admin = await userFactory({ email: "john.snow@trackdechets.fr" });
+    const company = await companyFactory();
+    await associateUserToCompany(admin.id, company.siret, "ADMIN");
+    const { mutate } = makeClient(requester);
+    const { data } = await mutate(SEND_MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    const { id, status, sentTo, email, siret } = data.sendMembershipRequest;
+    expect(status).toEqual("PENDING");
+    // emails should be hidden
+    expect(sentTo).toEqual(["jo****@trackdechets.fr"]);
+    expect(email).toEqual(requester.email);
+    expect(siret).toEqual(company.siret);
+    const membershipRequest = await prisma.membershipRequest({ id });
+
+    // check relation to user was created
+    const linkedUser = await prisma.membershipRequest({ id }).user();
+    expect(linkedUser.id).toEqual(requester.id);
+
+    // check relation to company was created
+    const linkedCompany = await prisma.membershipRequest({ id }).company();
+    expect(linkedCompany.id).toEqual(company.id);
+
+    expect(membershipRequest.sentTo).toEqual(["john.snow@trackdechets.fr"]);
+    expect(membershipRequest.status).toEqual("PENDING");
+    expect(membershipRequest.statusUpdatedBy).toBeNull();
+
+    expect(sendMailSpy).toHaveBeenNthCalledWith(
+      1,
+      userMails.membershipRequest(
+        [{ email: admin.email, name: admin.name }],
+        `${process.env.UI_URL_SCHEME}://${process.env.UI_HOST}/membership-request/${membershipRequest.id}`,
+        requester,
+        company
+      )
+    );
+
+    expect(sendMailSpy).toHaveBeenNthCalledWith(
+      2,
+      userMails.membershipRequestConfirmation(requester, company)
+    );
+  });
+
+  it("should return an error if company does not exist", async () => {
+    const user = await userFactory();
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(SEND_MEMBERSHIP_REQUEST, {
+      variables: { siret: "12365478958956" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cet établissement n'existe pas dans Trackdéchets"
+    );
+  });
+
+  it("should return an error if user is already member of the company", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(SEND_MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Vous êtes déjà membre de cet établissement"
+    );
+  });
+
+  it("should return an error if a pending request already exists", async () => {
+    const requester = await userFactory();
+    const company = await companyFactory();
+
+    await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+
+    const { mutate } = makeClient(requester);
+
+    const { errors } = await mutate(SEND_MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Une demande de rattachement a déjà été faite pour cet établissement"
+    );
+  });
+});

--- a/back/src/users/resolvers/mutations/acceptMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/acceptMembershipRequest.ts
@@ -1,0 +1,67 @@
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { sendMail } from "../../../common/mails.helper";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { MutationResolvers } from "../../../generated/graphql/types";
+import { prisma } from "../../../generated/prisma-client";
+import {
+  associateUserToCompany,
+  getMembershipRequestOrNotFoundError
+} from "../../database";
+import {
+  InvitationRequestAlreadyAccepted,
+  InvitationRequestAlreadyRefused
+} from "../../errors";
+import { userMails } from "../../mails";
+import { checkIsCompanyAdmin } from "../../permissions";
+
+const acceptMembershipRequestResolver: MutationResolvers["acceptMembershipRequest"] = async (
+  parent,
+  { id, role },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+
+  const user = checkIsAuthenticated(context);
+
+  // throw error if invitation does not exist
+  const membershipRequest = await getMembershipRequestOrNotFoundError({ id });
+
+  const company = await prisma
+    .membershipRequest({ id: membershipRequest.id })
+    .company();
+
+  // check authenticated user is admin of the company
+  await checkIsCompanyAdmin(user, company);
+
+  // throw error if invitation was already accepted
+  if (membershipRequest.status === "ACCEPTED") {
+    throw new InvitationRequestAlreadyAccepted();
+  }
+
+  // throw error if invitation was already refused
+  if (membershipRequest.status === "REFUSED") {
+    throw new InvitationRequestAlreadyRefused();
+  }
+
+  const requester = await prisma
+    .membershipRequest({ id: membershipRequest.id })
+    .user();
+
+  // associate invitation requester to company with the role decided by the admin
+  await associateUserToCompany(requester.id, company.siret, role);
+
+  await prisma.updateMembershipRequest({
+    where: { id },
+    data: {
+      status: "ACCEPTED",
+      statusUpdatedBy: user.email
+    }
+  });
+
+  // notify requester of acceptance
+  await sendMail(userMails.membershipRequestAccepted(requester, company));
+
+  return prisma.company({ id: company.id });
+};
+
+export default acceptMembershipRequestResolver;

--- a/back/src/users/resolvers/mutations/acceptMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/acceptMembershipRequest.ts
@@ -8,8 +8,8 @@ import {
   getMembershipRequestOrNotFoundError
 } from "../../database";
 import {
-  InvitationRequestAlreadyAccepted,
-  InvitationRequestAlreadyRefused
+  MembershipRequestAlreadyAccepted,
+  MembershipRequestAlreadyRefused
 } from "../../errors";
 import { userMails } from "../../mails";
 import { checkIsCompanyAdmin } from "../../permissions";
@@ -23,7 +23,7 @@ const acceptMembershipRequestResolver: MutationResolvers["acceptMembershipReques
 
   const user = checkIsAuthenticated(context);
 
-  // throw error if invitation does not exist
+  // throw error if membership request does not exist
   const membershipRequest = await getMembershipRequestOrNotFoundError({ id });
 
   const company = await prisma
@@ -33,21 +33,21 @@ const acceptMembershipRequestResolver: MutationResolvers["acceptMembershipReques
   // check authenticated user is admin of the company
   await checkIsCompanyAdmin(user, company);
 
-  // throw error if invitation was already accepted
+  // throw error if membership request was already accepted
   if (membershipRequest.status === "ACCEPTED") {
-    throw new InvitationRequestAlreadyAccepted();
+    throw new MembershipRequestAlreadyAccepted();
   }
 
-  // throw error if invitation was already refused
+  // throw error if membership request was already refused
   if (membershipRequest.status === "REFUSED") {
-    throw new InvitationRequestAlreadyRefused();
+    throw new MembershipRequestAlreadyRefused();
   }
 
   const requester = await prisma
     .membershipRequest({ id: membershipRequest.id })
     .user();
 
-  // associate invitation requester to company with the role decided by the admin
+  // associate membership requester to company with the role decided by the admin
   await associateUserToCompany(requester.id, company.siret, role);
 
   await prisma.updateMembershipRequest({

--- a/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
@@ -5,8 +5,8 @@ import { MutationResolvers } from "../../../generated/graphql/types";
 import { prisma } from "../../../generated/prisma-client";
 import { getMembershipRequestOrNotFoundError } from "../../database";
 import {
-  InvitationRequestAlreadyAccepted,
-  InvitationRequestAlreadyRefused
+  MembershipRequestAlreadyAccepted,
+  MembershipRequestAlreadyRefused
 } from "../../errors";
 import { userMails } from "../../mails";
 import { checkIsCompanyAdmin } from "../../permissions";
@@ -20,7 +20,7 @@ const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipReques
 
   const user = checkIsAuthenticated(context);
 
-  // throw error if invitation does not exist
+  // throw error if membership request does not exist
   const membershipRequest = await getMembershipRequestOrNotFoundError({ id });
 
   const company = await prisma
@@ -30,14 +30,14 @@ const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipReques
   // check authenticated user is admin of the company
   await checkIsCompanyAdmin(user, company);
 
-  // throw error if invitation was already accepted
+  // throw error if membership request was already accepted
   if (membershipRequest.status === "ACCEPTED") {
-    throw new InvitationRequestAlreadyAccepted();
+    throw new MembershipRequestAlreadyAccepted();
   }
 
-  // throw error if invitation was already refused
+  // throw error if membership request was already refused
   if (membershipRequest.status === "REFUSED") {
-    throw new InvitationRequestAlreadyRefused();
+    throw new MembershipRequestAlreadyRefused();
   }
 
   await prisma.updateMembershipRequest({

--- a/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
@@ -1,0 +1,58 @@
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { sendMail } from "../../../common/mails.helper";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { MutationResolvers } from "../../../generated/graphql/types";
+import { prisma } from "../../../generated/prisma-client";
+import { getMembershipRequestOrNotFoundError } from "../../database";
+import {
+  InvitationRequestAlreadyAccepted,
+  InvitationRequestAlreadyRefused
+} from "../../errors";
+import { userMails } from "../../mails";
+import { checkIsCompanyAdmin } from "../../permissions";
+
+const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipRequest"] = async (
+  parent,
+  { id },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+
+  const user = checkIsAuthenticated(context);
+
+  // throw error if invitation does not exist
+  const membershipRequest = await getMembershipRequestOrNotFoundError({ id });
+
+  const company = await prisma
+    .membershipRequest({ id: membershipRequest.id })
+    .company();
+
+  // check authenticated user is admin of the company
+  await checkIsCompanyAdmin(user, company);
+
+  // throw error if invitation was already accepted
+  if (membershipRequest.status === "ACCEPTED") {
+    throw new InvitationRequestAlreadyAccepted();
+  }
+
+  // throw error if invitation was already refused
+  if (membershipRequest.status === "REFUSED") {
+    throw new InvitationRequestAlreadyRefused();
+  }
+
+  await prisma.updateMembershipRequest({
+    where: { id },
+    data: {
+      status: "REFUSED",
+      statusUpdatedBy: user.email
+    }
+  });
+
+  // notify requester of refusal
+  const requester = await prisma.membershipRequest({ id }).user();
+  await sendMail(userMails.membershipRequestRefused(requester, company));
+
+  return prisma.company({ id: company.id });
+};
+
+export default refuseMembershipRequestResolver;

--- a/back/src/users/resolvers/mutations/sendMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/sendMembershipRequest.ts
@@ -27,7 +27,7 @@ const sendMembershipRequestResolver: MutationResolvers["sendMembershipRequest"] 
     throw new UserInputError("Vous êtes déjà membre de cet établissement");
   }
 
-  // check there is no existing invitation requests for this
+  // check there is no existing membership request for this
   // user and company
   const alreadyRequested = await prisma.$exists.membershipRequest({
     user: { id: user.id },
@@ -42,29 +42,29 @@ const sendMembershipRequestResolver: MutationResolvers["sendMembershipRequest"] 
   const admins = await getCompanyAdminUsers(siret);
   const emails = admins.map(a => a.email);
 
-  const invitationRequest = await prisma.createMembershipRequest({
+  const membershipRequest = await prisma.createMembershipRequest({
     user: { connect: { id: user.id } },
     company: { connect: { id: company.id } },
     sentTo: { set: emails }
   });
 
-  // send invitation request to all admins of the company
+  // send membership request to all admins of the company
   const recipients = admins.map(a => ({ email: a.email, name: a.name }));
-  const invitationRequestLink = `${UI_URL_SCHEME}://${UI_HOST}/membership-request/${invitationRequest.id}`;
+  const membershipRequestLink = `${UI_URL_SCHEME}://${UI_HOST}/membership-request/${membershipRequest.id}`;
   await sendMail(
     userMails.membershipRequest(
       recipients,
-      invitationRequestLink,
+      membershipRequestLink,
       user,
       company
     )
   );
 
-  // send invitation request confirmation to requester
+  // send membership request confirmation to requester
   await sendMail(userMails.membershipRequestConfirmation(user, company));
 
   return {
-    ...invitationRequest,
+    ...membershipRequest,
     email: user.email,
     siret: company.siret,
     name: company.name

--- a/back/src/users/resolvers/mutations/sendMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/sendMembershipRequest.ts
@@ -1,0 +1,74 @@
+import { UserInputError } from "apollo-server-express";
+import { sendMail } from "../../../common/mails.helper";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import {
+  getCompanyAdminUsers,
+  getCompanyOrCompanyNotFound,
+  isCompanyMember
+} from "../../../companies/database";
+import { MutationResolvers } from "../../../generated/graphql/types";
+import { prisma } from "../../../generated/prisma-client";
+import { userMails } from "../../mails";
+
+const { UI_HOST, UI_URL_SCHEME } = process.env;
+
+const sendMembershipRequestResolver: MutationResolvers["sendMembershipRequest"] = async (
+  parent,
+  { siret },
+  context
+) => {
+  const user = checkIsAuthenticated(context);
+
+  const company = await getCompanyOrCompanyNotFound({ siret });
+
+  // check user is not already member of company
+  const isMember = await isCompanyMember(user, company);
+  if (isMember) {
+    throw new UserInputError("Vous êtes déjà membre de cet établissement");
+  }
+
+  // check there is no existing invitation requests for this
+  // user and company
+  const alreadyRequested = await prisma.$exists.membershipRequest({
+    user: { id: user.id },
+    company: { id: company.id }
+  });
+  if (alreadyRequested) {
+    throw new UserInputError(
+      "Une demande de rattachement a déjà été faite pour cet établissement"
+    );
+  }
+
+  const admins = await getCompanyAdminUsers(siret);
+  const emails = admins.map(a => a.email);
+
+  const invitationRequest = await prisma.createMembershipRequest({
+    user: { connect: { id: user.id } },
+    company: { connect: { id: company.id } },
+    sentTo: { set: emails }
+  });
+
+  // send invitation request to all admins of the company
+  const recipients = admins.map(a => ({ email: a.email, name: a.name }));
+  const invitationRequestLink = `${UI_URL_SCHEME}://${UI_HOST}/membership-request/${invitationRequest.id}`;
+  await sendMail(
+    userMails.membershipRequest(
+      recipients,
+      invitationRequestLink,
+      user,
+      company
+    )
+  );
+
+  // send invitation request confirmation to requester
+  await sendMail(userMails.membershipRequestConfirmation(user, company));
+
+  return {
+    ...invitationRequest,
+    email: user.email,
+    siret: company.siret,
+    name: company.name
+  };
+};
+
+export default sendMembershipRequestResolver;

--- a/back/src/users/resolvers/queries/__tests__/membershipRequest.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/membershipRequest.integration.ts
@@ -1,0 +1,106 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { ErrorCode } from "../../../../common/errors";
+import { prisma } from "../../../../generated/prisma-client";
+import {
+  companyFactory,
+  userFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+const MEMBERSHIP_REQUEST = `
+  query MembershipRequest($id: ID, $siret: String) {
+    membershipRequest(id: $id, siret: $siret){
+      id
+      email
+      siret
+      name
+      status
+    }
+  }
+`;
+
+describe("query membershipRequest", () => {
+  afterAll(resetDatabase);
+
+  it("should deny access to unauthenticated users", async () => {
+    const { query } = makeClient();
+    const { errors } = await query(MEMBERSHIP_REQUEST);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].extensions.code).toEqual(ErrorCode.UNAUTHENTICATED);
+  });
+
+  it("should return an error when trying to pass both id and siret", async () => {
+    const user = await userFactory();
+    const { query } = makeClient(user);
+    const { errors } = await query(MEMBERSHIP_REQUEST, {
+      variables: { id: "id", siret: "siret" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Vous devez faire une recherche par `id` ou `siret` mais pas les deux"
+    );
+  });
+
+  it("should return error if invitation request by id does not exist", async () => {
+    const user = await userFactory();
+    const { query } = makeClient(user);
+    const { errors } = await query(MEMBERSHIP_REQUEST, {
+      variables: { id: "does_not_exist" }
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(
+      "Cette demande de rattachement n'existe pas"
+    );
+  });
+
+  it("should return null when no request found for authenticated user and siret", async () => {
+    const user = await userFactory();
+    const company = await companyFactory();
+    const { query } = makeClient(user);
+    const { data } = await query(MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    expect(data.membershipRequest).toBeNull();
+  });
+
+  it("should return an invitation request by id", async () => {
+    const { user: admin, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+    const { query } = makeClient(admin);
+    const { data } = await query(MEMBERSHIP_REQUEST, {
+      variables: { id: membershipRequest.id }
+    });
+
+    expect(data.membershipRequest).toMatchObject({
+      status: "PENDING",
+      email: requester.email,
+      siret: company.siret,
+      name: company.name
+    });
+  });
+
+  it("should return a membership request by siret", async () => {
+    const { user: _admin, company } = await userWithCompanyFactory("ADMIN");
+    const requester = await userFactory();
+    const membershipRequest = await prisma.createMembershipRequest({
+      user: { connect: { id: requester.id } },
+      company: { connect: { id: company.id } }
+    });
+    const { query } = makeClient(requester);
+    const { data } = await query(MEMBERSHIP_REQUEST, {
+      variables: { siret: company.siret }
+    });
+    expect(data.membershipRequest).toMatchObject({
+      id: membershipRequest.id,
+      status: "PENDING",
+      email: requester.email,
+      siret: company.siret,
+      name: company.name
+    });
+  });
+});

--- a/back/src/users/resolvers/queries/membershipRequest.ts
+++ b/back/src/users/resolvers/queries/membershipRequest.ts
@@ -1,0 +1,70 @@
+import { ForbiddenError, UserInputError } from "apollo-server-express";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { getCompanyAdminUsers } from "../../../companies/database";
+import { QueryResolvers } from "../../../generated/graphql/types";
+import { MembershipRequest, prisma } from "../../../generated/prisma-client";
+import { getMembershipRequestOrNotFoundError } from "../../database";
+
+const invitationRequestResolver: QueryResolvers["membershipRequest"] = async (
+  parent,
+  { id, siret },
+  context
+) => {
+  const user = checkIsAuthenticated(context);
+
+  if (id && siret) {
+    throw new UserInputError(
+      "Vous devez faire une recherche par `id` ou `siret` mais pas les deux"
+    );
+  }
+
+  let invitationRequest: MembershipRequest = null;
+
+  if (id) {
+    invitationRequest = await getMembershipRequestOrNotFoundError({ id });
+  }
+
+  if (siret) {
+    // search a matching invitation for authenticated user and siret
+    const requests = await prisma.membershipRequests({
+      where: { user: { id: user.id }, company: { siret } }
+    });
+    if (requests.length === 0) {
+      return null;
+    } else {
+      invitationRequest = requests[0];
+    }
+  }
+
+  const { email } = await prisma
+    .membershipRequest({ id: invitationRequest.id })
+    .user();
+
+  const company = await prisma
+    .membershipRequest({ id: invitationRequest.id })
+    .company();
+
+  // check user is requester or company admin
+  const isRequester = user.email === email;
+
+  if (!isRequester) {
+    const admins = await getCompanyAdminUsers(company.siret);
+    if (!admins.map(u => u.id).includes(user.id)) {
+      // user is neither requester nor admin of the company, throw error
+      throw new ForbiddenError(
+        "Vous n'avez pas le droit de consulter cette demande de rattachement"
+      );
+    }
+  }
+
+  return {
+    id: invitationRequest.id,
+    sentTo: invitationRequest.sentTo,
+    status: invitationRequest.status,
+    email,
+    siret: company.siret,
+    name: company.name
+  };
+};
+
+export default invitationRequestResolver;

--- a/back/src/users/users.graphql
+++ b/back/src/users/users.graphql
@@ -7,7 +7,7 @@ type Query {
   à partir de l'identifiant de cette demande ou du SIRET de l'établissement
   auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
   paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
-  permet notamment de suivre l'état d'avancement de la demande d'invitation
+  permet notamment de suivre l'état d'avancement de la demande de rattachement
   (en attente, accepté, refusé)
   """
   membershipRequest(id: ID, siret: String): MembershipRequest
@@ -112,12 +112,12 @@ type MembershipRequest {
   "Nom de l'établissement"
   name: String!
 
-  "Statut de la demande d'invitation"
+  "Statut de la demande de rattachement"
   status: MembershipRequestStatus!
 
   """
   Liste des adresses email correspondant aux comptes administrateurs à qui la demande
-  d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+  de rattachement a été envoyée. Les adresses emails sont partiellement masquées de la
   façon suivante j********w@trackdechets.fr
   """
   sentTo: [String!]!

--- a/back/src/users/users.graphql
+++ b/back/src/users/users.graphql
@@ -1,6 +1,16 @@
 type Query {
   "Renvoie les informations sur l'utilisateur authentifié"
   me: User!
+
+  """
+  Récupère une demande de rattachement effectuée par l'utilisateur courant
+  à partir de l'identifiant de cette demande ou du SIRET de l'établissement
+  auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
+  paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
+  permet notamment de suivre l'état d'avancement de la demande d'invitation
+  (en attente, accepté, refusé)
+  """
+  membershipRequest(id: ID, siret: String): MembershipRequest
 }
 
 type Mutation {
@@ -12,6 +22,14 @@ type Mutation {
   d'un utilisateur.
   """
   login(email: String!, password: String!): AuthPayload!
+
+  """
+  Envoie une demande de rattachement de l'utilisateur courant
+  à rejoindre l'établissement dont le siret est précisé en paramètre.
+  Cette demande est communiquée à l'ensemble des administrateurs de
+  l'établissement qui ont le choix de l'accepter ou de la refuser.
+  """
+  sendMembershipRequest(siret: String!): MembershipRequest
 }
 
 "Cet objet est renvoyé par la mutation login qui est dépréciée"
@@ -66,4 +84,41 @@ pour le détail de chacun des rôles
 enum UserRole {
   MEMBER
   ADMIN
+}
+
+"""
+Différents statuts possibles pour une demande de rattachement
+à un établissement
+"""
+enum MembershipRequestStatus {
+  PENDING
+  ACCEPTED
+  REFUSED
+}
+
+"""
+Demande de rattachement à un établissement effectué par
+un utilisateur.
+"""
+type MembershipRequest {
+  id: ID!
+
+  "Email de l'utilisateur faisant la demande"
+  email: String!
+
+  "SIRET de l'établissement"
+  siret: String!
+
+  "Nom de l'établissement"
+  name: String!
+
+  "Statut de la demande d'invitation"
+  status: MembershipRequestStatus!
+
+  """
+  Liste des adresses email correspondant aux comptes administrateurs à qui la demande
+  d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+  façon suivante j********w@trackdechets.fr
+  """
+  sentTo: [String!]!
 }

--- a/back/src/users/users.private.graphql
+++ b/back/src/users/users.private.graphql
@@ -71,6 +71,19 @@ type Mutation {
   Supprime une invitation à un établissement
   """
   deleteInvitation(email: String!, siret: String!): CompanyPrivate!
+
+  """
+  USAGE INTERNE
+  Accepte une demande de rattachement à un établissement
+  en spécifiant le rôle accordé au nouvel utilisateur
+  """
+  acceptMembershipRequest(id: ID!, role: UserRole!): CompanyPrivate!
+
+  """
+  USAGE INTERNE
+  Refuse une demande de rattachement à un un établissement
+  """
+  refuseMembershipRequest(id: ID!): CompanyPrivate!
 }
 
 """

--- a/back/src/users/utils.ts
+++ b/back/src/users/utils.ts
@@ -1,4 +1,5 @@
 import { hash } from "bcrypt";
+import * as yup from "yup";
 
 const saltRound = 10;
 
@@ -8,4 +9,20 @@ export function hashPassword(password: string) {
 
 export function generatePassword() {
   return Math.random().toString(36).slice(-10);
+}
+
+/**
+ * This function hides part of an email
+ * john.snow@trackdechets.fr => jo***@trackdechets.fr
+ */
+export function partiallyHideEmail(email: string) {
+  // validate email or throw error
+  yup.string().email().validateSync(email);
+  const parts = email.split("@");
+  if (parts[0].length <= 2) {
+    return `${parts[0]}****@${parts[1]}`;
+  }
+  const hide = email.split("@")[0].length - 2;
+  const r = new RegExp(`.{${hide}}@`);
+  return email.replace(r, "****@");
 }

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -446,6 +446,30 @@ Renvoie les informations sur l'utilisateur authentifié
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>membershipRequest</strong></td>
+<td valign="top"><a href="#membershiprequest">MembershipRequest</a></td>
+<td>
+
+Récupère une demande de rattachement effectuée par l'utilisateur courant
+à partir de l'identifiant de cette demande ou du SIRET de l'établissement
+auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
+paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
+permet notamment de suivre l'état d'avancement de la demande d'invitation
+(en attente, accepté, refusé)
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>searchCompanies</strong></td>
 <td valign="top">[<a href="#companysearchresult">CompanySearchResult</a>!]!</td>
 <td>
@@ -896,6 +920,23 @@ Utiliser createForm / updateForm selon le besoin
 Payload du BSD
 
 </td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sendMembershipRequest</strong></td>
+<td valign="top"><a href="#membershiprequest">MembershipRequest</a></td>
+<td>
+
+Envoie une demande de rattachement de l'utilisateur courant
+à rejoindre l'établissement dont le siret est précisé en paramètre.
+Cette demande est communiquée à l'ensemble des administrateurs de
+l'établissement qui ont le choix de l'accepter ou de la refuser.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">siret</td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>signedByTransporter</strong></td>
@@ -2399,6 +2440,76 @@ Liste des rubriques associées
 <td>
 
 Liste des déclarations GEREP
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### MembershipRequest
+
+Demande de rattachement à un établissement effectué par
+un utilisateur.
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>email</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Email de l'utilisateur faisant la demande
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>siret</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+SIRET de l'établissement
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>name</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+Nom de l'établissement
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>status</strong></td>
+<td valign="top"><a href="#membershiprequeststatus">MembershipRequestStatus</a>!</td>
+<td>
+
+Statut de la demande d'invitation
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sentTo</strong></td>
+<td valign="top">[<a href="#string">String</a>!]!</td>
+<td>
+
+Liste des adresses email correspondant aux comptes administrateurs à qui la demande
+d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+façon suivante j********w@trackdechets.fr
 
 </td>
 </tr>
@@ -5729,6 +5840,32 @@ Type d'une déclaration GEREP
 </tr>
 <tr>
 <td valign="top"><strong>Traiteur</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### MembershipRequestStatus
+
+Différents statuts possibles pour une demande de rattachement
+à un établissement
+
+<table>
+<thead>
+<th align="left">Value</th>
+<th align="left">Description</th>
+</thead>
+<tbody>
+<tr>
+<td valign="top"><strong>PENDING</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>ACCEPTED</strong></td>
+<td></td>
+</tr>
+<tr>
+<td valign="top"><strong>REFUSED</strong></td>
 <td></td>
 </tr>
 </tbody>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -454,7 +454,7 @@ Récupère une demande de rattachement effectuée par l'utilisateur courant
 à partir de l'identifiant de cette demande ou du SIRET de l'établissement
 auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
 paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
-permet notamment de suivre l'état d'avancement de la demande d'invitation
+permet notamment de suivre l'état d'avancement de la demande de rattachement
 (en attente, accepté, refusé)
 
 </td>
@@ -2498,7 +2498,7 @@ Nom de l'établissement
 <td valign="top"><a href="#membershiprequeststatus">MembershipRequestStatus</a>!</td>
 <td>
 
-Statut de la demande d'invitation
+Statut de la demande de rattachement
 
 </td>
 </tr>
@@ -2508,7 +2508,7 @@ Statut de la demande d'invitation
 <td>
 
 Liste des adresses email correspondant aux comptes administrateurs à qui la demande
-d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+de rattachement a été envoyée. Les adresses emails sont partiellement masquées de la
 façon suivante j********w@trackdechets.fr
 
 </td>

--- a/front/src/account/AccountCompanyAdd.tsx
+++ b/front/src/account/AccountCompanyAdd.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useMutation } from "@apollo/react-hooks";
-import { Field, Form, Formik, FormikProps, FormikValues } from "formik";
+import { Field, Form, Formik, FormikValues } from "formik";
 import gql from "graphql-tag";
 import { generatePath, useHistory } from "react-router-dom";
 import routes from "common/routes";
@@ -10,8 +10,9 @@ import RedErrorMessage from "../common/components/RedErrorMessage";
 import CompanyType from "../login/CompanyType";
 import AccountCompanyAddTransporterReceipt from "./accountCompanyAdd/AccountCompanyAddTransporterReceipt";
 import AccountCompanyAddTraderReceipt from "./accountCompanyAdd/AccountCompanyAddTraderReceipt";
-import AccountCompanyAddEcoOrganisme from "./accountCompanyAdd/AccountCompanyAddEcoOrganisme";
 import AccountCompanyAddSiret from "./accountCompanyAdd/AccountCompanyAddSiret";
+import AccountCompanyAddEcoOrganisme from "./accountCompanyAdd/AccountCompanyAddEcoOrganisme";
+import AccountCompanyAddMembershipRequest from "./accountCompanyAdd/AccountCompanyAddMembershipRequest";
 import styles from "./AccountCompanyAdd.module.scss";
 import { FaHourglassHalf } from "react-icons/fa";
 import {
@@ -19,6 +20,7 @@ import {
   MutationCreateCompanyArgs,
   Query,
   CompanyType as _CompanyType,
+  CompanyPublic,
 } from "generated/graphql/types";
 
 const CREATE_COMPANY = gql`
@@ -70,10 +72,10 @@ interface Values extends FormikValues {
   transporterReceiptNumber: string;
   transporterReceiptValidity: string;
   transporterReceiptDepartment: string;
+  ecoOrganismeAgreements: string[];
   traderReceiptNumber: string;
   traderReceiptValidity: string;
   traderReceiptDepartment: string;
-  ecoOrganismeAgreements: string[];
 }
 
 /**
@@ -83,8 +85,8 @@ interface Values extends FormikValues {
 export default function AccountCompanyAdd() {
   const history = useHistory();
 
-  // STATES
-  const [toggleForm, setToggleForm] = useState(false);
+  // STATE
+  const [companyInfos, setCompanyInfos] = useState<CompanyPublic | null>(null);
 
   // QUERIES AND MUTATIONS
   const [createCompany, { error: savingError }] = useMutation<
@@ -128,46 +130,6 @@ export default function AccountCompanyAdd() {
   const [createUploadLink, { error: uploadError }] = useMutation<{
     createUploadLink: { signedUrl: string; key: string };
   }>(CREATE_UPLOAD_LINK);
-
-  /**
-   * Callback passed to AccountCompanyAddSiret to update the form
-   * based on the result of { query { companyInfos } }
-   * @param companyInfos
-   * @param param1
-   */
-  function onCompanyInfos(
-    companyInfos,
-    {
-      values,
-      setFieldValue,
-    }: Pick<FormikProps<any>, "values" | "setFieldValue">
-  ) {
-    // auto-complete field name
-    setFieldValue("companyName", companyInfos?.name || "");
-
-    // auto-complete field address
-    setFieldValue("address", companyInfos?.address || "");
-
-    // auto-complete field gerepId
-    setFieldValue("gerepId", companyInfos?.installation?.codeS3ic || "");
-
-    // auto-complete field codeNaf
-    setFieldValue("codeNaf", companyInfos?.naf || "");
-
-    // auto-complete companyTypes
-    if (companyInfos && companyInfos.installation) {
-      let categories = companyInfos.installation.rubriques
-        .filter(r => !!r.category) // null blocks form submitting
-        .map(r => r.category);
-      const companyTypes = categories.filter((value, index, self) => {
-        return self.indexOf(value) === index;
-      });
-      const currentValue = values.companyTypes;
-      setFieldValue("companyTypes", [...currentValue, ...companyTypes]);
-    }
-
-    setToggleForm(!!companyInfos);
-  }
 
   function isTransporter(companyTypes: _CompanyType[]) {
     return companyTypes.includes(_CompanyType.Transporter);
@@ -285,7 +247,6 @@ export default function AccountCompanyAdd() {
           documentKeys,
           transporterReceiptId,
           traderReceiptId,
-
           // Filter out empty agreements
           ecoOrganismeAgreements: ecoOrganismeAgreements.filter(Boolean),
         },
@@ -299,264 +260,274 @@ export default function AccountCompanyAdd() {
     );
   }
 
+  function getCompanyTypes(companyInfos: CompanyPublic) {
+    if (companyInfos?.installation?.rubriques) {
+      const categories = companyInfos.installation.rubriques
+        .filter(r => !!r.category)
+        .map(r => r.category as _CompanyType);
+      const companyTypes = categories.filter((value, index, self) => {
+        return self.indexOf(value) === index;
+      });
+      return companyTypes;
+    }
+    return [];
+  }
+
   return (
     <div className="panel">
-      <Formik<Values>
-        initialValues={{
-          siret: "",
-          companyName: "",
-          address: "",
-          companyTypes: [],
-          gerepId: "",
-          codeNaf: "",
-          document: null,
-          isAllowed: false,
-          transporterReceiptNumber: "",
-          transporterReceiptValidity: "",
-          transporterReceiptDepartment: "",
-          traderReceiptNumber: "",
-          traderReceiptValidity: "",
-          traderReceiptDepartment: "",
-          ecoOrganismeAgreements: [],
+      <h5 className={styles.subtitle}>Identification</h5>
+      <AccountCompanyAddSiret
+        {...{
+          onCompanyInfos: companyInfos => setCompanyInfos(companyInfos),
         }}
-        validate={values => {
-          // whether or not one of the transporter receipt field is set
-          const anyTransporterReceipField =
-            !!values.transporterReceiptNumber ||
-            !!values.transporterReceiptValidity ||
-            !!values.transporterReceiptDepartment;
+      />
+      {companyInfos && companyInfos.isRegistered && (
+        <AccountCompanyAddMembershipRequest siret={companyInfos.siret} />
+      )}
+      {companyInfos && !companyInfos.isRegistered && (
+        <Formik<Values>
+          initialValues={{
+            siret: companyInfos?.siret ?? "",
+            companyName: companyInfos?.name ?? "",
+            address: companyInfos?.address ?? "",
+            companyTypes: getCompanyTypes(companyInfos),
+            gerepId: companyInfos?.installation?.codeS3ic ?? "",
+            codeNaf: companyInfos?.naf ?? "",
+            document: null,
+            isAllowed: false,
+            transporterReceiptNumber: "",
+            transporterReceiptValidity: "",
+            transporterReceiptDepartment: "",
+            traderReceiptNumber: "",
+            traderReceiptValidity: "",
+            traderReceiptDepartment: "",
+            ecoOrganismeAgreements: [],
+          }}
+          validate={values => {
+            // whether or not one of the transporter receipt field is set
+            const anyTransporterReceipField =
+              !!values.transporterReceiptNumber ||
+              !!values.transporterReceiptValidity ||
+              !!values.transporterReceiptDepartment;
 
-          const isTransporter_ = isTransporter(values.companyTypes);
+            const isTransporter_ = isTransporter(values.companyTypes);
 
-          // whether or not one of the transporter receipt field is set
-          const anyTraderReceipField =
-            !!values.traderReceiptNumber ||
-            !!values.traderReceiptValidity ||
-            !!values.traderReceiptDepartment;
+            // whether or not one of the transporter receipt field is set
+            const anyTraderReceipField =
+              !!values.traderReceiptNumber ||
+              !!values.traderReceiptValidity ||
+              !!values.traderReceiptDepartment;
 
-          const isTrader_ = isTrader(values.companyTypes);
+            const isTrader_ = isTrader(values.companyTypes);
 
-          return {
-            ...(values.companyTypes.length === 0 && {
-              companyTypes: "Vous devez préciser le type d'établissement",
-            }),
-            ...(!values.isAllowed && {
-              isAllowed:
-                "Vous devez certifier être autorisé à créer ce compte pour votre entreprise",
-            }),
-            ...(values.siret.replace(/\s/g, "").length !== 14 && {
-              siret: "Le SIRET doit faire 14 caractères",
-            }),
-            ...(anyTransporterReceipField &&
-              isTransporter_ &&
-              !values.transporterReceiptNumber && {
-                transporterReceiptNumber: "Champ obligatoire",
+            return {
+              ...(values.companyTypes.length === 0 && {
+                companyTypes: "Vous devez préciser le type d'établissement",
               }),
-            ...(anyTransporterReceipField &&
-              isTransporter_ &&
-              !values.transporterReceiptValidity && {
-                transporterReceiptValidity: "Champ obligatoire",
+              ...(!values.isAllowed && {
+                isAllowed:
+                  "Vous devez certifier être autorisé à créer ce compte pour votre entreprise",
               }),
-            ...(anyTraderReceipField &&
-              isTrader_ &&
-              !values.traderReceiptDepartment && {
-                traderReceiptDepartment: "Champ obligatoire",
+              ...(values.siret.replace(/\s/g, "").length !== 14 && {
+                siret: "Le SIRET doit faire 14 caractères",
               }),
-            ...(anyTraderReceipField &&
-              isTrader_ &&
-              !values.traderReceiptNumber && {
-                traderReceiptNumber: "Champ obligatoire",
-              }),
-            ...(anyTraderReceipField &&
-              isTrader_ &&
-              !values.traderReceiptValidity && {
-                traderReceiptValidity: "Champ obligatoire",
-              }),
-            ...(anyTraderReceipField &&
-              isTrader_ &&
-              !values.traderReceiptDepartment && {
-                traderReceiptDepartment: "Champ obligatoire",
-              }),
-            ...(isEcoOrganisme(values.companyTypes) &&
-              values.ecoOrganismeAgreements.length < 1 && {
-                ecoOrganismeAgreements: "Champ obligatoire",
-              }),
-          };
-        }}
-        onSubmit={onSubmit}
-      >
-        {({ values, setFieldValue, isSubmitting }) => (
-          <Form className={styles.companyAddForm}>
-            <h5 className={styles.subtitle}>Identification</h5>
-            <AccountCompanyAddSiret
-              {...{
-                values,
-                onCompanyInfos: companyInfo =>
-                  onCompanyInfos(companyInfo, { values, setFieldValue }),
-              }}
-            />
-            {toggleForm && (
-              <>
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>
-                    Nom de l'entreprise
-                  </label>
-                  <div className={styles.field__value}>
-                    <Field
-                      type="text"
-                      name="companyName"
-                      className={`td-input ${styles.textField}`}
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>
-                    Code NAF
-                  </label>
-                  <div className={styles.field__value}>
-                    <Field
-                      type="text"
-                      name="codeNaf"
-                      className={`td-input ${styles.textField}`}
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>Adresse</label>
-                  <div className={styles.field__value}>
-                    <Field
-                      type="text"
-                      name="address"
-                      className={`td-input ${styles.textField}`}
-                    />
-                  </div>
-                </div>
-
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>
-                    Justificatif (optionnel)
-                  </label>
-
-                  <div className={styles.field__value}>
-                    <input
-                      type="file"
-                      className={`button ${styles.textField}`}
-                      accept="image/png, image/jpeg, image/gif, application/pdf "
-                      onChange={async event => {
-                        const file = event.currentTarget.files?.item(0);
-                        if (!!file) {
-                          setFieldValue("document", file);
-                        }
-                      }}
-                    />
-                    <div className={styles.smaller}>
-                      KBIS, justificatif du siège social de l'entreprise... Ce
-                      document est suceptible d'être vérifié par l'équipe
-                      Trackdéchets afin de lutter contre la fraude. Formats
-                      acceptés: jpeg, png, pdf.
-                    </div>
-                  </div>
-                </div>
-
-                <h5 className={styles.subtitle}>Activité</h5>
-
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>Profil</label>
-                  <div className={styles.field__value}>
-                    <Field name="companyTypes" component={CompanyType} />
-
-                    <RedErrorMessage name="companyTypes" />
-                  </div>
-                </div>
-
-                {isTransporter(values.companyTypes) && (
-                  <AccountCompanyAddTransporterReceipt />
-                )}
-
-                {isTrader(values.companyTypes) && (
-                  <AccountCompanyAddTraderReceipt />
-                )}
-
-                {isEcoOrganisme(values.companyTypes) && (
-                  <AccountCompanyAddEcoOrganisme />
-                )}
-
-                <div className={styles.field}>
-                  <label className={`text-right ${styles.bold}`}>
-                    Identifiant GEREP (optionnel)
-                  </label>
-                  <div className={styles.field__value}>
-                    <Field
-                      type="text"
-                      name="gerepId"
-                      className={`td-input ${styles.textField}`}
-                    />
-                    <div className={styles.smaller}>
-                      Gestion Electronique du Registre des Emissions Polluantes.{" "}
-                      <a
-                        href="https://faq.trackdechets.fr/la-gestion-des-dechets-dangereux#quest-ce-quun-identifiant-gerep"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        Plus d'informations sur la FAQ
-                      </a>
-                    </div>
-                  </div>
-                </div>
-
-                <div className={styles.field}>
-                  <div className={styles.field__value}>
-                    <label>
-                      <Field
-                        type="checkbox"
-                        name="isAllowed"
-                        className="td-checkbox"
-                      />
-                      Je certifie disposer du pouvoir pour créer un compte au
-                      nom de mon entreprise
-                    </label>
-
-                    <RedErrorMessage name="isAllowed" />
-                  </div>
-                </div>
-
-                <div className={styles["submit-form"]}>
-                  <button
-                    className="btn btn--outline-primary"
-                    disabled={isSubmitting}
-                    onClick={() => {
-                      history.goBack();
-                    }}
-                  >
-                    Annuler
-                  </button>
-
-                  <button
-                    className="btn btn--primary"
-                    type="submit"
-                    disabled={isSubmitting}
-                  >
-                    {isSubmitting ? <FaHourglassHalf /> : "Créer"}
-                  </button>
-                </div>
-                {/* // ERRORS */}
-                {uploadError && <NotificationError apolloError={uploadError} />}
-                {createTransporterReceiptError && (
-                  <NotificationError
-                    apolloError={createTransporterReceiptError}
+              ...(anyTransporterReceipField &&
+                isTransporter_ &&
+                !values.transporterReceiptNumber && {
+                  transporterReceiptNumber: "Champ obligatoire",
+                }),
+              ...(anyTransporterReceipField &&
+                isTransporter_ &&
+                !values.transporterReceiptValidity && {
+                  transporterReceiptValidity: "Champ obligatoire",
+                }),
+              ...(anyTraderReceipField &&
+                isTrader_ &&
+                !values.traderReceiptDepartment && {
+                  traderReceiptDepartment: "Champ obligatoire",
+                }),
+              ...(anyTraderReceipField &&
+                isTrader_ &&
+                !values.traderReceiptNumber && {
+                  traderReceiptNumber: "Champ obligatoire",
+                }),
+              ...(anyTraderReceipField &&
+                isTrader_ &&
+                !values.traderReceiptValidity && {
+                  traderReceiptValidity: "Champ obligatoire",
+                }),
+              ...(anyTraderReceipField &&
+                isTrader_ &&
+                !values.traderReceiptDepartment && {
+                  traderReceiptDepartment: "Champ obligatoire",
+                }),
+              ...(isEcoOrganisme(values.companyTypes) &&
+                values.ecoOrganismeAgreements.length < 1 && {
+                  ecoOrganismeAgreements: "Champ obligatoire",
+                }),
+            };
+          }}
+          onSubmit={onSubmit}
+        >
+          {({ values, setFieldValue, isSubmitting }) => (
+            <Form className={styles.companyAddForm}>
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>
+                  Nom de l'entreprise
+                </label>
+                <div className={styles.field__value}>
+                  <Field
+                    type="text"
+                    name="companyName"
+                    className={`td-input ${styles.textField}`}
                   />
-                )}
-                {createTraderReceiptError && (
-                  <NotificationError apolloError={createTraderReceiptError} />
-                )}
-                {savingError && <NotificationError apolloError={savingError} />}
-              </>
-            )}
-          </Form>
-        )}
-      </Formik>
+                </div>
+              </div>
+
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>Code NAF</label>
+                <div className={styles.field__value}>
+                  <Field
+                    type="text"
+                    name="codeNaf"
+                    className={`td-input ${styles.textField}`}
+                  />
+                </div>
+              </div>
+
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>Adresse</label>
+                <div className={styles.field__value}>
+                  <Field
+                    type="text"
+                    name="address"
+                    className={`td-input ${styles.textField}`}
+                  />
+                </div>
+              </div>
+
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>
+                  Justificatif (optionnel)
+                </label>
+
+                <div className={styles.field__value}>
+                  <input
+                    type="file"
+                    className={`button ${styles.textField}`}
+                    accept="image/png, image/jpeg, image/gif, application/pdf "
+                    onChange={async event => {
+                      const file = event.currentTarget.files?.item(0);
+                      if (!!file) {
+                        setFieldValue("document", file);
+                      }
+                    }}
+                  />
+                  <div className={styles.smaller}>
+                    KBIS, justificatif du siège social de l'entreprise... Ce
+                    document est suceptible d'être vérifié par l'équipe
+                    Trackdéchets afin de lutter contre la fraude. Formats
+                    acceptés: jpeg, png, pdf.
+                  </div>
+                </div>
+              </div>
+
+              <h5 className={styles.subtitle}>Activité</h5>
+
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>Profil</label>
+                <div className={styles.field__value}>
+                  <Field name="companyTypes" component={CompanyType} />
+
+                  <RedErrorMessage name="companyTypes" />
+                </div>
+              </div>
+
+              {isTransporter(values.companyTypes) && (
+                <AccountCompanyAddTransporterReceipt />
+              )}
+
+              {isTrader(values.companyTypes) && (
+                <AccountCompanyAddTraderReceipt />
+              )}
+
+              {isEcoOrganisme(values.companyTypes) && (
+                <AccountCompanyAddEcoOrganisme />
+              )}
+
+              <div className={styles.field}>
+                <label className={`text-right ${styles.bold}`}>
+                  Identifiant GEREP (optionnel)
+                </label>
+                <div className={styles.field__value}>
+                  <Field
+                    type="text"
+                    name="gerepId"
+                    className={`td-input ${styles.textField}`}
+                  />
+                  <div className={styles.smaller}>
+                    Gestion Electronique du Registre des Emissions Polluantes.{" "}
+                    <a
+                      href="https://faq.trackdechets.fr/la-gestion-des-dechets-dangereux#quest-ce-quun-identifiant-gerep"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Plus d'informations sur la FAQ
+                    </a>
+                  </div>
+                </div>
+              </div>
+
+              <div className={styles.field}>
+                <div className={styles.field__value}>
+                  <label>
+                    <Field
+                      type="checkbox"
+                      name="isAllowed"
+                      className="td-checkbox"
+                    />
+                    Je certifie disposer du pouvoir pour créer un compte au nom
+                    de mon entreprise
+                  </label>
+
+                  <RedErrorMessage name="isAllowed" />
+                </div>
+              </div>
+
+              <div className={styles["submit-form"]}>
+                <button
+                  className="btn btn--outline-primary"
+                  disabled={isSubmitting}
+                  onClick={() => {
+                    history.goBack();
+                  }}
+                >
+                  Annuler
+                </button>
+
+                <button
+                  className="btn btn--primary"
+                  type="submit"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? <FaHourglassHalf /> : "Créer"}
+                </button>
+              </div>
+              {/* // ERRORS */}
+              {uploadError && <NotificationError apolloError={uploadError} />}
+              {createTransporterReceiptError && (
+                <NotificationError
+                  apolloError={createTransporterReceiptError}
+                />
+              )}
+              {createTraderReceiptError && (
+                <NotificationError apolloError={createTraderReceiptError} />
+              )}
+              {savingError && <NotificationError apolloError={savingError} />}
+            </Form>
+          )}
+        </Formik>
+      )}
     </div>
   );
 }

--- a/front/src/account/AccountMembershipRequest.tsx
+++ b/front/src/account/AccountMembershipRequest.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/react-hooks";
+import { InlineError, NotificationError } from "common/components/Error";
+import Loader from "common/components/Loaders";
+import {
+  MembershipRequestStatus,
+  Mutation,
+  Query,
+  UserRole,
+} from "generated/graphql/types";
+import gql from "graphql-tag";
+import { useHistory, useParams } from "react-router-dom";
+import { FaHourglassHalf } from "react-icons/fa";
+import cogoToast from "cogo-toast";
+
+const MEMBERSHIP_REQUEST = gql`
+  query MembershipRequest($id: ID!) {
+    membershipRequest(id: $id) {
+      email
+      siret
+      name
+      status
+    }
+  }
+`;
+
+const ACCEPT_MEMBERSHIP_REQUEST = gql`
+  mutation AcceptMembershipRequest($id: ID!, $role: UserRole!) {
+    acceptMembershipRequest(id: $id, role: $role) {
+      id
+      users {
+        id
+      }
+    }
+  }
+`;
+
+const REFUSE_MEMBERSHIP_REQUEST = gql`
+  mutation RefuseMembershipRequest($id: ID!) {
+    refuseMembershipRequest(id: $id) {
+      id
+      users {
+        id
+      }
+    }
+  }
+`;
+
+export default function AccountMembershipRequest() {
+  const { id } = useParams<{ id: string }>();
+
+  const history = useHistory();
+
+  const [userRole, setUserRole] = useState<UserRole>(UserRole.Member);
+
+  const { loading, error, data } = useQuery<Pick<Query, "membershipRequest">>(
+    MEMBERSHIP_REQUEST,
+    {
+      variables: { id },
+    }
+  );
+
+  const [
+    acceptMembershipRequest,
+    { loading: acceptLoading, error: acceptError },
+  ] = useMutation<Pick<Mutation, "acceptMembershipRequest">>(
+    ACCEPT_MEMBERSHIP_REQUEST,
+    {
+      onCompleted: () => {
+        cogoToast.success("La demande de rattachement a bien été acceptée", {
+          hideAfter: 5,
+        });
+        history.push("/");
+      },
+    }
+  );
+
+  const [
+    refuseMembershipRequest,
+    { loading: refuseLoading, error: refuseError },
+  ] = useMutation<Pick<Mutation, "refuseMembershipRequest">>(
+    REFUSE_MEMBERSHIP_REQUEST,
+    {
+      onCompleted: () => {
+        cogoToast.success("La demande de rattachement a bien été refusée", {
+          hideAfter: 5,
+        });
+        history.push("/");
+      },
+    }
+  );
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <InlineError apolloError={error} />;
+  }
+
+  if (
+    data &&
+    data.membershipRequest?.status !== MembershipRequestStatus.Pending
+  ) {
+    return (
+      <div>Cette demande de rattachement a déjà été acceptée ou refusée</div>
+    );
+  }
+
+  if (data && data.membershipRequest) {
+    const { email, siret, name } = data.membershipRequest;
+
+    return (
+      <div className="container-narrow">
+        <section className="section section-white">
+          <h4 className="h4 tw-mb-10">
+            Un utilisateur aimerait rejoindre l'établissement {name} ({siret})
+          </h4>
+
+          <div className="tw-flex tw-flex-row tw-justify-start">
+            <label className="tw-mr-5">{email}</label>
+            <select
+              name="role"
+              className="td-select"
+              value={userRole}
+              onChange={e => setUserRole(e.target.value as UserRole)}
+            >
+              <option value={UserRole.Member}>Collaborateur</option>
+              <option value={UserRole.Admin}>Administrateur</option>
+            </select>
+          </div>
+
+          <div className="td-flex tw-space-x-3 tw-mt-10">
+            <a className="btn btn--outline-primary" href="/">
+              Annuler
+            </a>
+            <button
+              className="btn btn--primary"
+              type="button"
+              onClick={() => refuseMembershipRequest({ variables: { id } })}
+            >
+              {refuseLoading ? <FaHourglassHalf /> : "Refuser"}
+            </button>
+            <button
+              className="btn btn--primary"
+              type="button"
+              onClick={() =>
+                acceptMembershipRequest({ variables: { id, role: userRole } })
+              }
+            >
+              {acceptLoading ? <FaHourglassHalf /> : "Accepter"}
+            </button>
+          </div>
+          {acceptError && <NotificationError apolloError={acceptError} />}
+          {refuseError && <NotificationError apolloError={refuseError} />}
+        </section>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
@@ -1,0 +1,53 @@
+import { useMutation } from "@apollo/react-hooks";
+import { NotificationError } from "common/components/Error";
+import gql from "graphql-tag";
+import React from "react";
+import { FaHourglassHalf } from "react-icons/fa";
+
+const SEND_MEMBERSHIP_REQUEST = gql`
+  mutation SendMembershipRequest($siret: String!) {
+    sendMembershipRequest(siret: $siret) {
+      email
+    }
+  }
+`;
+
+/**
+ * Allows users to send an invitation request to join a company
+ * when there is already an admin for this company
+ */
+export default function AccountCompanyAddInvitationRequest({ siret }) {
+  const [sendMembershipRequest, { data, error, loading }] = useMutation(
+    SEND_MEMBERSHIP_REQUEST
+  );
+
+  if (data) {
+    return (
+      <div>
+        <h4 className="h4">Demande de rattachement envoyée</h4>
+        <div>
+          Vous recevrez un email de confirmation lorsque votre demande sera
+          validée
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4 className="h4">Cet établissement possède déjà un administrateur</h4>
+      <button
+        type="button"
+        className="btn btn--primary tw-mt-5"
+        onClick={() =>
+          sendMembershipRequest({
+            variables: { siret: siret.replace(/\s/g, "") },
+          })
+        }
+      >
+        {loading ? <FaHourglassHalf /> : "Envoyer une demande de rattachement"}
+      </button>
+      {error && <NotificationError apolloError={error} />}
+    </div>
+  );
+}

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useLazyQuery } from "@apollo/react-hooks";
-import { Field, FormikProps } from "formik";
+import { Field, Form, Formik } from "formik";
 import { FaHourglassHalf } from "react-icons/fa";
 import cogoToast from "cogo-toast";
 import { COMPANY_INFOS } from "form/company/query";
@@ -8,8 +8,9 @@ import RedErrorMessage from "common/components/RedErrorMessage";
 import AutoFormattingSiret from "common/components/AutoFormattingSiret";
 import { NotificationError } from "common/components/Error";
 import styles from "../AccountCompanyAdd.module.scss";
+import { Query } from "generated/graphql/types";
 
-type IProps = Pick<FormikProps<any>, "values"> & {
+type IProps = {
   onCompanyInfos: (companyInfos) => void;
 };
 
@@ -21,58 +22,62 @@ type IProps = Pick<FormikProps<any>, "values"> & {
  * - it is not already registered in TD
  * - it is not closed
  */
-export default function AccountCompanyAddSiret({
-  values,
-  onCompanyInfos,
-}: IProps) {
-  const [searchCompany, { loading, error }] = useLazyQuery(COMPANY_INFOS, {
+export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
+  const [searchCompany, { loading, error }] = useLazyQuery<
+    Pick<Query, "companyInfos">
+  >(COMPANY_INFOS, {
     onCompleted: data => {
       if (data && data.companyInfos) {
         const companyInfos = data.companyInfos;
-        if (companyInfos.isRegistered) {
-          cogoToast.error(
-            "Ce SIRET existe déjà dans Trackdéchets, impossible de le re-créer."
-          );
-          onCompanyInfos(null);
-        } else if (data.companyInfos.etatAdministratif === "F") {
+        if (companyInfos.etatAdministratif === "F") {
           cogoToast.error(
             "Cet établissement est fermé, impossible de le créer"
           );
-          onCompanyInfos(null);
         } else {
-          onCompanyInfos(data.companyInfos);
+          onCompanyInfos(companyInfos);
         }
       }
     },
-    onError: () => {
-      onCompanyInfos(null);
-    },
+    fetchPolicy: "no-cache",
   });
 
   return (
     <>
       {error && <NotificationError apolloError={error} />}
-      <div className={styles.field}>
-        <label className={`text-right ${styles.bold}`}>SIRET</label>
-        <div className={styles.field__value}>
-          <Field name="siret" component={AutoFormattingSiret} />
-          <RedErrorMessage name="siret" />
-          <br />
-          <button
-            className="btn btn--primary tw-mt-2"
-            type="button"
-            onClick={() => {
-              const trimedSiret = values.siret.replace(/\s/g, "");
-              if (trimedSiret.length !== 14) {
-                return;
-              }
-              searchCompany({ variables: { siret: trimedSiret } });
-            }}
-          >
-            {loading ? <FaHourglassHalf /> : "Valider"}
-          </button>
-        </div>
-      </div>
+      <Formik
+        initialValues={{ siret: "" }}
+        validate={values => {
+          const trimedSiret = values.siret.replace(/\s/g, "");
+          if (trimedSiret.length !== 14) {
+            return { siret: "Le SIRET doit faire 14 caractères" };
+          }
+        }}
+        onSubmit={values => {
+          // reset company infos
+          onCompanyInfos(null);
+          searchCompany({
+            variables: { siret: values.siret.replace(/\s/g, "") },
+          });
+        }}
+      >
+        <Form className={styles.companyAddForm}>
+          <div className={styles.field}>
+            <label className={`text-right ${styles.bold}`}>SIRET</label>
+            <div className={styles.field__value}>
+              <Field name="siret" component={AutoFormattingSiret} />
+              <RedErrorMessage name="siret" />
+              <br />
+              <button
+                disabled={loading}
+                className="btn btn--primary tw-mt-2"
+                type="submit"
+              >
+                {loading ? <FaHourglassHalf /> : "Valider"}
+              </button>
+            </div>
+          </div>
+        </Form>
+      </Formik>
     </>
   );
 }

--- a/front/src/common/routes.ts
+++ b/front/src/common/routes.ts
@@ -1,6 +1,7 @@
 export default {
   login: "/login",
   invite: "/invite",
+  membershipRequest: "/membership-request/:id",
   signup: {
     index: "/signup",
     details: "/signup/details",

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -806,8 +806,47 @@ export type Invitation = {
 };
 
 
+/**
+ * Demande de rattachement à un établissement effectué par
+ * un utilisateur.
+ */
+export type MembershipRequest = {
+  __typename?: 'MembershipRequest';
+  id: Scalars['ID'];
+  /** Email de l'utilisateur faisant la demande */
+  email: Scalars['String'];
+  /** SIRET de l'établissement */
+  siret: Scalars['String'];
+  /** Nom de l'établissement */
+  name: Scalars['String'];
+  /** Statut de la demande d'invitation */
+  status: MembershipRequestStatus;
+  /**
+   * Liste des adresses email correspondant aux comptes administrateurs à qui la demande
+   * d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+   * façon suivante j********w@trackdechets.fr
+   */
+  sentTo: Array<Scalars['String']>;
+};
+
+/**
+ * Différents statuts possibles pour une demande de rattachement
+ * à un établissement
+ */
+export enum MembershipRequestStatus {
+  Pending = 'PENDING',
+  Accepted = 'ACCEPTED',
+  Refused = 'REFUSED'
+}
+
 export type Mutation = {
   __typename?: 'Mutation';
+  /**
+   * USAGE INTERNE
+   * Accepte une demande de rattachement à un établissement
+   * en spécifiant le rôle accordé au nouvel utilisateur
+   */
+  acceptMembershipRequest: CompanyPrivate;
   /**
    * USAGE INTERNE
    * Modifie le mot de passe d'un utilisateur
@@ -966,6 +1005,11 @@ export type Mutation = {
   prepareSegment: Maybe<TransportSegment>;
   /**
    * USAGE INTERNE
+   * Refuse une demande de rattachement à un un établissement
+   */
+  refuseMembershipRequest: CompanyPrivate;
+  /**
+   * USAGE INTERNE
    * Supprime les droits d'un utilisateurs sur un établissement
    */
   removeUserFromCompany: CompanyPrivate;
@@ -989,6 +1033,13 @@ export type Mutation = {
    * @deprecated Utiliser createForm / updateForm selon le besoin
    */
   saveForm: Maybe<Form>;
+  /**
+   * Envoie une demande de rattachement de l'utilisateur courant
+   * à rejoindre l'établissement dont le siret est précisé en paramètre.
+   * Cette demande est communiquée à l'ensemble des administrateurs de
+   * l'établissement qui ont le choix de l'accepter ou de la refuser.
+   */
+  sendMembershipRequest: Maybe<MembershipRequest>;
   /**
    * Permet de transférer le déchet à un transporteur lors de la collecte initiale (signatures en case 8 et 9)
    * ou après une étape d'entreposage provisoire ou de reconditionnement (signatures en case 18 et 19).
@@ -1027,6 +1078,12 @@ export type Mutation = {
    * Édite les informations d'un récépissé transporteur
    */
   updateTransporterReceipt: Maybe<TransporterReceipt>;
+};
+
+
+export type MutationAcceptMembershipRequestArgs = {
+  id: Scalars['ID'];
+  role: UserRole;
 };
 
 
@@ -1180,6 +1237,11 @@ export type MutationPrepareSegmentArgs = {
 };
 
 
+export type MutationRefuseMembershipRequestArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type MutationRemoveUserFromCompanyArgs = {
   userId: Scalars['ID'];
   siret: Scalars['String'];
@@ -1204,6 +1266,11 @@ export type MutationResetPasswordArgs = {
 
 export type MutationSaveFormArgs = {
   formInput: FormInput;
+};
+
+
+export type MutationSendMembershipRequestArgs = {
+  siret: Scalars['String'];
 };
 
 
@@ -1420,6 +1487,15 @@ export type Query = {
   /** Renvoie les informations sur l'utilisateur authentifié */
   me: User;
   /**
+   * Récupère une demande de rattachement effectuée par l'utilisateur courant
+   * à partir de l'identifiant de cette demande ou du SIRET de l'établissement
+   * auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
+   * paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
+   * permet notamment de suivre l'état d'avancement de la demande d'invitation
+   * (en attente, accepté, refusé)
+   */
+  membershipRequest: Maybe<MembershipRequest>;
+  /**
    * Effectue une recherche floue sur la base SIRENE et enrichit
    * les résultats avec des informations provenant de Trackdéchets
    */
@@ -1495,6 +1571,12 @@ export type QueryFormsRegisterArgs = {
 
 export type QueryInvitationArgs = {
   hash: Scalars['String'];
+};
+
+
+export type QueryMembershipRequestArgs = {
+  id: Maybe<Scalars['ID']>;
+  siret: Maybe<Scalars['String']>;
 };
 
 
@@ -2530,6 +2612,19 @@ export function createInvitationMock(props: Partial<Invitation>): Invitation {
     hash: "",
     role: UserRole.Member,
     acceptedAt: null,
+    ...props,
+  };
+}
+
+export function createMembershipRequestMock(props: Partial<MembershipRequest>): MembershipRequest {
+  return {
+    __typename: "MembershipRequest",
+    id: "",
+    email: "",
+    siret: "",
+    name: "",
+    status: MembershipRequestStatus.Pending,
+    sentTo: [],
     ...props,
   };
 }

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -819,11 +819,11 @@ export type MembershipRequest = {
   siret: Scalars['String'];
   /** Nom de l'établissement */
   name: Scalars['String'];
-  /** Statut de la demande d'invitation */
+  /** Statut de la demande de rattachement */
   status: MembershipRequestStatus;
   /**
    * Liste des adresses email correspondant aux comptes administrateurs à qui la demande
-   * d'invitation a été envoyée. Les adresses emails sont partiellement masquées de la
+   * de rattachement a été envoyée. Les adresses emails sont partiellement masquées de la
    * façon suivante j********w@trackdechets.fr
    */
   sentTo: Array<Scalars['String']>;
@@ -1491,7 +1491,7 @@ export type Query = {
    * à partir de l'identifiant de cette demande ou du SIRET de l'établissement
    * auquel l'utilisateur a demandé à être rattaché. L'un ou l'autre des
    * paramètres (id ou siret) doit être être passé mais pas les deux. Cette query
-   * permet notamment de suivre l'état d'avancement de la demande d'invitation
+   * permet notamment de suivre l'état d'avancement de la demande de rattachement
    * (en attente, accepté, refusé)
    */
   membershipRequest: Maybe<MembershipRequest>;

--- a/front/src/layout/LayoutContainer.tsx
+++ b/front/src/layout/LayoutContainer.tsx
@@ -16,6 +16,9 @@ import gql from "graphql-tag";
 
 const Dashboard = lazy(() => import("dashboard/Dashboard"));
 const Account = lazy(() => import("account/Account"));
+const AccountMembershipRequest = lazy(() =>
+  import("account/AccountMembershipRequest")
+);
 const FormContainer = lazy(() => import("form/FormContainer"));
 const SignupInfo = lazy(() => import("login/SignupInfos"));
 const WasteSelector = lazy(() => import("login/WasteSelector"));
@@ -158,7 +161,12 @@ export default withRouter(function LayoutContainer({ history }) {
               >
                 <Account />
               </PrivateRoute>
-
+              <PrivateRoute
+                path={routes.membershipRequest}
+                isAuthenticated={isAuthenticated}
+              >
+                <AccountMembershipRequest />
+              </PrivateRoute>
               <Redirect
                 to={
                   data


### PR DESCRIPTION
Possibilité pour un utilisateur de faire une demande de rattachement à un établissement 
* Par API via `sendMembershipRequest`. Il est ensuite possible de suivre le statut d'une demande grâce à la query `membershipRequest`.
* Via l'interface Trackdéchets si l'on tente de créer un établissement qui possède déjà un administrateur. 

La demande est envoyée à l'ensemble des administrateurs de l'établissement par email. Elle peut être acceptée ou refusée. 

![Capture d’écran 2020-10-13 à 11 18 32](https://user-images.githubusercontent.com/2269165/96270576-1f6e4f00-0fcc-11eb-9d3e-66e0cc665e5b.png)

![Capture d’écran 2020-10-13 à 11 18 41](https://user-images.githubusercontent.com/2269165/96270593-25fcc680-0fcc-11eb-973c-f48c9a34184a.png)

![Capture d’écran 2020-10-16 à 11 35 12](https://user-images.githubusercontent.com/2269165/96270601-2ac17a80-0fcc-11eb-983c-e52d0fd4e889.png)


- [ x ] Mettre à jour la documentation
- [ x ] Mettre à jour le change log
- [ x ] Documenter les breaking changes dans le change log

https://trello.com/c/tZkiLnTs