### PR TITLE
Correctif UI bsdd quantity type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
-- Correctif de l'affichag du type de quantité dans l'UI du BSDD [PR 1102](https://github.com/MTES-MCT/trackdechets/pull/1102)
+- Correctif de l'affichage du type de quantité dans l'UI du BSDD [PR 1102](https://github.com/MTES-MCT/trackdechets/pull/1102)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correctif de l'affichag du type de quantité dans l'UI du BSDD [PR 1102](https://github.com/MTES-MCT/trackdechets/pull/1102)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -50,6 +50,7 @@ export const wasteDetailsFragment = gql`
       quantity
     }
     quantity
+    quantityType
     consistence
     pop
   }


### PR DESCRIPTION
Mini correctif suite retour support: dans l'UI le type de quantité du bsdd ne correspond pas à la valeur retournée par l'api.

- [x] Mettre à jour le change log

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6972)
