### PR TITLE
Ajout de la configuration Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/back"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "npm"
+    directory: "/front"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "yarn"
+    directory: "/doc"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    open-pull-requests-limit: 2
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
Cette PR ajoute une configuration explicite au Dependabot. L'idée c'est d'une part de réduire le bruit causé par des dépendances de dev et d'autre part de mieux maîtriser le flux des mises à jour (en limitant le nombre de PR ouvertes en même temps).