### PR TITLE
Correction des bugs sur le formulaire d'acceptation d'un déchet

### DIFF
--- a/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Field, Form, Formik } from "formik";
+import * as yup from "yup";
 import NumberInput from "form/custom-inputs/NumberInput";
 import DateInput from "form/custom-inputs/DateInput";
 import { InlineRadioButton, RadioButton } from "form/custom-inputs/RadioButton";
@@ -20,6 +21,19 @@ export type AcceptedInfoValues = {
   wasteRefusalReason: string;
   quantityType?: QuantityType;
 };
+
+const validationSchema: yup.ObjectSchema<AcceptedInfoValues> = yup.object({
+  signedBy: yup.string().required("Le nom du responsable est un champ requis"),
+  signedAt: yup.string().required("La date de signature est un champ requis"),
+  quantityReceived: yup
+    .number()
+    .nullable()
+    .required("Le poids accepté est un champ requis"),
+  wasteAcceptationStatus: yup
+    .string<WasteAcceptationStatus>()
+    .required("Le statut d'acceptation du lot est un champ requis"),
+  wasteRefusalReason: yup.string(),
+});
 
 /**
  * Accepted info form shared between markAsAccepted and markAsTempStorerAccepted
@@ -43,6 +57,7 @@ export default function AcceptedInfo({
         wasteRefusalReason: "",
       }}
       onSubmit={onSubmit}
+      validationSchema={validationSchema}
     >
       {({ isSubmitting, setFieldValue, values, handleReset }) => (
         <Form>

--- a/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Field, Form, Formik } from "formik";
-import { formatISO } from "date-fns";
 import NumberInput from "form/custom-inputs/NumberInput";
 import DateInput from "form/custom-inputs/DateInput";
 import { InlineRadioButton, RadioButton } from "form/custom-inputs/RadioButton";
@@ -38,14 +37,14 @@ export default function AcceptedInfo({
     <Formik<AcceptedInfoValues>
       initialValues={{
         signedBy: "",
-        signedAt: formatISO(new Date(), { representation: "date" }),
+        signedAt: new Date().toISOString(),
         quantityReceived: null,
         wasteAcceptationStatus: "" as WasteAcceptationStatus,
         wasteRefusalReason: "",
       }}
       onSubmit={onSubmit}
     >
-      {({ errors, isSubmitting, setFieldValue, values, handleReset }) => (
+      {({ isSubmitting, setFieldValue, values, handleReset }) => (
         <Form>
           <div className="form__row">
             <div className="form__row">

--- a/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/AcceptedInfo.tsx
@@ -87,7 +87,7 @@ export default function AcceptedInfo({
               </fieldset>
             </div>
           </div>
-          <p className="form__row">
+          <div className="form__row">
             <label>
               Poids à l'arrivée
               <Field
@@ -105,7 +105,7 @@ export default function AcceptedInfo({
               </span>
             </label>
             <RedErrorMessage name="quantityReceived" />
-          </p>
+          </div>
           {form.recipient?.isTempStorage && form.status === FormStatus.Sent && (
             <fieldset className="form__row">
               <legend>Cette quantité est</legend>
@@ -128,15 +128,15 @@ export default function AcceptedInfo({
             WasteAcceptationStatus.Refused.toString(),
             WasteAcceptationStatus.PartiallyRefused.toString(),
           ].includes(values.wasteAcceptationStatus) && (
-            <p className="form__row">
+            <div className="form__row">
               <label>
                 {textConfig[values.wasteAcceptationStatus].refusalReasonText}
                 <Field name="wasteRefusalReason" className="td-input" />
               </label>
               <RedErrorMessage name="wasteRefusalReason" />
-            </p>
+            </div>
           )}
-          <p className="form__row">
+          <div className="form__row">
             <label>
               Nom du responsable
               <Field
@@ -147,8 +147,8 @@ export default function AcceptedInfo({
               />
             </label>
             <RedErrorMessage name="signedBy" />
-          </p>
-          <p className="form__row">
+          </div>
+          <div className="form__row">
             <label>
               Date d'acceptation
               <Field
@@ -158,7 +158,7 @@ export default function AcceptedInfo({
               />
             </label>
             <RedErrorMessage name="signedAt" />
-          </p>
+          </div>
           <p>
             {values.wasteAcceptationStatus &&
               textConfig[values.wasteAcceptationStatus].validationText}

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsAccepted.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsAccepted.tsx
@@ -37,7 +37,7 @@ export default function MarkAsAccepted({ form }: WorkflowActionProps) {
           <AcceptedInfo
             form={form}
             close={close}
-            onSubmit={values => {
+            onSubmit={values =>
               markAsAccepted({
                 variables: {
                   id: form.id,
@@ -46,8 +46,8 @@ export default function MarkAsAccepted({ form }: WorkflowActionProps) {
                     quantityReceived: values.quantityReceived ?? 0,
                   },
                 },
-              });
-            }}
+              })
+            }
           />
 
           {error && (

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsProcessed.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsProcessed.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import { Formik, Field, Form, useFormikContext } from "formik";
-import { formatISO } from "date-fns";
 import {
   PROCESSING_OPERATIONS,
   PROCESSING_OPERATIONS_GROUPEMENT_CODES,
@@ -229,7 +228,7 @@ export default function MarkAsProcessed({ form, siret }: WorkflowActionProps) {
               processingOperationDone: "",
               processingOperationDescription: "",
               processedBy: "",
-              processedAt: formatISO(new Date(), { representation: "date" }),
+              processedAt: new Date().toISOString(),
               nextDestination: null,
               noTraceability: false,
             }}

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsResealed.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsResealed.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { mergeDefaults, updateApolloCache } from "common/helper";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import CompanySelector from "form/company/CompanySelector";
-import DateInput from "form/custom-inputs/DateInput";
 import NumberInput from "form/custom-inputs/NumberInput";
 import { RadioButton } from "form/custom-inputs/RadioButton";
 import Packagings from "form/packagings/Packagings";

--- a/front/src/dashboard/slips/slips-actions/workflow/MarkAsTempStorerAccepted.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/MarkAsTempStorerAccepted.tsx
@@ -54,7 +54,7 @@ export default function MarkAsTempStorerAccepted({
           <AcceptedInfo
             form={form}
             close={close}
-            onSubmit={values => {
+            onSubmit={values =>
               markAsTempStorerAccepted({
                 variables: {
                   id: form.id,
@@ -64,8 +64,8 @@ export default function MarkAsTempStorerAccepted({
                     quantityType: values.quantityType ?? QuantityType.Real,
                   },
                 },
-              });
-            }}
+              })
+            }
           />
 
           {error && (

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Field, Form, Formik } from "formik";
-import { isBefore, formatISO, startOfDay } from "date-fns";
+import { formatISO, startOfDay } from "date-fns";
 import { parseDate } from "common/datetime";
 import * as yup from "yup";
 import { RedErrorMessage } from "common/components";
@@ -95,7 +95,7 @@ export default function ReceivedInfo({
         receivedBy: "",
         receivedAt: formatISO(new Date(), { representation: "date" }),
         signedAt: formatISO(new Date(), { representation: "date" }),
-        quantityReceived: null,
+        quantityReceived: form.stateSummary?.quantity ?? 0,
         wasteAcceptationStatus: null,
         wasteRefusalReason: "",
         ...(form.recipient?.isTempStorage &&
@@ -110,7 +110,7 @@ export default function ReceivedInfo({
     >
       {({ values, isSubmitting, handleReset, setFieldValue }) => (
         <Form>
-          <p className="form__row">
+          <div className="form__row">
             <label>
               Date de présentation
               <Field
@@ -121,7 +121,7 @@ export default function ReceivedInfo({
               />
             </label>
             <RedErrorMessage name="receivedAt" />
-          </p>
+          </div>
           <div className="form__row">
             <div className="form__row">
               <fieldset className="form__radio-group">
@@ -163,7 +163,7 @@ export default function ReceivedInfo({
               <RedErrorMessage name="wasteAcceptationStatus" />
             </div>
           </div>
-          <p className="form__row">
+          <div className="form__row">
             <label>
               Poids à l'arrivée
               <Field
@@ -181,7 +181,7 @@ export default function ReceivedInfo({
               </span>
             </label>
             <RedErrorMessage name="quantityReceived" />
-          </p>
+          </div>
           {form.recipient?.isTempStorage && form.status === FormStatus.Sent && (
             <fieldset className="form__row">
               <legend>Cette quantité est</legend>
@@ -205,15 +205,15 @@ export default function ReceivedInfo({
               WasteAcceptationStatus.Refused.toString(),
               WasteAcceptationStatus.PartiallyRefused.toString(),
             ].includes(values.wasteAcceptationStatus) && (
-              <p className="form__row">
+              <div className="form__row">
                 <label>
                   {textConfig[values.wasteAcceptationStatus].refusalReasonText}
                   <Field name="wasteRefusalReason" className="td-input" />
                 </label>
                 <RedErrorMessage name="wasteRefusalReason" />
-              </p>
+              </div>
             )}
-          <p className="form__row">
+          <div className="form__row">
             <label>
               Nom du responsable
               <Field
@@ -224,8 +224,8 @@ export default function ReceivedInfo({
               />
             </label>
             <RedErrorMessage name="receivedBy" />
-          </p>
-          <p className="form__row">
+          </div>
+          <div className="form__row">
             <label>
               Date d'acceptation
               <Field
@@ -238,7 +238,7 @@ export default function ReceivedInfo({
               />
             </label>
             <RedErrorMessage name="signedAt" />
-          </p>
+          </div>
           <p>
             {values.wasteAcceptationStatus &&
               textConfig[values.wasteAcceptationStatus].validationText}

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -48,10 +48,7 @@ export type ReceivedInfoValues = {
 
 const validationSchema = (form: TdForm) =>
   yup.object({
-    wasteAcceptationStatus: yup
-      .string()
-      .nullable()
-      .required("Le statut d'acceptation du lot est un champ requis"),
+    wasteAcceptationStatus: yup.string().nullable(),
     quantityReceived: yup
       .number()
       .nullable()
@@ -73,7 +70,6 @@ const validationSchema = (form: TdForm) =>
     signedAt: yup
       .date()
       .nullable()
-      .required("La date de signature est un champ requis")
       .transform(value => startOfDay(parseDate(value))),
   });
 

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -55,7 +55,6 @@ const validationSchema = (form: TdForm) =>
     quantityReceived: yup
       .number()
       .nullable()
-      .positive("La quantité reçu doit être supérieure à 0")
       .required("Le poids à l'arrivée est un champ requis"),
     receivedAt: yup
       .date()

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -55,6 +55,7 @@ const validationSchema = (form: TdForm) =>
     quantityReceived: yup
       .number()
       .nullable()
+      .positive("La quantité reçu doit être supérieure à 0")
       .required("Le poids à l'arrivée est un champ requis"),
     receivedAt: yup
       .date()

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Field, Form, Formik } from "formik";
-import { formatISO, startOfDay } from "date-fns";
+import { Field, Form, Formik, FormikConfig } from "formik";
+import { startOfDay } from "date-fns";
 import { parseDate } from "common/datetime";
 import * as yup from "yup";
 import { RedErrorMessage } from "common/components";
@@ -87,15 +87,15 @@ export default function ReceivedInfo({
   onSubmit,
 }: {
   form: TdForm;
-  onSubmit: (values: ReceivedInfoValues) => Promise<any>;
+  onSubmit: FormikConfig<ReceivedInfoValues>["onSubmit"];
   close: () => void;
 }) {
   return (
     <Formik<ReceivedInfoValues>
       initialValues={{
         receivedBy: "",
-        receivedAt: formatISO(new Date(), { representation: "date" }),
-        signedAt: formatISO(new Date(), { representation: "date" }),
+        receivedAt: new Date().toISOString(),
+        signedAt: new Date().toISOString(),
         quantityReceived: null,
         wasteAcceptationStatus: null,
         wasteRefusalReason: "",
@@ -228,10 +228,8 @@ export default function ReceivedInfo({
             <label>
               Date d'acceptation
               <Field
-                min={formatISO(parseDate(form.sentAt!), {
-                  representation: "date",
-                })}
                 component={DateInput}
+                minDate={parseDate(values.receivedAt)}
                 name="signedAt"
                 className="td-input"
               />

--- a/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
+++ b/front/src/dashboard/slips/slips-actions/workflow/ReceivedInfo.tsx
@@ -96,7 +96,7 @@ export default function ReceivedInfo({
         receivedBy: "",
         receivedAt: formatISO(new Date(), { representation: "date" }),
         signedAt: formatISO(new Date(), { representation: "date" }),
-        quantityReceived: form.stateSummary?.quantity ?? 0,
+        quantityReceived: null,
         wasteAcceptationStatus: null,
         wasteRefusalReason: "",
         ...(form.recipient?.isTempStorage &&
@@ -104,9 +104,7 @@ export default function ReceivedInfo({
             quantityType: QuantityType.Real,
           }),
       }}
-      onSubmit={(values, { setSubmitting }) =>
-        onSubmit(values).finally(() => setSubmitting(false))
-      }
+      onSubmit={onSubmit}
       validationSchema={() => validationSchema(form)}
     >
       {({ values, isSubmitting, handleReset, setFieldValue }) => (

--- a/front/src/dashboard/transport/actions/PrepareSegment.tsx
+++ b/front/src/dashboard/transport/actions/PrepareSegment.tsx
@@ -1,5 +1,4 @@
 import { useMutation, gql } from "@apollo/client";
-import { formatISO } from "date-fns";
 import { NotificationError } from "common/components/Error";
 import { IconBusTransfer } from "common/components/Icons";
 
@@ -109,7 +108,7 @@ export default function PrepareSegment({
       isExemptedOfReceipt: false,
       receipt: "",
       department: "",
-      validityLimit: formatISO(new Date(), { representation: "date" }),
+      validityLimit: new Date().toISOString(),
       numberPlate: "",
     },
 

--- a/front/src/dashboard/transport/actions/TakeOverSegment.tsx
+++ b/front/src/dashboard/transport/actions/TakeOverSegment.tsx
@@ -1,6 +1,5 @@
 import { Field, Form as FormikForm, Formik } from "formik";
 import React, { useState } from "react";
-import { formatISO } from "date-fns";
 import {
   Form,
   Mutation,
@@ -96,7 +95,7 @@ export default function TakeOverSegment({
 
   const initialValues = {
     takenOverBy: "",
-    takenOverAt: formatISO(new Date(), { representation: "date" }),
+    takenOverAt: new Date().toISOString(),
   };
 
   if (!segment) {

--- a/front/src/dashboard/transport/actions/TransportSignatureModal/TransportSignatureModal.tsx
+++ b/front/src/dashboard/transport/actions/TransportSignatureModal/TransportSignatureModal.tsx
@@ -31,13 +31,11 @@ const SIGNED_BY_TRANSPORTER = gql`
 
 interface TransportSignatureModalProps {
   form: Form;
-  isOpen: boolean;
   onClose: () => void;
 }
 
 export function TransportSignatureModal({
   form,
-  isOpen,
   onClose,
 }: TransportSignatureModalProps) {
   const [stepIndex, setStepIndex] = React.useState(0);
@@ -56,7 +54,7 @@ export function TransportSignatureModal({
   const { Component } = steps[stepIndex];
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} ariaLabel="Signer l'enlèvement">
+    <Modal isOpen onClose={onClose} ariaLabel="Signer l'enlèvement">
       <h2 className="td-modal-title">Signature</h2>
 
       <Breadcrumb>

--- a/front/src/dashboard/transport/actions/TransportSignatureModal/TransportSignatureModalToggle.tsx
+++ b/front/src/dashboard/transport/actions/TransportSignatureModal/TransportSignatureModalToggle.tsx
@@ -46,11 +46,9 @@ export function TransportSignatureModalToggle({
           iconSize="32px"
         />
       )}
-      <TransportSignatureModal
-        form={form}
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
-      />
+      {isOpen && (
+        <TransportSignatureModal form={form} onClose={() => setIsOpen(false)} />
+      )}
     </>
   );
 }

--- a/front/src/form/Transporter.tsx
+++ b/front/src/form/Transporter.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import CompanySelector from "./company/CompanySelector";
-import { Field, connect, useFormikContext } from "formik";
+import { Field, useFormikContext } from "formik";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import DateInput from "./custom-inputs/DateInput";
 import TdSwitch from "common/components/Switch";

--- a/front/src/form/custom-inputs/DateInput.module.scss
+++ b/front/src/form/custom-inputs/DateInput.module.scss
@@ -1,0 +1,4 @@
+:global(.react-datepicker-wrapper) {
+  // overwrite the default style's inline-block
+  display: block;
+}

--- a/front/src/form/custom-inputs/DateInput.tsx
+++ b/front/src/form/custom-inputs/DateInput.tsx
@@ -8,6 +8,7 @@ import DatePicker, {
   ReactDatePickerProps,
 } from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
+import "./DateInput.module.scss";
 
 registerLocale("fr", fr);
 setDefaultLocale("fr");
@@ -22,16 +23,14 @@ export default function DateInput({
   const { value, ...rest } = field;
 
   return (
-    <div>
-      <DatePicker
-        {...rest}
-        {...props}
-        dateFormat="dd/MM/yyyy"
-        selected={value ? parseDate(value) : null}
-        onChange={(value: Date | null) => {
-          setFieldValue(field.name, value?.toISOString() ?? null);
-        }}
-      />
-    </div>
+    <DatePicker
+      {...rest}
+      {...props}
+      dateFormat="dd/MM/yyyy"
+      selected={value ? parseDate(value) : null}
+      onChange={(value: Date | null) => {
+        setFieldValue(field.name, value?.toISOString() ?? null);
+      }}
+    />
   );
 }

--- a/front/src/form/custom-inputs/NumberInput.tsx
+++ b/front/src/form/custom-inputs/NumberInput.tsx
@@ -10,7 +10,7 @@ type NumberInputProps = FieldProps & { label: string } & InputHTMLAttributes<
   };
 
 export default function NumberInput({
-  field,
+  field: { value, ...field },
   label,
   noSpin,
   ...props
@@ -26,6 +26,7 @@ export default function NumberInput({
         className={classNames(props.className, {
           [styles.NumberInputNoSpin]: noSpin,
         })}
+        value={value == null ? "" : value}
       />
     </label>
   );


### PR DESCRIPTION
Cette PR corrige les bugs identifiés par Julieta lors du recettage de l'acceptation d'un déchet :

1. Les fonctions `onSubmit` ne retournait pas la `promise` de retour des mutations. Ce qui gardait `isSubmitting` à `false` indéfiniment et donc impossible de soumettre le formulaire à nouveau après une erreur.
2. La date envoyée au serveur était au format `YYYY-mm-dd` plutôt qu'au format ISO, ce qui provoquait une erreur.
3. Les valeurs n'étaient pas validées avant l'envoi au serveur sur l'écran d'acceptation d'un déchet. On pouvait donc soumettre un formulaire vide et recevoir une erreur 400 en retour.
4. La validation sur l'écran de réception d'un déchet ne permettait plus de recevoir et d'accepter en deux temps. Elle marquait comme requis des champs qui ne le sont pas.

- [ ] ~Mettre à jour la documentation~
- [ ] ~Mettre à jour le change log~
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/SBdIcVj9/1189-%C3%A9chec-lors-de-la-validation-de-lacceptation-du-dd)
