### PR TITLE
Recettage POP

### DIFF
--- a/front/src/common/components/Switch.tsx
+++ b/front/src/common/components/Switch.tsx
@@ -32,14 +32,17 @@ type FieldSwitchProps = FieldProps & {
 
 // Compatilibty layer between the Switch and Formik's <Field />
 export function FieldSwitch({
-  field: { checked, onChange, ...field },
+  field: { checked, ...field },
+  form: { setFieldValue },
   ...props
 }: FieldSwitchProps) {
   return (
     <Switch
       {...field}
       {...props}
-      onChange={(checked, event) => onChange(event)}
+      onChange={checked => {
+        setFieldValue(field.name, checked);
+      }}
       checked={Boolean(checked)}
     />
   );

--- a/front/src/common/components/Tooltip.tsx
+++ b/front/src/common/components/Tooltip.tsx
@@ -25,7 +25,7 @@ const TdTooltip = ({ msg }: Props) => {
         border: "none",
         borderRadius: "3px",
         padding: "0.5em 1em",
-        whiteSpace: "pre",
+        whiteSpace: "pre-wrap",
       }}
     >
       <button className={style.tdTooltip} type="button">

--- a/front/src/form/WasteInfo.tsx
+++ b/front/src/form/WasteInfo.tsx
@@ -45,6 +45,26 @@ export default connect<{}, Values>(function WasteInfo(props) {
         <RedErrorMessage name="wasteDetails.name" />
       </div>
 
+      <div className="form__row" style={{ flexDirection: "row" }}>
+        <Field
+          type="checkbox"
+          component={FieldSwitch}
+          name="wasteDetails.pop"
+          label="Le déchet contient des polluants organiques persistants"
+        />
+        <a
+          className="link tw-ml-2"
+          href="https://www.ecologique-solidaire.gouv.fr/polluants-organiques-persistants-pop"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Tooltip
+            msg="Le terme POP recouvre un ensemble de substances organiques qui
+        possèdent 4 propriétés : persistantes, bioaccumulables, toxiques et mobiles."
+          />
+        </a>
+      </div>
+
       {values.emitter.type === "APPENDIX1" && <AppendixInfo />}
 
       {values.emitter.type === "APPENDIX2" && (
@@ -87,26 +107,6 @@ export default connect<{}, Values>(function WasteInfo(props) {
         </fieldset>
 
         <RedErrorMessage name="wasteDetails.consistence" />
-      </div>
-
-      <div className="form__row" style={{ flexDirection: "row" }}>
-        <Field
-          type="checkbox"
-          component={FieldSwitch}
-          name="wasteDetails.pop"
-          label="Le déchet contient des polluants organiques persistants"
-        />
-        <a
-          className="link tw-ml-2"
-          href="https://www.ecologique-solidaire.gouv.fr/polluants-organiques-persistants-pop"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Tooltip
-            msg="Le terme POP recouvre un ensemble de substances organiques qui
-        possèdent 4 propriétés : persistantes, bioaccumulables, toxiques et mobiles."
-          />
-        </a>
       </div>
 
       <h4 className="form__section-heading">Quantité en tonnes</h4>

--- a/front/src/form/WasteInfo.tsx
+++ b/front/src/form/WasteInfo.tsx
@@ -102,7 +102,10 @@ export default connect<{}, Values>(function WasteInfo(props) {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Question color="currentColor" size={20} />
+          <Tooltip
+            msg="Le terme POP recouvre un ensemble de substances organiques qui
+        possèdent 4 propriétés : persistantes, bioaccumulables, toxiques et mobiles."
+          />
         </a>
       </div>
 

--- a/front/src/form/initial-state.ts
+++ b/front/src/form/initial-state.ts
@@ -50,6 +50,7 @@ export default {
     quantity: null,
     quantityType: "ESTIMATED",
     consistence: "SOLID",
+    pop: false,
   },
   appendix2Forms: [],
   ecoOrganisme: {


### PR DESCRIPTION
Quelques corrections suite aux retours d'Emmanuel et Claire 

- le toggle du switch ne fonctionnait pas au clic, il fallait le faire glisser de gauche à droite ou de droite à gauche. 
- ajout d'un texte au hover sur la tooltip POP 
- déplacement de l'input POP dans la catégorie "Description du déchet"

---

- [Ticket Trello](https://trello.com/c/8oRL9ilq)
