### PR TITLE
Correction de la pagination par curseur

### DIFF
--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -61,7 +61,7 @@ export async function getForms(
 
   const queriedForms = await prisma.forms({
     ...getPaginationFilter(rest),
-    orderBy: "createdAt_DESC",
+    // orderBy: "createdAt_DESC",
     where: {
       updatedAt_gte: rest.updatedAfter,
       sentAt_gte: rest.sentAfter,


### PR DESCRIPTION
L'implémentation actuelle de la pagination par curseur avec `first, after` ou `last, before` n'est pas conforme aux conventions que l'on trouve dans d'autres API GraphQL. 

## Fonctionnement désiré 

La pagination par curseur devrait permettre une pagination _forward_ avec `first, after` et une pagination _backward_ avec `last, before`. Dans le cas de la pagination _forward_, on part du début de la liste et les résultats sont ordonnés par ordre croissant. Dans le cas de la pagination _backward_, on part de la fin de la liste et les résultats sont ordonnés dans l'ordre décroissant. Voir fonctionnement Prisma ci-dessous  
On pourrait éventuellement garder un ordre constant des enregistrements retournés comme sur l'API Github ci-dessous (décroissant pour nous) mais en gardant le fait que `first` pagine en avant et `after` en arrière 

MAJ https://relay.dev/graphql/connections.htm#sec-Edge-order
>You may order the edges however your business logic dictates, and may determine the ordering based upon additional arguments not covered by this specification. But the ordering must be consistent from page to page, and importantly, The ordering of edges should be the same when using first/after as when using last/before, all other arguments being equal. It should not be reversed when using last/before. More formally:
When before: cursor is used, the edge closest to cursor must come last in the result edges.
When after: cursor is used, the edge closest to cursor must come first in the result edges.


### Fonctionnement désiré sur une liste de dix forms `[F1, F2, F3, ..., F10]` 

```
forms(first: 3) => [F1, F2, F3]
forms(first: 3, cursorAfter: F3) => [F4, F5, F6]
forms(first: 3, cursorAfter: F6) => [F7, F8, F9]
forms(first: 3, cursorAfter: F9) => [F10]
```

```
forms(last: 3) => [F10, F9, F8]
forms(last: 3, cursorBefore: F8) => [F7, F6, F5]
forms(last: 3, cursorBefore: F5) => [F4, F3, F2]
forms(last: 3, cursorBefore: F2) => [F1]
```  

En gardant un ordre décroissant pour les deux on pourrait éventuellement avoir

```
forms(first: 3) => [F3, F2, F1]
forms(first: 3, cursorAfter: F3) => [F6, F5, F4]
forms(first: 3, cursorAfter: F6) => [F9, F8, F7]
forms(first: 3, cursorAfter: F9) => [F10]
```

### Exemple Prisma

#### Pagination forward

```graphql
query {
  forms(first: 2){
    createdAt
    id
    readableId
  }
}

{
  "data": {
    "forms": [
      {
        "createdAt": "2019-01-08T10:19:12.761Z",
        "id": "cjqnlrv96003q08434hip7ta2",
        "readableId": "TD-19-AAA00003"
      },
      {
        "createdAt": "2019-01-08T10:19:14.320Z",
        "id": "cjqnlrwgh003w0843kgva29ub",
        "readableId": "TD-19-AAA00004"
      }
    ]
  }
}

```

#### Pagination backward

```graphql
query {
  forms(last: 2){
    createdAt
    id
    readableId
  }
}

{
  "data": {
    "forms": [
      {
        "createdAt": "2020-11-03T15:36:08.946Z",
        "id": "ckh24wxki1s730765mfuut3r7",
        "readableId": "TD-20-AAA00554"
      },
      {
        "createdAt": "2020-11-04T08:39:46.343Z",
        "id": "ckh35hbjc1t4g0765kyaq4zno",
        "readableId": "TD-20-AAA00555"
      }
    ]
  }
}
```

### Exemple Github API 

#### Pagination forward 

```graphql
query { 
  viewer { 
    repositories(first: 2) {
      edges {
        node {
          createdAt
          name
        }
      }
    }
  }
}

{
  "data": {
    "viewer": {
      "repositories": {
        "edges": [
          {
            "node": {
              "createdAt": "2012-01-07T15:36:34Z",
              "name": "myrailsapi"
            }
          },
          {
            "node": {
              "createdAt": "2013-10-03T17:12:05Z",
              "name": "color-genius"
            }
          }
        ]
      }
    }
  }
}

```

#### Pagination backward 

```graphql
query { 
  viewer { 
    repositories(last: 2) {
      edges {
        node {
          createdAt
          name
        }
      }
    }
  }
}

{
  "data": {
    "viewer": {
      "repositories": {
        "edges": [
          {
            "node": {
              "createdAt": "2020-05-23T12:17:23Z",
              "name": "lincassable-website"
            }
          },
          {
            "node": {
              "createdAt": "2020-09-23T07:02:04Z",
              "name": "marseille-travel-guide"
            }
          }
        ]
      }
    }
  }
}
```

### Fonctionnement observé 

Dans l'état actuel de la query `forms`, on a une pagination`first, cursorAfter` qui fonctionne comme une pagination _backward_ (résultat par ordre décroissant en partant de la fin de la liste) et on a une pagination `last, cursorBefore` qui fonctionne comme une pagination _forward_ mais avec un ordre décroissant.


#### Illustration fonctionnement observé sur une liste de 10 forms `[F1, F2, ..., F10]` 

```
forms(first: 3) => [F10, F9, F8]
forms(first: 3, cursorAfter: F8) => [F7, F6, F5]
forms(first: 3, cursorAfter: F5) => [F4, F3, F2]
forms(first: 3, cursorAfter: F2) => [F1]
```
```
forms(last: 3) => [F10, F9, F8, ...., F2, F1] # ne fonctionne pas renvoie tout
forms(last: 3, cursorBefore: F3) => [F6, F5, F4]
forms(last: 3, cursorBefore: F6) => [F9, F8, F7]
forms(last: 3, cursorBefore: F9) => [F10]
```  

Plusieurs points à corriger donc à mon sens:
* faire en sorte que `last` fonctionne tout seul  (sans `cursorBefore`) 
* intervertir le rôle de `first, cursorAfter` et `last, cursorBefore` 
* éventuellement changer l'ordre des résultats (décroissant => croissant) en pagination forward 

----

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les breaking changes dans le change log

---

- [Ticket Trello]()
