### PR TITLE
Ajout du courtier à la liste des acteurs pouvant lister ses bsdas

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Ajout du courtier à la liste des acteurs pouvant lister ses bsdas [PR 1103](https://github.com/MTES-MCT/trackdechets/pull/1103)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -4,18 +4,26 @@ import { NotFormContributor } from "../forms/errors";
 import { getFullUser } from "../users/database";
 import prisma from "../prisma";
 
+type BsdaContributors = Pick<
+  Bsda,
+  | "emitterCompanySiret"
+  | "destinationCompanySiret"
+  | "transporterCompanySiret"
+  | "workerCompanySiret"
+  | "brokerCompanySiret"
+>;
+
+export const BSDA_CONTRIBUTORS_FIELDS: Array<keyof BsdaContributors> = [
+  "emitterCompanySiret",
+  "destinationCompanySiret",
+  "transporterCompanySiret",
+  "workerCompanySiret",
+  "brokerCompanySiret"
+];
+
 export async function checkIsBsdaContributor(
   user: User,
-  form: Partial<
-    Pick<
-      Bsda,
-      | "emitterCompanySiret"
-      | "destinationCompanySiret"
-      | "transporterCompanySiret"
-      | "workerCompanySiret"
-      | "brokerCompanySiret"
-    >
-  >,
+  form: Partial<BsdaContributors>,
   errorMsg: string
 ) {
   const isContributor = await isBsdaContributor(user, form);
@@ -31,13 +39,7 @@ export async function isBsdaContributor(user: User, form: Partial<Bsda>) {
   const fullUser = await getFullUser(user);
   const userSirets = fullUser.companies.map(c => c.siret);
 
-  const formSirets = [
-    form.emitterCompanySiret,
-    form.destinationCompanySiret,
-    form.transporterCompanySiret,
-    form.workerCompanySiret,
-    form.brokerCompanySiret
-  ];
+  const formSirets = BSDA_CONTRIBUTORS_FIELDS.map(field => form[field]);
 
   const siretsInCommon = userSirets.filter(siret => formSirets.includes(siret));
 

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -13,13 +13,14 @@ type BsdaContributors = Pick<
   | "brokerCompanySiret"
 >;
 
-export const BSDA_CONTRIBUTORS_FIELDS: Array<keyof BsdaContributors> = [
-  "emitterCompanySiret",
-  "destinationCompanySiret",
-  "transporterCompanySiret",
-  "workerCompanySiret",
-  "brokerCompanySiret"
-];
+export const BSDA_CONTRIBUTORS_FIELDS: Record<string, keyof BsdaContributors> =
+  {
+    emitter: "emitterCompanySiret",
+    destination: "destinationCompanySiret",
+    transporter: "transporterCompanySiret",
+    worker: "workerCompanySiret",
+    broker: "brokerCompanySiret"
+  };
 
 export async function checkIsBsdaContributor(
   user: User,
@@ -39,7 +40,9 @@ export async function isBsdaContributor(user: User, form: Partial<Bsda>) {
   const fullUser = await getFullUser(user);
   const userSirets = fullUser.companies.map(c => c.siret);
 
-  const formSirets = BSDA_CONTRIBUTORS_FIELDS.map(field => form[field]);
+  const formSirets = Object.values(BSDA_CONTRIBUTORS_FIELDS).map(
+    field => form[field]
+  );
 
   const siretsInCommon = userSirets.filter(siret => formSirets.includes(siret));
 

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -6,6 +6,7 @@ import {
   companyAssociatedToExistingUserFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
+import { BSDA_CONTRIBUTORS_FIELDS } from "../../../permissions";
 import { bsdaFactory } from "../../../__tests__/factories";
 
 const GET_BSDAS = `
@@ -87,31 +88,18 @@ describe("Query.bsdas", () => {
     expect(data.bsdas.edges.length).toBe(2);
   });
 
-  it.each(["emitter", "worker", "transporter", "destination"])(
+  it.each(BSDA_CONTRIBUTORS_FIELDS)(
     "should filter bsdas where user appears as %s",
-    async role => {
+    async field => {
       const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
 
-      await bsdaFactory({
-        opt: {
-          emitterCompanySiret: company.siret
-        }
-      });
-      await bsdaFactory({
-        opt: {
-          workerCompanySiret: company.siret
-        }
-      });
-      await bsdaFactory({
-        opt: {
-          transporterCompanySiret: company.siret
-        }
-      });
-      await bsdaFactory({
-        opt: {
-          destinationCompanySiret: company.siret
-        }
-      });
+      for (const otherField of BSDA_CONTRIBUTORS_FIELDS) {
+        await bsdaFactory({
+          opt: {
+            [otherField]: company.siret
+          }
+        });
+      }
 
       const { query } = makeClient(user);
       const { data } = await query<Pick<Query, "bsdas">, QueryBsdasArgs>(
@@ -119,7 +107,7 @@ describe("Query.bsdas", () => {
         {
           variables: {
             where: {
-              [role]: {
+              [field]: {
                 company: {
                   siret: { _eq: company.siret }
                 }

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -7,6 +7,7 @@ import { getConnectionsArgs } from "../../../bsvhu/pagination";
 import { expandBsdaFromDb } from "../../converter";
 import { toPrismaWhereInput } from "../../where";
 import { applyMask } from "../../../common/where";
+import { BSDA_CONTRIBUTORS_FIELDS } from "../../permissions";
 
 export default async function bsdas(
   _,
@@ -28,12 +29,7 @@ export default async function bsdas(
   const userSirets = userCompanies.map(c => c.siret);
 
   const mask = {
-    OR: [
-      { emitterCompanySiret: { in: userSirets } },
-      { workerCompanySiret: { in: userSirets } },
-      { transporterCompanySiret: { in: userSirets } },
-      { destinationCompanySiret: { in: userSirets } }
-    ]
+    OR: BSDA_CONTRIBUTORS_FIELDS.map(field => ({ [field]: { in: userSirets } }))
   };
 
   const prismaWhere = {

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -29,7 +29,9 @@ export default async function bsdas(
   const userSirets = userCompanies.map(c => c.siret);
 
   const mask = {
-    OR: BSDA_CONTRIBUTORS_FIELDS.map(field => ({ [field]: { in: userSirets } }))
+    OR: Object.values(BSDA_CONTRIBUTORS_FIELDS).map(field => ({
+      [field]: { in: userSirets }
+    }))
   };
 
   const prismaWhere = {

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -18,6 +18,8 @@ input BsdaWhere {
   transporter: BsdaTransporterWhere
   "Filtre sur le champ destination."
   destination: BsdaDestinationWhere
+  "Filtre sur le champ broker."
+  broker: BsdaBrokerWhere
   "ET logique"
   _and: [BsdaWhere!]
   "OU logique"
@@ -59,6 +61,11 @@ input BsdaDestinationWhere {
   company: CompanyWhere
   reception: BsdaReceptionWhere
   operation: BsdaOperationWhere
+}
+
+"Champs possible pour le filtre sur le courtier."
+input BsdaBrokerWhere {
+  company: CompanyWhere
 }
 
 "Champs possibles pour le filtre sur la réception"

--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -38,7 +38,8 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
     ),
     destinationOperationSignatureDate: toPrismaDateFilter(
       where.destination?.operation?.signature?.date
-    )
+    ),
+    brokerCompanySiret: toPrismaStringFilter(where.broker?.company?.siret)
   });
 }
 


### PR DESCRIPTION
Signalé sur le forum, le courtier ne retrouve pas ses bsdas via la query associée : https://forum.trackdechets.beta.gouv.fr/t/le-suivi-des-bsdas-dans-le-cas-dune-entreprise-de-courtage-ne-remonte-pas-dans-la-query/372

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] ~Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)~
- [ ] ~S'assurer que la numérotation des nouvelles migrations est bien cohérente~

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6973)
