### PR TITLE
Ajout d'une page permettant de renvoyer un email d'activation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,18 +5,6 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-# Unplanified release
-
-#### :rocket: Nouvelles fonctionnalités
-#### :boom: Breaking changes
-#### :bug: Corrections de bugs
-#### :nail_care: Améliorations
-
-- Ajout d'un mécanisme permettant de renvoyer un email d'activation [PR 874](https://github.com/MTES-MCT/trackdechets/pull/874)
-
-#### :memo: Documentation
-#### :house: Interne
-
 # Next release (June)
 
 #### :rocket: Nouvelles fonctionnalités
@@ -35,7 +23,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Masquage des informations liées à l'émetteur initial d'une annexe 2 dans le PDF d'un bordereau de regroupement lorsqu'il est téléchargé par un autre acteur que l'installation effectuant le regroupement [PR 865](https://github.com/MTES-MCT/trackdechets/pull/865)
-
+- Ajout d'un mécanisme permettant de renvoyer un email d'activation [PR 874](https://github.com/MTES-MCT/trackdechets/pull/874)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,18 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Unplanified release
+
+#### :rocket: Nouvelles fonctionnalités
+#### :boom: Breaking changes
+#### :bug: Corrections de bugs
+#### :nail_care: Améliorations
+
+- Ajout d'un mécanisme permettant de renvoyer un email d'activation [PR 874](https://github.com/MTES-MCT/trackdechets/pull/874)
+
+#### :memo: Documentation
+#### :house: Interne
+
 # Next release (June)
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -2835,6 +2835,11 @@ export type Mutation = {
   renewSecurityCode: CompanyPrivate;
   /**
    * USAGE INTERNE
+   * Renvoie un email d'activation
+   */
+  resendActivationEmail: Scalars["Boolean"];
+  /**
+   * USAGE INTERNE
    * Renvoie l'email d'invitation à un établissement
    */
   resendInvitation: Scalars["Boolean"];
@@ -3209,6 +3214,10 @@ export type MutationRemoveUserFromCompanyArgs = {
 
 export type MutationRenewSecurityCodeArgs = {
   siret: Scalars["String"];
+};
+
+export type MutationResendActivationEmailArgs = {
+  email: Scalars["String"];
 };
 
 export type MutationResendInvitationArgs = {
@@ -7637,6 +7646,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationRenewSecurityCodeArgs, "siret">
+  >;
+  resendActivationEmail?: Resolver<
+    ResolversTypes["Boolean"],
+    ParentType,
+    ContextType,
+    RequireFields<MutationResendActivationEmailArgs, "email">
   >;
   resendInvitation?: Resolver<
     ResolversTypes["Boolean"],

--- a/back/src/mailer/templates/__tests__/templates.test.ts
+++ b/back/src/mailer/templates/__tests__/templates.test.ts
@@ -21,9 +21,9 @@ const to = [{ name: "John Snow", email: "john.snow@trackdechets.fr" }];
 
 describe("templates", () => {
   test("onSignup", () => {
-    const activationHash = "abcd";
+    const activationHash = "abcd/";
     const rendered = renderMail(onSignup, {
-      variables: { activationHash: "abcd" },
+      variables: { activationHash: "abcd/" },
       to
     });
     expect(rendered.body).toContain(activationHash);

--- a/back/src/mailer/templates/mustache/confirmation-de-compte.html
+++ b/back/src/mailer/templates/mustache/confirmation-de-compte.html
@@ -4,7 +4,7 @@
 <br />
 <p>
   Pour finaliser votre inscription, veuillez confirmer votre email
-  <a href="{{{API_URL}}}/userActivation?hash={{activationHash}}">en cliquant ici.
+  <a href="{{{API_URL}}}/userActivation?hash={{{activationHash}}}">en cliquant ici.
   </a>
 </p>
 <br />

--- a/back/src/mailer/templates/mustache/information-demande-de-rattachement.html
+++ b/back/src/mailer/templates/mustache/information-demande-de-rattachement.html
@@ -5,5 +5,5 @@
 <br />
 <p>
   Pour valider ou refuser sa demande, cliquez sur
-  <a href="{{UI_URL}}/membership-request/{{membershipRequestId}}">ce lien</a>.
+  <a href="{{{UI_URL}}}/membership-request/{{{membershipRequestId}}}">ce lien</a>.
 </p>

--- a/back/src/mailer/templates/mustache/invitation-par-administrateur.html
+++ b/back/src/mailer/templates/mustache/invitation-par-administrateur.html
@@ -3,6 +3,6 @@
 </p>
 <br />
 <p>Pour finaliser la création de votre compte et commencer à utiliser la plateforme, cliquez <a
-    href="{{{API_URL}}}/invite?hash={{hash}}">sur ce lien</a> et renseignez les informations demandées.</p>
+    href="{{{API_URL}}}/invite?hash={{{hash}}}">sur ce lien</a> et renseignez les informations demandées.</p>
 <br />
 <p>Vous aurez accès à l'ensemble des informations concernant l'entreprise <strong>{{companyName}}</strong>.</p>

--- a/back/src/mailer/templates/mustache/notification-invitation.html
+++ b/back/src/mailer/templates/mustache/notification-invitation.html
@@ -3,7 +3,7 @@
   Trackdéchets.
 </p>
 <br />
-<p>Vous pouvez dès à présent accéder aux informations de cette entreprise sur le <a href="{{UI_URL}}">portail
+<p>Vous pouvez dès à présent accéder aux informations de cette entreprise sur le <a href="{{{UI_URL}}}">portail
     Trackdéchets</a>.</p>
 <br />
 <p>Vous aurez accès à l'ensemble des données concernant l'entreprise <strong>{{companyName}}</strong>.</p>

--- a/back/src/mailer/templates/mustache/suite-transmission-bsd.html
+++ b/back/src/mailer/templates/mustache/suite-transmission-bsd.html
@@ -1,6 +1,6 @@
 <p>
   Votre entreprise {{company.name}} ({{company.siret}}) a été identifiée sur un
-  BSD dématérialisé disponible sur <a href="{{UI_URL}}">la plateforme Trackdéchets</a>
+  BSD dématérialisé disponible sur <a href="{{{UI_URL}}}">la plateforme Trackdéchets</a>
 </p>
 <br />
 <h3 style="color: #000091">Qu’est-ce que Trackdéchets ?</h3>
@@ -31,7 +31,7 @@
 <br />
 <h3 style="color: #000091">Comment aller voir ce BSD ? </h3>
 <p>
-  Vous pouvez créer votre compte en cliquant <a href="{{UI_URL}}/signup">sur ce lien</a> et en suivant la
+  Vous pouvez créer votre compte en cliquant <a href="{{{UI_URL}}}/signup">sur ce lien</a> et en suivant la
   procédure d'inscription. C’est rapide, vous pouvez finaliser votre inscription en 3’ max une fois muni.e de votre
   SIRET. Vous pourrez alors commencer à utiliser Trackdéchets et découvrir ses fonctionnalités.
 </p>

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -3,6 +3,7 @@ import signup from "./mutations/signup";
 import login from "./mutations/login";
 import changePassword from "./mutations/changePassword";
 import resetPassword from "./mutations/resetPassword";
+import resendActivationEmail from "./mutations/resendActivationEmail";
 import editProfile from "./mutations/editProfile";
 import inviteUserToCompany from "./mutations/inviteUserToCompany";
 import deleteInvitation from "./mutations/deleteInvitation";
@@ -26,7 +27,8 @@ const Mutation: MutationResolvers = {
   removeUserFromCompany,
   sendMembershipRequest,
   acceptMembershipRequest,
-  refuseMembershipRequest
+  refuseMembershipRequest,
+  resendActivationEmail
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/mutations/__tests__/resendActivationEmail.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/resendActivationEmail.integration.ts
@@ -18,7 +18,7 @@ const RESEND_ACTIVATION_EMAIL = gql`
 const sendMailSpy = jest.spyOn(mailing, "sendMail");
 sendMailSpy.mockImplementation(() => Promise.resolve());
 
-describe("mutation resendActivationLink", () => {
+describe("mutation resendActivationEmail", () => {
   afterAll(resetDatabase);
 
   it("should resend activation email to user", async () => {

--- a/back/src/users/resolvers/mutations/__tests__/resendActivationEmail.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/resendActivationEmail.integration.ts
@@ -1,0 +1,69 @@
+import { gql } from "apollo-server-express";
+import prisma from "../../../../prisma";
+import { userFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import * as mailing from "../../../../mailer/mailing";
+import { ErrorCode } from "../../../../common/errors";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { renderMail } from "../../../../mailer/templates/renderers";
+import { onSignup } from "../../../../mailer/templates";
+
+const RESEND_ACTIVATION_EMAIL = gql`
+  mutation ResendActivationEmail($email: String!) {
+    resendActivationEmail(email: $email)
+  }
+`;
+
+// No mails
+const sendMailSpy = jest.spyOn(mailing, "sendMail");
+sendMailSpy.mockImplementation(() => Promise.resolve());
+
+describe("mutation resendActivationLink", () => {
+  afterAll(resetDatabase);
+
+  it("should resend activation email to user", async () => {
+    const user = await userFactory({ isActive: false });
+    const hash = "hash_1";
+    await prisma.userActivationHash.create({
+      data: { userId: user.id, hash }
+    });
+    const { mutate } = makeClient();
+    await mutate(RESEND_ACTIVATION_EMAIL, { variables: { email: user.email } });
+    expect(sendMailSpy).toHaveBeenCalledWith(
+      renderMail(onSignup, {
+        to: [{ name: user.name, email: user.email }],
+        variables: { activationHash: hash }
+      })
+    );
+  });
+
+  it("should return UserInputError if user does not exist", async () => {
+    const { mutate } = makeClient();
+    const { errors } = await mutate(RESEND_ACTIVATION_EMAIL, {
+      variables: { email: "john.snow@trackdechets.fr" }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Cet email n'existe pas sur notre plateforme.",
+        extensions: { code: ErrorCode.BAD_USER_INPUT }
+      })
+    ]);
+  });
+
+  it("should return UserInputError if user is already active", async () => {
+    const user = await userFactory({ isActive: true });
+    await prisma.userActivationHash.create({
+      data: { userId: user.id, hash: "hash_2" }
+    });
+    const { mutate } = makeClient();
+    const { errors } = await mutate(RESEND_ACTIVATION_EMAIL, {
+      variables: { email: user.email }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Ce compte a déjà été activé",
+        extensions: { code: ErrorCode.BAD_USER_INPUT }
+      })
+    ]);
+  });
+});

--- a/back/src/users/resolvers/mutations/resendActivationEmail.ts
+++ b/back/src/users/resolvers/mutations/resendActivationEmail.ts
@@ -1,0 +1,43 @@
+import prisma from "../../../prisma";
+import { sendMail } from "../../../mailer/mailing";
+import { MutationResolvers } from "../../../generated/graphql/types";
+import { renderMail } from "../../../mailer/templates/renderers";
+import { onSignup } from "../../../mailer/templates";
+import { UserInputError } from "apollo-server-express";
+
+const resendActivationEmail: MutationResolvers["resendActivationEmail"] = async (
+  parent,
+  { email }
+) => {
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    throw new UserInputError(`Cet email n'existe pas sur notre plateforme.`);
+  }
+
+  if (user.isActive) {
+    throw new UserInputError("Ce compte a déjà été activé");
+  }
+
+  const activationHashes = await prisma.userActivationHash.findMany({
+    where: { userId: user.id }
+  });
+
+  if (activationHashes?.length === 0) {
+    throw new Error(
+      `L'utlisateur ${user.email} non actif ne possède pas de hash d'activation`
+    );
+  }
+
+  const { hash } = activationHashes[0];
+
+  await sendMail(
+    renderMail(onSignup, {
+      to: [{ name: user.name, email: user.email }],
+      variables: { activationHash: hash }
+    })
+  );
+
+  return true;
+};
+
+export default resendActivationEmail;

--- a/back/src/users/users.private.graphql
+++ b/back/src/users/users.private.graphql
@@ -22,6 +22,12 @@ type Mutation {
 
   """
   USAGE INTERNE
+  Renvoie un email d'activation
+  """
+  resendActivationEmail(email: String!): Boolean!
+
+  """
+  USAGE INTERNE
   Modifie le mot de passe d'un utilisateur
   """
   changePassword(oldPassword: String!, newPassword: String!): User!

--- a/back/src/vhu/__tests__/workflow.integration.ts
+++ b/back/src/vhu/__tests__/workflow.integration.ts
@@ -185,5 +185,5 @@ describe("Exemples de circuit du bordereau de suivi de véhicule hors d'usage", 
     expect(broyeurSignatureResponse.body.data.signBsvhu.status).toBe(
       "PROCESSED"
     );
-  });
+  }, 10000);
 });

--- a/front/src/common/routes.ts
+++ b/front/src/common/routes.ts
@@ -11,6 +11,7 @@ export default {
     details: "/signup/details",
     activation: "/signup/activation",
   },
+  resendActivationEmail: "/resend-activation-email",
   resetPassword: "/reset-password",
   company: "/company/:siret",
   wasteTree: "/wasteTree",

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -2887,6 +2887,11 @@ export type Mutation = {
   renewSecurityCode: CompanyPrivate;
   /**
    * USAGE INTERNE
+   * Renvoie un email d'activation
+   */
+  resendActivationEmail: Scalars["Boolean"];
+  /**
+   * USAGE INTERNE
    * Renvoie l'email d'invitation à un établissement
    */
   resendInvitation: Scalars["Boolean"];
@@ -3261,6 +3266,10 @@ export type MutationRemoveUserFromCompanyArgs = {
 
 export type MutationRenewSecurityCodeArgs = {
   siret: Scalars["String"];
+};
+
+export type MutationResendActivationEmailArgs = {
+  email: Scalars["String"];
 };
 
 export type MutationResendInvitationArgs = {

--- a/front/src/layout/LayoutContainer.tsx
+++ b/front/src/layout/LayoutContainer.tsx
@@ -15,6 +15,7 @@ import Layout from "./Layout";
 import routes from "common/routes";
 import { useQuery, gql } from "@apollo/client";
 import { Query } from "../generated/graphql/types";
+import ResendActivationEmail from "login/ResendActivationEmail";
 
 const Admin = lazy(() => import("admin/Admin"));
 const Dashboard = lazy(() => import("dashboard/Dashboard"));
@@ -122,6 +123,10 @@ export default withRouter(function LayoutContainer({ history }) {
 
               <Route exact path={routes.resetPassword}>
                 <ResetPassword />
+              </Route>
+
+              <Route exact path={routes.resendActivationEmail}>
+                <ResendActivationEmail />
               </Route>
 
               <Route exact path={routes.company}>

--- a/front/src/login/Login.tsx
+++ b/front/src/login/Login.tsx
@@ -108,6 +108,13 @@ export default withRouter(function Login(
             </Link>
           </p>
           <p className="tw-my-5">
+            Vous n'avez pas reçu d'email d'activation suite à votre inscription
+            ?{" "}
+            <Link to={routes.resendActivationEmail} className="link">
+              Renvoyez l'email d'activation
+            </Link>
+          </p>
+          <p className="tw-my-5">
             Vous avez perdu votre mot de passe ?{" "}
             <Link to={routes.resetPassword} className="link">
               Réinitialisez le

--- a/front/src/login/ResendActivationEmail.tsx
+++ b/front/src/login/ResendActivationEmail.tsx
@@ -1,0 +1,61 @@
+import { useMutation, gql } from "@apollo/client";
+import React, { useState } from "react";
+import { NotificationError } from "../common/components/Error";
+import { Mutation, MutationResetPasswordArgs } from "generated/graphql/types";
+
+const RESEND_ACTIVATION_EMAIL = gql`
+  mutation ResendActivationEmail($email: String!) {
+    resendActivationEmail(email: $email)
+  }
+`;
+export default function ResendActivationEmail() {
+  const [email, setEmail] = useState("");
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [resendActivationEmail, { error }] = useMutation<
+    Pick<Mutation, "resendActivationEmail">,
+    MutationResetPasswordArgs
+  >(RESEND_ACTIVATION_EMAIL);
+  return (
+    <section className="section section--white">
+      <div className="container">
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            resendActivationEmail({ variables: { email } })
+              .then(_ => setShowSuccess(true))
+              .catch(_ => setShowSuccess(false));
+          }}
+        >
+          <h1 className="h1">Renvoyer l'email d'activation</h1>
+          <p className="tw-my-2">
+            Si vous n'avez pas reçu d'email d'activation suite à votre
+            inscription, vous pouvez en renvoyer un en renseignant votre adresse
+            email ci-dessous :
+          </p>
+          <div className="form__row tw-my-2">
+            <label>
+              <input
+                type="text"
+                placeholder="Saisissez votre email"
+                className="td-input"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+              />
+            </label>
+          </div>
+          <div className="form__actions">
+            <button className="btn btn--primary" type="submit">
+              Renvoyer l'email
+            </button>
+          </div>
+        </form>
+        {showSuccess && (
+          <div className="notification success tw-mt-2">
+            Un email d'activation vous a été renvoyé.
+          </div>
+        )}
+        {error && <NotificationError apolloError={error} />}
+      </div>
+    </section>
+  );
+}

--- a/front/src/login/SignupInfos.tsx
+++ b/front/src/login/SignupInfos.tsx
@@ -17,7 +17,7 @@ export default function SignupInfo() {
         <h2 className="h2 tw-mb-6">On y est presque !</h2>
 
         <p className="lead-text tw-mb-6">
-          Un mail de confirmation vous a été envoyé à l'adresse {signupEmail}
+          Un email de confirmation vous a été envoyé à l'adresse {signupEmail}
           <span role="img" aria-label="Valise" className="tw-ml-1">
             📨
           </span>
@@ -53,6 +53,20 @@ export default function SignupInfo() {
             </span>
             Pour recevoir nos emails sans encombres, vous pouvez ajouter
             hello@trackdechets.beta.gouv.fr à votre liste de contacts
+          </li>
+          <li>
+            <span
+              role="img"
+              aria-label="Index d'une main pointant à droite"
+              className="tw-mr-1"
+            >
+              👉
+            </span>
+            Si vous n'avez pas reçu l'email de confirmation au bout d'une heure,
+            vous pouvez le renvoyer depuis{" "}
+            <Link to={routes.resendActivationEmail} className="link">
+              cette page
+            </Link>
           </li>
         </ul>
         <p className="lead-text tw-mb-5">


### PR DESCRIPTION
Ajout d'un mécanisme permettant à l'utilisateur de renvoyer un email d'activation 

<img width="756" alt="Capture d’écran 2021-05-31 à 10 15 52" src="https://user-images.githubusercontent.com/2269165/120163355-b6a1b300-c1f9-11eb-927b-ef7b5f20923c.png">
<img width="645" alt="Capture d’écran 2021-05-31 à 10 16 48" src="https://user-images.githubusercontent.com/2269165/120163357-b73a4980-c1f9-11eb-8e33-5323748fac41.png">
<img width="1265" alt="Capture d’écran 2021-05-31 à 10 20 16" src="https://user-images.githubusercontent.com/2269165/120163445-ce793700-c1f9-11eb-901e-bc8feb27a6d5.png">


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Trello](https://trello.com/c/8vcvAwyk)
