### PR TITLE
Amélioration du gestionnaire d'erreur

### DIFF
--- a/back/src/common/middlewares/errorHandler.ts
+++ b/back/src/common/middlewares/errorHandler.ts
@@ -17,10 +17,14 @@ export default (
   next: NextFunction
 ) => {
   logger.error(err.message, { stacktrace: err.stack });
-  if (NODE_ENV === "dev") {
-    next(err);
-  } else {
-    // do not leak errors in production
-    res.status(500).send("Erreur serveur");
+  if (res.headersSent) {
+    // see https://expressjs.com/fr/guide/error-handling.html
+    return next(err);
   }
+  if (NODE_ENV === "production") {
+    if (err instanceof SyntaxError) {
+      res.status(400).send({ error: "JSON mal formaté" });
+    }
+  }
+  next(err);
 };

--- a/back/src/common/middlewares/errorHandler.ts
+++ b/back/src/common/middlewares/errorHandler.ts
@@ -23,8 +23,8 @@ export default (
   }
   if (NODE_ENV === "production") {
     if (err instanceof SyntaxError) {
-      res.status(400).send({ error: "JSON mal formaté" });
+      return res.status(400).send({ error: "JSON mal formaté" });
     }
   }
-  next(err);
+  return next(err);
 };


### PR DESCRIPTION
Actuellement on renvoie "Erreur Serveur" en production pour toutes les erreurs non gérées afin de ne pas leaker d'information. Or cette protection lorsque `NODE_ENV="production"` est déjà assurée par le gestionnaire d'erreur Express par défaut (voir https://expressjs.com/fr/guide/error-handling.html) avec les messages suivants.
```
   // message d'erreur 500
 
    <!DOCTYPE html>
    <html lang="en">
    <head>
    <meta charset="utf-8">
    <title>Error</title>
    </head>
    <body>
    <pre>Internal Server Error</pre>
    </body>
    </html>
```

```
  // message d'erreur 400
 
    <!DOCTYPE html>
    <html lang="en">
    <head>
    <meta charset="utf-8">
    <title>Error</title>
    </head>
    <body>
    <pre>Bad Request</pre>
    </body>
    </html>
```

Le gestionnaire par défaut permet donc en outre de gérer plus finement les messages d'erreur en fonction du code de statut. Le traitement indifférencié des erreurs en place actuellement ne permet pas aux intégrateurs de savoir lorsqu'ils envoient un JSON mal formaté => Cf https://forum.trackdechets.beta.gouv.fr/t/markastempstored-ne-fonctionne-pas/40. 

L'idée de cette PR est donc de s'appuyer sur le gestionnaire d'erreur Express par défaut en traitant en plus le cas particulier des erreurs de formattage JSON (fréquent) avec un message explicite. 

