### PR TITLE
Utilse le header xff pour déduire l'ip de l'utilisateur

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -6,6 +6,10 @@ API_URL_SCHEME=https
 # Should be set to 4000 when running the API on the host with nginx container in development
 API_PORT=4000
 
+# PROXY/CDN
+# Set to true if app runs behind a trusted cdn, false otherwise as it can lead to security issues
+TRUST_PROXY=false|true
+
 # UI domain configuration
 UI_HOST=trackdechets.beta.gouv.fr
 UI_URL_SCHEME=https

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -45,7 +45,8 @@ const {
   SESSION_NAME,
   UI_HOST,
   MAX_REQUESTS_PER_WINDOW = "1000",
-  NODE_ENV
+  NODE_ENV,
+  TRUST_PROXY
 } = process.env;
 
 const Sentry = initSentry();
@@ -104,6 +105,11 @@ export const server = new ApolloServer({
 });
 
 export const app = express();
+
+if (TRUST_PROXY === "true") {
+  // when app runs behind a cdn, this allows us to get the forwarded user ip for rate limit
+  app.set("trust proxy", true);
+}
 
 if (Sentry) {
   // The request handler must be the first middleware on the app
@@ -229,9 +235,9 @@ app.use(authRouter);
 app.use(oauth2Router);
 
 app.get("/ping", (_, res) => res.send("Pong!"));
-app.get("/ip", (req, res) =>
-  res.send(`IP: ${req.ip} XFF: ${req.get("X-Forwarded-For")}`)
-);
+app.get("/ip", (req, res) => {
+  return res.send(`IP: ${req.ip} XFF: ${req.get("X-Forwarded-For")}`);
+});
 app.get("/userActivation", userActivationHandler);
 app.get("/download", downloadRouter);
 


### PR DESCRIPTION
La mise en place d'un cdn remplace l'ip de l'utilisateur par les ips du cdn, ce qui compromet le fonctionnement du rate-limit. Cette pr utilise le header x-forwarded-for fourni par le cdn pour déduire l'ip utilisateur. Ce comportement est activable par le setting TRUST_PROXY afin de pas l'utiliser sur les instances sans cdn.

 