### PR TITLE
Corrige le message d'erreur d'imbrication d'opérateurs de requêtes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Désactive au moment de l'envoi le bouton du formulaire dans la modale permettant de mettre à jour la plaque d'immatriculation transporteur [PR 1371](https://github.com/MTES-MCT/trackdechets/pull/1371)
 - La modale de publication du Bsdasri n'affiche pas toutes les informations [PR 1359](https://github.com/MTES-MCT/trackdechets/pull/1359)
 - Indexation Sirene : correctifs [PR 1365](https://github.com/MTES-MCT/trackdechets/pull/1365) et [PR 1364](https://github.com/MTES-MCT/trackdechets/pull/1364)
+- Corrige le message d'erreur affiché en cas de dépassement d'imbrication d'opérateurs sur les filtres de requêtes[PR 1374](https://github.com/MTES-MCT/trackdechets/pull/1374)
 
 #### :boom: Breaking changes
 

--- a/back/src/common/where.ts
+++ b/back/src/common/where.ts
@@ -30,7 +30,7 @@ export class NestingWhereError extends UserInputError {
   constructor(depthLimit = 2) {
     super(
       `Vous ne pouvez pas imbriquer des opérations` +
-        ` _and, _or et _not sur plus de ${depthLimit} niveaux`
+        ` _and, _or et _not sur plus de ${depthLimit - 1} niveaux`
     );
   }
 }

--- a/doc/docs/tutoriels/courant/query-bordereaux.md
+++ b/doc/docs/tutoriels/courant/query-bordereaux.md
@@ -1,0 +1,207 @@
+---
+title: Requêter et filtrer les bordereaux Bsda, Bsdasri, Bsff et Bsvhu
+---
+
+Les bordereaux Bsda, Bsdasri, Bsff et Bsvhu, ont bénéficié des retours utiilisateurs et proposent des filtres de requêtes puissants.
+
+Veuillez noter que les Bsdd (requête forms) ne disposent pas des mêmes filtres. 
+
+Pour une documentation exhaustive, veuillez consulter la référence des requêtes de chaque bordereau, par exemple [la requête bsdasri](../../reference/api-reference/bsdasri/queries#bsdasris).
+ 
+Les exemples suivants portent sur les dasris, mais sont aisément transposables aux autres bordereaux. 
+Ils ne prétendent pas avoir un intérêt métier particulier, mais simplement expliciter la syntaxe de requête.
+
+### Filtres simples
+
+
+#### Sur l'état de brouillon (boolean)
+ 
+Renvoie les dasris non brouillons.
+
+```graphql
+query {
+  bsdasris(where: { isDraft: false }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+#### Sur un statut
+
+
+Renvoie les dasris SENT.
+
+```graphql
+query {
+  bsdasris(where: {  status: {_eq : SENT} }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+
+#### Egalité stricte: Sur le siret d'un producteur
+
+Renvoie les dasris dont le siret de l'émetteur est "UN-SIRET".
+
+```graphql
+query {
+  bsdasris(where: { emitter : {company	: {siret :  {_eq: "UN-SIRET"}}} }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+#### Filtres temporels
+
+Les opérateurs et formats de date acceptés sont documentés dans [la référence de DateFilter](../../reference/api-reference/bsdasri/inputObjects#datefilter).
+
+
+Renvoie les dasris dont la date de création est égale ou postérieure au 23/11/2021.
+
+```graphql
+query {
+  bsdasris(where: { createdAt: { _gte: " 2021-11-23" } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+
+#### Filtre d'appartenance
+
+Il est possible de filtrer certains champs sur un tableau de valeurs.
+
+##### Sur les statuts
+
+
+Renvoie les dasri en statut INITIAL ou SENT.
+
+```
+query {
+  bsdasris(where: { status: { _in: [SENT, INITIAL] } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+#### Sur des identifiants
+
+
+Renvoie les dasris dont l'identifiant vaut "DASRI-123" ou "DASRI-456".
+
+```
+query {
+  bsdasris(where: { id: { _in: ["DASRI-123", "DASRI-456"] } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+### Filtres combinés
+
+Il est possible de combiner des filtres avec _and, _or, _not. L'imbrication de tels opérateurs est néanmoins limitée.
+
+
+### Not  (_not)
+
+
+Renvoie les dasris non SENT
+
+```graphql
+query {
+  bsdasris(where: { _not: { status: { _eq: SENT } } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+```
+### And implicite
+
+Renvoie les dasris INITIAL non brouillons.
+
+```graphql
+query {
+  bsdasris(where: { isDraft: false, status: { _eq: INITIAL } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  }
+}
+
+```
+
+### Or (_or)
+
+Renvoie les dasris dont la date de création est égale ou postérieure au 03/05/2022 ou dont le statut est PROCESSED.
+
+```graphql
+query {
+  bsdasris(
+    where: {
+      _or: [
+        { createdAt: { _gte: "2022-05-03" } }
+        { status: { _eq: PROCESSED } }
+      ]
+    }
+  ) {
+    edges {
+      node {
+        id
+        updatedAt
+      }
+    }
+  }
+}
+```
+
+### And (_and)
+
+Renvoie les dasris dont la date de création est égale ou postérieure au 03/05/2022, dont le statut est INITIAL et non brouillon.
+
+
+```graphql
+query {
+  bsdasris(
+    where: {
+      createdAt: { _gte: "2022-05-03" }
+      _and: [{ status: { _eq: INITIAL } }, { isDraft: false }]
+    }
+  ) {
+    edges {
+      node {
+        id
+        updatedAt
+      }
+    }
+  }
+}
+```

--- a/doc/sidebars.js
+++ b/doc/sidebars.js
@@ -46,6 +46,12 @@ module.exports = {
           ],
         },
         {
+          "Usage Courant": [
+            "tutoriels/courant/query-bordereaux",
+           
+          ],
+        },
+        {
           Exemples: [
             {
               BSDD: [


### PR DESCRIPTION
Suite retour support: sur les nouveaux bsds,  les requêtes listes disposent d'opérateur de combinaison (or, and, not). L'imbrication est limitée à 1 niveau, mais le message d'erreur en cas de dépassement indiquait "2".

Ajout d'une sous section de la documentation développeur pour expliquer le fonctionnement de ces filtres.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
 
### Aperçu de la doc ajoutée

![Screenshot 2022-05-05 at 18-26-40 Requêter et filtre les bordereaux Bsda Bsdasri Bsff et Bsvhu Documentation de l'API Trackdéchets](https://user-images.githubusercontent.com/878396/166972341-d634196c-dbba-4a02-a08b-04f83d8592b4.png)

