### PR TITLE
packagings bug fixes

### DIFF
--- a/back/src/forms/pdf/helpers.ts
+++ b/back/src/forms/pdf/helpers.ts
@@ -244,7 +244,8 @@ const getWasteDetailsPackagings = params => {
     const key = `wasteDetailsPackagings${capitalize(elem.type)}`;
     return {
       ...acc,
-      [key]: true
+      [key]: true,
+      ...(elem.other ? { wasteDetailsPackagingsAutreDetails: elem.other } : {})
     };
   }, {});
 };

--- a/back/src/forms/pdf/settings.ts
+++ b/back/src/forms/pdf/settings.ts
@@ -52,7 +52,8 @@ export const mainFormFieldSettings = {
   wasteDetailsPackagingsCiterne: { x: 179, y: 358, fontSize: 12 },
   wasteDetailsPackagingsGrv: { x: 230, y: 358, fontSize: 12 },
   wasteDetailsPackagingsFut: { x: 272, y: 358, fontSize: 12 },
-  wasteDetailsPackagingsOther: { x: 324, y: 358, fontSize: 12 },
+  wasteDetailsPackagingsAutre: { x: 324, y: 358, fontSize: 12 },
+  wasteDetailsPackagingsAutreDetails: { x: 387, y: 355, maxLength: 15 },
   wasteDetailsNumberOfPackages: { x: 505, y: 355 },
 
   wasteDetailsQuantityReal: { x: 112, y: 380, fontSize: 12 },

--- a/front/src/dashboard/bsdds/view/BSDDetailContent.tsx
+++ b/front/src/dashboard/bsdds/view/BSDDetailContent.tsx
@@ -102,7 +102,8 @@ const TempStorage = ({ form }) => {
 
           <PackagingRow
             packagingInfos={
-              temporaryStorageDetail?.wasteDetails?.packagingInfos
+              temporaryStorageDetail?.wasteDetails?.packagingInfos ||
+              form.wasteDetails?.packagingInfos
             }
           />
           <DetailRow
@@ -372,9 +373,8 @@ export default function BSDDetailContent({
               <dd>{form.stateSummary?.quantity ?? "?"} tonnes</dd>
               <PackagingRow
                 packagingInfos={
-                  hasTempStorage
-                    ? form.temporaryStorageDetail?.wasteDetails?.packagingInfos
-                    : form.wasteDetails?.packagingInfos
+                  form.temporaryStorageDetail?.wasteDetails?.packagingInfos ||
+                  form.wasteDetails?.packagingInfos
                 }
               />
               <dt>Consistance</dt>{" "}

--- a/front/src/dashboard/bsdds/view/utils.tsx
+++ b/front/src/dashboard/bsdds/view/utils.tsx
@@ -10,7 +10,12 @@ export const getVerboseConsistence = (
   if (!consistence) {
     return "";
   }
-  const verbose = { SOLID: "Solide", LIQUID: "Liquide", GASEOUS: "Gazeux" };
+  const verbose = {
+    SOLID: "Solide",
+    LIQUID: "Liquide",
+    GASEOUS: "Gazeux",
+    DOUGHY: "Pâteux",
+  };
   return verbose[consistence];
 };
 


### PR DESCRIPTION
- [x] Le conditionnement initial d'un bordereau avec entreposage provisoire ne s'affiche pas sur la modale
- [x] La consistance "Pâteux" ne s'affiche pas sur la modale
- [x] La case Autre n'est pas cochée sur le pdf
- [x] Le détails du conditionnement Autre n'apparait pas sur le pdf

