### PR TITLE
Fix API package lock

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -4510,8 +4510,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -8762,6 +8761,14 @@
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
+      }
+    },
+    "graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "requires": {
+        "arrify": "^1.0.1"
       }
     },
     "graphql-extensions": {


### PR DESCRIPTION
Le package-lock n'était pas à jour, faisant [planter la MEP](https://app.circleci.com/pipelines/github/MTES-MCT/trackdechets/2564/workflows/d2b61078-206d-41a6-80cf-eb65e6a026f8/jobs/5419) (recette)