### PR TITLE
Création et édition de dasri de groupement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,12 +5,27 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Next release
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :boom: Breaking changes
+
+#### :bug: Corrections de bugs
+
+#### :nail_care: Améliorations
+
+- Création et édition de bordereaux Dasri de groupement [PR934](https://github.com/MTES-MCT/trackdechets/pull/934)
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2021.07.1] 12/07/2021
 
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout d'un bouton pour choisir le type de bordereau à créer [PR 899](https://github.com/MTES-MCT/trackdechets/pull/899)
-- Les producteurs peuvent autoriser l'emport de dasri sans leur signature depuis l'UI[PR 904] (https://github.com/MTES-MCT/trackdechets/pull/904)
+- Les producteurs peuvent autoriser l'emport de dasri sans leur signature depuis l'UI[PR 904](https://github.com/MTES-MCT/trackdechets/pull/904)
 - Ajout des BSFFs au tableau de bord [PR 909](https://github.com/MTES-MCT/trackdechets/pull/909)
 - Évolutions de l'API BSFF suite aux retours de nos partenaires [PR 909][https://github.com/mtes-mct/trackdechets/pull/909]
   - Refonte de la gestion des fiches d'intervention : modification du modèle et des mutations
@@ -40,6 +55,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :memo: Documentation
 
 - Re-structuration de la documentation et ajout d'exemples de bout en bout [PR 905](https://github.com/MTES-MCT/trackdechets/pull/905)
+
 #### :house: Interne
 
 - Indexation des BSFF dans Elastic Search [PR 909](https://github.com/MTES-MCT/trackdechets/pull/909)

--- a/back/prisma/migrations/27_dasri_subtypes.sql
+++ b/back/prisma/migrations/27_dasri_subtypes.sql
@@ -1,0 +1,3 @@
+CREATE TYPE "default$default"."BsdasriType" AS ENUM ('SIMPLE', 'GROUPING', 'SYNTHESIS');
+
+alter TABLE "default$default"."Bsdasri" ADD COLUMN "bsdasriType" "default$default"."BsdasriType" NOT NULL DEFAULT E'SIMPLE';

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -679,8 +679,15 @@ enum BsdasriEmitterType {
   COLLECTOR
 }
 
+enum BsdasriType {
+  SIMPLE
+  GROUPING
+  SYNTHESIS
+}
+
 model Bsdasri {
   id        String        @unique
+  bsdasriType BsdasriType @default(SIMPLE)
   status    BsdasriStatus @default(INITIAL)
   createdAt DateTime      @default(now())
   updatedAt DateTime      @updatedAt

--- a/back/src/bsdasris/dasri-converter.ts
+++ b/back/src/bsdasris/dasri-converter.ts
@@ -34,7 +34,7 @@ export function expandBsdasriFromDb(bsdasri: Bsdasri): GqlBsdasri {
   return {
     id: bsdasri.id,
     isDraft: bsdasri.isDraft,
-
+    bsdasriType: bsdasri.bsdasriType,
     emitter: nullIfNoValues<BsdasriEmitter>({
       company: nullIfNoValues<FormCompany>({
         name: bsdasri.emitterCompanyName,

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
@@ -13,6 +13,7 @@ mutation DasriCreate($input: BsdasriCreateInput!) {
   createBsdasri(input: $input)  {
     id
     isDraft
+    bsdasriType
     status
     emitter {
       company {
@@ -165,6 +166,7 @@ describe("Mutation.createDasri", () => {
     );
     expect(data.createBsdasri.isDraft).toEqual(false);
     expect(data.createBsdasri.status).toEqual("INITIAL");
+    expect(data.createBsdasri.bsdasriType).toEqual("SIMPLE");
 
     expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
   });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriRegroup.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriRegroup.integration.ts
@@ -12,6 +12,7 @@ mutation DasriCreate($input: BsdasriCreateInput!) {
   createBsdasri(input: $input)  {
     id
     isDraft
+    bsdasriType
     status
     emitter {
       company {
@@ -220,7 +221,7 @@ describe("Mutation.createDasri", () => {
       toRegroup1.id,
       toRegroup2.id
     ]);
-
+    expect(data.createBsdasri.bsdasriType).toEqual("GROUPING");
     const regrouped1 = await prisma.bsdasri.findUnique({
       where: { id: toRegroup1.id }
     });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
@@ -14,6 +14,7 @@ mutation DasriCreate($input: BsdasriCreateInput!) {
   createDraftBsdasri(input: $input)  {
     id
     isDraft
+    bsdasriType
     status
     recipient {
       company {
@@ -104,6 +105,7 @@ describe("Mutation.createDraftBsdasri", () => {
 
     expect(data.createDraftBsdasri.isDraft).toBe(true);
     expect(data.createDraftBsdasri.status).toBe("INITIAL");
+    expect(data.createDraftBsdasri.bsdasriType).toBe("SIMPLE");
     expect(data.createDraftBsdasri.recipient.company).toMatchObject(
       input.recipient.company
     );

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -80,7 +80,7 @@ describe("Mutation.updateBsdasri", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Vous ne pouvez pas modifier un bordereau sur lequel votre entreprise n'apparait pas",
+          "Vous ne pouvez pas modifier un bordereau sur lequel votre entreprise n'apparaît pas",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriRegroup.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriRegroup.integration.ts
@@ -1,0 +1,94 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { bsdasriFactory } from "../../../__tests__/factories";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { BsdasriStatus } from "@prisma/client";
+
+import { Mutation } from "../../../../generated/graphql/types";
+
+const UPDATE_DASRI = `
+mutation UpdateDasri($id: ID!, $input: BsdasriUpdateInput!) {
+  updateBsdasri(id: $id, input: $input) {
+    id
+    status
+    bsdasriType
+    emitter {
+       company {
+          mail
+        }
+      }
+    regroupedBsdasris
+  }
+}`;
+describe("Mutation.updateBsdasri", () => {
+  afterEach(resetDatabase);
+
+  it("should set dasri type to GROUPING when regrouping", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["COLLECTOR"]
+      }
+    });
+    const toRegroup = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        status: BsdasriStatus.PROCESSED,
+        emitterCompanySiret: "1234",
+        recipientCompanySiret: company.siret,
+        processingOperation: "R1"
+      }
+    });
+    const dasri = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        status: BsdasriStatus.INITIAL,
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const { data } = await mutate<Pick<Mutation, "updateBsdasri">>(
+      UPDATE_DASRI,
+      {
+        variables: {
+          id: dasri.id,
+          input: { regroupedBsdasris: [{ id: toRegroup.id }] }
+        }
+      }
+    );
+    expect(data.updateBsdasri.regroupedBsdasris).toEqual([toRegroup.id]);
+    expect(data.updateBsdasri.bsdasriType).toEqual("GROUPING");
+  });
+
+  it("should set dasri type to SIMPLE when ungrouping", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: {
+        set: ["COLLECTOR"]
+      }
+    });
+
+    const dasri = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        status: BsdasriStatus.INITIAL,
+        emitterCompanySiret: company.siret,
+        bsdasriType: "GROUPING"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const { data } = await mutate<Pick<Mutation, "updateBsdasri">>(
+      UPDATE_DASRI,
+      {
+        variables: {
+          id: dasri.id,
+          input: { regroupedBsdasris: null }
+        }
+      }
+    );
+    expect(data.updateBsdasri.regroupedBsdasris).toEqual([]);
+    expect(data.updateBsdasri.bsdasriType).toEqual("SIMPLE");
+  });
+});

--- a/back/src/bsdasris/resolvers/mutations/create.ts
+++ b/back/src/bsdasris/resolvers/mutations/create.ts
@@ -15,6 +15,10 @@ import { checkIsBsdasriContributor } from "../../permissions";
 import { emitterIsAllowedToGroup, checkDasrisAreGroupable } from "./utils";
 import { indexBsdasri } from "../../elastic";
 
+/**
+ * Bsdasri creation mutation
+ * sets bsdasriType to `GROUPING` if a non empty array of regroupedBsdasris is provided
+ */
 const createBsdasri = async (
   parent: ResolversParentTypes["Mutation"],
   { input: input }: MutationCreateBsdasriArgs,
@@ -58,6 +62,7 @@ const createBsdasri = async (
     data: {
       ...flattenedInput,
       id: getReadableId(ReadableIdPrefix.DASRI),
+      bsdasriType: isRegrouping ? "GROUPING" : "SIMPLE",
       owner: { connect: { id: user.id } },
       regroupedBsdasris: { connect: regroupedBsdasris },
       isDraft: isDraft

--- a/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
@@ -16,13 +16,20 @@ const publishBsdasriResolver: MutationResolvers["publishBsdasri"] = async (
   context
 ) => {
   const user = checkIsAuthenticated(context);
-  const bsdasri = await getBsdasriOrNotFound({ id });
+  const { regroupedBsdasris, ...bsdasri } = await getBsdasriOrNotFound({
+    id,
+    includeRegrouped: true
+  });
   await checkIsBsdasriContributor(
     user,
     bsdasri,
     "Vous ne pouvez publier ce bordereau si vous ne figurez pas dessus"
   );
-  await checkIsBsdasriPublishable(user, bsdasri);
+  await checkIsBsdasriPublishable(
+    user,
+    bsdasri,
+    regroupedBsdasris.map(el => el.id)
+  );
 
   await validateBsdasri(bsdasri, { emissionSignature: true });
   // publish  dasri

--- a/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
@@ -6,7 +6,8 @@ import { Bsdasri, BsdasriStatus } from "@prisma/client";
 import prisma from "../../../prisma";
 import {
   ResolversParentTypes,
-  MutationUpdateBsdasriArgs
+  MutationUpdateBsdasriArgs,
+  RegroupedBsdasriInput
 } from "../../../generated/graphql/types";
 
 import { checkIsAuthenticated } from "../../../common/permissions";
@@ -78,7 +79,10 @@ const getFieldsAllorwedForUpdate = (bsdasri: Bsdasri) => {
   };
   return allowedFields[bsdasri.status];
 };
-const getRegroupedBsdasriArgs = inputRegroupedBsdasris => {
+
+const getRegroupedBsdasriArgs = (
+  inputRegroupedBsdasris: RegroupedBsdasriInput[] | null | undefined
+) => {
   if (inputRegroupedBsdasris === null) {
     return { regroupedBsdasris: { set: [] }, bsdasriType: "SIMPLE" };
   }
@@ -86,6 +90,7 @@ const getRegroupedBsdasriArgs = inputRegroupedBsdasris => {
   const args = !!inputRegroupedBsdasris ? { set: inputRegroupedBsdasris } : {};
   return { regroupedBsdasris: args, bsdasriType: "GROUPING" };
 };
+
 const getIsRegrouping = (dbRegroupedBsdasris, regroupedBsdasris) => {
   if (regroupedBsdasris === null) {
     return { isRegrouping: false };
@@ -163,7 +168,8 @@ const dasriUpdateResolver = async (
     where: { id },
     data: {
       ...flattenedInput,
-      ...getRegroupedBsdasriArgs(inputRegroupedBsdasris)
+      ...getRegroupedBsdasriArgs(inputRegroupedBsdasris),
+      bsdasriType: "SIMPLE"
     }
   });
 

--- a/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
@@ -83,12 +83,12 @@ const getFieldsAllorwedForUpdate = (bsdasri: Bsdasri) => {
 const getRegroupedBsdasriArgs = (
   inputRegroupedBsdasris: RegroupedBsdasriInput[] | null | undefined
 ) => {
-  if (inputRegroupedBsdasris === null) {
-    return { regroupedBsdasris: { set: [] }, bsdasriType: "SIMPLE" };
+  if (inputRegroupedBsdasris === null || inputRegroupedBsdasris?.length === 0) {
+    return { regroupedBsdasris: { set: [] } };
   }
 
   const args = !!inputRegroupedBsdasris ? { set: inputRegroupedBsdasris } : {};
-  return { regroupedBsdasris: args, bsdasriType: "GROUPING" };
+  return { regroupedBsdasris: args };
 };
 
 const getIsRegrouping = (dbRegroupedBsdasris, regroupedBsdasris) => {
@@ -169,7 +169,10 @@ const dasriUpdateResolver = async (
     data: {
       ...flattenedInput,
       ...getRegroupedBsdasriArgs(inputRegroupedBsdasris),
-      bsdasriType: "SIMPLE"
+      bsdasriType:
+        inputRegroupedBsdasris === null || inputRegroupedBsdasris?.length === 0
+          ? "SIMPLE"
+          : "GROUPING"
     }
   });
 

--- a/back/src/bsdasris/resolvers/mutations/utils.ts
+++ b/back/src/bsdasris/resolvers/mutations/utils.ts
@@ -17,7 +17,7 @@ export const checkDasrisAreGroupable = async (
   // whose id is in regroupedBsdasrisIds array
   // which are in PROCESSED status
   // whose processingOperation is either D12 or  R12
-  // which are not already grouped
+  // which are not already grouped or are grouped on an initial dasri
   // which are not regrouping other dasris
   // whose recipient in current emitter
   const found = await prisma.bsdasri.findMany({

--- a/back/src/bsdasris/resolvers/queries/__tests__/bsdasris.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/bsdasris.integration.ts
@@ -275,7 +275,7 @@ describe("Query.Bsdasris", () => {
     const { data } = await query<Pick<Query, "bsdasris">>(GET_BSDASRIS, {
       variables: {
         where: {
-          ids: [dasri2.id, dasri3.id]
+          id_in: [dasri2.id, dasri3.id]
         }
       }
     });

--- a/back/src/bsdasris/resolvers/queries/__tests__/bsdasris.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/bsdasris.integration.ts
@@ -245,4 +245,44 @@ describe("Query.Bsdasris", () => {
 
     expect(queryRecipientIids).toStrictEqual([dasri3.id]);
   });
+
+  it("should get dasris which id are requested", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        ...initialData(company)
+      }
+    });
+    const dasri2 = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        ...initialData(company)
+      }
+    });
+
+    const dasri3 = await bsdasriFactory({
+      ownerId: user.id,
+      opt: {
+        ...initialData(company)
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    // retrieve dasris which ids are requested
+    const { data } = await query<Pick<Query, "bsdasris">>(GET_BSDASRIS, {
+      variables: {
+        where: {
+          ids: [dasri2.id, dasri3.id]
+        }
+      }
+    });
+    const ids = data.bsdasris.edges.map(edge => edge.node.id);
+
+    expect(ids.length).toEqual(2);
+    expect(ids).toContain(dasri2.id);
+    expect(ids).toContain(dasri3.id);
+  });
 });

--- a/back/src/bsdasris/resolvers/queries/__tests__/where.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/where.integration.ts
@@ -123,4 +123,20 @@ describe("Bsdasri where conversion", () => {
       createdAt: { gt: now, lt: now }
     });
   });
+
+  it("should convert filter on request ids", () => {
+    const where: BsdasriWhere = {
+      ids: ["x", "y", "z"]
+    };
+
+    const dbFilter = buildDbFilter(where, [siret]);
+    expect(dbFilter).toEqual({
+      OR: [
+        { emitterCompanySiret: { in: [siret] } },
+        { transporterCompanySiret: { in: [siret] } },
+        { recipientCompanySiret: { in: [siret] } }
+      ],
+      id: { in: ["x", "y", "z"] }
+    });
+  });
 });

--- a/back/src/bsdasris/resolvers/queries/__tests__/where.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/where.integration.ts
@@ -124,9 +124,9 @@ describe("Bsdasri where conversion", () => {
     });
   });
 
-  it("should convert filter on request ids", () => {
+  it("should convert filter on request ids (id_in)", () => {
     const where: BsdasriWhere = {
-      ids: ["x", "y", "z"]
+      id_in: ["x", "y", "z"]
     };
 
     const dbFilter = buildDbFilter(where, [siret]);

--- a/back/src/bsdasris/resolvers/queries/where.ts
+++ b/back/src/bsdasris/resolvers/queries/where.ts
@@ -44,8 +44,12 @@ export function buildDbFilter(
 
 const getGroupableCondition = (groupable?: boolean) => {
   // groupable dasris should not regroup or be regrouped
+
   if (!!groupable) {
-    return { regroupedBsdasris: { none: {} }, regroupedOnBsdasri: null };
+    return {
+      regroupedBsdasris: { none: {} },
+      regroupedOnBsdasri: null
+    };
   }
   if (groupable === false) {
     return {
@@ -66,9 +70,9 @@ function toPrismaFilter(where: Omit<BsdasriWhere, "_or" | "_and" | "_not">) {
     updatedAt: where.updatedAt
       ? toPrismaDateFilter(where.updatedAt)
       : undefined,
+    ...(where.ids ? { id: { in: where.ids } } : {}),
     emitterCompanySiret: where.emitter?.company?.siret,
     transporterCompanySiret: where.transporter?.company?.siret,
-
     recipientCompanySiret: where.recipient?.company?.siret,
     ...(!!where.processingOperation
       ? { processingOperation: { in: where.processingOperation } }

--- a/back/src/bsdasris/resolvers/queries/where.ts
+++ b/back/src/bsdasris/resolvers/queries/where.ts
@@ -70,7 +70,7 @@ function toPrismaFilter(where: Omit<BsdasriWhere, "_or" | "_and" | "_not">) {
     updatedAt: where.updatedAt
       ? toPrismaDateFilter(where.updatedAt)
       : undefined,
-    ...(where.ids ? { id: { in: where.ids } } : {}),
+    ...(where.id_in ? { id: { in: where.id_in } } : {}),
     emitterCompanySiret: where.emitter?.company?.siret,
     transporterCompanySiret: where.transporter?.company?.siret,
     recipientCompanySiret: where.recipient?.company?.siret,

--- a/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
@@ -78,3 +78,13 @@ enum BsdasriSignatureType {
   "Signature du traitement du déchet"
   OPERATION
 }
+enum BsdasriType{
+  "Bordereau dasri simple"
+  SIMPLE
+
+  "Bordereau dasri de groupement"
+  GROUPING
+
+  "(Bientôt disponible) - Bordereau dasri de synthèse"
+  SYNTHESIS
+}

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -26,7 +26,10 @@ input BsdasriWhere {
   Défaut à vide.
   """
   status: BsdasriStatus
-  ids: [ID!]
+  """
+  Expérimental : Filtre le résultat sur l'ID des bordereaux
+  """
+  id_in: [ID!]
   createdAt: DateFilter
   updatedAt: DateFilter
   emitter: BsdasriEmitterWhere

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -26,7 +26,7 @@ input BsdasriWhere {
   Défaut à vide.
   """
   status: BsdasriStatus
-
+  ids: [ID!]
   createdAt: DateFilter
   updatedAt: DateFilter
   emitter: BsdasriEmitterWhere

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -152,6 +152,7 @@ type BsdasriOperation {
 type Bsdasri {
   id: ID!
   status: BsdasriStatus!
+  bsdasriType: BsdasriType!
   createdAt: DateTime
   updatedAt: DateTime
   isDraft: Boolean!
@@ -168,7 +169,7 @@ type Bsdasri {
 
   "Bordereaux regroupés"
   regroupedBsdasris: [ID!]
-
+  
   metadata: BsdasriMetadata!
 }
 

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -878,7 +878,8 @@ export type BsdasriWhere = {
    * Défaut à vide.
    */
   status?: Maybe<BsdasriStatus>;
-  ids?: Maybe<Array<Scalars["ID"]>>;
+  /** Expérimental : Filtre le résultat sur l'ID des bordereaux */
+  id_in?: Maybe<Array<Scalars["ID"]>>;
   createdAt?: Maybe<DateFilter>;
   updatedAt?: Maybe<DateFilter>;
   emitter?: Maybe<BsdasriEmitterWhere>;
@@ -9964,7 +9965,7 @@ export function createBsdasriWhereMock(
   return {
     isDraft: null,
     status: null,
-    ids: null,
+    id_in: null,
     createdAt: null,
     updatedAt: null,
     emitter: null,

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -450,6 +450,7 @@ export type Bsdasri = {
   __typename?: "Bsdasri";
   id: Scalars["ID"];
   status: BsdasriStatus;
+  bsdasriType: BsdasriType;
   createdAt?: Maybe<Scalars["DateTime"]>;
   updatedAt?: Maybe<Scalars["DateTime"]>;
   isDraft: Scalars["Boolean"];
@@ -824,6 +825,14 @@ export type BsdasriTransportWasteDetails = {
   packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
+export type BsdasriType =
+  /** Bordereau dasri simple */
+  | "SIMPLE"
+  /** Bordereau dasri de groupement */
+  | "GROUPING"
+  /** (Bientôt disponible) - Bordereau dasri de synthèse */
+  | "SYNTHESIS";
+
 export type BsdasriUpdateInput = {
   emitter?: Maybe<BsdasriEmitterInput>;
   emission?: Maybe<BsdasriEmissionInput>;
@@ -869,6 +878,7 @@ export type BsdasriWhere = {
    * Défaut à vide.
    */
   status?: Maybe<BsdasriStatus>;
+  ids?: Maybe<Array<Scalars["ID"]>>;
   createdAt?: Maybe<DateFilter>;
   updatedAt?: Maybe<DateFilter>;
   emitter?: Maybe<BsdasriEmitterWhere>;
@@ -4884,6 +4894,7 @@ export type ResolversTypes = {
   BsdaEdge: ResolverTypeWrapper<BsdaEdge>;
   Bsdasri: ResolverTypeWrapper<Bsdasri>;
   BsdasriStatus: BsdasriStatus;
+  BsdasriType: BsdasriType;
   BsdasriEmitter: ResolverTypeWrapper<BsdasriEmitter>;
   BsdasriEmitterType: BsdasriEmitterType;
   BsdasriEmission: ResolverTypeWrapper<BsdasriEmission>;
@@ -5778,6 +5789,11 @@ export type BsdasriResolvers<
 > = {
   id?: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
   status?: Resolver<ResolversTypes["BsdasriStatus"], ParentType, ContextType>;
+  bsdasriType?: Resolver<
+    ResolversTypes["BsdasriType"],
+    ParentType,
+    ContextType
+  >;
   createdAt?: Resolver<
     Maybe<ResolversTypes["DateTime"]>,
     ParentType,
@@ -9430,6 +9446,7 @@ export function createBsdasriMock(props: Partial<Bsdasri>): Bsdasri {
     __typename: "Bsdasri",
     id: "",
     status: "INITIAL",
+    bsdasriType: "SIMPLE",
     createdAt: null,
     updatedAt: null,
     isDraft: false,
@@ -9947,6 +9964,7 @@ export function createBsdasriWhereMock(
   return {
     isDraft: null,
     status: null,
+    ids: null,
     createdAt: null,
     updatedAt: null,
     emitter: null,

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -357,6 +357,7 @@ export const dasriFragment = gql`
   fragment DasriFragment on Bsdasri {
     id
     bsdasriStatus: status
+    bsdasriType
     isDraft
     emitter {
       onBehalfOfEcoorganisme
@@ -436,6 +437,7 @@ export const dasriFragment = gql`
         ...SignatureFragment
       }
     }
+    regroupedBsdasris
     createdAt
     updatedAt
   }

--- a/front/src/common/routes.ts
+++ b/front/src/common/routes.ts
@@ -34,6 +34,7 @@ export default {
     bsdasris: {
       view: "/dashboard/:siret/bsdasris/view/:id",
       create: "/dashboard/:siret/bsdasris/create",
+      createGroup: "/dashboard/:siret/bsdasris/create-group",
       edit: "/dashboard/:siret/bsdasris/edit/:id",
     },
     bsvhus: {

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
@@ -12,14 +12,26 @@ export interface WorkflowActionProps {
   siret: string;
 }
 
+const isPublishable = (form: Bsdasri) => {
+  if (!form.isDraft) {
+    return false;
+  }
+  if (form.bsdasriType === "GROUPING" && !form.regroupedBsdasris?.length) {
+    return false;
+  }
+  return true;
+};
 export function WorkflowAction(props: WorkflowActionProps) {
   const { form, siret } = props;
 
-  if (form.isDraft) {
+  if (isPublishable(form)) {
     return <PublishBsdasri {...props} />;
   }
   switch (form["bsdasriStatus"]) {
     case BsdasriStatus.Initial: {
+      if (form.isDraft) {
+        return null;
+      }
       if (siret === form.emitter?.company?.siret) {
         return (
           <SignBsdasri

--- a/front/src/dashboard/components/BSDList/BSDasri/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/index.tsx
@@ -25,8 +25,13 @@ export const COLUMNS: Record<
   }
 > = {
   type: {
-    accessor: () => null,
-    Cell: () => <IconBSDasri style={{ fontSize: "24px" }} />,
+    accessor: dasri => dasri.bsdasriType,
+    Cell: ({ value }) => (
+      <>
+        <IconBSDasri style={{ fontSize: "24px" }} />
+        {value === "GROUPING" && <span>Grp</span>}
+      </>
+    ),
   },
   readableId: {
     accessor: dasri => dasri.id,

--- a/front/src/dashboard/components/BSDList/NewBSDDropdown.tsx
+++ b/front/src/dashboard/components/BSDList/NewBSDDropdown.tsx
@@ -11,6 +11,10 @@ const links = [
     title: "Bordereau de suivi DASRI",
     route: routes.dashboard.bsdasris.create,
   },
+  {
+    title: "Bordereau de groupement DASRI",
+    route: routes.dashboard.bsdasris.createGroup,
+  },
   { title: "Bordereau de suivi VHU", route: routes.dashboard.bsvhus.create },
 ];
 

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -29,6 +29,7 @@ import {
 import { DateRow, DetailRow } from "dashboard/detail/common/Components";
 
 import classNames from "classnames";
+
 const getVerboseWasteName = (code: string): string => {
   const desc = {
     "18 01 03*": "DASRI origine humaine ",
@@ -295,6 +296,9 @@ export default function BsdasriDetailContent({
             [{form.isDraft ? "Brouillon" : statusLabels[form["bsdasriStatus"]]}]
           </span>
           {!form.isDraft && <span>{form.id}</span>}
+          {form?.regroupedBsdasris?.length && (
+            <span>Bordereau de groupement</span>
+          )}
         </h4>
 
         <div className={styles.detailContent}>
@@ -323,6 +327,15 @@ export default function BsdasriDetailContent({
           <div className={styles.detailGrid}>
             <dt>Code onu</dt>
             <dd>{form?.emission?.wasteDetails?.onuCode}</dd>
+          </div>
+
+          <div className={styles.detailGrid}>
+            {form?.regroupedBsdasris?.length && (
+              <>
+                <dt>Bordereau groupés:</dt>
+                <dd> {form?.regroupedBsdasris?.join(", ")}</dd>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -25,6 +25,7 @@ interface Props {
   children: (dasriForm: Bsdasri | undefined) => ReactElement;
   formId?: string;
   initialStep?: number;
+  bsdasriFormType?: string;
 }
 /**
  * Do not resend sections locked by relevant signatures
@@ -82,15 +83,23 @@ export default function BsdasriStepsList(props: Props) {
     }
     return dasri;
   };
+  const mapRegrouped = dasri => ({
+    ...dasri,
+    regroupedBsdasris: dasri?.regroupedBsdasris.map(r => ({
+      id: r,
+    })),
+  });
 
   const formState = useMemo(
     () =>
       prefillWasteDetails(
-        getComputedState(getInitialState(), formQuery.data?.bsdasri)
+        getComputedState(
+          getInitialState(),
+          mapRegrouped(formQuery.data?.bsdasri)
+        )
       ),
     [formQuery.data]
   );
-
   const status = formState.id
     ? formQuery?.data?.bsdasri?.["bsdasriStatus"]
     : "INITIAL";
@@ -121,6 +130,17 @@ export default function BsdasriStepsList(props: Props) {
     // As we want to be able to save draft, we skip validation on submit
     // and don't use the classic Formik mechanism
 
+    if (
+      props.bsdasriFormType === "bsdasriRegroup" ||
+      formQuery.data?.bsdasri?.bsdasriType === "GROUPING"
+    ) {
+      if (!values?.regroupedBsdasris?.length) {
+        cogoToast.error("Vous devez sélectionner des bordereaux à regrouper", {
+          hideAfter: 7,
+        });
+        return;
+      }
+    }
     const { id, ...input } = values;
     saveForm(input)
       .then(_ => {

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -25,14 +25,16 @@ import { useParams } from "react-router-dom";
  *
  * Emitter component with widget to group dasris
  */
-export function RegroupingEmitter({ status }) {
-  return <BaseEmitter status={status} isRegrouping={true} />;
+export function RegroupingEmitter({ status, stepName }) {
+  return (
+    <BaseEmitter status={status} isRegrouping={true} stepName={stepName} />
+  );
 }
-export default function Emitter({ status }) {
-  return <BaseEmitter status={status} />;
+export default function Emitter({ status, stepName }) {
+  return <BaseEmitter status={status} stepName={stepName} />;
 }
 
-export function BaseEmitter({ status, isRegrouping = false }) {
+export function BaseEmitter({ status, stepName, isRegrouping = false }) {
   const disabled = [
     BsdasriStatus.SignedByProducer,
     BsdasriStatus.Sent,
@@ -46,18 +48,6 @@ export function BaseEmitter({ status, isRegrouping = false }) {
     <>
       {emissionEmphasis && <FillFieldsInfo />}
       {disabled && <DisabledFieldsInfo />}
-      <div
-        className={classNames("form__row", {
-          "field-emphasis": emissionEmphasis,
-        })}
-      >
-        <CompanySelector
-          disabled={disabled}
-          name="emitter.company"
-          heading="Personne responsable de l'élimination des déchets"
-          optionalMail={true}
-        />
-      </div>
 
       {disabled && (
         <div className="notification notification--error">
@@ -81,12 +71,19 @@ export function BaseEmitter({ status, isRegrouping = false }) {
         </>
       )}
 
-      <CompanySelector
-        disabled={disabled}
-        name="emitter.company"
-        heading="Personne responsable de l'élimination des déchets"
-        optionalMail={true}
-      />
+      <div
+        className={classNames("form__row", {
+          "field-emphasis": emissionEmphasis,
+        })}
+      >
+        <CompanySelector
+          disabled={disabled}
+          name="emitter.company"
+          heading="Personne responsable de l'élimination des déchets"
+          optionalMail={true}
+        />
+      </div>
+
       <WorkSite
         disabled={disabled}
         switchLabel="Je souhaite ajouter une adresse de collecte ou d'enlèvement"

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -11,10 +11,9 @@ import {
 } from "./utils/initial-state";
 import WorkSite from "form/common/components/work-site/WorkSite";
 import DateInput from "form/common/components/custom-inputs/DateInput";
- 
+
 import QuantityWidget from "./components/Quantity";
- 
- 
+
 import { FillFieldsInfo, DisabledFieldsInfo } from "./utils/commons";
 import classNames from "classnames";
 

--- a/front/src/form/bsdasri/FormContainer.tsx
+++ b/front/src/form/bsdasri/FormContainer.tsx
@@ -1,13 +1,10 @@
 import { StepContainer } from "form/common/stepper/Step";
 import StepList from "./BsdasriStepList";
 import React from "react";
-<<<<<<< HEAD
+
 import { useParams, useLocation } from "react-router-dom";
-import Emitter from "./Emitter";
-=======
-import { useParams } from "react-router-dom";
 import Emitter, { RegroupingEmitter } from "./Emitter";
->>>>>>> Add dasri grouping UI
+
 import Recipient from "./Recipient";
 import Transporter from "./Transporter";
 import * as queryString from "query-string";
@@ -33,8 +30,11 @@ export default function FormContainer({
   return (
     <main className="main">
       <div className="container">
-        <StepList formId={id} initialStep={initialStep} bsdasriFormType={bsdasriFormType}>
- 
+        <StepList
+          formId={id}
+          initialStep={initialStep}
+          bsdasriFormType={bsdasriFormType}
+        >
           {bsdasri => {
             const state = !!bsdasri ? bsdasri["bsdasriStatus"] : "";
             // Use a tweaked emitter component when creating or updating a grouping bsdasri

--- a/front/src/form/bsdasri/FormContainer.tsx
+++ b/front/src/form/bsdasri/FormContainer.tsx
@@ -1,13 +1,24 @@
 import { StepContainer } from "form/common/stepper/Step";
 import StepList from "./BsdasriStepList";
 import React from "react";
+<<<<<<< HEAD
 import { useParams, useLocation } from "react-router-dom";
 import Emitter from "./Emitter";
+=======
+import { useParams } from "react-router-dom";
+import Emitter, { RegroupingEmitter } from "./Emitter";
+>>>>>>> Add dasri grouping UI
 import Recipient from "./Recipient";
 import Transporter from "./Transporter";
 import * as queryString from "query-string";
 
-export default function FormContainer() {
+type BsdasriFormType = "bsdasri" | "bsdasriRegroup";
+
+export default function FormContainer({
+  bsdasriFormType = "bsdasri",
+}: {
+  bsdasriFormType?: BsdasriFormType;
+}) {
   const { id } = useParams<{ id?: string }>();
   const location = useLocation();
   const parsed = queryString.parse(location.search);
@@ -22,14 +33,20 @@ export default function FormContainer() {
   return (
     <main className="main">
       <div className="container">
-        <StepList formId={id} initialStep={initialStep}>
+        <StepList formId={id} initialStep={initialStep} bsdasriFormType={bsdasriFormType}>
+ 
           {bsdasri => {
             const state = !!bsdasri ? bsdasri["bsdasriStatus"] : "";
-
+            // Use a tweaked emitter component when creating or updating a grouping bsdasri
+            const emitterComponent =
+              bsdasriFormType === "bsdasriRegroup" ||
+              bsdasri?.bsdasriType === "GROUPING"
+                ? RegroupingEmitter
+                : Emitter;
             return (
               <>
                 <StepContainer
-                  component={Emitter}
+                  component={emitterComponent}
                   title="PRED"
                   status={state}
                   stepName={stepName}

--- a/front/src/form/bsdasri/components/grouping/BsdasriSelector.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriSelector.tsx
@@ -1,0 +1,85 @@
+import { getIn, useFormikContext } from "formik";
+import React, { useEffect, useReducer, useMemo } from "react";
+
+import { Bsdasri } from "generated/graphql/types";
+import BsdasriTable from "./BsdasriTable";
+
+function reducer(
+  state: { selected: string[] },
+  action: { type: string; payload: Bsdasri | Bsdasri[] }
+) {
+  switch (action.type) {
+    case "select":
+      const sp = action.payload as Bsdasri;
+      return {
+        selected: [sp.id, ...state.selected],
+      };
+    case "unselect":
+      const usp = action.payload as Bsdasri;
+      return {
+        selected: state.selected.filter(v => v !== usp.id),
+      };
+    case "selectAll":
+      const sap = action.payload as Bsdasri[];
+      return {
+        selected: sap.map((v: Bsdasri) => v.id),
+      };
+    default:
+      throw new Error();
+  }
+}
+
+export default function BsdasriSelector({ name }) {
+  const { values, setFieldValue } = useFormikContext<Bsdasri>();
+
+  const [state, dispatch] = useReducer(reducer, {
+    selected: getIn(values, name).map(f => f.id),
+  });
+
+  // memoize stored regrouped dasris
+  const regroupedInDB = useMemo(
+    () => getIn(values, name).map(f => f.id) || [],
+    [name, values]
+  );
+
+  useEffect(() => {
+    setFieldValue(
+      name,
+      state.selected.map(s => ({ id: s }))
+    );
+  }, [state, name, setFieldValue]);
+
+  function onToggle(payload: Bsdasri | Bsdasri[]) {
+    if (Array.isArray(payload)) {
+      return dispatch({
+        type: "selectAll",
+        payload,
+      });
+    }
+
+    state.selected.find(s => s === payload.id)
+      ? dispatch({ type: "unselect", payload })
+      : dispatch({ type: "select", payload });
+  }
+
+  return (
+    <>
+      <h4 className="form__section-heading">Groupement de Dasris</h4>
+      <p className="tw-my-2">
+        Vous êtes en train de créer un bordereau de groupement. Veuillez
+        sélectionner ci-dessous les bordereaux à grouper.
+      </p>
+      <p className="tw-my-2">
+        Tous les bordereaux présentés ci-dessous correspondent à des bordereaux
+        dasris pour lesquels vous avez effectué une opération de traitement de
+        type R 12 ou D 12.
+      </p>
+
+      <BsdasriTable
+        selectedItems={state.selected}
+        onToggle={onToggle}
+        regroupedInDB={regroupedInDB}
+      />
+    </>
+  );
+}

--- a/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
@@ -54,7 +54,7 @@ export default function BsdasriTable({
   >(GET_GROUPABLE_BSDASRIS, {
     variables: {
       where: {
-        _or: [{ groupable: true }, { ids: regroupedInDB }],
+        _or: [{ groupable: true }, { id_in: regroupedInDB }],
         processingOperation: [
           ProcessingOperationTypes.D12,
           ProcessingOperationTypes.R12,

--- a/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { useQuery, gql } from "@apollo/client";
+import { useFormikContext } from "formik";
+import { InlineError } from "common/components/Error";
+import {
+  Bsdasri,
+  Query,
+  QueryBsdasrisArgs,
+  BsdasriStatus,
+  ProcessingOperationTypes,
+} from "generated/graphql/types";
+import { formatDate } from "common/datetime";
+const GET_GROUPABLE_BSDASRIS = gql`
+  query Bsdasris($where: BsdasriWhere) {
+    bsdasris(where: $where) {
+      edges {
+        node {
+          id
+          emitter {
+            company {
+              name
+            }
+          }
+          emission {
+            wasteCode
+          }
+          reception {
+            receivedAt
+            wasteDetails {
+              volume
+            }
+          }
+          operation {
+            processingOperation
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default function BsdasriTable({
+  selectedItems,
+  onToggle,
+  regroupedInDB,
+}) {
+  const { values } = useFormikContext<
+    Bsdasri & { dbRegroupedBsdasris: string[] }
+  >();
+
+  const { loading, error, data } = useQuery<
+    Pick<Query, "bsdasris">,
+    QueryBsdasrisArgs
+  >(GET_GROUPABLE_BSDASRIS, {
+    variables: {
+      where: {
+        _or: [{ groupable: true }, { ids: regroupedInDB }],
+        processingOperation: [
+          ProcessingOperationTypes.D12,
+          ProcessingOperationTypes.R12,
+        ],
+
+        status: BsdasriStatus.Processed,
+        recipient: {
+          company: { siret: values.emitter?.company?.siret as string },
+        },
+      },
+    },
+  });
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <InlineError apolloError={error} />;
+  if (!data) return <p>Aucune donnée à afficher</p>;
+
+  const bsdasris = data.bsdasris?.edges;
+
+  if (!bsdasris.length) {
+    return (
+      <div className="notification notification--error">
+        Vous n'avez actuellement aucun bordereau qui peut être inclus dans ce
+        groupement.
+      </div>
+    );
+  }
+  return (
+    <table className="td-table">
+      <thead>
+        <tr className="td-table__head-tr">
+          <th>
+            <input
+              type="checkbox"
+              className="td-checkbox"
+              checked={selectedItems.length === bsdasris.length}
+              onChange={e =>
+                onToggle(
+                  e.target.checked ? bsdasris.map(edge => edge.node) : []
+                )
+              }
+            />
+          </th>
+          <th>Numéro</th>
+          <th>Code déchet</th>
+          <th>Producteur</th>
+          <th>Date de réception</th>
+          <th>Quantité</th>
+          <th>Opération réalisée</th>
+        </tr>
+      </thead>
+      <tbody>
+        {bsdasris.map(edge => (
+          <tr
+            key={edge.node.id}
+            onClick={() => onToggle(edge.node)}
+            className="td-table__tr"
+          >
+            <td>
+              <input
+                type="checkbox"
+                className="td-checkbox"
+                checked={selectedItems.indexOf(edge.node.id) > -1}
+                onChange={() => true}
+              />
+            </td>
+            <td>{edge.node.id}</td>
+
+            <td>{edge.node.emission?.wasteCode}</td>
+            <td>{edge.node.emitter?.company?.name}</td>
+            <td>
+              {!!edge.node.reception?.receivedAt &&
+                formatDate(edge.node.reception?.receivedAt)}
+            </td>
+            <td>{edge.node.reception?.wasteDetails?.volume}</td>
+            <td>{edge.node.operation?.processingOperation}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -72,6 +72,7 @@ const getInitialState = (f?: Bsdasri | null) => ({
     receiptDepartment: null,
     receiptValidityLimit: null,
   },
+  regroupedBsdasris: [],
 });
 
 export default getInitialState;

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -75,7 +75,6 @@ export default function GenericStepList({
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <InlineError apolloError={error} />;
-
   return (
     <div>
       <Stepper>

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -453,6 +453,7 @@ export type Bsdasri = {
   __typename?: "Bsdasri";
   id: Scalars["ID"];
   status: BsdasriStatus;
+  bsdasriType: BsdasriType;
   createdAt?: Maybe<Scalars["DateTime"]>;
   updatedAt?: Maybe<Scalars["DateTime"]>;
   isDraft: Scalars["Boolean"];
@@ -832,6 +833,15 @@ export type BsdasriTransportWasteDetails = {
   packagingInfos?: Maybe<Array<BsdasriPackagingInfo>>;
 };
 
+export enum BsdasriType {
+  /** Bordereau dasri simple */
+  Simple = "SIMPLE",
+  /** Bordereau dasri de groupement */
+  Grouping = "GROUPING",
+  /** (Bientôt disponible) - Bordereau dasri de synthèse */
+  Synthesis = "SYNTHESIS"
+}
+
 export type BsdasriUpdateInput = {
   emitter?: Maybe<BsdasriEmitterInput>;
   emission?: Maybe<BsdasriEmissionInput>;
@@ -877,6 +887,7 @@ export type BsdasriWhere = {
    * Défaut à vide.
    */
   status?: Maybe<BsdasriStatus>;
+  ids?: Maybe<Array<Scalars["ID"]>>;
   createdAt?: Maybe<DateFilter>;
   updatedAt?: Maybe<DateFilter>;
   emitter?: Maybe<BsdasriEmitterWhere>;

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -887,7 +887,8 @@ export type BsdasriWhere = {
    * Défaut à vide.
    */
   status?: Maybe<BsdasriStatus>;
-  ids?: Maybe<Array<Scalars["ID"]>>;
+  /** Expérimental : Filtre le résultat sur l'ID des bordereaux */
+  id_in?: Maybe<Array<Scalars["ID"]>>;
   createdAt?: Maybe<DateFilter>;
   updatedAt?: Maybe<DateFilter>;
   emitter?: Maybe<BsdasriEmitterWhere>;

--- a/front/src/layout/LayoutContainer.tsx
+++ b/front/src/layout/LayoutContainer.tsx
@@ -198,7 +198,13 @@ export default withRouter(function LayoutContainer({ history }) {
               >
                 <BsdasriFormContainer />
               </PrivateRoute>
-
+              <PrivateRoute
+                path={routes.dashboard.bsdasris.createGroup}
+                isAuthenticated={isAuthenticated}
+                exact
+              >
+                <BsdasriFormContainer bsdasriFormType="bsdasriRegroup" />
+              </PrivateRoute>
               <PrivateRoute
                 path={routes.dashboard.bsdasris.edit}
                 isAuthenticated={isAuthenticated}


### PR DESCRIPTION
Implémentation de l'interface de pour la création et l'édition de bordereaux dasri de groupement

Une nouvelle clause where sur bsdasris a été introduite, permettant de récupérer les dasris dont l'id est contenu dans le tableau passé en paramètre, afin de faciliter l'affichage des dasris candidats à un regroupement.
 
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Trello](https://trello.com/c/dMB1xcDw/1554-gestion-des-bsdasris-de-groupement-ui)
