### PR TITLE
Correction de l'affichage des champs de saisie des récépissés

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,8 +30,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
-<<<<<<< HEAD
-
 - Migration de Prisma 1 vers Prisma 2 (ORM utilisé côté backend) [PR 733](https://github.com/MTES-MCT/trackdechets/pull/733)
 - Enregistrement et géocodage des adresses des établissements lors du rattachement [PR 766](https://github.com/MTES-MCT/trackdechets/pull/766)
 - Affichage de la dialogue de feedback Sentry en cas d'erreur dans l'application front [PR 774](https://github.com/MTES-MCT/trackdechets/pull/774)

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Correction du formulaire de réception [PR 769](https://github.com/MTES-MCT/trackdechets/pull/769)
 - Correction d'un bug de saisie de date sur Safari [PR 774](https://github.com/MTES-MCT/trackdechets/pull/774)
+- Correction d'un bug d'affichage des champs de saisie des récépissés transporteur et négociant [PR 783](https://github.com/MTES-MCT/trackdechets/pull/783)
 
 #### :nail_care: Améliorations
 
@@ -30,6 +31,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 <<<<<<< HEAD
+
 - Migration de Prisma 1 vers Prisma 2 (ORM utilisé côté backend) [PR 733](https://github.com/MTES-MCT/trackdechets/pull/733)
 - Enregistrement et géocodage des adresses des établissements lors du rattachement [PR 766](https://github.com/MTES-MCT/trackdechets/pull/766)
 - Affichage de la dialogue de feedback Sentry en cas d'erreur dans l'application front [PR 774](https://github.com/MTES-MCT/trackdechets/pull/774)

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddTraderReceipt.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddTraderReceipt.tsx
@@ -19,14 +19,22 @@ export default function AccountCompanyAddTraderReceipt() {
             <tr>
               <td>Numéro de récépissé</td>
               <td>
-                <Field type="text" name="traderReceiptNumber" />
+                <Field
+                  type="text"
+                  name="traderReceiptNumber"
+                  className="td-input"
+                />
                 <RedErrorMessage name="traderReceiptNumber" />
               </td>
             </tr>
             <tr>
               <td>Limite de validité</td>
               <td>
-                <Field name="traderReceiptValidity" component={DateInput} />
+                <Field
+                  name="traderReceiptValidity"
+                  component={DateInput}
+                  className="td-input"
+                />
                 <RedErrorMessage name="traderReceiptValidity" />
               </td>
             </tr>
@@ -37,6 +45,7 @@ export default function AccountCompanyAddTraderReceipt() {
                   type="text"
                   name="traderReceiptDepartment"
                   placeholder="75"
+                  className="td-input"
                 />
                 <RedErrorMessage name="traderReceiptDepartment" />
               </td>

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddTransporterReceipt.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddTransporterReceipt.tsx
@@ -19,7 +19,11 @@ export default function AccountCompanyAddTransporterReceipt() {
             <tr>
               <td>Numéro de récépissé</td>
               <td>
-                <Field type="text" name="transporterReceiptNumber" />
+                <Field
+                  type="text"
+                  name="transporterReceiptNumber"
+                  className="td-input"
+                />
                 <RedErrorMessage name="transporterReceiptNumber" />
               </td>
             </tr>
@@ -29,6 +33,7 @@ export default function AccountCompanyAddTransporterReceipt() {
                 <Field
                   name="transporterReceiptValidity"
                   component={DateInput}
+                  className="td-input"
                 />
                 <RedErrorMessage name="transporterReceiptValidity" />
               </td>
@@ -40,6 +45,7 @@ export default function AccountCompanyAddTransporterReceipt() {
                   type="text"
                   name="transporterReceiptDepartment"
                   placeholder="75"
+                  className="td-input"
                 />
                 <RedErrorMessage name="transporterReceiptDepartment" />
               </td>


### PR DESCRIPTION
Cette PR corrige l'affichage des champs de saisie des récépissés transporteur et négociant.

- [ ] ~Mettre à jour la documentation~
- [x] Mettre à jour le change log
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/dgF46bNL/1208-etq-administrateur-du-compte-quand-je-cr%C3%A9e-un-%C3%A9tablissement-je-ne-peux-pas-ajouter-le-r%C3%A9c%C3%A9piss%C3%A9-n%C3%A9gociant-ni-le-r%C3%A9c%C3%A9piss%C3%A9-transp)
