### PR TITLE
Bug report conditionnement en cas d'entreposage provisoire

### DIFF
--- a/back/src/forms/resolvers/forms/stateSummary.ts
+++ b/back/src/forms/resolvers/forms/stateSummary.ts
@@ -123,9 +123,11 @@ export async function getStateSummary(form: Form) {
     .temporaryStorageDetail();
 
   const packagingInfos =
-    (temporaryStorageDetail?.wasteDetailsPackagingInfos as PackagingInfo[]) ??
-    form.wasteDetails?.packagingInfos ??
-    [];
+    temporaryStorageDetail?.wasteDetailsPackagingInfos &&
+    (temporaryStorageDetail?.wasteDetailsPackagingInfos as PackagingInfo[])
+      .length > 0
+      ? (temporaryStorageDetail?.wasteDetailsPackagingInfos as PackagingInfo[])
+      : form.wasteDetails?.packagingInfos ?? [];
 
   return {
     quantity: getQuantity(form, temporaryStorageDetail),

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -107,12 +107,7 @@ const TempStorage = ({ form }) => {
             label="Code Onu"
           />
 
-          <PackagingRow
-            packagingInfos={
-              temporaryStorageDetail?.wasteDetails?.packagingInfos ||
-              form.wasteDetails?.packagingInfos
-            }
-          />
+          <PackagingRow packagingInfos={form.stateSummary?.packagingInfos} />
           <DetailRow
             value={temporaryStorageDetail?.temporaryStorer?.quantityReceived}
             label="Quantité reçue"
@@ -380,10 +375,7 @@ export default function BSDDetailContent({
               <dt>Quantité</dt>
               <dd>{form.stateSummary?.quantity ?? "?"} tonnes</dd>
               <PackagingRow
-                packagingInfos={
-                  form.temporaryStorageDetail?.wasteDetails?.packagingInfos ||
-                  form.wasteDetails?.packagingInfos
-                }
+                packagingInfos={form.stateSummary?.packagingInfos}
               />
               <dt>Consistance</dt>{" "}
               <dd>{getVerboseConsistence(form.wasteDetails?.consistence)}</dd>


### PR DESCRIPTION
`temporaryStorageDetail.packagingInfos` est initialisé à `[]`, il était donc sélectionné dans le `stateSummary` où l'on vérifiait s'il était "truthy"

- [bugs report conditionnement bsd](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7084)
