### PR TITLE
Hotfix : hotfix sur le rattachement des AnonymousCompany non-diffusibles et Ajout query companyPrivateInfos

### DIFF
--- a/back/src/companies/resolvers/CompanySearchPrivate.ts
+++ b/back/src/companies/resolvers/CompanySearchPrivate.ts
@@ -1,0 +1,46 @@
+import prisma from "../../prisma";
+import { CompanySearchPrivateResolvers } from "../../generated/graphql/types";
+import { CompanyBaseIdentifiers } from "../types";
+import { whereSiretOrVatNumber } from "./CompanySearchResult";
+
+const companySearchPrivateResolvers: CompanySearchPrivateResolvers = {
+  transporterReceipt: async parent => {
+    const transporterReceipt = await prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .transporterReceipt();
+    return transporterReceipt;
+  },
+  traderReceipt: async parent => {
+    const traderReceipt = await prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .traderReceipt();
+    return traderReceipt;
+  },
+  brokerReceipt: async parent => {
+    return await prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .brokerReceipt();
+  },
+  vhuAgrementBroyeur: parent => {
+    return prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .vhuAgrementBroyeur();
+  },
+  vhuAgrementDemolisseur: parent => {
+    return prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .vhuAgrementDemolisseur();
+  }
+};
+
+export default companySearchPrivateResolvers;

--- a/back/src/companies/resolvers/Query.ts
+++ b/back/src/companies/resolvers/Query.ts
@@ -1,5 +1,6 @@
 import { QueryResolvers } from "../../generated/graphql/types";
 import companyInfos from "./queries/companyInfos";
+import companyPrivateInfos from "./queries/companyPrivateInfos";
 import searchCompanies from "./queries/searchCompanies";
 import favorites from "./queries/favorites";
 import ecoOrganismes from "./queries/ecoOrganismes";
@@ -7,6 +8,7 @@ import companiesForVerification from "./queries/companiesForVerification";
 
 const Query: QueryResolvers = {
   companyInfos,
+  companyPrivateInfos,
   searchCompanies,
   favorites,
   ecoOrganismes,

--- a/back/src/companies/resolvers/index.ts
+++ b/back/src/companies/resolvers/index.ts
@@ -7,6 +7,7 @@ import CompanyPrivate from "./CompanyPrivate";
 import CompanyFavorite from "./CompanyFavorite";
 import CompanySearchResult from "./CompanySearchResult";
 import CompanyForVerification from "./CompanyForVerification";
+import CompanySearchPrivate from "./CompanySearchPrivate";
 
 export default {
   Query,
@@ -17,5 +18,6 @@ export default {
   CompanyPrivate,
   CompanyFavorite,
   CompanySearchResult,
-  CompanyForVerification
+  CompanyForVerification,
+  CompanySearchPrivate
 };

--- a/back/src/companies/resolvers/queries/companyPrivateInfos.ts
+++ b/back/src/companies/resolvers/queries/companyPrivateInfos.ts
@@ -1,0 +1,32 @@
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import {
+  CompanySearchPrivate,
+  QueryResolvers
+} from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+import { getCompanyInfos } from "./companyInfos";
+
+const companyInfosResolvers: QueryResolvers["companyPrivateInfos"] = async (
+  parent,
+  args,
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  checkIsAuthenticated(context);
+  const cleanClue = args.clue.replace(/\s/g, "").toUpperCase();
+  const [companyInfos, isAnonymousCompany] = await Promise.all([
+    getCompanyInfos(cleanClue),
+    prisma.anonymousCompany.count({
+      where: { siret: cleanClue }
+    })
+  ]);
+
+  return {
+    ...companyInfos,
+    // We don't need this infos in this query
+    isAnonymousCompany: isAnonymousCompany > 0
+  } as CompanySearchPrivate;
+};
+
+export default companyInfosResolvers;

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -70,6 +70,8 @@ export async function searchCompany(
     select: {
       id: true,
       siret: true,
+      name: true,
+      address: true,
       vatNumber: true,
       companyTypes: true,
       contactEmail: true,
@@ -85,8 +87,8 @@ export async function searchCompany(
     ecoOrganismeAgreements: [],
     isRegistered: trackdechetsCompanyInfo != null,
     companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
-    ...companyInfo,
-    ...convertUrls(trackdechetsCompanyInfo)
+    ...convertUrls(trackdechetsCompanyInfo),
+    ...companyInfo
   };
 }
 

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -32,7 +32,7 @@ export const searchCompanySocialGouvThrottled = backoffIfTestEnvs(
 
 // list different implementations of searchCompany by order of priority.
 // please keep searchCompanyTD then searchCompanyInseeThrottled in this order
-// in order to keep anonymous companies processing
+// in order to preserve anonymous companies processing
 const searchCompanyProviders = [
   searchCompanyTD,
   searchCompanyInseeThrottled,

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -90,6 +90,7 @@ type CompanyPrivate {
   """
   ecoOrganismeAgreements: [URL!]!
 
+  "L'entreprise autorise l'enlèvement d'un Dasri sans sa signature"
   allowBsdasriTakeOverWithoutSignature: Boolean!
 }
 

--- a/back/src/companies/typeDefs/company.queries.graphql
+++ b/back/src/companies/typeDefs/company.queries.graphql
@@ -13,8 +13,8 @@ type Query {
   ): CompanyPublic!
 
   """
-  Effectue une recherche floue sur la base SIRENE et enrichit
-  les résultats avec des informations provenant de Trackdéchets
+  Effectue une recherche floue sur la base SIRENE et enrichie
+  avec des informations provenant de Trackdéchets
   """
   searchCompanies(
     """

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -86,3 +86,113 @@ type AnonymousCompany {
   siret: String!
   vatNumber: String
 }
+
+"Information sur un établissement recherché par le frontend"
+type CompanySearchPrivate {
+  "Profil de l'établissement"
+  companyTypes: [CompanyType!]!
+
+  "Identifiant GEREP"
+  gerepId: String
+
+  "Code de signature permettant de signer les BSD"
+  securityCode: Int
+
+  "État du processus de vérification de l'établissement"
+  verificationStatus: CompanyVerificationStatus
+
+  "Email de contact (visible sur la fiche entreprise)"
+  contactEmail: String
+
+  "Numéro de téléphone de contact (visible sur la fiche entreprise)"
+  contactPhone: String
+
+  "Site web (visible sur la fiche entreprise)"
+  website: String
+
+  "Liste des utilisateurs appartenant à cet établissement"
+  users: [CompanyMember!]
+
+  "Rôle de l'utilisateur authentifié au sein de cet établissement"
+  userRole: UserRole
+
+  """
+  Nom d'usage de l'entreprise qui permet de différencier
+  différents établissements ayant le même nom
+  """
+  givenName: String
+
+  "SIRET de l'établissement"
+  siret: String
+
+  "Numéro de TVA de l'établissement"
+  vatNumber: String
+
+  "Adresse de l'établissement"
+  address: String
+
+  "Nom de l'établissement"
+  name: String
+
+  "Code NAF de l'établissement"
+  naf: String
+
+  "Libellé NAF de l'établissement"
+  libelleNaf: String
+
+  """
+  Installation classée pour la protection de l'environnement (ICPE)
+  associé à cet établissement (le cas échéant)
+  """
+  installation: Installation
+
+  """
+  Récépissé transporteur (le cas échéant, pour les profils transporteur)
+  """
+  transporterReceipt: TransporterReceipt
+
+  """
+  Récépissé négociant (le cas échéant, pour les profils négociant)
+  """
+  traderReceipt: TraderReceipt
+
+  """
+  Récépissé courtier (le cas échéant, pour les profils courtier)
+  """
+  brokerReceipt: BrokerReceipt
+
+  """
+  Agrément démolisseur (le cas échéant, pour les profils VHU)
+  """
+  vhuAgrementDemolisseur: VhuAgrement
+
+  """
+  Agrément broyeur (le cas échéant, pour les profils VHU)
+  """
+  vhuAgrementBroyeur: VhuAgrement
+
+  """
+  Liste des agréments de l'éco-organisme
+  """
+  ecoOrganismeAgreements: [URL!]
+
+  "L'entreprise autorise l'enlèvement d'un Dasri sans sa signature"
+  allowBsdasriTakeOverWithoutSignature: Boolean
+
+  "Code pays de l'établissement"
+  codePaysEtrangerEtablissement: String
+  "État administratif de l'établissement. A = Actif, F = Fermé"
+  etatAdministratif: String
+  "Statut de diffusion de l'établissement selon l'INSEE. O = Oui, N = Non"
+  statutDiffusionEtablissement: String
+
+  """
+  Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets
+  """
+  isRegistered: Boolean!
+
+  """
+  Si oui on non cet établissement est inscrit sur TD comme AnonymousCompany
+  """
+  isAnonymousCompany: Boolean
+}

--- a/back/src/companies/typeDefs/private/company.queries.graphql
+++ b/back/src/companies/typeDefs/private/company.queries.graphql
@@ -20,4 +20,13 @@ type Query {
     skip: Int
     where: CompanyForVerificationWhere
   ): CompanyForVerificationConnection!
+
+  """
+  Renvoie des informations restreintes sur un établissement
+  selon la même recherche par siret ou TVA que companyInfos
+  """
+  companyPrivateInfos(
+    """SIRET ou numéro TVA intracommunautaire"""
+    clue: String!
+  ): CompanySearchPrivate!
 }

--- a/back/src/companies/types.ts
+++ b/back/src/companies/types.ts
@@ -4,6 +4,7 @@ import { CompanyType } from "../generated/graphql/types";
 export interface CompanySearchResult extends CompanyBaseIdentifiers {
   address: string;
   name: string;
+  // Ouvert "A", Fermé "F" (INSEE)
   etatAdministratif?: string;
   codeCommune?: string;
   naf?: string;
@@ -11,9 +12,11 @@ export interface CompanySearchResult extends CompanyBaseIdentifiers {
   addressVoie?: string;
   addressCity?: string;
   addressPostalCode?: string;
+  // Enregistré sur TD
   isRegistered: boolean;
   companyTypes: CompanyType[];
   ecoOrganismeAgreements?: URL[];
+  // diffusible ou non-diffusible légalement (INSEE)
   statutDiffusionEtablissement: "O" | "N";
 }
 /**

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { gql, useLazyQuery, useMutation } from "@apollo/client";
 import { Field, Form, Formik } from "formik";
 import cogoToast from "cogo-toast";
-import { COMPANY_INFOS } from "form/common/components/company/query";
+import { COMPANY_PRIVATE_INFOS } from "form/common/components/company/query";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import AutoFormattingCompanyInfosInput from "common/components/AutoFormattingCompanyInfosInput";
 import {
@@ -42,17 +42,21 @@ export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
   const [isNonDiffusible, setIsNonDiffusible] = useState(false);
 
   const [searchCompany, { loading, error }] = useLazyQuery<
-    Pick<Query, "companyInfos">
-  >(COMPANY_INFOS, {
+    Pick<Query, "companyPrivateInfos">
+  >(COMPANY_PRIVATE_INFOS, {
     onCompleted: data => {
-      if (data && data.companyInfos) {
-        const companyInfos = data.companyInfos;
+      if (data && data.companyPrivateInfos) {
+        const companyInfos = data.companyPrivateInfos;
         if (companyInfos.etatAdministratif === "F") {
           cogoToast.error(
             "Cet établissement est fermé, impossible de le créer"
           );
         } else {
-          if (companyInfos?.statutDiffusionEtablissement === "N") {
+          // Non-diffusible mais pas encore inscrit en AnonymousCompany
+          if (
+            companyInfos?.statutDiffusionEtablissement === "N" &&
+            !companyInfos?.isAnonymousCompany
+          ) {
             setIsNonDiffusible(true);
             onCompanyInfos(null);
           } else {
@@ -112,7 +116,7 @@ export default function AccountCompanyAddSiret({ onCompanyInfos }: IProps) {
           // reset company infos
           onCompanyInfos(null);
           searchCompany({
-            variables: { siret: values.siret },
+            variables: { clue: values.siret },
           });
         }}
       >

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -36,7 +36,7 @@ export const FAVORITES = gql`
 `;
 
 export const COMPANY_INFOS = gql`
-  query SignupCompanyInfos($siret: String!, $clue: String) {
+  query CompanyInfos($siret: String!, $clue: String) {
     companyInfos(siret: $siret, clue: $clue) {
       siret
       vatNumber
@@ -96,6 +96,42 @@ export const SEARCH_COMPANIES = gql`
       }
       vhuAgrementBroyeur {
         agrementNumber
+        department
+      }
+    }
+  }
+`;
+
+export const COMPANY_PRIVATE_INFOS = gql`
+  query CompanyPrivateInfos($clue: String!) {
+    companyPrivateInfos(clue: $clue) {
+      siret
+      vatNumber
+      name
+      naf
+      libelleNaf
+      address
+      etatAdministratif
+      statutDiffusionEtablissement
+      isRegistered
+      isAnonymousCompany
+      companyTypes
+      installation {
+        codeS3ic
+        urlFiche
+        rubriques {
+          rubrique
+          category
+        }
+      }
+      transporterReceipt {
+        receiptNumber
+        validityLimit
+        department
+      }
+      traderReceipt {
+        receiptNumber
+        validityLimit
         department
       }
     }


### PR DESCRIPTION
# Fix sur le rattachement des AnonymousCompany non-diffusibles
### suite de #1368

- une nouvelle query réservée au frontend companyPrivateInfos pour le frontend car companyInfos étant publique, on ne peut divulguer certaines infos

---
- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8030)
