### PR TITLE
Display missing trader fields in revision detail

### DIFF
--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -828,6 +828,8 @@ export function expandBsddRevisionRequestContent(
     }),
     trader: nullIfNoValues<Trader>({
       company: nullIfNoValues<FormCompany>({
+        name: bsddRevisionRequest.traderCompanyName,
+        siret: bsddRevisionRequest.traderCompanySiret,
         address: bsddRevisionRequest.traderCompanyAddress,
         contact: bsddRevisionRequest.traderCompanyContact,
         phone: bsddRevisionRequest.traderCompanyPhone,


### PR DESCRIPTION
Les champs liés au Trader ne s'affichaient pas dans l'UI lors des consulations de révision.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
