### PR TITLE
Hotfix mode de transport bsda

### DIFF
--- a/back/prisma/migrations/66_bsda_transportmode_default.sql
+++ b/back/prisma/migrations/66_bsda_transportmode_default.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "default$default"."Bsda" 
+    ALTER COLUMN "transporterTransportMode" SET DEFAULT 'ROAD';

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1239,7 +1239,7 @@ model Bsda {
   transporterRecepisseDepartment    String?
   transporterRecepisseValidityLimit DateTime? @db.Timestamptz(6)
 
-  transporterTransportMode            TransportMode?
+  transporterTransportMode            TransportMode? @default(ROAD)
   transporterTransportPlates          String[]
   transporterTransportTakenOverAt     DateTime?      @db.Timestamptz(6)
   transporterTransportSignatureAuthor String?

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -82,7 +82,7 @@ export default function BsdaStepsList(props: Props) {
   const cleanupFields = (input: BsdaInput): BsdaInput => {
     // When created through api, this field might be null in db
     // We send it as false at creation time from the UI, but we dont have any
-    // mean to edit it, and it is lcoked once signe by worker
+    // mean to edit it, and it is locked once signed by worker
     // This can lead to unsolvable cases.
     // While waiting a better fix (eg. an editable field or to default the field as false),
     // this function unlocks users

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -20,13 +20,20 @@ import React, { ReactElement, useMemo } from "react";
 import { generatePath, useHistory, useParams } from "react-router-dom";
 import initialState from "./initial-state";
 import { CREATE_BSDA, UPDATE_BSDA, GET_BSDA } from "./queries";
+import omitDeep from "omit-deep-lodash";
 
 interface Props {
   children: (bsda: Bsda | undefined) => ReactElement;
   formId?: string;
   initialStep: number;
 }
+const prefillTransportMode = state => {
+  if (!state?.transporter?.transport?.mode) {
+    state.transporter.transport.mode = "ROAD";
+  }
 
+  return state;
+};
 export default function BsdaStepsList(props: Props) {
   const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
@@ -40,7 +47,10 @@ export default function BsdaStepsList(props: Props) {
   });
 
   const formState = useMemo(() => {
-    const computedState = getComputedState(initialState, formQuery.data?.bsda);
+    const computedState = prefillTransportMode(
+      getComputedState(initialState, formQuery.data?.bsda)
+    );
+
     if (formQuery.data?.bsda?.grouping) {
       computedState.grouping = formQuery.data?.bsda.grouping.map(
         bsda => bsda.id
@@ -49,6 +59,7 @@ export default function BsdaStepsList(props: Props) {
     if (formQuery.data?.bsda?.forwarding) {
       computedState.forwarding = formQuery.data?.bsda.forwarding.id;
     }
+
     return computedState;
   }, [formQuery.data]);
 
@@ -68,10 +79,21 @@ export default function BsdaStepsList(props: Props) {
     awaitRefetchQueries: true,
   });
 
+  const cleanupFields = (input: BsdaInput): BsdaInput => {
+    // When created through api, this field might be null in db
+    // We send it as false at creation time from the UI, but we dont have any
+    // mean to edit it, and it is lcoked once signe by worker
+    // This can lead to unsolvable cases.
+    // While waiting a better fix (eg. an editable field or to default the field as false),
+    // this function unlocks users
+
+    return omitDeep(input, "worker.work");
+  };
+
   function saveForm(input: BsdaInput): Promise<any> {
     return formState.id
       ? updateBsda({
-          variables: { id: formState.id, input },
+          variables: { id: formState.id, input: cleanupFields(input) },
         })
       : createBsda({ variables: { input } });
   }

--- a/front/src/form/common/stepper/GenericStepList.tsx
+++ b/front/src/form/common/stepper/GenericStepList.tsx
@@ -157,7 +157,7 @@ export function getComputedState(initialState, actualForm) {
     ) {
       prev[curKey] = getComputedState(initialValue, actualForm[curKey]);
     } else {
-      // Keep null values - only replace unedfined.
+      // Keep null values - only replace undefined.
       prev[curKey] =
         actualForm[curKey] === undefined ? initialValue : actualForm[curKey];
     }


### PR DESCRIPTION
Sur le bsda, la colonne mode de transport n'a pas de default. Si le bsda est créé via api sans spécifier le mode, la valeur reste à null, mais le select affiche "Route". Les utilisateurs se retrouvent bloqués (à moins d'agir sur le select).
Cette PR met un default sur le transport mode du bsda et remplit les données initiales des formulaires avec la valeur ROAD (pour les bsda déjà en db).

Par ailleurs, le champ worker.work.hasEmitterPaperSignature peut être null en db si le bsd est créé via en db, ce qui rend l'édition du bsd impossible car la valeur null est renvoyé par l'UI est le back attend un booleen. Ce champ est donc nettoyé dans le saveForm.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
