### PR TITLE
Fix / Secu avril

### DIFF
--- a/back/src/common/middlewares/__tests__/graphqlBatchLimiter.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlBatchLimiter.test.ts
@@ -7,7 +7,7 @@ const graphQLPath = "/gql";
 describe("graphqlBatchLimiterMiddleware", () => {
   const app = express();
   app.use(json());
-  app.use(graphqlBatchLimiterMiddleware(graphQLPath));
+  app.use(graphQLPath, graphqlBatchLimiterMiddleware());
   app.post(graphQLPath, (req, res) => {
     res.status(200).send(req.body);
   });

--- a/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
@@ -4,7 +4,7 @@ import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
 describe("graphqlQueryParserMiddleware", () => {
   const middleware = graphqlQueryParserMiddleware();
   const res = {} as Response;
-  const next = () => {};
+  const next = () => null;
 
   it("should return an empty array when there is no query", async () => {
     const req = {} as Request;

--- a/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
@@ -1,0 +1,51 @@
+import { Request, Response } from "express";
+import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
+
+describe("graphqlQueryParserMiddleware", () => {
+  const middleware = graphqlQueryParserMiddleware();
+  const res = {} as Response;
+  const next = () => {};
+
+  it("should return an empty array when there is no query", async () => {
+    const req = {} as Request;
+    middleware(req, res, next);
+
+    expect(req.gqlInfos).toEqual([]);
+  });
+
+  it("should return an empty array when parsing fails", async () => {
+    const req = { body: { query: "<?>" } } as Request;
+    middleware(req, res, next);
+
+    expect(req.gqlInfos).toEqual([]);
+  });
+
+  it("should return an empty array when there is no operation", async () => {
+    const req = { body: { query: "{}" } } as Request;
+    middleware(req, res, next);
+
+    expect(req.gqlInfos).toEqual([]);
+  });
+
+  it("should return a single operation info", async () => {
+    const req = { body: { query: "{me {id}}" } } as Request;
+    middleware(req, res, next);
+
+    expect(req.gqlInfos.length).toBe(1);
+    expect(req.gqlInfos[0].operation).toBe("query");
+    expect(req.gqlInfos[0].name).toBe("me");
+  });
+
+  it("should return several operations info", async () => {
+    const req = {
+      body: { query: "query { me { id } } mutation { sign { id } }" }
+    } as Request;
+    middleware(req, res, next);
+
+    expect(req.gqlInfos.length).toBe(2);
+    expect(req.gqlInfos[0].operation).toBe("query");
+    expect(req.gqlInfos[0].name).toBe("me");
+    expect(req.gqlInfos[1].operation).toBe("mutation");
+    expect(req.gqlInfos[1].name).toBe("sign");
+  });
+});

--- a/back/src/common/middlewares/__tests__/graphqlRateLimiter.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlRateLimiter.test.ts
@@ -1,0 +1,53 @@
+import express, { json } from "express";
+import supertest from "supertest";
+import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
+import { graphqlRateLimiterMiddleware } from "../graphqlRatelimiter";
+
+const graphQLPath = "/gql";
+
+describe("graphqlRateLimiterMiddleware", () => {
+  const app = express();
+  app.use(json());
+  app.use(graphQLPath, graphqlQueryParserMiddleware()); // We rely on `graphqlQueryParserMiddleware`
+  app.use(graphQLPath, 
+    graphqlRateLimiterMiddleware("resendInvitation", {
+      maxRequestsPerWindow: 1,
+      windowMs: 10000,
+      store: undefined
+    })
+  );
+  app.post(graphQLPath, (req, res) => {
+    res.status(200).send(req.body);
+  });
+  const request = supertest(app);
+
+  it("should only allow 1 request per timeframe on rate limited query", async () => {
+    const body = JSON.stringify({ query: "{resendInvitation { id } }" });
+    const response1 = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+    expect(response1.status).toEqual(200);
+
+    const response2 = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+    expect(response2.status).toEqual(429);
+  });
+
+  it("should not rate limite other queries", async () => {
+    const body = JSON.stringify({ query: "{otherQuery { id } }" });
+    const response1 = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+    expect(response1.status).toEqual(200);
+
+    const response2 = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+    expect(response2.status).toEqual(200);
+  });
+});

--- a/back/src/common/middlewares/__tests__/graphqlRateLimiter.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlRateLimiter.test.ts
@@ -9,7 +9,8 @@ describe("graphqlRateLimiterMiddleware", () => {
   const app = express();
   app.use(json());
   app.use(graphQLPath, graphqlQueryParserMiddleware()); // We rely on `graphqlQueryParserMiddleware`
-  app.use(graphQLPath, 
+  app.use(
+    graphQLPath,
     graphqlRateLimiterMiddleware("resendInvitation", {
       maxRequestsPerWindow: 1,
       windowMs: 10000,

--- a/back/src/common/middlewares/__tests__/graphqlRegenerateSession.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlRegenerateSession.test.ts
@@ -1,0 +1,41 @@
+import express, { json } from "express";
+import session from "express-session";
+import supertest from "supertest";
+import { sess } from "../../../server";
+import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
+import { graphqlRegenerateSessionMiddleware } from "../graphqlRegenerateSession";
+
+const graphQLPath = "/gql";
+
+describe("graphqlRegenerateSessionMiddleware", () => {
+  const app = express();
+  app.use(json());
+  app.use(graphQLPath, graphqlQueryParserMiddleware()); // We rely on `graphqlQueryParserMiddleware`
+  app.use(session(sess));
+  app.use(graphQLPath, graphqlRegenerateSessionMiddleware("changePassword"));
+  app.post(graphQLPath, (req, res) => {
+    res.status(200).send(req.body);
+  });
+  const request = supertest(app);
+
+  it("should send a new session cookie when calling targetted query", async () => {
+    const body = JSON.stringify({ query: "{ changePassword { id } }" });
+    const response = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+
+    // should send new connect.sid cookie
+    expect(response.header["set-cookie"]).toHaveLength(1);
+  });
+
+  it("should not send a new session cookie when calling a non targetted query", async () => {
+    const body = JSON.stringify({ query: "{ otherQuery { id } }" });
+    const response = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/json")
+      .send(body);
+
+    expect(response.header["set-cookie"]).toBeUndefined();
+  });
+});

--- a/back/src/common/middlewares/__tests__/graphqlRegenerateSession.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlRegenerateSession.test.ts
@@ -1,11 +1,21 @@
 import express, { json } from "express";
 import session from "express-session";
 import supertest from "supertest";
-import { sess } from "../../../server";
 import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
 import { graphqlRegenerateSessionMiddleware } from "../graphqlRegenerateSession";
 
 const graphQLPath = "/gql";
+const sess: session.SessionOptions = {
+  name: "connect.sid",
+  secret: "a secret",
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    secure: false,
+    domain: "test.local",
+    maxAge: 24 * 3600 * 1000
+  }
+};
 
 describe("graphqlRegenerateSessionMiddleware", () => {
   const app = express();

--- a/back/src/common/middlewares/__tests__/graphqlSpecificQueryHandler.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlSpecificQueryHandler.test.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from "express";
+import { graphqlSpecificQueryHandlerMiddleware } from "../graphqlSpecificQueryHandler";
+
+describe("graphqlQueryParserMiddleware", () => {
+  const targetQuery = "apiKey";
+  const mockFn = jest.fn();
+  const middleware = graphqlSpecificQueryHandlerMiddleware(targetQuery, mockFn);
+  const res = {} as Response;
+  const next = () => null;
+
+  afterEach(() => mockFn.mockReset());
+
+  it("should not call middleware if the query is not targetted by the middleware", async () => {
+    const req = {
+      gqlInfos: [{ operation: "query", name: "anotherQuery" }]
+    } as Request;
+    middleware(req, res, next);
+
+    expect(mockFn).not.toHaveBeenCalled();
+  });
+
+  it("should call middleware if the query is targetted by the middleware", async () => {
+    const req = {
+      gqlInfos: [{ operation: "query", name: targetQuery }]
+    } as Request;
+    middleware(req, res, next);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call middleware if the query is one of the targetted queries by the middleware", async () => {
+    const req = {
+      gqlInfos: [
+        { operation: "mutation", name: "iMutate" },
+        { operation: "query", name: targetQuery }
+      ]
+    } as Request;
+    middleware(req, res, next);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
+++ b/back/src/common/middlewares/__tests__/loggingMiddleware.test.ts
@@ -2,6 +2,7 @@ import express, { json } from "express";
 import supertest from "supertest";
 import Transport from "winston-transport";
 import logger from "../../../logging/logger";
+import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
 import loggingMiddleware from "../loggingMiddleware";
 
 const logMock = jest.fn();
@@ -29,6 +30,7 @@ describe("loggingMiddleware", () => {
   const app = express();
   const graphQLPath = "/";
   app.use(json());
+  app.use(graphQLPath, graphqlQueryParserMiddleware()); // We rely on `graphqlQueryParserMiddleware`
   app.use(loggingMiddleware("/"));
   app.get("/hello", (req, res) => {
     res.status(200).send("world");

--- a/back/src/common/middlewares/graphqlBatchLimiter.ts
+++ b/back/src/common/middlewares/graphqlBatchLimiter.ts
@@ -2,15 +2,11 @@ import { Request, Response, NextFunction } from "express";
 
 const MAX_OPERATIONS_PER_REQUEST = 5;
 
-export function graphqlBatchLimiterMiddleware(graphQLPath: string) {
+export function graphqlBatchLimiterMiddleware() {
   return function (req: Request, res: Response, next: NextFunction) {
-    const { body, path } = req;
+    const { body } = req;
 
-    if (
-      path === graphQLPath &&
-      Array.isArray(body) &&
-      body.length > MAX_OPERATIONS_PER_REQUEST
-    ) {
+    if (Array.isArray(body) && body.length > MAX_OPERATIONS_PER_REQUEST) {
       return res.status(400).send({
         error: `Batching is limited to ${MAX_OPERATIONS_PER_REQUEST} operations per request.`
       });

--- a/back/src/common/middlewares/graphqlQueryParser.ts
+++ b/back/src/common/middlewares/graphqlQueryParser.ts
@@ -1,0 +1,41 @@
+import { gql } from "apollo-server-core";
+import { Request, Response, NextFunction } from "express";
+import { DefinitionNode, FieldNode, OperationTypeNode } from "graphql";
+
+export type GqlInfo = { operation: OperationTypeNode; name: string };
+
+export function graphqlQueryParserMiddleware() {
+  return function (req: Request, _: Response, next: NextFunction) {
+    const { body } = req;
+    req.gqlInfos = parseGqlQuery(body?.query);
+
+    next();
+  };
+}
+
+function parseGqlQuery(query: string | undefined) {
+  try {
+    const parsedQuery = gql`
+      ${query}
+    `;
+
+    return parsedQuery.definitions
+      .flatMap(definition => parseGqlDefinition(definition))
+      .filter(Boolean);
+  } catch (_) {
+    return [];
+  }
+}
+
+function parseGqlDefinition(definition: DefinitionNode) {
+  if (definition.kind !== "OperationDefinition") return undefined;
+
+  const fieldSelections = definition.selectionSet.selections.filter(
+    (selection): selection is FieldNode => selection.kind === "Field"
+  );
+
+  return fieldSelections.map(field => ({
+    operation: definition.operation,
+    name: field.name.value
+  }));
+}

--- a/back/src/common/middlewares/graphqlRatelimiter.ts
+++ b/back/src/common/middlewares/graphqlRatelimiter.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction } from "express";
+import rateLimit from "express-rate-limit";
+import {
+  MutationResolvers,
+  QueryResolvers
+} from "../../generated/graphql/types";
+
+type AllowedQueries = keyof QueryResolvers | keyof MutationResolvers;
+type Options = {
+  store: rateLimit.Store;
+  windowMs: number;
+  maxRequestsPerWindow: number;
+};
+
+export function graphqlRateLimiterMiddleware(
+  rateLimitedQuery: AllowedQueries,
+  options: Options
+) {
+  return rateLimit({
+    message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédée pour cette requête et adresse IP, merci de réessayer plus tard.`,
+    windowMs: options.windowMs,
+    max: options.maxRequestsPerWindow,
+    store: options.store,
+    keyGenerator: req => {
+      if (!req.ip) {
+        throw new Error(
+          "express-rate-limit: req.ip is undefined - are you sure you're using express?"
+        );
+      }
+      return `gql_${rateLimitedQuery}_${req.ip}`;
+    },
+    skip: req => {
+      if (!req.gqlInfos) {
+        console.warn(
+          `The "gqlInfos" is not set on the request object. The "graphqlQueryParser" middleware must be called before this one, otherwise queries won't be rate limited.`
+        );
+        return true;
+      }
+      return !req.gqlInfos.map(info => info.name).includes(rateLimitedQuery);
+    }
+  });
+}

--- a/back/src/common/middlewares/graphqlRatelimiter.ts
+++ b/back/src/common/middlewares/graphqlRatelimiter.ts
@@ -1,9 +1,9 @@
-import { Request, Response, NextFunction } from "express";
 import rateLimit from "express-rate-limit";
 import {
   MutationResolvers,
   QueryResolvers
 } from "../../generated/graphql/types";
+import { graphqlSpecificQueryHandlerMiddleware } from "./graphqlSpecificQueryHandler";
 
 type AllowedQueries = keyof QueryResolvers | keyof MutationResolvers;
 type Options = {
@@ -16,27 +16,21 @@ export function graphqlRateLimiterMiddleware(
   rateLimitedQuery: AllowedQueries,
   options: Options
 ) {
-  return rateLimit({
-    message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédée pour cette requête et adresse IP, merci de réessayer plus tard.`,
-    windowMs: options.windowMs,
-    max: options.maxRequestsPerWindow,
-    store: options.store,
-    keyGenerator: req => {
-      if (!req.ip) {
-        throw new Error(
-          "express-rate-limit: req.ip is undefined - are you sure you're using express?"
-        );
+  return graphqlSpecificQueryHandlerMiddleware(
+    rateLimitedQuery,
+    rateLimit({
+      message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédée pour cette requête et adresse IP, merci de réessayer plus tard.`,
+      windowMs: options.windowMs,
+      max: options.maxRequestsPerWindow,
+      store: options.store,
+      keyGenerator: req => {
+        if (!req.ip) {
+          throw new Error(
+            "express-rate-limit: req.ip is undefined - are you sure you're using express?"
+          );
+        }
+        return `gql_${rateLimitedQuery}_${req.ip}`;
       }
-      return `gql_${rateLimitedQuery}_${req.ip}`;
-    },
-    skip: req => {
-      if (!req.gqlInfos) {
-        console.warn(
-          `The "gqlInfos" is not set on the request object. The "graphqlQueryParser" middleware must be called before this one, otherwise queries won't be rate limited.`
-        );
-        return true;
-      }
-      return !req.gqlInfos.map(info => info.name).includes(rateLimitedQuery);
-    }
-  });
+    })
+  );
 }

--- a/back/src/common/middlewares/graphqlRatelimiter.ts
+++ b/back/src/common/middlewares/graphqlRatelimiter.ts
@@ -5,7 +5,7 @@ import {
 } from "../../generated/graphql/types";
 import { graphqlSpecificQueryHandlerMiddleware } from "./graphqlSpecificQueryHandler";
 
-type AllowedQueries = keyof QueryResolvers | keyof MutationResolvers;
+type GqlQueryKey = keyof QueryResolvers | keyof MutationResolvers;
 type Options = {
   store: rateLimit.Store;
   windowMs: number;
@@ -13,13 +13,13 @@ type Options = {
 };
 
 export function graphqlRateLimiterMiddleware(
-  rateLimitedQuery: AllowedQueries,
+  rateLimitedQuery: GqlQueryKey,
   options: Options
 ) {
   return graphqlSpecificQueryHandlerMiddleware(
     rateLimitedQuery,
     rateLimit({
-      message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédée pour cette requête et adresse IP, merci de réessayer plus tard.`,
+      message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédé pour cette requête et adresse IP, merci de réessayer plus tard.`,
       windowMs: options.windowMs,
       max: options.maxRequestsPerWindow,
       store: options.store,

--- a/back/src/common/middlewares/graphqlRegenerateSession.ts
+++ b/back/src/common/middlewares/graphqlRegenerateSession.ts
@@ -2,9 +2,9 @@ import { Request, Response, NextFunction } from "express";
 import { MutationResolvers } from "../../generated/graphql/types";
 import { graphqlSpecificQueryHandlerMiddleware } from "./graphqlSpecificQueryHandler";
 
-type AllowedQueries = keyof MutationResolvers;
+type GqlQueryKey = keyof MutationResolvers;
 
-export function graphqlRegenerateSessionMiddleware(query: AllowedQueries) {
+export function graphqlRegenerateSessionMiddleware(query: GqlQueryKey) {
   return graphqlSpecificQueryHandlerMiddleware(
     query,
     function (req: Request, res: Response, next: NextFunction) {

--- a/back/src/common/middlewares/graphqlRegenerateSession.ts
+++ b/back/src/common/middlewares/graphqlRegenerateSession.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction } from "express";
+import { MutationResolvers } from "../../generated/graphql/types";
+import { graphqlSpecificQueryHandlerMiddleware } from "./graphqlSpecificQueryHandler";
+
+type AllowedQueries = keyof MutationResolvers;
+
+export function graphqlRegenerateSessionMiddleware(query: AllowedQueries) {
+  return graphqlSpecificQueryHandlerMiddleware(
+    query,
+    function (req: Request, res: Response, next: NextFunction) {
+      if (!req.session) {
+        throw new Error(
+          "The `graphqlRegenerateSessionMiddleware` middleware must be called after the `session` middleware."
+        );
+      }
+
+      const currentSession = req.session;
+      req.session.regenerate(regenerateError => {
+        if (regenerateError) {
+          res.status(500).send("Error while regenerating the session.");
+        }
+
+        Object.assign(req.session, currentSession);
+        req.session.save(saveError => {
+          if (saveError) {
+            res
+              .status(500)
+              .send("Error while saving session after regenerate.");
+          }
+
+          next();
+        });
+      });
+    }
+  );
+}

--- a/back/src/common/middlewares/graphqlSpecificQueryHandler.ts
+++ b/back/src/common/middlewares/graphqlSpecificQueryHandler.ts
@@ -4,10 +4,10 @@ import {
   QueryResolvers
 } from "../../generated/graphql/types";
 
-type AllowedQueries = keyof QueryResolvers | keyof MutationResolvers;
+type GqlQueryKey = keyof QueryResolvers | keyof MutationResolvers;
 
 export function graphqlSpecificQueryHandlerMiddleware(
-  query: AllowedQueries,
+  query: GqlQueryKey,
   middleware
 ) {
   return function (req: Request, res: Response, next: NextFunction) {

--- a/back/src/common/middlewares/graphqlSpecificQueryHandler.ts
+++ b/back/src/common/middlewares/graphqlSpecificQueryHandler.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from "express";
+import {
+  MutationResolvers,
+  QueryResolvers
+} from "../../generated/graphql/types";
+
+type AllowedQueries = keyof QueryResolvers | keyof MutationResolvers;
+
+export function graphqlSpecificQueryHandlerMiddleware(
+  query: AllowedQueries,
+  middleware
+) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    if (!req.gqlInfos) {
+      console.warn(
+        `The "gqlInfos" is not set on the request object. The "graphqlQueryParser" middleware must be called before this one, otherwise queries won't be rate limited.`
+      );
+      return next();
+    }
+
+    if (!req.gqlInfos.map(info => info.name).includes(query)) {
+      return next();
+    }
+
+    return middleware(req, res, next);
+  };
+}

--- a/back/src/forms/resolvers/queries/formRevisionRequests.ts
+++ b/back/src/forms/resolvers/queries/formRevisionRequests.ts
@@ -19,8 +19,8 @@ export default async function formRevisionRequests(
   context: GraphQLContext
 ) {
   const user = checkIsAuthenticated(context);
-  const company = await getCompanyOrCompanyNotFound({ siret });
   await checkIsCompanyMember({ id: user.id }, { siret });
+  const company = await getCompanyOrCompanyNotFound({ siret });
 
   const pageSize = Math.max(Math.min(first, MAX_SIZE), MIN_SIZE);
 

--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -48,11 +48,12 @@ authRouter.get("/isAuthenticated", nocache, (req, res) => {
 
 authRouter.post("/logout", (req, res) => {
   req.logout();
-  delete req.session.warningMessage;
-  res
-    .clearCookie(sess.name, {
-      domain: sess.cookie.domain,
-      path: "/"
-    })
-    .redirect(`${UI_BASE_URL}`);
+  req.session.destroy(() => {
+    res
+      .clearCookie(sess.name, {
+        domain: sess.cookie.domain,
+        path: "/"
+      })
+      .redirect(`${UI_BASE_URL}`);
+  });
 });

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -173,6 +173,14 @@ app.use(
     store
   })
 );
+app.use(
+  graphQLPath,
+  graphqlRateLimiterMiddleware("createPasswordResetRequest", {
+    windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
+    maxRequestsPerWindow: 1,
+    store
+  })
+);
 
 // logging middleware
 app.use(loggingMiddleware(graphQLPath));

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -23,6 +23,7 @@ import { graphqlBatchLimiterMiddleware } from "./common/middlewares/graphqlBatch
 import graphqlBodyParser from "./common/middlewares/graphqlBodyParser";
 import { graphqlQueryParserMiddleware } from "./common/middlewares/graphqlQueryParser";
 import { graphqlRateLimiterMiddleware } from "./common/middlewares/graphqlRatelimiter";
+import { graphqlRegenerateSessionMiddleware } from "./common/middlewares/graphqlRegenerateSession";
 import loggingMiddleware from "./common/middlewares/loggingMiddleware";
 import { graphiqlLandingPagePlugin } from "./common/plugins/graphiql";
 import sentryReporter from "./common/plugins/sentryReporter";
@@ -213,6 +214,7 @@ app.use(session(sess));
 
 app.use(passport.initialize());
 app.use(passport.session());
+app.use(graphQLPath, graphqlRegenerateSessionMiddleware("changePassword"));
 
 // authentification routes used by td-ui (/login /logout, /isAuthenticated)
 app.use(authRouter);

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -21,6 +21,8 @@ import { ErrorCode } from "./common/errors";
 import errorHandler from "./common/middlewares/errorHandler";
 import { graphqlBatchLimiterMiddleware } from "./common/middlewares/graphqlBatchLimiter";
 import graphqlBodyParser from "./common/middlewares/graphqlBodyParser";
+import { graphqlQueryParserMiddleware } from "./common/middlewares/graphqlQueryParser";
+import { graphqlRateLimiterMiddleware } from "./common/middlewares/graphqlRatelimiter";
 import loggingMiddleware from "./common/middlewares/loggingMiddleware";
 import { graphiqlLandingPagePlugin } from "./common/plugins/graphiql";
 import sentryReporter from "./common/plugins/sentryReporter";
@@ -109,16 +111,17 @@ if (Sentry) {
 
 const RATE_LIMIT_WINDOW_SECONDS = 60;
 const maxrequestPerWindows = parseInt(MAX_REQUESTS_PER_WINDOW, 10);
+const store = new RateLimitRedisStore({
+  client: redisClient,
+  expiry: RATE_LIMIT_WINDOW_SECONDS
+});
 
 app.use(
   rateLimit({
     message: `Quota de ${maxrequestPerWindows} requêtes par minute excédée pour cette adresse IP, merci de réessayer plus tard.`,
     windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
     max: maxrequestPerWindows,
-    store: new RateLimitRedisStore({
-      client: redisClient,
-      expiry: RATE_LIMIT_WINDOW_SECONDS
-    })
+    store
   })
 );
 
@@ -158,11 +161,20 @@ app.use(urlencoded({ extended: false }));
 app.use(json());
 
 // allow application/graphql header
-app.use(graphqlBodyParser);
+app.use(graphQLPath, graphqlBodyParser);
+app.use(graphQLPath, graphqlQueryParserMiddleware());
+app.use(graphQLPath, graphqlBatchLimiterMiddleware());
+app.use(
+  graphQLPath,
+  graphqlRateLimiterMiddleware("resendInvitation", {
+    windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
+    maxRequestsPerWindow: 1,
+    store
+  })
+);
 
 // logging middleware
 app.use(loggingMiddleware(graphQLPath));
-app.use(graphqlBatchLimiterMiddleware(graphQLPath));
 
 /**
  * Set the following headers for cross-domain cookie

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -119,7 +119,7 @@ const store = new RateLimitRedisStore({
 
 app.use(
   rateLimit({
-    message: `Quota de ${maxrequestPerWindows} requêtes par minute excédée pour cette adresse IP, merci de réessayer plus tard.`,
+    message: `Quota de ${maxrequestPerWindows} requêtes par minute excédé pour cette adresse IP, merci de réessayer plus tard.`,
     windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
     max: maxrequestPerWindows,
     store

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -1,4 +1,5 @@
 import { ExpressContext } from "apollo-server-express/dist/ApolloServer";
+import { GqlInfo } from "./common/middlewares/graphqlQueryParser";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createUserDataLoaders } from "./users/dataloaders";
 
@@ -13,5 +14,11 @@ export type GraphQLContext = ExpressContext & {
 declare module "express-session" {
   interface SessionData {
     warningMessage?: string;
+  }
+}
+
+declare module "express" {
+  interface Request {
+    gqlInfos?: GqlInfo[];
   }
 }

--- a/back/src/users/resolvers/mutations/__tests__/changePassword.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/changePassword.integration.ts
@@ -20,7 +20,7 @@ describe("mutation changePassword", () => {
   it("should update a user password", async () => {
     const user = await userFactory();
     const { mutate } = makeClient({ ...user, auth: AuthType.Session });
-    const newPassword = "newPass";
+    const newPassword = "newPassword";
     const { data } = await mutate<Pick<Mutation, "changePassword">>(
       CHANGE_PASSWORD,
       {

--- a/back/src/users/resolvers/mutations/changePassword.ts
+++ b/back/src/users/resolvers/mutations/changePassword.ts
@@ -7,7 +7,7 @@ import {
   MutationChangePasswordArgs,
   MutationResolvers
 } from "../../../generated/graphql/types";
-import { hashPassword } from "../../utils";
+import { hashPassword, isPasswordLongEnough } from "../../utils";
 
 /**
  * Change user password
@@ -24,7 +24,13 @@ export async function changePasswordFn(
     });
   }
 
-  const hashedPassword = await hashPassword(newPassword);
+  const trimmedPassword = newPassword.trim();
+  if (!isPasswordLongEnough(trimmedPassword)) {
+    throw new UserInputError("Le nouveau mot de passe est trop court.", {
+      invalidArgs: ["newPassword"]
+    });
+  }
+  const hashedPassword = await hashPassword(trimmedPassword);
   const updatedUser = await prisma.user.update({
     where: { id: userId },
     data: { password: hashedPassword }

--- a/back/src/users/resolvers/mutations/resendInvitation.ts
+++ b/back/src/users/resolvers/mutations/resendInvitation.ts
@@ -7,6 +7,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
 import { renderMail } from "../../../mailer/templates/renderers";
 import { inviteUserToJoin } from "../../../mailer/templates";
+import { checkIsCompanyAdmin } from "../../permissions";
 
 const resendInvitationResolver: MutationResolvers["resendInvitation"] = async (
   parent,
@@ -14,8 +15,9 @@ const resendInvitationResolver: MutationResolvers["resendInvitation"] = async (
   context
 ) => {
   applyAuthStrategies(context, [AuthType.Session]);
-  checkIsAuthenticated(context);
+  const user = checkIsAuthenticated(context);
   const company = await getCompanyOrCompanyNotFound({ siret });
+  await checkIsCompanyAdmin(user, company);
 
   const invitations = await prisma.userAccountHash.findMany({
     where: { email, companySiret: siret }

--- a/front/src/account/fields/forms/AccountFormChangePassword.tsx
+++ b/front/src/account/fields/forms/AccountFormChangePassword.tsx
@@ -7,6 +7,7 @@ import styles from "./AccountForm.module.scss";
 import { object, string } from "yup";
 import { MutationChangePasswordArgs, Mutation } from "generated/graphql/types";
 import classNames from "classnames";
+import { NotificationError } from "common/components/Error";
 
 type Props = {
   toggleEdition: () => void;
@@ -25,7 +26,7 @@ type V = MutationChangePasswordArgs & {
 };
 
 export default function AccountFormChangePassword({ toggleEdition }: Props) {
-  const [changePassword, { loading }] = useMutation<
+  const [changePassword, { loading, error }] = useMutation<
     Pick<Mutation, "changePassword">,
     MutationChangePasswordArgs
   >(CHANGE_PASSWORD, {
@@ -58,13 +59,9 @@ export default function AccountFormChangePassword({ toggleEdition }: Props) {
   return (
     <Formik<V>
       initialValues={initialValues}
-      onSubmit={(values, { setFieldError, setSubmitting }) => {
+      onSubmit={(values, { setSubmitting }) => {
         changePassword({ variables: values }).catch(() => {
           setSubmitting(false);
-          setFieldError(
-            "oldPassword",
-            "Erreur. Vérifiez la saisie de votre ancien mot de passe."
-          );
         });
       }}
       validateOnChange={false}
@@ -106,6 +103,7 @@ export default function AccountFormChangePassword({ toggleEdition }: Props) {
             <RedErrorMessage name="newPasswordConfirmation" />
           </div>
           {loading && <div>Envoi en cours...</div>}
+          {error && <NotificationError apolloError={error} />}
 
           <button
             className="btn btn--primary tw-mt-4"


### PR DESCRIPTION
Devait passer en hotfix, mais vu la taille je mets ça dans le sprint pour recette.
Plusieurs corrections de sécu:

- seuls les admins peuvent renvoyer une invitation à rejoindre un établissement
- kill de la session au `logout`
- renouvellement de la session au `changePassword`
- rate limiting sur des queries gql particulières (`resendInvitation` qui envoi des emails)
- sécurisation de `changePassword` qui permettait de mettre des mdp très courts
- modification du message d'erreur quand on saisi un siret auquel on n'appartient pas sur la query `formRevisionRequests`