### PR TITLE
Correction de la validation des informations déchets

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -36,6 +36,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction du lien présent dans l'email d'invitation suite à l'action "Renvoyer l'invitation" [PR 648](https://github.com/MTES-MCT/trackdechets/pull/648)
 - Champs requis dans le formulaire d'inscription suite à un lien d'invitation [PR 670](https://github.com/MTES-MCT/trackdechets/pull/670)
 - Affichage des bordereaux au statut `GROUPED` dans l'onglet "Suivi" du dashboard et corrections de la mutation `markAsSent` sur un BSD de regroupement [PR 672](https://github.com/MTES-MCT/trackdechets/pull/672)
+- Correction d'un bug permettant de sceller des bordereaux avec des informations sur le détail du déchet (cadre 3,4,5,6) erronnées ce qui causait des erreurs de validation ultérieures [PR 681](https://github.com/MTES-MCT/trackdechets/pull/681)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -154,6 +154,16 @@ describe("sealedFormSchema", () => {
       .isValid(testForm);
     expect(isValid).toEqual(false);
   });
+
+  test("when there is no waste details quantity", async () => {
+    const testForm = {
+      ...form,
+      wasteDetailsQuantity: null
+    };
+
+    const isValid = await sealedFormSchema.isValid(testForm);
+    expect(isValid).toEqual(false);
+  });
 });
 
 describe("receivedInfosSchema", () => {

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -66,7 +66,8 @@ describe("mutation / importPaperForm", () => {
           quantity: 1.0,
           quantityType: "ESTIMATED",
           packagings: ["BENNE"],
-          onuCode: "ONU"
+          onuCode: "ONU",
+          consistence: "SOLID"
         },
         signingInfo: {
           sentAt: "2019-12-20T00:00:00.000Z",
@@ -237,7 +238,8 @@ describe("mutation / importPaperForm", () => {
       wasteDetailsQuantity: 1.0,
       wasteDetailsQuantityType: "ESTIMATED",
       wasteDetailsPackagings: ["BENNE"],
-      wasteDetailsOnuCode: "ONU"
+      wasteDetailsOnuCode: "ONU",
+      wasteDetailsConsistence: "SOLID"
     };
 
     const importedData = {

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -301,24 +301,24 @@ export const wasteDetailsSchema: yup.ObjectSchema<WasteDetails> = yup
           .required(
             `La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
           ),
-      otherwise: () => yup.string().nullable(),
-      wasteDetailsPackagings: yup.array().ensure().required(),
-      wasteDetailsNumberOfPackages: yup
-        .number()
-        .integer()
-        .min(1, "Le nombre de colis doit être supérieur à 0")
-        .nullable(true),
-      wasteDetailsQuantity: yup
-        .number()
-        .required("La quantité du déchet en tonnes est obligatoire")
-        .min(0, "La quantité doit être supérieure à 0"),
-      wasteDetailsQuantityType: yup
-        .mixed<QuantityType>()
-        .required("Le type de quantité (réelle ou estimée) doit être précisé"),
-      wasteDetailsConsistence: yup
-        .mixed<Consistence>()
-        .required("La consistance du déchet doit être précisée")
-    })
+      otherwise: () => yup.string().nullable()
+    }),
+    wasteDetailsPackagings: yup.array().ensure().required(),
+    wasteDetailsNumberOfPackages: yup
+      .number()
+      .integer()
+      .min(1, "Le nombre de colis doit être supérieur à 0")
+      .nullable(true),
+    wasteDetailsQuantity: yup
+      .number()
+      .required("La quantité du déchet en tonnes est obligatoire")
+      .min(0, "La quantité doit être supérieure à 0"),
+    wasteDetailsQuantityType: yup
+      .mixed<QuantityType>()
+      .required("Le type de quantité (réelle ou estimée) doit être précisé"),
+    wasteDetailsConsistence: yup
+      .mixed<Consistence>()
+      .required("La consistance du déchet doit être précisée")
   });
 
 // 8 - Collecteur-transporteur


### PR DESCRIPTION
Un décalage s'était glissé dans la déclaration de l'objet yup  `wasteDetailsSchema`. On laissait donc passer au moment du scellement des bordereaux n'ayant pas de quantité ce qui causait des erreurs de validation aux étapes ultérieures (`signedByTransporter` notamment)

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/2GNs0xL5/1071-impossible-de-signer-lenlevlent-dune-annexe-1)
