### PR TITLE
FIX : emitter null with Appendix2Form resolver

### DIFF
--- a/back/src/forms/resolvers/Appendix2Form.ts
+++ b/back/src/forms/resolvers/Appendix2Form.ts
@@ -1,4 +1,3 @@
-import { ForbiddenError } from "apollo-server-express";
 import { Appendix2FormResolvers } from "../../generated/graphql/types";
 import prisma from "../../prisma";
 import { isFormContributor } from "../permissions";
@@ -7,9 +6,7 @@ const appendix2FormResolvers: Appendix2FormResolvers = {
   emitter: async (parent, _, { user }) => {
     const form = await prisma.form.findUnique({ where: { id: parent.id } });
     if (!(await isFormContributor(user, form))) {
-      throw new ForbiddenError(
-        "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2 car votre SIRET apparait uniquement sur le bordereau de regroupement"
-      );
+      return null;
     }
     return parent.emitter;
   }

--- a/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
+++ b/back/src/forms/resolvers/__tests__/Appendix2Form.integration.ts
@@ -1,5 +1,5 @@
 import { CompanyType, Status, UserRole } from "@prisma/client";
-import { gql } from "apollo-server-express";
+import { Query } from "../../../generated/graphql/types";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import {
   companyFactory,
@@ -8,7 +8,7 @@ import {
 } from "../../../__tests__/factories";
 import makeClient from "../../../__tests__/testClient";
 
-const FORM = gql`
+const FORM = `
   query Form($id: ID!) {
     form(id: $id) {
       appendix2Forms {
@@ -20,8 +20,7 @@ const FORM = gql`
         }
       }
     }
-  }
-`;
+  }`;
 
 describe("Appendix2Form", () => {
   afterAll(resetDatabase);
@@ -60,14 +59,11 @@ describe("Appendix2Form", () => {
 
     // destination cannot access appendix2.emitter
     const { query } = makeClient(destinationUser);
-    const { errors } = await query(FORM, {
-      variables: { id: regroupement.id }
+    const { data } = await query<Pick<Query, "form">>(FORM, {
+      variables: {
+        id: regroupement.id
+      }
     });
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "Vous ne pouvez pas accéder au champ `emitter` de cette annexe 2 car votre SIRET apparait uniquement sur le bordereau de regroupement"
-      })
-    ]);
+    expect(data.form.appendix2Forms[0]).toMatchObject({ emitter: null });
   });
 });

--- a/doc/yarn.lock
+++ b/doc/yarn.lock
@@ -6990,10 +6990,10 @@ querystring@0.2.0:
   resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+querystring@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -8497,14 +8497,6 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
-
-url-parse@^1.4.3, url-parse@^1.5.1:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 url@^0.11.0:
   version "0.11.0"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -6420,7 +6420,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -9622,7 +9622,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -13477,7 +13477,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
         "camelcase-keys": "^2.0.0",
@@ -14447,12 +14447,12 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -14706,7 +14706,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {


### PR DESCRIPTION
Le champ form { emitter { name } } est désormais demandé dans les fragments suite aux améliorations liées à l'annexe 2. Le problème est que c'est le même fragment utilisé pour les requêtes dashboard et donc lorsqu'un utilisateur essaye d'afficher un bordereau avec annexes 2 sans être centre de regroupement, il a une erreur "Vous ne pouvez pas accéder au champ emitter de cette annexe 2 car votre SIRET apparait uniquement sur le bordereau de regroupement".

Un fix propre consisterait à discriminer les frgaments utilisés en fonction de ce que l'on veut afficher mais c'est un travail plus conséquent.

[Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7604)
