### PR TITLE
HOTFIX - mise à jour d'un bordereau avec annexes 2

### DIFF
--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -680,6 +680,7 @@ export function expandAppendix2FormFromDb(
     readableId,
     wasteDetails,
     emitter,
+    recipient,
     signedAt,
     quantityReceived,
     processingOperationDone
@@ -691,6 +692,7 @@ export function expandAppendix2FormFromDb(
     emitter,
     emitterPostalCode: extractPostalCode(emitter?.company?.address),
     signedAt,
+    recipient,
     quantityReceived,
     processingOperationDone
   };

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -142,6 +142,10 @@ type Appendix2Form {
   """
   emitterPostalCode: String
   """
+  Destinataire du bordereau initial
+  """
+  recipient: Recipient
+  """
   Date d’acceptation du lot initial par l’installation réalisant une transformation ou un traitement aboutissant à des déchets
   dont la provenance reste identifiable. C'est la date qui figure au cadre 10 du bordereau initial.
   """

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -257,6 +257,11 @@ const mutableFieldsFragment = gql`
           name
         }
       }
+      recipient {
+        company {
+          siret
+        }
+      }
       signedAt
       processingOperationDone
     }

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -122,3 +122,11 @@ export const decodeHash = (hash: string | string[] | null): string => {
     ? decodeURIComponent(hash[0])
     : decodeURIComponent(hash);
 };
+
+export const sortCompaniesByName = values => {
+  return [...values].sort((a, b) => {
+    const aName = a.givenName || a.name || "";
+    const bName = b.givenName || b.name || "";
+    return aName.localeCompare(bName);
+  });
+};

--- a/front/src/dashboard/DashboardCompanySelector.tsx
+++ b/front/src/dashboard/DashboardCompanySelector.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 import { CompanyPrivate } from "generated/graphql/types";
+import { sortCompaniesByName } from "common/helper";
 
 interface IProps {
   siret: string;
   companies: CompanyPrivate[];
   handleCompanyChange: (siret: string) => void;
 }
-
-const sortCompaniesByName = values => {
-  return [...values].sort((a, b) => {
-    const aName = a.givenName || a.name || "";
-    const bName = b.givenName || b.name || "";
-    return aName.localeCompare(bName);
-  });
-};
 
 export const SIRET_STORAGE_KEY = "td-selectedSiret";
 

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -1,14 +1,11 @@
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
-import { Field, useFormikContext } from "formik";
+import { Field, useField, useFormikContext } from "formik";
 import { Form } from "generated/graphql/types";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import EcoOrganismes from "./components/eco-organismes/EcoOrganismes";
 import WorkSite from "form/common/components/work-site/WorkSite";
-import {
-  getInitialCompany,
-  getInitialEmitterWorkSite,
-} from "form/bsdd/utils/initial-state";
+import { getInitialEmitterWorkSite } from "form/bsdd/utils/initial-state";
 import "./Emitter.scss";
 import MyCompanySelector from "form/common/components/company/MyCompanySelector";
 import { emitterTypeLabels } from "dashboard/constants";
@@ -29,18 +26,16 @@ export default function Emitter() {
     setLockEmitterType(false);
   }, [values.ecoOrganisme, setFieldValue]);
 
-  const emitterType = useMemo(() => values.emitter?.type, [values.emitter]);
+  const [emitterTypeField] = useField("emitter.type");
 
-  useEffect(() => {
-    // make sure appendix2 forms is empty when emitter type is not APPENDIX2
-    if (emitterType !== "APPENDIX2" && values.appendix2Forms?.length) {
+  function onChangeEmitterType(e) {
+    const previousEmitterType = values.emitter?.type;
+    emitterTypeField.onChange(e);
+    if (previousEmitterType === "APPENDIX2" && values.appendix2Forms?.length) {
+      // make sure to empty appendix2 forms when de-selecting APPENDIX2
       setFieldValue("appendix2Forms", []);
     }
-    // make sure to remove favorite company when emitter type is set to APPENDIX2
-    if (emitterType === "APPENDIX2") {
-      setFieldValue("emitter.company", getInitialCompany());
-    }
-  }, [emitterType, values.appendix2Forms, setFieldValue]);
+  }
 
   return (
     <>
@@ -72,6 +67,7 @@ export default function Emitter() {
             id="PRODUCER"
             label={emitterTypeLabels["PRODUCER"]}
             component={RadioButton}
+            onChange={onChangeEmitterType}
             disabled={lockEmitterType}
           />
           <Field
@@ -79,6 +75,7 @@ export default function Emitter() {
             id="OTHER"
             label={emitterTypeLabels["OTHER"]}
             component={RadioButton}
+            onChange={onChangeEmitterType}
             disabled={lockEmitterType}
           />
           <Field
@@ -86,6 +83,7 @@ export default function Emitter() {
             id="APPENDIX2"
             label={emitterTypeLabels["APPENDIX2"]}
             component={RadioButton}
+            onChange={onChangeEmitterType}
             disabled={lockEmitterType}
           />
 
@@ -94,6 +92,7 @@ export default function Emitter() {
             id="APPENDIX1"
             label={emitterTypeLabels["APPENDIX1"]}
             component={RadioButton}
+            onChange={onChangeEmitterType}
             disabled={lockEmitterType}
           />
         </fieldset>
@@ -102,7 +101,16 @@ export default function Emitter() {
       {values.emitter?.type === "APPENDIX2" ? (
         <div className="tw-my-6">
           <h4 className="form__section-heading">Entreprise émettrice</h4>
-          <MyCompanySelector fieldName="emitter.company" />
+          <MyCompanySelector
+            fieldName="emitter.company"
+            onSelect={() => {
+              if (values.appendix2Forms?.length) {
+                // make sure to empty appendix2 forms because new emitter may
+                // not be recipient of the select appendix 2 forms
+                setFieldValue("appendix2Forms", []);
+              }
+            }}
+          />
         </div>
       ) : (
         <CompanySelector

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -54,12 +54,15 @@ export default function Appendix2MultiSelect() {
   // initial value of form.appendix2Forms when updating a BSDD
   const appendix2Candidates = useMemo(() => {
     const appendix2Forms = data?.appendixForms ?? [];
-    return [...(meta.initialValue ?? []), ...appendix2Forms].filter(f => {
+    const initialValue = (meta.initialValue ?? []).filter(f => {
+      return f.recipient?.company?.siret === values.emitter?.company?.siret;
+    });
+    return [...initialValue, ...appendix2Forms].filter(f => {
       return wasteCodeFilter?.length
         ? f.wasteDetails?.code?.includes(wasteCodeFilter)
         : true;
     });
-  }, [data, meta.initialValue, wasteCodeFilter]);
+  }, [data, meta.initialValue, wasteCodeFilter, values.emitter]);
 
   const appendix2Selected = useMemo(() => values.appendix2Forms ?? [], [
     values.appendix2Forms,
@@ -117,6 +120,10 @@ export default function Appendix2MultiSelect() {
     } else {
       setFieldValue("appendix2Forms", appendix2Candidates);
     }
+  }
+
+  if (loading) {
+    return <div>Chargement</div>;
   }
 
   return (
@@ -208,7 +215,6 @@ export default function Appendix2MultiSelect() {
         </tbody>
       </table>
       {error && <InlineError apolloError={error} />}
-      {loading && <div>Chargement</div>}
     </>
   );
 }

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -121,7 +121,7 @@ export default function GenericStepList({
                 </button>
 
                 <button className="btn btn--primary" type="submit">
-                  {!isLastStep ? "Suivant" : formId ? "Créer" : "Enregistrer"}
+                  {!isLastStep ? "Suivant" : formId ? "Enregistrer" : "Créer"}
                 </button>
               </div>
             </form>


### PR DESCRIPTION
Quelques glitchs relevés par un utilisateur lors de la mise à jour d'un BSDD avec annexe 2 : 
- L'établissement émetteur était écrasé à l'ouverture du formulaire pour mettre à jour 
- Si je change d'établissement émetteur, les annexes 2 n'étaient pas nettoyées 
- Les boutons "Enregistrer" et "Créer" du formulaire de création de BSDD étaient inversés ("Enregistrer" lors de la création et "Créer" lors de la mise à jour)

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
