### PR TITLE
Active les restrictions pour les établissements non vérifiés

### DIFF
--- a/back/prisma/scripts/send-verification-code-letter.ts
+++ b/back/prisma/scripts/send-verification-code-letter.ts
@@ -4,7 +4,7 @@ import { registerUpdater, Updater } from "./helper/helper";
 @registerUpdater(
   "Send verification code letters",
   "Send verification code letters to all companies that have not yet been verified manually",
-  true
+  false
 )
 export class SendVerificationCode implements Updater {
   run() {

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -231,7 +231,7 @@ describe("Mutation markAsResealed", () => {
     ]);
   });
 
-  it.skip("should throw an error if VERIFY_COMPANY=true and destination after temp storage is not verified", async () => {
+  it("should throw an error if VERIFY_COMPANY=true and destination after temp storage is not verified", async () => {
     // patch process.env and reload server
     process.env.VERIFY_COMPANY = "true";
     const makeClient = require("../../../../__tests__/testClient").default;

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -550,7 +550,7 @@ describe("Mutation.markAsSealed", () => {
     ]);
   });
 
-  it.skip("should throw an error if VERIFY_COMPANY=true and destination is not verified", async () => {
+  it("should throw an error if VERIFY_COMPANY=true and destination is not verified", async () => {
     // patch process.env and reload server
     process.env.VERIFY_COMPANY = "true";
     const makeClient = require("../../../../__tests__/testClient").default;
@@ -583,7 +583,7 @@ describe("Mutation.markAsSealed", () => {
     ]);
   });
 
-  it.skip("should throw an error if VERIFY_COMPANY=true and destination after temp storage is not verified", async () => {
+  it("should throw an error if VERIFY_COMPANY=true and destination after temp storage is not verified", async () => {
     // patch process.env and reload server
     process.env.VERIFY_COMPANY = "true";
     const makeClient = require("../../../../__tests__/testClient").default;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -6,7 +6,8 @@ import {
   Form,
   QuantityType,
   WasteAcceptationStatus,
-  Prisma
+  Prisma,
+  CompanyVerificationStatus
 } from "@prisma/client";
 import { UserInputError } from "apollo-server-express";
 import prisma from "../prisma";
@@ -23,6 +24,8 @@ import { PackagingInfo, Packagings } from "../generated/graphql/types";
 
 // set yup default error messages
 configureYup();
+
+const { VERIFY_COMPANY } = process.env;
 
 // ************************************************
 // BREAK DOWN FORM TYPE INTO INDIVIDUAL FRAME TYPES
@@ -967,16 +970,15 @@ async function checkDestination(siret: string) {
     );
   }
 
-  // DISABLED TEMPORARILY
-  // if (
-  //   VERIFY_COMPANY === "true" &&
-  //   company.verificationStatus !== CompanyVerificationStatus.VERIFIED
-  // ) {
-  //   throw new UserInputError(
-  //     `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue ${company.siret}
-  //     n'a pas encore été vérifié. Cette installation ne peut pas être visée en case 2 du bordereau.`
-  //   );
-  // }
+  if (
+    VERIFY_COMPANY === "true" &&
+    company.verificationStatus !== CompanyVerificationStatus.VERIFIED
+  ) {
+    throw new UserInputError(
+      `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue ${company.siret}
+      n'a pas encore été vérifié. Cette installation ne peut pas être visée en case 2 du bordereau.`
+    );
+  }
 
   return true;
 }
@@ -1007,16 +1009,15 @@ async function checkDestinationAfterTempStorage(siret: string) {
     );
   }
 
-  // DISABLED TEMPORARILY
-  // if (
-  //   VERIFY_COMPANY === "true" &&
-  //   company.verificationStatus !== CompanyVerificationStatus.VERIFIED
-  // ) {
-  //   throw new UserInputError(
-  //     `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue ${company.siret}
-  //     n'a pas encore été vérifié. Cette installation ne peut pas être visée en case 14 du bordereau.`
-  //   );
-  // }
+  if (
+    VERIFY_COMPANY === "true" &&
+    company.verificationStatus !== CompanyVerificationStatus.VERIFIED
+  ) {
+    throw new UserInputError(
+      `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue ${company.siret}
+      n'a pas encore été vérifié. Cette installation ne peut pas être visée en case 14 du bordereau.`
+    );
+  }
 
   return true;
 }


### PR DESCRIPTION
Les restrictions qui s'appliquent aux établissements pro non vérifiés avaient été désactivés pour laisser le temps aux courriers contenant les codes de sécurité d'arriver. 