### PR TITLE
Fix sib mailing

### DIFF
--- a/back/src/mailer/backends/sendInBlueBackend.ts
+++ b/back/src/mailer/backends/sendInBlueBackend.ts
@@ -12,8 +12,7 @@ const {
   NODE_ENV
 } = process.env;
 
-const baseUrl =
-  NODE_ENV === "production " ? SIB_BASE_URL : "http://mailservice"; // use a fake url for tests
+const baseUrl = NODE_ENV === "production" ? SIB_BASE_URL : "http://mailservice"; // use a fake url for tests
 const SIB_SMTP_URL = `${baseUrl}/smtp/email`;
 const SIB_CONTACT_URL = `${baseUrl}/contacts`;
 


### PR DESCRIPTION
Corrige un espace superflu à la fin d'une constante (  NODE_ENV === "production ") qui bloque l'utilisation de sib en recette
