### PR TITLE
Gestion cas particulier transfert multi-modal

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 - Pagination des établissements dans Mon Compte > Établissements. [PR 1113](https://github.com/MTES-MCT/trackdechets/pull/1113)
-
+- Possibilité pour le destinataire d'un BSDD de valider une réception même si un segment multi-modal a été crée par erreur [PR 1128](https://github.com/MTES-MCT/trackdechets/pull/1128)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/forms/errors.ts
+++ b/back/src/forms/errors.ts
@@ -82,14 +82,6 @@ export class DestinationCannotTempStore extends UserInputError {
   }
 }
 
-export class HasSegmentToTakeOverError extends UserInputError {
-  constructor() {
-    super(
-      "Vous ne pouvez pas passer ce bordereau à l'état souhaité, il n'est pas encore pris en charge par le dernier transporteur"
-    );
-  }
-}
-
 export class FormAlreadyInAppendix2 extends UserInputError {
   constructor(id: string) {
     super(


### PR DESCRIPTION
https://trackdechets.zammad.com/#ticket/zoom/1696 

De nombreux transporteur se font avoir et clique sur "Préparer le transfert" en pensant transférer à l'installation de destination. Un segment est crée et il ne peuvent pas revenir en arrière. 
Cette PR est un quick fix permettant d'invalider des segments en cas de réception effective à l'installation de destination. 