### PR TITLE
Fix Apollo cache for CompanyMember

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction d'une rare erreur d'affichage du rôle utilisateur sur la page "Mon compte -> Etablissements -> Membres" [PR 1061](https://github.com/MTES-MCT/trackdechets/pull/1061)
+
 #### :nail_care: Améliorations
 
 - Le nombre maximum de plaques d'immatriculations est limité à 2 sur les bsdasri et bsda [PR 1054](https://github.com/MTES-MCT/trackdechets/pull/1054)

--- a/front/src/graphql-client.ts
+++ b/front/src/graphql-client.ts
@@ -43,6 +43,9 @@ export default new ApolloClient({
           },
         },
       },
+      CompanyMember: {
+        keyFields: ["id", "role"],
+      },
     },
   }),
   link: ApolloLink.from([cleanTypeNameLink, httpLink]),


### PR DESCRIPTION
Correction d'un bug front sur le cache Apollo.
L'objet `CompanyMember` n'est pas unique par ID. Le rôle varie en fonction de l'entreprise dans laquelle il est. Ca posait problème sur la page `Mon compte -> Etablissements -> Membres`. Quand on affichait la liste des membres d'une entreprise, si un utilisateur était Admin d'une entreprise en début de page, il apparaissait admin sur toutes ses entreprises en dessous car Apollo renvoyait la valeur en cache et non la valeur API.

- [ ] ~~Mettre à jour la documentation~~
- [x] Mettre à jour le change log
- [ ] ~~Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~~
- [ ] ~~S'assurer que la numérotation des nouvelles migrations est bien cohérente~~
---

- [Ticket Favro]()
