### PR TITLE
Ajout d'un filtre sur le customId

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
   - extension de CompanySelector.tsx pour valider un numéro TVA et remplir les infos Company (le nom et l'adresse) automatiquement.
   - extension d' AccountCompanyAdd.tsx pour supporter un numéro TVA et remplir les infos Company (le nom et l'adresse) automatiquement.
   - Refacto `companyInfos` pour déplacer toute la logique dans `company/search.ts` et capable de chercher à la fois par SIRET et par TVA.
+  - Ajout de la possibilité de filtrer sur le champ `customId` (recherche exacte) sur le tableau de bord et dans la query `forms` [PR 1284](https://github.com/MTES-MCT/trackdechets/pull/1284)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -130,6 +130,7 @@ function toBsdElastic(bsda: Bsda): BsdElastic {
   return {
     type: "BSDA",
     id: bsda.id,
+    customId: "",
     readableId: bsda.id,
     createdAt: bsda.createdAt.getTime(),
     emitterCompanyName: bsda.emitterCompanyName ?? "",

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -113,6 +113,7 @@ function toBsdElastic(bsdasri: Bsdasri): BsdElastic {
   return {
     id: bsdasri.id,
     readableId: bsdasri.id,
+    customId: "",
     type: "BSDASRI",
     emitterCompanyName: bsdasri.emitterCompanyName ?? "",
     emitterCompanySiret: bsdasri.emitterCompanySiret ?? "",

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -87,13 +87,21 @@ async function buildQuery(
 
   if (where.readableId) {
     query.bool.must.push({
-      match: {
-        readableId: {
-          query: where.readableId,
-          // we need `and` operator here because the different components of
-          // the readableId (prefix, date and random chars) emit different tokens
-          operator: "and"
-        }
+      bool: {
+        // behaves like an OR
+        should: [
+          {
+            match: {
+              readableId: {
+                query: where.readableId,
+                // we need `and` operator here because the different components of
+                // the readableId (prefix, date and random chars) emit different tokens
+                operator: "and"
+              }
+            }
+          },
+          { term: { customId: where.readableId } }
+        ]
       }
     });
   }

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -9,6 +9,7 @@ function toBsdElastic(bsff: Bsff): BsdElastic {
     type: "BSFF" as const,
     id: bsff.id,
     readableId: bsff.id,
+    customId: "",
     createdAt: bsff.createdAt.getTime(),
     emitterCompanyName: bsff.emitterCompanyName ?? "",
     emitterCompanySiret: bsff.emitterCompanySiret ?? "",

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -107,6 +107,7 @@ function toBsdElastic(bsvhu: Bsvhu): BsdElastic {
     type: "BSVHU",
     id: bsvhu.id,
     readableId: bsvhu.id,
+    customId: "",
     createdAt: bsvhu.createdAt.getTime(),
     emitterCompanyName: bsvhu.emitterCompanyName ?? "",
     emitterCompanySiret: bsvhu.emitterCompanySiret ?? "",

--- a/back/src/common/__tests__/elastic.integration.ts
+++ b/back/src/common/__tests__/elastic.integration.ts
@@ -9,6 +9,7 @@ import { BsdElastic, client, index, indexBsds } from "../elastic";
 const defaultOpts: BsdElastic = {
   id: "id",
   readableId: "readableId",
+  customId: null,
   type: "BSDD" as BsdType,
   emitterCompanyName: "emitter name",
   emitterCompanySiret: "emitter siret",

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -30,6 +30,7 @@ export interface BsdElastic {
   id: string;
   createdAt: number;
   readableId: string;
+  customId: string;
   emitterCompanyName: string;
   emitterCompanySiret: string;
   transporterCompanyName: string;
@@ -104,6 +105,14 @@ const settings = {
         type: "char_group",
         tokenize_on_chars: ["whitespace", "-"]
       },
+      customId_ngram: {
+        type: "ngram",
+        token_chars: ["letter", "digit"]
+      },
+      customId_char_group: {
+        type: "char_group",
+        tokenize_on_chars: ["whitespace", "-", "_"]
+      },
       waste_ngram: {
         type: "ngram",
         min_gram: 1, // allow to search on "*" to get dangerous waste only
@@ -142,6 +151,9 @@ const properties: Record<keyof BsdElastic, Record<string, unknown>> = {
         type: "keyword"
       }
     }
+  },
+  customId: {
+    type: "keyword"
   },
   type: {
     type: "keyword"
@@ -288,7 +300,7 @@ export const index: BsdIndex = {
   // Changing the value of index is a way to "bump" the model
   // Doing so will cause all BSDs to be reindexed in Elastic Search
   // when running the appropriate script
-  index: "bsds_0.2.2",
+  index: "bsds_0.2.3",
 
   // The next major version of Elastic Search doesn't use "type" anymore
   // so while it's required for the current version, we are not using it too much

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -192,6 +192,7 @@ function toBsdElastic(form: FullForm): BsdElastic {
     type: "BSDD",
     id: form.id,
     readableId: form.readableId,
+    customId: form.customId,
     createdAt: form.createdAt.getTime(),
     emitterCompanyName: form.emitterCompanyName ?? "",
     emitterCompanySiret: form.emitterCompanySiret ?? "",

--- a/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
@@ -684,6 +684,41 @@ describe("Query.forms", () => {
     expect(data.forms[0].wasteDetails.code).toBe("01 03 04*");
   });
 
+  it("should filter by customId", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await createForms(user.id, [
+      {
+        customId: "custom1",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      },
+      {
+        customId: "custom2",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      },
+      {
+        customId: null,
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    ]);
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "forms">>(
+      `query Forms($customId: String) {
+          forms(customId: $customId) {
+            customId
+          }
+        }
+      `,
+      { variables: { customId: "custom1" } }
+    );
+
+    expect(data.forms.length).toBe(1);
+    expect(data.forms[0].customId).toBe("custom1");
+  });
+
   it("should filter by siretPresentOnForm", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const otherCompany = await companyFactory();

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -56,7 +56,8 @@ const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
         updatedAt: { gte: new Date(rest.updatedAfter) }
       }),
       ...(rest.sentAfter && { sentAt: { gte: new Date(rest.sentAfter) } }),
-      wasteDetailsCode: rest.wasteCode,
+      ...(rest.wasteCode && { wasteDetailsCode: rest.wasteCode }),
+      ...(rest.customId && { customId: rest.customId }),
       ...(status?.length && { status: { in: status } }),
       AND: [
         getFormsRightFilter(company.siret, roles),

--- a/back/src/forms/typeDefs/bsdd.queries.graphql
+++ b/back/src/forms/typeDefs/bsdd.queries.graphql
@@ -138,6 +138,12 @@ type Query {
     Défaut à vide.
     """
     wasteCode: String
+
+    """
+    (Optionnel) CustomId pour affiner la recherche
+    Défaut à vide.
+    """
+    customId: String
   ): [Form!]!
 
   "Renvoie des statistiques sur le volume de déchets entrant et sortant"

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -194,6 +194,7 @@ export const segmentFragment = gql`
 export const staticFieldsFragment = gql`
   fragment StaticFieldsFragment on Form {
     readableId
+    customId
     createdAt
     status
     stateSummary {

--- a/front/src/dashboard/components/BSDList/BSDD/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/index.tsx
@@ -21,7 +21,12 @@ export const COLUMNS: Record<
     Cell: () => <IconBSDD style={{ fontSize: "24px" }} />,
   },
   readableId: {
-    accessor: form => form.readableId,
+    accessor: form => {
+      if (form.customId && form.customId.length) {
+        return `${form.readableId} | ${form.customId}`;
+      }
+      return form.readableId;
+    },
   },
   emitter: {
     accessor: form => form.emitter?.company?.name ?? "",


### PR DESCRIPTION
Proposition à minima pour débloquer les utilisateurs qui ont besoin de filtrer sur le `customId`. 
- ajout d'un filtre `customId` sur la query `forms`
- indexation du champ `customId` de type keyword dans ES
- affichage du `customId` dans la liste des bordereaux après le `readableId`
- filtre exact sur le `customId` dans la barre de recherche de la colonne "Numéro"

https://user-images.githubusercontent.com/2269165/159473102-69ec29f3-30b9-43a1-ac92-1d19454bd1a2.mov


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b34c3fc79210a83db2dc1238?card=tra-7149)
