### PR TITLE
Fix cell returning undefined

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDasri/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/index.tsx
@@ -43,7 +43,7 @@ export const COLUMNS: Record<
     accessor: dasri => dasri?.destination?.company?.name ?? "",
   },
   waste: {
-    accessor: dasri => dasri?.waste?.code,
+    accessor: dasri => dasri?.waste?.code ?? "",
   },
   transporterCustomInfo: {
     accessor: dasri => dasri.transporter?.customInfo ?? "",


### PR DESCRIPTION
Je mets sur dev puisqu'on aura un merge de toute manière ce soir.

En gros on avait des `<Cell />` qui retournaient `undefined` et donc le dashboard plantait avec l'erreur suivante:
> Cell(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.

Cf https://trackdechets.zammad.com/#ticket/zoom/2809
