### PR TITLE
Correction de l'affichage des bordereaux à collecter après un entreposage provisoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,13 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
 # Next release
+
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout du rôle _courtier_ afin de suivre le cadre légal à venir. [PR 786](https://github.com/MTES-MCT/trackdechets/pull/786)
 
 - Ajout du champ `companyTypes` au type `CompanyPublic` retourné par la query `companyInfos` permettant de connaitre le profil d'un établissement inscrit sur Trackdéchets. Cette information apparait désormais également sur les fiches entreprise de l'interface Trackdéchets [PR 784](https://github.com/MTES-MCT/trackdechets/pull/784)
+
 #### :boom: Breaking changes
 
 - Seuls les établissements inscrits sur Trackdéchets en tant qu'installation de traitement ou de tri, transit, regoupement peuvent être visés en case 2 ou 14 [PR 784](https://github.com/MTES-MCT/trackdechets/pull/784)
@@ -19,13 +21,14 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Correction du support optionnel du champ "appendix2Forms" [PR 792](https://github.com/MTES-MCT/trackdechets/pull/792)
- 
+- Correction de l'affichage des bordereaux à collecter après un entreposage provisoire [PR 811](https://github.com/MTES-MCT/trackdechets/pull/811)
+
 #### :nail_care: Améliorations
 
 #### :memo: Documentation
 
 #### :house: Interne
- 
+
 - Segmentation des emails d'embarquement en fonction du profil utilisateur [PR 803](https://github.com/MTES-MCT/trackdechets/pull/803)
 
 - Utilisation d'un resolver GraphQL pour le scalaire DateTime [PR 802](https://github.com/MTES-MCT/trackdechets/pull/802)

--- a/front/src/dashboard/transport/Transport.tsx
+++ b/front/src/dashboard/transport/Transport.tsx
@@ -129,6 +129,9 @@ export function TransportContent({ formType }) {
       (statuses.includes(form.status) &&
         form.transporter?.company?.siret === siret) ||
       (formType === "TO_TAKE_OVER" &&
+        form.status === "RESEALED" &&
+        form.temporaryStorageDetail?.transporter?.company?.siret === siret) ||
+      (formType === "TO_TAKE_OVER" &&
         form.status === "SENT" &&
         !!segmentsToTakeOver.length) ||
       (formType === "TAKEN_OVER" &&


### PR DESCRIPTION
L'API retourne bien les bordereaux concernés, le problème se situait au niveau d'un filtre côté front. Cette PR corrige le filtre front. Avec l'ajout de la query basée sur Elastic Search je ferai en sorte de n'avoir un filtre que côté back et pas front.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)

---

- [Ticket Trello](https://trello.com/c/H9fh5OlS/1291-impossible-de-signer-lenl%C3%A8vement-apr%C3%A8s-entreposage-provisoire-pour-le-transporteur)
