### PR TITLE
Fix traitement après entreposage provisoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+
+# [2021.03.2] 23/03/2021
+
+#### :bug: Corrections de bugs
+
+- Correction d'un bug dans l'interface Trackdéchets empêchant la destination finale après entreposage provisoire de valider le traitement du déchet [PR 824](https://github.com/MTES-MCT/trackdechets/pull/824)
+
 # [2021.03.1] 16/03/2021
 
 #### :rocket: Nouvelles fonctionnalités


### PR DESCRIPTION
Ce fix vient corriger deux bugs liés à l'entreposage provisoire:
- En tant qu'installation d'entreposage provisoire, un BSD à l'état `ACCEPTED` apparait dans mon onglet "Pour Action" alors qu'il devrait apparaitre dans mon onglet "Suivi" (correction de `getHasNextStepFilter`)
- En tant qu'installation d'entreposage provisoire, le bouton "Valider le traitement" apparait pour un BSD à l'état `ACCEPTED` alors qu'il ne devrait pas (correction du composant front `WorkflowAction`)
- En tant qu'installation de destination après entreposage provisoire, le bouton "Valider le traitement" n'apparait pas alors qu'il devrait apparaitre (correction du composant front `WorkflowAction`)
---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Trello](https://trello.com/c/Be1ZJM5K)
