### PR TITLE
Masquage des informations liées à l'émetteur initial d'une annexe 2 dans le PDF d'un bordereau de regroupement lorsqu'il est téléchargé par un autre acteur que l'installation effectuant le regroupement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Masquage des informations liées à l'émetteur initial d'une annexe 2 dans le PDF d'un bordereau de regroupement lorsqu'il est téléchargé par un autre acteur que l'installation effectuant le regroupement [PR 865](https://github.com/MTES-MCT/trackdechets/pull/865)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/common/file-download.ts
+++ b/back/src/common/file-download.ts
@@ -3,7 +3,11 @@ import { redisClient, setInCache } from "./redis";
 import { randomNumber, getAPIBaseURL } from "../utils";
 
 type DownloadInfos = { type: string; params: any };
-type DownloadHandler = (res: Response, params: any) => void | Promise<void>;
+type DownloadHandler = (
+  req: Request,
+  res: Response,
+  params: any
+) => void | Promise<void>;
 
 // TODO register downloaders on server start if code is distributed on several machines
 const fileDownloaders = {};
@@ -67,5 +71,5 @@ export async function downloadFileHandler(req: Request, res: Response) {
     return res.status(500).send("Type de fichier inconnu.");
   }
 
-  return fileDownloader(res, params);
+  return fileDownloader(req, res, params);
 }

--- a/back/src/dasris/pdf/download.ts
+++ b/back/src/dasris/pdf/download.ts
@@ -1,11 +1,15 @@
-import { Response } from "express";
+import { Response, Request } from "express";
 import prisma from "../../prisma";
 import { buildPdf } from "./generator";
 
 /**
  * Render a dasri pdf as an HTTP response
  */
-export default async function downloadPdf(res: Response, { id }) {
+export default async function downloadPdf(
+  _req: Request,
+  res: Response,
+  { id }
+) {
   if (!id) {
     res.status(500).send("Identifiant du bordereau manquant.");
   }

--- a/back/src/forms/exports/handler.ts
+++ b/back/src/forms/exports/handler.ts
@@ -1,4 +1,4 @@
-import { Response } from "express";
+import { Response, Request } from "express";
 import * as Excel from "exceljs";
 import { format } from "@fast-csv/format";
 import { QueryFormsRegisterArgs } from "../../generated/graphql/types";
@@ -12,6 +12,7 @@ import { getXlsxHeaders } from "./columns";
  * Download handler for forms register
  */
 export async function downloadFormsRegister(
+  _req: Request,
   res: Response,
   args: QueryFormsRegisterArgs
 ) {

--- a/back/src/forms/pdf/__tests__/helpers.test.ts
+++ b/back/src/forms/pdf/__tests__/helpers.test.ts
@@ -1,4 +1,9 @@
-import { processMainFormParams, processSegment, dateFmt } from "../helpers";
+import {
+  processMainFormParams,
+  processSegment,
+  dateFmt,
+  extractPostalCode
+} from "../helpers";
 
 describe("processMainFormParams", () => {
   it("should format the fields", () => {
@@ -54,5 +59,16 @@ describe("processSegment", () => {
       transporterCompanySiren: params.transporterCompanySiret.slice(0, 9),
       transporterValidityLimit: dateFmt(params.transporterValidityLimit)
     });
+  });
+});
+
+describe("extractPostalCode", () => {
+  test("when there is a match", () => {
+    const address = "3 route du déchet, 07100 Annonay";
+    expect(extractPostalCode(address)).toEqual("07100");
+  });
+
+  test("when there is not match", () => {
+    expect(extractPostalCode("Somewhere")).toEqual("");
   });
 });

--- a/back/src/forms/pdf/downloadPdf.ts
+++ b/back/src/forms/pdf/downloadPdf.ts
@@ -1,11 +1,13 @@
-import { Response } from "express";
+import { Response, Request } from "express";
 import prisma from "../../prisma";
 import { buildPdf } from "./generator";
 
 /**
  * Render a form pdf as an HTTP response
  */
-export default async function downloadPdf(res: Response, { id }) {
+export default async function downloadPdf(req: Request, res: Response, { id }) {
+  const user = req.user;
+
   if (!id) {
     res.status(500).send("Identifiant du bordereau manquant.");
   }
@@ -13,7 +15,7 @@ export default async function downloadPdf(res: Response, { id }) {
   const form = await prisma.form.findUnique({ where: { id } });
 
   try {
-    const buffer = await buildPdf(form);
+    const buffer = await buildPdf(form, user);
 
     res.status(200);
     res.type("pdf");

--- a/back/src/forms/pdf/generator.ts
+++ b/back/src/forms/pdf/generator.ts
@@ -7,7 +7,8 @@ import {
   fillFields,
   drawImage,
   processSegment,
-  processAnnexParams
+  processAnnexParams,
+  hideEmitterFields
 } from "./helpers";
 import {
   pageHeight,
@@ -29,10 +30,11 @@ const multimodalYOffset = 85;
  * @param params - payload
  * @return Buffer
  */
-export const buildPdf = async (form: Form) => {
+export const buildPdf = async (form: Form, user?: Express.User | null) => {
   const appendix2Forms = await prisma.form
     .findUnique({ where: { id: form.id } })
     .appendix2Forms();
+
   const segments = await prisma.form
     .findUnique({ where: { id: form.id } })
     .transportSegments();
@@ -454,6 +456,7 @@ export const buildPdf = async (form: Form) => {
       subFormCounter = pageSubFormCounter + sheetCounter * formsByAppendix;
 
       let appendix = appendix2Forms[subFormCounter];
+      appendix = await hideEmitterFields(appendix, user);
       // process each annex and add numbering
       appendix = {
         ...processAnnexParams(appendix),

--- a/back/src/forms/pdf/helpers.ts
+++ b/back/src/forms/pdf/helpers.ts
@@ -411,13 +411,24 @@ export async function hideEmitterFields(appendix2: Form, user: Express.User) {
       ...rest,
       emitterCompanySiret: "",
       emitterCompanyName: "",
-      emitterCompanyAddress: "",
+      emitterCompanyAddress: extractPostalCode(emitterCompanyAddress),
       emitterCompanyContact: "",
       emitterCompanyMail: "",
       emitterCompanyPhone: ""
     };
   }
   return appendix2;
+}
+
+/**
+ *Try extracting a valid postal code
+ */
+export function extractPostalCode(address: string) {
+  const matches = address.match(/([0-9]{5})/);
+  if (matches && matches.length > 0) {
+    return matches[0];
+  }
+  return "";
 }
 
 const transportModeLabels = {

--- a/back/src/vhu/pdf/download.ts
+++ b/back/src/vhu/pdf/download.ts
@@ -1,11 +1,15 @@
-import { Response } from "express";
+import { Response, Request } from "express";
 import prisma from "../../prisma";
 import { buildPdf } from "./generator";
 
 /**
  * Render a form pdf as an HTTP response
  */
-export default async function downloadPdf(res: Response, { id }) {
+export default async function downloadPdf(
+  _req: Request,
+  res: Response,
+  { id }
+) {
   if (!id) {
     res.status(500).send("Identifiant du bordereau manquant.");
   }


### PR DESCRIPTION
L'idée est de faire apparaitre uniquement le code postal de l'émetteur dans la partie gauche du cadre sauf pour les acteurs 
faisant partie du bordereau initial (essentiellement l'installation effectuant le regroupement puisque le producteur initial n'a pas accès au bordereau de regroupement).

Il y aura une autre PR pour limiter les infos renvoyées par l'API dans `form { appendix2forms { ... } }` (à inclure dans une future release car breaking change).

![Capture_d%u2019écran_2021-04-02_à_16 03 16](https://user-images.githubusercontent.com/2269165/118973454-f9e66100-b971-11eb-9a58-b3e48dd15940.png)

- ~[ ] Mettre à jour la documentation~
- [x] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~
- ~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~
---

- [Ticket Trello](https://trello.com/c/2UB3HwiG)
