### PR TITLE
Désactivation de Matomo sur les environnements recette et sandbox

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 - Amélioration de la collecte des erreurs par Sentry, [PR 605](https://github.com/MTES-MCT/trackdechets/pull/605)
+- Désactivation de Matomo en dehors de l'environnement de production, [PR 736](https://github.com/MTES-MCT/trackdechets/pull/736)
 
 # [2020.11.2] 30/11/2020
 

--- a/front/.env.production
+++ b/front/.env.production
@@ -8,4 +8,4 @@ REACT_APP_MATOMO_TRACKER_URL=https://stats.data.gouv.fr/
 
 REACT_APP_SENTRY_DSN=https://13723c4e586d4958b659727fa69cbb8c@sentry.io/3045190
 REACT_APP_SENTRY_ENVIRONMENT=production
-REACT_TD_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr
+REACT_APP_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr

--- a/front/.env.recette
+++ b/front/.env.recette
@@ -3,8 +3,13 @@ REACT_APP_DEVELOPERS_ENDPOINT=https://developers.trackdechets.fr
 REACT_APP_HOSTNAME=recette.trackdechets.fr
 REACT_APP_URL_SCHEME=https
 
-REACT_APP_WARNING_MESSAGE=Veuillez désormais utiliser https://sandbox.trackdechets.beta.gouv.fr
+# disable Matomo by emptying site ID and tracker URL
+REACT_APP_MATOMO_TRACKER_SITE_ID=
+REACT_APP_MATOMO_TRACKER_URL=
 
 REACT_APP_SENTRY_DSN=https://13723c4e586d4958b659727fa69cbb8c@sentry.io/3045190
 REACT_APP_SENTRY_ENVIRONMENT=recette
+
 REACT_TD_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr
+
+REACT_APP_WARNING_MESSAGE=Veuillez désormais utiliser https://sandbox.trackdechets.beta.gouv.fr

--- a/front/.env.recette
+++ b/front/.env.recette
@@ -10,6 +10,6 @@ REACT_APP_MATOMO_TRACKER_URL=
 REACT_APP_SENTRY_DSN=https://13723c4e586d4958b659727fa69cbb8c@sentry.io/3045190
 REACT_APP_SENTRY_ENVIRONMENT=recette
 
-REACT_TD_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr
+REACT_APP_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr
 
 REACT_APP_WARNING_MESSAGE=Veuillez désormais utiliser https://sandbox.trackdechets.beta.gouv.fr

--- a/front/.env.sandbox
+++ b/front/.env.sandbox
@@ -10,4 +10,4 @@ REACT_APP_MATOMO_TRACKER_URL=
 REACT_APP_SENTRY_DSN=https://13723c4e586d4958b659727fa69cbb8c@sentry.io/3045190
 REACT_APP_SENTRY_ENVIRONMENT=sandbox
 
-REACT_TD_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr
+REACT_APP_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr

--- a/front/.env.sandbox
+++ b/front/.env.sandbox
@@ -3,6 +3,11 @@ REACT_APP_DEVELOPERS_ENDPOINT=https://developers.sandbox.trackdechets.beta.gouv.
 REACT_APP_HOSTNAME=sandbox.trackdechets.beta.gouv.fr
 REACT_APP_URL_SCHEME=https
 
+# disable Matomo by emptying site ID and tracker URL
+REACT_APP_MATOMO_TRACKER_SITE_ID=
+REACT_APP_MATOMO_TRACKER_URL=
+
 REACT_APP_SENTRY_DSN=https://13723c4e586d4958b659727fa69cbb8c@sentry.io/3045190
 REACT_APP_SENTRY_ENVIRONMENT=sandbox
+
 REACT_TD_CONTACT_EMAIL=hello@trackdechets.beta.gouv.fr

--- a/front/src/common/config.tsx
+++ b/front/src/common/config.tsx
@@ -8,4 +8,4 @@ export const COLORS = {
   blue: "#0053b3",
 };
 
-export const tdContactEmail = process.env.REACT_TD_CONTACT_EMAIL;
+export const tdContactEmail = process.env.REACT_APP_CONTACT_EMAIL;

--- a/front/src/tracker.ts
+++ b/front/src/tracker.ts
@@ -13,8 +13,8 @@ window._paq.push(["enableLinkTracking"]);
 
 if (
   process.env.NODE_ENV === "production" &&
-  process.env.REACT_APP_MATOMO_TRACKER_SITE_ID != null &&
-  process.env.REACT_APP_MATOMO_TRACKER_URL != null
+  process.env.REACT_APP_MATOMO_TRACKER_SITE_ID &&
+  process.env.REACT_APP_MATOMO_TRACKER_URL
 ) {
   loadTracker();
 }


### PR DESCRIPTION
Cette PR fait en sorte de vider les variables d'environnement Matomo afin qu'elles ne soient plus prises du fichier `.env.production` au moment du build.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/baVPxmdJ/1146-d%C3%A9sactivation-de-matomo-sur-recette-et-sandbox)
