### PR TITLE
Fix/companies

### DIFF
--- a/front/public/index.html
+++ b/front/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -48,6 +48,11 @@ export default function Dashboard() {
   if (data) {
     const companies = data.me.companies;
 
+    companies.sort((a, b) => {
+      let aName = a.givenName ? a.givenName : a.name ? a.name : "";
+      let bName = b.givenName ? b.givenName : b.name ? b.name : "";
+      return aName.toLowerCase() > bName.toLowerCase() ? 1 : -1;
+    });
     // if the user is not part of the company whose siret is in the url
     // redirect them to their first company or account if they're not part of any company
     if (!companies.find(company => company.siret === siret)) {

--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -45,7 +45,17 @@ export default function Received(props: SlipActionProps) {
           ...(props.form.recipient?.isTempStorage &&
             props.form.status === FormStatus.Sent && { quantityType: "REAL" }),
         }}
-        onSubmit={values => props.onSubmit({ info: values })}
+        onSubmit={(values, { setFieldError }) => {
+          if (
+            props.form.sentAt !== null &&
+            props.form.sentAt > values.receivedAt
+          ) {
+            setFieldError(
+              "receivedAt",
+              "Erreur. La date de réception doit être supérieure à la date d'émission du déchet."
+            );
+          } else props.onSubmit({ info: values });
+        }}
       >
         {({ values, errors, touched, handleReset, setFieldValue }) => {
           const hasErrors = !!Object.keys(errors).length;


### PR DESCRIPTION
  Les entreprises sont maintenant triées par ordre alphabétique.
  Ajout d'un contrôle de date, afin que la date de réception d'un déchet ne puisse être inférieure à sa date d'émission

---

- [Ticket Trello : Ordre alphabétique](https://trello.com/c/CKoBJo3Z/1049-trier-les-entreprises-par-ordre-alphab%C3%A9tiques-dans-la-liste-du-dashboard)
- [Ticket Trello : Contrôle de dates](https://trello.com/c/uv5IzF7z/890-les-dates-peuvent-%C3%AAtre-libres-et-d%C3%A9pass%C3%A9es)
