### PR TITLE
Restreindre company.companyType à TRANSPORTER quand identifié par TVA

### DIFF
--- a/.github/workflows/deploy-recette.yml
+++ b/.github/workflows/deploy-recette.yml
@@ -32,3 +32,4 @@ jobs:
           environment: recette
           sourcemaps: ./back/dist/src ./front/build/assets
           projects: trackdechets-api trackdechets-front
+          ignore_missing: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
           environment: production
           sourcemaps: ./back/dist/src ./front/build/assets
           projects: trackdechets-api trackdechets-front
+          ignore_missing: true
 
   doc:
     # Taken from https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Auto-remplissage du pays et du numéro TVA éventuel pour le PDF des BSDD (transporteurs identifiés par TVA) [PR 1399](https://github.com/MTES-MCT/trackdechets/pull/1399)
 - Permettre d'éditer les champs Bsdd champ libre et plaques d'immatriculations pour le statut SIGNED_BY_PRODUCER [PR 1416](https://github.com/MTES-MCT/trackdechets/pull/1416)
+- Restreindre les changements de type d'établissement à Transporteur seulement quand un établissement est identifié par un numéro de TVA. [PR 1390](https://github.com/MTES-MCT/trackdechets/pull/1390)
 
 #### :memo: Documentation
 

--- a/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
@@ -114,4 +114,39 @@ describe("mutation updateCompany", () => {
       })
     ]);
   });
+
+  it("should return an error when trying to change Company type of a TRANSPORTER identified by VAT number", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      companyTypes: {
+        set: ["TRANSPORTER"]
+      },
+      vatNumber: "RO17579668",
+      siret: "RO17579668"
+    });
+
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const { errors } = await mutate(UPDATE_COMPANY, {
+      variables: {
+        siret: company.vatNumber,
+        companyTypes: ["ECO_ORGANISME", "TRANSPORTER"]
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Impossible de changer de type TRANSPORTER pour un établissement transporteur identifié par son numéro de TVA"
+      })
+    ]);
+
+    const { errors: errors2 } = await mutate(UPDATE_COMPANY, {
+      variables: {
+        siret: company.vatNumber,
+        companyTypes: ["TRANSPORTER"]
+      }
+    });
+
+    expect(errors2).toBeUndefined();
+  });
 });

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { CompanyType, Prisma } from "@prisma/client";
 import { UserInputError } from "apollo-server-express";
 import { convertUrls } from "../../database";
 import prisma from "../../../prisma";
@@ -57,6 +57,11 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
   let vatNumber: string;
   if (isVat(orgId)) {
     vatNumber = orgId;
+    if (companyTypes.join("") !== CompanyType.TRANSPORTER) {
+      throw new UserInputError(
+        "Impossible de créer un établissement identifié par un numéro de TVA d'un autre type que TRANSPORTER"
+      );
+    }
   }
   const existingCompany = await prisma.company.findUnique({
     where: whereSiretOrVatNumber({ siret, vatNumber })

--- a/back/src/companies/resolvers/mutations/updateCompany.ts
+++ b/back/src/companies/resolvers/mutations/updateCompany.ts
@@ -82,6 +82,16 @@ const updateCompanyResolver: MutationResolvers["updateCompany"] = async (
 
   const companyTypes = args.companyTypes || company.companyTypes;
   const { ecoOrganismeAgreements } = args;
+  // update to anything else than ony a TRANSPORTER
+  const updateOtherThanTransporter = args.companyTypes?.some(
+    elt => elt !== "TRANSPORTER"
+  );
+  // check that a TRANSPORTER identified by VAT is not updated to any other type
+  if (company.vatNumber === company.siret && updateOtherThanTransporter) {
+    throw new UserInputError(
+      "Impossible de changer de type TRANSPORTER pour un établissement transporteur identifié par son numéro de TVA"
+    );
+  }
   if (companyTypes.includes("ECO_ORGANISME")) {
     if (
       Array.isArray(ecoOrganismeAgreements) &&

--- a/front/src/account/fields/forms/AccountFormCompanyTypes.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyTypes.tsx
@@ -73,7 +73,7 @@ export default function AccountFormCompanyTypes({
           {loading && <div>Envoi en cours...</div>}
 
           {props.errors[name] && (
-            <RedErrorMessage name="phone">{props.errors[name]}</RedErrorMessage>
+            <RedErrorMessage name={name}>{props.errors[name]}</RedErrorMessage>
           )}
           {error && <InlineError apolloError={error} />}
 


### PR DESCRIPTION
Quand on crée le compte, on est restreint au profil de transporteur, mais on peut, depuis Mon Compte, ajouter les profils qu'on veut dans un second temps .

# Solution

- l'api createCompany et updateCompany contrôle et renvoie des erreurs si besoin

![image](https://user-images.githubusercontent.com/76620/169851887-373b5672-d044-4f06-ba01-36b54daa08ec.png)


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7764)
