### PR TITLE
Rectification de la liste des codes traitement éligibles au regroupement

### DIFF
--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -4,7 +4,10 @@ import Tooltip from "common/components/Tooltip";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import { connect, Field } from "formik";
-import { isDangerous } from "generated/constants";
+import {
+  isDangerous,
+  PROCESSING_OPERATIONS_GROUPEMENT_CODES,
+} from "generated/constants";
 import React, { useEffect } from "react";
 import Appendix2MultiSelect from "./components/appendix/Appendix2MultiSelect";
 import AppendixInfo from "./components/appendix/AppendixInfo";
@@ -116,7 +119,8 @@ export default connect<{}, Values>(function WasteInfo(props) {
           <p className="tw-my-2">
             Tous les bordereaux présentés ci-dessous correspondent à des
             bordereaux pour lesquels vous avez effectué une opération de
-            traitement de type D 13, D 14, D 15 ou R 13.
+            traitement de type{" "}
+            {PROCESSING_OPERATIONS_GROUPEMENT_CODES.join(", ")}.
           </p>
           <Appendix2MultiSelect />
         </>


### PR DESCRIPTION
### Avant
 
![image](https://user-images.githubusercontent.com/2269165/168562166-8d27d68f-67bc-4956-b7c2-80b6b1449f21.png)


### Après 

![Capture d’écran 2022-05-16 à 11 23 56](https://user-images.githubusercontent.com/2269165/168561819-075e6654-3503-47da-9968-87472799e0e5.png)

- [[BSDD] Rectifier la Liste des codes traitement éligibles au regroupement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-8037)
