### PR TITLE
Fix - Nettoyage du cache après supression d'agrément

### DIFF
--- a/front/src/account/fields/forms/AccountFormCompanyAddVhuAgrementBroyeur.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyAddVhuAgrementBroyeur.tsx
@@ -84,7 +84,7 @@ export default function AccountFormCompanyAddVhuAgrementBroyeur({
   ] = useMutation(DELETE_VHU_AGREMENT, {
     update(cache) {
       cache.writeFragment({
-        id: company.id,
+        id: `CompanyPrivate:${company.id}`,
         fragment: gql`
           fragment VhuAgrementBroyeurCompanyFragment on CompanyPrivate {
             id
@@ -93,7 +93,7 @@ export default function AccountFormCompanyAddVhuAgrementBroyeur({
             }
           }
         `,
-        data: { vhuAgrementBroyeur: null, __typename: "CompanyPrivate" },
+        data: { vhuAgrementBroyeur: null },
       });
     },
   });

--- a/front/src/account/fields/forms/AccountFormCompanyAddVhuAgrementDemolisseur.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyAddVhuAgrementDemolisseur.tsx
@@ -87,7 +87,7 @@ export default function AccountFormCompanyAddVhuAgrementDemolisseur({
   ] = useMutation(DELETE_VHU_AGREMENT, {
     update(cache) {
       cache.writeFragment({
-        id: company.id,
+        id: `CompanyPrivate:${company.id}`,
         fragment: gql`
           fragment VhuAgrementDemolisseurCompanyFragment on CompanyPrivate {
             id
@@ -96,7 +96,7 @@ export default function AccountFormCompanyAddVhuAgrementDemolisseur({
             }
           }
         `,
-        data: { vhuAgrementDemolisseur: null, __typename: "CompanyPrivate" },
+        data: { vhuAgrementDemolisseur: null },
       });
     },
   });

--- a/front/src/account/fields/forms/AccountFormCompanyBrokerReceipt.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyBrokerReceipt.tsx
@@ -89,16 +89,15 @@ export default function AccountFormCompanyTransporterReceipt({
   ] = useMutation(DELETE_BROKER_RECEIPT, {
     update(cache) {
       cache.writeFragment({
-        id: company.id,
+        id: `CompanyPrivate:${company.id}`,
         fragment: gql`
           fragment BrokerReceiptCompanyFragment on CompanyPrivate {
-            id
             brokerReceipt {
               id
             }
           }
         `,
-        data: { brokerReceipt: null, __typename: "CompanyPrivate" },
+        data: { brokerReceipt: null },
       });
     },
   });

--- a/front/src/account/fields/forms/AccountFormCompanyTraderReceipt.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyTraderReceipt.tsx
@@ -89,7 +89,7 @@ export default function AccountFormCompanyTransporterReceipt({
   ] = useMutation(DELETE_TRADER_RECEIPT, {
     update(cache) {
       cache.writeFragment({
-        id: company.id,
+        id: `CompanyPrivate:${company.id}`,
         fragment: gql`
           fragment TraderReceiptCompanyFragment on CompanyPrivate {
             id
@@ -98,7 +98,7 @@ export default function AccountFormCompanyTransporterReceipt({
             }
           }
         `,
-        data: { traderReceipt: null, __typename: "CompanyPrivate" },
+        data: { traderReceipt: null },
       });
     },
   });

--- a/front/src/account/fields/forms/AccountFormCompanyTransporterReceipt.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyTransporterReceipt.tsx
@@ -89,7 +89,7 @@ export default function AccountFormCompanyTransporterReceipt({
   ] = useMutation(DELETE_TRANSPORTER_RECEIPT, {
     update(cache) {
       cache.writeFragment({
-        id: company.id,
+        id: `CompanyPrivate:${company.id}`,
         fragment: gql`
           fragment TransporterReceiptCompanyFragment on CompanyPrivate {
             id
@@ -98,7 +98,7 @@ export default function AccountFormCompanyTransporterReceipt({
             }
           }
         `,
-        data: { transporterReceipt: null, __typename: "CompanyPrivate" },
+        data: { transporterReceipt: null },
       });
     },
   });


### PR DESCRIPTION
Lorsqu'on supprimait un récépissé / agrément le cache n'était pas nettoyé et il apparaissait encore sur l'UI.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7267)
