### PR TITLE
Limit transporter plates to 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Le nombre maximum de plaques d'immatriculations est limité à 2 sur les bsdasri et bsda [PR 1054](https://github.com/MTES-MCT/trackdechets/pull/1054)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -20900,31 +20900,41 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "yup": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.8.tgz",
-      "integrity": "sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==",
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
       "requires": {
-        "@babel/runtime": "^7.10.5",
-        "@types/lodash": "^4.14.165",
-        "lodash": "^4.17.20",
-        "lodash-es": "^4.17.11",
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "nanoclone": "^0.2.1",
         "property-expr": "^2.0.4",
         "toposort": "^2.0.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
+        "@types/lodash": {
+          "version": "4.14.176",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
+          "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ=="
+        },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "lodash-es": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+          "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         }
       }
     },

--- a/back/package.json
+++ b/back/package.json
@@ -97,7 +97,7 @@
     "winston-transport": "^4.3.0",
     "world-countries": "^4.0.0",
     "xstate": "^4.13.0",
-    "yup": "^0.32.8"
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@fast-csv/parse": "^4.3.0",

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -261,7 +261,7 @@ input BsdaRecepisseInput {
 input BsdaTransportInput {
   "Mode de transport"
   mode: TransportMode
-  "Plaque(s) d'immatriculation"
+  "Plaque(s) d'immatriculation - maximum 2"
   plates: [String!]
   "Date de prise en charge"
   takenOverAt: DateTime

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -82,6 +82,7 @@ type Transporter = Pick<
   | "transporterRecepisseNumber"
   | "transporterRecepisseDepartment"
   | "transporterRecepisseValidityLimit"
+  | "transporterTransportPlates"
 >;
 
 type WasteDescription = Pick<
@@ -504,7 +505,11 @@ const transporterSchema: FactorySchemaOf<
         context.transportSignature,
         `Transporteur: ${MISSING_COMPANY_EMAIL}`
       ),
-    transporterCompanyVatNumber: yup.string().nullable()
+    transporterCompanyVatNumber: yup.string().nullable(),
+    transporterTransportPlates: yup
+      .array()
+      .of(yup.string())
+      .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
   });
 
 const wasteDescriptionSchema: FactorySchemaOf<

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -11,6 +11,7 @@ input BsdasriTransporterWhere {
   company: CompanyWhere
   transport: BsdasriTransportWhere
 }
+
 input BsdasriTransportWhere {
   signature: SignatureWhere
 }
@@ -32,6 +33,7 @@ input BsdasriOperationWhere {
   signature: SignatureWhere
 }
 
+"Filtres possibles pour la récupération de bordereaux."
 input BsdasriWhere {
   "(Optionnel) Permet de récupérer uniquement les bordereaux en brouillon"
   isDraft: Boolean
@@ -120,16 +122,23 @@ input BsdasriEcoOrganismeInput {
 }
 
 input BsdasriWeightInput {
+  "Poids en kilogrammes"
   value: Float
+  "Le poids est il une estimation"
   isEstimate: Boolean
 }
+
 input BsdasriRealWeightInput {
+  "Poids en kilogrammes"
   value: Float!
 }
 
 input BsdasriAcceptationInput {
+  "Accepté, refusé ou refusé partiellement"
   status: WasteAcceptationStatusInput
+  "Raison en cas de refus ou refus partiel"
   refusalReason: String
+  "Poids en kilogrammes de déchets refusé"
   refusedWeight: Float
 }
 
@@ -138,14 +147,19 @@ input BsdasriTransportInput {
   packagings: [BsdasriPackagingsInput!]
   takenOverAt: DateTime
   handedOverAt: DateTime
+  "Mode de transport"
   acceptation: BsdasriAcceptationInput
   mode: TransportMode
+  "Plaque(s) d'immatriculation - maximum 2"
   plates: [String!]
 }
 
 input BsdasriRecepisseInput {
+  "Numéro de récépissé"
   number: String
+  "Département"
   department: String
+  "Date limite de validité"
   validityLimit: DateTime
 }
 
@@ -201,15 +215,20 @@ input BsdasriInput {
 
   destination: BsdasriDestinationInput
 
+  "Liste des bordereaux que celui-ci groupe"
   grouping: [ID!]
 }
 
 input BsdasriSignatureInput {
+  "Type de signature apposée"
   type: BsdasriSignatureType!
+  "Nom et prénom du signataire"
   author: String!
 }
 
 input BsdasriSignatureWithSecretCodeInput {
+  "Nom et prénom du signataire"
   author: String!
+  "Code de sécurité de l'entreprise pour laquelle on signe. Permet de signer en tant que. Optionnel"
   securityCode: Int!
 }

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -74,6 +74,7 @@ type Transport = Pick<
   | "transporterWasteWeightValue"
   | "transporterWasteWeightIsEstimate"
   | "handedOverToRecipientAt"
+  | "transporterTransportPlates"
 >;
 type Recipient = Pick<
   Prisma.BsdasriCreateInput,
@@ -441,7 +442,12 @@ export const transportSchema: FactorySchemaOf<
         context.transportSignature,
         "Le date de prise en charge du déchet est obligatoire"
       ),
-    handedOverToRecipientAt: yup.date().nullable() // optional field
+    handedOverToRecipientAt: yup.date().nullable(), // optional field
+
+    transporterTransportPlates: yup
+      .array()
+      .of(yup.string())
+      .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
   });
 
 export const recipientSchema: FactorySchemaOf<


### PR DESCRIPTION
Le bsdas et bsdasris peuvent recevoir plusieurs numéros de plaques d'immatriculation. Cette PR limite leur nombre à 2.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
 
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-2390) (feedback)
