### PR TITLE
Hotfix: Protège le moniteur de task queue derrière une auth session

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -245,7 +245,17 @@ app.use(
   serveStatic(path.join(__dirname, "common/plugins/graphiql/assets"))
 );
 
-app.use(bullBoardPath, serverAdapter.getRouter());
+function ensureLoggedInAndAdmin() {
+  // check passeport populated user is admin
+  return function (req, res, next) {
+    if (!req.isAuthenticated || !req.isAuthenticated() || !req?.user?.isAdmin) {
+      return res.status(404).send("Not found");
+    }
+
+    next();
+  };
+}
+app.use(bullBoardPath, ensureLoggedInAndAdmin(), serverAdapter.getRouter());
 
 // Apply passport auth middlewares to the graphQL endpoint
 app.use(graphQLPath, passportBearerMiddleware, passportJwtMiddleware);


### PR DESCRIPTION
Le queue monitor a été mis en place rapidement et reste accessible sans authentification. Cette PR le restreint aux utilisateurs admins loggués.

- [Ticket Favro]()
