### PR TITLE
Ajout des enregistrements SIRENE non diffusables de la gendarmerie

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Amélioration de l'expérience utilisateur de la signature éco-organisme, [PR 693](https://github.com/MTES-MCT/trackdechets/pull/693)
+- Intégration des établissements de la gendarmerie nationale dans une table interne destinée aux entreprises "non diffusables" de la base SIRENE. Il est donc désormais possible de créer ces établissements ou de les viser sur un BSDD à partir de la recherche par N°Siret dans l'interface Trackdéchets. [PR 718](https://github.com/MTES-MCT/trackdechets/pull/718)
+
 #### :memo: Documentation
 
 #### :house: Interne
@@ -46,7 +49,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Amélioration des suggestions d'entreprise lors de la création d'un BSD depuis l'interface, [PR 673](https://github.com/MTES-MCT/trackdechets/pull/673)
 - Légende du QR Code dans l'UI [PR 709](https://github.com/MTES-MCT/trackdechets/pull/709)
-- Amélioration de l'expérience utilisateur de la signature éco-organisme, [PR 693](https://github.com/MTES-MCT/trackdechets/pull/693)
 
 #### :memo: Documentation
 

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -2,3 +2,4 @@
 /csv
 /dist
 /prisma/seed.dev.ts
+/src/companies/sirene/fixtures/anonymousCompanies.json

--- a/back/prisma/database/company.prisma
+++ b/back/prisma/database/company.prisma
@@ -135,3 +135,22 @@ type Declaration {
   libDechet: String
   gerepType: GerepType
 }
+
+"""
+Companies with restricted diffusion of SIRENE information (police, army, etc)
+
+"Certaines entreprises demandent à ne pas figurer sur les listes de diffusion publique
+en vertu de l'article A123-96 du code du commerce. On parle d‘entreprise non diffusable.
+Dans ce cas les API SIRENE ne diffusent pas les informations de cette entreprise dans
+les résultats de recherche. Pour des raisons de sécurité, certaines associations et les
+organismes relevant du Ministère de la Défense ne sont pas diffusibles non plus."
+"""
+type AnonymousCompany {
+  id: ID! @id
+  siret: String! @unique
+  name: String!
+  address: String!
+  codeNaf: String!
+  libelleNaf: String!
+  codeCommune: String!
+}

--- a/back/prisma/scripts/load-anonymous-companies.ts
+++ b/back/prisma/scripts/load-anonymous-companies.ts
@@ -1,0 +1,30 @@
+import * as fs from "fs";
+import { Updater, registerUpdater } from "./helper/helper";
+import { prisma } from "../../src/generated/prisma-client";
+
+@registerUpdater(
+  "Load anonymous companies",
+  "Load anonymous SIRENE companies from file ./src/companies/sirene/fixtures/anonymousCompanies.json",
+  true
+)
+export class LoadAnonymousCompaniesUpdater implements Updater {
+  async run() {
+    try {
+      console.info("Starting script to load anonymous SIRENE companies...");
+
+      // For security reasons, this file is git ignored, make sure
+      // you get a copy of it before running the script
+      const fixturePath =
+        "./src/companies/sirene/fixtures/anonymousCompanies.json";
+
+      const data = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+      for (const companyInput of data) {
+        await prisma.createAnonymousCompany(companyInput);
+      }
+    } catch (err) {
+      console.error("☠ Something went wrong during the update", err);
+      throw new Error();
+    }
+  }
+}

--- a/back/src/companies/sirene/__tests__/index.integration.ts
+++ b/back/src/companies/sirene/__tests__/index.integration.ts
@@ -1,0 +1,35 @@
+import * as searchCompanyDecorated from "../searchCompany";
+import { searchCompany } from "../index";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { UserInputError } from "apollo-server-express";
+import { prisma } from "../../../generated/prisma-client";
+
+const searchCompanySpy = jest.spyOn(searchCompanyDecorated, "default");
+// Mock the fact a siret is not found in SIRENE API's
+searchCompanySpy.mockRejectedValue(new UserInputError("SIRET inconnue"));
+
+describe("searchCompany", () => {
+  const OLD_ENV = process.env;
+
+  afterAll(resetDatabase);
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("should return anonymous company if it exists", async () => {
+    // do not bypass sirene client call
+    process.env.NODE_ENV = "production";
+    const siret = "11111111111111";
+    const anonymousCompany = await prisma.createAnonymousCompany({
+      siret,
+      name: "GENDARMERIE NATIONALE",
+      address: "Rue des tropiques, Saint Tropez",
+      codeNaf: "7150",
+      libelleNaf: "Service du ministère de la Défense",
+      codeCommune: "83119 "
+    });
+    const searchResult = await searchCompany(siret);
+    expect(searchResult).toMatchObject(anonymousCompany);
+  });
+});

--- a/back/src/companies/sirene/anonymous.ts
+++ b/back/src/companies/sirene/anonymous.ts
@@ -1,0 +1,26 @@
+import { CompanySearchResult } from "../../generated/graphql/types";
+import { prisma } from "../../generated/prisma-client";
+
+/**
+ * "Certaines entreprises demandent à ne pas figurer sur les listes de diffusion publique
+ * en vertu de l'article A123-96 du code du commerce. On parle d‘entreprise non diffusable.
+ * Dans ce cas les API SIRENE ne diffusent pas les informations de cette entreprise dans
+ * les résultats de recherche. Pour des raisons de sécurité, certaines associations et les
+ * organismes relevant du Ministère de la Défense ne sont pas diffusibles non plus."
+ *
+ * This function looks into the table AnonymousCompany where we store anonymous SIRENE records
+ * @param siret
+ */
+export async function searchAnonymousCompany(
+  siret: string
+): Promise<CompanySearchResult> {
+  const company = await prisma.anonymousCompany({ siret });
+  if (company) {
+    return {
+      ...company,
+      etatAdministratif: "A",
+      naf: company.codeNaf
+    };
+  }
+  return null;
+}

--- a/back/src/companies/sirene/ratelimit.ts
+++ b/back/src/companies/sirene/ratelimit.ts
@@ -36,3 +36,10 @@ export function throttle<T>(
   };
   return rateLimited;
 }
+
+export function throttleErrorMessage(apiType: string) {
+  return `Trop de requêtes sur l'API Sirene ${apiType}`;
+}
+
+export const INSEE_THROTTLE_KEY = "insee_throttle";
+export const DATA_GOUV_THROTTLE_KEY = "data_gouv_throttle";

--- a/back/src/companies/sirene/searchCompanies.ts
+++ b/back/src/companies/sirene/searchCompanies.ts
@@ -1,0 +1,27 @@
+import { searchCompanies as searchCompaniesInsee } from "./insee/client";
+import { searchCompanies as searchCompaniesDataGouv } from "./entreprise.data.gouv.fr/client";
+import {
+  DATA_GOUV_THROTTLE_KEY,
+  INSEE_THROTTLE_KEY,
+  throttle,
+  throttleErrorMessage
+} from "./ratelimit";
+import { redundant } from "./redundancy";
+
+/**
+ * Apply throttle and redundant decorator to searchCompanies functions
+ * We use entreprise.data.gouv.fr API in priority and fallback to INSEE
+ * because fuzzy search is way better in entreprise.data.gouv.fr
+ */
+const decoratedSearchCompanies = redundant(
+  throttle(searchCompaniesDataGouv, {
+    cacheKey: DATA_GOUV_THROTTLE_KEY,
+    errorMessage: throttleErrorMessage("entreprise.data.gouv.fr")
+  }),
+  throttle(searchCompaniesInsee, {
+    cacheKey: INSEE_THROTTLE_KEY,
+    errorMessage: throttleErrorMessage("INSEE")
+  })
+);
+
+export default decoratedSearchCompanies;

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -1,0 +1,33 @@
+import { searchCompany as searchCompanyInsee } from "./insee/client";
+import { searchCompany as searchCompanyDataGouv } from "./entreprise.data.gouv.fr/client";
+import {
+  throttle,
+  throttleErrorMessage,
+  INSEE_THROTTLE_KEY,
+  DATA_GOUV_THROTTLE_KEY
+} from "./ratelimit";
+import { redundant } from "./redundancy";
+import { cache } from "./cache";
+
+/**
+ * Apply throttle, redundant and cache decorators to searchCompany functions
+ * We use INSEE API in priority and fall back to entreprise.data.gouv.fr
+ */
+const decoratedSearchCompany = cache(
+  redundant(
+    throttle(searchCompanyInsee, {
+      cacheKey: INSEE_THROTTLE_KEY,
+      errorMessage: throttleErrorMessage("INSEE")
+    }),
+    throttle(searchCompanyDataGouv, {
+      cacheKey: DATA_GOUV_THROTTLE_KEY,
+      errorMessage: throttleErrorMessage("entreprise.data.gouv.fr")
+    })
+  )
+);
+
+//export default decoratedSearchCompany
+
+export default function searchCompany(siret: string) {
+  return decoratedSearchCompany(siret);
+}

--- a/back/src/generated/prisma-client/index.ts
+++ b/back/src/generated/prisma-client/index.ts
@@ -17,6 +17,7 @@ export type Maybe<T> = T | undefined | null;
 
 export interface Exists {
   accessToken: (where?: AccessTokenWhereInput) => Promise<boolean>;
+  anonymousCompany: (where?: AnonymousCompanyWhereInput) => Promise<boolean>;
   application: (where?: ApplicationWhereInput) => Promise<boolean>;
   company: (where?: CompanyWhereInput) => Promise<boolean>;
   companyAssociation: (
@@ -85,6 +86,27 @@ export interface Prisma {
     first?: Int;
     last?: Int;
   }) => AccessTokenConnectionPromise;
+  anonymousCompany: (
+    where: AnonymousCompanyWhereUniqueInput
+  ) => AnonymousCompanyNullablePromise;
+  anonymousCompanies: (args?: {
+    where?: AnonymousCompanyWhereInput;
+    orderBy?: AnonymousCompanyOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => FragmentableArray<AnonymousCompany>;
+  anonymousCompaniesConnection: (args?: {
+    where?: AnonymousCompanyWhereInput;
+    orderBy?: AnonymousCompanyOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => AnonymousCompanyConnectionPromise;
   application: (
     where: ApplicationWhereUniqueInput
   ) => ApplicationNullablePromise;
@@ -475,6 +497,28 @@ export interface Prisma {
   deleteManyAccessTokens: (
     where?: AccessTokenWhereInput
   ) => BatchPayloadPromise;
+  createAnonymousCompany: (
+    data: AnonymousCompanyCreateInput
+  ) => AnonymousCompanyPromise;
+  updateAnonymousCompany: (args: {
+    data: AnonymousCompanyUpdateInput;
+    where: AnonymousCompanyWhereUniqueInput;
+  }) => AnonymousCompanyPromise;
+  updateManyAnonymousCompanies: (args: {
+    data: AnonymousCompanyUpdateManyMutationInput;
+    where?: AnonymousCompanyWhereInput;
+  }) => BatchPayloadPromise;
+  upsertAnonymousCompany: (args: {
+    where: AnonymousCompanyWhereUniqueInput;
+    create: AnonymousCompanyCreateInput;
+    update: AnonymousCompanyUpdateInput;
+  }) => AnonymousCompanyPromise;
+  deleteAnonymousCompany: (
+    where: AnonymousCompanyWhereUniqueInput
+  ) => AnonymousCompanyPromise;
+  deleteManyAnonymousCompanies: (
+    where?: AnonymousCompanyWhereInput
+  ) => BatchPayloadPromise;
   createApplication: (data: ApplicationCreateInput) => ApplicationPromise;
   updateApplication: (args: {
     data: ApplicationUpdateInput;
@@ -833,6 +877,9 @@ export interface Subscription {
   accessToken: (
     where?: AccessTokenSubscriptionWhereInput
   ) => AccessTokenSubscriptionPayloadSubscription;
+  anonymousCompany: (
+    where?: AnonymousCompanySubscriptionWhereInput
+  ) => AnonymousCompanySubscriptionPayloadSubscription;
   application: (
     where?: ApplicationSubscriptionWhereInput
   ) => ApplicationSubscriptionPayloadSubscription;
@@ -946,6 +993,22 @@ export type AccessTokenOrderByInput =
   | "isRevoked_DESC"
   | "lastUsed_ASC"
   | "lastUsed_DESC";
+
+export type AnonymousCompanyOrderByInput =
+  | "id_ASC"
+  | "id_DESC"
+  | "siret_ASC"
+  | "siret_DESC"
+  | "name_ASC"
+  | "name_DESC"
+  | "address_ASC"
+  | "address_DESC"
+  | "codeNaf_ASC"
+  | "codeNaf_DESC"
+  | "libelleNaf_ASC"
+  | "libelleNaf_DESC"
+  | "codeCommune_ASC"
+  | "codeCommune_DESC";
 
 export type ApplicationOrderByInput =
   | "id_ASC"
@@ -2029,6 +2092,115 @@ export interface ApplicationWhereInput {
   AND?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
   OR?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
   NOT?: Maybe<ApplicationWhereInput[] | ApplicationWhereInput>;
+}
+
+export type AnonymousCompanyWhereUniqueInput = AtLeastOne<{
+  id: Maybe<ID_Input>;
+  siret?: Maybe<String>;
+}>;
+
+export interface AnonymousCompanyWhereInput {
+  id?: Maybe<ID_Input>;
+  id_not?: Maybe<ID_Input>;
+  id_in?: Maybe<ID_Input[] | ID_Input>;
+  id_not_in?: Maybe<ID_Input[] | ID_Input>;
+  id_lt?: Maybe<ID_Input>;
+  id_lte?: Maybe<ID_Input>;
+  id_gt?: Maybe<ID_Input>;
+  id_gte?: Maybe<ID_Input>;
+  id_contains?: Maybe<ID_Input>;
+  id_not_contains?: Maybe<ID_Input>;
+  id_starts_with?: Maybe<ID_Input>;
+  id_not_starts_with?: Maybe<ID_Input>;
+  id_ends_with?: Maybe<ID_Input>;
+  id_not_ends_with?: Maybe<ID_Input>;
+  siret?: Maybe<String>;
+  siret_not?: Maybe<String>;
+  siret_in?: Maybe<String[] | String>;
+  siret_not_in?: Maybe<String[] | String>;
+  siret_lt?: Maybe<String>;
+  siret_lte?: Maybe<String>;
+  siret_gt?: Maybe<String>;
+  siret_gte?: Maybe<String>;
+  siret_contains?: Maybe<String>;
+  siret_not_contains?: Maybe<String>;
+  siret_starts_with?: Maybe<String>;
+  siret_not_starts_with?: Maybe<String>;
+  siret_ends_with?: Maybe<String>;
+  siret_not_ends_with?: Maybe<String>;
+  name?: Maybe<String>;
+  name_not?: Maybe<String>;
+  name_in?: Maybe<String[] | String>;
+  name_not_in?: Maybe<String[] | String>;
+  name_lt?: Maybe<String>;
+  name_lte?: Maybe<String>;
+  name_gt?: Maybe<String>;
+  name_gte?: Maybe<String>;
+  name_contains?: Maybe<String>;
+  name_not_contains?: Maybe<String>;
+  name_starts_with?: Maybe<String>;
+  name_not_starts_with?: Maybe<String>;
+  name_ends_with?: Maybe<String>;
+  name_not_ends_with?: Maybe<String>;
+  address?: Maybe<String>;
+  address_not?: Maybe<String>;
+  address_in?: Maybe<String[] | String>;
+  address_not_in?: Maybe<String[] | String>;
+  address_lt?: Maybe<String>;
+  address_lte?: Maybe<String>;
+  address_gt?: Maybe<String>;
+  address_gte?: Maybe<String>;
+  address_contains?: Maybe<String>;
+  address_not_contains?: Maybe<String>;
+  address_starts_with?: Maybe<String>;
+  address_not_starts_with?: Maybe<String>;
+  address_ends_with?: Maybe<String>;
+  address_not_ends_with?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  codeNaf_not?: Maybe<String>;
+  codeNaf_in?: Maybe<String[] | String>;
+  codeNaf_not_in?: Maybe<String[] | String>;
+  codeNaf_lt?: Maybe<String>;
+  codeNaf_lte?: Maybe<String>;
+  codeNaf_gt?: Maybe<String>;
+  codeNaf_gte?: Maybe<String>;
+  codeNaf_contains?: Maybe<String>;
+  codeNaf_not_contains?: Maybe<String>;
+  codeNaf_starts_with?: Maybe<String>;
+  codeNaf_not_starts_with?: Maybe<String>;
+  codeNaf_ends_with?: Maybe<String>;
+  codeNaf_not_ends_with?: Maybe<String>;
+  libelleNaf?: Maybe<String>;
+  libelleNaf_not?: Maybe<String>;
+  libelleNaf_in?: Maybe<String[] | String>;
+  libelleNaf_not_in?: Maybe<String[] | String>;
+  libelleNaf_lt?: Maybe<String>;
+  libelleNaf_lte?: Maybe<String>;
+  libelleNaf_gt?: Maybe<String>;
+  libelleNaf_gte?: Maybe<String>;
+  libelleNaf_contains?: Maybe<String>;
+  libelleNaf_not_contains?: Maybe<String>;
+  libelleNaf_starts_with?: Maybe<String>;
+  libelleNaf_not_starts_with?: Maybe<String>;
+  libelleNaf_ends_with?: Maybe<String>;
+  libelleNaf_not_ends_with?: Maybe<String>;
+  codeCommune?: Maybe<String>;
+  codeCommune_not?: Maybe<String>;
+  codeCommune_in?: Maybe<String[] | String>;
+  codeCommune_not_in?: Maybe<String[] | String>;
+  codeCommune_lt?: Maybe<String>;
+  codeCommune_lte?: Maybe<String>;
+  codeCommune_gt?: Maybe<String>;
+  codeCommune_gte?: Maybe<String>;
+  codeCommune_contains?: Maybe<String>;
+  codeCommune_not_contains?: Maybe<String>;
+  codeCommune_starts_with?: Maybe<String>;
+  codeCommune_not_starts_with?: Maybe<String>;
+  codeCommune_ends_with?: Maybe<String>;
+  codeCommune_not_ends_with?: Maybe<String>;
+  AND?: Maybe<AnonymousCompanyWhereInput[] | AnonymousCompanyWhereInput>;
+  OR?: Maybe<AnonymousCompanyWhereInput[] | AnonymousCompanyWhereInput>;
+  NOT?: Maybe<AnonymousCompanyWhereInput[] | AnonymousCompanyWhereInput>;
 }
 
 export type ApplicationWhereUniqueInput = AtLeastOne<{
@@ -5082,6 +5254,34 @@ export interface AccessTokenUpdateManyMutationInput {
   lastUsed?: Maybe<DateTimeInput>;
 }
 
+export interface AnonymousCompanyCreateInput {
+  id?: Maybe<ID_Input>;
+  siret: String;
+  name: String;
+  address: String;
+  codeNaf: String;
+  libelleNaf: String;
+  codeCommune: String;
+}
+
+export interface AnonymousCompanyUpdateInput {
+  siret?: Maybe<String>;
+  name?: Maybe<String>;
+  address?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  libelleNaf?: Maybe<String>;
+  codeCommune?: Maybe<String>;
+}
+
+export interface AnonymousCompanyUpdateManyMutationInput {
+  siret?: Maybe<String>;
+  name?: Maybe<String>;
+  address?: Maybe<String>;
+  codeNaf?: Maybe<String>;
+  libelleNaf?: Maybe<String>;
+  codeCommune?: Maybe<String>;
+}
+
 export interface ApplicationUpdateInput {
   clientSecret?: Maybe<String>;
   name?: Maybe<String>;
@@ -8089,6 +8289,26 @@ export interface AccessTokenSubscriptionWhereInput {
   >;
 }
 
+export interface AnonymousCompanySubscriptionWhereInput {
+  mutation_in?: Maybe<MutationType[] | MutationType>;
+  updatedFields_contains?: Maybe<String>;
+  updatedFields_contains_every?: Maybe<String[] | String>;
+  updatedFields_contains_some?: Maybe<String[] | String>;
+  node?: Maybe<AnonymousCompanyWhereInput>;
+  AND?: Maybe<
+    | AnonymousCompanySubscriptionWhereInput[]
+    | AnonymousCompanySubscriptionWhereInput
+  >;
+  OR?: Maybe<
+    | AnonymousCompanySubscriptionWhereInput[]
+    | AnonymousCompanySubscriptionWhereInput
+  >;
+  NOT?: Maybe<
+    | AnonymousCompanySubscriptionWhereInput[]
+    | AnonymousCompanySubscriptionWhereInput
+  >;
+}
+
 export interface ApplicationSubscriptionWhereInput {
   mutation_in?: Maybe<MutationType[] | MutationType>;
   updatedFields_contains?: Maybe<String>;
@@ -8845,6 +9065,108 @@ export interface AggregateAccessTokenPromise
 
 export interface AggregateAccessTokenSubscription
   extends Promise<AsyncIterator<AggregateAccessToken>>,
+    Fragmentable {
+  count: () => Promise<AsyncIterator<Int>>;
+}
+
+export interface AnonymousCompany {
+  id: ID_Output;
+  siret: String;
+  name: String;
+  address: String;
+  codeNaf: String;
+  libelleNaf: String;
+  codeCommune: String;
+}
+
+export interface AnonymousCompanyPromise
+  extends Promise<AnonymousCompany>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  siret: () => Promise<String>;
+  name: () => Promise<String>;
+  address: () => Promise<String>;
+  codeNaf: () => Promise<String>;
+  libelleNaf: () => Promise<String>;
+  codeCommune: () => Promise<String>;
+}
+
+export interface AnonymousCompanySubscription
+  extends Promise<AsyncIterator<AnonymousCompany>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  siret: () => Promise<AsyncIterator<String>>;
+  name: () => Promise<AsyncIterator<String>>;
+  address: () => Promise<AsyncIterator<String>>;
+  codeNaf: () => Promise<AsyncIterator<String>>;
+  libelleNaf: () => Promise<AsyncIterator<String>>;
+  codeCommune: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AnonymousCompanyNullablePromise
+  extends Promise<AnonymousCompany | null>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  siret: () => Promise<String>;
+  name: () => Promise<String>;
+  address: () => Promise<String>;
+  codeNaf: () => Promise<String>;
+  libelleNaf: () => Promise<String>;
+  codeCommune: () => Promise<String>;
+}
+
+export interface AnonymousCompanyConnection {
+  pageInfo: PageInfo;
+  edges: AnonymousCompanyEdge[];
+}
+
+export interface AnonymousCompanyConnectionPromise
+  extends Promise<AnonymousCompanyConnection>,
+    Fragmentable {
+  pageInfo: <T = PageInfoPromise>() => T;
+  edges: <T = FragmentableArray<AnonymousCompanyEdge>>() => T;
+  aggregate: <T = AggregateAnonymousCompanyPromise>() => T;
+}
+
+export interface AnonymousCompanyConnectionSubscription
+  extends Promise<AsyncIterator<AnonymousCompanyConnection>>,
+    Fragmentable {
+  pageInfo: <T = PageInfoSubscription>() => T;
+  edges: <T = Promise<AsyncIterator<AnonymousCompanyEdgeSubscription>>>() => T;
+  aggregate: <T = AggregateAnonymousCompanySubscription>() => T;
+}
+
+export interface AnonymousCompanyEdge {
+  node: AnonymousCompany;
+  cursor: String;
+}
+
+export interface AnonymousCompanyEdgePromise
+  extends Promise<AnonymousCompanyEdge>,
+    Fragmentable {
+  node: <T = AnonymousCompanyPromise>() => T;
+  cursor: () => Promise<String>;
+}
+
+export interface AnonymousCompanyEdgeSubscription
+  extends Promise<AsyncIterator<AnonymousCompanyEdge>>,
+    Fragmentable {
+  node: <T = AnonymousCompanySubscription>() => T;
+  cursor: () => Promise<AsyncIterator<String>>;
+}
+
+export interface AggregateAnonymousCompany {
+  count: Int;
+}
+
+export interface AggregateAnonymousCompanyPromise
+  extends Promise<AggregateAnonymousCompany>,
+    Fragmentable {
+  count: () => Promise<Int>;
+}
+
+export interface AggregateAnonymousCompanySubscription
+  extends Promise<AsyncIterator<AggregateAnonymousCompany>>,
     Fragmentable {
   count: () => Promise<AsyncIterator<Int>>;
 }
@@ -11070,6 +11392,65 @@ export interface AccessTokenPreviousValuesSubscription
   lastUsed: () => Promise<AsyncIterator<DateTimeOutput>>;
 }
 
+export interface AnonymousCompanySubscriptionPayload {
+  mutation: MutationType;
+  node: AnonymousCompany;
+  updatedFields: String[];
+  previousValues: AnonymousCompanyPreviousValues;
+}
+
+export interface AnonymousCompanySubscriptionPayloadPromise
+  extends Promise<AnonymousCompanySubscriptionPayload>,
+    Fragmentable {
+  mutation: () => Promise<MutationType>;
+  node: <T = AnonymousCompanyPromise>() => T;
+  updatedFields: () => Promise<String[]>;
+  previousValues: <T = AnonymousCompanyPreviousValuesPromise>() => T;
+}
+
+export interface AnonymousCompanySubscriptionPayloadSubscription
+  extends Promise<AsyncIterator<AnonymousCompanySubscriptionPayload>>,
+    Fragmentable {
+  mutation: () => Promise<AsyncIterator<MutationType>>;
+  node: <T = AnonymousCompanySubscription>() => T;
+  updatedFields: () => Promise<AsyncIterator<String[]>>;
+  previousValues: <T = AnonymousCompanyPreviousValuesSubscription>() => T;
+}
+
+export interface AnonymousCompanyPreviousValues {
+  id: ID_Output;
+  siret: String;
+  name: String;
+  address: String;
+  codeNaf: String;
+  libelleNaf: String;
+  codeCommune: String;
+}
+
+export interface AnonymousCompanyPreviousValuesPromise
+  extends Promise<AnonymousCompanyPreviousValues>,
+    Fragmentable {
+  id: () => Promise<ID_Output>;
+  siret: () => Promise<String>;
+  name: () => Promise<String>;
+  address: () => Promise<String>;
+  codeNaf: () => Promise<String>;
+  libelleNaf: () => Promise<String>;
+  codeCommune: () => Promise<String>;
+}
+
+export interface AnonymousCompanyPreviousValuesSubscription
+  extends Promise<AsyncIterator<AnonymousCompanyPreviousValues>>,
+    Fragmentable {
+  id: () => Promise<AsyncIterator<ID_Output>>;
+  siret: () => Promise<AsyncIterator<String>>;
+  name: () => Promise<AsyncIterator<String>>;
+  address: () => Promise<AsyncIterator<String>>;
+  codeNaf: () => Promise<AsyncIterator<String>>;
+  libelleNaf: () => Promise<AsyncIterator<String>>;
+  codeCommune: () => Promise<AsyncIterator<String>>;
+}
+
 export interface ApplicationSubscriptionPayload {
   mutation: MutationType;
   node: Application;
@@ -12680,6 +13061,10 @@ export const models: Model[] = [
   },
   {
     name: "Declaration",
+    embedded: false
+  },
+  {
+    name: "AnonymousCompany",
     embedded: false
   }
 ];

--- a/back/src/generated/prisma-client/prisma-schema.ts
+++ b/back/src/generated/prisma-client/prisma-schema.ts
@@ -160,6 +160,10 @@ type AggregateAccessToken {
   count: Int!
 }
 
+type AggregateAnonymousCompany {
+  count: Int!
+}
+
 type AggregateApplication {
   count: Int!
 }
@@ -230,6 +234,209 @@ type AggregateUserAccountHash {
 
 type AggregateUserActivationHash {
   count: Int!
+}
+
+type AnonymousCompany {
+  id: ID!
+  siret: String!
+  name: String!
+  address: String!
+  codeNaf: String!
+  libelleNaf: String!
+  codeCommune: String!
+}
+
+type AnonymousCompanyConnection {
+  pageInfo: PageInfo!
+  edges: [AnonymousCompanyEdge]!
+  aggregate: AggregateAnonymousCompany!
+}
+
+input AnonymousCompanyCreateInput {
+  id: ID
+  siret: String!
+  name: String!
+  address: String!
+  codeNaf: String!
+  libelleNaf: String!
+  codeCommune: String!
+}
+
+type AnonymousCompanyEdge {
+  node: AnonymousCompany!
+  cursor: String!
+}
+
+enum AnonymousCompanyOrderByInput {
+  id_ASC
+  id_DESC
+  siret_ASC
+  siret_DESC
+  name_ASC
+  name_DESC
+  address_ASC
+  address_DESC
+  codeNaf_ASC
+  codeNaf_DESC
+  libelleNaf_ASC
+  libelleNaf_DESC
+  codeCommune_ASC
+  codeCommune_DESC
+}
+
+type AnonymousCompanyPreviousValues {
+  id: ID!
+  siret: String!
+  name: String!
+  address: String!
+  codeNaf: String!
+  libelleNaf: String!
+  codeCommune: String!
+}
+
+type AnonymousCompanySubscriptionPayload {
+  mutation: MutationType!
+  node: AnonymousCompany
+  updatedFields: [String!]
+  previousValues: AnonymousCompanyPreviousValues
+}
+
+input AnonymousCompanySubscriptionWhereInput {
+  mutation_in: [MutationType!]
+  updatedFields_contains: String
+  updatedFields_contains_every: [String!]
+  updatedFields_contains_some: [String!]
+  node: AnonymousCompanyWhereInput
+  AND: [AnonymousCompanySubscriptionWhereInput!]
+  OR: [AnonymousCompanySubscriptionWhereInput!]
+  NOT: [AnonymousCompanySubscriptionWhereInput!]
+}
+
+input AnonymousCompanyUpdateInput {
+  siret: String
+  name: String
+  address: String
+  codeNaf: String
+  libelleNaf: String
+  codeCommune: String
+}
+
+input AnonymousCompanyUpdateManyMutationInput {
+  siret: String
+  name: String
+  address: String
+  codeNaf: String
+  libelleNaf: String
+  codeCommune: String
+}
+
+input AnonymousCompanyWhereInput {
+  id: ID
+  id_not: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_contains: ID
+  id_not_contains: ID
+  id_starts_with: ID
+  id_not_starts_with: ID
+  id_ends_with: ID
+  id_not_ends_with: ID
+  siret: String
+  siret_not: String
+  siret_in: [String!]
+  siret_not_in: [String!]
+  siret_lt: String
+  siret_lte: String
+  siret_gt: String
+  siret_gte: String
+  siret_contains: String
+  siret_not_contains: String
+  siret_starts_with: String
+  siret_not_starts_with: String
+  siret_ends_with: String
+  siret_not_ends_with: String
+  name: String
+  name_not: String
+  name_in: [String!]
+  name_not_in: [String!]
+  name_lt: String
+  name_lte: String
+  name_gt: String
+  name_gte: String
+  name_contains: String
+  name_not_contains: String
+  name_starts_with: String
+  name_not_starts_with: String
+  name_ends_with: String
+  name_not_ends_with: String
+  address: String
+  address_not: String
+  address_in: [String!]
+  address_not_in: [String!]
+  address_lt: String
+  address_lte: String
+  address_gt: String
+  address_gte: String
+  address_contains: String
+  address_not_contains: String
+  address_starts_with: String
+  address_not_starts_with: String
+  address_ends_with: String
+  address_not_ends_with: String
+  codeNaf: String
+  codeNaf_not: String
+  codeNaf_in: [String!]
+  codeNaf_not_in: [String!]
+  codeNaf_lt: String
+  codeNaf_lte: String
+  codeNaf_gt: String
+  codeNaf_gte: String
+  codeNaf_contains: String
+  codeNaf_not_contains: String
+  codeNaf_starts_with: String
+  codeNaf_not_starts_with: String
+  codeNaf_ends_with: String
+  codeNaf_not_ends_with: String
+  libelleNaf: String
+  libelleNaf_not: String
+  libelleNaf_in: [String!]
+  libelleNaf_not_in: [String!]
+  libelleNaf_lt: String
+  libelleNaf_lte: String
+  libelleNaf_gt: String
+  libelleNaf_gte: String
+  libelleNaf_contains: String
+  libelleNaf_not_contains: String
+  libelleNaf_starts_with: String
+  libelleNaf_not_starts_with: String
+  libelleNaf_ends_with: String
+  libelleNaf_not_ends_with: String
+  codeCommune: String
+  codeCommune_not: String
+  codeCommune_in: [String!]
+  codeCommune_not_in: [String!]
+  codeCommune_lt: String
+  codeCommune_lte: String
+  codeCommune_gt: String
+  codeCommune_gte: String
+  codeCommune_contains: String
+  codeCommune_not_contains: String
+  codeCommune_starts_with: String
+  codeCommune_not_starts_with: String
+  codeCommune_ends_with: String
+  codeCommune_not_ends_with: String
+  AND: [AnonymousCompanyWhereInput!]
+  OR: [AnonymousCompanyWhereInput!]
+  NOT: [AnonymousCompanyWhereInput!]
+}
+
+input AnonymousCompanyWhereUniqueInput {
+  id: ID
+  siret: String
 }
 
 type Application {
@@ -5372,6 +5579,12 @@ type Mutation {
   upsertAccessToken(where: AccessTokenWhereUniqueInput!, create: AccessTokenCreateInput!, update: AccessTokenUpdateInput!): AccessToken!
   deleteAccessToken(where: AccessTokenWhereUniqueInput!): AccessToken
   deleteManyAccessTokens(where: AccessTokenWhereInput): BatchPayload!
+  createAnonymousCompany(data: AnonymousCompanyCreateInput!): AnonymousCompany!
+  updateAnonymousCompany(data: AnonymousCompanyUpdateInput!, where: AnonymousCompanyWhereUniqueInput!): AnonymousCompany
+  updateManyAnonymousCompanies(data: AnonymousCompanyUpdateManyMutationInput!, where: AnonymousCompanyWhereInput): BatchPayload!
+  upsertAnonymousCompany(where: AnonymousCompanyWhereUniqueInput!, create: AnonymousCompanyCreateInput!, update: AnonymousCompanyUpdateInput!): AnonymousCompany!
+  deleteAnonymousCompany(where: AnonymousCompanyWhereUniqueInput!): AnonymousCompany
+  deleteManyAnonymousCompanies(where: AnonymousCompanyWhereInput): BatchPayload!
   createApplication(data: ApplicationCreateInput!): Application!
   updateApplication(data: ApplicationUpdateInput!, where: ApplicationWhereUniqueInput!): Application
   updateManyApplications(data: ApplicationUpdateManyMutationInput!, where: ApplicationWhereInput): BatchPayload!
@@ -5508,6 +5721,9 @@ type Query {
   accessToken(where: AccessTokenWhereUniqueInput!): AccessToken
   accessTokens(where: AccessTokenWhereInput, orderBy: AccessTokenOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [AccessToken]!
   accessTokensConnection(where: AccessTokenWhereInput, orderBy: AccessTokenOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): AccessTokenConnection!
+  anonymousCompany(where: AnonymousCompanyWhereUniqueInput!): AnonymousCompany
+  anonymousCompanies(where: AnonymousCompanyWhereInput, orderBy: AnonymousCompanyOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [AnonymousCompany]!
+  anonymousCompaniesConnection(where: AnonymousCompanyWhereInput, orderBy: AnonymousCompanyOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): AnonymousCompanyConnection!
   application(where: ApplicationWhereUniqueInput!): Application
   applications(where: ApplicationWhereInput, orderBy: ApplicationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Application]!
   applicationsConnection(where: ApplicationWhereInput, orderBy: ApplicationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): ApplicationConnection!
@@ -6013,6 +6229,7 @@ input StatusLogWhereUniqueInput {
 
 type Subscription {
   accessToken(where: AccessTokenSubscriptionWhereInput): AccessTokenSubscriptionPayload
+  anonymousCompany(where: AnonymousCompanySubscriptionWhereInput): AnonymousCompanySubscriptionPayload
   application(where: ApplicationSubscriptionWhereInput): ApplicationSubscriptionPayload
   company(where: CompanySubscriptionWhereInput): CompanySubscriptionPayload
   companyAssociation(where: CompanyAssociationSubscriptionWhereInput): CompanyAssociationSubscriptionPayload


### PR DESCRIPTION
Certaines entreprises "non diffusables" n'apparaissent pas dans les résultats de recherche des API SIRENE. Il peut s'agir: 

* d'organismes relevant du Ministère de la Défense qui n'y apparaissent pas pour des raisons de sécurité. 
* d'entreprises ayant fait une demande auprès de l'INSEE pour ne pas figurer sur les listes de diffusion publique en vertu de l'article A123-96 du code du commerce

Actuellement il est impossible de rattacher une entreprise non diffusable ou de viser une entreprise non diffusable sur un bordereau à partir de l'interface Trackdéchets. 

Cette PR crée une table `AnonymousCompany` que l'on peut alimenter pour enrichir les résultats de la recherche par N°Siret dans la query `companyInfos` (et donc permettre le rattachement et la création d'un BSD). La recherche full text via `searchCompanies` est en revanche désactivée pour ces enregistrements. 

Un script permet d'importer les établissements non diffusables de la gendarmerie nationale à partir d'un fichier non versionnée disponible dans la carte Trello de cette feature. 
Il sera également possible d'ajouter à la main des enregistrements à la table `AnonymousCompany` pour les entreprises non diffusables désirant créer un compte sur Trackdéchet. 


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/0Px0qeNd)
