### PR TITLE
Suppression de metabase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
                 if [ "${CIRCLE_BRANCH}" == "dev" ]; then
                   docker-compose up -d postgres td-doc-redirect
                 fi
-                docker-compose up -d prisma redis td-api td-ui td-pdf td-mail td-doc metabase
+                docker-compose up -d prisma redis td-api td-ui td-pdf td-mail td-doc
                 docker exec \$(docker ps -qf 'name=td-api') npx prisma deploy"
 
   integration-tests:

--- a/.env.model
+++ b/.env.model
@@ -18,7 +18,6 @@ DEVELOPERS_URL_SCHEME=https
 
 # Other domain configurations
 ETL_HOST=etl.trackdechets.beta.gouv.fr
-METABASE_HOST=metabase.trackdechets.beta.gouv.fr
 
 # Email used for Let's encrypt SSL certificate
 EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,6 @@ Afin de pouvoir accéder aux différents services via des URLs du type `http://t
    127.0.0.1 api.trackdechets.local
    127.0.0.1 trackdechets.local
    127.0.0.1 etl.trackdechets.local
-   127.0.0.1 metabase.trackdechets.local
    127.0.0.1 doc.trackdechets.local
    127.0.0.1 developers.trackdechets.local
    ```
@@ -88,7 +87,7 @@ Pour plus de détails, se référer au post ["Set a local web development enviro
 
    Le démarrage du service `td-mail` est déconseillé en développement pour éviter des envois de courriels intempestifs mais vous pouvez l'activer pour le bon fonctionnement de certaines fonctionnalités (ex: validation de l'inscription, invitation à rejoindre un établissement, etc)
 
-   Vous pouvez également démarrer les services `td-doc`, `td-etl` et `metabase` au cas par cas mais ceux-ci ne sont pas essentiels au fonctionnement de l'API ou de l'interface utilisateur.
+   Vous pouvez également démarrer les services `td-doc`, `td-etl` au cas par cas mais ceux-ci ne sont pas essentiels au fonctionnement de l'API ou de l'interface utilisateur.
 
 4. Synchroniser la base de données avec le schéma prisma.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Unreleased
+
+- Suppression du service metabase suite au basculement vers une instance metabase dédiée [PR 453](https://github.com/MTES-MCT/trackdechets/pull/453)
+
 # [2020.10.1] 05/10/2020
 
 - Ajout d'une limitation de 1000 requêtes possible par une même adresse IP dans une fenêtre de 1 minute, [PR 407](https://github.com/MTES-MCT/trackdechets/pull/407)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -142,20 +142,8 @@ services:
       LETSENCRYPT_HOST: $DEVELOPERS_HOST
       LETSENCRYPT_EMAIL: $EMAIL_LETS_ENCRYPT
 
-  metabase:
-    image: metabase/metabase:v0.34.2
-    volumes:
-      - metabase:/metabase-data
-    environment:
-      - MB_DB_FILE=/metabase-data/metabase.db
-      - VIRTUAL_HOST=$METABASE_HOST
-      - VIRTUAL_PORT=3000
-      - LETSENCRYPT_HOST=$METABASE_HOST
-      - LETSENCRYPT_EMAIL=$EMAIL_LETS_ENCRYPT
-
 volumes:
   postgres:
-  metabase:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,20 +124,8 @@ services:
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgres://$AIRFLOW_POSTGRES_USER:$AIRFLOW_POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/airflow
       AIRFLOW_CONN_POSTGRES_ETL: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$ETL_DB
       AIRFLOW_CONN_POSTGRES_PRISMA: postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/prisma
-  metabase:
-    image: metabase/metabase:v0.34.2
-    volumes:
-      - metabase:/metabase-data
-    environment:
-      - MB_DB_FILE=/metabase-data/metabase.db
-      - VIRTUAL_HOST=$METABASE_HOST
-      - VIRTUAL_PORT=3000
-      - LETSENCRYPT_HOST=$METABASE_HOST
-      - LETSENCRYPT_EMAIL=$EMAIL_LETS_ENCRYPT
-
 volumes:
   postgres:
-  metabase:
 
 networks:
   default:


### PR DESCRIPTION
Suppression des services metabase suite au basculement sur une instance externe. 

Documentation de l'administration du nouveau serveur: https://github.com/MTES-MCT/trackdechets-metabase.

Mise à jour des URL's de la page stats du site web:
https://github.com/MTES-MCT/trackdechets-website/pull/9

- [ x ] Mettre à jour la documentation
- [ x ] Mettre à jour le change log
- [ x ] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/2v5NlqOe/911-mettre-en-place-une-instance-metabase-externe-qui-se-connecte-%C3%A0-sandbox-prod)
