### PR TITLE
Test timezone

### DIFF
--- a/back/integration-tests/docker-compose.yml
+++ b/back/integration-tests/docker-compose.yml
@@ -51,3 +51,4 @@ services:
       POST_BACKEND: console
       ELASTIC_SEARCH_URL: $ELASTIC_SEARCH_URL
       QUEUE_NAME_SENDMAIL: td-integration-tests-queue
+      TZ: "UTC"


### PR DESCRIPTION
Test qui reproduit le bug sur les timezones et le corrige en ajoutant `TZ=UTC` en variable d'environnement. 
