### PR TITLE
Rendre visible quand `NODE_ENV=DEV` dans la console les logs du serveur.

### DIFF
--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -16,8 +16,8 @@ const logger = createLogger({
 
 // If we're not in production then log to the `console` with the format:
 // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
-//
-if (process.env.NODE_ENV === "dev") {
+// avoid using missing console.log() function in CI https://jestjs.io/docs/environment-variables
+if (process.env.NODE_ENV === "dev" && !process.env.JEST_WORKER_ID) {
   logger.add(
     new transports.Console({
       format: format.simple()

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -14,4 +14,15 @@ const logger = createLogger({
   transports: [new transports.File({ filename: LOG_PATH })]
 });
 
+// If we're not in production then log to the `console` with the format:
+// `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
+//
+if (process.env.NODE_ENV === "dev") {
+  logger.add(
+    new transports.Console({
+      format: format.simple()
+    })
+  );
+}
+
 export default logger;


### PR DESCRIPTION
# Proposition

- Rendre visible dans la console les logs du serveur.

- [ ] Mettre à jour la documentation

