### PR TITLE
HotFix dasri grp publish button

### DIFF
--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -397,6 +397,9 @@ export const dashboardDasriFragment = gql`
         ...CompanyFragment
       }
     }
+    grouping {
+      id
+    }
     createdAt
     updatedAt
     allowDirectTakeOver


### PR DESCRIPTION
Le champ des dasris regroupés n'était plus requêté par le dashboard, le bouton de publication de dasri de regroupement ne s'affichait plus

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
