### PR TITLE
Exécution du script d'indexation Elastic Search après déploiement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
                 fi
                 docker-compose up -d redis td-api td-ui
                 docker exec \$(docker ps -qf 'name=td-api') npm run migrate"
+                docker exec \$(docker ps -qf 'name=td-api') npm run index-elastic-search"
 
   integration-tests:
     machine:


### PR DESCRIPTION
Cette PR ajoute la commande permettant de mettre automatiquement à jour l'indexation Elastic Search après un déploiement.