### PR TITLE
Fix : Order of companies

### DIFF
--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -47,7 +47,6 @@ export default function Dashboard() {
 
   if (data) {
     const companies = data.me.companies;
-
     // if the user is not part of the company whose siret is in the url
     // redirect them to their first company or account if they're not part of any company
     if (!companies.find(company => company.siret === siret)) {

--- a/front/src/dashboard/DashboardCompanySelector.tsx
+++ b/front/src/dashboard/DashboardCompanySelector.tsx
@@ -7,6 +7,14 @@ interface IProps {
   handleCompanyChange: (siret: string) => void;
 }
 
+const orderOptions = values => {
+  return [...values].sort((a, b) => {
+    const aName = a.givenName || a.name || "";
+    const bName = b.givenName || b.name || "";
+    return aName.localeCompare(bName);
+  });
+};
+
 export const SIRET_STORAGE_KEY = "td-selectedSiret";
 
 export default function DashboardCompanySelector({
@@ -17,6 +25,8 @@ export default function DashboardCompanySelector({
   const handleChange = (siret: string) => {
     handleCompanyChange(siret);
   };
+
+  companies = orderOptions(companies);
 
   return (
     <select

--- a/front/src/dashboard/DashboardCompanySelector.tsx
+++ b/front/src/dashboard/DashboardCompanySelector.tsx
@@ -7,7 +7,7 @@ interface IProps {
   handleCompanyChange: (siret: string) => void;
 }
 
-const orderOptions = values => {
+const sortCompaniesByName = values => {
   return [...values].sort((a, b) => {
     const aName = a.givenName || a.name || "";
     const bName = b.givenName || b.name || "";
@@ -26,7 +26,7 @@ export default function DashboardCompanySelector({
     handleCompanyChange(siret);
   };
 
-  companies = orderOptions(companies);
+  const sortedCompanies = sortCompaniesByName(companies);
 
   return (
     <select
@@ -34,7 +34,7 @@ export default function DashboardCompanySelector({
       value={siret}
       onChange={e => handleChange(e.target.value)}
     >
-      {companies.map(c => (
+      {sortedCompanies.map(c => (
         <option key={c.siret} value={c.siret}>
           {c.givenName || c.name} ({c.siret})
         </option>


### PR DESCRIPTION
Corrige un problème ou les entreprises n'étaient pas triées par ordre alphabétique dans le dashboard.

---

- [Ticket Trello : Ordre alphabétique](https://trello.com/c/CKoBJo3Z/1049-trier-les-entreprises-par-ordre-alphab%C3%A9tiques-dans-la-liste-du-dashboard)
