### PR TITLE
Autoriser la modification et la suppresion d'un bordereau scellé

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout d'un nouveau champ `packagingInfos` qui viendra remplacer `packagings`, `numberOfPackages` et `otherPackaging`. Ces champs sont encore supportés pour quelques temps mais marqué comme dépréciés. Nous vous invitons à migrer aussi vite que possible. [PR 600](https://github.com/MTES-MCT/trackdechets/pull/600)
+- Descellement BSD
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout d'un nouveau champ `packagingInfos` qui viendra remplacer `packagings`, `numberOfPackages` et `otherPackaging`. Ces champs sont encore supportés pour quelques temps mais marqué comme dépréciés. Nous vous invitons à migrer aussi vite que possible. [PR 600](https://github.com/MTES-MCT/trackdechets/pull/600)
-- Descellement BSD
+- Ajout de la possibilité de supprimer ou modifier un bordereau tant qu'aucune signature (transporteur ou producteur) n'a été apposée (statut `DRAFT` ou `SEALED`). [PR 720](https://github.com/MTES-MCT/trackdechets/pull/720)
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/__tests__/permissions.integration.ts
+++ b/back/src/forms/__tests__/permissions.integration.ts
@@ -1,5 +1,8 @@
 import {
-  checkIsFormContributor,
+  checkCanRead,
+  checkCanDuplicate,
+  checkCanUpdate,
+  checkCanDelete,
   checkCanMarkAsSealed,
   checkCanSignedByTransporter,
   checkCanMarkAsReceived,
@@ -19,64 +22,61 @@ import { prisma, User, Form } from "../../generated/prisma-client";
 import { ErrorCode } from "../../common/errors";
 import { resetDatabase } from "../../../integration-tests/helper";
 
-async function checkOwnerPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
-) {
-  const user = await userFactory();
-  const form = await formFactory({ ownerId: user.id });
-  return permission(user, form);
-}
-
 async function checkEmitterPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formFactory({
     ownerId: owner.id,
-    opt: { emitterCompanySiret: company.siret }
+    opt: { emitterCompanySiret: company.siret, status: formStatus }
   });
   return permission(user, form);
 }
 
 async function checkRecipientPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formFactory({
     ownerId: owner.id,
-    opt: { recipientCompanySiret: company.siret }
+    opt: { recipientCompanySiret: company.siret, status: formStatus }
   });
   return permission(user, form);
 }
 
 async function checkTransporterPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formFactory({
     ownerId: owner.id,
-    opt: { transporterCompanySiret: company.siret }
+    opt: { transporterCompanySiret: company.siret, status: formStatus }
   });
   return permission(user, form);
 }
 
 async function checkTraderPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formFactory({
     ownerId: owner.id,
-    opt: { traderCompanySiret: company.siret }
+    opt: { traderCompanySiret: company.siret, status: formStatus }
   });
   return permission(user, form);
 }
 
 async function checkEcoOrganismePermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
@@ -89,19 +89,24 @@ async function checkEcoOrganismePermission(
     ownerId: owner.id,
     opt: {
       ecoOrganismeSiret: ecoOrganisme.siret,
-      ecoOrganismeName: ecoOrganisme.name
+      ecoOrganismeName: ecoOrganisme.name,
+      status: formStatus
     }
   });
   return permission(user, form);
 }
 
 async function checkTransporterAfterTempStoragePermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formWithTempStorageFactory({
-    ownerId: owner.id
+    ownerId: owner.id,
+    opt: {
+      status: formStatus
+    }
   });
   const tempStorageDetail = await prisma
     .form({ id: form.id })
@@ -114,12 +119,16 @@ async function checkTransporterAfterTempStoragePermission(
 }
 
 async function checkDestinationAfterTempStoragePermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formWithTempStorageFactory({
-    ownerId: owner.id
+    ownerId: owner.id,
+    opt: {
+      status: formStatus
+    }
   });
   const tempStorageDetail = await prisma
     .form({ id: form.id })
@@ -132,12 +141,16 @@ async function checkDestinationAfterTempStoragePermission(
 }
 
 async function checkMultiModalTransporterPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
   const form = await formWithTempStorageFactory({
-    ownerId: owner.id
+    ownerId: owner.id,
+    opt: {
+      status: formStatus
+    }
   });
   await prisma.createTransportSegment({
     form: { connect: { id: form.id } },
@@ -147,21 +160,28 @@ async function checkMultiModalTransporterPermission(
 }
 
 async function checkRandomUserPermission(
-  permission: (user: User, form: Form) => Promise<boolean>
+  permission: (user: User, form: Form) => Promise<boolean>,
+  formStatus = "DRAFT"
 ) {
   const owner = await userFactory();
   const user = await userFactory();
   const form = await formWithTempStorageFactory({
-    ownerId: owner.id
+    ownerId: owner.id,
+    opt: {
+      status: formStatus
+    }
   });
   return permission(user, form);
 }
 
-describe("checkIsFormContributor", () => {
+describe.each([
+  checkCanRead,
+  checkCanDuplicate,
+  checkCanUpdate,
+  checkCanDelete,
+  checkCanMarkAsSealed
+])("%p", permission => {
   afterAll(resetDatabase);
-
-  const permission = (user, form) =>
-    checkIsFormContributor(user, form, "Forbidden");
 
   it("should deny access to random user", async () => {
     expect.assertions(1);
@@ -209,50 +229,6 @@ describe("checkIsFormContributor", () => {
 
   it("should allow multimodal transporter", async () => {
     const check = await checkMultiModalTransporterPermission(permission);
-    expect(check).toEqual(true);
-  });
-});
-
-describe("checkCanMarkAsSealed", () => {
-  afterAll(resetDatabase);
-
-  const permission = checkCanMarkAsSealed;
-
-  it("should deny access to random user", async () => {
-    expect.assertions(1);
-    try {
-      await checkRandomUserPermission(permission);
-    } catch (err) {
-      expect(err.extensions.code).toEqual(ErrorCode.FORBIDDEN);
-    }
-  });
-  it("should allow owner", async () => {
-    const check = await checkOwnerPermission(permission);
-    expect(check).toEqual(true);
-  });
-
-  it("should allow emitter", async () => {
-    const check = await checkEmitterPermission(permission);
-    expect(check).toEqual(true);
-  });
-
-  it("should allow recipient", async () => {
-    const check = await checkRecipientPermission(permission);
-    expect(check).toEqual(true);
-  });
-
-  it("should allow transporter", async () => {
-    const check = await checkTransporterPermission(permission);
-    expect(check).toEqual(true);
-  });
-
-  it("should allow trader", async () => {
-    const check = await checkTraderPermission(permission);
-    expect(check).toEqual(true);
-  });
-
-  it("should allow destination after temp storage", async () => {
-    const check = await checkDestinationAfterTempStoragePermission(permission);
     expect(check).toEqual(true);
   });
 });

--- a/back/src/forms/__tests__/permissions.integration.ts
+++ b/back/src/forms/__tests__/permissions.integration.ts
@@ -1,5 +1,5 @@
 import {
-  checkCanReadUpdateDeleteForm,
+  checkIsFormContributor,
   checkCanMarkAsSealed,
   checkCanSignedByTransporter,
   checkCanMarkAsReceived,
@@ -157,10 +157,11 @@ async function checkRandomUserPermission(
   return permission(user, form);
 }
 
-describe("checkCanReadUpdateDeleteForm", () => {
+describe("checkIsFormContributor", () => {
   afterAll(resetDatabase);
 
-  const permission = checkCanReadUpdateDeleteForm;
+  const permission = (user, form) =>
+    checkIsFormContributor(user, form, "Forbidden");
 
   it("should deny access to random user", async () => {
     expect.assertions(1);
@@ -169,11 +170,6 @@ describe("checkCanReadUpdateDeleteForm", () => {
     } catch (err) {
       expect(err.extensions.code).toEqual(ErrorCode.FORBIDDEN);
     }
-  });
-
-  it("should allow owner", async () => {
-    const check = await checkOwnerPermission(permission);
-    expect(check).toEqual(true);
   });
 
   it("should allow emitter", async () => {

--- a/back/src/forms/database.ts
+++ b/back/src/forms/database.ts
@@ -19,7 +19,6 @@ import { FormRole } from "../generated/graphql/types";
  * @param form
  */
 export async function getFullForm(form: Form): Promise<FullForm> {
-  const owner = await prisma.form({ id: form.id }).owner();
   const temporaryStorageDetail = await prisma
     .form({ id: form.id })
     .temporaryStorageDetail();
@@ -28,7 +27,6 @@ export async function getFullForm(form: Form): Promise<FullForm> {
     .transportSegments();
   return {
     ...form,
-    owner,
     temporaryStorageDetail,
     transportSegments
   };

--- a/back/src/forms/database.ts
+++ b/back/src/forms/database.ts
@@ -20,7 +20,7 @@ import { FormRole } from "../generated/graphql/types";
  */
 export async function getFullForm(form: Form): Promise<FullForm> {
   const owner = await prisma.form({ id: form.id }).owner();
-  const temporaryStorage = await prisma
+  const temporaryStorageDetail = await prisma
     .form({ id: form.id })
     .temporaryStorageDetail();
   const transportSegments = await prisma
@@ -29,7 +29,7 @@ export async function getFullForm(form: Form): Promise<FullForm> {
   return {
     ...form,
     owner,
-    temporaryStorage,
+    temporaryStorageDetail,
     transportSegments
   };
 }

--- a/back/src/forms/errors.ts
+++ b/back/src/forms/errors.ts
@@ -29,9 +29,10 @@ export class MissingTempStorageFlag extends UserInputError {
 }
 
 export class NotFormContributor extends ForbiddenError {
-  constructor() {
+  constructor(msg?: string) {
     super(
-      "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas."
+      msg ??
+        "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas."
     );
   }
 }

--- a/back/src/forms/errors.ts
+++ b/back/src/forms/errors.ts
@@ -29,11 +29,8 @@ export class MissingTempStorageFlag extends UserInputError {
 }
 
 export class NotFormContributor extends ForbiddenError {
-  constructor(msg?: string) {
-    super(
-      msg ??
-        "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas."
-    );
+  constructor(msg: string) {
+    super(msg);
   }
 }
 

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -283,8 +283,8 @@ type Mutation {
   duplicateForm("ID d'un BSD" id: ID!): Form
 
   """
-  Scelle un BSD
-  Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+  Finalise un BSD
+  Les champs suivants sont obligatoires pour pouvoir finaliser un bordereau et
   doivent avoir été renseignés au préalable
 
   ```

--- a/back/src/forms/pdf/__tests__/downloadPdf.integration.ts
+++ b/back/src/forms/pdf/__tests__/downloadPdf.integration.ts
@@ -1,6 +1,9 @@
 import supertest from "supertest";
 import { app } from "../../../server";
-import { formFactory, userFactory } from "../../../__tests__/factories";
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import { prisma } from "../../../generated/prisma-client";
 
@@ -17,12 +20,15 @@ query {
 describe("downloadPdf", () => {
   afterAll(resetDatabase);
   it("should download a pdf", async () => {
-    const user = await userFactory();
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const { token } = await prisma.createAccessToken({
       user: { connect: { id: user.id } },
       token: "token"
     });
-    const form = await formFactory({ ownerId: user.id });
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
+    });
     const formPdfResponse = await request
       .post("/")
       .set("Authorization", `Bearer ${token}`)

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -118,6 +118,76 @@ export async function checkCanReadUpdateDeleteForm(user: User, form: Form) {
   return true;
 }
 
+export async function checkCanReadForm(user: User, form: Form) {
+  const fullForm = await getFullForm(form);
+
+  const isContributor = await isFormContributor(user, fullForm);
+  const isOwner = isFormOwner(user, fullForm);
+
+  if (!isContributor && !isOwner) {
+    throw new NotFormContributor(
+      "Vous n'êtes pas autorisé à accéder à ce bordereau"
+    );
+  }
+  return true;
+}
+
+export async function checkCanDuplicateForm(user: User, form: Form) {
+  const fullForm = await getFullForm(form);
+
+  const isContributor = await isFormContributor(user, fullForm);
+  const isOwner = isFormOwner(user, fullForm);
+
+  if (!isContributor && !isOwner) {
+    throw new NotFormContributor(
+      "Vous n'êtes pas autorisé à dupliquer ce bordereau"
+    );
+  }
+  return true;
+}
+
+export async function checkCanUpdateForm(user: User, form: Form) {
+  const fullForm = await getFullForm(form);
+
+  const isContributor = await isFormContributor(user, fullForm);
+  const isOwner = isFormOwner(user, fullForm);
+
+  if (!isContributor && !isOwner) {
+    throw new NotFormContributor(
+      "Vous n'êtes pas autorisé à modifier ce bordereau"
+    );
+  }
+
+  if (!["DRAFT", "SEALED"].includes(form.status)) {
+    throw new ForbiddenError(
+      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être modifiés"
+    );
+  }
+
+  return true;
+}
+
+export async function checkCanDeleteForm(user: User, form: Form) {
+  const fullForm = await getFullForm(form);
+
+  const isContributor = await isFormContributor(user, fullForm);
+  const isOwner = isFormOwner(user, fullForm);
+
+  if (!isContributor && !isOwner) {
+    throw new NotFormContributor(
+      "Vous n'êtes pas autorisé à supprimer ce bordereau"
+    );
+  }
+
+  if (!["DRAFT", "SEALED"].includes(form.status)) {
+    throw new ForbiddenError(
+      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être supprimés"
+    );
+  }
+
+  return true;
+}
+
 export async function checkCanUpdateTransporterFields(user: User, form: Form) {
   const fullUser = await getFullUser(user);
 

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,15 +1,7 @@
-import {
-  Form,
-  Company,
-  User,
-  TemporaryStorageDetail,
-  TransportSegment,
-  prisma
-} from "../generated/prisma-client";
-import { FormSirets, FullForm } from "./types";
+import { Form, Company, User, prisma } from "../generated/prisma-client";
+import { FormSirets } from "./types";
 import { NotFormContributor, InvaliSecurityCode } from "./errors";
 import { getFullUser } from "../users/database";
-import { FullUser } from "../users/types";
 import { getFullForm } from "./database";
 import { ForbiddenError } from "apollo-server-express";
 

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -100,63 +100,57 @@ export async function isFormContributor(user: User, form: FormSirets) {
 }
 
 /**
+ * Check that at least one of user's company is present somewhere in the form
+ * or throw a ForbiddenError
+ * */
+export async function checkIsFormContributor(
+  user: User,
+  form: FormSirets,
+  errorMsg: string
+) {
+  const isContributor = await isFormContributor(user, form);
+
+  if (!isContributor) {
+    throw new NotFormContributor(errorMsg);
+  }
+
+  return true;
+}
+
+/**
  * Only owner of the form or users who belongs to a company that appears on the BSD
  * can read, update or delete it
  */
 export async function checkCanReadUpdateDeleteForm(user: User, form: Form) {
-  const fullForm = await getFullForm(form);
-
-  const isContributor = await isFormContributor(user, fullForm);
-  const isOwner = isFormOwner(user, fullForm);
-
-  if (!isContributor && !isOwner) {
-    throw new NotFormContributor(
-      "Vous n'êtes pas autorisé à lire, modifier ou supprimer ce bordereau"
-    );
-  }
-
-  return true;
+  return checkIsFormContributor(
+    user,
+    await getFullForm(form),
+    "Vous n'êtes pas autorisé à lire, modifier ou supprimer ce bordereau"
+  );
 }
 
 export async function checkCanReadForm(user: User, form: Form) {
-  const fullForm = await getFullForm(form);
-
-  const isContributor = await isFormContributor(user, fullForm);
-  const isOwner = isFormOwner(user, fullForm);
-
-  if (!isContributor && !isOwner) {
-    throw new NotFormContributor(
-      "Vous n'êtes pas autorisé à accéder à ce bordereau"
-    );
-  }
-  return true;
+  return checkIsFormContributor(
+    user,
+    await getFullForm(form),
+    "Vous n'êtes pas autorisé à accéder à ce bordereau"
+  );
 }
 
 export async function checkCanDuplicateForm(user: User, form: Form) {
-  const fullForm = await getFullForm(form);
-
-  const isContributor = await isFormContributor(user, fullForm);
-  const isOwner = isFormOwner(user, fullForm);
-
-  if (!isContributor && !isOwner) {
-    throw new NotFormContributor(
-      "Vous n'êtes pas autorisé à dupliquer ce bordereau"
-    );
-  }
-  return true;
+  return checkIsFormContributor(
+    user,
+    await getFullForm(form),
+    "Vous n'êtes pas autorisé à dupliquer ce bordereau"
+  );
 }
 
 export async function checkCanUpdateForm(user: User, form: Form) {
-  const fullForm = await getFullForm(form);
-
-  const isContributor = await isFormContributor(user, fullForm);
-  const isOwner = isFormOwner(user, fullForm);
-
-  if (!isContributor && !isOwner) {
-    throw new NotFormContributor(
-      "Vous n'êtes pas autorisé à modifier ce bordereau"
-    );
-  }
+  await checkIsFormContributor(
+    user,
+    await getFullForm(form),
+    "Vous n'êtes pas autorisé à dupliquer ce bordereau"
+  );
 
   if (!["DRAFT", "SEALED"].includes(form.status)) {
     throw new ForbiddenError(
@@ -168,24 +162,17 @@ export async function checkCanUpdateForm(user: User, form: Form) {
 }
 
 export async function checkCanDeleteForm(user: User, form: Form) {
-  const fullForm = await getFullForm(form);
-
-  const isContributor = await isFormContributor(user, fullForm);
-  const isOwner = isFormOwner(user, fullForm);
-
-  if (!isContributor && !isOwner) {
-    throw new NotFormContributor(
-      "Vous n'êtes pas autorisé à supprimer ce bordereau"
-    );
-  }
+  await checkIsFormContributor(
+    user,
+    await getFullForm(form),
+    "Vous n'êtes pas autorisé à supprimer ce bordereau"
+  );
 
   if (!["DRAFT", "SEALED"].includes(form.status)) {
     throw new ForbiddenError(
       "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être supprimés"
     );
   }
-
-  return true;
 }
 
 export async function checkCanUpdateTransporterFields(user: User, form: Form) {

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -102,7 +102,7 @@ describe("Mutation.createForm", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas.",
+          "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })

--- a/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
@@ -57,8 +57,7 @@ describe("Mutation.deleteForm", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message:
-          "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas.",
+        message: "Vous n'êtes pas autorisé à supprimer ce bordereau",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })
@@ -68,11 +67,11 @@ describe("Mutation.deleteForm", () => {
     expect(intactForm.isDeleted).toBe(false);
   });
 
-  it("should not be possible de delete a signed form", async () => {
-    const user = await userFactory();
+  it("should not be possible to delete a signed form", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const form = await formFactory({
       ownerId: user.id,
-      opt: { status: "SENT" }
+      opt: { status: "SENT", emitterCompanySiret: company.siret }
     });
     const { mutate } = makeClient(user);
     const { errors } = await mutate(DELETE_FORM, {
@@ -84,7 +83,7 @@ describe("Mutation.deleteForm", () => {
         message:
           "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être supprimés",
         extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
+          code: ErrorCode.FORBIDDEN
         })
       })
     ]);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -158,7 +158,7 @@ describe("Mutation.markAsSealed", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message: [
-          "Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.",
+          "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.",
           `Erreur(s): Émetteur: Le type d'émetteur doit être "OTHER" lorsqu'un éco-organisme est responsable du déchet`
         ].join("\n")
       })
@@ -216,7 +216,7 @@ describe("Mutation.markAsSealed", () => {
 
     // check error message is relevant and only failing fields are reported
     const errMessage =
-      "Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.\n" +
+      "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.\n" +
       "Erreur(s): Émetteur: Le siret de l'entreprise est obligatoire\n" +
       "Émetteur: Le SIRET doit faire 14 caractères numériques\n" +
       "Émetteur: Le contact dans l'entreprise est obligatoire";
@@ -305,7 +305,7 @@ describe("Mutation.markAsSealed", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message: [
-          "Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.",
+          "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.",
           `Erreur(s): La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
         ].join("\n")
       })

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -193,9 +193,7 @@ describe("Mutation.markAsSealed", () => {
   });
 
   it("the BSD can not be sealed if data do not validate", async () => {
-    const { user } = await userWithCompanyFactory("MEMBER");
-
-    const recipientCompany = await companyFactory();
+    const { user, company } = await userWithCompanyFactory("MEMBER");
 
     let form = await formFactory({
       ownerId: user.id,
@@ -203,7 +201,7 @@ describe("Mutation.markAsSealed", () => {
         status: "DRAFT",
         emitterCompanySiret: "", // this field is required and will make the mutation fail
         emitterCompanyContact: "", // this field is required and will make the mutation fail
-        recipientCompanySiret: recipientCompany.siret
+        recipientCompanySiret: company.siret
       }
     });
 
@@ -339,14 +337,14 @@ describe("Mutation.markAsSealed", () => {
   });
 
   it("should mark appendix2 forms as grouped", async () => {
-    const user = await userFactory();
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const appendix2 = await formFactory({
       ownerId: user.id,
       opt: { status: "AWAITING_GROUP" }
     });
     const form = await formFactory({
       ownerId: user.id,
-      opt: { status: "DRAFT" }
+      opt: { status: "DRAFT", emitterCompanySiret: company.siret }
     });
     await prisma.updateForm({
       where: { id: form.id },

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -100,8 +100,7 @@ describe("Mutation.updateForm", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message:
-          "Vous n'êtes pas autorisé à lire, modifier ou supprimer ce bordereau",
+        message: "Vous n'êtes pas autorisé à modifier ce bordereau",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })
@@ -135,7 +134,7 @@ describe("Mutation.updateForm", () => {
         message:
           "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être modifiés",
         extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
+          code: ErrorCode.FORBIDDEN
         })
       })
     ]);

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -101,7 +101,7 @@ describe("Mutation.updateForm", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas.",
+          "Vous n'êtes pas autorisé à lire, modifier ou supprimer ce bordereau",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })
@@ -163,7 +163,6 @@ describe("Mutation.updateForm", () => {
       const { data } = await mutate(UPDATE_FORM, {
         variables: { updateFormInput }
       });
-
       expect(data.updateForm.wasteDetails).toMatchObject(
         updateFormInput.wasteDetails
       );
@@ -257,7 +256,7 @@ describe("Mutation.updateForm", () => {
 
     expect(errors).toMatchObject([
       expect.objectContaining({
-        extensions: { code: ErrorCode.BAD_USER_INPUT },
+        extensions: { code: ErrorCode.FORBIDDEN },
         message: "Vous ne pouvez pas enlever votre établissement du bordereau"
       })
     ]);

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -199,6 +199,10 @@ describe("Mutation.updateForm", () => {
     }
   );
 
+  it("should not be possible invalidate a sealed form", async () => {
+    expect(true).toBe(false);
+  });
+
   it("should allow an eco-organisme to update a form", async () => {
     const { user, company: eo } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -231,38 +231,6 @@ describe("Mutation.updateForm", () => {
     ]);
   });
 
-  it("should not be possible to remove its own company from a sealed form", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER");
-    const form = await formFactory({
-      ownerId: user.id,
-      opt: {
-        emitterCompanySiret: company.siret,
-        status: "SEALED"
-      }
-    });
-
-    const { mutate } = makeClient(user);
-    const updateFormInput = {
-      id: form.id,
-      // try to remove user's company from the form
-      emitter: {
-        company: {
-          siret: "11111111111111"
-        }
-      }
-    };
-    const { errors } = await mutate(UPDATE_FORM, {
-      variables: { updateFormInput }
-    });
-
-    expect(errors).toMatchObject([
-      expect.objectContaining({
-        extensions: { code: ErrorCode.BAD_USER_INPUT },
-        message: "Vous ne pouvez pas enlever votre établissement du bordereau"
-      })
-    ]);
-  });
-
   it("should allow an eco-organisme to update a form", async () => {
     const { user, company: eo } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -35,13 +35,13 @@ const createFormResolver = async (
   const isContributor = await isFormContributor(user, {
     emitterCompanySiret: formContent.emitter?.company?.siret,
     recipientCompanySiret: formContent.recipient?.company?.siret,
-    transporterCompanySiret: formContent.trader?.company?.siret,
+    transporterCompanySiret: formContent.transporter?.company?.siret,
     traderCompanySiret: formContent.trader?.company?.siret,
     ecoOrganismeSiret: formContent.ecoOrganisme?.siret,
-    ...(temporaryStorageDetail
+    ...(temporaryStorageDetail?.destination?.company?.siret
       ? {
           destinationCompanySiret:
-            temporaryStorageDetail.destination?.company?.siret
+            temporaryStorageDetail.destination.company.siret
         }
       : {})
   });

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -13,11 +13,11 @@ import {
   MutationCreateFormArgs,
   ResolversParentTypes
 } from "../../../generated/graphql/types";
-import { MissingTempStorageFlag, NotFormContributor } from "../../errors";
+import { MissingTempStorageFlag } from "../../errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { GraphQLContext } from "../../../types";
 import { draftFormSchema } from "../../validation";
-import { checkIsFormContributor, isFormContributor } from "../../permissions";
+import { checkIsFormContributor } from "../../permissions";
 import { FormSirets } from "../../types";
 
 const createFormResolver = async (

--- a/back/src/forms/resolvers/mutations/deleteForm.ts
+++ b/back/src/forms/resolvers/mutations/deleteForm.ts
@@ -15,9 +15,9 @@ const deleteFormResolver: MutationResolvers["deleteForm"] = async (
 
   const form = await getFormOrFormNotFound({ id });
 
-  if (form.status !== "DRAFT") {
+  if (!["DRAFT", "SEALED"].includes(form.status)) {
     const errMessage =
-      "Seuls les BSD à l'état de brouillon peuvent être supprimés";
+      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être supprimés";
     throw new UserInputError(errMessage);
   }
 

--- a/back/src/forms/resolvers/mutations/deleteForm.ts
+++ b/back/src/forms/resolvers/mutations/deleteForm.ts
@@ -2,9 +2,8 @@ import { MutationResolvers } from "../../../generated/graphql/types";
 import { prisma } from "../../../generated/prisma-client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { expandFormFromDb } from "../../form-converter";
-import { checkCanReadUpdateDeleteForm } from "../../permissions";
+import { checkCanDeleteForm } from "../../permissions";
 import { getFormOrFormNotFound } from "../../database";
-import { UserInputError } from "apollo-server-express";
 
 const deleteFormResolver: MutationResolvers["deleteForm"] = async (
   parent,
@@ -15,13 +14,7 @@ const deleteFormResolver: MutationResolvers["deleteForm"] = async (
 
   const form = await getFormOrFormNotFound({ id });
 
-  if (!["DRAFT", "SEALED"].includes(form.status)) {
-    const errMessage =
-      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être supprimés";
-    throw new UserInputError(errMessage);
-  }
-
-  await checkCanReadUpdateDeleteForm(user, form);
+  await checkCanDeleteForm(user, form);
 
   const deletedForm = await prisma.updateForm({
     where: { id },

--- a/back/src/forms/resolvers/mutations/deleteForm.ts
+++ b/back/src/forms/resolvers/mutations/deleteForm.ts
@@ -2,7 +2,7 @@ import { MutationResolvers } from "../../../generated/graphql/types";
 import { prisma } from "../../../generated/prisma-client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { expandFormFromDb } from "../../form-converter";
-import { checkCanDeleteForm } from "../../permissions";
+import { checkCanDelete } from "../../permissions";
 import { getFormOrFormNotFound } from "../../database";
 
 const deleteFormResolver: MutationResolvers["deleteForm"] = async (
@@ -14,7 +14,7 @@ const deleteFormResolver: MutationResolvers["deleteForm"] = async (
 
   const form = await getFormOrFormNotFound({ id });
 
-  await checkCanDeleteForm(user, form);
+  await checkCanDelete(user, form);
 
   const deletedForm = await prisma.updateForm({
     where: { id },

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -9,9 +9,8 @@ import { expandFormFromDb } from "../../form-converter";
 import { getReadableId } from "../../readable-id";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { getFormOrFormNotFound, getFullForm } from "../../database";
-import { checkCanDuplicateForm, isFormContributor } from "../../permissions";
-import { NotFormContributor } from "../../errors";
+import { getFormOrFormNotFound } from "../../database";
+import { checkCanDuplicate } from "../../permissions";
 
 /**
  * Duplicate a form by stripping the properties that should not be copied.
@@ -116,7 +115,7 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
 
   const existingForm = await getFormOrFormNotFound({ id });
 
-  await checkCanDuplicateForm(user, existingForm);
+  await checkCanDuplicate(user, existingForm);
 
   const newForm = await duplicateForm(user, existingForm);
 

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -117,11 +117,14 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
 
   const existingForm = await getFormOrFormNotFound({ id });
 
-  const fullUser = await getFullUser(user);
   const fullExistingForm = await getFullForm(existingForm);
 
-  if (!(await isFormContributor(fullUser, fullExistingForm))) {
-    throw new NotFormContributor();
+  const isContributor = await isFormContributor(user, fullExistingForm);
+
+  if (!isContributor) {
+    throw new NotFormContributor(
+      "Vous ne pouvez pas dupliquer ce BSD car votre entreprise n'y apparait pas"
+    );
   }
 
   const newForm = await duplicateForm(user, existingForm);

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -10,7 +10,6 @@ import { getReadableId } from "../../readable-id";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getFormOrFormNotFound, getFullForm } from "../../database";
-import { getFullUser } from "../../../users/database";
 import { isFormContributor } from "../../permissions";
 import { NotFormContributor } from "../../errors";
 

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -120,16 +120,16 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
   const fullUser = await getFullUser(user);
   const fullExistingForm = await getFullForm(existingForm);
 
-  if (!isFormContributor(fullUser, fullExistingForm)) {
+  if (!(await isFormContributor(fullUser, fullExistingForm))) {
     throw new NotFormContributor();
   }
 
   const newForm = await duplicateForm(user, existingForm);
 
-  if (fullExistingForm.temporaryStorage) {
+  if (fullExistingForm.temporaryStorageDetail) {
     await duplicateTemporaryStorageDetail(
       newForm,
-      fullExistingForm.temporaryStorage
+      fullExistingForm.temporaryStorageDetail
     );
   }
 

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -8,22 +8,13 @@ import {
   ResolversParentTypes,
   MutationUpdateFormArgs
 } from "../../../generated/graphql/types";
-import {
-  MissingTempStorageFlag,
-  InvalidWasteCode,
-  NotFormContributor
-} from "../../errors";
+import { MissingTempStorageFlag, InvalidWasteCode } from "../../errors";
 import { WASTES_CODES } from "../../../common/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import {
-  checkCanUpdateForm,
-  checkIsFormContributor,
-  isFormContributor
-} from "../../permissions";
+import { checkCanUpdate, checkIsFormContributor } from "../../permissions";
 import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
 import { draftFormSchema, sealedFormSchema } from "../../validation";
-import { UserInputError } from "apollo-server-express";
 import { FormSirets } from "../../types";
 
 function validateArgs(args: MutationUpdateFormArgs) {
@@ -52,7 +43,7 @@ const updateFormResolver = async (
 
   const existingForm = await getFormOrFormNotFound({ id });
 
-  await checkCanUpdateForm(user, existingForm);
+  await checkCanUpdate(user, existingForm);
 
   const form = flattenFormInput(formContent);
 

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -23,7 +23,6 @@ import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
 import { draftFormSchema, sealedFormSchema } from "../../validation";
 import { UserInputError } from "apollo-server-express";
-import { getUserCompanies } from "../../../users/database";
 import { FormSirets } from "../../types";
 
 function validateArgs(args: MutationUpdateFormArgs) {

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -64,23 +64,7 @@ const updateFormResolver = async (
   if (existingForm.status === "DRAFT") {
     await draftFormSchema.validate(formUpdateInput);
   } else if (existingForm.status === "SEALED") {
-    const sealedForm = { ...existingForm, ...formUpdateInput };
-    await sealedFormSchema.validate(sealedForm);
-    // Make sure user's company is stil present on the form
-    const formInputSirets = [
-      sealedForm.emitterCompanySiret,
-      sealedForm.recipientCompanySiret,
-      sealedForm.traderCompanySiret,
-      sealedForm.transporterCompanySiret,
-      sealedForm.ecoOrganismeSiret
-    ];
-    const userCompanies = await getUserCompanies(user.id);
-    const userSirets = userCompanies.map(c => c.siret);
-    if (!formInputSirets.some(siret => userSirets.includes(siret))) {
-      throw new UserInputError(
-        "Vous ne pouvez pas enlever votre établissement du bordereau"
-      );
-    }
+    await sealedFormSchema.validate({ ...existingForm, ...formUpdateInput });
   }
 
   const isOrWillBeTempStorage =

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -15,7 +15,11 @@ import {
 } from "../../errors";
 import { WASTES_CODES } from "../../../common/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkCanUpdateForm, isFormContributor } from "../../permissions";
+import {
+  checkCanUpdateForm,
+  checkIsFormContributor,
+  isFormContributor
+} from "../../permissions";
 import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
 import { draftFormSchema, sealedFormSchema } from "../../validation";
@@ -95,13 +99,11 @@ const updateFormResolver = async (
     };
   }
 
-  const willBeFormContributor = await isFormContributor(user, nextFormSirets);
-
-  if (!willBeFormContributor) {
-    throw new NotFormContributor(
-      "Vous ne pouvez pas enlever votre établissement du bordereau"
-    );
-  }
+  await checkIsFormContributor(
+    user,
+    nextFormSirets,
+    "Vous ne pouvez pas enlever votre établissement du bordereau"
+  );
 
   if (
     existingTemporaryStorageDetail &&

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -15,10 +15,7 @@ import {
 } from "../../errors";
 import { WASTES_CODES } from "../../../common/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import {
-  checkCanReadUpdateDeleteForm,
-  isFormContributor
-} from "../../permissions";
+import { checkCanUpdateForm, isFormContributor } from "../../permissions";
 import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
 import { draftFormSchema, sealedFormSchema } from "../../validation";
@@ -51,13 +48,7 @@ const updateFormResolver = async (
 
   const existingForm = await getFormOrFormNotFound({ id });
 
-  await checkCanReadUpdateDeleteForm(user, existingForm);
-
-  if (!["DRAFT", "SEALED"].includes(existingForm.status)) {
-    const errMessage =
-      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être modifiés";
-    throw new UserInputError(errMessage);
-  }
+  await checkCanUpdateForm(user, existingForm);
 
   const form = flattenFormInput(formContent);
 

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -45,9 +45,9 @@ const updateFormResolver = async (
 
   await checkCanReadUpdateDeleteForm(user, existingForm);
 
-  if (existingForm.status != "DRAFT") {
+  if (!["DRAFT", "SEALED"].includes(existingForm.status)) {
     const errMessage =
-      "Seuls les bordereaux en brouillon peuvent être modifiés";
+      "Seuls les bordereaux en brouillon ou en attente de collecte peuvent être modifiés";
     throw new UserInputError(errMessage);
   }
 

--- a/back/src/forms/resolvers/queries/__tests__/form.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/form.integration.ts
@@ -82,7 +82,7 @@ describe("Query.form", () => {
     });
 
     expect(errors[0].message).toBe(
-      "Vous n'êtes pas autorisé à accéder à un bordereau sur lequel votre entreprise n'apparait pas."
+      "Vous n'êtes pas autorisé à accéder à ce bordereau"
     );
   });
 

--- a/back/src/forms/resolvers/queries/form.ts
+++ b/back/src/forms/resolvers/queries/form.ts
@@ -6,7 +6,7 @@ import { expandFormFromDb } from "../../form-converter";
 import { UserInputError } from "apollo-server-express";
 import { MissingIdOrReadableId } from "../../errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkCanReadUpdateDeleteForm } from "../../permissions";
+import { checkCanReadForm } from "../../permissions";
 import { getFormOrFormNotFound } from "../../database";
 
 function validateArgs(args: QueryFormArgs) {
@@ -29,7 +29,7 @@ const formResolver: QueryResolvers["form"] = async (_, args, context) => {
 
   const form = await getFormOrFormNotFound(validArgs);
 
-  await checkCanReadUpdateDeleteForm(user, form);
+  await checkCanReadForm(user, form);
 
   return expandFormFromDb(form);
 };

--- a/back/src/forms/resolvers/queries/form.ts
+++ b/back/src/forms/resolvers/queries/form.ts
@@ -6,7 +6,7 @@ import { expandFormFromDb } from "../../form-converter";
 import { UserInputError } from "apollo-server-express";
 import { MissingIdOrReadableId } from "../../errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkCanReadForm } from "../../permissions";
+import { checkCanRead } from "../../permissions";
 import { getFormOrFormNotFound } from "../../database";
 
 function validateArgs(args: QueryFormArgs) {
@@ -29,7 +29,7 @@ const formResolver: QueryResolvers["form"] = async (_, args, context) => {
 
   const form = await getFormOrFormNotFound(validArgs);
 
-  await checkCanReadForm(user, form);
+  await checkCanRead(user, form);
 
   return expandFormFromDb(form);
 };

--- a/back/src/forms/resolvers/queries/formPdf.ts
+++ b/back/src/forms/resolvers/queries/formPdf.ts
@@ -3,7 +3,7 @@ import { getFileDownloadToken } from "../../../common/file-download";
 import downloadPdf from "../../pdf/downloadPdf";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getFormOrFormNotFound } from "../../database";
-import { checkCanReadUpdateDeleteForm } from "../../permissions";
+import { checkCanReadForm } from "../../permissions";
 
 const TYPE = "form_pdf";
 
@@ -17,7 +17,7 @@ const formPdfResolver: QueryResolvers["formPdf"] = async (
 
   const form = await getFormOrFormNotFound({ id });
 
-  await checkCanReadUpdateDeleteForm(user, form);
+  await checkCanReadForm(user, form);
 
   return getFileDownloadToken({ type: TYPE, params: { id } }, downloadPdf);
 };

--- a/back/src/forms/resolvers/queries/formPdf.ts
+++ b/back/src/forms/resolvers/queries/formPdf.ts
@@ -3,7 +3,7 @@ import { getFileDownloadToken } from "../../../common/file-download";
 import downloadPdf from "../../pdf/downloadPdf";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getFormOrFormNotFound } from "../../database";
-import { checkCanReadForm } from "../../permissions";
+import { checkCanRead } from "../../permissions";
 
 const TYPE = "form_pdf";
 
@@ -17,7 +17,7 @@ const formPdfResolver: QueryResolvers["formPdf"] = async (
 
   const form = await getFormOrFormNotFound({ id });
 
-  await checkCanReadForm(user, form);
+  await checkCanRead(user, form);
 
   return getFileDownloadToken({ type: TYPE, params: { id } }, downloadPdf);
 };

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -1,6 +1,5 @@
 import {
   Form,
-  User,
   TemporaryStorageDetail,
   TransportSegment
 } from "../generated/prisma-client";
@@ -9,7 +8,6 @@ import {
  * A Prisma Form with linked objects
  */
 export interface FullForm extends Form {
-  owner: User;
   temporaryStorageDetail: TemporaryStorageDetail;
   transportSegments: TransportSegment[];
 }

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -10,6 +10,22 @@ import {
  */
 export interface FullForm extends Form {
   owner: User;
-  temporaryStorage: TemporaryStorageDetail;
+  temporaryStorageDetail: TemporaryStorageDetail;
   transportSegments: TransportSegment[];
 }
+
+export type FormSirets = Pick<
+  Form,
+  | "emitterCompanySiret"
+  | "recipientCompanySiret"
+  | "transporterCompanySiret"
+  | "traderCompanySiret"
+  | "ecoOrganismeSiret"
+> & {
+  temporaryStorageDetail?: Pick<
+    TemporaryStorageDetail,
+    "transporterCompanySiret" | "destinationCompanySiret"
+  >;
+} & {
+  transportSegments?: Pick<TransportSegment, "transporterCompanySiret">[];
+};

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -812,7 +812,7 @@ export async function checkCanBeSealed(form: Form) {
     if (err.name === "ValidationError") {
       const stringifiedErrors = err.errors?.join("\n");
       throw new UserInputError(
-        `Erreur, impossible de sceller le bordereau car des champs obligatoires ne sont pas renseignés.\nErreur(s): ${stringifiedErrors}`
+        `Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.\nErreur(s): ${stringifiedErrors}`
       );
     } else {
       throw err;

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -932,8 +932,8 @@ export type Mutation = {
    */
   markAsResent?: Maybe<Form>;
   /**
-   * Scelle un BSD
-   * Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+   * Finalise un BSD
+   * Les champs suivants sont obligatoires pour pouvoir finaliser un bordereau et
    * doivent avoir été renseignés au préalable
    * 
    * ```

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -763,8 +763,8 @@ Utiliser la mutation signedByTransporter permettant d'apposer les signatures du 
 <td valign="top"><a href="#form">Form</a></td>
 <td>
 
-Scelle un BSD
-Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+Finalise un BSD
+Les champs suivants sont obligatoires pour pouvoir finaliser un bordereau et
 doivent avoir été renseignés au préalable
 
 ```

--- a/doc/docs/workflow.md
+++ b/doc/docs/workflow.md
@@ -39,7 +39,7 @@ Un QRCode généré dans l'interface utilisateur encode le champ `readableId`.
 L'ensemble des champs du BSD numérique est décrit dans la [référence de l'API](api-reference.md#form). Au cours de son cycle de vie, un BSD numérique peut passer par différents états décrits [ici](api-reference.md#formstatus).
 
 - `DRAFT` (brouillon): État initial à la création d'un BSD. Des champs obligatoires peuvent manquer.
-- `SEALED` (finalisé): BSD finalisé ou "scellé". Les informations ne sont plus modifiables.
+- `SEALED` (finalisé): BSD finalisé. Les données sont validées et un numéro de BSD `readableId` est affecté.
 - `SENT` (envoyé): BSD en transit vers l'installation de destination, d'entreposage ou de reconditionnement
 - `RECEIVED` (reçu): BSD reçu sur l'installation de destination, d'entreposage ou de reconditionnement
 - `REFUSED` (refusé): Déchet refusé
@@ -53,7 +53,7 @@ Chaque changement d'état s'effectue grâce à une mutation.
 | Mutation              | Transition                                                                                                                      | Données                                                                           | Permissions                                                                                                                                                                             |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `createForm`          | `-> DRAFT` <br />                                                                                                               | [FormInput](api-reference.md#forminput)                                           | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>                                                                 |
-| `updateForm`          | `DRAFT -> DRAFT` <br />                                                                                                         | [FormInput](api-reference.md#forminput)                                           | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>                                                                 |
+| `updateForm`          | `DRAFT -> DRAFT` <br />    `SEALED -> SEALED` <br />                                                                                                       | [FormInput](api-reference.md#forminput)                                           | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>                                                                 |
 | `markAsSealed`        | `DRAFT -> SEALED`                                                                                                               |                                                                                   | <div><ul><li>émetteur</li><li>destinataire</li><li>transporteur</li><li>négociant</li><li>éco-organisme</li></ul></div>                                                                 |
 | `signedByTransporter` | <div><ul><li>`SEALED -> SENT`</li><li>`RESEALED -> RESENT`</li></ul></div>                                                      | [TransporterSignatureFormInput](api-reference.md#s#transportersignatureforminput) | Uniquement le collecteur-transporteur, l'émetteur ou le site d'entreposage provisoire/reconditionnement étant authentifié grâce au code de sécurité présent en paramètre de la mutation |
 | `markAsReceived`      | <div><ul><li>`SENT -> RECEIVED`</li><li>`SENT -> REFUSED`</li></ul></div>                                                       | [ReceivedFormInput](api-reference.md#receivedforminput)                           | Uniquement le destinataire du BSD                                                                                                                                                       |
@@ -71,6 +71,7 @@ Le diagramme ci dessous retrace le cycle de vie d'un BSD dans Trackdéchets:
 graph TD
 AO(NO STATE) -->|createForm| A
 A -->|updateForm| A
+B -->|updateForm| B
 A[DRAFT] -->|markAsSealed| B(SEALED)
 B -->|signedByTransporter| C(SENT)
 B -->|importPaperForm| E(PROCESSED)

--- a/front/src/dashboard/slip/SlipDetailContent.tsx
+++ b/front/src/dashboard/slip/SlipDetailContent.tsx
@@ -466,7 +466,7 @@ export default function SlipDetailContent({
       </Tabs>
       <div className={styles.detailActions}>
         <Duplicate formId={form.id} small={false} redirectToDashboard={true} />
-        {form.status === "DRAFT" ? (
+        {["DRAFT", "SEALED"].includes(form.status) ? (
           <>
             <Delete formId={form.id} small={false} redirectToDashboard={true} />
             <Edit formId={form.id} small={false} />

--- a/front/src/dashboard/slip/SlipDetailContent.tsx
+++ b/front/src/dashboard/slip/SlipDetailContent.tsx
@@ -6,7 +6,12 @@ import Duplicate from "dashboard/slips/slips-actions/Duplicate";
 import Delete from "dashboard/slips/slips-actions/Delete";
 import Edit from "dashboard/slips/slips-actions/Edit";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import { TransportSegment, Form, FormCompany } from "generated/graphql/types";
+import {
+  TransportSegment,
+  Form,
+  FormCompany,
+  FormStatus,
+} from "generated/graphql/types";
 import { statusesWithDynamicActions, statusLabels } from "../constants";
 import {
   WarehouseDeliveryIcon,
@@ -466,9 +471,9 @@ export default function SlipDetailContent({
       </Tabs>
       <div className={styles.detailActions}>
         <Duplicate formId={form.id} small={false} redirectToDashboard={true} />
-        {["DRAFT", "SEALED"].includes(form.status) ? (
+        {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) ? (
           <>
-            <Delete formId={form.id} small={false} redirectToDashboard={true} />
+            <Delete formId={form.id} small={false} />
             <Edit formId={form.id} small={false} />
           </>
         ) : (

--- a/front/src/dashboard/slips/slips-actions/Delete.tsx
+++ b/front/src/dashboard/slips/slips-actions/Delete.tsx
@@ -7,6 +7,7 @@ import { GET_SLIPS } from "../query";
 import { useMutation } from "@apollo/client";
 import { updateApolloCache } from "common/helper";
 import {
+  FormStatus,
   Mutation,
   MutationDeleteFormArgs,
   Query,
@@ -44,6 +45,7 @@ export default function Delete({
         return;
       }
       const deleteForm = data.deleteForm;
+
       updateApolloCache<Pick<Query, "forms">>(cache, {
         query: GET_SLIPS,
         variables: { siret, status: ["DRAFT"] },
@@ -54,7 +56,7 @@ export default function Delete({
     },
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
-
+      !!onClose && onClose();
       if (redirectToDashboard) {
         history.push(
           generatePath(routes.dashboard.slips.drafts, {

--- a/front/src/dashboard/slips/slips-actions/Delete.tsx
+++ b/front/src/dashboard/slips/slips-actions/Delete.tsx
@@ -12,15 +12,13 @@ import {
   MutationDeleteFormArgs,
   Query,
 } from "generated/graphql/types";
-import { generatePath, useHistory, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
-import routes from "common/routes";
 
 type Props = {
   formId: string;
   small?: boolean;
-  redirectToDashboard?: boolean;
   onOpen?: () => void;
   onClose?: () => void;
 };
@@ -30,10 +28,8 @@ export default function Delete({
   small = true,
   onOpen,
   onClose,
-  redirectToDashboard,
 }: Props) {
   const { siret } = useParams<{ siret: string }>();
-  const history = useHistory();
   const [isOpen, setIsOpen] = useState(false);
   const [deleteForm] = useMutation<
     Pick<Mutation, "deleteForm">,
@@ -46,24 +42,42 @@ export default function Delete({
       }
       const deleteForm = data.deleteForm;
 
-      updateApolloCache<Pick<Query, "forms">>(cache, {
-        query: GET_SLIPS,
-        variables: { siret, status: ["DRAFT"] },
-        getNewData: data => ({
-          forms: [...data.forms.filter(f => f.id !== deleteForm.id)],
-        }),
-      });
+      if (deleteForm.status === FormStatus.Draft) {
+        // update draft tab
+        updateApolloCache<Pick<Query, "forms">>(cache, {
+          query: GET_SLIPS,
+          variables: { siret, status: [FormStatus.Draft] },
+          getNewData: data => ({
+            forms: [...data.forms.filter(f => f.id !== deleteForm.id)],
+          }),
+        });
+      } else if (deleteForm.status === FormStatus.Sealed) {
+        // update follow tab
+        updateApolloCache<Pick<Query, "forms">>(cache, {
+          query: GET_SLIPS,
+          variables: {
+            siret,
+            status: [
+              FormStatus.Sealed,
+              FormStatus.Sent,
+              FormStatus.Received,
+              FormStatus.TempStored,
+              FormStatus.Resealed,
+              FormStatus.Resent,
+              FormStatus.AwaitingGroup,
+              FormStatus.Grouped,
+            ],
+            hasNextStep: false,
+          },
+          getNewData: data => ({
+            forms: [...data.forms.filter(f => f.id !== deleteForm.id)],
+          }),
+        });
+      }
     },
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
-      if (redirectToDashboard) {
-        history.push(
-          generatePath(routes.dashboard.slips.drafts, {
-            siret,
-          })
-        );
-      }
     },
     onError: () =>
       cogoToast.error("Le bordereau n'a pas pu être supprimé", {

--- a/front/src/dashboard/slips/slips-actions/Sealed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Sealed.tsx
@@ -16,10 +16,11 @@ export default function Sealed(props: SlipActionProps) {
   return (
     <div>
       <p>
-        Cette action aura pour effet de finaliser votre bordereau, c'est à dire
-        qu'il ne sera plus éditable. Cette action est nécessaire pour générer un
-        bordereau PDF et permet au bordereau d'entrer dans le circuit de
-        validation.
+        Cette action aura pour effet de valider les données du bordereau et de
+        le faire apparaitre dans l'onglet "À collecter" du tableau de bord
+        transporteur. Un identifiant unique lui sera attribué et vous pourrez
+        générer un PDF. Le bordereau pourra cependant toujours être modifié ou
+        supprimé depuis l'onglet "Suivi".
       </p>
 
       <div className="td-modal-actions">

--- a/front/src/dashboard/slips/slips-actions/SlipActions.tsx
+++ b/front/src/dashboard/slips/slips-actions/SlipActions.tsx
@@ -9,7 +9,7 @@ import {
   ChevronDown,
   ChevronUp,
 } from "common/components/Icons";
-import { Form } from "generated/graphql/types";
+import { Form, FormStatus } from "generated/graphql/types";
 import "./SlipActions.scss";
 import Delete from "./Delete";
 import DownloadPdf from "./DownloadPdf";
@@ -88,7 +88,7 @@ export const SlipActions = ({ form, siret }: SlipActionsProps) => {
                 />
               </li>
 
-              {["DRAFT", "SEALED"].includes(form.status) ? (
+              {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) ? (
                 <>
                   <li className="slips-actions__item">
                     <Delete

--- a/front/src/dashboard/slips/slips-actions/SlipActions.tsx
+++ b/front/src/dashboard/slips/slips-actions/SlipActions.tsx
@@ -88,7 +88,7 @@ export const SlipActions = ({ form, siret }: SlipActionsProps) => {
                 />
               </li>
 
-              {form.status === "DRAFT" ? (
+              {["DRAFT", "SEALED"].includes(form.status) ? (
                 <>
                   <li className="slips-actions__item">
                     <Delete

--- a/front/src/dashboard/slips/slips-actions/slip-actions.mutations.ts
+++ b/front/src/dashboard/slips/slips-actions/slip-actions.mutations.ts
@@ -57,6 +57,7 @@ const DELETE_FORM = gql`
   mutation DeleteForm($id: ID!) {
     deleteForm(id: $id) {
       id
+      status
     }
   }
 `;

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -10,7 +10,12 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import { useHistory, useParams, generatePath } from "react-router-dom";
+import {
+  useHistory,
+  useParams,
+  generatePath,
+  useLocation,
+} from "react-router-dom";
 
 import { InlineError } from "common/components/Error";
 import { updateApolloCache } from "common/helper";
@@ -131,6 +136,11 @@ export default function StepList(props: IProps) {
   if (loading) return <p>Chargement...</p>;
   if (error) return <InlineError apolloError={error} />;
 
+  const redirectTo =
+    data?.form?.status === "SEALED"
+      ? generatePath(routes.dashboard.slips.follow, { siret })
+      : generatePath(routes.dashboard.slips.drafts, { siret });
+
   return (
     <div>
       <ul className="step-header">
@@ -183,11 +193,7 @@ export default function StepList(props: IProps) {
                   // and don't use the classic Formik mechanism
 
                   saveForm(formInput)
-                    .then(_ =>
-                      history.push(
-                        generatePath(routes.dashboard.slips.drafts, { siret })
-                      )
-                    )
+                    .then(_ => history.push(redirectTo))
                     .catch(err => {
                       err.graphQLErrors.map(err =>
                         cogoToast.error(err.message, { hideAfter: 7 })

--- a/front/src/form/stepper/StepList.tsx
+++ b/front/src/form/stepper/StepList.tsx
@@ -10,12 +10,7 @@ import React, {
   useState,
   useMemo,
 } from "react";
-import {
-  useHistory,
-  useParams,
-  generatePath,
-  useLocation,
-} from "react-router-dom";
+import { useHistory, useParams, generatePath } from "react-router-dom";
 
 import { InlineError } from "common/components/Error";
 import { updateApolloCache } from "common/helper";

--- a/front/src/form/stepper/queries.ts
+++ b/front/src/form/stepper/queries.ts
@@ -10,9 +10,18 @@ export const GET_FORM = gql`
   ${fullFormFragment}
 `;
 
-export const SAVE_FORM = gql`
-  mutation SaveForm($formInput: FormInput!) {
-    saveForm(formInput: $formInput) {
+export const CREATE_FORM = gql`
+  mutation CreateForm($createFormInput: CreateFormInput!) {
+    createForm(createFormInput: $createFormInput) {
+      ...FullForm
+    }
+  }
+  ${fullFormFragment}
+`;
+
+export const UPDATE_FORM = gql`
+  mutation UpdateForm($updateFormInput: UpdateFormInput!) {
+    updateForm(updateFormInput: $updateFormInput) {
       ...FullForm
     }
   }

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -939,8 +939,8 @@ export type Mutation = {
    */
   markAsResent: Maybe<Form>;
   /**
-   * Scelle un BSD
-   * Les champs suivants sont obligatoires pour pouvoir sceller un bordereau et
+   * Finalise un BSD
+   * Les champs suivants sont obligatoires pour pouvoir finaliser un bordereau et
    * doivent avoir été renseignés au préalable
    * 
    * ```


### PR DESCRIPTION
Cette PR permet de modifier ou supprimer un bordereau au statut `SEALED`. 
Concernant la modification d'un BSD  scellé, des tests ont été ajoutés pour s'assurer qu'on n'invalide pas le BSD. Je vérifie également que l'utilisateur sera toujours "contributeur" du BSD après l'update.
Au passage utilisation de `createForm` et `updateForm` côté front à la place de `saveForm` (deprecated).
La logique de mise à jour du cache après suppression d'un bordereau n'est pas trop DRY mais je vais améliorer ça dans https://trello.com/c/5AdXxycR

  ---

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/18D7cb9C)

# Conception

## Fonctionnalité

Cette fonctionnalité correspond en fait à deux besoins sous-jacents:
* ETQ utilisateur je peux annuler/supprimer un BSDD "scellé" correspondant à une collecte qui n'aura pas lieu 
* ETQ utilisateur je peux modifier les informations d'un BSDD "scellé" tant qu'aucune signature n'a été apposée

Les différentes solutions envisagées 

## Solution 1: Autoriser les modifications et la suppression sur un BSD scellé 

### Avantages

* On n'introduit pas de nouveau statut 
* On n'introduit pas de nouvelle mutation
* Ça s'insère facilement dans l'interface existante en dupliquant les actions qui existent déjà pour les bordereaux Brouillons 
 
### Inconvénients 

* On introduit une confusion sémantique sur la signification du statut SEALED pour les utilisateurs de l'API. À noter que cette confusion n'existe pas vraiment côté interface où il n'est pas vraiment question de bordereau "scellé": "Valider le bordereau", "Permettre au bordereau d'entrer dans le circuit de validation" , "En attente de collecte".

## Solution 2: Permettre de "désceller" un bordereau 

### Avantages:

* On n'introduit pas de nouveau statut 
* On ne modifie pas la signification du statut SEALED

### Inconvénients 

* On doit ajouter une mutation `unsealForm` 
* Enchainement d'actions complexe côté interface. Convertir en Brouillon => Chercher le BSD dans les brouillons => Faire la modification => Re-valider
 
## Solution 3: Permettre de supprimer uniquement un bordereau scellé (pas de modification directe)

### Avantages:

* On ne modifie pas la signification du statut SEALED, au sens de non éditable
* On s'appuie sur la duplication de BSD 
* On peut côté interface proposer une action permettant de supprimer et dupliquer en un seul clic

### Inconvénients:

* Le BSD dupliqué bascule dans brouillon ce qui peut être dur à suivre, il faut ensuite le re-valider 
* Mécanique complexe pour les consommateurs de l'API avec un changement de numéro de BSD
