### PR TITLE
fetchPolicy: no-cache sur l'onglet Suivi

### DIFF
--- a/front/src/dashboard/slips/slips-actions/Sealed.tsx
+++ b/front/src/dashboard/slips/slips-actions/Sealed.tsx
@@ -8,7 +8,7 @@ export default function Sealed(props: SlipActionProps) {
       .onSubmit({})
       .then(() =>
         cogoToast.success(
-          `Le numéro #${props.form.readableId} a été affecté au bordereau`
+          `Le numéro #${props.form.readableId} a été affecté au bordereau. Vous pouvez le retrouver dans l'onglet "Suivi"`
         )
       );
   }

--- a/front/src/dashboard/slips/tabs/FollowTab.tsx
+++ b/front/src/dashboard/slips/tabs/FollowTab.tsx
@@ -30,6 +30,9 @@ export default function FollowTab() {
       hasNextStep: false,
     },
     notifyOnNetworkStatusChange: true,
+    // workaround waiting for a way to append a sealed form to the cache
+    // after markAsSealed has been called
+    fetchPolicy: "no-cache",
   });
 
   if (networkStatus === NetworkStatus.loading) return <Loader />;


### PR DESCRIPTION
Actuellement les actions "dynamiques" de type: "Finaliser le bordereau", "Valider la réception", "Valider le traitement" ont été mise en commun dans le composant `DynamicActions` de sorte qu'il n'est pas possible de customiser la mise à jour du cache après l'appel à telle ou telle mutation autre que par le paramètre `refetch` qui permet de rafraichir l'onglet courant. Du coup lorsqu'une action fait passer un bordereau d'un onglet à un autre, on n'a aucun moyen de modifier le cache pour l'ajouter à l'onglet de destination. Le problème concerne à minima 

1 - le passage `Brouillon` => `Suivi` après validation du bordereau 
2 - le passage `Pour Action` => `Archives` pour un destinataire qui valide le traitement. 

 Le workaround proposé permet de résoudre 1. Le deuxième cas étant moins critique, je préfère le laisser en attente d'une solution pérenne => https://trello.com/c/5AdXxycR