### PR TITLE
Fix resealedInfos typing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction du typage de `ResealedFormInput.wasteDetails` [PR 889](https://github.com/MTES-MCT/trackdechets/pull/889)
 #### :nail_care: Améliorations
 
 #### :memo: Documentation

--- a/back/src/forms/forms-input.graphql
+++ b/back/src/forms/forms-input.graphql
@@ -159,7 +159,7 @@ input CreateFormInput {
   "Transporteur du déchet (case 8)"
   transporter: TransporterInput
 
-  "Détails du déchet (case 3)"
+  "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput
 
   "Négociant (case 7)"
@@ -199,7 +199,7 @@ input UpdateFormInput {
   "Transporteur du déchet (case 8)"
   transporter: TransporterInput
 
-  "Détails du déchet (case 3)"
+  "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput
 
   "Négociant (case 7)"
@@ -239,7 +239,7 @@ input FormInput {
   "Transporteur du déchet (case 8)"
   transporter: TransporterInput
 
-  "Détails du déchet (case 3)"
+  "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput
 
   "Négociant (case 7)"
@@ -458,7 +458,7 @@ input PackagingInfoInput {
   quantity: Int!
 }
 
-"Payload lié au détails du déchet (case 3, 4, 5, 6)"
+"Payload lié au détails du déchet (case 3 à 6)"
 input WasteDetailsInput {
   """
   Code du déchet dangereux ou non-dangereux qui doit faire partie de la liste officielle du code de l'environnement :
@@ -511,6 +511,23 @@ input WasteDetailsInput {
   pop: Boolean
 }
 
+"""
+Payload lié au reconditionnement (case 15 à 17)
+"""
+input WasteDetailsRepackagingInput {
+  "Code ONU"
+  onuCode: String
+
+  "Conditionnements"
+  packagingInfos: [PackagingInfoInput!]
+
+  "Quantité en tonnes"
+  quantity: Float
+
+  "Réelle ou estimée"
+  quantityType: QuantityType
+}
+
 input TempStorerAcceptedFormInput {
   "Date à laquelle le déchet a été accepté ou refusé (case 13)."
   signedAt: DateTime!
@@ -560,7 +577,7 @@ input ResentFormInput {
   destination: DestinationInput
 
   "Détail du déchet en cas de reconditionnement (case 15 à 19)"
-  wasteDetails: WasteDetailsInput
+  wasteDetails: WasteDetailsRepackagingInput
 
   "Transporteur du déchet reconditionné"
   transporter: TransporterInput
@@ -578,7 +595,7 @@ input ResealedFormInput {
   destination: DestinationInput
 
   "Détail du déchet en cas de reconditionnement (case 15 à 19)"
-  wasteDetails: WasteDetailsInput
+  wasteDetails: WasteDetailsRepackagingInput
 
   "Transporteur du déchet reconditionné"
   transporter: TransporterInput
@@ -623,7 +640,7 @@ input ImportPaperFormInput {
   "Transporteur du déchet (case 8)"
   transporter: TransporterInput
 
-  "Détails du déchet (case 3)"
+  "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput
 
   "Négociant (case 7)"

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -162,8 +162,7 @@ describe("Mutation markAsResealed", () => {
     );
 
     const destination = await companyFactory({
-      companyTypes: [CompanyType.WASTEPROCESSOR],
-      verificationStatus: CompanyVerificationStatus.VERIFIED
+      companyTypes: [CompanyType.WASTEPROCESSOR]
     });
 
     const { mutate } = makeClient(user);

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1935,7 +1935,7 @@ export type CreateFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -2276,7 +2276,7 @@ export type FormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -2448,7 +2448,7 @@ export type ImportPaperFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -3842,7 +3842,7 @@ export type ResealedFormInput = {
   /** Destination finale du déchet (case 14) */
   destination?: Maybe<DestinationInput>;
   /** Détail du déchet en cas de reconditionnement (case 15 à 19) */
-  wasteDetails?: Maybe<WasteDetailsInput>;
+  wasteDetails?: Maybe<WasteDetailsRepackagingInput>;
   /** Transporteur du déchet reconditionné */
   transporter?: Maybe<TransporterInput>;
 };
@@ -3852,7 +3852,7 @@ export type ResentFormInput = {
   /** Destination finale du déchet (case 14) */
   destination?: Maybe<DestinationInput>;
   /** Détail du déchet en cas de reconditionnement (case 15 à 19) */
-  wasteDetails?: Maybe<WasteDetailsInput>;
+  wasteDetails?: Maybe<WasteDetailsRepackagingInput>;
   /** Transporteur du déchet reconditionné */
   transporter?: Maybe<TransporterInput>;
   /** Nom du signataire du BSD suite  (case 19) */
@@ -4276,7 +4276,7 @@ export type UpdateFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -4435,7 +4435,7 @@ export type WasteDetails = {
   pop?: Maybe<Scalars["Boolean"]>;
 };
 
-/** Payload lié au détails du déchet (case 3, 4, 5, 6) */
+/** Payload lié au détails du déchet (case 3 à 6) */
 export type WasteDetailsInput = {
   /**
    * Code du déchet dangereux ou non-dangereux qui doit faire partie de la liste officielle du code de l'environnement :
@@ -4476,6 +4476,18 @@ export type WasteDetailsInput = {
   consistence?: Maybe<Consistence>;
   /** Contient des Polluants Organiques Persistants (POP) oui / non */
   pop?: Maybe<Scalars["Boolean"]>;
+};
+
+/** Payload lié au reconditionnement (case 15 à 17) */
+export type WasteDetailsRepackagingInput = {
+  /** Code ONU */
+  onuCode?: Maybe<Scalars["String"]>;
+  /** Conditionnements */
+  packagingInfos?: Maybe<Array<PackagingInfoInput>>;
+  /** Quantité en tonnes */
+  quantity?: Maybe<Scalars["Float"]>;
+  /** Réelle ou estimée */
+  quantityType?: Maybe<QuantityType>;
 };
 
 /** Type de déchets autorisé pour une rubrique */
@@ -4915,6 +4927,7 @@ export type ResolversTypes = {
   AuthPayload: ResolverTypeWrapper<AuthPayload>;
   AcceptedFormInput: AcceptedFormInput;
   ResealedFormInput: ResealedFormInput;
+  WasteDetailsRepackagingInput: WasteDetailsRepackagingInput;
   ResentFormInput: ResentFormInput;
   SentFormInput: SentFormInput;
   TempStoredFormInput: TempStoredFormInput;
@@ -4942,8 +4955,8 @@ export type ResolversTypes = {
   VerifyCompanyByAdminInput: VerifyCompanyByAdminInput;
   Subscription: ResolverTypeWrapper<{}>;
   FormSubscription: ResolverTypeWrapper<FormSubscription>;
-  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriInput: BsdasriInput;
+  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriRole: BsdasriRole;
 };
 
@@ -5198,6 +5211,7 @@ export type ResolversParentTypes = {
   AuthPayload: AuthPayload;
   AcceptedFormInput: AcceptedFormInput;
   ResealedFormInput: ResealedFormInput;
+  WasteDetailsRepackagingInput: WasteDetailsRepackagingInput;
   ResentFormInput: ResentFormInput;
   SentFormInput: SentFormInput;
   TempStoredFormInput: TempStoredFormInput;
@@ -5222,8 +5236,8 @@ export type ResolversParentTypes = {
   VerifyCompanyByAdminInput: VerifyCompanyByAdminInput;
   Subscription: {};
   FormSubscription: FormSubscription;
-  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriInput: BsdasriInput;
+  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
 };
 
 export type AdminForVerificationResolvers<
@@ -11791,6 +11805,18 @@ export function createWasteDetailsInputMock(
     quantityType: null,
     consistence: null,
     pop: null,
+    ...props
+  };
+}
+
+export function createWasteDetailsRepackagingInputMock(
+  props: Partial<WasteDetailsRepackagingInput>
+): WasteDetailsRepackagingInput {
+  return {
+    onuCode: null,
+    packagingInfos: null,
+    quantity: null,
+    quantityType: null,
     ...props
   };
 }

--- a/doc/docs/api-reference.md
+++ b/doc/docs/api-reference.md
@@ -11126,7 +11126,7 @@ Transporteur du déchet (case 8)
 <td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
 <td>
 
-Détails du déchet (case 3)
+Détails du déchet (case 3 à 6)
 
 </td>
 </tr>
@@ -11396,7 +11396,7 @@ Transporteur du déchet (case 8)
 <td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
 <td>
 
-Détails du déchet (case 3)
+Détails du déchet (case 3 à 6)
 
 </td>
 </tr>
@@ -11508,7 +11508,7 @@ Transporteur du déchet (case 8)
 <td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
 <td>
 
-Détails du déchet (case 3)
+Détails du déchet (case 3 à 6)
 
 </td>
 </tr>
@@ -11996,7 +11996,7 @@ Destination finale du déchet (case 14)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteDetails</strong></td>
-<td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
+<td valign="top"><a href="#wastedetailsrepackaginginput">WasteDetailsRepackagingInput</a></td>
 <td>
 
 Détail du déchet en cas de reconditionnement (case 15 à 19)
@@ -12039,7 +12039,7 @@ Destination finale du déchet (case 14)
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>wasteDetails</strong></td>
-<td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
+<td valign="top"><a href="#wastedetailsrepackaginginput">WasteDetailsRepackagingInput</a></td>
 <td>
 
 Détail du déchet en cas de reconditionnement (case 15 à 19)
@@ -12661,7 +12661,7 @@ Transporteur du déchet (case 8)
 <td valign="top"><a href="#wastedetailsinput">WasteDetailsInput</a></td>
 <td>
 
-Détails du déchet (case 3)
+Détails du déchet (case 3 à 6)
 
 </td>
 </tr>
@@ -12707,7 +12707,7 @@ Annexe 2
 
 ### WasteDetailsInput
 
-Payload lié au détails du déchet (case 3, 4, 5, 6)
+Payload lié au détails du déchet (case 3 à 6)
 
 <table>
 <thead>
@@ -12829,6 +12829,58 @@ Consistance
 <td>
 
 Contient des Polluants Organiques Persistants (POP) oui / non
+
+</td>
+</tr>
+</tbody>
+</table>
+
+### WasteDetailsRepackagingInput
+
+Payload lié au reconditionnement (case 15 à 17)
+
+<table>
+<thead>
+<tr>
+<th colspan="2" align="left">Field</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>onuCode</strong></td>
+<td valign="top"><a href="#string">String</a></td>
+<td>
+
+Code ONU
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>packagingInfos</strong></td>
+<td valign="top">[<a href="#packaginginfoinput">PackagingInfoInput</a>!]</td>
+<td>
+
+Conditionnements
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantity</strong></td>
+<td valign="top"><a href="#float">Float</a></td>
+<td>
+
+Quantité en tonnes
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>quantityType</strong></td>
+<td valign="top"><a href="#quantitytype">QuantityType</a></td>
+<td>
+
+Réelle ou estimée
 
 </td>
 </tr>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1974,7 +1974,7 @@ export type CreateFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -2317,7 +2317,7 @@ export type FormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -2496,7 +2496,7 @@ export type ImportPaperFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -3905,7 +3905,7 @@ export type ResealedFormInput = {
   /** Destination finale du déchet (case 14) */
   destination?: Maybe<DestinationInput>;
   /** Détail du déchet en cas de reconditionnement (case 15 à 19) */
-  wasteDetails?: Maybe<WasteDetailsInput>;
+  wasteDetails?: Maybe<WasteDetailsRepackagingInput>;
   /** Transporteur du déchet reconditionné */
   transporter?: Maybe<TransporterInput>;
 };
@@ -3915,7 +3915,7 @@ export type ResentFormInput = {
   /** Destination finale du déchet (case 14) */
   destination?: Maybe<DestinationInput>;
   /** Détail du déchet en cas de reconditionnement (case 15 à 19) */
-  wasteDetails?: Maybe<WasteDetailsInput>;
+  wasteDetails?: Maybe<WasteDetailsRepackagingInput>;
   /** Transporteur du déchet reconditionné */
   transporter?: Maybe<TransporterInput>;
   /** Nom du signataire du BSD suite  (case 19) */
@@ -4350,7 +4350,7 @@ export type UpdateFormInput = {
   recipient?: Maybe<RecipientInput>;
   /** Transporteur du déchet (case 8) */
   transporter?: Maybe<TransporterInput>;
-  /** Détails du déchet (case 3) */
+  /** Détails du déchet (case 3 à 6) */
   wasteDetails?: Maybe<WasteDetailsInput>;
   /** Négociant (case 7) */
   trader?: Maybe<TraderInput>;
@@ -4513,7 +4513,7 @@ export type WasteDetails = {
   pop?: Maybe<Scalars["Boolean"]>;
 };
 
-/** Payload lié au détails du déchet (case 3, 4, 5, 6) */
+/** Payload lié au détails du déchet (case 3 à 6) */
 export type WasteDetailsInput = {
   /**
    * Code du déchet dangereux ou non-dangereux qui doit faire partie de la liste officielle du code de l'environnement :
@@ -4554,6 +4554,18 @@ export type WasteDetailsInput = {
   consistence?: Maybe<Consistence>;
   /** Contient des Polluants Organiques Persistants (POP) oui / non */
   pop?: Maybe<Scalars["Boolean"]>;
+};
+
+/** Payload lié au reconditionnement (case 15 à 17) */
+export type WasteDetailsRepackagingInput = {
+  /** Code ONU */
+  onuCode?: Maybe<Scalars["String"]>;
+  /** Conditionnements */
+  packagingInfos?: Maybe<Array<PackagingInfoInput>>;
+  /** Quantité en tonnes */
+  quantity?: Maybe<Scalars["Float"]>;
+  /** Réelle ou estimée */
+  quantityType?: Maybe<QuantityType>;
 };
 
 /** Type de déchets autorisé pour une rubrique */


### PR DESCRIPTION
Correction du typage de `ResealedFormInput.wasteDetails`. Je ne pense pas que ce soit vraiment un breaking change car de toute façon on pétait une erreur si on utilisait les champs supprimés. 

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- ~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)~
- ~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~
---

- [Ticket Trello](https://trello.com/c/aoytuMGW)
