### PR TITLE
Disable submit button during form submission

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Sandbox : permettre de créer et rechercher un établissment de test (siret commençant par "0000"). Améliorer la recherche d'établissements par `getCompanyInfos` en accélérant la recherche en cas d'entreprise de test, évitant de chercher les API de recherche interne ou tierces.
-
+- Désactive au moment de l'envoi le bouton du formulaire dans la modale permettant de mettre à jour la plaque d'immatriculation transporteur [PR 1371](https://github.com/MTES-MCT/trackdechets/pull/1371)
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
@@ -59,7 +59,7 @@ export default function TransporterInfoEdit({
         : null,
     },
     onSubmit: values => {
-      updateTransporterPlate({
+      return updateTransporterPlate({
         variables: { id: form.id, [mutationFieldName]: values[fieldName] },
       });
     },

--- a/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
@@ -105,8 +105,12 @@ export default function TransporterInfoEdit({
             >
               Annuler
             </button>
-            <button className="btn btn--primary" type="submit">
-              Modifier
+            <button
+              className="btn btn--primary"
+              type="submit"
+              disabled={formik.isSubmitting}
+            >
+              {formik.isSubmitting ? "Envoi en cours" : "Modifier"}
             </button>
           </div>
         </form>


### PR DESCRIPTION
Le bouton de validation du formulaire dans la modale de modification de la plaque d'immatriculation transporteur n'était pas désactivé pendant la soumission du formulaire. Ce bug peut être lié d'une façon ou d'une autre au problème que l'on a constaté sur cette requête en DB. 


https://user-images.githubusercontent.com/2269165/166887284-b12ea577-7044-4118-b987-5585d0f15165.mov




- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
