### PR TITLE
Ajout du détails pour les packagings "Autre" 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,11 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Affichage d'un message d'erreur lorsque le statut d'acceptation d'un déchet dangereux n'est pas précisé lors de la signature de l'acceptation [PR 1152](https://github.com/MTES-MCT/trackdechets/pull/1152)
 - Affichage d'un message d'erreur lorsque la validation du traitement d'un déchet dangereux n'aboutit pas lors de la signature du traitement [PR 1152](https://github.com/MTES-MCT/trackdechets/pull/1152)
+- Corrections récépissé PDF [PR 1153](https://github.com/MTES-MCT/trackdechets/pull/1153) :
+  - ajout du détail des contenants pour le packaging "Autre".
+  - affichage de l'adresse chantier complète.
+  - case exemption de récépissé.
+
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -35,6 +35,7 @@ import {
 } from "../form-converter";
 import { getFullForm } from "../database";
 import prisma from "../../prisma";
+import { buildAddress } from "../../companies/sirene/utils";
 
 type ReceiptFieldsProps = Partial<
   Pick<GraphQLForm["transporter"], "department" | "receipt" | "validityLimit">
@@ -345,7 +346,13 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
             <p>
               Nom/raison sociale : {form.emitter?.workSite?.name}
               <br />
-              Adresse : {form.emitter?.workSite?.address}
+              Adresse :{" "}
+              {form.emitter?.workSite &&
+                buildAddress([
+                  form.emitter?.workSite?.address,
+                  form.emitter?.workSite?.postalCode,
+                  form.emitter?.workSite?.city
+                ])}
               <br />
               Info libre : {form.emitter?.workSite?.infos}
             </p>

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -232,8 +232,13 @@ function TransporterFormCompanyFields({
       </div>
       <div className="Col">
         <p>
-          <input type="checkbox" readOnly /> Je déclare être exempté de
-          récépissé au titre de l’article R.541-50 du code de l’environnement
+          <input
+            type="checkbox"
+            checked={transporter?.isExemptedOfReceipt}
+            readOnly
+          />{" "}
+          Je déclare être exempté de récépissé au titre de l’article R.541-50 du
+          code de l’environnement
         </p>
         <ReceiptFields {...(transporter ?? {})} />
         <p>

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -150,6 +150,17 @@ type PackagingInfosTableProps = {
   packagingInfos: PackagingInfo[];
 };
 
+export function getOtherPackagingLabel(packagingInfos: PackagingInfo[]) {
+  const otherPackagings = packagingInfos.filter(p => p.type === "AUTRE");
+  const otherPackagingsSummary =
+    otherPackagings.length === 0
+      ? "à préciser"
+      : otherPackagings
+          .map(({ quantity, other }) => `${quantity} ${other ?? "?"}`)
+          .join(", ");
+  return `Autre (${otherPackagingsSummary})`;
+}
+
 function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
   return (
     <table>
@@ -165,7 +176,7 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
           { label: "Citerne", value: "CITERNE" },
           { label: "GRV", value: "GRV" },
           { label: "Fûts", value: "FUT" },
-          { label: "Autre (à préciser)", value: "AUTRE" }
+          { label: getOtherPackagingLabel(packagingInfos), value: "AUTRE" }
         ].map((packagingType, index) => (
           <tr key={index}>
             <td>
@@ -179,6 +190,7 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
                 // leave the box empty if it's 0
                 null}
             </td>
+
             <td>{packagingType.label}</td>
           </tr>
         ))}


### PR DESCRIPTION
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7113)

---

- Ajout du détails pour les packagings "Autre" 
- Adresse chantier incomplète
- Case exemption récépissé non coché   

### Screenshot packagings

Comportement inchangé si on n'a pas de conditionnement "Autre"

![Capture d’écran 2022-01-21 à 16 36 14](https://user-images.githubusercontent.com/2269165/150555001-82a80237-7276-4aa1-9b85-b95df80d49a0.png)

Ajout du détail lorsqu'on a ou un plusieurs conditionnements "Autre"

![Capture d’écran 2022-01-21 à 16 35 44](https://user-images.githubusercontent.com/2269165/150554942-cc116a26-049b-46a4-baa6-5252193d87d1.png)


### Screenshots adresse chantier


avant 
![Capture d’écran 2022-01-21 à 18 25 22](https://user-images.githubusercontent.com/2269165/150572248-77611842-86ec-4905-b7ac-841bf51f978d.png)

après
![Capture d’écran 2022-01-21 à 18 25 52](https://user-images.githubusercontent.com/2269165/150572305-47a389ee-0e4e-4116-b198-5025763aa1e1.png)


