### PR TITLE
Correction de la signature traitement du bsdasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Correctif de l'affichage du type de quantité dans l'UI du BSDD [PR 1102](https://github.com/MTES-MCT/trackdechets/pull/1102)
+- Correctif de la signature du traitement du Bsdasri dans l'UI [PR 1119](https://github.com/MTES-MCT/trackdechets/pull/1102)
 
 #### :boom: Breaking changes
 
@@ -33,7 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Initialisation explicite des gestionnaires de téléchargement de fichier [PR 1092](https://github.com/MTES-MCT/trackdechets/pull/1092)
 
-# Next release ~06/12
+# [2021.12.1] 06/12/2021
 
 #### :rocket: Nouvelles fonctionnalités
 

--- a/front/src/dashboard/bsds/history/RouteBsdsHistory.tsx
+++ b/front/src/dashboard/bsds/history/RouteBsdsHistory.tsx
@@ -37,7 +37,7 @@ export function RouteBsdsHistory() {
               Il n'y a aucun bordereau en archive
             </BlankslateTitle>
             <BlankslateDescription>
-              Des bordereaux apparaissent dans cet onglet lorsqu'ils terminé
+              Des bordereaux apparaissent dans cet onglet lorsqu'ils ont terminé
               leur cycle de vie. Ils sont alors disponible en lecture seule pour
               consultation.
             </BlankslateDescription>

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -224,6 +224,7 @@ export const removeSections = (input, signatureType: SignatureType) => {
   const companyKey = "company";
   const customInfoKey = "customInfo";
   const groupingBsdasrisKey = "grouping";
+  const identificationKey = "identification";
   const common = [
     wasteKey,
     companyKey,
@@ -253,6 +254,7 @@ export const removeSections = (input, signatureType: SignatureType) => {
       emitterKey,
       transporterKey,
       receptionKey,
+      identificationKey,
       ...common,
     ],
   };

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -27,6 +27,8 @@ interface Props {
   initialStep?: number;
   bsdasriFormType?: string;
 }
+type removableKey = keyof Bsdasri;
+
 /**
  * Do not resend sections locked by relevant signatures
  */
@@ -36,8 +38,9 @@ const removeSignedSections = (input: BsdasriInput, status: BsdasriStatus) => {
   const emitterKey = "emitter";
   const transporterKey = "transporter";
   const destinationKey = "destination";
+  const identificationKey = "identification";
 
-  const mapping = {
+  const mapping: Partial<Record<BsdasriStatus, removableKey[]>> = {
     INITIAL: [],
     SIGNED_BY_PRODUCER: [wasteKey, ecoOrganismeKey, emitterKey],
     SENT: [wasteKey, ecoOrganismeKey, emitterKey, transporterKey],
@@ -47,6 +50,7 @@ const removeSignedSections = (input: BsdasriInput, status: BsdasriStatus) => {
       emitterKey,
       transporterKey,
       destinationKey,
+      identificationKey,
     ],
   };
   return omit(input, mapping[status]);


### PR DESCRIPTION
La signature du dasri par l'UI était cassée, la mutation renvoyait `identification { numbers }` qui est un cahmp verrouillé après la réception.

- [x] Mettre à jour le change log

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-7016)
