### PR TITLE
Rafraichissement automatique de la liste des bordereaux dans l'UI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug d'affichage dans la préparation d'un transfert multi-modal [PR 997](https://github.com/MTES-MCT/trackdechets/pull/997)
 #### :nail_care: Améliorations
 
+- Rafraichissement automatique de la liste des bordereaux dans l'UI Trackdéchets [PR 985](https://github.com/MTES-MCT/trackdechets/pull/985)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -1,6 +1,7 @@
 import { Bsda, BsdaStatus } from "@prisma/client";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
 import prisma from "../prisma";
+import { GraphQLContext } from "../types";
 
 // | state              | emitter          | worker           | transporter | destination      |
 // |--------------------|------------------|------------------|-------------|------------------|
@@ -157,6 +158,6 @@ export async function indexAllBsdas(
   return indexAllBsdas(idx, { skip: skip + take });
 }
 
-export function indexBsda(bsda: Bsda) {
-  return indexBsd(toBsdElastic(bsda));
+export function indexBsda(bsda: Bsda, ctx?: GraphQLContext) {
+  return indexBsd(toBsdElastic(bsda), ctx);
 }

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -55,7 +55,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     }
   });
 
-  await indexBsda(newBsda);
+  await indexBsda(newBsda, context);
 
   return expandBsdaFromDb(newBsda);
 }

--- a/back/src/bsda/resolvers/mutations/delete.ts
+++ b/back/src/bsda/resolvers/mutations/delete.ts
@@ -22,7 +22,7 @@ export default async function deleteBsda(
     data: { isDeleted: true }
   });
 
-  await deleteBsd(deletedBsda);
+  await deleteBsd(deletedBsda, context);
 
   return expandBsdaFromDb(deletedBsda);
 }

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -24,7 +24,7 @@ export default async function duplicate(
   );
 
   const newBsda = await duplicateForm(prismaForm);
-  await indexBsda(newBsda);
+  await indexBsda(newBsda, context);
 
   return expandBsdaFromDb(newBsda);
 }

--- a/back/src/bsda/resolvers/mutations/publish.ts
+++ b/back/src/bsda/resolvers/mutations/publish.ts
@@ -36,7 +36,7 @@ export default async function create(
     data: { isDraft: false }
   });
 
-  await indexBsda(updatedBsda);
+  await indexBsda(updatedBsda, context);
 
   return expandBsdaFromDb(updatedBsda);
 }

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -82,7 +82,7 @@ export default async function sign(
     }
   });
 
-  await indexBsda(signedBsda);
+  await indexBsda(signedBsda, context);
 
   return expandBsdaFromDb(signedBsda);
 }

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -57,7 +57,7 @@ export default async function edit(
     }
   });
 
-  await indexBsda(updatedBsda);
+  await indexBsda(updatedBsda, context);
 
   return expandBsdaFromDb(updatedBsda);
 }

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -3,6 +3,7 @@ import prisma from "../prisma";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
 
 import { DASRI_WASTE_CODES_MAPPING } from "../common/constants/DASRI_CONSTANTS";
+import { GraphQLContext } from "../types";
 
 // | state              | emitter | transporter | recipient |
 // |--------------------|---------|-------------|-----------|
@@ -163,6 +164,6 @@ export async function indexAllBsdasris(
   return indexAllBsdasris(idx, { skip: skip + take });
 }
 
-export function indexBsdasri(bsdasri: Bsdasri) {
-  return indexBsd(toBsdElastic(bsdasri));
+export function indexBsdasri(bsdasri: Bsdasri, ctx?: GraphQLContext) {
+  return indexBsd(toBsdElastic(bsdasri), ctx);
 }

--- a/back/src/bsdasris/resolvers/mutations/create.ts
+++ b/back/src/bsdasris/resolvers/mutations/create.ts
@@ -69,7 +69,7 @@ const createBsdasri = async (
     }
   });
 
-  await indexBsdasri(newDasri);
+  await indexBsdasri(newDasri, context);
 
   return expandBsdasriFromDb(newDasri);
 };

--- a/back/src/bsdasris/resolvers/mutations/deleteBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/deleteBsdasri.ts
@@ -39,7 +39,7 @@ const deleteBsdasriResolver: MutationResolvers["deleteBsdasri"] = async (
     data: { isDeleted: true }
   });
 
-  await elastic.deleteBsd(deletedBsdasri);
+  await elastic.deleteBsd(deletedBsdasri, context);
 
   return expandBsdasriFromDb(deletedBsdasri);
 };

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -37,7 +37,7 @@ const duplicateBsdasriResolver: MutationResolvers["duplicateBsdasri"] = async (
   );
 
   const newBsdasri = await duplicateBsdasri(user, bsdasri);
-  await indexBsdasri(newBsdasri);
+  await indexBsdasri(newBsdasri, context);
   return expandBsdasriFromDb(newBsdasri);
 };
 

--- a/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
@@ -38,7 +38,7 @@ const publishBsdasriResolver: MutationResolvers["publishBsdasri"] = async (
     data: { isDraft: false }
   });
   const expandedDasri = expandBsdasriFromDb(publishedBsdasri);
-  await indexBsdasri(publishedBsdasri);
+  await indexBsdasri(publishedBsdasri, context);
   return expandedDasri;
 };
 

--- a/back/src/bsdasris/resolvers/mutations/sign.ts
+++ b/back/src/bsdasris/resolvers/mutations/sign.ts
@@ -60,7 +60,7 @@ const basesign = async ({ id, input, context, securityCode = null }) => {
   );
 
   const expandedDasri = expandBsdasriFromDb(updatedDasri);
-  await indexBsdasri(updatedDasri);
+  await indexBsdasri(updatedDasri, context);
   return expandedDasri;
 };
 

--- a/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
@@ -171,7 +171,7 @@ const dasriUpdateResolver = async (
   });
 
   const expandedDasri = expandBsdasriFromDb(updatedDasri);
-  await indexBsdasri(updatedDasri);
+  await indexBsdasri(updatedDasri, context);
   return expandedDasri;
 };
 

--- a/back/src/bsffs/database.ts
+++ b/back/src/bsffs/database.ts
@@ -8,6 +8,7 @@ import { flattenBsffInput, unflattenBsff } from "./converter";
 import { isBsffContributor } from "./permissions";
 import { validateBsff } from "./validation";
 import { indexBsff } from "./elastic";
+import { GraphQLContext } from "../types";
 
 export async function getNextBsffs(
   bsff: Bsff,
@@ -118,7 +119,7 @@ export async function createBsff(
 
   const bsff = await prisma.bsff.create({ data });
 
-  await indexBsff(bsff);
+  await indexBsff(bsff, { user } as GraphQLContext);
 
   return unflattenBsff(bsff);
 }

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -1,6 +1,7 @@
 import { Bsff, BsffStatus } from "@prisma/client";
 import prisma from "../prisma";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
+import { GraphQLContext } from "../types";
 
 function toBsdElastic(bsff: Bsff): BsdElastic {
   const bsd = {
@@ -117,6 +118,6 @@ export async function indexAllBsffs(
   return indexAllBsffs(idx, { skip: skip + take });
 }
 
-export function indexBsff(form: Bsff) {
-  return indexBsd(toBsdElastic(form));
+export function indexBsff(form: Bsff, ctx?: GraphQLContext) {
+  return indexBsd(toBsdElastic(form), ctx);
 }

--- a/back/src/bsffs/resolvers/mutations/deleteBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/deleteBsff.ts
@@ -31,7 +31,7 @@ const deleteBsff: MutationResolvers["deleteBsff"] = async (
     }
   });
 
-  await elastic.deleteBsd(updatedBsff);
+  await elastic.deleteBsd(updatedBsff, context);
 
   return unflattenBsff(updatedBsff);
 };

--- a/back/src/bsffs/resolvers/mutations/publishBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/publishBsff.ts
@@ -35,7 +35,7 @@ const publishBsffResolver: MutationResolvers["publishBsff"] = async (
     }
   });
 
-  await indexBsff(updatedBsff);
+  await indexBsff(updatedBsff, context);
 
   return unflattenBsff(updatedBsff);
 };

--- a/back/src/bsffs/resolvers/mutations/signBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/signBsff.ts
@@ -162,7 +162,7 @@ const signBsff: MutationResolvers["signBsff"] = async (_, args, context) => {
   const sign = signatures[args.type];
   const updatedBsff = await sign(args, user, existingBsff);
 
-  await indexBsff(updatedBsff);
+  await indexBsff(updatedBsff, context);
 
   return unflattenBsff(updatedBsff);
 };

--- a/back/src/bsffs/resolvers/mutations/updateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsff.ts
@@ -119,7 +119,7 @@ const updateBsff: MutationResolvers["updateBsff"] = async (
     where: { id }
   });
 
-  await indexBsff(updatedBsff);
+  await indexBsff(updatedBsff, context);
 
   return unflattenBsff(updatedBsff);
 };

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,6 +1,7 @@
 import { BsvhuStatus, Bsvhu } from "@prisma/client";
 import prisma from "../prisma";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
+import { GraphQLContext } from "../types";
 
 // | state              | emitter | transporter | destination |
 // |--------------------|---------|-------------|-------------|
@@ -151,6 +152,6 @@ export async function indexAllBsvhus(
   return indexAllBsvhus(idx, { skip: skip + take });
 }
 
-export function indexBsvhu(bsvhu: Bsvhu) {
-  return indexBsd(toBsdElastic(bsvhu));
+export function indexBsvhu(bsvhu: Bsvhu, ctx?: GraphQLContext) {
+  return indexBsd(toBsdElastic(bsvhu), ctx);
 }

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -42,6 +42,6 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
 
   // TODO Status log ?
   // TODO emit event ?
-  await indexBsvhu(newForm);
+  await indexBsvhu(newForm, context);
   return expandVhuFormFromDb(newForm);
 }

--- a/back/src/bsvhu/resolvers/mutations/delete.ts
+++ b/back/src/bsvhu/resolvers/mutations/delete.ts
@@ -27,7 +27,7 @@ const deleteBsvhuResolver: MutationResolvers["deleteBsvhu"] = async (
     data: { isDeleted: true }
   });
 
-  await elastic.deleteBsd(deletedBsvhu);
+  await elastic.deleteBsd(deletedBsvhu, context);
 
   return expandVhuFormFromDb(deletedBsvhu);
 };

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -24,7 +24,7 @@ export default async function duplicate(
 
   const newForm = await duplicateForm(prismaForm);
 
-  await indexBsvhu(newForm);
+  await indexBsvhu(newForm, context);
   return expandVhuFormFromDb(newForm);
 }
 

--- a/back/src/bsvhu/resolvers/mutations/publish.ts
+++ b/back/src/bsvhu/resolvers/mutations/publish.ts
@@ -34,6 +34,6 @@ export default async function create(
     where: { id },
     data: { isDraft: false }
   });
-  await indexBsvhu(updatedForm);
+  await indexBsvhu(updatedForm, context);
   return expandVhuFormFromDb(updatedForm);
 }

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -74,7 +74,7 @@ export default async function sign(
       status: newStatus as BsvhuStatus
     }
   });
-  await indexBsvhu(signedForm);
+  await indexBsvhu(signedForm, context);
   return expandVhuFormFromDb(signedForm);
 }
 

--- a/back/src/bsvhu/resolvers/mutations/update.ts
+++ b/back/src/bsvhu/resolvers/mutations/update.ts
@@ -48,6 +48,6 @@ export default async function edit(
     data: formUpdate
   });
 
-  await indexBsvhu(updatedForm);
+  await indexBsvhu(updatedForm, context);
   return expandVhuFormFromDb(updatedForm);
 }

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -2,6 +2,7 @@ import { Status } from "@prisma/client";
 import prisma from "../prisma";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
 import { FullForm } from "./types";
+import { GraphQLContext } from "../types";
 
 function getWhere(
   form: FullForm
@@ -276,6 +277,6 @@ export async function indexAllForms(
   return indexAllForms(idx, { skip: skip + take });
 }
 
-export function indexForm(form: FullForm) {
-  return indexBsd(toBsdElastic(form));
+export function indexForm(form: FullForm, ctx?: GraphQLContext) {
+  return indexBsd(toBsdElastic(form), ctx);
 }

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -124,7 +124,7 @@ const createFormResolver = async (
   });
 
   const fullForm = await getFullForm(newForm);
-  await indexForm(fullForm);
+  await indexForm(fullForm, context);
 
   return expandFormFromDb(newForm);
 };

--- a/back/src/forms/resolvers/mutations/deleteForm.ts
+++ b/back/src/forms/resolvers/mutations/deleteForm.ts
@@ -24,7 +24,7 @@ const deleteFormResolver: MutationResolvers["deleteForm"] = async (
 
   // TODO: create a statusLog
 
-  await elastic.deleteBsd(deletedForm);
+  await elastic.deleteBsd(deletedForm, context);
 
   return expandFormFromDb(deletedForm);
 };

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -150,7 +150,7 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
   });
 
   const fullForm = await getFullForm(newForm);
-  await indexForm(fullForm);
+  await indexForm(fullForm, context);
 
   return expandFormFromDb(newForm);
 };

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -146,7 +146,7 @@ const updateFormResolver = async (
   // so the form might have changed in-between without a proper statusLog
 
   const fullForm = await getFullForm(updatedForm);
-  await indexForm(fullForm);
+  await indexForm(fullForm, context);
 
   return expandFormFromDb(updatedForm);
 };

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -7,6 +7,7 @@ import { formDiff } from "./diff";
 import { eventEmitter, TDEvent } from "../../events/emitter";
 import { indexForm } from "../elastic";
 import { getFullForm } from "../database";
+import { GraphQLContext } from "../../types";
 
 /**
  * Transition a form from initial state (ex: DRAFT) to next state (ex: SEALED)
@@ -79,7 +80,7 @@ export default async function transitionForm(
   });
 
   const fullForm = await getFullForm(updatedForm);
-  await indexForm(fullForm);
+  await indexForm(fullForm, { user } as GraphQLContext);
 
   return updatedForm;
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -5,58 +5,49 @@
   "requires": true,
   "dependencies": {
     "@apollo/client": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.5.tgz",
-      "integrity": "sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.10.tgz",
+      "integrity": "sha512-b+8TT3jBM2BtEJi+V2FuLpvoYDZCY3baNYrgAgEyw4fjnuBCSRPY7qVjqriZAwMaGiTLtyVifGhmdeICQs4Eow==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
-        "@types/zen-observable": "^0.8.0",
-        "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.2.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-tag": "^2.11.0",
+        "@wry/context": "^0.6.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.3",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.0",
+        "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
-        "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.4.4",
-        "tslib": "^1.10.0",
-        "zen-observable": "^0.8.14"
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.9.0",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.1.0"
       },
       "dependencies": {
-        "@wry/context": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-          "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
         "@wry/equality": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
-          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
+          "integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
           "requires": {
-            "tslib": "^1.9.3"
-          }
-        },
-        "graphql-tag": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-          "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
-        },
-        "optimism": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.0.tgz",
-          "integrity": "sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==",
-          "requires": {
-            "@wry/context": "^0.5.2"
+            "tslib": "^2.3.0"
           }
         },
         "symbol-observable": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
-          "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+          "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+        },
+        "ts-invariant": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.1.tgz",
+          "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -4368,9 +4359,9 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@types/zen-observable": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
     },
     "@types/zxcvbn": {
       "version": "4.4.0",
@@ -4644,12 +4635,42 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/context": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
+      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "@wry/equality": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
       "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
       "requires": {
         "tslib": "^1.9.3"
+      }
+    },
+    "@wry/trie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
+      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -10199,7 +10220,6 @@
       "version": "2.12.4",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.4.tgz",
       "integrity": "sha512-VV1U4O+9x99EkNpNmCUV5RZwq6MnK4+pGbRYWG+lA/m3uo7TSqJF81OkcOP148gFP6fzdl7JWYBrwWVTS9jXww==",
-      "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -10207,8 +10227,7 @@
         "tslib": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
         }
       }
     },
@@ -14289,6 +14308,15 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "requires": {
         "is-wsl": "^1.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
+      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "requires": {
+        "@wry/context": "^0.6.0",
+        "@wry/trie": "^0.3.0"
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -21507,6 +21535,15 @@
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "requires": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
+      }
     },
     "zxcvbn": {
       "version": "4.4.2",

--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.2.5",
+    "@apollo/client": "^3.4.10",
     "@reach/dialog": "^0.11.2",
     "@reach/menu-button": "^0.11.2",
     "@reach/tooltip": "^0.11.2",

--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
@@ -24,6 +24,7 @@ import { DeleteModal } from "./DeleteModal";
 import { useDuplicate } from "./useDuplicate";
 import { useDownloadPdf } from "./useDownloadPdf";
 import styles from "../../BSDActions.module.scss";
+import { Loader } from "common/components";
 
 interface BSDDActionsProps {
   form: Form;
@@ -33,7 +34,9 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
   const { siret } = useParams<{ siret: string }>();
   const location = useLocation();
   const [downloadPdf] = useDownloadPdf({ variables: { id: form.id } });
-  const [duplicateForm] = useDuplicate({ variables: { id: form.id } });
+  const [duplicateForm, { loading: isDuplicating }] = useDuplicate({
+    variables: { id: form.id },
+  });
   const [isDeleting, setIsDeleting] = React.useState(false);
 
   return (
@@ -107,6 +110,7 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
           formId={form.id}
         />
       )}
+      {isDuplicating && <Loader />}
     </>
   );
 };

--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/DeleteModal.tsx
@@ -4,6 +4,8 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteFormArgs } from "generated/graphql/types";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const DELETE_FORM = gql`
   mutation DeleteForm($id: ID!) {
@@ -23,11 +25,13 @@ export function DeleteModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [deleteForm] = useMutation<
+  const [deleteForm, { loading }] = useMutation<
     Pick<Mutation, "deleteForm">,
     MutationDeleteFormArgs
   >(DELETE_FORM, {
     variables: { id: formId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
@@ -57,6 +61,7 @@ export function DeleteModal({
           <span> Supprimer</span>
         </button>
       </div>
+      {loading && <Loader />}
     </TdModal>
   );
 }

--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/useDuplicate.tsx
@@ -2,6 +2,7 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import cogoToast from "cogo-toast";
 import { Mutation, MutationDuplicateFormArgs } from "generated/graphql/types";
 import { fullFormFragment } from "common/fragments";
+import { GET_BSDS } from "common/queries";
 
 const DUPLICATE_FORM = gql`
   mutation DuplicateForm($id: ID!) {
@@ -23,6 +24,8 @@ export function useDuplicate(
     MutationDuplicateFormArgs
   >(DUPLICATE_FORM, {
     ...options,
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       cogoToast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
@@ -4,10 +4,11 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconWaterDam } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 import AcceptedInfo from "./AcceptedInfo";
+import { GET_BSDS } from "common/queries";
 
 const MARK_AS_ACCEPTED = gql`
   mutation MarkAsAccepted($id: ID!, $acceptedInfo: AcceptedFormInput!) {
@@ -19,10 +20,13 @@ const MARK_AS_ACCEPTED = gql`
 `;
 
 export default function MarkAsAccepted({ form }: WorkflowActionProps) {
-  const [markAsAccepted, { error }] = useMutation<
+  const [markAsAccepted, { loading, error }] = useMutation<
     Pick<Mutation, "markAsAccepted">,
     MutationMarkAsAcceptedArgs
-  >(MARK_AS_ACCEPTED);
+  >(MARK_AS_ACCEPTED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   const actionLabel = "Valider l'acceptation";
 
@@ -55,6 +59,7 @@ export default function MarkAsAccepted({ form }: WorkflowActionProps) {
           {error && (
             <NotificationError className="action-error" apolloError={error} />
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -16,10 +16,11 @@ import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconCogApproved } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 import cogoToast from "cogo-toast";
+import { GET_BSDS } from "common/queries";
 
 const MARK_AS_PROCESSED = gql`
   mutation MarkAsProcessed($id: ID!, $processedInfo: ProcessedFormInput!) {
@@ -177,10 +178,12 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
 }
 
 export default function MarkAsProcessed({ form, siret }: WorkflowActionProps) {
-  const [markAsProcessed, { error }] = useMutation<
+  const [markAsProcessed, { loading, error }] = useMutation<
     Pick<Mutation, "markAsProcessed">,
     MutationMarkAsProcessedArgs
   >(MARK_AS_PROCESSED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: data => {
       if (
         data.markAsProcessed &&
@@ -225,6 +228,7 @@ export default function MarkAsProcessed({ form, siret }: WorkflowActionProps) {
           {error && (
             <NotificationError className="action-error" apolloError={error} />
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
@@ -4,10 +4,11 @@ import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconWaterDam } from "common/components/Icons";
 import ReceivedInfo from "./ReceivedInfo";
 import { NotificationError } from "common/components/Error";
+import { GET_BSDS } from "common/queries";
 
 const MARK_AS_RECEIVED = gql`
   mutation MarkAsReceived($id: ID!, $receivedInfo: ReceivedFormInput!) {
@@ -19,10 +20,13 @@ const MARK_AS_RECEIVED = gql`
 `;
 
 export default function MarkAsReceived({ form }: WorkflowActionProps) {
-  const [markAsReceived, { error }] = useMutation<
+  const [markAsReceived, { loading, error }] = useMutation<
     Pick<Mutation, "markAsReceived">,
     MutationMarkAsReceivedArgs
-  >(MARK_AS_RECEIVED);
+  >(MARK_AS_RECEIVED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   const actionLabel = "Valider la réception";
 
@@ -52,6 +56,7 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
             {error && (
               <NotificationError className="action-error" apolloError={error} />
             )}
+            {loading && <Loader />}
           </div>
         )}
       />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
@@ -10,13 +10,14 @@ import { FormStatus, Mutation, WasteDetails } from "generated/graphql/types";
 import ProcessingOperationSelect from "common/components/ProcessingOperationSelect";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconPaperWrite } from "common/components/Icons";
 import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { NotificationError } from "common/components/Error";
 import cogoToast from "cogo-toast";
 import Transporter from "form/bsdd/Transporter";
+import { GET_BSDS } from "common/queries";
 
 const MARK_RESEALED = gql`
   mutation MarkAsResealed($id: ID!, $resealedInfos: ResealedFormInput!) {
@@ -75,9 +76,11 @@ export default function MarkAsResealed({ form, siret }: WorkflowActionProps) {
     }
   }
 
-  const [markAsResealed, { error }] = useMutation<
+  const [markAsResealed, { error, loading }] = useMutation<
     Pick<Mutation, "markAsResealed">
   >(MARK_RESEALED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: data => {
       if (
         data.markAsResealed &&
@@ -242,6 +245,7 @@ export default function MarkAsResealed({ form, siret }: WorkflowActionProps) {
           {error && (
             <NotificationError className="action-error" apolloError={error} />
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation } from "@apollo/client";
 import React from "react";
 import { statusChangeFragment } from "common/fragments";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconPaperWrite } from "common/components/Icons";
 import {
   FormStatus,
@@ -12,6 +12,7 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { NotificationError } from "common/components/Error";
 import { TdModalTrigger } from "common/components/Modal";
 import cogoToast from "cogo-toast";
+import { GET_BSDS } from "common/queries";
 
 const MARK_AS_SEALED = gql`
   mutation MarkAsSealed($id: ID!) {
@@ -24,11 +25,13 @@ const MARK_AS_SEALED = gql`
 `;
 
 export default function MarkAsSealed({ form, siret }: WorkflowActionProps) {
-  const [markAsSealed, { error }] = useMutation<
+  const [markAsSealed, { loading, error }] = useMutation<
     Pick<Mutation, "markAsSealed">,
     MutationMarkAsSealedArgs
   >(MARK_AS_SEALED, {
     variables: { id: form.id },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: data => {
       if (data.markAsSealed) {
         const sealedForm = data.markAsSealed;
@@ -84,6 +87,7 @@ export default function MarkAsSealed({ form, siret }: WorkflowActionProps) {
           {error && (
             <NotificationError className="action-error" apolloError={error} />
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
@@ -9,10 +9,11 @@ import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconWarehouseStorage } from "common/components/Icons";
 import ReceivedInfo from "./ReceivedInfo";
 import { NotificationError } from "common/components/Error";
+import { GET_BSDS } from "common/queries";
 
 const MARK_AS_TEMP_STORED = gql`
   mutation MarkAsTempStored($id: ID!, $tempStoredInfos: TempStoredFormInput!) {
@@ -24,10 +25,13 @@ const MARK_AS_TEMP_STORED = gql`
 `;
 
 export default function MarkAsTempStored({ form }: WorkflowActionProps) {
-  const [markAsTempStored, { error }] = useMutation<
+  const [markAsTempStored, { loading, error }] = useMutation<
     Pick<Mutation, "markAsTempStored">,
     MutationMarkAsTempStoredArgs
-  >(MARK_AS_TEMP_STORED);
+  >(MARK_AS_TEMP_STORED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   const actionLabel = "Valider l'entreposage provisoire";
 
@@ -67,6 +71,7 @@ export default function MarkAsTempStored({ form }: WorkflowActionProps) {
             {error && (
               <NotificationError className="action-error" apolloError={error} />
             )}
+            {loading && <Loader />}
           </div>
         )}
       />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
@@ -8,10 +8,11 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "common/fragments";
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconWarehouseStorage } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 import AcceptedInfo from "./AcceptedInfo";
+import { GET_BSDS } from "common/queries";
 
 const MARK_TEMP_STORER_ACCEPTED = gql`
   mutation MarkAsTempStorerAccepted(
@@ -32,10 +33,13 @@ export default function MarkAsTempStorerAccepted({
   form,
   siret,
 }: WorkflowActionProps) {
-  const [markAsTempStorerAccepted, { error }] = useMutation<
+  const [markAsTempStorerAccepted, { loading, error }] = useMutation<
     Pick<Mutation, "markAsTempStorerAccepted">,
     MutationMarkAsTempStorerAcceptedArgs
-  >(MARK_TEMP_STORER_ACCEPTED);
+  >(MARK_TEMP_STORER_ACCEPTED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   const actionLabel = "Valider l'acceptation de l'entreposage provisoire";
 
@@ -72,6 +76,7 @@ export default function MarkAsTempStorerAccepted({
           {error && (
             <NotificationError className="action-error" apolloError={error} />
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkSegmentAsReadyToTakeOver.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkSegmentAsReadyToTakeOver.tsx
@@ -12,6 +12,8 @@ import ActionButton from "common/components/ActionButton";
 import { IconPaperWrite } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 import { WorkflowActionProps } from "./WorkflowAction";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const MARK_SEGMENT_AS_READY_TO_TAKE_OVER = gql`
   mutation markSegmentAsReadyToTakeOver($id: ID!) {
@@ -27,10 +29,12 @@ export default function MarkSegmentAsReadyToTakeOver({
   siret,
 }: WorkflowActionProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [markSegmentAsReadyToTakeOver, { error }] = useMutation<
+  const [markSegmentAsReadyToTakeOver, { loading, error }] = useMutation<
     Pick<Mutation, "markSegmentAsReadyToTakeOver">,
     MutationMarkSegmentAsReadyToTakeOverArgs
   >(MARK_SEGMENT_AS_READY_TO_TAKE_OVER, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       setIsOpen(false);
       cogoToast.success(
@@ -95,6 +99,7 @@ export default function MarkSegmentAsReadyToTakeOver({
               </FormikForm>
             )}
           </Formik>
+          {loading && <Loader />}
         </TdModal>
       )}
     </>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
@@ -17,6 +17,8 @@ import DateInput from "form/common/components/custom-inputs/DateInput";
 import { transportModeLabels } from "dashboard/constants";
 import { WorkflowActionProps } from "./WorkflowAction";
 import TdSwitch from "common/components/Switch";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const PREPARE_SEGMENT = gql`
   mutation prepareSegment(
@@ -33,10 +35,12 @@ const PREPARE_SEGMENT = gql`
 
 export default function PrepareSegment({ form, siret }: WorkflowActionProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [prepareSegment, { error }] = useMutation<
+  const [prepareSegment, { loading, error }] = useMutation<
     Pick<Mutation, "prepareSegment">,
     MutationPrepareSegmentArgs
   >(PREPARE_SEGMENT, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       setIsOpen(false);
       cogoToast.success("Le segment a été créé", {
@@ -209,6 +213,7 @@ export default function PrepareSegment({ form, siret }: WorkflowActionProps) {
               </FormikForm>
             )}
           </Formik>
+          {loading && <Loader />}
         </TdModal>
       )}
     </>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignedByTransporter/SignedByTransporterModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignedByTransporter/SignedByTransporterModal.tsx
@@ -9,9 +9,10 @@ import {
   SignatureAuthor,
   TransporterSignatureFormInput,
 } from "generated/graphql/types";
-import { Stepper, StepperItem, Modal } from "common/components";
+import { Stepper, StepperItem, Modal, Loader } from "common/components";
 import steps from "./steps";
 import * as yup from "yup";
+import { GET_BSDS } from "common/queries";
 
 const SIGNED_BY_TRANSPORTER = gql`
   mutation SignedByTransporter(
@@ -41,10 +42,12 @@ export function SignedByTransporterModal({
   onClose,
 }: SignedByTransporterModalProps) {
   const [stepIndex, setStepIndex] = React.useState(0);
-  const [signedByTransporter, { error }] = useMutation<
+  const [signedByTransporter, { error, loading }] = useMutation<
     Pick<Mutation, "signedByTransporter">,
     MutationSignedByTransporterArgs
   >(SIGNED_BY_TRANSPORTER, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("La prise en charge du bordereau est validée", {
         hideAfter: 5,
@@ -136,6 +139,7 @@ export function SignedByTransporterModal({
           )}
         </Formik>
       </div>
+      {loading && <Loader />}
     </Modal>
   );
 }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/TakeOverSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/TakeOverSegment.tsx
@@ -9,6 +9,8 @@ import TdModal from "common/components/Modal";
 import { NotificationError } from "common/components/Error";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { WorkflowActionProps } from "./WorkflowAction";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const TAKE_OVER_SEGMENT = gql`
   mutation takeOverSegment($id: ID!, $takeOverInfo: TakeOverInput!) {
@@ -20,10 +22,12 @@ const TAKE_OVER_SEGMENT = gql`
 
 export default function TakeOverSegment({ form }: WorkflowActionProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [takeOverSegment, { error }] = useMutation<
+  const [takeOverSegment, { loading, error }] = useMutation<
     Pick<Mutation, "takeOverSegment">,
     MutationTakeOverSegmentArgs
   >(TAKE_OVER_SEGMENT, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       setIsOpen(false);
       cogoToast.success("La prise en charge du bordereau est validée", {
@@ -105,6 +109,7 @@ export default function TakeOverSegment({ form }: WorkflowActionProps) {
               </FormikForm>
             )}
           </Formik>
+          {loading && <Loader />}
         </TdModal>
       )}
     </>

--- a/front/src/dashboard/components/BSDList/BSDList.tsx
+++ b/front/src/dashboard/components/BSDList/BSDList.tsx
@@ -74,6 +74,7 @@ export function BSDList({
     variables: {
       where: defaultWhere,
     },
+    fetchPolicy: "cache-and-network",
     notifyOnNetworkStatusChange: true,
   });
 

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
@@ -25,6 +25,7 @@ import { useDownloadPdf } from "./useDownloadPdf";
 import { useDuplicate } from "./useDuplicate";
 
 import styles from "../../BSDActions.module.scss";
+import { Loader } from "common/components";
 
 interface BSdaActionsProps {
   form: Bsda;
@@ -34,7 +35,7 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
   const { siret } = useParams<{ siret: string }>();
   const location = useLocation();
 
-  const [duplicateBsda] = useDuplicate({
+  const [duplicateBsda, { loading }] = useDuplicate({
     variables: { id: form.id },
   });
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -108,6 +109,7 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
           </>
         )}
       </Menu>
+      {loading && <Loader />}
       {isDeleting && (
         <DeleteBsdaModal
           isOpen

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/DeleteModal.tsx
@@ -4,6 +4,8 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteBsdaArgs } from "generated/graphql/types";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const DELETE_BSDA = gql`
   mutation DeleteBsda($id: ID!) {
@@ -23,11 +25,13 @@ export function DeleteBsdaModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [deleteBsda] = useMutation<
+  const [deleteBsda, { loading }] = useMutation<
     Pick<Mutation, "deleteBsda">,
     MutationDeleteBsdaArgs
   >(DELETE_BSDA, {
     variables: { id: formId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
@@ -56,6 +60,7 @@ export function DeleteBsdaModal({
           <IconTrash />
           <span> Supprimer</span>
         </button>
+        {loading && <Loader />}
       </div>
     </TdModal>
   );

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/useDuplicate.ts
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/useDuplicate.ts
@@ -2,6 +2,7 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import cogoToast from "cogo-toast";
 import { Mutation, MutationDuplicateBsdaArgs } from "generated/graphql/types";
 import { bsdaFragment } from "common/fragments";
+import { GET_BSDS } from "common/queries";
 
 const DUPLICATE_BSDA = gql`
   mutation DuplicateBsda($id: ID!) {
@@ -23,6 +24,8 @@ export function useDuplicate(
     MutationDuplicateBsdaArgs
   >(DUPLICATE_BSDA, {
     ...options,
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       cogoToast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/PublishBsda.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/PublishBsda.tsx
@@ -4,13 +4,14 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { gql, useMutation } from "@apollo/client";
 
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconPaperWrite } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 
 import cogoToast from "cogo-toast";
 import { generatePath, Link } from "react-router-dom";
 import routes from "common/routes";
+import { GET_BSDS } from "common/queries";
 
 const PUBLISH_BSDA = gql`
   mutation PublishBsda($id: ID!) {
@@ -22,11 +23,13 @@ const PUBLISH_BSDA = gql`
 `;
 
 export default function PublishBsda({ form, siret }: WorkflowActionProps) {
-  const [publishBsda, { error }] = useMutation<
+  const [publishBsda, { error, loading }] = useMutation<
     Pick<Mutation, "publishBsda">,
     MutationPublishBsdaArgs
   >(PUBLISH_BSDA, {
     variables: { id: form.id },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success(`Bordereau ${form.id} publié`, { hideAfter: 5 });
     },
@@ -72,7 +75,7 @@ export default function PublishBsda({ form, siret }: WorkflowActionProps) {
               <span>Publier le bordereau</span>
             </button>
           </div>
-
+          {loading && <Loader />}
           {error && (
             <>
               <NotificationError className="action-error" apolloError={error} />

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from "@apollo/client";
-import { Loader, RedErrorMessage } from "common/components";
+import { RedErrorMessage } from "common/components";
 import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
-import { RedErrorMessage } from "common/components";
+import { Loader, RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -25,7 +26,10 @@ export function SignEmission({ siret, bsdaId }: Props) {
   const [signBsda, { loading }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA);
+  >(SIGN_BSDA, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   return (
     <SignBsda title="Signer l'enlèvement" bsdaId={bsdaId}>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { UPDATE_BSDA } from "form/bsda/stepper/queries";
 import Operation from "form/bsda/stepper/steps/Operation";
@@ -34,7 +35,10 @@ export function SignOperation({ siret, bsdaId }: Props) {
   const [signBsda, { loading }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA);
+  >(SIGN_BSDA, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   return (
     <SignBsda title="Signer le traitement" bsdaId={bsdaId}>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -25,7 +26,7 @@ export function SignTransport({ siret, bsdaId }: Props) {
   const [signBsda, { loading }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA);
+  >(SIGN_BSDA, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <SignBsda title="Signer l'enlèvement" bsdaId={bsdaId}>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -25,7 +26,7 @@ export function SignWork({ siret, bsdaId }: Props) {
   const [signBsda, { loading }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA);
+  >(SIGN_BSDA, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <SignBsda title="Signer la fin de chantier" bsdaId={bsdaId}>

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/DeleteModal.tsx
@@ -4,6 +4,8 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteBsdasriArgs } from "generated/graphql/types";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const DELETE_BSDASRI = gql`
   mutation DeleteBsdasri($id: ID!) {
@@ -23,11 +25,13 @@ export function DeleteBsdasriModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [deleteBsdasri] = useMutation<
+  const [deleteBsdasri, { loading }] = useMutation<
     Pick<Mutation, "deleteBsdasri">,
     MutationDeleteBsdasriArgs
   >(DELETE_BSDASRI, {
     variables: { id: formId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
@@ -57,6 +61,7 @@ export function DeleteBsdasriModal({
           <span> Supprimer</span>
         </button>
       </div>
+      {loading && <Loader />}
     </TdModal>
   );
 }

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
@@ -5,6 +5,7 @@ import {
   MutationDuplicateBsdasriArgs,
 } from "generated/graphql/types";
 import { dasriFragment } from "common/fragments";
+import { GET_BSDS } from "common/queries";
 
 const DUPLICATE_BSDASRI = gql`
   mutation DuplicateBsdasri($id: ID!) {
@@ -26,6 +27,8 @@ export function useBsdasriDuplicate(
     MutationDuplicateBsdasriArgs
   >(DUPLICATE_BSDASRI, {
     ...options,
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       cogoToast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PublishBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PublishBsdasri.tsx
@@ -5,13 +5,14 @@ import { gql, useMutation } from "@apollo/client";
 import { BdasriSummary } from "dashboard/components/BSDList/BSDasri/Summary/BsdasriSummary";
 
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconPaperWrite } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 import { Link, generatePath } from "react-router-dom";
 import routes from "common/routes";
 
 import cogoToast from "cogo-toast";
+import { GET_BSDS } from "common/queries";
 
 const PUBLISH_BSDASRI = gql`
   mutation PublishBsdasri($id: ID!) {
@@ -23,11 +24,13 @@ const PUBLISH_BSDASRI = gql`
 `;
 
 export default function PublishBsdasri({ form, siret }: WorkflowActionProps) {
-  const [publishBsdasri, { error }] = useMutation<
+  const [publishBsdasri, { loading, error }] = useMutation<
     Pick<Mutation, "publishBsdasri">,
     MutationPublishBsdasriArgs
   >(PUBLISH_BSDASRI, {
     variables: { id: form.id },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success(`Bordereau ${form.id} publié`, { hideAfter: 5 });
     },
@@ -93,6 +96,7 @@ export default function PublishBsdasri({ form, siret }: WorkflowActionProps) {
               </Link>
             </>
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/DeleteModal.tsx
@@ -4,6 +4,8 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteBsffArgs } from "generated/graphql/types";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const DELETE_BSFF = gql`
   mutation DeleteBsff($id: ID!) {
@@ -23,11 +25,13 @@ export function DeleteBsffModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [deleteBsff] = useMutation<
+  const [deleteBsff, { loading }] = useMutation<
     Pick<Mutation, "deleteBsff">,
     MutationDeleteBsffArgs
   >(DELETE_BSFF, {
     variables: { id: formId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
@@ -57,6 +61,7 @@ export function DeleteBsffModal({
           <span> Supprimer</span>
         </button>
       </div>
+      {loading && <Loader />}
     </TdModal>
   );
 }

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PublishBsff.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PublishBsff.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationPublishBsffArgs } from "generated/graphql/types";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { TdModalTrigger } from "common/components/Modal";
 import { IconPaperWrite } from "common/components/Icons";
+import { GET_BSDS } from "common/queries";
 
 const PUBLISH_BSFF = gql`
   mutation PublishBsff($id: ID!) {
@@ -19,11 +20,13 @@ interface PublishBsffProps {
 }
 
 export function PublishBsff({ bsffId }: PublishBsffProps) {
-  const [publishBsff] = useMutation<
+  const [publishBsff, { loading }] = useMutation<
     Pick<Mutation, "publishBsff">,
     MutationPublishBsffArgs
   >(PUBLISH_BSFF, {
     variables: { id: bsffId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
   });
 
   const actionLabel = "Publier le bordereau";
@@ -54,6 +57,7 @@ export function PublishBsff({ bsffId }: PublishBsffProps) {
               <span>Publier le bordereau</span>
             </button>
           </div>
+          {loading && <Loader />}
         </>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
@@ -12,6 +12,7 @@ import { RedErrorMessage } from "common/components";
 import { NotificationError } from "common/components/Error";
 import { SIGN_BSFF } from "form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
+import { GET_BSDS } from "common/queries";
 
 const validationSchema = yup.object({
   signatureAuthor: yup
@@ -29,7 +30,7 @@ function SignEmissionForm({ bsff, onCancel }: SignEmissionFormProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF);
+  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <Formik

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
@@ -15,6 +15,7 @@ import { NotificationError } from "common/components/Error";
 import { SIGN_BSFF, UPDATE_BSFF_FORM } from "form/bsff/utils/queries";
 import { OPERATION } from "form/bsff/utils/constants";
 import { SignBsff } from "./SignBsff";
+import { GET_BSDS } from "common/queries";
 
 const validationSchema = yup.object({
   operationCode: yup
@@ -43,7 +44,7 @@ function SignOperationModal({ bsff, onCancel }: SignOperationModalProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF);
+  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   const loading = updateBsffResult.loading || signBsffResult.loading;
   const error = updateBsffResult.error ?? signBsffResult.error;

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
@@ -15,6 +15,7 @@ import DateInput from "form/common/components/custom-inputs/DateInput";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
 import { SIGN_BSFF, UPDATE_BSFF_FORM } from "form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
+import { GET_BSDS } from "common/queries";
 
 const validationSchema = yup.object({
   receptionDate: yup.date().required(),
@@ -42,7 +43,7 @@ function SignReceptionModal({ bsff, onCancel }: SignReceptionModalProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF);
+  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   const loading = updateBsffResult.loading || signBsffResult.loading;
   const error = updateBsffResult.error ?? signBsffResult.error;

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -12,6 +12,7 @@ import { RedErrorMessage } from "common/components";
 import { NotificationError } from "common/components/Error";
 import { SIGN_BSFF } from "form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
+import { GET_BSDS } from "common/queries";
 
 const validationSchema = yup.object({
   signatureAuthor: yup
@@ -29,7 +30,7 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF);
+  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <Formik

--- a/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/BSVhuActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/BSVhuActions.tsx
@@ -25,6 +25,7 @@ import { useDownloadPdf } from "./useDownloadPdf";
 import { useDuplicate } from "./useDuplicate";
 
 import styles from "../../BSDActions.module.scss";
+import { Loader } from "common/components";
 
 interface BSVhuActionsProps {
   form: Bsvhu;
@@ -34,7 +35,7 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
   const { siret } = useParams<{ siret: string }>();
   const location = useLocation();
 
-  const [duplicateBsvhu] = useDuplicate({
+  const [duplicateBsvhu, { loading: isDuplicating }] = useDuplicate({
     variables: { id: form.id },
   });
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -115,6 +116,7 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
           formId={form.id}
         />
       )}
+      {isDuplicating && <Loader />}
     </>
   );
 };

--- a/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/DeleteModal.tsx
@@ -4,6 +4,8 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteBsvhuArgs } from "generated/graphql/types";
 import cogoToast from "cogo-toast";
 import TdModal from "common/components/Modal";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 const DELETE_BSVHU = gql`
   mutation DeleteBsvhu($id: ID!) {
@@ -23,11 +25,13 @@ export function DeleteBsvhuModal({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const [deleteBsvhu] = useMutation<
+  const [deleteBsvhu, { loading }] = useMutation<
     Pick<Mutation, "deleteBsvhu">,
     MutationDeleteBsvhuArgs
   >(DELETE_BSVHU, {
     variables: { id: formId },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success("Bordereau supprimé", { hideAfter: 5 });
       !!onClose && onClose();
@@ -57,6 +61,7 @@ export function DeleteBsvhuModal({
           <span> Supprimer</span>
         </button>
       </div>
+      {loading && <Loader />}
     </TdModal>
   );
 }

--- a/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/useDuplicate.tsx
@@ -2,6 +2,7 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import cogoToast from "cogo-toast";
 import { Mutation, MutationDuplicateBsvhuArgs } from "generated/graphql/types";
 import { vhuFragment } from "common/fragments";
+import { GET_BSDS } from "common/queries";
 
 const DUPLICATE_BSVHU = gql`
   mutation DuplicateBsvhu($id: ID!) {
@@ -23,6 +24,8 @@ export function useDuplicate(
     MutationDuplicateBsvhuArgs
   >(DUPLICATE_BSVHU, {
     ...options,
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       cogoToast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/PublishBsvhu.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/PublishBsvhu.tsx
@@ -4,13 +4,14 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { gql, useMutation } from "@apollo/client";
 
 import { TdModalTrigger } from "common/components/Modal";
-import { ActionButton } from "common/components";
+import { ActionButton, Loader } from "common/components";
 import { IconPaperWrite } from "common/components/Icons";
 import { NotificationError } from "common/components/Error";
 
 import cogoToast from "cogo-toast";
 import { generatePath, Link } from "react-router-dom";
 import routes from "common/routes";
+import { GET_BSDS } from "common/queries";
 
 const PUBLISH_BSVHU = gql`
   mutation PublishBsvhu($id: ID!) {
@@ -22,11 +23,13 @@ const PUBLISH_BSVHU = gql`
 `;
 
 export default function PublishBsvhu({ form, siret }: WorkflowActionProps) {
-  const [publishBsvhu, { error }] = useMutation<
+  const [publishBsvhu, { loading, error }] = useMutation<
     Pick<Mutation, "publishBsvhu">,
     MutationPublishBsvhuArgs
   >(PUBLISH_BSVHU, {
     variables: { id: form.id },
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
     onCompleted: () => {
       cogoToast.success(`Bordereau ${form.id} publié`, { hideAfter: 5 });
     },
@@ -87,6 +90,7 @@ export default function PublishBsvhu({ form, siret }: WorkflowActionProps) {
               </Link>
             </>
           )}
+          {loading && <Loader />}
         </div>
       )}
     />

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignBsvhu.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignBsvhu.tsx
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client";
 import { ActionButton } from "common/components";
 import { IconCheckCircle1 } from "common/components/Icons";
-import React from "react";
+import React, { useState } from "react";
 import { SignBsvhuModal } from "./SignBsvhuModal";
 
 export const SIGN_BSVHU = gql`
@@ -20,7 +20,7 @@ type Props = {
 };
 
 export function SignBsvhu({ title, bsvhuId, children }: Props) {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -24,7 +25,7 @@ export function SignEmission({ siret, bsvhuId }: Props) {
   const [signBsvhu, { loading }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
-  >(SIGN_BSVHU);
+  >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <SignBsvhu title="Signer l'enlèvement" bsvhuId={bsvhuId}>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
 import Operation from "form/bsvhu/Operation";
 import { UPDATE_VHU_FORM } from "form/bsvhu/utils/queries";
@@ -31,7 +32,7 @@ export function SignOperation({ siret, bsvhuId }: Props) {
   const [signBsvhu, { loading }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
-  >(SIGN_BSVHU);
+  >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <SignBsvhu title="Signer le traitement" bsvhuId={bsvhuId}>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -24,7 +25,7 @@ export function SignTransport({ siret, bsvhuId }: Props) {
   const [signBsvhu, { loading }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
-  >(SIGN_BSVHU);
+  >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
     <SignBsvhu title="Signer l'enlèvement" bsvhuId={bsvhuId}>

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -44,6 +44,7 @@ import {
 } from "dashboard/detail/common/Components";
 import { WorkflowAction } from "dashboard/components/BSDList";
 import EditSegment from "./EditSegment";
+import { Loader } from "common/components";
 
 type CompanyProps = {
   company?: FormCompany | null;
@@ -328,7 +329,7 @@ export default function BSDDetailContent({
   const history = useHistory();
   const [isDeleting, setIsDeleting] = useState(false);
   const [downloadPdf] = useDownloadPdf({ variables: { id: form.id } });
-  const [duplicate] = useDuplicate({
+  const [duplicate, { loading: isDuplicating }] = useDuplicate({
     variables: { id: form.id },
     onCompleted: () => {
       history.push(
@@ -611,6 +612,7 @@ export default function BSDDetailContent({
           onClose={() => setIsDeleting(false)}
         />
       )}
+      {isDuplicating && <Loader />}
     </>
   );
 }

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery } from "@apollo/client";
 import cogoToast from "cogo-toast";
+import { Loader } from "common/components";
+import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
@@ -42,15 +44,21 @@ export default function BsdaStepsList(props: Props) {
     [formQuery.data]
   );
 
-  const [createdaForm] = useMutation<
+  const [createdaForm, { loading: creating }] = useMutation<
     Pick<Mutation, "createBsda">,
     MutationCreateBsdaArgs
-  >(CREATE_BSDA);
+  >(CREATE_BSDA, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
-  const [updatedaForm] = useMutation<
+  const [updatedaForm, { loading: updating }] = useMutation<
     Pick<Mutation, "updateBsda">,
     MutationUpdateBsdaArgs
-  >(UPDATE_BSDA);
+  >(UPDATE_BSDA, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+  });
 
   function saveForm(input: BsdaInput): Promise<any> {
     return formState.id
@@ -88,14 +96,17 @@ export default function BsdaStepsList(props: Props) {
   >[];
 
   return (
-    <GenericStepList
-      children={steps}
-      formId={props.formId}
-      formQuery={formQuery}
-      onSubmit={onSubmit}
-      initialValues={formState}
-      validationSchema={null}
-      initialStep={props.initialStep}
-    />
+    <>
+      <GenericStepList
+        children={steps}
+        formId={props.formId}
+        formQuery={formQuery}
+        onSubmit={onSubmit}
+        initialValues={formState}
+        validationSchema={null}
+        initialStep={props.initialStep}
+      />
+      {(creating || updating) && <Loader />}
+    </>
   );
 }

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Field, useFormikContext } from "formik";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Bsda } from "generated/graphql/types";

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -16,6 +16,8 @@ import { formSchema } from "./utils/schema";
 import GenericStepList from "../common/stepper/GenericStepList";
 import { CREATE_FORM, GET_FORM, UPDATE_FORM } from "./utils/queries";
 import { IStepContainerProps } from "../common/stepper/Step";
+import { GET_BSDS } from "common/queries";
+import { Loader } from "common/components";
 
 interface Props {
   children: ReactElement<IStepContainerProps>[];
@@ -38,15 +40,15 @@ export default function StepsList(props: Props) {
     formQuery.data,
   ]);
 
-  const [createForm] = useMutation<
+  const [createForm, { loading: creating }] = useMutation<
     Pick<Mutation, "createForm">,
     MutationCreateFormArgs
-  >(CREATE_FORM);
+  >(CREATE_FORM, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
-  const [updateForm] = useMutation<
+  const [updateForm, { loading: updating }] = useMutation<
     Pick<Mutation, "updateForm">,
     MutationUpdateFormArgs
-  >(UPDATE_FORM);
+  >(UPDATE_FORM, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   function saveForm(formInput: FormInput): Promise<any> {
     const { id, ...input } = formInput;
@@ -89,13 +91,16 @@ export default function StepsList(props: Props) {
   }
 
   return (
-    <GenericStepList
-      children={props.children}
-      formId={props.formId}
-      formQuery={formQuery}
-      onSubmit={onSubmit}
-      initialValues={formState}
-      validationSchema={formSchema}
-    />
+    <>
+      <GenericStepList
+        children={props.children}
+        formId={props.formId}
+        formQuery={formQuery}
+        onSubmit={onSubmit}
+        initialValues={formState}
+        validationSchema={formSchema}
+      />
+      {(creating || updating) && <Loader />}
+    </>
   );
 }


### PR DESCRIPTION
* mise à jour d'apollo client 
* utilisation du paramètre `refetchQueries: [GET_BSDS]` dans les mutations qui affectent la liste des bordereaux du dashboard. Cf https://www.apollographql.com/docs/react/data/mutations/#refetchqueries
* utilisation de [refresh: wait_for](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-refresh.html) dans les opérations d'indexation (create / update / delete) effectuées depuis l'UI pour que la recherche fonctionne immédiatement après la mutation. 
* ajout de loaders un peu partout 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Trello de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Trello](https://trello.com/c/oh42Tqsx)
