### PR TITLE
Validation Yup commune des draft & sealed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :boom: Breaking changes
 
 - Utilisation du format `BSD-{yyyyMMdd}-{XXXXXXXXX}` pour le champ `readableId` de l'objet `Form` en remplacement de l'ancien format `TD-{yy}-{XXXXXXXX}` [PR 759](https://github.com/MTES-MCT/trackdechets/pull/759)
+- Validation exhaustive des champs pour les brouillons. Il était jusqu'à présent possible de saisir des valeurs invalides tant qu'un BSD était en brouillon. Les mêmes règles de validation que pour les bordereaux scéllés sont désormais appliquées [PR 764](https://github.com/MTES-MCT/trackdechets/pull/764)
 
 #### :bug: Corrections de bugs
 

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -4335,6 +4335,11 @@
         "@types/koa": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.167",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.167.tgz",
+      "integrity": "sha512-w7tQPjARrvdeBkX/Rwg95S592JwxqOjmms3zWQ0XZgSyxSLdzWaYH3vErBhdVS/lRBX7F8aBYcYJYTr5TMGOzw=="
+    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -4551,12 +4556,6 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
-      "dev": true
-    },
-    "@types/yup": {
-      "version": "0.29.4",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.29.4.tgz",
-      "integrity": "sha512-OQ7gZRQb7eSbGu5h57tbK67sgX8UH5wbuqPORTFBG7qiBtOkEf1dXAr0QULyHIeRwaGLPYxPXiQru+40ClR6ng==",
       "dev": true
     },
     "@types/zen-observable": {
@@ -9066,6 +9065,11 @@
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-3.0.0.tgz",
       "integrity": "sha512-eNMNr5exLoavuAMhIUVsOKF79SWd/zG104ef6sxBTSw+cZc6BXdQXDvYcGvp0VbxVVSp1XDUNoz7mg1xMtSznA=="
     },
+    "flow-bin": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.87.0.tgz",
+      "integrity": "sha512-mnvBXXZkUp4y6A96bR5BHa3q1ioIIN2L10w5osxJqagAakTXFYZwjl0t9cT3y2aCEf1wnK6n91xgYypQS/Dqbw=="
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -13399,6 +13403,12 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.20.tgz",
       "integrity": "sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA=="
     },
+    "lodash.ary": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.ary/-/lodash.ary-4.1.1.tgz",
+      "integrity": "sha1-ZgZfqRusx6A02cj85S+D08fkAhI=",
+      "dev": true
+    },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -13903,6 +13913,11 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16664,11 +16679,6 @@
         }
       }
     },
-    "synchronous-promise": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.15.tgz",
-      "integrity": "sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg=="
-    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -18003,16 +18013,16 @@
       "dev": true
     },
     "yup": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.29.3.tgz",
-      "integrity": "sha512-RNUGiZ/sQ37CkhzKFoedkeMfJM0vNQyaz+wRZJzxdKE7VfDeVKH8bb4rr7XhRLbHJz5hSjoDNwMEIaKhuMZ8gQ==",
+      "version": "0.32.8",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.8.tgz",
+      "integrity": "sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==",
       "requires": {
         "@babel/runtime": "^7.10.5",
-        "fn-name": "~3.0.0",
-        "lodash": "^4.17.15",
+        "@types/lodash": "^4.14.165",
+        "lodash": "^4.17.20",
         "lodash-es": "^4.17.11",
-        "property-expr": "^2.0.2",
-        "synchronous-promise": "^2.0.13",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       },
       "dependencies": {
@@ -18023,6 +18033,11 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         }
       }
     },

--- a/back/package.json
+++ b/back/package.json
@@ -78,7 +78,7 @@
     "winston-transport": "^4.3.0",
     "world-countries": "^4.0.0",
     "xstate": "^4.13.0",
-    "yup": "^0.29.3"
+    "yup": "^0.32.8"
   },
   "devDependencies": {
     "@fast-csv/parse": "^4.3.0",
@@ -107,7 +107,6 @@
     "@types/passport-oauth2-client-password": "^0.1.2",
     "@types/rate-limit-redis": "^1.7.1",
     "@types/supertest": "^2.0.10",
-    "@types/yup": "0.29.4",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
     "apollo-server-integration-testing": "^2.3.0",

--- a/back/src/common/yup/configureYup.ts
+++ b/back/src/common/yup/configureYup.ts
@@ -7,5 +7,17 @@ export default function configureYup() {
       required: "${path} est un champ requis et doit avoir une valeur",
       notType: "${path} ne peut pas être null"
     }
-  } as yup.LocaleObject);
+  });
+
+  yup.addMethod<yup.BaseSchema>(
+    yup.mixed,
+    "sealedRequired",
+    function sealedRequired(message?: string) {
+      return this.when("$isDraft", {
+        is: true,
+        then: s => s.nullable().notRequired(),
+        otherwise: s => s.nullable().required(message) // nullable to treat null as a missing value, not a type error
+      }).transform(val => (val === "" ? null : val));
+    }
+  );
 }

--- a/back/src/common/yup/configureYup.ts
+++ b/back/src/common/yup/configureYup.ts
@@ -1,4 +1,11 @@
 import * as yup from "yup";
+import { AnyObject } from "yup/lib/types";
+
+declare module "yup" {
+  interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
+    requiredIf<T>(contextKey: string, message?: string): this;
+  }
+}
 
 export default function configureYup() {
   yup.setLocale({
@@ -9,15 +16,15 @@ export default function configureYup() {
     }
   });
 
-  yup.addMethod<yup.BaseSchema>(
-    yup.mixed,
-    "sealedRequired",
-    function sealedRequired(message?: string) {
-      return this.when("$isDraft", {
-        is: true,
-        then: s => s.nullable().notRequired(),
-        otherwise: s => s.nullable().required(message) // nullable to treat null as a missing value, not a type error
-      }).transform(val => (val === "" ? null : val));
+  yup.addMethod<yup.BaseSchema>(yup.mixed, "requiredIf", function requiredIf(
+    condition: boolean,
+    message?: string
+  ) {
+    if (condition) {
+      return this.nullable().notRequired();
     }
-  );
+
+    // nullable to treat null as a missing value, not a type error
+    return this.nullable().required(message);
+  });
 }

--- a/back/src/common/yup/configureYup.ts
+++ b/back/src/common/yup/configureYup.ts
@@ -3,7 +3,7 @@ import { AnyObject } from "yup/lib/types";
 
 declare module "yup" {
   interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
-    requiredIf<T>(contextKey: string, message?: string): this;
+    requiredIf<T>(condition: boolean, message?: string): this;
   }
 }
 

--- a/back/src/common/yup/yup.d.ts
+++ b/back/src/common/yup/yup.d.ts
@@ -1,0 +1,7 @@
+import { AnyObject } from "yup/lib/types";
+
+declare module "yup" {
+  interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
+    sealedRequired<T>(message?: string): this;
+  }
+}

--- a/back/src/common/yup/yup.d.ts
+++ b/back/src/common/yup/yup.d.ts
@@ -2,6 +2,6 @@ import { AnyObject } from "yup/lib/types";
 
 declare module "yup" {
   interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
-    sealedRequired<T>(message?: string): this;
+    requiredIf<T>(contextKey: string, message?: string): this;
   }
 }

--- a/back/src/common/yup/yup.d.ts
+++ b/back/src/common/yup/yup.d.ts
@@ -2,6 +2,6 @@ import { AnyObject } from "yup/lib/types";
 
 declare module "yup" {
   interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
-    requiredIf<T>(contextKey: string, message?: string): this;
+    requiredIf<T>(condition: boolean, message?: string): this;
   }
 }

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1,5 +1,6 @@
 import { Form } from "@prisma/client";
 import {
+  draftFormSchema,
   sealedFormSchema,
   ecoOrganismeSchema,
   receivedInfoSchema
@@ -305,9 +306,7 @@ describe("draftFormSchema", () => {
   };
 
   it("should be valid when passing empty strings", () => {
-    const isValid = sealedFormSchema.isValidSync(form, {
-      context: { isDraft: true }
-    });
+    const isValid = draftFormSchema.isValidSync(form);
     expect(isValid).toBe(true);
   });
 
@@ -322,31 +321,23 @@ describe("draftFormSchema", () => {
       transporterCompanyMail: null,
       transporterValidityLimit: null
     };
-    const isValid = sealedFormSchema.isValidSync(form, {
-      context: { isDraft: true }
-    });
+    const isValid = draftFormSchema.isValidSync(form);
 
     expect(isValid).toBe(true);
   });
 
   it("should be valid when passing undefined values", () => {
-    const isValid = sealedFormSchema.isValidSync(
-      {},
-      { context: { isDraft: true } }
-    );
+    const isValid = draftFormSchema.isValidSync({});
 
     expect(isValid).toBe(true);
   });
 
   it("should not be valid when passing an invalid siret", async () => {
     const validateFn = () =>
-      sealedFormSchema.validate(
-        {
-          ...form,
-          emitterCompanySiret: "this is not a siret"
-        },
-        { context: { isDraft: true } }
-      );
+      draftFormSchema.validate({
+        ...form,
+        emitterCompanySiret: "this is not a siret"
+      });
 
     await expect(validateFn()).rejects.toThrow(
       "Émetteur: Le SIRET doit faire 14 caractères numériques"
@@ -355,13 +346,10 @@ describe("draftFormSchema", () => {
 
   it("should be invalid when passing an invalid waste code", async () => {
     const validateFn = () =>
-      sealedFormSchema.validate(
-        {
-          ...form,
-          wasteDetailsCode: "this is not a waste cde"
-        },
-        { context: { isDraft: true } }
-      );
+      draftFormSchema.validate({
+        ...form,
+        wasteDetailsCode: "this is not a waste cde"
+      });
 
     await expect(validateFn()).rejects.toThrow(
       "Le code déchet n'est pas reconnu comme faisant partie de la liste officielle du code de l'environnement."
@@ -370,13 +358,10 @@ describe("draftFormSchema", () => {
 
   it("should be invalid when passing an invalid email", async () => {
     const validateFn = () =>
-      sealedFormSchema.validate(
-        {
-          ...form,
-          emitterCompanyMail: "this is not an email"
-        },
-        { context: { isDraft: true } }
-      );
+      draftFormSchema.validate({
+        ...form,
+        emitterCompanyMail: "this is not an email"
+      });
 
     await expect(validateFn()).rejects.toThrow(
       "emitterCompanyMail must be a valid email"

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -2,8 +2,7 @@ import { Form } from "@prisma/client";
 import {
   sealedFormSchema,
   ecoOrganismeSchema,
-  receivedInfoSchema,
-  draftFormSchema
+  receivedInfoSchema
 } from "../validation";
 import { ReceivedFormInput } from "../../generated/graphql/types";
 
@@ -18,7 +17,7 @@ const form: Partial<Form> = {
   emitterWorkSitePostalCode: "",
   emitterWorkSiteInfos: "",
   emitterCompanyName: "A company 2",
-  emitterCompanySiret: "XXXXXXXXXX0002",
+  emitterCompanySiret: "00000000000002",
   emitterCompanyContact: "Emetteur",
   emitterCompanyPhone: "01",
   emitterCompanyAddress: "8 rue du Général de Gaulle",
@@ -26,7 +25,7 @@ const form: Partial<Form> = {
   recipientCap: "1234",
   recipientProcessingOperation: "D 6",
   recipientCompanyName: "A company 3",
-  recipientCompanySiret: "XXXXXXXXXX0003",
+  recipientCompanySiret: "00000000000003",
   recipientCompanyAddress: "8 rue du Général de Gaulle",
   recipientCompanyContact: "Destination",
   recipientCompanyPhone: "02",
@@ -35,7 +34,7 @@ const form: Partial<Form> = {
   transporterDepartment: "82",
   transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
   transporterCompanyName: "A company 4",
-  transporterCompanySiret: "XXXXXXXXXX0004",
+  transporterCompanySiret: "00000000000004",
   transporterCompanyAddress: "8 rue du Général de Gaulle",
   transporterCompanyContact: "Transporteur",
   transporterCompanyPhone: "03",
@@ -306,7 +305,9 @@ describe("draftFormSchema", () => {
   };
 
   it("should be valid when passing empty strings", () => {
-    const isValid = draftFormSchema.isValidSync(form);
+    const isValid = sealedFormSchema.isValidSync(form, {
+      context: { isDraft: true }
+    });
     expect(isValid).toBe(true);
   });
 
@@ -321,21 +322,31 @@ describe("draftFormSchema", () => {
       transporterCompanyMail: null,
       transporterValidityLimit: null
     };
-    const isValid = draftFormSchema.isValidSync(form);
+    const isValid = sealedFormSchema.isValidSync(form, {
+      context: { isDraft: true }
+    });
+
     expect(isValid).toBe(true);
   });
 
   it("should be valid when passing undefined values", () => {
-    const isValid = draftFormSchema.isValidSync({});
+    const isValid = sealedFormSchema.isValidSync(
+      {},
+      { context: { isDraft: true } }
+    );
+
     expect(isValid).toBe(true);
   });
 
   it("should not be valid when passing an invalid siret", async () => {
     const validateFn = () =>
-      draftFormSchema.validate({
-        ...form,
-        emitterCompanySiret: "this is not a siret"
-      });
+      sealedFormSchema.validate(
+        {
+          ...form,
+          emitterCompanySiret: "this is not a siret"
+        },
+        { context: { isDraft: true } }
+      );
 
     await expect(validateFn()).rejects.toThrow(
       "Émetteur: Le SIRET doit faire 14 caractères numériques"
@@ -344,10 +355,13 @@ describe("draftFormSchema", () => {
 
   it("should be invalid when passing an invalid waste code", async () => {
     const validateFn = () =>
-      draftFormSchema.validate({
-        ...form,
-        wasteDetailsCode: "this is not a waste cde"
-      });
+      sealedFormSchema.validate(
+        {
+          ...form,
+          wasteDetailsCode: "this is not a waste cde"
+        },
+        { context: { isDraft: true } }
+      );
 
     await expect(validateFn()).rejects.toThrow(
       "Le code déchet n'est pas reconnu comme faisant partie de la liste officielle du code de l'environnement."
@@ -356,10 +370,13 @@ describe("draftFormSchema", () => {
 
   it("should be invalid when passing an invalid email", async () => {
     const validateFn = () =>
-      draftFormSchema.validate({
-        ...form,
-        emitterCompanyMail: "this is not an email"
-      });
+      sealedFormSchema.validate(
+        {
+          ...form,
+          emitterCompanyMail: "this is not an email"
+        },
+        { context: { isDraft: true } }
+      );
 
     await expect(validateFn()).rejects.toThrow(
       "emitterCompanyMail must be a valid email"

--- a/back/src/forms/pagination.ts
+++ b/back/src/forms/pagination.ts
@@ -58,7 +58,7 @@ const positiveInteger = yup
 export function getConnectionsArgs(args: PaginationArgs) {
   const maxPaginateBy = args.maxPaginateBy ?? 1000;
 
-  const validationSchema = yup.object().shape<PaginationArgs>({
+  const validationSchema = yup.object().shape({
     first: positiveInteger.max(
       maxPaginateBy,
       `\`first\` doit être inférieur à ${maxPaginateBy}`

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -432,4 +432,60 @@ describe("Mutation.createForm", () => {
       expectedPackagingInfos
     );
   });
+
+  it("should disallow a form with several CITERNE", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      wasteDetails: {
+        packagingInfos: [{ type: "CITERNE", quantity: 3 }]
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(CREATE_FORM, {
+      variables: { createFormInput }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le nombre de benne ou de citerne ne peut être supérieur à 1.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should disallow a form with several BENNE", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      wasteDetails: {
+        packagingInfos: [{ type: "BENNE", quantity: 3 }]
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(CREATE_FORM, {
+      variables: { createFormInput }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le nombre de benne ou de citerne ne peut être supérieur à 1.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -222,7 +222,6 @@ describe("Mutation.markAsSealed", () => {
     const errMessage =
       "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.\n" +
       "Erreur(s): Émetteur: Le siret de l'entreprise est obligatoire\n" +
-      "Émetteur: Le SIRET doit faire 14 caractères numériques\n" +
       "Émetteur: Le contact dans l'entreprise est obligatoire";
     expect(errors[0].message).toBe(errMessage);
 
@@ -236,7 +235,7 @@ describe("Mutation.markAsSealed", () => {
     expect(statusLogs.length).toEqual(0);
   });
 
-  it.each(["toto", "", "lorem ipsum", "01 02 03", "101309*"])(
+  it.each(["toto", "lorem ipsum", "01 02 03", "101309*"])(
     "wrong waste code (%p) must invalidate mutation",
     async wrongWasteCode => {
       const { user, company: recipientCompany } = await userWithCompanyFactory(

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSent.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSent.integration.ts
@@ -238,7 +238,7 @@ describe("{ mutation { markAsSent } }", () => {
     expect(resultingForm.currentTransporterSiret).toBeNull();
   });
 
-  test.each(["toto", "", "lorem ipsum", "01 02 03", "101309*"])(
+  test.each(["toto", "lorem ipsum", "01 02 03", "101309*"])(
     "wrong waste code (%p) must invalidate mutation",
     async wrongWasteCode => {
       const { user, company: recipientCompany } = await userWithCompanyFactory(

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -278,6 +278,7 @@ describe("Mutation.updateForm", () => {
       ownerId: user.id,
       opt: {
         status: "DRAFT",
+        emitterType: "OTHER",
         ecoOrganismeName: eo.name,
         ecoOrganismeSiret: eo.siret
       }
@@ -336,6 +337,9 @@ describe("Mutation.updateForm", () => {
 
     const updateFormInput = {
       id: form.id,
+      emitter: {
+        type: "OTHER"
+      },
       ecoOrganisme: {
         name: "",
         siret: "does_not_exist"
@@ -399,6 +403,9 @@ describe("Mutation.updateForm", () => {
       variables: {
         updateFormInput: {
           id: form.id,
+          emitter: {
+            type: "OTHER"
+          },
           ecoOrganisme: {
             name: newEO.name,
             siret: newEO.siret

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -14,7 +14,7 @@ import {
   flattenFormInput,
   flattenTemporaryStorageDetailInput
 } from "../../form-converter";
-import { sealedFormSchema } from "../../validation";
+import { draftFormSchema } from "../../validation";
 import { checkIsFormContributor } from "../../permissions";
 import { FormSirets } from "../../types";
 
@@ -59,9 +59,7 @@ const createFormResolver = async (
     appendix2Forms: { connect: appendix2Forms }
   };
 
-  await sealedFormSchema.validate(formCreateInput, {
-    context: { isDraft: true }
-  });
+  await draftFormSchema.validate(formCreateInput);
 
   if (temporaryStorageDetail) {
     if (formContent.recipient?.isTempStorage !== true) {

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -14,7 +14,7 @@ import {
   flattenFormInput,
   flattenTemporaryStorageDetailInput
 } from "../../form-converter";
-import { draftFormSchema } from "../../validation";
+import { sealedFormSchema } from "../../validation";
 import { checkIsFormContributor } from "../../permissions";
 import { FormSirets } from "../../types";
 
@@ -59,7 +59,9 @@ const createFormResolver = async (
     appendix2Forms: { connect: appendix2Forms }
   };
 
-  await draftFormSchema.validate(formCreateInput);
+  await sealedFormSchema.validate(formCreateInput, {
+    context: { isDraft: true }
+  });
 
   if (temporaryStorageDetail) {
     if (formContent.recipient?.isTempStorage !== true) {

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -3,7 +3,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import transitionForm from "../../workflow/transitionForm";
 import { getFormOrFormNotFound } from "../../database";
 import { checkCanMarkAsTempStored } from "../../permissions";
-import { tempStoredInfoSchema, TempStorageInfo } from "../../validation";
+import { tempStoredInfoSchema } from "../../validation";
 import { EventType } from "../../workflow/types";
 import { expandFormFromDb } from "../../form-converter";
 import { DestinationCannotTempStore } from "../../errors";
@@ -23,7 +23,7 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
     throw new DestinationCannotTempStore();
   }
 
-  const tempStorageUpdateInput: TempStorageInfo = {
+  const tempStorageUpdateInput = {
     tempStorerQuantityType: tempStoredInfos.quantityType,
     tempStorerQuantityReceived: tempStoredInfos.quantityReceived,
     tempStorerWasteAcceptationStatus: tempStoredInfos.wasteAcceptationStatus,

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -15,7 +15,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { checkCanUpdate, checkIsFormContributor } from "../../permissions";
 import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
-import { sealedFormSchema } from "../../validation";
+import { draftFormSchema, sealedFormSchema } from "../../validation";
 import { FormSirets } from "../../types";
 
 function validateArgs(args: MutationUpdateFormArgs) {
@@ -55,10 +55,11 @@ const updateFormResolver = async (
   };
 
   // Validate form input
-  await sealedFormSchema.validate(
-    { ...existingForm, ...formUpdateInput },
-    { context: { isDraft: existingForm.status === "DRAFT" } }
-  );
+  if (existingForm.status === "DRAFT") {
+    await draftFormSchema.validate({ ...existingForm, ...formUpdateInput });
+  } else {
+    await sealedFormSchema.validate({ ...existingForm, ...formUpdateInput });
+  }
 
   const isOrWillBeTempStorage =
     (existingForm.recipientIsTempStorage &&

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -15,7 +15,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { checkCanUpdate, checkIsFormContributor } from "../../permissions";
 import { GraphQLContext } from "../../../types";
 import { getFormOrFormNotFound } from "../../database";
-import { draftFormSchema, sealedFormSchema } from "../../validation";
+import { sealedFormSchema } from "../../validation";
 import { FormSirets } from "../../types";
 
 function validateArgs(args: MutationUpdateFormArgs) {
@@ -55,11 +55,10 @@ const updateFormResolver = async (
   };
 
   // Validate form input
-  if (existingForm.status === "DRAFT") {
-    await draftFormSchema.validate(formUpdateInput);
-  } else if (existingForm.status === "SEALED") {
-    await sealedFormSchema.validate({ ...existingForm, ...formUpdateInput });
-  }
+  await sealedFormSchema.validate(
+    { ...existingForm, ...formUpdateInput },
+    { context: { isDraft: existingForm.status === "DRAFT" } }
+  );
 
   const isOrWillBeTempStorage =
     (existingForm.recipientIsTempStorage &&

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -202,12 +202,12 @@ const EXTRANEOUS_NEXT_DESTINATION = `L'opération de traitement renseignée ne p
 // *************************************************************
 
 // 1 - Émetteur du bordereau
-export const emitterSchema: yup.ObjectSchema<Partial<
-  Emitter
->> = yup.object().shape({
+export const emitterSchema = yup.object().shape({
   emitterType: yup.mixed<EmitterType>().when("ecoOrganismeSiret", {
     is: ecoOrganismeSiret => !ecoOrganismeSiret,
-    then: yup.mixed().required(`Émetteur: Le type d'émetteur est obligatoire`),
+    then: yup
+      .mixed()
+      .sealedRequired(`Émetteur: Le type d'émetteur est obligatoire`),
     otherwise: yup
       .mixed()
       .oneOf(
@@ -218,29 +218,31 @@ export const emitterSchema: yup.ObjectSchema<Partial<
   emitterCompanyName: yup
     .string()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_NAME}`),
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_NAME}`),
   emitterCompanySiret: yup
     .string()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_SIRET}`)
-    .length(14, `Émetteur: ${INVALID_SIRET_LENGTH}`),
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_SIRET}`)
+    .matches(/^$|^\d{14}$/, {
+      message: `Émetteur: ${INVALID_SIRET_LENGTH}`
+    }),
   emitterCompanyAddress: yup
     .string()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_ADDRESS}`),
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_ADDRESS}`),
   emitterCompanyContact: yup
     .string()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_CONTACT}`),
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_CONTACT}`),
   emitterCompanyPhone: yup
     .string()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_PHONE}`),
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_PHONE}`),
   emitterCompanyMail: yup
     .string()
     .email()
     .ensure()
-    .required(`Émetteur: ${MISSING_COMPANY_EMAIL}`)
+    .sealedRequired(`Émetteur: ${MISSING_COMPANY_EMAIL}`)
 });
 
 // Optional validation schema for eco-organisme appearing in frame 1
@@ -265,43 +267,43 @@ export const ecoOrganismeSchema = yup.object().shape({
 });
 
 // 2 - Installation de destination ou d’entreposage ou de reconditionnement prévue
-export const recipientSchema: yup.ObjectSchema<Partial<
-  Recipient
->> = yup.object().shape({
+export const recipientSchema = yup.object().shape({
   recipientProcessingOperation: yup
     .string()
     .label("Opération d’élimination / valorisation")
     .ensure()
-    .required(),
+    .sealedRequired(),
   recipientCompanyName: yup
     .string()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_NAME}`),
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_NAME}`),
   recipientCompanySiret: yup
     .string()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_SIRET}`)
-    .length(14, `Destinataire: ${INVALID_SIRET_LENGTH}`),
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_SIRET}`)
+    .matches(/^$|^\d{14}$/, {
+      message: `Destinataire: ${INVALID_SIRET_LENGTH}`
+    }),
   recipientCompanyAddress: yup
     .string()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_ADDRESS}`),
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_ADDRESS}`),
   recipientCompanyContact: yup
     .string()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_CONTACT}`),
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_CONTACT}`),
   recipientCompanyPhone: yup
     .string()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_PHONE}`),
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_PHONE}`),
   recipientCompanyMail: yup
     .string()
     .email()
     .ensure()
-    .required(`Destinataire: ${MISSING_COMPANY_EMAIL}`)
+    .sealedRequired(`Destinataire: ${MISSING_COMPANY_EMAIL}`)
 });
 
-const packagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
+const packagingInfo = yup.object().shape({
   type: yup
     .mixed<Packagings>()
     .required("Le type de conditionnement doit être précisé."),
@@ -309,7 +311,7 @@ const packagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
     .string()
     .when("type", (type, schema) =>
       type === "AUTRE"
-        ? schema.required(
+        ? schema.sealedRequired(
             "La description doit être précisée pour le conditionnement 'AUTRE'."
           )
         : schema
@@ -321,38 +323,9 @@ const packagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
     ),
   quantity: yup
     .number()
-    .required(
+    .sealedRequired(
       "Le nombre de colis associé au conditionnement doit être précisé."
     )
-    .integer()
-    .min(1, "Le nombre de colis doit être supérieur à 0.")
-    .when("type", (type, schema) =>
-      ["CITERNE", "BENNE"].includes(type)
-        ? schema.max(
-            1,
-            "Le nombre de benne ou de citerne ne peut être supérieur à 1."
-          )
-        : schema
-    )
-});
-
-const draftPackagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
-  type: yup.mixed<Packagings>().nullable(),
-  other: yup
-    .string()
-    .when("type", (type, schema) =>
-      type === "AUTRE"
-        ? schema.nullable()
-        : schema
-            .nullable()
-            .max(
-              0,
-              "${path} ne peut être renseigné que lorsque le type de conditionnement est 'AUTRE'."
-            )
-    ),
-  quantity: yup
-    .number()
-    .nullable()
     .integer()
     .min(1, "Le nombre de colis doit être supérieur à 0.")
     .when("type", (type, schema) =>
@@ -369,28 +342,25 @@ const draftPackagingInfo: yup.ObjectSchema<PackagingInfo> = yup.object().shape({
 // 4 - Mentions au titre des règlements ADR, RID, ADNR, IMDG
 // 5 - Conditionnement
 // 6 - Quantité
-export const wasteDetailsSchema: yup.ObjectSchema<Partial<
-  WasteDetails
->> = yup.object().shape({
+export const wasteDetailsSchema = yup.object().shape({
   wasteDetailsCode: yup
     .string()
-    .ensure()
-    .required("Le code déchet est obligatoire")
-    .oneOf(WASTES_CODES, INVALID_WASTE_CODE),
+    .sealedRequired("Le code déchet est obligatoire")
+    .oneOf([...WASTES_CODES, null], INVALID_WASTE_CODE),
   wasteDetailsOnuCode: yup.string().when("wasteDetailsCode", {
     is: (wasteCode: string) => isDangerous(wasteCode || ""),
     then: () =>
       yup
         .string()
         .ensure()
-        .required(
+        .sealedRequired(
           `La mention ADR est obligatoire pour les déchets dangereux. Merci d'indiquer "non soumis" si nécessaire.`
         ),
     otherwise: () => yup.string().nullable()
   }),
   wasteDetailsPackagingInfos: yup
     .array()
-    .required("Le détail du conditionnement est obligatoire")
+    .sealedRequired("Le détail du conditionnement est obligatoire")
     .of(packagingInfo)
     .test(
       "is-valid-packaging-infos",
@@ -415,49 +385,51 @@ export const wasteDetailsSchema: yup.ObjectSchema<Partial<
     ),
   wasteDetailsQuantity: yup
     .number()
-    .required("La quantité du déchet en tonnes est obligatoire")
+    .sealedRequired("La quantité du déchet en tonnes est obligatoire")
     .min(0, "La quantité doit être supérieure à 0"),
   wasteDetailsQuantityType: yup
     .mixed<QuantityType>()
-    .required("Le type de quantité (réelle ou estimée) doit être précisé"),
+    .sealedRequired(
+      "Le type de quantité (réelle ou estimée) doit être précisé"
+    ),
   wasteDetailsConsistence: yup
     .mixed<Consistence>()
-    .required("La consistance du déchet doit être précisée"),
+    .sealedRequired("La consistance du déchet doit être précisée"),
   wasteDetailsPop: yup
     .boolean()
-    .required("La présence (ou non) de POP doit être précisée")
+    .sealedRequired("La présence (ou non) de POP doit être précisée")
 });
 
 // 8 - Collecteur-transporteur
-export const transporterSchema: yup.ObjectSchema<Partial<
-  Transporter
->> = yup.object().shape({
+export const transporterSchema = yup.object().shape({
   transporterCompanyName: yup
     .string()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_NAME}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_NAME}`),
   transporterCompanySiret: yup
     .string()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_SIRET}`)
-    .length(14, `Transporteur: ${INVALID_SIRET_LENGTH}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_SIRET}`)
+    .matches(/^$|^\d{14}$/, {
+      message: `Transporteur: ${INVALID_SIRET_LENGTH}`
+    }),
   transporterCompanyAddress: yup
     .string()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_ADDRESS}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_ADDRESS}`),
   transporterCompanyContact: yup
     .string()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_CONTACT}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_CONTACT}`),
   transporterCompanyPhone: yup
     .string()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_PHONE}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_PHONE}`),
   transporterCompanyMail: yup
     .string()
     .email()
     .ensure()
-    .required(`Transporteur: ${MISSING_COMPANY_EMAIL}`),
+    .sealedRequired(`Transporteur: ${MISSING_COMPANY_EMAIL}`),
   transporterIsExemptedOfReceipt: yup.boolean().notRequired().nullable(),
   transporterReceipt: yup
     .string()
@@ -466,7 +438,7 @@ export const transporterSchema: yup.ObjectSchema<Partial<
         ? schema.notRequired().nullable()
         : schema
             .ensure()
-            .required(
+            .sealedRequired(
               "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, il est donc est obligatoire"
             )
     ),
@@ -477,7 +449,7 @@ export const transporterSchema: yup.ObjectSchema<Partial<
         ? schema.notRequired().nullable()
         : schema
             .ensure()
-            .required("Le département du transporteur est obligatoire")
+            .sealedRequired("Le département du transporteur est obligatoire")
     ),
   transporterValidityLimit: validDatetime({
     verboseFieldName: "date de validité"
@@ -486,9 +458,7 @@ export const transporterSchema: yup.ObjectSchema<Partial<
 
 // 8 - Collecteur-transporteur
 // 9 - Déclaration générale de l’émetteur du bordereau :
-export const signingInfoSchema: yup.ObjectSchema<Partial<
-  SigningInfo
->> = yup.object().shape({
+export const signingInfoSchema = yup.object().shape({
   sentAt: validDatetime({
     verboseFieldName: "date d'envoi",
     required: true
@@ -500,111 +470,107 @@ export const signingInfoSchema: yup.ObjectSchema<Partial<
 });
 
 // 10 - Expédition reçue à l’installation de destination
-export const receivedInfoSchema: yup.ObjectSchema<ReceivedInfo> = yup
-  .object()
-  .shape({
-    isAccepted: yup.boolean(),
-    receivedBy: yup
-      .string()
-      .ensure()
-      .required("Vous devez saisir un responsable de la réception."),
-    receivedAt: validDatetime({
-      verboseFieldName: "date de réception",
-      required: true
-    }),
-    signedAt: validDatetime({
-      verboseFieldName: "date d'acceptation"
-    }),
-    quantityReceived: yup
-      .number()
-      // if waste is refused, quantityReceived must be 0
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.test(
-              "is-zero",
-              "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé",
-              v => v === 0
+export const receivedInfoSchema = yup.object().shape({
+  isAccepted: yup.boolean(),
+  receivedBy: yup
+    .string()
+    .ensure()
+    .required("Vous devez saisir un responsable de la réception."),
+  receivedAt: validDatetime({
+    verboseFieldName: "date de réception",
+    required: true
+  }),
+  signedAt: validDatetime({
+    verboseFieldName: "date d'acceptation"
+  }),
+  quantityReceived: yup
+    .number()
+    // if waste is refused, quantityReceived must be 0
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.test(
+            "is-zero",
+            "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé",
+            v => v === 0
+          )
+        : schema
+    )
+    // if waste is partially or totally accepted, we check it is a positive value
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.test(
+            "is-strictly-positive",
+            "Vous devez saisir une quantité reçue supérieure à 0.",
+            v => v > 0
+          )
+        : schema
+    ),
+  wasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>(),
+  wasteRefusalReason: yup
+    .string()
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.ensure().required("Vous devez saisir un motif de refus")
+        : schema
+            .notRequired()
+            .nullable()
+            .test(
+              "is-empty",
+              "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
+              v => !v
             )
-          : schema
-      )
-      // if waste is partially or totally accepted, we check it is a positive value
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.test(
-              "is-strictly-positive",
-              "Vous devez saisir une quantité reçue supérieure à 0.",
-              v => v > 0
-            )
-          : schema
-      ),
-    wasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>(),
-    wasteRefusalReason: yup
-      .string()
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.ensure().required("Vous devez saisir un motif de refus")
-          : schema
-              .notRequired()
-              .nullable()
-              .test(
-                "is-empty",
-                "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-                v => !v
-              )
-      )
-  });
+    )
+});
 
 // 10 - Expédition acceptée (ou refusée) à l’installation de destination
-export const acceptedInfoSchema: yup.ObjectSchema<AcceptedInfo> = yup
-  .object()
-  .shape({
-    isAccepted: yup.boolean(),
-    signedAt: validDatetime({
-      verboseFieldName: "date d'acceptation"
-    }),
-    signedBy: yup
-      .string()
-      .ensure()
-      .required("Vous devez saisir un responsable de la réception."),
-    quantityReceived: yup
-      .number()
-      .required()
-      // if waste is refused, quantityReceived must be 0
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.test(
-              "is-zero",
-              "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé",
-              v => v === 0
+export const acceptedInfoSchema = yup.object().shape({
+  isAccepted: yup.boolean(),
+  signedAt: validDatetime({
+    verboseFieldName: "date d'acceptation"
+  }),
+  signedBy: yup
+    .string()
+    .ensure()
+    .required("Vous devez saisir un responsable de la réception."),
+  quantityReceived: yup
+    .number()
+    .required()
+    // if waste is refused, quantityReceived must be 0
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.test(
+            "is-zero",
+            "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé",
+            v => v === 0
+          )
+        : schema
+    )
+    // if waste is partially or totally accepted, we check it is a positive value
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.test(
+            "is-strictly-positive",
+            "Vous devez saisir une quantité reçue supérieure à 0.",
+            v => v > 0
+          )
+        : schema
+    ),
+  wasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>().required(),
+  wasteRefusalReason: yup
+    .string()
+    .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
+      ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+        ? schema.ensure().required("Vous devez saisir un motif de refus")
+        : schema
+            .notRequired()
+            .nullable()
+            .test(
+              "is-empty",
+              "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
+              v => !v
             )
-          : schema
-      )
-      // if waste is partially or totally accepted, we check it is a positive value
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.test(
-              "is-strictly-positive",
-              "Vous devez saisir une quantité reçue supérieure à 0.",
-              v => v > 0
-            )
-          : schema
-      ),
-    wasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>().required(),
-    wasteRefusalReason: yup
-      .string()
-      .when("wasteAcceptationStatus", (wasteAcceptationStatus, schema) =>
-        ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-          ? schema.ensure().required("Vous devez saisir un motif de refus")
-          : schema
-              .notRequired()
-              .nullable()
-              .test(
-                "is-empty",
-                "Le champ wasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-                v => !v
-              )
-      )
-  });
+    )
+});
 
 const withNextDestination = yup.object().shape({
   nextDestinationProcessingOperation: yup
@@ -717,133 +683,126 @@ export const processedInfoSchema = yup.lazy(processedInfoSchemaFn);
 // *********************************************************************
 
 // 13 - Réception dans l’installation d’entreposage ou de reconditionnement
-export const tempStoredInfoSchema: yup.ObjectSchema<TempStorageInfo> = yup
-  .object()
-  .shape({
-    tempStorerReceivedBy: yup
-      .string()
-      .ensure()
-      .required("Vous devez saisir un responsable de la réception."),
-    tempStorerReceivedAt: validDatetime({
-      verboseFieldName: "date de réception",
-      required: true
-    }),
-    tempStorerSignedAt: validDatetime({
-      verboseFieldName: "date d'acceptation"
-    }),
-    tempStorerQuantityType: yup.mixed<QuantityType>(),
-    tempStorerWasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>(),
-    tempStorerQuantityReceived: yup
-      .number()
-      // if waste is refused, quantityReceived must be 0
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.test(
-                "is-zero",
-                "Vous devez saisir une quantité reçue égale à 0.",
-                v => v === 0
+export const tempStoredInfoSchema = yup.object().shape({
+  tempStorerReceivedBy: yup
+    .string()
+    .ensure()
+    .required("Vous devez saisir un responsable de la réception."),
+  tempStorerReceivedAt: validDatetime({
+    verboseFieldName: "date de réception",
+    required: true
+  }),
+  tempStorerSignedAt: validDatetime({
+    verboseFieldName: "date d'acceptation"
+  }),
+  tempStorerQuantityType: yup.mixed<QuantityType>(),
+  tempStorerWasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>(),
+  tempStorerQuantityReceived: yup
+    .number()
+    // if waste is refused, quantityReceived must be 0
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.test(
+              "is-zero",
+              "Vous devez saisir une quantité reçue égale à 0.",
+              v => v === 0
+            )
+          : schema
+    )
+    // if waste is partially or totally accepted, we check it is a positive value
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.test(
+              "is-strictly-positive",
+              "Vous devez saisir une quantité reçue supérieure à 0.",
+              v => v > 0
+            )
+          : schema
+    ),
+  tempStorerWasteRefusalReason: yup
+    .string()
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.required("Vous devez renseigner la raison du refus")
+          : schema
+              .notRequired()
+              .nullable()
+              .test(
+                "is-empty",
+                "Le champ tempStorerWasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
+                v => !v
               )
-            : schema
-      )
-      // if waste is partially or totally accepted, we check it is a positive value
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.test(
-                "is-strictly-positive",
-                "Vous devez saisir une quantité reçue supérieure à 0.",
-                v => v > 0
-              )
-            : schema
-      ),
-    tempStorerWasteRefusalReason: yup
-      .string()
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.required("Vous devez renseigner la raison du refus")
-            : schema
-                .notRequired()
-                .nullable()
-                .test(
-                  "is-empty",
-                  "Le champ tempStorerWasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-                  v => !v
-                )
-      )
-  });
+    )
+});
 
-export const tempStorerAcceptedInfoSchema: yup.ObjectSchema<TempStorageInfo> = yup
-  .object()
-  .shape({
-    tempStorerReceivedAt: validDatetime({
-      verboseFieldName: "date de réception"
-    }),
-    tempStorerReceivedBy: yup.string(),
-    tempStorerQuantityType: yup.mixed<QuantityType>().required(),
-    tempStorerWasteAcceptationStatus: yup
-      .mixed<WasteAcceptationStatus>()
-      .required(),
-    tempStorerSignedBy: yup
-      .string()
-      .ensure()
-      .required("Vous devez saisir un responsable de l'acceptation."),
-    tempStorerSignedAt: validDatetime({
-      verboseFieldName: "date d'acceptation"
-    }),
-    tempStorerQuantityReceived: yup
-      .number()
-      .required()
-      // if waste is refused, quantityReceived must be 0
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.test(
-                "is-zero",
-                "Vous devez saisir une quantité reçue égale à 0.",
-                v => v === 0
+export const tempStorerAcceptedInfoSchema = yup.object().shape({
+  tempStorerReceivedAt: validDatetime({
+    verboseFieldName: "date de réception"
+  }),
+  tempStorerQuantityType: yup.mixed<QuantityType>().required(),
+  tempStorerWasteAcceptationStatus: yup
+    .mixed<WasteAcceptationStatus>()
+    .required(),
+  tempStorerSignedBy: yup
+    .string()
+    .ensure()
+    .required("Vous devez saisir un responsable de l'acceptation."),
+  tempStorerSignedAt: validDatetime({
+    verboseFieldName: "date d'acceptation"
+  }),
+  tempStorerQuantityReceived: yup
+    .number()
+    .required()
+    // if waste is refused, quantityReceived must be 0
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.test(
+              "is-zero",
+              "Vous devez saisir une quantité reçue égale à 0.",
+              v => v === 0
+            )
+          : schema
+    )
+    // if waste is partially or totally accepted, we check it is a positive value
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.test(
+              "is-strictly-positive",
+              "Vous devez saisir une quantité reçue supérieure à 0.",
+              v => v > 0
+            )
+          : schema
+    ),
+  tempStorerWasteRefusalReason: yup
+    .string()
+    .when(
+      "tempStorerWasteAcceptationStatus",
+      (wasteAcceptationStatus, schema) =>
+        ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
+          ? schema.required("Vous devez renseigner la raison du refus")
+          : schema
+              .notRequired()
+              .nullable()
+              .test(
+                "is-empty",
+                "Le champ tempStorerWasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
+                v => !v
               )
-            : schema
-      )
-      // if waste is partially or totally accepted, we check it is a positive value
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["ACCEPTED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.test(
-                "is-strictly-positive",
-                "Vous devez saisir une quantité reçue supérieure à 0.",
-                v => v > 0
-              )
-            : schema
-      ),
-    tempStorerWasteRefusalReason: yup
-      .string()
-      .when(
-        "tempStorerWasteAcceptationStatus",
-        (wasteAcceptationStatus, schema) =>
-          ["REFUSED", "PARTIALLY_REFUSED"].includes(wasteAcceptationStatus)
-            ? schema.required("Vous devez renseigner la raison du refus")
-            : schema
-                .notRequired()
-                .nullable()
-                .test(
-                  "is-empty",
-                  "Le champ tempStorerWasteRefusalReason ne doit pas être rensigné si le déchet est accepté ",
-                  v => !v
-                )
-      )
-  });
+    )
+});
 
 // 14 - Installation de destination prévue
-export const destinationAfterTempStorageSchema: yup.ObjectSchema<Partial<
-  DestinationAfterTempStorage
->> = yup.object().shape({
+export const destinationAfterTempStorageSchema = yup.object().shape({
   destinationCompanyName: yup
     .string()
     .ensure()
@@ -877,9 +836,7 @@ export const destinationAfterTempStorageSchema: yup.ObjectSchema<Partial<
 // 15 - Mentions au titre des règlements ADR, RID, ADNR, IMDG
 // 16 - Conditionnement
 // 17 - Quantité
-export const wasteRepackagingSchema: yup.ObjectSchema<Partial<
-  WasteRepackaging
->> = yup.object().shape({
+export const wasteRepackagingSchema = yup.object().shape({
   wasteDetailsNumberOfPackages: yup
     .number()
     .nullable()
@@ -894,78 +851,11 @@ export const wasteRepackagingSchema: yup.ObjectSchema<Partial<
 });
 
 // 18 - Collecteur-transporteur reconditionnement
-export const transporterAfterTempStorageSchema: yup.ObjectSchema<Partial<
-  TransporterAfterTempStorage
->> = transporterSchema;
+export const transporterAfterTempStorageSchema = transporterSchema;
 
 // *******************************************************************
 // COMPOSE VALIDATION SCHEMAS TO VALIDATE A FORM FOR A SPECIFIC STATUS
 // *******************************************************************
-
-// validation schema for a form in draft mode, all fields are nullable
-export const draftFormSchema = yup
-  .object()
-  .shape({
-    emitterCompanySiret: yup
-      .string()
-      .nullable()
-      .notRequired()
-      .matches(/^$|^\d{14}$/, {
-        message: `Émetteur: ${INVALID_SIRET_LENGTH}`
-      }),
-    emitterCompanyMail: yup.string().email().nullable().notRequired(),
-    recipientCompanySiret: yup
-      .string()
-      .notRequired()
-      .nullable()
-      .matches(/^$|^\d{14}$/, {
-        message: `Destinataire: ${INVALID_SIRET_LENGTH}`
-      }),
-    recipientCompanyMail: yup.string().notRequired().nullable().email(),
-    wasteDetailsCode: yup
-      .string()
-      .notRequired()
-      .nullable()
-      .oneOf([...WASTES_CODES, "", null], INVALID_WASTE_CODE),
-    wasteDetailsPackagingInfos: yup
-      .array()
-      .nullable()
-      .of(draftPackagingInfo)
-      .test(
-        "is-valid-packaging-infos",
-        "${path} ne peut pas à la fois contenir 1 citerne ou 1 benne et un autre conditionnement.",
-        (infos: PackagingInfo[]) => {
-          const hasCiterne = infos?.find(i => i.type === "CITERNE");
-          const hasBenne = infos?.find(i => i.type === "BENNE");
-
-          if (hasCiterne && hasBenne) {
-            return false;
-          }
-
-          const hasOtherPackaging = infos?.find(
-            i => !["CITERNE", "BENNE"].includes(i.type)
-          );
-          if ((hasCiterne || hasBenne) && hasOtherPackaging) {
-            return false;
-          }
-
-          return true;
-        }
-      ),
-    transporterCompanySiret: yup
-      .string()
-      .notRequired()
-      .nullable()
-      .matches(/^$|^\d{14}$/, {
-        message: `Transporteur: ${INVALID_SIRET_LENGTH}`
-      }),
-    transporterCompanyMail: yup.string().notRequired().nullable().email(),
-    transporterValidityLimit: validDatetime({
-      verboseFieldName: "date de validité",
-      required: false
-    })
-  })
-  .concat(ecoOrganismeSchema);
 
 // validation schema for BSD before it can be sealed
 export const sealedFormSchema = emitterSchema

--- a/back/src/users/bulk-creation/__tests__/validation.test.ts
+++ b/back/src/users/bulk-creation/__tests__/validation.test.ts
@@ -192,7 +192,7 @@ describe("role validation", () => {
     { siret: "12345678901234", companyTypes: ["PRODUCER" as CompanyType] }
   ];
 
-  const validateRole = validateRoleGenerator(companies);
+  const validateRole = validateRoleGenerator(companies as any);
 
   test("valid role", async () => {
     const role = {

--- a/back/src/users/bulk-creation/sirene.ts
+++ b/back/src/users/bulk-creation/sirene.ts
@@ -28,11 +28,11 @@ export async function sirenify(
   company: CompanyRow
 ): Promise<CompanyRow & CompanyInfo> {
   try {
-    const companyInfo = await getCompanyThrottled(company.siret);
+    const { naf: codeNaf, name } = await getCompanyThrottled(company.siret);
     return {
       ...company,
-      codeNaf: companyInfo.naf,
-      name: companyInfo.name
+      codeNaf,
+      name
     };
   } catch (err) {
     throw new Error(`SIRET ${company.siret} does not exist`);

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -56,11 +56,9 @@ export const companyValidationSchema = yup.object().shape({
     .ensure()
     .compact()
     .required()
+    .min(1)
     .test("is-companyType", "${value} is not a valid company type", value => {
-      const isCompanyType = value.reduce((acc: boolean, curr: string) => {
-        return acc && COMPANY_TYPES.includes(curr);
-      }, true);
-      return isCompanyType;
+      return value.every(type => COMPANY_TYPES.includes(type));
     }),
   givenName: yup.string().notRequired(),
   contactEmail: yup.string().notRequired().email(),

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -18,7 +18,7 @@ const ROLES = ["MEMBER", "ADMIN"];
 /**
  * Validation schema for company
  */
-export const companyValidationSchema = yup.object().shape({
+export const companyValidationSchema = yup.object({
   siret: yup
     .string()
     .required()
@@ -53,13 +53,11 @@ export const companyValidationSchema = yup.object().shape({
   gerepId: yup.string().notRequired(),
   companyTypes: yup
     .array()
+    .of(yup.string().oneOf(COMPANY_TYPES))
     .ensure()
     .compact()
     .required()
-    .min(1)
-    .test("is-companyType", "${value} is not a valid company type", value => {
-      return value.every(type => COMPANY_TYPES.includes(type));
-    }),
+    .min(1),
   givenName: yup.string().notRequired(),
   contactEmail: yup.string().notRequired().email(),
   contactPhone: yup


### PR DESCRIPTION
Remplace #763 car plus global.
- Maj de yup
- supression su `draftValidationSchema`
- utilisation partout du `sealedValidationSchema`
- paramètre `isDraft` du contexte permet de rendre les champs optionnels

L'idée étant que les règles métiers soient quand même respectées à la création d'un brouillon. On n'est pas obligé de remplir les champs en brouillon, mais si on rempli les valeurs saisies doivent être correctes.

Je ne suis pas certain de si on devrait marquer ca comme "breaking change" ou non...

- [x] Mettre à jour le change log

---

- [Ticket Trello](https://trello.com/c/SCMkg5sf/1167-le-nombre-de-benne-citerne-ne-devrait-pas-pouvoir-%C3%AAtre-sup%C3%A9rieur-%C3%A0-1-lors-dune-cr%C3%A9ation-de-bsd-par-api)
