### PR TITLE
Move CompanyPrivate installation to own resolver

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 - Rend le rate limit configurable [PR 1056](https://github.com/MTES-MCT/trackdechets/pull/1056)
+- Le champ installation de CompanyPrivate est dans son propre resolver [PR 1059](https://github.com/MTES-MCT/trackdechets/pull/1059)
 
 # [2021.10.2] 25/10/2021
 

--- a/back/src/companies/resolvers/CompanyPrivate.ts
+++ b/back/src/companies/resolvers/CompanyPrivate.ts
@@ -1,6 +1,6 @@
 import prisma from "../../prisma";
 import { CompanyPrivateResolvers } from "../../generated/graphql/types";
-import { getCompanyUsers, getUserRole } from "../database";
+import { getCompanyUsers, getUserRole, getInstallation } from "../database";
 
 const companyPrivateResolvers: CompanyPrivateResolvers = {
   users: parent => {
@@ -34,6 +34,10 @@ const companyPrivateResolvers: CompanyPrivateResolvers = {
     return prisma.company
       .findUnique({ where: { siret: parent.siret } })
       .vhuAgrementDemolisseur();
+  },
+  installation: async parent => {
+    const installation = await getInstallation(parent.siret);
+    return installation;
   }
 };
 

--- a/back/src/users/resolvers/User.ts
+++ b/back/src/users/resolvers/User.ts
@@ -1,26 +1,22 @@
-import { convertUrls, getInstallation } from "../../companies/database";
+import { convertUrls } from "../../companies/database";
 import { UserResolvers, CompanyPrivate } from "../../generated/graphql/types";
 import { getUserCompanies } from "../database";
 import { nafCodes } from "../../common/constants/NAF";
 
 const userResolvers: UserResolvers = {
   // Returns the list of companies a user belongs to
-  // Information from TD and s3ic are merged
+  // Information from TD and s3ic are merged in a separate resolver (CompanyPrivate.installation)
   // to make up an instance of CompanyPrivate
   companies: async parent => {
     const companies = await getUserCompanies(parent.id);
     return Promise.all(
       companies.map(async company => {
-        let companyPrivate: CompanyPrivate = convertUrls(company);
+        const companyPrivate: CompanyPrivate = convertUrls(company);
 
         const { codeNaf: naf, address } = company;
         const libelleNaf = naf in nafCodes ? nafCodes[naf] : "";
 
-        companyPrivate = { ...companyPrivate, naf, libelleNaf, address };
-
-        // retrieves associated ICPE
-        const installation = await getInstallation(company.siret);
-        return { ...companyPrivate, installation };
+        return { ...companyPrivate, naf, libelleNaf, address };
       })
     );
   }

--- a/doc/docs/intro.mdx
+++ b/doc/docs/intro.mdx
@@ -30,6 +30,12 @@ Forum technique destiné aux utilisateurs de l'API Trackdéchets et aux question
 
 [Accéder au forum](https://forum.trackdechets.beta.gouv.fr)
 
+#### Support technique
+
+Support technique destiné aux utilisateurs de l'API Trackdéchets
+
+Contact par email:  tech _at_ trackdechets.beta.gouv.fr
+
 #### Infolettre technique
 
 Restez informé des évolutions de l'API


### PR DESCRIPTION
Le sous-resolver company de la query `me` effectuait des requêtes sur la table Installation que les champs concernés soient réclamés ou pas.
Le champ `installation` est désormais dans son propre resolver, la durée de la query est réduite de moitié quand le champ `installation` n'est pas requis

- [x] Mettre à jour le change log
---

