### PR TITLE
Correction de la complétion du BSD suite depuis l'interface

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Champs requis dans le formulaire d'inscription suite à un lien d'invitation [PR 670](https://github.com/MTES-MCT/trackdechets/pull/670)
 - Affichage des bordereaux au statut `GROUPED` dans l'onglet "Suivi" du dashboard et corrections de la mutation `markAsSent` sur un BSD de regroupement [PR 672](https://github.com/MTES-MCT/trackdechets/pull/672)
 - Correction d'un bug permettant de sceller des bordereaux avec des informations sur le détail du déchet (cadre 3,4,5,6) erronnées ce qui causait des erreurs de validation ultérieures [PR 681](https://github.com/MTES-MCT/trackdechets/pull/681)
+- Correction d'un bug empêchant la complétion du BSD suite depuis l'interface [PR 662](https://github.com/MTES-MCT/trackdechets/pull/662)
 
 # [2020.10.1] 05/10/2020
 

--- a/front/package.json
+++ b/front/package.json
@@ -18,7 +18,6 @@
     "cleave.js": "^1.6.0",
     "cogo-toast": "^4.1.3",
     "constant-case": "^3.0.3",
-    "deepmerge": "^2.2.1",
     "env-cmd": "^10.0.1",
     "formik": "2.1.5",
     "graphql": "^14.0.2",

--- a/front/src/common/__tests__/helper.test.ts
+++ b/front/src/common/__tests__/helper.test.ts
@@ -1,0 +1,67 @@
+import { mergeDefaults } from "../helper";
+
+describe("mergeDefaults", () => {
+  it("should keep the defaults", () => {
+    expect(mergeDefaults({ foo: "" }, {})).toEqual({
+      foo: "",
+    });
+  });
+
+  it("should favor the provided options", () => {
+    expect(mergeDefaults({ foo: "" }, { foo: "FOO" })).toEqual({
+      foo: "FOO",
+    });
+  });
+
+  it("should not mutate defaults object", () => {
+    const defaults = { foo: "" };
+    mergeDefaults(defaults, { foo: "FOO" });
+
+    expect(defaults).toEqual({
+      foo: "",
+    });
+  });
+
+  it("should keep the nested defaults", () => {
+    expect(mergeDefaults({ foo: { bar: "" } }, {})).toEqual({
+      foo: {
+        bar: "",
+      },
+    });
+  });
+
+  it("should favor the nested provided options", () => {
+    expect(
+      mergeDefaults({ foo: { bar: "" } }, { foo: { bar: "BAR" } })
+    ).toEqual({
+      foo: {
+        bar: "BAR",
+      },
+    });
+  });
+
+  it("should not mutate defaults object nested", () => {
+    const defaults = { foo: { bar: "" } };
+    mergeDefaults(defaults, { foo: { bar: "BAR" } });
+
+    expect(defaults).toEqual({
+      foo: {
+        bar: "",
+      },
+    });
+  });
+
+  it("should not extend the defaults", () => {
+    expect(mergeDefaults({ foo: "" }, { bar: "" })).toEqual({
+      foo: "",
+    });
+  });
+
+  it("should not extend the nested defaults", () => {
+    expect(mergeDefaults({ foo: { bar: "" } }, { foo: { baz: "" } })).toEqual({
+      foo: {
+        bar: "",
+      },
+    });
+  });
+});

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -43,6 +43,18 @@ function isObject(value: any): boolean {
   return Object.prototype.toString.call(value) === "[object Object]";
 }
 
+/**
+ * Merge options into defaults without extending that object.
+ *
+ * @example
+ * mergeDefaults({ foo: "" }, { foo: "foo", bar: "bar" })
+ * // returns { foo: "foo" }
+ *
+ * @param {Object} defaults The shape of the final object, with all default values.
+ * @param {Object} options Values that should overwrite defaults'.
+ *
+ * @returns {Object} Object with the exact shape as defaults, with values from options where provided.
+ */
 export function mergeDefaults<T>(defaults: T, options: Record<string, any>): T {
   return Object.keys(defaults).reduce((acc, key) => {
     if (options[key] == null) {

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -39,14 +39,23 @@ export function getErrorMessages(err: ApolloError) {
   return err.graphQLErrors.map(error => error.message);
 }
 
-export function removeNulls(obj) {
-  const isArray = obj instanceof Array;
-  for (const k in obj) {
-    if (obj[k] === null) isArray ? obj.splice(k, 1) : delete obj[k];
-    else if (typeof obj[k] == "object") removeNulls(obj[k]);
-  }
-
-  return obj;
+function isObject(value: any): boolean {
+  return Object.prototype.toString.call(value) === "[object Object]";
 }
 
- 
+export function mergeDefaults<T>(defaults: T, options: Record<string, any>): T {
+  return Object.keys(defaults).reduce((acc, key) => {
+    if (options[key] == null) {
+      return {
+        ...acc,
+      };
+    }
+
+    return {
+      ...acc,
+      [key]: isObject(acc[key])
+        ? mergeDefaults(acc[key], options[key])
+        : options[key],
+    };
+  }, defaults);
+}

--- a/front/src/dashboard/slips/slips-actions/Resealed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Resealed.tsx
@@ -1,7 +1,6 @@
-import merge from "deepmerge";
 import { Field, Form, Formik } from "formik";
 import React, { useState } from "react";
-import { removeNulls } from "common/helper";
+import { mergeDefaults } from "common/helper";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import CompanySelector from "form/company/CompanySelector";
 import DateInput from "form/custom-inputs/DateInput";
@@ -17,11 +16,9 @@ export default function Resealed({
   onSubmit,
   onCancel,
 }: SlipActionProps) {
-  // We need a deep merge as sub-objects may be partially filled
-  // But without the null values as they break form elements (uncontrolled)
-  const initialValues = merge(
+  const initialValues = mergeDefaults(
     emptyState,
-    removeNulls(form.temporaryStorageDetail)
+    form.temporaryStorageDetail || {}
   );
   const [isRefurbished, setIsRefurbished] = useState(
     !!form.temporaryStorageDetail?.wasteDetails?.quantity
@@ -282,7 +279,7 @@ export default function Resealed({
               >
                 Annuler
               </button>
-              <button type="submit" className="btn btn--outline">
+              <button type="submit" className="btn btn--primary">
                 Je valide
               </button>
             </div>

--- a/front/src/dashboard/slips/slips-actions/Resent.tsx
+++ b/front/src/dashboard/slips/slips-actions/Resent.tsx
@@ -1,7 +1,6 @@
-import merge from "deepmerge";
 import { Field, Form, Formik } from "formik";
 import React, { useState } from "react";
-import { removeNulls } from "common/helper";
+import { mergeDefaults } from "common/helper";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import CompanySelector from "form/company/CompanySelector";
 import DateInput from "form/custom-inputs/DateInput";
@@ -13,11 +12,9 @@ import { PROCESSING_OPERATIONS } from "generated/constants";
 import { WasteDetails } from "generated/graphql/types";
 
 export default function Resent({ form, onSubmit, onCancel }: SlipActionProps) {
-  // We need a deep merge as sub-objects may be partially filled
-  // But without the null values as they break form elements (uncontrolled)
-  const initialValues = merge(
+  const initialValues = mergeDefaults(
     emptyState,
-    removeNulls(form.temporaryStorageDetail)
+    form.temporaryStorageDetail || {}
   );
 
   const [isRefurbished, setIsRefurbished] = useState(


### PR DESCRIPTION
Cette PR corrige un soucis de l'application front où il est impossible de compléter le BSD suite.

Le soucis venait du fait qu'on fusionnait le BSD avec les valeurs par défaut du formulaire. Sauf que certains champs du BSD ne sont pas valide dans le cas de ces formulaires. Du coup j'ai fait en sorte de fusionner sans étendre les valeurs.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/gF1IzGF8/1058-impossible-de-compl%C3%A9ter-le-bsd-suite-depuis-linterface)
