### PR TITLE
Release 2021.02.2 - Hotfix format de date

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2021.02.2] 10/02/2021
+
+- Correction d'un bug empêchant l'utilisation de certains formats de date dans les mutations `markAsAccepted`, `markAsTempStorerAccepted` et `markAsSent` [PR 798](https://github.com/MTES-MCT/trackdechets/pull/798)
+
 # [2021.02.1] 03/02/2021
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/common/dates.ts
+++ b/back/src/common/dates.ts
@@ -1,0 +1,7 @@
+export const allowedFormats = [
+  "yyyy-MM-dd",
+  "yyyy-MM-dd'T'HH:mm:ss",
+  "yyyy-MM-dd'T'HH:mm:ssX",
+  "yyyy-MM-dd'T'HH:mm:ss.SSS",
+  "yyyy-MM-dd'T'HH:mm:ss.SSSX"
+];

--- a/back/src/common/yup/validDatetime.ts
+++ b/back/src/common/yup/validDatetime.ts
@@ -1,13 +1,6 @@
 import { parse, isDate, isValid } from "date-fns";
 import * as yup from "yup";
-
-const allowedFormats = [
-  "yyyy-MM-dd",
-  "yyyy-MM-dd'T'HH:mm:ss",
-  "yyyy-MM-dd'T'HH:mm:ssX",
-  "yyyy-MM-dd'T'HH:mm:ss.SSS",
-  "yyyy-MM-dd'T'HH:mm:ss.SSSX"
-];
+import { allowedFormats } from "../dates";
 
 /**
  * Check input is a date or a date string formatted according to allowed_formats

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -467,7 +467,9 @@ describe("Mutation.createForm", () => {
           createFormInput
         }
       });
-      const form = await prisma.form.findUnique(data.createForm.id);
+      const form = await prisma.form.findUnique({
+        where: { id: data.createForm.id }
+      });
       expect(form.transporterValidityLimit).toEqual(validityLimit);
       expect(form.traderValidityLimit).toEqual(validityLimit);
     }

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import prisma from "../../../../prisma";
 import { ErrorCode } from "../../../../common/errors";
@@ -7,6 +8,7 @@ import {
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
+import { allowedFormats } from "../../../../common/dates";
 
 const CREATE_FORM = `
   mutation CreateForm($createFormInput: CreateFormInput!) {
@@ -52,6 +54,19 @@ const CREATE_FORM = `
         validityLimit
         numberPlate
         customInfo
+      }
+      trader {
+        company {
+          siret
+          name
+          address
+          contact
+          mail
+          phone
+        }
+        receipt
+        department
+        validityLimit
       }
       wasteDetails {
         packagingInfos {
@@ -403,6 +418,60 @@ describe("Mutation.createForm", () => {
       createFormInput.transporter
     );
   });
+
+  test.each(allowedFormats)(
+    "%p should be a valid format for transporter and trader receipt validity limit",
+    async f => {
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+
+      const validityLimit = new Date("2040-01-01");
+      const createFormInput = {
+        emitter: {
+          company: {
+            siret: company.siret
+          }
+        },
+        transporter: {
+          company: {
+            siret: "12345678901234",
+            name: "Transporter",
+            address: "123 whatever street, Somewhere",
+            contact: "Jane Doe",
+            mail: "janedoe@transporter.com",
+            phone: "06"
+          },
+          isExemptedOfReceipt: false,
+          receipt: "8043",
+          department: "69",
+          validityLimit: format(validityLimit, f),
+          numberPlate: "AX-123-69",
+          customInfo: "T-456"
+        },
+        trader: {
+          company: {
+            siret: "12345678901234",
+            name: "Trader",
+            address: "123 Wall Street, NY",
+            contact: "Jane Doe",
+            mail: "janedoe@trader.com",
+            phone: "06"
+          },
+          validityLimit: format(validityLimit, f),
+          receipt: "8043",
+          department: "07"
+        }
+      };
+      const { mutate } = makeClient(user);
+      const { data } = await mutate(CREATE_FORM, {
+        variables: {
+          createFormInput
+        }
+      });
+      const form = await prisma.form.findUnique(data.createForm.id);
+      expect(form.transporterValidityLimit).toEqual(validityLimit);
+      expect(form.traderValidityLimit).toEqual(validityLimit);
+    }
+  );
 
   it("should create a form from deprecated packagings fields", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -21,7 +21,10 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
 
   const acceptedForm = await transitionForm(user, form, {
     type: EventType.MarkAsAccepted,
-    formUpdateInput: acceptedInfo
+    formUpdateInput: {
+      ...acceptedInfo,
+      signedAt: new Date(acceptedInfo.signedAt)
+    }
   });
 
   return expandFormFromDb(acceptedForm);

--- a/back/src/forms/resolvers/mutations/markAsSent.ts
+++ b/back/src/forms/resolvers/mutations/markAsSent.ts
@@ -32,6 +32,7 @@ const markAsSentResolver: MutationResolvers["markAsSent"] = async (
   // when form is sent, we store transporterCompanySiret as currentTransporterSiret to ease multimodal management
   const formUpdateInput = {
     ...sentInfo,
+    sentAt: new Date(sentInfo.sentAt),
     currentTransporterSiret: form.transporterCompanySiret,
     signedByTransporter: false
   };

--- a/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
@@ -32,7 +32,10 @@ const markAsTempStorerAcceptedResolver: MutationResolvers["markAsTempStorerAccep
 
   const formUpdateInput = {
     temporaryStorageDetail: {
-      update: tempStorageUpdateInput
+      update: {
+        ...tempStorageUpdateInput,
+        tempStorerSignedAt: new Date(tempStorageUpdateInput.tempStorerSignedAt)
+      }
     }
   };
 


### PR DESCRIPTION
Le parsing des string en date n'était pas effectué explicitement dans les mutations `markAsAccepted`, `markAsTempStorerAccepted` et `markAsSent` . On s'en remettait donc à prisma (qui accepte des strings en input pour ces champs DateTime) pour effectuer cette conversion. Or il semblerait que prisma2 soit plus restrictif sur les formats acceptés (je n'ai pas trouvé de doc à ce sujet). 


 - "yyyy-MM-dd" :red_circle:
 - "yyyy-MM-dd'T'HH:mm:ss" :red_circle:
 - "yyyy-MM-dd'T'HH:mm:ssX" :white_check_mark:
 - "yyyy-MM-dd'T'HH:mm:ss.SSS" :red_circle:
 - "yyyy-MM-dd'T'HH:mm:ss.SSSX" :white_check_mark:

---

- ~[ ] Mettre à jour la documentation~
- [ ] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/xuzzwDHT)
