### PR TITLE
Hotfix bad csv parsing

### DIFF
--- a/search/.env.model
+++ b/search/.env.model
@@ -1,5 +1,9 @@
 NODE_ENV=dev
+# Datadog tracer env name
 DD_ENV=dev
 # Elastic Search host and credentials
 ELASTICSEARCH_URL=http://localhost:9201
-# FORCE_LOGGER_CONSOLE=true
+# Log to console instead of file logs/
+FORCE_LOGGER_CONSOLE=true
+# Maximum CSV lines to parse
+MAX_ROWS=1000

--- a/search/src/indexation/elasticSearch.helpers.ts
+++ b/search/src/indexation/elasticSearch.helpers.ts
@@ -284,7 +284,12 @@ export const unzipAndIndex = async (
   const writableStream = getWritableParserAndIndexer(indexConfig, indexName);
   await pipeline(
     fs.createReadStream(csvPath),
-    parse({ headers, ignoreEmpty: true })
+    parse({
+      headers,
+      ignoreEmpty: true,
+      discardUnmappedColumns: true,
+      ...(parseInt(process.env.MAX_ROWS, 10) && { maxRows: parseInt(process.env.MAX_ROWS, 10)})
+    })
       .on("error", error => {
         throw error;
       })


### PR DESCRIPTION
Ajout d'une option fast-csv pour ignorer les titres de  colonnes en décalage, en Mai ajout  l'INSEE ajoute `societeMissionUniteLegale` mais le CSV manquent des colonnes

Ajout d'une option d'une var d'env MAX_ROWS pour tester un  nombre limite de linges à indexer