### PR TITLE
Recette caractère dangereux d'un déchet

### DIFF
--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -422,11 +422,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
               oui{" "}
               <input
                 type="checkbox"
-                checked={
-                  form.wasteDetails?.code
-                    ? !isDangerous(form.wasteDetails?.code)
-                    : false
-                }
+                checked={form.wasteDetails?.isDangerous === false}
                 readOnly
               />{" "}
               non

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -373,6 +373,7 @@ describe("Mutation.markAsSealed", () => {
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
         wasteDetailsCode: "01 01 01",
+        wasteDetailsIsDangerous: false,
         wasteDetailsOnuCode: null
       }
     });
@@ -438,6 +439,7 @@ describe("Mutation.markAsSealed", () => {
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
         wasteDetailsCode: "01 01 01",
+        wasteDetailsIsDangerous: false,
         recipientCap: null
       }
     });

--- a/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
@@ -165,6 +165,7 @@ describe("Mutation.signedByTransporter", () => {
         sentAt: null,
         status: "SEALED",
         wasteDetailsCode: "01 01 01",
+        wasteDetailsIsDangerous: false,
         emitterCompanySiret: emitter.siret,
         transporterCompanySiret: transporter.siret
       }

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -295,12 +295,7 @@ const recipientSchemaFn: FactorySchemaOf<boolean, Recipient> = isDraft =>
         "Le champ CAP est obligatoire pour les déchets dangereux",
         (value, testContext) => {
           const rootValue = testContext.parent;
-
-          if (
-            !isDraft &&
-            isDangerous(rootValue?.wasteDetailsCode ?? "") &&
-            !value
-          ) {
+          if (!isDraft && rootValue?.wasteDetailsIsDangerous && !value) {
             return false;
           }
           return true;
@@ -391,8 +386,9 @@ const wasteDetailsSchemaFn: FactorySchemaOf<boolean, WasteDetails> = isDraft =>
       .string()
       .requiredIf(!isDraft, "Le code déchet est obligatoire")
       .oneOf([...WASTES_CODES, "", null], INVALID_WASTE_CODE),
-    wasteDetailsOnuCode: yup.string().when("wasteDetailsCode", {
-      is: (wasteCode: string) => isDangerous(wasteCode || ""),
+    wasteDetailsOnuCode: yup.string().when("wasteDetailsIsDangerous", {
+      is: (wasteDetailsIsDangerous: boolean) =>
+        wasteDetailsIsDangerous === true,
       then: () =>
         yup
           .string()


### PR DESCRIPTION
- Double tickbox sur le pdf en cas de déchet dangereux non *.
![image](https://user-images.githubusercontent.com/2269165/158989978-91b16461-f7e9-4922-b5b8-7bc7f887bb27.png)
- CAP obligatoire aussi pour les déchets non * mais dangereux

--- 
- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-2362)
