### PR TITLE
Fix dasri nullable fields

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Correction d'une rare erreur d'affichage du rôle utilisateur sur la page "Mon compte -> Etablissements -> Membres" [PR 1061](https://github.com/MTES-MCT/trackdechets/pull/1061)
+- Correction d'erreurs sur le bsdasri liées à l'harmmonisation et la gestion des plaques d'immatriculation [PR 1071](https://github.com/MTES-MCT/trackdechets/pull/1071)
 
 #### :nail_care: Améliorations
 

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -101,6 +101,7 @@ input BsdasriWasteInput {
   adr: String
   code: String
 }
+
 input BsdasriEmissionInput {
   weight: BsdasriWeightInput
   packagings: [BsdasriPackagingsInput!]

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -79,6 +79,7 @@ type BsdasriWeight {
   "Le poids est-il estimé (pesé si false)"
   isEstimate: Boolean!
 }
+
 "Informations sur un poids reçu (toujours pesé)"
 type BsdasriOperationWeight {
   "Pois en kg (pesé)"
@@ -88,9 +89,9 @@ type BsdasriOperationWeight {
 "Informations relatives au déchet"
 type BsdasriWaste {
   "Code adr"
-  adr: String!
+  adr: String
   "Code déchet"
-  code: String!
+  code: String
 }
 
 "Informations relatives à l'acceptation ou au refus du déchet (Bsdasri)"

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -364,7 +364,47 @@ const wasteAcceptationFragment = gql`
     refusedWeight
   }
 `;
-export const dasriFragment = gql`
+
+export const dashboardDasriFragment = gql`
+  fragment DasriFragment on Bsdasri {
+    id
+    bsdasriStatus: status
+    type
+    isDraft
+    bsdasriWaste: waste {
+      code
+    }
+    emitter {
+      company {
+        ...CompanyFragment
+      }
+      emission {
+        isTakenOverWithoutEmitterSignature
+        isTakenOverWithSecretCode
+      }
+    }
+    transporter {
+      company {
+        ...CompanyFragment
+      }
+      customInfo
+      transport {
+        plates
+      }
+    }
+    destination {
+      company {
+        ...CompanyFragment
+      }
+    }
+    createdAt
+    updatedAt
+    allowDirectTakeOver
+  }
+  ${companyFragment}
+`;
+
+export const fullDasriFragment = gql`
   fragment DasriFragment on Bsdasri {
     id
     bsdasriStatus: status

--- a/front/src/common/queries.ts
+++ b/front/src/common/queries.ts
@@ -2,7 +2,8 @@ import { gql } from "@apollo/client";
 import {
   detailFormFragment,
   fullFormFragment,
-  dasriFragment,
+  fullDasriFragment,
+  dashboardDasriFragment,
   vhuFragment,
   bsdaFragment,
 } from "./fragments";
@@ -23,7 +24,7 @@ export const GET_DETAIL_DASRI = gql`
       ...DasriFragment
     }
   }
-  ${dasriFragment}
+  ${fullDasriFragment}
 `;
 
 export const GET_DETAIL_DASRI_WITH_METADATA = gql`
@@ -38,7 +39,7 @@ export const GET_DETAIL_DASRI_WITH_METADATA = gql`
       }
     }
   }
-  ${dasriFragment}
+  ${fullDasriFragment}
 `;
 
 export const GET_DASRI_METADATA = gql`
@@ -120,7 +121,7 @@ export const GET_BSDS = gql`
     }
   }
   ${fullFormFragment}
-  ${dasriFragment}
+  ${dashboardDasriFragment}
   ${vhuFragment}
   ${bsdaFragment}
 `;

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
@@ -4,7 +4,7 @@ import {
   Mutation,
   MutationDuplicateBsdasriArgs,
 } from "generated/graphql/types";
-import { dasriFragment } from "common/fragments";
+import { fullDasriFragment } from "common/fragments";
 import { GET_BSDS } from "common/queries";
 
 const DUPLICATE_BSDASRI = gql`
@@ -13,7 +13,7 @@ const DUPLICATE_BSDASRI = gql`
       ...DasriFragment
     }
   }
-  ${dasriFragment}
+  ${fullDasriFragment}
 `;
 
 export function useBsdasriDuplicate(

--- a/front/src/dashboard/components/BSDList/BSDasri/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/index.tsx
@@ -43,7 +43,7 @@ export const COLUMNS: Record<
     accessor: dasri => dasri?.destination?.company?.name ?? "",
   },
   waste: {
-    accessor: dasri => dasri?.waste?.code ?? "",
+    accessor: dasri => dasri["bsdasriWaste"]?.code ?? "",
   },
   transporterCustomInfo: {
     accessor: dasri => dasri.transporter?.customInfo ?? "",

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -51,7 +51,7 @@ const getInitialState = (f?: Bsdasri | null) => ({
       weight: !!f?.transporter?.transport?.weight
         ? getInitialWeightFn(f?.transporter?.transport?.weight)
         : null,
-      plates: null,
+      plates: [],
       takenOverAt: null,
       handedOverAt: null,
       acceptation: {

--- a/front/src/form/bsdasri/utils/queries.ts
+++ b/front/src/form/bsdasri/utils/queries.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 
-import { dasriFragment } from "common/fragments";
+import { fullDasriFragment } from "common/fragments";
 
 export const GET_BSDASRI = gql`
   query Bsdasri($id: ID!) {
@@ -8,7 +8,7 @@ export const GET_BSDASRI = gql`
       ...DasriFragment
     }
   }
-  ${dasriFragment}
+  ${fullDasriFragment}
 `;
 
 export const CREATE_BSDASRI = gql`


### PR DESCRIPTION
Suite à l'harmonisation, les dasri renvoient waste { adr! code! }, mais ces champs peuvent être null en brouillon, occasionnant une erreur et casser le dashboard brouillon.
Cette PR passe les champs gql en optionnel et adapte le dashboard pour gérer les conflits générés par des champs waste différents. J'en profite d'ailleurs pour alléger le fragment dasri du dashboard.

Corrige également la création de dasri depuis l'UI qui échouait lorsqu'aucune plaque d'immat n'était renseignée

- ~~[ ] Mettre à jour la documentation~~
- [x] Mettre à jour le change log
- ~~[ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~~
- ~~[ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente~~
---

 
