### PR TITLE
Ignorer NetworkError sur Sentry, spécifique Firefox 

### DIFF
--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -14,6 +14,7 @@ if (process.env.REACT_APP_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     environment: process.env.REACT_APP_SENTRY_ENVIRONMENT,
+    ignoreErrors: ["NetworkError when attempting to fetch resource."],
   });
 }
 


### PR DESCRIPTION
# Mini fix pas urgent pour Sentry

- 23K erreurs non pertinentes, https://sentry.io/organizations/betagouv-f7/issues/2863273508/?project=6084800&query=is%3Aunresolved
- Explications https://forum.sentry.io/t/typeerror-failed-to-fetch-reported-over-and-overe/8447


- [ ] Mettre à jour le change log
---
