### PR TITLE
Gestion cas particulier transport multi modal

### DIFF
--- a/back/src/forms/errors.ts
+++ b/back/src/forms/errors.ts
@@ -82,14 +82,6 @@ export class DestinationCannotTempStore extends UserInputError {
   }
 }
 
-export class HasSegmentToTakeOverError extends UserInputError {
-  constructor() {
-    super(
-      "Vous ne pouvez pas passer ce bordereau à l'état souhaité, il n'est pas encore pris en charge par le dernier transporteur"
-    );
-  }
-}
-
 export class FormAlreadyInAppendix2 extends UserInputError {
   constructor() {
     super(

--- a/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
@@ -476,7 +476,7 @@ describe("Test Form reception", () => {
     expect(logs[0].status).toBe("ACCEPTED");
   });
 
-  it("should not mark as received a form with segment not taken over", async () => {
+  it("should delete stale transport segments not yet taken over after a reception occured", async () => {
     const {
       emitterCompany,
       recipient,
@@ -499,8 +499,8 @@ describe("Test Form reception", () => {
       }
     });
 
-    // this segment is still not yet taken over, the form should not be accepted
-    await transportSegmentFactory({
+    // this segment has not been taken over yet
+    const staleSegment = await transportSegmentFactory({
       formId: form.id,
       segmentPayload: { transporterCompanySiret: "7777", readyToTakeOver: true }
     });
@@ -511,6 +511,7 @@ describe("Test Form reception", () => {
 
     const { mutate } = makeClient(recipient);
 
+    // the truck finally goes directly to the destination
     await mutate(MARK_AS_RECEIVED, {
       variables: {
         id: form.id,
@@ -525,16 +526,15 @@ describe("Test Form reception", () => {
 
     const frm = await prisma.form.findUnique({ where: { id: form.id } });
 
-    expect(frm.status).toBe("SENT");
+    expect(frm.status).toBe("ACCEPTED");
 
-    // currentTransporterSiret was not cleaned up
-    expect(frm.currentTransporterSiret).toEqual("5678");
+    // currentTransporterSiret was cleaned up
+    expect(frm.currentTransporterSiret).toEqual("");
 
-    // A StatusLog object is created
-    const logs = await prisma.statusLog.findMany({
-      where: { form: { id: frm.id }, user: { id: recipient.id } }
+    const deleted = await prisma.transportSegment.findFirst({
+      where: { id: staleSegment.id }
     });
-    expect(logs.length).toBe(0);
+    expect(deleted).toEqual(null);
   });
 
   it("should fail if recipient is temp storage", async () => {


### PR DESCRIPTION
Dans le cas où un segment multi modal a été crée mais n'a pas été pris en charge (soit par erreur, soit parce que le plan de route a changé), l'installation de destination ne peut pas accepter la réception. 
Cette PR propose de supprimer les segments qui deviennent "obsolètes" lors de la réception. Si le dernier transporteur arrive à bon port, il n'y a pas lieu de bloquer la réception. 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6584)
