### PR TITLE
Hotfix - Missing user role property for cache computation

### DIFF
--- a/front/src/account/AccountMembershipRequest.tsx
+++ b/front/src/account/AccountMembershipRequest.tsx
@@ -28,6 +28,7 @@ const ACCEPT_MEMBERSHIP_REQUEST = gql`
       id
       users {
         id
+        role
       }
     }
   }
@@ -39,6 +40,7 @@ const REFUSE_MEMBERSHIP_REQUEST = gql`
       id
       users {
         id
+        role
       }
     }
   }


### PR DESCRIPTION
A l'acceptation d'une demande d'invitation, on peut avoir l'erreur suivante qui s'affiche sur l'UI (l'acceptation / refus fonctionne)

![image](https://user-images.githubusercontent.com/5145523/142436283-11da88c1-baaf-4565-8f39-c91fd79fdad5.png)

C'est lié au fait que le cache apollo pour les users s'attend désormais à avoir 2 clés: id et role
