### PR TITLE
Création d'un client pour l'index Sirene "maison"

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -130,3 +130,8 @@ MAX_REQUESTS_PER_WINDOW=1000
 
 # JOB QUEUE CONFIG
 QUEUE_NAME_SENDMAIL=developmentsendmailqueue
+
+# TD COMPANY SEARCH INDEX check search/README.md in order to initialize local index
+TD_COMPANY_ELASTICSEARCH_URL=http://elasticsearch:9201
+TD_COMPANY_ELASTICSEARCH_INDEX=stocketablissement-dev
+# TD_COMPANY_ELASTICSEARCH_CACERT=optional

--- a/.env.model
+++ b/.env.model
@@ -134,4 +134,5 @@ QUEUE_NAME_SENDMAIL=developmentsendmailqueue
 # TD COMPANY SEARCH INDEX check search/README.md in order to initialize local index
 TD_COMPANY_ELASTICSEARCH_URL=http://elasticsearch:9201
 TD_COMPANY_ELASTICSEARCH_INDEX=stocketablissement-dev
+# Paste the contents of ca.pem certificate from your ElasticSearch hosting https proxy.
 # TD_COMPANY_ELASTICSEARCH_CACERT=optional

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,6 +70,10 @@ jobs:
           PROFESSIONAL_SECOND_ONBOARDING_TEMPLATE_ID: "9"
           SECURITY_CODE_RENEWAL_TEMPLATE_ID: "6"
           DATABASE_URL: "postgresql://user:password@postgres:5432/db"
+          TD_COMPANY_ELASTICSEARCH_INDEX: "stocketablissement-production"
+          TD_COMPANY_ELASTICSEARCH_URL: ${{ secrets.TD_COMPANY_ELASTICSEARCH_URL }}
+          TD_COMPANY_ELASTICSEARCH_CACERT: ${{ secrets.TD_COMPANY_ELASTICSEARCH_CACERT }}
+
 
   doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run integration tests
+        env:
+          TD_COMPANY_ELASTICSEARCH_URL: ${{ secrets.TD_COMPANY_ELASTICSEARCH_URL }}
+          TD_COMPANY_ELASTICSEARCH_CACERT: ${{ secrets.TD_COMPANY_ELASTICSEARCH_CACERT }}
+
         run: |
           chmod +x ./run.sh
           ./run.sh -c ${{ matrix.chunk }}-${{ strategy.job-total }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :rocket: Nouvelles fonctionnalités
 
+- Ajout d'un client primaire nommé trackdechets dans `companies/sirene` base sur notre propre index ElasticSearch des données Sirene INSEE.
+
 #### :bug: Corrections de bugs
 
 #### :boom: Breaking changes

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :rocket: Nouvelles fonctionnalités
 
-- Ajout d'un client primaire nommé trackdechets dans `companies/sirene` base sur notre propre index ElasticSearch des données Sirene INSEE.
+- Ajout d'un client primaire nommé trackdechets dans `companies/sirene` basé sur notre propre index  ElasticSearch des données Sirene INSEE [PR 1214](https://github.com/MTES-MCT/trackdechets/pull/1214)
 
 #### :bug: Corrections de bugs
 

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -4,3 +4,4 @@
 /prisma/seed.dev.ts
 /src/companies/sirene/fixtures/anonymousCompanies.json
 /src/generated
+es.cert

--- a/back/integration-tests/.integration-tests-env
+++ b/back/integration-tests/.integration-tests-env
@@ -9,3 +9,4 @@ UI_HOST=trackdechets.local
 ELASTIC_SEARCH_URL=http://elasticsearch:9200
 DD_TRACE_ENABLED=false
 QUEUE_NAME_SENDMAIL=td-integration-tests-queue
+TD_COMPANY_ELASTICSEARCH_INDEX=stocketablissement-production

--- a/back/package.json
+++ b/back/package.json
@@ -7,7 +7,7 @@
     "predev": "npm run generate",
     "dev": "npm run watch:all",
     "watch:all": "concurrently -k -p \"[{name}]\" -n \"Api,Queue\" -c \"yellow.bold,cyan.bold\" \"npm run watch:node\" \"npm run watch:queue\"",
-    "watch:node": "nodemon -r dotenv/config --watch src --exec \"ts-eager\" src/index.ts -e ts,tsx",
+    "watch:node": "nodemon -r dotenv/config --watch src --exec ts-eager --inspect=0.0.0.0:9229 src/index.ts -e ts,tsx",
     "start": "node dist/src/index.js",
     "update": "node dist/prisma/scripts/index.js",
     "update:dev": "ts-node prisma/scripts/index.ts",
@@ -30,7 +30,7 @@
     "bulk-create-account:dev": "ts-node src/users/bulk-creation/index.ts",
     "index-elastic-search": "node dist/src/scripts/bin/indexElasticSearch.js",
     "index-elastic-search:dev": "ts-node -r dotenv/config ./src/scripts/bin/indexElasticSearch.ts",
-    "watch:queue": "nodemon -r dotenv/config --watch src --exec \"ts-eager\" --inspect=0.0.0.0:9230 src/queue/consumer.ts -e ts,tsx",
+    "watch:queue": "nodemon -r dotenv/config --watch src --exec ts-eager --inspect=0.0.0.0:9230 src/queue/consumer.ts -e ts,tsx",
     "queue": "node dist/src/queue/consumer.js"
   },
   "engines": {

--- a/back/src/companies/sirene/redundancy.ts
+++ b/back/src/companies/sirene/redundancy.ts
@@ -1,4 +1,6 @@
+import { UserInputError } from "apollo-server-express";
 import type { AsyncReturnType } from "type-fest";
+import { AnonymousCompanyError } from "./errors";
 
 /**
  * Loop over the functions until one of them returns a result
@@ -12,6 +14,13 @@ export function redundant<F extends (...args: any[]) => any>(...fns: F[]) {
         const response = await fn(...args);
         return response;
       } catch (error) {
+        // fail fast for user-input errors
+        if (error instanceof AnonymousCompanyError) {
+          throw error;
+        }
+        if (error instanceof UserInputError) {
+          throw error;
+        }
         if (firstError == null) {
           firstError = error;
         }

--- a/back/src/companies/sirene/searchCompanies.ts
+++ b/back/src/companies/sirene/searchCompanies.ts
@@ -5,8 +5,6 @@ import { searchCompanies as searchCompaniesTD } from "./trackdechets/client";
 import { backoffIfTooManyRequests, throttle } from "./ratelimit";
 import { redundant } from "./redundancy";
 
-const { INSEE_MAINTENANCE } = process.env;
-
 const searchCompaniesInseeThrottled = backoffIfTooManyRequests(
   searchCompaniesInsee,
   {
@@ -28,7 +26,7 @@ const searchCompaniesSocialGouvThrottled = throttle(searchCompaniesSocialGouv, {
 // order of priority.
 const searchCompaniesProviders = [
   searchCompaniesTD,
-  ...(INSEE_MAINTENANCE === "true" ? [] : [searchCompaniesInseeThrottled]),
+  searchCompaniesInseeThrottled,
   searchCompaniesDataGouvThrottled,
   searchCompaniesSocialGouvThrottled
 ];

--- a/back/src/companies/sirene/searchCompanies.ts
+++ b/back/src/companies/sirene/searchCompanies.ts
@@ -1,6 +1,7 @@
 import { searchCompanies as searchCompaniesInsee } from "./insee/client";
 import { searchCompanies as searchCompaniesDataGouv } from "./entreprise.data.gouv.fr/client";
 import { searchCompanies as searchCompaniesSocialGouv } from "./social.gouv/client";
+import { searchCompanies as searchCompaniesTD } from "./trackdechets/client";
 import { backoffIfTooManyRequests, throttle } from "./ratelimit";
 import { redundant } from "./redundancy";
 
@@ -26,6 +27,7 @@ const searchCompaniesSocialGouvThrottled = throttle(searchCompaniesSocialGouv, {
 // list different implementations of searchCompanies by
 // order of priority.
 const searchCompaniesProviders = [
+  searchCompaniesTD,
   ...(INSEE_MAINTENANCE === "true" ? [] : [searchCompaniesInseeThrottled]),
   searchCompaniesDataGouvThrottled,
   searchCompaniesSocialGouvThrottled

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -6,8 +6,6 @@ import { backoffIfTooManyRequests, throttle } from "./ratelimit";
 import { redundant } from "./redundancy";
 import { cache } from "./cache";
 
-const { INSEE_MAINTENANCE } = process.env;
-
 const searchCompanyInseeThrottled = backoffIfTooManyRequests(
   searchCompanyInsee,
   {
@@ -29,7 +27,7 @@ const searchCompanySocialGouvThrottled = throttle(searchCompanySocialGouv, {
 // order of priority.
 const searchCompanyProviders = [
   searchCompanyTD,
-  ...(INSEE_MAINTENANCE === "true" ? [] : [searchCompanyInseeThrottled]),
+  searchCompanyInseeThrottled,
   searchCompanyDataGouvThrottled,
   searchCompanySocialGouvThrottled
 ];

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -1,6 +1,7 @@
 import { searchCompany as searchCompanyInsee } from "./insee/client";
 import { searchCompany as searchCompanyDataGouv } from "./entreprise.data.gouv.fr/client";
 import { searchCompany as searchCompanySocialGouv } from "./social.gouv/client";
+import { searchCompany as searchCompanyTD } from "./trackdechets/client";
 import { backoffIfTooManyRequests, throttle } from "./ratelimit";
 import { redundant } from "./redundancy";
 import { cache } from "./cache";
@@ -27,9 +28,10 @@ const searchCompanySocialGouvThrottled = throttle(searchCompanySocialGouv, {
 // list different implementations of searchCompany by
 // order of priority.
 const searchCompanyProviders = [
+  searchCompanyTD,
   ...(INSEE_MAINTENANCE === "true" ? [] : [searchCompanyInseeThrottled]),
-  searchCompanySocialGouvThrottled,
-  searchCompanyDataGouvThrottled
+  searchCompanyDataGouvThrottled,
+  searchCompanySocialGouvThrottled
 ];
 
 /**

--- a/back/src/companies/sirene/trackdechets/README.md
+++ b/back/src/companies/sirene/trackdechets/README.md
@@ -1,0 +1,98 @@
+# Index Établissements Trackdéchets
+
+L'index `stocketablissement_utf-8` est indéxé à partir du StockEtabblissements de l'[insee](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/).
+Chaque entrée est un Siret et pour chaque Siret sont recopiées les infos de l'unité légale décrite ci-dessous
+
+
+## Champs Etablissements
+
+Nom	|	Libellé	|	Longueur	|	Type
+----|---------|-----------|----------
+activitePrincipaleEtablissement	|	Activité principale de l'établissement pendant la période	|	6	|	Liste de codes
+activitePrincipaleRegistreMetiersEtablissement	|	Activité exercée par l’artisan inscrit au registre des métiers	|	6	|	Liste de codes
+anneeEffectifsEtablissement	|	Année de validité de la tranche d’effectif salarié de l’établissement	|	4	|	Date
+caractereEmployeurEtablissement	|	Caractère employeur de l’établissement	|	1	|	Liste de codes
+codeCedex2Etablissement	|	Code cedex de l’adresse secondaire	|	9	|	Texte
+codeCedexEtablissement	|	Code cedex	|	9	|	Texte
+codeCommune2Etablissement	|	Code commune de l’adresse secondaire	|	5	|	Liste de codes
+codeCommuneEtablissement	|	Code commune de l’établissement	|	5	|	Liste de codes
+codePaysEtranger2Etablissement	|	Code pays de l’adresse secondaire pour un établissement situé à l’étranger	|	5	|	Liste de codes
+codePaysEtrangerEtablissement	|	Code pays pour un établissement situé à l’étranger	|	5	|	Liste de codes
+codePostal2Etablissement	|	Code postal de l’adresse secondaire	|	5	|	Texte
+codePostalEtablissement	|	Code postal	|	5	|	Texte
+complementAdresse2Etablissement	|	Complément d’adresse secondaire	|	38	|	Texte
+complementAdresseEtablissement	|	Complément d’adresse	|	38	|	Texte
+dateCreationEtablissement	|	Date de création de l’établissement	|	10	|	Date
+dateDebut	|	Date de début d'une période d'historique d'un établissement	|	10	|	Date
+dateDernierTraitementEtablissement	|	Date du dernier traitement de l’établissement dans le répertoire Sirene	|	19	|	Date
+denominationUsuelleEtablissement	|	Dénomination usuelle de l’établissement	|	100	|	Texte
+distributionSpeciale2Etablissement	|	Distribution spéciale de l’adresse secondaire de l’établissement	|	26	|	Texte
+distributionSpecialeEtablissement	|	Distribution spéciale de l’établissement	|	26	|	Texte
+enseigne1Etablissement	|	Première ligne d’enseigne de l’établissement	|	50	|	Texte
+enseigne2Etablissement	|	Deuxième ligne d’enseigne de l’établissement	|	50	|	Texte
+enseigne3Etablissement	|	Troisième ligne d’enseigne de l’établissement	|	50	|	Texte
+etablissementSiege	|	Qualité de siège ou non de l’établissement	|	5	|	Texte
+etatAdministratifEtablissement	|	État administratif de l’établissement	|	1	|	Liste de codes
+indiceRepetition2Etablissement	|	Indice de répétition dans la voie pour l’adresse secondaire	|	1	|	Texte
+indiceRepetitionEtablissement	|	Indice de répétition dans la voie	|	1	|	Texte
+libelleCedex2Etablissement	|	Libellé du code cedex de l’adresse secondaire	|	100	|	Texte
+libelleCedexEtablissement	|	Libellé du code cedex	|	100	|	Texte
+libelleCommune2Etablissement	|	Libellé de la commune de l’adresse secondaire	|	100	|	Texte
+libelleCommuneEtablissement	|	Libellé de la commune	|	100	|	Texte
+libelleCommuneEtranger2Etablissement	|	Libellé de la commune de l’adresse secondaire pour un établissement situé à l’étranger	|	100	|	Texte
+libelleCommuneEtrangerEtablissement	|	Libellé de la commune pour un établissement situé à l’étranger	|	100	|	Texte
+libellePaysEtranger2Etablissement	|	Libellé du pays de l’adresse secondaire pour un établissement situé à l’étranger	|	100	|	Texte
+libellePaysEtrangerEtablissement	|	Libellé du pays pour un établissement situé à l’étranger	|	100	|	Texte
+libelleVoie2Etablissement	|	Libellé de voie de l’adresse secondaire	|	100	|	Texte
+libelleVoieEtablissement	|	Libellé de voie	|	100	|	Texte
+nic	|	Numéro interne de classement de l'établissement	|	5	|	Texte
+nombrePeriodesEtablissement	|	Nombre de périodes de l’établissement	|	2	|	Numérique
+nomenclatureActivitePrincipaleEtablissement	|	Nomenclature d’activité de la variable activitePrincipaleEtablissement	|	8	|	Liste de codes
+numeroVoie2Etablissement	|	Numéro de la voie de l’adresse secondaire	|	4	|	Texte
+numeroVoieEtablissement	|	Numéro de voie	|	4	|	Texte
+siren	|	Numéro Siren	|	9	|	Texte
+siret	|	Numéro Siret	|	14	|	Texte
+statutDiffusionEtablissement	|	Statut de diffusion de l’établissement	|	1	|	Liste de codes
+trancheEffectifsEtablissement	|	Tranche d’effectif salarié de l’établissement	|	2	|	Liste de codes
+typeVoie2Etablissement	|	Type de voie de l’adresse secondaire	|	4	|	Liste de codes
+typeVoieEtablissement	|	Type de voie	|	4	|	Liste de codes
+
+
+## Champs Unité légale
+
+Nom	|	Libellé	|	Longueur	|	Type
+----|---------|-----------|----------
+activitePrincipaleUniteLegale	|	Activité principale de l’unité légale	|	6	|	Liste de codes
+anneeCategorieEntreprise	|	Année de validité de la catégorie d’entreprise	|	4	|	Date
+anneeEffectifsUniteLegale	|	Année de validité de la tranche d’effectif salarié de l’unité légale	|	4	|	Date
+caractereEmployeurUniteLegale	|	Caractère employeur de l’unité légale	|	1	|	Liste de codes
+categorieEntreprise	|	Catégorie à laquelle appartient l’entreprise	|	3	|	Liste de codes
+categorieJuridiqueUniteLegale	|	Catégorie juridique de l’unité légale	|	4	|	Liste de codes
+dateCreationUniteLegale	|	Date de création de l'unité légale	|	10	|	Date
+dateDebut	|	Date de début d'une période d'historique d'une unité légale	|	10	|	Date
+dateDernierTraitementUniteLegale	|	Date du dernier traitement de l’unité légale dans le répertoire Sirene	|	19	|	Date
+denominationUniteLegale	|	Dénomination de l’unité légale	|	120	|	Texte
+denominationUsuelle1UniteLegale	|	Dénomination usuelle de l’unité légale	|	70	|	Texte
+denominationUsuelle2UniteLegale	|	Dénomination usuelle de l’unité légale – deuxième champ	|	70	|	Texte
+denominationUsuelle3UniteLegale	|	Dénomination usuelle de l’unité légale – troisième champ	|	70	|	Texte
+economieSocialeSolidaireUniteLegale	|	Appartenance au champ de l’économie sociale et solidaire	|	1	|	Liste de codes
+etatAdministratifUniteLegale	|	État administratif de l’unité légale	|	1	|	Liste de codes
+identifiantAssociationUniteLegale	|	Numéro au Répertoire National des Associations	|	10	|	Texte
+nicSiegeUniteLegale	|	Numéro interne de classement (Nic) de l’unité légale	|	5	|	Texte
+nombrePeriodesUniteLegale	|	Nombre de périodes de l’unité légale	|	2	|	Numérique
+nomenclatureActivitePrincipaleUniteLegale	|	Nomenclature d’activité de la variable activitePrincipaleUniteLegale	|	8	|	Liste de codes
+nomUniteLegale	|	Nom de naissance de la personnes physique	|	100	|	Texte
+nomUsageUniteLegale	|	Nom d’usage de la personne physique	|	100	|	Texte
+prenom1UniteLegale	|	Premier prénom déclaré pour un personne physique	|	20	|	Texte
+prenom2UniteLegale	|	Deuxième prénom déclaré pour un personne physique	|	20	|	Texte
+prenom3UniteLegale	|	Troisième prénom déclaré pour un personne physique	|	20	|	Texte
+prenom4UniteLegale	|	Quatrième prénom déclaré pour un personne physique	|	20	|	Texte
+prenomUsuelUniteLegale	|	Prénom usuel de la personne physique	|	20	|	Texte
+pseudonymeUniteLegale	|	Pseudonyme de la personne physique	|	100	|	Texte
+sexeUniteLegale	|	Caractère féminin ou masculin de la personne physique	|	1	|	Liste de codes
+sigleUniteLegale	|	Sigle de l’unité légale	|	20	|	Texte
+siren	|	Numéro Siren	|	9	|	Texte
+statutDiffusionUniteLegale	|	Statut de diffusion de l’unité légale	|	1	|	Liste de codes
+trancheEffectifsUniteLegale	|	Tranche d’effectif salarié de l’unité légale	|	2	|	Liste de codes
+unitePurgeeUniteLegale	|	Unité légale purgée	|	5	|	Texte
+

--- a/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
+++ b/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
@@ -1,0 +1,295 @@
+import { searchCompany, searchCompanies } from "../client";
+import { ErrorCode } from "../../../../common/errors";
+import client from "../esClient";
+import { ResponseError } from "@elastic/elasticsearch/lib/errors";
+import { ApiResponse } from "@elastic/elasticsearch/lib/Transport";
+import { SearchHit } from "../types";
+
+jest.mock("../esClient");
+
+describe("searchCompany", () => {
+  afterEach(() => {
+    (client.get as jest.Mock).mockReset();
+  });
+
+  it("should retrieve a company by siret", async () => {
+    (client.get as jest.Mock).mockResolvedValueOnce({
+      body: {
+        _source: {
+          siret: "85001946400013",
+          statutDiffusionEtablissement: "A",
+          etatAdministratifEtablissement: "A",
+          numeroVoieEtablissement: "4",
+          indiceRepetitionEtablissement: "bis",
+          typeVoieEtablissement: "BD",
+          libelleVoieEtablissement: "LONGCHAMP",
+          complementAdresseEtablissement: "Bat G",
+          codePostalEtablissement: "13001",
+          codeCommuneEtablissement: "13201",
+          libelleCommuneEtablissement: "MARSEILLE",
+          activitePrincipaleEtablissement: "62.01Z",
+          denominationUniteLegale: "CODE EN STOCK"
+        }
+      }
+    });
+    const company = await searchCompany("85001946400013");
+    const expected = {
+      siret: "85001946400013",
+      etatAdministratif: "A",
+      address: "4 bis BD LONGCHAMP Bat G 13001 MARSEILLE",
+      addressVoie: "4 bis BD LONGCHAMP Bat G",
+      addressPostalCode: "13001",
+      addressCity: "MARSEILLE",
+      codeCommune: "13201",
+      name: "CODE EN STOCK",
+      naf: "62.01Z",
+      libelleNaf: "Programmation informatique"
+    };
+    expect(company).toEqual(expected);
+  });
+
+  it("should raise AnonymousCompanyError if non-diffusible", async () => {
+    (client.get as jest.Mock).mockResolvedValueOnce({
+      body: {
+        _source: {
+          siret: "85001946400013",
+          statutDiffusionEtablissement: "N"
+        }
+      }
+    });
+    expect.assertions(1);
+    try {
+      await searchCompany("85001946400013");
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+
+  it(`should set name for an individual enterprise
+      by concatenating first and last name`, async () => {
+    (client.get as jest.Mock).mockResolvedValueOnce({
+      body: {
+        _source: {
+          siret: "34393738900041",
+          etatAdministratifEtablissement: "A",
+          numeroVoieEtablissement: "4",
+          typeVoieEtablissement: "RUE",
+          libelleVoieEtablissement: "DES ROSIERS",
+          codePostalEtablissement: "13001",
+          codeCommuneEtablissement: "13201",
+          libelleCommuneEtablissement: "MARSEILLE",
+          activitePrincipaleEtablissement: "86.21Z",
+          denominationUniteLegale: null,
+          prenom1UniteLegale: "JOHN",
+          nomUniteLegale: "SNOW",
+          categorieJuridiqueUniteLegale: "1000"
+        }
+      }
+    });
+    const company = await searchCompany("34393738900041");
+    expect(company.name).toEqual("JOHN SNOW");
+  });
+
+  it("should raise BAD_USER_INPUT if error 404 (siret not found)", async () => {
+    (client.get as jest.Mock).mockRejectedValueOnce(
+      new ResponseError({
+        statusCode: 404
+      } as unknown as ApiResponse)
+    );
+    expect.assertions(1);
+    try {
+      await searchCompany("xxxxxxxxxxxxxx");
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
+    }
+  });
+
+  it(`should escalate other types of errors
+          (network, internal server error, etc)`, async () => {
+    (client.get as jest.Mock).mockRejectedValueOnce({
+      message: "Erreur inconnue"
+    });
+    expect.assertions(1);
+    try {
+      await searchCompany("85001946400013");
+    } catch (e) {
+      expect(e.message).toEqual("Erreur inconnue");
+    }
+  });
+});
+
+describe("searchCompanies", () => {
+  afterEach(() => {
+    (client.search as jest.Mock).mockReset();
+  });
+
+  it("perform a full text search based on a clue", async () => {
+    (client.search as jest.Mock).mockResolvedValueOnce({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                siret: "85001946400013",
+                denominationUniteLegale: "CODE EN STOCK",
+                numeroVoieEtablissement: "4",
+                typeVoieEtablissement: "BD",
+                libelleVoieEtablissement: "LONGCHAMP",
+                codePostalEtablissement: "13001",
+                libelleCommuneEtablissement: "MARSEILLE",
+                activitePrincipaleEtablissement: "6201Z",
+                etatAdministratifEtablissement: "A"
+              }
+            }
+          ] as SearchHit[]
+        }
+      }
+    });
+    const companies = await searchCompanies("code en stock");
+    expect(companies).toHaveLength(1);
+    const expected = {
+      siret: "85001946400013",
+      address: "4 BD LONGCHAMP 13001 MARSEILLE",
+      addressVoie: "4 BD LONGCHAMP",
+      addressPostalCode: "13001",
+      addressCity: "MARSEILLE",
+      name: "CODE EN STOCK",
+      naf: "6201Z",
+      libelleNaf: "Programmation informatique",
+      etatAdministratif: "A",
+      codeCommuneEtablissement: undefined
+    };
+    expect(companies[0]).toEqual(expected);
+  });
+
+  it("should remove diacritics (accents) from clue", async () => {
+    (client.search as jest.Mock).mockResolvedValueOnce({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                siret: "85001946400013",
+                denominationUniteLegale: "LE BAR A PAIN",
+                numeroVoieEtablissement: "40",
+                typeVoieEtablissement: "COURS",
+                libelleVoieEtablissement: "LONGCHAMP",
+                codePostalEtablissement: "13001",
+                libelleCommuneEtablissement: "MARSEILLE",
+                activitePrincipaleEtablissement: "1071C",
+                etatAdministratifEtablissement: "A"
+              }
+            }
+          ] as SearchHit[]
+        }
+      }
+    });
+    const companies = await searchCompanies("le bar à pain");
+    expect(companies).toHaveLength(1);
+    const expected = {
+      siret: "85001946400013",
+      address: "40 COURS LONGCHAMP 13001 MARSEILLE",
+      addressVoie: "40 COURS LONGCHAMP",
+      addressPostalCode: "13001",
+      addressCity: "MARSEILLE",
+      name: "LE BAR A PAIN",
+      naf: "1071C",
+      etatAdministratif: "A",
+      libelleNaf: "Boulangerie et boulangerie-pâtisserie",
+      codeCommuneEtablissement: undefined
+    };
+    expect(companies[0]).toEqual(expected);
+  });
+
+  it("should return empty array if no results", async () => {
+    (client.search as jest.Mock).mockResolvedValueOnce({
+      body: {
+        hits: {
+          hits: []
+        }
+      }
+    });
+    const companies = await searchCompanies("sdsdhuu876gbshdsdsd");
+    expect(companies).toHaveLength(0);
+  });
+
+  it(`should escalate other types of errors
+      (network, internal server error, etc)`, async () => {
+    (client.search as jest.Mock).mockRejectedValueOnce({
+      message: "Erreur inconnue"
+    });
+    expect.assertions(1);
+    try {
+      await searchCompanies("boulangerie");
+    } catch (e) {
+      expect(e.message).toEqual("Erreur inconnue");
+    }
+  });
+
+  it("should filter results by departement", async () => {
+    (client.search as jest.Mock).mockResolvedValueOnce({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                siret: "xxxxxxxxxxxxxx",
+                denominationUniteLegale: "BOULANGERIE",
+                numeroVoieEtablissement: "1",
+                typeVoieEtablissement: "ROUTE",
+                libelleVoieEtablissement: "DES BLÉS",
+                codePostalEtablissement: "07100",
+                libelleCommuneEtablissement: "ANNONAY",
+                activitePrincipaleEtablissement: "4724Z",
+                etatAdministratifEtablissement: "A"
+              }
+            }
+          ] as SearchHit[]
+        }
+      }
+    });
+
+    const companies = await searchCompanies("boulangerie", "07");
+    expect(companies).toHaveLength(1);
+    const expected = {
+      siret: "xxxxxxxxxxxxxx",
+      address: "1 ROUTE DES BLÉS 07100 ANNONAY",
+      addressVoie: "1 ROUTE DES BLÉS",
+      addressPostalCode: "07100",
+      addressCity: "ANNONAY",
+      name: "BOULANGERIE",
+      naf: "4724Z",
+      libelleNaf:
+        "Commerce de détail de pain, pâtisserie et confiserie en magasin spécialisé",
+      etatAdministratif: "A",
+      codeCommune: undefined
+    };
+    expect(companies[0]).toEqual(expected);
+  });
+
+  it("should search by siret if clue is formatted like a siret", async () => {
+    (client.search as jest.Mock).mockResolvedValueOnce({
+      body: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                siret: "85001946400013",
+                denominationUniteLegale: "CODE EN STOCK",
+                numeroVoieEtablissement: "4",
+                typeVoieEtablissement: "BD",
+                libelleVoieEtablissement: "LONGCHAMP",
+                codePostalEtablissement: "13001",
+                libelleCommuneEtablissement: "MARSEILLE",
+                activitePrincipaleEtablissement: "6201Z",
+                etatAdministratifEtablissement: "A"
+              }
+            }
+          ] as SearchHit[]
+        }
+      }
+    });
+    const companies = await searchCompanies("85001946400013");
+    expect(companies).toHaveLength(1);
+  });
+});

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -1,0 +1,187 @@
+import {
+  GetResponse,
+  QueryDslQueryContainer
+} from "@elastic/elasticsearch/api/types";
+import { TransportRequestOptions } from "@elastic/elasticsearch/lib/Transport";
+import { UserInputError } from "apollo-server-express";
+import logger from "../../../logging/logger";
+import { libelleFromCodeNaf, buildAddress, removeDiacritics } from "../utils";
+import { CompanySearchResult } from "../types";
+import { AnonymousCompanyError } from "../errors";
+import {
+  SearchHit,
+  SearchOptions,
+  SearchResponse,
+  SearchStockEtablissement,
+  ProviderErrors
+} from "./types";
+import client from "./esClient";
+import { ResponseError } from "@elastic/elasticsearch/lib/errors";
+
+const index = process.env.TD_COMPANY_ELASTICSEARCH_INDEX;
+
+/**
+ * Build a company object from a search response
+ * @param data etablissement response object
+ */
+const searchResponseToCompany = (
+  etablissement: SearchStockEtablissement
+): CompanySearchResult => {
+  const addressVoie = buildAddress([
+    etablissement.numeroVoieEtablissement,
+    etablissement.indiceRepetitionEtablissement,
+    etablissement.typeVoieEtablissement,
+    etablissement.libelleVoieEtablissement,
+    etablissement.complementAdresseEtablissement
+  ]);
+
+  const fullAddress = buildAddress([
+    addressVoie,
+    etablissement.codePostalEtablissement,
+    etablissement.libelleCommuneEtablissement
+  ]);
+
+  const company = {
+    siret: etablissement.siret,
+    etatAdministratif: etablissement.etatAdministratifEtablissement,
+    address: fullAddress,
+    addressVoie,
+    addressPostalCode: etablissement.codePostalEtablissement,
+    addressCity: etablissement.libelleCommuneEtablissement,
+    codeCommune: etablissement.codeCommuneEtablissement,
+    name: etablissement.denominationUniteLegale,
+    naf: etablissement.activitePrincipaleEtablissement,
+    libelleNaf: etablissement.activitePrincipaleEtablissement
+      ? libelleFromCodeNaf(etablissement.activitePrincipaleEtablissement)
+      : ""
+  };
+
+  const isEntrepreneurIndividuel =
+    etablissement.categorieJuridiqueUniteLegale === "1000";
+
+  if (isEntrepreneurIndividuel) {
+    // concatenate prénom et nom
+    company.name = [
+      etablissement.prenom1UniteLegale,
+      etablissement.nomUniteLegale
+    ]
+      .join(" ")
+      .trim();
+  }
+
+  return company;
+};
+
+/**
+ * Search a company by SIRET
+ * @param siret
+ */
+export const searchCompany = (siret: string): Promise<CompanySearchResult> =>
+  client
+    .get<GetResponse<SearchStockEtablissement>>({
+      id: siret,
+      index
+    })
+    .then(r => {
+      if (r.warnings) {
+        logger.warn(r.warnings);
+      }
+      if (r.body._source.statutDiffusionEtablissement === "N") {
+        throw new AnonymousCompanyError();
+      }
+      return searchResponseToCompany(r.body._source);
+    })
+    .catch((error: Error) => {
+      if (error instanceof AnonymousCompanyError) {
+        throw error;
+      }
+      // 404 "no results found"
+      if (error instanceof ResponseError && error.meta.statusCode === 404) {
+        throw new UserInputError(ProviderErrors.SiretNotFound, {
+          invalidArgs: ["siret"]
+        });
+      }
+      logger.error(
+        `${ProviderErrors.ServerError}: ${error.name}, ${error.message}, \n`,
+        { stacktrace: error.stack }
+      );
+      throw new Error(`${ProviderErrors.ServerError}`);
+    });
+
+/**
+ * Build a list of company objects from a full text search response
+ */
+const fullTextSearchResponseToCompanies = (
+  r: SearchHit[]
+): CompanySearchResult[] =>
+  r.map(({ _source }) => searchResponseToCompany(_source));
+
+/**
+ * Full text search
+ */
+export const searchCompanies = (
+  clue: string,
+  department?: string,
+  options?: Partial<SearchOptions>,
+  requestOptions?: Partial<TransportRequestOptions>
+): Promise<CompanySearchResult[]> => {
+  const qs = removeDiacritics(clue);
+  // Multi-match query docs https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+  const must: QueryDslQueryContainer[] = [
+    {
+      match: {
+        // field created during indexation from the copy of multiple fields
+        // check this in indexInseeSiret.ts and "stocketablissement" index mapping
+        td_search_companies: {
+          query: qs,
+          operator: "or"
+        }
+      }
+    }
+  ];
+
+  if (department && department.length === 2) {
+    // this might a french department code
+    must.push({
+      wildcard: { codePostalEtablissement: `${department}*` }
+    });
+  }
+
+  if (department && department.length === 5) {
+    // this might be a french postal code
+    must.push({
+      term: { codePostalEtablissement: department }
+    });
+  }
+
+  const searchRequest: SearchOptions = {
+    ...options,
+    index,
+    // default_operator: "OR",
+    body: {
+      // QueryDSL docs https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+      query: {
+        bool: {
+          must
+        }
+      }
+    }
+  };
+
+  return client
+    .search<SearchResponse>(searchRequest, requestOptions)
+    .then(r => {
+      if (r.body.timed_out) {
+        throw new Error(`Server timed out`);
+      }
+      if (r.warnings) {
+        logger.warn(r.warnings);
+      }
+      logger.info(`Request took : ${r.body.took}ms`);
+      return fullTextSearchResponseToCompanies(r.body.hits.hits);
+    })
+    .catch(error => {
+      logger.error(`${ProviderErrors.ServerError}\n`, error);
+      throw new Error(`${ProviderErrors.ServerError}`);
+    });
+};

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -140,14 +140,14 @@ export const searchCompanies = (
     }
   ];
 
-  if (department && department.length === 2) {
+  if (department?.length >= 2 && department?.length <= 3) {
     // this might a french department code
     must.push({
       wildcard: { codePostalEtablissement: `${department}*` }
     });
   }
 
-  if (department && department.length === 5) {
+  if (department?.length === 5) {
     // this might be a french postal code
     must.push({
       term: { codePostalEtablissement: department }
@@ -177,7 +177,6 @@ export const searchCompanies = (
       if (r.warnings) {
         logger.warn(r.warnings);
       }
-      logger.info(`Request took : ${r.body.took}ms`);
       return fullTextSearchResponseToCompanies(r.body.hits.hits);
     })
     .catch(error => {

--- a/back/src/companies/sirene/trackdechets/esClient.ts
+++ b/back/src/companies/sirene/trackdechets/esClient.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import { Client } from "@elastic/elasticsearch";
+
+const certPath = path.join(__dirname, "es.cert");
+
+let ssl = undefined;
+
+if (fs.existsSync(certPath)) {
+  ssl = { ca: fs.readFileSync(certPath, "utf-8") };
+} else if (process.env.TD_COMPANY_ELASTICSEARCH_CACERT) {
+  ssl = { ca: process.env.TD_COMPANY_ELASTICSEARCH_CACERT };
+}
+
+const client = new Client({
+  node: process.env.TD_COMPANY_ELASTICSEARCH_URL || "http://elasticsearch:9200",
+  ssl
+});
+
+export default client;

--- a/back/src/companies/sirene/trackdechets/types.ts
+++ b/back/src/companies/sirene/trackdechets/types.ts
@@ -1,0 +1,123 @@
+export interface SearchStockEtablissement {
+  siren: string;
+  nic: string;
+  siret: string;
+  statutDiffusionEtablissement: string;
+  dateCreationEtablissement: string;
+  trancheEffectifsEtablissement: string;
+  anneeEffectifsEtablissement: string;
+  activitePrincipaleRegistreMetiersEtablissement: string;
+  dateDernierTraitementEtablissement: string;
+  etablissementSiege: string;
+  nombrePeriodesEtablissement: string;
+  complementAdresseEtablissement: string;
+  numeroVoieEtablissement: string;
+  indiceRepetitionEtablissement: string;
+  typeVoieEtablissement: string;
+  libelleVoieEtablissement: string;
+  codePostalEtablissement: string;
+  libelleCommuneEtablissement: string;
+  libelleCommuneEtrangerEtablissement: string;
+  distributionSpecialeEtablissement: string;
+  codeCommuneEtablissement: string;
+  codeCedexEtablissement: string;
+  libelleCedexEtablissement: string;
+  codePaysEtrangerEtablissement: string;
+  libellePaysEtrangerEtablissement: string;
+  complementAdresse2Etablissement: string;
+  numeroVoie2Etablissement: string;
+  indiceRepetition2Etablissement: string;
+  typeVoie2Etablissement: string;
+  libelleVoie2Etablissement: string;
+  codePostal2Etablissement: string;
+  libelleCommune2Etablissement: string;
+  libelleCommuneEtranger2Etablissement: string;
+  distributionSpeciale2Etablissement: string;
+  codeCommune2Etablissement: string;
+  codeCedex2Etablissement: string;
+  libelleCedex2Etablissement: string;
+  codePaysEtranger2Etablissement: string;
+  libellePaysEtranger2Etablissement: string;
+  dateDebut: string;
+  etatAdministratifEtablissement: string;
+  enseigne1Etablissement: string;
+  enseigne2Etablissement: string;
+  enseigne3Etablissement: string;
+  denominationUsuelleEtablissement: string;
+  activitePrincipaleEtablissement: string;
+  nomenclatureActivitePrincipaleEtablissement: string;
+  caractereEmployeurEtablissement: string;
+  statutDiffusionUniteLegale: string;
+  unitePurgeeUniteLegale: string;
+  dateCreationUniteLegale: string;
+  sigleUniteLegale: string;
+  sexeUniteLegale: string;
+  prenom1UniteLegale: string;
+  prenom2UniteLegale: string;
+  prenom3UniteLegale: string;
+  prenom4UniteLegale: string;
+  prenomUsuelUniteLegale: string;
+  pseudonymeUniteLegale: string;
+  identifiantAssociationUniteLegale: string;
+  trancheEffectifsUniteLegale: string;
+  anneeEffectifsUniteLegale: string;
+  dateDernierTraitementUniteLegale: string;
+  nombrePeriodesUniteLegale: string;
+  categorieEntreprise: string;
+  anneeCategorieEntreprise: string;
+  etatAdministratifUniteLegale: string;
+  nomUniteLegale: string;
+  nomUsageUniteLegale: string;
+  denominationUniteLegale: string;
+  denominationUsuelle1UniteLegale: string;
+  denominationUsuelle2UniteLegale: string;
+  denominationUsuelle3UniteLegale: string;
+  categorieJuridiqueUniteLegale: string;
+  activitePrincipaleUniteLegale: string;
+  nomenclatureActivitePrincipaleUniteLegale: string;
+  nicSiegeUniteLegale: string;
+  economieSocialeSolidaireUniteLegale: string;
+  caractereEmployeurUniteLegale: string;
+}
+
+/**
+ * Partial Search API parameters
+ * Docs https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
+ */
+export interface SearchOptions {
+  body: any;
+  index: string | string[];
+  analyzer?: string;
+  analyze_wildcard?: boolean;
+  explain?: boolean;
+  from?: number;
+  size?: number;
+  sort?: string | string[];
+  _source?: string | string[];
+  _source_excludes?: string | string[];
+  _source_includes?: string | string[];
+}
+
+export interface SearchResponse {
+  timed_out: boolean;
+  took: number;
+  hits: {
+    total: { value: number; relation: "eq" | "gte" };
+    max_score: number;
+    hits: SearchHit[];
+  };
+}
+
+export interface SearchHit {
+  _id: string;
+  _score: number;
+  _source: SearchStockEtablissement;
+}
+
+/**
+ * Public API error code names
+ */
+export enum ProviderErrors {
+  SiretNotFound = "Aucun établissement trouvé avec ce SIRET",
+  ServerError = "Erreur inconnue"
+}

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -38,13 +38,12 @@ export interface Opts {
   validateOnly: boolean;
   csvDir: string;
   console?: any;
-  sireneProvider: "entreprise.data.gouv.fr" | "insee" | "social.gouv";
+  sireneProvider?: "entreprise.data.gouv.fr" | "insee" | "social.gouv";
 }
 
 export const opts: Opts = {
   validateOnly: false,
-  csvDir: `${__dirname}/../../../csv`,
-  sireneProvider: "entreprise.data.gouv.fr"
+  csvDir: `${__dirname}/../../../csv`
 };
 
 async function run(argv = process.argv.slice(2)): Promise<void> {

--- a/search/README.md
+++ b/search/README.md
@@ -32,8 +32,8 @@ export INSEE_SIRENE_ZIP_PATH=~/Téléchargements/StockUniteLegale_utf8.zip
 npm run index:dev
 ```
 
-Au final, vous disposez de l'index "stocketablissement_utf8-dev" où les données d'unité légale de l'index Siren (`http://localhost:9201/stockunitelegale_utf8-dev/_search`) ont été dupliquées:
-`http://localhost:9201/stocketablissement_utf8-dev/_search`
+Au final, vous disposez de l'index "stocketablissement-dev" où les données d'unité légale de l'index Siren (`http://localhost:9201/stockunitelegale-dev/_search`) ont été dupliquées:
+`http://localhost:9201/stocketablissement-dev/_search`
 
 Ces index sont des alias et les commandes se chargent de faire un roulement des index à la fin du processus pour ne pas couper le service de l'index en cours de mise à jour.
 

--- a/search/docker-compose.yml
+++ b/search/docker-compose.yml
@@ -2,21 +2,19 @@
 version: '3.4'
 services:
   es01:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.17.0}
     environment:
       - node.name=es01
-      - cluster.name=${CLUSTER_NAME}
+      - cluster.name=${CLUSTER_NAME:-tdsearchclustername}
       - cluster.initial_master_nodes=es01,es02,es03
       - discovery.seed_hosts=es02,es03
-      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-pass}
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms10g -Xmx10g"
-      - xpack.license.self_generated.type=${LICENSE}
-      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms${JVM_RAM:-512m} -Xmx${JVM_RAM:-512m}"
     volumes:
       - esdata01:/usr/share/elasticsearch/data
     ports:
-      - ${ES_PORT}:9200
+      - ${ES_PORT:-9201}:9200
     ulimits:
       memlock:
         soft: -1
@@ -33,16 +31,14 @@ services:
   es02:
     depends_on:
       - es01
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.17.0}
     environment:
       - node.name=es02
-      - cluster.name=${CLUSTER_NAME}
+      - cluster.name=${CLUSTER_NAME:-tdsearchclustername}
       - cluster.initial_master_nodes=es01,es02,es03
       - discovery.seed_hosts=es01,es03
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms10g -Xmx10g"
-      - xpack.license.self_generated.type=${LICENSE}
-      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms${JVM_RAM:-512m} -Xmx${JVM_RAM:-512m}"
     volumes:
       - esdata02:/usr/share/elasticsearch/data
     ulimits:
@@ -62,18 +58,16 @@ services:
   es03:
     depends_on:
       - es02
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION:-7.17.0}
     volumes:
       - esdata03:/usr/share/elasticsearch/data
     environment:
       - node.name=es03
-      - cluster.name=${CLUSTER_NAME}
+      - cluster.name=${CLUSTER_NAME:-tdsearchclustername}
       - cluster.initial_master_nodes=es01,es02,es03
       - discovery.seed_hosts=es01,es02
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms10g -Xmx10g"
-      - xpack.license.self_generated.type=${LICENSE}
-      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms${JVM_RAM:-512m} -Xmx${JVM_RAM:-512m}"
     ulimits:
       memlock:
         soft: -1
@@ -83,31 +77,6 @@ services:
         [
           "CMD-SHELL",
           "curl -s http://localhost:9200 | grep -q 'missing authentication credentials'",
-        ]
-      interval: 10s
-      timeout: 10s
-      retries: 120
-
-  kibana:
-    depends_on:
-      - es01
-      - es02
-      - es03
-    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
-    volumes:
-      - kibanadata:/usr/share/kibana/data
-    ports:
-      - ${KIBANA_PORT}:5601
-    environment:
-      - SERVERNAME=kibana
-      - ELASTICSEARCH_HOSTS=http://es01:9200
-      - ELASTICSEARCH_USERNAME=kibana_system
-      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
         ]
       interval: 10s
       timeout: 10s

--- a/search/package-lock.json
+++ b/search/package-lock.json
@@ -477,9 +477,9 @@
       }
     },
     "@elastic/elasticsearch": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.16.0.tgz",
-      "integrity": "sha512-lMY2MFZZFG3om7QNHninxZZOXYx3NdIUwEISZxqaI9dXPoL3DNhU31keqjvx1gN6T74lGXAzrRNP4ag8CJ/VXw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-7.17.0.tgz",
+      "integrity": "sha512-5QLPCjd0uLmLj1lSuKSThjNpq39f6NmlTy9ROLFwG5gjyTgpwSqufDeYG/Fm43Xs05uF7WcscoO7eguI3HuuYA==",
       "requires": {
         "debug": "^4.3.1",
         "hpagent": "^0.1.1",
@@ -775,80 +775,6 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
-    "@sentry/core": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.1.tgz",
-      "integrity": "sha512-dRcKs3+IKx2w7+xwg3mWRc4ghjnY+36W+qCOJXRbWyRjlzb67Es+TDYY3BxWwN4beNr2dvQkRt5HoPxJnrzGVQ==",
-      "requires": {
-        "@sentry/hub": "6.17.1",
-        "@sentry/minimal": "6.17.1",
-        "@sentry/types": "6.17.1",
-        "@sentry/utils": "6.17.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/hub": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.1.tgz",
-      "integrity": "sha512-14lNcM4kt2sKhsfZ6WG2gbsPMydxBAY1OSk+WodO/x0Esdr7VbaVngSJSFzCI0iRBPLSQuFVtUWaAZzSF+WdiA==",
-      "requires": {
-        "@sentry/types": "6.17.1",
-        "@sentry/utils": "6.17.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.1.tgz",
-      "integrity": "sha512-0V5YqVCylMjjDhD98Xod1ZdxzVRUjDSq7ssCJ2PRjfRAEtk7mN5oeznyZUhyx4pZB8hNh2G9PdasIR2WIjYN9w==",
-      "requires": {
-        "@sentry/hub": "6.17.1",
-        "@sentry/types": "6.17.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/node": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.17.1.tgz",
-      "integrity": "sha512-rGLNPSBZnszXCrdajxsMgsNzYdEVE+QeY3kGraXJUhriU9cAvAYFsyjlh5JjvSuuvp2CtUNpgQzC9ae8uUgmsw==",
-      "requires": {
-        "@sentry/core": "6.17.1",
-        "@sentry/hub": "6.17.1",
-        "@sentry/tracing": "6.17.1",
-        "@sentry/types": "6.17.1",
-        "@sentry/utils": "6.17.1",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/tracing": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.1.tgz",
-      "integrity": "sha512-2to3Y3I+kdoJWdbPbK4llALXc+765W0SAAghFWEJ5L3mups59CGf03HtRHPE8p2Hw2Tr6YO6gjtZhvm+I49LPg==",
-      "requires": {
-        "@sentry/hub": "6.17.1",
-        "@sentry/minimal": "6.17.1",
-        "@sentry/types": "6.17.1",
-        "@sentry/utils": "6.17.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/types": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.1.tgz",
-      "integrity": "sha512-EBFiN3utd1xoxowy+WFSDQGgS4J+VEZbc7j3uYVZNjn03/w5pe9FfeLsszJ2s1/hCf/K7GAGH4NA7i0r7SWF3g=="
-    },
-    "@sentry/utils": {
-      "version": "6.17.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.1.tgz",
-      "integrity": "sha512-FOjxMZ4yBflYvJYhNDacRfSa0NTKLsjCXQ3u1phxODRUwhQ7wwqmtwy86AL5uzfpiqZKwXAPlWoWihBluw7vqw==",
-      "requires": {
-        "@sentry/types": "6.17.1",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1024,6 +950,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -1424,11 +1351,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -1904,6 +1826,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -2742,11 +2665,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "lru_map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
-      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3529,11 +3447,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/search/package.json
+++ b/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trackdechets-search",
   "version": "1.0.1",
-  "description": "Search for companies on Trackdéchets from open INSEE data and others",
+  "description": "Search index for entities on Trackdéchets",
   "main": "src/index.ts",
   "scripts": {
     "test": "jest --passWithNoTests",
@@ -29,7 +29,7 @@
     "elasticsearch",
     "typescript"
   ],
-  "author": "Elias Showk <elias@showk.me>",
+  "author": "Trackdechets Devs <tech@trackdechets.beta.gouv.fr>",
   "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/MTES-MCT/trackdechets/issues"
@@ -40,8 +40,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^7.16.0",
-    "@sentry/node": "^6.16.1",
+    "@elastic/elasticsearch": "^7.17.0",
     "app-root-path": "^3.0.0",
     "dd-trace": "^1.6.0",
     "node-stream-zip": "^1.15.0",

--- a/search/src/common/logger.ts
+++ b/search/src/common/logger.ts
@@ -12,7 +12,8 @@ if (process.env.NODE_ENV !== "dev") {
  */
 
 // Avoid using undefined console.log() in jest context
-const LOG_TO_CONSOLE = process.env.FORCE_LOGGER_CONSOLE && !process.env.JEST_WORKER_ID;
+const LOG_TO_CONSOLE =
+  process.env.FORCE_LOGGER_CONSOLE && process.env.JEST_WORKER_ID === undefined;
 
 // Docs https://docs.datadoghq.com/fr/logs/log_collection/nodejs/?tab=winston30
 const logger = createLogger({
@@ -24,7 +25,7 @@ const logger = createLogger({
     format.json()
   ),
   transports: [
-    LOG_TO_CONSOLE
+    !LOG_TO_CONSOLE
       ? new transports.File({ filename: LOG_PATH })
       : new transports.Console({
           // Simple `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
@@ -33,7 +34,7 @@ const logger = createLogger({
   ],
   // capture exceptions, also for datadog to report it
   exceptionHandlers: [
-    LOG_TO_CONSOLE
+    !LOG_TO_CONSOLE
       ? new transports.File({ filename: LOG_PATH })
       : new transports.Console({
           format: format.simple()


### PR DESCRIPTION
## Résumé

- Un client companies/sirene "`trackdechets`" ajouté en **1er dans le système de clients redondants**
- La recherche `searchCompanies` est analogue au client `entreprise.data.gouv.fr`. L'indexation a dû être améliorée pour optimiser les perfs (passer d'environ 250ms vs +3000ms) puisqu'on match sur un grand nombre de champs texte le paramètre "`clue`". Tester simplement avec la query GQL `searchCompanies`. Le backend match sur un champ concaténé dans ES et spécifique `td_search_companies`
- La recherche `searchCompany` testable simplement par la query GQL `companyInfos` est un simple `GET` sur l'index


## TODO

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-2863)
