### PR TITLE
Prise en compte de la date d'association pour l'envoi des emails d'onboarding

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,9 +28,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :memo: Documentation
 
 #### :house: Interne
-
+- Prise en compte de la date d'activation pour les emails d'onboarding (au lieu de la date d'inscription) [PR 817](https://github.com/MTES-MCT/trackdechets/pull/817)
 - Segmentation des emails d'embarquement en fonction du profil utilisateur [PR 803](https://github.com/MTES-MCT/trackdechets/pull/803)
-
 - Utilisation d'un resolver GraphQL pour le scalaire DateTime [PR 802](https://github.com/MTES-MCT/trackdechets/pull/802)
 - Conversion du champ `processedAt` en champ date [PR 802](https://github.com/MTES-MCT/trackdechets/pull/802)
 

--- a/back/prisma/migrations/12_add_user_steps_dates.sql
+++ b/back/prisma/migrations/12_add_user_steps_dates.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE "default$default"."User" 
+    ADD COLUMN "activatedAt"  TIMESTAMP(3),
+    ADD COLUMN "associatedAt"  TIMESTAMP(3);

--- a/back/prisma/migrations/12_add_user_steps_dates.sql
+++ b/back/prisma/migrations/12_add_user_steps_dates.sql
@@ -1,4 +1,4 @@
 
 ALTER TABLE "default$default"."User" 
     ADD COLUMN "activatedAt"  TIMESTAMP(3),
-    ADD COLUMN "associatedAt"  TIMESTAMP(3);
+    ADD COLUMN "firstAssociationDate"  TIMESTAMP(3);

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -494,6 +494,8 @@ model User {
   phone               String?
   createdAt           DateTime             @default(now())
   updatedAt           DateTime             @updatedAt
+  activatedAt         DateTime?            // when was this user activated ? - emailing purpose
+  associatedAt        DateTime?            // when was this user first associated to any company ? - emailing purpose
   isActive            Boolean?             @default(false)
   applicationId       String?
   application         Application?         @relation(fields: [applicationId], references: [id])

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -487,25 +487,25 @@ model TransportSegment {
 }
 
 model User {
-  id                  String               @id @default(cuid())
-  email               String               @unique
-  password            String
-  name                String?
-  phone               String?
-  createdAt           DateTime             @default(now())
-  updatedAt           DateTime             @updatedAt
-  activatedAt         DateTime?            // when was this user activated ? - emailing purpose
-  associatedAt        DateTime?            // when was this user first associated to any company ? - emailing purpose
-  isActive            Boolean?             @default(false)
-  applicationId       String?
-  application         Application?         @relation(fields: [applicationId], references: [id])
-  companyAssociations CompanyAssociation[]
-  AccessToken         AccessToken[]
-  Form                Form[]
-  Grant               Grant[]
-  MembershipRequest   MembershipRequest[]
-  StatusLog           StatusLog[]
-  UserActivationHash  UserActivationHash[]
+  id                          String               @id @default(cuid())
+  email                       String               @unique
+  password                    String
+  name                        String?
+  phone                       String?
+  createdAt                   DateTime             @default(now())
+  updatedAt                   DateTime             @updatedAt
+  activatedAt                 DateTime?            // when was this user activated ? - emailing purpose
+  firstAssociationDate        DateTime?            // when was this user first associated to any company ? - emailing purpose
+  isActive                    Boolean?             @default(false)
+  applicationId               String?
+  application                 Application?         @relation(fields: [applicationId], references: [id])
+  companyAssociations         CompanyAssociation[]
+  AccessToken                 AccessToken[]
+  Form                        Form[]
+  Grant                       Grant[]
+  MembershipRequest           MembershipRequest[]
+  StatusLog                   StatusLog[]
+  UserActivationHash          UserActivationHash[]
 }
 
 model UserAccountHash {

--- a/back/src/commands/__tests__/helpers.integration.ts
+++ b/back/src/commands/__tests__/helpers.integration.ts
@@ -12,8 +12,8 @@ describe("Retrieve relevant users for onboarding emails", () => {
   it("should retrieve users associated yesterday", async () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    const user = await userFactory({ associatedAt: yesterday });
-    await userFactory({ associatedAt: new Date() }); // user associated just now
+    const user = await userFactory({ firstAssociationDate: yesterday });
+    await userFactory({ firstAssociationDate: new Date() }); // user associated just now
     await userFactory(); // user non associated
     const recipients = await getRecentlyAssociatedUsers({ daysAgo: 1 });
     expect(recipients.length).toEqual(1);
@@ -27,9 +27,9 @@ describe("Retrieve relevant users for onboarding emails", () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     await prisma.user.update({
       where: { id: user.id },
-      data: { associatedAt: yesterday }
+      data: { firstAssociationDate: yesterday }
     });
-    await userFactory({ associatedAt: new Date() }); // user associated just now
+    await userFactory({ firstAssociationDate: new Date() }); // user associated just now
     await userFactory(); // user non associated
     const recipients = await getRecentlyAssociatedUsers({
       daysAgo: 1,

--- a/back/src/commands/__tests__/sendmails.integration.ts
+++ b/back/src/commands/__tests__/sendmails.integration.ts
@@ -26,12 +26,12 @@ describe("sendOnboardingFirstStepMails", () => {
     );
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    const user = await userFactory({ createdAt: yesterday });
-    // Users created today and 2 days ago, should not receive any email
+    const user = await userFactory({ associatedAt: yesterday });
+    // Users associatedAt today and 2 days ago, should not receive any email
     await userFactory();
     const twoDaysAgo = new Date();
     twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-    await userFactory({ createdAt: twoDaysAgo });
+    await userFactory({ associatedAt: twoDaysAgo });
 
     await sendOnboardingFirstStepMails();
 
@@ -86,7 +86,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
       await prisma.user.update({
         where: { id: producer.id },
-        data: { createdAt: someDaysAgo }
+        data: { associatedAt: someDaysAgo }
       });
       const { user: professional } = await userWithCompanyFactory("ADMIN", {
         companyTypes: {
@@ -96,7 +96,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
       await prisma.user.update({
         where: { id: professional.id },
-        data: { createdAt: someDaysAgo }
+        data: { associatedAt: someDaysAgo }
       });
 
       (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
@@ -122,7 +122,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
     await prisma.user.update({
       where: { id: user.id },
-      data: { createdAt: threeDaysAgo }
+      data: { associatedAt: threeDaysAgo }
     });
 
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
@@ -178,7 +178,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
     await prisma.user.update({
       where: { id: user.id },
-      data: { createdAt: threeDaysAgo }
+      data: { associatedAt: threeDaysAgo }
     });
 
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>

--- a/back/src/commands/__tests__/sendmails.integration.ts
+++ b/back/src/commands/__tests__/sendmails.integration.ts
@@ -26,12 +26,12 @@ describe("sendOnboardingFirstStepMails", () => {
     );
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    const user = await userFactory({ associatedAt: yesterday });
-    // Users associatedAt today and 2 days ago, should not receive any email
+    const user = await userFactory({ firstAssociationDate: yesterday });
+    // Users firstAssociationDate today and 2 days ago, should not receive any email
     await userFactory();
     const twoDaysAgo = new Date();
     twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-    await userFactory({ associatedAt: twoDaysAgo });
+    await userFactory({ firstAssociationDate: twoDaysAgo });
 
     await sendOnboardingFirstStepMails();
 
@@ -86,7 +86,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
       await prisma.user.update({
         where: { id: producer.id },
-        data: { associatedAt: someDaysAgo }
+        data: { firstAssociationDate: someDaysAgo }
       });
       const { user: professional } = await userWithCompanyFactory("ADMIN", {
         companyTypes: {
@@ -96,7 +96,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
       await prisma.user.update({
         where: { id: professional.id },
-        data: { associatedAt: someDaysAgo }
+        data: { firstAssociationDate: someDaysAgo }
       });
 
       (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
@@ -122,7 +122,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
     await prisma.user.update({
       where: { id: user.id },
-      data: { associatedAt: threeDaysAgo }
+      data: { firstAssociationDate: threeDaysAgo }
     });
 
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>
@@ -178,7 +178,7 @@ describe("sendOnboardingSecondStepMails", () => {
 
     await prisma.user.update({
       where: { id: user.id },
-      data: { associatedAt: threeDaysAgo }
+      data: { firstAssociationDate: threeDaysAgo }
     });
 
     (mockedAxiosPost as jest.Mock<any>).mockImplementationOnce(() =>

--- a/back/src/commands/onboarding.helpers.ts
+++ b/back/src/commands/onboarding.helpers.ts
@@ -20,20 +20,20 @@ type getRecentlyJoinedUsersParams = {
   daysAgo: number;
   retrieveCompanies?: boolean;
 };
-export const getRecentlyJoinedUsers = async ({
+export const getRecentlyAssociatedUsers = async ({
   daysAgo,
   retrieveCompanies = false
 }: getRecentlyJoinedUsersParams) => {
   const now = new Date();
 
-  const inscriptionDateGt = xDaysAgo(now, daysAgo);
-  const inscriptionDateLt = xDaysAgo(now, daysAgo - 1);
+  const associatedDateGt = xDaysAgo(now, daysAgo);
+  const associatedDateLt = xDaysAgo(now, daysAgo - 1);
   // retrieve users whose account was created xDaysAgo
   // and associated company(ies) to tell apart producers and waste professionals according to their type
 
   return prisma.user.findMany({
     where: {
-      createdAt: { gt: inscriptionDateGt, lt: inscriptionDateLt },
+      associatedAt: { gt: associatedDateGt, lt: associatedDateLt },
       isActive: true
     },
     ...(retrieveCompanies && {
@@ -46,7 +46,7 @@ export const getRecentlyJoinedUsers = async ({
  * Send first step onboarding email to active users who suscribed yesterday
  */
 export const sendOnboardingFirstStepMails = async () => {
-  const recipients = await getRecentlyJoinedUsers({ daysAgo: 1 });
+  const recipients = await getRecentlyAssociatedUsers({ daysAgo: 1 });
   await Promise.all(
     recipients.map(recipient => {
       const payload = userMails.onboardingFirstStep(
@@ -92,7 +92,7 @@ export const selectSecondOnboardingEmail = (recipient: recipientType) => {
 export const sendOnboardingSecondStepMails = async () => {
   // we explictly retrieve user companies to tell apart producers from waste
   // professionals to selectthe right email template
-  const recipients = await getRecentlyJoinedUsers({
+  const recipients = await getRecentlyAssociatedUsers({
     daysAgo: 3,
     retrieveCompanies: true
   });

--- a/back/src/commands/onboarding.helpers.ts
+++ b/back/src/commands/onboarding.helpers.ts
@@ -33,7 +33,7 @@ export const getRecentlyAssociatedUsers = async ({
 
   return prisma.user.findMany({
     where: {
-      associatedAt: { gt: associatedDateGt, lt: associatedDateLt },
+      firstAssociationDate: { gt: associatedDateGt, lt: associatedDateLt },
       isActive: true
     },
     ...(retrieveCompanies && {

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -85,7 +85,7 @@ describe("Mutation.createCompany", () => {
     });
 
     // association date is filled
-    expect(refreshedUser.associatedAt).toBeTruthy();
+    expect(refreshedUser.firstAssociationDate).toBeTruthy();
   });
 
   it("should link to a transporterReceipt", async () => {

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -79,6 +79,13 @@ describe("Mutation.createCompany", () => {
         where: { company: { siret: companyInput.siret }, user: { id: user.id } }
       })) != null;
     expect(newCompanyAssociationExists).toBe(true);
+
+    const refreshedUser = await prisma.user.findUnique({
+      where: { id: user.id }
+    });
+
+    // association date is filled
+    expect(refreshedUser.associatedAt).toBeTruthy();
   });
 
   it("should link to a transporterReceipt", async () => {

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -118,7 +118,12 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
   });
 
   const company = await companyAssociationPromise.company();
-
+  
+  // fill associatedAt field if null (no need to update it if user was previously already associated)
+  await prisma.user.updateMany({
+    where: { id: user.id, associatedAt: null },
+    data: { associatedAt: new Date() }
+  });
   await warnIfUserCreatesTooManyCompanies(user, company);
 
   return convertUrls(company);

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -119,10 +119,10 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
 
   const company = await companyAssociationPromise.company();
 
-  // fill associatedAt field if null (no need to update it if user was previously already associated)
+  // fill firstAssociationDate field if null (no need to update it if user was previously already associated)
   await prisma.user.updateMany({
-    where: { id: user.id, associatedAt: null },
-    data: { associatedAt: new Date() }
+    where: { id: user.id, firstAssociationDate: null },
+    data: { firstAssociationDate: new Date() }
   });
   await warnIfUserCreatesTooManyCompanies(user, company);
 

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -118,7 +118,7 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
   });
 
   const company = await companyAssociationPromise.company();
-  
+
   // fill associatedAt field if null (no need to update it if user was previously already associated)
   await prisma.user.updateMany({
     where: { id: user.id, associatedAt: null },

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -108,7 +108,7 @@ export type BrokerReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé courtier */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -346,7 +346,7 @@ export type Consistence =
 export type CreateBrokerReceiptInput = {
   /** Numéro de récépissé courtier */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -385,7 +385,7 @@ export type CreateFormInput = {
 export type CreateTraderReceiptInput = {
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -395,7 +395,7 @@ export type CreateTraderReceiptInput = {
 export type CreateTransporterReceiptInput = {
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2057,7 +2057,7 @@ export type TraderReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2106,7 +2106,7 @@ export type TransporterReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2163,7 +2163,7 @@ export type UpdateBrokerReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé courtier */
   receiptNumber?: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit?: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department?: Maybe<Scalars["String"]>;
@@ -2206,7 +2206,7 @@ export type UpdateTraderReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé négociant */
   receiptNumber?: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit?: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department?: Maybe<Scalars["String"]>;
@@ -2218,7 +2218,7 @@ export type UpdateTransporterReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé transporteur */
   receiptNumber?: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit?: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department?: Maybe<Scalars["String"]>;

--- a/back/src/users/__tests__/activation.integration.ts
+++ b/back/src/users/__tests__/activation.integration.ts
@@ -9,20 +9,22 @@ import supertest from "supertest";
 
 import { app } from "../../server";
 const request = supertest(app);
-describe("createUserAccountHash", () => {
+
+describe("user activation", () => {
   afterEach(resetDatabase);
-  it("should return user account hash", async () => {
+
+  it("should activate an user", async () => {
     const user = await userFactory({
       email: "bruce.banner@trackdechets.fr",
       isActive: false
     });
 
     const userActivationHash = await createActivationHash(user);
-    const activate = await request.get(
-      `/userActivation?hash=${userActivationHash.hash}`
-    );
+    await request.get(`/userActivation?hash=${userActivationHash.hash}`);
 
-    const refreshedUser = await prisma.user.findUnique({ where :  { id: user.id }});
+    const refreshedUser = await prisma.user.findUnique({
+      where: { id: user.id }
+    });
 
     expect(refreshedUser.isActive).toEqual(true);
     expect(refreshedUser.activatedAt).toBeTruthy();

--- a/back/src/users/__tests__/activation.integration.ts
+++ b/back/src/users/__tests__/activation.integration.ts
@@ -1,0 +1,30 @@
+import { resetDatabase } from "../../../integration-tests/helper";
+import prisma from "../../prisma";
+
+import { userFactory } from "../../__tests__/factories";
+
+import { createActivationHash } from "../resolvers/mutations/signup";
+
+import supertest from "supertest";
+
+import { app } from "../../server";
+const request = supertest(app);
+describe("createUserAccountHash", () => {
+  afterEach(resetDatabase);
+  it("should return user account hash", async () => {
+    const user = await userFactory({
+      email: "bruce.banner@trackdechets.fr",
+      isActive: false
+    });
+
+    const userActivationHash = await createActivationHash(user);
+    const activate = await request.get(
+      `/userActivation?hash=${userActivationHash.hash}`
+    );
+
+    const refreshedUser = await prisma.user.findUnique({ where :  { id: user.id }});
+
+    expect(refreshedUser.isActive).toEqual(true);
+    expect(refreshedUser.activatedAt).toBeTruthy();
+  });
+});

--- a/back/src/users/__tests__/database.integration.ts
+++ b/back/src/users/__tests__/database.integration.ts
@@ -1,8 +1,16 @@
 import { resetDatabase } from "../../../integration-tests/helper";
 import prisma from "../../prisma";
 import { ErrorCode } from "../../common/errors";
-import { userWithCompanyFactory } from "../../__tests__/factories";
-import { associateUserToCompany, createUserAccountHash } from "../database";
+import {
+  userWithCompanyFactory,
+  userFactory,
+  companyFactory
+} from "../../__tests__/factories";
+import {
+  associateUserToCompany,
+  createUserAccountHash,
+  getFullUser
+} from "../database";
 
 describe("createUserAccountHash", () => {
   afterAll(resetDatabase);
@@ -52,5 +60,17 @@ describe("associateUserToCompany", () => {
         "L'utilisateur est déjà membre de l'établissement"
       );
     }
+  });
+
+  it("should associate an user to a company", async () => {
+    const user = await userFactory();
+    const company = await companyFactory();
+
+    await associateUserToCompany(user.id, company.siret, "MEMBER");
+    const refreshedUser = await prisma.user.findUnique({ where: { id: user.id } });
+    const fullUser = await getFullUser(refreshedUser);
+    expect(fullUser.associatedAt).toBeTruthy();
+    expect(fullUser.companies).toEqual([company]);
+    
   });
 });

--- a/back/src/users/__tests__/database.integration.ts
+++ b/back/src/users/__tests__/database.integration.ts
@@ -67,10 +67,11 @@ describe("associateUserToCompany", () => {
     const company = await companyFactory();
 
     await associateUserToCompany(user.id, company.siret, "MEMBER");
-    const refreshedUser = await prisma.user.findUnique({ where: { id: user.id } });
+    const refreshedUser = await prisma.user.findUnique({
+      where: { id: user.id }
+    });
     const fullUser = await getFullUser(refreshedUser);
     expect(fullUser.associatedAt).toBeTruthy();
     expect(fullUser.companies).toEqual([company]);
-    
   });
 });

--- a/back/src/users/__tests__/database.integration.ts
+++ b/back/src/users/__tests__/database.integration.ts
@@ -71,7 +71,7 @@ describe("associateUserToCompany", () => {
       where: { id: user.id }
     });
     const fullUser = await getFullUser(refreshedUser);
-    expect(fullUser.associatedAt).toBeTruthy();
+    expect(fullUser.firstAssociationDate).toBeTruthy();
     expect(fullUser.companies).toEqual([company]);
   });
 });

--- a/back/src/users/activation.ts
+++ b/back/src/users/activation.ts
@@ -18,7 +18,7 @@ export const userActivationHandler = async (req, res) => {
 
   await prisma.user.update({
     where: { id: user.id },
-    data: { isActive: true }
+    data: { isActive: true, activatedAt: new Date() }
   });
 
   const UI_BASE_URL = getUIBaseURL();

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -124,20 +124,18 @@ describe("bulk create users and companies from csv files", () => {
 
   test("already existing user", async () => {
     // assume a user with this email already exists
-    const { associatedAt:_1, updatedAt:_2, ...john } = await userFactory({
+    const { associatedAt: _1, updatedAt: _2, ...john } = await userFactory({
       email: "john.snow@trackdechets.fr"
     });
 
     await bulkCreateIdempotent();
 
     await expectNumberOfRecords(2, 3, 4);
-    const {
-      associatedAt   ,
-      updatedAt ,
-      ...dbJohn
-    } = await prisma.user.findUnique({
-      where: { email: "john.snow@trackdechets.fr" }
-    });
+    const { associatedAt, updatedAt, ...dbJohn } = await prisma.user.findUnique(
+      {
+        where: { email: "john.snow@trackdechets.fr" }
+      }
+    );
 
     // john snow user should be untouched
     expect(dbJohn).toEqual(john);

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -93,7 +93,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(john.name).toEqual("john.snow@trackdechets.fr");
     expect(john.isActive).toEqual(true);
     expect(john.activatedAt).toBeTruthy();
-    expect(john.associatedAt).toBeTruthy();
+    expect(john.firstAssociationDate).toBeTruthy();
 
     // check fields are OK for first company
     const codeEnStock = await prisma.company.findUnique({
@@ -124,22 +124,28 @@ describe("bulk create users and companies from csv files", () => {
 
   test("already existing user", async () => {
     // assume a user with this email already exists
-    const { associatedAt: _1, updatedAt: _2, ...john } = await userFactory({
+    const {
+      firstAssociationDate: _1,
+      updatedAt: _2,
+      ...john
+    } = await userFactory({
       email: "john.snow@trackdechets.fr"
     });
 
     await bulkCreateIdempotent();
 
     await expectNumberOfRecords(2, 3, 4);
-    const { associatedAt, updatedAt, ...dbJohn } = await prisma.user.findUnique(
-      {
-        where: { email: "john.snow@trackdechets.fr" }
-      }
-    );
+    const {
+      firstAssociationDate,
+      updatedAt,
+      ...dbJohn
+    } = await prisma.user.findUnique({
+      where: { email: "john.snow@trackdechets.fr" }
+    });
 
     // john snow user should be untouched
     expect(dbJohn).toEqual(john);
-    expect(associatedAt).toBeTruthy();
+    expect(firstAssociationDate).toBeTruthy();
 
     // associations should exist between John Snow and Code en Stock
     const associations = await prisma.companyAssociation.findMany({

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -92,6 +92,8 @@ describe("bulk create users and companies from csv files", () => {
     });
     expect(john.name).toEqual("john.snow@trackdechets.fr");
     expect(john.isActive).toEqual(true);
+    expect(john.activatedAt).toBeTruthy();
+    expect(john.associatedAt).toBeTruthy();
 
     // check fields are OK for first company
     const codeEnStock = await prisma.company.findUnique({
@@ -122,18 +124,24 @@ describe("bulk create users and companies from csv files", () => {
 
   test("already existing user", async () => {
     // assume a user with this email already exists
-    const john = await userFactory({ email: "john.snow@trackdechets.fr" });
+    const { associatedAt:_1, updatedAt:_2, ...john } = await userFactory({
+      email: "john.snow@trackdechets.fr"
+    });
 
     await bulkCreateIdempotent();
 
     await expectNumberOfRecords(2, 3, 4);
+    const {
+      associatedAt   ,
+      updatedAt ,
+      ...dbJohn
+    } = await prisma.user.findUnique({
+      where: { email: "john.snow@trackdechets.fr" }
+    });
 
     // john snow user should be untouched
-    expect(
-      await prisma.user.findUnique({
-        where: { email: "john.snow@trackdechets.fr" }
-      })
-    ).toEqual(john);
+    expect(dbJohn).toEqual(john);
+    expect(associatedAt).toBeTruthy();
 
     // associations should exist between John Snow and Code en Stock
     const associations = await prisma.companyAssociation.findMany({

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -163,7 +163,8 @@ export async function bulkCreate(opts: Opts): Promise<void> {
           name: email,
           email,
           password: hashedPassword,
-          isActive: true
+          isActive: true,
+          activatedAt: new Date()
         }
       });
 
@@ -175,7 +176,14 @@ export async function bulkCreate(opts: Opts): Promise<void> {
     await Promise.all(
       usersWithRoles[email].map(async ({ role, siret }) => {
         try {
-          return await associateUserToCompany(user.id, siret, role);
+          const association =  await associateUserToCompany(user.id, siret, role);
+          if (!user.associatedAt) {
+            await prisma.user.update({
+              where: { id: user.id },
+              data: { associatedAt: new Date() }
+            });
+          }
+          return association
         } catch (err) {
           if (err instanceof UserInputError) {
             // association already exist, return it

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -181,10 +181,10 @@ export async function bulkCreate(opts: Opts): Promise<void> {
             siret,
             role
           );
-          if (!user.associatedAt) {
+          if (!user.firstAssociationDate) {
             await prisma.user.update({
               where: { id: user.id },
-              data: { associatedAt: new Date() }
+              data: { firstAssociationDate: new Date() }
             });
           }
           return association;

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -176,14 +176,18 @@ export async function bulkCreate(opts: Opts): Promise<void> {
     await Promise.all(
       usersWithRoles[email].map(async ({ role, siret }) => {
         try {
-          const association =  await associateUserToCompany(user.id, siret, role);
+          const association = await associateUserToCompany(
+            user.id,
+            siret,
+            role
+          );
           if (!user.associatedAt) {
             await prisma.user.update({
               where: { id: user.id },
               data: { associatedAt: new Date() }
             });
           }
-          return association
+          return association;
         } catch (err) {
           if (err instanceof UserInputError) {
             // association already exist, return it

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -106,10 +106,10 @@ export async function associateUserToCompany(userId, siret, role) {
     }
   });
 
-  // fill associatedAt field if null (no need to update it if user was previously already associated)
+  // fill firstAssociationDate field if null (no need to update it if user was previously already associated)
   await prisma.user.updateMany({
-    where: { id: userId, associatedAt: null },
-    data: { associatedAt: new Date() }
+    where: { id: userId, firstAssociationDate: null },
+    data: { firstAssociationDate: new Date() }
   });
   return association;
 }
@@ -184,10 +184,10 @@ export async function acceptNewUserCompanyInvitations(user: User) {
       })
     )
   );
-  if (!user.associatedAt) {
+  if (!user.firstAssociationDate) {
     await prisma.user.update({
       where: { id: user.id },
-      data: { associatedAt: new Date() }
+      data: { firstAssociationDate: new Date() }
     });
   }
 

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -105,7 +105,7 @@ export async function associateUserToCompany(userId, siret, role) {
       company: { connect: { siret } }
     }
   });
-  
+
   // fill associatedAt field if null (no need to update it if user was previously already associated)
   await prisma.user.updateMany({
     where: { id: userId, associatedAt: null },

--- a/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
@@ -96,6 +96,12 @@ describe("joinWithInvite mutation", () => {
         }
       })) != null;
     expect(isCompanyMember).toEqual(true);
+
+    const createdUser = await prisma.user.findUnique({
+      where: { email: invitee }
+    });
+    expect(createdUser.activatedAt).toBeTruthy();
+    expect(createdUser.associatedAt).toBeTruthy();
   });
 
   it("should accept other pending invitations", async () => {

--- a/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
@@ -101,7 +101,7 @@ describe("joinWithInvite mutation", () => {
       where: { email: invitee }
     });
     expect(createdUser.activatedAt).toBeTruthy();
-    expect(createdUser.associatedAt).toBeTruthy();
+    expect(createdUser.firstAssociationDate).toBeTruthy();
   });
 
   it("should accept other pending invitations", async () => {

--- a/back/src/users/resolvers/mutations/__tests__/signup.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.test.ts
@@ -11,6 +11,7 @@ const userInfos = {
 jest.mock("../../../../prisma", () => ({
   user: {
     create: jest.fn(() => Promise.resolve(userInfos)),
+    update: jest.fn(() => Promise.resolve(userInfos)),
     findFirst: jest.fn(() => Promise.resolve(null)),
     findMany: jest.fn(() => Promise.resolve([])),
     count: jest.fn(() => Promise.resolve(0))

--- a/back/src/users/resolvers/mutations/joinWithInvite.ts
+++ b/back/src/users/resolvers/mutations/joinWithInvite.ts
@@ -45,7 +45,8 @@ const joinWithInviteResolver: MutationResolvers["joinWithInvite"] = async (
       email: existingHash.email,
       password: hashedPassword,
       phone: "",
-      isActive: true
+      isActive: true,
+      activatedAt: new Date()
     }
   });
 

--- a/back/src/users/resolvers/mutations/signup.ts
+++ b/back/src/users/resolvers/mutations/signup.ts
@@ -75,7 +75,7 @@ const signupResolver: MutationResolvers["signup"] = async (parent, args) => {
  *
  * @param user
  */
-async function createActivationHash(user: User) {
+export async function createActivationHash(user: User) {
   const activationHash = await hash(
     new Date().valueOf().toString() + Math.random().toString(),
     10

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -98,7 +98,7 @@ export type BrokerReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé courtier */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -338,7 +338,7 @@ export enum Consistence {
 export type CreateBrokerReceiptInput = {
   /** Numéro de récépissé courtier */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -377,7 +377,7 @@ export type CreateFormInput = {
 export type CreateTraderReceiptInput = {
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -387,7 +387,7 @@ export type CreateTraderReceiptInput = {
 export type CreateTransporterReceiptInput = {
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2065,7 +2065,7 @@ export type TraderReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé négociant */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2114,7 +2114,7 @@ export type TransporterReceipt = {
   id: Scalars["ID"];
   /** Numéro de récépissé transporteur */
   receiptNumber: Scalars["String"];
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Scalars["DateTime"];
   /** Département ayant enregistré la déclaration */
   department: Scalars["String"];
@@ -2177,7 +2177,7 @@ export type UpdateBrokerReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé courtier */
   receiptNumber: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department: Maybe<Scalars["String"]>;
@@ -2220,7 +2220,7 @@ export type UpdateTraderReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé négociant */
   receiptNumber: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department: Maybe<Scalars["String"]>;
@@ -2232,7 +2232,7 @@ export type UpdateTransporterReceiptInput = {
   id: Scalars["ID"];
   /** Numéro de récépissé transporteur */
   receiptNumber: Maybe<Scalars["String"]>;
-  /** Limite de validatié du récépissé */
+  /** Limite de validité du récépissé */
   validityLimit: Maybe<Scalars["DateTime"]>;
   /** Département ayant enregistré la déclaration */
   department: Maybe<Scalars["String"]>;


### PR DESCRIPTION
Les emails d'onboarding sont envoyés à J+1 et J+3, J étant la date de rattachement initiale d'un utilisateur  une entreprise.
Pour ce faire: ajout de dates d'activation et d'association sur le modèle User, remplissage de ces champs lors des différents workflows d'inscription.
Une PR à venir gèrera les les utilisateurs non validés et non rattachés

- ~[ ] Mettre à jour la documentation~
- [x] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~

---

- [Ticket Trello](https://trello.com/c/nRe0g85c/1279-dates-de-r%C3%A9f%C3%A9rence-des-mails-donboarding)
