### PR TITLE
Améliorations BSVHU & BSDA, le retour du retour

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -140,6 +140,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Nombreuses améliorations et corrections de bugs sur les formulaires de création de bordereaux VHU et BSDA [PR 1058](https://github.com/MTES-MCT/trackdechets/pull/1058)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/bsda/__tests__/workflow.integration.ts
+++ b/back/src/bsda/__tests__/workflow.integration.ts
@@ -81,7 +81,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                   acceptationStatus: ACCEPTED
               }
               operation: {
-                  code: "R 13"
+                  code: "D 13"
                   date: "2020-06-30"
               }
           }
@@ -242,7 +242,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "R 13"
+                      code: "D 13"
                       date: "2020-06-30"
                   }
               }
@@ -432,7 +432,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "R 13"
+                      code: "D 13"
                       date: "2020-06-30"
                   }
               }

--- a/back/src/bsda/__tests__/workflow.integration.ts
+++ b/back/src/bsda/__tests__/workflow.integration.ts
@@ -51,7 +51,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
             weight: { isEstimate: true, value: 1.2 }
             destination: {
                 cap: "A cap"
-                plannedOperationCode: "D 13"
+                plannedOperationCode: "D 9"
                 company: {
                     siret: "${exutoireCompany.siret}"
                     name: "destination"
@@ -81,7 +81,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                   acceptationStatus: ACCEPTED
               }
               operation: {
-                  code: "D 13"
+                  code: "D 9"
                   date: "2020-06-30"
               }
           }
@@ -160,7 +160,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
               weight: { isEstimate: true, value: 1.2 }
               destination: {
                   cap: "A cap"
-                  plannedOperationCode: "D 13"
+                  plannedOperationCode: "D 9"
                   company: {
                       siret: "${destinationCompany.siret}"
                       name: "destination"
@@ -242,7 +242,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "D 13"
+                      code: "D 9"
                       date: "2020-06-30"
                   }
               }
@@ -331,7 +331,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                 }
                 destination: {
                     cap: "A cap"
-                    plannedOperationCode: "D 13"
+                    plannedOperationCode: "D 9"
                     company: {
                         siret: "${destinationCompany.siret}",
                         name: "destination"
@@ -432,7 +432,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "D 13"
+                      code: "D 9"
                       date: "2020-06-30"
                   }
               }

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -25,7 +25,8 @@ import {
   BsdaBroker,
   BsdaPickupSite,
   BsdaWeight,
-  BsdaEcoOrganisme
+  BsdaEcoOrganisme,
+  BsdaNextDestination
 } from "../generated/graphql/types";
 import { Prisma, Bsda as PrismaBsda } from "@prisma/client";
 
@@ -104,6 +105,19 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
         signature: nullIfNoValues<Signature>({
           author: form.destinationOperationSignatureAuthor,
           date: form.destinationOperationSignatureDate
+        }),
+        nextDestination: nullIfNoValues<BsdaNextDestination>({
+          company: nullIfNoValues<FormCompany>({
+            name: form.destinationOperationNextDestinationCompanyName,
+            siret: form.destinationOperationNextDestinationCompanySiret,
+            address: form.destinationOperationNextDestinationCompanyAddress,
+            contact: form.destinationOperationNextDestinationCompanyContact,
+            phone: form.destinationOperationNextDestinationCompanyPhone,
+            mail: form.destinationOperationNextDestinationCompanyMail
+          }),
+          cap: form.destinationOperationNextDestinationCap,
+          plannedOperationCode:
+            form.destinationOperationNextDestinationPlannedOperationCode
         })
       })
     }),

--- a/back/src/bsda/edition-rules.ts
+++ b/back/src/bsda/edition-rules.ts
@@ -49,11 +49,7 @@ const editableFields = {
     work: ifAwaitingSignature("WORK")
   },
   broker: ifAwaitingSignature("EMISSION"),
-  transporter: {
-    company: ifAwaitingSignature("EMISSION"),
-    recepisse: ifAwaitingSignature("TRANSPORT"),
-    transport: ifAwaitingSignature("TRANSPORT")
-  },
+  transporter: ifAwaitingSignature("TRANSPORT"),
   grouping: ifAwaitingSignature("EMISSION"),
   forwarding: ifAwaitingSignature("EMISSION")
 };

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -42,7 +42,7 @@ function getWhere(
 
   const siretsFilters = new Map<string, keyof typeof where>(
     Object.entries(formSirets)
-      .filter(([_, siret]) => !!siret)
+      .filter(([_, siret]) => Boolean(siret))
       .map(([actor, _]) => [actor, "isFollowFor"])
   );
   type Mapping = Map<string, keyof typeof where>;

--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -56,7 +56,7 @@ export const machine = Machine<never, Event>(
             },
             {
               target: BsdaStatus.AWAITING_CHILD,
-              cond: "hasChildBsda"
+              cond: "isGroupingOrReshipmentOperation"
             },
             {
               target: BsdaStatus.PROCESSED
@@ -78,10 +78,8 @@ export const machine = Machine<never, Event>(
         event.bsda?.workerWorkHasEmitterPaperSignature,
       isCollectedBy2010: (_, event) =>
         event.bsda?.type === BsdaType.COLLECTION_2710,
-      hasChildBsda: (_, event) =>
-        [BsdaType.GATHERING, BsdaType.RESHIPMENT].includes(
-          event.bsda?.type as any
-        )
+      isGroupingOrReshipmentOperation: (_, event) =>
+        ["D 13", "D 15"].includes(event.bsda?.destinationOperationCode)
     }
   }
 );

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -14,6 +14,7 @@ const SIGN_BSDA = `
 mutation SignBsda($id: ID!, $input: BsdaSignatureInput!) {
   signBsda(id: $id, input: $input) {
       id
+      status
   }
 }
 `;
@@ -518,6 +519,41 @@ describe("Mutation.Bsda.sign", () => {
       });
 
       expect(data.signBsda.id).toBeTruthy();
+    });
+
+    it("should mark as AWAITING_CHILD if operation code implies it", async () => {
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          emitterEmissionSignatureAuthor: "Emétteur",
+          emitterEmissionSignatureDate: new Date(),
+          workerWorkSignatureAuthor: "Worker",
+          workerWorkSignatureDate: new Date(),
+          transporterTransportSignatureAuthor: "Transporter",
+          transporterTransportSignatureDate: new Date(),
+          destinationCompanySiret: company.siret,
+          destinationOperationCode: "D 13"
+        }
+      });
+
+      const { mutate } = makeClient(user);
+      const { data } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "OPERATION",
+            author: user.name
+          }
+        }
+      });
+
+      expect(data.signBsda.id).toBeTruthy();
+      expect(data.signBsda.status).toBe(BsdaStatus.AWAITING_CHILD);
     });
 
     it("should allow destination to sign operation on intial bsda for déchetteries", async () => {

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -663,7 +663,7 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: ttr2.siret,
           transporterCompanySiret: transporter.siret,
           destinationCompanySiret: destination.siret,
-          destinationOperationCode: "D 10",
+          destinationOperationCode: "D 9",
           forwarding: { connect: { id: bsda2.id } }
         }
       });

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -641,7 +641,7 @@ describe("Mutation.Bsda.sign", () => {
           transporterCompanySiret: transporter.siret,
           destinationCompanySiret: ttr1.siret,
           status: BsdaStatus.AWAITING_CHILD,
-          destinationOperationCode: "D 13"
+          destinationOperationCode: "D 9"
         }
       });
 
@@ -651,7 +651,7 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: emitter.siret,
           transporterCompanySiret: transporter.siret,
           destinationCompanySiret: ttr2.siret,
-          destinationOperationCode: "D 13",
+          destinationOperationCode: "D 9",
           status: BsdaStatus.AWAITING_CHILD,
           forwarding: { connect: { id: bsda1.id } }
         }

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -641,7 +641,7 @@ describe("Mutation.Bsda.sign", () => {
           transporterCompanySiret: transporter.siret,
           destinationCompanySiret: ttr1.siret,
           status: BsdaStatus.AWAITING_CHILD,
-          destinationOperationCode: "R 13"
+          destinationOperationCode: "D 13"
         }
       });
 
@@ -651,7 +651,7 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: emitter.siret,
           transporterCompanySiret: transporter.siret,
           destinationCompanySiret: ttr2.siret,
-          destinationOperationCode: "R 13",
+          destinationOperationCode: "D 13",
           status: BsdaStatus.AWAITING_CHILD,
           forwarding: { connect: { id: bsda1.id } }
         }

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -47,6 +47,7 @@ function duplicateForm({
   destinationOperationSignatureAuthor,
   destinationOperationSignatureDate,
   destinationOperationDate,
+  wasteSealNumbers,
   ...rest
 }: Bsda) {
   return prisma.bsda.create({

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -76,7 +76,7 @@ export default async function sign(
     where: { id },
     data: {
       [signatureTypeInfos.dbAuthorKey]: input.author,
-      [signatureTypeInfos.dbDateKey]: new Date(input.date),
+      [signatureTypeInfos.dbDateKey]: new Date(input.date ?? Date.now()),
       isDraft: false,
       status: newStatus as BsdaStatus
     }

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -415,10 +415,17 @@ const destinationSchema: FactorySchemaOf<BsdaValidationContext, Destination> =
         ),
       destinationOperationCode: yup
         .string()
-        .requiredIf(
-          context.operationSignature,
-          `Entreprise de destination: vous devez préciser le code d'opétation réalisé`
-        ),
+        .oneOf(["D 5", "D 9","D 13","D 15", "", null])
+        .when("destinationReceptionAcceptationStatus", {
+          is: value => value === WasteAcceptationStatus.REFUSED,
+          then: schema =>
+            schema.sting().nullable(),
+          otherwise: schema =>
+            schema.requiredIf(
+              context.operationSignature,
+              `Entreprise de destination: vous devez préciser le code d'opétation réalisé`
+            )
+        }),
       destinationOperationDate: yup
         .date()
         .requiredIf(

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -415,11 +415,10 @@ const destinationSchema: FactorySchemaOf<BsdaValidationContext, Destination> =
         ),
       destinationOperationCode: yup
         .string()
-        .oneOf(["D 5", "D 9","D 13","D 15", "", null])
+        .oneOf(["D 5", "D 9", "D 13", "D 15", "", null])
         .when("destinationReceptionAcceptationStatus", {
           is: value => value === WasteAcceptationStatus.REFUSED,
-          then: schema =>
-            schema.sting().nullable(),
+          then: schema => schema.nullable(),
           otherwise: schema =>
             schema.requiredIf(
               context.operationSignature,

--- a/back/src/bsds/typeDefs/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/bsd.inputs.graphql
@@ -22,6 +22,9 @@ input CompanyInput {
 
   "Numéro de TVA intracommunautaire"
   vatNumber: String
+
+  "Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise"
+  country: String
 }
 
 "Filtre de date"

--- a/back/src/bsds/typeDefs/bsd.objects.graphql
+++ b/back/src/bsds/typeDefs/bsd.objects.graphql
@@ -32,7 +32,7 @@ type FormCompany {
   Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise :
   https://fr.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
-  Seul la destination ultérieure case 12 (`form.nextDestination.company`) peut être à l'étranger.
+  Utilisé uniquement lorsque l'entreprise est à l'étranger
   """
   country: String
 

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -69,7 +69,7 @@ export default async function sign(
     where: { id },
     data: {
       [signatureTypeInfos.dbAuthorKey]: input.author,
-      [signatureTypeInfos.dbDateKey]: new Date(input.date),
+      [signatureTypeInfos.dbDateKey]: new Date(input.date ?? Date.now()),
       isDraft: false, // If it was one, signing always "un-drafts" it,
       status: newStatus as BsvhuStatus
     }

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -10,7 +10,7 @@ type BsvhuEdge {
 }
 
 type BsvhuMetadata {
-  errors: [BsvhuError!]!
+  errors: [BsvhuError!]
 }
 
 type BsvhuError {

--- a/back/src/companies/resolvers/CompanyFavorite.ts
+++ b/back/src/companies/resolvers/CompanyFavorite.ts
@@ -14,6 +14,12 @@ const companyFavoriteResolvers: CompanyFavoriteResolvers = {
       .traderReceipt();
     return traderReceipt;
   },
+  brokerReceipt: async parent => {
+    const brokerReceipt = await prisma.company
+      .findUnique({ where: { siret: parent.siret } })
+      .brokerReceipt();
+    return brokerReceipt;
+  },
   vhuAgrementBroyeur: parent => {
     return prisma.company
       .findUnique({ where: { siret: parent.siret } })

--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -36,6 +36,7 @@ import {
   RouteBsvhusView,
   RouteBsffsView,
   RouteBSDDsView,
+  RouteBSDasView,
 } from "./detail";
 import { RouteTransportToCollect, RouteTransportCollected } from "./transport";
 
@@ -137,6 +138,9 @@ export default function Dashboard() {
             </Route>
             <Route path={routes.dashboard.bsvhus.view}>
               <RouteBsvhusView />
+            </Route>
+            <Route path={routes.dashboard.bsdas.view}>
+              <RouteBSDasView />
             </Route>
             <Route path={routes.dashboard.bsffs.view}>
               <RouteBsffsView />
@@ -271,6 +275,17 @@ export default function Dashboard() {
                   wide={true}
                 >
                   <RouteBsvhusView />
+                </Modal>
+              </Route>
+              <Route path={routes.dashboard.bsdas.view}>
+                <Modal
+                  onClose={() => history.goBack()}
+                  ariaLabel="Aperçu du bordereau"
+                  isOpen
+                  padding={false}
+                  wide={true}
+                >
+                  <RouteBSDasView />
                 </Modal>
               </Route>
               <Route path={routes.dashboard.bsffs.view}>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/BsdaWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/BsdaWasteSummary.tsx
@@ -48,11 +48,9 @@ export function BsdaWasteSummary({ bsda }: Props) {
       <DataListItem>
         <DataListTerm>Conditionnement</DataListTerm>
         <DataListDescription>
-          {bsda.packagings?.map(p => (
-            <span key={`${p.quantity}-${p.type}`}>
-              {p.quantity} {PACKAGINGS_NAMES[p.type]}
-            </span>
-          ))}
+          {bsda.packagings
+            ?.map(p => `${p.quantity} ${PACKAGINGS_NAMES[p.type]}`)
+            .join(", ")}
         </DataListDescription>
       </DataListItem>
     </DataList>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -69,6 +69,7 @@ export function SignOperation({ siret, bsdaId }: Props) {
               ...getComputedState(
                 {
                   destination: {
+                    plannedOperationCode: bsda.plannedOperationCode,
                     reception: {
                       date: new Date().toISOString(),
                       acceptationStatus: "ACCEPTED",

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/BsvhuWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/BsvhuWasteSummary.tsx
@@ -33,13 +33,13 @@ export function BsvhuWasteSummary({ bsvhu }: Props) {
         <DataListDescription>
           {bsvhu.destination?.reception?.quantity == null ? (
             <>
-              {bsvhu.quantity ?? 0} unité(s){" "}
-              {bsvhu.weight?.value && <>(tonne(s))</>}
+              {bsvhu.quantity ?? 0} unité(s) ({bsvhu.weight?.value || "?"}{" "}
+              tonne(s))
             </>
           ) : (
             <>
-              {bsvhu.destination.reception.quantity} unité(s){" "}
-              {bsvhu.destination.reception.weight && <>(tonne(s))</>}
+              {bsvhu.destination.reception.quantity} unité(s) (
+              {bsvhu.destination.reception.weight || "?"} tonne(s))
             </>
           )}
         </DataListDescription>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
@@ -28,7 +28,7 @@ export function SignEmission({ siret, bsvhuId }: Props) {
   >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   return (
-    <SignBsvhu title="Signer l'enlèvement" bsvhuId={bsvhuId}>
+    <SignBsvhu title="Signer" bsvhuId={bsvhuId}>
       {({ bsvhu, onClose }) =>
         bsvhu.metadata?.errors.some(
           error => error.requiredFor === SignatureTypeInput.Emission

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -7,6 +7,7 @@ import { UPDATE_VHU_FORM } from "form/bsvhu/utils/queries";
 import { getComputedState } from "form/common/stepper/GenericStepList";
 import { Field, Form, Formik } from "formik";
 import {
+  BsvhuDestinationType,
   Mutation,
   MutationSignBsvhuArgs,
   MutationUpdateBsvhuArgs,
@@ -29,7 +30,7 @@ export function SignOperation({ siret, bsvhuId }: Props) {
     Pick<Mutation, "updateBsvhu">,
     MutationUpdateBsvhuArgs
   >(UPDATE_VHU_FORM);
-  const [signBsvhu, { loading }] = useMutation<
+  const [signBsvhu, { loading, error }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
   >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
@@ -43,6 +44,7 @@ export function SignOperation({ siret, bsvhuId }: Props) {
             ...getComputedState(
               {
                 destination: {
+                  type: bsvhu.destination.type,
                   reception: {
                     date: new Date().toISOString(),
                     acceptationStatus: null,
@@ -102,6 +104,8 @@ export function SignOperation({ siret, bsvhuId }: Props) {
                 </label>
                 <RedErrorMessage name="author" />
               </div>
+
+              {error && <div className="error-message">{error.message}</div>}
 
               <div className="form__actions">
                 <button

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -7,7 +7,6 @@ import { UPDATE_VHU_FORM } from "form/bsvhu/utils/queries";
 import { getComputedState } from "form/common/stepper/GenericStepList";
 import { Field, Form, Formik } from "formik";
 import {
-  BsvhuDestinationType,
   Mutation,
   MutationSignBsvhuArgs,
   MutationUpdateBsvhuArgs,

--- a/front/src/dashboard/components/BSDList/BSVhu/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/index.tsx
@@ -51,7 +51,6 @@ export const COLUMNS: Record<
     accessor: vhu =>
       vhu.isDraft ? "Brouillon" : vhuVerboseStatuses[vhu["bsvhuStatus"]], // unable to use dot notation because of conflicting status fields
   },
-
   workflow: {
     accessor: () => null,
     Cell: ({ row }) => {

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -1,0 +1,330 @@
+import {
+  IconBSDa,
+  IconDuplicateFile,
+  IconRenewableEnergyEarth,
+  IconWarehouseDelivery,
+  IconWaterDam,
+} from "common/components/Icons";
+import routes from "common/routes";
+import { useDuplicate } from "dashboard/components/BSDList/BSDa/BSDaActions/useDuplicate";
+import { statusLabels } from "dashboard/constants";
+import styles from "dashboard/detail/common/BSDDetailContent.module.scss";
+import { DateRow, DetailRow } from "dashboard/detail/common/Components";
+import { getVerboseAcceptationStatus } from "dashboard/detail/common/utils";
+import { PACKAGINGS_NAMES } from "form/bsda/components/packagings/Packagings";
+import { Bsda, FormCompany } from "generated/graphql/types";
+import React from "react";
+import QRCodeIcon from "react-qr-code";
+import { generatePath, useHistory, useParams } from "react-router-dom";
+import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
+
+type CompanyProps = {
+  company?: FormCompany | null;
+  label: string;
+};
+const Company = ({ company, label }: CompanyProps) => (
+  <>
+    <dt>{label}</dt> <dd>{company?.name}</dd>
+    <dt>Siret</dt> <dd>{company?.siret}</dd>
+    <dt>Adresse</dt> <dd>{company?.address}</dd>
+    <dt>Tél</dt> <dd>{company?.phone}</dd>
+    <dt>Mél</dt> <dd>{company?.mail}</dd>
+    <dt>Contact</dt> <dd>{company?.contact}</dd>
+  </>
+);
+
+type SlipDetailContentProps = {
+  form: Bsda;
+  children?: React.ReactNode;
+  refetch?: () => void;
+};
+
+const Emitter = ({ form }: { form: Bsda }) => {
+  const { emitter } = form;
+  return (
+    <div className={styles.detailColumns}>
+      <div className={styles.detailGrid}>
+        <Company label="Émetteur" company={emitter?.company} />
+        <DetailRow value={emitter?.pickupSite?.name} label="Adresse collecte" />
+        <DetailRow value={emitter?.pickupSite?.name} label="Informations" />
+        {!!emitter?.pickupSite?.address && (
+          <>
+            <dt>Adresse</dt>
+            <dd>
+              {emitter?.pickupSite?.address} {emitter?.pickupSite?.postalCode}{" "}
+              {emitter?.pickupSite?.city}
+            </dd>
+          </>
+        )}
+      </div>
+      <div className={styles.detailGrid}>
+        <DateRow value={emitter?.emission?.signature?.date} label="Signé le" />
+        <DetailRow
+          value={emitter?.emission?.signature?.author}
+          label="Signé par"
+        />
+      </div>
+    </div>
+  );
+};
+
+const Worker = ({ form }: { form: Bsda }) => {
+  const { worker } = form;
+  return (
+    <div className={styles.detailColumns}>
+      <div className={styles.detailGrid}>
+        <Company label="Entreprise de travaux" company={worker?.company} />
+      </div>
+      <div className={styles.detailGrid}>
+        <DateRow value={worker?.work?.signature?.date} label="Signé le" />
+        <DetailRow value={worker?.work?.signature?.author} label="Signé par" />
+      </div>
+    </div>
+  );
+};
+
+const Transporter = ({ form }: { form: Bsda }) => {
+  const { transporter } = form;
+  return (
+    <>
+      <div className={styles.detailGrid}>
+        <Company label="Transporteur" company={transporter?.company} />
+      </div>
+      <div className={styles.detailGrid}>
+        <DetailRow
+          value={transporter?.recepisse?.number}
+          label="Numéro de récépissé"
+        />
+        <DetailRow
+          value={transporter?.recepisse?.department}
+          label="Département"
+        />
+        <DateRow
+          value={transporter?.recepisse?.validityLimit}
+          label="Date de validité"
+        />
+      </div>
+      <div className={`${styles.detailGrid} `}>
+        <DateRow
+          value={transporter?.transport?.takenOverAt}
+          label="Emporté le"
+        />
+
+        <DateRow
+          value={transporter?.transport?.signature?.date}
+          label="Signé le"
+        />
+        <DetailRow
+          value={transporter?.transport?.signature?.author}
+          label="Signé par"
+        />
+        <DetailRow
+          value={transporter?.customInfo}
+          label="Informations tranporteur"
+        />
+      </div>
+    </>
+  );
+};
+
+const Recipient = ({ form }: { form: Bsda }) => {
+  const { destination } = form;
+
+  return (
+    <>
+      <div className={styles.detailGrid}>
+        <Company label="Destinataire" company={destination?.company} />
+      </div>
+      <div className={styles.detailGrid}>
+        <DetailRow
+          value={destination?.reception?.weight}
+          label="Poids reçu"
+          units="kg"
+        />
+      </div>
+      <div className={styles.detailGrid}>
+        <DetailRow
+          value={getVerboseAcceptationStatus(
+            destination?.reception?.acceptationStatus
+          )}
+          label="Lot accepté"
+        />
+        <DetailRow
+          value={destination?.reception?.refusalReason}
+          label="Motif de refus"
+        />
+        <DetailRow
+          value={destination?.reception?.signature?.author}
+          label="Réception signée par"
+        />
+        <DateRow
+          value={destination?.reception?.signature?.date}
+          label="Réception signée le"
+        />
+      </div>
+      <div className={styles.detailGrid}>
+        <DetailRow
+          value={destination?.operation?.code}
+          label="Opération de traitement"
+        />
+        <DateRow
+          value={destination?.operation?.date}
+          label="Traitement effectué le"
+        />
+
+        <DetailRow
+          value={destination?.operation?.signature?.author}
+          label="Traitement signé par"
+        />
+        <DateRow
+          value={destination?.operation?.signature?.date}
+          label="Traitement signé le"
+        />
+        <DetailRow
+          value={destination?.customInfo}
+          label="Informations destinataire"
+        />
+      </div>
+    </>
+  );
+};
+
+export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
+  const { siret } = useParams<{ siret: string }>();
+  const history = useHistory();
+
+  const [duplicate] = useDuplicate({
+    variables: { id: form.id },
+    onCompleted: () => {
+      history.push(
+        generatePath(routes.dashboard.bsds.drafts, {
+          siret,
+        })
+      );
+    },
+  });
+  return (
+    <div className={styles.detail}>
+      <div className={styles.detailSummary}>
+        <h4 className={styles.detailTitle}>
+          <IconBSDa className="tw-mr-2" />
+          <span className={styles.detailStatus}>
+            [{form.isDraft ? "Brouillon" : statusLabels[form["bsdaStatus"]]}]
+          </span>
+          {!form.isDraft && <span>{form.id}</span>}
+          {!!form?.grouping?.length && <span>Bordereau de groupement</span>}
+        </h4>
+
+        <div className={styles.detailContent}>
+          <div className={`${styles.detailQRCodeIcon}`}>
+            {!form.isDraft && (
+              <div className={styles.detailQRCode}>
+                <QRCodeIcon value={form.id} size={96} />
+                <span>Ce QR code contient le numéro du bordereau </span>
+              </div>
+            )}
+          </div>
+          <div className={styles.detailGrid}>
+            <DateRow
+              value={form.updatedAt}
+              label="Dernière action sur le BSD"
+            />
+            <dt>Code déchet</dt>
+            <dd>{form.waste?.code}</dd>
+            <dt>Description du déchet</dt>
+            <dd>
+              {form.waste?.name} {form.waste?.materialName}{" "}
+              {form.waste?.familyCode}
+            </dd>
+          </div>
+
+          <div className={styles.detailGrid}>
+            <dt>Code onu</dt>
+            <dd>{form?.waste?.adr}</dd>
+
+            <dt>Conditionnement</dt>
+            <dd>
+              {form?.packagings
+                ?.map(p => `${p.quantity} ${PACKAGINGS_NAMES[p.type]}`)
+                .join(", ")}
+            </dd>
+
+            <dt>Scellés</dt>
+            <dd>{form?.waste?.sealNumbers?.join(", ")}</dd>
+          </div>
+
+          <div className={styles.detailGrid}>
+            {form?.grouping?.length && (
+              <>
+                <dt>Bordereau groupés:</dt>
+                <dd> {form?.grouping?.join(", ")}</dd>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Tabs selectedTabClassName={styles.detailTabSelected}>
+        {/* Tabs menu */}
+        <TabList className={styles.detailTabs}>
+          <Tab className={styles.detailTab}>
+            <IconWaterDam size="25px" />
+            <span className={styles.detailTabCaption}>Producteur</span>
+          </Tab>
+
+          <Tab className={styles.detailTab}>
+            <IconWaterDam size="25px" />
+            <span className={styles.detailTabCaption}>
+              Entreprise de travaux
+            </span>
+          </Tab>
+
+          <Tab className={styles.detailTab}>
+            <IconWarehouseDelivery size="25px" />
+            <span className={styles.detailTabCaption}>
+              <span> Transporteur</span>
+            </span>
+          </Tab>
+
+          <Tab className={styles.detailTab}>
+            <IconRenewableEnergyEarth size="25px" />
+            <span className={styles.detailTabCaption}>Destinataire</span>
+          </Tab>
+        </TabList>
+        {/* Tabs content */}
+        <div className={styles.detailTabPanels}>
+          {/* Emitter tab panel */}
+          <TabPanel className={styles.detailTabPanel}>
+            <Emitter form={form} />
+          </TabPanel>
+
+          {/* Worker tab panel */}
+          <TabPanel className={styles.detailTabPanel}>
+            <Worker form={form} />
+          </TabPanel>
+
+          {/* Transporter tab panel */}
+          <TabPanel className={styles.detailTabPanel}>
+            <Transporter form={form} />
+          </TabPanel>
+
+          {/* Recipient  tab panel */}
+          <TabPanel className={styles.detailTabPanel}>
+            <div className={styles.detailColumns}>
+              <Recipient form={form} />
+            </div>
+          </TabPanel>
+        </div>
+      </Tabs>
+      <div className={styles.detailActions}>
+        <button
+          className="btn btn--outline-primary"
+          onClick={() => duplicate()}
+        >
+          <IconDuplicateFile size="24px" color="blueLight" />
+          <span>Dupliquer</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/front/src/dashboard/detail/bsda/RouteBSDasView.tsx
+++ b/front/src/dashboard/detail/bsda/RouteBSDasView.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import BsdaDetailContent from "./BsdaDetailContent";
+import Loader from "common/components/Loaders";
+import { useQuery } from "@apollo/client";
+import { Query, QueryBsdaArgs } from "generated/graphql/types";
+import { useParams } from "react-router-dom";
+import { InlineError } from "common/components/Error";
+import EmptyDetail from "dashboard/detail/common/EmptyDetailView";
+import { GET_BSDA } from "form/bsda/stepper/queries";
+
+export function RouteBSDasView() {
+  const { id: formId } = useParams<{ id: string }>();
+  const { error, data, loading } = useQuery<Pick<Query, "bsda">, QueryBsdaArgs>(
+    GET_BSDA,
+    {
+      variables: {
+        id: formId,
+      },
+      skip: !formId,
+      fetchPolicy: "network-only",
+    }
+  );
+
+  if (error) {
+    return <InlineError apolloError={error} />;
+  }
+  if (loading) {
+    return <Loader />;
+  }
+  if (data == null) {
+    return <EmptyDetail />;
+  }
+
+  return <BsdaDetailContent form={data.bsda} />;
+}

--- a/front/src/dashboard/detail/bsda/index.ts
+++ b/front/src/dashboard/detail/bsda/index.ts
@@ -1,0 +1,1 @@
+export * from "./RouteBSDasView";

--- a/front/src/dashboard/detail/index.ts
+++ b/front/src/dashboard/detail/index.ts
@@ -2,3 +2,4 @@ export * from "./bsdasri";
 export * from "./bsdd";
 export * from "./bsvhu";
 export * from "./bsff";
+export * from "./bsda";

--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -10,18 +10,27 @@ import {
 } from "common/components";
 import { GET_BSDAS } from "form/bsda/stepper/queries";
 import { FieldArray, useField } from "formik";
-import { BsdaStatus, Query, QueryBsdasArgs } from "generated/graphql/types";
+import {
+  BsdaStatus,
+  CompanyInput,
+  Query,
+  QueryBsdasArgs,
+} from "generated/graphql/types";
 import React from "react";
 
-type Props = { singleSelect: boolean; name: string };
-export function BsdaPicker({ singleSelect, name }: Props) {
+type Props = { singleSelect: boolean; name: string; code: string };
+export function BsdaPicker({ singleSelect, name, code }: Props) {
   const { data } = useQuery<Pick<Query, "bsdas">, QueryBsdasArgs>(GET_BSDAS, {
     variables: {
       where: {
         status: { _eq: BsdaStatus.AwaitingChild },
+        destination: { operation: { code: { _eq: code } } },
       },
     },
   });
+  const [emitter, , { setValue: setEmitterCompany }] = useField<CompanyInput>(
+    "emitter.company"
+  );
 
   const [{ value: associations }] = useField<string[]>(name);
 
@@ -62,6 +71,11 @@ export function BsdaPicker({ singleSelect, name }: Props) {
 
                     if (singleSelect) pop();
                     push(bsda.id);
+
+                    if (!emitter && bsda.destination?.company) {
+                      const { country, ...company } = bsda.destination.company;
+                      setEmitterCompany(company);
+                    }
                   }}
                 >
                   <TableCell>

--- a/front/src/form/bsda/stepper/initial-state.ts
+++ b/front/src/form/bsda/stepper/initial-state.ts
@@ -54,9 +54,7 @@ export default {
     plannedOperationCode: "",
     company: getInitialCompany(),
     operation: {
-      nextDestination: {
-        company: getInitialCompany(),
-      },
+      nextDestination: null,
     },
   },
   grouping: [],

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -1,13 +1,29 @@
-import React, { useState } from "react";
+import React from "react";
 import { Field, useFormikContext } from "formik";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Bsda } from "generated/graphql/types";
+import { getInitialCompany } from "form/bsdd/utils/initial-state";
 
 export function Destination({ disabled }) {
-  const { values } = useFormikContext<Bsda>();
-  const [hasNextDestination, setHasNextDestination] = useState(
-    Boolean(values.destination?.operation?.nextDestination?.company?.siret)
+  const { values, setFieldValue } = useFormikContext<Bsda>();
+  const hasNextDestination = Boolean(
+    values.destination?.operation?.nextDestination
   );
+
+  function onNextDestinationToggle() {
+    console.log(hasNextDestination);
+    if (hasNextDestination) {
+      setFieldValue("destination.operation.nextDestination", null);
+    } else {
+      setFieldValue(
+        "destination.operation.nextDestination",
+        {
+          company: getInitialCompany(),
+        },
+        false
+      );
+    }
+  }
 
   return (
     <>
@@ -27,7 +43,7 @@ export function Destination({ disabled }) {
         <label>
           <input
             type="checkbox"
-            onChange={() => setHasNextDestination(!hasNextDestination)}
+            onChange={onNextDestinationToggle}
             disabled={disabled}
             checked={hasNextDestination}
             className="td-checkbox"
@@ -57,7 +73,7 @@ export function Destination({ disabled }) {
           disabled={disabled}
         >
           <option />
-          {values.destination?.operation?.nextDestination?.company?.siret ? (
+          {hasNextDestination ? (
             <>
               <option value="D 13">D 13 - Groupement de déchets</option>
               <option value="D 15">D 15 - Entreposage provisoire</option>

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -36,16 +36,6 @@ export function Destination({ disabled }) {
         </label>
       </div>
 
-      {hasNextDestination && (
-        <>
-          <CompanySelector
-            disabled={disabled}
-            name="destination.operation.nextDestination.company"
-            heading="Exutoire final prévu"
-          />
-        </>
-      )}
-
       <div className="form__row">
         <label>
           N° CAP:
@@ -67,19 +57,67 @@ export function Destination({ disabled }) {
           disabled={disabled}
         >
           <option />
-          <option value="D 5">
-            D 5 - Mise en décharge aménagée et autorisée en ISDD
-          </option>
-          <option value="D 5">
-            D 5 - Mise en décharge aménagée et autorisée en ISDND
-          </option>
-          <option value="D 9">D 9 - Vitrification</option>
-          <option value="D 9">D 9 - Traitement chimique</option>
-          <option value="D 9">D 9 - Prétraitement</option>
-          <option value="D 13">D 13 - Groupement de déchets</option>
-          <option value="D 15">D 15 - Entreposage provisoire</option>
+          {values.destination?.operation?.nextDestination?.company?.siret ? (
+            <>
+              <option value="D 13">D 13 - Groupement de déchets</option>
+              <option value="D 15">D 15 - Entreposage provisoire</option>
+            </>
+          ) : (
+            <>
+              <option value="D 5">
+                D 5 - Mise en décharge aménagée et autorisée en ISDD ou ISDND
+              </option>
+              <option value="D 9">
+                D 9 - Vitrification, traitement chimique ou prétraitement
+              </option>
+            </>
+          )}
         </Field>
       </div>
+
+      {hasNextDestination && (
+        <>
+          <CompanySelector
+            disabled={disabled}
+            name="destination.operation.nextDestination.company"
+            heading="Exutoire final prévu"
+          />
+
+          <div className="form__row">
+            <label>
+              N° CAP:
+              <Field
+                disabled={disabled}
+                type="text"
+                name="destination.operation.nextDestination.cap"
+                className="td-input td-input--medium"
+              />
+            </label>
+          </div>
+
+          <div className="form__row">
+            <label>
+              Opération d’élimination / valorisation prévue (code D/R)
+            </label>
+            <Field
+              as="select"
+              name="destination.operation.nextDestination.plannedOperationCode"
+              className="td-select"
+              disabled={disabled}
+            >
+              <option />
+              <option value="D 5">
+                D 5 - Mise en décharge aménagée et autorisée en ISDD ou ISDND
+              </option>
+              <option value="D 9">
+                D 9 - Vitrification, traitement chimique ou prétraitement
+              </option>
+              <option value="D 13">D 13 - Groupement de déchets</option>
+              <option value="D 15">D 15 - Entreposage provisoire</option>
+            </Field>
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/front/src/form/bsda/stepper/steps/Emitter.tsx
+++ b/front/src/form/bsda/stepper/steps/Emitter.tsx
@@ -86,7 +86,7 @@ export function Emitter({ disabled }) {
       <WorkSite
         switchLabel="Je souhaite ajouter une adresse de chantier ou de collecte"
         headingTitle="Adresse chantier"
-        designation="de l'entreprise"
+        designation="du chantier"
         getInitialEmitterWorkSiteFn={getInitialEmitterPickupSite}
         disabled={disabled}
         modelKey="pickupSite"

--- a/front/src/form/bsda/stepper/steps/Operation.tsx
+++ b/front/src/form/bsda/stepper/steps/Operation.tsx
@@ -63,55 +63,58 @@ export default function Operation() {
           </div>
         ) : null}
       </div>
+      {values.destination?.reception?.acceptationStatus !== "REFUSED" && (
+        <>
+          <h4 className="form__section-heading">Quantité</h4>
 
-      <h4 className="form__section-heading">Quantité</h4>
+          <div className="form__row">
+            <label>
+              Quantité présentée
+              <Field
+                component={NumberInput}
+                name="destination.reception.weight"
+                className="td-input td-input--small"
+              />
+            </label>
 
-      <div className="form__row">
-        <label>
-          Quantité présentée
-          <Field
-            component={NumberInput}
-            name="destination.reception.weight"
-            className="td-input td-input--small"
-          />
-        </label>
+            <RedErrorMessage name="destination.reception.weight" />
+          </div>
 
-        <RedErrorMessage name="destination.reception.weight" />
-      </div>
+          <h4 className="form__section-heading">Opération</h4>
+          <div className="form__row">
+            <label>
+              Date de l'opération
+              <Field
+                component={DateInput}
+                name="destination.operation.date"
+                className={`td-input td-input--small`}
+              />
+            </label>
 
-      <h4 className="form__section-heading">Opération</h4>
-      <div className="form__row">
-        <label>
-          Date de l'opération
-          <Field
-            component={DateInput}
-            name="destination.operation.date"
-            className={`td-input td-input--small`}
-          />
-        </label>
+            <RedErrorMessage name="destination.operation.date" />
+          </div>
 
-        <RedErrorMessage name="destination.operation.date" />
-      </div>
-
-      <div className="form__row">
-        <label>Opération d’élimination / valorisation effectuée</label>
-        <Field
-          as="select"
-          name="destination.operation.code"
-          className="td-select"
-        >
-          <option value="...">Sélectionnez une valeur...</option>
-          <option value="D 5">
-            D 5 - Mise en décharge aménagée et autorisée en ISDD ou ISDND
-          </option>
-          <option value="D 9">
-            D 9 - Vitrification, traitement chimique ou prétraitement
-          </option>
-          <option value="D 13">D 13 - Groupement de déchets</option>
-          <option value="D 15">D 15 - Entreposage provisoire</option>
-        </Field>
-        <p>Opération prévue: {values.destination?.plannedOperationCode}</p>
-      </div>
+          <div className="form__row">
+            <label>Opération d’élimination / valorisation effectuée</label>
+            <Field
+              as="select"
+              name="destination.operation.code"
+              className="td-select"
+            >
+              <option value="...">Sélectionnez une valeur...</option>
+              <option value="D 5">
+                D 5 - Mise en décharge aménagée et autorisée en ISDD ou ISDND
+              </option>
+              <option value="D 9">
+                D 9 - Vitrification, traitement chimique ou prétraitement
+              </option>
+              <option value="D 13">D 13 - Groupement de déchets</option>
+              <option value="D 15">D 15 - Entreposage provisoire</option>
+            </Field>
+            <p>Opération prévue: {values.destination?.plannedOperationCode}</p>
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/front/src/form/bsda/stepper/steps/Operation.tsx
+++ b/front/src/form/bsda/stepper/steps/Operation.tsx
@@ -110,6 +110,7 @@ export default function Operation() {
           <option value="D 13">D 13 - Groupement de déchets</option>
           <option value="D 15">D 15 - Entreposage provisoire</option>
         </Field>
+        <p>Opération prévue: {values.destination?.plannedOperationCode}</p>
       </div>
     </>
   );

--- a/front/src/form/bsda/stepper/steps/Type.tsx
+++ b/front/src/form/bsda/stepper/steps/Type.tsx
@@ -1,7 +1,7 @@
 import { BsdaPicker } from "form/bsda/components/bsdaPicker/BsdaPicker";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import { Field, useField } from "formik";
-import { BsdaType } from "generated/graphql/types";
+import { BsdaType, CompanyInput } from "generated/graphql/types";
 import React from "react";
 
 type Props = { disabled: boolean };
@@ -50,10 +50,10 @@ export function Type({ disabled }: Props) {
         ))}
       </div>
       {BsdaType.Gathering === type && (
-        <BsdaPicker singleSelect={false} name="grouping" />
+        <BsdaPicker singleSelect={false} name="grouping" code="D 13" />
       )}
       {BsdaType.Reshipment === type && (
-        <BsdaPicker singleSelect={true} name="forwarding" />
+        <BsdaPicker singleSelect={true} name="forwarding" code="D 15" />
       )}
     </>
   );

--- a/front/src/form/bsda/stepper/steps/Type.tsx
+++ b/front/src/form/bsda/stepper/steps/Type.tsx
@@ -1,7 +1,7 @@
 import { BsdaPicker } from "form/bsda/components/bsdaPicker/BsdaPicker";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import { Field, useField } from "formik";
-import { BsdaType, CompanyInput } from "generated/graphql/types";
+import { BsdaType } from "generated/graphql/types";
 import React from "react";
 
 type Props = { disabled: boolean };

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -51,6 +51,7 @@ export function getInitialCompany(company?: FormCompany | null) {
     mail: company?.mail ?? "",
     phone: company?.phone ?? "",
     vatNumber: company?.vatNumber ?? "",
+    country: company?.country ?? "",
   };
 }
 

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -34,6 +34,7 @@ const companySchema: yup.SchemaOf<CompanyInput> = yup.object({
   phone: yup.string().required(),
   siret: yup.string().required(),
   vatNumber: yup.string().nullable(),
+  country: yup.string().nullable(),
 });
 const detenteurSchema: yup.SchemaOf<
   BsffFicheInterventionInput["detenteur"]

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -1,7 +1,11 @@
-import * as React from "react";
 import { gql, useMutation } from "@apollo/client";
-import { Formik, Form, Field } from "formik";
-import * as yup from "yup";
+import { Modal, RedErrorMessage } from "common/components";
+import { NotificationError } from "common/components/Error";
+import { IconClose } from "common/components/Icons";
+import { getInitialCompany } from "form/bsdd/utils/initial-state";
+import CompanySelector from "form/common/components/company/CompanySelector";
+import NumberInput from "form/common/components/custom-inputs/NumberInput";
+import { Field, Form, Formik } from "formik";
 import {
   BsffFicheIntervention,
   BsffFicheInterventionInput,
@@ -9,12 +13,9 @@ import {
   Mutation,
   MutationCreateFicheInterventionBsffArgs,
 } from "generated/graphql/types";
-import { Modal, RedErrorMessage } from "common/components";
-import { IconClose } from "common/components/Icons";
-import NumberInput from "form/common/components/custom-inputs/NumberInput";
-import CompanySelector from "form/common/components/company/CompanySelector";
-import { getInitialCompany } from "form/bsdd/utils/initial-state";
-import { NotificationError } from "common/components/Error";
+import * as React from "react";
+import countries from "world-countries";
+import * as yup from "yup";
 import { FicheInterventionFragment } from "./utils/queries";
 
 const CREATE_BSFF_FICHE_INTERVENTION = gql`
@@ -34,7 +35,10 @@ const companySchema: yup.SchemaOf<CompanyInput> = yup.object({
   phone: yup.string().required(),
   siret: yup.string().required(),
   vatNumber: yup.string().nullable(),
-  country: yup.string().nullable(),
+  country: yup
+    .string()
+    .oneOf([...countries.map(country => country.cca2), null])
+    .nullable(),
 });
 const detenteurSchema: yup.SchemaOf<
   BsffFicheInterventionInput["detenteur"]

--- a/front/src/form/bsvhu/Operation.tsx
+++ b/front/src/form/bsvhu/Operation.tsx
@@ -64,11 +64,13 @@ export default function Operation() {
             </label>
           </div>
         ) : null}
+
+        <RedErrorMessage name="destination.reception.acceptationStatus" />
       </div>
 
       <div className="form__row">
         <label>
-          En tonnes
+          Poids accepté en tonnes
           <Field
             component={NumberInput}
             name="destination.reception.weight"
@@ -95,20 +97,6 @@ export default function Operation() {
           </div>
         </>
       )}
-
-      <h4 className="form__section-heading">Quantité</h4>
-      <div className="form__row">
-        <label>
-          En nombre
-          <Field
-            component={NumberInput}
-            name="destination.reception.quantity"
-            className="td-input td-input--small"
-          />
-        </label>
-
-        <RedErrorMessage name="destination.reception.quantity" />
-      </div>
 
       <h4 className="form__section-heading">Opération</h4>
       <div className="form__row">

--- a/front/src/form/bsvhu/Transporter.tsx
+++ b/front/src/form/bsvhu/Transporter.tsx
@@ -48,7 +48,7 @@ export default function Transporter({ disabled }) {
           Numéro de TVA intracommunautaire
           <Field
             type="text"
-            name="transporter.tvaIntracommunautaire"
+            name="transporter.company.vatNumber"
             placeholder="Ex: DE 123456789"
             className="td-input"
             disabled={disabled}

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -155,10 +155,12 @@ export default function CompanySelector({
     return <InlineError apolloError={favoritesError} />;
   }
 
+  const isForeignCompany = field.value.siret == null;
+
   return (
     <div className="tw-my-6">
       {!!heading && <h4 className="form__section-heading">{heading}</h4>}
-      {field.value.siret != null && (
+      {!isForeignCompany && (
         <>
           <div className={styles.companySelectorSearchFields}>
             <div className={styles.companySelectorSearchGroup}>
@@ -228,7 +230,7 @@ export default function CompanySelector({
                 event.target.checked ? null : ""
               );
             }}
-            checked={field.value.siret == null}
+            checked={isForeignCompany}
             disabled={disabled}
           />
           L'entreprise est à l'étranger
@@ -236,7 +238,7 @@ export default function CompanySelector({
       )}
 
       <div className="form__row">
-        {field.value.siret == null && (
+        {isForeignCompany && (
           <>
             <label>
               Nom de l'entreprise

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -19,6 +19,11 @@ export const FAVORITES = gql`
         validityLimit
         department
       }
+      brokerReceipt {
+        receiptNumber
+        validityLimit
+        department
+      }
       vhuAgrementDemolisseur {
         agrementNumber
       }

--- a/front/src/form/common/components/custom-inputs/NumberInput.tsx
+++ b/front/src/form/common/components/custom-inputs/NumberInput.tsx
@@ -1,16 +1,12 @@
 import React, { InputHTMLAttributes } from "react";
-import { FieldProps } from "formik";
+import { FieldProps, useField } from "formik";
 
 type NumberInputProps = FieldProps & { label: string } & InputHTMLAttributes<
     HTMLInputElement
   >;
 
-export default function NumberInput({
-  field,
-  label,
-  ...props
-}: NumberInputProps) {
-  const value = field.value ?? "";
+export default function NumberInput({ label, ...props }: NumberInputProps) {
+  const [field, , { setValue }] = useField(props.field);
 
   return (
     <label>
@@ -18,8 +14,16 @@ export default function NumberInput({
       <input
         min="0"
         {...field}
-        value={value}
+        value={field.value ?? ""}
         {...props}
+        onChange={e => {
+          // By default, the value is set to `""` if we fill and then delete the value.
+          // We want to keep the `null` as a `Float` is expected by gql.
+          const cleanedValue = Boolean(e.target.value)
+            ? parseFloat(e.target.value)
+            : null;
+          setValue(cleanedValue);
+        }}
         type="number"
         className={props.className}
       />

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -148,7 +148,9 @@ export function getComputedState(initialState, actualForm) {
     ) {
       prev[curKey] = getComputedState(initialValue, actualForm[curKey]);
     } else {
-      prev[curKey] = actualForm[curKey] ?? initialValue;
+      // Keep null values - only replace unedfined.
+      prev[curKey] =
+        actualForm[curKey] === undefined ? initialValue : actualForm[curKey];
     }
 
     return prev;


### PR DESCRIPTION
Suite au point avec Emmanuel, un paquet de petites évos.

## BSVHU

- [x] BUG: Cocher / décocher entreprise à l'étranger sur transporteur (et courtier surement)
- [x] BUG: Quantité remplie puis effacée
- [x] BUG: aperçu, unités apparaissent mais pas le tonnage
- [x] Aperçu: "Signé par" => ajouter "Signé le"
- [x] Signature d'acceptation: meilleur label que "en tonnes" => poids accepté en tonnes
- [x] Signature d'acceptation: le broyeur n'a pas a donné le nombre de carcasses. Pas de champ "quantité en nombre" du coup. Ou alors on pré-rempli avec la quantité, et on dit de modifier si différent. En fait virer le champ, pas nécessaire
- [x] BUG: Aperçu quand BSVHU archivé ne s'affiche pas
- [x] "Signer l'enlèvement" pour le produteur à renommer en "Signer mon bordereau"
- [x] Casse auto numéro 2: champ de complétion pour "numéros de lots ou unités entrants"
- [x] Afficher l'erreur si on a pas coché "Accepté". Actuellement on ne peut pas valider mais on ne marque rien

## BSDA

- [x] Renommer "nom de l'entreprise" en "nom du chantier", et "adresse du chantier"
- [x] pré-remplissage recepisse courtier manquant
- [x] résumé à la signature: conditionnements => rajouter un espace ou virgule entre les détails
- [x] immatriculations obligatoires ? à checker, arrêté pas encore terminé => pour le moment NON
- [x] mettre opération prévue quand on rempli opération effectuée (signature)
- [x] duplication: ne pas reprendre les scellés
- [x] Si on fait un bordereau de groupement, l'émetteur est forcément "moi". (ce sont MES bordereaux que je regrouppe)
- [x] Filtrer les codes en fonction de la destination finale => D5 D9 si pas de nextDestination. Si nextDestination, D13 D15
- [x] CAP et opération à mettre au dessus de "la destination n'est pas lexutoire final". Pas clair sinon
- [x] Rajouter CAP et opération prévue pour nextDestination
- [x] Groupement & reexpédition: mauvais filtre ! Pas le bon statut ? Ou alors création devrait pas passer à processed ?
- [x] Autoriser modification siret transporteur jusqu'à la signature

---

- [ ] ~~Mettre à jour la documentation~~
- [x] Mettre à jour le change log
- [ ] ~~Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~~
- [ ] ~~S'assurer que la numérotation des nouvelles migrations est bien cohérente~~
---

- [Ticket Favro]()
