### PR TITLE
[Hotfix] Redondance recherche SIRET vers Api Sirene pour trouver établissements non-diffusibles

### DIFF
--- a/back/src/companies/sirene/trackdechets/types.ts
+++ b/back/src/companies/sirene/trackdechets/types.ts
@@ -118,6 +118,6 @@ export interface SearchHit {
  * Public API error code names
  */
 export enum ProviderErrors {
-  SiretNotFound = "Aucun établissement trouvé avec ce SIRET",
+  SiretNotFound = "Nous n'avons pas trouvé ce SIRET dans notre base de données, cherchons sur l'Api publique Sirene de l'INSEE",
   ServerError = "Erreur inconnue"
 }


### PR DESCRIPTION
# seule l'api Sirene publique du serveur INSEE dispose des siret non diffusibles, ils ne sont pas dans les fichiers INSEE dont on se sert pour notre index interne.


- docs https://www.sirene.fr/sirene/public/variable/statutDiffusionUniteLegale

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

