### PR TITLE
Correction des statuts suite à une mutation importPaperForm

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -342,7 +342,7 @@ describe("mutation / importPaperForm", () => {
         }
       );
 
-      expect(data.importPaperForm.status).toEqual("AWAITING_GROUP");
+      expect(data.importPaperForm.status).toEqual(Status.NO_TRACEABILITY);
       expect(data.importPaperForm.isImportedFromPaper).toEqual(true);
     });
   });

--- a/back/src/forms/resolvers/mutations/importPaperForm.ts
+++ b/back/src/forms/resolvers/mutations/importPaperForm.ts
@@ -105,15 +105,20 @@ async function createForm(input: ImportPaperFormInput, user: Express.User) {
     );
   }
 
+  const noTraceability = input.processedInfo?.noTraceability === true;
   const awaitingGroup = PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
-    input.processedInfo.processingOperationDone
+    input.processedInfo?.processingOperationDone
   );
 
   const formCreateInput: Prisma.FormCreateInput = {
     ...flattenedFormInput,
     readableId: getReadableId(),
     owner: { connect: { id: user.id } },
-    status: awaitingGroup ? Status.AWAITING_GROUP : Status.PROCESSED,
+    status: noTraceability
+      ? Status.NO_TRACEABILITY
+      : awaitingGroup
+      ? Status.AWAITING_GROUP
+      : Status.PROCESSED,
     isImportedFromPaper: true,
     signedByTransporter: true
   };

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -25,7 +25,14 @@ const machine = Machine<any, Event>(
               target: FormState.Sent
             }
           ],
-          [EventType.ImportPaperForm]: [{ target: FormState.Processed }]
+          [EventType.ImportPaperForm]: [
+            {
+              target: FormState.NoTraceability,
+              cond: "isExemptOfTraceability"
+            },
+            { target: FormState.AwaitingGroup, cond: "awaitsGroup" },
+            { target: FormState.Processed }
+          ]
         }
       },
       [FormState.Sent]: {


### PR DESCRIPTION
Le statut d'un bordereau importé via la mutation `importPaperForm` était toujours "PROCESSED" même en cas de code de regroupement ou de perte de traçabilité



- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7669)
