### PR TITLE
HOTFIX - Fix du sélecteur de destination ultérieure en cas de rupture de traçabilité 

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -60,16 +60,6 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
       if (noTraceability == null) {
         setFieldValue("noTraceability", false);
       }
-      if (noTraceability === true && nextDestination?.company?.siret?.length) {
-        setFieldValue("nextDestination.company", {
-          siret: "",
-          name: "",
-          address: "",
-          contact: "",
-          mail: "",
-          phone: "",
-        });
-      }
     } else {
       setFieldValue("nextDestination", null);
       setFieldValue("noTraceability", null);
@@ -130,7 +120,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
           />
         </label>
       </div>
-      {isGroupement && (
+      {isGroupement && noTraceability !== null && (
         <>
           <div className="form__row form__row--inline">
             <Field
@@ -181,6 +171,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
             allowForeignCompanies={true}
             displayVatSearch={false}
             skipFavorite={noTraceability === true}
+            optional={noTraceability === true}
           />
         </div>
       )}

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -40,6 +40,8 @@ interface CompanySelectorProps {
   disabled?: boolean;
   optionalMail?: boolean;
   skipFavorite?: boolean;
+  // whether the company is optional
+  optional?: boolean;
 }
 
 export default function CompanySelector({
@@ -52,6 +54,7 @@ export default function CompanySelector({
   disabled,
   optionalMail = false,
   skipFavorite = false,
+  optional = false,
 }: CompanySelectorProps) {
   // STATE
   const [isRegistered, setIsRegistered] = useState(true);
@@ -124,25 +127,45 @@ export default function CompanySelector({
     (company: CompanyFavorite) => {
       if (disabled) return;
 
-      const fields = {
-        siret: company.siret,
-        vatNumber: company.vatNumber,
-        name: company.name,
-        address: company.address,
-        contact: company.contact,
-        phone: company.phone,
-        mail: company.mail,
-      };
+      // avoid setting same company multiple times
+      if (company?.siret && company.siret !== field.value.siret) {
+        const fields = {
+          siret: company.siret,
+          vatNumber: company.vatNumber,
+          name: company.name,
+          address: company.address,
+          contact: company.contact,
+          phone: company.phone,
+          mail: company.mail,
+        };
 
-      Object.keys(fields).forEach(key => {
-        setFieldValue(`${field.name}.${key}`, fields[key]);
-      });
+        Object.keys(fields).forEach(key => {
+          setFieldValue(`${field.name}.${key}`, fields[key]);
+        });
+      } else if (optional) {
+        // allow unselecting the company
+        setFieldValue(field.name, {
+          siret: "",
+          name: "",
+          address: "",
+          contact: "",
+          mail: "",
+          phone: "",
+        });
+      }
 
       if (onCompanySelected) {
         onCompanySelected(company);
       }
     },
-    [field.name, setFieldValue, onCompanySelected, disabled]
+    [
+      field.name,
+      field.value.siret,
+      setFieldValue,
+      onCompanySelected,
+      disabled,
+      optional,
+    ]
   );
 
   const searchResults: CompanyFavorite[] = useMemo(
@@ -185,10 +208,12 @@ export default function CompanySelector({
   );
 
   useEffect(() => {
-    if (searchResults.length === 1 && field.value.siret === "") {
-      selectCompany(searchResults[0]);
+    if (!optional) {
+      if (searchResults.length === 1 && field.value.siret === "") {
+        selectCompany(searchResults[0]);
+      }
     }
-  }, [searchResults, field.value.siret, selectCompany]);
+  }, [searchResults, field.value.siret, selectCompany, optional]);
 
   useEffect(() => {
     const timeoutID = setTimeout(() => {


### PR DESCRIPTION
Le sélecteur d'entreprise n'avait pas été conçu comme un champ optionnel. En effet on ne peut pas désélectionner une entreprise et lorsqu'il y a un seul résultat de recherche, ce résultat est sélectionné par défaut. Or dans le cas de la rupture de traçabilité, l'entreprise destination ultérieure est optionnelle. J'avais dans un premier temps ajouté un effet pour cleaner l'entreprise sélectionnée lorsque l'on cochait "Rupture de traçabilité" mais ça causait des mises à jour en boucle et empêchait tout simplement de sélectionner une destination ultérieure en cas de rupture de traçabilité. 

La solution proposée consiste à ajouter un paramètre (encore un !) au composant `CompanySelector` permettant de déselectionner une entreprise. 

https://user-images.githubusercontent.com/2269165/168088124-ca5fff31-b46f-4602-9dcc-03e0050f1f8f.mov

[[BSDD] Rupture de traçabilité : freeze de la UI quand on recherche l'installation ultérieure](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8032)
[[BSDD] Rupture de traçabilité : impossible de choisir la destination ultérieure (non-cliquable)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8010)
