### PR TITLE
Amélioration de la pagination

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Correction de la mutation `duplicateForm` pour dupliquer l'entreposage provisoire, [PR 700](https://github.com/)
 - Correction d'un bug affichant une erreur serveur à la place d'une erreur de validation graphQL lorsque le typage des variables graphQL est erronée [PR 711](https://github.com/MTES-MCT/trackdechets/pull/711)
+- Correction d'un bug empêchant de paginer les bordereaux "en arrière" dans la query `forms` lorsque `cursorBefore` n'est pas précisé et amélioration de la validation des paramètres de pagination [PR 699](https://github.com/MTES-MCT/trackdechets/pull/699)
 
 #### :nail_care: Améliorations
 

--- a/back/src/forms/__tests__/pagination.test.ts
+++ b/back/src/forms/__tests__/pagination.test.ts
@@ -1,0 +1,98 @@
+import { getConnectionsArgs } from "../pagination";
+
+describe("getConnectionArgs", () => {
+  it("should default to forward pagination if no arguments is provided", () => {
+    const args = getConnectionsArgs({ defaultPaginateBy: 100 });
+    expect(args).toEqual({ first: 100 });
+  });
+  it("should default to forward pagination if only `skip` is provided", () => {
+    const args = getConnectionsArgs({ defaultPaginateBy: 100, skip: 2 });
+    expect(args).toEqual({ first: 100, skip: 2 });
+  });
+  it("should set default value to `first` if cursorAfter is provided", () => {
+    const args = getConnectionsArgs({
+      cursorAfter: "after",
+      defaultPaginateBy: 100
+    });
+    expect(args).toEqual({ first: 100, after: "after" });
+  });
+  it("should set default value to `last` if cursorBefore is provided", () => {
+    const args = getConnectionsArgs({
+      cursorBefore: "before",
+      defaultPaginateBy: 100
+    });
+    expect(args).toEqual({ last: 100, before: "before" });
+  });
+  it.each(["first", "last"])(
+    "should throw a validation error if %p is not an integer",
+    p => {
+      const shouldThrow = () =>
+        getConnectionsArgs({
+          [p]: 1.2
+        });
+      expect(shouldThrow).toThrow(`\`${p}\` doit être un entier`);
+    }
+  );
+  it.each(["first", "last"])(
+    "should throw a validation error if %p is not positive",
+    p => {
+      const shouldThrow = () =>
+        getConnectionsArgs({
+          [p]: -1
+        });
+      expect(shouldThrow).toThrow(`\`${p}\` doit être positif`);
+    }
+  );
+  it.each(["first", "last"])(
+    "should throw a validation error if %p is higher than max value allowed",
+    p => {
+      const shouldThrow = () =>
+        getConnectionsArgs({
+          [p]: 11,
+          maxPaginateBy: 10
+        });
+      expect(shouldThrow).toThrow(`\`${p}\` doit être inférieur à 10`);
+    }
+  );
+  it("should throw an error when passing both `first` and `last`", () => {
+    const shouldThrow = () => getConnectionsArgs({ first: 10, last: 10 });
+    expect(shouldThrow).toThrow(
+      "L'utilisation simultanée de `first` et `last` n'est pas supportée"
+    );
+  });
+
+  it("should throw an error when passing both `cursorAfter` and `cursorBefore`", () => {
+    const shouldThrow = () =>
+      getConnectionsArgs({ cursorAfter: "after", cursorBefore: "before" });
+    expect(shouldThrow).toThrow(
+      "L'utilisation simultanée de `cursorAfter` et `cursorBefore` n'est pas supportée"
+    );
+  });
+  it("should throw error when passing `first` with `cursorBefore`", () => {
+    const shouldThrow = () =>
+      getConnectionsArgs({ first: 10, cursorBefore: "before" });
+    expect(shouldThrow).toThrow(
+      "`first` ne peut pas être utilisé en conjonction avec `cursorBefore`"
+    );
+  });
+  it("should throw error when passing `last` with `cursorAfter`", () => {
+    const shouldThrow = () =>
+      getConnectionsArgs({ last: 10, cursorAfter: "after" });
+    expect(shouldThrow).toThrow(
+      "`last` ne peut pas être utilisé en conjonction avec `cursorAfter`"
+    );
+  });
+  it.each(["cursorAfter", "cursorBefore"])(
+    "should throw a validation error if skip is used in conjunction with %p",
+    p => {
+      const shouldThrow = () =>
+        getConnectionsArgs({
+          [p]: 10,
+          skip: 10
+        });
+      expect(shouldThrow).toThrow(
+        "`skip` (pagination par offset) ne peut pas être utilisé en conjonction avec `cursorAfter` ou `cursorBefore` (pagination par curseur)"
+      );
+    }
+  );
+});

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -46,32 +46,40 @@ type Query {
     """
     DEPRECATED - (Optionnel) PAGINATION
     Nombre d'éléments à ne pas récupérer en début de liste
+    dans le mode de pagination par "offset"
+    Utiliser en conjonction avec `first` pour paginer "en avant" (des plus récents aux plus anciens)
+    Utiliser en conjonction avec `last` pour paginer "en arrière" (des plus anciens aux plus récents)
     Défaut à 0
     """
     skip: Int
 
     """
     (Optionnel) PAGINATION
+    Permet en conjonction avec `first` de paginer "en avant"
+    (des bordereaux les plus récents aux bordereaux les plus anciens)
     Curseur après lequel les bordereaux doivent être retournés
     Attend un identifiant (propriété `id`) de BSD
-    Défaut à vide, pour retourner les "premiers" bordereaux
+    Défaut à vide, pour retourner les bordereaux les plus récents
     Le BSD précisé dans le curseur ne fait pas partie du résultat
     """
     cursorAfter: ID
 
     """
     (Optionnel) PAGINATION
+    Permet en conjonction avec `cursorAfter` de paginer "en avant"
+    (des bordereaux les plus récents aux bordereaux les plus anciens)
     Nombre de bordereaux retournés après le `cursorAfter`
     Défaut à 50, maximum à 500
-    Ignoré si utilisé avec `cursorBefore`
     """
     first: Int
 
     """
     (Optionnel) PAGINATION
+    Permet en conjonction avec `last` de paginer "en arrière"
+    (des bordereaux les plus anciens aux bordereaux les plus récents)
     Curseur avant lequel les bordereaux doivent être retournés
     Attend un identifiant (propriété `id`) de BSD
-    Défaut à vide, pour retourner les "derniers" bordereaux
+    Défaut à vide, pour retourner les bordereaux les plus anciens
     Le BSD précisé dans le curseur ne fait pas partie du résultat
     """
     cursorBefore: ID
@@ -80,7 +88,6 @@ type Query {
     (Optionnel) PAGINATION
     Nombre de bordereaux retournés avant le `cursorBefore`
     Défaut à 50, maximum à 500
-    Ignoré si utilisé avec `cursorAfter`
     """
     last: Int
 
@@ -215,9 +222,25 @@ type Query {
     loggedBefore: String
     "(Optionnel) Date formatée avant laquelle les changements de statut doivent être retournés (YYYY-MM-DD), optionnel"
     loggedAfter: String
-    "(Optionnel) PAGINATION - Curseur après lequel les changements de statut doivent être retournés"
+    """
+    (Optionnel) PAGINATION
+    Permet de paginer les changements de statut "en avant"
+    (des changements de statut les plus récents aux changements de statut les plus anciens)
+    Curseur après lequel les changements de statuts doivent être retournés
+    Attend un identifiant (propriété `id`) d'un changement de statut
+    Défaut à vide, pour retourner les changements de statut les plus récents
+    Le changement de statut précisé dans le curseur ne fait pas partie du résultat
+    """
     cursorAfter: String
-    "(Optionnel) PAGINATION - Curseur avant lequel les changements de statut doivent être retournés"
+    """
+    (Optionnel) PAGINATION
+    Permet de paginer les changements de statut "en arrière"
+    (des changements de statut les plus anciens aux changements de statut les plus récents)
+    Curseur avant lequel les changements de statuts doivent être retournés
+    Attend un identifiant (propriété `id`) d'un changement de statut
+    Défaut à vide, pour retourner les changements de statut les plus anciens
+    Le changement de statut précisé dans le curseur ne fait pas partie du résultat
+    """
     cursorBefore: String
     "(Optionnel) ID d'un BSD en particulier"
     formId: ID

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -45,8 +45,7 @@ type Query {
 
     """
     DEPRECATED - (Optionnel) PAGINATION
-    Nombre d'éléments à ne pas récupérer en début de liste
-    dans le mode de pagination par "offset"
+    Nombre d'éléments à ne pas récupérer en début de liste dans le mode de pagination par "offset"
     Utiliser en conjonction avec `first` pour paginer "en avant" (des plus récents aux plus anciens)
     Utiliser en conjonction avec `last` pour paginer "en arrière" (des plus anciens aux plus récents)
     Défaut à 0
@@ -213,7 +212,7 @@ type Query {
   """
   Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
   La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
-  Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
+  Seuls les changements de statut disposant d'un champ `loggedAt` non nul sont retournés
   """
   formsLifeCycle(
     "(Optionnel) SIRET d'un établissement dont je suis membre"
@@ -226,7 +225,7 @@ type Query {
     (Optionnel) PAGINATION
     Permet de paginer les changements de statut "en avant"
     (des changements de statut les plus récents aux changements de statut les plus anciens)
-    Curseur après lequel les changements de statuts doivent être retournés
+    Curseur après lequel les changements de statut doivent être retournés
     Attend un identifiant (propriété `id`) d'un changement de statut
     Défaut à vide, pour retourner les changements de statut les plus récents
     Le changement de statut précisé dans le curseur ne fait pas partie du résultat
@@ -236,7 +235,7 @@ type Query {
     (Optionnel) PAGINATION
     Permet de paginer les changements de statut "en arrière"
     (des changements de statut les plus anciens aux changements de statut les plus récents)
-    Curseur avant lequel les changements de statuts doivent être retournés
+    Curseur avant lequel les changements de statut doivent être retournés
     Attend un identifiant (propriété `id`) d'un changement de statut
     Défaut à vide, pour retourner les changements de statut les plus anciens
     Le changement de statut précisé dans le curseur ne fait pas partie du résultat

--- a/back/src/forms/pagination.ts
+++ b/back/src/forms/pagination.ts
@@ -1,0 +1,127 @@
+import { UserInputError } from "apollo-server-express";
+import * as yup from "yup";
+
+type PaginationArgs = {
+  skip?: number;
+  first?: number;
+  cursorAfter?: string;
+  last?: number;
+  cursorBefore?: string;
+  // default value for `first` and `last` if omitted
+  defaultPaginateBy?: number;
+  // max value for `first` and `last`
+  maxPaginateBy?: number;
+};
+
+const positiveInteger = yup
+  .number()
+  .nullable(true)
+  .notRequired()
+  .integer("`${path}` doit être un entier")
+  .positive("`${path}` doit être positif"); // strictly positive (n > 0)
+
+/**
+ * Validate and convert GraphQL pagination args (skip, first, last, cursorAfter, cursorBefore)
+ * to Prisma connection arguments (skip, first, last, after, before)
+ *
+ * Four paginations modes are possible:
+ * - offset forward pagination (first, skip)
+ * - offset backward pagination (last, skip)
+ * - cursor forward pagination (first, cursorAfter)
+ * - cursor backward pagination (last, cursorBefore)
+ *
+ * The following rules are applied
+ * - if `first` is used without `skip` or `cursorAfter`  we start at the beginning of the list
+ * - if `last` is used without `skip` or `cursorBefore`  we start at the end of the list
+ * - if `cursorAfter` is used without `first`, we set `first` to a default value
+ * - if `cursorBefore` is used without `last`, we set `last` to a default value
+ * - if `skip` is used without `first` or `last`, we default to forward pagination and set `first` to a default value
+ * - if neither `skip`, `first`, `last`, `cursorAfter` or `cursorBefore` is used,
+ * we default to forward pagination from the beginning of the list and set `first` to a default value
+ *
+ * Any other combinations of inputs (for example passing `first` and `cursorBefore`) causes an error to be thrown
+ *
+ * The resulting connection arguments can be used with extra ordering argument that will influence the resulting pages
+ * ordering.
+ *
+ * Suppose the following list [A, B, C, D, E]
+ * (first: 2, after: C, orderBy: *ASC) => [D, E]
+ * (last: 2, before: C, orderBy: *ASC) => [A, B]
+ * (first: 2, after: C, orderBy: *DESC) => [B, A]
+ * (last: 2, before: C, orderBy: *DESC) => [E, D]
+ *
+ * See also
+ * - https://v1.prisma.io/docs/1.34/prisma-client/basic-data-access/reading-data-JAVASCRIPT-rsc2/#pagination
+ * - https://graphql.org/learn/pagination/
+ * - https://relay.dev/graphql/connections.htm#sec-Backward-pagination-arguments
+ */
+export function getConnectionsArgs(args: PaginationArgs) {
+  const maxPaginateBy = args.maxPaginateBy ?? 1000;
+
+  const validationSchema = yup.object().shape<PaginationArgs>({
+    first: positiveInteger.max(
+      maxPaginateBy,
+      `\`first\` doit être inférieur à ${maxPaginateBy}`
+    ),
+    last: positiveInteger.max(
+      maxPaginateBy,
+      `\`last\` doit être inférieur à ${maxPaginateBy}`
+    ),
+    skip: positiveInteger,
+    defaultPaginateBy: positiveInteger
+  });
+
+  // validate number formats
+  validationSchema.validateSync(args);
+
+  if (args.first & args.last) {
+    throw new UserInputError(
+      "L'utilisation simultanée de `first` et `last` n'est pas supportée"
+    );
+  }
+
+  if (args.cursorAfter && args.cursorBefore) {
+    throw new UserInputError(
+      "L'utilisation simultanée de `cursorAfter` et `cursorBefore` n'est pas supportée"
+    );
+  }
+
+  if (args.first && args.cursorBefore) {
+    throw new UserInputError(
+      "`first` ne peut pas être utilisé en conjonction avec `cursorBefore`"
+    );
+  }
+
+  if (args.last && args.cursorAfter) {
+    throw new UserInputError(
+      "`last` ne peut pas être utilisé en conjonction avec `cursorAfter`"
+    );
+  }
+
+  if ((args.skip && args.cursorAfter) || (args.skip && args.cursorBefore)) {
+    throw new UserInputError(
+      "`skip` (pagination par offset) ne peut pas être utilisé en conjonction avec `cursorAfter` ou `cursorBefore` (pagination par curseur)"
+    );
+  }
+
+  let first = args.first;
+  let last = args.last;
+
+  if (!first && !last) {
+    const paginateBy = args.defaultPaginateBy ?? 50;
+
+    if (args.cursorBefore) {
+      last = args.defaultPaginateBy ?? paginateBy;
+    } else {
+      first = args.defaultPaginateBy ?? paginateBy;
+    }
+  }
+
+  return {
+    ...(args.skip ? { skip: args.skip } : {}),
+    ...(first ? { first } : {}),
+    ...(last ? { last } : {}),
+    ...(args.cursorAfter ? { after: args.cursorAfter } : {}),
+    ...(args.cursorBefore ? { before: args.cursorBefore } : {})
+  };
+}

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -1,51 +1,27 @@
-import { UserInputError } from "apollo-server-express";
+import { getCompanyOrCompanyNotFound } from "../../../companies/database";
+import { Company, prisma } from "../../../generated/prisma-client";
 import { MissingSiret } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { getCompanyOrCompanyNotFound } from "../../../companies/database";
-import {
-  Form,
-  QueryFormsArgs,
-  QueryResolvers
-} from "../../../generated/graphql/types";
-import { Company, prisma } from "../../../generated/prisma-client";
+import { QueryResolvers } from "../../../generated/graphql/types";
 import { getUserCompanies } from "../../../users/database";
 import { checkIsCompanyMember } from "../../../users/permissions";
 import { getFormsRightFilter } from "../../database";
 import { expandFormFromDb } from "../../form-converter";
-
-function validateArgs(args: QueryFormsArgs) {
-  if (args.first < 1 || args.first > 500) {
-    throw new UserInputError(
-      "Le paramètre `first` doit être compris entre 1 et 500"
-    );
-  }
-  // DEPRECATED. To remove with skip
-  if (args.skip < 0) {
-    throw new UserInputError("Le paramètre `skip` doit être positif");
-  }
-  return args;
-}
-
-const DEFAULT_PAGINATE_BY = 50;
+import { getConnectionsArgs } from "../../pagination";
 
 const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
   const user = checkIsAuthenticated(context);
-  const validArgs = validateArgs(args);
-  return getForms(user.id, validArgs);
-};
 
-export async function getForms(
-  userId: string,
-  { siret, status, roles, hasNextStep, ...rest }: QueryFormsArgs
-): Promise<Form[]> {
+  const { siret, status, roles, hasNextStep, ...rest } = args;
+
   let company: Company | null = null;
 
   if (siret) {
     // a siret is specified, check user has permission on this company
     company = await getCompanyOrCompanyNotFound({ siret });
-    await checkIsCompanyMember({ id: userId }, { siret });
+    await checkIsCompanyMember({ id: user.id }, { siret });
   } else {
-    const userCompanies = await getUserCompanies(userId);
+    const userCompanies = await getUserCompanies(user.id);
 
     if (userCompanies.length === 0) {
       // the user is not member of any companies, return empty array
@@ -61,8 +37,16 @@ export async function getForms(
     company = userCompanies[0];
   }
 
+  // validate pagination arguments (skip, first, last, cursorAfter, cursorBefore)
+  // and convert them to prisma connections args: (skip, first, last, after, before)
+  const connectionsArgs = getConnectionsArgs({
+    ...rest,
+    defaultPaginateBy: 50,
+    maxPaginateBy: 500
+  });
+
   const queriedForms = await prisma.forms({
-    ...getPaginationFilter(rest),
+    ...connectionsArgs,
     orderBy: "createdAt_DESC",
     where: {
       updatedAt_gte: rest.updatedAfter,
@@ -81,7 +65,7 @@ export async function getForms(
   });
 
   return queriedForms.map(f => expandFormFromDb(f));
-}
+};
 
 function getHasNextStepFilter(siret: string, hasNextStep?: boolean | null) {
   if (hasNextStep == null) {
@@ -138,35 +122,6 @@ function getHasNextStepFilter(siret: string, hasNextStep?: boolean | null) {
   };
 
   return hasNextStep ? filter : { NOT: filter };
-}
-
-function getPaginationFilter({
-  first = DEFAULT_PAGINATE_BY,
-  last = DEFAULT_PAGINATE_BY,
-  skip,
-  cursorAfter: after,
-  cursorBefore: before
-}: Partial<QueryFormsArgs>) {
-  // DEPRECATED. To remove with skip
-  if (skip) {
-    return {
-      first,
-      skip
-    };
-  }
-
-  if (before) {
-    return {
-      before,
-      last
-    };
-  }
-
-  // By default, if no cursorAfter is provided we'll return the first elements
-  return {
-    after,
-    first
-  };
 }
 
 export default formsResolver;

--- a/back/src/forms/resolvers/queries/formsLifeCycle.ts
+++ b/back/src/forms/resolvers/queries/formsLifeCycle.ts
@@ -7,6 +7,7 @@ import {
 import { ForbiddenError, UserInputError } from "apollo-server-express";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getFormsRightFilter } from "../../database";
+import { getConnectionsArgs } from "../../pagination";
 
 const PAGINATE_BY = 100;
 
@@ -88,12 +89,16 @@ const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
 
   const formsFilter = getFormsRightFilter(selectedCompany.siret);
 
+  const connectionArgs = getConnectionsArgs({
+    cursorAfter,
+    cursorBefore,
+    defaultPaginateBy: PAGINATE_BY
+  });
+
   const statusLogsCx = await prisma
     .statusLogsConnection({
       orderBy: "loggedAt_DESC",
-      [cursorAfter ? "first" : "last"]: PAGINATE_BY,
-      after: cursorAfter,
-      before: cursorBefore,
+      ...connectionArgs,
       where: {
         loggedAt_not: null,
         loggedAt_gte: loggedAfter,

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1487,7 +1487,7 @@ export type Query = {
   /**
    * Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
    * La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
-   * Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
+   * Seuls les changements de statut disposant d'un champ `loggedAt` non nul sont retournés
    */
   formsLifeCycle: FormsLifeCycleData;
   /**

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -160,8 +160,7 @@ SIRET d'un établissement dont je suis membre
 <td>
 
 DEPRECATED - (Optionnel) PAGINATION
-Nombre d'éléments à ne pas récupérer en début de liste
-dans le mode de pagination par "offset"
+Nombre d'éléments à ne pas récupérer en début de liste dans le mode de pagination par "offset"
 Utiliser en conjonction avec `first` pour paginer "en avant" (des plus récents aux plus anciens)
 Utiliser en conjonction avec `last` pour paginer "en arrière" (des plus anciens aux plus récents)
 Défaut à 0
@@ -315,7 +314,7 @@ Défaut à vide.
 
 Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
 La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
-Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
+Seuls les changements de statut disposant d'un champ `loggedAt` non nul sont retournés
 
 </td>
 </tr>
@@ -354,7 +353,7 @@ Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont re
 (Optionnel) PAGINATION
 Permet de paginer les changements de statut "en avant"
 (des changements de statut les plus récents aux changements de statut les plus anciens)
-Curseur après lequel les changements de statuts doivent être retournés
+Curseur après lequel les changements de statut doivent être retournés
 Attend un identifiant (propriété `id`) d'un changement de statut
 Défaut à vide, pour retourner les changements de statut les plus récents
 Le changement de statut précisé dans le curseur ne fait pas partie du résultat
@@ -369,7 +368,7 @@ Le changement de statut précisé dans le curseur ne fait pas partie du résulta
 (Optionnel) PAGINATION
 Permet de paginer les changements de statut "en arrière"
 (des changements de statut les plus anciens aux changements de statut les plus récents)
-Curseur avant lequel les changements de statuts doivent être retournés
+Curseur avant lequel les changements de statut doivent être retournés
 Attend un identifiant (propriété `id`) d'un changement de statut
 Défaut à vide, pour retourner les changements de statut les plus anciens
 Le changement de statut précisé dans le curseur ne fait pas partie du résultat

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -161,6 +161,9 @@ SIRET d'un établissement dont je suis membre
 
 DEPRECATED - (Optionnel) PAGINATION
 Nombre d'éléments à ne pas récupérer en début de liste
+dans le mode de pagination par "offset"
+Utiliser en conjonction avec `first` pour paginer "en avant" (des plus récents aux plus anciens)
+Utiliser en conjonction avec `last` pour paginer "en arrière" (des plus anciens aux plus récents)
 Défaut à 0
 
 </td>
@@ -171,9 +174,11 @@ Défaut à 0
 <td>
 
 (Optionnel) PAGINATION
+Permet en conjonction avec `first` de paginer "en avant"
+(des bordereaux les plus récents aux bordereaux les plus anciens)
 Curseur après lequel les bordereaux doivent être retournés
 Attend un identifiant (propriété `id`) de BSD
-Défaut à vide, pour retourner les "premiers" bordereaux
+Défaut à vide, pour retourner les bordereaux les plus récents
 Le BSD précisé dans le curseur ne fait pas partie du résultat
 
 </td>
@@ -184,9 +189,10 @@ Le BSD précisé dans le curseur ne fait pas partie du résultat
 <td>
 
 (Optionnel) PAGINATION
+Permet en conjonction avec `cursorAfter` de paginer "en avant"
+(des bordereaux les plus récents aux bordereaux les plus anciens)
 Nombre de bordereaux retournés après le `cursorAfter`
 Défaut à 50, maximum à 500
-Ignoré si utilisé avec `cursorBefore`
 
 </td>
 </tr>
@@ -196,9 +202,11 @@ Ignoré si utilisé avec `cursorBefore`
 <td>
 
 (Optionnel) PAGINATION
+Permet en conjonction avec `last` de paginer "en arrière"
+(des bordereaux les plus anciens aux bordereaux les plus récents)
 Curseur avant lequel les bordereaux doivent être retournés
 Attend un identifiant (propriété `id`) de BSD
-Défaut à vide, pour retourner les "derniers" bordereaux
+Défaut à vide, pour retourner les bordereaux les plus anciens
 Le BSD précisé dans le curseur ne fait pas partie du résultat
 
 </td>
@@ -211,7 +219,6 @@ Le BSD précisé dans le curseur ne fait pas partie du résultat
 (Optionnel) PAGINATION
 Nombre de bordereaux retournés avant le `cursorBefore`
 Défaut à 50, maximum à 500
-Ignoré si utilisé avec `cursorAfter`
 
 </td>
 </tr>
@@ -344,7 +351,13 @@ Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont re
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-(Optionnel) PAGINATION - Curseur après lequel les changements de statut doivent être retournés
+(Optionnel) PAGINATION
+Permet de paginer les changements de statut "en avant"
+(des changements de statut les plus récents aux changements de statut les plus anciens)
+Curseur après lequel les changements de statuts doivent être retournés
+Attend un identifiant (propriété `id`) d'un changement de statut
+Défaut à vide, pour retourner les changements de statut les plus récents
+Le changement de statut précisé dans le curseur ne fait pas partie du résultat
 
 </td>
 </tr>
@@ -353,7 +366,13 @@ Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont re
 <td valign="top"><a href="#string">String</a></td>
 <td>
 
-(Optionnel) PAGINATION - Curseur avant lequel les changements de statut doivent être retournés
+(Optionnel) PAGINATION
+Permet de paginer les changements de statut "en arrière"
+(des changements de statut les plus anciens aux changements de statut les plus récents)
+Curseur avant lequel les changements de statuts doivent être retournés
+Attend un identifiant (propriété `id`) d'un changement de statut
+Défaut à vide, pour retourner les changements de statut les plus anciens
+Le changement de statut précisé dans le curseur ne fait pas partie du résultat
 
 </td>
 </tr>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1496,7 +1496,7 @@ export type Query = {
   /**
    * Renvoie les changements de statut des bordereaux de l'entreprise sélectionnée.
    * La liste est paginée par pages de 100 items, ordonnée par date décroissante (champ `loggedAt`)
-   * Seuls les changements de statuts disposant d'un champ `loggedAt` non nul sont retournés
+   * Seuls les changements de statut disposant d'un champ `loggedAt` non nul sont retournés
    */
   formsLifeCycle: FormsLifeCycleData;
   /**


### PR DESCRIPTION
- Mise en commun du code qui calcule les paramètres de pagination prisma (`skip`, `first`, `last`, `after`, `before`) à partir des paramètres de pagination que l'on est susceptible de passer côté GraphQL(`skip`, `first`, `last`, `cursorAfter`, `cursorBefore`) dans les requêtes `forms` et `formsLifeCycle` . Cela permet de commencer à standardiser le fonctionnement de la pagination à travers le code. 
- Ça corrige au passage le bug rencontré sur la query `forms` lorsqu'on passe uniquement `last` et ça ajoute un certain nombre de validation sur les paramètres (entier positif, valeur max, combinaisons de paramètres invalide, etc).
- Amélioration de la documentation

Après pas mal de réflexions sur le fonctionnement désiré de la pagination par curseur dans https://github.com/MTES-MCT/trackdechets/pull/698, j'ai pu conclure que notre mode de fonctionnement était bien valide mais que l'utilisation de l'ordre décroissant par défaut n'était pas idéal: quand on demande les derniers avec `last` on obtient les premiers et quand on demande les premiers avec `first`, on obtient les derniers, sans que cette ordre soit explicite dans les paramètres passés. Dans la perspective d'une v2, il faudrait soit avoir un ordre croissant (comme c'est la cas sur l'API Github), soit donner le contrôle à l'utilisateur sur l'ordre pour rendre cela explicite.


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/ckVUwjcE)
