### PR TITLE
Corrections liés aux annexes 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug affichant une invitation en attente même quand celle-ci a déjà été acceptée [PR 671](https://github.com/MTES-MCT/trackdechets/pull/671)
 - Correction du lien présent dans l'email d'invitation suite à l'action "Renvoyer l'invitation" [PR 648](https://github.com/MTES-MCT/trackdechets/pull/648)
 - Champs requis dans le formulaire d'inscription suite à un lien d'invitation [PR 670](https://github.com/MTES-MCT/trackdechets/pull/670)
+- Affichage des bordereaux au statut `GROUPED` dans l'onglet "Suivi" du dashboard et corrections de la mutation `markAsSent` sur un BSD de regroupement [PR 672](https://github.com/MTES-MCT/trackdechets/pull/672)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/forms/resolvers/mutations/markAsSent.ts
+++ b/back/src/forms/resolvers/mutations/markAsSent.ts
@@ -41,7 +41,10 @@ const markAsSentResolver: MutationResolvers["markAsSent"] = async (
   });
 
   // mark appendix2Forms as GROUPED
-  const appendix2Forms = await prisma.form({ id: form.id }).appendix2Forms();
+  const appendix2Forms = await prisma
+    .form({ id: form.id })
+    .appendix2Forms({ where: { status: "AWAITING_GROUP" } });
+
   if (appendix2Forms.length > 0) {
     const promises = appendix2Forms.map(appendix => {
       return transitionForm(user, appendix, {

--- a/front/src/dashboard/constants.tsx
+++ b/front/src/dashboard/constants.tsx
@@ -6,7 +6,7 @@ export const statusLabels: { [key: string]: string } = {
   RECEIVED: "Reçu, en attente de traitement",
   PROCESSED: "Traité",
   AWAITING_GROUP: "Traité, en attente de regroupement",
-  GROUPED: "Traité, annexé à un bordereau de regroupement",
+  GROUPED: "Annexé à un bordereau de regroupement",
   NO_TRACEABILITY: "Regroupé, avec autorisation de perte de traçabilité",
   REFUSED: "Refusé",
   TEMP_STORED: "Entreposé temporairement ou en reconditionnement",
@@ -22,7 +22,6 @@ export const transportModeLabels: { [key: string]: string } = {
   RAIL: "Voie ferrée",
   RIVER: "Voie fluviale",
 };
-
 
 export const statusesWithDynamicActions = [
   FormStatus.Sealed,

--- a/front/src/dashboard/slips/tabs/FollowTab.tsx
+++ b/front/src/dashboard/slips/tabs/FollowTab.tsx
@@ -26,6 +26,7 @@ export default function FollowTab() {
         FormStatus.Resealed,
         FormStatus.Resent,
         FormStatus.AwaitingGroup,
+        FormStatus.Grouped,
       ],
       hasNextStep: false,
     },


### PR DESCRIPTION
- Affichage des bordereaux au statut `GROUPED` dans l'onglet "Suivi"
- Correction d'un bug dans la mutation `markAsSent` dans le cas où les annexes 2 ont déjà été passés au statut `GROUPED` Cette mutation peut en effet être appelée sur un bordereau de regroupement au statut `DRAFT` ou au statut `SEALED`. Dans le cas où la mutation est appelée sur un bordereau de regroupement au statut `SEALED`, les annexes sont déjà au statut `GROUPED` et on tente de faire une transition `GROUPED` -> `GROUPED` sur les annexes ce qui est impossible. 

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log


---

- [Ticket Trello](https://trello.com/c/YJRRyeqQ)
