### PR TITLE
Flatten log metadata

### DIFF
--- a/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
+++ b/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
@@ -43,19 +43,19 @@ describe("loggingMiddleware", () => {
     await request.get("/hello");
     expect(logMock.mock.calls).toHaveLength(2);
     for (const logCall of logMock.mock.calls) {
-      const { message, level, metadata } = logCall[0];
+      const { message, level, user } = logCall[0];
       expect(message).toEqual("GET /hello");
       expect(level).toEqual("info");
-      expect(metadata.user).toEqual("anonyme");
+      expect(user).toEqual("anonyme");
     }
     const startLog = logMock.mock.calls[0][0];
-    expect(startLog.metadata.request_timing).toEqual("start");
+    expect(startLog.request_timing).toEqual("start");
 
     const responseLog = logMock.mock.calls[1][0];
-    expect(responseLog.metadata.response_body).toEqual("world");
-    expect(responseLog.metadata.execution_time_num).toBeGreaterThanOrEqual(0);
-    expect(responseLog.metadata.http_status).toEqual(200);
-    expect(responseLog.metadata.request_timing).toEqual("end");
+    expect(responseLog.response_body).toEqual("world");
+    expect(responseLog.execution_time_num).toBeGreaterThanOrEqual(0);
+    expect(responseLog.http_status).toEqual(200);
+    expect(responseLog.request_timing).toEqual("end");
   });
 
   it("should log requests to GraphQL endpoint", async () => {
@@ -63,22 +63,22 @@ describe("loggingMiddleware", () => {
     expect(logMock.mock.calls).toHaveLength(2);
 
     for (const logCall of logMock.mock.calls) {
-      const { message, level, metadata } = logCall[0];
+      const { message, level, user, graphql_query } = logCall[0];
       expect(message).toEqual("POST /");
       expect(level).toEqual("info");
-      expect(metadata.user).toEqual("anonyme");
-      expect(metadata.graphql_query).toEqual("{ me { name } }");
+      expect(user).toEqual("anonyme");
+      expect(graphql_query).toEqual("{ me { name } }");
     }
 
     const startLog = logMock.mock.calls[0][0];
-    expect(startLog.metadata.request_timing).toEqual("start");
+    expect(startLog.request_timing).toEqual("start");
 
     const responseLog = logMock.mock.calls[1][0];
-    expect(responseLog.metadata.response_body).toEqual(
+    expect(responseLog.response_body).toEqual(
       '{"data":{"me":{"name":"John Snow"}}}'
     );
-    expect(responseLog.metadata.execution_time_num).toBeGreaterThanOrEqual(0);
-    expect(responseLog.metadata.http_status).toEqual(200);
-    expect(responseLog.metadata.request_timing).toEqual("end");
+    expect(responseLog.execution_time_num).toBeGreaterThanOrEqual(0);
+    expect(responseLog.http_status).toEqual(200);
+    expect(responseLog.request_timing).toEqual("end");
   });
 });

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -8,7 +8,6 @@ const logger = createLogger({
   exitOnError: false,
   format: format.combine(
     format.errors({ stack: true }),
-    format.metadata({ fillExcept: ["level", "message", "dd"] }), // `dd` enable connecting logs & traces
     format.json()
   ),
   transports: [new transports.File({ filename: LOG_PATH })]

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -6,10 +6,7 @@ const LOG_PATH = `${appRoot}/logs/app.log`;
 const logger = createLogger({
   level: "info",
   exitOnError: false,
-  format: format.combine(
-    format.errors({ stack: true }),
-    format.json()
-  ),
+  format: format.combine(format.errors({ stack: true }), format.json()),
   transports: [new transports.File({ filename: LOG_PATH })]
 });
 


### PR DESCRIPTION
Suppression de la sous clef `metadata` dans les logs. Tout est maintenant ajouté à la racine.
Le log injecteur DD met sa clef dans `metadata`, ce qui peut être empêche le lien auto log <> trace.