### PR TITLE
Règles de validation des quantités dasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,12 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :boom: Breaking changes
 
 - Les établissements apparaissant sur le bordereau de regroupement mais pas sur le bordereau annexé (ex: l'exutoire finale) n'ont plus accès à toutes les informations du bordereau annexé pour préserver les infos commerciales de l'établissement effectuant le regroupement [PR 872](https://github.com/MTES-MCT/trackdechets/pull/872).
+- Sur le bsdasri, nouvelles règles pour la gestion des quantités [PR 910](https://github.com/MTES-MCT/trackdechets/pull/910):
+  - les champs quantity et quantityType deviennent quantity { value type } 
+  - la pesée finale est transférée de reception à operation 
+  - les quantity sont facultatives pour le producteur et le transporteur
+  - si la quantité (value) est renseignée, le type doit l'être également
+  - la quantity est obligatoire pour le destinatire si le code correspond à  un traitement final
 
 #### :bug: Corrections de bugs
 

--- a/back/prisma/migrations/24_remove_bsdasri_operation_recipientwastequantitytype.sql
+++ b/back/prisma/migrations/24_remove_bsdasri_operation_recipientwastequantitytype.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "default$default"."Bsdasri" DROP COLUMN "recipientWasteQuantityType";

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -775,7 +775,6 @@ model Bsdasri {
   recipientWasteRefusalReason     String?
   recipientWasteRefusedQuantity   Int? // kg
   recipientWasteQuantity          Int? // kg
-  recipientWasteQuantityType      QuantityType?
 
   recipientWasteVolume Int? // liters
   receivedAt           DateTime? // accepted or refused date

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -163,14 +163,13 @@ describe("Query.bsds.dasris base workflow", () => {
             },
             reception: {
               wasteDetails: {
-                quantity: { value: 99, type: "REAL" },
-
                 packagingInfos: [{ type: "FUT", quantity: 44, volume: 123 }]
               },
               wasteAcceptation: { status: WasteAcceptationStatus.ACCEPTED },
               receivedAt: new Date().toISOString() as any
             },
             operation: {
+              quantity: { value: 99 },
               processingOperation: "D10",
               processedAt: new Date().toISOString() as any
             }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -117,8 +117,8 @@ describe("Query.bsds.dasris base workflow", () => {
             emission: {
               wasteCode: "18 01 03*",
               wasteDetails: {
-                quantity: 23,
-                quantityType: "REAL",
+                quantity: { value: 23, type: "REAL" },
+
                 onuCode: "xyz 33",
                 packagingInfos: [
                   {
@@ -145,8 +145,8 @@ describe("Query.bsds.dasris base workflow", () => {
             transport: {
               takenOverAt: new Date().toISOString() as any,
               wasteDetails: {
-                quantity: 99,
-                quantityType: "REAL",
+                quantity: { value: 99, type: "REAL" },
+
                 packagingInfos: [{ type: "FUT", quantity: 44, volume: 123 }]
               },
               wasteAcceptation: { status: WasteAcceptationStatus.ACCEPTED }
@@ -163,8 +163,8 @@ describe("Query.bsds.dasris base workflow", () => {
             },
             reception: {
               wasteDetails: {
-                quantity: 99,
-                quantityType: "REAL",
+                quantity: { value: 99, type: "REAL" },
+
                 packagingInfos: [{ type: "FUT", quantity: 44, volume: 123 }]
               },
               wasteAcceptation: { status: WasteAcceptationStatus.ACCEPTED },

--- a/back/src/dasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
+++ b/back/src/dasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
@@ -2,7 +2,8 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import {
   userFactory,
-  userWithCompanyFactory
+  userWithCompanyFactory,
+  companyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { Mutation } from "../../../../generated/graphql/types";
@@ -143,6 +144,359 @@ describe("Mutation.createDasri", () => {
           quantity: 23,
           quantityType: "REAL",
           onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(data.createBsdasri.isDraft).toEqual(false);
+    expect(data.createBsdasri.status).toEqual("INITIAL");
+
+    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+  });
+});
+
+describe("Mutation.createDasri validation scenarii", () => {
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  it("Emitter quantity type is required when quantity is provided", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const input = {
+      emitter: {
+        company: {
+          mail: "emitter@test.fr",
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          quantity: 15, // quantity provided, not quantityType
+
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le type de quantité (réelle ou estimée) émise doit être précisé si vous renseignez une quantité",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+  it("Emitter quantity is required when quantity type is provided", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const input = {
+      emitter: {
+        company: {
+          mail: "emitter@test.fr",
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          quantityType: "REAL", // quantityType provided, not quantity
+
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "La quantité du déchet émis en kg est obligatoire si vous renseignez le type de quantité",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+  it("create a dasri without emission quantity and type", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const input = {
+      emitter: {
+        company: {
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          mail: "emitter@test.fr",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(data.createBsdasri.isDraft).toEqual(false);
+    expect(data.createBsdasri.status).toEqual("INITIAL");
+
+    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+  });
+
+  it("Transport quantity type is required when quantity is provided", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory();
+    const input = {
+      emitter: {
+        company: {
+          mail: "emitter@test.fr",
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      },
+      transporter: {
+        company: {
+          mail: "trans@test.fr",
+          name: "El transporter",
+          siret: transporterCompany.siret,
+          contact: "Jason Statham",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      transport: {
+        wasteDetails: {
+          quantity: 22,
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le type de quantité (réelle ou estimée) transportée doit être précisé si vous renseignez une quantité",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+  it("Transport quantity is required when quantity type is provided", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory();
+    const input = {
+      emitter: {
+        company: {
+          mail: "emitter@test.fr",
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      },
+      transporter: {
+        company: {
+          mail: "trans@test.fr",
+          name: "El transporter",
+          siret: transporterCompany.siret,
+          contact: "Jason Statham",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      transport: {
+        wasteDetails: {
+          quantityType: "ESTIMATED",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      }
+    };
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsdasri">>(
+      CREATE_DASRI,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "La quantité du déchet transporté en kg est obligatoire si vous renseignez le type de quantité",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+  it("create a dasri without transport quantity and type", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory();
+    const input = {
+      emitter: {
+        company: {
+          name: "hopital blanc",
+          siret: company.siret,
+          contact: "jean durand",
+          phone: "06 18 76 02 00",
+          mail: "emitter@test.fr",
+          address: "avenue de la mer"
+        }
+      },
+      emission: {
+        wasteCode: "18 01 03*",
+        wasteDetails: {
+          onuCode: "xyz 33",
+          packagingInfos: [
+            {
+              type: "BOITE_CARTON",
+              volume: 22,
+              quantity: 3
+            }
+          ]
+        }
+      },
+      transporter: {
+        company: {
+          mail: "trans@test.fr",
+          name: "El transporter",
+          siret: transporterCompany.siret,
+          contact: "Jason Statham",
+          phone: "06 18 76 02 00",
+          address: "avenue de la mer"
+        }
+      },
+      transport: {
+        wasteDetails: {
           packagingInfos: [
             {
               type: "BOITE_CARTON",

--- a/back/src/dasris/resolvers/mutations/__tests__/createBsdasriRegroup.integration.ts
+++ b/back/src/dasris/resolvers/mutations/__tests__/createBsdasriRegroup.integration.ts
@@ -53,8 +53,8 @@ describe("Mutation.createDasri", () => {
       emission: {
         wasteCode: "18 01 03*",
         wasteDetails: {
-          quantity: 23,
-          quantityType: "REAL",
+          quantity: { value: 23, type: "REAL" },
+
           onuCode: "xyz 33",
           packagingInfos: [
             {
@@ -118,8 +118,8 @@ describe("Mutation.createDasri", () => {
       emission: {
         wasteCode: "18 01 03*",
         wasteDetails: {
-          quantity: 23,
-          quantityType: "REAL",
+          quantity: { value: 23, type: "REAL" },
+
           onuCode: "xyz 33",
           packagingInfos: [
             {
@@ -192,8 +192,8 @@ describe("Mutation.createDasri", () => {
       emission: {
         wasteCode: "18 01 03*",
         wasteDetails: {
-          quantity: 23,
-          quantityType: "REAL",
+          quantity: { value: 23, type: "REAL" },
+
           onuCode: "xyz 33",
           packagingInfos: [
             {

--- a/back/src/dasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/dasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -477,7 +477,7 @@ describe("Mutation.updateBsdasri", () => {
 
     const { mutate } = makeClient(user);
     const input = {
-      operation: { processingOperation: "D10" }
+      operation: { processingOperation: "D10", quantity: { value: 20 } }
     };
 
     await mutate<Pick<Mutation, "updateBsdasri">>(UPDATE_DASRI, {

--- a/back/src/dasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/dasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -440,7 +440,7 @@ describe("Mutation.updateBsdasri", () => {
           mail: "test@test.test"
         }
       },
-      reception: { wasteDetails: { quantity: 22 } }
+      reception: { wasteAcceptation: { status: "ACCEPTED" } }
     };
 
     const { errors } = await mutate<Pick<Mutation, "updateBsdasri">>(
@@ -453,7 +453,7 @@ describe("Mutation.updateBsdasri", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés: recipientCompanyMail,recipientWasteQuantity",
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés: recipientCompanyMail,recipientWasteAcceptationStatus",
 
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN

--- a/back/src/dasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/dasris/resolvers/mutations/duplicateBsdasri.ts
@@ -74,7 +74,6 @@ function duplicateBsdasri(
     recipientWasteRefusalReason,
     recipientWasteRefusedQuantity,
     recipientWasteQuantity,
-    recipientWasteQuantityType,
     recipientWasteVolume,
     receivedAt,
 

--- a/back/src/dasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/dasris/resolvers/mutations/updateBsdasri.ts
@@ -21,7 +21,8 @@ import { indexBsdasri } from "../../elastic";
 type BsdasriField = keyof Bsdasri;
 const fieldsAllowedForUpdateOnceReceived: BsdasriField[] = [
   "processingOperation",
-  "processedAt"
+  "processedAt",
+  "recipientWasteQuantity"
 ];
 
 const fieldsAllowedForUpdateOnceSent: BsdasriField[] = fieldsAllowedForUpdateOnceReceived.concat(
@@ -36,7 +37,6 @@ const fieldsAllowedForUpdateOnceSent: BsdasriField[] = fieldsAllowedForUpdateOnc
     "recipientWasteAcceptationStatus",
     "recipientWasteRefusalReason",
     "recipientWasteRefusedQuantity",
-    "recipientWasteQuantity",
     "recipientWasteVolume",
     "receivedAt",
     "handedOverToRecipientAt",

--- a/back/src/dasris/resolvers/queries/__tests__/bsdasri.integration.ts
+++ b/back/src/dasris/resolvers/queries/__tests__/bsdasri.integration.ts
@@ -32,8 +32,8 @@ query GetBsdasri($id: ID!) {
       wasteDetails {
         onuCode
         volume
-        quantity
-        quantityType
+        quantity { value type}
+ 
       }
       handedOverAt
       signature {
@@ -51,8 +51,11 @@ query GetBsdasri($id: ID!) {
       handedOverAt
       takenOverAt
       wasteDetails {
-        quantity
-        quantityType
+        quantity { 
+          value
+           type
+          }
+         
         volume
       }
       wasteAcceptation {
@@ -75,14 +78,21 @@ query GetBsdasri($id: ID!) {
     reception {
       wasteDetails {
         volume
-        quantity
-        quantityType
+    
+   
       }
       wasteAcceptation {
         status
         refusalReason
         refusedQuantity
       }
+    }
+    operation {
+      processingOperation
+      processedAt
+      quantity { 
+        value
+        }
     }
     createdAt
     updatedAt

--- a/back/src/dasris/resolvers/queries/__tests__/bsdasris.integration.ts
+++ b/back/src/dasris/resolvers/queries/__tests__/bsdasris.integration.ts
@@ -40,8 +40,8 @@ query bsDasris($where: BsdasriWhere) {
           wasteDetails {
             onuCode
             volume
-            quantity
-            quantityType
+            quantity { value type}
+    
           }
           handedOverAt
           signature {
@@ -59,8 +59,8 @@ query bsDasris($where: BsdasriWhere) {
           handedOverAt
           takenOverAt
           wasteDetails {
-            quantity
-            quantityType
+            quantity { value type}
+ 
             volume
           }
           wasteAcceptation {
@@ -83,8 +83,6 @@ query bsDasris($where: BsdasriWhere) {
         reception {
           wasteDetails {
             volume
-            quantity
-            quantityType
           }
           wasteAcceptation {
             status
@@ -96,6 +94,11 @@ query bsDasris($where: BsdasriWhere) {
             author
             date
           }
+        }
+        operation {
+          quantity { value }
+          processingOperation
+          processedAt
         }
         createdAt
         updatedAt

--- a/back/src/dasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/dasris/typeDefs/bsdasri.inputs.graphql
@@ -52,7 +52,7 @@ input BsdasriPackagingInfoInput {
   "Description du conditionnement dans le cas où le type de conditionnement est `AUTRE`"
   other: String
 
-  "Nombre de colis associés à ce conditionnement"
+  "Volume de chaque colis associé à ce conditionnement"
   volume: Int!
 
   "Nombre de colis associés à ce conditionnement"
@@ -77,15 +77,25 @@ input BsdasriEmitterInput {
   onBehalfOfEcoorganisme: Boolean
 }
 
-input BsdasriWasteDetailInput {
-  quantity: Int
-  quantityType: QuantityType
+input BsdasriQuantityInput {
+  value: Int
+  type: QuantityType
+}
+
+input BsdasriWasteDetailEmissionInput {
+  quantity: BsdasriQuantityInput
   packagingInfos: [BsdasriPackagingInfoInput!]
   onuCode: String
 }
+
+input BsdasriWasteDetailTransportInput {
+  quantity: BsdasriQuantityInput
+  packagingInfos: [BsdasriPackagingInfoInput!]
+}
 input BsdasriRecipientWasteDetailInput {
-  quantity: Int
   volume: Int
+  packagingInfos: [BsdasriPackagingInfoInput!]
+
 }
 input BsdasriWasteAcceptationInput {
   status: WasteAcceptationStatusInput
@@ -94,11 +104,11 @@ input BsdasriWasteAcceptationInput {
 }
 input BsdasriEmissionInput {
   wasteCode: String
-  wasteDetails: BsdasriWasteDetailInput
+  wasteDetails: BsdasriWasteDetailEmissionInput
   handedOverAt: DateTime
 }
 input BsdasriTransportInput {
-  wasteDetails: BsdasriWasteDetailInput
+  wasteDetails: BsdasriWasteDetailTransportInput
   takenOverAt: DateTime
   handedOverAt: DateTime
   wasteAcceptation: BsdasriWasteAcceptationInput
@@ -131,12 +141,13 @@ input BsdasriRecipientInput {
 }
 
 input BsdasriReceptionInput {
-  wasteDetails: BsdasriWasteDetailInput
+  wasteDetails: BsdasriRecipientWasteDetailInput
   receivedAt: DateTime
   wasteAcceptation: BsdasriWasteAcceptationInput
 }
 
 input BsdasriOperationInput {
+  quantity: BsdasriQuantityInput
   processingOperation: String
   processedAt: DateTime
 }

--- a/back/src/dasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/dasris/typeDefs/bsdasri.objects.graphql
@@ -63,22 +63,39 @@ type BsdasriPackagingInfo {
 
   volume: Int!
 }
+
+type BsdasriQuantity {
+  "Quantité en kg"
+  value: Int
+  "Quantité réélle (pesée ou estimée)"
+  type: QuantityType
+}
+type BsdasriOperationQuantity {
+  "Quantité en kg"
+  value: Int
+}
+
 "Détail sur le déchet emis du Bsdasri"
 type BsdasriEmissionWasteDetails {
-  "Quantité en kg"
-  quantity: Int
-  quantityType: QuantityType
+  "Quantité émise"
+  quantity: BsdasriQuantity
   "Volume en litres"
   volume: Int
   packagingInfos: [BsdasriPackagingInfo!]
   onuCode: String
 }
 
-"Détail sur le déchet transporté ou reçu du Bsdasri"
-type BsdasriWasteDetails {
-  "Quantité en kg"
-  quantity: Int
-  quantityType: QuantityType
+"Détail sur le déchet transporté"
+type BsdasriTransportWasteDetails {
+  "Quantité transportée"
+  quantity: BsdasriQuantity
+ 
+  volume: Int
+  packagingInfos: [BsdasriPackagingInfo!]
+}
+
+"Détail sur le déchet reçu du Bsdasri"
+type BsdasriReceptionWasteDetails {
   volume: Int
   packagingInfos: [BsdasriPackagingInfo!]
 }
@@ -104,7 +121,7 @@ type BsdasriWasteAcceptation {
 
 "Informations relatives au transport du Bsdasri"
 type BsdasriTransport {
-  wasteDetails: BsdasriWasteDetails
+  wasteDetails: BsdasriTransportWasteDetails
   wasteAcceptation: BsdasriWasteAcceptation
   handedOverAt: DateTime
   takenOverAt: DateTime
@@ -114,7 +131,7 @@ type BsdasriTransport {
 
 "Informations relatives à la réception du Bsdasri"
 type BsdasriReception {
-  wasteDetails: BsdasriWasteDetails
+  wasteDetails: BsdasriReceptionWasteDetails
   wasteAcceptation: BsdasriWasteAcceptation
   receivedAt: DateTime
   signature: BsdasriSignature
@@ -122,7 +139,11 @@ type BsdasriReception {
 
 "Informations relatives au traitement du Bsdasri"
 type BsdasriOperation {
+  "Quantité traitée"
+  quantity: BsdasriOperationQuantity
+  "Code de l'opération de traitement"
   processingOperation: String
+  "Date de l'opération de traitement"
   processedAt: DateTime
   signature: BsdasriSignature
 }

--- a/back/src/dasris/validation.ts
+++ b/back/src/dasris/validation.ts
@@ -241,13 +241,6 @@ export const emissionSchema: FactorySchemaOf<
       .string()
       .ensure()
       .requiredIf(context.emissionSignature, `La mention ADR est obligatoire.`),
-    emitterWasteQuantity: yup
-      .number()
-      .requiredIf(
-        context.emissionSignature,
-        "La quantité du déchet émis en kg est obligatoire"
-      )
-      .min(0, "La quantité émise doit être supérieure à 0"),
     emitterWasteVolume: yup
       .number()
       .requiredIf(
@@ -255,12 +248,28 @@ export const emissionSchema: FactorySchemaOf<
         "La quantité du déchet émis en litres est obligatoire"
       )
       .min(0, "La quantité émise doit être supérieure à 0"),
+    emitterWasteQuantity: yup
+      .number()
+      .nullable()
+      .test(
+        "emission-quantity-required-if-type-is-provided",
+        "La quantité du déchet émis en kg est obligatoire si vous renseignez le type de quantité",
+        function (value) {
+          return !!this.parent.emitterWasteQuantityType ? !!value : true;
+        }
+      )
+      .min(0, "La quantité émise doit être supérieure à 0"),
+
     emitterWasteQuantityType: yup
       .mixed<QuantityType>()
-      .requiredIf(
-        context.emissionSignature,
-        "Le type de quantité (réelle ou estimée) émis doit être précisé"
+      .test(
+        "emission-quantity-type-required-if-quantity-is-provided",
+        "Le type de quantité (réelle ou estimée) émise doit être précisé si vous renseignez une quantité",
+        function (value) {
+          return !!this.parent.emitterWasteQuantity ? !!value : true;
+        }
       ),
+
     emitterWastePackagingsInfo: yup
       .array()
       .requiredIf(
@@ -388,11 +397,26 @@ export const transportSchema: FactorySchemaOf<
       ),
     transporterWasteQuantity: yup
       .number()
-      .requiredIf(
-        context.transportSignature,
-        "La quantité du déchet transporté en kg est obligatoire"
+      .nullable()
+      .test(
+        "transport-quantity-required-if-type-is-provided",
+        "La quantité du déchet transporté en kg est obligatoire si vous renseignez le type de quantité",
+        function (value) {
+          return !!this.parent.transporterWasteQuantityType ? !!value : true;
+        }
       )
       .min(0, "La quantité transportée doit être supérieure à 0"),
+    transporterWasteQuantityType: yup
+      .mixed<QuantityType>()
+
+      .test(
+        "emission-quantity-type-required-if-quantity-is-provided",
+        "Le type de quantité (réelle ou estimée) transportée doit être précisé si vous renseignez une quantité",
+        function (value) {
+          return !!this.parent.transporterWasteQuantity ? !!value : true;
+        }
+      ),
+
     transporterWasteVolume: yup
       .number()
       .requiredIf(
@@ -400,12 +424,6 @@ export const transportSchema: FactorySchemaOf<
         "La quantité du déchet transporté en litres est obligatoire"
       )
       .min(0, "La quantité transportée doit être supérieure à 0"),
-    transporterWasteQuantityType: yup
-      .mixed<QuantityType>()
-      .requiredIf(
-        context.transportSignature,
-        "Le type de quantité (réelle ou estimée) transportée doit être précisé"
-      ),
 
     transporterWastePackagingsInfo: yup
       .array()

--- a/back/src/dasris/workflow/__tests__/workflow.integration.ts
+++ b/back/src/dasris/workflow/__tests__/workflow.integration.ts
@@ -89,8 +89,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
               emission: {
                 wasteCode: "18 01 03*"
                 wasteDetails: {
-                  quantity: 1
-                  quantityType: REAL
+                  quantity: { value:1, type: REAL},
                   onuCode: "non soumis"
                   packagingInfos: [{type: BOITE_CARTON, quantity: 1, volume: 1}]
                 }
@@ -164,8 +163,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
               transport: {
                 wasteAcceptation: { status: ACCEPTED }
                 wasteDetails: {
-                  quantity: 1
-                  quantityType: REAL
+                  quantity:   { value:1,  type: REAL },
                   packagingInfos: [{ type: BOITE_CARTON, quantity: 1, volume: 1 }]
                 }
                 takenOverAt: "2022-04-27"
@@ -213,8 +211,6 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
               reception: {
                 wasteAcceptation: { status: ACCEPTED }
                 wasteDetails: {
-                  quantity: 1
-                  quantityType: REAL
                   packagingInfos: [{ type: BOITE_CARTON, quantity: 1, volume: 1 }]
                 }
                 receivedAt: "2021-04-27"
@@ -260,6 +256,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
             id: "${bsdasri.id}",
             input: {
               operation: {
+                quantity: { value:1,  type: REAL },
                 processingOperation: "D10",
                 processedAt: "2020-04-28"
               }

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -5142,7 +5142,6 @@ export type ResolversTypes = {
   Subscription: ResolverTypeWrapper<{}>;
   FormSubscription: ResolverTypeWrapper<FormSubscription>;
   BsdasriInput: BsdasriInput;
-  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriRole: BsdasriRole;
 };
 
@@ -5433,7 +5432,6 @@ export type ResolversParentTypes = {
   Subscription: {};
   FormSubscription: FormSubscription;
   BsdasriInput: BsdasriInput;
-  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
 };
 
 export type AdminForVerificationResolvers<

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -508,16 +508,15 @@ export type BsdasriEmission = {
 
 export type BsdasriEmissionInput = {
   wasteCode?: Maybe<Scalars["String"]>;
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriWasteDetailEmissionInput>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
 };
 
 /** Détail sur le déchet emis du Bsdasri */
 export type BsdasriEmissionWasteDetails = {
   __typename?: "BsdasriEmissionWasteDetails";
-  /** Quantité en kg */
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
+  /** Quantité émise */
+  quantity?: Maybe<BsdasriQuantity>;
   /** Volume en litres */
   volume?: Maybe<Scalars["Int"]>;
   packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
@@ -588,14 +587,25 @@ export type BsdasriMetadata = {
 /** Informations relatives au traitement du Bsdasri */
 export type BsdasriOperation = {
   __typename?: "BsdasriOperation";
+  /** Quantité traitée */
+  quantity?: Maybe<BsdasriOperationQuantity>;
+  /** Code de l'opération de traitement */
   processingOperation?: Maybe<Scalars["String"]>;
+  /** Date de l'opération de traitement */
   processedAt?: Maybe<Scalars["DateTime"]>;
   signature?: Maybe<BsdasriSignature>;
 };
 
 export type BsdasriOperationInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
   processingOperation?: Maybe<Scalars["String"]>;
   processedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type BsdasriOperationQuantity = {
+  __typename?: "BsdasriOperationQuantity";
+  /** Quantité en kg */
+  value?: Maybe<Scalars["Int"]>;
 };
 
 /** Informations sur le conditionnement Bsdasri */
@@ -615,7 +625,7 @@ export type BsdasriPackagingInfoInput = {
   type: BsdasriPackagings;
   /** Description du conditionnement dans le cas où le type de conditionnement est `AUTRE` */
   other?: Maybe<Scalars["String"]>;
-  /** Nombre de colis associés à ce conditionnement */
+  /** Volume de chaque colis associé à ce conditionnement */
   volume: Scalars["Int"];
   /** Nombre de colis associés à ce conditionnement */
   quantity: Scalars["Int"];
@@ -636,19 +646,39 @@ export type BsdasriPackagings =
   /** Autre */
   | "AUTRE";
 
+export type BsdasriQuantity = {
+  __typename?: "BsdasriQuantity";
+  /** Quantité en kg */
+  value?: Maybe<Scalars["Int"]>;
+  /** Quantité réélle (pesée ou estimée) */
+  type?: Maybe<QuantityType>;
+};
+
+export type BsdasriQuantityInput = {
+  value?: Maybe<Scalars["Int"]>;
+  type?: Maybe<QuantityType>;
+};
+
 /** Informations relatives à la réception du Bsdasri */
 export type BsdasriReception = {
   __typename?: "BsdasriReception";
-  wasteDetails?: Maybe<BsdasriWasteDetails>;
+  wasteDetails?: Maybe<BsdasriReceptionWasteDetails>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptation>;
   receivedAt?: Maybe<Scalars["DateTime"]>;
   signature?: Maybe<BsdasriSignature>;
 };
 
 export type BsdasriReceptionInput = {
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriRecipientWasteDetailInput>;
   receivedAt?: Maybe<Scalars["DateTime"]>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptationInput>;
+};
+
+/** Détail sur le déchet reçu du Bsdasri */
+export type BsdasriReceptionWasteDetails = {
+  __typename?: "BsdasriReceptionWasteDetails";
+  volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
 /** Destinataire du Bsdasri */
@@ -668,8 +698,8 @@ export type BsdasriRecipientInput = {
 };
 
 export type BsdasriRecipientWasteDetailInput = {
-  quantity?: Maybe<Scalars["Int"]>;
   volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
 };
 
 export type BsdasriRecipientWhere = {
@@ -732,7 +762,7 @@ export type BsdasriStatus =
 /** Informations relatives au transport du Bsdasri */
 export type BsdasriTransport = {
   __typename?: "BsdasriTransport";
-  wasteDetails?: Maybe<BsdasriWasteDetails>;
+  wasteDetails?: Maybe<BsdasriTransportWasteDetails>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptation>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
   takenOverAt?: Maybe<Scalars["DateTime"]>;
@@ -774,11 +804,20 @@ export type BsdasriTransporterWhere = {
 };
 
 export type BsdasriTransportInput = {
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriWasteDetailTransportInput>;
   takenOverAt?: Maybe<Scalars["DateTime"]>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptationInput>;
   mode?: Maybe<TransportMode>;
+};
+
+/** Détail sur le déchet transporté */
+export type BsdasriTransportWasteDetails = {
+  __typename?: "BsdasriTransportWasteDetails";
+  /** Quantité transportée */
+  quantity?: Maybe<BsdasriQuantity>;
+  volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
 export type BsdasriUpdateInput = {
@@ -806,21 +845,15 @@ export type BsdasriWasteAcceptationInput = {
   refusedQuantity?: Maybe<Scalars["Int"]>;
 };
 
-export type BsdasriWasteDetailInput = {
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
+export type BsdasriWasteDetailEmissionInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
   packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
   onuCode?: Maybe<Scalars["String"]>;
 };
 
-/** Détail sur le déchet transporté ou reçu du Bsdasri */
-export type BsdasriWasteDetails = {
-  __typename?: "BsdasriWasteDetails";
-  /** Quantité en kg */
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
-  volume?: Maybe<Scalars["Int"]>;
-  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
+export type BsdasriWasteDetailTransportInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
 };
 
 export type BsdasriWhere = {
@@ -4849,16 +4882,23 @@ export type ResolversTypes = {
   BsdasriEmitterType: BsdasriEmitterType;
   BsdasriEmission: ResolverTypeWrapper<BsdasriEmission>;
   BsdasriEmissionWasteDetails: ResolverTypeWrapper<BsdasriEmissionWasteDetails>;
+  BsdasriQuantity: ResolverTypeWrapper<BsdasriQuantity>;
   BsdasriPackagingInfo: ResolverTypeWrapper<BsdasriPackagingInfo>;
   BsdasriPackagings: BsdasriPackagings;
   BsdasriSignature: ResolverTypeWrapper<BsdasriSignature>;
   BsdasriTransporter: ResolverTypeWrapper<BsdasriTransporter>;
   BsdasriTransport: ResolverTypeWrapper<BsdasriTransport>;
-  BsdasriWasteDetails: ResolverTypeWrapper<BsdasriWasteDetails>;
+  BsdasriTransportWasteDetails: ResolverTypeWrapper<
+    BsdasriTransportWasteDetails
+  >;
   BsdasriWasteAcceptation: ResolverTypeWrapper<BsdasriWasteAcceptation>;
   BsdasriRecipient: ResolverTypeWrapper<BsdasriRecipient>;
   BsdasriReception: ResolverTypeWrapper<BsdasriReception>;
+  BsdasriReceptionWasteDetails: ResolverTypeWrapper<
+    BsdasriReceptionWasteDetails
+  >;
   BsdasriOperation: ResolverTypeWrapper<BsdasriOperation>;
+  BsdasriOperationQuantity: ResolverTypeWrapper<BsdasriOperationQuantity>;
   BsdasriMetadata: ResolverTypeWrapper<BsdasriMetadata>;
   BsdasriError: ResolverTypeWrapper<BsdasriError>;
   BsdasriSignatureType: BsdasriSignatureType;
@@ -5005,14 +5045,17 @@ export type ResolversTypes = {
   BsdasriEmitterInput: BsdasriEmitterInput;
   WorkSiteInput: WorkSiteInput;
   BsdasriEmissionInput: BsdasriEmissionInput;
-  BsdasriWasteDetailInput: BsdasriWasteDetailInput;
+  BsdasriWasteDetailEmissionInput: BsdasriWasteDetailEmissionInput;
+  BsdasriQuantityInput: BsdasriQuantityInput;
   BsdasriPackagingInfoInput: BsdasriPackagingInfoInput;
   BsdasriTransporterInput: BsdasriTransporterInput;
   BsdasriTransportInput: BsdasriTransportInput;
+  BsdasriWasteDetailTransportInput: BsdasriWasteDetailTransportInput;
   BsdasriWasteAcceptationInput: BsdasriWasteAcceptationInput;
   WasteAcceptationStatusInput: WasteAcceptationStatusInput;
   BsdasriRecipientInput: BsdasriRecipientInput;
   BsdasriReceptionInput: BsdasriReceptionInput;
+  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriOperationInput: BsdasriOperationInput;
   RegroupedBsdasriInput: RegroupedBsdasriInput;
   BsffInput: BsffInput;
@@ -5167,15 +5210,18 @@ export type ResolversParentTypes = {
   BsdasriEmitter: BsdasriEmitter;
   BsdasriEmission: BsdasriEmission;
   BsdasriEmissionWasteDetails: BsdasriEmissionWasteDetails;
+  BsdasriQuantity: BsdasriQuantity;
   BsdasriPackagingInfo: BsdasriPackagingInfo;
   BsdasriSignature: BsdasriSignature;
   BsdasriTransporter: BsdasriTransporter;
   BsdasriTransport: BsdasriTransport;
-  BsdasriWasteDetails: BsdasriWasteDetails;
+  BsdasriTransportWasteDetails: BsdasriTransportWasteDetails;
   BsdasriWasteAcceptation: BsdasriWasteAcceptation;
   BsdasriRecipient: BsdasriRecipient;
   BsdasriReception: BsdasriReception;
+  BsdasriReceptionWasteDetails: BsdasriReceptionWasteDetails;
   BsdasriOperation: BsdasriOperation;
+  BsdasriOperationQuantity: BsdasriOperationQuantity;
   BsdasriMetadata: BsdasriMetadata;
   BsdasriError: BsdasriError;
   BsdasriWhere: BsdasriWhere;
@@ -5294,13 +5340,16 @@ export type ResolversParentTypes = {
   BsdasriEmitterInput: BsdasriEmitterInput;
   WorkSiteInput: WorkSiteInput;
   BsdasriEmissionInput: BsdasriEmissionInput;
-  BsdasriWasteDetailInput: BsdasriWasteDetailInput;
+  BsdasriWasteDetailEmissionInput: BsdasriWasteDetailEmissionInput;
+  BsdasriQuantityInput: BsdasriQuantityInput;
   BsdasriPackagingInfoInput: BsdasriPackagingInfoInput;
   BsdasriTransporterInput: BsdasriTransporterInput;
   BsdasriTransportInput: BsdasriTransportInput;
+  BsdasriWasteDetailTransportInput: BsdasriWasteDetailTransportInput;
   BsdasriWasteAcceptationInput: BsdasriWasteAcceptationInput;
   BsdasriRecipientInput: BsdasriRecipientInput;
   BsdasriReceptionInput: BsdasriReceptionInput;
+  BsdasriRecipientWasteDetailInput: BsdasriRecipientWasteDetailInput;
   BsdasriOperationInput: BsdasriOperationInput;
   RegroupedBsdasriInput: RegroupedBsdasriInput;
   BsffInput: BsffInput;
@@ -5842,9 +5891,8 @@ export type BsdasriEmissionWasteDetailsResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriEmissionWasteDetails"] = ResolversParentTypes["BsdasriEmissionWasteDetails"]
 > = {
-  quantity?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
-  quantityType?: Resolver<
-    Maybe<ResolversTypes["QuantityType"]>,
+  quantity?: Resolver<
+    Maybe<ResolversTypes["BsdasriQuantity"]>,
     ParentType,
     ContextType
   >;
@@ -5925,6 +5973,11 @@ export type BsdasriOperationResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriOperation"] = ResolversParentTypes["BsdasriOperation"]
 > = {
+  quantity?: Resolver<
+    Maybe<ResolversTypes["BsdasriOperationQuantity"]>,
+    ParentType,
+    ContextType
+  >;
   processingOperation?: Resolver<
     Maybe<ResolversTypes["String"]>,
     ParentType,
@@ -5943,6 +5996,14 @@ export type BsdasriOperationResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type BsdasriOperationQuantityResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes["BsdasriOperationQuantity"] = ResolversParentTypes["BsdasriOperationQuantity"]
+> = {
+  value?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type BsdasriPackagingInfoResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriPackagingInfo"] = ResolversParentTypes["BsdasriPackagingInfo"]
@@ -5954,12 +6015,25 @@ export type BsdasriPackagingInfoResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type BsdasriQuantityResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes["BsdasriQuantity"] = ResolversParentTypes["BsdasriQuantity"]
+> = {
+  value?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  type?: Resolver<
+    Maybe<ResolversTypes["QuantityType"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type BsdasriReceptionResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriReception"] = ResolversParentTypes["BsdasriReception"]
 > = {
   wasteDetails?: Resolver<
-    Maybe<ResolversTypes["BsdasriWasteDetails"]>,
+    Maybe<ResolversTypes["BsdasriReceptionWasteDetails"]>,
     ParentType,
     ContextType
   >;
@@ -5975,6 +6049,19 @@ export type BsdasriReceptionResolvers<
   >;
   signature?: Resolver<
     Maybe<ResolversTypes["BsdasriSignature"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type BsdasriReceptionWasteDetailsResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes["BsdasriReceptionWasteDetails"] = ResolversParentTypes["BsdasriReceptionWasteDetails"]
+> = {
+  volume?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  packagingInfos?: Resolver<
+    Maybe<Array<ResolversTypes["BsdasriPackagingInfo"]>>,
     ParentType,
     ContextType
   >;
@@ -6012,7 +6099,7 @@ export type BsdasriTransportResolvers<
   ParentType extends ResolversParentTypes["BsdasriTransport"] = ResolversParentTypes["BsdasriTransport"]
 > = {
   wasteDetails?: Resolver<
-    Maybe<ResolversTypes["BsdasriWasteDetails"]>,
+    Maybe<ResolversTypes["BsdasriTransportWasteDetails"]>,
     ParentType,
     ContextType
   >;
@@ -6068,6 +6155,24 @@ export type BsdasriTransporterResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type BsdasriTransportWasteDetailsResolvers<
+  ContextType = GraphQLContext,
+  ParentType extends ResolversParentTypes["BsdasriTransportWasteDetails"] = ResolversParentTypes["BsdasriTransportWasteDetails"]
+> = {
+  quantity?: Resolver<
+    Maybe<ResolversTypes["BsdasriQuantity"]>,
+    ParentType,
+    ContextType
+  >;
+  volume?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  packagingInfos?: Resolver<
+    Maybe<Array<ResolversTypes["BsdasriPackagingInfo"]>>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type BsdasriWasteAcceptationResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriWasteAcceptation"] = ResolversParentTypes["BsdasriWasteAcceptation"]
@@ -6080,25 +6185,6 @@ export type BsdasriWasteAcceptationResolvers<
   >;
   refusedQuantity?: Resolver<
     Maybe<ResolversTypes["Int"]>,
-    ParentType,
-    ContextType
-  >;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type BsdasriWasteDetailsResolvers<
-  ContextType = GraphQLContext,
-  ParentType extends ResolversParentTypes["BsdasriWasteDetails"] = ResolversParentTypes["BsdasriWasteDetails"]
-> = {
-  quantity?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
-  quantityType?: Resolver<
-    Maybe<ResolversTypes["QuantityType"]>,
-    ParentType,
-    ContextType
-  >;
-  volume?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
-  packagingInfos?: Resolver<
-    Maybe<Array<ResolversTypes["BsdasriPackagingInfo"]>>,
     ParentType,
     ContextType
   >;
@@ -8782,14 +8868,21 @@ export type Resolvers<ContextType = GraphQLContext> = {
   BsdasriError?: BsdasriErrorResolvers<ContextType>;
   BsdasriMetadata?: BsdasriMetadataResolvers<ContextType>;
   BsdasriOperation?: BsdasriOperationResolvers<ContextType>;
+  BsdasriOperationQuantity?: BsdasriOperationQuantityResolvers<ContextType>;
   BsdasriPackagingInfo?: BsdasriPackagingInfoResolvers<ContextType>;
+  BsdasriQuantity?: BsdasriQuantityResolvers<ContextType>;
   BsdasriReception?: BsdasriReceptionResolvers<ContextType>;
+  BsdasriReceptionWasteDetails?: BsdasriReceptionWasteDetailsResolvers<
+    ContextType
+  >;
   BsdasriRecipient?: BsdasriRecipientResolvers<ContextType>;
   BsdasriSignature?: BsdasriSignatureResolvers<ContextType>;
   BsdasriTransport?: BsdasriTransportResolvers<ContextType>;
   BsdasriTransporter?: BsdasriTransporterResolvers<ContextType>;
+  BsdasriTransportWasteDetails?: BsdasriTransportWasteDetailsResolvers<
+    ContextType
+  >;
   BsdasriWasteAcceptation?: BsdasriWasteAcceptationResolvers<ContextType>;
-  BsdasriWasteDetails?: BsdasriWasteDetailsResolvers<ContextType>;
   BsdaTransport?: BsdaTransportResolvers<ContextType>;
   BsdaTransporter?: BsdaTransporterResolvers<ContextType>;
   BsdaWaste?: BsdaWasteResolvers<ContextType>;
@@ -9404,7 +9497,6 @@ export function createBsdasriEmissionWasteDetailsMock(
   return {
     __typename: "BsdasriEmissionWasteDetails",
     quantity: null,
-    quantityType: null,
     volume: null,
     packagingInfos: null,
     onuCode: null,
@@ -9492,6 +9584,7 @@ export function createBsdasriOperationMock(
 ): BsdasriOperation {
   return {
     __typename: "BsdasriOperation",
+    quantity: null,
     processingOperation: null,
     processedAt: null,
     signature: null,
@@ -9503,8 +9596,19 @@ export function createBsdasriOperationInputMock(
   props: Partial<BsdasriOperationInput>
 ): BsdasriOperationInput {
   return {
+    quantity: null,
     processingOperation: null,
     processedAt: null,
+    ...props
+  };
+}
+
+export function createBsdasriOperationQuantityMock(
+  props: Partial<BsdasriOperationQuantity>
+): BsdasriOperationQuantity {
+  return {
+    __typename: "BsdasriOperationQuantity",
+    value: null,
     ...props
   };
 }
@@ -9534,6 +9638,27 @@ export function createBsdasriPackagingInfoInputMock(
   };
 }
 
+export function createBsdasriQuantityMock(
+  props: Partial<BsdasriQuantity>
+): BsdasriQuantity {
+  return {
+    __typename: "BsdasriQuantity",
+    value: null,
+    type: null,
+    ...props
+  };
+}
+
+export function createBsdasriQuantityInputMock(
+  props: Partial<BsdasriQuantityInput>
+): BsdasriQuantityInput {
+  return {
+    value: null,
+    type: null,
+    ...props
+  };
+}
+
 export function createBsdasriReceptionMock(
   props: Partial<BsdasriReception>
 ): BsdasriReception {
@@ -9554,6 +9679,17 @@ export function createBsdasriReceptionInputMock(
     wasteDetails: null,
     receivedAt: null,
     wasteAcceptation: null,
+    ...props
+  };
+}
+
+export function createBsdasriReceptionWasteDetailsMock(
+  props: Partial<BsdasriReceptionWasteDetails>
+): BsdasriReceptionWasteDetails {
+  return {
+    __typename: "BsdasriReceptionWasteDetails",
+    volume: null,
+    packagingInfos: null,
     ...props
   };
 }
@@ -9583,8 +9719,8 @@ export function createBsdasriRecipientWasteDetailInputMock(
   props: Partial<BsdasriRecipientWasteDetailInput>
 ): BsdasriRecipientWasteDetailInput {
   return {
-    quantity: null,
     volume: null,
+    packagingInfos: null,
     ...props
   };
 }
@@ -9704,6 +9840,18 @@ export function createBsdasriTransportInputMock(
   };
 }
 
+export function createBsdasriTransportWasteDetailsMock(
+  props: Partial<BsdasriTransportWasteDetails>
+): BsdasriTransportWasteDetails {
+  return {
+    __typename: "BsdasriTransportWasteDetails",
+    quantity: null,
+    volume: null,
+    packagingInfos: null,
+    ...props
+  };
+}
+
 export function createBsdasriUpdateInputMock(
   props: Partial<BsdasriUpdateInput>
 ): BsdasriUpdateInput {
@@ -9743,26 +9891,22 @@ export function createBsdasriWasteAcceptationInputMock(
   };
 }
 
-export function createBsdasriWasteDetailInputMock(
-  props: Partial<BsdasriWasteDetailInput>
-): BsdasriWasteDetailInput {
+export function createBsdasriWasteDetailEmissionInputMock(
+  props: Partial<BsdasriWasteDetailEmissionInput>
+): BsdasriWasteDetailEmissionInput {
   return {
     quantity: null,
-    quantityType: null,
     packagingInfos: null,
     onuCode: null,
     ...props
   };
 }
 
-export function createBsdasriWasteDetailsMock(
-  props: Partial<BsdasriWasteDetails>
-): BsdasriWasteDetails {
+export function createBsdasriWasteDetailTransportInputMock(
+  props: Partial<BsdasriWasteDetailTransportInput>
+): BsdasriWasteDetailTransportInput {
   return {
-    __typename: "BsdasriWasteDetails",
     quantity: null,
-    quantityType: null,
-    volume: null,
     packagingInfos: null,
     ...props
   };

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -40,7 +40,6 @@ export const wasteDetailsFragment = gql`
       quantity
     }
     quantity
-    quantityType
     consistence
     pop
   }
@@ -303,10 +302,13 @@ const signatureFragment = gql`
   }
 `;
 
-const dasriWasteDetailsFragment = gql`
-  fragment DasriWasteDetailsFragment on BsdasriWasteDetails {
-    quantity
-    quantityType
+const dasriEmissionWasteDetailsFragment = gql`
+  fragment DasriEmissionWasteDetailsFragment on BsdasriEmissionWasteDetails {
+    onuCode
+    quantity {
+      type
+      value
+    }
     volume
     packagingInfos {
       type
@@ -317,11 +319,12 @@ const dasriWasteDetailsFragment = gql`
   }
 `;
 
-const dasriEmissionWasteDetailsFragment = gql`
-  fragment DasriEmissionWasteDetailsFragment on BsdasriEmissionWasteDetails {
-    onuCode
-    quantity
-    quantityType
+const dasriTransportWasteDetailsFragment = gql`
+  fragment DasriTransportWasteDetailsFragment on BsdasriTransportWasteDetails {
+    quantity {
+      type
+      value
+    }
     volume
     packagingInfos {
       type
@@ -331,6 +334,18 @@ const dasriEmissionWasteDetailsFragment = gql`
     }
   }
 `;
+const dasriReceptionWasteDetailsFragment = gql`
+  fragment DasriReceptionWasteDetailsFragment on BsdasriReceptionWasteDetails {
+    volume
+    packagingInfos {
+      type
+      other
+      quantity
+      volume
+    }
+  }
+`;
+
 const wasteAcceptationFragment = gql`
   fragment WasteAcceptationFragment on BsdasriWasteAcceptation {
     status
@@ -362,7 +377,6 @@ export const dasriFragment = gql`
       isTakenOverWithoutEmitterSignature
       isTakenOverWithSecretCode
       wasteDetails {
-        onuCode
         ...DasriEmissionWasteDetailsFragment
       }
       handedOverAt
@@ -384,7 +398,7 @@ export const dasriFragment = gql`
       handedOverAt
       takenOverAt
       wasteDetails {
-        ...DasriWasteDetailsFragment
+        ...DasriTransportWasteDetailsFragment
       }
       wasteAcceptation {
         ...WasteAcceptationFragment
@@ -401,7 +415,7 @@ export const dasriFragment = gql`
     }
     reception {
       wasteDetails {
-        ...DasriWasteDetailsFragment
+        ...DasriReceptionWasteDetailsFragment
       }
       wasteAcceptation {
         ...WasteAcceptationFragment
@@ -413,6 +427,9 @@ export const dasriFragment = gql`
       receivedAt
     }
     operation {
+      quantity {
+        value
+      }
       processedAt
       processingOperation
       signature {
@@ -424,8 +441,10 @@ export const dasriFragment = gql`
   }
   ${companyFragment}
   ${signatureFragment}
-  ${dasriWasteDetailsFragment}
+
   ${dasriEmissionWasteDetailsFragment}
+  ${dasriTransportWasteDetailsFragment}
+  ${dasriReceptionWasteDetailsFragment}
   ${wasteAcceptationFragment}
 `;
 

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -83,12 +83,12 @@ const Emitter = ({ form }: { form: Bsdasri }) => {
       </div>
       <div className={styles.detailGrid}>
         <DetailRow
-          value={emission?.wasteDetails?.quantity}
+          value={emission?.wasteDetails?.quantity?.value}
           label="Quantité"
           units="kg"
         />
         <DetailRow
-          value={getVerboseQuantityType(emission?.wasteDetails?.quantityType)}
+          value={getVerboseQuantityType(emission?.wasteDetails?.quantity?.type)}
           label="Quantité"
         />
         <DetailRow
@@ -144,12 +144,14 @@ const Transporter = ({ form }: { form: Bsdasri }) => {
           label="Mode de transport"
         />
         <DetailRow
-          value={transport?.wasteDetails?.quantity}
+          value={transport?.wasteDetails?.quantity?.value}
           label="Quantité"
           units="kg"
         />
         <DetailRow
-          value={getVerboseQuantityType(transport?.wasteDetails?.quantityType)}
+          value={getVerboseQuantityType(
+            transport?.wasteDetails?.quantity?.type
+          )}
           label="Quantité"
         />
         <DetailRow
@@ -200,15 +202,6 @@ const Recipient = ({ form }: { form: Bsdasri }) => {
       </div>
       <div className={styles.detailGrid}>
         <DetailRow
-          value={reception?.wasteDetails?.quantity}
-          label="Quantité"
-          units="kg"
-        />
-        <DetailRow
-          value={getVerboseQuantityType(reception?.wasteDetails?.quantityType)}
-          label="Quantité"
-        />
-        <DetailRow
           value={reception?.wasteDetails?.volume}
           label="Volume"
           units="l"
@@ -243,6 +236,12 @@ const Recipient = ({ form }: { form: Bsdasri }) => {
         />
       </div>
       <div className={styles.detailGrid}>
+        <DetailRow
+          value={operation?.quantity?.value}
+          label="Quantité"
+          units="kg"
+        />
+
         <DetailRow
           value={operation?.processingOperation}
           label="Opération de traitement"

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -82,14 +82,14 @@ export default function Emitter({ status }) {
         disabled={disabled}
       />
 
-      <h4 className="form__section-heading">Quantité en kg</h4>
+      <h4 className="form__section-heading">Quantité remise</h4>
 
       <div className="form__row">
         <label>
-          Quantité remise :
+          Quantité en kg :
           <Field
             component={NumberInput}
-            name="emission.wasteDetails.quantity"
+            name="emission.wasteDetails.quantity.value"
             className="td-input dasri__waste-details__quantity"
             disabled={disabled}
             placeholder="En kg"
@@ -99,21 +99,21 @@ export default function Emitter({ status }) {
           <span className="tw-ml-2">kg</span>
         </label>
 
-        <RedErrorMessage name="emission.wasteDetails.quantity" />
+        <RedErrorMessage name="emission.wasteDetails.quantity.value" />
       </div>
 
       <div className="form__row">
         <fieldset>
           <legend className="tw-font-semibold">Cette quantité est</legend>
           <Field
-            name="emission.wasteDetails.quantityType"
+            name="emission.wasteDetails.quantity.type"
             id="REAL"
             label="Réélle"
             component={RadioButton}
             disabled={disabled}
           />
           <Field
-            name="emission.wasteDetails.quantityType"
+            name="emission.wasteDetails.quantity.type"
             id="ESTIMATED"
             label="Estimée"
             component={RadioButton}

--- a/front/src/form/bsdasri/Recipient.tsx
+++ b/front/src/form/bsdasri/Recipient.tsx
@@ -5,14 +5,16 @@ import { Field } from "formik";
 import React from "react";
 import { BsdasriStatus } from "generated/graphql/types";
 import Packagings from "./components/packagings/Packagings";
-import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
 
 export default function Recipient({ status }) {
   const receptionDisabled = BsdasriStatus.Received === status;
   // it's pointless to show reception or operation fields until form has relevant signatures
-  const showReceptionFields = status === BsdasriStatus.Sent;
+  const showReceptionFields = [
+    BsdasriStatus.Sent,
+    BsdasriStatus.Received,
+  ].includes(status);
   const showOperationFields = status === BsdasriStatus.Received;
 
   return (
@@ -65,46 +67,6 @@ export default function Recipient({ status }) {
             component={Packagings}
             disabled={receptionDisabled}
           />
-
-          <h4 className="form__section-heading">Quantité en kg</h4>
-
-          <div className="form__row">
-            <label>
-              Quantité réceptionnée :
-              <Field
-                component={NumberInput}
-                name="reception.wasteDetails.quantity"
-                className="td-input dasri__waste-details__quantity"
-                disabled={receptionDisabled}
-                placeholder="En kg"
-                min="0"
-                step="1"
-              />
-              <span className="tw-ml-2">kg</span>
-            </label>
-
-            <RedErrorMessage name="emission.wasteDetails.quantity" />
-          </div>
-
-          <div className="form__row">
-            <fieldset>
-              <legend className="tw-font-semibold">Cette quantité est</legend>
-              <Field
-                name="reception.wasteDetails.quantityType"
-                id="REAL"
-                label="Réélle"
-                component={RadioButton}
-                disabled={receptionDisabled}
-              />
-              <Field
-                name="reception.wasteDetails.quantityType"
-                id="ESTIMATED"
-                label="Estimée"
-                component={RadioButton}
-                disabled={receptionDisabled}
-              />
-            </fieldset>
-          </div>
         </>
       ) : (
         <p>Cette section sera disponible quand le déchet aura été envoyé</p>
@@ -146,6 +108,25 @@ export default function Recipient({ status }) {
                 />
               </div>
             </label>
+          </div>
+
+          <h4 className="form__section-heading">Quantité traitée</h4>
+
+          <div className="form__row">
+            <label>
+              Quantité en kg :
+              <Field
+                component={NumberInput}
+                name="operation.quantity.value"
+                className="td-input dasri__waste-details__quantity"
+                placeholder="En kg"
+                min="0"
+                step="1"
+              />
+              <span className="tw-ml-2">kg</span>
+            </label>
+
+            <RedErrorMessage name="operation.quantity.value" />
           </div>
         </>
       ) : (

--- a/front/src/form/bsdasri/Transporter.tsx
+++ b/front/src/form/bsdasri/Transporter.tsx
@@ -17,6 +17,7 @@ export default function Transporter({ status }) {
   const showTransportFields = [
     BsdasriStatus.SignedByProducer,
     BsdasriStatus.Sent,
+    BsdasriStatus.Received,
   ].includes(status);
   // handedOverAt is editable even after dasri reception
   const showHandedOverAtField = [
@@ -160,14 +161,14 @@ export default function Transporter({ status }) {
             component={Packagings}
             disabled={disabled}
           />
-          <h4 className="form__section-heading">Quantité en kg</h4>
+          <h4 className="form__section-heading">Quantité transportée</h4>
 
           <div className="form__row">
             <label>
-              Quantité transportée :
+              Quantité en kg :
               <Field
                 component={NumberInput}
-                name="transport.wasteDetails.quantity"
+                name="transport.wasteDetails.quantity.value"
                 className="td-input dasri__waste-details__quantity"
                 disabled={disabled}
                 placeholder="En kg"
@@ -177,21 +178,21 @@ export default function Transporter({ status }) {
               <span className="tw-ml-2">kg</span>
             </label>
 
-            <RedErrorMessage name="transport.wasteDetails.quantity" />
+            <RedErrorMessage name="transport.wasteDetails.quantity.value" />
           </div>
 
           <div className="form__row">
             <fieldset>
               <legend className="tw-font-semibold">Cette quantité est</legend>
               <Field
-                name="transport.wasteDetails.quantityType"
+                name="transport.wasteDetails.quantity.type"
                 id="REAL"
                 label="Réélle"
                 component={RadioButton}
                 disabled={disabled}
               />
               <Field
-                name="transport.wasteDetails.quantityType"
+                name="transport.wasteDetails.quantity.type"
                 id="ESTIMATED"
                 label="Estimée"
                 component={RadioButton}

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -21,11 +21,20 @@ const initialState = {
     wasteCode: "18 01 03*",
     wasteDetails: {
       packagingInfos: [],
-      quantity: null,
-      quantityType: null,
+      quantity: { value: null, type: null },
       onuCode: null,
     },
     handedOverAt: null,
+  },
+  transport: {
+    wasteDetails: { packagingInfos: [], quantity: { value: null, type: null } },
+    takenOverAt: null,
+    handedOverAt: null,
+    wasteAcceptation: {
+      status: null,
+      refusalReason: null,
+      refusedQuantity: null,
+    },
   },
   recipient: {
     company: getInitialCompany(),
@@ -34,29 +43,21 @@ const initialState = {
   reception: {
     wasteDetails: {
       packagingInfos: [],
-      quantity: null,
-      quantityType: null,
     },
     wasteAcceptation: null,
     receivedAt: null,
   },
-  operation: { processingOperation: null, processedAt: null },
+  operation: {
+    processingOperation: null,
+    processedAt: null,
+    quantity: { value: null },
+  },
   transporter: {
     company: getInitialCompany(),
     customInfo: null,
     receipt: null,
     receiptDepartment: null,
     receiptValidityLimit: null,
-  },
-  transport: {
-    wasteDetails: { packagingInfos: [], quantity: null, quantityType: null },
-    takenOverAt: null,
-    handedOverAt: null,
-    wasteAcceptation: {
-      status: null,
-      refusalReason: null,
-      refusedQuantity: null,
-    },
   },
 };
 

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -511,16 +511,15 @@ export type BsdasriEmission = {
 
 export type BsdasriEmissionInput = {
   wasteCode?: Maybe<Scalars["String"]>;
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriWasteDetailEmissionInput>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
 };
 
 /** Détail sur le déchet emis du Bsdasri */
 export type BsdasriEmissionWasteDetails = {
   __typename?: "BsdasriEmissionWasteDetails";
-  /** Quantité en kg */
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
+  /** Quantité émise */
+  quantity?: Maybe<BsdasriQuantity>;
   /** Volume en litres */
   volume?: Maybe<Scalars["Int"]>;
   packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
@@ -592,14 +591,25 @@ export type BsdasriMetadata = {
 /** Informations relatives au traitement du Bsdasri */
 export type BsdasriOperation = {
   __typename?: "BsdasriOperation";
+  /** Quantité traitée */
+  quantity?: Maybe<BsdasriOperationQuantity>;
+  /** Code de l'opération de traitement */
   processingOperation?: Maybe<Scalars["String"]>;
+  /** Date de l'opération de traitement */
   processedAt?: Maybe<Scalars["DateTime"]>;
   signature?: Maybe<BsdasriSignature>;
 };
 
 export type BsdasriOperationInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
   processingOperation?: Maybe<Scalars["String"]>;
   processedAt?: Maybe<Scalars["DateTime"]>;
+};
+
+export type BsdasriOperationQuantity = {
+  __typename?: "BsdasriOperationQuantity";
+  /** Quantité en kg */
+  value?: Maybe<Scalars["Int"]>;
 };
 
 /** Informations sur le conditionnement Bsdasri */
@@ -619,7 +629,7 @@ export type BsdasriPackagingInfoInput = {
   type: BsdasriPackagings;
   /** Description du conditionnement dans le cas où le type de conditionnement est `AUTRE` */
   other?: Maybe<Scalars["String"]>;
-  /** Nombre de colis associés à ce conditionnement */
+  /** Volume de chaque colis associé à ce conditionnement */
   volume: Scalars["Int"];
   /** Nombre de colis associés à ce conditionnement */
   quantity: Scalars["Int"];
@@ -641,19 +651,39 @@ export enum BsdasriPackagings {
   Autre = "AUTRE"
 }
 
+export type BsdasriQuantity = {
+  __typename?: "BsdasriQuantity";
+  /** Quantité en kg */
+  value?: Maybe<Scalars["Int"]>;
+  /** Quantité réélle (pesée ou estimée) */
+  type?: Maybe<QuantityType>;
+};
+
+export type BsdasriQuantityInput = {
+  value?: Maybe<Scalars["Int"]>;
+  type?: Maybe<QuantityType>;
+};
+
 /** Informations relatives à la réception du Bsdasri */
 export type BsdasriReception = {
   __typename?: "BsdasriReception";
-  wasteDetails?: Maybe<BsdasriWasteDetails>;
+  wasteDetails?: Maybe<BsdasriReceptionWasteDetails>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptation>;
   receivedAt?: Maybe<Scalars["DateTime"]>;
   signature?: Maybe<BsdasriSignature>;
 };
 
 export type BsdasriReceptionInput = {
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriRecipientWasteDetailInput>;
   receivedAt?: Maybe<Scalars["DateTime"]>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptationInput>;
+};
+
+/** Détail sur le déchet reçu du Bsdasri */
+export type BsdasriReceptionWasteDetails = {
+  __typename?: "BsdasriReceptionWasteDetails";
+  volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
 /** Destinataire du Bsdasri */
@@ -673,8 +703,8 @@ export type BsdasriRecipientInput = {
 };
 
 export type BsdasriRecipientWasteDetailInput = {
-  quantity?: Maybe<Scalars["Int"]>;
   volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
 };
 
 export type BsdasriRecipientWhere = {
@@ -740,7 +770,7 @@ export enum BsdasriStatus {
 /** Informations relatives au transport du Bsdasri */
 export type BsdasriTransport = {
   __typename?: "BsdasriTransport";
-  wasteDetails?: Maybe<BsdasriWasteDetails>;
+  wasteDetails?: Maybe<BsdasriTransportWasteDetails>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptation>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
   takenOverAt?: Maybe<Scalars["DateTime"]>;
@@ -782,11 +812,20 @@ export type BsdasriTransporterWhere = {
 };
 
 export type BsdasriTransportInput = {
-  wasteDetails?: Maybe<BsdasriWasteDetailInput>;
+  wasteDetails?: Maybe<BsdasriWasteDetailTransportInput>;
   takenOverAt?: Maybe<Scalars["DateTime"]>;
   handedOverAt?: Maybe<Scalars["DateTime"]>;
   wasteAcceptation?: Maybe<BsdasriWasteAcceptationInput>;
   mode?: Maybe<TransportMode>;
+};
+
+/** Détail sur le déchet transporté */
+export type BsdasriTransportWasteDetails = {
+  __typename?: "BsdasriTransportWasteDetails";
+  /** Quantité transportée */
+  quantity?: Maybe<BsdasriQuantity>;
+  volume?: Maybe<Scalars["Int"]>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
 export type BsdasriUpdateInput = {
@@ -814,21 +853,15 @@ export type BsdasriWasteAcceptationInput = {
   refusedQuantity?: Maybe<Scalars["Int"]>;
 };
 
-export type BsdasriWasteDetailInput = {
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
+export type BsdasriWasteDetailEmissionInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
   packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
   onuCode?: Maybe<Scalars["String"]>;
 };
 
-/** Détail sur le déchet transporté ou reçu du Bsdasri */
-export type BsdasriWasteDetails = {
-  __typename?: "BsdasriWasteDetails";
-  /** Quantité en kg */
-  quantity?: Maybe<Scalars["Int"]>;
-  quantityType?: Maybe<QuantityType>;
-  volume?: Maybe<Scalars["Int"]>;
-  packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
+export type BsdasriWasteDetailTransportInput = {
+  quantity?: Maybe<BsdasriQuantityInput>;
+  packagingInfos?: Maybe<Array<BsdasriPackagingInfoInput>>;
 };
 
 export type BsdasriWhere = {


### PR DESCRIPTION
Le contenu de la PR a évolué:

## Refactor

- par souci d'harmonisation, quantity, quantityType devient quantity { value type}
- la quantity finale passe de Reception à Operation
- la pesée étant obligatoire pour les codes de traitement finaux, le type est superflu

## Nouvelles règles de validation

Les quantités et leurs types sont:
- obligatoires pour la réception si le code correspond à un traitement final
- facultatives pour transport et pred
Si la quantité est renseignée, le type est obligatoire

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
 
---

- [Ticket Trello](https://trello.com/c/oj0Ow0sN/1500-dasris-gestion-des-quantit%C3%A9s)
