### PR TITLE
Configuration du dependabot pour ignorer les dépendances de développement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/back"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "npm"
+    directory: "/front"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "npm"
+    directory: "/doc"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,29 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/back"
+    schedule:
+      interval: "daily"
     open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/search"
+    schedule:
+      interval: "daily"
     open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/front"
+    schedule:
+      interval: "daily"
     open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/doc"
+    schedule:
+      interval: "daily"
     open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     allow:
       - dependency-type: "production"
   - package-ecosystem: "npm"
+    directory: "/search"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "npm"
     directory: "/front"
     open-pull-requests-limit: 0
     allow:


### PR DESCRIPTION
Le fichier de configuration est de retour, cette fois-ci sans les options qui le rende incompatible avec les mises à jour de sécurité. Cette fois-ci je désactive le reste des mises à jour via `open-pull-requests-limit: 0` pour ne pas créer de bruit.

L'objectif de ce fichier de configuration est de faire en sorte que le dependabot n'ouvre des alertes de vulnérabilités que pour les dépendances de production. Ce qui réduira le bruit et le besoin de mettre des alertes en `DISMISSED`.