### PR TITLE
Correction de la configuration Redis

### DIFF
--- a/back/src/common/redis.ts
+++ b/back/src/common/redis.ts
@@ -2,9 +2,9 @@ import Redis from "ioredis";
 
 const { REDIS_URL } = process.env;
 
-const connexionArgs = REDIS_URL ? { path: REDIS_URL } : { host: "redis" };
-
-export const redisClient = new Redis(connexionArgs);
+export const redisClient = REDIS_URL
+  ? new Redis(REDIS_URL)
+  : new Redis({ host: "redis" });
 
 /**
  * Generate a cache key


### PR DESCRIPTION
Cette PR corrige la configuration redis. L'instantiation avec une URL en paramètre a un comportement assez magique qu'il est dur de répliquer sous la forme d'objet (cf [ioredis#1078](https://github.com/luin/ioredis/issues/1078)). Avec cette PR il est possible de se connecter à redis dans un container depuis une app qui tourne sur la machine avec `REDIS_URL=localhost:6379`. Ça fonctionne également avec Scalingo (en ouvrant un tunnel ssh en local).