### PR TITLE
Correction de `stateSummary.lastActionOn`

### DIFF
--- a/back/src/forms/resolvers/forms/stateSummary.ts
+++ b/back/src/forms/resolvers/forms/stateSummary.ts
@@ -81,9 +81,9 @@ function getLastActionOn(
     case "TEMP_STORED":
     case "TEMP_STORER_ACCEPTED":
     case "RESEALED":
-      return temporaryStorageDetail.tempStorerReceivedAt.toString();
+      return temporaryStorageDetail.tempStorerReceivedAt.toISOString();
     case "RESENT":
-      return temporaryStorageDetail.signedAt.toString();
+      return temporaryStorageDetail.signedAt.toISOString();
     default:
       return form.createdAt;
   }


### PR DESCRIPTION
Cette PR corrige le bug qui a été observé en essayant d'afficher l'aperçu d'un BSD qui en est à l'étape d'entreposage provisoire. Une erreur était levée parce que la date n'était pas au format ISO et était donc impossible à parser / formater.

Je ne touche pas au change log, le bug n'a pas été release.

- [ ] ~Mettre à jour la documentation~
- [ ] ~Mettre à jour le change log~
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/ThKQ1cAh/1199-la-recette-saute-page-blanche-syst%C3%A9matiquement-lorsque-je-veux-afficher-laper%C3%A7u-apr%C3%A8s-lentreposage-provisoire)
