### PR TITLE
Fix affichage "En attente" d'une invitation déjà acceptée

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout d'un mécanisme de demande de rattachement à un établissement [PR 418](https://github.com/MTES-MCT/trackdechets/pull/418)
 - Mise à jour des liens Géorisques cassés [PR 645](https://github.com/MTES-MCT/trackdechets/pull/645)
 - Correction d'un bug empêchant l'affichage du dashboard lorsqu'un BSD n'avait pas d'émetteur [PR 644](https://github.com/MTES-MCT/trackdechets/pull/644)
+- Correction d'un bug affichant une invitation en attente même quand celle-ci a déjà été acceptée [PR 671](https://github.com/MTES-MCT/trackdechets/pull/671)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/companies/__tests__/database.integration.ts
+++ b/back/src/companies/__tests__/database.integration.ts
@@ -1,0 +1,39 @@
+import { resetDatabase } from "../../../integration-tests/helper";
+import { prisma } from "../../generated/prisma-client";
+import { companyFactory } from "../../__tests__/factories";
+import { getCompanyInvitedUsers } from "../database";
+
+describe("getInvitedUsers", () => {
+  afterAll(resetDatabase);
+
+  it("should not return a user who has already joined", async () => {
+    const company = await companyFactory();
+    await prisma.createUserAccountHash({
+      email: "john.snow@trackdechets.fr",
+      companySiret: company.siret,
+      hash: "hash1",
+      role: "MEMBER",
+      acceptedAt: new Date().toISOString()
+    });
+    const invitedUsers = await getCompanyInvitedUsers(company.siret);
+    expect(invitedUsers).toEqual([]);
+  });
+
+  it("should return list of invited users", async () => {
+    const company = await companyFactory();
+    const invitation = await prisma.createUserAccountHash({
+      email: "john.snow@trackdechets.fr",
+      companySiret: company.siret,
+      hash: "hash2",
+      role: "MEMBER"
+    });
+    const invitedUsers = await getCompanyInvitedUsers(company.siret);
+    expect(invitedUsers).toHaveLength(1);
+    expect(invitedUsers[0]).toMatchObject({
+      email: invitation.email,
+      isPendingInvitation: true,
+      name: "Invité",
+      role: invitation.role
+    });
+  });
+});

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -171,7 +171,7 @@ export async function getCompanyInvitedUsers(
   siret: string
 ): Promise<CompanyMember[]> {
   const hashes = await prisma.userAccountHashes({
-    where: { companySiret: siret }
+    where: { companySiret: siret, acceptedAt: null }
   });
   return hashes.map(h => {
     return {


### PR DESCRIPTION
La fonction `getInvitedUsers` ne filtrait pas sur `acceptedAt: null`

- [ x ] Mettre à jour la documentation
- [ x ] Mettre à jour le change log
- [ x ] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/27KUGNZ9)
