### PR TITLE
Fix code ADR perdu après duplication

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteEmissionSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteEmissionSummary.tsx
@@ -64,6 +64,7 @@ export function FormWasteEmissionSummary({
   form,
 }: FormWasteEmissionSummaryProps) {
   const { values } = useFormikContext<FormValues>();
+
   const [fields, setFields] = React.useState<FormKeys[]>([]);
   const addField = (name: FormKeys) =>
     setFields(currentFields =>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionForm.tsx
@@ -64,21 +64,33 @@ function SignEmissionFormModal({
     MutationSignEmissionFormArgs
   >(SIGN_EMISSION_FORM);
 
+  const initialValues = {
+    emittedBy: "",
+    emittedByType: EmitterType.Emitter,
+    securityCode: "",
+    ...(form.status === FormStatus.Resealed
+      ? {
+          packagingInfos:
+            form.temporaryStorageDetail?.wasteDetails?.packagingInfos,
+          quantity: form.temporaryStorageDetail?.wasteDetails?.quantity ?? 0,
+          onuCode: form.temporaryStorageDetail?.wasteDetails?.onuCode ?? "",
+          transporterNumberPlate:
+            form.temporaryStorageDetail?.transporter?.numberPlate ?? "",
+        }
+      : {
+          packagingInfos: form.wasteDetails?.packagingInfos,
+          quantity: form.wasteDetails?.quantity ?? 0,
+          onuCode: form.wasteDetails?.onuCode ?? "",
+          transporterNumberPlate: form.transporter?.numberPlate ?? "",
+        }),
+  };
+
   return (
     <Modal onClose={onClose} ariaLabel={title} isOpen>
       <h2 className="td-modal-title">{title}</h2>
 
       <Formik
-        initialValues={{
-          packagingInfos: form.stateSummary?.packagingInfos,
-          quantity: form.stateSummary?.quantity ?? 0,
-          onuCode: form.stateSummary?.onuCode ?? "",
-          transporterNumberPlate:
-            form.stateSummary?.transporterNumberPlate ?? "",
-          emittedBy: "",
-          emittedByType: EmitterType.Emitter,
-          securityCode: "",
-        }}
+        initialValues={initialValues}
         validationSchema={validationSchema}
         onSubmit={async values => {
           try {


### PR DESCRIPTION
[BSDD: Code ADR perdu après duplication -  en cas d'entreposage provisoire](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8043)

Correction d'un bug lié à l'utilisation de `stateSummary` dans la modale d'émission d'un BSDD en cas de duplication de bordereau.
