### PR TITLE
HOTFIX - Use `searchCompany` in bulk-create-account

### DIFF
--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -9,16 +9,11 @@ const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
 sendMailSpy.mockImplementation(() => Promise.resolve());
 
 jest.mock("../sirene", () => ({
-  getCompanyThrottled: jest.fn(() =>
-    Promise.resolve({
-      naf: "62.01Z",
-      name: "NAME FROM SIRENE"
-    })
-  ),
   sirenify: jest.fn(company =>
     Promise.resolve({
       ...company,
       name: "NAME FROM SIRENE",
+      address: "40 boulevard Volatire 13001 Marseille",
       codeNaf: "62.01Z"
     })
   )
@@ -58,8 +53,7 @@ describe("bulk create users and companies from csv files", () => {
       info: jest.fn(),
       error: jest.fn(),
       log: global.console.log
-    },
-    sireneProvider: "entreprise.data.gouv.fr"
+    }
   };
 
   async function bulkCreateIdempotent() {

--- a/back/src/users/bulk-creation/__tests__/validation.test.ts
+++ b/back/src/users/bulk-creation/__tests__/validation.test.ts
@@ -20,7 +20,7 @@ describe("company validation", () => {
   beforeEach(() => {
     mockCompanyExists.mockResolvedValue(false);
     mockUserExists.mockResolvedValue(false);
-    mockSirene.mockReset();
+    mockSirene.mockResolvedValue({});
   });
 
   const originalWarn = console.warn;
@@ -184,6 +184,20 @@ describe("company validation", () => {
         contactPhone: "01-00-00-00" // missing two digits
       })
     ).rejects.toThrow(ValidationError);
+  });
+
+  test("closed company", async () => {
+    mockSirene.mockImplementationOnce(() =>
+      Promise.resolve({ etatAdministratif: "F" })
+    );
+    await expect(
+      validateCompany({
+        siret: "12345678901234",
+        companyTypes: ["PRODUCER"]
+      })
+    ).rejects.toThrow(
+      "Siret 12345678901234 was not found in SIRENE database or company is closed"
+    );
   });
 });
 

--- a/back/src/users/bulk-creation/__tests__/validation.test.ts
+++ b/back/src/users/bulk-creation/__tests__/validation.test.ts
@@ -12,8 +12,8 @@ jest.mock("../../../prisma", () => ({
 
 const mockSirene = jest.fn();
 
-jest.mock("../sirene", () => ({
-  getCompanyThrottled: jest.fn(() => mockSirene())
+jest.mock("../../../companies/search", () => ({
+  searchCompany: jest.fn(() => mockSirene())
 }));
 
 describe("company validation", () => {

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -29,7 +29,6 @@ function printHelp() {
   Options:
   -- --help                         Print help
   -- --validateOnly                 Only perform validation csv files
-  -- --sireneProvider=providerName  Choose provider name (directory name under src/companies/sirene/*)
   -- --csvDir=/path/to/csv/dir      Specify custom csv directory
   `);
 }
@@ -38,7 +37,6 @@ export interface Opts {
   validateOnly: boolean;
   csvDir: string;
   console?: any;
-  sireneProvider?: "entreprise.data.gouv.fr" | "insee" | "social.gouv";
 }
 
 export const opts: Opts = {
@@ -60,10 +58,6 @@ async function run(argv = process.argv.slice(2)): Promise<void> {
 
   if (args.csvDir) {
     opts.csvDir = args.csvDir;
-  }
-
-  if (args.sireneProvider) {
-    opts.sireneProvider = args.sireneProvider;
   }
 
   await bulkCreate(opts);
@@ -142,7 +136,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
   for (const c of companies) {
     try {
       console.info(`Add sirene info for company ${c.siret}`);
-      const sirenified = await sirenify(c, opts);
+      const sirenified = await sirenify(c);
       sirenifiedCompanies.push(sirenified);
     } catch (err) {
       console.error(err);

--- a/back/src/users/bulk-creation/sirene.ts
+++ b/back/src/users/bulk-creation/sirene.ts
@@ -1,67 +1,15 @@
 import { CompanyRow, CompanyInfo } from "./types";
-import {
-  searchCompanyInseeThrottled,
-  searchCompanyDataGouvThrottled,
-  searchCompanySocialGouvThrottled
-} from "../../companies/sirene/searchCompany";
-import { searchCompany as trackdechets } from "../../companies/sirene/trackdechets/client";
 import geocode from "../../companies/geocode";
-import { CompanySearchResult } from "../../generated/graphql/types";
-import { Opts } from ".";
-
-/**
- * Throttled version of search clients to avoid hitting rate limit
- * of 7 requests / seconds
- * We wait 500ms before executing the function
- * @param siret
- */
-export function getCompanyThrottled(
-  siret: string,
-  opts: Opts
-): Promise<CompanySearchResult> {
-  let throttledClient = null;
-  switch (opts.sireneProvider) {
-    case "entreprise.data.gouv.fr":
-      throttledClient = searchCompanyDataGouvThrottled;
-      break;
-
-    case "social.gouv":
-      throttledClient = searchCompanySocialGouvThrottled;
-      break;
-
-    case "insee":
-      throttledClient = searchCompanyInseeThrottled;
-      break;
-
-    default:
-      // Not throtlled in-house client
-      return trackdechets(siret);
-  }
-
-  if (throttledClient) {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        throttledClient(siret)
-          .then(c => resolve(c))
-          .catch(err => reject(err));
-      }, 500);
-    });
-  }
-}
+import { searchCompany } from "../../companies/search";
 
 /**
  * Validate SIRET against SIRENE database and add company name
  * @param companies
  */
 export async function sirenify(
-  company: CompanyRow,
-  opts: Opts
+  company: CompanyRow
 ): Promise<CompanyRow & CompanyInfo> {
-  const {
-    naf: codeNaf,
-    name,
-    address
-  } = await getCompanyThrottled(company.siret, opts);
+  const { naf: codeNaf, name, address } = await searchCompany(company.siret);
   const { latitude, longitude } = await geocode(address);
   return {
     ...company,

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -1,9 +1,8 @@
 import { CompanyType, UserRole } from "@prisma/client";
 import * as yup from "yup";
 import prisma from "../../prisma";
-import { getCompanyThrottled } from "./sirene";
 import { CompanyRow } from "./types";
-import { opts } from ".";
+import { searchCompany } from "../../companies/search";
 
 /**
  * Validation schema for company
@@ -18,7 +17,7 @@ export const companyValidationSchema = yup.object({
       "Siret ${value} was not found in SIRENE database",
       async value => {
         try {
-          await getCompanyThrottled(value, opts);
+          await searchCompany(value);
           return true;
         } catch (err) {
           return false;

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -14,10 +14,13 @@ export const companyValidationSchema = yup.object({
     .length(14)
     .test(
       "sirene-validation-failed",
-      "Siret ${value} was not found in SIRENE database",
+      "Siret ${value} was not found in SIRENE database or company is closed",
       async value => {
         try {
-          await searchCompany(value);
+          const company = await searchCompany(value);
+          if (company.etatAdministratif === "F") {
+            return false;
+          }
           return true;
         } catch (err) {
           return false;


### PR DESCRIPTION
L'implémentation actuelle ne permet pas de créer des comptes en masse pour des établissements non diffusible ajoutées à la table `AnonymousCompany`.

