### PR TITLE
Correction de l'indexation des filtres d'onglet

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction de l'indexation des filtres d'onglet du tableau de bord [PR 1215](https://github.com/MTES-MCT/trackdechets/pull/1215)
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/forms/__tests__/elastic.integration.ts
+++ b/back/src/forms/__tests__/elastic.integration.ts
@@ -1,0 +1,221 @@
+import { Status } from "@prisma/client";
+import { resetDatabase } from "../../../integration-tests/helper";
+import prisma from "../../prisma";
+import {
+  companyFactory,
+  formFactory,
+  formWithTempStorageFactory,
+  userFactory
+} from "../../__tests__/factories";
+import { getFullForm } from "../database";
+import { getTabs } from "../elastic";
+
+describe("getTabs", () => {
+  afterEach(resetDatabase);
+
+  test("status DRAFT", async () => {
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { status: Status.DRAFT }
+    });
+    const fullForm = await getFullForm(form);
+    const { isDraftFor } = getTabs(fullForm);
+    expect(isDraftFor).toContain(form.emitterCompanySiret);
+    expect(isDraftFor).toContain(form.recipientCompanySiret);
+    expect(isDraftFor).toContain(form.transporterCompanySiret);
+  });
+
+  test("status SEALED", async () => {
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { status: Status.SEALED }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isToCollectFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.recipientCompanySiret);
+    expect(isToCollectFor).toContain(form.transporterCompanySiret);
+  });
+
+  test("status SENT", async () => {
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { status: Status.SENT }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isCollectedFor, isForActionFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+    expect(isCollectedFor).toContain(form.transporterCompanySiret);
+  });
+
+  test("status SENT multi-modal", async () => {
+    // In case of multi-modal transport, it is always possible for
+    // recipient to receive waste at any time. That's why a BSDD
+    // with a SENT status will always appear in recipient's "For Action" tab
+
+    const user = await userFactory();
+    const transporter2 = await companyFactory();
+    // waste is still in transporter n°1 truck
+    // BSDD should be in transporter n°1 "collected" tab and
+    // in transporter n°2 follow tab
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: Status.SENT,
+        transportSegments: {
+          create: {
+            transporterCompanySiret: transporter2.siret,
+            readyToTakeOver: false
+          }
+        }
+      }
+    });
+
+    let fullForm = await getFullForm(form);
+    let tabs = getTabs(fullForm);
+    let isFollowFor = tabs.isFollowFor;
+    let isCollectedFor = tabs.isCollectedFor;
+    let isToCollectFor = tabs.isToCollectFor;
+    let isForActionFor = tabs.isForActionFor;
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+    expect(isFollowFor).toContain(transporter2.siret);
+    expect(isCollectedFor).toContain(form.transporterCompanySiret);
+    // next segment is marked as ready to take over
+    // BSDD should appear in transporter n°1 "collected" tab and
+    // in transporter n°2 to "to collect" tab
+    await prisma.transportSegment.updateMany({
+      where: { formId: form.id },
+      data: { readyToTakeOver: true }
+    });
+    fullForm = await getFullForm(form);
+    tabs = getTabs(fullForm);
+    isFollowFor = tabs.isFollowFor;
+    isCollectedFor = tabs.isCollectedFor;
+    isToCollectFor = tabs.isToCollectFor;
+    isForActionFor = tabs.isForActionFor;
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isCollectedFor).toContain(form.transporterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+    expect(isToCollectFor).toContain(transporter2.siret);
+
+    // waste is taken over by transporter n°2. BSDD should
+    // be in transporter n°1 "Follow" tab and in transporter n°2
+    // "Collected" tab
+    await prisma.transportSegment.updateMany({
+      where: { formId: form.id },
+      data: { takenOverAt: new Date() }
+    });
+    fullForm = await getFullForm(form);
+    tabs = getTabs(fullForm);
+    isFollowFor = tabs.isFollowFor;
+    isCollectedFor = tabs.isCollectedFor;
+    isToCollectFor = tabs.isToCollectFor;
+    isForActionFor = tabs.isForActionFor;
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+    expect(isCollectedFor).toContain(transporter2.siret);
+  });
+
+  test("SENT with temporary storage", async () => {
+    const user = await userFactory();
+    const form = await formWithTempStorageFactory({
+      ownerId: user.id,
+      opt: { status: Status.SENT }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isCollectedFor, isForActionFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(
+      fullForm.temporaryStorageDetail.transporterCompanySiret
+    );
+    expect(isFollowFor).toContain(
+      fullForm.temporaryStorageDetail.destinationCompanySiret
+    );
+
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+    expect(isCollectedFor).toContain(form.transporterCompanySiret);
+  });
+
+  test("status RECEIVED", async () => {
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { status: Status.RECEIVED }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+  });
+
+  test("status ACCEPTED", async () => {
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: { status: Status.ACCEPTED }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+  });
+
+  test("status TEMP_STORED", async () => {
+    const user = await userFactory();
+    const form = await formWithTempStorageFactory({
+      ownerId: user.id,
+      opt: { status: Status.TEMP_STORED }
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isForActionFor).toContain(form.recipientCompanySiret);
+  });
+
+  test("status RESEALED", async () => {
+    const user = await userFactory();
+    const form = await formWithTempStorageFactory({
+      opt: { status: Status.RESEALED },
+      ownerId: user.id
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isToCollectFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isFollowFor).toContain(form.recipientCompanySiret);
+    expect(isFollowFor).toContain(
+      fullForm.temporaryStorageDetail.destinationCompanySiret
+    );
+    expect(isToCollectFor).toContain(
+      fullForm.temporaryStorageDetail.transporterCompanySiret
+    );
+  });
+
+  test("status RESENT", async () => {
+    const user = await userFactory();
+    const form = await formWithTempStorageFactory({
+      opt: { status: Status.RESENT },
+      ownerId: user.id
+    });
+    const fullForm = await getFullForm(form);
+    const { isFollowFor, isForActionFor, isCollectedFor } = getTabs(fullForm);
+    expect(isFollowFor).toContain(form.emitterCompanySiret);
+    expect(isFollowFor).toContain(form.transporterCompanySiret);
+    expect(isFollowFor).toContain(form.recipientCompanySiret);
+    expect(isForActionFor).toContain(
+      fullForm.temporaryStorageDetail.destinationCompanySiret
+    );
+    expect(isCollectedFor).toContain(
+      fullForm.temporaryStorageDetail.transporterCompanySiret
+    );
+  });
+});

--- a/back/src/forms/__tests__/elastic.integration.ts
+++ b/back/src/forms/__tests__/elastic.integration.ts
@@ -8,7 +8,7 @@ import {
   userFactory
 } from "../../__tests__/factories";
 import { getFullForm } from "../database";
-import { getTabs } from "../elastic";
+import { getSiretsByTab } from "../elastic";
 
 describe("getTabs", () => {
   afterEach(resetDatabase);
@@ -20,7 +20,7 @@ describe("getTabs", () => {
       opt: { status: Status.DRAFT }
     });
     const fullForm = await getFullForm(form);
-    const { isDraftFor } = getTabs(fullForm);
+    const { isDraftFor } = getSiretsByTab(fullForm);
     expect(isDraftFor).toContain(form.emitterCompanySiret);
     expect(isDraftFor).toContain(form.recipientCompanySiret);
     expect(isDraftFor).toContain(form.transporterCompanySiret);
@@ -33,7 +33,7 @@ describe("getTabs", () => {
       opt: { status: Status.SEALED }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isToCollectFor } = getTabs(fullForm);
+    const { isFollowFor, isToCollectFor } = getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.recipientCompanySiret);
     expect(isToCollectFor).toContain(form.transporterCompanySiret);
@@ -46,7 +46,8 @@ describe("getTabs", () => {
       opt: { status: Status.SENT }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isCollectedFor, isForActionFor } = getTabs(fullForm);
+    const { isFollowFor, isCollectedFor, isForActionFor } =
+      getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isForActionFor).toContain(form.recipientCompanySiret);
     expect(isCollectedFor).toContain(form.transporterCompanySiret);
@@ -76,7 +77,7 @@ describe("getTabs", () => {
     });
 
     let fullForm = await getFullForm(form);
-    let tabs = getTabs(fullForm);
+    let tabs = getSiretsByTab(fullForm);
     let isFollowFor = tabs.isFollowFor;
     let isCollectedFor = tabs.isCollectedFor;
     let isToCollectFor = tabs.isToCollectFor;
@@ -93,7 +94,7 @@ describe("getTabs", () => {
       data: { readyToTakeOver: true }
     });
     fullForm = await getFullForm(form);
-    tabs = getTabs(fullForm);
+    tabs = getSiretsByTab(fullForm);
     isFollowFor = tabs.isFollowFor;
     isCollectedFor = tabs.isCollectedFor;
     isToCollectFor = tabs.isToCollectFor;
@@ -111,7 +112,7 @@ describe("getTabs", () => {
       data: { takenOverAt: new Date() }
     });
     fullForm = await getFullForm(form);
-    tabs = getTabs(fullForm);
+    tabs = getSiretsByTab(fullForm);
     isFollowFor = tabs.isFollowFor;
     isCollectedFor = tabs.isCollectedFor;
     isToCollectFor = tabs.isToCollectFor;
@@ -129,7 +130,8 @@ describe("getTabs", () => {
       opt: { status: Status.SENT }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isCollectedFor, isForActionFor } = getTabs(fullForm);
+    const { isFollowFor, isCollectedFor, isForActionFor } =
+      getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(
       fullForm.temporaryStorageDetail.transporterCompanySiret
@@ -149,7 +151,7 @@ describe("getTabs", () => {
       opt: { status: Status.RECEIVED }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    const { isFollowFor, isForActionFor } = getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.transporterCompanySiret);
     expect(isForActionFor).toContain(form.recipientCompanySiret);
@@ -162,7 +164,7 @@ describe("getTabs", () => {
       opt: { status: Status.ACCEPTED }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    const { isFollowFor, isForActionFor } = getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.transporterCompanySiret);
     expect(isForActionFor).toContain(form.recipientCompanySiret);
@@ -175,7 +177,7 @@ describe("getTabs", () => {
       opt: { status: Status.TEMP_STORED }
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isForActionFor } = getTabs(fullForm);
+    const { isFollowFor, isForActionFor } = getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.transporterCompanySiret);
     expect(isForActionFor).toContain(form.recipientCompanySiret);
@@ -188,7 +190,7 @@ describe("getTabs", () => {
       ownerId: user.id
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isToCollectFor } = getTabs(fullForm);
+    const { isFollowFor, isToCollectFor } = getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.transporterCompanySiret);
     expect(isFollowFor).toContain(form.recipientCompanySiret);
@@ -207,7 +209,8 @@ describe("getTabs", () => {
       ownerId: user.id
     });
     const fullForm = await getFullForm(form);
-    const { isFollowFor, isForActionFor, isCollectedFor } = getTabs(fullForm);
+    const { isFollowFor, isForActionFor, isCollectedFor } =
+      getSiretsByTab(fullForm);
     expect(isFollowFor).toContain(form.emitterCompanySiret);
     expect(isFollowFor).toContain(form.transporterCompanySiret);
     expect(isFollowFor).toContain(form.recipientCompanySiret);

--- a/back/src/forms/__tests__/elastic.integration.ts
+++ b/back/src/forms/__tests__/elastic.integration.ts
@@ -10,7 +10,7 @@ import {
 import { getFullForm } from "../database";
 import { getSiretsByTab } from "../elastic";
 
-describe("getTabs", () => {
+describe("getSiretsByTab", () => {
   afterEach(resetDatabase);
 
   test("status DRAFT", async () => {

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -5,7 +5,7 @@ import { FullForm } from "./types";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 
-function getWhere(
+export function getTabs(
   form: FullForm
 ): Pick<
   BsdElastic,
@@ -118,16 +118,6 @@ function getWhere(
     case Status.TEMP_STORED:
     case Status.TEMP_STORER_ACCEPTED: {
       appendToSirets(siretsFilters, "recipientCompanySiret", "isForActionFor");
-      appendToSirets(
-        siretsFilters,
-        "transporterCompanySiret",
-        "isCollectedFor"
-      );
-
-      form.transportSegments.forEach(segment => {
-        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
-      });
-
       break;
     }
     case Status.RESEALED: {
@@ -137,18 +127,14 @@ function getWhere(
         "isToCollectFor"
       );
 
-      appendToSirets(
-        siretsFilters,
-        "transporterCompanySiret",
-        "isCollectedFor"
-      );
-      form.transportSegments.forEach(segment => {
-        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
-      });
-
       break;
     }
     case Status.RESENT:
+      appendToSirets(
+        siretsFilters,
+        "temporaryStorageDetailTransporterCompanySiret",
+        "isCollectedFor"
+      );
     case Status.RECEIVED:
     case Status.ACCEPTED: {
       appendToSirets(
@@ -197,7 +183,7 @@ function getRecipient(form: FullForm) {
  * Convert a BSD from the forms table to Elastic Search's BSD model.
  */
 function toBsdElastic(form: FullForm): BsdElastic {
-  const where = getWhere(form);
+  const where = getTabs(form);
   const recipient = getRecipient(form);
   return {
     type: "BSDD",

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -90,14 +90,13 @@ function getWhere(
     }
     case Status.SENT: {
       appendToSirets(siretsFilters, "recipientCompanySiret", "isForActionFor");
-      appendToSirets(
-        siretsFilters,
-        "transporterCompanySiret",
-        "isCollectedFor"
-      );
+
+      // whether or not this BSD has been handed over by transporter n°1
+      let hasBeenHandedOver = false;
 
       form.transportSegments.forEach(segment => {
         if (segment.readyToTakeOver) {
+          hasBeenHandedOver = hasBeenHandedOver || !!segment.takenOverAt;
           appendToSirets(
             siretsFilters,
             segment.id,
@@ -105,6 +104,14 @@ function getWhere(
           );
         }
       });
+
+      if (!hasBeenHandedOver) {
+        appendToSirets(
+          siretsFilters,
+          "transporterCompanySiret",
+          "isCollectedFor"
+        );
+      }
 
       break;
     }
@@ -152,44 +159,10 @@ function getWhere(
         "isForActionFor"
       );
 
-      appendToSirets(
-        siretsFilters,
-        "temporaryStorageDetailTransporterCompanySiret",
-        "isCollectedFor"
-      );
-
-      appendToSirets(
-        siretsFilters,
-        "transporterCompanySiret",
-        "isCollectedFor"
-      );
-
-      form.transportSegments.forEach(segment => {
-        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
-      });
-
       break;
     }
     case Status.AWAITING_GROUP:
-    case Status.GROUPED: {
-      appendToSirets(
-        siretsFilters,
-        "temporaryStorageDetailTransporterCompanySiret",
-        "isCollectedFor"
-      );
-
-      appendToSirets(
-        siretsFilters,
-        "transporterCompanySiret",
-        "isCollectedFor"
-      );
-
-      form.transportSegments.forEach(segment => {
-        appendToSirets(siretsFilters, segment.id, "isCollectedFor");
-      });
-
-      break;
-    }
+    case Status.GROUPED:
     case Status.REFUSED:
     case Status.PROCESSED:
     case Status.NO_TRACEABILITY: {

--- a/back/src/forms/resolvers/mutations/multiModal.ts
+++ b/back/src/forms/resolvers/mutations/multiModal.ts
@@ -321,7 +321,7 @@ export async function takeOverSegment(
   });
 
   const fullForm = await getFullForm(updatedForm);
-  await indexForm(fullForm);
+  await indexForm(fullForm, context);
 
   return expandTransportSegmentFromDb(updatedSegment);
 }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/PrepareSegment.tsx
@@ -111,7 +111,13 @@ export default function PrepareSegment({ form, siret }: WorkflowActionProps) {
           >
             {({ values, setFieldValue }) => (
               <FormikForm>
-                <h3>Préparer un transfert multimodal</h3>
+                <h3 className="h3">Préparer un transfert multimodal</h3>
+                <div className="notification success tw-mt-3">
+                  À compléter uniquement en cas de transport multimodal. En cas
+                  de transport simple, vous n'avez rien à faire, c'est à
+                  l'installation de destination ou d'entreposage provisoire de
+                  valider la réception.
+                </div>
                 <h4 className="form__section-heading">Transporteur</h4>
                 <label htmlFor="id_mode">Mode de transport</label>
                 <Field

--- a/front/src/dashboard/constants.tsx
+++ b/front/src/dashboard/constants.tsx
@@ -3,8 +3,7 @@ import { TransportMode } from "generated/graphql/types";
 export const statusLabels: { [key: string]: string } = {
   DRAFT: "Brouillon",
   SEALED: "En attente de collecte par le transporteur",
-  SENT:
-    "En attente de réception ou de prise en charge par un autre transporteur (multimodal)",
+  SENT: "En attente de réception",
   RECEIVED: "Reçu, en attente d'acceptation ou de refus",
   ACCEPTED: "Accepté, en attente de traitement",
   PROCESSED: "Traité",

--- a/front/src/dashboard/constants.tsx
+++ b/front/src/dashboard/constants.tsx
@@ -3,7 +3,8 @@ import { TransportMode } from "generated/graphql/types";
 export const statusLabels: { [key: string]: string } = {
   DRAFT: "Brouillon",
   SEALED: "En attente de collecte par le transporteur",
-  SENT: "En attente de réception",
+  SENT:
+    "En attente de réception ou de prise en charge par un autre transporteur (multimodal)",
   RECEIVED: "Reçu, en attente d'acceptation ou de refus",
   ACCEPTED: "Accepté, en attente de traitement",
   PROCESSED: "Traité",


### PR DESCRIPTION
PR un peu plus large que le scope initial du ticket Favro : 

- Lorsqu'un déchet est reçu, il doit passer dans l'onglet "Suivi" du ou des transporteurs et non pas dans l'onglet "Collecté". (dans le cas d'un BSD simple et après entreposage provisoire)
- Lorsqu'un déchet est pris en charge par le transporteur n°N en cas de transport multi-modal, il doit passer dans l'onglet "Suivi" des transporteurs précédents et non pas dans l'onglet "Collecté".
- Lorsqu'un déchet était pris en charge par le transporteur après entreposage provisoire, il n'apparaissait pas dans "Collecté".
- Ajout de tests sur l'indexation des filtres d'onglet. 
- Renommage de certaines variables pour améliorer la lisibilité du code.

--- 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7276)
