### PR TITLE
keep 10000 completed job in mail queue

### DIFF
--- a/back/src/queue/producer.ts
+++ b/back/src/queue/producer.ts
@@ -7,7 +7,11 @@ const { REDIS_URL, QUEUE_NAME_SENDMAIL } = process.env;
 /**
  * Connect to mailQueue once for the server
  */
-export const mailQueue = new Queue(`${QUEUE_NAME_SENDMAIL}`, `${REDIS_URL}`);
+export const mailQueue = new Queue(`${QUEUE_NAME_SENDMAIL}`, `${REDIS_URL}`, {
+  defaultJobOptions: {
+    removeOnComplete: 10_000
+  }
+});
 
 /**
  * Utility function to add a sendMailJob to the queue


### PR DESCRIPTION
# A number specified the amount of jobs to keep. Default behavior is to keep the job in the completed set.

https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue
