### PR TITLE
Fix query `appendixForms`

### DIFF
--- a/back/src/forms/resolvers/queries/appendixForms.ts
+++ b/back/src/forms/resolvers/queries/appendixForms.ts
@@ -14,11 +14,21 @@ const appendixFormsResolver: QueryResolvers["appendixForms"] = async (
 
   const queriedForms = await prisma.form.findMany({
     where: {
-      ...(wasteCode && { wasteDetailsCode: wasteCode }),
-      status: "AWAITING_GROUP",
-      recipientCompanySiret: siret,
-      isDeleted: false,
-      appendix2RootFormId: null
+      AND: [
+        ...(wasteCode ? [{ wasteDetailsCode: wasteCode }] : []),
+        { status: "AWAITING_GROUP" },
+        {
+          OR: [
+            { recipientCompanySiret: siret },
+            {
+              recipientIsTempStorage: true,
+              temporaryStorageDetail: { destinationCompanySiret: siret }
+            }
+          ]
+        },
+        { isDeleted: false },
+        { appendix2RootFormId: null }
+      ]
     }
   });
 


### PR DESCRIPTION
La query ne faisait pas remonter les bordereaux en attente de regroupement après entreposage provisoire

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
