### PR TITLE
Correction du crash de l'application sur mobile lorsque l'URL est invalide

### DIFF
--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -81,10 +81,11 @@ export default function Dashboard() {
   }
 
   const companies = data.me.companies;
+  const currentCompany = companies.find(company => company.siret === siret);
 
   // if the user is not part of the company whose siret is in the url
   // redirect them to their first company or account if they're not part of any company
-  if (!companies.find(company => company.siret === siret)) {
+  if (currentCompany == null) {
     return (
       <Redirect
         to={
@@ -103,7 +104,10 @@ export default function Dashboard() {
       <OnboardingSlideshow />
       <div id="dashboard" className="dashboard">
         <SideMenu>
-          <DashboardTabs siret={siret} me={data.me} />
+          <DashboardTabs
+            currentCompany={currentCompany}
+            companies={companies}
+          />
         </SideMenu>
 
         <div className="dashboard-content">

--- a/front/src/dashboard/DashboardTabs.tsx
+++ b/front/src/dashboard/DashboardTabs.tsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { generatePath, NavLink, useHistory } from "react-router-dom";
-import { CompanyType, User } from "generated/graphql/types";
+import { CompanyPrivate, CompanyType } from "generated/graphql/types";
 import DashboardCompanySelector from "./DashboardCompanySelector";
 import routes from "common/routes";
 import "./DashboardTabs.scss";
 
 interface DashboardTabsProps {
-  me: User;
-  siret: string;
+  currentCompany: CompanyPrivate;
+  companies: CompanyPrivate[];
 }
 
-export function DashboardTabs({ me, siret }: DashboardTabsProps) {
+export function DashboardTabs({
+  currentCompany,
+  companies,
+}: DashboardTabsProps) {
   const history = useHistory();
-  const companies = me.companies || [];
-  const currentCompany = companies.find(company => company.siret === siret)!;
 
   return (
     <>
       {companies.length > 1 ? (
         <div className="company-select">
           <DashboardCompanySelector
-            siret={siret}
+            siret={currentCompany.siret!}
             companies={companies}
             handleCompanyChange={siret =>
               history.push(
@@ -40,7 +41,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
         <ul>
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.bsds.drafts, { siret })}
+              to={generatePath(routes.dashboard.bsds.drafts, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--indented"
               activeClassName="sidebar__link--active"
             >
@@ -50,7 +53,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
 
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.bsds.act, { siret })}
+              to={generatePath(routes.dashboard.bsds.act, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--indented"
               activeClassName="sidebar__link--active"
             >
@@ -60,7 +65,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
 
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.bsds.follow, { siret })}
+              to={generatePath(routes.dashboard.bsds.follow, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--indented"
               activeClassName="sidebar__link--active"
             >
@@ -69,7 +76,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
           </li>
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.bsds.history, { siret })}
+              to={generatePath(routes.dashboard.bsds.history, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--indented"
               activeClassName="sidebar__link--active"
             >
@@ -78,7 +87,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
           </li>
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.bsds.reviews, { siret })}
+              to={generatePath(routes.dashboard.bsds.reviews, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--indented"
               activeClassName="sidebar__link--active"
             >
@@ -94,7 +105,7 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
               <li>
                 <NavLink
                   to={generatePath(routes.dashboard.transport.toCollect, {
-                    siret,
+                    siret: currentCompany.siret,
                   })}
                   className="sidebar__link sidebar__link--indented"
                   activeClassName="sidebar__link--active"
@@ -105,7 +116,7 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
               <li>
                 <NavLink
                   to={generatePath(routes.dashboard.transport.collected, {
-                    siret,
+                    siret: currentCompany.siret,
                   })}
                   className="sidebar__link sidebar__link--indented"
                   activeClassName="sidebar__link--active"
@@ -120,7 +131,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
         <ul>
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.exports, { siret })}
+              to={generatePath(routes.dashboard.exports, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--chapter"
               activeClassName="sidebar__link--active"
             >
@@ -130,7 +143,9 @@ export function DashboardTabs({ me, siret }: DashboardTabsProps) {
 
           <li>
             <NavLink
-              to={generatePath(routes.dashboard.stats, { siret })}
+              to={generatePath(routes.dashboard.stats, {
+                siret: currentCompany.siret,
+              })}
               className="sidebar__link sidebar__link--chapter"
               activeClassName="sidebar__link--active"
             >

--- a/front/src/layout/Header.tsx
+++ b/front/src/layout/Header.tsx
@@ -50,7 +50,18 @@ function MobileSubNav({ currentSiret }) {
   if (error) return <InlineError apolloError={error} />;
   if (data?.me == null) return <Loader />;
 
-  return <DashboardTabs siret={currentSiret} me={data.me} />;
+  const companies = data.me.companies;
+  const currentCompany = companies.find(
+    company => company.siret === currentSiret
+  );
+
+  if (currentCompany == null) {
+    return null;
+  }
+
+  return (
+    <DashboardTabs currentCompany={currentCompany} companies={companies} />
+  );
 }
 
 const getMenuEntries = (isAuthenticated, isAdmin, currentSiret) => {


### PR DESCRIPTION
Le composant qui affiche les onglets du tableau de bord `DashboardTabs` est inclus à deux endroits. Pour le desktop dans `Dashboard` et pour le mobile dans `Header`. Le composant n'est jamais inclus sur desktop si le siret qui est dans l'URL ne correspond pas à une des entreprises de l'utilisateur courant. En revanche cette même vérification n'était pas faite sur mobile.

J'ai retravaillé les props de `DashboardTabs` pour que ses pré-requis soient plus clairs et corrigé l'affichage sur mobile.