### PR TITLE
Pré-selection de l'entreprise utilisateur dans la création d'un BSD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Migration du service td-etl dans un projet Github à part [PR 683](https://github.com/MTES-MCT/trackdechets/pull/683)
 - Ajout d'un nouveau champ `packagingInfos` qui viendra remplacer `packagings`, `numberOfPackages` et `otherPackaging`. Ces champs sont encore supportés pour quelques temps mais marqué comme dépréciés. Nous vous invitons à migrer aussi vite que possible. [PR 600](https://github.com/MTES-MCT/trackdechets/pull/600)
 - Correction de la mutation `duplicateForm` pour dupliquer l'entreposage provisoire, [PR 700](https://github.com/
+- Amélioration des suggestions d'entreprise lors de la création d'un BSD depuis l'interface, [PR 673](https://github.com/MTES-MCT/trackdechets/pull/673)
 
 # [2020.10.1] 03/11/2020
 

--- a/back/integration-tests/.integration-tests-env
+++ b/back/integration-tests/.integration-tests-env
@@ -1,4 +1,6 @@
 NODE_ENV=test
+PRISMA_ENDPOINT=http://prisma:4467/default/staging
+PRISMA_SECRET=any_secret
 JWT_SECRET=any_secret
 SESSION_SECRET=any_secret
 API_HOST=api.trackdechets.local

--- a/back/integration-tests/.integration-tests-env
+++ b/back/integration-tests/.integration-tests-env
@@ -1,6 +1,4 @@
 NODE_ENV=test
-PRISMA_ENDPOINT=http://prisma:4467/default/staging
-PRISMA_SECRET=any_secret
 JWT_SECRET=any_secret
 SESSION_SECRET=any_secret
 API_HOST=api.trackdechets.local

--- a/back/integration-tests/docker-compose.yml
+++ b/back/integration-tests/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     env_file:
       - .integration-tests-env
     environment:
-      NODE_ENV: dev
       VIRTUAL_HOST: $API_HOST
       LETSENCRYPT_HOST: $API_HOST
       PRISMA_ENDPOINT: $PRISMA_ENDPOINT

--- a/back/integration-tests/docker-compose.yml
+++ b/back/integration-tests/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     env_file:
       - .integration-tests-env
     environment:
+      NODE_ENV: test
       VIRTUAL_HOST: $API_HOST
       LETSENCRYPT_HOST: $API_HOST
       PRISMA_ENDPOINT: $PRISMA_ENDPOINT

--- a/back/package.json
+++ b/back/package.json
@@ -35,6 +35,7 @@
     "axios": "^0.19.2",
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",
+    "camel-case": "^4.1.1",
     "connect-redis": "^4.0.4",
     "cors": "^2.8.5",
     "csv-parser": "^2.3.3",

--- a/back/src/companies/__tests__/verif.integration.ts
+++ b/back/src/companies/__tests__/verif.integration.ts
@@ -27,14 +27,14 @@ describe("verifyPrestataire", () => {
   });
 
   it("should return SIRET_UNKNOWN if siret does not exist", async () => {
-    const [_, anomaly] = await verifyPrestataire("12345678912345");
     mockSearchCompany.mockRejectedValue(new Error());
+    const [_, anomaly] = await verifyPrestataire("12345678912345");
     expect(anomaly).toEqual(anomalies.SIRET_UNKNOWN);
   });
 
   it("should return NOT_ICPE_27XX_35XX if not ICPE", async () => {
-    const [_, anomaly] = await verifyPrestataire("85001946400013");
     mockSearchCompany.mockResolvedValueOnce(company);
+    const [_, anomaly] = await verifyPrestataire("85001946400013");
     expect(anomaly).toEqual(anomalies.NOT_ICPE_27XX_35XX);
   });
 

--- a/back/src/companies/companies.graphql
+++ b/back/src/companies/companies.graphql
@@ -317,17 +317,6 @@ type CompanyMember {
   isMe: Boolean
 }
 
-"Type d'établissement favoris"
-enum FavoriteType {
-  EMITTER
-  TRANSPORTER
-  RECIPIENT
-  TRADER
-  NEXT_DESTINATION
-  TEMPORARY_STORAGE_DETAIL
-  DESTINATION
-}
-
 """
 Rubrique ICPE d'un établissement avec les autorisations associées
 Pour plus de détails, se référer à la

--- a/back/src/companies/companies.private.graphql
+++ b/back/src/companies/companies.private.graphql
@@ -100,6 +100,17 @@ type Mutation {
   ): UploadLink!
 }
 
+"Type d'établissement favoris"
+enum FavoriteType {
+  EMITTER
+  TRANSPORTER
+  RECIPIENT
+  TRADER
+  NEXT_DESTINATION
+  TEMPORARY_STORAGE_DETAIL
+  DESTINATION
+}
+
 """
 Information sur établissement accessible dans la liste des favoris
 La liste des favoris est constituée à partir de l'historique des

--- a/back/src/companies/companies.private.graphql
+++ b/back/src/companies/companies.private.graphql
@@ -3,7 +3,12 @@ type Query {
   Renvoie les établissements favoris de l'utilisateur. C'est à dire les
   établissements qui font souvent partis des BSD édités
   """
-  favorites("type de favoris" type: FavoriteType!): [CompanyFavorite!]!
+  favorites(
+    "siret de l'entreprise pour laquelle retourner les favoris"
+    siret: String!
+    "type de favoris"
+    type: FavoriteType!
+  ): [CompanyFavorite!]!
 }
 
 type Mutation {

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -254,4 +254,32 @@ describe("query favorites", () => {
       })
     ]);
   });
+
+  it("should suggest a next destination", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        nextDestinationCompanySiret: "0".repeat(14)
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "NEXT_DESTINATION"
+      }
+    });
+
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: form.nextDestinationCompanySiret
+      })
+    ]);
+  });
 });

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -13,7 +13,7 @@ const FAVORITES = `query Favorites($siret: String!, $type: FavoriteType!) {
 }`;
 
 describe("query favorites", () => {
-  afterAll(resetDatabase);
+  afterEach(resetDatabase);
 
   it("should return the recent EMITTER", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
@@ -40,8 +40,148 @@ describe("query favorites", () => {
     ]);
   });
 
-  it.todo("should return the user's company if it matches the favorite type");
-  it.todo("should return the user's company even if there are other results");
-  it.todo("should return the user's company based on an existing BSD");
-  it.todo("should not return the same company twice");
+  it("should return the user's company if it matches the favorite type", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data, errors } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
+    });
+
+    expect(errors).toBeUndefined();
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: company.siret
+      })
+    ]);
+  });
+
+  it("should return the user's company even if there are other results", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+    const firstForm = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: "0".repeat(14)
+      }
+    });
+    const secondForm = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: "1".repeat(14)
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
+    });
+
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: secondForm.emitterCompanySiret
+      }),
+      expect.objectContaining({
+        siret: firstForm.emitterCompanySiret
+      }),
+      expect.objectContaining({
+        siret: company.siret
+      })
+    ]);
+  });
+
+  it("should return the user's company based on an existing BSD", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+    const firstForm = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: "0".repeat(14)
+      }
+    });
+    await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+    const thirdForm = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: "2".repeat(14)
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
+    });
+
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: thirdForm.emitterCompanySiret
+      }),
+      expect.objectContaining({
+        siret: company.siret
+      }),
+      expect.objectContaining({
+        siret: firstForm.emitterCompanySiret
+      })
+    ]);
+  });
+
+  it("should not return the same company twice", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["COLLECTOR"]
+      }
+    });
+    const firstForm = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanyName: "A Name",
+        emitterCompanySiret: "0".repeat(14)
+      }
+    });
+    await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanyName: "Another Name",
+        emitterCompanySiret: firstForm.emitterCompanySiret
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
+    });
+
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: firstForm.emitterCompanySiret
+      })
+    ]);
+  });
 });

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -6,8 +6,8 @@ import makeClient from "../../../../__tests__/testClient";
 import { AuthType } from "../../../../auth";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 
-const FAVORITES = `query Favorites($type: FavoriteType!){
-  favorites(type: $type){
+const FAVORITES = `query Favorites($siret: String!, $type: FavoriteType!) {
+  favorites(siret: $siret, type: $type) {
     siret
   }
 }`;
@@ -16,7 +16,7 @@ describe("query favorites", () => {
   afterAll(resetDatabase);
 
   it("should return the recent EMITTER", async () => {
-    const { user } = await userWithCompanyFactory("MEMBER", {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
         set: ["COLLECTOR"]
       }
@@ -27,7 +27,10 @@ describe("query favorites", () => {
 
     const { query } = makeClient({ ...user, auth: AuthType.Session });
     const { data } = await query(FAVORITES, {
-      variables: { type: "EMITTER" }
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
     });
 
     expect(data.favorites).toEqual([

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -15,15 +15,30 @@ const FAVORITES = `query Favorites($type: FavoriteType!){
 describe("query favorites", () => {
   afterAll(resetDatabase);
 
-  it("should return most common companies used in forms", async () => {
-    const { user } = await userWithCompanyFactory("MEMBER");
-    const form = await formFactory({ ownerId: user.id });
+  it("should return the recent EMITTER", async () => {
+    const { user } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["COLLECTOR"]
+      }
+    });
+    const form = await formFactory({
+      ownerId: user.id
+    });
+
     const { query } = makeClient({ ...user, auth: AuthType.Session });
     const { data } = await query(FAVORITES, {
       variables: { type: "EMITTER" }
     });
-    expect(data.favorites.map(c => c.siret)).toEqual([
-      form.emitterCompanySiret
+
+    expect(data.favorites).toEqual([
+      expect.objectContaining({
+        siret: form.emitterCompanySiret
+      })
     ]);
   });
+
+  it.todo("should return the user's company if it matches the favorite type");
+  it.todo("should return the user's company even if there are other results");
+  it.todo("should return the user's company based on an existing BSD");
+  it.todo("should not return the same company twice");
 });

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -52,23 +52,30 @@ async function getCompanies(
   siret: string,
   type: FavoriteType
 ): Promise<CompanyFavorite[]> {
+  const defaultFilters = {
+    where: {
+      OR: [
+        { owner: { id: userID } },
+        { recipientCompanySiret: siret },
+        { emitterCompanySiret: siret }
+      ],
+      isDeleted: false
+    },
+    orderBy: "updatedAt_DESC" as const,
+    first: 50
+  };
+
   switch (type) {
     case "TEMPORARY_STORAGE_DETAIL": {
       const forms = await prisma.forms({
+        ...defaultFilters,
         where: {
-          OR: [
-            { owner: { id: userID } },
-            { recipientCompanySiret: siret },
-            { emitterCompanySiret: siret }
-          ],
+          ...defaultFilters.where,
           AND: {
             recipientIsTempStorage: true,
             recipientCompanySiret_not: null
-          },
-          isDeleted: false
-        },
-        orderBy: "updatedAt_DESC",
-        first: 50
+          }
+        }
       });
       return forms.map(form => ({
         name: form.recipientCompanyName,
@@ -81,20 +88,14 @@ async function getCompanies(
     }
     case "DESTINATION": {
       const forms = await prisma.forms({
+        ...defaultFilters,
         where: {
-          OR: [
-            { owner: { id: userID } },
-            { recipientCompanySiret: siret },
-            { emitterCompanySiret: siret }
-          ],
+          ...defaultFilters.where,
           AND: {
             recipientIsTempStorage: true,
             recipientCompanySiret_not: null
-          },
-          isDeleted: false
-        },
-        orderBy: "updatedAt_DESC",
-        first: 50
+          }
+        }
       }).$fragment<
         Array<{ temporaryStorageDetail: TemporaryStorageDetail }>
       >(`fragment TemporaryStorageDetail on Form {
@@ -123,19 +124,13 @@ async function getCompanies(
     case "NEXT_DESTINATION": {
       const lowerType = type.toLowerCase();
       const forms = await prisma.forms({
+        ...defaultFilters,
         where: {
-          OR: [
-            { owner: { id: userID } },
-            { recipientCompanySiret: siret },
-            { emitterCompanySiret: siret }
-          ],
+          ...defaultFilters.where,
           AND: {
             [`${lowerType}CompanySiret_not`]: null
-          },
-          isDeleted: false
-        },
-        orderBy: "updatedAt_DESC",
-        first: 50
+          }
+        }
       });
 
       return forms.map(form => ({

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -95,9 +95,9 @@ const favoritesResolver: QueryResolvers["favorites"] = async (
     // their company is not included in the results yet
     favorites.find(favorite => favorite.siret === company.siret) == null
   ) {
-    // prepend the results with their own company
+    // append their own company to the results
     const companySearchResult = await searchCompany(company.siret);
-    favorites.unshift({
+    favorites.push({
       name: company.name,
       siret: company.siret,
       address: companySearchResult.address,

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -1,9 +1,45 @@
-import { QueryResolvers } from "../../../generated/graphql/types";
+import {
+  CompanyFavorite,
+  FavoriteType,
+  QueryResolvers
+} from "../../../generated/graphql/types";
+import { Company, CompanyType, prisma } from "../../../generated/prisma-client";
 import { searchCompany } from "../../sirene";
 import { getUserCompanies } from "../../../users/database";
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { prisma } from "../../../generated/prisma-client";
+
+function matchesFavoriteType(
+  company: Company,
+  favoriteType: FavoriteType
+): boolean {
+  const EMITTER: CompanyType[] = ["PRODUCER", "ECO_ORGANISME"];
+  const TRANSPORTER: CompanyType[] = ["TRANSPORTER"];
+  const TRADER: CompanyType[] = ["TRADER"];
+  const RECIPIENT: CompanyType[] = [
+    "COLLECTOR",
+    "WASTEPROCESSOR",
+    "WASTE_VEHICLES",
+    "WASTE_CENTER"
+  ];
+  const DESTINATION = RECIPIENT;
+  const NEXT_DESTINATION = RECIPIENT;
+  const TEMPORARY_STORAGE_DETAIL = RECIPIENT;
+
+  const COMPANY_TYPES: Record<FavoriteType, CompanyType[]> = {
+    EMITTER,
+    TRANSPORTER,
+    TRADER,
+    RECIPIENT,
+    DESTINATION,
+    NEXT_DESTINATION,
+    TEMPORARY_STORAGE_DETAIL
+  };
+
+  return COMPANY_TYPES[favoriteType].some(matchingCompanyType =>
+    company.companyTypes.includes(matchingCompanyType)
+  );
+}
 
 const favoritesResolver: QueryResolvers["favorites"] = async (
   parent,
@@ -23,44 +59,62 @@ const favoritesResolver: QueryResolvers["favorites"] = async (
     );
   }
 
+  const company = companies[0];
   const forms = await prisma.forms({
     where: {
       OR: [
         { owner: { id: userId } },
-        { recipientCompanySiret: companies[0].siret },
-        { emitterCompanySiret: companies[0].siret }
+        { recipientCompanySiret: company.siret },
+        { emitterCompanySiret: company.siret }
       ],
+      AND: {
+        [`${lowerType}CompanySiret_not`]: null
+      },
       isDeleted: false
     },
-    orderBy: "createdAt_DESC",
+    orderBy: "updatedAt_DESC",
+
+    // Take more than needed as duplicates are filtered out
     first: 50
   });
 
-  const favorites = forms
-    // Filter out forms with no data
-    .filter(f => f[`${lowerType}CompanySiret`])
-    .map(f => ({
-      name: f[`${lowerType}CompanyName`],
-      siret: f[`${lowerType}CompanySiret`],
-      address: f[`${lowerType}CompanyAddress`],
-      contact: f[`${lowerType}CompanyContact`],
-      phone: f[`${lowerType}CompanyPhone`],
-      mail: f[`${lowerType}CompanyMail`]
+  const favorites: CompanyFavorite[] = forms
+    .map(form => ({
+      name: form[`${lowerType}CompanyName`],
+      siret: form[`${lowerType}CompanySiret`],
+      address: form[`${lowerType}CompanyAddress`],
+      contact: form[`${lowerType}CompanyContact`],
+      phone: form[`${lowerType}CompanyPhone`],
+      mail: form[`${lowerType}CompanyMail`]
     }))
-    // Remove duplicates (by company names)
-    .reduce((prev, cur) => {
-      if (prev.findIndex(el => el.name === cur.name) === -1) {
-        prev.push(cur);
+    // Remove duplicates (by company siret)
+    .reduce<CompanyFavorite[]>((prev, cur) => {
+      if (prev.find(el => el.siret === cur.siret) == null) {
+        return prev.concat([cur]);
       }
       return prev;
-    }, [])
-    .slice(0, 10);
+    }, []);
 
-  // If there is no data yet, propose his own companies as favorites
-  // We won't have every props populated, but it's a start
-  if (!favorites.length) {
-    return Promise.all(companies.map(c => searchCompany(c.siret)));
+  if (
+    // the user's company matches the provided favorite type
+    matchesFavoriteType(company, type) &&
+    // their company is not included in the results yet
+    favorites.find(favorite => favorite.siret === company.siret) == null
+  ) {
+    // prepend the results with their own company
+    const companySearchResult = await searchCompany(company.siret);
+    favorites.unshift({
+      name: company.name,
+      siret: company.siret,
+      address: companySearchResult.address,
+      contact: user.name,
+      phone: user.phone,
+      mail: user.email
+    });
   }
+
+  // Return up to 10 results
+  favorites.splice(10);
 
   return favorites;
 };

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -1,3 +1,4 @@
+import { camelCase } from "camel-case";
 import {
   CompanyFavorite,
   FavoriteType,
@@ -122,7 +123,7 @@ async function getCompanies(
     case "RECIPIENT":
     case "TRADER":
     case "NEXT_DESTINATION": {
-      const lowerType = type.toLowerCase();
+      const lowerType = camelCase(type);
       const forms = await prisma.forms({
         ...defaultFilters,
         where: {

--- a/back/src/companies/sirene/index.ts
+++ b/back/src/companies/sirene/index.ts
@@ -42,6 +42,12 @@ export function searchCompany(siret: string): Promise<CompanySearchResult> {
       invalidArgs: ["siret"]
     });
   }
+
+  if (process.env.NODE_ENV === "test") {
+    // do not call the APIs when running integration tests
+    return Promise.resolve({});
+  }
+
   return decoratedSearchCompany(siret);
 }
 

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1535,6 +1535,7 @@ export type QueryCompanyInfosArgs = {
 
 
 export type QueryFavoritesArgs = {
+  siret: Scalars['String'];
   type: FavoriteType;
 };
 
@@ -2829,7 +2830,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   appendixForms?: Resolver<Array<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<QueryAppendixFormsArgs, 'siret'>>;
   companyInfos?: Resolver<ResolversTypes['CompanyPublic'], ParentType, ContextType, RequireFields<QueryCompanyInfosArgs, 'siret'>>;
   ecoOrganismes?: Resolver<Array<ResolversTypes['EcoOrganisme']>, ParentType, ContextType>;
-  favorites?: Resolver<Array<ResolversTypes['CompanyFavorite']>, ParentType, ContextType, RequireFields<QueryFavoritesArgs, 'type'>>;
+  favorites?: Resolver<Array<ResolversTypes['CompanyFavorite']>, ParentType, ContextType, RequireFields<QueryFavoritesArgs, 'siret' | 'type'>>;
   form?: Resolver<Maybe<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<QueryFormArgs, never>>;
   formPdf?: Resolver<ResolversTypes['FileDownload'], ParentType, ContextType, RequireFields<QueryFormPdfArgs, never>>;
   forms?: Resolver<Array<ResolversTypes['Form']>, ParentType, ContextType, RequireFields<QueryFormsArgs, never>>;

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -123,7 +123,7 @@ export const server = new ApolloServer({
     }
     if (
       err.extensions.code === ErrorCode.INTERNAL_SERVER_ERROR &&
-      NODE_ENV !== "dev"
+      NODE_ENV === "production"
     ) {
       // Do not leak error for internal server error in production
       return new ApolloError("Erreur serveur", ErrorCode.INTERNAL_SERVER_ERROR);

--- a/back/src/users/permissions.ts
+++ b/back/src/users/permissions.ts
@@ -1,6 +1,6 @@
-import { User, Company } from "../generated/prisma-client";
+import { User, Company, prisma } from "../generated/prisma-client";
 import { getCompanyAdminUsers } from "../companies/database";
-import { NotCompanyAdmin } from "../common/errors";
+import { NotCompanyAdmin, NotCompanyMember } from "../common/errors";
 
 export async function checkIsCompanyAdmin(user: User, company: Company) {
   const admins = await getCompanyAdminUsers(company.siret);
@@ -8,4 +8,24 @@ export async function checkIsCompanyAdmin(user: User, company: Company) {
     throw new NotCompanyAdmin(company.siret);
   }
   return true;
+}
+
+export async function checkIsCompanyMember(
+  { id }: { id: string },
+  { siret }: { siret: string }
+) {
+  const isCompanyMember = await prisma.$exists.companyAssociation({
+    user: {
+      id
+    },
+    company: {
+      siret
+    }
+  });
+
+  if (isCompanyMember) {
+    return true;
+  }
+
+  throw new NotCompanyMember(siret);
 }

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -5694,47 +5694,6 @@ Personne ayant transformé ou réalisé un traitement dont la provenance des dé
 </tbody>
 </table>
 
-### FavoriteType
-
-Type d'établissement favoris
-
-<table>
-<thead>
-<th align="left">Value</th>
-<th align="left">Description</th>
-</thead>
-<tbody>
-<tr>
-<td valign="top"><strong>EMITTER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>TRANSPORTER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>RECIPIENT</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>TRADER</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>NEXT_DESTINATION</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>TEMPORARY_STORAGE_DETAIL</strong></td>
-<td></td>
-</tr>
-<tr>
-<td valign="top"><strong>DESTINATION</strong></td>
-<td></td>
-</tr>
-</tbody>
-</table>
-
 ### FormRole
 
 <table>

--- a/front/src/form/company/CompanySelector.tsx
+++ b/front/src/form/company/CompanySelector.tsx
@@ -18,6 +18,7 @@ import {
 } from "generated/graphql/types";
 import CountrySelector from "./CountrySelector";
 import { v4 as uuidv4 } from "uuid";
+import { useParams } from "react-router-dom";
 
 interface CompanySelectorProps {
   name:
@@ -39,6 +40,7 @@ export default function CompanySelector({
   allowForeignCompanies,
   heading,
 }: CompanySelectorProps) {
+  const { siret } = useParams<{ siret: string }>();
   const [uniqId] = useState(() => uuidv4());
   const [field] = useField<FormCompany>({ name });
   const { setFieldValue } = useFormikContext();
@@ -56,6 +58,7 @@ export default function CompanySelector({
     error: favoritesError,
   } = useQuery<Pick<Query, "favorites">, QueryFavoritesArgs>(FAVORITES, {
     variables: {
+      siret,
       // Load different favorites depending on the object we are filling
       type: constantCase(field.name.split(".")[0]) as FavoriteType,
     },

--- a/front/src/form/company/query.ts
+++ b/front/src/form/company/query.ts
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
 
 export const FAVORITES = gql`
-  query Favorites($type: FavoriteType!) {
-    favorites(type: $type) {
+  query Favorites($siret: String!, $type: FavoriteType!) {
+    favorites(siret: $siret, type: $type) {
       siret
       name
       address

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1544,6 +1544,7 @@ export type QueryCompanyInfosArgs = {
 
 
 export type QueryFavoritesArgs = {
+  siret: Scalars['String'];
   type: FavoriteType;
 };
 


### PR DESCRIPTION
Cette PR améliore la query `favorites` pour faire en sorte de pré-selectionner l'entreprise de l'utilisateur connecté pour les champs qui ont du sens.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello 1](https://trello.com/c/m9KVumMa/1039-etq-entreprise-quand-je-cr%C3%A9%C3%A9-un-bsd-mon-entreprise-est-pr%C3%A9s%C3%A9lectionn%C3%A9e-comme-producteur)
- [Ticket Trello 2](https://trello.com/c/DgeBGWhg/980-la-query-favorites-peut-retourner-plusieurs-fois-la-m%C3%AAme-entreprise)
- [Ticket Trello 3](https://trello.com/c/eYwlNv16/1074-la-requ%C3%AAte-favoris-ne-renvoie-pas-de-r%C3%A9sultats-pertinents-pour-lentreprosage-provisoire)
