### PR TITLE
Correction du support optionnel du champ "appendix2Forms"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Next release
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :boom: Breaking changes
+
+#### :bug: Corrections de bugs
+
+- Correction du support optionnel du champ "appendix2Forms" [PR 792](https://github.com/MTES-MCT/trackdechets/pull/792)
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2021.02.2] 10/02/2021
 
 - Correction d'un bug empêchant l'utilisation de certains formats de date dans les mutations `markAsAccepted`, `markAsTempStorerAccepted` et `markAsSent` [PR 798](https://github.com/MTES-MCT/trackdechets/pull/798)
@@ -59,6 +75,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 - Mise à jour du template de PR Github [PR 756](https://github.com/MTES-MCT/trackdechets/pull/756)
+
 # [2021.01.1] 07/01/2021
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -162,7 +162,7 @@ input CreateFormInput {
   trader: TraderInput
 
   "Annexe 2"
-  appendix2Forms: [AppendixFormInput]
+  appendix2Forms: [AppendixFormInput!]
   ecoOrganisme: EcoOrganismeInput
 
   temporaryStorageDetail: TemporaryStorageDetailInput
@@ -195,7 +195,7 @@ input UpdateFormInput {
   trader: TraderInput
 
   "Annexe 2"
-  appendix2Forms: [AppendixFormInput]
+  appendix2Forms: [AppendixFormInput!]
   ecoOrganisme: EcoOrganismeInput
 
   temporaryStorageDetail: TemporaryStorageDetailInput
@@ -228,7 +228,7 @@ input FormInput {
   trader: TraderInput
 
   "Annexe 2"
-  appendix2Forms: [AppendixFormInput]
+  appendix2Forms: [AppendixFormInput!]
   ecoOrganisme: EcoOrganismeInput
 
   temporaryStorageDetail: TemporaryStorageDetailInput

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -56,7 +56,7 @@ const createFormResolver = async (
     ...form,
     readableId: getReadableId(),
     owner: { connect: { id: user.id } },
-    appendix2Forms: { connect: appendix2Forms }
+    appendix2Forms: appendix2Forms ? { connect: appendix2Forms } : undefined
   };
 
   await draftFormSchema.validate(formCreateInput);

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -51,7 +51,7 @@ const updateFormResolver = async (
   // Construct form update payload
   const formUpdateInput: Prisma.FormUpdateInput = {
     ...form,
-    appendix2Forms: { set: appendix2Forms }
+    appendix2Forms: appendix2Forms ? { set: appendix2Forms } : undefined
   };
 
   // Validate form input

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -308,7 +308,7 @@ export type CreateFormInput = {
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms?: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms?: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme?: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail?: Maybe<TemporaryStorageDetailInput>;
 };
@@ -606,7 +606,7 @@ export type FormInput = {
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms?: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms?: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme?: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail?: Maybe<TemporaryStorageDetailInput>;
 };
@@ -2050,7 +2050,7 @@ export type UpdateFormInput = {
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms?: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms?: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme?: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail?: Maybe<TemporaryStorageDetailInput>;
 };

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -4136,7 +4136,7 @@ Négociant (case 7)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
-<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>]</td>
+<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>!]</td>
 <td>
 
 Annexe 2
@@ -4354,7 +4354,7 @@ Négociant (case 7)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
-<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>]</td>
+<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>!]</td>
 <td>
 
 Annexe 2
@@ -5548,7 +5548,7 @@ Négociant (case 7)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
-<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>]</td>
+<td valign="top">[<a href="#appendixforminput">AppendixFormInput</a>!]</td>
 <td>
 
 Annexe 2

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -300,7 +300,7 @@ export type CreateFormInput = {
   /** Négociant (case 7) */
   trader: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail: Maybe<TemporaryStorageDetailInput>;
 };
@@ -600,7 +600,7 @@ export type FormInput = {
   /** Négociant (case 7) */
   trader: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail: Maybe<TemporaryStorageDetailInput>;
 };
@@ -2064,7 +2064,7 @@ export type UpdateFormInput = {
   /** Négociant (case 7) */
   trader: Maybe<TraderInput>;
   /** Annexe 2 */
-  appendix2Forms: Maybe<Array<Maybe<AppendixFormInput>>>;
+  appendix2Forms: Maybe<Array<AppendixFormInput>>;
   ecoOrganisme: Maybe<EcoOrganismeInput>;
   temporaryStorageDetail: Maybe<TemporaryStorageDetailInput>;
 };


### PR DESCRIPTION
Cette PR corrige un bug avec les mutations `saveForm`, `createForm` et `updateForm` lorsque le champ `appendix2Forms` est passé à `null`. C'est une valeur possible puisque c'est un champ optionnel. J'ai hésité à ajouter des tests d'intégration parce que ça me paraît un peu overkill mais surtout parce que c'est une erreur statique détectable par TypeScript, avec le `strictNullChecks` d'activé.

À noter que j'ai laissé le `appendix2Forms` optionnel mais j'ai quand même forcer le type des éléments du tableau pour éviter d'avoir `[null, null]`.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)

---

- [Ticket Trello](https://trello.com/c/IuVzxz7y/1234-erreur-serveur-lorsque-appendix2forms-est-pass%C3%A9-%C3%A0-null-%C3%A0-la-mutation-saveform)
