### PR TITLE
Ajout du type d'authentification utilisé dans les logs de statut

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,7 +33,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Migration du service td-etl dans un projet Github à part [PR 683](https://github.com/MTES-MCT/trackdechets/pull/683)
 - Intégration du service de génération de pdf en tant que module interne au backend [PR 172](https://github.com/MTES-MCT/trackdechets/pull/712)
-
+- Ajout du type d'authentification utilisé dans les logs de statut [PR 702](https://github.com/MTES-MCT/trackdechets/pull/702)
 
 # [2020.10.1] 03/11/2020
 

--- a/back/prisma/database/form.prisma
+++ b/back/prisma/database/form.prisma
@@ -233,9 +233,16 @@ enum Status {
   RESENT
 }
 
+enum AuthType {
+  SESSION
+  BEARER
+  JWT
+}
+
 type StatusLog {
   id: ID! @id
   user: User!
+  authType: AuthType
   form: Form!
   status: Status!
   loggedAt: DateTime

--- a/back/prisma/database/form.prisma
+++ b/back/prisma/database/form.prisma
@@ -233,12 +233,6 @@ enum Status {
   RESENT
 }
 
-enum AuthType {
-  SESSION
-  BEARER
-  JWT
-}
-
 type StatusLog {
   id: ID! @id
   user: User!

--- a/back/prisma/database/user.prisma
+++ b/back/prisma/database/user.prisma
@@ -65,6 +65,18 @@ type MembershipRequest {
 }
 
 """
+Different types of authentication possible to Trackdechet's API
+"""
+enum AuthType {
+  # Session authentification from Trackdechets'UI
+  SESSION
+  # Bearer access token (stored in database)
+  BEARER
+  # JWT token
+  JWT
+}
+
+"""
 OAuth2 - Access token to a user resource
 https://tools.ietf.org/html/rfc6749#section-5
 """

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -13,8 +13,7 @@ import {
   User,
   AccessToken,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  User as PrismaUser,
-  AuthType as PrismaAuthType
+  User as PrismaUser
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
 import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
@@ -33,21 +32,9 @@ declare global {
 }
 
 export enum AuthType {
-  Session = "session",
-  JWT = "jwt",
-  Bearer = "bearer"
-}
-
-// Convert express AuthType to Prisma AuthType
-export function toPrismaAuthType(authType: AuthType): PrismaAuthType {
-  const SESSION: PrismaAuthType = "SESSION";
-  const BEARER: PrismaAuthType = "BEARER";
-  const JWT: PrismaAuthType = "JWT";
-  return {
-    [AuthType.Session]: SESSION,
-    [AuthType.Bearer]: BEARER,
-    [AuthType.JWT]: JWT
-  }[authType];
+  Session = "SESSION",
+  JWT = "JWT",
+  Bearer = "BEARER"
 }
 
 // verbose error message and related errored field

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -13,7 +13,8 @@ import {
   User,
   AccessToken,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  User as PrismaUser
+  User as PrismaUser,
+  AuthType as PrismaAuthType
 } from "./generated/prisma-client";
 import { compare } from "bcrypt";
 import { sameDayMidnight, daysBetween, sanitizeEmail } from "./utils";
@@ -35,6 +36,18 @@ export enum AuthType {
   Session = "session",
   JWT = "jwt",
   Bearer = "bearer"
+}
+
+// Convert express AuthType to Prisma AuthType
+export function toPrismaAuthType(authType: AuthType): PrismaAuthType {
+  const SESSION: PrismaAuthType = "SESSION";
+  const BEARER: PrismaAuthType = "BEARER";
+  const JWT: PrismaAuthType = "JWT";
+  return {
+    [AuthType.Session]: SESSION,
+    [AuthType.Bearer]: BEARER,
+    [AuthType.JWT]: JWT
+  }[authType];
 }
 
 // verbose error message and related errored field

--- a/back/src/forms/workflow/__tests__/transitionForm.integration.ts
+++ b/back/src/forms/workflow/__tests__/transitionForm.integration.ts
@@ -1,4 +1,5 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
+import { AuthType } from "../../../auth";
 import { FormUpdateInput, prisma } from "../../../generated/prisma-client";
 import { formFactory, userFactory } from "../../../__tests__/factories";
 import transitionForm from "../transitionForm";
@@ -23,7 +24,7 @@ describe("transition form", () => {
     };
 
     const event = { type: EventType.MarkAsReceived, formUpdateInput };
-    await transitionForm(user, form, event);
+    await transitionForm({ ...user, auth: AuthType.Bearer }, form, event);
 
     const updatedForm = await prisma.form({ id: form.id });
 
@@ -38,6 +39,7 @@ describe("transition form", () => {
     const statusLogForm = await prisma.statusLog({ id: statusLog.id }).form();
 
     expect(statusLog.status).toEqual(nextStatus);
+    expect(statusLog.authType).toEqual("BEARER");
     expect(statusLog.loggedAt.length).toBeGreaterThan(0);
     expect(statusLog.updatedFields).toEqual(formUpdateInput);
     expect(statusLogUser.id).toEqual(user.id);

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -2,7 +2,6 @@ import {
   Form,
   FormUpdateInput,
   Status,
-  AuthType,
   prisma
 } from "../../generated/prisma-client";
 import { Event } from "./types";

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -8,7 +8,6 @@ import { Event } from "./types";
 import machine from "./machine";
 import { InvalidTransition } from "../errors";
 import { formDiff } from "./diff";
-import { toPrismaAuthType } from "../../auth";
 
 /**
  * Transition a form from initial state (ex: DRAFT) to next state (ex: SEALED)
@@ -66,7 +65,7 @@ export default async function transitionForm(
     user: { connect: { id: user.id } },
     form: { connect: { id: form.id } },
     status: nextStatus,
-    authType: toPrismaAuthType(user.auth),
+    authType: user.auth,
     loggedAt: new Date(),
     updatedFields
   });

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -2,13 +2,14 @@ import {
   Form,
   FormUpdateInput,
   Status,
-  prisma,
-  User
+  AuthType,
+  prisma
 } from "../../generated/prisma-client";
 import { Event } from "./types";
 import machine from "./machine";
 import { InvalidTransition } from "../errors";
 import { formDiff } from "./diff";
+import { toPrismaAuthType } from "../../auth";
 
 /**
  * Transition a form from initial state (ex: DRAFT) to next state (ex: SEALED)
@@ -17,7 +18,7 @@ import { formDiff } from "./diff";
  * logged in the StatusLogs table
  */
 export default async function transitionForm(
-  user: User,
+  user: Express.User,
   form: Form,
   event: Event
 ) {
@@ -66,6 +67,7 @@ export default async function transitionForm(
     user: { connect: { id: user.id } },
     form: { connect: { id: form.id } },
     status: nextStatus,
+    authType: toPrismaAuthType(user.auth),
     loggedAt: new Date(),
     updatedFields
   });

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -1334,6 +1334,8 @@ export type RubriqueOrderByInput =
   | "wasteType_ASC"
   | "wasteType_DESC";
 
+export type AuthType = "SESSION" | "BEARER" | "JWT";
+
 export type Status =
   | "DRAFT"
   | "SEALED"
@@ -1351,6 +1353,8 @@ export type Status =
 export type StatusLogOrderByInput =
   | "id_ASC"
   | "id_DESC"
+  | "authType_ASC"
+  | "authType_DESC"
   | "status_ASC"
   | "status_DESC"
   | "loggedAt_ASC"
@@ -4393,6 +4397,10 @@ export interface StatusLogWhereInput {
   id_ends_with?: Maybe<ID_Input>;
   id_not_ends_with?: Maybe<ID_Input>;
   user?: Maybe<UserWhereInput>;
+  authType?: Maybe<AuthType>;
+  authType_not?: Maybe<AuthType>;
+  authType_in?: Maybe<AuthType[] | AuthType>;
+  authType_not_in?: Maybe<AuthType[] | AuthType>;
   form?: Maybe<FormWhereInput>;
   status?: Maybe<Status>;
   status_not?: Maybe<Status>;
@@ -7351,6 +7359,7 @@ export interface RubriqueUpdateManyMutationInput {
 export interface StatusLogCreateInput {
   id?: Maybe<ID_Input>;
   user: UserCreateOneInput;
+  authType?: Maybe<AuthType>;
   form: FormCreateOneInput;
   status: Status;
   loggedAt?: Maybe<DateTimeInput>;
@@ -7364,6 +7373,7 @@ export interface FormCreateOneInput {
 
 export interface StatusLogUpdateInput {
   user?: Maybe<UserUpdateOneRequiredInput>;
+  authType?: Maybe<AuthType>;
   form?: Maybe<FormUpdateOneRequiredInput>;
   status?: Maybe<Status>;
   loggedAt?: Maybe<DateTimeInput>;
@@ -7383,6 +7393,7 @@ export interface FormUpsertNestedInput {
 }
 
 export interface StatusLogUpdateManyMutationInput {
+  authType?: Maybe<AuthType>;
   status?: Maybe<Status>;
   loggedAt?: Maybe<DateTimeInput>;
   updatedFields?: Maybe<Json>;
@@ -10408,6 +10419,7 @@ export interface AggregateRubriqueSubscription
 
 export interface StatusLog {
   id: ID_Output;
+  authType?: AuthType;
   status: Status;
   loggedAt?: DateTimeOutput;
   updatedFields?: Json;
@@ -10416,6 +10428,7 @@ export interface StatusLog {
 export interface StatusLogPromise extends Promise<StatusLog>, Fragmentable {
   id: () => Promise<ID_Output>;
   user: <T = UserPromise>() => T;
+  authType: () => Promise<AuthType>;
   form: <T = FormPromise>() => T;
   status: () => Promise<Status>;
   loggedAt: () => Promise<DateTimeOutput>;
@@ -10427,6 +10440,7 @@ export interface StatusLogSubscription
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
   user: <T = UserSubscription>() => T;
+  authType: () => Promise<AsyncIterator<AuthType>>;
   form: <T = FormSubscription>() => T;
   status: () => Promise<AsyncIterator<Status>>;
   loggedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
@@ -10438,6 +10452,7 @@ export interface StatusLogNullablePromise
     Fragmentable {
   id: () => Promise<ID_Output>;
   user: <T = UserPromise>() => T;
+  authType: () => Promise<AuthType>;
   form: <T = FormPromise>() => T;
   status: () => Promise<Status>;
   loggedAt: () => Promise<DateTimeOutput>;
@@ -11942,6 +11957,7 @@ export interface StatusLogSubscriptionPayloadSubscription
 
 export interface StatusLogPreviousValues {
   id: ID_Output;
+  authType?: AuthType;
   status: Status;
   loggedAt?: DateTimeOutput;
   updatedFields?: Json;
@@ -11951,6 +11967,7 @@ export interface StatusLogPreviousValuesPromise
   extends Promise<StatusLogPreviousValues>,
     Fragmentable {
   id: () => Promise<ID_Output>;
+  authType: () => Promise<AuthType>;
   status: () => Promise<Status>;
   loggedAt: () => Promise<DateTimeOutput>;
   updatedFields: () => Promise<Json>;
@@ -11960,6 +11977,7 @@ export interface StatusLogPreviousValuesSubscription
   extends Promise<AsyncIterator<StatusLogPreviousValues>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
+  authType: () => Promise<AsyncIterator<AuthType>>;
   status: () => Promise<AsyncIterator<Status>>;
   loggedAt: () => Promise<AsyncIterator<DateTimeOutput>>;
   updatedFields: () => Promise<AsyncIterator<Json>>;
@@ -12566,6 +12584,10 @@ export const models: Model[] = [
   },
   {
     name: "Status",
+    embedded: false
+  },
+  {
+    name: "AuthType",
     embedded: false
   },
   {

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -12587,10 +12587,6 @@ export const models: Model[] = [
     embedded: false
   },
   {
-    name: "AuthType",
-    embedded: false
-  },
-  {
     name: "StatusLog",
     embedded: false
   },
@@ -12624,6 +12620,10 @@ export const models: Model[] = [
   },
   {
     name: "MembershipRequest",
+    embedded: false
+  },
+  {
+    name: "AuthType",
     embedded: false
   },
   {

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -448,6 +448,12 @@ input ApplicationWhereUniqueInput {
   id: ID
 }
 
+enum AuthType {
+  SESSION
+  BEARER
+  JWT
+}
+
 type BatchPayload {
   count: Long!
 }
@@ -5880,6 +5886,7 @@ enum Status {
 type StatusLog {
   id: ID!
   user: User!
+  authType: AuthType
   form: Form!
   status: Status!
   loggedAt: DateTime
@@ -5895,6 +5902,7 @@ type StatusLogConnection {
 input StatusLogCreateInput {
   id: ID
   user: UserCreateOneInput!
+  authType: AuthType
   form: FormCreateOneInput!
   status: Status!
   loggedAt: DateTime
@@ -5909,6 +5917,8 @@ type StatusLogEdge {
 enum StatusLogOrderByInput {
   id_ASC
   id_DESC
+  authType_ASC
+  authType_DESC
   status_ASC
   status_DESC
   loggedAt_ASC
@@ -5919,6 +5929,7 @@ enum StatusLogOrderByInput {
 
 type StatusLogPreviousValues {
   id: ID!
+  authType: AuthType
   status: Status!
   loggedAt: DateTime
   updatedFields: Json
@@ -5944,6 +5955,7 @@ input StatusLogSubscriptionWhereInput {
 
 input StatusLogUpdateInput {
   user: UserUpdateOneRequiredInput
+  authType: AuthType
   form: FormUpdateOneRequiredInput
   status: Status
   loggedAt: DateTime
@@ -5951,6 +5963,7 @@ input StatusLogUpdateInput {
 }
 
 input StatusLogUpdateManyMutationInput {
+  authType: AuthType
   status: Status
   loggedAt: DateTime
   updatedFields: Json
@@ -5972,6 +5985,10 @@ input StatusLogWhereInput {
   id_ends_with: ID
   id_not_ends_with: ID
   user: UserWhereInput
+  authType: AuthType
+  authType_not: AuthType
+  authType_in: [AuthType!]
+  authType_not_in: [AuthType!]
   form: FormWhereInput
   status: Status
   status_not: Status


### PR DESCRIPTION
Ajout du type d'authentification utilisé dans les logs de statut afin d'avoir une connaissance plus fine de l'utilisation de Trackdéchets "en propre" versus "par API". Cette donnée est déjà présente dans les logs Graylog mais la durée de rétention d'un mois ne nous permet pas d'analyser les comportements dans la durée. 

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/DZSvSuj0)
