### PR TITLE
Le réglage d'autorisation d'emport direct de dasri est proposé à la création des entreprises

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# Next Release (~25/10)
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :boom: Breaking changes
+ 
+#### :bug: Corrections de bugs
+ 
+#### :nail_care: Améliorations
+
+- À la création d'une entreprise, le réglage "j'autorise l'emport direct de dasris" est proposé [PR 1006](https://github.com/MTES-MCT/trackdechets/pull/1006)
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2021.10.1] 04/10/2021
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -40,7 +40,8 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
     transporterReceiptId,
     traderReceiptId,
     vhuAgrementDemolisseurId,
-    vhuAgrementBroyeurId
+    vhuAgrementBroyeurId,
+    allowBsdasriTakeOverWithoutSignature
   } = companyInput;
   const ecoOrganismeAgreements =
     companyInput.ecoOrganismeAgreements?.map(a => a.href) || [];
@@ -95,7 +96,8 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
     verificationCode: randomNumber(5).toString(),
     ecoOrganismeAgreements: {
       set: ecoOrganismeAgreements
-    }
+    },
+    allowBsdasriTakeOverWithoutSignature
   };
 
   if (!!transporterReceiptId) {

--- a/back/src/companies/typeDefs/private/company.inputs.graphql
+++ b/back/src/companies/typeDefs/private/company.inputs.graphql
@@ -267,6 +267,11 @@ input PrivateCompanyInput {
   Liste des agréments de l'éco-organisme
   """
   ecoOrganismeAgreements: [URL!]
+
+  """
+  L'entreprise autorise l'enlèvement d'un Dasri sans sa signature
+  """
+  allowBsdasriTakeOverWithoutSignature: Boolean
 }
 
 input CompanyForVerificationWhere {

--- a/front/src/account/AccountCompanyAdd.module.scss
+++ b/front/src/account/AccountCompanyAdd.module.scss
@@ -33,6 +33,7 @@
   }
 
   .submit-form {
+   
     display: flex;
     justify-content: flex-end;
   }

--- a/front/src/dashboard/bsds/drafts/RouteBsdsDrafts.tsx
+++ b/front/src/dashboard/bsds/drafts/RouteBsdsDrafts.tsx
@@ -47,7 +47,7 @@ export function RouteBsdsDrafts() {
               </Link>
               ou dupliquer un bordereau déjà existant dans un autre onglet grâce
               à l'icône{" "}
-              <span style={{ display: "inline" }}>
+              <span className="tw-inline-flex tw-ml-1">
                 <IconDuplicateFile color="blueLight" />
               </span>
             </BlankslateDescription>

--- a/front/src/login/CompanyType.tsx
+++ b/front/src/login/CompanyType.tsx
@@ -74,7 +74,7 @@ export default function CompanyTypeField({
           {COMPANY_TYPES.map((companyType, idx) => (
             <div key={idx}>
               <label
-                style={{ display: "inline-block" }}
+                className="tw-flex tw-items-center"
                 key={companyType.value}
               >
                 <input

--- a/scripts/get-db-backup-link.js
+++ b/scripts/get-db-backup-link.js
@@ -73,7 +73,7 @@ function buildFetcher(API_KEY) {
       const req = https.request(options, (res) => {
         if (res.statusCode < 200 || res.statusCode >= 300) {
           console.log(res.statusMessage);
-          return reject(new Error(`${statusMessage} - code ${res.statusCode}`));
+          return reject(new Error(`${res.statusMessage} - code ${res.statusCode}`));
         }
 
         const data = [];


### PR DESCRIPTION
Les producteurs de dasris ne pensent pas à  aller cocher la case autorisant l'emport direct, les transporteurs se voient dans l'impossibilité d'emporter le déchet en l'absence du producteur . 
Désormais un producteur de dasri doit choisir à la création de l'entreprise

 
- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-4039)
