### PR TITLE
Documentation de la validation

### DIFF
--- a/back/src/bsda/typeDefs/bsda.mutations.graphql
+++ b/back/src/bsda/typeDefs/bsda.mutations.graphql
@@ -20,7 +20,97 @@ type Mutation {
   publishBsda(id: ID!): Bsda
 
   """
-  Signe un Bsda
+  Signe un Bsda.
+
+  **Champs requis pour `EMISSION` :**
+
+  ```
+  emitter {
+    isPrivateIndividual
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+  }
+  waste {
+    code
+    name
+  }
+  destination {
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+    cap
+    plannedOperationCode
+  }
+  worker {
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+  }
+  ```
+
+  **Champs requis pour `WORK` :**
+
+  ```
+  waste {
+    consistence
+  }
+  weight {
+    value
+    isEstimate
+  }
+  ```
+
+  **Champs requis pour `TRANSPORT` :**
+
+  ```
+  transporter {
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+    recepisse {
+      number
+      department
+      validityLimit
+    }
+  }
+  ```
+
+  **Champs requis pour `OPERATION` :**
+
+  ```
+  destination {
+    reception {
+      date
+      weight
+      acceptationStatus
+    }
+    operation {
+      code
+      date
+    }
+  }
+  ```
   """
   signBsda(id: ID!, input: BsdaSignatureInput!): Bsda
 

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -459,7 +459,7 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
         .date()
         .requiredIf(
           context.transportSignature,
-          `Transporteur: ${MISSING_COMPANY_NAME}`
+          `Transporteur: la date limite de validité du récépissé est obligatoire`
         ) as any,
       transporterCompanyName: yup
         .string()

--- a/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
@@ -10,10 +10,7 @@ type Mutation {
   """
   Crée un nouveau dasri
   """
-  createBsdasri(
-    "Payload de création d'un dasri"
-    input: BsdasriInput!
-  ): Bsdasri!
+  createBsdasri("Payload de création d'un dasri" input: BsdasriInput!): Bsdasri!
 
   """
   Met à jour un dasri existant.
@@ -32,13 +29,107 @@ type Mutation {
   publishBsdasri("ID d'un Bsdasri" id: ID!): Bsdasri
 
   """
-  Appose une signature sur un Bsdasri, verrouille les cadres correspondant
+  Appose une signature sur un Bsdasri, verrouille les cadres correspondant.
 
-  Une signature ne peut être apposée que par un membre de l'entreprise figurant sur le cadre concerné
-  Ex: la signature TRANSPORT ne peut être apposée que par un membre de l'entreprise de transport
+  Une signature ne peut être apposée que par un membre de l'entreprise figurant sur le cadre concerné.
+  Ex: la signature TRANSPORT ne peut être apposée que par un membre de l'entreprise de transport.
 
   Pour signer l'emission avec un compte transporteur (cas de la signature sur device transporteur),
-  utiliser la mutation signBsdasriEmissionWithSecretCode
+  utiliser la mutation signBsdasriEmissionWithSecretCode.
+
+  **Champs requis pour `EMISSION` :**
+
+  ```
+  emitter {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+    }
+    emission {
+      packagings {
+        type
+        volume
+        quantity
+      }
+    }
+  }
+  waste {
+    code
+    adr
+  }
+  ```
+
+  **Champs requis pour `TRANSPORT` :**
+
+  ```
+  transporter {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+    }
+    transport {
+      acceptation {
+        status
+      }
+      packagings {
+        type
+        volume
+        quantity
+      }
+      takenOverAt
+    }
+    recepisse {
+      number
+      department
+      validityLimit
+    }
+  }
+  ```
+
+  **Champs requis pour `RECEPTION` :**
+
+  ```
+  destination {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+    }
+    reception {
+      acceptation {
+        status
+      }
+      packagings {
+        type
+        volume
+        quantity
+      }
+      date
+    }
+  }
+  ```
+
+  **Champs requis pour `OPERATION` :**
+
+  ```
+  destination {
+    operation {
+      weight {
+        value
+      }
+      code
+      date
+    }
+  }
+  ```
   """
   signBsdasri(id: ID!, input: BsdasriSignatureInput!): Bsdasri
 

--- a/back/src/bsffs/typeDefs/bsff.mutations.graphql
+++ b/back/src/bsffs/typeDefs/bsff.mutations.graphql
@@ -3,15 +3,26 @@ type Mutation {
   Mutation permettant de créer un nouveau bordereau de suivi de fluides frigorigènes.
 
   Ces champs sont requis :
-  - emitter.company.name
-  - emitter.company.siret
-  - emitter.company.address
-  - emitter.company.contact
-  - emitter.company.phone
-  - emitter.company.mail
-  - waste.code
-  - waste.adr
-  - weight.value
+
+  ```
+  emitter {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+      mail
+    }
+  }
+  waste {
+    code
+    adr
+  }
+  weight {
+    value
+  }
+  ```
 
   Si vous souhaitez créer un BSFF sans ces informations, utilisez createDraftBsff.
   """
@@ -41,6 +52,83 @@ type Mutation {
 
   """
   Mutation permettant d'apposer une signature sur le bordereau.
+
+  **Champs requis pour `EMISSION` :**
+
+  ```
+  emitter {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+      mail
+    }
+  }
+  waste {
+    code
+    adr
+  }
+  weight {
+    value
+  }
+  ```
+
+  **Champs requis pour `TRANSPORT` :**
+
+  ```
+  transporter {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+      mail
+    }
+    transport {
+      mode
+    }
+  }
+  packagings {
+    name
+    numero
+    weight
+  }
+  ```
+
+  **Champs requis pour `RECEPTION` :**
+
+  ```
+  destination {
+    company {
+      name
+      siret
+      address
+      contact
+      phone
+      mail
+    }
+    reception {
+      date
+      weight
+      acceptation {
+        status
+      }
+    }
+  }
+  ```
+
+  **Champs requis pour `OPERATION` :**
+
+  ```
+  destination {
+    operation {
+      code
+    }
+  }
+  ```
   """
   signBsff(
     "Identifiant du BSFF à signer."

--- a/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
@@ -20,7 +20,78 @@ type Mutation {
   publishBsvhu(id: ID!): Bsvhu
 
   """
-  Signe un BSVHU
+  Signe un BSVHU.
+
+  **Champs requis pour `EMISSION` :**
+
+  ```
+  emitter {
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+    agrementNumber
+  }
+  quantity
+  weight {
+    value
+  }
+  identification {
+    type
+  }
+  packaging
+  destination {
+    type
+    plannedOperationCode
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+  }
+  ```
+
+  **Champs requis pour `TRANSPORT` :**
+
+  ```
+  transporter {
+    company {
+      siret
+      name
+      address
+      contact
+      mail
+      phone
+    }
+    recepisse {
+      number
+      department
+      validityLimit
+    }
+  }
+  ```
+
+  **Champs requis pour `OPERATION` :**
+
+  ```
+  destination {
+    reception {
+      weight
+      acceptationStatus
+    }
+    operation {
+      code
+    }
+    agrementNumber
+  }
+  ```
   """
   signBsvhu(id: ID!, input: BsvhuSignatureInput!): Bsvhu
 

--- a/back/src/forms/typeDefs/bsdd.mutations.graphql
+++ b/back/src/forms/typeDefs/bsdd.mutations.graphql
@@ -36,9 +36,9 @@ type Mutation {
   Les champs suivants sont obligatoires pour pouvoir finaliser un bordereau et
   doivent avoir été renseignés au préalable
   ```
-  emitter: {
+  emitter {
     type
-    company: {
+    company {
       siret
       name
       address
@@ -47,10 +47,10 @@ type Mutation {
       mail
     }
   }
-  recipient: {
+  recipient {
     processingOperation
     cap // requis pour les déchets dangereux uniquement
-    company: {
+    company {
       siret
       name
       address
@@ -59,8 +59,8 @@ type Mutation {
       mail
     }
   }
-  transporter: {
-    company: {
+  transporter {
+    company {
       siret
       name
       address
@@ -68,17 +68,14 @@ type Mutation {
       mail
       phone
     }
-    isExemptedOfReceipt
-    receipt
+    receipt // non requis si isExemptedOfReceipt=true
     department // non requis si isExemptedOfReceipt=true
     validityLimit // peut-être omis si isExemptedOfReceipt=true
-    numberPlate // peut-être omis si isExemptedOfReceipt=true
   }
-  wasteDetails: {
+  wasteDetails {
     code
     onuCode // requis pour les déchets dangereux uniquement
-    name
-    packagings {
+    packagingInfos {
       type
       other // requis si type=OTHER
       quantity

--- a/doc/docs/reference/changelog.md
+++ b/doc/docs/reference/changelog.md
@@ -1,5 +1,0 @@
----
-title: Changelog
----
-
-Le changelog est disponible sur [le projet Github](https://github.com/MTES-MCT/trackdechets/blob/master/Changelog.md)

--- a/doc/docs/reference/validation.md
+++ b/doc/docs/reference/validation.md
@@ -1,0 +1,15 @@
+---
+title: Validation des données
+---
+
+La validation des données entrantes passe principalement par les restrictions du schéma GraphQL. Vous pouvez donc vous référer à la documentation du type d'un champ pour savoir ce qui est attendu.
+
+Si vous ne trouvez pas de mention spéciale concernant un champ, vous pouvez partir du principe que la documentation de son type est complète. Par exemple un champ `String` est une chaîne de caractères sans contraintes particulières. Si ce champ avait une taille limite, il en serait fait mention.
+
+Le nom d'un champ est également un indicateur de ce qui est attendu, par exemple un champ `email: String` s'attend à une adresse email valide, `url: String` à une URL valide, `siret: String` à une suite de 14 chiffres.
+
+## Champs requis
+
+Les champs requis sont marqués d'un point d'exclamation avec GraphQL : `!`. Il y a une exception pour les bordereaux qui peuvent être complété au fil du temps. Dans ce cas, la majorité des champs seront marqués comme optionnels, pour permettre de créer un bordereau partiel et de le compléter. Ceci étant dit, certains champs doivent être renseignés avant certaines signatures. Dans ce cas, vous retrouverez la liste de ces champs sur la mutation de signature qui vous intéresse.
+
+Par exemple, pour connaître les champs requis avant de pouvoir signer un BSDD, vous pouvez vous référer à la documentation de la mutation [`markAsSealed`](./api-reference/bsdd/mutations.md#markassealed).

--- a/doc/docs/reference/validation.md
+++ b/doc/docs/reference/validation.md
@@ -8,6 +8,8 @@ Si vous ne trouvez pas de mention spéciale concernant un champ, vous pouvez par
 
 Le nom d'un champ est également un indicateur de ce qui est attendu, par exemple un champ `email: String` s'attend à une adresse email valide, `url: String` à une URL valide, `siret: String` à une suite de 14 chiffres.
 
+Consultez la page [Erreurs](./errors.md) pour apprendre plus sur le format des erreurs dans le cas d'un problème de validation.
+
 ## Champs requis
 
 Les champs requis sont marqués d'un point d'exclamation avec GraphQL : `!`. Il y a une exception pour les bordereaux qui peuvent être complété au fil du temps. Dans ce cas, la majorité des champs seront marqués comme optionnels, pour permettre de créer un bordereau partiel et de le compléter. Ceci étant dit, certains champs doivent être renseignés avant certaines signatures. Dans ce cas, vous retrouverez la liste de ces champs sur la mutation de signature qui vous intéresse.

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -94,6 +94,7 @@ module.exports = {
         "reference/authentification",
         "reference/permissions",
         "reference/identifiants",
+        "reference/validation",
         "reference/errors",
         "reference/notifications",
         "reference/limitations",

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -77,7 +77,14 @@ module.exports = {
     {
       Référence: [
         {
-          "Référence API ": [...apiReference, "reference/changelog"],
+          "Référence API ": [
+            ...apiReference,
+            {
+              type: "link",
+              label: "Changelog",
+              href: "https://github.com/MTES-MCT/trackdechets/blob/master/Changelog.md",
+            },
+          ],
         },
         {
           Statuts: ["reference/statuts/bsdd", "reference/statuts/bsdasri"],


### PR DESCRIPTION
Cette PR ajoute une PR qui décrit l'approche de l'API au sujet de la validation des données. J'en profite également pour mettre à jour la documentation des champs requis pour la mutation `markAsSealed`.

- [x] Mettre à jour la documentation
- [ ] ~Mettre à jour le change log~
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~
- [ ] ~S'assurer que la numérotation des nouvelles migrations est bien cohérente~

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-6784)
