### PR TITLE
La recherche d'établissements par SIRET ne doit pas retourner d'établissements fermés

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- La recherche d'établissements par n°SIRET ne retourne plus d'établissement fermé [PR 1140](https://github.com/MTES-MCT/trackdechets/pull/1140)
+
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/companies/sirene/__tests__/index.test.ts
+++ b/back/src/companies/sirene/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { searchCompany } from "..";
+import { makeSearchCompanies, searchCompany } from "..";
 import { ErrorCode } from "../../../common/errors";
 
 describe("searchCompany", () => {
@@ -10,5 +10,66 @@ describe("searchCompany", () => {
     } catch (e) {
       expect(e.extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
     }
+  });
+});
+
+describe("searchCompanies", () => {
+  const searchCompanyMock = jest.fn();
+  const searchCompanies = makeSearchCompanies({
+    searchCompany: searchCompanyMock
+  });
+
+  beforeEach(() => {
+    searchCompanyMock.mockReset();
+  });
+
+  it("should call searchCompany when the clue is formatted like a SIRET", async () => {
+    const company = {
+      siret: "11111111111111",
+      name: "ACME",
+      naf: "NAF",
+      libelleNaf: "Autres activités",
+      codeCommune: "13001",
+      address: "40 boulevard Voltaire 13001 Marseille",
+      addressVoie: "40 boulevard",
+      addressCity: "Marseille",
+      addressPostalCode: "13001",
+      etatAdministratif: "A"
+    };
+    searchCompanyMock.mockResolvedValue(company);
+    const searchCompanies = makeSearchCompanies({
+      searchCompany: searchCompanyMock
+    });
+    const companies = await searchCompanies("11111111111111");
+    expect(searchCompanyMock).toHaveBeenCalledWith("11111111111111");
+    expect(companies[0]).toEqual(company);
+  });
+
+  it(`should not return closed companies when searching by SIRET`, async () => {
+    searchCompanyMock.mockResolvedValue({
+      siret: "11111111111111",
+      name: "ACME",
+      naf: "NAF",
+      libelleNaf: "Autres activités",
+      codeCommune: "13001",
+      address: "40 boulevard Voltaire 13001 Marseille",
+      addressVoie: "40 boulevard",
+      addressCity: "Marseille",
+      addressPostalCode: "13001",
+      etatAdministratif: "F"
+    });
+    const searchCompanies = makeSearchCompanies({
+      searchCompany: searchCompanyMock
+    });
+    const companies = await searchCompanies("11111111111111");
+    expect(searchCompanyMock).toHaveBeenCalledWith("11111111111111");
+    expect(companies).toEqual([]);
+  });
+
+  it(`should return [] if SIRET does not exist when searching by SIRET`, async () => {
+    searchCompanyMock.mockRejectedValue(new Error("Not found"));
+    const companies = await searchCompanies("11111111111111");
+    expect(searchCompanyMock).toHaveBeenCalledWith("11111111111111");
+    expect(companies).toEqual([]);
   });
 });

--- a/back/src/companies/sirene/__tests__/index.test.ts
+++ b/back/src/companies/sirene/__tests__/index.test.ts
@@ -37,9 +37,6 @@ describe("searchCompanies", () => {
       etatAdministratif: "A"
     };
     searchCompanyMock.mockResolvedValue(company);
-    const searchCompanies = makeSearchCompanies({
-      searchCompany: searchCompanyMock
-    });
     const companies = await searchCompanies("11111111111111");
     expect(searchCompanyMock).toHaveBeenCalledWith("11111111111111");
     expect(companies[0]).toEqual(company);
@@ -57,9 +54,6 @@ describe("searchCompanies", () => {
       addressCity: "Marseille",
       addressPostalCode: "13001",
       etatAdministratif: "F"
-    });
-    const searchCompanies = makeSearchCompanies({
-      searchCompany: searchCompanyMock
     });
     const companies = await searchCompanies("11111111111111");
     expect(searchCompanyMock).toHaveBeenCalledWith("11111111111111");


### PR DESCRIPTION
Lorsque la `clue` est formattée comme un SIRET dans `searchCompanies`, on délègue à `searchCompany`. Problème : on ne pensait pas à filtrer les établissements fermés.
