### PR TITLE
Hotfix bugs sur l'ajout d'établissement de test et de non diffusibles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
-- Sandbox : permettre de créer et rechercher un établissment de test (siret commençant par "0000"). Améliorer la recherche d'établissements par `getCompanyInfos` en accélérant la recherche en cas d'entreprise de test, évitant de chercher les API de recherche interne ou tierces.
+- Sandbox : permettre de créer et rechercher un établissment de test (siret commençant par "0000"). Améliorer la recherche d'établissements par `getCompanyInfos` en accélérant la recherche en cas d'entreprise de test, évitant de chercher les API de recherche interne ou tierces. Les établissements de test ont `statutDiffusionEtablissement` à "O" pour ne pas apparaître comme des établissements non-diffusibles.
 
 #### :boom: Breaking changes
 

--- a/back/src/users/bulk-creation/sirene.ts
+++ b/back/src/users/bulk-creation/sirene.ts
@@ -10,7 +10,7 @@ import { CompanySearchResult } from "../../generated/graphql/types";
 import { Opts } from ".";
 
 /**
- * Throttled version of searchCompanyInfo to avoid hitting rate limit
+ * Throttled version of search clients to avoid hitting rate limit
  * of 7 requests / seconds
  * We wait 500ms before executing the function
  * @param siret

--- a/front/src/common/components/Error.tsx
+++ b/front/src/common/components/Error.tsx
@@ -62,3 +62,21 @@ export function NotificationError({ apolloError, className, message }: Props) {
     </ErrorProvider>
   );
 }
+
+export function SimpleNotificationError({
+  className,
+  message,
+}: {
+  className?: string;
+  message: string;
+}) {
+  return (
+    <div
+      className={`notification notification--error tw-mt-2 ${
+        styles.lineBreak
+      } ${className ?? ""}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -1,7 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import { InlineError } from "common/components/Error";
 
-import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import { Field, useField, useFormikContext } from "formik";
 import {
   Bsdasri,
@@ -45,7 +44,7 @@ const TRANSPORTER_OPTIONS = [
   {
     title: "de synthèse",
 
-    explanation: `Bordereau qui permet de faire la synthèse de BSDASRI simples qui ont été pris en charge 
+    explanation: `Bordereau qui permet de faire la synthèse de BSDASRI simples qui ont été pris en charge
       par le collecteur au statut "collecté" pour simplifier la prise en charge par le destinataire
       - ce bordereau ne peut être établi que par un collecteur/transporteur`,
 

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -45,6 +45,7 @@ export const COMPANY_INFOS = gql`
       libelleNaf
       address
       etatAdministratif
+      statutDiffusionEtablissement
       isRegistered
       companyTypes
       installation {


### PR DESCRIPTION
# 2 Bugs dans l'ajout d'une établissement de compte.

- [Retour forum sur les tests sur la sandbox](https://forum.trackdechets.beta.gouv.fr/t/query-companypublicinfo-ne-renvoit-pas-les-donnees-de-letablissement/765)
- [Ticket Favro sur le problème des non-diffusibles](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7953)

## Solutions

### GQL query companyInfos pour les établissement de test => statutDiffusionEtablissement = "0"
```json
{
  "data": {
    "companyInfos": {
      "siret": "00000000000002",
      "naf": "XXXXX",
      "name": "Établissement de test",
      "address": "Adresse test",
      "statutDiffusionEtablissement": "O"
    }
  }
}
```

### add company pour les non diffusibles

https://www.loom.com/share/8db28c5ec8354f25915790fab8c32b35

### ajout etablissement fermé

![image](https://user-images.githubusercontent.com/76620/166886471-beda5a69-b15d-4b61-8cff-01121358784f.png)

### ajout établissement déjà enregistré

![image](https://user-images.githubusercontent.com/76620/166886706-d1bd694d-9b44-431d-9b77-ad0e7636c824.png)


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---


