### PR TITLE
Gère l'indexation des bsdd quand une même entreprise joue plusieurs rôles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Amélioration de l'indexation des bsdd [PR 858](https://github.com/MTES-MCT/trackdechets/pull/858)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
-- Amélioration de l'indexation des bsdd [PR 858](https://github.com/MTES-MCT/trackdechets/pull/858)
+- Correction de l'indexation des bsdds afin qu'ils soient listés dans tous les onglets appropriés pour une même entreprise [PR 858](https://github.com/MTES-MCT/trackdechets/pull/858)
 
 #### :memo: Documentation
 

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
@@ -50,7 +50,6 @@ describe("Query.bsds workflow", () => {
   let formId: string;
 
   beforeAll(async () => {
-    await resetDatabase();
     emitter = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["PRODUCER"]
@@ -415,9 +414,6 @@ describe("Query.bsds workflow", () => {
 });
 
 describe("Query.bsds edge cases", () => {
-  beforeAll(async () => {
-    await resetDatabase();
-  });
   afterAll(resetDatabase);
 
   it("should return bsds where same company plays different roles", async () => {
@@ -431,13 +427,13 @@ describe("Query.bsds edge cases", () => {
       UserRole.ADMIN,
       {
         companyTypes: {
-          set: ["WASTEPROCESSOR"]
+          set: ["WASTEPROCESSOR", "TRANSPORTER"]
         }
       }
     );
     // let's build a form where the same company is both transporter & recipient
     // this SENT form now is collected by transporter (isCollectedFor) and awaiting reception (isForActionFor) by recipient,
-    // who are the same company (recipient)
+    // which are the same company (recipient)
     const form = await formFactory({
       ownerId: emitter.user.id,
       opt: {
@@ -473,7 +469,7 @@ describe("Query.bsds edge cases", () => {
     ]);
 
     const { query: recipientQuery } = makeClient(recipientAndTransporter.user);
-    // form shows when whe request `isForActionFor`
+    // form shows when we request `isForActionFor`
     res = await recipientQuery<Pick<Query, "bsds">, QueryBsdsArgs>(GET_BSDS, {
       variables: {
         where: {

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
@@ -8,8 +8,7 @@ import {
   MutationMarkAsSealedArgs,
   MutationSignedByTransporterArgs,
   MutationMarkAsReceivedArgs,
-  MutationMarkAsProcessedArgs,
-  EmitterType
+  MutationMarkAsProcessedArgs
 } from "../../../../generated/graphql/types";
 import {
   resetDatabase,
@@ -43,62 +42,6 @@ mutation CreateForm($createFormInput: CreateFormInput!) {
   }
 }
 `;
-const buildFormPayload = (
-  emitterSiret,
-  transporterSiret,
-  recipientSiret
-): MutationCreateFormArgs => ({
-  createFormInput: {
-    emitter: {
-      company: {
-        siret: emitterSiret,
-        name: "MARIE PRODUCTEUR",
-        address: "12 chemin des caravanes",
-        contact: "Marie",
-        mail: "marie@gmail.com",
-        phone: "06"
-      },
-      type: "PRODUCER" as EmitterType
-    },
-    transporter: {
-      company: {
-        siret: transporterSiret,
-        name: "JM TRANSPORT",
-        address: "2 rue des pâquerettes",
-        contact: "Jean-Michel",
-        mail: "jean.michel@gmaiL.com",
-        phone: "06"
-      },
-      receipt: "123456789",
-      department: "69",
-      validityLimit: addYears(new Date(), 1).toISOString() as any
-    },
-    recipient: {
-      company: {
-        siret: recipientSiret,
-        name: "JEANNE COLLECTEUR",
-        address: "38 bis allée des anges",
-        contact: "Jeanne",
-        mail: "jeanne@gmail.com",
-        phone: "06"
-      },
-      processingOperation: "R 1"
-    },
-    wasteDetails: {
-      code: "01 01 01",
-      name: "Stylos bille",
-      consistence: "SOLID",
-      packagingInfos: [
-        {
-          type: "BENNE",
-          quantity: 1
-        }
-      ],
-      quantityType: "ESTIMATED",
-      quantity: 1
-    }
-  }
-});
 
 describe("Query.bsds workflow", () => {
   let emitter: { user: User; company: Company };
@@ -137,11 +80,58 @@ describe("Query.bsds workflow", () => {
       } = await mutate<Pick<Mutation, "createForm">, MutationCreateFormArgs>(
         CREATE_FORM,
         {
-          variables: buildFormPayload(
-            emitter.company.siret,
-            transporter.company.siret,
-            recipient.company.siret
-          )
+          variables: {
+            createFormInput: {
+              emitter: {
+                company: {
+                  siret: emitter.company.siret,
+                  name: "MARIE PRODUCTEUR",
+                  address: "12 chemin des caravanes",
+                  contact: "Marie",
+                  mail: "marie@gmail.com",
+                  phone: "06"
+                },
+                type: "PRODUCER"
+              },
+              transporter: {
+                company: {
+                  siret: transporter.company.siret,
+                  name: "JM TRANSPORT",
+                  address: "2 rue des pâquerettes",
+                  contact: "Jean-Michel",
+                  mail: "jean.michel@gmaiL.com",
+                  phone: "06"
+                },
+                receipt: "123456789",
+                department: "69",
+                validityLimit: addYears(new Date(), 1).toISOString() as any
+              },
+              recipient: {
+                company: {
+                  siret: recipient.company.siret,
+                  name: "JEANNE COLLECTEUR",
+                  address: "38 bis allée des anges",
+                  contact: "Jeanne",
+                  mail: "jeanne@gmail.com",
+                  phone: "06"
+                },
+                processingOperation: "R 1"
+              },
+              wasteDetails: {
+                code: "01 01 01",
+                name: "Stylos bille",
+                consistence: "SOLID",
+                packagingInfos: [
+                  {
+                    type: "BENNE",
+                    quantity: 1
+                  }
+                ],
+                quantityType: "ESTIMATED",
+                quantity: 1
+              }
+            }
+          }
         }
       );
       formId = id;

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -179,7 +179,6 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
     }
   );
   const hits = body.hits.hits.slice(0, size);
-
   const ids = hits.reduce<Record<BsdType, string[]>>(
     (acc, { _source: { type, id } }) => ({
       ...acc,
@@ -187,7 +186,6 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
     }),
     { BSDD: [] }
   );
-
   const bsds: Record<BsdType, Bsd[]> = {
     BSDD: (
       await prisma.form.findMany({
@@ -199,7 +197,6 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
       })
     ).map(expandFormFromDb)
   };
-
   const edges = hits
     .reduce<Array<Bsd>>((acc, { _source: { type, id } }) => {
       const bsd = bsds[type].find(bsd => bsd.id === id);

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -179,6 +179,7 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
     }
   );
   const hits = body.hits.hits.slice(0, size);
+
   const ids = hits.reduce<Record<BsdType, string[]>>(
     (acc, { _source: { type, id } }) => ({
       ...acc,
@@ -186,6 +187,7 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
     }),
     { BSDD: [] }
   );
+
   const bsds: Record<BsdType, Bsd[]> = {
     BSDD: (
       await prisma.form.findMany({
@@ -197,6 +199,7 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
       })
     ).map(expandFormFromDb)
   };
+
   const edges = hits
     .reduce<Array<Bsd>>((acc, { _source: { type, id } }) => {
       const bsd = bsds[type].find(bsd => bsd.id === id);

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -14,6 +14,30 @@ function getWhere(
   | "isToCollectFor"
   | "isCollectedFor"
 > {
+  // we build a mapping where each key has to be unique.
+  // Same siret can be used by different actors on he same form, so we can't use them as keys.
+  // Instead we rely on field names and segments ids
+  const segments = form.transportSegments
+    .filter(segment => !!segment.transporterCompanySiret)
+    .map(segment => ({
+      [`${segment.id}`]: segment.transporterCompanySiret
+    }))
+    .reduce((el, acc) => ({ ...acc, ...el }), {});
+
+  const formSirets = {
+    emitterCompanySiret: form.emitterCompanySiret,
+    recipientCompanySiret: form.recipientCompanySiret,
+    temporaryStorageDetailDestinationCompanySiret:
+      form.temporaryStorageDetail?.destinationCompanySiret,
+    temporaryStorageDetailTransporterCompanySiret:
+      form.temporaryStorageDetail?.transporterCompanySiret,
+    traderCompanySiret: form.traderCompanySiret,
+    brokerCompanySiret: form.brokerCompanySiret,
+    ecoOrganismeSiret: form.ecoOrganismeSiret,
+    transporterCompanySiret: form.transporterCompanySiret,
+    ...segments
+  };
+
   const where = {
     isDraftFor: [],
     isForActionFor: [],
@@ -22,106 +46,153 @@ function getWhere(
     isToCollectFor: [],
     isCollectedFor: []
   };
-  const sirets = new Map<string, keyof typeof where>(
-    [
-      form.emitterCompanySiret,
-      form.recipientCompanySiret,
-      form.temporaryStorageDetail?.destinationCompanySiret,
-      form.transporterCompanySiret,
-      ...form.transportSegments.map(segment => segment.transporterCompanySiret),
-      form.temporaryStorageDetail?.transporterCompanySiret,
-      form.traderCompanySiret,
-      form.brokerCompanySiret,
-      form.ecoOrganismeSiret
-    ].map(siret => [siret, "isFollowFor"])
-  );
 
+  type Mapping = Map<string, keyof typeof where>;
+  /**
+   * Set where clause to a given mapping
+   */
+  const appendToSirets = (
+    map: Mapping,
+    key: string,
+    newValue: keyof typeof where
+  ) => {
+    if (!map.has(key)) {
+      return;
+    }
+
+    map.set(key, newValue);
+  };
+
+  // build a mapping to store which actor will see this form appear on a given UI tab
+  // eg: 'transporterCompanySiret' : 'isCollectedFor'
+  const siretsFilters = new Map<string, keyof typeof where>(
+    Object.entries(formSirets)
+      .filter(item => !!item[1])
+      .map(item => [item[0], "isFollowFor"])
+  );
   switch (form.status) {
     case Status.DRAFT: {
-      for (const siret of sirets.keys()) {
-        sirets.set(siret, "isDraftFor");
+      for (const fieldName of siretsFilters.keys()) {
+        appendToSirets(siretsFilters, fieldName, "isDraftFor");
       }
       break;
     }
     case Status.SEALED: {
-      sirets.set(form.transporterCompanySiret, "isToCollectFor");
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isToCollectFor"
+      );
+
       break;
     }
     case Status.SENT: {
-      sirets.set(form.recipientCompanySiret, "isForActionFor");
-      sirets.set(form.transporterCompanySiret, "isCollectedFor");
+      appendToSirets(siretsFilters, "recipientCompanySiret", "isForActionFor");
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isCollectedFor"
+      );
 
       form.transportSegments.forEach(segment => {
         if (segment.readyToTakeOver) {
-          sirets.set(
-            segment.transporterCompanySiret,
+          appendToSirets(
+            siretsFilters,
+            segment.id,
             segment.takenOverAt ? "isCollectedFor" : "isToCollectFor"
           );
         }
       });
+
       break;
     }
     case Status.TEMP_STORED:
     case Status.TEMP_STORER_ACCEPTED: {
-      sirets.set(form.recipientCompanySiret, "isForActionFor");
-      sirets.set(form.transporterCompanySiret, "isCollectedFor");
+      appendToSirets(siretsFilters, "recipientCompanySiret", "isForActionFor");
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isCollectedFor"
+      );
 
       form.transportSegments.forEach(segment => {
-        sirets.set(segment.transporterCompanySiret, "isCollectedFor");
+        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
       });
+
       break;
     }
     case Status.RESEALED: {
-      sirets.set(
-        form.temporaryStorageDetail.transporterCompanySiret,
+      appendToSirets(
+        siretsFilters,
+        "temporaryStorageDetailTransporterCompanySiret",
         "isToCollectFor"
       );
-      sirets.set(form.transporterCompanySiret, "isCollectedFor");
 
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isCollectedFor"
+      );
       form.transportSegments.forEach(segment => {
-        sirets.set(segment.transporterCompanySiret, "isCollectedFor");
+        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
       });
+
       break;
     }
     case Status.RESENT:
     case Status.RECEIVED:
     case Status.ACCEPTED: {
-      sirets.set(
+      appendToSirets(
+        siretsFilters,
         form.recipientIsTempStorage
-          ? form.temporaryStorageDetail.destinationCompanySiret
-          : form.recipientCompanySiret,
+          ? "temporaryStorageDetailDestinationCompanySiret"
+          : "recipientCompanySiret",
         "isForActionFor"
       );
 
-      sirets.set(
-        form.temporaryStorageDetail?.transporterCompanySiret,
+      appendToSirets(
+        siretsFilters,
+        "temporaryStorageDetailTransporterCompanySiret",
         "isCollectedFor"
       );
-      sirets.set(form.transporterCompanySiret, "isCollectedFor");
+
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isCollectedFor"
+      );
 
       form.transportSegments.forEach(segment => {
-        sirets.set(segment.transporterCompanySiret, "isCollectedFor");
+        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
       });
+
       break;
     }
     case Status.AWAITING_GROUP:
     case Status.GROUPED: {
-      sirets.set(
-        form.temporaryStorageDetail?.transporterCompanySiret,
+      appendToSirets(
+        siretsFilters,
+        "temporaryStorageDetailTransporterCompanySiret",
         "isCollectedFor"
       );
-      sirets.set(form.transporterCompanySiret, "isCollectedFor");
+
+      appendToSirets(
+        siretsFilters,
+        "transporterCompanySiret",
+        "isCollectedFor"
+      );
 
       form.transportSegments.forEach(segment => {
-        sirets.set(segment.transporterCompanySiret, "isCollectedFor");
+        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
       });
+
       break;
     }
     case Status.REFUSED:
     case Status.PROCESSED:
     case Status.NO_TRACEABILITY: {
-      for (const siret of sirets.keys()) {
-        sirets.set(siret, "isArchivedFor");
+      for (const siret of siretsFilters.keys()) {
+        appendToSirets(siretsFilters, siret, "isArchivedFor");
       }
       break;
     }
@@ -129,9 +200,9 @@ function getWhere(
       break;
   }
 
-  for (const [siret, filter] of sirets.entries()) {
-    if (siret) {
-      where[filter].push(siret);
+  for (const [fieldName, filter] of siretsFilters.entries()) {
+    if (fieldName) {
+      where[filter].push(formSirets[fieldName]);
     }
   }
 
@@ -172,7 +243,7 @@ function toBsdElastic(form: FullForm): BsdElastic {
  * Index all BSDs from the forms table.
  */
 export async function indexAllForms(
-  idx: string,
+  idx: string | null | undefined,
   { skip = 0 }: { skip?: number } = {}
 ) {
   const take = 1000;

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -15,7 +15,7 @@ function getWhere(
   | "isCollectedFor"
 > {
   // we build a mapping where each key has to be unique.
-  // Same siret can be used by different actors on he same form, so we can't use them as keys.
+  // Same siret can be used by different actors on the same form, so we can't use them as keys.
   // Instead we rely on field names and segments ids
   const segments = form.transportSegments
     .filter(segment => !!segment.transporterCompanySiret)
@@ -243,7 +243,7 @@ function toBsdElastic(form: FullForm): BsdElastic {
  * Index all BSDs from the forms table.
  */
 export async function indexAllForms(
-  idx: string | null | undefined,
+  idx: string,
   { skip = 0 }: { skip?: number } = {}
 ) {
   const take = 1000;

--- a/back/src/vhu/resolvers/mutations/sign.ts
+++ b/back/src/vhu/resolvers/mutations/sign.ts
@@ -60,7 +60,6 @@ export default async function sign(
     type: input.type,
     bsvhu: prismaForm
   });
-  //console.log(prismaForm.status,newStatus)
   const signedForm = await prisma.bsvhu.update({
     where: { id },
     data: {


### PR DESCRIPTION
Un même siret peut remplir plusieurs rôle sur un bsdd, et peut donc apparaître dans différents onglets pour un m^me statut:
eg un bsdd SENT où le transporteur et le destinataire sont la même entreprise doit apparaitre dans l'onglet collecté et l'onglet pour action.
Cette PR vise à prendre en compte ce cas de figure.

- ~[ ] Mettre à jour la documentation~
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- ~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~
---

- [Ticket Trello]()
