### PR TITLE
Fix sendMail

### DIFF
--- a/back/src/mailer/backends/mailjetBackend.ts
+++ b/back/src/mailer/backends/mailjetBackend.ts
@@ -51,7 +51,7 @@ const mailjetBackend = {
     const request = mj
       .post("send", { version: "v3.1" })
       .request({ Messages: [payload] });
-    request
+    return request
       .then(() => {
         const allRecipients = [...mail.to, ...(!!mail.cc ? mail.cc : [])];
         for (const recipient of allRecipients) {

--- a/back/src/mailer/backends/sendInBlueBackend.ts
+++ b/back/src/mailer/backends/sendInBlueBackend.ts
@@ -51,7 +51,7 @@ const sendInBlueBackend = {
       headers: headers,
       timeout: 5000
     });
-    req
+    return req
       .then(() => {
         const allRecipients = [...mail.to, ...(!!mail.cc ? mail.cc : [])];
         for (const recipient of allRecipients) {


### PR DESCRIPTION
Ajout d'un `return` dans l'implémentation de `sendMail` sur les backends SendInBlue et Mailjet permettant d'utiliser `await`