### PR TITLE
HOTFIX - Signature transporteur après entreposage provisoire

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -111,7 +111,10 @@ function SignTransportFormModal({
               <RedErrorMessage name="takenOverBy" />
             </div>
 
-            {siret !== form.transporter?.company?.siret && (
+            {![
+              form.transporter?.company?.siret,
+              form.temporaryStorageDetail?.transporter?.company?.siret,
+            ].includes(siret) && (
               <div className="form__row">
                 <label>
                   Code de signature du transporteur

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -106,12 +106,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return null;
     }
     case FormStatus.SignedByTempStorer: {
-      if (
-        [
-          form.emitter?.company?.siret,
-          form.transporter?.company?.siret,
-        ].includes(siret)
-      ) {
+      if (siret === form.temporaryStorageDetail?.transporter?.company?.siret) {
         return <SignTransportForm {...props} />;
       }
       return null;


### PR DESCRIPTION
L'action "Signer en tant que transporteur" n'apparait pas sur le dashboard du transporteur après entreposage provisoire. L'action apparait à tort sur le dashboard de l'émetteur initial et du transporteur n°1.

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7785)
