### PR TITLE
Fix / Révision

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :rocket: Nouvelles fonctionnalités
 #### :bug: Corrections de bugs
+
+- Correction d'un bug d'affichage sur les révisions: lorsque plusieurs validations étaient nécessaires, les boutons d'action restaient affichés même après que la validation ait été acceptée [PR 1332](https://github.com/MTES-MCT/trackdechets/pull/1332)
+
 #### :boom: Breaking changes
 #### :nail_care: Améliorations
 

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/BsddRevisionRequestTable.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/BsddRevisionRequestTable.tsx
@@ -10,16 +10,10 @@ import {
   TableCell,
 } from "common/components";
 import { BsddRevisionAction } from "./approve/BsddRevisionAction";
+import { BsddRevisionStatus } from "./approve/BsddRevisionStatus";
 
 type Props = {
   revisions: FormRevisionRequest[];
-};
-
-const STATUS_LABELS = {
-  PENDING: "En attente de validation",
-  ACCEPTED: "Approuvée",
-  REFUSED: "Refusée",
-  CANCELLED: "Annulée",
 };
 
 const COLUMNS = [
@@ -34,7 +28,8 @@ const COLUMNS = [
   },
   {
     Header: "Statut",
-    accessor: row => STATUS_LABELS[row.status],
+    accessor: () => null,
+    Cell: ({ row }) => <BsddRevisionStatus review={row.original} />,
   },
   {
     Header: "Actions",

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddRevisionAction.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddRevisionAction.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   FormRevisionRequest,
+  RevisionRequestApprovalStatus,
   RevisionRequestStatus,
 } from "generated/graphql/types";
 import { useParams } from "react-router-dom";
@@ -14,12 +15,18 @@ type Props = {
 
 export function BsddRevisionAction({ review }: Props) {
   const { siret } = useParams<{ siret: string }>();
+  const currentApproval = review.approvals.find(
+    approval => approval.approverSiret === siret
+  );
 
-  if (review.status !== RevisionRequestStatus.Pending) {
-    return <BsddConsultRevision review={review} />;
+  if (currentApproval?.status === RevisionRequestApprovalStatus.Pending) {
+    return <BsddApproveRevision review={review} />;
   }
 
-  if (siret === review.authoringCompany.siret) {
+  if (
+    review.authoringCompany.siret === siret &&
+    review.status === RevisionRequestStatus.Pending
+  ) {
     return (
       <>
         <BsddConsultRevision review={review} />
@@ -28,5 +35,5 @@ export function BsddRevisionAction({ review }: Props) {
     );
   }
 
-  return <BsddApproveRevision review={review} />;
+  return <BsddConsultRevision review={review} />;
 }

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddRevisionStatus.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddRevisionStatus.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import {
+  FormRevisionRequest,
+  RevisionRequestApprovalStatus,
+} from "generated/graphql/types";
+import Tooltip from "common/components/Tooltip";
+
+type Props = {
+  review: FormRevisionRequest;
+};
+
+const STATUS_LABELS = {
+  PENDING: "En attente de validation",
+  ACCEPTED: "Approuvée",
+  REFUSED: "Refusée",
+  CANCELLED: "Annulée",
+};
+
+export function BsddRevisionStatus({ review }: Props) {
+  const remainingApprovalsSirets = review.approvals
+    .filter(
+      approval => approval.status === RevisionRequestApprovalStatus.Pending
+    )
+    .map(approval => approval.approverSiret);
+
+  return (
+    <span>
+      {STATUS_LABELS[review.status]}{" "}
+      <Tooltip
+        msg={`En attente de ${
+          remainingApprovalsSirets.length
+        } validation(s) (SIRETS: ${remainingApprovalsSirets.join(", ")})`}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
Correction d'un bug sur la validation quand il y a plusieurs validateurs.
On avait des boutons d'action alors qu'on a déjà validé
En plus on en profite pour afficher le nombre de validateur restants, ainsi que leur siret.

Cf ticket https://trackdechets.zammad.com/#ticket/zoom/8205

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7753)
