### PR TITLE
Correction des erreurs les plus signalées par Sentry

### DIFF
--- a/back/src/common/plugins/sentryReporter.ts
+++ b/back/src/common/plugins/sentryReporter.ts
@@ -19,10 +19,10 @@ const sentryReporter: ApolloServerPlugin = {
         }
 
         for (const error of errorContext.errors) {
-          const err = error.originalError || error;
-
           // don't do anything with errors we expect.
-          if (knownErrors.some(expectedError => err instanceof expectedError)) {
+          if (
+            knownErrors.some(expectedError => error instanceof expectedError)
+          ) {
             continue;
           }
 
@@ -58,7 +58,9 @@ const sentryReporter: ApolloServerPlugin = {
           // kinda of a hack but seems to be the only way to pass
           // info down to formatError. See also
           // https://github.com/apollographql/apollo-server/issues/4010
-          (err as any).sentryId = sentryId;
+          if (error.originalError) {
+            (error.originalError as any).sentryId = sentryId;
+          }
         }
       }
     };

--- a/back/src/common/plugins/sentryReporter.ts
+++ b/back/src/common/plugins/sentryReporter.ts
@@ -21,7 +21,11 @@ const sentryReporter: ApolloServerPlugin = {
         for (const error of errorContext.errors) {
           // don't do anything with errors we expect.
           if (
-            knownErrors.some(expectedError => error instanceof expectedError)
+            knownErrors.some(
+              expectedError =>
+                error instanceof expectedError ||
+                error.originalError instanceof expectedError
+            )
           ) {
             continue;
           }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -4032,6 +4032,15 @@
       "integrity": "sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==",
       "dev": true
     },
+    "@types/cleave.js": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/cleave.js/-/cleave.js-1.4.6.tgz",
+      "integrity": "sha512-OVW8lDUfaMa13OkWpH0ydQOB9IMLN9UZP4lBz63xCDZr/b7SqImRlBuzM1+eQb4whGPGGkZBOUe0Q7naOVO2dQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -6334,7 +6343,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -12865,7 +12874,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -13386,7 +13395,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -13829,7 +13838,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
@@ -14356,12 +14365,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -14615,7 +14624,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14706,7 +14715,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -19174,7 +19183,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/front/package.json
+++ b/front/package.json
@@ -96,6 +96,7 @@
     "@testing-library/jest-dom": "^4.1.2",
     "@testing-library/react": "^9.3.3",
     "@types/classnames": "^2.2.10",
+    "@types/cleave.js": "^1.4.6",
     "@types/graphql": "^14.0.7",
     "@types/jest": "^24.9.1",
     "@types/jwt-decode": "^2.2.1",

--- a/front/src/common/components/AutoFormattingSiret.tsx
+++ b/front/src/common/components/AutoFormattingSiret.tsx
@@ -11,6 +11,12 @@ export default function AutoFormattingSiret({ field, form, ...props }) {
       options={{ blocks: [3, 3, 3, 5] }}
       {...field}
       {...props}
+      onInit={owner => {
+        // cleave.js doesn't seem to be maintained anymore
+        // there's a know issue that's been reported since june 2020:
+        // https://github.com/nosir/cleave.js/issues/601#issuecomment-902747682
+        (owner as any).lastInputValue = "";
+      }}
       className={`td-input ${styles.autoformattingSiret}`}
     />
   );

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
@@ -26,6 +26,9 @@ export default function MarkAsAccepted({ form }: WorkflowActionProps) {
   >(MARK_AS_ACCEPTED, {
     refetchQueries: [GET_BSDS],
     awaitRefetchQueries: true,
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider l'acceptation";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -194,6 +194,9 @@ export default function MarkAsProcessed({ form, siret }: WorkflowActionProps) {
         );
       }
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider le traitement";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
@@ -26,6 +26,9 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
   >(MARK_AS_RECEIVED, {
     refetchQueries: [GET_BSDS],
     awaitRefetchQueries: true,
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider la réception";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
@@ -91,6 +91,9 @@ export default function MarkAsResealed({ form, siret }: WorkflowActionProps) {
         );
       }
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Compléter le BSD suite";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
@@ -41,6 +41,9 @@ export default function MarkAsSealed({ form, siret }: WorkflowActionProps) {
           );
       }
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider le bordereau";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
@@ -31,6 +31,9 @@ export default function MarkAsTempStored({ form }: WorkflowActionProps) {
   >(MARK_AS_TEMP_STORED, {
     refetchQueries: [GET_BSDS],
     awaitRefetchQueries: true,
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider l'entreposage provisoire";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
@@ -39,6 +39,9 @@ export default function MarkAsTempStorerAccepted({
   >(MARK_TEMP_STORER_ACCEPTED, {
     refetchQueries: [GET_BSDS],
     awaitRefetchQueries: true,
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const actionLabel = "Valider l'acceptation de l'entreposage provisoire";

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkSegmentAsReadyToTakeOver.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkSegmentAsReadyToTakeOver.tsx
@@ -42,6 +42,9 @@ export default function MarkSegmentAsReadyToTakeOver({
         { hideAfter: 5 }
       );
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const segments = form.transportSegments!;

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
@@ -47,6 +47,9 @@ export default function PrepareSegment({ form, siret }: WorkflowActionProps) {
         hideAfter: 5,
       });
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const initialValues = {

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignedByTransporter/SignedByTransporterModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignedByTransporter/SignedByTransporterModal.tsx
@@ -53,6 +53,9 @@ export function SignedByTransporterModal({
       });
       onClose();
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
 
   const { Component } = steps[stepIndex];

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/TakeOverSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/TakeOverSegment.tsx
@@ -34,6 +34,9 @@ export default function TakeOverSegment({ form }: WorkflowActionProps) {
         hideAfter: 5,
       });
     },
+    onError: () => {
+      // The error is handled in the UI
+    },
   });
   const transportSegments = form.transportSegments!;
   const segment = transportSegments[transportSegments.length - 1];
@@ -66,7 +69,7 @@ export default function TakeOverSegment({ form }: WorkflowActionProps) {
                 id: segment.id,
               };
 
-              takeOverSegment({ variables }).catch(() => {});
+              takeOverSegment({ variables });
             }}
           >
             {({ values }) => (

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -17,6 +17,10 @@ if (process.env.REACT_APP_SENTRY_DSN) {
     ignoreErrors: [
       "NetworkError when attempting to fetch resource.",
       "Non-Error promise rejection captured with value: Object Not Found Matching Id:2",
+
+      // The following is caused by cache mismatches,
+      // possibly because of the ServiceWorker
+      "Unexpected token '<'",
     ],
   });
 }

--- a/front/src/login/ResendActivationEmail.tsx
+++ b/front/src/login/ResendActivationEmail.tsx
@@ -19,11 +19,17 @@ export default function ResendActivationEmail() {
     <section className="section section--white">
       <div className="container">
         <form
-          onSubmit={e => {
+          onSubmit={async e => {
             e.preventDefault();
-            resendActivationEmail({ variables: { email } })
-              .then(_ => setShowSuccess(true))
-              .catch(_ => setShowSuccess(false));
+
+            setShowSuccess(false);
+
+            try {
+              await resendActivationEmail({ variables: { email } });
+              setShowSuccess(true);
+            } catch (err) {
+              // The error is handled in the UI
+            }
           }}
         >
           <h1 className="h1">Renvoyer l'email d'activation</h1>

--- a/front/src/login/ResetPassword.tsx
+++ b/front/src/login/ResetPassword.tsx
@@ -19,13 +19,18 @@ export default function ResetPassword() {
     <section className="section section--white">
       <div className="container">
         <form
-          onSubmit={e => {
+          onSubmit={async e => {
             e.preventDefault();
-            resetPassword({ variables: { email } }).then(_ =>
-              setShowSuccess(true)
-            );
+
             setShowSuccess(false);
             setEmail("");
+
+            try {
+              await resetPassword({ variables: { email } });
+              setShowSuccess(true);
+            } catch (err) {
+              // The error is handled in the UI
+            }
           }}
         >
           <h1 className="h1">Réinitialisation de votre mot de passe</h1>


### PR DESCRIPTION
Cette PR propose des correctifs pour les erreurs qui reviennent le plus souvent sur Sentry. On en avait principalement deux types :

- Côté serveur, les erreurs de validation étaient remontés par notre `sentryReporter`. Il y en a deux types : les erreurs de validation GraphQL (par exemple une variable qui n'est pas du bon type) et les erreurs de validation métier (UserInputError). Pour le premier type `error.originalError` n'est pas une instance d'une erreur connu mais `error` l'est bien. Pour le deuxième type c'est l'inverse, `error` n'est pas une instance d'une erreur connu mais `error.originalError` l'est bien.
- Côté client, on avait beaucoup d'erreurs de validation également. Ça vient des mutations dont on ne gère pas les erreurs au niveau de l'appel. Il y a plusieurs solutions, la première c'est d'ajouter un `onError` aux paramètres de `useMutation` ce qui fera que l'appel ne lèvera pas d'erreur en cas d'échec. La deuxième c'est d'utiliser un `try` / `catch`. Je suis tombé sur cette excellente réponse Stackoverflow pour plus de détails : https://stackoverflow.com/a/59472340/2373066 Je ne suis pas passé sur tous les endroits où on utilise `useMutation` mais j'ai fait ceux qui lèvent le plus d'erreur. Il faudra qu'on continue l'effort.

Il y a également d'autres petits correctifs que j'ai commenté dans le code. Tout ça représente le plus gros de ce qui est remonté aujourd'hui.