### PR TITLE
Fix/tr 975 - Le négociant n'a pas accès au cycle de vie du bordereau

### DIFF
--- a/back/src/forms/resolvers/queries/__tests__/formsLifeCycle.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formsLifeCycle.integration.ts
@@ -355,8 +355,7 @@ describe("Test formsLifeCycle query", () => {
       emitter,
       emitterCompany,
       recipient,
-      recipientCompany,
-      form
+      recipientCompany
     } = await prepareDB();
 
     await prepareRedis({

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -1,6 +1,5 @@
 import {
   QueryResolvers,
-  FormRole,
   QueryFormsArgs,
   Form
 } from "../../../generated/graphql/types";
@@ -10,6 +9,7 @@ import { expandFormFromDb } from "../../form-converter";
 import { UserInputError } from "apollo-server-express";
 import { NotCompanyMember, MissingSiret } from "../../../common/errors";
 import { getUserCompanies } from "../../../users/database";
+import { getFormsRightFilter } from "../../database";
 
 function validateArgs(args: QueryFormsArgs) {
   if (args.first < 0 || args.first > 500) {
@@ -80,7 +80,7 @@ export async function getForms(
     where: {
       ...(status?.length && { status_in: status }),
       AND: [
-        getRolesFilter(company.siret, roles ?? []),
+        getFormsRightFilter(company.siret, roles),
         getHasNextStepFilter(company.siret, hasNextStep)
       ],
       isDeleted: false
@@ -88,42 +88,6 @@ export async function getForms(
   });
 
   return queriedForms.map(f => expandFormFromDb(f));
-}
-
-export function getRolesFilter(siret: string, roles: FormRole[]) {
-  const filtersByRole = {
-    ["RECIPIENT"]: [
-      { recipientCompanySiret: siret },
-      {
-        temporaryStorageDetail: {
-          destinationCompanySiret: siret
-        }
-      }
-    ],
-    ["EMITTER"]: [{ emitterCompanySiret: siret }],
-    ["TRANSPORTER"]: [
-      { transporterCompanySiret: siret },
-      {
-        transportSegments_some: {
-          transporterCompanySiret: siret
-        }
-      },
-      {
-        temporaryStorageDetail: {
-          transporterCompanySiret: siret
-        }
-      }
-    ],
-    ["TRADER"]: [{ traderCompanySiret: siret }],
-    ["ECO_ORGANISME"]: [{ ecoOrganisme: { siret: siret } }]
-  };
-
-  return {
-    OR: (Object.keys(filtersByRole) as Array<keyof typeof filtersByRole>)
-      .filter(role => (roles.length > 0 ? roles.includes(role) : true))
-      .map(role => filtersByRole[role])
-      .flat()
-  };
 }
 
 function getHasNextStepFilter(siret: string, hasNextStep?: boolean | null) {

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -90,7 +90,7 @@ export async function getForms(
   return queriedForms.map(f => expandFormFromDb(f));
 }
 
-function getRolesFilter(siret: string, roles: FormRole[]) {
+export function getRolesFilter(siret: string, roles: FormRole[]) {
   const filtersByRole = {
     ["RECIPIENT"]: [
       { recipientCompanySiret: siret },

--- a/back/src/forms/resolvers/queries/formsLifeCycle.ts
+++ b/back/src/forms/resolvers/queries/formsLifeCycle.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../generated/prisma-client";
 import { ForbiddenError, UserInputError } from "apollo-server-express";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { getRolesFilter } from "./forms";
+import { getFormsRightFilter } from "../../database";
 
 const PAGINATE_BY = 100;
 
@@ -86,7 +86,7 @@ const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
   const selectedCompany =
     userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
 
-  const formsFilter = getRolesFilter(selectedCompany.siret, []);
+  const formsFilter = getFormsRightFilter(selectedCompany.siret);
 
   const statusLogsCx = await prisma
     .statusLogsConnection({

--- a/back/src/forms/resolvers/queries/formsLifeCycle.ts
+++ b/back/src/forms/resolvers/queries/formsLifeCycle.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../generated/prisma-client";
 import { ForbiddenError, UserInputError } from "apollo-server-express";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { getRolesFilter } from "./forms";
 
 const PAGINATE_BY = 100;
 
@@ -49,80 +50,6 @@ const statusLogFragment = `
       }
     `;
 
-export const formsLifecycle = async (
-  _,
-  { siret, loggedAfter, loggedBefore, cursorAfter, cursorBefore, formId },
-  context: GraphQLContext
-) => {
-  const userId = context.user.id;
-
-  const userCompanies = await prisma
-    .companyAssociations({ where: { user: { id: userId } } })
-    .$fragment<{ company: Company }[]>(companyFragment)
-    .then(associations => associations.map(a => a.company));
-
-  // User must be associated with a company
-  if (!userCompanies.length) {
-    throw new ForbiddenError(
-      "Vous n'êtes pas autorisé à consulter le cycle de vie des bordereaux."
-    );
-  }
-  // If user is associated with several companies, siret is mandatory
-  if (userCompanies.length > 1 && !siret) {
-    throw new UserInputError(
-      "Vous devez préciser pour quel siret vous souhaitez consulter",
-      {
-        invalidArgs: ["siret"]
-      }
-    );
-  }
-  // If requested siret does not belong to user, raise an error
-  if (!!siret && !userCompanies.map(c => c.siret).includes(siret)) {
-    throw new ForbiddenError(
-      "Vous n'avez pas le droit d'accéder au siret précisé"
-    );
-  }
-  // Select user company matching siret or get the first
-  const selectedCompany =
-    userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
-
-  const formsFilter = {
-    OR: [
-      { owner: { id: userId } },
-      { recipientCompanySiret: selectedCompany.siret },
-      { emitterCompanySiret: selectedCompany.siret },
-      {
-        transporterCompanySiret: selectedCompany.siret,
-        status: "SEALED"
-      }
-    ]
-  };
-  const statusLogsCx = await prisma
-    .statusLogsConnection({
-      orderBy: "loggedAt_DESC",
-      first: PAGINATE_BY,
-      after: cursorAfter,
-      before: cursorBefore,
-      where: {
-        loggedAt_not: null,
-        loggedAt_gte: loggedAfter,
-        loggedAt_lte: loggedBefore,
-        form: { ...formsFilter, isDeleted: false, id: formId }
-      }
-    })
-    .$fragment<
-      StatusLogConnection & {
-        aggregate: { count: number };
-      }
-    >(statusLogFragment);
-
-  return {
-    statusLogs: statusLogsCx.edges.map(el => el.node),
-    ...statusLogsCx.pageInfo,
-    count: statusLogsCx.aggregate.count
-  };
-};
-
 const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
   parent,
   { siret, loggedAfter, loggedBefore, cursorAfter, cursorBefore, formId },
@@ -160,17 +87,8 @@ const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
   const selectedCompany =
     userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
 
-  const formsFilter = {
-    OR: [
-      { owner: { id: user.id } },
-      { recipientCompanySiret: selectedCompany.siret },
-      { emitterCompanySiret: selectedCompany.siret },
-      {
-        transporterCompanySiret: selectedCompany.siret,
-        status: "SEALED"
-      }
-    ]
-  };
+  const formsFilter = getRolesFilter(selectedCompany.siret, []);
+
   const statusLogsCx = await prisma
     .statusLogsConnection({
       orderBy: "loggedAt_DESC",

--- a/back/src/forms/resolvers/queries/formsLifeCycle.ts
+++ b/back/src/forms/resolvers/queries/formsLifeCycle.ts
@@ -1,5 +1,4 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
-import { GraphQLContext } from "../../../types";
 import {
   prisma,
   StatusLogConnection,


### PR DESCRIPTION
Correction de droits sur les `FormLifecycle`. On applique désormais les mêmes droits que pour l'API `form`, ce qui devrait permettre aux utilisateurs de voir tous les BSDs qui les concernent.

---

- [Ticket Trello](https://trello.com/c/NQGiTrfN/975-le-n%C3%A9gociant-na-pas-acc%C3%A8s-au-cycle-de-vie-du-bordereau)
