### PR TITLE
Correction du formulaire de réception

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction du formulaire de réception [PR 769](https://github.com/MTES-MCT/trackdechets/pull/769)
 #### :nail_care: Améliorations
 
 - Amélioration du rafraichissement automatique de la liste des bordereaux entre les différents onglets du tableau de bord [PR 746](https://github.com/MTES-MCT/trackdechets/pull/746)

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Utilisation du format `BSD-{yyyyMMdd}-{XXXXXXXXX}` pour le champ `readableId` de l'objet `Form` en remplacement de l'ancien format `TD-{yy}-{XXXXXXXX}` [PR 759](https://github.com/MTES-MCT/trackdechets/pull/759)
 
 #### :bug: Corrections de bugs
-
 - Correction du formulaire de réception [PR 769](https://github.com/MTES-MCT/trackdechets/pull/769)
 #### :nail_care: Améliorations
 

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsReceived.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsReceived.tsx
@@ -42,7 +42,7 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
             <ReceivedInfo
               form={form}
               onSubmit={values => {
-                markAsReceived({
+                return markAsReceived({
                   variables: {
                     id: form.id,
                     receivedInfo: values,

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsTempStored.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsTempStored.tsx
@@ -48,7 +48,7 @@ export default function MarkAsTempStored({ form }: WorkflowActionProps) {
               form={form}
               close={close}
               onSubmit={values => {
-                markAsTempStored({
+                return markAsTempStored({
                   variables: {
                     id: form.id,
                     tempStoredInfos: {

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -54,7 +54,7 @@ export default function ReceivedInfo({
   onSubmit,
 }: {
   form: TdForm;
-  onSubmit: (values: ReceivedInfoValues) => void;
+  onSubmit: (values: ReceivedInfoValues) => Promise<any>;
   close: () => void;
 }) {
   return (
@@ -71,13 +71,39 @@ export default function ReceivedInfo({
             quantityType: QuantityType.Real,
           }),
       }}
-      onSubmit={onSubmit}
+      onSubmit={(values, { setSubmitting }) =>
+        onSubmit(values).finally(() => setSubmitting(false))
+      }
+      validate={values => {
+        return {
+          ...(values.wasteAcceptationStatus === null
+            ? {
+                wasteAcceptationStatus:
+                  "Le statut d'acceptation du lot est un champ requis",
+              }
+            : {}),
+          ...(values.quantityReceived === null
+            ? {
+                quantityReceived: "Le poids à l'arrivée est un champ requis",
+              }
+            : {}),
+          ...(values.receivedBy === ""
+            ? { receivedBy: "Le nom du responsable est un champ requis" }
+            : {}),
+          ...(values.receivedAt === ""
+            ? { receivedAt: "La date de présentation est un champ requis" }
+            : {}),
+          ...(values.signedAt === ""
+            ? { signedAt: "La date de signature est un champ requis" }
+            : {}),
+        };
+      }}
     >
       {({ values, isSubmitting, handleReset, setFieldValue }) => (
         <Form>
           <p className="form__row">
             <label>
-              Date d'arrivée
+              Date de présentation
               <Field
                 min={formatISO(parseDate(form.sentAt!), {
                   representation: "date",
@@ -140,6 +166,7 @@ export default function ReceivedInfo({
                   component={InlineRadioButton}
                 />
               </fieldset>
+              <RedErrorMessage name="wasteAcceptationStatus" />
             </div>
           </div>
           <p className="form__row">


### PR DESCRIPTION
Correction du formulaire de réception

Valide les champs côté front 
Set `isSubmitting=false` après une erreur


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)

---

- [Ticket Trello](https://trello.com/c/bteyGPgT)
