### PR TITLE
Log start & end of request

### DIFF
--- a/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
+++ b/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
@@ -41,28 +41,44 @@ describe("loggingMiddleware", () => {
 
   it("should log requests to standard express endpoint", async () => {
     await request.get("/hello");
-    expect(logMock.mock.calls).toHaveLength(1);
-    const { message, level, metadata } = logMock.mock.calls[0][0];
-    expect(message).toEqual("GET /hello");
-    expect(level).toEqual("info");
-    expect(metadata.user).toEqual("anonyme");
-    expect(metadata.response_body).toEqual("world");
-    expect(metadata.execution_time_num).toBeGreaterThanOrEqual(0);
-    expect(metadata.http_status).toEqual(200);
+    expect(logMock.mock.calls).toHaveLength(2);
+    for (const logCall of logMock.mock.calls) {
+      const { message, level, metadata } = logCall[0];
+      expect(message).toEqual("GET /hello");
+      expect(level).toEqual("info");
+      expect(metadata.user).toEqual("anonyme");
+    }
+    const startLog = logMock.mock.calls[0][0];
+    expect(startLog.metadata.request_timing).toEqual("start");
+
+    const responseLog = logMock.mock.calls[1][0];
+    expect(responseLog.metadata.response_body).toEqual("world");
+    expect(responseLog.metadata.execution_time_num).toBeGreaterThanOrEqual(0);
+    expect(responseLog.metadata.http_status).toEqual(200);
+    expect(responseLog.metadata.request_timing).toEqual("end");
   });
 
   it("should log requests to GraphQL endpoint", async () => {
     await request.post(graphQLPath).send({ query: "{ me { name } }" });
-    expect(logMock.mock.calls).toHaveLength(1);
-    const { message, level, metadata } = logMock.mock.calls[0][0];
-    expect(message).toEqual("POST /");
-    expect(level).toEqual("info");
-    expect(metadata.user).toEqual("anonyme");
-    expect(metadata.response_body).toEqual(
+    expect(logMock.mock.calls).toHaveLength(2);
+
+    for (const logCall of logMock.mock.calls) {
+      const { message, level, metadata } = logCall[0];
+      expect(message).toEqual("POST /");
+      expect(level).toEqual("info");
+      expect(metadata.user).toEqual("anonyme");
+      expect(metadata.graphql_query).toEqual("{ me { name } }");
+    }
+
+    const startLog = logMock.mock.calls[0][0];
+    expect(startLog.metadata.request_timing).toEqual("start");
+
+    const responseLog = logMock.mock.calls[1][0];
+    expect(responseLog.metadata.response_body).toEqual(
       '{"data":{"me":{"name":"John Snow"}}}'
     );
-    expect(metadata.execution_time_num).toBeGreaterThanOrEqual(0);
-    expect(metadata.http_status).toEqual(200);
-    expect(metadata.graphql_query).toEqual("{ me { name } }");
+    expect(responseLog.metadata.execution_time_num).toBeGreaterThanOrEqual(0);
+    expect(responseLog.metadata.http_status).toEqual(200);
+    expect(responseLog.metadata.request_timing).toEqual("end");
   });
 });

--- a/back/src/common/middlewares/loggingMiddleware.ts
+++ b/back/src/common/middlewares/loggingMiddleware.ts
@@ -16,7 +16,6 @@ export default function (graphQLPath: string) {
       ip: req.ip,
       http_params: req.params,
       http_query: req.query,
-      http_status: res.statusCode,
       request_timing: "start",
       request_id: getUid(16)
     };
@@ -44,6 +43,7 @@ export default function (graphQLPath: string) {
 
       const metadataWithReponse = {
         ...requestMetadata,
+        http_status: res.statusCode,
         request_timing: "end",
         execution_time_num: end.getTime() - start.getTime(), // in millis
         response_body: Buffer.isBuffer(responseBody) ? null : responseBody

--- a/back/src/common/middlewares/loggingMiddleware.ts
+++ b/back/src/common/middlewares/loggingMiddleware.ts
@@ -1,11 +1,34 @@
 import { Request, Response, NextFunction } from "express";
 import logger from "../../logging/logger";
+import { getUid } from "../../utils";
 
 /**
  * Logging middleware
+ * For each request we generate a log on start and finish. This enable us to detect requests that never finish.
+ * The logs share the same `request_id`. A `request_timing` property indicates the timing of the log (start/end)
  */
 export default function (graphQLPath: string) {
   return (req: Request, res: Response, next: NextFunction) => {
+    const message = `${req.method} ${req.path}`;
+    const requestMetadata: { [key: string]: any } = {
+      user: req.user?.email || "anonyme",
+      auth: req.user?.auth,
+      ip: req.ip,
+      http_params: req.params,
+      http_query: req.query,
+      http_status: res.statusCode,
+      request_timing: "start",
+      request_id: getUid(16)
+    };
+    // GraphQL specific fields
+    if (req.path === graphQLPath && req.method === "POST") {
+      requestMetadata.graphql_operation_name = req.body?.operationName;
+      requestMetadata.graphql_variables = req.body?.variables;
+      requestMetadata.graphql_query = req.body?.query;
+    }
+
+    logger.info(message, requestMetadata);
+
     // Monkey patch res.send to retrieves response body
     let responseBody = null;
     const originalSend = res.send;
@@ -18,24 +41,15 @@ export default function (graphQLPath: string) {
 
     res.on("finish", () => {
       const end = new Date();
-      const message = `${req.method} ${req.path}`;
-      const meta: { [key: string]: any } = {
-        user: req.user?.email || "anonyme",
-        auth: req.user?.auth,
-        ip: req.ip,
-        execution_time_num: end.getTime() - start.getTime(), // in millis,
-        http_params: req.params,
-        http_query: req.query,
-        http_status: res.statusCode,
+
+      const metadataWithReponse = {
+        ...requestMetadata,
+        request_timing: "end",
+        execution_time_num: end.getTime() - start.getTime(), // in millis
         response_body: Buffer.isBuffer(responseBody) ? null : responseBody
       };
-      // GraphQL specific fields
-      if (req.path === graphQLPath && req.method === "POST") {
-        meta.graphql_operation_name = req.body?.operationName;
-        meta.graphql_variables = req.body?.variables;
-        meta.graphql_query = req.body?.query;
-      }
-      logger.info(message, meta);
+
+      logger.info(message, metadataWithReponse);
     });
 
     next();

--- a/back/src/forms/examples/__tests__/examples.integration.ts
+++ b/back/src/forms/examples/__tests__/examples.integration.ts
@@ -21,7 +21,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
     async () => {
       await testWorkflow(entreposageProvisoireWorkflow);
     },
-    10000
+    15000
   );
 
   test(

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -6,7 +6,11 @@ const LOG_PATH = `${appRoot}/logs/app.log`;
 const logger = createLogger({
   level: "info",
   exitOnError: false,
-  format: format.combine(format.errors({ stack: true }), format.json()),
+  format: format.combine(
+    format.errors({ stack: true }),
+    format.metadata({ fillExcept: ["level", "message", "dd"] }), // `dd` enable connecting logs & traces
+    format.json()
+  ),
   transports: [new transports.File({ filename: LOG_PATH })]
 });
 

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -8,7 +8,6 @@ const logger = createLogger({
   exitOnError: false,
   format: format.combine(
     format.errors({ stack: true }),
-    format.metadata(),
     format.json()
   ),
   transports: [new transports.File({ filename: LOG_PATH })]

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -6,10 +6,7 @@ const LOG_PATH = `${appRoot}/logs/app.log`;
 const logger = createLogger({
   level: "info",
   exitOnError: false,
-  format: format.combine(
-    format.errors({ stack: true }),
-    format.json()
-  ),
+  format: format.combine(format.errors({ stack: true }), format.json()),
   transports: [new transports.File({ filename: LOG_PATH })]
 });
 


### PR DESCRIPTION
Log des requêtes avant et après traitement.
Auparavant on loggait uniquement après. Si on avait des requêtes sans réponses (arrivent jamais dans le `finish`) elles n'apparaissaient donc pas dans nos logs.

