### PR TITLE
Prisma 2 schema compat migrations

### DIFF
--- a/back/prisma/migrations/06_add_not_null_constraints.sql
+++ b/back/prisma/migrations/06_add_not_null_constraints.sql
@@ -31,6 +31,10 @@ WHERE "authType" IS NULL;
 
 ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "authType" SET NOT NULL;
 
+-- Delete statusLogs where formId is null
+DELETE FROM "default$default"."StatusLog"
+WHERE "formId" IS NULL;
+
 ALTER TABLE "default$default"."StatusLog"
 ALTER COLUMN "formId" SET NOT NULL,
 ALTER COLUMN "userId" SET NOT NULL;
@@ -41,12 +45,6 @@ SET "updatedFields" = '{}'
 WHERE "updatedFields" IS NULL;
 
 ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "updatedFields" SET NOT NULL;
-
--- Delete statusLogs where formId is null
-DELETE FROM "default$default"."StatusLog"
-WHERE "formId" IS NULL;
-
-ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "formId" SET NOT NULL;
 
 -- TRANSPORT_SEGMENT
 

--- a/back/prisma/migrations/06_add_not_null_constraints.sql
+++ b/back/prisma/migrations/06_add_not_null_constraints.sql
@@ -1,0 +1,34 @@
+--- Fix nullable columns required in prisma
+
+-- STATUS LOGS
+
+-- Set default value for records where authType is null
+UPDATE "default$default"."StatusLog"
+SET "authType" = 'BEARER'
+WHERE "authType" IS NULL;
+
+ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "authType" SET NOT NULL;
+
+-- Set default value for records where updatedFields is null
+UPDATE "default$default"."StatusLog"
+SET "updatedFields" = '{}'
+WHERE "updatedFields" IS NULL;
+
+
+ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "updatedFields" SET NOT NULL;
+
+-- Delete statusLogs where formId is null
+DELETE FROM "default$default"."StatusLog"
+WHERE "formId" IS NULL;
+
+ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "formId" SET NOT NULL;
+
+-- USER ACTIVATION HASH
+
+-- Delete records where userId is null
+DELETE FROM "default$default"."UserActivationHash"
+WHERE "userId" IS NULL;
+
+ALTER TABLE "default$default"."UserActivationHash" ALTER COLUMN "userId" SET NOT NULL;
+
+

--- a/back/prisma/migrations/06_add_not_null_constraints.sql
+++ b/back/prisma/migrations/06_add_not_null_constraints.sql
@@ -1,6 +1,28 @@
 --- Fix nullable columns required in prisma
 
--- STATUS LOGS
+-- ACCESS_TOKEN
+ALTER TABLE "default$default"."AccessToken" ALTER COLUMN "userId" SET NOT NULL;
+
+-- COMPANY_ASSOCIATION
+ALTER TABLE "default$default"."CompanyAssociation"
+ALTER COLUMN "userId" SET NOT NULL,
+ALTER COLUMN "companyId" SET NOT NULL;
+
+-- FORM
+ALTER TABLE "default$default"."Form"
+ALTER COLUMN "ownerId" SET NOT NULL;
+
+-- GRANT
+ALTER TABLE "default$default"."Grant"
+ALTER COLUMN "userId" SET NOT NULL,
+ALTER COLUMN "applicationId" SET NOT NULL;
+
+-- INSTALLATION
+ALTER TABLE "default$default"."MembershipRequest"
+ALTER COLUMN "userId" SET NOT NULL,
+ALTER COLUMN "companyId" SET NOT NULL;
+
+-- STATUS_LOG
 
 -- Set default value for records where authType is null
 UPDATE "default$default"."StatusLog"
@@ -9,11 +31,14 @@ WHERE "authType" IS NULL;
 
 ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "authType" SET NOT NULL;
 
+ALTER TABLE "default$default"."StatusLog"
+ALTER COLUMN "formId" SET NOT NULL,
+ALTER COLUMN "userId" SET NOT NULL;
+
 -- Set default value for records where updatedFields is null
 UPDATE "default$default"."StatusLog"
 SET "updatedFields" = '{}'
 WHERE "updatedFields" IS NULL;
-
 
 ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "updatedFields" SET NOT NULL;
 
@@ -23,7 +48,13 @@ WHERE "formId" IS NULL;
 
 ALTER TABLE "default$default"."StatusLog" ALTER COLUMN "formId" SET NOT NULL;
 
--- USER ACTIVATION HASH
+-- TRANSPORT_SEGMENT
+
+ALTER TABLE "default$default"."TransportSegment"
+ALTER COLUMN "formId" SET NOT NULL;
+
+
+-- USER_ACTIVATION_HASH
 
 -- Delete records where userId is null
 DELETE FROM "default$default"."UserActivationHash"

--- a/back/prisma/migrations/07_drop_relayId.sql
+++ b/back/prisma/migrations/07_drop_relayId.sql
@@ -1,0 +1,4 @@
+--- Drop deprecated table _RelayId
+--- https://v1.prisma.io/docs/1.34/prisma-server/database-connector-POSTGRES-jgfr/
+
+DROP TABLE IF EXISTS "default$default"."_RelayId";

--- a/back/prisma/migrations/08_cast_types.sql
+++ b/back/prisma/migrations/08_cast_types.sql
@@ -1,0 +1,24 @@
+--- Fix types incoherences
+
+ALTER TABLE "default$default"."Form"
+ALTER COLUMN "wasteDetailsPackagingInfos"
+SET DATA TYPE JSONB USING "wasteDetailsPackagingInfos"::TEXT::JSONB;
+
+
+ALTER TABLE "default$default"."TemporaryStorageDetail"
+ALTER COLUMN "wasteDetailsPackagingInfos"
+SET DATA TYPE JSONB USING "wasteDetailsPackagingInfos"::TEXT::JSONB;
+
+
+ALTER TABLE "default$default"."Form"
+ALTER COLUMN "status" DROP DEFAULT,
+ALTER COLUMN "status" SET DATA TYPE "default$default"."Status" using "status"::"default$default"."Status",
+ALTER COLUMN "status" SET DEFAULT 'DRAFT'::"default$default"."Status";
+
+
+CREATE TYPE "default$default"."AuthType" AS ENUM ('SESSION', 'BEARER', 'JWT');
+
+ALTER TABLE "default$default"."StatusLog"
+ALTER COLUMN "authType"
+SET DATA TYPE "default$default"."AuthType"
+using "authType"::"default$default"."AuthType";

--- a/back/prisma/migrations/09_add_default.sql
+++ b/back/prisma/migrations/09_add_default.sql
@@ -1,0 +1,4 @@
+-- Fix missing default
+
+ALTER TABLE "default$default"."Form"
+ALTER COLUMN "wasteDetailsPop" SET DEFAULT FALSE;


### PR DESCRIPTION
En faisant `prisma introspect` sur une copie de la base de données de prod "migrée", je me suis aperçu qu'il y avait encore pas mal de différences entre la structure des tables de la base et le schéma prisma. Cette PR vise à corriger ces différences en appliquant des migrations supplémentaires.

- ~[ ] Mettre à jour la documentation~
- ~[ ] Mettre à jour le change log~
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/9nI4Awj8)
