### PR TITLE
Correction du code postal émetteur d'une annexe 2

### DIFF
--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -685,12 +685,17 @@ export function expandAppendix2FormFromDb(
     quantityReceived,
     processingOperationDone
   } = expandFormFromDb(prismaForm);
+
+  const hasPickupSite = emitter?.workSite?.postalCode?.length > 0;
+
   return {
     id,
     readableId,
     wasteDetails,
     emitter,
-    emitterPostalCode: extractPostalCode(emitter?.company?.address),
+    emitterPostalCode: hasPickupSite
+      ? emitter?.workSite?.postalCode
+      : extractPostalCode(emitter?.company?.address),
     signedAt,
     recipient,
     quantityReceived,


### PR DESCRIPTION
https://forum.trackdechets.beta.gouv.fr/t/nouvel-ecran-affichage-annexe-2-code-postal-errone-si-point-de-collecte-chantier-a-une-adresse-differente-de-lemetteur/662/3

Il faut faire apparaitre l'adresse de collecte lorsque cette information est renseignée

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7684)
