### PR TITLE
Ajout de `Bsff.transporter.transport.takenOverAt`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
+- Ajout d'une date de prise en charge du déchet par le transporteur sur le `Bsff` [PR 1065](https://github.com/MTES-MCT/trackdechets/pull/1065)
+  - Ajout du champ `transporter.transport.takenOverAt` à l'objet `Bsff`
+  - Ajout du champ optionnel `takenOverAt` à l'input `BsffTransporterTransportInput`.
+  - Dans le cas où `takenOverAt` n'est pas renseigné, `bsff.transporter.transport.takenOverAt` renvoie la date de signature transport par défaut.
 #### :bug: Corrections de bugs
 
 - Correction d'une rare erreur d'affichage du rôle utilisateur sur la page "Mon compte -> Etablissements -> Membres" [PR 1061](https://github.com/MTES-MCT/trackdechets/pull/1061)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,19 +4,19 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
-# Next release ~15/11
+# Next release ~6/12
 
 #### :rocket: Nouvelles fonctionnalités
 
 #### :boom: Breaking changes
 
-- Harmonisation du statut d'acceptation du déchet [PR 1040](https://github.com/MTES-MCT/trackdechets/pull/1040)
-  - Remplacement de `BsdaAcceptationStatus`, `BsffAcceptationStatus` et `BsvhuAcceptationStatus` par `WasteAcceptationStatus`
-  - Remplacement de l'input `WasteAcceptationStatusInput` par l'enum `WasteAcceptationStatus`
-  - Les champs `Form.wasteAcceptationStatus`, `TemporaryStorer.wasteAcceptationStatus` et `BsdasriWasteAcceptation.status` ne sont plus du type `String` mais `WasteAcceptationStatus`
-
+- Ajout d'une date de prise en charge du déchet par le transporteur sur le `Bsff` [PR 1065](https://github.com/MTES-MCT/trackdechets/pull/1065)
+  - Ajout du champ `transporter.transport.takenOverAt` à l'objet `Bsff`
+  - Ajout du champ optionnel `takenOverAt` à l'input `BsffTransporterTransportInput`.
+  - Dans le cas où `takenOverAt` n'est pas renseigné, `bsff.transporter.transport.takenOverAt` renvoie la date de signature transport par défaut.
 #### :bug: Corrections de bugs
 
+- Correction d'un bug empêchant la mise à jour partielle de champs imbriqués via la mutation `updateBsff` [PR 1065](https://github.com/MTES-MCT/trackdechets/pull/1065)
 
 #### :nail_care: Améliorations
 
@@ -32,10 +32,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
-- Ajout d'une date de prise en charge du déchet par le transporteur sur le `Bsff` [PR 1065](https://github.com/MTES-MCT/trackdechets/pull/1065)
-  - Ajout du champ `transporter.transport.takenOverAt` à l'objet `Bsff`
-  - Ajout du champ optionnel `takenOverAt` à l'input `BsffTransporterTransportInput`.
-  - Dans le cas où `takenOverAt` n'est pas renseigné, `bsff.transporter.transport.takenOverAt` renvoie la date de signature transport par défaut.
+- Harmonisation du statut d'acceptation du déchet [PR 1040](https://github.com/MTES-MCT/trackdechets/pull/1040)
+  - Remplacement de `BsdaAcceptationStatus`, `BsffAcceptationStatus` et `BsvhuAcceptationStatus` par `WasteAcceptationStatus`
+  - Remplacement de l'input `WasteAcceptationStatusInput` par l'enum `WasteAcceptationStatus`
+  - Les champs `Form.wasteAcceptationStatus`, `TemporaryStorer.wasteAcceptationStatus` et `BsdasriWasteAcceptation.status` ne sont plus du type `String` mais `WasteAcceptationStatus`
 #### :bug: Corrections de bugs
 
 - Correction d'une rare erreur d'affichage du rôle utilisateur sur la page "Mon compte -> Etablissements -> Membres" [PR 1061](https://github.com/MTES-MCT/trackdechets/pull/1061)

--- a/back/prisma/migrations/42_add_bsff_taken_over_at.sql
+++ b/back/prisma/migrations/42_add_bsff_taken_over_at.sql
@@ -1,0 +1,2 @@
+-- AlterTable Bsff
+ALTER TABLE "default$default"."Bsff" ADD COLUMN  "transporterTransportTakenOverAt" TIMESTAMP(3);

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -855,6 +855,7 @@ model Bsff {
   transporterRecepisseValidityLimit DateTime?
 
   transporterTransportMode            TransportMode?
+  transporterTransportTakenOverAt     DateTime?
   transporterTransportSignatureAuthor String?
   transporterTransportSignatureDate   DateTime?
 

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -204,7 +204,8 @@ export function unflattenBsff(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
           date: prismaBsff.destinationOperationSignatureDate
         })
       }),
-      plannedOperationCode: prismaBsff.destinationPlannedOperationCode as GraphQL.BsffOperationCode,
+      plannedOperationCode:
+        prismaBsff.destinationPlannedOperationCode as GraphQL.BsffOperationCode,
       cap: prismaBsff.destinationCap
     }),
     // the following relations will be set in Bsff resolver

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -26,12 +26,12 @@ export function flattenBsffInput(
   return safeInput({
     type: bsffInput.type,
 
-    emitterCompanyName: bsffInput.emitter?.company.name,
-    emitterCompanySiret: bsffInput.emitter?.company.siret,
-    emitterCompanyAddress: bsffInput.emitter?.company.address,
-    emitterCompanyContact: bsffInput.emitter?.company.contact,
-    emitterCompanyPhone: bsffInput.emitter?.company.phone,
-    emitterCompanyMail: bsffInput.emitter?.company.mail,
+    emitterCompanyName: bsffInput.emitter?.company?.name,
+    emitterCompanySiret: bsffInput.emitter?.company?.siret,
+    emitterCompanyAddress: bsffInput.emitter?.company?.address,
+    emitterCompanyContact: bsffInput.emitter?.company?.contact,
+    emitterCompanyPhone: bsffInput.emitter?.company?.phone,
+    emitterCompanyMail: bsffInput.emitter?.company?.mail,
     emitterCustomInfo: bsffInput.emitter?.customInfo,
 
     packagings: bsffInput.packagings,
@@ -43,13 +43,13 @@ export function flattenBsffInput(
     weightValue: bsffInput.weight?.value,
     weightIsEstimate: bsffInput.weight?.isEstimate,
 
-    transporterCompanyName: bsffInput.transporter?.company.name,
-    transporterCompanySiret: bsffInput.transporter?.company.siret,
-    transporterCompanyVatNumber: bsffInput.transporter?.company.vatNumber,
-    transporterCompanyAddress: bsffInput.transporter?.company.address,
-    transporterCompanyContact: bsffInput.transporter?.company.contact,
-    transporterCompanyPhone: bsffInput.transporter?.company.phone,
-    transporterCompanyMail: bsffInput.transporter?.company.mail,
+    transporterCompanyName: bsffInput.transporter?.company?.name,
+    transporterCompanySiret: bsffInput.transporter?.company?.siret,
+    transporterCompanyVatNumber: bsffInput.transporter?.company?.vatNumber,
+    transporterCompanyAddress: bsffInput.transporter?.company?.address,
+    transporterCompanyContact: bsffInput.transporter?.company?.contact,
+    transporterCompanyPhone: bsffInput.transporter?.company?.phone,
+    transporterCompanyMail: bsffInput.transporter?.company?.mail,
     transporterCustomInfo: bsffInput.transporter?.customInfo,
 
     transporterRecepisseNumber: bsffInput.transporter?.recepisse?.number,
@@ -59,6 +59,8 @@ export function flattenBsffInput(
       bsffInput.transporter?.recepisse?.validityLimit,
 
     transporterTransportMode: bsffInput.transporter?.transport?.mode,
+    transporterTransportTakenOverAt:
+      bsffInput.transporter?.transport?.takenOverAt,
 
     destinationCompanyName: bsffInput.destination?.company?.name,
     destinationCompanySiret: bsffInput.destination?.company?.siret,
@@ -81,19 +83,19 @@ export function flattenBsffInput(
     destinationOperationCode: bsffInput.destination?.operation?.code,
 
     destinationOperationNextDestinationCompanyName:
-      bsffInput.destination?.operation?.nextDestination?.company.name,
+      bsffInput.destination?.operation?.nextDestination?.company?.name,
     destinationOperationNextDestinationCompanySiret:
-      bsffInput.destination?.operation?.nextDestination?.company.siret,
+      bsffInput.destination?.operation?.nextDestination?.company?.siret,
     destinationOperationNextDestinationCompanyVatNumber:
-      bsffInput.destination?.operation?.nextDestination?.company.vatNumber,
+      bsffInput.destination?.operation?.nextDestination?.company?.vatNumber,
     destinationOperationNextDestinationCompanyAddress:
-      bsffInput.destination?.operation?.nextDestination?.company.address,
+      bsffInput.destination?.operation?.nextDestination?.company?.address,
     destinationOperationNextDestinationCompanyContact:
-      bsffInput.destination?.operation?.nextDestination?.company.contact,
+      bsffInput.destination?.operation?.nextDestination?.company?.contact,
     destinationOperationNextDestinationCompanyPhone:
-      bsffInput.destination?.operation?.nextDestination?.company.phone,
+      bsffInput.destination?.operation?.nextDestination?.company?.phone,
     destinationOperationNextDestinationCompanyMail:
-      bsffInput.destination?.operation?.nextDestination?.company.mail,
+      bsffInput.destination?.operation?.nextDestination?.company?.mail,
 
     destinationCap: bsffInput.destination?.cap
   });
@@ -152,6 +154,7 @@ export function unflattenBsff(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
       customInfo: prismaBsff.transporterCustomInfo,
       transport: nullIfNoValues<GraphQL.BsffTransport>({
         mode: prismaBsff.transporterTransportMode,
+        takenOverAt: prismaBsff.transporterTransportTakenOverAt,
         signature: nullIfNoValues<GraphQL.Signature>({
           author: prismaBsff.transporterTransportSignatureAuthor,
           date: prismaBsff.transporterTransportSignatureDate
@@ -201,8 +204,7 @@ export function unflattenBsff(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
           date: prismaBsff.destinationOperationSignatureDate
         })
       }),
-      plannedOperationCode:
-        prismaBsff.destinationPlannedOperationCode as GraphQL.BsffOperationCode,
+      plannedOperationCode: prismaBsff.destinationPlannedOperationCode as GraphQL.BsffOperationCode,
       cap: prismaBsff.destinationCap
     }),
     // the following relations will be set in Bsff resolver

--- a/back/src/bsffs/pdf/assets/index.html
+++ b/back/src/bsffs/pdf/assets/index.html
@@ -192,8 +192,10 @@
               </span>
               Date limite de validité : {{#formatDate}}{{
               bsff.transporterRecepisseValidityLimit }}{{/formatDate}}<br />
-              Date de prise en charge : {{#formatDate}}{{
-              bsff.transporterTransportSignatureDate }}{{/formatDate}} <br />
+              Date de prise en charge :
+              {{#bsff.transporterTransportTakenOverAt}}{{#formatDate}}{{bsff.transporterTransportTakenOverAt}}{{/formatDate}}{{/bsff.transporterTransportTakenOverAt}}
+              {{^bsff.transporterTransportTakenOverAt}}{{#formatDate}}{{bsff.transporterTransportSignatureDate}}{{/formatDate}}{{/bsff.transporterTransportTakenOverAt}}
+              <br />
               Mode de transport : Route<br />
             </p>
             <p>

--- a/back/src/bsffs/typeDefs/bsff.inputs.graphql
+++ b/back/src/bsffs/typeDefs/bsff.inputs.graphql
@@ -140,6 +140,8 @@ input BsffTransporterRecepisseInput {
   validityLimit: DateTime!
 }
 input BsffTransporterTransportInput {
+  "Date de prise en charge"
+  takenOverAt: DateTime
   mode: TransportMode!
 }
 

--- a/back/src/bsffs/typeDefs/bsff.objects.graphql
+++ b/back/src/bsffs/typeDefs/bsff.objects.graphql
@@ -207,6 +207,8 @@ type BsffTransporterRecepisse {
   validityLimit: DateTime!
 }
 type BsffTransport {
+  "Date de prise en charge"
+  takenOverAt: DateTime
   "Mode de transport utilisé."
   mode: TransportMode!
   "Signature du transporteur lors de l'enlèvement auprès de l'émetteur."

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -7,10 +7,12 @@ import {
   BsffSignatureType,
   Mutation,
   MutationSignBsffArgs,
+  MutationUpdateBsffArgs,
+  TransportMode,
 } from "generated/graphql/types";
 import { RedErrorMessage } from "common/components";
 import { NotificationError } from "common/components/Error";
-import { SIGN_BSFF } from "form/bsff/utils/queries";
+import { SIGN_BSFF, UPDATE_BSFF_FORM } from "form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
 import { GET_BSDS } from "common/queries";
 
@@ -27,6 +29,11 @@ interface SignTransportFormProps {
 }
 
 function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
+  const [updateBsff, updateBsffResult] = useMutation<
+    Pick<Mutation, "updateBsff">,
+    MutationUpdateBsffArgs
+  >(UPDATE_BSFF_FORM);
+
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
@@ -39,6 +46,19 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
       }}
       validationSchema={validationSchema}
       onSubmit={async values => {
+        await updateBsff({
+          variables: {
+            id: bsff.id,
+            input: {
+              transporter: {
+                transport: {
+                  takenOverAt: new Date().toISOString(),
+                  mode: bsff.transporter?.transport?.mode ?? TransportMode.Road,
+                },
+              },
+            },
+          },
+        });
         await signBsff({
           variables: {
             id: bsff.id,
@@ -89,7 +109,7 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
               disabled={signBsffResult.loading}
             >
               <span>
-                {signBsffResult.loading
+                {updateBsffResult.loading || signBsffResult.loading
                   ? "Signature en cours..."
                   : "Signer l'enlèvement"}
               </span>


### PR DESCRIPTION
- ajout d'un champ `transporter.transport.takenOverAt` différent de `transporter.transport.signature.date` pour être raccord avec le récépissé et les autres bordereaux. 
- correction du converter  `flattenBsffInput` qui omettait les `?` sur des company et empêchait des update partiels.  

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
