### PR TITLE
Recette registre multi-bordereaux 

### DIFF
--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -104,6 +104,9 @@ export function toIncomingWaste(
 
   return {
     ...genericWaste,
+    destinationCompanyName: bsda.destinationCompanyName,
+    destinationCompanySiret: bsda.destinationCompanySiret,
+    destinationCompanyAddress: bsda.destinationCompanyAddress,
     destinationReceptionDate: bsda.destinationReceptionDate,
     destinationReceptionWeight: bsda.destinationReceptionWeight
       ? bsda.destinationReceptionWeight / 1000
@@ -172,6 +175,8 @@ export function toOutgoingWaste(
     destinationCompanySiret: bsda.destinationCompanySiret,
     destinationPlannedOperationCode: bsda.destinationPlannedOperationCode,
     destinationPlannedOperationMode: null,
+    emitterCompanyName: bsda.emitterCompanyName,
+    emitterCompanySiret: bsda.emitterCompanySiret,
     emitterCompanyAddress: bsda.emitterCompanyAddress,
     emitterPickupsiteAddress: bsda.emitterPickupSiteAddress,
     ...initialEmitter,
@@ -228,6 +233,9 @@ export function toTransportedWaste(
     transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
     destinationReceptionDate: bsda.destinationReceptionDate,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,
+    transporterCompanyName: bsda.transporterCompanyName,
+    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterNumberPlates: bsda.transporterTransportPlates,
     ...initialEmitter,
     emitterCompanyAddress: bsda.emitterCompanyAddress,
@@ -284,6 +292,12 @@ export function toManagedWaste(
 
   return {
     ...genericWaste,
+    managedStartDate: null,
+    managedEndDate: null,
+    traderCompanyName: null,
+    traderCompanySiret: null,
+    brokerCompanyName: bsda.brokerCompanyName,
+    brokerCompanySiret: bsda.brokerCompanySiret,
     destinationCompanyAddress: bsda.destinationCompanyAddress,
     destinationCompanyName: bsda.destinationCompanyName,
     destinationCompanySiret: bsda.destinationCompanySiret,

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -342,6 +342,9 @@ export function toAllWaste(
 
   return {
     ...genericWaste,
+    createdAt: bsda.createdAt,
+    transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
+    destinationReceptionDate: bsda.destinationReceptionDate,
     brokerCompanyName: bsda.brokerCompanyName,
     brokerCompanySiret: bsda.brokerCompanySiret,
     brokerRecepisseNumber: bsda.brokerRecepisseNumber,

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -322,6 +322,9 @@ export function toAllWaste(
 
   return {
     ...genericWaste,
+    createdAt: bsdasri.createdAt,
+    transporterTakenOverAt: bsdasri.transporterTakenOverAt,
+    destinationReceptionDate: bsdasri.destinationReceptionDate,
     brokerCompanyName: null,
     brokerCompanySiret: null,
     brokerRecepisseNumber: null,

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -92,6 +92,9 @@ export function toIncomingWaste(
 
   return {
     ...genericWaste,
+    destinationCompanyName: bsdasri.destinationCompanyName,
+    destinationCompanySiret: bsdasri.destinationCompanySiret,
+    destinationCompanyAddress: bsdasri.destinationCompanyAddress,
     destinationReceptionDate: bsdasri.destinationReceptionDate,
     destinationReceptionWeight: bsdasri.destinationReceptionWasteWeightValue
       ? bsdasri.destinationReceptionWasteWeightValue / 1000
@@ -156,6 +159,8 @@ export function toOutgoingWaste(
     destinationCompanySiret: bsdasri.destinationCompanySiret,
     destinationPlannedOperationCode: bsdasri.destinationOperationCode,
     destinationPlannedOperationMode: null,
+    emitterCompanyName: bsdasri.emitterCompanyName,
+    emitterCompanySiret: bsdasri.emitterCompanySiret,
     emitterCompanyAddress: bsdasri.emitterCompanyAddress,
     emitterPickupsiteAddress: buildAddress([
       bsdasri.emitterPickupSiteName,
@@ -212,6 +217,9 @@ export function toTransportedWaste(
     weight: bsdasri.emitterWasteWeightValue
       ? bsdasri.emitterWasteWeightValue / 1000
       : bsdasri.emitterWasteWeightValue,
+    transporterCompanyName: bsdasri.transporterCompanyName,
+    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanyAddress: bsdasri.transporterCompanyAddress,
     transporterNumberPlates: bsdasri.transporterTransportPlates,
     ...initialEmitter,
     emitterCompanyAddress: bsdasri.emitterCompanyAddress,
@@ -268,6 +276,12 @@ export function toManagedWaste(
 
   return {
     ...genericWaste,
+    managedStartDate: null,
+    managedEndDate: null,
+    traderCompanyName: null,
+    traderCompanySiret: null,
+    brokerCompanyName: null,
+    brokerCompanySiret: null,
     destinationCompanyAddress: bsdasri.destinationCompanyAddress,
     destinationCompanyName: bsdasri.destinationCompanyName,
     destinationCompanySiret: bsdasri.destinationCompanySiret,

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -105,6 +105,9 @@ export function toIncomingWaste(
 
   return {
     ...genericWaste,
+    destinationCompanyName: bsff.destinationCompanyName,
+    destinationCompanySiret: bsff.destinationCompanySiret,
+    destinationCompanyAddress: bsff.destinationCompanyAddress,
     destinationReceptionDate: bsff.destinationReceptionDate,
     destinationReceptionWeight: bsff.destinationReceptionWeight
       ? bsff.destinationReceptionWeight / 1000
@@ -178,6 +181,8 @@ export function toOutgoingWaste(
     destinationCompanySiret: bsff.destinationCompanySiret,
     destinationPlannedOperationCode: bsff.destinationPlannedOperationCode,
     destinationPlannedOperationMode: null,
+    emitterCompanyName: bsff.emitterCompanyName,
+    emitterCompanySiret: bsff.emitterCompanySiret,
     emitterCompanyAddress: bsff.emitterCompanyAddress,
     emitterPickupsiteAddress: null,
     ...initialEmitter,
@@ -240,6 +245,9 @@ export function toTransportedWaste(
     transporterTakenOverAt: bsff.transporterTransportSignatureDate,
     destinationReceptionDate: bsff.destinationReceptionDate,
     weight: bsff.weightValue ? bsff.weightValue / 1000 : bsff.weightValue,
+    transporterCompanyName: bsff.transporterCompanyName,
+    transporterCompanySiret: bsff.transporterCompanySiret,
+    transporterCompanyAddress: bsff.transporterCompanyAddress,
     transporterNumberPlates: null,
     ...initialEmitter,
     emitterCompanyAddress: bsff.emitterCompanyAddress,
@@ -305,6 +313,12 @@ export function toManagedWaste(
 
   return {
     ...genericWaste,
+    managedStartDate: null,
+    managedEndDate: null,
+    traderCompanyName: null,
+    traderCompanySiret: null,
+    brokerCompanyName: null,
+    brokerCompanySiret: null,
     destinationCompanyAddress: bsff.destinationCompanyAddress,
     destinationCompanyName: bsff.destinationCompanyName,
     destinationCompanySiret: bsff.destinationCompanySiret,

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -369,6 +369,9 @@ export function toAllWaste(
 
   return {
     ...genericWaste,
+    createdAt: bsff.createdAt,
+    transporterTakenOverAt: bsff.transporterTransportTakenOverAt,
+    destinationReceptionDate: bsff.destinationReceptionDate,
     brokerCompanyName: null,
     brokerCompanySiret: null,
     brokerRecepisseNumber: null,

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -255,6 +255,9 @@ export function toAllWaste(bsvhu: Bsvhu): AllWaste {
 
   return {
     ...genericWaste,
+    createdAt: bsvhu.createdAt,
+    transporterTakenOverAt: bsvhu.transporterTransportTakenOverAt,
+    destinationReceptionDate: bsvhu.destinationReceptionDate,
     brokerCompanyName: null,
     brokerCompanySiret: null,
     brokerRecepisseNumber: null,

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -82,6 +82,9 @@ export function toIncomingWaste(bsvhu: Bsvhu): IncomingWaste {
 
   return {
     ...genericWaste,
+    destinationCompanyName: bsvhu.destinationCompanyName,
+    destinationCompanySiret: bsvhu.destinationCompanySiret,
+    destinationCompanyAddress: bsvhu.destinationCompanyAddress,
     destinationReceptionDate: bsvhu.destinationReceptionDate,
     destinationReceptionWeight: bsvhu.destinationReceptionWeight
       ? bsvhu.destinationReceptionWeight / 1000
@@ -133,6 +136,8 @@ export function toOutgoingWaste(bsvhu: Bsvhu): OutgoingWaste {
     destinationCompanySiret: bsvhu.destinationCompanySiret,
     destinationPlannedOperationCode: bsvhu.destinationPlannedOperationCode,
     destinationPlannedOperationMode: null,
+    emitterCompanyName: bsvhu.emitterCompanyName,
+    emitterCompanySiret: bsvhu.emitterCompanySiret,
     emitterCompanyAddress: bsvhu.emitterCompanyAddress,
     emitterPickupsiteAddress: null,
     ...initialEmitter,
@@ -171,6 +176,9 @@ export function toTransportedWaste(bsvhu: Bsvhu): TransportedWaste {
     transporterTakenOverAt: bsvhu.transporterTransportTakenOverAt,
     destinationReceptionDate: bsvhu.destinationReceptionDate,
     weight: bsvhu.weightValue ? bsvhu.weightValue / 1000 : bsvhu.weightValue,
+    transporterCompanyName: bsvhu.transporterCompanyName,
+    transporterCompanySiret: bsvhu.transporterCompanySiret,
+    transporterCompanyAddress: bsvhu.transporterCompanyAddress,
     transporterNumberPlates: bsvhu.transporterTransportPlates,
     ...initialEmitter,
     emitterCompanyAddress: bsvhu.emitterCompanyAddress,
@@ -214,6 +222,12 @@ export function toManagedWaste(bsvhu: Bsvhu): ManagedWaste {
 
   return {
     ...genericWaste,
+    managedStartDate: null,
+    managedEndDate: null,
+    traderCompanyName: null,
+    traderCompanySiret: null,
+    brokerCompanyName: null,
+    brokerCompanySiret: null,
     destinationCompanyAddress: bsvhu.destinationCompanyAddress,
     destinationCompanyName: bsvhu.destinationCompanyName,
     destinationCompanySiret: bsvhu.destinationCompanySiret,

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -116,6 +116,9 @@ export function toIncomingWaste(
 
   return {
     ...genericWaste,
+    destinationCompanyName: bsdd.destinationCompanyName,
+    destinationCompanySiret: bsdd.destinationCompanySiret,
+    destinationCompanyAddress: bsdd.destinationCompanyAddress,
     destinationReceptionDate: bsdd.destinationReceptionDate,
     destinationReceptionWeight: bsdd.destinationReceptionWeight,
     emitterCompanyName: bsdd.emitterCompanyName,
@@ -209,6 +212,8 @@ export function toOutgoingWaste(
     destinationCompanySiret: bsdd.destinationCompanySiret,
     destinationPlannedOperationCode: bsdd.destinationPlannedOperationCode,
     destinationPlannedOperationMode: null,
+    emitterCompanyName: bsdd.emitterCompanyName,
+    emitterCompanySiret: bsdd.emitterCompanySiret,
     emitterCompanyAddress: bsdd.emitterCompanyAddress,
     emitterPickupsiteAddress: bsdd.emitterPickupSiteAddress,
     ...initialEmitter,
@@ -292,6 +297,9 @@ export function toTransportedWaste(
     transporterTakenOverAt: bsdd.transporterTransportTakenOverAt,
     destinationReceptionDate: bsdd.destinationReceptionDate,
     weight: bsdd.weightValue,
+    transporterCompanyName: bsdd.transporterCompanyName,
+    transporterCompanySiret: bsdd.transporterCompanySiret,
+    transporterCompanyAddress: bsdd.transporterCompanyAddress,
     transporterNumberPlates: bsdd.transporterNumberPlates,
     ...initialEmitter,
     emitterCompanyAddress: bsdd.emitterCompanyAddress,
@@ -376,6 +384,12 @@ export function toManagedWaste(
 
   return {
     ...genericWaste,
+    managedStartDate: null,
+    managedEndDate: null,
+    traderCompanyName: bsdd.traderCompanyName,
+    traderCompanySiret: bsdd.traderCompanySiret,
+    brokerCompanyName: null,
+    brokerCompanySiret: null,
     destinationCompanyAddress: bsdd.destinationCompanyAddress,
     destinationCompanyName: bsdd.destinationCompanyName,
     destinationCompanySiret: bsdd.destinationCompanySiret,

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -441,6 +441,9 @@ export function toAllWaste(
 
   return {
     ...genericWaste,
+    createdAt: bsdd.createdAt,
+    transporterTakenOverAt: bsdd.transporterTransportTakenOverAt,
+    destinationReceptionDate: bsdd.destinationReceptionDate,
     brokerCompanyName: bsdd.brokerCompanyName,
     brokerCompanySiret: bsdd.brokerCompanySiret,
     brokerRecepisseNumber: bsdd.brokerRecepisseNumber,

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -32,8 +32,13 @@ const columns: Column[] = [
   // Dénomination, nature et quantité :
   { field: "id", label: "N° de bordereau" },
   {
+    field: "createdAt",
+    label: "Date de création du bordereau",
+    format: formatDate
+  },
+  {
     field: "transporterTakenOverAt",
-    label: "Date d'enlèvement",
+    label: "Date d'expédition",
     format: formatDate
   },
   {

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -94,6 +94,13 @@ type IncomingWaste {
   # d) Concernant l'opération de traitement effectuée par l'établissement :
   #########################################################################
 
+  "La raison sociale de l'établissement vers lequel le déchet est expédié"
+  destinationCompanyName: String
+  "Le N°SIRET de l'établissement vers lequel le déchet est expédié"
+  destinationCompanySiret: String
+  "L'adresse de l'établissement vers lequel le déchet est expédié"
+  destinationCompanyAddress: String
+
   "Le code du traitement qui va être opéré dans l'établissement selon les annexes I et II de la directive 2008/98/CE relative aux déchets"
   destinationOperationCode: String
 
@@ -192,6 +199,11 @@ type OutgoingWaste {
   #####################################
   # c) Concernant l'origine du déchet :
   #####################################
+
+  "La raison sociale de l'établissement expéditeur des déchets"
+  emitterCompanyName: String
+  "Le numéro SIRET de l'établissement expéditeur des déchets"
+  emitterCompanySiret: String
 
   "L'adresse de l'établissement"
   emitterCompanyAddress: String
@@ -358,6 +370,13 @@ type TransportedWaste {
   # c) Concernant le transport du déchet :
   ########################################
 
+  "La raison sociale du transporteur"
+  transporterCompanyName: String
+  "Le N°SIRET du transporteur"
+  transporterCompanySiret: String
+  "L'adresse du transporteur"
+  transporterCompanyAddress: String
+
   "Le numéro d'immatriculation du ou des véhicules transportant le déchet"
   transporterNumberPlates: [String!]
   """
@@ -492,8 +511,17 @@ type ManagedWaste {
   id: ID
 
   ################################################
-  # a) Concernant les dates de gestion du déchet :
+  # a) Concernant la gestion du déchet :
   ################################################
+
+  "La raison sociale du négociant si le déchet est géré par un courtier"
+  traderCompanyName: String
+  "Le N°SIRET du négociant si le déchet est géré par un négociant"
+  traderCompanySiret: String
+  "La raison sociale du courtier si le déchet est géré par un courtier"
+  brokerCompanyName: String
+  "Le N°SIRET du courtier si le déchet est géré par un courtier"
+  brokerCompanySiret: String
 
   "NON IMPLÉMENTÉ. La date d'acquisition du déchet par le négociant, ou la date de début de gestion du déchet par le courtier"
   managedStartDate: DateTime

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -649,8 +649,20 @@ type AllWaste {
   """
   id: ID
 
+  "Date de création du bordereau"
+  createdAt: DateTime
+
   ################################################
-  # a) Concernant les dates de gestion du déchet :
+  # Concernant les dates de transit du déchet :
+  ################################################
+
+  "La date d'enlèvement du déchet"
+  transporterTakenOverAt: DateTime
+  "La date de déchargement du déchet"
+  destinationReceptionDate: DateTime
+
+  ################################################
+  # Concernant les dates de gestion du déchet :
   ################################################
 
   "NON IMPLÉMENTÉ. La date d'acquisition du déchet par le négociant, ou la date de début de gestion du déchet par le courtier"
@@ -659,7 +671,7 @@ type AllWaste {
   managedEndDate: DateTime
 
   #####################################################
-  # b) Concernant la dénomination, nature et quantité :
+  # Concernant la dénomination, nature et quantité :
   #####################################################
 
   "Dénomination usuelle du déchet"
@@ -676,7 +688,7 @@ type AllWaste {
   pop: Boolean
 
   #################################################################
-  # c) Concernant l'origine, la gestion et le transport du déchet :
+  # Concernant l'origine, la gestion et le transport du déchet :
   #################################################################
 
   """


### PR DESCRIPTION
- Filtre les valeurs nulles sur le champ servant à ordonner les données. Il ne devrait normalement pas en avoir mais on se protège ainsi de potentielles incohérences dans les données.
- Au passage correction du registre exhaustif qui incluait aussi les bordereaux à l'état de brouillon alors qu'il n'aurait pas dû. 
-  Ajout de champs SIRET pour discriminer les différents établissements lorsqu'on exporte un registre de plusieurs établissements
