### PR TITLE
Declare onCompanySelect before query

### DIFF
--- a/front/src/form/common/components/company/MyCompanySelector.tsx
+++ b/front/src/form/common/components/company/MyCompanySelector.tsx
@@ -33,20 +33,6 @@ export default function MyCompanySelector({ fieldName, onSelect }) {
   const { setFieldValue } = useFormikContext<CreateFormInput>();
   const [field] = useField({ name: fieldName });
 
-  const { loading, error, data } = useQuery<Pick<Query, "me">>(GET_ME, {
-    onCompleted: data => {
-      // check user is member of selected company or reset emitter company
-      const companies = data.me.companies;
-      if (!companies.map(c => c.siret).includes(field.value.siret)) {
-        if (companies.length === 1) {
-          onCompanySelect(companies[0]);
-        } else {
-          onCompanySelect(getInitialCompany());
-        }
-      }
-    },
-  });
-
   const onCompanySelect = useCallback(
     (
       company: Pick<
@@ -65,6 +51,20 @@ export default function MyCompanySelector({ fieldName, onSelect }) {
     },
     [fieldName, setFieldValue, onSelect]
   );
+
+  const { loading, error, data } = useQuery<Pick<Query, "me">>(GET_ME, {
+    onCompleted: data => {
+      // check user is member of selected company or reset emitter company
+      const companies = data.me.companies;
+      if (!companies.map(c => c.siret).includes(field.value.siret)) {
+        if (companies.length === 1) {
+          onCompanySelect(companies[0]);
+        } else {
+          onCompanySelect(getInitialCompany());
+        }
+      }
+    },
+  });
 
   const companies = useMemo(() => {
     return sortCompaniesByName(data?.me.companies ?? []);


### PR DESCRIPTION
Problème remonté par Christian en recette à la création d'un bsdd quand on sélectionn pour la deuxième fois annexe 2. (classique => annexe 2 => classique => annexe 2 par exemple).

J'imagine que l'appel http a déjà été effectué et est donc mis en cache, ce qui cause une execution du `onCompleted` synchrone ? Avant donc que la variable `h` ne soit initialisée. Ce n'est pas une function donc il n'y a pas de hoisting... Du coup j'ai remonté simplement la déclaration du `useCallback`.

![image](https://user-images.githubusercontent.com/5145523/160414508-52fa39c7-f112-411b-858d-3adad7f89171.png)

