### PR TITLE
Emport direct de dasris

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Création et édition de bordereaux Dasri de groupement [PR934](https://github.com/MTES-MCT/trackdechets/pull/934)
+- Emport direct de bordereaux Dasris quand le producteur l'a autorisé [935](https://github.com/MTES-MCT/trackdechets/pull/935)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/bsdasris/dasri-converter.ts
+++ b/back/src/bsdasris/dasri-converter.ts
@@ -157,7 +157,8 @@ export function expandBsdasriFromDb(bsdasri: Bsdasri): GqlBsdasri {
     createdAt: bsdasri.createdAt,
     updatedAt: bsdasri.updatedAt,
     status: bsdasri.status as BsdasriStatus,
-    metadata: null
+    metadata: null,
+    allowDirectTakeOver: null
   };
 }
 

--- a/back/src/bsdasris/resolvers/queries/where.ts
+++ b/back/src/bsdasris/resolvers/queries/where.ts
@@ -70,7 +70,9 @@ function toPrismaFilter(where: Omit<BsdasriWhere, "_or" | "_and" | "_not">) {
     updatedAt: where.updatedAt
       ? toPrismaDateFilter(where.updatedAt)
       : undefined,
+
     ...(where.id_in ? { id: { in: where.id_in } } : {}),
+
     emitterCompanySiret: where.emitter?.company?.siret,
     transporterCompanySiret: where.transporter?.company?.siret,
     recipientCompanySiret: where.recipient?.company?.siret,

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -30,6 +30,7 @@ input BsdasriWhere {
   Expérimental : Filtre le résultat sur l'ID des bordereaux
   """
   id_in: [ID!]
+
   createdAt: DateFilter
   updatedAt: DateFilter
   emitter: BsdasriEmitterWhere

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -89,7 +89,7 @@ type BsdasriEmissionWasteDetails {
 type BsdasriTransportWasteDetails {
   "Quantité transportée"
   quantity: BsdasriQuantity
- 
+
   volume: Int
   packagingInfos: [BsdasriPackagingInfo!]
 }
@@ -169,8 +169,10 @@ type Bsdasri {
 
   "Bordereaux regroupés"
   regroupedBsdasris: [ID!]
-  
+
   metadata: BsdasriMetadata!
+
+  allowDirectTakeOver: Boolean
 }
 
 type BsdasriError {

--- a/back/src/generated/graphql/types.ts
+++ b/back/src/generated/graphql/types.ts
@@ -464,6 +464,7 @@ export type Bsdasri = {
   /** Bordereaux regroupés */
   regroupedBsdasris?: Maybe<Array<Scalars["ID"]>>;
   metadata: BsdasriMetadata;
+  allowDirectTakeOver?: Maybe<Scalars["Boolean"]>;
 };
 
 export type BsdasriCompanyWhere = {
@@ -5851,6 +5852,11 @@ export type BsdasriResolvers<
     ParentType,
     ContextType
   >;
+  allowDirectTakeOver?: Resolver<
+    Maybe<ResolversTypes["Boolean"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -9460,6 +9466,7 @@ export function createBsdasriMock(props: Partial<Bsdasri>): Bsdasri {
     operation: null,
     regroupedBsdasris: null,
     metadata: createBsdasriMetadataMock({}),
+    allowDirectTakeOver: null,
     ...props
   };
 }

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -356,6 +356,7 @@ const wasteAcceptationFragment = gql`
 export const dasriFragment = gql`
   fragment DasriFragment on Bsdasri {
     id
+
     bsdasriStatus: status
     bsdasriType
     isDraft
@@ -440,6 +441,7 @@ export const dasriFragment = gql`
     regroupedBsdasris
     createdAt
     updatedAt
+    allowDirectTakeOver
   }
   ${companyFragment}
   ${signatureFragment}

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/SignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/SignBsdasri.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { RedErrorMessage, ActionButton } from "common/components";
-import * as yup from "yup";
+
 import Loader from "common/components/Loaders";
 import * as queryString from "query-string";
 import { Formik, Field, Form } from "formik";
+
 import {
   Mutation,
   Query,
@@ -13,7 +14,9 @@ import {
   BsdasriSignatureType,
   BsdasriStatus,
 } from "generated/graphql/types";
-import { gql, useMutation, useQuery } from "@apollo/client";
+
+import { useMutation, useQuery } from "@apollo/client";
+
 import { Link, generatePath } from "react-router-dom";
 import routes from "common/routes";
 import { WorkflowActionProps } from "./WorkflowAction";
@@ -22,20 +25,10 @@ import { TdModalTrigger } from "common/components/Modal";
 import { IconCheckCircle1 } from "common/components/Icons";
 
 import { NotificationError } from "common/components/Error";
-import { GET_DASRI_METADATA } from "common/queries";
-const SIGN_BSDASRI = gql`
-  mutation SignBsdasri($id: ID!, $input: BsdasriSignatureInput!) {
-    signBsdasri(id: $id, input: $input) {
-      id
-      status
-    }
-  }
-`;
 
-const validationSchema = (form: Bsdasri) =>
-  yup.object({
-    author: yup.string().nullable().required("Le nom du signataire est requis"),
-  });
+import { GET_DASRI_METADATA } from "common/queries";
+
+import { validationSchema, SIGN_BSDASRI } from "./utils";
 
 const settings: {
   [id: string]: {

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/SignBsdasriDirectTakeover.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/SignBsdasriDirectTakeover.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { RedErrorMessage, ActionButton } from "common/components";
+import { validationSchema, SIGN_BSDASRI } from "./utils";
+
+import { Formik, Field, Form } from "formik";
+import {
+  Mutation,
+  MutationSignBsdasriArgs,
+  BsdasriSignatureType,
+} from "generated/graphql/types";
+import { useMutation } from "@apollo/client";
+import { Link, generatePath } from "react-router-dom";
+import routes from "common/routes";
+import { WorkflowActionProps } from "./WorkflowAction";
+import { TdModalTrigger } from "common/components/Modal";
+
+import { IconCheckCircle1 } from "common/components/Icons";
+
+import { NotificationError } from "common/components/Error";
+
+export default function SignBsdasriDirectTakeover({
+  form,
+  siret,
+}: WorkflowActionProps) {
+  const [signBsdasri, { error }] = useMutation<
+    Pick<Mutation, "signBsdasri">,
+    MutationSignBsdasriArgs
+  >(SIGN_BSDASRI);
+
+  return (
+    <TdModalTrigger
+      ariaLabel="Emport direct"
+      trigger={open => (
+        <ActionButton icon={<IconCheckCircle1 size="24px" />} onClick={open}>
+          Emport direct transporteur
+        </ActionButton>
+      )}
+      modalContent={close => (
+        <div>
+          <Formik
+            initialValues={{
+              author: "",
+            }}
+            validationSchema={() => validationSchema(form)}
+            onSubmit={values => {
+              signBsdasri({
+                variables: {
+                  id: form.id,
+                  input: { ...values, type: BsdasriSignatureType.Transport },
+                },
+              });
+              // close();
+            }}
+          >
+            {({ isSubmitting, handleReset }) => (
+              <Form>
+                <div>
+                  L'émetteur de bordereau a autorisé son emport direct, en tant
+                  que transporteur vous pouvez donc emporter le déchet concerné
+                </div>
+                <div className="form__row">
+                  <label>
+                    Nom du signataire
+                    <Field
+                      type="text"
+                      name="author"
+                      placeholder="NOM Prénom"
+                      className="td-input"
+                    />
+                  </label>
+                  <RedErrorMessage name="author" />
+                </div>
+
+                <div className="form__actions">
+                  <button
+                    type="button"
+                    className="btn btn--outline-primary"
+                    onClick={() => {
+                      handleReset();
+                      close();
+                    }}
+                  >
+                    Annuler
+                  </button>
+
+                  <button
+                    type="submit"
+                    className="btn btn--primary"
+                    disabled={isSubmitting}
+                  >
+                    Signer
+                  </button>
+                </div>
+              </Form>
+            )}
+          </Formik>
+
+          {error && (
+            <>
+              <p className="tw-mt-2 tw-text-red-700">
+                Vous devez mettre à jour le bordereau et renseigner les champs
+                nécessaires avant de le signer.
+              </p>
+              <NotificationError className="action-error" apolloError={error} />
+
+              <Link
+                to={generatePath(routes.dashboard.bsdasris.edit, {
+                  siret,
+                  id: form.id,
+                })}
+                className="btn btn--primary"
+              >
+                Mettre le bordereau à jour pour le signer
+              </Link>
+            </>
+          )}
+        </div>
+      )}
+    />
+  );
+}

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
@@ -6,6 +6,7 @@ import {
 } from "generated/graphql/types";
 import PublishBsdasri from "./PublishBsdasri";
 import SignBsdasri from "./SignBsdasri";
+import SignBsdasriDirectTakeover from "./SignBsdasriDirectTakeover";
 
 export interface WorkflowActionProps {
   form: Bsdasri;
@@ -32,6 +33,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       if (form.isDraft) {
         return null;
       }
+
       if (siret === form.emitter?.company?.siret) {
         return (
           <SignBsdasri
@@ -39,6 +41,12 @@ export function WorkflowAction(props: WorkflowActionProps) {
             signatureType={BsdasriSignatureType.Emission}
           />
         );
+      }
+      if (
+        siret === form.transporter?.company?.siret &&
+        form?.allowDirectTakeOver
+      ) {
+        return <SignBsdasriDirectTakeover {...props} />;
       }
       return null;
     }

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/utils.ts
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/utils.ts
@@ -1,0 +1,19 @@
+import * as yup from "yup";
+
+import { Bsdasri } from "generated/graphql/types";
+
+import { gql } from "@apollo/client";
+
+export const validationSchema = (form: Bsdasri) =>
+  yup.object({
+    author: yup.string().nullable().required("Le nom du signataire est requis"),
+  });
+
+export const SIGN_BSDASRI = gql`
+  mutation SignBsdasri($id: ID!, $input: BsdasriSignatureInput!) {
+    signBsdasri(id: $id, input: $input) {
+      id
+      status
+    }
+  }
+`;

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -105,12 +105,18 @@ export function BaseEmitter({ status, stepName, isRegrouping = false }) {
         </>
       )}
 
-      <CompanySelector
-        disabled={disabled}
-        name="emitter.company"
-        heading="Personne responsable de l'élimination des déchets"
-        optionalMail={true}
-      />
+      <div
+        className={classNames("form__row", {
+          "field-emphasis": emissionEmphasis,
+        })}
+      >
+        <CompanySelector
+          disabled={disabled}
+          name="emitter.company"
+          heading="Personne responsable de l'élimination des déchets"
+          optionalMail={true}
+        />
+      </div>
 
       <WorkSite
         disabled={disabled}

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -24,6 +24,7 @@ import { useParams } from "react-router-dom";
  *
  * Emitter component with widget to group dasris
  */
+
 export function RegroupingEmitter({ status, stepName }) {
   return (
     <BaseEmitter status={status} isRegrouping={true} stepName={stepName} />
@@ -39,10 +40,12 @@ export function BaseEmitter({ status, stepName, isRegrouping = false }) {
     BsdasriStatus.Sent,
     BsdasriStatus.Received,
   ].includes(status);
+
   const emissionEmphasis = stepName === "emission";
   const { values } = useFormikContext<Bsdasri>();
   const { siret } = useParams<{ siret: string }>();
   const isUserCurrentEmitter = values?.emitter?.company?.siret === siret;
+
   return (
     <>
       {emissionEmphasis && <FillFieldsInfo />}
@@ -141,6 +144,7 @@ export function BaseEmitter({ status, stepName, isRegrouping = false }) {
         <RedErrorMessage name="emitter.onBehalfOfEcoorganisme" />
       </div>
       <h4 className="form__section-heading">Détail du déchet</h4>
+
       <div
         className={classNames("form__row", {
           "field-emphasis": emissionEmphasis,

--- a/front/src/form/bsdasri/Emitter.tsx
+++ b/front/src/form/bsdasri/Emitter.tsx
@@ -83,6 +83,35 @@ export function BaseEmitter({ status, stepName, isRegrouping = false }) {
         />
       </div>
 
+      {disabled && (
+        <div className="notification notification--error">
+          Les champs grisés ci-dessous ont été scellés via signature et ne sont
+          plus modifiables.
+        </div>
+      )}
+
+      {isRegrouping && (
+        <>
+          <h3 className="form__section-heading">
+            Bordereau dasri de groupement
+          </h3>
+
+          {values?.emitter?.company?.siret && !isUserCurrentEmitter && (
+            <p className="notification notification--error">
+              Pour préparer un bordereau de regroupement, vous devez y figurer
+              comme producteur
+            </p>
+          )}
+        </>
+      )}
+
+      <CompanySelector
+        disabled={disabled}
+        name="emitter.company"
+        heading="Personne responsable de l'élimination des déchets"
+        optionalMail={true}
+      />
+
       <WorkSite
         disabled={disabled}
         switchLabel="Je souhaite ajouter une adresse de collecte ou d'enlèvement"

--- a/front/src/form/bsdasri/FormContainer.tsx
+++ b/front/src/form/bsdasri/FormContainer.tsx
@@ -6,8 +6,10 @@ import { useParams, useLocation } from "react-router-dom";
 import Emitter, { RegroupingEmitter } from "./Emitter";
 
 import Recipient from "./Recipient";
-import Transporter from "./Transporter";
+
 import * as queryString from "query-string";
+
+import Transporter, { TransporterShowingTakeOverFields } from "./Transporter";
 
 type BsdasriFormType = "bsdasri" | "bsdasriRegroup";
 
@@ -16,7 +18,7 @@ export default function FormContainer({
 }: {
   bsdasriFormType?: BsdasriFormType;
 }) {
-  const { id } = useParams<{ id?: string }>();
+  const { id, siret } = useParams<{ id?: string; siret: string }>();
   const location = useLocation();
   const parsed = queryString.parse(location.search);
 
@@ -43,6 +45,16 @@ export default function FormContainer({
               bsdasri?.bsdasriType === "GROUPING"
                 ? RegroupingEmitter
                 : Emitter;
+
+            // When transporter proceeds to direct takeover, form has to display some transporter tab fields
+            // which are usually not displayed yet
+            const transporterComponent =
+              state === "INITIAL" &&
+              !bsdasri?.isDraft &&
+              siret === bsdasri?.transporter?.company?.siret
+                ? TransporterShowingTakeOverFields
+                : Transporter;
+
             return (
               <>
                 <StepContainer
@@ -52,7 +64,7 @@ export default function FormContainer({
                   stepName={stepName}
                 />
                 <StepContainer
-                  component={Transporter}
+                  component={transporterComponent}
                   title="Collecteur - Transporteur"
                   status={state}
                   stepName={stepName}

--- a/front/src/form/bsdasri/Transporter.tsx
+++ b/front/src/form/bsdasri/Transporter.tsx
@@ -10,17 +10,37 @@ import { getInitialQuantityFn } from "./utils/initial-state";
 import { transportModeLabels } from "dashboard/constants";
 import { FillFieldsInfo, DisabledFieldsInfo } from "./utils/commons";
 import classNames from "classnames";
+
 import QuantityWidget from "./components/Quantity";
 
+/**
+ *
+ * Tweaked Transporter component where takeover fields can be displayed on demand
+ * This is useful to edit these fields for direct takeover, as they're usually hidden as long as the dasri is not SIGNED_BY_TRANPORTER
+ */
+export function TransporterShowingTakeOverFields({ status, stepName }) {
+  return (
+    <BaseTransporter
+      status={status}
+      displayTakeoverFields={true}
+      stepName={stepName}
+    />
+  );
+}
+
 export default function Transporter({ status, stepName }) {
+  return <BaseTransporter status={status} stepName={stepName} />;
+}
+function BaseTransporter({ status, displayTakeoverFields = false, stepName }) {
   const { setFieldValue } = useFormikContext();
 
   // it's pointless to show transport fields until form is signed by producer
-  const showTransportFields = [
-    BsdasriStatus.SignedByProducer,
-    BsdasriStatus.Sent,
-    BsdasriStatus.Received,
-  ].includes(status);
+  const showTransportFields =
+    [
+      BsdasriStatus.SignedByProducer,
+      BsdasriStatus.Sent,
+      BsdasriStatus.Received,
+    ].includes(status) || displayTakeoverFields;
   // handedOverAt is editable even after dasri reception
   const showHandedOverAtField = [
     BsdasriStatus.Sent,

--- a/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
@@ -55,6 +55,7 @@ export default function BsdasriTable({
     variables: {
       where: {
         _or: [{ groupable: true }, { id_in: regroupedInDB }],
+
         processingOperation: [
           ProcessingOperationTypes.D12,
           ProcessingOperationTypes.R12,

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -27,6 +27,7 @@ const getInitialState = (f?: Bsdasri | null) => ({
     wasteCode: "18 01 03*",
     wasteDetails: {
       packagingInfos: [],
+
       quantity: !!f?.emission?.wasteDetails?.quantity
         ? getInitialQuantityFn(f?.emission?.wasteDetails?.quantity)
         : null,

--- a/front/src/generated/graphql/types.ts
+++ b/front/src/generated/graphql/types.ts
@@ -467,6 +467,7 @@ export type Bsdasri = {
   /** Bordereaux regroupés */
   regroupedBsdasris?: Maybe<Array<Scalars["ID"]>>;
   metadata: BsdasriMetadata;
+  allowDirectTakeOver?: Maybe<Scalars["Boolean"]>;
 };
 
 export type BsdasriCompanyWhere = {


### PR DESCRIPTION
Cette PR permet aux transporteurs de procéder à un enlèvement direct (sans signature producteur).
La partie api de signature proprement dite existait déjà.
Le problème principal était d'afficher le bouton d'enlèvement sur les dasris dont l'émetteur avait autorisé l'emport direct, cette information étant sur le modèle Company et pas le Bsdasri.
J'ai pris l'option d'enrichir les données retournées par la requête bsds en récupérant les données nécessaires sur le modèle Company lors de la phase d'expandFromDb.


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
 
---

- [Ticket Trello](https://trello.com/c/1OOX62hR/1605-ui-etq-transporteur-je-peux-proc%C3%A9der-%C3%A0-lemport-dun-dasri-sans-signature-producteur-si-le-celui-ci-la-autoris%C3%A9)
