### PR TITLE
Use app-root-path

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -4347,6 +4347,11 @@
         "tslib": "^1.10.0"
       }
     },
+    "app-root-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
+    },
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",

--- a/back/package.json
+++ b/back/package.json
@@ -53,6 +53,7 @@
     "apollo-server-core": "^3.4.0",
     "apollo-server-express": "^3.4.0",
     "apollo-server-plugin-base": "^3.3.0",
+    "app-root-path": "^3.0.0",
     "axios": "^0.23.0",
     "bcrypt": "^5.0.0",
     "body-parser": "^1.19.0",

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -1,6 +1,8 @@
+import appRoot from "app-root-path";
 import { createLogger, format, transports } from "winston";
 
-const LOG_PATH = `${process.cwd()}/logs/app.log`;
+const LOG_PATH = `${appRoot}/logs/app.log`;
+
 const logger = createLogger({
   level: "info",
   exitOnError: false,


### PR DESCRIPTION
Si `process.cwd()` fonctionne bien en local, il ne semble pas fonctionner en recette. En tout cas on ne voit pas les logs remonter dans Datadog.
C'est possible que Scalingo lance les process depuis autre part que la racine du projet. On passe à l'utilisation de `app-root-path` qui est plus "reliable" pour trouver la racine d'un projet node.
