### PR TITLE
index INSEE Siren & Siret data

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
-/csv
+/csv*
 /dist
 /prisma/seed.dev.ts
 /src/companies/sirene/fixtures/anonymousCompanies.json

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -12611,6 +12611,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
+    "node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw=="
+    },
     "nodemon": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.14.tgz",

--- a/back/package.json
+++ b/back/package.json
@@ -87,6 +87,7 @@
     "minimist": "^1.2.5",
     "mustache": "^4.2.0",
     "node-mailjet": "^3.3.1",
+    "node-stream-zip": "^1.15.0",
     "oauth2orize": "^1.11.0",
     "object.omit": "^3.0.0",
     "passport": "^0.5.0",

--- a/back/src/commands/elasticSearch.helpers.ts
+++ b/back/src/commands/elasticSearch.helpers.ts
@@ -1,0 +1,329 @@
+import fs from "fs";
+import https from "https";
+import path from "path";
+import { Writable } from "stream";
+import StreamZip from "node-stream-zip";
+import logger from "../logging/logger";
+import { client } from "../common/elastic";
+import {
+  ElasticBulkIndexError,
+  ElasticBulkNonFlatPayload,
+  ElasticBulkPayloadDocument,
+  ElasticBulkPrepayload,
+  IndexProcessConfig
+} from "./types";
+import { ApiResponse } from "@elastic/elasticsearch";
+
+// Max size of documents to index at once, also depends on ES JVM memory available
+const CHUNK_SIZE = 10_000;
+
+// ES Mapping docs: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping.html
+export const standardMapping = {
+  _doc: {
+    dynamic_templates: [
+      {
+        dateType: {
+          match_pattern: "regex",
+          match: "^date.*$",
+          mapping: {
+            type: "date",
+            // docs : https://www.elastic.co/guide/en/elasticsearch/reference/6.8/ignore-malformed.html
+            ignore_malformed: true
+          }
+        }
+      }
+    ]
+  }
+};
+
+export const sireneIndexConfig: IndexProcessConfig = {
+  alias: `stockunitelegale_utf8-${process.env.NODE_ENV}`,
+  // to match the filename inside zip
+  csvFileName: "StockUniteLegale_utf8.csv",
+  // zip target filename
+  zipFileName: "StockUniteLegale_utf8.zip",
+  idKey: "siren",
+  mappings: standardMapping
+};
+
+const INDEX_ALIAS_NAME_SEPARATOR = "-";
+export const getIndexVersionName = (indexConfig: IndexProcessConfig) =>
+  `${indexConfig.alias}${INDEX_ALIAS_NAME_SEPARATOR}${Date.now()}`;
+
+/**
+ * Create a new index with timestamp appended to the alias name
+ * overrides the index alias with a timestamp in order to handle roll-over indices
+ */
+export const createIndexRelease = async (
+  indexConfig: IndexProcessConfig
+): Promise<string> => {
+  const indexName = getIndexVersionName(indexConfig);
+  const { mappings, settings } = indexConfig;
+  await client.indices.create({
+    index: indexName,
+    body: {
+      ...(mappings && { mappings }),
+      ...(settings && { settings })
+    }
+  });
+  logger.info(`Created a new index ${indexName}`);
+  return indexName;
+};
+
+/**
+ * Clean older indexes and attach the newest one to the alias
+ */
+export const cleanOldIndexes = async (
+  indexAlias: string,
+  indexName: string
+) => {
+  const aliases = await client.cat.aliases({
+    name: indexAlias,
+    format: "json"
+  });
+  const bindedIndexes = aliases.body.map(info => info.index);
+  logger.info(
+    `Pointing the index alias ${indexAlias} to the index ${indexName}`
+  );
+  await client.indices.putAlias({
+    index: indexName,
+    name: indexAlias
+  });
+  logger.info(
+    `Removing alias pointers to older indices ${bindedIndexes.join(", ")}.`
+  );
+  // Delete old alias pointers
+  await client.indices.deleteAlias({
+    index: bindedIndexes,
+    name: indexAlias
+  });
+  // Delete old indices completely
+  const indices = await client.cat.indices({
+    index: `${indexAlias}${INDEX_ALIAS_NAME_SEPARATOR}*`,
+    format: "json"
+  });
+  const oldIndexes = indices.body
+    .map(info => info.index)
+    // Filter out the last indexName
+    // TODO later : keep alse the previous index in order to roll-back
+    .filter(name => name !== indexName);
+  logger.info(
+    `Removing ${oldIndexes.length} old index(es) (${oldIndexes.join(", ")})`
+  );
+  await client.indices.delete({ index: oldIndexes.join(",") });
+};
+
+/**
+ * Bulk Index and collect errors
+ * controls the maximum chunk size because unzip does not
+ */
+export const bulkIndex = async (
+  body: ElasticBulkNonFlatPayload,
+  indexConfig: IndexProcessConfig
+) => {
+  // Promise returning function chunks
+  const request = async bodyChunk => {
+    const requestBulkIndex = body => {
+      if (!body || !body.length) {
+        // nothing to index
+        return Promise.resolve(null);
+      }
+      return client.bulk({
+        body,
+        // lighten the response
+        _source_excludes: ["items.index._*", "took"]
+      });
+    };
+    logger.info(`Bulk index ${bodyChunk.length} documents`);
+    // append new data to the body before indexation
+    if (typeof indexConfig.dataFormatterFn === "function") {
+      const formattedChunk = await indexConfig.dataFormatterFn(bodyChunk, {
+        sireneIndexConfig
+      });
+      return requestBulkIndex(formattedChunk.flat());
+    }
+    return requestBulkIndex(bodyChunk.flat());
+  };
+
+  const logBulkIndexErrors = (
+    bulkResponse: ApiResponse,
+    slice: [ElasticBulkPrepayload, ElasticBulkPayloadDocument][]
+  ) => {
+    if (bulkResponse?.body?.errors) {
+      bulkResponse.body.items.forEach((action, k: number) => {
+        const [operation] = Object.keys(action);
+        if (action[operation].error) {
+          const elasticBulkIndexError: ElasticBulkIndexError = {
+            // If the status is 429 it means that you can retry the document,
+            // otherwise it's very likely a mapping error, and you should fix the document content
+            status: action[operation].status,
+            error: action[operation].error,
+            bulkBody: slice[k]
+          };
+          logger.error(`Error in bulkIndex operation`, {
+            elasticBulkIndexError
+          });
+        }
+      });
+    }
+  };
+
+  // immediat return the chunk larger than the data streamed
+  if (CHUNK_SIZE > body.length) {
+    const bulkResponse = await request(body);
+    // Collect error data
+    logBulkIndexErrors(bulkResponse, body);
+    return;
+  }
+
+  // loop over other chunks
+  for (let i = 0; i < body.length; i += CHUNK_SIZE) {
+    const end = i + CHUNK_SIZE;
+    const slice = body.slice(i, end);
+    const bulkResponse = await request(slice);
+    // Collect error data
+    logBulkIndexErrors(bulkResponse, slice);
+  }
+};
+
+/**
+ * Writable stream that parses CSV to an ES bulk body
+ */
+export const getWritableParserAndIndexer = (
+  indexConfig: IndexProcessConfig,
+  headers: string[],
+  indexName: string
+) =>
+  new Writable({
+    // seems a reasonanle data size to go with CHUNK_SIZE = 10000
+    highWaterMark: 8_192_000,
+    writev: (chunks, next) => {
+      const bufferChunk = chunks.map(({ chunk }) => chunk);
+      const csvLines: string[] = bufferChunk.toString().split("\n");
+      // get columns names in the csv header
+      // pre-suppose that the first column === indexConfig.idKey (eg. "siren" or "siret")
+      if (csvLines[0].startsWith(indexConfig.idKey) && !headers) {
+        headers = csvLines[0].split(",");
+        csvLines.shift();
+      }
+
+      const body: ElasticBulkNonFlatPayload = csvLines
+        .filter(line => {
+          // exclude invalid like ones not starting with a SIREN numbers string
+          const values = line.split(",");
+          return (
+            values && values.length && values[0] && /^\d+$/.test(values[0])
+          );
+        })
+        .map(line => {
+          const values = line.split(",");
+          const doc = {};
+          // build the document to index
+          for (let i = 0; i < headers.length; i++) {
+            doc[headers[i]] = values[i];
+          }
+          return [
+            {
+              index: {
+                _id: doc[indexConfig.idKey],
+                _index: indexName,
+                // Next major ES version won't need _type anymore
+                _type: "_doc"
+              }
+            },
+            doc
+          ];
+        });
+
+      bulkIndex(body, indexConfig)
+        .then(() => next())
+        .catch(err => next(err));
+    }
+  });
+
+/**
+ * Streaming unzip, formatting documents and index them
+ */
+export const unzipAndIndex = async (
+  zipPath: string,
+  indexConfig: IndexProcessConfig
+) => {
+  const indexName = await createIndexRelease(indexConfig);
+  const zip = new StreamZip.async({ file: zipPath });
+  const stm = await zip.stream(indexConfig.csvFileName);
+  let headers: string[];
+  const writable = getWritableParserAndIndexer(indexConfig, headers, indexName);
+  stm.pipe(writable);
+  stm.on("end", async () => {
+    zip.close();
+    // roll-over index alias
+    await cleanOldIndexes(indexConfig.alias, indexName);
+    logger.info(
+      `Finished indexing ${indexName} with alias ${indexConfig.alias}`
+    );
+  });
+  stm.on("error", err => {
+    throw err;
+  });
+};
+
+/**
+ * Download and launch indexation
+ */
+
+export const downloadAndIndex = async (
+  url: string,
+  indexConfig: IndexProcessConfig
+) => {
+  // path ../../csv* is in .gitignore or override with INSEE_DOWNLOAD_DIRECTORY
+  const destination = fs.mkdtempSync(
+    process.env.INSEE_DOWNLOAD_DIRECTORY ||
+      path.join(__dirname, "..", "..", "csv")
+  );
+
+  const zipPath = path.join(destination, indexConfig.zipFileName);
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, res => {
+        const contentLength = parseInt(res.headers["content-length"], 10);
+        logger.info(
+          `Start downloading the INSEE archive of ${
+            contentLength / 1000000
+          } MB from ${url} to ${zipPath}`
+        );
+        const interval = setInterval(
+          () =>
+            logger.info(
+              `Downloading the INSEE archive : ${currentLength / 1000000} MB`
+            ),
+          5000
+        );
+        // Bytes progess var
+        let currentLength = 0;
+        const file = fs.createWriteStream(zipPath);
+        // monitor progress
+        res.on("data", chunk => {
+          currentLength += Buffer.byteLength(chunk);
+        });
+        // stream into the file
+        res.pipe(file);
+        // Close the file
+        file.on("finish", () => {
+          clearInterval(interval);
+          file.close();
+          logger.info(`Finished downloading the INSEE archive to ${zipPath}`);
+        });
+        res.on("end", () => {
+          try {
+            resolve(unzipAndIndex(zipPath, indexConfig));
+          } catch (e) {
+            reject(e.message);
+          }
+        });
+      })
+      .on("error", err => {
+        logger.info("HTTP download Error: ", err.message);
+        reject(err.message);
+      });
+  });
+};

--- a/back/src/commands/indexInseeSirene.ts
+++ b/back/src/commands/indexInseeSirene.ts
@@ -1,0 +1,37 @@
+import logger from "../logging/logger";
+import { initSentry } from "../common/sentry";
+import {
+  downloadAndIndex,
+  unzipAndIndex,
+  sireneIndexConfig
+} from "./elasticSearch.helpers";
+
+const Sentry = initSentry();
+/**
+ * StockUniteLegale data specifications
+ * infos : https://www.insee.fr/fr/statistiques/4202741?sommaire=3357459
+ */
+const sireneUrl =
+  process.env.INSEE_SIRENE_URL ||
+  "https://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip";
+
+process.on("exit", function () {
+  console.log(`Command indexInseeSirene.ts finished`);
+  logger.end();
+});
+
+/**
+ * Index the Sirene INSEE database
+ */
+(async function main() {
+  logger.info("Starting indexation of StockUniteLegale");
+  try {
+    if (process.env.INSEE_SIRENE_ZIP_PATH) {
+      await unzipAndIndex(process.env.INSEE_SIRENE_ZIP_PATH, sireneIndexConfig);
+    } else {
+      await downloadAndIndex(sireneUrl, sireneIndexConfig);
+    }
+  } catch (exc) {
+    Sentry.captureException(exc);
+  }
+})();

--- a/back/src/commands/indexInseeSiret.ts
+++ b/back/src/commands/indexInseeSiret.ts
@@ -1,0 +1,80 @@
+import { client } from "../common/elastic";
+import { initSentry } from "../common/sentry";
+import logger from "../logging/logger";
+import { ElasticBulkNonFlatPayload, IndexProcessConfig } from "./types";
+import {
+  downloadAndIndex,
+  standardMapping,
+  unzipAndIndex
+} from "./elasticSearch.helpers";
+
+const Sentry = initSentry();
+
+process.on("exit", function () {
+  console.log(`Command indexInseeSirene.ts finished`);
+  logger.end();
+});
+
+const multiGet = (
+  body: ElasticBulkNonFlatPayload,
+  sireneIndexConfig: IndexProcessConfig
+) =>
+  client.mget({
+    index: sireneIndexConfig.alias,
+    body: {
+      ids: body.map(doc => doc[1].siren)
+    }
+  });
+
+/**
+ * Append SIREN data to SIRET data
+ */
+const siretWithUniteLegaleFormatter = async (
+  body: ElasticBulkNonFlatPayload,
+  extras: { sireneIndexConfig: IndexProcessConfig }
+): Promise<ElasticBulkNonFlatPayload> => {
+  const response = await multiGet(body, extras.sireneIndexConfig);
+  return response.body.docs.map((sirenDoc, i) => [
+    body[i][0],
+    {
+      ...body[i][1],
+      ...sirenDoc._source
+    }
+  ]);
+};
+
+/**
+ * StockEtablissement configuration
+ */
+const siretUrl =
+  process.env.INSEE_SIRET_URL ||
+  "https://files.data.gouv.fr/insee-sirene/StockEtablissement_utf8.zip";
+
+const siretIndexConfig: IndexProcessConfig = {
+  alias: `stocketablissement_utf8-${process.env.NODE_ENV}`,
+  // to match the filename inside zip
+  csvFileName: "StockEtablissement_utf8.csv",
+  // zip target filename
+  zipFileName: "StockEtablissement_utf8.zip",
+  idKey: "siren",
+  // append StockUniteLegale by JOINING ON "siren"
+  dataFormatterFn: siretWithUniteLegaleFormatter,
+  mappings: standardMapping
+};
+
+/**
+ * Index the SIRET INSEE database
+ */
+(async function main() {
+  logger.info("Starting indexation of StockEtablissements");
+  try {
+    if (process.env.INSEE_SIRET_ZIP_PATH) {
+      await unzipAndIndex(process.env.INSEE_SIRET_ZIP_PATH, siretIndexConfig);
+    } else {
+      await downloadAndIndex(siretUrl, siretIndexConfig);
+    }
+    logger.info(`Command indexInseeSiret.ts finished`);
+  } catch (exc) {
+    Sentry.captureException(exc);
+  }
+})();

--- a/back/src/commands/types.ts
+++ b/back/src/commands/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Indexing process configuration
+ */
+export interface IndexProcessConfig {
+  alias: string;
+  csvFileName: string;
+  idKey: string;
+  zipFileName: string;
+  dataFormatterFn?: (
+    body: ElasticBulkNonFlatPayload,
+    extras: any
+  ) => Promise<ElasticBulkNonFlatPayload>;
+  mappings?: Record<string, any>;
+  settings?: Record<string, any>;
+}
+
+/**
+ * Bulk Indexing error
+ */
+export interface ElasticBulkIndexError {
+  status: number;
+  error: any;
+  bulkBody?: Array<Record<string, any>>;
+}
+
+export type ElasticBulkPrepayload = {
+  index: {
+    _id: string;
+    _index: string;
+    // Next major ES version won't need _type anymore
+    _type: "_doc";
+  };
+};
+
+export type ElasticBulkPayloadDocument = Record<string, any>;
+
+/**
+ * Preprocessing Bulk payload
+ */
+export type ElasticBulkNonFlatPayload = Array<
+  [ElasticBulkPrepayload, ElasticBulkPayloadDocument]
+>;


### PR DESCRIPTION
# Internaliser la recherche d'établissements PARTIE 1  : Indexation seulement
## Mettre en place notre propre Api annuaire entreprise

- 2 scripts à lancer l'un après l'autre.

```
docker-compose up -d elasticsearch
cd back/
ts-node src/commands/indexInseeSirene.ts
ts-node src/commands/indexInseeSiret.ts
```

Au final si tout se passe bien, on pourra utiliser l'index "stockEtablissement" où les données d'unité légale de l'index Siren (`http://elasticsearch:9200/stockunitelegale_utf8-dev/_search`) ont été dupliquées:
`http://elasticsearch:9200/stocketablissement_utf8-dev/_search`

En cas d'erreur l'index alias en place n'est pas ecrasé, ce qui permet une roll-over release d'un nouvel index sans encombres si l'indexation plante.

- Si une archive zip locale des données existe, il est possible de passer le téléchargement en passant ces variables d'environnement:

```
export INSEE_SIRET_ZIP_PATH=~/Téléchargements/StockEtablissement_utf8.zip
export INSEE_SIRENE_ZIP_PATH=~/Téléchargements/StockUniteLegale_utf8.zip
```
Puis de relancer chaque script

## Checklist

- [x] s'assurer que les serveurs ES de chaque environnement tiennent la charge (minimum RAM JVM à 1G pour ce script)
- [ ] Mettre en place ces scripts dans un cron mensuel dans les 3 environnements
- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-6870)
