### PR TITLE
Corrige les urls de confirmation d'inscription et d'invitation

### DIFF
--- a/back/src/mailer/templates/mustache/confirmation-de-compte.html
+++ b/back/src/mailer/templates/mustache/confirmation-de-compte.html
@@ -4,7 +4,7 @@
 <br />
 <p>
   Pour finaliser votre inscription, veuillez confirmer votre email
-  <a href="{{UI_URL}}/userActivation?hash={{activationHash}}">en cliquant ici.
+  <a href="{{{API_URL}}}/userActivation?hash={{activationHash}}">en cliquant ici.
   </a>
 </p>
 <br />

--- a/back/src/mailer/templates/mustache/invitation-par-administrateur.html
+++ b/back/src/mailer/templates/mustache/invitation-par-administrateur.html
@@ -3,6 +3,6 @@
 </p>
 <br />
 <p>Pour finaliser la création de votre compte et commencer à utiliser la plateforme, cliquez <a
-    href="{{{UI_URL}}}/invite?hash={{hash}}">sur ce lien</a> et renseignez les informations demandées.</p>
+    href="{{{API_URL}}}/invite?hash={{hash}}">sur ce lien</a> et renseignez les informations demandées.</p>
 <br />
 <p>Vous aurez accès à l'ensemble des informations concernant l'entreprise <strong>{{companyName}}</strong>.</p>

--- a/back/src/mailer/templates/renderers.ts
+++ b/back/src/mailer/templates/renderers.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import mustache from "mustache";
-import { getUIBaseURL } from "../../utils";
+import { getUIBaseURL, getAPIBaseURL } from "../../utils";
 import { Attachment, Mail, MailTemplate, Recipient } from "../types";
 
 const TEMPLATE_DIR = `${__dirname}/mustache`;
@@ -35,7 +35,7 @@ type MailRendererInput<V> = {
 };
 
 // These variables will be made available to all templates
-const context = { UI_URL: getUIBaseURL() };
+const context = { UI_URL: getUIBaseURL(), API_URL: getAPIBaseURL() };
 
 /**
  * Render a mail definition into a fully featured mail that can


### PR DESCRIPTION
Les urls /userActivation?hash={{activationHash}} et /invite?hash={{hash}} renvoyaient sur le front