### PR TITLE
Ajout de la création d'une entreprise anonyme via l'interface d'administration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Rend le rate limit configurable [PR 1056](https://github.com/MTES-MCT/trackdechets/pull/1056)
 - Le champ installation de CompanyPrivate est dans son propre resolver [PR 1059](https://github.com/MTES-MCT/trackdechets/pull/1059)
 - Mise à jour de l'utilitaire de restauration [PR 1060](https://github.com/MTES-MCT/trackdechets/pull/1060)
+- Ajout de la création d'une entreprise anonyme via le panneau d'administration [PR 1057](https://github.com/MTES-MCT/trackdechets/pull/1057)
 
 # [2021.10.2] 25/10/2021
 

--- a/back/src/applications/resolvers/mutations/createApplication.ts
+++ b/back/src/applications/resolvers/mutations/createApplication.ts
@@ -6,37 +6,34 @@ import prisma from "../../../prisma";
 import { getUid } from "../../../utils";
 import { ApplicationInputSchema } from "../../validation";
 
-const createApplicationResolver: MutationResolvers["createApplication"] = async (
-  _,
-  { input },
-  context
-) => {
-  applyAuthStrategies(context, [AuthType.Session]);
-  const user = checkIsAuthenticated(context);
+const createApplicationResolver: MutationResolvers["createApplication"] =
+  async (_, { input }, context) => {
+    applyAuthStrategies(context, [AuthType.Session]);
+    const user = checkIsAuthenticated(context);
 
-  if (user.applicationId) {
-    throw new UserInputError(
-      "Vous ne pouvez pas administrer plus d'une application."
-    );
-  }
-
-  await ApplicationInputSchema.validate(input, { abortEarly: false });
-
-  const application = await prisma.application.create({
-    data: {
-      name: input.name,
-      logoUrl: input.logoUrl,
-      redirectUris: input.redirectUris,
-      admins: {
-        connect: {
-          id: user.id
-        }
-      },
-      clientSecret: getUid(40)
+    if (user.applicationId) {
+      throw new UserInputError(
+        "Vous ne pouvez pas administrer plus d'une application."
+      );
     }
-  });
 
-  return application;
-};
+    await ApplicationInputSchema.validate(input, { abortEarly: false });
+
+    const application = await prisma.application.create({
+      data: {
+        name: input.name,
+        logoUrl: input.logoUrl,
+        redirectUris: input.redirectUris,
+        admins: {
+          connect: {
+            id: user.id
+          }
+        },
+        clientSecret: getUid(40)
+      }
+    });
+
+    return application;
+  };
 
 export default createApplicationResolver;

--- a/back/src/applications/validation.ts
+++ b/back/src/applications/validation.ts
@@ -1,8 +1,8 @@
 import * as yup from "yup";
 import { ApplicationInput } from "../generated/graphql/types";
 
-export const ApplicationInputSchema: yup.SchemaOf<ApplicationInput> = yup.object(
-  {
+export const ApplicationInputSchema: yup.SchemaOf<ApplicationInput> =
+  yup.object({
     name: yup.string().required(),
     logoUrl: yup
       .string()
@@ -18,5 +18,4 @@ export const ApplicationInputSchema: yup.SchemaOf<ApplicationInput> = yup.object
       )
       .required()
       .min(1, "Vous devez préciser au moins une URL de redirection")
-  }
-);
+  });

--- a/back/src/companies/resolvers/Mutation.ts
+++ b/back/src/companies/resolvers/Mutation.ts
@@ -19,6 +19,7 @@ import verifyCompanyByAdmin from "./mutations/verifyCompanyByAdmin";
 import sendVerificationCodeLetter from "./mutations/sendVerificationCodeLetter";
 import createTestCompany from "./mutations/createTestCompany";
 import deleteCompany from "./mutations/deleteCompany";
+import createAnonymousCompany from "./mutations/createAnonymousCompany";
 
 const Mutation: MutationResolvers = {
   createCompany,
@@ -40,7 +41,8 @@ const Mutation: MutationResolvers = {
   verifyCompanyByAdmin,
   sendVerificationCodeLetter,
   createTestCompany,
-  deleteCompany
+  deleteCompany,
+  createAnonymousCompany
 };
 
 export default Mutation;

--- a/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompany.integration.ts
@@ -92,7 +92,7 @@ describe("createAnonymousCompany", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `L'entreprise au SIRET "${validInput.siret}" est déjà connue de notre répertoire privée.`
+        message: `L'entreprise au SIRET "${validInput.siret}" est déjà connue de notre répertoire privé.`
       })
     ]);
   });

--- a/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompany.integration.ts
@@ -1,0 +1,99 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import {
+  Mutation,
+  MutationCreateAnonymousCompanyArgs
+} from "../../../../generated/graphql/types";
+import prisma from "../../../../prisma";
+import { userFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+const CREATE_ANONYMOUS_COMPANY = `
+  mutation CreateAnonymousCompany($input: AnonymousCompanyInput!) {
+    createAnonymousCompany(input: $input) {
+      id
+    }
+  }
+`;
+
+const validInput = {
+  address: "12 rue de la liberté",
+  codeCommune: "69000",
+  codeNaf: "0111Z",
+  name: "Acme",
+  siret: "12345678901234"
+};
+
+describe("createAnonymousCompany", () => {
+  afterEach(resetDatabase);
+
+  it("should create an anonymous company", async () => {
+    const user = await userFactory({ isAdmin: true });
+    const { mutate } = makeClient(user);
+
+    await mutate<
+      Pick<Mutation, "createAnonymousCompany">,
+      MutationCreateAnonymousCompanyArgs
+    >(CREATE_ANONYMOUS_COMPANY, { variables: { input: validInput } });
+
+    const anonymousCompany = await prisma.anonymousCompany.findUnique({
+      where: { siret: validInput.siret }
+    });
+    expect(anonymousCompany).toBeTruthy();
+  });
+
+  it("should prevent non-admin from creating an anonymous company", async () => {
+    const user = await userFactory({ isAdmin: false });
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate<
+      Pick<Mutation, "createAnonymousCompany">,
+      MutationCreateAnonymousCompanyArgs
+    >(CREATE_ANONYMOUS_COMPANY, { variables: { input: validInput } });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas administrateur"
+      })
+    ]);
+  });
+
+  it("should prevent creating an anonymous company with an unknown naf code", async () => {
+    const user = await userFactory({ isAdmin: true });
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate<
+      Pick<Mutation, "createAnonymousCompany">,
+      MutationCreateAnonymousCompanyArgs
+    >(CREATE_ANONYMOUS_COMPANY, {
+      variables: { input: { ...validInput, codeNaf: "abc" } }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le code NAF ne fait pas partie de la liste reconnue."
+      })
+    ]);
+  });
+
+  it("should prevent creating an anonymous company that already exists", async () => {
+    const user = await userFactory({ isAdmin: true });
+    const { mutate } = makeClient(user);
+
+    await prisma.anonymousCompany.create({
+      data: { ...validInput, libelleNaf: "Libellé NAF" }
+    });
+
+    const { errors } = await mutate<
+      Pick<Mutation, "createAnonymousCompany">,
+      MutationCreateAnonymousCompanyArgs
+    >(CREATE_ANONYMOUS_COMPANY, {
+      variables: { input: validInput }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: `L'entreprise au SIRET "${validInput.siret}" est déjà connue de notre répertoire privée.`
+      })
+    ]);
+  });
+});

--- a/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
@@ -40,7 +40,7 @@ const createAnonymousCompanyResolver: MutationResolvers["createAnonymousCompany"
   });
   if (existingAnonymousCompany) {
     throw new UserInputError(
-      `L'entreprise au SIRET "${input.siret}" est déjà connue de notre répertoire privée.`
+      `L'entreprise au SIRET "${input.siret}" est déjà connue de notre répertoire privé.`
     );
   }
 

--- a/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
@@ -1,0 +1,57 @@
+import * as yup from "yup";
+import { UserInputError } from "apollo-server-express";
+import {
+  AnonymousCompanyInput,
+  MutationResolvers
+} from "../../../generated/graphql/types";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { checkIsAdmin } from "../../../common/permissions";
+import prisma from "../../../prisma";
+import { nafCodes } from "../../../common/constants/NAF";
+
+const AnonymousCompanyInputSchema: yup.SchemaOf<AnonymousCompanyInput> = yup.object(
+  {
+    address: yup.string().required(),
+    codeCommune: yup.string().required(),
+    codeNaf: yup
+      .string()
+      .oneOf(
+        Object.keys(nafCodes),
+        "Le code NAF ne fait pas partie de la liste reconnue."
+      )
+      .required(),
+    name: yup.string().required(),
+    siret: yup.string().length(14).required()
+  }
+);
+
+const createAnonymousCompanyResolver: MutationResolvers["createAnonymousCompany"] = async (
+  parent,
+  { input },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  checkIsAdmin(context);
+
+  await AnonymousCompanyInputSchema.validate(input);
+
+  const existingAnonymousCompany = await prisma.anonymousCompany.findUnique({
+    where: { siret: input.siret }
+  });
+  if (existingAnonymousCompany) {
+    throw new UserInputError(
+      `L'entreprise au SIRET "${input.siret}" est déjà connue de notre répertoire privée.`
+    );
+  }
+
+  const anonymousCompany = await prisma.anonymousCompany.create({
+    data: {
+      ...input,
+      libelleNaf: nafCodes[input.codeNaf]
+    }
+  });
+
+  return anonymousCompany;
+};
+
+export default createAnonymousCompanyResolver;

--- a/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompany.ts
@@ -9,8 +9,8 @@ import { checkIsAdmin } from "../../../common/permissions";
 import prisma from "../../../prisma";
 import { nafCodes } from "../../../common/constants/NAF";
 
-const AnonymousCompanyInputSchema: yup.SchemaOf<AnonymousCompanyInput> = yup.object(
-  {
+const AnonymousCompanyInputSchema: yup.SchemaOf<AnonymousCompanyInput> =
+  yup.object({
     address: yup.string().required(),
     codeCommune: yup.string().required(),
     codeNaf: yup
@@ -22,36 +22,32 @@ const AnonymousCompanyInputSchema: yup.SchemaOf<AnonymousCompanyInput> = yup.obj
       .required(),
     name: yup.string().required(),
     siret: yup.string().length(14).required()
-  }
-);
-
-const createAnonymousCompanyResolver: MutationResolvers["createAnonymousCompany"] = async (
-  parent,
-  { input },
-  context
-) => {
-  applyAuthStrategies(context, [AuthType.Session]);
-  checkIsAdmin(context);
-
-  await AnonymousCompanyInputSchema.validate(input);
-
-  const existingAnonymousCompany = await prisma.anonymousCompany.findUnique({
-    where: { siret: input.siret }
   });
-  if (existingAnonymousCompany) {
-    throw new UserInputError(
-      `L'entreprise au SIRET "${input.siret}" est déjà connue de notre répertoire privé.`
-    );
-  }
 
-  const anonymousCompany = await prisma.anonymousCompany.create({
-    data: {
-      ...input,
-      libelleNaf: nafCodes[input.codeNaf]
+const createAnonymousCompanyResolver: MutationResolvers["createAnonymousCompany"] =
+  async (parent, { input }, context) => {
+    applyAuthStrategies(context, [AuthType.Session]);
+    checkIsAdmin(context);
+
+    await AnonymousCompanyInputSchema.validate(input);
+
+    const existingAnonymousCompany = await prisma.anonymousCompany.findUnique({
+      where: { siret: input.siret }
+    });
+    if (existingAnonymousCompany) {
+      throw new UserInputError(
+        `L'entreprise au SIRET "${input.siret}" est déjà connue de notre répertoire privé.`
+      );
     }
-  });
 
-  return anonymousCompany;
-};
+    const anonymousCompany = await prisma.anonymousCompany.create({
+      data: {
+        ...input,
+        libelleNaf: nafCodes[input.codeNaf]
+      }
+    });
+
+    return anonymousCompany;
+  };
 
 export default createAnonymousCompanyResolver;

--- a/back/src/companies/typeDefs/private/company.inputs.graphql
+++ b/back/src/companies/typeDefs/private/company.inputs.graphql
@@ -286,3 +286,11 @@ input VerifyCompanyByAdminInput {
 input SendVerificationCodeLetterInput {
   siret: String!
 }
+
+input AnonymousCompanyInput {
+  siret: String!
+  name: String!
+  codeNaf: String!
+  address: String!
+  codeCommune: String!
+}

--- a/back/src/companies/typeDefs/private/company.mutations.graphql
+++ b/back/src/companies/typeDefs/private/company.mutations.graphql
@@ -149,4 +149,6 @@ type Mutation {
   createTestCompany: String!
 
   deleteCompany(id: ID!): CompanyPrivate!
+
+  createAnonymousCompany(input: AnonymousCompanyInput!): AnonymousCompany!
 }

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -71,3 +71,13 @@ type CompanyForVerificationConnection {
   totalCount: Int!
   companies: [CompanyForVerification!]!
 }
+
+type AnonymousCompany {
+  id: String!
+  address: String!
+  codeCommune: String!
+  codeNaf: String!
+  libelleNaf: String!
+  name: String!
+  siret: String!
+}

--- a/front/src/admin/Admin.tsx
+++ b/front/src/admin/Admin.tsx
@@ -2,6 +2,7 @@ import SideMenu from "common/components/SideMenu";
 import routes from "common/routes";
 import React from "react";
 import { NavLink, Switch, Route, Redirect } from "react-router-dom";
+import { CreateAnonymousCompany } from "./anonymousCompany";
 import CompaniesVerification from "./verification/CompaniesVerification";
 
 /**
@@ -23,6 +24,15 @@ export default function Admin() {
                 Vérification
               </NavLink>
             </li>
+            <li className="tw-mb-1">
+              <NavLink
+                to={routes.admin.anonymousCompany}
+                className="sidebar__link"
+                activeClassName="sidebar__link--active"
+              >
+                Entreprise anonyme
+              </NavLink>
+            </li>
           </ul>
         </>
       </SideMenu>
@@ -30,6 +40,9 @@ export default function Admin() {
         <Switch>
           <Route exact path={routes.admin.verification}>
             <CompaniesVerification />
+          </Route>
+          <Route exact path={routes.admin.anonymousCompany}>
+            <CreateAnonymousCompany />
           </Route>
           <Redirect to={routes.admin.verification} />
         </Switch>

--- a/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
+++ b/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
@@ -1,0 +1,113 @@
+import * as React from "react";
+import { Formik, Form, Field } from "formik";
+import * as yup from "yup";
+import { gql, useMutation } from "@apollo/client";
+import cogoToast from "cogo-toast";
+import {
+  AnonymousCompanyInput,
+  Mutation,
+  MutationCreateAnonymousCompanyArgs,
+} from "generated/graphql/types";
+import { InlineError } from "common/components/Error";
+import { RedErrorMessage } from "common/components";
+
+const CREATE_ANONYMOUS_COMPANY = gql`
+  mutation CreateAnonymousCompany($input: AnonymousCompanyInput!) {
+    createAnonymousCompany(input: $input) {
+      siret
+    }
+  }
+`;
+
+const AnonymousCompanyInputSchema: yup.SchemaOf<AnonymousCompanyInput> = yup.object(
+  {
+    address: yup.string().required(),
+    codeCommune: yup.string().required(),
+    codeNaf: yup.string().required(),
+    name: yup.string().required(),
+    siret: yup.string().length(14).required(),
+  }
+);
+
+export function CreateAnonymousCompany() {
+  const [createAnonymousCompany, { loading, error }] = useMutation<
+    Pick<Mutation, "createAnonymousCompany">,
+    MutationCreateAnonymousCompanyArgs
+  >(CREATE_ANONYMOUS_COMPANY);
+
+  return (
+    <Formik
+      initialValues={{
+        address: "",
+        codeCommune: "",
+        codeNaf: "",
+        name: "",
+        siret: "",
+      }}
+      validationSchema={AnonymousCompanyInputSchema}
+      onSubmit={async values => {
+        await createAnonymousCompany({ variables: { input: values } });
+        cogoToast.success(
+          `L'entreprise au SIRET "${values.siret}" est maintenant connue de notre répertoire privé et peut être créé via l'interface.`,
+          { hideAfter: 6000 }
+        );
+      }}
+    >
+      {() => (
+        <Form>
+          <div className="form__row">
+            <label>
+              SIRET
+              <Field
+                name="siret"
+                placeholder="12345678901234"
+                className="td-input"
+              />
+            </label>
+            <RedErrorMessage name="siret" />
+          </div>
+          <div className="form__row">
+            <label>
+              Nom
+              <Field name="name" placeholder="Acme" className="td-input" />
+            </label>
+            <RedErrorMessage name="name" />
+          </div>
+          <div className="form__row">
+            <label>
+              Adresse
+              <Field
+                name="address"
+                placeholder="12 rue de la Liberté"
+                className="td-input"
+              />
+            </label>
+            <RedErrorMessage name="address" />
+          </div>
+          <div className="form__row">
+            <label>
+              Code NAF
+              <Field name="codeNaf" placeholder="8690D" className="td-input" />
+            </label>
+            <RedErrorMessage name="codeNaf" />
+          </div>
+          <div className="form__row">
+            <label>
+              Code commune
+              <Field
+                name="codeCommune"
+                placeholder="69000"
+                className="td-input"
+              />
+            </label>
+            <RedErrorMessage name="codeCommune" />
+          </div>
+          {error && <InlineError apolloError={error} />}
+          <button type="submit" className="btn btn--primary" disabled={loading}>
+            {loading ? "Création..." : "Créer"}
+          </button>
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
+++ b/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
@@ -45,8 +45,9 @@ export function CreateAnonymousCompany() {
         siret: "",
       }}
       validationSchema={AnonymousCompanyInputSchema}
-      onSubmit={async values => {
+      onSubmit={async (values, { resetForm }) => {
         await createAnonymousCompany({ variables: { input: values } });
+        resetForm();
         cogoToast.success(
           `L'entreprise au SIRET "${values.siret}" est maintenant connue de notre répertoire privé et peut être créée via l'interface.`,
           { hideAfter: 6 }

--- a/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
+++ b/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
@@ -49,7 +49,7 @@ export function CreateAnonymousCompany() {
         await createAnonymousCompany({ variables: { input: values } });
         cogoToast.success(
           `L'entreprise au SIRET "${values.siret}" est maintenant connue de notre répertoire privé et peut être créée via l'interface.`,
-          { hideAfter: 6000 }
+          { hideAfter: 6 }
         );
       }}
     >

--- a/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
+++ b/front/src/admin/anonymousCompany/CreateAnonymousCompany.tsx
@@ -48,7 +48,7 @@ export function CreateAnonymousCompany() {
       onSubmit={async values => {
         await createAnonymousCompany({ variables: { input: values } });
         cogoToast.success(
-          `L'entreprise au SIRET "${values.siret}" est maintenant connue de notre répertoire privé et peut être créé via l'interface.`,
+          `L'entreprise au SIRET "${values.siret}" est maintenant connue de notre répertoire privé et peut être créée via l'interface.`,
           { hideAfter: 6000 }
         );
       }}

--- a/front/src/admin/anonymousCompany/index.ts
+++ b/front/src/admin/anonymousCompany/index.ts
@@ -1,0 +1,1 @@
+export * from "./CreateAnonymousCompany";

--- a/front/src/common/routes.ts
+++ b/front/src/common/routes.ts
@@ -2,6 +2,7 @@ export default {
   admin: {
     index: "/admin",
     verification: "/admin/verification",
+    anonymousCompany: "/admin/anonymous-company",
   },
   login: "/login",
   invite: "/invite",


### PR DESCRIPTION
Cette PR vient répondre à une demande de plus en plus fréquente au support : la création d'un établissement non-diffusable. Elle ajoute un formulaire sur une page de l'administration qui permet de saisir les informations requises.

- [ ] ~Mettre à jour la documentation~
- [x] Mettre à jour le change log
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~
- [ ] ~S'assurer que la numérotation des nouvelles migrations est bien cohérente~

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6757)
