### PR TITLE
Ne pas laisser les navigateurs compléter automatiquement le champ de signature BSD (confusion avec mot de passe TD)

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6334,7 +6334,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -12865,7 +12865,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -13386,7 +13386,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -13829,7 +13829,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -14356,12 +14356,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -14615,7 +14615,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14706,7 +14706,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -19174,7 +19174,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -19765,6 +19765,11 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
+    },
+    "text-security": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/text-security/-/text-security-3.2.1.tgz",
+      "integrity": "sha512-MjDQ3lyLeLqcGqZfQCZ6kvjQiuNfJaicdgIczPJDtD4tj0vIPT8WwIOKTi8wgXCVS/F1WJmapO3SppXemrwbIA=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/front/package.json
+++ b/front/package.json
@@ -41,6 +41,7 @@
     "react-table": "^7.6.3",
     "react-tabs": "3.1.1",
     "tailwindcss": "^1.4.6",
+    "text-security": "^3.2.1",
     "use-media": "^1.4.0",
     "uuid": "^8.3.1",
     "world-countries": "^4.0.0",

--- a/front/src/form/common/components/custom-inputs/SignatureCodeInput.tsx
+++ b/front/src/form/common/components/custom-inputs/SignatureCodeInput.tsx
@@ -13,10 +13,10 @@ export default function SignatureCodeInput({
       {...field}
       value={value}
       {...props}
-      type="password"
-      autoComplete="off"
+      type="text"
       pattern="[0-9]*"
       inputMode="numeric"
+      className="td-input-text-security td-input"
     />
   );
 }

--- a/front/src/form/common/components/custom-inputs/SignatureCodeInput.tsx
+++ b/front/src/form/common/components/custom-inputs/SignatureCodeInput.tsx
@@ -1,5 +1,6 @@
 import React, { InputHTMLAttributes } from "react";
 import { FieldProps } from "formik";
+import "text-security/text-security-disc.css";
 
 type NumberInputProps = FieldProps & InputHTMLAttributes<HTMLInputElement>;
 export default function SignatureCodeInput({

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -9,6 +9,7 @@ import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import * as Sentry from "@sentry/browser";
 import "@reach/tooltip/styles.css";
+import "text-security/text-security-disc.css";
 
 if (process.env.REACT_APP_SENTRY_DSN) {
   Sentry.init({

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -9,7 +9,6 @@ import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import * as Sentry from "@sentry/browser";
 import "@reach/tooltip/styles.css";
-import "text-security/text-security-disc.css";
 
 if (process.env.REACT_APP_SENTRY_DSN) {
   Sentry.init({

--- a/front/src/scss/Inputs.scss
+++ b/front/src/scss/Inputs.scss
@@ -158,3 +158,8 @@ select:-moz-focusring {
   background-position: right 0.7em top 50%, 0 0;
   background-size: 0.65em auto, 100%;
 }
+.td-input-text-security {
+  font-family: "text-security-disc";
+  /* Use -webkit-text-security if the browser supports it */
+  -webkit-text-security: disc;
+}

--- a/front/src/scss/index.scss
+++ b/front/src/scss/index.scss
@@ -33,7 +33,7 @@
 html,
 body,
 * {
-  font-family: "marianne" !important;
+  font-family: "marianne";
 }
 html {
   font-size: 16px;


### PR DESCRIPTION
# Eviter d'avoir l'autocomplete des navigo de gérer le champ de signature transporteurs n'est pas trivial.

- Solution d'évitement simple avec l'ajout d'un FONT de caractères "disc"

Aperçu
![image](https://user-images.githubusercontent.com/76620/153192193-ef8794ed-0591-4ce0-bbc5-cd1a146fb455.png)


- autocomplete="off" ne fonctionne pas sur tous les navigos https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
- Problème soulevé sur le support https://forum.trackdechets.beta.gouv.fr/t/le-code-signature-saisi-par-le-client-tente-systematiquement-decraser-le-mot-de-passe-du-compte-td-dans-le-navigateur-web/551/2
- ajout dépendance front https://github.com/noppa/text-security
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7275)
