### PR TITLE
augmentation parallélisme jest & utilisation de `jest --shard` avec v28

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,11 +5,11 @@ on: pull_request
 jobs:
   back:
     runs-on: ubuntu-latest
-    name: Integration tests (chunk ${{ matrix.chunk }}/${{ strategy.job-total }})
+    name: Integration tests (chunk ${{ matrix.shard }}/${{ strategy.job-total }})
     strategy:
       fail-fast: false
       matrix:
-        chunk: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     defaults:
       run:
         working-directory: back/integration-tests
@@ -22,4 +22,4 @@ jobs:
 
         run: |
           chmod +x ./run.sh
-          ./run.sh -c ${{ matrix.chunk }}-${{ strategy.job-total }}
+          ./run.sh -c ${{ matrix.shard }}/${{ strategy.job-total }}

--- a/back/integration-tests/run.sh
+++ b/back/integration-tests/run.sh
@@ -41,14 +41,8 @@ all(){
 
 chunk() {
     startcontainers
-
-    mapfile -t chunk_infos < <(echo "$1" | tr "-" "\n")
-    echo "🔢 >> Chunk index: ${chunk_infos[0]}/${chunk_infos[1]}"
-    tests_to_run=$(dockerexec "./integration-tests/get-chunk.sh ${chunk_infos[0]} ${chunk_infos[1]}")
-    chunk_length=$(echo "$tests_to_run" | tr -cd '|' | wc -c)
-    echo "📏 >> Chunk length $chunk_length"
-
-    runtest "(${tests_to_run::-1})"
+    echo "🔢 >> Chunk index: $1"
+    runtest "-- --shard=$1"
     stopcontainers
 }
 


### PR DESCRIPTION
- Les 4 shards étaient très lents
- J'en propose 6
- Jest v28 propose un param de sharding facile que j'utilise du coup https://jestjs.io/blog/2022/04/25/jest-28#sharding-of-test-run


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

