### PR TITLE
Hotfix registre

### DIFF
--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -95,7 +95,7 @@ export function toIncomingWaste(
     ].filter(s => !!s);
   }
 
-  if (bsda.grouping) {
+  if (bsda.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsda.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -158,7 +158,7 @@ export function toOutgoingWaste(
       bsda.forwarding.emitterCompanySiret;
   }
 
-  if (bsda.grouping) {
+  if (bsda.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsda.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -221,7 +221,7 @@ export function toTransportedWaste(
     ].filter(s => !!s);
   }
 
-  if (bsda.grouping) {
+  if (bsda.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsda.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -283,7 +283,7 @@ export function toManagedWaste(
     ].filter(s => !!s);
   }
 
-  if (bsda.grouping) {
+  if (bsda.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsda.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -347,7 +347,7 @@ export function toAllWaste(
     ].filter(s => !!s);
   }
 
-  if (bsda.grouping) {
+  if (bsda.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsda.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -83,7 +83,7 @@ export function toIncomingWaste(
     initialEmitterPostalCodes: null
   };
 
-  if (bsdasri.grouping) {
+  if (bsdasri.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdasri.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -142,7 +142,7 @@ export function toOutgoingWaste(
     initialEmitterPostalCodes: null
   };
 
-  if (bsdasri.grouping) {
+  if (bsdasri.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdasri.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -203,7 +203,7 @@ export function toTransportedWaste(
     initialEmitterPostalCodes: null
   };
 
-  if (bsdasri.grouping) {
+  if (bsdasri.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdasri.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -267,7 +267,7 @@ export function toManagedWaste(
     initialEmitterPostalCodes: null
   };
 
-  if (bsdasri.grouping) {
+  if (bsdasri.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdasri.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -327,7 +327,7 @@ export function toAllWaste(
     initialEmitterPostalCodes: null
   };
 
-  if (bsdasri.grouping) {
+  if (bsdasri.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdasri.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -90,13 +90,13 @@ export function toIncomingWaste(
     ].filter(s => !!s);
   }
 
-  if (bsff.repackaging) {
+  if (bsff.repackaging?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.repackaging
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
   }
 
-  if (bsff.grouping) {
+  if (bsff.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -159,13 +159,13 @@ export function toOutgoingWaste(
       bsff.forwarding.emitterCompanySiret;
   }
 
-  if (bsff.repackaging) {
+  if (bsff.repackaging?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.repackaging
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
   }
 
-  if (bsff.grouping) {
+  if (bsff.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -227,13 +227,13 @@ export function toTransportedWaste(
     ].filter(s => !!s);
   }
 
-  if (bsff.repackaging) {
+  if (bsff.repackaging?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.repackaging
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
   }
 
-  if (bsff.grouping) {
+  if (bsff.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -298,13 +298,13 @@ export function toManagedWaste(
       bsff.forwarding.emitterCompanySiret;
   }
 
-  if (bsff.repackaging) {
+  if (bsff.repackaging?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.repackaging
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
   }
 
-  if (bsff.grouping) {
+  if (bsff.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -368,13 +368,13 @@ export function toAllWaste(
     ].filter(s => !!s);
   }
 
-  if (bsff.repackaging) {
+  if (bsff.repackaging?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.repackaging
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
   }
 
-  if (bsff.grouping) {
+  if (bsff.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsff.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -498,17 +498,17 @@ export async function toPrismaBsds(
       where: {
         id: {
           in: BSDA.map(bsda => bsda.id)
-        },
-        ...(include.BSDA ? { include: include.BSDA } : {})
-      }
+        }
+      },
+      ...(include.BSDA ? { include: include.BSDA } : {})
     }),
     prisma.bsff.findMany({
       where: {
         id: {
           in: BSFF.map(bsff => bsff.id)
-        },
-        ...(include.BSFF ? { include: include.BSFF } : {})
-      }
+        }
+      },
+      ...(include.BSFF ? { include: include.BSFF } : {})
     })
   ];
 

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -5,7 +5,7 @@ import { BsdType } from "../generated/graphql/types";
 import { GraphQLContext } from "../types";
 import { AuthType } from "../auth";
 import prisma from "../prisma";
-import { Bsda, Bsdasri, Bsff, Bsvhu, Form } from "@prisma/client";
+import { Bsda, Bsdasri, Bsff, Bsvhu, Form, Prisma } from "@prisma/client";
 import { indexAllForms } from "../forms/elastic";
 import { indexAllBsdasris } from "../bsdasris/elastic";
 import { indexAllBsvhus } from "../bsvhu/elastic";
@@ -453,11 +453,19 @@ export type PrismaBsdMap = {
   bsffs: Bsff[];
 };
 
+type PrismaBsdsInclude = {
+  BSDD?: Prisma.FormInclude;
+  BSDASRI?: Prisma.BsdasriInclude;
+  BSDA?: Prisma.BsdaInclude;
+  BSFF?: Prisma.BsffInclude;
+};
+
 /**
  * Convert a list of BsdElastic to a mapping of prisma Bsds
  */
 export async function toPrismaBsds(
-  bsdsElastic: BsdElastic[]
+  bsdsElastic: BsdElastic[],
+  include: PrismaBsdsInclude = {}
 ): Promise<PrismaBsdMap> {
   const { BSDD, BSDASRI, BSVHU, BSDA, BSFF } = groupByBsdType(bsdsElastic);
   const prismaBsdsPromises: [
@@ -472,10 +480,12 @@ export async function toPrismaBsds(
         id: {
           in: BSDD.map(bsdd => bsdd.id)
         }
-      }
+      },
+      ...(include.BSDD ? { include: include.BSDD } : {})
     }),
     prisma.bsdasri.findMany({
-      where: { id: { in: BSDASRI.map(bsdasri => bsdasri.id) } }
+      where: { id: { in: BSDASRI.map(bsdasri => bsdasri.id) } },
+      ...(include.BSDASRI ? { include: include.BSDASRI } : {})
     }),
     prisma.bsvhu.findMany({
       where: {
@@ -488,14 +498,16 @@ export async function toPrismaBsds(
       where: {
         id: {
           in: BSDA.map(bsda => bsda.id)
-        }
+        },
+        ...(include.BSDA ? { include: include.BSDA } : {})
       }
     }),
     prisma.bsff.findMany({
       where: {
         id: {
           in: BSFF.map(bsff => bsff.id)
-        }
+        },
+        ...(include.BSFF ? { include: include.BSFF } : {})
       }
     })
   ];

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -107,7 +107,7 @@ export function toIncomingWaste(
     ].filter(s => !!s);
   }
 
-  if (bsdd.grouping) {
+  if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -195,7 +195,7 @@ export function toOutgoingWaste(
       bsdd.forwarding.emitterCompanySiret;
   }
 
-  if (bsdd.grouping) {
+  if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -285,7 +285,7 @@ export function toTransportedWaste(
     ].filter(s => !!s);
   }
 
-  if (bsdd.grouping) {
+  if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -375,7 +375,7 @@ export function toManagedWaste(
     ].filter(s => !!s);
   }
 
-  if (bsdd.grouping) {
+  if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);
@@ -446,7 +446,7 @@ export function toAllWaste(
     ].filter(s => !!s);
   }
 
-  if (bsdd.grouping) {
+  if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
       .map(grouped => extractPostalCode(grouped.emitterCompanyAddress))
       .filter(s => !!s);

--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -71,7 +71,7 @@ describe("formatRow", () => {
       POP: "O",
       "Producteur initial raison sociale": "initial emitter company name",
       "Producteur initial SIRET": "initial emitter company siret",
-      "Code postaux collecte": "13001,13002",
+      "Producteurs initiaux code postaux": "13001,13002",
       "Producteur initial adresse": "initial emitter address",
       "Expéditeur raison sociale": "emitter name",
       "Expéditeur SIRET": "emitter siret",

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -66,7 +66,7 @@ const columns: Column[] = [
   { field: "initialEmitterCompanySiret", label: "Producteur initial SIRET" },
   {
     field: "initialEmitterPostalCodes",
-    label: "Code postaux collecte",
+    label: "Producteurs initiaux code postaux",
     format: formatArray
   },
   {

--- a/back/src/registry/converters.ts
+++ b/back/src/registry/converters.ts
@@ -101,6 +101,7 @@ export function toWastes<WasteType extends GenericWaste>(
 ): WasteMap<WasteType> {
   const converter = bsdsToWastes[registryType];
   const { bsdds, bsdas, bsdasris, bsvhus, bsffs } = bsds;
+
   return {
     BSDD: bsdds.map(bsd => converter.BSDD(bsd, sirets)).flat(),
     BSDASRI: bsdasris.map(converter.BSDASRI),

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -28,7 +28,9 @@ import { getFullForm } from "../../../../forms/database";
 import { indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
+  companyFactory,
   formFactory,
+  formWithTempStorageFactory,
   userFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
@@ -315,5 +317,47 @@ describe("Incoming wastes registry", () => {
     expect(page3.incomingWastes.totalCount).toEqual(5);
     expect(page3.incomingWastes.pageInfo.startCursor).toEqual(bsd1.id);
     expect(page3.incomingWastes.pageInfo.hasPreviousPage).toEqual(false);
+  });
+
+  it("should hide initial emitter info and returns only postal codes", async () => {
+    const { company: destination, user: userDestination } =
+      await userWithCompanyFactory(UserRole.MEMBER);
+    const { company: emitter, user: userEmitter } =
+      await userWithCompanyFactory(UserRole.MEMBER, {
+        address: "8 rue des Lilas, 07100 Annonay"
+      });
+    const ttr = await companyFactory();
+    const form = await formWithTempStorageFactory({
+      ownerId: userEmitter.id,
+      opt: {
+        emitterCompanySiret: emitter.siret,
+        emitterCompanyAddress: emitter.address,
+        recipientCompanySiret: ttr.siret,
+        status: Status.PROCESSED,
+        receivedAt: new Date(),
+        processedAt: new Date()
+      },
+      tempStorageOpts: {
+        destinationCompanySiret: destination.siret,
+        tempStorerReceivedAt: new Date()
+      }
+    });
+    await indexForm(await getFullForm(form));
+    await refreshElasticSearch();
+    const { query } = makeClient(userDestination);
+    const { data } = await query<Pick<Query, "incomingWastes">>(
+      INCOMING_WASTES,
+      {
+        variables: {
+          sirets: [destination.siret]
+        }
+      }
+    );
+    expect(data.incomingWastes.edges).toHaveLength(1);
+    const incomingWaste = data.incomingWastes.edges.map(e => e.node)[0];
+    expect(incomingWaste.emitterCompanySiret).toEqual(ttr.siret);
+    expect(incomingWaste.initialEmitterCompanySiret).toBeNull();
+    expect(incomingWaste.initialEmitterCompanyName).toBeNull();
+    expect(incomingWaste.initialEmitterPostalCodes).toEqual(["07100"]);
   });
 });

--- a/back/src/registry/resolvers/queries/__tests__/queries.ts
+++ b/back/src/registry/resolvers/queries/__tests__/queries.ts
@@ -28,6 +28,11 @@ export const INCOMING_WASTES = gql`
         cursor
         node {
           id
+          initialEmitterCompanySiret
+          initialEmitterCompanyName
+          initialEmitterCompanyAddress
+          initialEmitterPostalCodes
+          emitterCompanySiret
         }
       }
     }

--- a/back/src/registry/wastes.ts
+++ b/back/src/registry/wastes.ts
@@ -43,7 +43,15 @@ async function getWasteConnection<WasteType extends GenericWaste>(
 
   const hits = searchHits.hits.slice(0, size);
 
-  const bsds = await toPrismaBsds(searchHits.hits.map(hit => hit._source));
+  const bsds = await toPrismaBsds(
+    searchHits.hits.map(hit => hit._source),
+    {
+      BSDD: { temporaryStorageDetail: true, appendix2Forms: true },
+      BSDA: { grouping: true, forwarding: true },
+      BSDASRI: { grouping: true },
+      BSFF: { grouping: true, forwarding: true, repackaging: true }
+    }
+  );
 
   const wastes = toWastes<WasteType>(registryType, args.sirets, bsds);
 


### PR DESCRIPTION
Les infos de réexpédition, reconditionnement, groupement n'étaient pas incluses dans la requête prisma.