### PR TITLE
Change alerts email address recipient

### DIFF
--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -176,7 +176,7 @@ export async function warnIfUserCreatesTooManyCompanies(
         "Alerte: Grand mombre de compagnies créées par un même utilisateur",
       to: [
         {
-          email: "tech@trackdechets.beta.gouv.fr ",
+          email: "alerts@trackdechets.beta.gouv.fr ",
           name: "Equipe Trackdéchets"
         }
       ],


### PR DESCRIPTION
Les emails "Grand mombre de compagnies créées" sont envoyés vers un autre adresse pour éviter de créer des tickets inutilement.
