### PR TITLE
Amélioration stepper formulaire

### DIFF
--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -68,11 +68,7 @@ export default function BsdaStepsList(props: Props) {
       : createBsda({ variables: { input } });
   }
 
-  function onSubmit(e, values) {
-    e.preventDefault();
-    // As we want to be able to save draft, we skip validation on submit
-    // and don't use the classic Formik mechanism
-
+  function onSubmit(values) {
     const { id, ...input } = values;
     saveForm(input)
       .then(_ => {

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -123,11 +123,7 @@ export default function BsdasriStepsList(props: Props) {
       : createBsdasri({ variables: { input: input } });
   }
 
-  function onSubmit(e, values) {
-    e.preventDefault();
-    // As we want to be able to save draft, we skip validation on submit
-    // and don't use the classic Formik mechanism
-
+  function onSubmit(values) {
     if (
       props.bsdasriFormType === "bsdasriRegroup" ||
       formQuery.data?.bsdasri?.type === "GROUPING"

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -64,7 +64,7 @@ export default function StepsList(props: Props) {
       ? generatePath(routes.dashboard.bsds.follow, { siret })
       : generatePath(routes.dashboard.bsds.drafts, { siret });
 
-  function onSubmit(e, values) {
+  function onSubmit(values) {
     const { temporaryStorageDetail, ecoOrganisme, ...rest } = values;
 
     const formInput = {
@@ -76,10 +76,6 @@ export default function StepsList(props: Props) {
       // discard ecoOrganisme if not selected
       ...(ecoOrganisme?.siret ? { ecoOrganisme } : { ecoOrganisme: null }),
     };
-
-    e.preventDefault();
-    // As we want to be able to save draft, we skip validation on submit
-    // and don't use the classic Formik mechanism
 
     saveForm(formInput)
       .then(_ => history.push(redirectTo))

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -76,11 +76,7 @@ export default function BsffStepsList(props: Props) {
       : createDraftBsff({ variables: { input } });
   }
 
-  function onSubmit(e, values) {
-    e.preventDefault();
-    // As we want to be able to save draft, we skip validation on submit
-    // and don't use the classic Formik mechanism
-
+  function onSubmit(values) {
     const { id, ficheInterventions, previousBsffs, ...input } = values;
 
     saveForm({

--- a/front/src/form/bsvhu/BsvhuStepList.tsx
+++ b/front/src/form/bsvhu/BsvhuStepList.tsx
@@ -66,11 +66,7 @@ export default function BsvhuStepsList(props: Props) {
       : createVhuForm({ variables: { input } });
   }
 
-  function onSubmit(e, values) {
-    e.preventDefault();
-    // As we want to be able to save draft, we skip validation on submit
-    // and don't use the classic Formik mechanism
-
+  function onSubmit(values) {
     const { id, ...input } = values;
     saveForm(input)
       .then(_ => {

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -4,14 +4,14 @@ import { InlineError } from "common/components/Error";
 import { Formik, setNestedObjectValues } from "formik";
 import React, {
   Children,
-  createElement,
   ReactElement,
   useEffect,
   useRef,
   useState,
 } from "react";
-import { IStepContainerProps, Step } from "./Step";
+import { useHistory } from "react-router-dom";
 import "./GenericStepList.scss";
+import { IStepContainerProps } from "./Step";
 
 interface Props {
   children: ReactElement<IStepContainerProps>[];
@@ -20,7 +20,7 @@ interface Props {
   validationSchema: any;
   initialStep?: number;
   formQuery: QueryResult<any, any>;
-  onSubmit: (e, values) => void;
+  onSubmit: (values) => void;
 }
 export default function GenericStepList({
   children,
@@ -31,14 +31,17 @@ export default function GenericStepList({
   validationSchema,
   initialStep = 0,
 }: Props) {
-  const totalSteps = children.length - 1;
+  const history = useHistory();
+
+  const steps = React.Children.toArray(children);
+  const totalSteps = steps.length;
   const [currentStep, setCurrentStep] = useState(
     initialStep <= totalSteps ? initialStep : 0
   );
+  const step = steps[currentStep];
+  const isLastStep = currentStep === totalSteps - 1;
 
   const { loading, error } = formQuery;
-
-  useEffect(() => window.scrollTo(0, 0), [currentStep]);
 
   // When we edit a draft we want to automatically display on error on init
   const formikForm: any = useRef();
@@ -57,21 +60,26 @@ export default function GenericStepList({
     };
   });
 
-  const childrenComponents = Children.map(children, (child, index) => {
-    return createElement(
-      Step,
-      {
-        isActive: index === currentStep,
-        displayPrevious: currentStep > 0,
-        displayNext: currentStep < totalSteps,
-        displaySubmit: currentStep === totalSteps,
-        goToPreviousStep: () => setCurrentStep(currentStep - 1),
-        goToNextStep: () => setCurrentStep(currentStep + 1),
-        formId: formId,
-      },
-      child
-    );
-  });
+  function handleSubmit(
+    event: React.FormEvent<HTMLFormElement>,
+    values: unknown
+  ) {
+    event.preventDefault();
+
+    if (isLastStep) {
+      onSubmit(values);
+    } else {
+      setCurrentStep(currentStep + 1);
+    }
+  }
+
+  function previous() {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    } else {
+      history.goBack();
+    }
+  }
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <InlineError apolloError={error} />;
@@ -98,25 +106,26 @@ export default function GenericStepList({
           innerRef={formikForm}
           initialValues={initialValues}
           validationSchema={validationSchema}
-          onSubmit={() => Promise.resolve()}
+          onSubmit={() => Promise.resolve()} // To skip formik validation upon submit (=allow drafts) we use a custom submit handler
         >
-          {({ values }) => {
-            return (
-              <form onSubmit={e => onSubmit(e, values)}>
-                <div
-                  onKeyPress={e => {
-                    // Disable submit on Enter key press
-                    // We prevent it from bubbling further
-                    if (e.key === "Enter") {
-                      e.stopPropagation();
-                    }
-                  }}
+          {({ values }) => (
+            <form onSubmit={e => handleSubmit(e, values)}>
+              {step}
+              <div className="step-buttons form__actions">
+                <button
+                  className="btn btn--outline-primary"
+                  type="button"
+                  onClick={() => previous()}
                 >
-                  {childrenComponents}
-                </div>
-              </form>
-            );
-          }}
+                  {currentStep === 0 ? "Annuler" : "Précédent"}
+                </button>
+
+                <button className="btn btn--primary" type="submit">
+                  {!isLastStep ? "Suivant" : formId ? "Créer" : "Enregistrer"}
+                </button>
+              </div>
+            </form>
+          )}
         </Formik>
       </div>
     </div>

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -33,7 +33,7 @@ export default function GenericStepList({
 }: Props) {
   const history = useHistory();
 
-  const steps = React.Children.toArray(children);
+  const steps = Children.toArray(children);
   const totalSteps = steps.length;
   const [currentStep, setCurrentStep] = useState(
     initialStep <= totalSteps ? initialStep : 0

--- a/front/src/form/common/stepper/Step.tsx
+++ b/front/src/form/common/stepper/Step.tsx
@@ -1,6 +1,4 @@
-import React, { ReactNode, createElement } from "react";
-import { Link } from "react-router-dom";
-import { NextButton, PreviousButton } from "common/components/Buttons";
+import { createElement, ReactNode } from "react";
 import "./Step.scss";
 
 interface IStepProps {
@@ -34,57 +32,6 @@ export function StepContainer(props: IStepContainerProps) {
     : null;
 }
 
-export function Step(props: IStepProps) {
-  if (props.isActive === false) return null;
-  const submitCaption = props.formId ? "Enregistrer" : "Créer";
-  const cancelLink = props.formId ? "/bsds/drafts" : "x";
-  return (
-    <>
-      {props.children}
-      <div className="step-buttons form__actions">
-        <Previous
-          isActive={props.displayPrevious}
-          goToPreviousStep={() => props.goToPreviousStep()}
-        />
-
-        <Cancel link={cancelLink} />
-
-        <Next
-          isActive={props.displayNext}
-          goToNextStep={() => props.goToNextStep()}
-        />
-        <Submit isActive={props.displaySubmit} caption={submitCaption} />
-      </div>
-    </>
-  );
-}
-
-function Next(props: { isActive: boolean; goToNextStep: Function }) {
-  if (props.isActive === false) return null;
-
-  return <NextButton onClick={props.goToNextStep} />;
-}
-
-function Previous(props: { isActive: boolean; goToPreviousStep: Function }) {
-  if (props.isActive === false) return null;
-
-  return <PreviousButton onClick={props.goToPreviousStep} />;
-}
-
-function Submit(props: { isActive: boolean; caption: string }) {
-  if (props.isActive === false) return null;
-
-  return (
-    <button className="btn btn--primary" type="submit">
-      {props.caption ? props.caption : "Enregistrer"}
-    </button>
-  );
-}
-
-function Cancel(props: { link: string }) {
-  return (
-    <Link to={props.link}>
-      <button className="btn btn--outline-primary">Annuler</button>
-    </Link>
-  );
+export function Step({ children }) {
+  return children;
 }


### PR DESCRIPTION
Petite amélioration du formulaire à étapes.
- Appuyer sur <kbd>Enter</kbd> ne soumettra plus automatiquement le formulaire mais fera suivant s'il reste des étapes.
- Le bouton "Annuler" ne redirige plus vers `drafts` mais fait un `history.goBack()`. C'est probablement ce qu'on devrait utiliser également sur les étapes de signature (le retour sur l'écran draft alors qu'on vient d'ailleurs est souvent remonté.)
- Simplification du code