### PR TITLE
Retire le lien de création de bsdd apparaissant sur le dashboard brouillon vide

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+# [2022.01.2] 31/01/2022
 
 # [2022.01.2] 31/01/2022
 
@@ -19,6 +20,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - La recherche d'établissements par n°SIRET ne retourne plus d'établissement fermé [PR 1140](https://github.com/MTES-MCT/trackdechets/pull/1140)
+- Retrait du lien de création de bsdd apparaissant sur le dashboard brouillon vide #1150 [PR 1150](https://github.com/MTES-MCT/trackdechets/pull/1150)
 
 #### :memo: Documentation
 

--- a/doc/docs/reference/multi-bsd.md
+++ b/doc/docs/reference/multi-bsd.md
@@ -2,11 +2,6 @@
 title: Différences entre les bordereaux
 ---
 
-:::caution
-L'API pour les bordereaux DASRI, amiante, VHU et Fluides Frigorigènes est encore en mode expérimental
-:::caution
-
-
 Le mode opératoire de l'API pour les bordereaux DASRI, amiante, VHU et Fluides Frigorigènes diffère sensiblement de celui pour le BSDD.
 
 le champ `id` stocke un champ lisible (équivalent du `readableId` du bsdd). Il n'y a donc pas de champ `readableId`.

--- a/front/src/dashboard/bsds/drafts/RouteBsdsDrafts.tsx
+++ b/front/src/dashboard/bsds/drafts/RouteBsdsDrafts.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { IconDuplicateFile } from "common/components/Icons";
-import { generatePath, Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -9,7 +9,7 @@ import {
   BlankslateTitle,
   BlankslateDescription,
 } from "common/components";
-import routes from "common/routes";
+
 import { BSDList } from "../../components/BSDList";
 import illustration from "./assets/blankslateDrafts.svg";
 
@@ -39,14 +39,9 @@ export function RouteBsdsDrafts() {
               Il n'y a aucun bordereau en brouillon
             </BlankslateTitle>
             <BlankslateDescription>
-              Si vous le souhaitez, vous pouvez{" "}
-              <Link to={generatePath(routes.dashboard.bsdds.create, { siret })}>
-                <button className="btn btn--outline-primary btn--medium-text">
-                  Créer un bordereau
-                </button>{" "}
-              </Link>
-              ou dupliquer un bordereau déjà existant dans un autre onglet grâce
-              à l'icône{" "}
+              Si vous le souhaitez, vous pouvez créer un bordereau depuis le
+              menu de création ci-dessus ou dupliquer un bordereau déjà existant
+              dans un autre onglet grâce à l'icône{" "}
               <span className="tw-inline-flex tw-ml-1">
                 <IconDuplicateFile color="blueLight" />
               </span>


### PR DESCRIPTION
Retire le lien de création de bsdd apparaissant sur le dashboard brouillon vide
Retrait de l'avertissement "expérimental" de la documentation.
 
- [x] Mettre à jour le change log
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-2263)
