### PR TITLE
Synthesis bsdasri post-qa fixes

### DIFF
--- a/back/src/bsdasris/__tests__/permissions.integration.ts
+++ b/back/src/bsdasris/__tests__/permissions.integration.ts
@@ -1,0 +1,91 @@
+import { checkCanReadBsdasri } from "../permissions";
+import { BsdasriType } from "@prisma/client";
+
+import { resetDatabase } from "../../../integration-tests/helper";
+import { ErrorCode } from "../../common/errors";
+import { bsdasriFactory, initialData } from "../__tests__/factories";
+import {
+  userWithCompanyFactory,
+  companyFactory
+} from "../../__tests__/factories";
+
+describe("Dasri permission helpers", () => {
+  afterEach(resetDatabase);
+
+  it("should deny dasri reading access to random user", async () => {
+    const company = await companyFactory();
+    const { user } = await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(company)
+      }
+    });
+
+    try {
+      await checkCanReadBsdasri(user, dasri);
+    } catch (err) {
+      expect(err.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+
+  it("should grant dasri reading access to user whose siret belongs to the form", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(company)
+      }
+    });
+
+    const grant = await checkCanReadBsdasri(user, dasri);
+
+    expect(grant).toBe(true);
+  });
+  it("should deny synthesis dasri reading access to user whose siret is not emitter on the associated form", async () => {
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const mainCompany = await companyFactory();
+    const initialCompany = await companyFactory();
+
+    const initialBsdasri = await bsdasriFactory({
+      opt: {
+        ...initialData(initialCompany)
+      }
+    });
+    const synthesisBsdasri = await bsdasriFactory({
+      opt: {
+        type: BsdasriType.SYNTHESIS,
+        ...initialData(mainCompany),
+        synthesizing: { connect: [{ id: initialBsdasri.id }] }
+      }
+    });
+    try {
+      await checkCanReadBsdasri(user, synthesisBsdasri);
+    } catch (err) {
+      expect(err.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+  it("should grant synthesis dasri reading access to user whose siret is emitter on the associated form", async () => {
+    const { user, company: initialCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const mainCompany = await companyFactory();
+
+    const initialBsdasri = await bsdasriFactory({
+      opt: {
+        ...initialData(initialCompany)
+      }
+    });
+    const synthesisBsdasri = await bsdasriFactory({
+      opt: {
+        type: BsdasriType.SYNTHESIS,
+        ...initialData(mainCompany),
+        synthesizing: { connect: [{ id: initialBsdasri.id }] }
+      }
+    });
+
+    const grant = await checkCanReadBsdasri(user, synthesisBsdasri);
+
+    expect(grant).toBe(true);
+  });
+});

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -1,4 +1,4 @@
-import { BsdasriStatus, Bsdasri } from "@prisma/client";
+import { BsdasriStatus, Bsdasri, BsdasriType } from "@prisma/client";
 import prisma from "../prisma";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
 
@@ -10,6 +10,7 @@ import { getRegistryFields } from "./registry";
 // |--------------------|---------|-------------|-----------|
 // | initial (draft)    | draft   | draft       | draft     |
 // | initial            | action  | to collect  | follow    |
+// | initial(synthesis) | follow  | to collect  | follow    |
 // | signed_by_producer | follow  | to collect  | follow    |
 // | sent               | follow  | collected   | action    |
 // | received           | follow  | follow      | action    |
@@ -62,7 +63,11 @@ function getWhere(
           setTab(siretsFilters, fieldName, "isDraftFor");
         }
       } else {
-        setTab(siretsFilters, "emitterCompanySiret", "isForActionFor");
+        if (bsdasri.type !== BsdasriType.SYNTHESIS) {
+          // for Synthesis dasri emitter & transporter are the same company, INITIAL bsd should appear in `isToCollectFor` tab
+          setTab(siretsFilters, "emitterCompanySiret", "isForActionFor");
+        }
+
         setTab(siretsFilters, "transporterCompanySiret", "isToCollectFor");
       }
       break;

--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -491,7 +491,7 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               checked={bsdasri?.type === BsdasriType.GROUPING}
               readOnly
             />{" "}
-            Groupement de déchets en transit (massification)
+            Groupement de DASRI sur un site relevant de la rubrique 2718
           </p>
           <p>
             <input
@@ -499,7 +499,7 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               checked={bsdasri?.type === BsdasriType.SYNTHESIS}
               readOnly
             />{" "}
-            Bordereau de synthèse de BSDASRI / DASRI dans un transport
+            Synthèse de bordereaux de DASRI simples, pris en charge par le collecteur et au statut "collecté"
           </p>
           <h3 className="TextAlignCenter">
             Bordereau(x) associé(s) constituant l’historique de la traçabilité

--- a/back/src/bsdasris/pdf/components/TraceabilityTable.tsx
+++ b/back/src/bsdasris/pdf/components/TraceabilityTable.tsx
@@ -23,7 +23,7 @@ export function TraceabilityTable({ previousBsdasris }) {
             <td>{bsdasri?.id}</td>
             <td>{bsdasri?.quantity}</td>
             <td>{bsdasri?.volume}</td>
-            <td>{bsdasri?.weight}</td>
+            <td>{bsdasri?.weight || "Pesée non effectuée"}</td>
             <td>{formatDate(bsdasri?.takenOverAt)}</td>
             <td>{bsdasri?.postalCode}</td>
           </tr>

--- a/back/src/bsdasris/permissions.ts
+++ b/back/src/bsdasris/permissions.ts
@@ -1,5 +1,5 @@
-import { User, Bsdasri, BsdasriStatus } from "@prisma/client";
-
+import { User, Bsdasri, BsdasriStatus, BsdasriType } from "@prisma/client";
+import prisma from "../prisma";
 import { getCachedUserSirets } from "../common/redis/users";
 
 import { BsdasriSirets } from "./types";
@@ -26,6 +26,18 @@ export async function isDasriContributorHelper(
   ].filter(Boolean);
 
   return userSirets.some(siret => formSirets.includes(siret));
+}
+
+// Don't call directly in resolver to handle permissions
+export async function isDasriInitialEmitterHelper(user: User, dasriId: string) {
+  const userSirets = await getCachedUserSirets(user.id);
+  const bsdasris = await prisma.bsdasri.findMany({
+    where: { synthesizedIn: { id: dasriId } },
+    select: { emitterCompanySiret: true }
+  });
+  const synthesizedEmitterSirets = bsdasris.map(bsd => bsd.emitterCompanySiret);
+
+  return userSirets.some(siret => synthesizedEmitterSirets.includes(siret));
 }
 
 export async function checkIsBsdasriContributor(
@@ -57,10 +69,30 @@ export async function checkIsBsdasriPublishable(
 
   return true;
 }
+
+/**
+ *
+ * User can read :
+ * - simple bsdasri on which is siret is present
+ * - synthesis bsdasri which associates child dasris whose emitter is user
+ */
 export async function checkCanReadBsdasri(user: User, bsdasri: Bsdasri) {
-  return checkIsBsdasriContributor(
-    user,
-    bsdasri,
+  const isContributor = await isDasriContributorHelper(user, bsdasri);
+  if (isContributor) {
+    return true;
+  }
+
+  if (bsdasri.type === BsdasriType.SYNTHESIS) {
+    const isInitialEmitter = await isDasriInitialEmitterHelper(
+      user,
+      bsdasri.id
+    );
+    if (isInitialEmitter) {
+      return true;
+    }
+  }
+
+  throw new NotFormContributor(
     "Vous n'êtes pas autorisé à accéder à ce bordereau"
   );
 }

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
@@ -74,6 +74,11 @@ describe("Mutation.createDasri", () => {
           phone: "06 18 76 02 00",
           mail: "transporteur@test.fr",
           address: "avenue de la mer"
+        },
+        recepisse: {
+          number: "abcd",
+          department: "21",
+          validityLimit: new Date().toISOString()
         }
       },
 
@@ -81,7 +86,7 @@ describe("Mutation.createDasri", () => {
     };
 
     const { mutate } = makeClient(user);
-    const { data } = await mutate<Pick<Mutation, "createBsdasri">>(
+    const { data, errors } = await mutate<Pick<Mutation, "createBsdasri">>(
       CREATE_DASRI,
       {
         variables: {
@@ -89,7 +94,7 @@ describe("Mutation.createDasri", () => {
         }
       }
     );
-
+    console.log(errors);
     expect(data.createBsdasri.synthesizing.map(bsd => bsd.id)).toEqual([
       toAssociate1.id,
       toAssociate2.id

--- a/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
@@ -91,7 +91,8 @@ const createSynthesisBsdasri = async (
   const synthesizedBsdasrisId = synthesizing.map(id => ({ id }));
 
   await validateBsdasri(flattenedInput, {
-    emissionSignature: true
+    emissionSignature: true,
+    isSynthesis: true
   });
 
   const newDasri = await prisma.bsdasri.create({

--- a/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
@@ -115,7 +115,7 @@ const updateSynthesisBsdasri = async ({
   const expectedBsdasri = { ...dbBsdasri, ...flattenedArgs };
 
   await validateBsdasri(expectedBsdasri, {
-    isGrouping: false
+    isSynthesis: true
   });
 
   const synthesizingArgs = !!inputSynthesizing?.length

--- a/front/src/common/components/Table.module.scss
+++ b/front/src/common/components/Table.module.scss
@@ -25,6 +25,11 @@
   font-size: 14px;
   padding: 8px 20px;
   border-bottom: 1px solid $grey-light;
+  
+}
+
+.TableRowDigest .TableCell{
+  border-top: 3px solid $grey-light;
 }
 
 .TableHeaderCell {

--- a/front/src/common/components/Table.tsx
+++ b/front/src/common/components/Table.tsx
@@ -66,6 +66,18 @@ export function TableRow({ children, className, ...props }: TableRowProps) {
   );
 }
 
+export function TableRowDigest({
+  children,
+  className,
+  ...props
+}: TableRowProps) {
+  return (
+    <TableRow className={classNames(styles.TableRowDigest, className)}>
+      {children}
+    </TableRow>
+  );
+}
+
 interface TableHeaderCellProps
   extends React.HTMLAttributes<HTMLTableHeaderCellElement> {
   children?: React.ReactNode;

--- a/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
@@ -13,13 +13,14 @@ interface BsdasriWasteSummaryProps {
 
 export function BsdasriWasteSummary({ bsdasri }: BsdasriWasteSummaryProps) {
   const section = {
-    INITIAL: "emission",
-    SIGNED_BY_PRODUCER: "emission",
-    SENT: "transport",
-    RECEIVED: "reception",
-    PROCESSED: "reception",
+    INITIAL: ["emitter", "emission"],
+    SIGNED_BY_PRODUCER: ["emitter", "emission"],
+    SENT: ["transporter", "transport"],
+    RECEIVED: ["destination", "reception"],
+    PROCESSED: ["destination", "reception"],
   }[bsdasri["bsdasriStatus"]];
 
+  const packagings = bsdasri?.[section[0]]?.[section[1]]?.packagings;
   return (
     <DataList>
       <DataListItem>
@@ -39,14 +40,14 @@ export function BsdasriWasteSummary({ bsdasri }: BsdasriWasteSummaryProps) {
       <DataListItem>
         <DataListTerm>Volume</DataListTerm>
         <DataListDescription>
-          {bsdasri?.[section]?.volume} litres
+          {bsdasri?.[section[0]]?.[section[1]]?.volume} litres
         </DataListDescription>
       </DataListItem>
       <DataListItem>
         <DataListTerm>Contenant(s)</DataListTerm>
         <DataListDescription>
-          {!!bsdasri[section]?.packagingInfos?.length &&
-            bsdasri[section]?.packagingInfos
+          {!!packagings?.length &&
+            packagings
               .map(
                 packaging =>
                   `${packaging.quantity}  ${packaging.other} ${packaging.type} (${packaging.volume} litre(s))`

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { RedErrorMessage } from "common/components";
 import { BsdasriSignatureType, BsdasriStatus } from "generated/graphql/types";
 import Packagings from "form/bsdasri/components/packagings/Packagings";
@@ -102,6 +102,13 @@ export function TransportSignatureForm() {
 }
 
 export function SynthesisTransportSignatureForm() {
+  const { setFieldValue, values } = useFormikContext<Bsdasri>();
+
+  // is always accepted for synthesis
+  useEffect(() => {
+    setFieldValue(`transporter.transport.acceptation.status`, "ACCEPTED");
+  }, []);
+
   return (
     <>
       <div className="form__row">
@@ -145,12 +152,6 @@ export function SynthesisTransportSignatureForm() {
       </div>
 
       <div className="form__row">
-        <Field
-          name="transporter.transport.acceptation"
-          component={AcceptOnlyField}
-        />
-      </div>
-      <div className="form__row">
         <label>
           Date de prise en charge
           <div className="td-date-wrapper">
@@ -180,9 +181,15 @@ export function SynthesisTransportSignatureForm() {
 }
 
 export function ReceptionSignatureForm() {
-  const { values } = useFormikContext<Bsdasri>();
-  const AcceptationComponent =
-    values.type === BsdasriType.Synthesis ? AcceptOnlyField : Acceptation;
+  const { values, setFieldValue } = useFormikContext<Bsdasri>();
+
+  // is always accepted for synthesis
+  useEffect(() => {
+    if (values.type === BsdasriType.Synthesis) {
+      setFieldValue(`destination.reception.acceptation.status`, "ACCEPTED");
+    }
+  }, []);
+
   return (
     <>
       <div className="form__row">
@@ -208,13 +215,17 @@ export function ReceptionSignatureForm() {
         </label>
         <RedErrorMessage name="destination.company.phone" />
       </div>
-
       <div className="form__row">
-        <Field
-          name="destination.reception.acceptation"
-          component={AcceptationComponent}
-        />
+        <Field name="destination.reception.packagings" component={Packagings} />
       </div>
+      {values.type !== BsdasriType.Synthesis && (
+        <div className="form__row">
+          <Field
+            name="destination.reception.acceptation"
+            component={Acceptation}
+          />
+        </div>
+      )}
       <div className="form__row">
         <label>
           Date de réception

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -10,6 +10,7 @@ import {
   BsdasriType,
 } from "generated/graphql/types";
 import routes from "common/routes";
+import { useDownloadPdf } from "dashboard/components/BSDList/BSDasri/BSDasriActions/useDownloadPdf";
 
 import {
   IconWarehouseDelivery,
@@ -334,6 +335,7 @@ export default function BsdasriDetailContent({
             )}
           </div>
           <div className={styles.detailGrid}>
+            {form?.synthesizedIn && <SynthesizedIn form={form.synthesizedIn} />}
             <DateRow
               value={form.updatedAt}
               label="Dernière action sur le BSD"
@@ -507,5 +509,25 @@ const AcceptationStatusRow = ({
       <dt>Lot accepté :</dt>
       <dd>{value ? getVerboseAcceptationStatus(value) : ""}</dd>
     </>
+  );
+};
+
+const SynthesizedIn = ({ form }: { form: Bsdasri }) => {
+  const [downloadPdf] = useDownloadPdf({
+    variables: { id: form.id },
+  });
+  return (
+    <DetailRow
+      value={
+        <span>
+          {form.id} (
+          <button className="link" onClick={() => downloadPdf()}>
+            PDF
+          </button>
+          )
+        </span>
+      }
+      label={`Associé au bordereau n°`}
+    />
   );
 };

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -95,7 +95,9 @@ const Emitter = ({ form }: { form: Bsdasri }) => {
         />
         <DetailRow value={emitter?.emission?.volume} label="Volume" units="l" />
 
-        <Dasripackaging packagings={emitter?.emission?.packagings} />
+        {form.type !== BsdasriType.Synthesis && (
+          <Dasripackaging packagings={emitter?.emission?.packagings} />
+        )}
       </div>
       <div className={styles.detailGrid}>
         {emitter?.emission?.isTakenOverWithoutEmitterSignature && (
@@ -355,13 +357,6 @@ export default function BsdasriDetailContent({
               <dd> {form?.grouping?.join(", ")}</dd>
             </div>
           )}
-
-          {form?.synthesizing?.length && (
-            <div className={styles.detailGrid}>
-              <dt>Bordereau associés:</dt>
-              <dd> {form?.synthesizing.map(el => el.id)?.join(", ")}</dd>
-            </div>
-          )}
         </div>
       </div>
 
@@ -482,7 +477,7 @@ const Dasripackaging = ({
                 </td>
 
                 <td>{row.quantity}</td>
-                <td>{row.volume} l</td>
+                <td className="tw-whitespace-no-wrap">{row.volume} l</td>
               </tr>
             ))}
           </tbody>

--- a/front/src/dashboard/detail/bsdasri/InitialDasris.tsx
+++ b/front/src/dashboard/detail/bsdasri/InitialDasris.tsx
@@ -1,33 +1,62 @@
 import React from "react";
 import { formatDate } from "common/datetime";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  TableRowDigest,
+} from "common/components";
+
 export const InitialDasris = ({ initialBsdasris }) => {
   if (!initialBsdasris?.length) {
     return <div>Aucun bordereau associé</div>;
   }
+
   return (
-    <table className="td-table">
-      <thead>
-        <tr className="td-table__head-tr">
-          <th>Id</th>
-          <th>Quantité</th>
-          <th>Volume</th>
-          <th>Poids</th>
-          <th>Date d'enlèvement</th>
-          <th>Code postal</th>
-        </tr>
-      </thead>
-      <tbody>
+    <Table style={{ tableLayout: "fixed" }}>
+      <TableHead>
+        <TableRow>
+          <TableHeaderCell>Id</TableHeaderCell>
+          <TableHeaderCell>Quantité</TableHeaderCell>
+          <TableHeaderCell>Volume</TableHeaderCell>
+          <TableHeaderCell>Poids</TableHeaderCell>
+          <TableHeaderCell>Enlèvement</TableHeaderCell>
+          <TableHeaderCell>Code postal</TableHeaderCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
         {initialBsdasris.map(el => (
-          <tr key={el.id}>
-            <td>{el.id}</td>
-            <td>{el.quantity}</td>
-            <td>{el.volume}</td>
-            <td>{el.weight}</td>
-            <td>{formatDate(el.takenOverAt)}</td>
-            <td>{el.postalCode}</td>
-          </tr>
+          <TableRow key={el.id}>
+            <TableCell>{el.id}</TableCell>
+            <TableCell>{el.quantity}</TableCell>
+            <TableCell>{el.volume}</TableCell>
+            <TableCell>{el.weight || "Pesée non effectuée"}</TableCell>
+            <TableCell>{formatDate(el.takenOverAt)}</TableCell>
+            <TableCell>{el.postalCode}</TableCell>
+          </TableRow>
         ))}
-      </tbody>
-    </table>
+        <TableRowDigest>
+          <TableCell>
+            <strong>Total</strong>{" "}
+          </TableCell>
+          <TableCell>
+            {initialBsdasris.reduce((prev, curr) => prev + curr.quantity, 0)}
+          </TableCell>
+          <TableCell>
+            {initialBsdasris.reduce((prev, curr) => prev + curr.volume, 0)}
+          </TableCell>
+
+          <TableCell>
+            {initialBsdasris.reduce((prev, curr) => prev + curr.weight, 0) ||
+              "N/A"}
+          </TableCell>
+          <TableCell>{null}</TableCell>
+          <TableCell>{null}</TableCell>
+        </TableRowDigest>
+      </TableBody>
+    </Table>
   );
 };

--- a/front/src/dashboard/detail/common/BSDDetailContent.module.scss
+++ b/front/src/dashboard/detail/common/BSDDetailContent.module.scss
@@ -35,9 +35,7 @@
     @include desktop {
       flex-direction: row;
     }
-    > div {
-      width: 100%; // equal width child grid divs
-    }
+   
   }
   &Grid {
     display: inline-grid;

--- a/front/src/dashboard/detail/common/Components.tsx
+++ b/front/src/dashboard/detail/common/Components.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo } from "react";
 import { formatDate } from "common/datetime";
 import { PackagingInfo } from "generated/graphql/types";
 import { getPackagingInfosSummary } from "form/bsdd/utils/packagings";
-
+const nbsp = "\u00A0";
 export const DetailRow = ({
   value,
   label,
@@ -20,7 +20,8 @@ export const DetailRow = ({
     <>
       <dt>{label}</dt>
       <dd>
-        {value} {value ? units : null}
+        {value}
+        {!!units ? `${nbsp}${units}` : null}
       </dd>
     </>
   );

--- a/front/src/form/bsdasri/components/acceptation/Acceptation.tsx
+++ b/front/src/form/bsdasri/components/acceptation/Acceptation.tsx
@@ -7,10 +7,7 @@ import { Label, RedErrorMessage } from "common/components";
 import TdSwitch from "common/components/Switch";
 import { getNestedNode } from "common/helper";
 
-export function AcceptOnlyField({
-  field: { name, value },
-  dasriPath = "transporter.transport",
-}) {
+export function AcceptOnlyField({ field: { name } }) {
   const { values, setFieldValue } = useFormikContext<Bsdasri>();
 
   const acceptationPath = `${name}.status`;

--- a/front/src/form/bsdasri/components/grouping/BsdasriSelectorForSynthesis.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriSelectorForSynthesis.tsx
@@ -46,6 +46,7 @@ export default function BsdasriSelectorForSynthesis({ disabled }) {
         id: values?.id,
       },
       fetchPolicy: "network-only",
+      skip: !values?.id,
     }
   );
 

--- a/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTable.tsx
@@ -10,6 +10,7 @@ import {
   DestinationOperationCodeTypes,
 } from "generated/graphql/types";
 import { formatDate } from "common/datetime";
+
 const GET_GROUPABLE_BSDASRIS = gql`
   query Bsdasris($where: BsdasriWhere) {
     bsdasris(where: $where) {

--- a/front/src/form/bsdasri/steps/Emitter.tsx
+++ b/front/src/form/bsdasri/steps/Emitter.tsx
@@ -37,16 +37,18 @@ export function SynthesisEmitter({
   editionDisabled = false,
   emissionEmphasis = false,
 }) {
+  const { values } = useFormikContext<Bsdasri>();
   const disabled = !!status && status !== BsdasriStatus.Initial;
 
   return (
     <>
       <h3 className="form__section-heading">Bordereau de synthèse DASRI</h3>
       <p>
-        Vous apparaitrez comme producteur et transporteur du bordereau de
-        synthèse
+        Votre établissement {values?.emitter?.company?.name} (
+        {values?.emitter?.company?.siret}) apparaîtra comme le détenteur et le
+        collecteur/transporteur sur ce bordereau de synthèse.
       </p>
-      <BsdasriSelectorForSynthesis disabled={disabled} />
+
       <div
         className={classNames("form__row", {
           "field-emphasis": emissionEmphasis,
@@ -70,6 +72,7 @@ export function SynthesisEmitter({
           />
         </fieldset>
       </div>
+      <BsdasriSelectorForSynthesis disabled={disabled} />
       <div
         className={classNames("form__row", {
           "field-emphasis": emissionEmphasis,

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -31,7 +31,7 @@ export default function Transport({ status, editionDisabled = false }) {
 
   const transportEmphasis = false;
   const AcceptationComponent =
-    values.type === BsdasriType.Synthesis ? AcceptOnlyField : Acceptation;
+    values.type === BsdasriType.Synthesis ? null : Acceptation;
 
   const disabled =
     editionDisabled ||
@@ -134,11 +134,13 @@ export default function Transport({ status, editionDisabled = false }) {
               "field-emphasis": transportEmphasis,
             })}
           >
-            <Field
-              name="transporter.transport.acceptation"
-              component={AcceptationComponent}
-              disabled={disabled}
-            />
+            {values.type !== BsdasriType.Synthesis && (
+              <Field
+                name="transporter.transport.acceptation"
+                component={Acceptation}
+                disabled={disabled}
+              />
+            )}
           </div>
           <div
             className={classNames("form__row", {

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -149,7 +149,7 @@ const COMPANY_INFOS = gql`
 `;
 
 function CurrentCompanyWidget({ disabled = false }) {
-  const { setFieldValue } = useFormikContext();
+  const { values, setFieldValue } = useFormikContext<Bsdasri>();
 
   const { siret } = useParams<{ siret: string }>();
   const { data, loading, error } = useQuery<
@@ -160,18 +160,19 @@ function CurrentCompanyWidget({ disabled = false }) {
     fetchPolicy: "no-cache",
 
     onCompleted: () => {
-      setFieldValue(
-        `transporter.company.mail`,
-        data?.companyInfos?.contactEmail
-      );
-      setFieldValue(
-        `transporter.company.phone`,
-        data?.companyInfos?.contactPhone
-      );
-      setFieldValue(
-        `transporter.company.phone`,
-        data?.companyInfos?.contactPhone
-      );
+      if (!values?.transporter?.company?.mail) {
+        setFieldValue(
+          `transporter.company.mail`,
+          data?.companyInfos?.contactEmail
+        );
+      }
+
+      if (!values?.transporter?.company?.phone) {
+        setFieldValue(
+          `transporter.company.phone`,
+          data?.companyInfos?.contactPhone
+        );
+      }
       if (data?.companyInfos?.transporterReceipt) {
         setFieldValue(
           "transporter.recepisse.number",
@@ -243,6 +244,7 @@ function CurrentCompanyWidget({ disabled = false }) {
               name={`transporter.company.phone`}
               placeholder="Numéro"
               className={`td-input`}
+              disabled={disabled}
             />
           </label>
 

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -12,7 +12,7 @@ import {
 } from "generated/graphql/types";
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
-
+import Tooltip from "common/components/Tooltip";
 type Props = { disabled: boolean };
 
 const COMPANY_INFOS = gql`
@@ -29,16 +29,26 @@ const COMPANY_INFOS = gql`
 const COMMON_OPTIONS = [
   {
     title: "simple",
+    explanation:
+      "Bordereau nécessaire à la collecte initiale chez un producteur/détenteur",
     value: BsdasriType.Simple,
   },
   {
     title: "de groupement",
+    explanation:
+      "Bordereau qui permet de grouper les BSDASRI simples et les déchets associés depuis un site relevant de la rubrique ICPE 2718",
+
     value: BsdasriType.Grouping,
   },
 ];
 const TRANSPORTER_OPTIONS = [
   {
     title: "de synthèse",
+
+    explanation: `Bordereau qui permet de faire la synthèse de BSDASRI simples qui ont été pris en charge 
+      par le collecteur au statut "collecté" pour simplifier la prise en charge par le destinataire
+      - ce bordereau ne peut être établi que par un collecteur/transporteur`,
+
     value: BsdasriType.Synthesis,
   },
 ];
@@ -101,19 +111,27 @@ export function Type({ disabled }: Props) {
       <h4 className="form__section-heading">Type de BSDASRI</h4>
 
       <div className="form__row">
-        <p>J'édite un BSDASRI :</p>
+        <p id="type-radio-group">J'édite un BSDASRI :</p>
       </div>
 
-      <div className="form__row">
+      <div
+        className="form__row"
+        role="radiogroup"
+        aria-labelledby="type-radio-group"
+      >
         {typeOptions.map(option => (
-          <Field
-            key={option.value}
-            disabled={disabled}
-            name="type"
-            id={option.value}
-            label={option.title}
-            component={RadioButton}
-          />
+          <label className="tw-block tw-flex tw-items-start" key={option.value}>
+            <Field
+              type="radio"
+              disabled={disabled}
+              name="type"
+              id={option.value}
+              value={option.value}
+              className="td-radio"
+            />
+            {option.title}
+            <Tooltip msg={option.explanation} />
+          </label>
         ))}
       </div>
     </>


### PR DESCRIPTION
Correctifs post-recettes:
- formulaire de création/édition: labels de choix de type de dasri plus explicites
- formulaire: avertissement si mélange de codes déchets ou si le code des dasris associés ne correspond pas au code sélectionné
- indexation: les dasris de synthèse INITIAL doivent apparaître dans "à collecter" et pas "action"
- pdf: mise à jour des libellés figurant sur la liste des dasris initiaux
- aperçu: affichage des dasris initiaux plus compact, aération des colonnes des onglets
- correctif du calcul des packagings
- ne pas afficher le widget d'acception (toujours accepté) dans les modale de signature
- ajout d'un lien pour accéder au pdf d'un dasri de synthèse si on figure parmi les émetteurs d'un de ses bordereaux associés

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-7858)
