### PR TITLE
Allow rate limit configuration

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -127,3 +127,6 @@ KIBANA_HOST=kibana.trackdechets.local
 GOTENBERG_URL=https://gotenberg.service.url
 # Gotenberg auth token
 GOTENBERG_TOKEN=A_SECRET_TOKEN
+
+# Rate limit
+MAX_REQUESTS_PER_WINDOW=1000 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+- Rend le rate limit configurable [PR 1056](https://github.com/MTES-MCT/trackdechets/pull/1056)
+
 # [2021.10.2] 25/10/2021
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -39,6 +39,7 @@ const {
   SESSION_COOKIE_SECURE,
   SESSION_NAME,
   UI_HOST,
+  MAX_REQUESTS_PER_WINDOW = "1000",
   NODE_ENV
 } = process.env;
 
@@ -108,12 +109,13 @@ if (Sentry) {
 }
 
 const RATE_LIMIT_WINDOW_SECONDS = 60;
-const MAX_REQUESTS_PER_WINDOW = 1000;
+const maxrequestPerWindows = parseInt(MAX_REQUESTS_PER_WINDOW, 10);
+
 app.use(
   rateLimit({
-    message: `Quota de ${MAX_REQUESTS_PER_WINDOW} requêtes par minute excédée pour cette adresse IP, merci de réessayer plus tard.`,
+    message: `Quota de ${maxrequestPerWindows} requêtes par minute excédée pour cette adresse IP, merci de réessayer plus tard.`,
     windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
-    max: MAX_REQUESTS_PER_WINDOW,
+    max: maxrequestPerWindows,
     store: new RateLimitRedisStore({
       client: redisClient,
       expiry: RATE_LIMIT_WINDOW_SECONDS


### PR DESCRIPTION
Rend le rate limit configurable pour le débrider lors des tests de montée en charge

- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
 
