### PR TITLE
Limite les infos que l'on peut voir sur une annexe 2 par API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
+- Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau annexé (ex: l'exutoire finale) n'ont plus accès à toutes les informations du bordereau annexé pour préserver les infos commerciales de l'établissement effectuant le regroupement [PR 872](https://github.com/MTES-MCT/trackdechets/pull/872).
 #### :bug: Corrections de bugs
 
 - Correction du typage de `ResealedFormInput.wasteDetails` [PR 889](https://github.com/MTES-MCT/trackdechets/pull/889)

--- a/back/src/__tests__/utils.test.ts
+++ b/back/src/__tests__/utils.test.ts
@@ -3,7 +3,8 @@ import {
   sameDayMidnight,
   daysBetween,
   base32Encode,
-  hashToken
+  hashToken,
+  extractPostalCode
 } from "../utils";
 
 test("getUid returns a unique identifier of fixed length", () => {
@@ -45,5 +46,24 @@ describe("base32Encode", () => {
       "97706c213b37c5347a40da50f4ae1f34ef18503cd4ef33fd5e2780b0ed0bb3a7"
     );
     process.env = { ...OLD_ENV };
+  });
+});
+
+describe("extractPostalCode", () => {
+  test("when there is a match", () => {
+    const address = "3 route du déchet, 07100 Annonay";
+    expect(extractPostalCode(address)).toEqual("07100");
+  });
+
+  test("when there is not match", () => {
+    expect(extractPostalCode("Somewhere")).toEqual("");
+  });
+
+  test("when address is empty", () => {
+    expect(extractPostalCode("")).toEqual("");
+  });
+
+  test("when address is null", () => {
+    expect(extractPostalCode(null)).toEqual("");
   });
 });

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -656,6 +656,7 @@ type Form {
 }
 
 type Appendix2Form {
+  id: ID!
   readableId: String!
   wasteDetails: WasteDetails
   emitter: Emitter

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -655,13 +655,42 @@ type Form {
   nextTransporterSiret: String
 }
 
+"""
+Information sur le bordereau initial lors d'une réexpédition après transformation ou traitement aboutissant
+à des déchets dont la provenance reste identifiable (annexe 2)
+"""
 type Appendix2Form {
+  "Identifiant unique du bordereau initial"
   id: ID!
+  "Identifiant lisible du bordereau initial"
   readableId: String!
+  "Détails du déchet du bordereau initial (case 3)"
   wasteDetails: WasteDetails
+  """
+  Émetteur du bordereau initial
+  Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau initial (ex: l'exutoire finale)
+  n'ont pas accès à ce champs pour préserver les informations commerciales de l'établissement effectuant le regroupemnt
+  """
   emitter: Emitter
-  receivedAt: DateTime
+  """
+  Code postal de l'émetteur du bordereau initial permettant aux établissements qui apparaissent sur le bordereau de regroupement
+  mais pas sur le bordereau initial (ex: l'exutoire finale) de connaitre la zone de chalandise de l'émetteur initial.
+  """
+  emitterPostalCode: String
+  """
+  Date d’acceptation du lot initial par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+  dont la provenance reste identifiable. C'est la date qui figure au cadre 10 du bordereau initial.
+  """
+  signedAt: DateTime
+  """
+  Quantité reçue par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+  dont la provenance reste identifiable
+  """
   quantityReceived: Float
+  """
+  Opération de transformation ou un traitement aboutissant à des déchets dont la provenance reste identifiable effectuée
+  par l'installation de regroupement
+  """
   processingOperationDone: String
 }
 

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -639,7 +639,7 @@ type Form {
   nextDestination: NextDestination
 
   "Annexe 2"
-  appendix2Forms: [Form!]
+  appendix2Forms: [Appendix2Form!]
 
   ecoOrganisme: FormEcoOrganisme
 
@@ -653,6 +653,15 @@ type Form {
 
   currentTransporterSiret: String
   nextTransporterSiret: String
+}
+
+type Appendix2Form {
+  readableId: String!
+  wasteDetails: WasteDetails
+  emitter: Emitter
+  receivedAt: DateTime
+  quantityReceived: Float
+  processingOperationDone: String
 }
 
 """

--- a/back/src/forms/pdf/__tests__/helpers.test.ts
+++ b/back/src/forms/pdf/__tests__/helpers.test.ts
@@ -1,9 +1,4 @@
-import {
-  processMainFormParams,
-  processSegment,
-  dateFmt,
-  extractPostalCode
-} from "../helpers";
+import { processMainFormParams, processSegment, dateFmt } from "../helpers";
 
 describe("processMainFormParams", () => {
   it("should format the fields", () => {
@@ -59,16 +54,5 @@ describe("processSegment", () => {
       transporterCompanySiren: params.transporterCompanySiret.slice(0, 9),
       transporterValidityLimit: dateFmt(params.transporterValidityLimit)
     });
-  });
-});
-
-describe("extractPostalCode", () => {
-  test("when there is a match", () => {
-    const address = "3 route du déchet, 07100 Annonay";
-    expect(extractPostalCode(address)).toEqual("07100");
-  });
-
-  test("when there is not match", () => {
-    expect(extractPostalCode("Somewhere")).toEqual("");
   });
 });

--- a/back/src/forms/pdf/helpers.ts
+++ b/back/src/forms/pdf/helpers.ts
@@ -1,4 +1,5 @@
 import { Form } from ".prisma/client";
+import { extractPostalCode } from "../../utils";
 import { isFormContributor } from "../permissions";
 import { pageHeight, imageLocations } from "./settings";
 
@@ -418,17 +419,6 @@ export async function hideEmitterFields(appendix2: Form, user: Express.User) {
     };
   }
   return appendix2;
-}
-
-/**
- *Try extracting a valid postal code
- */
-export function extractPostalCode(address: string) {
-  const matches = address.match(/([0-9]{5})/);
-  if (matches && matches.length > 0) {
-    return matches[0];
-  }
-  return "";
 }
 
 const transportModeLabels = {

--- a/back/src/forms/resolvers/Appendix2Form.ts
+++ b/back/src/forms/resolvers/Appendix2Form.ts
@@ -1,0 +1,12 @@
+import { ForbiddenError } from "apollo-server-express";
+import { Appendix2FormResolvers } from "../../generated/graphql/types";
+
+const appendix2FormResolvers: Appendix2FormResolvers = {
+  emitter: (parent, _, { user }) => {
+    console.log(user);
+    throw new ForbiddenError("Not Authorized");
+    return parent.emitter;
+  }
+};
+
+export default appendix2FormResolvers;

--- a/back/src/forms/resolvers/Appendix2Form.ts
+++ b/back/src/forms/resolvers/Appendix2Form.ts
@@ -8,7 +8,7 @@ const appendix2FormResolvers: Appendix2FormResolvers = {
     const form = await prisma.form.findUnique({ where: { id: parent.id } });
     if (!(await isFormContributor(user, form))) {
       throw new ForbiddenError(
-        "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2"
+        "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2 car votre SIRET apparait uniquement sur le bordereau de regroupement"
       );
     }
     return parent.emitter;

--- a/back/src/forms/resolvers/Appendix2Form.ts
+++ b/back/src/forms/resolvers/Appendix2Form.ts
@@ -1,10 +1,16 @@
 import { ForbiddenError } from "apollo-server-express";
 import { Appendix2FormResolvers } from "../../generated/graphql/types";
+import prisma from "../../prisma";
+import { isFormContributor } from "../permissions";
 
 const appendix2FormResolvers: Appendix2FormResolvers = {
-  emitter: (parent, _, { user }) => {
-    console.log(user);
-    throw new ForbiddenError("Not Authorized");
+  emitter: async (parent, _, { user }) => {
+    const form = await prisma.form.findUnique({ where: { id: parent.id } });
+    if (!(await isFormContributor(user, form))) {
+      throw new ForbiddenError(
+        "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2"
+      );
+    }
     return parent.emitter;
   }
 };

--- a/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
@@ -1,6 +1,5 @@
 import { CompanyType, Status, UserRole } from ".prisma/client";
 import { gql } from "apollo-server-express";
-import { Appendix2Form } from "../../../generated/graphql/types";
 import {
   companyFactory,
   formFactory,
@@ -13,98 +12,17 @@ const FORM = gql`
     form(id: $id) {
       appendix2Forms {
         id
-        readableId
-        wasteDetails {
-          code
-          quantity
-          quantityType
-        }
         emitter {
           company {
-            siret
             name
           }
         }
-        emitterPostalCode
-        signedAt
-        quantityReceived
-        processingOperationDone
       }
     }
   }
 `;
 
 describe("Appendix2Form", () => {
-  it("should return initial form information info", async () => {
-    const {
-      user: emitterUser,
-      company: emitter
-    } = await userWithCompanyFactory(UserRole.MEMBER, {
-      companyTypes: { set: [CompanyType.PRODUCER] }
-    });
-
-    const {
-      user: collectorUser,
-      company: collector
-    } = await userWithCompanyFactory(UserRole.MEMBER, {
-      companyTypes: { set: [CompanyType.COLLECTOR] }
-    });
-
-    const appendix2 = await formFactory({
-      ownerId: emitterUser.id,
-      opt: {
-        status: Status.AWAITING_GROUP,
-        emitterCompanySiret: emitter.siret,
-        emitterCompanyAddress: "40 boulevard Voltaire 13001 Marseille",
-        recipientCompanySiret: collector.siret,
-        processingOperationDone: "R 12",
-        signedAt: new Date()
-      }
-    });
-
-    const regroupement = await formFactory({
-      ownerId: emitterUser.id,
-      opt: {
-        emitterCompanySiret: collector.siret,
-        appendix2Forms: { connect: { id: appendix2.id } }
-      }
-    });
-
-    const { query } = makeClient(collectorUser);
-    const { data } = await query<{ form: { appendix2Forms: [Appendix2Form] } }>(
-      FORM,
-      {
-        variables: { id: regroupement.id }
-      }
-    );
-
-    const appendix2Result = data?.form.appendix2Forms[0];
-
-    expect(appendix2Result.wasteDetails.code).toEqual(
-      appendix2.wasteDetailsCode
-    );
-    expect(appendix2Result.wasteDetails.quantity).toEqual(
-      appendix2.wasteDetailsQuantity
-    );
-    expect(appendix2Result.wasteDetails.quantityType).toEqual(
-      appendix2.wasteDetailsQuantityType
-    );
-    expect(appendix2Result.emitter.company.siret).toEqual(
-      appendix2.emitterCompanySiret
-    );
-    expect(appendix2Result.emitter.company.name).toEqual(
-      appendix2.emitterCompanyName
-    );
-    expect(appendix2Result.emitterPostalCode).toEqual("13001");
-    expect(appendix2Result.signedAt).toEqual(appendix2.signedAt.toISOString());
-    expect(appendix2Result.quantityReceived).toEqual(
-      appendix2.quantityReceived
-    );
-    expect(appendix2Result.processingOperationDone).toEqual(
-      appendix2.processingOperationDone
-    );
-  });
-
   it("should deny access to `emitter` field is user is not form contributor", async () => {
     const {
       user: emitterUser,

--- a/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
@@ -1,5 +1,6 @@
 import { CompanyType, Status, UserRole } from ".prisma/client";
 import { gql } from "apollo-server-express";
+import { resetDatabase } from "../../../../integration-tests/helper";
 import {
   companyFactory,
   formFactory,
@@ -23,6 +24,8 @@ const FORM = gql`
 `;
 
 describe("Appendix2Form", () => {
+  afterAll(resetDatabase);
+
   it("should deny access to `emitter` field is user is not form contributor", async () => {
     const {
       user: emitterUser,

--- a/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
@@ -4,8 +4,8 @@ import {
   companyFactory,
   formFactory,
   userWithCompanyFactory
-} from "../../../../__tests__/factories";
-import makeClient from "../../../../__tests__/testClient";
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
 
 const FORM = gql`
   query Form($id: ID!) {
@@ -67,7 +67,7 @@ describe("Appendix2Form", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2"
+          "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2 car votre SIRET apparait uniquement sur le bordereau de regroupement"
       })
     ]);
   });

--- a/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
@@ -1,5 +1,6 @@
 import { CompanyType, Status, UserRole } from ".prisma/client";
 import { gql } from "apollo-server-express";
+import { Appendix2Form } from "../../../generated/graphql/types";
 import {
   companyFactory,
   formFactory,
@@ -12,17 +13,98 @@ const FORM = gql`
     form(id: $id) {
       appendix2Forms {
         id
+        readableId
+        wasteDetails {
+          code
+          quantity
+          quantityType
+        }
         emitter {
           company {
+            siret
             name
           }
         }
+        emitterPostalCode
+        signedAt
+        quantityReceived
+        processingOperationDone
       }
     }
   }
 `;
 
 describe("Appendix2Form", () => {
+  it("should return initial form information info", async () => {
+    const {
+      user: emitterUser,
+      company: emitter
+    } = await userWithCompanyFactory(UserRole.MEMBER, {
+      companyTypes: { set: [CompanyType.PRODUCER] }
+    });
+
+    const {
+      user: collectorUser,
+      company: collector
+    } = await userWithCompanyFactory(UserRole.MEMBER, {
+      companyTypes: { set: [CompanyType.COLLECTOR] }
+    });
+
+    const appendix2 = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        status: Status.AWAITING_GROUP,
+        emitterCompanySiret: emitter.siret,
+        emitterCompanyAddress: "40 boulevard Voltaire 13001 Marseille",
+        recipientCompanySiret: collector.siret,
+        processingOperationDone: "R 12",
+        signedAt: new Date()
+      }
+    });
+
+    const regroupement = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        emitterCompanySiret: collector.siret,
+        appendix2Forms: { connect: { id: appendix2.id } }
+      }
+    });
+
+    const { query } = makeClient(collectorUser);
+    const { data } = await query<{ form: { appendix2Forms: [Appendix2Form] } }>(
+      FORM,
+      {
+        variables: { id: regroupement.id }
+      }
+    );
+
+    const appendix2Result = data?.form.appendix2Forms[0];
+
+    expect(appendix2Result.wasteDetails.code).toEqual(
+      appendix2.wasteDetailsCode
+    );
+    expect(appendix2Result.wasteDetails.quantity).toEqual(
+      appendix2.wasteDetailsQuantity
+    );
+    expect(appendix2Result.wasteDetails.quantityType).toEqual(
+      appendix2.wasteDetailsQuantityType
+    );
+    expect(appendix2Result.emitter.company.siret).toEqual(
+      appendix2.emitterCompanySiret
+    );
+    expect(appendix2Result.emitter.company.name).toEqual(
+      appendix2.emitterCompanyName
+    );
+    expect(appendix2Result.emitterPostalCode).toEqual("13001");
+    expect(appendix2Result.signedAt).toEqual(appendix2.signedAt.toISOString());
+    expect(appendix2Result.quantityReceived).toEqual(
+      appendix2.quantityReceived
+    );
+    expect(appendix2Result.processingOperationDone).toEqual(
+      appendix2.processingOperationDone
+    );
+  });
+
   it("should deny access to `emitter` field is user is not form contributor", async () => {
     const {
       user: emitterUser,

--- a/back/src/forms/resolvers/forms/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/forms/__tests__/Appendix2Form.integration.ts
@@ -1,0 +1,74 @@
+import { CompanyType, Status, UserRole } from ".prisma/client";
+import { gql } from "apollo-server-express";
+import {
+  companyFactory,
+  formFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+const FORM = gql`
+  query Form($id: ID!) {
+    form(id: $id) {
+      appendix2Forms {
+        id
+        emitter {
+          company {
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+describe("Appendix2Form", () => {
+  it("should deny access to `emitter` field is user is not form contributor", async () => {
+    const {
+      user: emitterUser,
+      company: emitter
+    } = await userWithCompanyFactory(UserRole.MEMBER, {
+      companyTypes: { set: [CompanyType.PRODUCER] }
+    });
+
+    const collector = await companyFactory({
+      companyTypes: { set: [CompanyType.COLLECTOR] }
+    });
+
+    const {
+      user: destinationUser,
+      company: destination
+    } = await userWithCompanyFactory(UserRole.MEMBER, {
+      companyTypes: { set: [CompanyType.WASTEPROCESSOR] }
+    });
+
+    const appendix2 = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        status: Status.AWAITING_GROUP,
+        emitterCompanySiret: emitter.siret,
+        recipientCompanySiret: collector.siret
+      }
+    });
+
+    const regroupement = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        appendix2Forms: { connect: { id: appendix2.id } },
+        recipientCompanySiret: destination.siret
+      }
+    });
+
+    // destination cannot access appendix2.emitter
+    const { query } = makeClient(destinationUser);
+    const { errors } = await query(FORM, {
+      variables: { id: regroupement.id }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2"
+      })
+    ]);
+  });
+});

--- a/back/src/forms/resolvers/forms/__tests__/appendix2Forms.integration.ts
+++ b/back/src/forms/resolvers/forms/__tests__/appendix2Forms.integration.ts
@@ -1,0 +1,101 @@
+import { UserRole } from ".prisma/client";
+import { gql } from "apollo-server-express";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+const FORM = gql`
+  query GetForm($id: ID, $readableId: String) {
+    form(id: $id, readableId: $readableId) {
+      id
+      appendix2Forms {
+        id
+        readableId
+        wasteDetails {
+          code
+        }
+        emitter {
+          company {
+            name
+          }
+        }
+        receivedAt
+        quantityReceived
+        processingOperationDone
+      }
+    }
+  }
+`;
+
+describe("appendix2Forms resolver", () => {
+  afterAll(resetDatabase);
+
+  it("should return an empty array when no appendix2 is appended", async () => {
+    const { user, company: emitter } = await userWithCompanyFactory(
+      UserRole.MEMBER
+    );
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: emitter.siret }
+    });
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "form">>(FORM, {
+      variables: { id: form.id }
+    });
+    expect(data.form.appendix2Forms).toEqual([]);
+  });
+
+  it("should return appendix2 forms", async () => {
+    const {
+      user: emitter,
+      company: emitterCompany
+    } = await userWithCompanyFactory(UserRole.MEMBER);
+
+    const {
+      user: collector,
+      company: collectorCompany
+    } = await userWithCompanyFactory(UserRole.MEMBER);
+
+    const appendix2 = await formFactory({
+      ownerId: emitter.id,
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        recipientCompanySiret: collectorCompany.siret
+      }
+    });
+
+    const regroupementForm = await formFactory({
+      ownerId: collector.id,
+      opt: {
+        emitterCompanySiret: collectorCompany.siret,
+        appendix2Forms: { connect: { id: appendix2.id } }
+      }
+    });
+
+    const { query } = makeClient(collector);
+    const { data } = await query<Pick<Query, "form">>(FORM, {
+      variables: { id: regroupementForm.id }
+    });
+    expect(data.form.appendix2Forms).toEqual([
+      {
+        id: appendix2.id,
+        readableId: appendix2.readableId,
+        wasteDetails: {
+          code: appendix2.wasteDetailsCode
+        },
+        emitter: {
+          company: {
+            name: appendix2.emitterCompanyName
+          }
+        },
+        receivedAt: appendix2.receivedAt,
+        quantityReceived: appendix2.quantityReceived,
+        processingOperationDone: appendix2.processingOperationDone
+      }
+    ]);
+  });
+});

--- a/back/src/forms/resolvers/forms/__tests__/appendix2Forms.integration.ts
+++ b/back/src/forms/resolvers/forms/__tests__/appendix2Forms.integration.ts
@@ -23,9 +23,10 @@ const FORM = gql`
             name
           }
         }
-        receivedAt
+        signedAt
         quantityReceived
         processingOperationDone
+        emitterPostalCode
       }
     }
   }
@@ -64,6 +65,7 @@ describe("appendix2Forms resolver", () => {
       ownerId: emitter.id,
       opt: {
         emitterCompanySiret: emitterCompany.siret,
+        emitterCompanyAddress: "40 boulevard Voltaire 13001 Marseille",
         recipientCompanySiret: collectorCompany.siret
       }
     });
@@ -92,9 +94,10 @@ describe("appendix2Forms resolver", () => {
             name: appendix2.emitterCompanyName
           }
         },
-        receivedAt: appendix2.receivedAt,
+        signedAt: appendix2.signedAt,
         quantityReceived: appendix2.quantityReceived,
-        processingOperationDone: appendix2.processingOperationDone
+        processingOperationDone: appendix2.processingOperationDone,
+        emitterPostalCode: "13001"
       }
     ]);
   });

--- a/back/src/forms/resolvers/forms/appendix2Forms.ts
+++ b/back/src/forms/resolvers/forms/appendix2Forms.ts
@@ -1,11 +1,22 @@
 import { FormResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
+import { expandFormFromDb } from "../../form-converter";
 
 const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async form => {
   const appendix2Forms = await prisma.form
     .findUnique({ where: { id: form.id } })
     .appendix2Forms();
-  return appendix2Forms;
+  return appendix2Forms.map(f => {
+    const form = expandFormFromDb(f);
+    return {
+      readableId: form.readableId,
+      wasteDetails: form.wasteDetails,
+      emitter: form.emitter,
+      receivedAt: form.receivedAt,
+      quantityReceived: form.quantityReceived,
+      processingOperationDone: form.processingOperationDone
+    };
+  });
 };
 
 export default appendix2FormsResolver;

--- a/back/src/forms/resolvers/forms/appendix2Forms.ts
+++ b/back/src/forms/resolvers/forms/appendix2Forms.ts
@@ -1,5 +1,6 @@
 import { FormResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
+import { extractPostalCode } from "../../../utils";
 import { expandFormFromDb } from "../../form-converter";
 
 const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async form => {
@@ -13,7 +14,8 @@ const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async form => {
       readableId: form.readableId,
       wasteDetails: form.wasteDetails,
       emitter: form.emitter,
-      receivedAt: form.receivedAt,
+      emitterPostalCode: extractPostalCode(form.emitter?.company?.address),
+      signedAt: form.signedAt,
       quantityReceived: form.quantityReceived,
       processingOperationDone: form.processingOperationDone
     };

--- a/back/src/forms/resolvers/forms/appendix2Forms.ts
+++ b/back/src/forms/resolvers/forms/appendix2Forms.ts
@@ -9,6 +9,7 @@ const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async form => {
   return appendix2Forms.map(f => {
     const form = expandFormFromDb(f);
     return {
+      id: form.id,
       readableId: form.readableId,
       wasteDetails: form.wasteDetails,
       emitter: form.emitter,

--- a/back/src/forms/resolvers/index.ts
+++ b/back/src/forms/resolvers/index.ts
@@ -4,6 +4,7 @@ import Form from "./Form";
 import WasteDetails from "./WasteDetails";
 import StateSummary from "./StateSummary";
 import FormCompany from "./FormCompany";
+import Appendix2Form from "./Appendix2Form";
 import Bsd from "./Bsd";
 
 export default {
@@ -13,5 +14,6 @@ export default {
   WasteDetails,
   StateSummary,
   FormCompany,
+  Appendix2Form,
   Bsd
 };

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -59,6 +59,16 @@ export type AdminForVerification = {
   phone?: Maybe<Scalars["String"]>;
 };
 
+export type Appendix2Form = {
+  __typename?: "Appendix2Form";
+  readableId: Scalars["String"];
+  wasteDetails?: Maybe<WasteDetails>;
+  emitter?: Maybe<Emitter>;
+  receivedAt?: Maybe<Scalars["DateTime"]>;
+  quantityReceived?: Maybe<Scalars["Float"]>;
+  processingOperationDone?: Maybe<Scalars["String"]>;
+};
+
 /** Payload de création d'une annexe 2 */
 export type AppendixFormInput = {
   /** Identifiant unique du bordereau */
@@ -2217,7 +2227,7 @@ export type Form = {
   /** Destination ultérieure prévue (case 12) */
   nextDestination?: Maybe<NextDestination>;
   /** Annexe 2 */
-  appendix2Forms?: Maybe<Array<Form>>;
+  appendix2Forms?: Maybe<Array<Appendix2Form>>;
   ecoOrganisme?: Maybe<FormEcoOrganisme>;
   /** BSD suite - détail des champs de la partie entreposage provisoire ou reconditionnement */
   temporaryStorageDetail?: Maybe<TemporaryStorageDetail>;
@@ -4661,6 +4671,7 @@ export type ResolversTypes = {
   Broker: ResolverTypeWrapper<Broker>;
   FormStatus: FormStatus;
   NextDestination: ResolverTypeWrapper<NextDestination>;
+  Appendix2Form: ResolverTypeWrapper<Appendix2Form>;
   FormEcoOrganisme: ResolverTypeWrapper<FormEcoOrganisme>;
   TemporaryStorageDetail: ResolverTypeWrapper<TemporaryStorageDetail>;
   TemporaryStorer: ResolverTypeWrapper<TemporaryStorer>;
@@ -4985,6 +4996,7 @@ export type ResolversParentTypes = {
   Trader: Trader;
   Broker: Broker;
   NextDestination: NextDestination;
+  Appendix2Form: Appendix2Form;
   FormEcoOrganisme: FormEcoOrganisme;
   TemporaryStorageDetail: TemporaryStorageDetail;
   TemporaryStorer: TemporaryStorer;
@@ -5253,6 +5265,35 @@ export type AdminForVerificationResolvers<
   email?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   phone?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Appendix2FormResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes["Appendix2Form"] = ResolversParentTypes["Appendix2Form"]
+> = {
+  readableId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  wasteDetails?: Resolver<
+    Maybe<ResolversTypes["WasteDetails"]>,
+    ParentType,
+    ContextType
+  >;
+  emitter?: Resolver<Maybe<ResolversTypes["Emitter"]>, ParentType, ContextType>;
+  receivedAt?: Resolver<
+    Maybe<ResolversTypes["DateTime"]>,
+    ParentType,
+    ContextType
+  >;
+  quantityReceived?: Resolver<
+    Maybe<ResolversTypes["Float"]>,
+    ParentType,
+    ContextType
+  >;
+  processingOperationDone?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -7167,7 +7208,7 @@ export type FormResolvers<
     ContextType
   >;
   appendix2Forms?: Resolver<
-    Maybe<Array<ResolversTypes["Form"]>>,
+    Maybe<Array<ResolversTypes["Appendix2Form"]>>,
     ParentType,
     ContextType
   >;
@@ -8556,6 +8597,7 @@ export type WorkSiteResolvers<
 
 export type Resolvers<ContextType = GraphQLContext> = {
   AdminForVerification?: AdminForVerificationResolvers<ContextType>;
+  Appendix2Form?: Appendix2FormResolvers<ContextType>;
   AuthPayload?: AuthPayloadResolvers<ContextType>;
   Broker?: BrokerResolvers<ContextType>;
   BrokerReceipt?: BrokerReceiptResolvers<ContextType>;
@@ -8714,6 +8756,21 @@ export function createAdminForVerificationMock(
     email: "",
     name: null,
     phone: null,
+    ...props
+  };
+}
+
+export function createAppendix2FormMock(
+  props: Partial<Appendix2Form>
+): Appendix2Form {
+  return {
+    __typename: "Appendix2Form",
+    readableId: "",
+    wasteDetails: null,
+    emitter: null,
+    receivedAt: null,
+    quantityReceived: null,
+    processingOperationDone: null,
     ...props
   };
 }

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -61,6 +61,7 @@ export type AdminForVerification = {
 
 export type Appendix2Form = {
   __typename?: "Appendix2Form";
+  id: Scalars["ID"];
   readableId: Scalars["String"];
   wasteDetails?: Maybe<WasteDetails>;
   emitter?: Maybe<Emitter>;
@@ -5272,6 +5273,7 @@ export type Appendix2FormResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["Appendix2Form"] = ResolversParentTypes["Appendix2Form"]
 > = {
+  id?: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
   readableId?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   wasteDetails?: Resolver<
     Maybe<ResolversTypes["WasteDetails"]>,
@@ -8765,6 +8767,7 @@ export function createAppendix2FormMock(
 ): Appendix2Form {
   return {
     __typename: "Appendix2Form",
+    id: "",
     readableId: "",
     wasteDetails: null,
     emitter: null,

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -59,14 +59,45 @@ export type AdminForVerification = {
   phone?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Information sur le bordereau initial lors d'une réexpédition après transformation ou traitement aboutissant
+ * à des déchets dont la provenance reste identifiable (annexe 2)
+ */
 export type Appendix2Form = {
   __typename?: "Appendix2Form";
+  /** Identifiant unique du bordereau initial */
   id: Scalars["ID"];
+  /** Identifiant lisible du bordereau initial */
   readableId: Scalars["String"];
+  /** Détails du déchet du bordereau initial (case 3) */
   wasteDetails?: Maybe<WasteDetails>;
+  /**
+   * Émetteur du bordereau initial
+   * Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau initial (ex: l'exutoire finale)
+   * n'ont pas accès à ce champs pour préserver les informations commerciales de l'établissement effectuant le regroupemnt
+   */
   emitter?: Maybe<Emitter>;
-  receivedAt?: Maybe<Scalars["DateTime"]>;
+  /**
+   * Code postal de l'émetteur du bordereau initial permettant aux établissements
+   * qui apparaissent sur le bordereau de regroupement
+   * mais pas sur le bordereau initial (ex: l'exutoire finale) de connaitre la zone de chalandise de l'émetteur initial.
+   */
+  emitterPostalCode?: Maybe<Scalars["String"]>;
+  /**
+   * Date d’acceptation du lot initial par l’installation réalisant une
+   * transformation ou un traitement aboutissant à des déchets
+   * dont la provenance reste identifiable. C'est la date qui figure au cadre 10 du bordereau initial.
+   */
+  signedAt?: Maybe<Scalars["DateTime"]>;
+  /**
+   * Quantité reçue par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+   * dont la provenance reste identifiable
+   */
   quantityReceived?: Maybe<Scalars["Float"]>;
+  /**
+   * Opération de transformation ou un traitement aboutissant à des déchets dont la provenance reste identifiable effectuée
+   * par l'installation de regroupement
+   */
   processingOperationDone?: Maybe<Scalars["String"]>;
 };
 
@@ -5281,7 +5312,12 @@ export type Appendix2FormResolvers<
     ContextType
   >;
   emitter?: Resolver<Maybe<ResolversTypes["Emitter"]>, ParentType, ContextType>;
-  receivedAt?: Resolver<
+  emitterPostalCode?: Resolver<
+    Maybe<ResolversTypes["String"]>,
+    ParentType,
+    ContextType
+  >;
+  signedAt?: Resolver<
     Maybe<ResolversTypes["DateTime"]>,
     ParentType,
     ContextType
@@ -8771,7 +8807,8 @@ export function createAppendix2FormMock(
     readableId: "",
     wasteDetails: null,
     emitter: null,
-    receivedAt: null,
+    emitterPostalCode: null,
+    signedAt: null,
     quantityReceived: null,
     processingOperationDone: null,
     ...props

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -94,3 +94,16 @@ export const hashToken = (token: string) =>
     .createHmac("sha256", process.env.API_TOKEN_SECRET)
     .update(token)
     .digest("hex");
+
+/**
+ *Try extracting a valid postal code
+ */
+export function extractPostalCode(address: string) {
+  if (address) {
+    const matches = address.match(/([0-9]{5})/);
+    if (matches && matches.length > 0) {
+      return matches[0];
+    }
+  }
+  return "";
+}

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -1992,6 +1992,51 @@ Champ libre, utilisable par exemple pour noter les tournées des transporteurs
 
 ## Objects
 
+### Appendix2Form
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>readableId</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wasteDetails</strong></td>
+<td valign="top"><a href="#wastedetails">WasteDetails</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>emitter</strong></td>
+<td valign="top"><a href="#emitter">Emitter</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>receivedAt</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityReceived</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
 ### AuthPayload
 
 Cet objet est renvoyé par la mutation login qui est dépréciée
@@ -6196,7 +6241,7 @@ Destination ultérieure prévue (case 12)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>appendix2Forms</strong></td>
-<td valign="top">[<a href="#form">Form</a>!]</td>
+<td valign="top">[<a href="#appendix2form">Appendix2Form</a>!]</td>
 <td>
 
 Annexe 2

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -2005,6 +2005,11 @@ Champ libre, utilisable par exemple pour noter les tournées des transporteurs
 </thead>
 <tbody>
 <tr>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#id">ID</a>!</td>
+<td></td>
+</tr>
+<tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td></td>

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -1994,6 +1994,9 @@ Champ libre, utilisable par exemple pour noter les tournées des transporteurs
 
 ### Appendix2Form
 
+Information sur le bordereau initial lors d'une réexpédition après transformation ou traitement aboutissant
+à des déchets dont la provenance reste identifiable (annexe 2)
+
 <table>
 <thead>
 <tr>
@@ -2007,37 +2010,80 @@ Champ libre, utilisable par exemple pour noter les tournées des transporteurs
 <tr>
 <td colspan="2" valign="top"><strong>id</strong></td>
 <td valign="top"><a href="#id">ID</a>!</td>
-<td></td>
+<td>
+
+Identifiant unique du bordereau initial
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>readableId</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+Identifiant lisible du bordereau initial
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteDetails</strong></td>
 <td valign="top"><a href="#wastedetails">WasteDetails</a></td>
-<td></td>
+<td>
+
+Détails du déchet du bordereau initial (case 3)
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>emitter</strong></td>
 <td valign="top"><a href="#emitter">Emitter</a></td>
-<td></td>
+<td>
+
+Émetteur du bordereau initial
+Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau initial (ex: l'exutoire finale)
+n'ont pas accès à ce champs pour préserver les informations commerciales de l'établissement effectuant le regroupemnt
+
+</td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>receivedAt</strong></td>
+<td colspan="2" valign="top"><strong>emitterPostalCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Code postal de l'émetteur du bordereau initial permettant aux établissements qui apparaissent sur le bordereau de regroupement
+mais pas sur le bordereau initial (ex: l'exutoire finale) de connaitre la zone de chalandise de l'émetteur initial.
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>signedAt</strong></td>
 <td valign="top"><a href="#datetime">DateTime</a></td>
-<td></td>
+<td>
+
+Date d’acceptation du lot initial par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+dont la provenance reste identifiable. C'est la date qui figure au cadre 10 du bordereau initial.
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>quantityReceived</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
-<td></td>
+<td>
+
+Quantité reçue par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+dont la provenance reste identifiable
+
+</td>
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>processingOperationDone</strong></td>
 <td valign="top"><a href="#string">String</a></td>
-<td></td>
+<td>
+
+Opération de transformation ou un traitement aboutissant à des déchets dont la provenance reste identifiable effectuée
+par l'installation de regroupement
+
+</td>
 </tr>
 </tbody>
 </table>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -50,6 +50,7 @@ export type AdminForVerification = {
 
 export type Appendix2Form = {
   __typename?: "Appendix2Form";
+  id: Scalars["ID"];
   readableId: Scalars["String"];
   wasteDetails?: Maybe<WasteDetails>;
   emitter?: Maybe<Emitter>;

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -48,6 +48,16 @@ export type AdminForVerification = {
   phone?: Maybe<Scalars["String"]>;
 };
 
+export type Appendix2Form = {
+  __typename?: "Appendix2Form";
+  readableId: Scalars["String"];
+  wasteDetails?: Maybe<WasteDetails>;
+  emitter?: Maybe<Emitter>;
+  receivedAt?: Maybe<Scalars["DateTime"]>;
+  quantityReceived?: Maybe<Scalars["Float"]>;
+  processingOperationDone?: Maybe<Scalars["String"]>;
+};
+
 /** Payload de création d'une annexe 2 */
 export type AppendixFormInput = {
   /** Identifiant unique du bordereau */
@@ -2258,7 +2268,7 @@ export type Form = {
   /** Destination ultérieure prévue (case 12) */
   nextDestination?: Maybe<NextDestination>;
   /** Annexe 2 */
-  appendix2Forms?: Maybe<Array<Form>>;
+  appendix2Forms?: Maybe<Array<Appendix2Form>>;
   ecoOrganisme?: Maybe<FormEcoOrganisme>;
   /** BSD suite - détail des champs de la partie entreposage provisoire ou reconditionnement */
   temporaryStorageDetail?: Maybe<TemporaryStorageDetail>;

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -48,14 +48,45 @@ export type AdminForVerification = {
   phone?: Maybe<Scalars["String"]>;
 };
 
+/**
+ * Information sur le bordereau initial lors d'une réexpédition après transformation ou traitement aboutissant
+ * à des déchets dont la provenance reste identifiable (annexe 2)
+ */
 export type Appendix2Form = {
   __typename?: "Appendix2Form";
+  /** Identifiant unique du bordereau initial */
   id: Scalars["ID"];
+  /** Identifiant lisible du bordereau initial */
   readableId: Scalars["String"];
+  /** Détails du déchet du bordereau initial (case 3) */
   wasteDetails?: Maybe<WasteDetails>;
+  /**
+   * Émetteur du bordereau initial
+   * Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau initial (ex: l'exutoire finale)
+   * n'ont pas accès à ce champs pour préserver les informations commerciales de l'établissement effectuant le regroupemnt
+   */
   emitter?: Maybe<Emitter>;
-  receivedAt?: Maybe<Scalars["DateTime"]>;
+  /**
+   * Code postal de l'émetteur du bordereau initial permettant aux établissements
+   * qui apparaissent sur le bordereau de regroupement
+   * mais pas sur le bordereau initial (ex: l'exutoire finale) de connaitre la zone de chalandise de l'émetteur initial.
+   */
+  emitterPostalCode?: Maybe<Scalars["String"]>;
+  /**
+   * Date d’acceptation du lot initial par l’installation réalisant une
+   * transformation ou un traitement aboutissant à des déchets
+   * dont la provenance reste identifiable. C'est la date qui figure au cadre 10 du bordereau initial.
+   */
+  signedAt?: Maybe<Scalars["DateTime"]>;
+  /**
+   * Quantité reçue par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
+   * dont la provenance reste identifiable
+   */
   quantityReceived?: Maybe<Scalars["Float"]>;
+  /**
+   * Opération de transformation ou un traitement aboutissant à des déchets dont la provenance reste identifiable effectuée
+   * par l'installation de regroupement
+   */
   processingOperationDone?: Maybe<Scalars["String"]>;
 };
 


### PR DESCRIPTION
- Limite les informations visibles sur une annexe 2 aux champs présents sur le CERFA. 
- Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau annexé (ex: l'exutoire finale) n'ont pas accès au champ `emitter` pour préserver les données commerciales de l'établissement effectuant le regroupement. 

:boom: Breaking Change API, à annoncer dans la NL tech et à passer dans la prochaine release

 - ~[ ] Mettre à jour la documentation~
- [x] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~
- ~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~
---

- [Ticket Trello](https://trello.com/c/2UB3HwiG)
