### PR TITLE
Implémentation de isFilledByEmitter

### DIFF
--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -284,6 +284,9 @@ input DestinationInput {
 
   "Opération d'élimination / valorisation prévue (code D/R)"
   processingOperation: String
+  
+  "Indique si c'est l'émetteur initial ou l'installation d'entreposage ou de reconditionnement qui a saisi les informations"
+  isFilledByEmitter: Boolean
 }
 
 """

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
@@ -116,6 +116,18 @@ export default function MarkAsResealed({ form, siret }: WorkflowActionProps) {
                   Installation de destination prévue
                 </h5>
 
+                <div className="form__row form__row--inline">
+                  <Field
+                    name="destination.isFilledByEmitter"
+                    type="checkbox"
+                    id="isFilledByEmitter"
+                    className="td-checkbox"
+                  />
+                  <label htmlFor="isFilledByEmitter">
+                    Je suis l'émetteur du bordereau
+                  </label>
+                </div>
+
                 <CompanySelector name="destination.company" />
 
                 <div className="form__row">
@@ -248,6 +260,7 @@ const emptyState = {
     },
     cap: "",
     processingOperation: "",
+    isFilledByEmitter: true,
   },
   transporter: {
     isExemptedOfReceipt: false,


### PR DESCRIPTION
Le champs `isFilledByEmitter` n'était pas implémenté au niveau, et par conséquent était toujours à `true` (sa valeur par défaut).
Implémentation dans le shcéma graphql + modale de signature

---

- [Ticket Trello](https://trello.com/c/p38zsiJe/1544-le-champ-isfilledbyemitter-dans-le-cas-dun-entreposage-provisoire-est-toujours-%C3%A0-true)
