### PR TITLE
Correction des changements à venir du change log

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,17 +4,6 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
-# [2020.10.2] [upcoming]
-
-- Refonte de l'interface utilisateur
-
-# Unreleased
-
-- Ajout du champ `customInfo` à `TransporterInput`, ce qui permet de renseigner cette information via les mutations `createForm`, `updateForm`, `markAsResent`, `markAsResealed`, [PR 417](https://github.com/MTES-MCT/trackdechets/pull/417)
-
-# Unreleased
-
-- Suppression du service metabase suite au basculement vers une instance metabase dédiée [PR 453](https://github.com/MTES-MCT/trackdechets/pull/453)
 
 # Unreleased
 
@@ -35,6 +24,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 **Changes**
 
+- Refonte de l'interface utilisateur
+- Ajout du champ `customInfo` à `TransporterInput`, ce qui permet de renseigner cette information via les mutations `createForm`, `updateForm`, `markAsResent`, `markAsResealed`, [PR 417](https://github.com/MTES-MCT/trackdechets/pull/417)
+- Suppression du service metabase suite au basculement vers une instance metabase dédiée [PR 453](https://github.com/MTES-MCT/trackdechets/pull/453)
 - Ajout du profil d'entreprise "éco-organisme". Ce type d'entreprise peut renseigner ses agréments et signer un BSD à la place du détenteur lorsqu'il est responsable des déchets. [PR 400](https://github.com/MTES-MCT/trackdechets/pull/400)
 
 # [2020.10.1] 05/10/2020


### PR DESCRIPTION
On a eu quelques soucis de merge dans le change log, le bloc "unreleased" a été dupliqué plusieurs fois.