### PR TITLE
BSFF - Missing status filter

### DIFF
--- a/back/src/bsffs/where.ts
+++ b/back/src/bsffs/where.ts
@@ -12,6 +12,7 @@ import {
 function toPrismaBsffWhereInput(where: BsffWhere): Prisma.BsffWhereInput {
   return safeInput<Prisma.BsffWhereInput>({
     ...toPrismaGenericWhereInput(where),
+    status: toPrismaEnumFilter(where.status),
     emitterCompanySiret: toPrismaStringFilter(where.emitter?.company?.siret),
     emitterEmissionSignatureDate: toPrismaDateFilter(
       where.emitter?.emission?.signature?.date


### PR DESCRIPTION
Mini correctif suite à une remontée client. Le filtre statut était dispo sur l'api mais pas pris en compte