### PR TITLE
Assouplissement du rate limit pour le renvoi d'invitations

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -168,8 +168,8 @@ app.use(graphQLPath, graphqlBatchLimiterMiddleware());
 app.use(
   graphQLPath,
   graphqlRateLimiterMiddleware("resendInvitation", {
-    windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
-    maxRequestsPerWindow: 1,
+    windowMs: RATE_LIMIT_WINDOW_SECONDS * 3 * 1000,
+    maxRequestsPerWindow: 10, // 10 requests each 3 minutes
     store
   })
 );

--- a/front/src/account/AccountCompanyMember.tsx
+++ b/front/src/account/AccountCompanyMember.tsx
@@ -71,7 +71,7 @@ export default function AccountCompanyMember({ company, user }: Props) {
     Pick<Mutation, "removeUserFromCompany">,
     MutationRemoveUserFromCompanyArgs
   >(REMOVE_USER_FROM_COMPANY);
-  const [deleteInvitation] = useMutation<
+  const [deleteInvitation, { loading: deleteLoading }] = useMutation<
     Pick<Mutation, "deleteInvitation">,
     MutationDeleteInvitationArgs
   >(DELETE_INVITATION, {
@@ -84,16 +84,22 @@ export default function AccountCompanyMember({ company, user }: Props) {
       });
     },
   });
-  const [resendInvitation] = useMutation(RESEND_INVITATION, {
-    onCompleted: () => {
-      cogoToast.success("Invitation renvoyée", { hideAfter: 5 });
-    },
-    onError: () => {
-      cogoToast.error("L'invitation n'a pas pu être renvoyée", {
-        hideAfter: 5,
-      });
-    },
-  });
+  const [resendInvitation, { loading: resendLoading }] = useMutation(
+    RESEND_INVITATION,
+    {
+      onCompleted: () => {
+        cogoToast.success("Invitation renvoyée", { hideAfter: 5 });
+      },
+      onError: () => {
+        cogoToast.error(
+          "L'invitation n'a pas pu être renvoyée. Veuillez réessayer dans quelques minutes.",
+          {
+            hideAfter: 5,
+          }
+        );
+      },
+    }
+  );
   return (
     <>
       <tr key={user.id}>
@@ -130,25 +136,31 @@ export default function AccountCompanyMember({ company, user }: Props) {
             <td className={styles["right-column"]}>
               <button
                 className="btn btn--primary"
+                disabled={deleteLoading}
                 onClick={() => {
                   deleteInvitation({
                     variables: { email: user.email, siret: company.siret },
                   });
                 }}
               >
-                <IconTrash /> Supprimer l'invitation
+                <IconTrash />{" "}
+                {deleteLoading
+                  ? "Suppression en cours"
+                  : "Supprimer l'invitation"}
               </button>
             </td>
             <td className={styles["right-column"]}>
               <button
                 className="btn btn--primary"
+                disabled={resendLoading}
                 onClick={() => {
                   resendInvitation({
                     variables: { email: user.email, siret: company.siret },
                   });
                 }}
               >
-                <IconEmailActionUnread /> Renvoyer l'invitation
+                <IconEmailActionUnread />{" "}
+                {resendLoading ? "Envoi en cours" : "Renvoyer l'invitation"}
               </button>
             </td>
           </>


### PR DESCRIPTION
Par sécurité, le renvoi d'invitations a été limité à une req/minutes, ce qui est pénalisant pour un utilisateur qui souhaite renvoyer plusieurs invitations distinctes.
Cette pr monte la limite à 10 requêtes par tranche de 3 minutes. 
Mise à jour du front pour afficher un message d'erreur plus explicite et figer les boutons pendant l’exécution de la requête.
 

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8031)
