### PR TITLE
Improve dasri quantity widget

### DIFF
--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -3,12 +3,15 @@ import CompanySelector from "form/common/components/company/CompanySelector";
 import { Field } from "formik";
 import React from "react";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
-import NumberInput from "form/common/components/custom-inputs/NumberInput";
 import Packagings from "./components/packagings/Packagings";
 import "./Bsdasri.scss";
-import { getInitialEmitterWorkSite } from "./utils/initial-state";
+import {
+  getInitialEmitterWorkSite,
+  getInitialQuantityFn,
+} from "./utils/initial-state";
 import WorkSite from "form/common/components/work-site/WorkSite";
 import DateInput from "form/common/components/custom-inputs/DateInput";
+import QuantityWidget from "./components/Quantity";
 import { BsdasriStatus } from "generated/graphql/types";
 import { FillFieldsInfo, DisabledFieldsInfo } from "./utils/commons";
 import classNames from "classnames";
@@ -95,49 +98,18 @@ export default function Emitter({ status, stepName }) {
         />
       </div>
       <h4 className="form__section-heading">Quantité remise</h4>
-
       <div
         className={classNames("form__row", {
           "field-emphasis": emissionEmphasis,
         })}
       >
-        <label>
-          Quantité en kg :
-          <Field
-            component={NumberInput}
-            name="emission.wasteDetails.quantity.value"
-            className="td-input dasri__waste-details__quantity"
-            disabled={disabled}
-            placeholder="En kg"
-            min="0"
-            step="0.1"
-          />
-          <span className="tw-ml-2">kg</span>
-        </label>
-
-        <RedErrorMessage name="emission.wasteDetails.quantity.value" />
+        <QuantityWidget
+          disabled={disabled}
+          switchLabel="Je souhaite ajouter une quantité"
+          dasriSection="emission"
+          getInitialQuantityFn={getInitialQuantityFn}
+        />
       </div>
-
-      <div className="form__row">
-        <fieldset>
-          <legend className="tw-font-semibold">Cette quantité est</legend>
-          <Field
-            name="emission.wasteDetails.quantity.type"
-            id="REAL"
-            label="Réélle"
-            component={RadioButton}
-            disabled={disabled}
-          />
-          <Field
-            name="emission.wasteDetails.quantity.type"
-            id="ESTIMATED"
-            label="Estimée"
-            component={RadioButton}
-            disabled={disabled}
-          />
-        </fieldset>
-      </div>
-
       <div
         className={classNames("form__row", {
           "field-emphasis": emissionEmphasis,

--- a/front/src/form/bsdasri/Transporter.tsx
+++ b/front/src/form/bsdasri/Transporter.tsx
@@ -6,11 +6,12 @@ import { BsdasriStatus } from "generated/graphql/types";
 import React from "react";
 import Acceptation from "form/bsdasri/components/acceptation/Acceptation";
 import Packagings from "./components/packagings/Packagings";
-import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
-import NumberInput from "form/common/components/custom-inputs/NumberInput";
+import { getInitialQuantityFn } from "./utils/initial-state";
 import { transportModeLabels } from "dashboard/constants";
 import { FillFieldsInfo, DisabledFieldsInfo } from "./utils/commons";
 import classNames from "classnames";
+import QuantityWidget from "./components/Quantity";
+
 export default function Transporter({ status, stepName }) {
   const { setFieldValue } = useFormikContext();
 
@@ -192,43 +193,12 @@ export default function Transporter({ status, stepName }) {
           </div>
           <h4 className="form__section-heading">Quantité transportée</h4>
 
-          <div className="form__row">
-            <label>
-              Quantité en kg :
-              <Field
-                component={NumberInput}
-                name="transport.wasteDetails.quantity.value"
-                className="td-input dasri__waste-details__quantity"
-                disabled={disabled}
-                placeholder="En kg"
-                min="0"
-                step="0.1"
-              />
-              <span className="tw-ml-2">kg</span>
-            </label>
-
-            <RedErrorMessage name="transport.wasteDetails.quantity.value" />
-          </div>
-
-          <div className="form__row">
-            <fieldset>
-              <legend className="tw-font-semibold">Cette quantité est</legend>
-              <Field
-                name="transport.wasteDetails.quantity.type"
-                id="REAL"
-                label="Réélle"
-                component={RadioButton}
-                disabled={disabled}
-              />
-              <Field
-                name="transport.wasteDetails.quantity.type"
-                id="ESTIMATED"
-                label="Estimée"
-                component={RadioButton}
-                disabled={disabled}
-              />
-            </fieldset>
-          </div>
+          <QuantityWidget
+            disabled={disabled}
+            switchLabel="Je souhaite ajouter une quantité"
+            dasriSection="transport"
+            getInitialQuantityFn={getInitialQuantityFn}
+          />
         </>
       ) : (
         <p>

--- a/front/src/form/bsdasri/components/Quantity.tsx
+++ b/front/src/form/bsdasri/components/Quantity.tsx
@@ -1,0 +1,91 @@
+import TdSwitch from "common/components/Switch";
+import { RedErrorMessage } from "common/components";
+import { Field, useFormikContext } from "formik";
+import { Bsdasri } from "generated/graphql/types";
+import React from "react";
+import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
+import NumberInput from "form/common/components/custom-inputs/NumberInput";
+
+export default function QuantityWidget({
+  switchLabel,
+  dasriSection,
+  getInitialQuantityFn,
+  disabled = false,
+}: {
+  switchLabel: string;
+  dasriSection: "emission" | "transport";
+  getInitialQuantityFn: () => any;
+  disabled?: boolean;
+}) {
+  const { values, setFieldValue } = useFormikContext<Bsdasri>();
+
+  const showQuantity = !!values[dasriSection]?.wasteDetails?.quantity;
+
+  function handleQuantityToggle() {
+    if (showQuantity) {
+      setFieldValue(`${dasriSection}.wasteDetails.quantity`, null, false);
+    } else {
+      setFieldValue(
+        `${dasriSection}.wasteDetails.quantity`,
+        getInitialQuantityFn(),
+        false
+      );
+    }
+  }
+
+  return (
+    <div className="form__row tw-mb-4">
+      {!disabled && (
+        <TdSwitch
+          checked={showQuantity}
+          onChange={handleQuantityToggle}
+          label={switchLabel}
+        />
+      )}
+
+      {showQuantity && (
+        <>
+          <div className="form__row">
+            <label>
+              Quantité en kg :
+              <Field
+                component={NumberInput}
+                name={`${dasriSection}.wasteDetails.quantity.value`}
+                className="td-input dasri__waste-details__quantity"
+                disabled={disabled}
+                placeholder="En kg"
+                min="0"
+                step="0.1"
+              />
+              <span className="tw-ml-2">kg</span>
+            </label>
+
+            <RedErrorMessage
+              name={`${dasriSection}.wasteDetails.quantity.value`}
+            />
+          </div>
+
+          <div className="form__row">
+            <fieldset>
+              <legend className="tw-font-semibold">Cette quantité est</legend>
+              <Field
+                name={`${dasriSection}.wasteDetails.quantity.type`}
+                id="REAL"
+                label="Réélle"
+                component={RadioButton}
+                disabled={disabled}
+              />
+              <Field
+                name={`${dasriSection}.wasteDetails.quantity.type`}
+                id="ESTIMATED"
+                label="Estimée"
+                component={RadioButton}
+                disabled={disabled}
+              />
+            </fieldset>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -1,6 +1,6 @@
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
 
-import { WorkSite } from "generated/graphql/types";
+import { WorkSite, BsdasriQuantity, Bsdasri } from "generated/graphql/types";
 
 export function getInitialEmitterWorkSite(workSite?: WorkSite | null) {
   return {
@@ -11,7 +11,13 @@ export function getInitialEmitterWorkSite(workSite?: WorkSite | null) {
     infos: workSite?.infos ?? "",
   };
 }
-const initialState = {
+
+export const getInitialQuantityFn = (quantity?: BsdasriQuantity | null) => ({
+  value: quantity?.value,
+  type: quantity?.type,
+});
+
+const getInitialState = (f?: Bsdasri | null) => ({
   emitter: {
     company: getInitialCompany(),
     workSite: null,
@@ -21,14 +27,20 @@ const initialState = {
     wasteCode: "18 01 03*",
     wasteDetails: {
       packagingInfos: [],
-      quantity: { value: null, type: null },
-
-      onuCode: "",
+      quantity: !!f?.emission?.wasteDetails?.quantity
+        ? getInitialQuantityFn(f?.emission?.wasteDetails?.quantity)
+        : null,
+      onuCode: null,
     },
     handedOverAt: null,
   },
   transport: {
-    wasteDetails: { packagingInfos: [], quantity: { value: null, type: null } },
+    wasteDetails: {
+      packagingInfos: [],
+      quantity: !!f?.transport?.wasteDetails?.quantity
+        ? getInitialQuantityFn(f?.transport?.wasteDetails?.quantity)
+        : null,
+    },
     takenOverAt: null,
     handedOverAt: null,
     wasteAcceptation: {
@@ -60,8 +72,6 @@ const initialState = {
     receiptDepartment: null,
     receiptValidityLimit: null,
   },
-};
-
-const getInitialState = () => initialState;
+});
 
 export default getInitialState;


### PR DESCRIPTION
Sur le formulaire dasri, on peut préciser le type de quantité. On ne peut cependant pas le décocher (bouton radio).
Un widget semblable à celui de l'adresse chantier (sélecteur oui/non qui déplie un sous formulaire et le raz sur fermeture) semble plus indiqué 
 
- [x ] Mettre à jour le change log
---

- [Ticket Trello](https://trello.com/c/pDuHLksm/1613-am%C3%A9lioration-ui-quantit%C3%A9s-dasri)
