### PR TITLE
Je ne dois pas pouvoir indiquer une rupture de traçabilité avec un code de traitement final

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Suppression du statut de vérification de l'établissement dans Mon Compte en sandbox [PR 895](https://github.com/MTES-MCT/trackdechets/pull/895)
+- Limite la rupture de traçabilité aux opérations correspondant à un regroupement [PR 878](https://github.com/MTES-MCT/trackdechets/pull/878)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/common/constants/PROCESSING_OPERATIONS.ts
+++ b/back/src/common/constants/PROCESSING_OPERATIONS.ts
@@ -130,7 +130,7 @@ export const PROCESSING_OPERATIONS: ProcessingOperation[] = [
       "Traitement biologique non spécifié ailleurs dans la présente liste, aboutissant à des composés ou à des mélanges qui sont éliminés selon l'un des procédés numérotés D1 à D12"
   },
   {
-    type: ProcessingOperationType.Eliminiation,
+    type: ProcessingOperationType.Groupement,
     code: "D 9",
     description:
       "Traitement physico-chimique non spécifié ailleurs dans la présente liste, aboutissant à des composés ou à des mélanges qui sont éliminés selon l'un des procédés numérotés D1 à D12 ( par exemple, évaporation, séchage, calcination, etc …)"

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -3,7 +3,8 @@ import {
   draftFormSchema,
   sealedFormSchema,
   ecoOrganismeSchema,
-  receivedInfoSchema
+  receivedInfoSchema,
+  processedInfoSchema
 } from "../validation";
 import { ReceivedFormInput } from "../../generated/graphql/types";
 
@@ -413,5 +414,129 @@ describe("draftFormSchema", () => {
     await expect(validateFn()).rejects.toThrow(
       "emitterCompanyMail must be a valid email"
     );
+  });
+});
+
+describe("processedInfoSchema", () => {
+  test("noTraceability can be true when processing operation is groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      noTraceability: true,
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanySiret: "11111111111111",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability can be false when processing operation is groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      noTraceability: false,
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanySiret: "11111111111111",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability can be undefined when processing operation is groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanySiret: "11111111111111",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability can be null when processing operation is groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      noTraceability: false,
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanySiret: "11111111111111",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability cannot be true when processing operation is not groupement", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 8",
+      processingOperationDescription: "Traitement biologique",
+      noTraceability: true
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Vous ne pouvez pas indiquer une rupture de traçabilité avec un code de traitement final"
+    );
+  });
+
+  test("noTraceability can be false when processing operation is not groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 8",
+      processingOperationDescription: "Traitement biologique",
+      noTraceability: false
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability can be undefined when processing operation is not groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 8",
+      processingOperationDescription: "Traitement biologique"
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
+  });
+
+  test("noTraceability can be null when processing operation is not groupement", () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 8",
+      processingOperationDescription: "Traitement biologique",
+      noTraceability: null
+    };
+    expect(processedInfoSchema.isValidSync(processedInfo)).toEqual(true);
   });
 });

--- a/back/src/forms/forms.graphql
+++ b/back/src/forms/forms.graphql
@@ -632,7 +632,7 @@ type Form {
   "Date à laquelle le déchet a été traité"
   processedAt: DateTime
 
-  "Si oui ou non il y a eu perte de traçabalité"
+  "Si oui ou non il y a eu rupture de traçabilité"
   noTraceability: Boolean
 
   "Destination ultérieure prévue (case 12)"

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -275,10 +275,21 @@ describe("mutation.markAsProcessed", () => {
         id: form.id,
         processedInfo: {
           processingOperationDescription: "Une description",
-          processingOperationDone: "D 1",
+          processingOperationDone: "D 13",
           processedBy: "A simple bot",
           processedAt: "2018-12-11T00:00:00.000Z",
-          noTraceability: true
+          noTraceability: true,
+          nextDestination: {
+            processingOperation: "D 1",
+            company: {
+              mail: "m@m.fr",
+              siret: "97874512984578",
+              name: "company",
+              phone: "0101010101",
+              contact: "The famous bot",
+              address: "A beautiful place..."
+            }
+          }
         }
       }
     });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -700,6 +700,20 @@ const withoutNextDestination = yup.object().shape({
     .max(0, EXTRANEOUS_NEXT_DESTINATION)
 });
 
+const traceabilityBreakAllowed = yup.object({
+  noTraceability: yup.boolean().nullable()
+});
+
+const traceabilityBreakForbidden = yup.object({
+  noTraceability: yup
+    .boolean()
+    .nullable()
+    .notOneOf(
+      [true],
+      "Vous ne pouvez pas indiquer une rupture de traçabilité avec un code de traitement final"
+    )
+});
+
 // 11 - Réalisation de l’opération :
 const processedInfoSchemaFn: (
   value: any
@@ -713,15 +727,14 @@ const processedInfoSchemaFn: (
     processingOperationDone: yup
       .string()
       .oneOf(PROCESSING_OPERATIONS_CODES, INVALID_PROCESSING_OPERATION),
-    processingOperationDescription: yup.string().nullable(),
-    noTraceability: yup.boolean().nullable()
+    processingOperationDescription: yup.string().nullable()
   });
 
   return PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
     value?.processingOperationDone
   )
-    ? base.concat(withNextDestination)
-    : base.concat(withoutNextDestination);
+    ? base.concat(withNextDestination).concat(traceabilityBreakAllowed)
+    : base.concat(withoutNextDestination).concat(traceabilityBreakForbidden);
 };
 
 export const processedInfoSchema = yup.lazy(processedInfoSchemaFn);

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -2212,7 +2212,7 @@ export type Form = {
   processedBy?: Maybe<Scalars["String"]>;
   /** Date à laquelle le déchet a été traité */
   processedAt?: Maybe<Scalars["DateTime"]>;
-  /** Si oui ou non il y a eu perte de traçabalité */
+  /** Si oui ou non il y a eu rupture de traçabilité */
   noTraceability?: Maybe<Scalars["Boolean"]>;
   /** Destination ultérieure prévue (case 12) */
   nextDestination?: Maybe<NextDestination>;

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -6181,7 +6181,7 @@ Date à laquelle le déchet a été traité
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td>
 
-Si oui ou non il y a eu perte de traçabalité
+Si oui ou non il y a eu rupture de traçabilité
 
 </td>
 </tr>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Formik, Field, Form, useFormikContext } from "formik";
 import {
   PROCESSING_OPERATIONS,
@@ -36,10 +36,12 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
     setFieldValue,
   } = useFormikContext<MutationMarkAsProcessedArgs["processedInfo"]>();
 
+  const isGroupement =
+    processingOperationDone &&
+    PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(processingOperationDone);
+
   useEffect(() => {
-    if (
-      PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(processingOperationDone)
-    ) {
+    if (isGroupement) {
       if (nextDestination == null) {
         setFieldValue("nextDestination", {
           processingOperation: "",
@@ -55,6 +57,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
       }
     } else {
       setFieldValue("nextDestination", null);
+      setFieldValue("noTraceability", false);
     }
   }, [processingOperationDone, nextDestination, setFieldValue]);
 
@@ -111,20 +114,23 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
           />
         </label>
       </div>
-      <div className="form__row form__row--inline">
-        <Field
-          type="checkbox"
-          name="noTraceability"
-          id="id_noTraceability"
-          className="td-checkbox"
-        />
+      {isGroupement && (
+        <div className="form__row form__row--inline">
+          <Field
+            type="checkbox"
+            name="noTraceability"
+            id="id_noTraceability"
+            className="td-checkbox"
+          />
 
-        <label htmlFor="id_noTraceability">
-          {" "}
-          Rupture de traçabilité autorisée par arrêté préfectoral pour ce déchet
-          - la responsabilité du producteur du déchet est transférée
-        </label>
-      </div>
+          <label htmlFor="id_noTraceability">
+            {" "}
+            Rupture de traçabilité autorisée par arrêté préfectoral pour ce
+            déchet - la responsabilité du producteur du déchet est transférée
+          </label>
+        </div>
+      )}
+
       {nextDestination && (
         <div className="form__row">
           <h4>Destination ultérieure prévue</h4>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { Formik, Field, Form, useFormikContext } from "formik";
 import {
   PROCESSING_OPERATIONS,
@@ -32,7 +32,7 @@ const MARK_AS_PROCESSED = gql`
 
 function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
   const {
-    values: { processingOperationDone, nextDestination },
+    values: { processingOperationDone, noTraceability, nextDestination },
     setFieldValue,
   } = useFormikContext<MutationMarkAsProcessedArgs["processedInfo"]>();
 
@@ -55,11 +55,14 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
           },
         });
       }
+      if (noTraceability == null) {
+        setFieldValue("noTraceability", false);
+      }
     } else {
       setFieldValue("nextDestination", null);
-      setFieldValue("noTraceability", false);
+      setFieldValue("noTraceability", null);
     }
-  }, [processingOperationDone, nextDestination, setFieldValue]);
+  }, [isGroupement, nextDestination, noTraceability, setFieldValue]);
 
   return (
     <Form>
@@ -209,7 +212,7 @@ export default function MarkAsProcessed({ form, siret }: WorkflowActionProps) {
               processedBy: "",
               processedAt: new Date().toISOString(),
               nextDestination: null,
-              noTraceability: false,
+              noTraceability: null,
             }}
             onSubmit={values => {
               markAsProcessed({

--- a/front/src/dashboard/constants.tsx
+++ b/front/src/dashboard/constants.tsx
@@ -7,7 +7,7 @@ export const statusLabels: { [key: string]: string } = {
   PROCESSED: "Traité",
   AWAITING_GROUP: "Traité, en attente de regroupement",
   GROUPED: "Annexé à un bordereau de regroupement",
-  NO_TRACEABILITY: "Regroupé, avec autorisation de perte de traçabilité",
+  NO_TRACEABILITY: "Regroupé, avec autorisation de rupture de traçabilité",
   REFUSED: "Refusé",
   TEMP_STORED: "Arrivé à l'entreposage provisoire, en attente d'acceptation",
   TEMP_STORER_ACCEPTED: "Entreposé temporairement ou en reconditionnement",

--- a/front/src/generated/constants/PROCESSING_OPERATIONS.ts
+++ b/front/src/generated/constants/PROCESSING_OPERATIONS.ts
@@ -130,7 +130,7 @@ export const PROCESSING_OPERATIONS: ProcessingOperation[] = [
       "Traitement biologique non spécifié ailleurs dans la présente liste, aboutissant à des composés ou à des mélanges qui sont éliminés selon l'un des procédés numérotés D1 à D12"
   },
   {
-    type: ProcessingOperationType.Eliminiation,
+    type: ProcessingOperationType.Groupement,
     code: "D 9",
     description:
       "Traitement physico-chimique non spécifié ailleurs dans la présente liste, aboutissant à des composés ou à des mélanges qui sont éliminés selon l'un des procédés numérotés D1 à D12 ( par exemple, évaporation, séchage, calcination, etc …)"

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -2253,7 +2253,7 @@ export type Form = {
   processedBy?: Maybe<Scalars["String"]>;
   /** Date à laquelle le déchet a été traité */
   processedAt?: Maybe<Scalars["DateTime"]>;
-  /** Si oui ou non il y a eu perte de traçabalité */
+  /** Si oui ou non il y a eu rupture de traçabilité */
   noTraceability?: Maybe<Scalars["Boolean"]>;
   /** Destination ultérieure prévue (case 12) */
   nextDestination?: Maybe<NextDestination>;


### PR DESCRIPTION
- Vu avec Emmanuel, le code D9 passe en groupement 
- Affichage de la checkbox "Rupture de traçabilité" côté front uniquement lorsque l'on choisit un code de regroupement
- Validation côté back qui empêche d'indiquer une rupture de traçabilité avec un code qui n'est pas un code de regroupement 

----

- ~[ ] Mettre à jour la documentation~
- [x] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~
- ~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~
---

- [Ticket Trello](https://trello.com/c/GnNJPJlc)
