### PR TITLE
Update fuzziness on transporterCustomInfo search

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - La recherche d'établissements par n°SIRET ne retourne plus d'établissement fermé [PR 1140](https://github.com/MTES-MCT/trackdechets/pull/1140)
 - Retrait du lien de création de bsdd apparaissant sur le dashboard brouillon vide #1150 [PR 1150](https://github.com/MTES-MCT/trackdechets/pull/1150)
+- La recherche sur `customInfo` dans le tableau de bord transporteur se fait de façon exacte et non plus floue [PR 1144](https://github.com/MTES-MCT/trackdechets/pull/1144)
 
 #### :memo: Documentation
 

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -60,8 +60,7 @@ async function buildQuery(
 
   Object.entries({
     emitterCompanyName: where.emitter,
-    destinationCompanyName: where.recipient,
-    transporterCustomInfo: where.transporterCustomInfo
+    destinationCompanyName: where.recipient
   })
     .filter(([_, value]) => value != null)
     .forEach(([key, value]) => {
@@ -74,6 +73,17 @@ async function buildQuery(
         }
       });
     });
+
+  if (where.transporterCustomInfo) {
+    query.bool.must.push({
+      match: {
+        transporterCustomInfo: {
+          query: where.transporterCustomInfo,
+          fuzziness: 0
+        }
+      }
+    });
+  }
 
   if (where.readableId) {
     query.bool.must.push({


### PR DESCRIPTION
[Ticket Zammad ](https://trackdechets.zammad.com/#ticket/zoom/4816)

Avec une fuzziness en "AUTO", ça rendait difficile une recherche par identifiant à cause de nombreux faux positifs. J'ai hésité à carrément basculé la recherche en `keyword` mais je trouvais que ça présumait un peu trop de l'utilisation de ce champ pour des identifiants. 


