### PR TITLE
Make CAP mandatory for dangerous waste

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
+- Le numéro de CAP devient obligatoire pour les déchets dangereux [PR 840](https://github.com/MTES-MCT/trackdechets/pull/840)
+
 #### :bug: Corrections de bugs
 
 #### :nail_care: Améliorations

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -174,7 +174,7 @@ const formdata = {
   emitterWorkSiteCity: "",
   emitterWorkSitePostalCode: "",
   emitterWorkSiteInfos: "",
-  recipientCap: "",
+  recipientCap: "I am a CAP",
   emitterCompanyPhone: "06 18 76 02 96",
   isAccepted: null,
   emitterCompanyMail: "emitter@compnay.fr",

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -40,6 +40,7 @@ describe("mutation / importPaperForm", () => {
         },
         recipient: {
           processingOperation: "R 1",
+          cap: "It's a cap",
           company: {
             siret: "98017829178192",
             name: "Destination",
@@ -290,6 +291,7 @@ describe("mutation / importPaperForm", () => {
       recipientCompanyPhone: "0000000000",
       recipientCompanyContact: "Mr Destination",
       recipientCompanyMail: "recipient@trackdechets.fr",
+      recipientCap: "it's a CAP",
       transporterIsExemptedOfReceipt: true,
       transporterCompanySiret: "09167289178291",
       transporterCompanyName: "Transporteur",

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -408,11 +408,14 @@ describe("Mutation.markAsSealed", () => {
 
     const { mutate } = makeClient(user);
 
-    const { errors } = await mutate(MARK_AS_SEALED, {
-      variables: {
-        id: form.id
+    const { errors } = await mutate<Pick<Mutation, "markAsSealed">>(
+      MARK_AS_SEALED,
+      {
+        variables: {
+          id: form.id
+        }
       }
-    });
+    );
     expect(errors).toEqual([
       expect.objectContaining({
         message: [
@@ -440,11 +443,14 @@ describe("Mutation.markAsSealed", () => {
     });
 
     const { mutate } = makeClient(user);
-    const { data } = await mutate(MARK_AS_SEALED, {
-      variables: {
-        id: form.id
+    const { data } = await mutate<Pick<Mutation, "markAsSealed">>(
+      MARK_AS_SEALED,
+      {
+        variables: {
+          id: form.id
+        }
       }
-    });
+    );
 
     expect(data.markAsSealed.status).toBe("SEALED");
   });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -35,8 +35,6 @@ const MARK_AS_SEALED = `
 `;
 
 describe("Mutation.markAsSealed", () => {
-  afterAll(() => resetDatabase());
-
   const OLD_ENV = process.env;
 
   beforeEach(() => {
@@ -47,6 +45,7 @@ describe("Mutation.markAsSealed", () => {
   afterEach(() => {
     jest.resetAllMocks();
     process.env = OLD_ENV;
+    return resetDatabase();
   });
 
   it("should fail if SEALED is not a possible next state", async () => {

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -295,7 +295,7 @@ const recipientSchemaFn: FactorySchemaOf<boolean, Recipient> = isDraft =>
 
           if (
             !isDraft &&
-            rootValue?.wasteDetailsCode?.includes("*") &&
+            isDangerous(rootValue?.wasteDetailsCode ?? "") &&
             !value
           ) {
             return false;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -284,18 +284,25 @@ export const ecoOrganismeSchema = yup.object().shape({
 // 2 - Installation de destination ou d’entreposage ou de reconditionnement prévue
 const recipientSchemaFn: FactorySchemaOf<boolean, Recipient> = isDraft =>
   yup.object({
-    recipientCap: yup.string().nullable().test(
-      "required-when-dangerous",
-      "Le champ CAP est obligatoire pour les déchets dangereux",
-      (value, testContext) => {
-        const rootValue = testContext.parent;
+    recipientCap: yup
+      .string()
+      .nullable()
+      .test(
+        "required-when-dangerous",
+        "Le champ CAP est obligatoire pour les déchets dangereux",
+        (value, testContext) => {
+          const rootValue = testContext.parent;
 
-        if (!isDraft && rootValue?.wasteDetailsCode?.includes("*") && !value) {
-          return false;
+          if (
+            !isDraft &&
+            rootValue?.wasteDetailsCode?.includes("*") &&
+            !value
+          ) {
+            return false;
+          }
+          return true;
         }
-        return true;
-      }
-    ),
+      ),
     recipientIsTempStorage: yup.boolean().nullable(),
     recipientProcessingOperation: yup
       .string()

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -284,7 +284,18 @@ export const ecoOrganismeSchema = yup.object().shape({
 // 2 - Installation de destination ou d’entreposage ou de reconditionnement prévue
 const recipientSchemaFn: FactorySchemaOf<boolean, Recipient> = isDraft =>
   yup.object({
-    recipientCap: yup.string().nullable(),
+    recipientCap: yup.string().nullable().test(
+      "required-when-dangerous",
+      "Le champ CAP est obligatoire pour les déchets dangereux",
+      (value, testContext) => {
+        const rootValue = testContext.parent;
+
+        if (!isDraft && rootValue?.wasteDetailsCode?.includes("*") && !value) {
+          return false;
+        }
+        return true;
+      }
+    ),
     recipientIsTempStorage: yup.boolean().nullable(),
     recipientProcessingOperation: yup
       .string()

--- a/back/src/forms/workflow/__tests__/workflow.integration.ts
+++ b/back/src/forms/workflow/__tests__/workflow.integration.ts
@@ -161,6 +161,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
           }
           recipient: {
             processingOperation: "D 10"
+            cap: "it's a cap"
             company: {
               siret: "${traiteur.siret}"
               name: "${traiteur.name}"
@@ -472,6 +473,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
             }
             recipient: {
               processingOperation: "D 10"
+              cap: "it's a cap"
               company: {
                 siret: "${traiteur.siret}"
                 name: "${traiteur.name}"
@@ -735,6 +737,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
           }
           recipient: {
             processingOperation: "D 13"
+            cap: "it's a cap"
             company: {
               siret: "${entreposage.siret}"
               name: "${entreposage.name}"
@@ -1266,6 +1269,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
           }
           recipient: {
             processingOperation: "D 10"
+            cap: "it's a cap"
             company: {
               siret: "${traiteur.siret}"
               name: "${traiteur.name}"

--- a/back/src/vhu/__tests__/workflow.integration.ts
+++ b/back/src/vhu/__tests__/workflow.integration.ts
@@ -8,7 +8,7 @@ import { userWithCompanyFactory } from "../../__tests__/factories";
 const request = supertest(app);
 
 describe("Exemples de circuit du bordereau de suivi de véhicule hors d'usage", () => {
-  afterEach(() => resetDatabase());
+  afterEach(resetDatabase);
 
   async function apiKey(user: User) {
     const { clearToken } = await createAccessToken(user);

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -2509,6 +2509,11 @@
       "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
+    },
     "@types/mapbox-gl": {
       "version": "0.54.5",
       "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-0.54.5.tgz",
@@ -2703,12 +2708,6 @@
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
-    },
-    "@types/yup": {
-      "version": "0.26.37",
-      "resolved": "https://registry.npmjs.org/@types/yup/-/yup-0.26.37.tgz",
-      "integrity": "sha512-cDqR/ez4+iAVQYOwadXjKX4Dq1frtnDGV2GNVKj3aUVKVCKRvsr8esFk66j+LgeeJGmrMcBkkfCf3zk13MjV7A==",
-      "dev": true
     },
     "@types/zen-observable": {
       "version": "0.8.0",
@@ -7435,11 +7434,6 @@
         "readable-stream": "^2.3.6"
       }
     },
-    "fn-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
-      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
-    },
     "focus-lock": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
@@ -10656,6 +10650,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -12869,9 +12868,9 @@
       }
     },
     "property-expr": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
-      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.4.tgz",
+      "integrity": "sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg=="
     },
     "protocol-buffers-schema": {
       "version": "3.4.0",
@@ -15643,11 +15642,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
-    "synchronous-promise": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
-      "integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A=="
-    },
     "tabbable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
@@ -16279,9 +16273,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ua-parser-js": {
@@ -17515,30 +17509,36 @@
       }
     },
     "yup": {
-      "version": "0.26.10",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.26.10.tgz",
-      "integrity": "sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==",
+      "version": "0.32.9",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.9.tgz",
+      "integrity": "sha512-Ci1qN+i2H0XpY7syDQ0k5zKQ/DoxO0LzPg8PAR/X4Mpj6DqaeCoIYEEjDJwhArh3Fa7GWbQQVDZKeXYlSH4JMg==",
       "requires": {
-        "@babel/runtime": "7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
+        "@babel/runtime": "^7.10.5",
+        "@types/lodash": "^4.14.165",
+        "lodash": "^4.17.20",
+        "lodash-es": "^4.17.15",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0.tgz",
-          "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
+          "version": "7.13.17",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+          "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "^0.13.4"
           }
         },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         }
       }
     },

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,7 @@
     "use-media": "^1.4.0",
     "uuid": "^8.3.1",
     "world-countries": "^4.0.0",
-    "yup": "^0.26.10",
+    "yup": "^0.32.9",
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
@@ -102,7 +102,6 @@
     "@types/react-select": "^3.0.16",
     "@types/react-tabs": "^2.3.2",
     "@types/uuid": "^8.3.0",
-    "@types/yup": "^0.26.37",
     "@types/zxcvbn": "^4.4.0",
     "@typescript-eslint/parser": "^3.0.2",
     "browserslist-useragent-regexp": "^2.0.5",
@@ -113,6 +112,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.21.2",
     "prettier": "^2.0.5",
-    "typescript": "^3.7.5"
+    "typescript": "^4.2.4"
   }
 }

--- a/front/src/account/fields/forms/AccountFormCompanyInviteNewUser.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyInviteNewUser.tsx
@@ -62,7 +62,7 @@ export default function AccountFormCompanyInviteNewUser({ company }: Props) {
       }}
       onSubmit={(values, { setSubmitting, setFieldError, resetForm }) => {
         inviteUserToCompany({
-          variables: { siret: company.siret, ...values },
+          variables: values,
         })
           .then(() => {
             setSubmitting(false);

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/AcceptedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/AcceptedInfo.tsx
@@ -25,7 +25,7 @@ export type AcceptedInfoValues = {
   quantityType?: QuantityType;
 };
 
-const validationSchema: yup.ObjectSchema<AcceptedInfoValues> = yup.object({
+const validationSchema: yup.SchemaOf<AcceptedInfoValues> = yup.object({
   signedBy: yup.string().required("Le nom du responsable est un champ requis"),
   signedAt: yup.string().required("La date de signature est un champ requis"),
   quantityReceived: yup
@@ -33,9 +33,11 @@ const validationSchema: yup.ObjectSchema<AcceptedInfoValues> = yup.object({
     .nullable()
     .required("Le poids accepté est un champ requis"),
   wasteAcceptationStatus: yup
-    .string<WasteAcceptationStatus>()
+    .mixed<WasteAcceptationStatus>()
+    .oneOf(Object.values(WasteAcceptationStatus))
     .required("Le statut d'acceptation du lot est un champ requis"),
-  wasteRefusalReason: yup.string(),
+  wasteRefusalReason: yup.string().ensure(),
+  quantityType: yup.mixed<QuantityType>(),
 });
 
 /**

--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import TdSwitch from "common/components/Switch";
+import Tooltip from "common/components/Tooltip";
 import ProcessingOperation from "form/common/components/processing-operation/ProcessingOperation";
 import { Field, useFormikContext } from "formik";
 import { Form } from "generated/graphql/types";
@@ -106,7 +107,11 @@ export default function Recipient() {
       </div>
       <div className="form__row">
         <label>
-          Numéro de CAP (optionnel)
+          Numéro de CAP
+          <Tooltip
+            msg={`Le champ CAP est obligatoire pour les déchets dangereux.
+Il est important car il qualifie les conditions de gestion et de traitement du déchets entre le producteur et l'entreprise de destination.`}
+          />
           <Field
             type="text"
             name="recipient.cap"

--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -23,6 +23,7 @@ export default function Recipient() {
   const hasTrader = !!values.trader;
   const hasBroker = !!values.broker;
   const isTempStorage = !!values.recipient?.isTempStorage;
+  const isDangerousWaste = values.wasteDetails?.code?.includes("*");
 
   function handleNoneToggle() {
     setFieldValue("broker", null, false);
@@ -108,10 +109,14 @@ export default function Recipient() {
       <div className="form__row">
         <label>
           Numéro de CAP
-          <Tooltip
-            msg={`Le champ CAP est obligatoire pour les déchets dangereux.
+          {isDangerousWaste ? (
+            <Tooltip
+              msg={`Le champ CAP est obligatoire pour les déchets dangereux.
 Il est important car il qualifie les conditions de gestion et de traitement du déchets entre le producteur et l'entreprise de destination.`}
-          />
+            />
+          ) : (
+            " (Optionnel pour les déchets non dangereux)"
+          )}
           <Field
             type="text"
             name="recipient.cap"

--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -4,6 +4,7 @@ import TdSwitch from "common/components/Switch";
 import Tooltip from "common/components/Tooltip";
 import ProcessingOperation from "form/common/components/processing-operation/ProcessingOperation";
 import { Field, useFormikContext } from "formik";
+import { isDangerous } from "generated/constants";
 import { Form } from "generated/graphql/types";
 import React from "react";
 import CompanySelector from "../common/components/company/CompanySelector";
@@ -23,7 +24,7 @@ export default function Recipient() {
   const hasTrader = !!values.trader;
   const hasBroker = !!values.broker;
   const isTempStorage = !!values.recipient?.isTempStorage;
-  const isDangerousWaste = values.wasteDetails?.code?.includes("*");
+  const isDangerousWaste = isDangerous(values.wasteDetails?.code ?? "");
 
   function handleNoneToggle() {
     setFieldValue("broker", null, false);

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -217,7 +217,7 @@ export const formSchema = object().shape({
       .test(
         "is-valid-packaging-infos",
         "Le conditionnement ne peut pas à la fois contenir 1 citerne ou 1 benne et un autre conditionnement.",
-        (infos) => {
+        infos => {
           const hasCiterne = infos?.find(i => i.type === "CITERNE") != null;
           const hasBenne = infos?.find(i => i.type === "BENNE") != null;
 

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -6,10 +6,9 @@ import {
   array,
   boolean,
   setLocale,
-  LocaleObject,
   StringSchema,
   mixed,
-  ObjectSchema,
+  SchemaOf,
 } from "yup";
 import countries from "world-countries";
 
@@ -28,7 +27,7 @@ setLocale({
   mixed: {
     notType: "Ce champ ne peut pas être nul",
   },
-} as LocaleObject);
+});
 
 const companySchema = object().shape({
   name: string().required(),
@@ -88,22 +87,27 @@ const destinationSchema = companySchema.concat(
   })
 );
 
-const packagingInfo: ObjectSchema<PackagingInfo> = object().shape({
+const packagingInfo: SchemaOf<Omit<
+  PackagingInfo,
+  "__typename"
+>> = object().shape({
   type: mixed<Packagings>().required(
     "Le type de conditionnement doit être précisé."
   ),
-  other: string().when("type", (type, schema) =>
-    type === "AUTRE"
-      ? schema.required(
-          "La description doit être précisée pour le conditionnement 'AUTRE'."
-        )
-      : schema
-          .nullable()
-          .max(
-            0,
-            "Le description du conditionnement ne peut être renseignée que lorsque le type de conditionnement est 'AUTRE'."
+  other: string()
+    .ensure()
+    .when("type", (type, schema) =>
+      type === "AUTRE"
+        ? schema.required(
+            "La description doit être précisée pour le conditionnement 'AUTRE'."
           )
-  ),
+        : schema
+            .nullable()
+            .max(
+              0,
+              "Le description du conditionnement ne peut être renseignée que lorsque le type de conditionnement est 'AUTRE'."
+            )
+    ),
   quantity: number()
     .required(
       "Le nombre de colis associé au conditionnement doit être précisé."
@@ -143,9 +147,23 @@ export const formSchema = object().shape({
       .test(
         "selected",
         "Vous devez sélectionner une valeur",
-        (v: string) => v !== ""
+        (v: string | undefined) => v !== ""
       ),
-    cap: string().nullable(true),
+    cap: string()
+      .nullable(true)
+      .test(
+        "required-when-dangerous",
+        "Le champ CAP est obligatoire pour les déchets dangereux",
+        (value, testContext) => {
+          const from = (testContext as any).from; // Typings are still missing from the lib. Original PR here https://github.com/jquense/yup/pull/556
+          const { value: rootValue } = from[1]; // from is an array of parents. Each index goes one step further. Root is 2 steps away so its from[1]
+
+          if (rootValue?.wasteDetails?.code?.includes("*") && !value) {
+            return false;
+          }
+          return true;
+        }
+      ),
     company: destinationSchema,
   }),
   transporter: object().shape({
@@ -194,11 +212,12 @@ export const formSchema = object().shape({
     }),
     packagingInfos: array()
       .required()
+      .min(1)
       .of(packagingInfo)
       .test(
         "is-valid-packaging-infos",
         "Le conditionnement ne peut pas à la fois contenir 1 citerne ou 1 benne et un autre conditionnement.",
-        (infos: PackagingInfo[]) => {
+        (infos) => {
           const hasCiterne = infos?.find(i => i.type === "CITERNE") != null;
           const hasBenne = infos?.find(i => i.type === "BENNE") != null;
 
@@ -207,7 +226,7 @@ export const formSchema = object().shape({
           }
 
           const hasOtherPackaging = infos?.find(
-            i => !["CITERNE", "BENNE"].includes(i.type)
+            i => i.type && !["CITERNE", "BENNE"].includes(i.type)
           );
           if ((hasCiterne || hasBenne) && hasOtherPackaging) {
             return false;


### PR DESCRIPTION
Le numéro de CAP devient obligatoire pour les BSDD avec un code déchet dangereux.
⚠ C'est un breaking change. Il faudra au minimum l'annoncer un peu à l'avance.

J'ai du mettre à jour Yup pour utiliser une feature récente qui permet d'accéder aux parent d'un objet sur n niveaux. Et cette maj de Yup m'a également obligé à upgrade Typescript (pour les type only import), ce qui a nécessité qques changements mineurs dans le code pour que ca compile.

- [x] Mettre à jour le change log
---

- [Ticket Trello](https://trello.com/c/giKrryjU/1372-rendre-le-cap-obligatoire-pour-les-dd)
