### PR TITLE
Hotfix : ignorer fausse erreur Sentry front et ajout option --sireneProvider pour la commande de création en masse d'utilisateurs

### DIFF
--- a/back/src/users/bulk-creation/README.md
+++ b/back/src/users/bulk-creation/README.md
@@ -28,6 +28,7 @@ La démarche est la suivante :
    node ./dist/src/users/bulk-creation/index.js --validateOnly --csvDir=/tmp/
    ```
    Note : le flag `--validateOnly` permet de faire une simple vérification sans créer les comptes.
+   Note : en cas de problème avec un service de recherche d'établissement par SIRET, `--sireneProvider=social.gouv` permet d'utiliser un autre server que le service par défaut `entreprise.data.gouv.fr`
    Relancez la commande sans ce flag pour créer les comptes.
 
 Pour plus de détails sur l'exécution de tâches dans une application Scalingo, voir :

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -2,7 +2,7 @@ import { resetDatabase } from "../../../../integration-tests/helper";
 import prisma from "../../../prisma";
 import * as mailsHelper from "../../../mailer/mailing";
 import { companyFactory, userFactory } from "../../../__tests__/factories";
-import { bulkCreate } from "../index";
+import { bulkCreate, Opts } from "../index";
 
 // No mails
 const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
@@ -50,7 +50,7 @@ describe("bulk create users and companies from csv files", () => {
   // bulkCreate is called twice in all tests to verify
   // the idempotency of the function
 
-  const opts = {
+  const opts: Opts = {
     validateOnly: false,
     csvDir: `${__dirname}/csv`,
     console: {
@@ -58,7 +58,8 @@ describe("bulk create users and companies from csv files", () => {
       info: jest.fn(),
       error: jest.fn(),
       log: global.console.log
-    }
+    },
+    sireneProvider: "entreprise.data.gouv.fr"
   };
 
   async function bulkCreateIdempotent() {

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -27,11 +27,25 @@ function printHelp() {
   * roles.csv
   See validations.ts for the format of each file
   Options:
-  -- --help                       Print help
-  -- --validateOnly               Only perform validation csv files
-  -- --csvDir=/path/to/csv/dir    Specify custom csv directory
+  -- --help                         Print help
+  -- --validateOnly                 Only perform validation csv files
+  -- --sireneProvider=providerName  Choose provider name (directory name under src/companies/sirene/*)
+  -- --csvDir=/path/to/csv/dir      Specify custom csv directory
   `);
 }
+
+export interface Opts {
+  validateOnly: boolean;
+  csvDir: string;
+  console?: any;
+  sireneProvider: "entreprise.data.gouv.fr" | "insee" | "social.gouv";
+}
+
+export const opts: Opts = {
+  validateOnly: false,
+  csvDir: `${__dirname}/../../../csv`,
+  sireneProvider: "entreprise.data.gouv.fr"
+};
 
 async function run(argv = process.argv.slice(2)): Promise<void> {
   const args = parseArgs(argv);
@@ -39,11 +53,6 @@ async function run(argv = process.argv.slice(2)): Promise<void> {
   if (args.help) {
     printHelp();
   }
-
-  const opts = {
-    validateOnly: false,
-    csvDir: `${__dirname}/../../../csv`
-  };
 
   if (args.validateOnly) {
     opts.validateOnly = args.validateOnly;
@@ -54,13 +63,11 @@ async function run(argv = process.argv.slice(2)): Promise<void> {
     opts.csvDir = args.csvDir;
   }
 
-  await bulkCreate(opts);
-}
+  if (args.sireneProvider) {
+    opts.sireneProvider = args.sireneProvider;
+  }
 
-interface Opts {
-  validateOnly: boolean;
-  csvDir: string;
-  console?: any;
+  await bulkCreate(opts);
 }
 
 export async function bulkCreate(opts: Opts): Promise<void> {
@@ -123,7 +130,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
   for (const c of companies) {
     try {
       console.info(`Add sirene info for company ${c.siret}`);
-      const sirenified = await sirenify(c);
+      const sirenified = await sirenify(c, opts);
       sirenifiedCompanies.push(sirenified);
     } catch (err) {
       console.error(err);

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -3,6 +3,7 @@ import * as yup from "yup";
 import prisma from "../../prisma";
 import { getCompanyThrottled } from "./sirene";
 import { CompanyRow } from "./types";
+import { opts } from ".";
 
 /**
  * Validation schema for company
@@ -17,7 +18,7 @@ export const companyValidationSchema = yup.object({
       "Siret ${value} was not found in SIRENE database",
       async value => {
         try {
-          await getCompanyThrottled(value);
+          await getCompanyThrottled(value, opts);
           return true;
         } catch (err) {
           return false;

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -14,7 +14,10 @@ if (process.env.REACT_APP_SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
     environment: process.env.REACT_APP_SENTRY_ENVIRONMENT,
-    ignoreErrors: ["NetworkError when attempting to fetch resource."],
+    ignoreErrors: [
+      "NetworkError when attempting to fetch resource.",
+      "Non-Error promise rejection captured with value: Object Not Found Matching Id:2",
+    ],
   });
 }
 


### PR DESCRIPTION
Hotfix : ignorer fausse erreur Sentry front et ajout option --sireneProvider pour la commande de création en masse d'utilisateurs

- [x] Mettre à jour la documentation
- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7369)
