### PR TITLE
Ajout de l'éco-organisme A.D.I VALOR

### DIFF
--- a/back/prisma/scripts/add-ecoorganisme-type.ts
+++ b/back/prisma/scripts/add-ecoorganisme-type.ts
@@ -4,7 +4,7 @@ import { Updater, registerUpdater } from "./helper/helper";
 @registerUpdater(
   "Add the eco-organisme type",
   "Add the eco-organisme company type to the existing eco-organismes",
-  true
+  false
 )
 export class AddEcoOrganismeType implements Updater {
   async run() {

--- a/back/prisma/scripts/add-ecoorganisme-type.ts
+++ b/back/prisma/scripts/add-ecoorganisme-type.ts
@@ -4,7 +4,7 @@ import { Updater, registerUpdater } from "./helper/helper";
 @registerUpdater(
   "Add the eco-organisme type",
   "Add the eco-organisme company type to the existing eco-organismes",
-  false
+  true
 )
 export class AddEcoOrganismeType implements Updater {
   async run() {

--- a/back/prisma/scripts/update-eco-organismes.ts
+++ b/back/prisma/scripts/update-eco-organismes.ts
@@ -96,6 +96,11 @@ const ecoOrganismes = [
     name: "APER PYRO",
     siret: "81761178300017",
     address: "PORT DE JAVEL 75015 PARIS"
+  },
+  {
+    name: "A.D.I VALOR",
+    siret: "43836840900043",
+    address: "68 CRS ALBERT THOMAS 69008 LYON"
   }
 ];
 


### PR DESCRIPTION
Cette PR ajoute l'éco-organisme A.D.I VALOR à la liste des éco-organismes reconnus par Trackdéchets.