### PR TITLE
HotFix bsda workflow action

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/WorkflowAction.tsx
@@ -34,11 +34,13 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return <SignEmission {...props} bsdaId={form.id} />;
 
     case BsdaStatus.SignedByProducer:
-      if (
-        form["bsdaType"] === "GATHERING" ||
-        form["bsdaType"] === "RESHIPMENT"
-      ) {
+      if (form["bsdaType"] === "GATHERING") {
         return siret === form.worker?.company?.siret ? (
+          <SignTransport {...props} bsdaId={form.id} />
+        ) : null;
+      }
+      if (form["bsdaType"] === "RESHIPMENT") {
+        return siret === form.transporter?.company?.siret ? (
           <SignTransport {...props} bsdaId={form.id} />
         ) : null;
       }


### PR DESCRIPTION
Les bsda de réexpédition n'ont pas de bouton "signer l'enlèvement" quand ils sont signés par le producteur.
(Ce sous-type de bsda n'a pas de signature "entreprise de travaux")

 

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?onShow=mycards&card=tra-7508)
