### PR TITLE
Prevent dasri form fail for anonymous companies

### DIFF
--- a/front/src/form/bsda/stepper/steps/Type.tsx
+++ b/front/src/form/bsda/stepper/steps/Type.tsx
@@ -83,12 +83,12 @@ export function Type({ disabled }: Props) {
   }, [type, setFieldValue, data]);
 
   if (loading) return <p>Loading...</p>;
-  if (error) return <InlineError apolloError={error} />;
 
-  const typeOptions = data?.companyInfos.companyTypes?.includes(
-    "WASTE_CENTER" as CompanyType
-  )
-    ? [...COMMON_OPTIONS, ...DECHETTERIE_OPTIONS]
+  // On sandbox env, some AnonymousCompanies do not exist in Sirene index, let's default to common options
+  const typeOptions = !error
+    ? data?.companyInfos.companyTypes?.includes("WASTE_CENTER" as CompanyType)
+      ? [...COMMON_OPTIONS, ...DECHETTERIE_OPTIONS]
+      : COMMON_OPTIONS
     : COMMON_OPTIONS;
 
   return (

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -102,9 +102,9 @@ export function Type({ disabled }: Props) {
   }, [type, setFieldValue, data]);
 
   if (loading) return <p>Loading...</p>;
-  if (error) return <InlineError apolloError={error} />;
 
-  const typeOptions = getTypeOptions(data, !!id);
+  // On sandbox env, some AnonymousCompanies do not exist in Sirene index, let's default to common options
+  const typeOptions = error!! ? COMMON_OPTIONS : getTypeOptions(data, !!id);
 
   return (
     <>


### PR DESCRIPTION
Les formulaires dasri et bsdas font appel à companyInfos pour obtenir les type de la company en cours, afin d'afficher ou pas certaines options ( le champ companies de me étant déprécié).
En sandbox certaines companies existent dans la db mais pas dans l'index sirene, ce qui bloque les 2 formulaires . Cette PR met en place un workaround UI pour ne pas bloquer l’utilisateur, mais il faudra réfléchir à soit:
- une nouvelle query interne pour récupérer les infos DB d'une company sans requêter l'index sirene
- passer les infos de currentCompany via un store global


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
