### PR TITLE
Ignore pgsql files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .vscode
 .idea
+*.pgsql


### PR DESCRIPTION
La mise à jour du script de backup utilise des fichiers pgsql. Il est préférable de les gitignorer pour éviter tout push accidentel


