### PR TITLE
Ajout de la mutation de duplication de dasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,23 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-# Next release
+# Next release (June)
+
+#### :rocket: Nouvelles fonctionnalités
+
+- Ajout de la mutation de duplication bordereaux dasri [PR 848](https://github.com/MTES-MCT/trackdechets/pull/848)
+
+#### :boom: Breaking changes
+
+#### :bug: Corrections de bugs
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+
+# [2021.05.1] 04/05/2021
 
 #### :rocket: Nouvelles fonctionnalités
 

--- a/back/src/dasris/graphql/dasri.mutations.graphql
+++ b/back/src/dasris/graphql/dasri.mutations.graphql
@@ -214,4 +214,9 @@ type Mutation {
     id: ID!
     signatureInput: BsdasriSignatureWithSecretCodeInput!
   ): Bsdasri
+    """
+  EXPERIMENTAL - Ne pas utiliser dans un contexte de production
+  Duplique un bordereau Dasri
+  """
+  duplicateBsdasri("ID d'un Bsdasri" id: ID!): Bsdasri
 }

--- a/back/src/dasris/resolvers/Mutation.ts
+++ b/back/src/dasris/resolvers/Mutation.ts
@@ -4,6 +4,7 @@ import updateBsdasri from "./mutations/updateBsdasri";
 import publishBsdasri from "./mutations/publishBsdasri";
 import signBsdasri from "./mutations/signBsdasri";
 import signBsdasriEmissionWithSecretCode from "./mutations/signBsdasriEmissionWithSecretCode";
+import duplicateBsdasri from "./mutations/duplicateBsdasri";
 import { MutationResolvers } from "../../generated/graphql/types";
 
 const Mutation: MutationResolvers = {
@@ -12,7 +13,8 @@ const Mutation: MutationResolvers = {
   updateBsdasri,
   publishBsdasri,
   signBsdasri,
-  signBsdasriEmissionWithSecretCode
+  signBsdasriEmissionWithSecretCode,
+  duplicateBsdasri
 };
 
 export default Mutation;

--- a/back/src/dasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/dasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -1,0 +1,105 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { ErrorCode } from "../../../../common/errors";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { bsdasriFactory, initialData } from "../../../__tests__/factories";
+import { Mutation } from "../../../../generated/graphql/types";
+const DUPLICATE_DASRI = `
+mutation DuplicateDasri($id: ID!){
+  duplicateBsdasri(id: $id)  {
+    id
+    status
+    isDraft
+  }
+}
+`;
+describe("Mutation.duplicateBsdasri", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const dasri = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+    const { mutate } = makeClient(); // unauthenticated user
+    const { errors } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: dasri.id
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+  it("should disallow users not belonging to the duplicated dasri", async () => {
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const {
+      user: otherUser,
+      company: otherCompany
+    } = await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      ownerId: otherUser.id,
+      opt: {
+        ...initialData(otherCompany)
+      }
+    });
+
+    const { mutate } = makeClient(user); // emitter
+
+    const { errors } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: dasri.id
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez pas modifier un bordereau sur lequel votre entreprise n'apparait pas.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+  it("should duplicate a  dasri", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        ...initialData(company)
+      }
+    });
+
+    const { mutate } = makeClient(user); // emitter
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: dasri.id
+        }
+      }
+    );
+
+    expect(data.duplicateBsdasri.status).toBe("INITIAL");
+    expect(data.duplicateBsdasri.isDraft).toBe(true);
+  });
+});

--- a/back/src/dasris/resolvers/mutations/create.ts
+++ b/back/src/dasris/resolvers/mutations/create.ts
@@ -57,7 +57,7 @@ const createBsdasri = async (
   const newDasri = await prisma.bsdasri.create({
     data: {
       ...flattenedInput,
-      id: await getReadableId(ReadableIdPrefix.DASRI),
+      id: getReadableId(ReadableIdPrefix.DASRI),
       owner: { connect: { id: user.id } },
       regroupedBsdasris: { connect: regroupedBsdasris },
       isDraft: isDraft

--- a/back/src/dasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/dasris/resolvers/mutations/duplicateBsdasri.ts
@@ -1,0 +1,106 @@
+import { Bsdasri, BsdasriStatus, User } from "@prisma/client";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
+import {
+  MutationDuplicateBsdasriArgs,
+  MutationResolvers
+} from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+import { expandBsdasriFromDb } from "../../dasri-converter";
+import { getBsdasriOrNotFound } from "../../database";
+import { checkIsBsdasriContributor } from "../../permissions";
+
+/**
+ *
+ * Duplicate a bsdasri
+ * Get rid of out a bunch of non duplicatable fields, including:
+ *  - regroupment info
+ *  - signatures
+ *  - acceptation statuses and related fields
+ *  - waste details info for transporter and recipient
+ */
+const duplicateBsdasriResolver: MutationResolvers["duplicateBsdasri"] = async (
+  _,
+  { id }: MutationDuplicateBsdasriArgs,
+  context
+) => {
+  const user = checkIsAuthenticated(context);
+
+  const bsdasri = await getBsdasriOrNotFound({
+    id
+  });
+
+  await checkIsBsdasriContributor(
+    user,
+    bsdasri,
+    "Vous ne pouvez pas modifier un bordereau sur lequel votre entreprise n'apparait pas."
+  );
+
+  const newBsdasri = await duplicateBsdasri(user, bsdasri);
+
+  return expandBsdasriFromDb(newBsdasri);
+};
+
+function duplicateBsdasri(
+  user: User,
+  {
+    id,
+    createdAt,
+    updatedAt,
+
+    emissionSignatoryId,
+    emissionSignatureDate,
+    emissionSignatureAuthor,
+
+    isEmissionDirectTakenOver,
+    isEmissionTakenOverWithSecretCode,
+
+    transporterWasteAcceptationStatus,
+    transporterWasteRefusalReason,
+    transporterWasteRefusedQuantity,
+    transporterTakenOverAt,
+    transporterWastePackagingsInfo,
+    transporterWasteQuantity,
+    transporterWasteQuantityType,
+    transporterWasteVolume,
+    handedOverToRecipientAt,
+
+    transportSignatoryId,
+    transportSignatureDate,
+    transportSignatureAuthor,
+
+    recipientWastePackagingsInfo,
+    recipientWasteAcceptationStatus,
+    recipientWasteRefusalReason,
+    recipientWasteRefusedQuantity,
+    recipientWasteQuantity,
+    recipientWasteQuantityType,
+    recipientWasteVolume,
+    receivedAt,
+
+    receptionSignatoryId,
+    receptionSignatureDate,
+    receptionSignatureAuthor,
+
+    processedAt,
+
+    operationSignatoryId,
+    operationSignatureDate,
+    operationSignatureAuthor,
+    regroupedOnBsdasriId,
+    ownerId,
+    ...fieldsToCopy
+  }: Bsdasri
+) {
+  return prisma.bsdasri.create({
+    data: {
+      ...fieldsToCopy,
+      id: getReadableId(ReadableIdPrefix.DASRI),
+      status: BsdasriStatus.INITIAL,
+      isDraft: true,
+      owner: { connect: { id: user.id } }
+    }
+  });
+}
+
+export default duplicateBsdasriResolver;

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1893,6 +1893,11 @@ export type Mutation = {
   deleteVhuAgrement?: Maybe<VhuAgrement>;
   /**
    * EXPERIMENTAL - Ne pas utiliser dans un contexte de production
+   * Duplique un bordereau Dasri
+   */
+  duplicateBsdasri?: Maybe<Bsdasri>;
+  /**
+   * EXPERIMENTAL - Ne pas utiliser dans un contexte de production
    * Duplique un BSVHU
    */
   duplicateBsvhu?: Maybe<Bsvhu>;
@@ -2234,6 +2239,10 @@ export type MutationDeleteTransporterReceiptArgs = {
 
 export type MutationDeleteVhuAgrementArgs = {
   input: DeleteVhuAgrementInput;
+};
+
+export type MutationDuplicateBsdasriArgs = {
+  id: Scalars["ID"];
 };
 
 export type MutationDuplicateBsvhuArgs = {
@@ -5709,6 +5718,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationDeleteVhuAgrementArgs, "input">
+  >;
+  duplicateBsdasri?: Resolver<
+    Maybe<ResolversTypes["Bsdasri"]>,
+    ParentType,
+    ContextType,
+    RequireFields<MutationDuplicateBsdasriArgs, "id">
   >;
   duplicateBsvhu?: Resolver<
     Maybe<ResolversTypes["Bsvhu"]>,

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -867,6 +867,25 @@ ID d'un BSD
 </td>
 </tr>
 <tr>
+<td colspan="2" valign="top"><strong>duplicateBsdasri</strong></td>
+<td valign="top"><a href="#bsdasri">Bsdasri</a></td>
+<td>
+
+EXPERIMENTAL - Ne pas utiliser dans un contexte de production
+Duplique un bordereau Dasri
+
+</td>
+</tr>
+<tr>
+<td colspan="2" align="right" valign="top">id</td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td>
+
+ID d'un Bsdasri
+
+</td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>duplicateBsvhu</strong></td>
 <td valign="top"><a href="#bsvhu">Bsvhu</a></td>
 <td>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1917,6 +1917,11 @@ export type Mutation = {
   deleteVhuAgrement?: Maybe<VhuAgrement>;
   /**
    * EXPERIMENTAL - Ne pas utiliser dans un contexte de production
+   * Duplique un bordereau Dasri
+   */
+  duplicateBsdasri?: Maybe<Bsdasri>;
+  /**
+   * EXPERIMENTAL - Ne pas utiliser dans un contexte de production
    * Duplique un BSVHU
    */
   duplicateBsvhu?: Maybe<Bsvhu>;
@@ -2258,6 +2263,10 @@ export type MutationDeleteTransporterReceiptArgs = {
 
 export type MutationDeleteVhuAgrementArgs = {
   input: DeleteVhuAgrementInput;
+};
+
+export type MutationDuplicateBsdasriArgs = {
+  id: Scalars["ID"];
 };
 
 export type MutationDuplicateBsvhuArgs = {


### PR DESCRIPTION
Permet de dupliquer un dasri.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- ~~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~~
- ~~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~~
---

 
