### PR TITLE
Corrections suite au recettage de l'interface des BSFFs

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDCards/BSDCards.tsx
+++ b/front/src/dashboard/components/BSDList/BSDCards/BSDCards.tsx
@@ -6,9 +6,11 @@ import routes from "common/routes";
 import { IconView } from "common/components/Icons";
 import { WorkflowAction } from "../BSDD/WorkflowAction";
 import { WorkflowAction as BsdasriWorkflowAction } from "../BSDasri/WorkflowAction";
+import { WorkflowAction as BsffWorkflowAction } from "../BSFF/WorkflowAction";
 import { Column } from "../columns";
 import styles from "./BSDCards.module.scss";
 import { BsdTypename } from "dashboard/constants";
+import { BsffFragment } from "../BSFF";
 
 interface BSDCardsProps {
   bsds: Bsd[];
@@ -69,6 +71,12 @@ export function BSDCards({ bsds, columns }: BSDCardsProps) {
             {form.__typename === "Bsdasri" ? (
               <BsdasriWorkflowAction siret={siret} form={form} />
             ) : null}
+            {form.__typename === "Bsff" ? (
+              <BsffWorkflowAction
+                siret={siret}
+                form={(form as unknown) as BsffFragment}
+              />
+            ) : null}
           </div>
         </div>
       ))}
@@ -80,4 +88,5 @@ const getViewRoute = (bsdTypename: BsdTypename): string =>
   ({
     Form: routes.dashboard.bsdds.view,
     Bsdasri: routes.dashboard.bsdasris.view,
+    Bsff: routes.dashboard.bsffs.view,
   }[bsdTypename]);

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/WorkflowAction.tsx
@@ -34,28 +34,6 @@ export function WorkflowAction(props: WorkflowActionProps) {
         />
       );
 
-    case BsffStatus.Sent:
-      if (siret !== form.bsffDestination?.company?.siret) return null;
-      return (
-        <SignBsff
-          {...props}
-          signatureType={BsffSignatureType.Reception}
-          label="Signature réception"
-          helptext="En signant, je confirme la réception des déchets pour la quantité indiquée dans ce bordereau. La signature est horodatée."
-        />
-      );
-
-    case BsffStatus.Received:
-      if (siret !== form.bsffDestination?.company?.siret) return null;
-      return (
-        <SignBsff
-          {...props}
-          signatureType={BsffSignatureType.Operation}
-          label="Signature opération"
-          helptext="En signant, je confirme le traitement des déchets pour la quantité indiquée dans ce bordereau. La signature est horodatée."
-        />
-      );
-
     default:
       return null;
   }

--- a/front/src/form/bsff/Destination.tsx
+++ b/front/src/form/bsff/Destination.tsx
@@ -27,11 +27,22 @@ export default function Destination({ disabled }) {
           disabled={disabled}
         >
           <option />
-          <option value="R2">R2</option>
-          <option value="R12">R12</option>
-          <option value="D10">D10</option>
-          <option value="D13">D13</option>
-          <option value="D14">D14</option>
+          <option value="R2">
+            R2 - Récupération ou régénération des solvants
+          </option>
+          <option value="R12">
+            R12 - Échange de déchets en vue de les soumettre à l'une des
+            opérations numérotées R1 à R11
+          </option>
+          <option value="D10">D10 - Incinération à terre</option>
+          <option value="D13">
+            D13 - Regroupement préalablement à l'une des opérations numérotées
+            D1 à D12
+          </option>
+          <option value="D14">
+            D14 - Reconditionnement préalablement à l’une des opérations
+            numérotées D1 à D13
+          </option>
         </Field>
       </div>
     </>


### PR DESCRIPTION
Cette PR corrige quelques bugs relevés lors du recettage de l'interface des BSFFs :

- Correction des actions sur le dashboard en mode "carte"
- Suppression des boutons de signature de réception et traitement (pas encore implémenté)
- Ajout de la description des codes de traitement

---

- [Recettage Emmanuel](https://trello.com/c/HmwXeE8H/1639-recette-ff-manu)
- [Recettage Maxime](https://trello.com/c/Eo9UsxB9/1633-recette-max-sur-ff)
