### PR TITLE
Correction de la conversion des inputs de packagings

### DIFF
--- a/back/src/forms/__tests__/form-converter.test.ts
+++ b/back/src/forms/__tests__/form-converter.test.ts
@@ -6,7 +6,7 @@ import {
   chain
 } from "../form-converter";
 import { Form } from "../../generated/prisma-client";
-import { FormInput } from "../../generated/graphql/types";
+import { FormInput, WasteDetailsInput } from "../../generated/graphql/types";
 
 test("nullIfNoValues", () => {
   let obj = { a: null, b: null };
@@ -255,87 +255,152 @@ test("expandFormFromDb", () => {
   expect(expanded).toEqual(expected);
 });
 
-test("flattenFormInput", () => {
-  const input: FormInput = {
-    customId: "TD-20-AAA00256",
-    emitter: {
-      type: "PRODUCER",
-      workSite: {
-        address: "5 rue du chantier",
-        city: "Annonay",
-        postalCode: "07100",
-        infos: "Site de stockage de boues"
+describe("flattenFormInput", () => {
+  it("should convert form input to prisma input", () => {
+    const input: FormInput = {
+      customId: "TD-20-AAA00256",
+      emitter: {
+        type: "PRODUCER",
+        workSite: {
+          address: "5 rue du chantier",
+          city: "Annonay",
+          postalCode: "07100",
+          infos: "Site de stockage de boues"
+        },
+        company: {
+          siret: "11111111111111",
+          name: "Boues and Co",
+          address: "1 rue de paradis, 75010 PARIS",
+          contact: "Jean Dupont de la Boue",
+          mail: "jean.dupont@boues.fr",
+          phone: "01 00 00 00 00"
+        }
       },
-      company: {
-        siret: "11111111111111",
-        name: "Boues and Co",
-        address: "1 rue de paradis, 75010 PARIS",
-        contact: "Jean Dupont de la Boue",
-        mail: "jean.dupont@boues.fr",
-        phone: "01 00 00 00 00"
-      }
-    },
-    recipient: {
-      processingOperation: "D 10",
-      company: {
-        siret: "22222222222222",
-        name: "Incinérateur du Grand Est",
-        address: "1 avenue de Colmar 67100 Strasbourg",
-        contact: "Thomas Largeron",
-        mail: "thomas.largeron@incinerateur.fr",
-        phone: "03 00 00 00 00"
-      }
-    },
-    transporter: {
-      receipt: "12379",
-      department: "07",
-      validityLimit: "2020-06-30",
-      numberPlate: "AD-007-TS",
-      company: null
-    },
-    wasteDetails: null
-  };
+      recipient: {
+        processingOperation: "D 10",
+        company: {
+          siret: "22222222222222",
+          name: "Incinérateur du Grand Est",
+          address: "1 avenue de Colmar 67100 Strasbourg",
+          contact: "Thomas Largeron",
+          mail: "thomas.largeron@incinerateur.fr",
+          phone: "03 00 00 00 00"
+        }
+      },
+      transporter: {
+        receipt: "12379",
+        department: "07",
+        validityLimit: "2020-06-30",
+        numberPlate: "AD-007-TS",
+        company: null
+      },
+      wasteDetails: null
+    };
 
-  const flattened = flattenFormInput(input);
+    const flattened = flattenFormInput(input);
 
-  const expected = {
-    customId: input.customId,
-    emitterType: input.emitter.type,
-    emitterWorkSiteAddress: input.emitter.workSite.address,
-    emitterWorkSiteCity: input.emitter.workSite.city,
-    emitterWorkSitePostalCode: input.emitter.workSite.postalCode,
-    emitterWorkSiteInfos: input.emitter.workSite.infos,
-    emitterCompanyName: input.emitter.company.name,
-    emitterCompanySiret: input.emitter.company.siret,
-    emitterCompanyAddress: input.emitter.company.address,
-    emitterCompanyContact: input.emitter.company.contact,
-    emitterCompanyPhone: input.emitter.company.phone,
-    emitterCompanyMail: input.emitter.company.mail,
-    recipientProcessingOperation: input.recipient.processingOperation,
-    recipientCompanyName: input.recipient.company.name,
-    recipientCompanySiret: input.recipient.company.siret,
-    recipientCompanyAddress: input.recipient.company.address,
-    recipientCompanyContact: input.recipient.company.contact,
-    recipientCompanyPhone: input.recipient.company.phone,
-    recipientCompanyMail: input.recipient.company.mail,
-    transporterCompanyName: null,
-    transporterCompanySiret: null,
-    transporterCompanyAddress: null,
-    transporterCompanyContact: null,
-    transporterCompanyPhone: null,
-    transporterCompanyMail: null,
-    transporterReceipt: input.transporter.receipt,
-    transporterDepartment: input.transporter.department,
-    transporterValidityLimit: input.transporter.validityLimit,
-    transporterNumberPlate: input.transporter.numberPlate,
-    wasteDetailsCode: null,
-    wasteDetailsName: null,
-    wasteDetailsOnuCode: null,
-    wasteDetailsPackagingInfos: null,
-    wasteDetailsQuantity: null,
-    wasteDetailsQuantityType: null,
-    wasteDetailsConsistence: null
-  };
+    const expected = {
+      customId: input.customId,
+      emitterType: input.emitter.type,
+      emitterWorkSiteAddress: input.emitter.workSite.address,
+      emitterWorkSiteCity: input.emitter.workSite.city,
+      emitterWorkSitePostalCode: input.emitter.workSite.postalCode,
+      emitterWorkSiteInfos: input.emitter.workSite.infos,
+      emitterCompanyName: input.emitter.company.name,
+      emitterCompanySiret: input.emitter.company.siret,
+      emitterCompanyAddress: input.emitter.company.address,
+      emitterCompanyContact: input.emitter.company.contact,
+      emitterCompanyPhone: input.emitter.company.phone,
+      emitterCompanyMail: input.emitter.company.mail,
+      recipientProcessingOperation: input.recipient.processingOperation,
+      recipientCompanyName: input.recipient.company.name,
+      recipientCompanySiret: input.recipient.company.siret,
+      recipientCompanyAddress: input.recipient.company.address,
+      recipientCompanyContact: input.recipient.company.contact,
+      recipientCompanyPhone: input.recipient.company.phone,
+      recipientCompanyMail: input.recipient.company.mail,
+      transporterCompanyName: null,
+      transporterCompanySiret: null,
+      transporterCompanyAddress: null,
+      transporterCompanyContact: null,
+      transporterCompanyPhone: null,
+      transporterCompanyMail: null,
+      transporterReceipt: input.transporter.receipt,
+      transporterDepartment: input.transporter.department,
+      transporterValidityLimit: input.transporter.validityLimit,
+      transporterNumberPlate: input.transporter.numberPlate,
+      wasteDetailsCode: null,
+      wasteDetailsName: null,
+      wasteDetailsOnuCode: null,
+      wasteDetailsPackagingInfos: null,
+      wasteDetailsQuantity: null,
+      wasteDetailsQuantityType: null,
+      wasteDetailsConsistence: null
+    };
 
-  expect(flattened).toEqual(expected);
+    expect(flattened).toEqual(expected);
+  });
+
+  it("should not set any fiels if wasteDetails is undefined", () => {
+    const flattened = flattenFormInput({});
+    expect(flattened).toEqual({});
+  });
+
+  it("should set all fields to null if wasteDetails is null", () => {
+    const flattened = flattenFormInput({ wasteDetails: null });
+    expect(flattened).toEqual({
+      wasteDetailsCode: null,
+      wasteDetailsConsistence: null,
+      wasteDetailsName: null,
+      wasteDetailsOnuCode: null,
+      wasteDetailsPackagingInfos: null,
+      wasteDetailsQuantity: null,
+      wasteDetailsQuantityType: null
+    });
+  });
+
+  it("should not set wasteDetailPackagingInfos if wasteDetails.packagingInfos is not set", () => {
+    const wasteDetails: WasteDetailsInput = {
+      code: "01 01 01"
+    };
+    const flattened = flattenFormInput({ wasteDetails });
+    expect(flattened).toEqual({ wasteDetailsCode: wasteDetails.code });
+  });
+
+  it("should set wasteDetailPackagingInfos if wasteDetails.packagingInfos is set", () => {
+    const wasteDetails: WasteDetailsInput = {
+      packagingInfos: [{ type: "CITERNE", quantity: 1 }]
+    };
+    const flattened = flattenFormInput({ wasteDetails });
+    expect(flattened).toEqual({
+      wasteDetailsPackagingInfos: wasteDetails.packagingInfos
+    });
+  });
+
+  it("should convert old wasteDetails.packagings to new wasteDetails.packagingInfos", () => {
+    const wasteDetails: WasteDetailsInput = {
+      packagings: ["CITERNE"]
+    };
+    const flattened = flattenFormInput({ wasteDetails });
+    expect(flattened).toEqual({
+      wasteDetailsPackagingInfos: [
+        {
+          other: null,
+          quantity: 1,
+          type: "CITERNE"
+        }
+      ]
+    });
+  });
+
+  it("should give priority to wasteDetails.packagingInfos over wasteDetails.packagings", () => {
+    const wasteDetails: WasteDetailsInput = {
+      packagingInfos: [{ type: "CITERNE", quantity: 1 }],
+      packagings: ["BENNE"]
+    };
+    const flattened = flattenFormInput({ wasteDetails });
+    expect(flattened).toEqual({
+      wasteDetailsPackagingInfos: wasteDetails.packagingInfos
+    });
+  });
 });


### PR DESCRIPTION
Lors d'un appel à `updateForm`, un tableau vide était automatiquement passé à `wasteDetailsPackagingInfos` si `packagingInfos` n'était pas précisé dans l'input. Exemple:

`{ wasteDetails: { code: "01 01 01"} }` => `{ wasteDetailsCode: "01 01 01", wasteDetailsPackagingInfos: [] } }`

Ce comportement n'est pas problématique dans l'interface Trackdéchets car on reprend les données pour faire la mise à jour mais peut s'avérer problématique lors d'une utilisation par API avec mise à jour partielle.
