### PR TITLE
Recettage mécanisme de demande de rattachement

### DIFF
--- a/back/src/users/mails.ts
+++ b/back/src/users/mails.ts
@@ -257,8 +257,8 @@ export const userMails = {
     L'utilisateur ${user.email} a demandé à rejoindre l'établissement ${company.name} (${company.siret})
     dont vous êtes administrateur.
 
-    Pour valider ou refuser sa demande, cliquer sur
-    <a href="${membershipRequestLink}">ce lien</a>
+    Pour valider ou refuser sa demande, cliquez sur
+    <a href="${membershipRequestLink}">ce lien</a>.
     `
   }),
   membershipRequestAccepted: (user: User, company: Company) => ({

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
@@ -23,39 +23,32 @@ export default function AccountCompanyAddInvitationRequest({ siret }) {
 
   if (data) {
     return (
-      <div>
-        <h4 className="h4">Demande de rattachement envoyée</h4>
-        <div>
-          Vous recevrez un email de confirmation lorsque votre demande sera
-          validée
-        </div>
+      <div className="notification notification--success">
+        <p>
+          Demande de rattachement envoyée. Vous recevrez un email de
+          confirmation lorsque votre demande sera validée
+        </p>
       </div>
     );
   }
 
   return (
-    <div>
-      <div className="notification">
-        <p>
-          Vous pouvez demander à l'administrateur de rejoindre l'établissement
-        </p>
-        <button
-          type="button"
-          className="btn btn--primary tw-mt-5"
-          onClick={() =>
-            sendMembershipRequest({
-              variables: { siret: siret.replace(/\s/g, "") },
-            })
-          }
-        >
-          {loading ? (
-            <FaHourglassHalf />
-          ) : (
-            "Envoyer une demande de rattachement"
-          )}
-        </button>
-        {error && <NotificationError apolloError={error} />}
-      </div>
+    <div className="notification">
+      <p>
+        Vous pouvez demander à l'administrateur de rejoindre l'établissement
+      </p>
+      <button
+        type="button"
+        className="btn btn--primary tw-mt-5"
+        onClick={() =>
+          sendMembershipRequest({
+            variables: { siret: siret.replace(/\s/g, "") },
+          })
+        }
+      >
+        {loading ? <FaHourglassHalf /> : "Envoyer une demande de rattachement"}
+      </button>
+      {error && <NotificationError apolloError={error} />}
     </div>
   );
 }

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
@@ -35,7 +35,10 @@ export default function AccountCompanyAddInvitationRequest({ siret }) {
 
   return (
     <div>
-      <h4 className="h4">Cet établissement possède déjà un administrateur</h4>
+      <h4 className="h4">
+        Cet établissement existe déjà dans Trackdéchets, vous pouvez demander à
+        l'administrateur de rejoindre l'établissement
+      </h4>
       <button
         type="button"
         className="btn btn--primary tw-mt-5"

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddMembershipRequest.tsx
@@ -35,22 +35,27 @@ export default function AccountCompanyAddInvitationRequest({ siret }) {
 
   return (
     <div>
-      <h4 className="h4">
-        Cet établissement existe déjà dans Trackdéchets, vous pouvez demander à
-        l'administrateur de rejoindre l'établissement
-      </h4>
-      <button
-        type="button"
-        className="btn btn--primary tw-mt-5"
-        onClick={() =>
-          sendMembershipRequest({
-            variables: { siret: siret.replace(/\s/g, "") },
-          })
-        }
-      >
-        {loading ? <FaHourglassHalf /> : "Envoyer une demande de rattachement"}
-      </button>
-      {error && <NotificationError apolloError={error} />}
+      <div className="notification">
+        <p>
+          Vous pouvez demander à l'administrateur de rejoindre l'établissement
+        </p>
+        <button
+          type="button"
+          className="btn btn--primary tw-mt-5"
+          onClick={() =>
+            sendMembershipRequest({
+              variables: { siret: siret.replace(/\s/g, "") },
+            })
+          }
+        >
+          {loading ? (
+            <FaHourglassHalf />
+          ) : (
+            "Envoyer une demande de rattachement"
+          )}
+        </button>
+        {error && <NotificationError apolloError={error} />}
+      </div>
     </div>
   );
 }

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useLazyQuery } from "@apollo/react-hooks";
 import { Field, Form, Formik } from "formik";
 import { FaHourglassHalf } from "react-icons/fa";
@@ -23,6 +23,8 @@ type IProps = {
  * - it is not closed
  */
 export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
+  const [isRegistered, setIsRegistered] = useState(false);
+
   const [searchCompany, { loading, error }] = useLazyQuery<
     Pick<Query, "companyInfos">
   >(COMPANY_INFOS, {
@@ -34,6 +36,7 @@ export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
             "Cet établissement est fermé, impossible de le créer"
           );
         } else {
+          setIsRegistered(companyInfos?.isRegistered ?? false);
           onCompanyInfos(companyInfos);
         }
       }
@@ -65,6 +68,11 @@ export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
             <label className={`text-right ${styles.bold}`}>SIRET</label>
             <div className={styles.field__value}>
               <Field name="siret" component={AutoFormattingSiret} />
+              {isRegistered && (
+                <p className="error-message">
+                  Cet établissement existe déjà dans Trackdéchets
+                </p>
+              )}
               <RedErrorMessage name="siret" />
               <br />
               <button

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -63,28 +63,38 @@ export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
           });
         }}
       >
-        <Form className={styles.companyAddForm}>
-          <div className={styles.field}>
-            <label className={`text-right ${styles.bold}`}>SIRET</label>
-            <div className={styles.field__value}>
-              <Field name="siret" component={AutoFormattingSiret} />
-              {isRegistered && (
-                <p className="error-message">
-                  Cet établissement existe déjà dans Trackdéchets
-                </p>
-              )}
-              <RedErrorMessage name="siret" />
-              <br />
-              <button
-                disabled={loading}
-                className="btn btn--primary tw-mt-2"
-                type="submit"
-              >
-                {loading ? <FaHourglassHalf /> : "Valider"}
-              </button>
+        {({ setFieldValue }) => (
+          <Form className={styles.companyAddForm}>
+            <div className={styles.field}>
+              <label className={`text-right ${styles.bold}`}>SIRET</label>
+              <div className={styles.field__value}>
+                <Field
+                  name="siret"
+                  component={AutoFormattingSiret}
+                  onChange={e => {
+                    setIsRegistered(false);
+                    setFieldValue("siret", e.target.value);
+                  }}
+                />
+                {isRegistered && (
+                  <p className="error-message">
+                    Cet établissement existe déjà dans Trackdéchets
+                  </p>
+                )}
+                <RedErrorMessage name="siret" />
+                <div>
+                  <button
+                    disabled={loading}
+                    className="btn btn--primary tw-mt-2"
+                    type="submit"
+                  >
+                    {loading ? <FaHourglassHalf /> : "Valider"}
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
-        </Form>
+          </Form>
+        )}
       </Formik>
     </>
   );


### PR DESCRIPTION
Ajustements UX suite review de Claire. On passe le message "Cet établissement existe déjà dans Trackdéchets" en erreur et on fait apparaitre le reste dans un encart de notification.

![Capture d’écran 2020-11-02 à 15 55 18](https://user-images.githubusercontent.com/2269165/97883299-f9171600-1d24-11eb-8278-3c5e907a02d7.png)

![Capture d’écran 2020-11-02 à 15 55 32](https://user-images.githubusercontent.com/2269165/97883306-fb797000-1d24-11eb-8b38-870dfe4795d1.png)


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/tZkiLnTs)
