### PR TITLE
Export xls registry numerical cell as numbers

### DIFF
--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -9,7 +9,7 @@ describe("formatRow", () => {
       brokerRecepisseNumber: "broker_recepisse",
       destinationOperationCode: "R10",
       destinationReceptionDate: new Date("2021-01-01"),
-      destinationReceptionWeight: 1,
+      destinationReceptionWeight: 1.2,
       ecoOrganismeName: null,
       ecoOrganismeSiren: null,
       emitterCompanyAddress: "emitter address",
@@ -61,7 +61,7 @@ describe("formatRow", () => {
       transporterRecepisseNumber: "transporter recepisse",
       destinationOperationCode: "R10",
       destinationReceptionDate: "2021-01-01",
-      destinationReceptionWeight: "1.000"
+      destinationReceptionWeight: 1.2
     });
     const formattedWithLabels = formatRow(waste, true);
     expect(formattedWithLabels).toEqual({
@@ -91,7 +91,7 @@ describe("formatRow", () => {
       "Transporteur récépissé": "transporter recepisse",
       "Code de traitement réalisée": "R10",
       "Date de réception": "2021-01-01",
-      "Quantité de déchet entrant (t)": "1.000"
+      "Quantité de déchet entrant (t)": 1.2
     });
     expect(Object.keys(formattedWithLabels).length).toEqual(
       Object.keys(waste).length

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -15,7 +15,9 @@ type Column = {
     ManagedWaste &
     AllWaste);
   label: string;
-  format?: (v: string | boolean | number | Date | string[]) => string;
+  format?: (
+    v: string | boolean | number | Date | string[]
+  ) => string | number | null;
 };
 
 const formatDate = (d: Date | null) => d?.toISOString().slice(0, 10) ?? "";
@@ -25,7 +27,7 @@ const formatBoolean = (b: boolean | null) => {
   }
   return b ? "O" : "N";
 };
-const formatNumber = (n: number) => n?.toFixed(3) ?? "";
+const formatNumber = (n: number) => (!!n ? parseFloat(n.toFixed(3)) : null); // return as a number to allow xls cells formulas
 const formatArray = (arr: any[]) => (Array.isArray(arr) ? arr.join(",") : "");
 
 const columns: Column[] = [

--- a/back/src/registry/resolvers/queries/wastesRegistryXls.ts
+++ b/back/src/registry/resolvers/queries/wastesRegistryXls.ts
@@ -43,6 +43,7 @@ export const wastesRegistryXlsDownloadHandler: DownloadHandler<QueryWastesRegist
           // write headers if not present
           worksheet.columns = getXlsxHeaders(waste);
         }
+
         worksheet.addRow(waste, "n").commit();
       });
 


### PR DESCRIPTION
L'export du registre au formatx xls traite les valeur numérique comme des chaînes de caractères, empêchant d'utiliser les formules xls,(sommes etc) 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7594)
