### PR TITLE
Forbid grouping dasris direct takeover

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- L'emport direct de dasris (sans signature producteur) est limité aux bordereaux simples (hors regroupement) [972](https://github.com/MTES-MCT/trackdechets/pull/972)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/__tests__/testWorkflow.ts
+++ b/back/src/__tests__/testWorkflow.ts
@@ -6,17 +6,17 @@ async function testWorkflow(workflow) {
   let context = {};
 
   // create the different companies used in this workflow
-  for (const worflowCompany of workflow.companies) {
+  for (const workflowCompany of workflow.companies) {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
-      companyTypes: worflowCompany.companyTypes
+      companyTypes: workflowCompany.companyTypes,
+      ...(workflowCompany?.opt || {})
     });
-    context = { ...context, [worflowCompany.name]: { ...company, user } };
+    context = { ...context, [workflowCompany.name]: { ...company, user } };
   }
 
   // run the steps one by one
   for (const step of workflow.steps) {
     const { mutate } = makeClient(context[step.company].user);
-
     const { data: response } = await mutate(step.mutation, {
       variables: step.variables(context)
     });

--- a/back/src/bsdasris/examples/__tests__/examples.integration.ts
+++ b/back/src/bsdasris/examples/__tests__/examples.integration.ts
@@ -1,6 +1,7 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import acheminementDirectWorkflow from "../workflows/acheminementDirect";
+import emportDirect from "../workflows/emportDirect";
 
 describe("Exemples de circuit du bordereau de suivi DASRI", () => {
   afterEach(resetDatabase);
@@ -9,6 +10,14 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     acheminementDirectWorkflow.title,
     async () => {
       await testWorkflow(acheminementDirectWorkflow);
+    },
+    10000
+  );
+
+  test(
+    emportDirect.title,
+    async () => {
+      await testWorkflow(emportDirect);
     },
     10000
   );

--- a/back/src/bsdasris/examples/steps/updateProducer.ts
+++ b/back/src/bsdasris/examples/steps/updateProducer.ts
@@ -1,0 +1,18 @@
+import mutations from "../mutations";
+import fixtures from "../fixtures";
+import { WorkflowStep } from "../../../common/workflow";
+
+export function updateProducer(company: string): WorkflowStep {
+  return {
+    description: `Les informations de transport sont complétées`,
+    mutation: mutations.updateBsdasri,
+    variables: ({ bsd }) => ({
+      id: bsd.id,
+      input: { transport: fixtures.transportInput }
+    }),
+    expected: { status: "SIGNED_BY_PRODUCER" },
+    data: response => response.updateBsdasri,
+    company,
+    setContext: (ctx, data) => ({ ...ctx, bsd: data })
+  };
+}

--- a/back/src/bsdasris/examples/steps/updateTransportBeforeDirectTakeover.ts
+++ b/back/src/bsdasris/examples/steps/updateTransportBeforeDirectTakeover.ts
@@ -1,0 +1,20 @@
+import mutations from "../mutations";
+import fixtures from "../fixtures";
+import { WorkflowStep } from "../../../common/workflow";
+
+export function updateTransportBeforeDirectTakeover(
+  company: string
+): WorkflowStep {
+  return {
+    description: `Les informations de transport sont complétées. Le producteur ayant autorisé l'emport direct de dasri, le transporteur peut signer l'enlèvement du déchet sans signature producteur`,
+    mutation: mutations.updateBsdasri,
+    variables: ({ bsd }) => ({
+      id: bsd.id,
+      input: { transport: fixtures.transportInput }
+    }),
+    expected: { status: "INITIAL" },
+    data: response => response.updateBsdasri,
+    company,
+    setContext: (ctx, data) => ({ ...ctx, bsd: data })
+  };
+}

--- a/back/src/bsdasris/examples/workflows/emportDirect.ts
+++ b/back/src/bsdasris/examples/workflows/emportDirect.ts
@@ -6,8 +6,12 @@ import { updateReception } from "../steps/updateReception";
 import { updateOperation } from "../steps/updateOperation";
 import { updateTransportBeforeDirectTakeover } from "../steps/updateTransportBeforeDirectTakeover";
 export default {
-  title: `Emport direct d'un dasri dans signature producteur`,
-  description: `L'emport d'un dasri (hors groupement) par un transporteur, sans signature producteur, est possible si ce dernier l'a autorisé (champ allowBsdasriTakeOverWithoutSignature).`,
+  title: `Emport direct d'un dasri sans signature producteur`,
+  description: `Habituellement, l'emport d'un dasri nécessite la signature du producteur. 
+  Néanmoins, ce dernier peut autoriser l'emport direct par un transporteur, sans signature producteur. 
+  Cette facilité est possible pour les dasris simples (hors groupement).
+  Le producteur doit pour ce faire cocher la case "Emport direct de DASRI autorisé" dans Mon compte > Établissements.
+  En termes d'api, ce paramétrage correspond au champ "allowBsdasriTakeOverWithoutSignature" accessible sur la query "companyInfos".`,
   companies: [
     {
       name: "pred",

--- a/back/src/bsdasris/examples/workflows/emportDirect.ts
+++ b/back/src/bsdasris/examples/workflows/emportDirect.ts
@@ -1,0 +1,44 @@
+import { createBsdasri } from "../steps/createBsdasri";
+import { signOperation } from "../steps/signOperation";
+import { signReception } from "../steps/signReception";
+import { signTransport } from "../steps/signTransport";
+import { updateReception } from "../steps/updateReception";
+import { updateOperation } from "../steps/updateOperation";
+import { updateTransportBeforeDirectTakeover } from "../steps/updateTransportBeforeDirectTakeover";
+export default {
+  title: `Emport direct d'un dasri dans signature producteur`,
+  description: `L'emport d'un dasri (hors groupement) par un transporteur, sans signature producteur, est possible si ce dernier l'a autorisé (champ allowBsdasriTakeOverWithoutSignature).`,
+  companies: [
+    {
+      name: "pred",
+      companyTypes: ["PRODUCER"],
+      opt: { allowBsdasriTakeOverWithoutSignature: true }
+    },
+    { name: "transporteur", companyTypes: ["TRANSPORTER"] },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createBsdasri("pred"),
+    updateTransportBeforeDirectTakeover("transporteur"),
+    signTransport("transporteur"),
+    updateReception("traiteur"),
+    signReception("traiteur"),
+    updateOperation("traiteur"),
+    signOperation("traiteur")
+  ],
+  docContext: {
+    pred: { siret: "SIRET_PRODUCTEUR", securityCode: "XXXX" },
+    transporteur: { siret: "SIRET_TRANSPORTEUR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsd: { id: "ID_BSD" }
+  },
+  chart: `
+graph LR
+AO(NO STATE) -->|createBsdasri| A(INITIAL)
+A -->|updateBsdasri| A
+A -->|"signBsdasri (TRANSPORT)"| B(SENT)
+B -->|updateBsdasri| B
+B -->|"signBsdasri (RECEPTION)"| C(RECEIVED)
+C -->|updateBsdasri| C
+C -->|"signBsdasri (OPERATION)"| PROCESSED`
+};

--- a/back/src/bsdasris/examples/workflows/index.ts
+++ b/back/src/bsdasris/examples/workflows/index.ts
@@ -1,5 +1,7 @@
 import acheminementDirect from "./acheminementDirect";
+import emportDirect from "./emportDirect";
 
 export default {
-  acheminementDirect
+  acheminementDirect,
+  emportDirect
 };

--- a/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
+++ b/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
@@ -3,7 +3,7 @@ import { BsdasriValidationContext } from "../../validation";
 
 import { BsdasriSignatureType } from "../../../generated/graphql/types";
 import { UserInputError } from "apollo-server-express";
-import { Bsdasri, BsdasriStatus } from "@prisma/client";
+import { Bsdasri, BsdasriStatus, BsdasriType } from "@prisma/client";
 
 import { BsdasriEventType } from "../../workflow/types";
 type checkEmitterAllowsDirectTakeOverFn = ({
@@ -23,6 +23,12 @@ export const checkEmitterAllowsDirectTakeOver: checkEmitterAllowsDirectTakeOverF
     signatureParams.eventType === BsdasriEventType.SignTransport &&
     bsdasri.status === BsdasriStatus.INITIAL
   ) {
+    if (bsdasri.bsdasriType !== BsdasriType.SIMPLE) {
+      throw new UserInputError(
+        "L'emport direct est interdit pour les bordereaux dasri de groupement"
+      );
+    }
+
     const emitterCompany = await getCompanyOrCompanyNotFound({
       siret: bsdasri.emitterCompanySiret
     });

--- a/doc/docs/tutoriels/examples/bsdasri/emport-direct.mdx
+++ b/doc/docs/tutoriels/examples/bsdasri/emport-direct.mdx
@@ -1,0 +1,8 @@
+---
+title: "Emport direct d'un dasri sans signature producteur"
+---
+
+
+import Workflow from "../../../../src/components/Workflow"
+
+<Workflow path="bsdasri.emportDirect"/>

--- a/doc/plugin/index.ts
+++ b/doc/plugin/index.ts
@@ -35,6 +35,9 @@ export default function plugin(): Plugin<any> {
           acheminementDirect: parseWorkflow(
             bsdasriWorkflows.acheminementDirect
           ),
+          emportDirect: parseWorkflow(
+            bsdasriWorkflows.emportDirect
+          ),
         },
         bsvhu: {
           vhuVersBroyeur: parseWorkflow(bsvhuWorkflows.vhuVersBroyeur),

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -12,7 +12,7 @@ const graphqlTypes = [
 ];
 
 function makeReference(apiId) {
-  return graphqlTypes.map((t) =>
+  return graphqlTypes.map(t =>
     path.join("reference", "api-reference", apiId, t)
   );
 }
@@ -53,12 +53,15 @@ module.exports = {
                 "tutoriels/examples/bsdd/entreposage-provisoire",
                 "tutoriels/examples/bsdd/import-bsd-papier",
               ],
-              BSDASRI: ["tutoriels/examples/bsdasri/acheminement-direct"],
-              BSVHU: ["tutoriels/examples/bsvhu/vhu-vers-broyeur"],
-            },
-          ],
-        },
-      ],
+              BSDASRI: [
+                "tutoriels/examples/bsdasri/acheminement-direct",
+                "tutoriels/examples/bsdasri/emport-direct",
+              ],
+              BSVHU: ["tutoriels/examples/bsvhu/vhu-vers-broyeur",],
+            }
+          ]
+        }
+      ]
     },
     {
       Guides: [

--- a/doc/src/components/Workflow.tsx
+++ b/doc/src/components/Workflow.tsx
@@ -7,7 +7,6 @@ import { resolve } from "../utils";
 export default function Workflow({ path }) {
   const { workflows } = usePluginData<any>("workflow-doc-plugin");
   const workflow = resolve(path, workflows);
-  console.log(workflows);
   return (
     <div>
       {workflow.description && <div>{workflow.description}</div>}

--- a/doc/src/components/Workflow.tsx
+++ b/doc/src/components/Workflow.tsx
@@ -7,13 +7,14 @@ import { resolve } from "../utils";
 export default function Workflow({ path }) {
   const { workflows } = usePluginData<any>("workflow-doc-plugin");
   const workflow = resolve(path, workflows);
+  console.log(workflows);
   return (
     <div>
       {workflow.description && <div>{workflow.description}</div>}
       {workflow.chart && <Mermaid chart={workflow.chart} />}
       <hr />
-      {workflow.steps.map((step) => (
-        <div>
+      {workflow.steps.map((step, idx) => (
+        <div key={idx}>
           <div className="margin-bottom--sm">{step.description}</div>
           <div className="margin-bottom--lg">
             <CodeBlock className="graphql">{step.mutation}</CodeBlock>

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
@@ -44,7 +44,8 @@ export function WorkflowAction(props: WorkflowActionProps) {
       }
       if (
         siret === form.transporter?.company?.siret &&
-        form?.allowDirectTakeOver
+        form?.allowDirectTakeOver &&
+        form.bsdasriType === "SIMPLE" // grouping dasri can't be directly taken over
       ) {
         return <SignBsdasriDirectTakeover {...props} />;
       }


### PR DESCRIPTION
Les dasris peuvent être emportés par le transporteur sans signature producteur si celui-ci l'autorise explicitement.
Cette PR ajoute une exception pour les bordereaux de groupement (et les futurs bordereaux de synthèse)

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log

---

- [Ticket Trello](https://trello.com/c/IbWoseRB/1506-dasris-si-regroupement-lemport-sans-signature-du-producteur-est-interdit)
