### PR TITLE
Correction de la configuration Nginx en local sur machine Linux

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -3,7 +3,6 @@ API_HOST=api.trackdechets.beta.gouv.fr
 API_URL_SCHEME=https
 
 # Port on which the API is served
-# Should not be set when running the API in a docker container
 # Should be set to 4000 when running the API on the host with nginx container in development
 API_PORT=4000
 
@@ -30,6 +29,16 @@ DATABASE_URL=postgresql://USER:PWD@HOST:PORT/prisma?schema=default$default
 
 # Redis configuration - let it blank to use 'redis' docker service
 REDIS_URL=redis://user:password@some-redis-service.com:1234/
+
+# Developement only
+# On Linux:
+#  - NGINX_PROXY_HOST=localhost
+#  - NGINX_NETWORK_MODE=host
+# On MacOS and Windows:
+#  - NGINX_PROXY_HOST=host.docker.internal
+#  - NGINX_NETWORK_MODE=bridge
+NGINX_PROXY_HOST=localhost|host.docker.internal
+NGINX_NETWORK_MODE=host|bridge
 
 # Secret used for encoding JSON web tokens
 JWT_SECRET=*********

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
     environment:
       NODE_ENV: dev
     ports:
-      - "4000:80"
+      - "4000:$API_PORT"
 
   td-ui:
     stdin_open: true
@@ -68,6 +68,7 @@ services:
 
   nginx:
     image: nginx:1.19.6
+    network_mode: $NGINX_NETWORK_MODE
     volumes:
       - ./nginx/templates:/etc/nginx/templates
     environment:
@@ -75,6 +76,7 @@ services:
       API_PORT: $API_PORT
       UI_HOST: $UI_HOST
       DEVELOPERS_HOST: $DEVELOPERS_HOST
+      NGINX_PROXY_HOST: $NGINX_PROXY_HOST
     ports:
       - "80:80"
 

--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -1,9 +1,11 @@
 server {
     listen 80;
+    listen [::]:80;
+
     server_name $UI_HOST;
 
     location / {
-        proxy_pass http://host.docker.internal:3000;
+        proxy_pass http://${NGINX_PROXY_HOST}:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -19,7 +21,7 @@ server {
     server_name $API_HOST;
 
     location / {
-        proxy_pass http://host.docker.internal:4000;
+        proxy_pass http://${NGINX_PROXY_HOST}:4000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -32,7 +34,7 @@ server {
     server_name $DEVELOPERS_HOST;
 
     location / {
-        proxy_pass http://host.docker.internal:5000;
+        proxy_pass http://${NGINX_PROXY_HOST}:5000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
La conf utilisait `host.docker.internal` qui ne fonctionne que sur Windows et MacOS. 
Utilise `network_mode=host` sur Linux à la place
