### PR TITLE
Fix/ Recette dasri draft

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/createDraftBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createDraftBsdasri.ts
@@ -7,11 +7,11 @@ import { UserInputError } from "apollo-server-express";
 import createBsdasri from "./createBsdasri";
 
 const createDraftBsdasriResolver = async (
-  parent: ResolversParentTypes["Mutation"],
+  _: ResolversParentTypes["Mutation"],
   args: MutationCreateBsdasriArgs,
   context: GraphQLContext
 ) => {
-  if (args.input.synthesizing !== undefined) {
+  if (args.input.synthesizing?.length > 0) {
     throw new UserInputError(
       `La création de dasri de synthèse en brouillon n'est pas possible`
     );


### PR DESCRIPTION
Fix pour la recette, remonté par Manu

Un objet `synthesizing: []` est envoyé même pour les dasri simple. On tolère la présence de la clé si elle est vide.