### PR TITLE
Fix/Pas plus de 1 citerne ou benne

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -431,4 +431,60 @@ describe("Mutation.createForm", () => {
       expectedPackagingInfos
     );
   });
+
+  it("should disallow a form with several CITERNE", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      wasteDetails: {
+        packagingInfos: [{ type: "CITERNE", quantity: 3 }]
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(CREATE_FORM, {
+      variables: { createFormInput }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le nombre de benne ou de citerne ne peut être supérieur à 1.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should disallow a form with several BENNE", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      wasteDetails: {
+        packagingInfos: [{ type: "BENNE", quantity: 3 }]
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(CREATE_FORM, {
+      variables: { createFormInput }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le nombre de benne ou de citerne ne peut être supérieur à 1.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
 });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -328,6 +328,35 @@ const packagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
     )
 });
 
+const draftPackagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
+  type: yup.mixed<Packagings>().nullable(),
+  other: yup
+    .string()
+    .when("type", (type, schema) =>
+      type === "AUTRE"
+        ? schema.nullable()
+        : schema
+            .nullable()
+            .max(
+              0,
+              "${path} ne peut être renseigné que lorsque le type de conditionnement est 'AUTRE'."
+            )
+    ),
+  quantity: yup
+    .number()
+    .nullable()
+    .integer()
+    .min(1, "Le nombre de colis doit être supérieur à 0.")
+    .when("type", (type, schema) =>
+      ["CITERNE", "BENNE"].includes(type)
+        ? schema.max(
+            1,
+            "Le nombre de benne ou de citerne ne peut être supérieur à 1."
+          )
+        : schema
+    )
+});
+
 // 3 - Dénomination du déchet
 // 4 - Mentions au titre des règlements ADR, RID, ADNR, IMDG
 // 5 - Conditionnement
@@ -882,6 +911,31 @@ export const draftFormSchema = yup
       .notRequired()
       .nullable()
       .oneOf([...WASTES_CODES, "", null], INVALID_WASTE_CODE),
+    wasteDetailsPackagingInfos: yup
+      .array()
+      .nullable()
+      .of(draftPackagingInfo)
+      .test(
+        "is-valid-packaging-infos",
+        "${path} ne peut pas à la fois contenir 1 citerne ou 1 benne et un autre conditionnement.",
+        (infos: PackagingInfo[]) => {
+          const hasCiterne = infos?.find(i => i.type === "CITERNE");
+          const hasBenne = infos?.find(i => i.type === "BENNE");
+
+          if (hasCiterne && hasBenne) {
+            return false;
+          }
+
+          const hasOtherPackaging = infos?.find(
+            i => !["CITERNE", "BENNE"].includes(i.type)
+          );
+          if ((hasCiterne || hasBenne) && hasOtherPackaging) {
+            return false;
+          }
+
+          return true;
+        }
+      ),
     transporterCompanySiret: yup
       .string()
       .notRequired()


### PR DESCRIPTION
Pas plus de 1 citerne ou benne.

Cette PR pose en fait la question de la validation des brouillons. On est actuellement TRES flexible sur la création de brouillon.
A mon avis ce qu'il faudrait c'est:
- autoriser tous les champs à null (c'est le cas)
- mais quand même valider les règles métier

Avec le `draftSchema` on vérifie quasi rien. On peut mettre ce qu'on veut comme code de traitement, on peut qvoir 15 citernes, bref chaque champ qui aune logique métier est libre.
Idéalement à mon sens il faudrait un schéma partagé, qu'on puisse rendre "100% nullable" selon le contexte de validation (2eme argument du `validate`). Je n'ai pas encore trouvé de manière propre/pas trop lourde à lire de faire ca avec Yup. Du coup avec cette PR je corrige uniquement le problème des bennes / citernes en dupliquant du code. Mais il faudra trouver quelque chose de plus générique je pense.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les breaking changes dans le change log

---

- [Ticket Trello](https://trello.com/c/SCMkg5sf/1167-le-nombre-de-benne-citerne-ne-devrait-pas-pouvoir-%C3%AAtre-sup%C3%A9rieur-%C3%A0-1-lors-dune-cr%C3%A9ation-de-bsd-par-api)
