### PR TITLE
Évolution api dasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,7 +28,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Les codes R12 et D12 autorisés uniquement si le destinataire est TTR [PR 914](https://github.com/MTES-MCT/trackdechets/pull/914)
 - Les champs emails du bordereau dasri sont facultatifs [PR 916](https://github.com/MTES-MCT/trackdechets/pull/916)
-- Les différentes quatités (masses) du Bsdasri deviennent des flottants, le champ `onBehalfOfEcoorganisme` n'est plus réservé au Bsdasri de groupement [PR 928](https://github.com/MTES-MCT/trackdechets/pull/928)
+- Les différentes quantités (masses) du Bsdasri deviennent des flottants, le champ `onBehalfOfEcoorganisme` n'est plus réservé au Bsdasri de groupement [PR 928](https://github.com/MTES-MCT/trackdechets/pull/928)
 
 #### :memo: Documentation
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
   - Renommage du champ `BsffPackaging.litres` en `BsffPackaging.kilos`
   - Renommage du champ `BsffWaste.description` en `BsffWaste.nature`
   - Ajout du champ `Bsff.status`
+- Le champ `allowBsdasriTakeOverWithoutSignature` est disponible sur companyPublic [PR 928][https://github.com/mtes-mct/trackdechets/pull/928]
 
 #### :boom: Breaking changes
 
@@ -27,6 +28,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Les codes R12 et D12 autorisés uniquement si le destinataire est TTR [PR 914](https://github.com/MTES-MCT/trackdechets/pull/914)
 - Les champs emails du bordereau dasri sont facultatifs [PR 916](https://github.com/MTES-MCT/trackdechets/pull/916)
+- Les différentes quatités (masses) du Bsdasri deviennent des flottants, le champ `onBehalfOfEcoorganisme` n'est plus réservé au Bsdasri de groupement [PR 928](https://github.com/MTES-MCT/trackdechets/pull/928)
 
 #### :memo: Documentation
 

--- a/back/prisma/migrations/26_cast_dasri_quantities_to_float.sql
+++ b/back/prisma/migrations/26_cast_dasri_quantities_to_float.sql
@@ -1,0 +1,6 @@
+alter TABLE "default$default"."Bsdasri" 
+  alter COLUMN "emitterWasteQuantity" type DECIMAL(65,30),
+  alter COLUMN "recipientWasteRefusedQuantity" type DECIMAL(65,30),
+  alter COLUMN "transporterWasteQuantity" type DECIMAL(65,30),
+  alter COLUMN "transporterWasteRefusedQuantity" type DECIMAL(65,30),
+  alter COLUMN "recipientWasteQuantity" type DECIMAL(65,30);

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -711,7 +711,7 @@ model Bsdasri {
   wasteDetailsCode    String?
   wasteDetailsOnuCode String?
 
-  emitterWasteQuantity       Int? // kg
+  emitterWasteQuantity       Float? // kg
   emitterWasteQuantityType   QuantityType?
   emitterWasteVolume         Int? // liters
   emitterWastePackagingsInfo Json?
@@ -742,12 +742,12 @@ model Bsdasri {
   transportMode                     TransportMode? @default(ROAD)
   transporterWasteAcceptationStatus WasteAcceptationStatus?
   transporterWasteRefusalReason     String?
-  transporterWasteRefusedQuantity   Int? // kg
+  transporterWasteRefusedQuantity   Float? // kg
 
   transporterTakenOverAt DateTime?
 
   transporterWastePackagingsInfo Json?
-  transporterWasteQuantity       Int? // kg
+  transporterWasteQuantity       Float? // kg
   transporterWasteQuantityType   QuantityType?
   transporterWasteVolume         Int? // liters
 
@@ -773,8 +773,8 @@ model Bsdasri {
   recipientWastePackagingsInfo    Json?
   recipientWasteAcceptationStatus WasteAcceptationStatus?
   recipientWasteRefusalReason     String?
-  recipientWasteRefusedQuantity   Int? // kg
-  recipientWasteQuantity          Int? // kg
+  recipientWasteRefusedQuantity   Float? // kg
+  recipientWasteQuantity          Float? // kg
 
   recipientWasteVolume Int? // liters
   receivedAt           DateTime? // accepted or refused date

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
@@ -140,7 +140,7 @@ describe("Mutation.createDasri", () => {
       emission: {
         wasteCode: "18 01 03*",
         wasteDetails: {
-          quantity: { value: 23, type: "REAL" },
+          quantity: { value: 23.2, type: "REAL" },
 
           onuCode: "xyz 33",
           packagingInfos: [

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -78,7 +78,7 @@ input BsdasriEmitterInput {
 }
 
 input BsdasriQuantityInput {
-  value: Int
+  value: Float
   type: QuantityType
 }
 
@@ -99,7 +99,7 @@ input BsdasriRecipientWasteDetailInput {
 input BsdasriWasteAcceptationInput {
   status: WasteAcceptationStatusInput
   refusalReason: String
-  refusedQuantity: Int
+  refusedQuantity: Float
 }
 input BsdasriEmissionInput {
   wasteCode: String

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -66,13 +66,13 @@ type BsdasriPackagingInfo {
 
 type BsdasriQuantity {
   "Quantité en kg"
-  value: Int
+  value: Float
   "Quantité réélle (pesée ou estimée)"
   type: QuantityType
 }
 type BsdasriOperationQuantity {
   "Quantité en kg"
-  value: Int
+  value: Float
 }
 
 "Détail sur le déchet emis du Bsdasri"
@@ -116,7 +116,7 @@ type BsdasriEmission {
 type BsdasriWasteAcceptation {
   status: String
   refusalReason: String
-  refusedQuantity: Int
+  refusedQuantity: Float
 }
 
 "Informations relatives au transport du Bsdasri"

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -165,15 +165,7 @@ export const emitterSchema: FactorySchemaOf<
     emitterWorkSiteCity: yup.string().nullable(),
     emitterWorkSitePostalCode: yup.string().nullable(),
     emitterWorkSiteInfos: yup.string().nullable(),
-    emitterOnBehalfOfEcoorganisme: yup
-      .boolean()
-      .notRequired()
-      .nullable()
-      .test(
-        "no-ecoorg-if-not-regrouping",
-        "Émetteur: le champ onBehalfOfEcoorganisme n'est à remplir que pour les bordereaux de regroupement",
-        v => (!context.isRegrouping ? !v : true)
-      )
+    emitterOnBehalfOfEcoorganisme: yup.boolean().notRequired().nullable()
   });
 
 const packagingsTypes: BsdasriPackagings[] = [

--- a/back/src/companies/resolvers/queries/__tests__/companyInfos.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyInfos.integration.ts
@@ -224,6 +224,42 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
     expect(response.data.companyInfos.traderReceipt).toEqual(receipt);
   });
 
+  test("Company with direct dasri takeover allowance", async () => {
+    searchCompanySpy.mockResolvedValueOnce({
+      siret: "85001946400013",
+      etatAdministratif: "A",
+      name: "CODE EN STOCK",
+      address: "4 Boulevard Longchamp 13001 Marseille",
+      codeCommune: "13201",
+      naf: "62.01Z",
+      libelleNaf: "Programmation informatique",
+      addressVoie: "4 boulevard Longchamp",
+      addressCity: "Marseille",
+      addressPostalCode: "13001"
+    });
+
+    await companyFactory({
+      siret: "85001946400013",
+      name: "Code en Stock",
+      securityCode: 1234,
+      contactEmail: "john.snow@trackdechets.fr",
+      contactPhone: "0600000000",
+      website: "https://trackdechets.beta.gouv.fr",
+      allowBsdasriTakeOverWithoutSignature: true
+    });
+
+    const gqlquery = `
+      query {
+        companyInfos(siret: "85001946400013") {
+          allowBsdasriTakeOverWithoutSignature
+        }
+      }`;
+    const response = await query<any>(gqlquery);
+    expect(
+      response.data.companyInfos.allowBsdasriTakeOverWithoutSignature
+    ).toEqual(true);
+  });
+
   test.skip("Closed company", async () => {
     // This test is skipped because it make a real call to SIRENE API
     // It can be used to check our code is working well on closed companies

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -36,7 +36,8 @@ export async function getCompanyInfos(siret: string): Promise<CompanyPublic> {
       contactEmail: true,
       contactPhone: true,
       website: true,
-      ecoOrganismeAgreements: true
+      ecoOrganismeAgreements: true,
+      allowBsdasriTakeOverWithoutSignature: true
     }
   });
 

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -161,6 +161,9 @@ type CompanyPublic {
   Liste des agréments de l'éco-organisme
   """
   ecoOrganismeAgreements: [URL!]!
+
+  "L'entreprise autorise l'enlèvement d'un Dasri sans sa signature"
+  allowBsdasriTakeOverWithoutSignature: Boolean
 }
 
 "Information sur un établissement accessible publiquement en recherche"

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -609,7 +609,7 @@ export type BsdasriOperationInput = {
 export type BsdasriOperationQuantity = {
   __typename?: "BsdasriOperationQuantity";
   /** Quantité en kg */
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
 };
 
 /** Informations sur le conditionnement Bsdasri */
@@ -653,13 +653,13 @@ export type BsdasriPackagings =
 export type BsdasriQuantity = {
   __typename?: "BsdasriQuantity";
   /** Quantité en kg */
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
   /** Quantité réélle (pesée ou estimée) */
   type?: Maybe<QuantityType>;
 };
 
 export type BsdasriQuantityInput = {
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
   type?: Maybe<QuantityType>;
 };
 
@@ -840,13 +840,13 @@ export type BsdasriWasteAcceptation = {
   __typename?: "BsdasriWasteAcceptation";
   status?: Maybe<Scalars["String"]>;
   refusalReason?: Maybe<Scalars["String"]>;
-  refusedQuantity?: Maybe<Scalars["Int"]>;
+  refusedQuantity?: Maybe<Scalars["Float"]>;
 };
 
 export type BsdasriWasteAcceptationInput = {
   status?: Maybe<WasteAcceptationStatusInput>;
   refusalReason?: Maybe<Scalars["String"]>;
-  refusedQuantity?: Maybe<Scalars["Int"]>;
+  refusedQuantity?: Maybe<Scalars["Float"]>;
 };
 
 export type BsdasriWasteDetailEmissionInput = {
@@ -6010,7 +6010,7 @@ export type BsdasriOperationQuantityResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriOperationQuantity"] = ResolversParentTypes["BsdasriOperationQuantity"]
 > = {
-  value?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  value?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -6029,7 +6029,7 @@ export type BsdasriQuantityResolvers<
   ContextType = GraphQLContext,
   ParentType extends ResolversParentTypes["BsdasriQuantity"] = ResolversParentTypes["BsdasriQuantity"]
 > = {
-  value?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
+  value?: Resolver<Maybe<ResolversTypes["Float"]>, ParentType, ContextType>;
   type?: Resolver<
     Maybe<ResolversTypes["QuantityType"]>,
     ParentType,
@@ -6194,7 +6194,7 @@ export type BsdasriWasteAcceptationResolvers<
     ContextType
   >;
   refusedQuantity?: Resolver<
-    Maybe<ResolversTypes["Int"]>,
+    Maybe<ResolversTypes["Float"]>,
     ParentType,
     ContextType
   >;

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -1961,6 +1961,8 @@ export type CompanyPublic = {
   vhuAgrementBroyeur?: Maybe<VhuAgrement>;
   /** Liste des agréments de l'éco-organisme */
   ecoOrganismeAgreements: Array<Scalars["URL"]>;
+  /** L'entreprise autorise l'enlèvement d'un Dasri sans sa signature */
+  allowBsdasriTakeOverWithoutSignature?: Maybe<Scalars["Boolean"]>;
 };
 
 /** Information sur un établissement accessible publiquement en recherche */
@@ -7198,6 +7200,11 @@ export type CompanyPublicResolvers<
     ParentType,
     ContextType
   >;
+  allowBsdasriTakeOverWithoutSignature?: Resolver<
+    Maybe<ResolversTypes["Boolean"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -11178,6 +11185,7 @@ export function createCompanyPublicMock(
     vhuAgrementDemolisseur: null,
     vhuAgrementBroyeur: null,
     ecoOrganismeAgreements: [],
+    allowBsdasriTakeOverWithoutSignature: null,
     ...props
   };
 }

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -95,7 +95,7 @@ export default function Emitter({ status }) {
             disabled={disabled}
             placeholder="En kg"
             min="0"
-            step="1"
+            step="0.1"
           />
           <span className="tw-ml-2">kg</span>
         </label>

--- a/front/src/form/bsdasri/Recipient.tsx
+++ b/front/src/form/bsdasri/Recipient.tsx
@@ -126,7 +126,7 @@ export default function Recipient({ status }) {
                 className="td-input dasri__waste-details__quantity"
                 placeholder="En kg"
                 min="0"
-                step="1"
+                step="0.1"
               />
               <span className="tw-ml-2">kg</span>
             </label>

--- a/front/src/form/bsdasri/Transporter.tsx
+++ b/front/src/form/bsdasri/Transporter.tsx
@@ -174,7 +174,7 @@ export default function Transporter({ status }) {
                 disabled={disabled}
                 placeholder="En kg"
                 min="0"
-                step="1"
+                step="0.1"
               />
               <span className="tw-ml-2">kg</span>
             </label>

--- a/front/src/form/bsdasri/components/acceptation/Acceptation.tsx
+++ b/front/src/form/bsdasri/components/acceptation/Acceptation.tsx
@@ -60,7 +60,7 @@ export default function Acceptation({
                   disabled={props?.disabled}
                   placeholder="En kg"
                   min="0"
-                  step="1"
+                  step="0.1"
                 />
                 <span className="tw-ml-2">kg</span>
               </label>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -613,7 +613,7 @@ export type BsdasriOperationInput = {
 export type BsdasriOperationQuantity = {
   __typename?: "BsdasriOperationQuantity";
   /** Quantité en kg */
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
 };
 
 /** Informations sur le conditionnement Bsdasri */
@@ -658,13 +658,13 @@ export enum BsdasriPackagings {
 export type BsdasriQuantity = {
   __typename?: "BsdasriQuantity";
   /** Quantité en kg */
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
   /** Quantité réélle (pesée ou estimée) */
   type?: Maybe<QuantityType>;
 };
 
 export type BsdasriQuantityInput = {
-  value?: Maybe<Scalars["Int"]>;
+  value?: Maybe<Scalars["Float"]>;
   type?: Maybe<QuantityType>;
 };
 
@@ -848,13 +848,13 @@ export type BsdasriWasteAcceptation = {
   __typename?: "BsdasriWasteAcceptation";
   status?: Maybe<Scalars["String"]>;
   refusalReason?: Maybe<Scalars["String"]>;
-  refusedQuantity?: Maybe<Scalars["Int"]>;
+  refusedQuantity?: Maybe<Scalars["Float"]>;
 };
 
 export type BsdasriWasteAcceptationInput = {
   status?: Maybe<WasteAcceptationStatusInput>;
   refusalReason?: Maybe<Scalars["String"]>;
-  refusedQuantity?: Maybe<Scalars["Int"]>;
+  refusedQuantity?: Maybe<Scalars["Float"]>;
 };
 
 export type BsdasriWasteDetailEmissionInput = {

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -1996,6 +1996,8 @@ export type CompanyPublic = {
   vhuAgrementBroyeur?: Maybe<VhuAgrement>;
   /** Liste des agréments de l'éco-organisme */
   ecoOrganismeAgreements: Array<Scalars["URL"]>;
+  /** L'entreprise autorise l'enlèvement d'un Dasri sans sa signature */
+  allowBsdasriTakeOverWithoutSignature?: Maybe<Scalars["Boolean"]>;
 };
 
 /** Information sur un établissement accessible publiquement en recherche */


### PR DESCRIPTION
Évolutions mineures api dasri:

- Supprimer la contrainte validation : champ onBehalfOfEcoorganisme réservé au bsd de regroupement
- les quantités (masses) deviennent des flottants
- le champ allowBsdasriTakeOverWithoutSignature est disponible sur  companyPublic pour permettre aux transporteurs de vérifier si l'emport direct est autorisé

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Trello](https://trello.com/c/mBtu8AIT/1598-mises-%C3%A0-jour-mineures-api-dasris)
