### PR TITLE
Hotfix: Impossible de créer une révision sur un bsdd avec entreposage provisoire

### DIFF
--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -1,4 +1,4 @@
-import { Form, User } from "@prisma/client";
+import { Form, User, TemporaryStorageDetail } from "@prisma/client";
 import { ForbiddenError } from "apollo-server-express";
 import prisma from "../prisma";
 import { FormSirets } from "./types";
@@ -341,13 +341,20 @@ export async function checkSecurityCode(siret: string, securityCode: number) {
   return true;
 }
 
-export async function checkCanRequestRevision(user: User, form: Form) {
+export async function checkCanRequestRevision(
+  user: User,
+  form: Form,
+  temporaryStorageDetail?: TemporaryStorageDetail
+) {
   const userSirets = await getCachedUserSirets(user.id);
+
   const canRequestRevision = [
     isFormEmitter,
     isFormRecipient,
     isFormDestinationAfterTempStorage
-  ].some(isFormRole => isFormRole(userSirets, form));
+  ].some(isFormRole =>
+    isFormRole(userSirets, { ...form, temporaryStorageDetail })
+  );
 
   if (!canRequestRevision) {
     throw new NotFormContributor(

--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -119,6 +119,59 @@ describe("Mutation.createFormRevisionRequest", () => {
     );
   });
 
+  it("should create a revisionRequest and identifying current user as the requester (temporary storage) ", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: "1234",
+        recipientCompanySiret: "5678",
+        temporaryStorageDetail: {
+          create: {
+            tempStorerQuantityType: "REAL",
+            tempStorerQuantityReceived: 2.4,
+            tempStorerWasteAcceptationStatus: "ACCEPTED",
+            tempStorerReceivedAt: "2022-03-20T00:00:00.000Z",
+            tempStorerReceivedBy: "John Doe",
+            tempStorerSignedAt: "2022-03-20T00:00:00.000Z",
+            destinationIsFilledByEmitter: false,
+            destinationCompanyName: company.name,
+            destinationCompanySiret: company.siret,
+            destinationCap: "",
+            destinationProcessingOperation: "R 6",
+            transporterCompanyName: "9876",
+            transporterCompanySiret: "Transporter",
+            transporterIsExemptedOfReceipt: false,
+            transporterReceipt: "Dabcd",
+            transporterDepartment: "10",
+            transporterValidityLimit: "2054-11-20T00:00:00.000Z",
+            transporterNumberPlate: ""
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: bsdd.id,
+          content: { wasteDetails: { code: "01 03 08" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret
+        }
+      }
+    });
+
+    expect(data.createFormRevisionRequest.form.id).toBe(bsdd.id);
+    expect(data.createFormRevisionRequest.authoringCompany.siret).toBe(
+      company.siret
+    );
+  });
+
   it("should create a revisionRequest and an approval targetting the company not requesting the revisionRequest", async () => {
     const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
     const { user, company } = await userWithCompanyFactory("ADMIN");


### PR DESCRIPTION
En cas d'entreposage provisoire, le destinatire final ne peut mettre en révision un bsdd.

 
- [ ] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7487)
