### PR TITLE
Corrections récépissé BSDD

### DIFF
--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -657,7 +657,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
             <p>
               Date de présentation :{" "}
               {formatDate(
-                form.temporaryStorageDetail?.temporaryStorer.receivedAt
+                form.temporaryStorageDetail?.temporaryStorer?.receivedAt
               )}
             </p>
             <AcceptationFields

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -653,7 +653,14 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
               </strong>
             </p>
             <p>Quantité présentée :</p>
-            <QuantityFields {...form.temporaryStorageDetail?.temporaryStorer} />
+            <QuantityFields
+              quantity={
+                form.temporaryStorageDetail?.temporaryStorer?.quantityReceived
+              }
+              quantityType={
+                form.temporaryStorageDetail?.temporaryStorer?.quantityType
+              }
+            />
             <p>
               Date de présentation :{" "}
               {formatDate(

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -171,7 +171,9 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
             <td>
               {packagingInfos.reduce(
                 (total, packaging) =>
-                  packaging.type === packagingType.value ? total + 1 : total,
+                  packaging.type === packagingType.value
+                    ? total + (packaging.quantity ?? 0)
+                    : total,
                 0
               ) ||
                 // leave the box empty if it's 0
@@ -183,7 +185,9 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
         <tr>
           <td>
             <strong>
-              {packagingInfos.length ||
+              {packagingInfos.reduce((total, packaging) => {
+                return total + (packaging.quantity ?? 0);
+              }, 0) ||
                 // leave the box empty if it's 0
                 null}
             </strong>


### PR DESCRIPTION
- [Nombre conditionnements sur récépissé incohérent](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7078)
- [Bug avec entreposage provisoire](https://forum.trackdechets.beta.gouv.fr/t/impossible-de-visualiser-un-bsd-dans-le-cas-dun-transit/433)
