### PR TITLE
Correction des résultats retournés par la query favorites

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug affichant une erreur serveur à la place d'une erreur de validation graphQL lorsque le typage des variables graphQL est erronée [PR 711](https://github.com/MTES-MCT/trackdechets/pull/711)
 - Correction d'un bug empêchant de paginer les bordereaux "en arrière" dans la query `forms` lorsque `cursorBefore` n'est pas précisé et amélioration de la validation des paramètres de pagination [PR 699](https://github.com/MTES-MCT/trackdechets/pull/699)
 - Correction de l'affichage de l'aperçu du bordereau avec entreposage provisoire, [PR 715](https://github.com/MTES-MCT/trackdechets/pull/715)
+- Correction d'un bug dans les entreprises proposées lors de la sélection d'une entreprise au moment de créer un BSD, [PR 713](https://github.com/MTES-MCT/trackdechets/pull/713)
 
 #### :nail_care: Améliorations
 

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -41,6 +41,30 @@ describe("query favorites", () => {
     ]);
   });
 
+  it("should ignore drafts", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["COLLECTOR"]
+      }
+    });
+    await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT"
+      }
+    });
+
+    const { query } = makeClient({ ...user, auth: AuthType.Session });
+    const { data } = await query(FAVORITES, {
+      variables: {
+        siret: company.siret,
+        type: "EMITTER"
+      }
+    });
+
+    expect(data.favorites).toEqual([]);
+  });
+
   it("should return the user's company if it matches the favorite type", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -7,6 +7,7 @@ import {
 import {
   Company,
   CompanyType,
+  FormWhereInput,
   prisma,
   TemporaryStorageDetail
 } from "../../../generated/prisma-client";
@@ -67,7 +68,7 @@ async function getRecentPartners(
     orderBy: "updatedAt_DESC" as const,
     first: 50
   };
-  const defaultWhere = {
+  const defaultWhere: FormWhereInput = {
     OR: [
       { owner: { id: userID } },
       { emitterCompanySiret: siret },
@@ -84,6 +85,10 @@ async function getRecentPartners(
         }
       }
     ],
+
+    // ignore drafts as they are likely to be incomplete
+    status_not: "DRAFT",
+
     isDeleted: false
   };
 

--- a/front/src/form/company/CompanyResults.tsx
+++ b/front/src/form/company/CompanyResults.tsx
@@ -37,18 +37,16 @@ export default function CompanyResults<
               <p>
                 {item.siret} - {item.address}
               </p>
-              {item.siret && (
-                <p>
-                  <a
-                    href={generatePath(routes.company, { siret: item.siret })}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="link"
-                  >
-                    Information sur l'entreprise
-                  </a>
-                </p>
-              )}
+              <p>
+                <a
+                  href={generatePath(routes.company, { siret: item.siret! })}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="link"
+                >
+                  Information sur l'entreprise
+                </a>
+              </p>
             </div>
             <div className={styles.icon}>
               {selectedItem?.siret === item.siret ? (


### PR DESCRIPTION
Cette PR corrige le bug remonté par Sentry:

> Expected "siret" to match "[^\/]+?", but received ""

La query `favorites` retournait des entreprises complètement vides (pas de siret, nom, etc.). Elles venaient des drafts, qui sont maintenant ignorés.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/BnFcHlTs/1116-expected-siret-to-match-but-received)
