### PR TITLE
Ajout de texte sur la page post inscription

### DIFF
--- a/front/src/dashboard/slips/slips-actions/SlipActions.tsx
+++ b/front/src/dashboard/slips/slips-actions/SlipActions.tsx
@@ -5,7 +5,6 @@ import {
   WaterDamIcon,
   CogApprovedIcon,
   PaperWriteIcon,
-  DeliveryTruckClockIcon,
   WarehouseStorageIcon,
 } from "common/components/Icons";
 import { Form } from "generated/graphql/types";

--- a/front/src/dashboard/slips/slips-actions/next-step.ts
+++ b/front/src/dashboard/slips/slips-actions/next-step.ts
@@ -57,7 +57,6 @@ export function getTabForms(
 }
 
 export function getNextStep(form: Form, currentSiret: string) {
-  const currentUserIsEmitter = currentSiret === form.emitter?.company?.siret;
   const currentUserIsRecipient =
     currentSiret === form.recipient?.company?.siret;
   const currentUserIsTempStorer =

--- a/front/src/login/SignupInfos.tsx
+++ b/front/src/login/SignupInfos.tsx
@@ -52,8 +52,16 @@ export default function SignupInfo() {
               👉
             </span>
             Pour recevoir nos emails sans encombres, vous pouvez d'ajouter
-            hello@trackdechets.beta.gouv.fr à votre carnet d'adresse
+            hello@trackdechets.beta.gouv.fr à votre liste de contacts
           </li>
+        </ul>
+        <p className="lead-text tw-mb-5">
+          Merci de noter que le message peut ne pas arriver pour les raisons
+          suivantes:
+        </p>
+        <ul className="tw-mb-4">
+          <li>- Adresse email erronée</li>
+          <li>- Antivirus ou suite logicielle de sécurité trop restrictifs</li>
         </ul>
         <p className="body-text">
           Afin de finaliser votre inscription, veuillez cliquer dans le lien qui

--- a/front/src/login/SignupInfos.tsx
+++ b/front/src/login/SignupInfos.tsx
@@ -15,12 +15,46 @@ export default function SignupInfo() {
     <div className={styles.signupInfoContainer}>
       <section className="section section--white">
         <h2 className="h2 tw-mb-6">On y est presque !</h2>
+
         <p className="lead-text tw-mb-6">
           Un mail de confirmation vous a été envoyé à l'adresse {signupEmail}
-          <span role="img" aria-label="Valise">
+          <span role="img" aria-label="Valise" className="tw-ml-1">
             📨
           </span>
         </p>
+        <ul className="tw-mb-4">
+          <li>
+            <span
+              role="img"
+              aria-label="Index d'une main pointant à droite"
+              className="tw-mr-1"
+            >
+              👉
+            </span>
+            Il peut mettre quelques minutes à arriver, merci pour votre patience
+          </li>
+          <li>
+            <span
+              role="img"
+              aria-label="Index d'une main pointant à droite"
+              className="tw-mr-1"
+            >
+              👉
+            </span>
+            Merci de vérifier vos spams
+          </li>
+          <li>
+            <span
+              role="img"
+              aria-label="Index d'une main pointant à droite"
+              className="tw-mr-1"
+            >
+              👉
+            </span>
+            Pour recevoir nos emails sans encombres, vous pouvez d'ajouter
+            hello@trackdechets.beta.gouv.fr à votre carnet d'adresse
+          </li>
+        </ul>
         <p className="body-text">
           Afin de finaliser votre inscription, veuillez cliquer dans le lien qui
           vous a été envoyé par mail. Vous pourrez ensuite vous connecter à


### PR DESCRIPTION
Des utilisateurs reçoivent l'email de confirmation d’inscription en retard ou dans leurs spams, cette PR ajoute un texte explicatif pour les aider à patienter ou résoudre le problème

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/Bop515qF/1125-ajouter-un-texte-explicatif-sur-la-page-dinscription-pour-indiquer-que-larriv%C3%A9e-du-mail-de-confirmation-peut-%C3%AAtre-diff%C3%A9r%C3%A9e)
