### PR TITLE
Permet d'éditer les champs transporteurs pour le statut SIGNED_BY_PRODUCER

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Auto-remplissage du pays et du numéro TVA éventuel pour le PDF des BSDD (transporteurs identifiés par TVA) [PR 1399](https://github.com/MTES-MCT/trackdechets/pull/1399)
+- Permettre d'éditer les champs Bsdd champ libre et plaques d'immatriculations pour le statut SIGNED_BY_PRODUCER [PR 1416](https://github.com/MTES-MCT/trackdechets/pull/1416)
 
 #### :memo: Documentation
 

--- a/back/src/common/constants/formHelpers.ts
+++ b/back/src/common/constants/formHelpers.ts
@@ -1,0 +1,2 @@
+export const isBsddTransporterFieldEditable = status =>
+  ["SEALED", "SIGNED_BY_PRODUCER"].includes(status);

--- a/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
@@ -97,7 +97,7 @@ describe("Forms -> updateTransporterFields mutation", () => {
   `;
     const { errors } = await mutate(mutation);
     expect(errors[0].message).toEqual(
-      "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé"
+      "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé ou signé par le producteur"
     );
 
     form = await prisma.form.findUnique({ where: { id: form.id } });

--- a/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
@@ -5,7 +5,7 @@ import {
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
-
+import { Status as FormStatus } from "@prisma/client";
 jest.mock("axios", () => ({
   default: {
     get: jest.fn(() => Promise.resolve({ data: {} }))
@@ -15,59 +15,65 @@ jest.mock("axios", () => ({
 describe("Forms -> updateTransporterFields mutation", () => {
   afterEach(resetDatabase);
 
-  it("should update transporter plate", async () => {
-    const { user: emitter } = await userWithCompanyFactory("MEMBER");
-    const { user: transporter, company: transporterCompany } =
-      await userWithCompanyFactory("MEMBER");
+  it.each([FormStatus.SEALED, FormStatus.SIGNED_BY_PRODUCER])(
+    "should update transporter plate (%p status)",
+    async status => {
+      const { user: emitter } = await userWithCompanyFactory("MEMBER");
+      const { user: transporter, company: transporterCompany } =
+        await userWithCompanyFactory("MEMBER");
 
-    let form = await formFactory({
-      ownerId: emitter.id,
-      opt: {
-        status: "SEALED",
-        transporterCompanySiret: transporterCompany.siret
-      }
-    });
-    const { mutate } = makeClient(transporter);
-    const mutation = `
+      let form = await formFactory({
+        ownerId: emitter.id,
+        opt: {
+          status,
+          transporterCompanySiret: transporterCompany.siret
+        }
+      });
+      const { mutate } = makeClient(transporter);
+      const mutation = `
     mutation {
       updateTransporterFields(id: "${form.id}", transporterNumberPlate: "ZBLOP 83") {
         id
       }
     }
   `;
-    await mutate(mutation);
+      await mutate(mutation);
 
-    form = await prisma.form.findUnique({ where: { id: form.id } });
+      form = await prisma.form.findUnique({ where: { id: form.id } });
 
-    expect(form.transporterNumberPlate).toEqual("ZBLOP 83");
-  });
+      expect(form.transporterNumberPlate).toEqual("ZBLOP 83");
+    }
+  );
 
-  it("should update transporter custom info", async () => {
-    const { user: emitter } = await userWithCompanyFactory("MEMBER");
-    const { user: transporter, company: transporterCompany } =
-      await userWithCompanyFactory("MEMBER");
+  it.each([FormStatus.SEALED, FormStatus.SIGNED_BY_PRODUCER])(
+    "should update transporter custom info (%p status)",
+    async status => {
+      const { user: emitter } = await userWithCompanyFactory("MEMBER");
+      const { user: transporter, company: transporterCompany } =
+        await userWithCompanyFactory("MEMBER");
 
-    let form = await formFactory({
-      ownerId: emitter.id,
-      opt: {
-        status: "SEALED",
-        transporterCompanySiret: transporterCompany.siret
-      }
-    });
-    const { mutate } = makeClient(transporter);
-    const mutation = `
+      let form = await formFactory({
+        ownerId: emitter.id,
+        opt: {
+          status,
+          transporterCompanySiret: transporterCompany.siret
+        }
+      });
+      const { mutate } = makeClient(transporter);
+      const mutation = `
     mutation {
       updateTransporterFields(id: "${form.id}", transporterCustomInfo: "tournée 493") {
         id
       }
     }
   `;
-    await mutate(mutation);
+      await mutate(mutation);
 
-    form = await prisma.form.findUnique({ where: { id: form.id } });
+      form = await prisma.form.findUnique({ where: { id: form.id } });
 
-    expect(form.transporterCustomInfo).toEqual("tournée 493");
-  });
+      expect(form.transporterCustomInfo).toEqual("tournée 493");
+    }
+  );
 
   it("should not update not SEALED forms", async () => {
     const { user: emitter } = await userWithCompanyFactory("MEMBER");

--- a/back/src/forms/resolvers/mutations/updateTransporterFields.ts
+++ b/back/src/forms/resolvers/mutations/updateTransporterFields.ts
@@ -16,7 +16,7 @@ const updateTransporterFieldsResolver: MutationResolvers["updateTransporterField
 
     const form = await getFormOrFormNotFound({ id });
 
-    if (form.status !== "SEALED") {
+    if (!["SEALED", "SIGNED_BY_PRODUCER"].includes(form.status)) {
       throw new ForbiddenError(
         "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé"
       );

--- a/back/src/forms/resolvers/mutations/updateTransporterFields.ts
+++ b/back/src/forms/resolvers/mutations/updateTransporterFields.ts
@@ -1,5 +1,6 @@
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { isBsddTransporterFieldEditable } from "../../../common/constants/formHelpers";
 import { getFormOrFormNotFound } from "../../database";
 import { ForbiddenError } from "apollo-server-express";
 import { checkCanUpdateTransporterFields } from "../../permissions";
@@ -16,9 +17,9 @@ const updateTransporterFieldsResolver: MutationResolvers["updateTransporterField
 
     const form = await getFormOrFormNotFound({ id });
 
-    if (!["SEALED", "SIGNED_BY_PRODUCER"].includes(form.status)) {
+    if (!isBsddTransporterFieldEditable(form.status)) {
       throw new ForbiddenError(
-        "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé"
+        "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé ou signé par le producteur"
       );
     }
 

--- a/back/src/forms/typeDefs/bsdd.mutations.graphql
+++ b/back/src/forms/typeDefs/bsdd.mutations.graphql
@@ -15,7 +15,10 @@ type Mutation {
   saveForm("Payload du BSD" formInput: FormInput!): Form
     @deprecated(reason: "Utiliser createForm / updateForm selon le besoin")
 
-  "Met à jour la plaque d'immatriculation ou le champ libre du transporteur"
+  """
+  Met à jour la plaque d'immatriculation ou le champ libre du transporteur.
+  Disponible pour le Bsdd au statut SEALED ou SIGNED_BY_PRODUCER.
+  """
   updateTransporterFields(
     "ID d'un BSD"
     id: ID!

--- a/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
@@ -2,7 +2,8 @@ import { useMutation, gql } from "@apollo/client";
 import { useFormik } from "formik";
 import React, { useState } from "react";
 
-import { Form as FormModel, FormStatus } from "generated/graphql/types";
+import { Form as FormModel } from "generated/graphql/types";
+import { isBsddTransporterFieldEditable } from "generated/constants/formHelpers";
 import { NotificationError } from "common/components/Error";
 import { capitalize } from "common/helper";
 import { IconPaperWrite } from "common/components/Icons";
@@ -65,7 +66,7 @@ export default function TransporterInfoEdit({
     },
   });
 
-  if (![FormStatus.Sealed, FormStatus.SignedByProducer].includes(form.status)) {
+  if (!isBsddTransporterFieldEditable(form.status)) {
     return null;
   }
   return (

--- a/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/TransporterInfoEdit.tsx
@@ -2,7 +2,7 @@ import { useMutation, gql } from "@apollo/client";
 import { useFormik } from "formik";
 import React, { useState } from "react";
 
-import { Form as FormModel } from "generated/graphql/types";
+import { Form as FormModel, FormStatus } from "generated/graphql/types";
 import { NotificationError } from "common/components/Error";
 import { capitalize } from "common/helper";
 import { IconPaperWrite } from "common/components/Icons";
@@ -65,7 +65,7 @@ export default function TransporterInfoEdit({
     },
   });
 
-  if (form.status !== "SEALED") {
+  if (![FormStatus.Sealed, FormStatus.SignedByProducer].includes(form.status)) {
     return null;
   }
   return (


### PR DESCRIPTION
Même si l'émetteur a signé en amont de la collecte, ETQ transporteur, je peux quand-même accéder au Champ Libre et plaque immat, qui est notamment présenté comme le moyen pour les transporteur d'assigner un BSD à un chauffeur donné pour sa tournée

- [x ] Mettre à jour la documentation
- [x] Mettre à jour le change log

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7854)
