### PR TITLE
Lint warnings & schema

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -19,6 +19,7 @@ DEVELOPERS_URL_SCHEME=http
 EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr
 
 # Postgres configuration
+# When developing with Docker, it should be "postgresql://trackdechets:pwd@postgres:5432/prisma"
 DATABASE_URL=postgresql://USER:PWD@HOST:PORT/prisma?schema=default$default
 
 # Redis configuration - let it blank to use 'redis' docker service

--- a/.env.model
+++ b/.env.model
@@ -20,7 +20,7 @@ EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr
 
 # Postgres configuration
 # When developing with Docker, it should be "postgresql://trackdechets:pwd@postgres:5432/prisma"
-DATABASE_URL=postgresql://USER:PWD@HOST:PORT/prisma?schema=default$default
+DATABASE_URL=postgresql://USER:PWD@HOST:PORT/DB_NAME
 
 # Redis configuration - let it blank to use 'redis' docker service
 REDIS_URL=redis://user:password@some-redis-service.com:1234/

--- a/.env.model
+++ b/.env.model
@@ -19,7 +19,7 @@ DEVELOPERS_URL_SCHEME=http
 EMAIL_LETS_ENCRYPT=orion.charlier@beta.gouv.fr
 
 # Postgres configuration
-# When developing with Docker, it should be "postgresql://trackdechets:pwd@postgres:5432/prisma"
+# When developing with Docker it's automatically set
 DATABASE_URL=postgresql://USER:PWD@HOST:PORT/DB_NAME
 
 # Redis configuration - let it blank to use 'redis' docker service

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -4510,9 +4510,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/json-stable-stringify": {
@@ -4813,58 +4813,86 @@
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
-      "integrity": "sha512-D52KwdgkjYc+fmTZKW7CZpH5ZBJREJKZXRrveMiRCmlzZ+Rw9wRVJ1JAmHQ9b/+Ehy1ZeaylofDB9wwXUt83wg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz",
+      "integrity": "sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.1.0",
+        "@typescript-eslint/experimental-utils": "3.10.1",
+        "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.1.0.tgz",
-      "integrity": "sha512-Zf8JVC2K1svqPIk1CB/ehCiWPaERJBBokbMfNTNRczCbQSlQXaXtO/7OfYz9wZaecNvdSvVADt6/XQuIxhC79w==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+      "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "3.1.0",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.1.0.tgz",
-      "integrity": "sha512-NcDSJK8qTA2tPfyGiPes9HtVKLbksmuYjlgGAUs7Ld2K0swdWibnCq9IJx9kJN8JJdgUJSorFiGaPHBgH81F/Q==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.10.1.tgz",
+      "integrity": "sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.1.0",
-        "@typescript-eslint/typescript-estree": "3.1.0",
+        "@typescript-eslint/experimental-utils": "3.10.1",
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/typescript-estree": "3.10.1",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
+    "@typescript-eslint/types": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "dev": true
+    },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.1.0.tgz",
-      "integrity": "sha512-+4nfYauqeQvK55PgFrmBWFVYb6IskLyOosYEmhH3mSVhfBp9AIJnjExdgDmKWoOBHRcPM8Ihfm2BFpZf0euUZQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/types": "3.10.1",
+        "@typescript-eslint/visitor-keys": "3.10.1",
         "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
@@ -4872,12 +4900,39 @@
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@wry/context": {
@@ -8715,13 +8770,32 @@
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "eslint-utils": {
@@ -18497,9 +18571,9 @@
       "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
     },
     "tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/back/src/common/redis.ts
+++ b/back/src/common/redis.ts
@@ -1,10 +1,10 @@
-import Redis from "ioredis";
+import IORedis from "ioredis";
 
 const { REDIS_URL } = process.env;
 
 export const redisClient = REDIS_URL
-  ? new Redis(REDIS_URL)
-  : new Redis({ host: "redis" });
+  ? new IORedis(REDIS_URL)
+  : new IORedis({ host: "redis" });
 
 /**
  * Generate a cache key

--- a/back/src/prisma.ts
+++ b/back/src/prisma.ts
@@ -2,12 +2,21 @@ import { URL } from "url";
 import { unescape } from "querystring";
 import { PrismaClient } from "@prisma/client";
 
-const dbUrl = new URL(process.env.DATABASE_URL);
-dbUrl.searchParams.set("schema", "default$default");
-
 const prisma = new PrismaClient({
   datasources: {
-    db: { url: unescape(dbUrl.href) }
+    db: { url: getDbUrl() }
   }
 });
+
+function getDbUrl() {
+  try {
+    const dbUrl = new URL(process.env.DATABASE_URL);
+    dbUrl.searchParams.set("schema", "default$default");
+
+    return unescape(dbUrl.href); // unescape needed because of the `$`
+  } catch (err) {
+    return "";
+  }
+}
+
 export default prisma;

--- a/back/src/prisma.ts
+++ b/back/src/prisma.ts
@@ -1,4 +1,11 @@
 import { PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient();
+const dbUrl = new URL(process.env.DATABASE_URL);
+dbUrl.searchParams.set("schema", "default$default");
+
+const prisma = new PrismaClient({
+  datasources: {
+    db: { url: dbUrl.href }
+  }
+});
 export default prisma;

--- a/back/src/prisma.ts
+++ b/back/src/prisma.ts
@@ -1,3 +1,5 @@
+import { URL } from "url";
+import { unescape } from "querystring";
 import { PrismaClient } from "@prisma/client";
 
 const dbUrl = new URL(process.env.DATABASE_URL);
@@ -5,7 +7,7 @@ dbUrl.searchParams.set("schema", "default$default");
 
 const prisma = new PrismaClient({
   datasources: {
-    db: { url: dbUrl.href }
+    db: { url: unescape(dbUrl.href) }
   }
 });
 export default prisma;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,6 +35,7 @@ services:
     environment:
       NODE_ENV: dev
       SIB_BASE_URL: "http://mailservice"
+      DATABASE_URL: "postgresql://trackdechets:pwd@postgres:5432/prisma"
     ports:
       - "4000:$API_PORT"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,6 @@ services:
     environment:
       POSTGRES_USER: trackdechets
       POSTGRES_PASSWORD: pwd
-      POSTGRES_DB: prisma
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,8 +4,9 @@ services:
     image: postgres:10.5
     restart: always
     environment:
-      POSTGRES_USER: $POSTGRES_USER
-      POSTGRES_PASSWORD: $POSTGRES_PASSWORD
+      POSTGRES_USER: trackdechets
+      POSTGRES_PASSWORD: pwd
+      POSTGRES_DB: prisma
     ports:
       - "5432:5432"
     volumes:

--- a/front/src/admin/verification/CompaniesVerificationTable.tsx
+++ b/front/src/admin/verification/CompaniesVerificationTable.tsx
@@ -3,7 +3,7 @@ import {
   CompanyVerificationStatus,
   CompanyVerificationMode,
 } from "generated/graphql/types";
-import React from "react";
+import React, { useMemo, useEffect } from "react";
 import { useTable, usePagination, useFilters } from "react-table";
 import { format } from "date-fns";
 import "./CompaniesVerificationTable.scss";
@@ -24,7 +24,7 @@ export default function CompaniesVerificationTable({
   totalCount,
   pageSize,
 }: Props) {
-  const columns = React.useMemo(
+  const columns = useMemo(
     () => [
       {
         Header: "Date de création",
@@ -108,7 +108,7 @@ export default function CompaniesVerificationTable({
     []
   );
 
-  const defaultColumn = React.useMemo(
+  const defaultColumn = useMemo(
     () => ({
       // Let's set up our default Filter UI
       Filter: DefaultColumnFilter,
@@ -149,7 +149,7 @@ export default function CompaniesVerificationTable({
   } = tableInstance;
 
   // Listen for changes in pagination and filters and use the state to fetch our new data
-  React.useEffect(() => {
+  useEffect(() => {
     fetchData({ pageIndex, pageSize, filters });
   }, [fetchData, pageIndex, pageSize, filters]);
 

--- a/front/src/common/datetime.ts
+++ b/front/src/common/datetime.ts
@@ -1,4 +1,6 @@
+// eslint-disable-next-line import/no-duplicates
 import { parseISO, format, toDate } from "date-fns";
+// eslint-disable-next-line import/no-duplicates
 import fr from "date-fns/locale/fr";
 
 export function parseDate(date: Date | number | string): Date {


### PR DESCRIPTION
Quelques corrections mineures:

- Corrections des warnings eslint (back & front. Ca apparait en dessous du code modifié dans toutes les PR sur github, c'est un peu pénible)
- les variables Docker `$POSTGRES_USER` et `$POSTGRES_PASSWORD` n'existent plus dans le `.env.model`. On met en dur les valeurs dans le compose de dev (c'était déjà le cas du nom de la base en qques sorte). On avait un warning en lancant Docker
- Comme mentionné par Gabin sur Slack, on a des soucis avec le nom du schéma quand on fait des modifs de la DB Scalingo. On utlise donc un schéma définit dans le code et non dans la connection string (d'ailleurs on pourrait peut être renommer ce `default$default` en qque chose de plus compréhensible...)
