### PR TITLE
Hotfix: Re-enable iff header parsing for rate limit

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -38,6 +38,7 @@ import { resolvers, typeDefs } from "./schema";
 import { userActivationHandler } from "./users/activation";
 import { createUserDataLoaders } from "./users/dataloaders";
 import { getUIBaseURL } from "./utils";
+import forwarded from "forwarded";
 
 const {
   SESSION_SECRET,
@@ -46,7 +47,8 @@ const {
   SESSION_NAME,
   UI_HOST,
   MAX_REQUESTS_PER_WINDOW = "1000",
-  NODE_ENV
+  NODE_ENV,
+  USE_XFF_HEADER
 } = process.env;
 
 const Sentry = initSentry();
@@ -123,6 +125,15 @@ app.use(
     message: `Quota de ${maxrequestPerWindows} requêtes par minute excédé pour cette adresse IP, merci de réessayer plus tard.`,
     windowMs: RATE_LIMIT_WINDOW_SECONDS * 1000,
     max: maxrequestPerWindows,
+    keyGenerator: request => {
+      // use xff data as client ip when behind a cdn
+      if (USE_XFF_HEADER !== "true") {
+        return request.ip;
+      }
+      const parsed = forwarded(request);
+      const clientIp = parsed.slice(-1).pop();
+      return !!clientIp ? clientIp : request.ip;
+    },
     store
   })
 );
@@ -230,6 +241,16 @@ app.use(authRouter);
 app.use(oauth2Router);
 
 app.get("/ping", (_, res) => res.send("Pong!"));
+
+app.get("/ip", (req, res) => {
+  const parsed = forwarded(req);
+
+  return res.send(
+    `IP: ${req.ip} | XFF: ${req.get("X-Forwarded-For")} | parsed: ${parsed
+      .slice(-1)
+      .pop()}`
+  );
+});
 
 app.get("/userActivation", userActivationHandler);
 app.get("/download", downloadRouter);


### PR DESCRIPTION
L'usage du header xff avait été désactivé lors de l'incident du 18/05.
