### PR TITLE
Les infos de contact et récepissé courtier / négociant sont obligatoires

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
     - `FormFraction`
     - `InitialFormFractionInput`
   - Suppression de `AppendixFormInput.readableId` qui était un champ déjà déprécié
+- Les informations de contact et de récépissé des courtiers et négociants sont désormais obligatoires lorsqu'un courtier ou un négociant apparait sur un BSDD. [PR 1418](https://github.com/MTES-MCT/trackdechets/pull/1418/)
 #### :nail_care: Améliorations
 
 - Auto-remplissage du pays et du numéro TVA éventuel pour le PDF des BSDD (transporteurs identifiés par TVA) [PR 1399](https://github.com/MTES-MCT/trackdechets/pull/1399)

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -74,7 +74,7 @@ describe("Mutation.markAsSealed", () => {
     );
   });
 
-  it.each(["emitter", "recipient", "trader", "transporter"])(
+  it.each(["emitter", "recipient", "trader", "broker", "transporter"])(
     "%p of the BSD can seal it",
     async role => {
       const companyType = (role: string) =>
@@ -96,6 +96,18 @@ describe("Mutation.markAsSealed", () => {
           [`${role}CompanySiret`]: company.siret,
           ...(role !== "recipient"
             ? { recipientCompanySiret: (await destinationFactory()).siret }
+            : {}),
+          ...(["trader", "broker"].includes(role)
+            ? {
+                [`${role}CompanyName`]: "Trader or Broker",
+                [`${role}CompanyContact`]: "Mr Trader or Broker",
+                [`${role}CompanyMail`]: "traderbroker@trackdechets.fr",
+                [`${role}CompanyAddress`]: "Wall street",
+                [`${role}CompanyPhone`]: "00 00 00 00 00",
+                [`${role}Receipt`]: "receipt",
+                [`${role}Department`]: "07",
+                [`${role}ValidityLimit`]: new Date("2023-01-01")
+              }
             : {})
         }
       });
@@ -126,11 +138,6 @@ describe("Mutation.markAsSealed", () => {
   it("the eco-organisme of the BSD can seal it", async () => {
     const emitterCompany = await companyFactory();
     const recipientCompany = await destinationFactory();
-    const traderCompany = await companyFactory({
-      companyTypes: {
-        set: [CompanyType.TRADER]
-      }
-    });
 
     const { user, company: ecoOrganismeCompany } = await userWithCompanyFactory(
       "MEMBER"
@@ -151,7 +158,6 @@ describe("Mutation.markAsSealed", () => {
         emitterType: "OTHER",
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: recipientCompany.siret,
-        traderCompanySiret: traderCompany.siret,
         ecoOrganismeSiret: eo.siret,
         ecoOrganismeName: eo.name
       }
@@ -805,5 +811,89 @@ describe("Mutation.markAsSealed", () => {
     });
 
     expect(sendMailSpy).not.toHaveBeenCalled();
+  });
+
+  it("should throw a ValidationError if missing broker contact info", async () => {
+    const { user, company: emitter } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: [CompanyType.PRODUCER]
+    });
+    const recipient = await companyFactory({
+      companyTypes: [CompanyType.WASTEPROCESSOR]
+    });
+
+    const broker = await companyFactory();
+
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: Status.DRAFT,
+        emitterCompanySiret: emitter.siret,
+        recipientCompanySiret: recipient.siret,
+        brokerCompanySiret: broker.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate(MARK_AS_SEALED, {
+      variables: { id: form.id }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.\n" +
+          "Erreur(s): Courtier : Le nom de l'entreprise est obligatoire\n" +
+          "Courtier : L'adresse de l'entreprise est obligatoire\n" +
+          "Courtier : Le contact dans l'entreprise est obligatoire\n" +
+          "Courtier : Le téléphone de l'entreprise est obligatoire\n" +
+          "Courtier : L'email de l'entreprise est obligatoire\n" +
+          "Courtier : Numéro de récepissé obligatoire\n" +
+          "Courtier : Département obligatoire\n" +
+          "Courtier : Date de validité obligatoire"
+      })
+    ]);
+  });
+
+  it("should throw a ValidationError if missing trader contact info", async () => {
+    const { user, company: emitter } = await userWithCompanyFactory("MEMBER", {
+      companyTypes: [CompanyType.PRODUCER]
+    });
+    const recipient = await companyFactory({
+      companyTypes: [CompanyType.WASTEPROCESSOR]
+    });
+
+    const broker = await companyFactory();
+
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: Status.DRAFT,
+        emitterCompanySiret: emitter.siret,
+        recipientCompanySiret: recipient.siret,
+        traderCompanySiret: broker.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate(MARK_AS_SEALED, {
+      variables: { id: form.id }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.\n" +
+          "Erreur(s): Négociant: Le nom de l'entreprise est obligatoire\n" +
+          "Négociant: L'adresse de l'entreprise est obligatoire\n" +
+          "Négociant: Le contact dans l'entreprise est obligatoire\n" +
+          "Négociant: Le téléphone de l'entreprise est obligatoire\n" +
+          "Négociant: L'email de l'entreprise est obligatoire\n" +
+          "Négociant: Numéro de récepissé obligatoire\n" +
+          "Négociant : Département obligatoire\n" +
+          "Négociant : Date de validité obligatoire"
+      })
+    ]);
   });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -156,7 +156,7 @@ describe("Mutation.updateForm", () => {
     ]);
   });
 
-  it.each(["emitter", "trader", "recipient", "transporter"])(
+  it.each(["emitter", "trader", "broker", "recipient", "transporter"])(
     "should allow %p to update a draft form",
     async role => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
@@ -184,7 +184,7 @@ describe("Mutation.updateForm", () => {
     }
   );
 
-  it.each(["emitter", "trader", "recipient", "transporter"])(
+  it.each(["emitter", "trader", "broker", "recipient", "transporter"])(
     "should allow %p to update a sealed form",
     async role => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
@@ -192,7 +192,19 @@ describe("Mutation.updateForm", () => {
         ownerId: user.id,
         opt: {
           [`${role}CompanySiret`]: company.siret,
-          status: "SEALED"
+          status: "SEALED",
+          ...(["trader", "broker"].includes(role)
+            ? {
+                [`${role}CompanyName`]: "Trader or Broker",
+                [`${role}CompanyContact`]: "Mr Trader or Broker",
+                [`${role}CompanyMail`]: "traderbroker@trackdechets.fr",
+                [`${role}CompanyAddress`]: "Wall street",
+                [`${role}CompanyPhone`]: "00 00 00 00 00",
+                [`${role}Receipt`]: "receipt",
+                [`${role}Department`]: "07",
+                [`${role}ValidityLimit`]: new Date("2023-01-01")
+              }
+            : {})
         }
       });
 

--- a/back/src/forms/typeDefs/bsdd.mutations.graphql
+++ b/back/src/forms/typeDefs/bsdd.mutations.graphql
@@ -86,6 +86,8 @@ type Mutation {
     pop
   }
   ```
+  Lorsqu'un courtier ou un négociant est présent sur le BSDD, les informations de contact,
+  ainsi que le numéro, la limite de validité et le département du récépissé sont obligatoires.
   """
   markAsSealed("ID d'un BSD" id: ID!): Form
 

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -107,6 +107,32 @@ type Transporter = Pick<
   | "transporterCompanyVatNumber"
 >;
 
+type Trader = Pick<
+  Prisma.FormCreateInput,
+  | "traderCompanyName"
+  | "traderCompanySiret"
+  | "traderCompanyAddress"
+  | "traderCompanyContact"
+  | "traderCompanyPhone"
+  | "traderCompanyMail"
+  | "traderReceipt"
+  | "traderDepartment"
+  | "traderValidityLimit"
+>;
+
+type Broker = Pick<
+  Prisma.FormCreateInput,
+  | "brokerCompanyName"
+  | "brokerCompanySiret"
+  | "brokerCompanyAddress"
+  | "brokerCompanyContact"
+  | "brokerCompanyPhone"
+  | "brokerCompanyMail"
+  | "brokerReceipt"
+  | "brokerDepartment"
+  | "brokerValidityLimit"
+>;
+
 type ReceivedInfo = Pick<
   Prisma.FormCreateInput,
   | "isAccepted"
@@ -532,6 +558,155 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
         ),
       transporterValidityLimit: yup.date().nullable()
     });
+
+export const traderSchemaFn: FactorySchemaOf<boolean, Trader> = isDraft =>
+  yup.object({
+    traderCompanySiret: yup
+      .string()
+      .notRequired()
+      .nullable()
+      .matches(/^$|^\d{14}$/, {
+        message: `Négociant: ${INVALID_SIRET_LENGTH}`
+      }),
+    traderCompanyName: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Négociant: ${MISSING_COMPANY_NAME}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderCompanyAddress: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Négociant: ${MISSING_COMPANY_ADDRESS}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderCompanyContact: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Négociant: ${MISSING_COMPANY_CONTACT}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderCompanyPhone: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Négociant: ${MISSING_COMPANY_PHONE}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderCompanyMail: yup
+      .string()
+      .email()
+      .when("traderCompanySiret", {
+        is: siret => siret?.length === 14,
+        then: schema =>
+          schema
+            .ensure()
+            .requiredIf(!isDraft, `Négociant: ${MISSING_COMPANY_EMAIL}`),
+        otherwise: schema => schema.notRequired().nullable()
+      }),
+    traderReceipt: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, "Négociant: Numéro de récepissé obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderDepartment: yup.string().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, "Négociant : Département obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    traderValidityLimit: yup.date().when("traderCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema.requiredIf(!isDraft, "Négociant : Date de validité obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    })
+  });
+
+export const brokerSchemaFn: FactorySchemaOf<boolean, Broker> = isDraft =>
+  yup.object({
+    brokerCompanySiret: yup
+      .string()
+      .notRequired()
+      .nullable()
+      .matches(/^$|^\d{14}$/, {
+        message: `Courtier : ${INVALID_SIRET_LENGTH}`
+      }),
+    brokerCompanyName: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Courtier : ${MISSING_COMPANY_NAME}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerCompanyAddress: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Courtier : ${MISSING_COMPANY_ADDRESS}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerCompanyContact: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Courtier : ${MISSING_COMPANY_CONTACT}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerCompanyPhone: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Courtier : ${MISSING_COMPANY_PHONE}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerCompanyMail: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, `Courtier : ${MISSING_COMPANY_EMAIL}`),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerReceipt: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, "Courtier : Numéro de récepissé obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerDepartment: yup.string().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema
+          .ensure()
+          .requiredIf(!isDraft, "Courtier : Département obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    }),
+    brokerValidityLimit: yup.date().when("brokerCompanySiret", {
+      is: siret => siret?.length === 14,
+      then: schema =>
+        schema.requiredIf(!isDraft, "Courtier : Date de validité obligatoire"),
+      otherwise: schema => schema.notRequired().nullable()
+    })
+  });
 
 // 8 - Collecteur-transporteur
 // 9 - Déclaration générale de l’émetteur du bordereau :
@@ -987,7 +1162,9 @@ const baseFormSchemaFn = (isDraft: boolean) =>
     .concat(ecoOrganismeSchema)
     .concat(recipientSchemaFn(isDraft))
     .concat(wasteDetailsSchemaFn(isDraft))
-    .concat(transporterSchemaFn(isDraft));
+    .concat(transporterSchemaFn(isDraft))
+    .concat(traderSchemaFn(isDraft))
+    .concat(brokerSchemaFn(isDraft));
 
 export const sealedFormSchema = baseFormSchemaFn(false);
 export const draftFormSchema = baseFormSchemaFn(true);

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -194,9 +194,22 @@ export const formSchema = object().shape({
     .nullable()
     .shape({
       company: companySchema,
-      validityLimit: date().nullable(true),
-      department: string().nullable(),
-      receipt: string().nullable(),
+      validityLimit: date().required(
+        "La date de limite de validité est obligatoire"
+      ),
+      department: string().required("Le département est obligatoire"),
+      receipt: string().required("Le numéro de récépissé est obligatoire"),
+    }),
+  broker: object()
+    .notRequired()
+    .nullable()
+    .shape({
+      company: companySchema,
+      validityLimit: date().required(
+        "La date de limite de validité est obligatoire"
+      ),
+      department: string().required("Le département est obligatoire"),
+      receipt: string().required("Le numéro de récépissé est obligatoire"),
     }),
   wasteDetails: object().shape({
     code: string().required("Code déchet manquant"),


### PR DESCRIPTION
Ajout d'une validation yup pour s'assurer que les infos de contact et de récépissé sont bien présentes lorsqu'un courtier ou un négociant et présent sur le BSDD.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7769)
