### PR TITLE
Nettoyage des __typename

### DIFF
--- a/front/src/graphql-client.ts
+++ b/front/src/graphql-client.ts
@@ -14,9 +14,7 @@ const cleanTypeNameLink = new ApolloLink((operation, forward) => {
       omitTypename
     );
   }
-  return forward(operation).map(data => {
-    return data;
-  });
+  return forward(operation);
 });
 
 export default new ApolloClient({

--- a/front/src/graphql-client.ts
+++ b/front/src/graphql-client.ts
@@ -1,7 +1,27 @@
-import { InMemoryCache, ApolloClient } from "@apollo/client";
+import { InMemoryCache, ApolloClient, ApolloLink } from "@apollo/client";
+
+/**
+ * Automatically erase `__typename` from variables
+ * This enable devs to use objects fetched from the server
+ * and not worry with the `__typename` potentially breaking a mutation
+ */
+const cleanTypeNameLink = new ApolloLink((operation, forward) => {
+  if (operation.variables) {
+    const omitTypename = (key, value) =>
+      key === "__typename" ? undefined : value;
+    operation.variables = JSON.parse(
+      JSON.stringify(operation.variables),
+      omitTypename
+    );
+  }
+  return forward(operation).map(data => {
+    return data;
+  });
+});
 
 export default new ApolloClient({
   uri: process.env.REACT_APP_API_ENDPOINT,
   cache: new InMemoryCache(),
   credentials: "include",
+  link: cleanTypeNameLink,
 });


### PR DESCRIPTION
Le retour du Link apollo 🦁

Supprime automatiquement `__typename` des variables => ce n'est jamais souhaitable d'envoyer un typename au serveur, ca ne fait pas partie des Input il plantera.
Ca arrive quand on utilise des objets qui ont été fetchés (le typename est volontaire au fetch pour le cache apollo) et qu'on les reposte "tel-quels".