### PR TITLE
Stabilisation des tests d'intégration

### DIFF
--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -177,11 +177,6 @@ export const client = new Client({
     ? { ca: fs.readFileSync(certPath, "utf-8") }
     : undefined
 });
-client.on("response", (err, result) => {
-  if (err) {
-    console.error(JSON.stringify(result, null, 2));
-  }
-});
 
 /**
  * Create/update a document in Elastic Search.


### PR DESCRIPTION
L'objectif de cette PR est d'identifier ce qui provoque l'échec aléatoire des tests d'intégration dans les actions GitHub et de corriger le problème.

Je n'ai pas réussi à reproduire l'erreur plus d'une fois mais les logs que j'ai ajouté indiquent un soucis de conflit Elastic Search dans la requête `deleteByQuery`. J'ai trouvé [une discussion](https://discuss.elastic.co/t/elasticsearch-delete-by-query-409-version-conflict/174150) intéressante à ce sujet.

Pour résumer, `deleteByQuery` (qui est utilisé pour remettre la base Elastic Search à zéro) lit tous les documents avant de les supprimer. Du coup si l'index n'est pas à jour au moment de l'appel à `deleteByQuery`, il y aura un conflit au moment où la suppression aura effectivement lieu. L'appel à `deleteByQuery` dans `resetDatabase` échoue et la base de donnée Postgres n'est pas remise à zéro, ce qui explique ensuite le soucis d'unicité sur le SIRET.

La solution dans notre cas c'est d'attendre que l'index Elastic Search est à jour avant de procéder à la suppression.