### PR TITLE
Correction de la duplication d'un BSD avec un entreposage provisoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 # Unreleased
 
 - Migration du service td-etl dans un projet Github à part [PR 683](https://github.com/MTES-MCT/trackdechets/pull/683)
+- Correction de la mutation `duplicateForm` pour dupliquer l'entreposage provisoire, [PR 700](https://github.com/
 
 # [2020.10.1] 03/11/2020
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 # Unreleased
 
 - Migration du service td-etl dans un projet Github à part [PR 683](https://github.com/MTES-MCT/trackdechets/pull/683)
+- Ajout d'un nouveau champ `packagingInfos` qui viendra remplacer `packagings`, `numberOfPackages` et `otherPackaging`. Ces champs sont encore supportés pour quelques temps mais marqué comme dépréciés. Nous vous invitons à migrer aussi vite que possible. [PR 600](https://github.com/MTES-MCT/trackdechets/pull/600)
 - Correction de la mutation `duplicateForm` pour dupliquer l'entreposage provisoire, [PR 700](https://github.com/
 
 # [2020.10.1] 03/11/2020
@@ -44,7 +45,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug permettant de sceller des bordereaux avec des informations sur le détail du déchet (cadre 3,4,5,6) erronnées ce qui causait des erreurs de validation ultérieures [PR 681](https://github.com/MTES-MCT/trackdechets/pull/681)
 - Correction d'un bug empêchant la complétion du BSD suite depuis l'interface [PR 662](https://github.com/MTES-MCT/trackdechets/pull/662)
 - Correction d'un bug lors de l'appel à la mutation `markAsTempStored` sans passer le paramètre optionnel `signedAt` [PR 602](https://github.com/MTES-MCT/trackdechets/pull/602)
-- Ajout d'un nouveau champ `packagingInfos` qui viendra remplacer `packagings`, `numberOfPackages` et `otherPackaging`. Ces champs sont encore supportés pour quelques temps mais marqué comme dépréciés. Nous vous invitons à migrer aussi vite que possible. [PR 600](https://github.com/MTES-MCT/trackdechets/pull/600)
 
 # [2020.10.1] 05/10/2020
 

--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -5,9 +5,7 @@ import {
   FormCreateInput,
   FormUpdateInput,
   TemporaryStorageDetailCreateInput,
-  TemporaryStorageDetailUpdateInput,
-  Form,
-  TransportSegment
+  TemporaryStorageDetailUpdateInput
 } from "../generated/prisma-client";
 import {
   Form as GraphQLForm,
@@ -628,50 +626,6 @@ export function expandTransportSegmentFromDb(
     readyToTakeOver: segment.readyToTakeOver,
     segmentNumber: segment.segmentNumber
   };
-}
-
-export function cleanUpNotDuplicatableFieldsInForm(form: Form): Partial<Form> {
-  const {
-    id,
-    createdAt,
-    updatedAt,
-    readableId,
-
-    transporterNumberPlate,
-
-    status,
-    sentAt,
-    sentBy,
-
-    isAccepted,
-    wasteAcceptationStatus,
-    wasteRefusalReason,
-    receivedBy,
-    receivedAt,
-    quantityReceived,
-    processingOperationDone,
-    currentTransporterSiret,
-    signedByTransporter,
-    transporterCustomInfo,
-    ...rest
-  } = form;
-
-  return rest;
-}
-
-export function cleanUpNonDuplicatableSegmentField(
-  segment: TransportSegment
-): Partial<TransportSegment> {
-  const {
-    id,
-    createdAt,
-    updatedAt,
-    takenOverAt,
-    takenOverBy,
-    ...rest
-  } = segment;
-
-  return rest;
 }
 
 /**

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -1,10 +1,10 @@
 import {
   formFactory,
+  formWithTempStorageFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { prisma } from "../../../../generated/prisma-client";
-import { cleanUpNotDuplicatableFieldsInForm } from "../../../form-converter";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 
 const DUPLICATE_FORM = `
@@ -18,12 +18,208 @@ const DUPLICATE_FORM = `
 describe("Mutation.duplicateForm", () => {
   afterEach(() => resetDatabase());
 
-  it("should duplicate an existing form", async () => {
+  it.each([
+    ["", {}],
+    [
+      "with an eco-organisme",
+      { ecoOrganismeName: "COREPILE", ecoOrganismeSiret: "12345678912345" }
+    ]
+  ])("should duplicate a form %s", async (_, opt) => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const form = await formFactory({
+    const {
+      id,
+      nextDestinationProcessingOperation,
+      nextDestinationCompanyName,
+      nextDestinationCompanySiret,
+      nextDestinationCompanyAddress,
+      nextDestinationCompanyCountry,
+      nextDestinationCompanyContact,
+      nextDestinationCompanyPhone,
+      nextDestinationCompanyMail,
+      emitterType,
+      emitterPickupSite,
+      emitterWorkSiteName,
+      emitterWorkSiteAddress,
+      emitterWorkSiteCity,
+      emitterWorkSitePostalCode,
+      emitterWorkSiteInfos,
+      emitterCompanyName,
+      emitterCompanySiret,
+      emitterCompanyAddress,
+      emitterCompanyContact,
+      emitterCompanyPhone,
+      emitterCompanyMail,
+      recipientCap,
+      recipientProcessingOperation,
+      recipientCompanyName,
+      recipientCompanySiret,
+      recipientCompanyAddress,
+      recipientCompanyContact,
+      recipientCompanyPhone,
+      recipientCompanyMail,
+      transporterCompanyName,
+      transporterCompanySiret,
+      transporterCompanyAddress,
+      transporterCompanyContact,
+      transporterCompanyPhone,
+      transporterCompanyMail,
+      transporterIsExemptedOfReceipt,
+      transporterReceipt,
+      transporterDepartment,
+      transporterValidityLimit,
+      wasteDetailsCode,
+      wasteDetailsName,
+      wasteDetailsOnuCode,
+      wasteDetailsPackagings,
+      wasteDetailsOtherPackaging,
+      wasteDetailsNumberOfPackages,
+      wasteDetailsQuantity,
+      wasteDetailsQuantityType,
+      wasteDetailsConsistence,
+      traderCompanyName,
+      traderCompanySiret,
+      traderCompanyAddress,
+      traderCompanyContact,
+      traderCompanyPhone,
+      traderCompanyMail,
+      traderReceipt,
+      traderDepartment,
+      traderValidityLimit,
+      ecoOrganismeName,
+      ecoOrganismeSiret,
+      nextTransporterSiret
+    } = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret, ...opt }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate(DUPLICATE_FORM, {
+      variables: {
+        id
+      }
+    });
+    const duplicatedForm = await prisma.form({ id: data.duplicateForm.id });
+
+    expect(duplicatedForm).toMatchObject({
+      customId: null,
+      isDeleted: false,
+      isImportedFromPaper: false,
+      signedByTransporter: null,
+      status: "DRAFT",
+      sentAt: null,
+      sentBy: null,
+      isAccepted: null,
+      wasteAcceptationStatus: null,
+      wasteRefusalReason: null,
+      receivedBy: null,
+      receivedAt: null,
+      signedAt: null,
+      quantityReceived: null,
+      processedBy: null,
+      processedAt: null,
+      processingOperationDone: null,
+      processingOperationDescription: null,
+      noTraceability: null,
+      nextDestinationProcessingOperation,
+      nextDestinationCompanyName,
+      nextDestinationCompanySiret,
+      nextDestinationCompanyAddress,
+      nextDestinationCompanyCountry,
+      nextDestinationCompanyContact,
+      nextDestinationCompanyPhone,
+      nextDestinationCompanyMail,
+      emitterType,
+      emitterPickupSite,
+      emitterWorkSiteName,
+      emitterWorkSiteAddress,
+      emitterWorkSiteCity,
+      emitterWorkSitePostalCode,
+      emitterWorkSiteInfos,
+      emitterCompanyName,
+      emitterCompanySiret,
+      emitterCompanyAddress,
+      emitterCompanyContact,
+      emitterCompanyPhone,
+      emitterCompanyMail,
+      recipientCap,
+      recipientProcessingOperation,
+      recipientIsTempStorage: false,
+      recipientCompanyName,
+      recipientCompanySiret,
+      recipientCompanyAddress,
+      recipientCompanyContact,
+      recipientCompanyPhone,
+      recipientCompanyMail,
+      transporterCompanyName,
+      transporterCompanySiret,
+      transporterCompanyAddress,
+      transporterCompanyContact,
+      transporterCompanyPhone,
+      transporterCompanyMail,
+      transporterIsExemptedOfReceipt,
+      transporterReceipt,
+      transporterDepartment,
+      transporterValidityLimit,
+      transporterNumberPlate: null,
+      transporterCustomInfo: null,
+      wasteDetailsCode,
+      wasteDetailsName,
+      wasteDetailsOnuCode,
+      wasteDetailsPackagings,
+      wasteDetailsOtherPackaging,
+      wasteDetailsNumberOfPackages,
+      wasteDetailsQuantity,
+      wasteDetailsQuantityType,
+      wasteDetailsConsistence,
+      traderCompanyName,
+      traderCompanySiret,
+      traderCompanyAddress,
+      traderCompanyContact,
+      traderCompanyPhone,
+      traderCompanyMail,
+      traderReceipt,
+      traderDepartment,
+      traderValidityLimit,
+      ecoOrganismeName,
+      ecoOrganismeSiret,
+      currentTransporterSiret: null,
+      nextTransporterSiret
+    });
+  });
+
+  it("should duplicate the temporary storage detail", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await formWithTempStorageFactory({
       ownerId: user.id,
       opt: { emitterCompanySiret: company.siret }
     });
+    const {
+      destinationCompanyName,
+      destinationCompanySiret,
+      destinationCompanyAddress,
+      destinationCompanyContact,
+      destinationCompanyPhone,
+      destinationCompanyMail,
+      destinationCap,
+      destinationProcessingOperation,
+      wasteDetailsOnuCode,
+      wasteDetailsPackagings,
+      wasteDetailsOtherPackaging,
+      wasteDetailsNumberOfPackages,
+      wasteDetailsQuantity,
+      wasteDetailsQuantityType,
+      transporterCompanyName,
+      transporterCompanySiret,
+      transporterCompanyAddress,
+      transporterCompanyContact,
+      transporterCompanyPhone,
+      transporterCompanyMail,
+      transporterIsExemptedOfReceipt,
+      transporterReceipt,
+      transporterDepartment,
+      transporterValidityLimit
+    } = await prisma.form({ id: form.id }).temporaryStorageDetail();
 
     const { mutate } = makeClient(user);
     const { data } = await mutate(DUPLICATE_FORM, {
@@ -31,14 +227,51 @@ describe("Mutation.duplicateForm", () => {
         id: form.id
       }
     });
+    const duplicatedForm = await prisma.form({ id: data.duplicateForm.id });
+    const duplicatedTemporaryStorageDetail = await prisma
+      .form({
+        id: duplicatedForm.id
+      })
+      .temporaryStorageDetail();
 
-    const duplicateForm = await prisma.form({
-      id: data.duplicateForm.id
+    expect(duplicatedForm.recipientIsTempStorage).toBe(true);
+    expect(duplicatedTemporaryStorageDetail).toMatchObject({
+      tempStorerQuantityType: null,
+      tempStorerQuantityReceived: null,
+      tempStorerWasteAcceptationStatus: null,
+      tempStorerWasteRefusalReason: null,
+      tempStorerReceivedAt: null,
+      tempStorerReceivedBy: null,
+      tempStorerSignedAt: null,
+      destinationCompanyName,
+      destinationCompanySiret,
+      destinationCompanyAddress,
+      destinationCompanyContact,
+      destinationCompanyPhone,
+      destinationCompanyMail,
+      destinationCap,
+      destinationProcessingOperation,
+      wasteDetailsOnuCode,
+      wasteDetailsPackagings,
+      wasteDetailsOtherPackaging,
+      wasteDetailsNumberOfPackages,
+      wasteDetailsQuantity,
+      wasteDetailsQuantityType,
+      transporterCompanyName,
+      transporterCompanySiret,
+      transporterCompanyAddress,
+      transporterCompanyContact,
+      transporterCompanyPhone,
+      transporterCompanyMail,
+      transporterIsExemptedOfReceipt,
+      transporterReceipt,
+      transporterDepartment,
+      transporterValidityLimit,
+      transporterNumberPlate: null,
+      signedByTransporter: null,
+      signedBy: null,
+      signedAt: null
     });
-
-    expect(cleanUpNotDuplicatableFieldsInForm(form)).toEqual(
-      cleanUpNotDuplicatableFieldsInForm(duplicateForm)
-    );
   });
 
   it("should create a status log", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -19,10 +19,19 @@ describe("Mutation.duplicateForm", () => {
   afterEach(() => resetDatabase());
 
   it.each([
-    ["", {}],
+    [
+      "",
+      {
+        transporterNumberPlate: "AB-1234-56",
+        transporterCustomInfo: "T001"
+      }
+    ],
     [
       "with an eco-organisme",
-      { ecoOrganismeName: "COREPILE", ecoOrganismeSiret: "12345678912345" }
+      {
+        ecoOrganismeName: "COREPILE",
+        ecoOrganismeSiret: "12345678912345"
+      }
     ]
   ])("should duplicate a form %s", async (_, opt) => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
@@ -90,7 +99,10 @@ describe("Mutation.duplicateForm", () => {
       nextTransporterSiret
     } = await formFactory({
       ownerId: user.id,
-      opt: { emitterCompanySiret: company.siret, ...opt }
+      opt: {
+        emitterCompanySiret: company.siret,
+        ...opt
+      }
     });
 
     const { mutate } = makeClient(user);

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -3,7 +3,7 @@ import {
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
-import { prisma, Form } from "../../../../generated/prisma-client";
+import { prisma } from "../../../../generated/prisma-client";
 import { cleanUpNotDuplicatableFieldsInForm } from "../../../form-converter";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 
@@ -32,22 +32,37 @@ describe("Mutation.duplicateForm", () => {
       }
     });
 
-    const duplicateForm = (await prisma.form({
+    const duplicateForm = await prisma.form({
       id: data.duplicateForm.id
-    })) as Form;
+    });
 
     expect(cleanUpNotDuplicatableFieldsInForm(form)).toEqual(
       cleanUpNotDuplicatableFieldsInForm(duplicateForm)
     );
+  });
 
-    // check relevant statusLog is created
+  it("should create a status log", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate(DUPLICATE_FORM, {
+      variables: {
+        id: form.id
+      }
+    });
+
     const statusLogs = await prisma.statusLogs({
       where: {
-        form: { id: duplicateForm.id },
+        form: { id: data.duplicateForm.id },
         user: { id: user.id },
         status: "DRAFT"
       }
     });
+
     expect(statusLogs.length).toEqual(1);
     expect(statusLogs[0].loggedAt).toBeTruthy();
   });

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -1,8 +1,11 @@
-import { prisma, Status } from "../../../generated/prisma-client";
 import {
-  cleanUpNotDuplicatableFieldsInForm,
-  expandFormFromDb
-} from "../../form-converter";
+  Form,
+  prisma,
+  Status,
+  TemporaryStorageDetail,
+  User
+} from "../../../generated/prisma-client";
+import { expandFormFromDb } from "../../form-converter";
 import { getReadableId } from "../../readable-id";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
@@ -10,6 +13,93 @@ import { getFormOrFormNotFound, getFullForm } from "../../database";
 import { getFullUser } from "../../../users/database";
 import { isFormContributor } from "../../permissions";
 import { NotFormContributor } from "../../errors";
+
+/**
+ * Duplicate a form by stripping the properties that should not be copied.
+ *
+ * @param {User} user user that should own the duplicated form
+ * @param {Form} form the form to duplicate
+ */
+async function duplicateForm(
+  user: User,
+  {
+    id,
+    readableId,
+    customId,
+    isDeleted,
+    isImportedFromPaper,
+    createdAt,
+    updatedAt,
+    signedByTransporter,
+    status,
+    sentAt,
+    sentBy,
+    isAccepted,
+    wasteAcceptationStatus,
+    wasteRefusalReason,
+    receivedBy,
+    receivedAt,
+    signedAt,
+    quantityReceived,
+    processedBy,
+    processedAt,
+    processingOperationDone,
+    processingOperationDescription,
+    noTraceability,
+    transporterNumberPlate,
+    transporterCustomInfo,
+    currentTransporterSiret,
+
+    ...rest
+  }: Form
+) {
+  return prisma.createForm({
+    ...rest,
+    readableId: await getReadableId(),
+    status: "DRAFT",
+    owner: { connect: { id: user.id } }
+  });
+}
+
+/**
+ * Duplicate a temporary storage detail by stripping
+ * the properties that should not be copied.
+ *
+ * @param {Form} form the form to which the duplicated temporary storage detail should be linked to
+ * @param {TemporaryStorageDetail} temporaryStorageDetail the temporary storage detail to duplicate
+ */
+function duplicateTemporaryStorageDetail(
+  form: Form,
+  {
+    id,
+    tempStorerQuantityType,
+    tempStorerQuantityReceived,
+    tempStorerWasteAcceptationStatus,
+    tempStorerWasteRefusalReason,
+    tempStorerReceivedAt,
+    tempStorerReceivedBy,
+    tempStorerSignedAt,
+    transporterNumberPlate,
+    signedByTransporter,
+    signedBy,
+    signedAt,
+
+    ...rest
+  }: TemporaryStorageDetail
+) {
+  return prisma.updateForm({
+    where: {
+      id: form.id
+    },
+    data: {
+      temporaryStorageDetail: {
+        create: {
+          ...rest
+        }
+      }
+    }
+  });
+}
 
 /**
  * Duplicate the content of a form into a new DRAFT form
@@ -34,19 +124,15 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
     throw new NotFormContributor();
   }
 
-  // get segments to duplicate them after cleanup
-  // const transportSegments = await prisma.transportSegments({
-  //   where: {
-  //     form: { id: formId }
-  //   }
-  // });
+  const newForm = await duplicateForm(user, existingForm);
 
-  const newForm = await prisma.createForm({
-    ...cleanUpNotDuplicatableFieldsInForm(existingForm),
-    readableId: await getReadableId(),
-    status: "DRAFT",
-    owner: { connect: { id: user.id } }
-  });
+  if (fullExistingForm.temporaryStorage) {
+    await duplicateTemporaryStorageDetail(
+      newForm,
+      fullExistingForm.temporaryStorage
+    );
+  }
+
   // create statuslog when form is created
   await prisma.createStatusLog({
     form: { connect: { id: newForm.id } },
@@ -55,15 +141,6 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
     updatedFields: {},
     loggedAt: new Date()
   });
-  // currently (non tranporter's) UI dashboard does not show segments, so this code is disabled until UI update.
-  // const segmentDuplicates = transportSegments.map(segment =>
-  //   prisma.createTransportSegment({
-  //     form: { connect: { id: newForm.id } },
-  //     ...cleanUpNonDuplicatableSegmentField(segment)
-  //   })
-  // );
-
-  // await Promise.all(segmentDuplicates);
 
   return expandFormFromDb(newForm);
 };


### PR DESCRIPTION
Cette PR corrige la mutation `duplicateForm` pour qu'elle duplique correctement le `TemporaryStorageDetail`.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/Sjy8Y7qe/1014-quand-je-duplique-un-bsd-scelle-avec-bsd-suite-lentreprise-initialement-en-destination-change-au-profit-de-la-dreal-me-concernan)
