### PR TITLE
Recettage de la validation de la date de réception

### DIFF
--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isBefore, isSameDay, formatISO } from "date-fns";
+import { isBefore, startOfDay, formatISO } from "date-fns";
 import { Formik, Field, Form } from "formik";
 import { parseDate } from "common/datetime";
 import { RedErrorMessage } from "common/components";
@@ -47,15 +47,12 @@ export default function Received(props: SlipActionProps) {
           props.onSubmit({ info: values });
         }}
         validate={values => {
-          const receivedAt = parseDate(values.receivedAt);
-          const sentAt = parseDate(props.form.sentAt!);
+          // we only care about the day, not the exact time
+          // that's why we are setting both dates to the start of day
+          const receivedAt = startOfDay(parseDate(values.receivedAt));
+          const sentAt = startOfDay(parseDate(props.form.sentAt!));
 
-          if (
-            isBefore(receivedAt, sentAt) &&
-            // receivedAt may be the same day as sentAt but earlier in the day
-            // that's ok since the exact time doesn't matter, we only really care about the day
-            !isSameDay(receivedAt, sentAt)
-          ) {
+          if (isBefore(receivedAt, sentAt)) {
             return {
               receivedAt:
                 "La date de réception du déchet ne peut pas être antérieure à sa date d'émission.",

--- a/front/src/dashboard/slips/slips-actions/Received.tsx
+++ b/front/src/dashboard/slips/slips-actions/Received.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isBefore, formatISO } from "date-fns";
+import { isBefore, isSameDay, formatISO } from "date-fns";
 import { Formik, Field, Form } from "formik";
 import { parseDate } from "common/datetime";
 import { RedErrorMessage } from "common/components";
@@ -47,15 +47,18 @@ export default function Received(props: SlipActionProps) {
           props.onSubmit({ info: values });
         }}
         validate={values => {
+          const receivedAt = parseDate(values.receivedAt);
+          const sentAt = parseDate(props.form.sentAt!);
+
           if (
-            isBefore(
-              parseDate(values.receivedAt),
-              parseDate(props.form.sentAt!)
-            )
+            isBefore(receivedAt, sentAt) &&
+            // receivedAt may be the same day as sentAt but earlier in the day
+            // that's ok since the exact time doesn't matter, we only really care about the day
+            !isSameDay(receivedAt, sentAt)
           ) {
             return {
               receivedAt:
-                "La date de réception du déchet doit être postérieure à sa date d'émission.",
+                "La date de réception du déchet ne peut pas être antérieure à sa date d'émission.",
             };
           }
         }}


### PR DESCRIPTION
Cette PR rend possible la sélection du jour d'émission comme jour de réception.

- [ ] ~Mettre à jour la documentation~
- [ ] ~Mettre à jour le change log~
- [ ] ~Documenter les breaking changes dans le change log~

---

- [Ticket Trello](https://trello.com/c/uv5IzF7z/890-les-dates-peuvent-%C3%AAtre-libres-et-d%C3%A9pass%C3%A9es)
