### PR TITLE
Correction de la valeur par défaut de "signedAt" dans markAsTempStored

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Affichage des bordereaux au statut `GROUPED` dans l'onglet "Suivi" du dashboard et corrections de la mutation `markAsSent` sur un BSD de regroupement [PR 672](https://github.com/MTES-MCT/trackdechets/pull/672)
 - Correction d'un bug permettant de sceller des bordereaux avec des informations sur le détail du déchet (cadre 3,4,5,6) erronnées ce qui causait des erreurs de validation ultérieures [PR 681](https://github.com/MTES-MCT/trackdechets/pull/681)
 - Correction d'un bug empêchant la complétion du BSD suite depuis l'interface [PR 662](https://github.com/MTES-MCT/trackdechets/pull/662)
+- Correction d'un bug lors de l'appel à la mutation `markAsTempStored` sans passer le paramètre optionnel `signedAt` [PR 602](https://github.com/MTES-MCT/trackdechets/pull/602)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
@@ -110,6 +110,44 @@ describe("{ mutation { markAsTempStored } }", () => {
     expect(statusLogs.length).toEqual(1);
   });
 
+  test("should fill the signature date when not provided", async () => {
+    const { user, company: tempStorerCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const emitterCompany = await companyFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SENT",
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: tempStorerCompany.siret,
+        recipientIsTempStorage: true,
+        temporaryStorageDetail: { create: {} }
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    await mutate(MARK_AS_TEMP_STORED, {
+      variables: {
+        id: form.id,
+        tempStoredInfos: {
+          wasteAcceptationStatus: "ACCEPTED",
+          receivedBy: "John Doe",
+          receivedAt: "2018-12-11T00:00:00.000Z",
+          quantityReceived: 2.4,
+          quantityType: "REAL"
+        }
+      }
+    });
+
+    const updatedTemporaryStorageDetail = await prisma
+      .form({ id: form.id })
+      .temporaryStorageDetail();
+    expect(
+      new Date(updatedTemporaryStorageDetail.tempStorerSignedAt).toDateString()
+    ).toBe(new Date().toDateString());
+  });
+
   test("the temp storer of the BSD can mark it as REFUSED", async () => {
     const { user, company: tempStorerCompany } = await userWithCompanyFactory(
       "MEMBER"

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -5,10 +5,7 @@ import { getFormOrFormNotFound } from "../../database";
 import { checkCanMarkAsTempStored } from "../../permissions";
 import { tempStoredInfoSchema, TempStorageInfo } from "../../validation";
 import { EventType } from "../../workflow/types";
-import {
-  expandFormFromDb,
-  expandTemporaryStorageFromDb
-} from "../../form-converter";
+import { expandFormFromDb } from "../../form-converter";
 import { DestinationCannotTempStore } from "../../errors";
 
 const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
@@ -49,12 +46,7 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
     formUpdateInput
   });
 
-  return {
-    ...expandFormFromDb(tempStoredForm),
-    temporaryStorageDetail: expandTemporaryStorageFromDb(
-      tempStoredForm.temporaryStorageDetail
-    )
-  };
+  return expandFormFromDb(tempStoredForm);
 };
 
 export default markAsTempStoredResolver;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -115,7 +115,7 @@ type ProcessedInfo = Pick<
   | "nextDestinationCompanyMail"
 >;
 
-type TempStorageInfo = Pick<
+export type TempStorageInfo = Pick<
   TemporaryStorageDetail,
   | "tempStorerQuantityType"
   | "tempStorerQuantityReceived"

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -1,6 +1,7 @@
 import {
   Form,
   FormUpdateInput,
+  TemporaryStorageDetail,
   Status,
   prisma,
   User
@@ -20,7 +21,7 @@ export default async function transitionForm(
   user: User,
   form: Form,
   event: Event
-) {
+): Promise<Form & { temporaryStorageDetail: TemporaryStorageDetail }> {
   const currentStatus = form.status;
 
   // Use state machine to calculate new status
@@ -70,5 +71,8 @@ export default async function transitionForm(
     updatedFields
   });
 
-  return updatedForm;
+  return {
+    ...updatedForm,
+    temporaryStorageDetail: updatedTemporaryStorageDetail
+  };
 }

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -1,7 +1,6 @@
 import {
   Form,
   FormUpdateInput,
-  TemporaryStorageDetail,
   Status,
   prisma,
   User
@@ -21,7 +20,7 @@ export default async function transitionForm(
   user: User,
   form: Form,
   event: Event
-): Promise<Form & { temporaryStorageDetail: TemporaryStorageDetail }> {
+) {
   const currentStatus = form.status;
 
   // Use state machine to calculate new status
@@ -71,8 +70,5 @@ export default async function transitionForm(
     updatedFields
   });
 
-  return {
-    ...updatedForm,
-    temporaryStorageDetail: updatedTemporaryStorageDetail
-  };
+  return updatedForm;
 }


### PR DESCRIPTION
Cette PR corrige le bug provoqué par une valeur par défaut invalide pour le champ `tempStorerSignedAt` dans la mutation `markAsTempStored`.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/dnUwAjg9/1051-la-mutation-markastempstored-%C3%A9choue-lorsque-signedat-nest-pas-fournit)
