### PR TITLE
Fix pdf action not available for sealed forms

### DIFF
--- a/front/src/dashboard/slip/SlipDetailContent.tsx
+++ b/front/src/dashboard/slip/SlipDetailContent.tsx
@@ -471,14 +471,15 @@ export default function SlipDetailContent({
         </div>
       </Tabs>
       <div className={styles.detailActions}>
+        {form.status !== FormStatus.Draft && (
+          <DownloadPdf formId={form.id} small={false} />
+        )}
         <Duplicate formId={form.id} small={false} redirectToDashboard={true} />
-        {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) ? (
+        {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) && (
           <>
             <Delete formId={form.id} small={false} />
             <Edit formId={form.id} small={false} />
           </>
-        ) : (
-          <DownloadPdf formId={form.id} small={false} />
         )}
         {statusesWithDynamicActions.includes(form.status) && (
           <DynamicActions siret={siret} form={form} refetch={refetch} />

--- a/front/src/dashboard/slips/slips-actions/SlipActions.tsx
+++ b/front/src/dashboard/slips/slips-actions/SlipActions.tsx
@@ -88,8 +88,12 @@ export const SlipActions = ({ form, siret }: SlipActionsProps) => {
                   onClose={onClose}
                 />
               </li>
-
-              {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) ? (
+              {form.status !== FormStatus.Draft && (
+                <li className="slips-actions__item">
+                  <DownloadPdf formId={form.id} onSuccess={onClose} />
+                </li>
+              )}
+              {[FormStatus.Draft, FormStatus.Sealed].includes(form.status) && (
                 <>
                   <li className="slips-actions__item">
                     <Delete
@@ -102,10 +106,6 @@ export const SlipActions = ({ form, siret }: SlipActionsProps) => {
                     <Edit formId={form.id} />
                   </li>
                 </>
-              ) : (
-                <li className="slips-actions__item">
-                  <DownloadPdf formId={form.id} onSuccess={onClose} />
-                </li>
               )}
               <li className="slips-actions__item">
                 <Duplicate formId={form.id} onClose={onClose} />


### PR DESCRIPTION
Correction d'un bug affectant le téléchargement PDF des bordereaux scellés en prod suite à https://github.com/MTES-MCT/trackdechets/pull/720/. Comme on a rien poussé sur `dev` à part https://github.com/MTES-MCT/trackdechets/pull/756 je pensais déployer normalement en recette puis faire une release ce soir à partir de la branche `dev`

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/2XkEljBO)
