### PR TITLE
Champ requis lors de l'inscription par lien d'invitation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug empêchant l'affichage du dashboard lorsqu'un BSD n'avait pas d'émetteur [PR 644](https://github.com/MTES-MCT/trackdechets/pull/644)
 - Correction d'un bug affichant une invitation en attente même quand celle-ci a déjà été acceptée [PR 671](https://github.com/MTES-MCT/trackdechets/pull/671)
 - Correction du lien présent dans l'email d'invitation suite à l'action "Renvoyer l'invitation" [PR 648](https://github.com/MTES-MCT/trackdechets/pull/648)
+- Champs requis dans le formulaire d'inscription suite à un lien d'invitation [PR 670](https://github.com/MTES-MCT/trackdechets/pull/670)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
@@ -20,7 +20,11 @@ describe("joinWithInvite mutation", () => {
 
   it("should raise exception if invitation does not exist", async () => {
     const { errors } = await mutate(JOIN_WITH_INVITE, {
-      variables: { inviteHash: "invalid", name: "John Snow", password: "pass" }
+      variables: {
+        inviteHash: "invalid",
+        name: "John Snow",
+        password: "password"
+      }
     });
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toEqual("Cette invitation n'existe pas");
@@ -43,7 +47,7 @@ describe("joinWithInvite mutation", () => {
       variables: {
         inviteHash: invitation.hash,
         name: "John Snow",
-        password: "pass"
+        password: "password"
       }
     });
     expect(errors).toHaveLength(1);
@@ -65,7 +69,7 @@ describe("joinWithInvite mutation", () => {
       variables: {
         inviteHash: invitation.hash,
         name: "John Snow",
-        password: "pass"
+        password: "password"
       }
     });
 
@@ -108,7 +112,7 @@ describe("joinWithInvite mutation", () => {
       variables: {
         name: "John Snow",
         inviteHash: invitation1.hash,
-        password: "pass"
+        password: "password"
       }
     });
 
@@ -125,5 +129,39 @@ describe("joinWithInvite mutation", () => {
       company1.siret,
       company2.siret
     ]);
+  });
+
+  it("should return an error if name is empty or password less than 8 characters", async () => {
+    const { mutate } = createTestClient({ apolloServer: server });
+
+    const company = await companyFactory();
+    const invitee = "john.snow@trackdechets.fr";
+
+    const invitation = await prisma.createUserAccountHash({
+      email: invitee,
+      companySiret: company.siret,
+      role: "MEMBER",
+      hash: "hash"
+    });
+    const { errors: errs1 } = await mutate(JOIN_WITH_INVITE, {
+      variables: {
+        inviteHash: invitation.hash,
+        name: "John Snow",
+        password: "pass"
+      }
+    });
+    expect(errs1).toHaveLength(1);
+    expect(errs1[0].message).toEqual(
+      "Le mot de passe doit faire au moins 8 caractères"
+    );
+    const { errors: errs2 } = await mutate(JOIN_WITH_INVITE, {
+      variables: {
+        inviteHash: invitation.hash,
+        name: "",
+        password: "password"
+      }
+    });
+    expect(errs2).toHaveLength(1);
+    expect(errs2[0].message).toEqual("Le nom est un champ requis");
   });
 });

--- a/back/src/users/resolvers/mutations/joinWithInvite.ts
+++ b/back/src/users/resolvers/mutations/joinWithInvite.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../../../generated/prisma-client";
+import * as yup from "yup";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { hashPassword } from "../../utils";
 import {
@@ -8,10 +9,22 @@ import {
 } from "../../database";
 import { UserInputError } from "apollo-server-express";
 
+const validationSchema = yup.object({
+  name: yup.string().required("Le nom est un champ requis"),
+  password: yup
+    .string()
+    .required("Le mot de passe est un champ requis")
+    .min(8, "Le mot de passe doit faire au moins 8 caractères")
+});
+
 const joinWithInviteResolver: MutationResolvers["joinWithInvite"] = async (
   parent,
-  { inviteHash, name, password }
+  args
 ) => {
+  validationSchema.validateSync(args);
+
+  const { inviteHash, name, password } = args;
+
   const existingHash = await getUserAccountHashOrNotFound({ hash: inviteHash });
 
   if (existingHash.acceptedAt) {

--- a/front/src/login/Invite.module.scss
+++ b/front/src/login/Invite.module.scss
@@ -1,0 +1,9 @@
+.showPassword {
+  color: #006be6;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  > span {
+    margin-left: 0.25rem;
+  }
+}

--- a/front/src/login/Invite.tsx
+++ b/front/src/login/Invite.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Formik, Form, Field, ErrorMessage, yupToFormErrors } from "formik";
+import { Formik, Form, Field, ErrorMessage } from "formik";
 import gql from "graphql-tag";
 import * as yup from "yup";
 import { useLocation, Link } from "react-router-dom";
@@ -14,7 +14,7 @@ import {
 import Loader from "common/components/Loaders";
 import { NotificationError } from "common/components/Error";
 import routes from "common/routes";
-import { FaEye, FaLock } from "react-icons/fa";
+import { FaEnvelope, FaEye, FaIdCard, FaLock } from "react-icons/fa";
 import PasswordMeter from "common/components/PasswordMeter";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import styles from "./Invite.module.scss";
@@ -191,22 +191,33 @@ export default function Invite() {
                   votre inscription, veuillez compléter le formulaire
                   ci-dessous.
                 </p>
+
                 <div className="form__row">
                   <label>Email</label>
-                  <Field
-                    type="email"
-                    name="email"
-                    readOnly
-                    className="td-input"
-                  />
+                  <div className="field-with-icon-wrapper">
+                    <Field
+                      type="email"
+                      name="email"
+                      className="td-input"
+                      readOnly
+                    />
+                    <i>
+                      <FaEnvelope />
+                    </i>
+                  </div>
                   <RedErrorMessage name="email" />
                 </div>
+
                 <div className="form__row">
-                  <label>
-                    Nom et prénom
+                  <label>Nom et prénom</label>
+                  <div className="field-with-icon-wrapper">
                     <Field type="text" name="name" className="td-input" />
-                    <RedErrorMessage name="name" />
-                  </label>
+                    <i>
+                      <FaIdCard />
+                    </i>
+                  </div>
+
+                  <RedErrorMessage name="name" />
                 </div>
 
                 <div className="form__row">


### PR DESCRIPTION
Requiert les champs `name` et `password` dans le formulaire d'inscription suite à un lien d'invitation.
Homogénéisation des champs de formulaire entre `Signup.tsx` et `Invite.tsx`

- [ x ] Mettre à jour la documentation
- [ x ] Mettre à jour le change log
- [ x ] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/GptX2WoZ)

![Capture d’écran 2020-10-30 à 09 16 33](https://user-images.githubusercontent.com/2269165/97676228-a0c7e600-1a90-11eb-908a-56df94f16c19.png)
