### PR TITLE
Route temporaire pour vérifier les headers

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -229,6 +229,9 @@ app.use(authRouter);
 app.use(oauth2Router);
 
 app.get("/ping", (_, res) => res.send("Pong!"));
+app.get("/ip", (req, res) =>
+  res.send(`IP: ${req.ip} XFF: ${req.get("X-Forwarded-For")}`)
+);
 app.get("/userActivation", userActivationHandler);
 app.get("/download", downloadRouter);
 


### PR DESCRIPTION
Ajoute une route temporaire pour vérifier les headers du CDN en vue de mettre à jour le rate limit.
