### PR TITLE
HOTFIX - Bordereaux éligibles au regroupement

### DIFF
--- a/back/src/forms/resolvers/queries/appendixForms.ts
+++ b/back/src/forms/resolvers/queries/appendixForms.ts
@@ -27,8 +27,7 @@ const appendixFormsResolver: QueryResolvers["appendixForms"] = async (
             }
           ]
         },
-        { isDeleted: false },
-        { appendix2RootFormId: null }
+        { isDeleted: false }
       ]
     }
   });


### PR DESCRIPTION
Les bordereaux "En attente de regroupement" avant la MEP n'apparaissent pas dans la liste des bordereaux éligibles au regroupement. 