### PR TITLE
Add/script run import

### DIFF
--- a/scripts/run-import.sh
+++ b/scripts/run-import.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ -f .env ]
+then
+  export "$(<.env xargs)"
+fi
+
+CURRENT_DIR=$(pwd)
+if [ -z "$TD_XSLX2CSV_PATH" ];
+then
+    echo -e "\e[91mPlease set \$TD_XSLX2CSV_PATH either as ENV or in .env file (ex: home/you/trackdechets-xslx2csv/src)\e[m"
+    exit
+fi
+
+while read -erp $'\e[1m? Enter local XLS path :\e[m ' xlsPath; do
+    if [ -f "$xlsPath" ]; then
+        break
+    else
+        echo -e "\e[91m$xlsPath is not a valid path.\e[m"
+    fi 
+done
+
+echo -e "\e[1m→ Spawning XSLX2CSV CLI...\e[m"
+echo -e "\e[1m→ Please use the 'Export csv' action\e[m"
+echo -e "\e[94m-------------------------------------------------------\e[m"
+cd "$TD_XSLX2CSV_PATH" || exit
+poetry run python xlsx2csv.py "$xlsPath"
+echo -e "\e[94m-------------------------------------------------------\e[m"
+
+cd "$CURRENT_DIR" || exit
+OUTPUT_DIR="$TD_XSLX2CSV_PATH/csv"
+
+echo -e "\e[1m→ Listing extracted files\e[m"
+ls "$OUTPUT_DIR"
+
+read -erp $'\e[1m? Proceed with import \e[m (Y/n) ' -n 1 PROCEED
+PROCEED=${PROCEED:-Y}
+
+if [[ ! $PROCEED =~ ^[Yy]$ ]]
+then
+    exit 1
+fi
+
+scalingo --region osc-secnum-fr1 --app trackdechets-production-api run --file "$OUTPUT_DIR" bash << EOF
+  tar -C /tmp -xvf /tmp/uploads/csv.tar.gz
+  node ./dist/src/users/bulk-creation/index.js --csvDir=/tmp/
+  exit
+EOF


### PR DESCRIPTION
Ajout d'un petit script, pour jouer les différentes étapes de l'import automatiquement. Perso, je suis obligé à chaque fois de retourner dans le README et copier coller les différentes commandes. L'idée ici est de gagner qques secondes...
Ca s'appuie sur le [CLI/convertisseur de Laurent](https://github.com/MTES-MCT/trackdechets-xslx2csv)

On passe le chemin vers le fichier xls, et joue la bonne action dans le CLI de Laurent, on dit ok et l'import est automatiquement appliqué.

Ca demande d'avoir une variable d'env `TD_XSLX2CSV_PATH` qui pointe vers le projet xslx2csv. Ca peut être passé en début de script ou via un fichier `.env` dans le dossier `scripts`

Exemple de run:
![image](https://user-images.githubusercontent.com/5145523/153871999-7208322c-d188-49dd-9f7b-211f5d48139b.png)

Il y a également une mini modif du package.json qui supprime des appels à npx inutiles.
