### PR TITLE
Fix Cannot log messages bigger than 177664 bytes

### DIFF
--- a/back/src/common/middlewares/loggingMiddleware.ts
+++ b/back/src/common/middlewares/loggingMiddleware.ts
@@ -27,7 +27,7 @@ export default function (graphQLPath: string) {
         http_params: req.params,
         http_query: req.query,
         http_status: res.statusCode,
-        response_body: typeof responseBody === "string" ? responseBody : ""
+        response_body: Buffer.isBuffer(responseBody) ? null : responseBody
       };
       // GraphQL specific fields
       if (req.path === graphQLPath && req.method === "POST") {

--- a/back/src/common/middlewares/loggingMiddleware.ts
+++ b/back/src/common/middlewares/loggingMiddleware.ts
@@ -27,7 +27,7 @@ export default function (graphQLPath: string) {
         http_params: req.params,
         http_query: req.query,
         http_status: res.statusCode,
-        response_body: responseBody
+        response_body: typeof responseBody === "string" ? responseBody : ""
       };
       // GraphQL specific fields
       if (req.path === graphQLPath && req.method === "POST") {


### PR DESCRIPTION
Cf https://sentry.io/organizations/providenz/issues/2064584743/?environment=sandbox&project=1762733&query=is%3Aunresolved
Permet de logguer uniquement les réponses au format texte