### PR TITLE
HOTFIX : `nextDestination.company` doit être optionnel

### DIFF
--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -28,7 +28,7 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
 
   const formUpdateInput: Prisma.FormUpdateInput =
     flattenProcessedFormInput(processedInfo);
-  await processedInfoSchema.validate(formUpdateInput);
+  await processedInfoSchema.validate(formUpdateInput, { abortEarly: false });
 
   // set default value for processingOperationDescription
   const operation = PROCESSING_OPERATIONS.find(

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -157,7 +157,7 @@ input NextDestinationInput {
   processingOperation: String!
 
   "Établissement de destination ultérieur"
-  company: InternationalCompanyInput!
+  company: InternationalCompanyInput
 }
 
 "Payload de création d'un bordereau"


### PR DESCRIPTION
Petit oubli de https://github.com/MTES-MCT/trackdechets/pull/1302. La définition de `NextDestinationInput` n'avait pas été modifiée pour permettre de ne pas renseigner de `company`.

Cf https://forum.trackdechets.beta.gouv.fr/t/perte-de-tracabilite/731/6

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---


