### PR TITLE
Fix/packaging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction d'un bug dans l'interface Trackdéchets lorsque sur mobile on souhaitait accéder à son compte. Le bouton n'apparaissait pas car on ne pouvait pas scroller [PR 828](https://github.com/MTES-MCT/trackdechets/pull/828)
+- Correction d'un bug dans l'interface lors de la saisie des conditionnements. Si on avait sélectionné "Autre" en précisant la description et qu'on changeait ensuite le type de conditionnement, un message d'erreur apparaissait  [PR 828](https://github.com/MTES-MCT/trackdechets/pull/828)
+- Correction d'un bug dans l'interface dans la modale de détail d'un bordereau. Le conditionnement ne donnait pas le détail des "Autre", et n'affichait pas le bon conditionnement dans le cas d'un entreposage provisoire [PR 828](https://github.com/MTES-MCT/trackdechets/pull/828)
+
 #### :nail_care: Améliorations
 
 #### :memo: Documentation

--- a/front/src/dashboard/bsdds/view/BSDDetailContent.tsx
+++ b/front/src/dashboard/bsdds/view/BSDDetailContent.tsx
@@ -371,7 +371,11 @@ export default function BSDDetailContent({
               <dt>Quantité</dt>
               <dd>{form.stateSummary?.quantity ?? "?"} tonnes</dd>
               <PackagingRow
-                packagingInfos={form.wasteDetails?.packagingInfos}
+                packagingInfos={
+                  hasTempStorage
+                    ? form.temporaryStorageDetail?.wasteDetails?.packagingInfos
+                    : form.wasteDetails?.packagingInfos
+                }
               />
               <dt>Consistance</dt>{" "}
               <dd>{getVerboseConsistence(form.wasteDetails?.consistence)}</dd>

--- a/front/src/dashboard/bsdds/view/Components.tsx
+++ b/front/src/dashboard/bsdds/view/Components.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { formatDate } from "common/datetime";
-import { formatPackagings } from "./utils";
 import { PackagingInfo } from "generated/graphql/types";
+import { getPackagingInfosSummary } from "form/bsdd/utils/packagings";
 
 export const DetailRow = ({ value, label }) => {
   if (!value) {
@@ -44,23 +44,15 @@ export const PackagingRow = ({
 }: {
   packagingInfos?: PackagingInfo[] | null;
 }) => {
-  const numberOfPackages = useMemo(
-    () => packagingInfos?.reduce((prev, cur) => cur.quantity + prev, 0),
+  const formatedPackagings = useMemo(
+    () => (packagingInfos ? getPackagingInfosSummary(packagingInfos) : ""),
     [packagingInfos]
   );
-  const formatedPackagings = useMemo(() => formatPackagings(packagingInfos), [
-    packagingInfos,
-  ]);
 
   return (
     <>
       <dt>Conditionnement</dt>
-      <dd>
-        {formatedPackagings}
-        {numberOfPackages && (
-          <span className="tw-ml-2">[Total {numberOfPackages}]</span>
-        )}
-      </dd>
+      <dd>{formatedPackagings}</dd>
     </>
   );
 };

--- a/front/src/dashboard/bsdds/view/Components.tsx
+++ b/front/src/dashboard/bsdds/view/Components.tsx
@@ -48,10 +48,9 @@ export const PackagingRow = ({
     () => packagingInfos?.reduce((prev, cur) => cur.quantity + prev, 0),
     [packagingInfos]
   );
-  const formatedPackagings = useMemo(
-    () => formatPackagings(packagingInfos?.map(p => p.type)),
-    [packagingInfos]
-  );
+  const formatedPackagings = useMemo(() => formatPackagings(packagingInfos), [
+    packagingInfos,
+  ]);
 
   return (
     <>
@@ -59,7 +58,7 @@ export const PackagingRow = ({
       <dd>
         {formatedPackagings}
         {numberOfPackages && (
-          <span className="tw-ml-2">({numberOfPackages})</span>
+          <span className="tw-ml-2">[Total {numberOfPackages}]</span>
         )}
       </dd>
     </>

--- a/front/src/dashboard/bsdds/view/utils.tsx
+++ b/front/src/dashboard/bsdds/view/utils.tsx
@@ -1,9 +1,7 @@
 import {
   Consistence,
-  Packagings,
   WasteAcceptationStatusInput as WasteAcceptationStatus,
   QuantityType,
-  PackagingInfo,
 } from "generated/graphql/types";
 
 export const getVerboseConsistence = (
@@ -14,27 +12,6 @@ export const getVerboseConsistence = (
   }
   const verbose = { SOLID: "Solide", LIQUID: "Liquide", GASEOUS: "Gazeux" };
   return verbose[consistence];
-};
-export const getVerbosePackaging = (
-  packagingInfo: PackagingInfo | null | undefined | ""
-): string => {
-  if (!packagingInfo) {
-    return "";
-  }
-
-  if (packagingInfo.type === Packagings.Autre) {
-    return packagingInfo.other ?? "";
-  }
-  return packagingInfo.type[0] + packagingInfo.type.slice(1).toLowerCase();
-};
-
-export const formatPackagings = (
-  packagingInfos: PackagingInfo[] | null | undefined
-): string => {
-  if (!packagingInfos) return "";
-  return packagingInfos
-    .map(p => `${getVerbosePackaging(p)} (${p.quantity})`)
-    .join(", ");
 };
 
 export const getVerboseAcceptationStatus = (

--- a/front/src/dashboard/bsdds/view/utils.tsx
+++ b/front/src/dashboard/bsdds/view/utils.tsx
@@ -3,6 +3,7 @@ import {
   Packagings,
   WasteAcceptationStatusInput as WasteAcceptationStatus,
   QuantityType,
+  PackagingInfo,
 } from "generated/graphql/types";
 
 export const getVerboseConsistence = (
@@ -15,20 +16,25 @@ export const getVerboseConsistence = (
   return verbose[consistence];
 };
 export const getVerbosePackaging = (
-  packaging: Packagings | null | undefined | ""
+  packagingInfo: PackagingInfo | null | undefined | ""
 ): string => {
-  if (!packaging) {
+  if (!packagingInfo) {
     return "";
   }
 
-  return packaging[0] + packaging.slice(1).toLowerCase();
+  if (packagingInfo.type === Packagings.Autre) {
+    return packagingInfo.other ?? "";
+  }
+  return packagingInfo.type[0] + packagingInfo.type.slice(1).toLowerCase();
 };
 
 export const formatPackagings = (
-  packagings: Packagings[] | undefined
+  packagingInfos: PackagingInfo[] | null | undefined
 ): string => {
-  if (!packagings) return "";
-  return packagings.map(p => getVerbosePackaging(p)).join(" ");
+  if (!packagingInfos) return "";
+  return packagingInfos
+    .map(p => `${getVerbosePackaging(p)} (${p.quantity})`)
+    .join(", ");
 };
 
 export const getVerboseAcceptationStatus = (

--- a/front/src/form/bsdd/components/packagings/Packagings.tsx
+++ b/front/src/form/bsdd/components/packagings/Packagings.tsx
@@ -62,14 +62,14 @@ export default function Packagings({
                             className="td-select"
                             value={p.type}
                             onChange={event => {
-                              if (event.target.value !== PackagingsEnum.Autre) {
-                                setFieldValue(`${fieldName}.other`, "");
-                              }
-
-                              setFieldValue(
-                                `${fieldName}.type`,
-                                event.target.value
-                              );
+                              setFieldValue(fieldName, {
+                                type: event.target.value,
+                                other:
+                                  event.target.value === PackagingsEnum.Autre
+                                    ? p.other
+                                    : "",
+                                quantity: p.quantity,
+                              });
                             }}
                           >
                             {(Object.entries(PACKAGINGS_NAMES) as Array<

--- a/front/src/form/bsdd/components/packagings/Packagings.tsx
+++ b/front/src/form/bsdd/components/packagings/Packagings.tsx
@@ -2,7 +2,7 @@ import Tooltip from "../../../../common/components/Tooltip";
 import { IconClose } from "common/components/Icons";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
-import { Field, FieldArray, FieldProps } from "formik";
+import { Field, FieldArray, FieldProps, useFormikContext } from "formik";
 import {
   PackagingInfo,
   Packagings as PackagingsEnum,
@@ -19,11 +19,12 @@ const PACKAGINGS = [
 ];
 
 export default function Packagings({
-  field: { name, value },
-  form: { errors },
+  field: { name, value, onChange },
+  form,
   id,
   ...props
 }: FieldProps<PackagingInfo[] | null> & InputHTMLAttributes<HTMLInputElement>) {
+  const { setFieldValue } = useFormikContext();
   const isAddButtonDisabled = useMemo(() => {
     if (value == null || value.length === 0) {
       return false;
@@ -61,6 +62,9 @@ export default function Packagings({
                           name={`${name}.${idx}.type`}
                           as="select"
                           className="td-select"
+                          onClick={() =>
+                            setFieldValue(`${name}.${idx}.other`, "")
+                          }
                         >
                           {PACKAGINGS.map(packaging => (
                             <option

--- a/front/src/form/bsdd/components/packagings/Packagings.tsx
+++ b/front/src/form/bsdd/components/packagings/Packagings.tsx
@@ -7,16 +7,12 @@ import {
   PackagingInfo,
   Packagings as PackagingsEnum,
 } from "generated/graphql/types";
+import {
+  PACKAGINGS_NAMES,
+  getPackagingInfosSummary,
+} from "form/bsdd/utils/packagings";
 import React, { InputHTMLAttributes, useMemo } from "react";
 import "./Packagings.scss";
-
-const PACKAGINGS = [
-  { value: PackagingsEnum.Benne, label: "Benne" },
-  { value: PackagingsEnum.Citerne, label: "Citerne" },
-  { value: PackagingsEnum.Grv, label: "GRV" },
-  { value: PackagingsEnum.Fut, label: "Fût" },
-  { value: PackagingsEnum.Autre, label: "Autre (à préciser)" },
-];
 
 export default function Packagings({
   field: { name, value, onChange },
@@ -66,29 +62,30 @@ export default function Packagings({
                             setFieldValue(`${name}.${idx}.other`, "")
                           }
                         >
-                          {PACKAGINGS.map(packaging => (
+                          {(Object.entries(PACKAGINGS_NAMES) as Array<
+                            [keyof typeof PACKAGINGS_NAMES, string]
+                          >).map(([optionValue, optionLabel]) => (
                             <option
-                              key={packaging.value}
-                              value={packaging.value}
+                              key={optionValue}
+                              value={optionValue}
                               disabled={
                                 value?.length > 1 &&
                                 ([
                                   PackagingsEnum.Citerne,
                                   PackagingsEnum.Benne,
-                                ].includes(packaging.value) ||
+                                ].includes(optionValue) ||
                                   value.some(p =>
                                     [
                                       PackagingsEnum.Citerne,
                                       PackagingsEnum.Benne,
-                                      ...(packaging.value !==
-                                      PackagingsEnum.Autre
-                                        ? [packaging.value]
+                                      ...(optionValue !== PackagingsEnum.Autre
+                                        ? [optionValue]
                                         : []),
                                     ].includes(p.type)
                                   ))
                               }
                             >
-                              {packaging.label}
+                              {optionLabel}
                             </option>
                           ))}
                         </Field>
@@ -164,15 +161,7 @@ export default function Packagings({
         )}
       />
       {value?.length > 0 && (
-        <div className="tw-mt-4">
-          Total : {value.reduce((prev, cur) => prev + cur.quantity, 0)} colis -{" "}
-          {value
-            .map(v => {
-              const packaging = PACKAGINGS.find(p => p.value === v.type);
-              return `${v.quantity} ${packaging?.label}(s)`;
-            })
-            .join(", ")}
-        </div>
+        <div className="tw-mt-4">{getPackagingInfosSummary(value)}</div>
       )}
     </div>
   );

--- a/front/src/form/bsdd/components/packagings/Packagings.tsx
+++ b/front/src/form/bsdd/components/packagings/Packagings.tsx
@@ -15,7 +15,7 @@ import React, { InputHTMLAttributes, useMemo } from "react";
 import "./Packagings.scss";
 
 export default function Packagings({
-  field: { name, value, onChange },
+  field: { name, value },
   form,
   id,
   ...props
@@ -44,98 +44,109 @@ export default function Packagings({
         name={name}
         render={arrayHelpers => (
           <div>
-            {value.map((p, idx) => (
-              <div
-                key={`${idx}-${p.type}`}
-                className="tw-border-2 tw-border-gray-400 tw-border-solid tw-rounded-md tw-px-4 tw-py-2 tw-mb-2"
-              >
-                <div className="tw-flex tw-mb-4 tw-items-end">
-                  <div className="tw-w-11/12 tw-flex">
-                    <div className="tw-w-1/3 tw-pr-2">
-                      <label>
-                        Type
-                        <Field
-                          name={`${name}.${idx}.type`}
-                          as="select"
-                          className="td-select"
-                          onClick={() =>
-                            setFieldValue(`${name}.${idx}.other`, "")
-                          }
-                        >
-                          {(Object.entries(PACKAGINGS_NAMES) as Array<
-                            [keyof typeof PACKAGINGS_NAMES, string]
-                          >).map(([optionValue, optionLabel]) => (
-                            <option
-                              key={optionValue}
-                              value={optionValue}
-                              disabled={
-                                value?.length > 1 &&
-                                ([
-                                  PackagingsEnum.Citerne,
-                                  PackagingsEnum.Benne,
-                                ].includes(optionValue) ||
-                                  value.some(p =>
-                                    [
-                                      PackagingsEnum.Citerne,
-                                      PackagingsEnum.Benne,
-                                      ...(optionValue !== PackagingsEnum.Autre
-                                        ? [optionValue]
-                                        : []),
-                                    ].includes(p.type)
-                                  ))
-                              }
-                            >
-                              {optionLabel}
-                            </option>
-                          ))}
-                        </Field>
-                      </label>
-                    </div>
-                    <div className="tw-w-1/3 tw-px-2">
-                      {p.type === "AUTRE" && (
+            {value.map((p, idx) => {
+              const fieldName = `${name}.${idx}`;
+
+              return (
+                <div
+                  key={`${idx}-${p.type}`}
+                  className="tw-border-2 tw-border-gray-400 tw-border-solid tw-rounded-md tw-px-4 tw-py-2 tw-mb-2"
+                >
+                  <div className="tw-flex tw-mb-4 tw-items-end">
+                    <div className="tw-w-11/12 tw-flex">
+                      <div className="tw-w-1/3 tw-pr-2">
                         <label>
-                          Précisez
-                          <Field
-                            className="td-input"
-                            name={`${name}.${idx}.other`}
-                            placeholder="..."
-                          />
+                          Type
+                          <select
+                            name={fieldName}
+                            className="td-select"
+                            value={p.type}
+                            onChange={event => {
+                              if (event.target.value !== PackagingsEnum.Autre) {
+                                setFieldValue(`${fieldName}.other`, "");
+                              }
+
+                              setFieldValue(
+                                `${fieldName}.type`,
+                                event.target.value
+                              );
+                            }}
+                          >
+                            {(Object.entries(PACKAGINGS_NAMES) as Array<
+                              [keyof typeof PACKAGINGS_NAMES, string]
+                            >).map(([optionValue, optionLabel]) => (
+                              <option
+                                key={optionValue}
+                                value={optionValue}
+                                disabled={
+                                  value?.length > 1 &&
+                                  ([
+                                    PackagingsEnum.Citerne,
+                                    PackagingsEnum.Benne,
+                                  ].includes(optionValue) ||
+                                    value.some(p =>
+                                      [
+                                        PackagingsEnum.Citerne,
+                                        PackagingsEnum.Benne,
+                                        ...(optionValue !== PackagingsEnum.Autre
+                                          ? [optionValue]
+                                          : []),
+                                      ].includes(p.type)
+                                    ))
+                                }
+                              >
+                                {optionLabel}
+                              </option>
+                            ))}
+                          </select>
                         </label>
-                      )}
+                      </div>
+                      <div className="tw-w-1/3 tw-px-2">
+                        {p.type === "AUTRE" && (
+                          <label>
+                            Précisez
+                            <Field
+                              className="td-input"
+                              name={`${name}.${idx}.other`}
+                              placeholder="..."
+                            />
+                          </label>
+                        )}
+                      </div>
+                      <div className="tw-w-1/3 tw-px-2">
+                        <Field
+                          label="Colis"
+                          component={NumberInput}
+                          className="td-input"
+                          name={`${name}.${idx}.quantity`}
+                          placeholder="Nombre de colis"
+                          min="1"
+                          max={
+                            [
+                              PackagingsEnum.Citerne,
+                              PackagingsEnum.Benne,
+                            ].includes(p.type)
+                              ? 1
+                              : undefined
+                          }
+                        />
+                      </div>
                     </div>
-                    <div className="tw-w-1/3 tw-px-2">
-                      <Field
-                        label="Colis"
-                        component={NumberInput}
-                        className="td-input"
-                        name={`${name}.${idx}.quantity`}
-                        placeholder="Nombre de colis"
-                        min="1"
-                        max={
-                          [
-                            PackagingsEnum.Citerne,
-                            PackagingsEnum.Benne,
-                          ].includes(p.type)
-                            ? 1
-                            : undefined
-                        }
-                      />
+                    <div
+                      className="tw-px-2"
+                      onClick={() => arrayHelpers.remove(idx)}
+                    >
+                      <button type="button">
+                        <IconClose />
+                      </button>
                     </div>
                   </div>
-                  <div
-                    className="tw-px-2"
-                    onClick={() => arrayHelpers.remove(idx)}
-                  >
-                    <button type="button">
-                      <IconClose />
-                    </button>
-                  </div>
+                  <RedErrorMessage name={`${name}.${idx}.type`} />
+                  <RedErrorMessage name={`${name}.${idx}.other`} />
+                  <RedErrorMessage name={`${name}.${idx}.quantity`} />
                 </div>
-                <RedErrorMessage name={`${name}.${idx}.type`} />
-                <RedErrorMessage name={`${name}.${idx}.other`} />
-                <RedErrorMessage name={`${name}.${idx}.quantity`} />
-              </div>
-            ))}
+              );
+            })}
             <button
               type="button"
               className="btn btn--outline-primary"

--- a/front/src/form/bsdd/utils/packagings.ts
+++ b/front/src/form/bsdd/utils/packagings.ts
@@ -1,0 +1,32 @@
+import { PackagingInfo, Packagings } from "generated/graphql/types";
+
+export const PACKAGINGS_NAMES = {
+  [Packagings.Benne]: "Benne(s)",
+  [Packagings.Citerne]: "Citerne(s)",
+  [Packagings.Fut]: "Fût(s)",
+  [Packagings.Grv]: "GRV(s)",
+  [Packagings.Autre]: "Autre(s)",
+};
+
+export function getPackagingInfosSummary(packagingInfos: PackagingInfo[]) {
+  const total = packagingInfos.reduce(
+    (acc, packagingInfo) => acc + packagingInfo.quantity,
+    0
+  );
+  const packages = packagingInfos
+    .map(packagingInfo => {
+      const name =
+        packagingInfo.type === Packagings.Autre
+          ? [
+              PACKAGINGS_NAMES[Packagings.Autre],
+              packagingInfo.other ? `(${packagingInfo.other})` : null,
+            ]
+              .filter(Boolean)
+              .join(" ")
+          : PACKAGINGS_NAMES[packagingInfo.type];
+      return `${packagingInfo.quantity} ${name}`;
+    })
+    .join(", ");
+
+  return `${total} colis : ${packages}`;
+}

--- a/front/src/layout/Header.module.scss
+++ b/front/src/layout/Header.module.scss
@@ -64,8 +64,10 @@
   margin-left: auto;
 
   z-index: 20;
+  overflow-y: auto;
 
   top: 0;
+  bottom: 0;
 
   width: 85vw;
   min-height: 100vh;


### PR DESCRIPTION
Bug fix. Essentiellement autour des packagings, et petit fix CSS pour le scroll de la navbar sur mobile.

Pour les conditionnements:
- problème lors de la saisie quand on avait un "Autre" avec une description. La description n'était pas supprimée au changement de type et on avait donc une erreur en front
- sur la modale d'affichage on a désormais le détail du "Autre" avec le nombre de contenants correspondants
![image](https://user-images.githubusercontent.com/5145523/112821662-40f95980-9087-11eb-83e2-877b7e4a2e99.png)
- affichage du bon conditionnement dans le cas d'un regroupement dans la modale
- sur la navbar mobile, on ne pouvait pas accéder à son compte: impossible de scroller quand les éléments étaient plus bas que la vue


- [x] Mettre à jour le change log
---

- [Ticket Trello](https://trello.com/c/NecVIUF7/1286-lors-que-je-veux-modifier-un-bsd-brouillon-je-ne-peux-pas-changer-le-conditionnement-si-avant-le-conditionnement-%C3%A9tait-autre)
- [Ticket](https://trello.com/c/fzYCMUqy/1260-bugs-daffichage-sur-la-modale-consistance-et-autre-conditionnement)
- [Ticket](https://trello.com/c/KvbZecOI/1225-etq-user-je-vois-lancien-conditionnement-sur-le-haut-de-la-modale-apr%C3%A8s-le-reconditionnement-alors-quil-saffiche-bien-sur-le-pdf)
- [Ticket](https://trello.com/c/VS36CdFT/1334-pb-affichage-portable-etq-utilisateur-connect%C3%A9-sur-iphone-je-narrive-pas-%C3%A0-cliquer-sur-mon-compte)
