### PR TITLE
Correction de la query favorites qui retourne des résultats vides

### DIFF
--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -98,10 +98,13 @@ async function getRecentPartners(
         ...defaultArgs,
         where: {
           ...defaultWhere,
-          AND: {
-            recipientIsTempStorage: true,
-            recipientCompanySiret_not: null
-          }
+          recipientIsTempStorage: true,
+          recipientCompanySiret_not: null,
+
+          // _not_in expects a list of string so we can't do
+          // _not_in: [null, ""]
+          // Note: this is a workaround until we have a chance to replace empty strings with null
+          recipientCompanySiret_not_in: [""]
         }
       });
       return forms.map(form => ({
@@ -119,7 +122,12 @@ async function getRecentPartners(
         where: {
           ...defaultWhere,
           temporaryStorageDetail: {
-            destinationCompanySiret_not: null
+            destinationCompanySiret_not: null,
+
+            // _not_in expects a list of string so we can't do
+            // _not_in: [null, ""]
+            // Note: this is a workaround until we have a chance to replace empty strings with null
+            destinationCompanySiret_not_in: [""]
           }
         }
       }).$fragment<
@@ -153,7 +161,12 @@ async function getRecentPartners(
         ...defaultArgs,
         where: {
           ...defaultWhere,
-          [`${lowerType}CompanySiret_not`]: null
+          [`${lowerType}CompanySiret_not`]: null,
+
+          // _not_in expects a list of string so we can't do
+          // _not_in: [null, ""]
+          // Note: this is a workaround until we have a chance to replace empty strings with null
+          [`${lowerType}CompanySiret_not_in`]: [""]
         }
       });
 


### PR DESCRIPTION
On a en base de donnée des champs non renseignés qui ont pour valeur une chaîne de caractère vide plutôt que `NULL`. Ça a conduit la query favorites à retourner des résultats incohérents.

Cette PR contourne le problème en filtrant ces informations au niveau de la requête SQL. J'ai créé [une carte](https://trello.com/c/FaYtxTqW/1137-remplacer-les-cha%C3%AEnes-de-caract%C3%A8res-vides-par-null-pour-les-sirets) pour écrire un script de nettoyage pour pouvoir ensuite enlever ce workaround.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

Je ne touche pas à la documentation parce que le bug n'est jamais arrivé jusqu'en production.
