### PR TITLE
Support des particuliers ou navires étrangers comme producteurs de BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ TEMP_STORER_ACCEPTED -->|markAsResealed| RESEALED(RESEALED)
 TEMP_STORER_ACCEPTED -.->|markAsProcessed| PROCESSED(PROCESSED / AWAITING_GROUP / NO_TRACEABILITY)
 ```
 - Permettre aux forces de l'ordre d’accéder au pdf des bordereaux sur présentation d'un QR-code à durée de vie limitée [PR 1433](https://github.com/MTES-MCT/trackdechets/pull/1433)
+- En tant que particulier ou navire étranger je peux être producteur d'un BSDD [PR 1452](https://github.com/MTES-MCT/trackdechets/pull/1452)
 
 #### :bug: Corrections de bugs
 

--- a/back/prisma/migrations/76_add_bsdd_omi_ship_and_private.sql
+++ b/back/prisma/migrations/76_add_bsdd_omi_ship_and_private.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE
+  "default$default"."Form"
+ADD
+  COLUMN "emitterIsForeignShip"  BOOLEAN NOT NULL DEFAULT false,
+ADD
+  COLUMN "emitterIsPrivateIndividual"  BOOLEAN NOT NULL DEFAULT false,
+ADD
+  COLUMN "emitterCompanyOmiNumber" TEXT;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -267,12 +267,15 @@ model Form {
   updatedAt                          DateTime                @updatedAt @db.Timestamptz(6)
   emitterType                        EmitterType?
   emitterPickupSite                  String?
+  emitterIsPrivateIndividual         Boolean?                 @default(false)
+  emitterIsForeignShip               Boolean?                 @default(false)
   emitterCompanyName                 String?
   emitterCompanySiret                String?
   emitterCompanyAddress              String?
   emitterCompanyContact              String?
   emitterCompanyPhone                String?
   emitterCompanyMail                 String?
+  emitterCompanyOmiNumber            String?
   recipientCap                       String?
   recipientProcessingOperation       String?
   recipientCompanyName               String?

--- a/back/src/bsds/typeDefs/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/bsd.inputs.graphql
@@ -30,6 +30,12 @@ input CompanyInput {
 
   "Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise"
   country: String
+
+  """
+  Numéro OMI ou IMO (International Maritime Organization) pour les navires étrangers (sans SIRET).
+  Il est composé des trois lettres IMO suivi d'un nombre de sept chiffres (ex: IMO 1234567).
+  """
+  omiNumber: String
 }
 
 "Filtre pour les établissement"

--- a/back/src/bsds/typeDefs/bsd.objects.graphql
+++ b/back/src/bsds/typeDefs/bsd.objects.graphql
@@ -28,6 +28,12 @@ type FormCompany {
 
   "Numéro de TVA intracommunautaire"
   vatNumber: String
+
+  """
+  Numéro OMI ou IMO (International Maritime Organization) pour les navires étrangers (sans SIRET).
+  Il est composé des trois lettres IMO suivi d'un nombre de sept chiffres (ex: IMO 1234567).
+  """
+  omiNumber: String
 }
 
 "Informations sur une adresse chantier"

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -92,3 +92,16 @@ export const isFRVat = (clue: string): boolean => {
   if (!clue) return false;
   return clue.replace(/\s/g, "").slice(0, 2).toUpperCase().startsWith("FR");
 };
+
+/**
+ * OMI number is "OMI1234567" (7 numbers)
+ */
+export const isOmi = (clue: string): boolean => {
+  if (!clue) return false;
+  const clean = clue.replace(/\s/g, "");
+
+  return (
+    clean.slice(0, 3).toUpperCase().startsWith("OMI") &&
+    /[0-9]{7}/.test(clean.slice(3))
+  );
+};

--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -8,9 +8,15 @@ const FRENCH_COUNTRY = countries.find(country => country.cca2 === "FR");
 
 type FormCompanyFieldsProps = {
   company?: FormCompany;
+  isForeignShip?: boolean;
+  isPrivateIndividual?: boolean;
 };
 
-export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
+export function FormCompanyFields({
+  company,
+  isForeignShip,
+  isPrivateIndividual
+}: FormCompanyFieldsProps) {
   let companyCountry: Country = null;
 
   if (company) {
@@ -33,6 +39,7 @@ export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
         <input
           type="checkbox"
           checked={
+            !isForeignShip &&
             !company?.vatNumber &&
             company?.siret &&
             companyCountry &&
@@ -45,18 +52,38 @@ export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
         <input
           type="checkbox"
           checked={
-            company?.vatNumber && companyCountry && companyCountry.cca2 !== "FR"
+            isForeignShip ||
+            (company?.vatNumber &&
+              companyCountry &&
+              companyCountry.cca2 !== "FR")
           }
           readOnly
         />{" "}
         Entreprise étrangère
       </p>
       <p>
-        N° SIRET : {!company?.vatNumber ? company?.siret : ""}
-        <br />
-        N° TVA intracommunautaire (le cas échéant) : {company?.vatNumber}
-        <br />
-        RAISON SOCIALE : {company?.name}
+        {!isForeignShip && !isPrivateIndividual && !company?.vatNumber && (
+          <div>
+            N° SIRET : {company?.siret}
+            <br />
+          </div>
+        )}
+        {!isForeignShip && !isPrivateIndividual && (
+          <div>
+            N° TVA intracommunautaire (le cas échéant) : {company?.vatNumber}
+            <br />
+          </div>
+        )}
+        {company?.omiNumber && (
+          <div>
+            Numéro navire OMI : {company?.omiNumber}
+            <br />
+          </div>
+        )}
+        {!company?.siret && !company?.vatNumber
+          ? "Nom Prénom"
+          : "RAISON SOCIALE"}{" "}
+        : {company?.name}
         <br />
         Adresse complète : {company?.address}
         <br />
@@ -69,8 +96,12 @@ export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
         Tel : {company?.phone}
         <br />
         Mail (facultatif) : {company?.mail}
-        <br />
-        Personne à contacter : {company?.contact}
+        {!isPrivateIndividual && (
+          <div>
+            <br />
+            Personne à contacter : {company?.contact}
+          </div>
+        )}
       </p>
     </>
   );

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -31,8 +31,11 @@ describe("expandFormFromDb", () => {
           address: form.emitterCompanyAddress,
           contact: form.emitterCompanyContact,
           phone: form.emitterCompanyPhone,
-          mail: form.emitterCompanyMail
-        }
+          mail: form.emitterCompanyMail,
+          omiNumber: null
+        },
+        isForeignShip: false,
+        isPrivateIndividual: false
       },
       recipient: {
         cap: form.recipientCap,

--- a/back/src/forms/__tests__/form-converter.test.ts
+++ b/back/src/forms/__tests__/form-converter.test.ts
@@ -86,8 +86,11 @@ describe("flattenFormInput", () => {
           address: "1 rue de paradis, 75010 PARIS",
           contact: "Jean Dupont de la Boue",
           mail: "jean.dupont@boues.fr",
-          phone: "01 00 00 00 00"
-        }
+          phone: "01 00 00 00 00",
+          omiNumber: "OMI1234567"
+        },
+        isForeignShip: true,
+        isPrivateIndividual: false
       },
       recipient: {
         processingOperation: "D 10",
@@ -125,6 +128,9 @@ describe("flattenFormInput", () => {
       emitterCompanyContact: input.emitter.company.contact,
       emitterCompanyPhone: input.emitter.company.phone,
       emitterCompanyMail: input.emitter.company.mail,
+      emitterIsPrivateIndividual: input.emitter.isPrivateIndividual,
+      emitterIsForeignShip: input.emitter.isForeignShip,
+      emitterCompanyOmiNumber: input.emitter.company.omiNumber,
       recipientProcessingOperation: input.recipient.processingOperation,
       recipientCompanyName: input.recipient.company.name,
       recipientCompanySiret: input.recipient.company.siret,

--- a/back/src/forms/__tests__/helpers.ts
+++ b/back/src/forms/__tests__/helpers.ts
@@ -27,42 +27,6 @@ export const prepareRedis = async ({ emitterCompany, recipientCompany }) => {
     company: recipientCompany,
     companyTypes: ["WASTE_PROCESSOR"]
   });
-  // const emitterCompanyInfos = async () => [
-  //   {
-  //     id: emitterCompany.id,
-  //     siret: emitterCompany.siret,
-  //     securityCode: "1234",
-  //     companyTypes: ["PRODUCER"]
-  //   }
-  // ];
-
-  // await cachedGet(
-  //   emitterCompanyInfos,
-  //   COMPANY_INFOS_CACHE_KEY,
-  //   emitterCompany.siret,
-  //   {
-  //     parser: JSON,
-  //     options: { EX: 60 }
-  //   }
-  // );
-  // const recipientCompanyInfos = async () => [
-  //   {
-  //     id: recipientCompany.id,
-  //     siret: recipientCompany.siret,
-  //     securityCode: "1234",
-  //     companyTypes: ["WASTE_PROCESSOR"]
-  //   }
-  // ];
-
-  // await cachedGet(
-  //   recipientCompanyInfos,
-  //   COMPANY_INFOS_CACHE_KEY,
-  //   recipientCompany.siret,
-  //   {
-  //     parser: JSON,
-  //     options: { EX: 60 }
-  //   }
-  // );
 };
 
 export const prepareDB = async () => {

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -130,9 +130,254 @@ describe("sealedFormSchema", () => {
         expect(isValid).toEqual(true);
       }
     );
+
+    test("when emitterIsForeignShip is true without emitter company siret", async () => {
+      const partialForm: Partial<Form> = {
+        id: "cjplbvecc000d0766j32r19am",
+        readableId: "BSD-20210101-AAAAAAAA",
+        status: "SEALED",
+        emitterType: "PRODUCER",
+        emitterIsForeignShip: true,
+        emitterWorkSiteName: "",
+        emitterWorkSiteAddress: "",
+        emitterWorkSiteCity: "",
+        emitterWorkSitePostalCode: "",
+        emitterWorkSiteInfos: "",
+        emitterCompanyName: "A company 2",
+        emitterCompanyAddress: "8 rue du Général de Gaulle",
+        emitterCompanyOmiNumber: "OMI1234567",
+        recipientCap: "1234",
+        recipientProcessingOperation: "D 6",
+        recipientCompanyName: "A company 3",
+        recipientCompanySiret: "00000000000003",
+        recipientCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCompanyContact: "Destination",
+        recipientCompanyPhone: "02",
+        recipientCompanyMail: "d@d.fr",
+        transporterReceipt: "sdfg",
+        transporterDepartment: "82",
+        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
+        transporterCompanyName: "A company 4",
+        transporterCompanySiret: "00000000000004",
+        transporterCompanyAddress: "8 rue du Général de Gaulle",
+        transporterCompanyContact: "Transporteur",
+        transporterCompanyPhone: "03",
+        transporterCompanyMail: "t@t.fr",
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsOnuCode: "AAA",
+        wasteDetailsPackagingInfos: [
+          { type: "FUT", other: null, quantity: 1 },
+          { type: "GRV", other: null, quantity: 1 }
+        ],
+        wasteDetailsQuantity: 1.5,
+        wasteDetailsQuantityType: "REAL",
+        wasteDetailsConsistence: "SOLID",
+        wasteDetailsPop: false
+      };
+      await sealedFormSchema.validate(partialForm);
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(true);
+    });
+    test("when emitterIsPrivateIndividual is true without emitter company siret", async () => {
+      const partialForm: Partial<Form> = {
+        id: "cjplbvecc000d0766j32r19am",
+        readableId: "BSD-20210101-AAAAAAAA",
+        status: "SEALED",
+        emitterType: "PRODUCER",
+        emitterIsPrivateIndividual: true,
+        emitterWorkSiteName: "",
+        emitterWorkSiteAddress: "",
+        emitterWorkSiteCity: "",
+        emitterWorkSitePostalCode: "",
+        emitterWorkSiteInfos: "",
+        emitterCompanyName: "A company 2",
+        emitterCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCap: "1234",
+        recipientProcessingOperation: "D 6",
+        recipientCompanyName: "A company 3",
+        recipientCompanySiret: "00000000000003",
+        recipientCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCompanyContact: "Destination",
+        recipientCompanyPhone: "02",
+        recipientCompanyMail: "d@d.fr",
+        transporterReceipt: "sdfg",
+        transporterDepartment: "82",
+        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
+        transporterCompanyName: "A company 4",
+        transporterCompanySiret: "00000000000004",
+        transporterCompanyAddress: "8 rue du Général de Gaulle",
+        transporterCompanyContact: "Transporteur",
+        transporterCompanyPhone: "03",
+        transporterCompanyMail: "t@t.fr",
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsOnuCode: "AAA",
+        wasteDetailsPackagingInfos: [
+          { type: "FUT", other: null, quantity: 1 },
+          { type: "GRV", other: null, quantity: 1 }
+        ],
+        wasteDetailsQuantity: 1.5,
+        wasteDetailsQuantityType: "REAL",
+        wasteDetailsConsistence: "SOLID",
+        wasteDetailsPop: false
+      };
+      await sealedFormSchema.validate(partialForm);
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(true);
+    });
   });
 
   describe("form cannot be sealed", () => {
+    test("when emitterIsForeignShip is true without emitterCompanyOmiNumber", async () => {
+      const partialForm: Partial<Form> = {
+        id: "cjplbvecc000d0766j32r19am",
+        readableId: "BSD-20210101-AAAAAAAA",
+        status: "SEALED",
+        emitterType: "PRODUCER",
+        emitterIsForeignShip: true,
+        emitterWorkSiteName: "",
+        emitterWorkSiteAddress: "",
+        emitterWorkSiteCity: "",
+        emitterWorkSitePostalCode: "",
+        emitterWorkSiteInfos: "",
+        emitterCompanyName: "A company 2",
+        emitterCompanySiret: "00000000000002",
+        emitterCompanyContact: "Emetteur",
+        emitterCompanyPhone: "01",
+        emitterCompanyAddress: "8 rue du Général de Gaulle",
+        emitterCompanyMail: "e@e.fr",
+        recipientCap: "1234",
+        recipientProcessingOperation: "D 6",
+        recipientCompanyName: "A company 3",
+        recipientCompanySiret: "00000000000003",
+        recipientCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCompanyContact: "Destination",
+        recipientCompanyPhone: "02",
+        recipientCompanyMail: "d@d.fr",
+        transporterReceipt: "sdfg",
+        transporterDepartment: "82",
+        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
+        transporterCompanyName: "A company 4",
+        transporterCompanySiret: "00000000000004",
+        transporterCompanyAddress: "8 rue du Général de Gaulle",
+        transporterCompanyContact: "Transporteur",
+        transporterCompanyPhone: "03",
+        transporterCompanyMail: "t@t.fr",
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsOnuCode: "AAA",
+        wasteDetailsPackagingInfos: [
+          { type: "FUT", other: null, quantity: 1 },
+          { type: "GRV", other: null, quantity: 1 }
+        ],
+        wasteDetailsQuantity: 1.5,
+        wasteDetailsQuantityType: "REAL",
+        wasteDetailsConsistence: "SOLID",
+        wasteDetailsPop: false
+      };
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(false);
+    });
+    test("when emitterIsForeignShip is true with invalid emitterCompanyOmiNumber", async () => {
+      const partialForm: Partial<Form> = {
+        id: "cjplbvecc000d0766j32r19am",
+        readableId: "BSD-20210101-AAAAAAAA",
+        status: "SEALED",
+        emitterType: "PRODUCER",
+        emitterIsForeignShip: true,
+        emitterWorkSiteName: "",
+        emitterWorkSiteAddress: "",
+        emitterWorkSiteCity: "",
+        emitterWorkSitePostalCode: "",
+        emitterWorkSiteInfos: "",
+        emitterCompanyName: "A company 2",
+        emitterCompanySiret: "00000000000002",
+        emitterCompanyContact: "Emetteur",
+        emitterCompanyPhone: "01",
+        emitterCompanyAddress: "8 rue du Général de Gaulle",
+        emitterCompanyMail: "e@e.fr",
+        emitterCompanyOmiNumber: "OMI123",
+        recipientCap: "1234",
+        recipientProcessingOperation: "D 6",
+        recipientCompanyName: "A company 3",
+        recipientCompanySiret: "00000000000003",
+        recipientCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCompanyContact: "Destination",
+        recipientCompanyPhone: "02",
+        recipientCompanyMail: "d@d.fr",
+        transporterReceipt: "sdfg",
+        transporterDepartment: "82",
+        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
+        transporterCompanyName: "A company 4",
+        transporterCompanySiret: "00000000000004",
+        transporterCompanyAddress: "8 rue du Général de Gaulle",
+        transporterCompanyContact: "Transporteur",
+        transporterCompanyPhone: "03",
+        transporterCompanyMail: "t@t.fr",
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsOnuCode: "AAA",
+        wasteDetailsPackagingInfos: [
+          { type: "FUT", other: null, quantity: 1 },
+          { type: "GRV", other: null, quantity: 1 }
+        ],
+        wasteDetailsQuantity: 1.5,
+        wasteDetailsQuantityType: "REAL",
+        wasteDetailsConsistence: "SOLID",
+        wasteDetailsPop: false
+      };
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(false);
+    });
+
+    test("when emitterIsForeignShip and emitterIsPrivateIndividual both true", async () => {
+      const partialForm: Partial<Form> = {
+        id: "cjplbvecc000d0766j32r19am",
+        readableId: "BSD-20210101-AAAAAAAA",
+        status: "SEALED",
+        emitterType: "PRODUCER",
+        emitterIsForeignShip: true,
+        emitterIsPrivateIndividual: true,
+        emitterWorkSiteName: "",
+        emitterWorkSiteAddress: "",
+        emitterWorkSiteCity: "",
+        emitterWorkSitePostalCode: "",
+        emitterWorkSiteInfos: "",
+        emitterCompanyName: "A company 2",
+        emitterCompanySiret: "00000000000002",
+        emitterCompanyContact: "Emetteur",
+        emitterCompanyPhone: "01",
+        emitterCompanyAddress: "8 rue du Général de Gaulle",
+        emitterCompanyMail: "e@e.fr",
+        emitterCompanyOmiNumber: "OMI1234567",
+        recipientCap: "1234",
+        recipientProcessingOperation: "D 6",
+        recipientCompanyName: "A company 3",
+        recipientCompanySiret: "00000000000003",
+        recipientCompanyAddress: "8 rue du Général de Gaulle",
+        recipientCompanyContact: "Destination",
+        recipientCompanyPhone: "02",
+        recipientCompanyMail: "d@d.fr",
+        transporterReceipt: "sdfg",
+        transporterDepartment: "82",
+        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
+        transporterCompanyName: "A company 4",
+        transporterCompanySiret: "00000000000004",
+        transporterCompanyAddress: "8 rue du Général de Gaulle",
+        transporterCompanyContact: "Transporteur",
+        transporterCompanyPhone: "03",
+        transporterCompanyMail: "t@t.fr",
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsOnuCode: "AAA",
+        wasteDetailsPackagingInfos: [
+          { type: "FUT", other: null, quantity: 1 },
+          { type: "GRV", other: null, quantity: 1 }
+        ],
+        wasteDetailsQuantity: 1.5,
+        wasteDetailsQuantityType: "REAL",
+        wasteDetailsConsistence: "SOLID",
+        wasteDetailsPop: false
+      };
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(false);
+    });
     test("when there is no receipt exemption and no receipt", async () => {
       const testForm = {
         ...form,
@@ -578,6 +823,40 @@ describe("draftFormSchema", () => {
     await expect(validateFn()).rejects.toThrow(
       "Parcelle: la coordonnée Y est obligatoire"
     );
+  });
+
+  it("should be valid when emitterIsForeignShip with empty fields", async () => {
+    const partialForm: Partial<Form> = {
+      id: "cjplbvecc000d0766j32r19am",
+      readableId: "BSD-20210101-AAAAAAAA",
+      status: "DRAFT",
+      emitterType: "PRODUCER",
+      emitterIsForeignShip: true,
+      emitterWorkSiteName: "",
+      emitterWorkSiteAddress: "",
+      emitterWorkSiteCity: "",
+      emitterWorkSitePostalCode: "",
+      emitterWorkSiteInfos: "",
+      emitterCompanyName: "A company 2",
+      emitterCompanyContact: "Emetteur",
+      emitterCompanyPhone: "01",
+      emitterCompanyAddress: "8 rue du Général de Gaulle",
+      emitterCompanyMail: "e@e.fr",
+      emitterCompanyOmiNumber: "OMI1234567",
+      wasteDetailsCode: "01 03 04*",
+      wasteDetailsOnuCode: "AAA",
+      wasteDetailsPackagingInfos: [
+        { type: "FUT", other: null, quantity: 1 },
+        { type: "GRV", other: null, quantity: 1 }
+      ],
+      wasteDetailsQuantity: 1.5,
+      wasteDetailsQuantityType: "REAL",
+      wasteDetailsConsistence: "SOLID",
+      wasteDetailsPop: false
+    };
+    draftFormSchema.validateSync(partialForm);
+    const isValid = await draftFormSchema.isValid(partialForm);
+    expect(isValid).toEqual(true);
   });
 });
 

--- a/back/src/forms/errors.ts
+++ b/back/src/forms/errors.ts
@@ -107,7 +107,10 @@ export const MISSING_COMPANY_CONTACT =
 export const MISSING_COMPANY_PHONE =
   "Le téléphone de l'entreprise est obligatoire";
 export const MISSING_COMPANY_EMAIL = "L'email de l'entreprise est obligatoire";
-
+export const MISSING_COMPANY_OMI_NUMBER =
+  "Le numéro OMI (Organisation maritime international) de l'entreprise est obligatoire";
+export const INVALID_COMPANY_OMI_NUMBER =
+  "Le numéro OMI (Organisation maritime international) de l'entreprise doit se composer des trois lettres OMI suivives de 7 chiffres (ex. OMI1234567)";
 export const INVALID_SIRET_LENGTH =
   "Le SIRET doit faire 14 caractères numériques";
 
@@ -121,3 +124,6 @@ export const INVALID_WASTE_CODE =
   "Le code déchet n'est pas reconnu comme faisant partie de la liste officielle du code de l'environnement.";
 
 export const EXTRANEOUS_NEXT_DESTINATION = `L'opération de traitement renseignée ne permet pas de destination ultérieure`;
+
+export const INVALID_INDIVIDUAL_OR_FOREIGNSHIP =
+  "Ne peut pas être à la fois un particulier et un navire étranger";

--- a/back/src/forms/form-converter.ts
+++ b/back/src/forms/form-converter.ts
@@ -206,6 +206,11 @@ function flattenEmitterInput(input: { emitter?: EmitterInput }) {
     emitterWorkSiteInfos: chain(input.emitter, e =>
       chain(e.workSite, w => w.infos)
     ),
+    emitterIsPrivateIndividual: chain(
+      input.emitter,
+      e => e.isPrivateIndividual
+    ),
+    emitterIsForeignShip: chain(input.emitter, e => e.isForeignShip),
     emitterCompanyName: chain(input.emitter, e =>
       chain(e.company, c => c.name)
     ),
@@ -221,7 +226,12 @@ function flattenEmitterInput(input: { emitter?: EmitterInput }) {
     emitterCompanyPhone: chain(input.emitter, e =>
       chain(e.company, c => c.phone)
     ),
-    emitterCompanyMail: chain(input.emitter, e => chain(e.company, c => c.mail))
+    emitterCompanyMail: chain(input.emitter, e =>
+      chain(e.company, c => c.mail)
+    ),
+    emitterCompanyOmiNumber: chain(input.emitter, e =>
+      chain(e.company, c => c.omiNumber)
+    )
   };
 }
 
@@ -518,13 +528,16 @@ export async function expandFormFromDb(form: PrismaForm): Promise<GraphQLForm> {
         infos: form.emitterWorkSiteInfos
       }),
       pickupSite: form.emitterPickupSite,
+      isPrivateIndividual: form.emitterIsPrivateIndividual,
+      isForeignShip: form.emitterIsForeignShip,
       company: nullIfNoValues<FormCompany>({
         name: form.emitterCompanyName,
         siret: form.emitterCompanySiret,
         address: form.emitterCompanyAddress,
         contact: form.emitterCompanyContact,
         phone: form.emitterCompanyPhone,
-        mail: form.emitterCompanyMail
+        mail: form.emitterCompanyMail,
+        omiNumber: form.emitterCompanyOmiNumber
       })
     }),
     recipient: nullIfNoValues<Recipient>({

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -353,7 +353,27 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
             <p>
               <strong>1.1 Producteur ou détenteur du déchet</strong>
             </p>
-            <FormCompanyFields company={form.emitter?.company} />
+            <p>
+              <input
+                type="checkbox"
+                checked={form.emitter?.isPrivateIndividual}
+                readOnly
+              />{" "}
+              L'émetteur est un particulier
+            </p>
+            <p>
+              <input
+                type="checkbox"
+                checked={form.emitter?.isForeignShip}
+                readOnly
+              />{" "}
+              L'émetteur est un navire étranger
+            </p>
+            <FormCompanyFields
+              company={form.emitter?.company}
+              isPrivateIndividual={form.emitter?.isPrivateIndividual}
+              isForeignShip={form.emitter?.isForeignShip}
+            />
 
             <p>
               <strong>1.2 Point de collecte/chantier</strong> (si adresse

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -3,7 +3,12 @@ import { MutationResolvers } from "../../../generated/graphql/types";
 import { getFormOrFormNotFound } from "../../database";
 import { expandFormFromDb } from "../../form-converter";
 import { checkCanMarkAsSealed } from "../../permissions";
-import { checkCanBeSealed, checkCompaniesType } from "../../validation";
+import {
+  beforeSignedByTransporterSchema,
+  checkCanBeSealed,
+  checkCompaniesType,
+  wasteDetailsSchema
+} from "../../validation";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import { sendMail } from "../../../mailer/mailing";
@@ -26,6 +31,28 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   await checkCanBeSealed(form);
 
   await checkCompaniesType(form);
+  let formUpdateInput = null;
+
+  if (
+    form.emitterIsForeignShip === true ||
+    form.emitterIsPrivateIndividual === true
+  ) {
+    // pre-validate when signature by producer will be by-passed at the end of this mutation
+    formUpdateInput = {
+      emittedAt: new Date(),
+      emittedBy: user.name,
+      emittedByEcoOrganisme: false,
+      // required for machine to authorize signature
+      emitterIsForeignShip: form.emitterIsForeignShip,
+      emitterIsPrivateIndividual: form.emitterIsPrivateIndividual
+    };
+    const futureForm: Form = {
+      ...form,
+      ...formUpdateInput
+    };
+    await wasteDetailsSchema.validate(futureForm);
+    await beforeSignedByTransporterSchema.validate(futureForm);
+  }
 
   const sealedForm = await transitionForm(user, form, {
     type: EventType.MarkAsSealed
@@ -40,14 +67,28 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     await formRepository.updateAppendix2Forms(appendix2Forms);
   }
 
-  // send welcome email to emitter if it is not registered in TD
-  const emitterCompanyExists =
-    (await prisma.company.count({
-      where: { siret: form.emitterCompanySiret }
-    })) > 0;
+  if (form.emitterCompanySiret) {
+    // send welcome email to emitter if it is not registered in TD
+    const emitterCompanyExists =
+      (await prisma.company.count({
+        where: { siret: form.emitterCompanySiret }
+      })) > 0;
 
-  if (!emitterCompanyExists) {
-    await mailToNonExistentEmitter(sealedForm, formRepository);
+    if (!emitterCompanyExists) {
+      await mailToNonExistentEmitter(sealedForm, formRepository);
+    }
+  }
+
+  if (
+    formUpdateInput &&
+    (sealedForm.emitterIsForeignShip === true ||
+      sealedForm.emitterIsPrivateIndividual === true)
+  ) {
+    const updatedForm = await transitionForm(user, sealedForm, {
+      type: EventType.SignedByProducer,
+      formUpdateInput
+    });
+    return expandFormFromDb(updatedForm);
   }
 
   return expandFormFromDb(sealedForm);

--- a/back/src/forms/resolvers/mutations/signEmissionForm.ts
+++ b/back/src/forms/resolvers/mutations/signEmissionForm.ts
@@ -34,7 +34,10 @@ const signatures: Partial<
         user,
         args.securityCode
       );
-    } else {
+    } else if (
+      !existingForm.emitterIsForeignShip &&
+      !existingForm.emitterIsPrivateIndividual
+    ) {
       await checkCanSignFor(
         existingForm.emitterCompanySiret,
         user,
@@ -55,7 +58,10 @@ const signatures: Partial<
 
       emittedAt: args.input.emittedAt,
       emittedBy: args.input.emittedBy,
-      emittedByEcoOrganisme: args.input.emittedByEcoOrganisme ?? false
+      emittedByEcoOrganisme: args.input.emittedByEcoOrganisme ?? false,
+      // required for machine to authorize signature
+      emitterIsForeignShip: existingForm.emitterIsForeignShip,
+      emitterIsPrivateIndividual: existingForm.emitterIsPrivateIndividual
     };
     const futureForm: Prisma.FormUpdateInput = {
       ...existingForm,

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -417,6 +417,12 @@ input EmitterInput {
 
   "Établissement émetteur"
   company: CompanyInput
+
+  "Indique si le détenteur est un particulier ou une entreprise"
+  isPrivateIndividual: Boolean
+
+  "Indique si le détenteur est un navire étranger"
+  isForeignShip: Boolean
 }
 
 """

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -340,6 +340,12 @@ type Emitter {
 
   "Établissement émetteur"
   company: FormCompany
+
+  "Indique si le détenteur est un particulier ou une entreprise"
+  isPrivateIndividual: Boolean
+
+  "Indique si le détenteur est un navire étranger"
+  isForeignShip: Boolean
 }
 
 """

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13081,7 +13081,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -13251,7 +13251,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -13326,7 +13326,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -17,6 +17,7 @@ export const companyFragment = gql`
     country
     phone
     mail
+    omiNumber
   }
 `;
 
@@ -94,6 +95,8 @@ const emitterFragment = gql`
     company {
       ...CompanyFragment
     }
+    isPrivateIndividual
+    isForeignShip
   }
   ${companyFragment}
   ${workSiteFragment}

--- a/front/src/dashboard/components/BSDList/BSDD/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/index.tsx
@@ -31,8 +31,16 @@ export const COLUMNS: Record<
   emitter: {
     accessor: form => (
       <>
-        <div>{form.emitter?.company?.name ?? ""}</div>
+        <div>
+          {form.emitter?.company?.name ?? ""}
+          {form.emitter?.isPrivateIndividual ? " (particulier)" : ""}
+        </div>
         <div>{form.emitter?.company?.siret ?? ""}</div>
+        <div>
+          {form.emitter?.company?.omiNumber
+            ? `${form.emitter?.company?.omiNumber}`
+            : ""}
+        </div>
       </>
     ),
   },

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -62,6 +62,9 @@ const Company = ({ company, label }: CompanyProps) => (
   <>
     <dt>{label}</dt> <dd>{company?.name}</dd>
     <dt>Siret</dt> <dd>{company?.siret}</dd>
+    <dt>Numéro de TVA</dt> <dd>{company?.vatNumber}</dd>
+    <dt>Numéro OMI (Organisation maritime internationale)</dt>{" "}
+    <dd>{company?.omiNumber}</dd>
     <dt>Adresse</dt> <dd>{company?.address}</dd>
     <dt>Tél</dt> <dd>{company?.phone}</dd>
     <dt>Mél</dt> <dd>{company?.mail}</dd>
@@ -583,7 +586,14 @@ export default function BSDDetailContent({
                         : ""
                     }
                   />
-                  <Company label="Émetteur" company={form.emitter?.company} />
+                  <Company
+                    label={
+                      form.emitter?.isPrivateIndividual !== true
+                        ? "Émetteur"
+                        : "Émetteur (Particulier)"
+                    }
+                    company={form.emitter?.company}
+                  />
                   <DetailRow
                     value={form.emitter?.workSite?.name}
                     label="Chantier"

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -9,12 +9,18 @@ import { getInitialEmitterWorkSite } from "form/bsdd/utils/initial-state";
 import "./Emitter.scss";
 import MyCompanySelector from "form/common/components/company/MyCompanySelector";
 import { emitterTypeLabels } from "dashboard/constants";
+import { isOmi } from "generated/constants/companySearchHelpers";
+import { RedErrorMessage } from "common/components";
 
-export default function Emitter() {
-  const { values, setFieldValue } = useFormikContext<Form>();
+export default function Emitter({ disabled }) {
+  const { values, handleChange, setFieldValue } = useFormikContext<Form>();
 
   const [lockEmitterType, setLockEmitterType] = useState(
     values.ecoOrganisme?.siret != null
+  );
+
+  const [lockEmitterProducer, setLockEmitterProducer] = useState(
+    values.emitter?.isForeignShip || values.emitter?.isPrivateIndividual
   );
 
   useEffect(() => {
@@ -26,6 +32,20 @@ export default function Emitter() {
     setLockEmitterType(false);
   }, [values.ecoOrganisme, setFieldValue]);
 
+  useEffect(() => {
+    if (values.emitter?.isForeignShip || values.emitter?.isPrivateIndividual) {
+      setLockEmitterProducer(true);
+      setLockEmitterType(false);
+      setFieldValue("emitter.type", "PRODUCER");
+      return;
+    }
+    setLockEmitterProducer(false);
+  }, [
+    values.emitter?.isForeignShip,
+    values.emitter?.isPrivateIndividual,
+    setFieldValue,
+  ]);
+
   const [emitterTypeField] = useField("emitter.type");
 
   function onChangeEmitterType(e) {
@@ -35,6 +55,13 @@ export default function Emitter() {
       // make sure to empty appendix2 forms when de-selecting APPENDIX2
       setFieldValue("grouping", []);
     }
+  }
+
+  function omiNumberValidator(omi: string) {
+    if (!isOmi(omi)) {
+      return "Le numéro OMI (Organisation maritime international) de l'entreprise doit se composer des trois lettres OMI suivives de 7 chiffres (ex. OMI1234567)";
+    }
+    return undefined;
   }
 
   return (
@@ -55,10 +82,18 @@ export default function Emitter() {
       {lockEmitterType && (
         <div className="form__row notification info">
           Lorsqu'un éco-organisme est indiqué comme responsable du déchet, le
-          type d'émetteur est verrouillé à <strong>Autre détenteur</strong>.
+          type d'émetteur est verrouillé à "Autre détenteur".
         </div>
       )}
 
+      {lockEmitterProducer && (
+        <div className="form__row notification notification--warning">
+          Lorsqu'un particulier ou un navire étranger est émetteur du déchet, le
+          type d'émetteur est verrouillé à "Producteur". La signature de
+          l'émetteur ne sera pas requise et après validation, le bordereau
+          passera à l'attente de la signature par le transporteur.
+        </div>
+      )}
       <div className="form__row">
         <fieldset>
           <legend className="tw-font-semibold"> L'émetteur est</legend>
@@ -68,7 +103,7 @@ export default function Emitter() {
             label={emitterTypeLabels["PRODUCER"]}
             component={RadioButton}
             onChange={onChangeEmitterType}
-            disabled={lockEmitterType}
+            disabled={lockEmitterType || lockEmitterProducer}
           />
           <Field
             name="emitter.type"
@@ -76,7 +111,7 @@ export default function Emitter() {
             label={emitterTypeLabels["OTHER"]}
             component={RadioButton}
             onChange={onChangeEmitterType}
-            disabled={lockEmitterType}
+            disabled={lockEmitterType || lockEmitterProducer}
           />
           <Field
             name="emitter.type"
@@ -84,7 +119,7 @@ export default function Emitter() {
             label={emitterTypeLabels["APPENDIX2"]}
             component={RadioButton}
             onChange={onChangeEmitterType}
-            disabled={lockEmitterType}
+            disabled={lockEmitterType || lockEmitterProducer}
           />
 
           <Field
@@ -93,12 +128,165 @@ export default function Emitter() {
             label={emitterTypeLabels["APPENDIX1"]}
             component={RadioButton}
             onChange={onChangeEmitterType}
-            disabled={lockEmitterType}
+            disabled={lockEmitterType || lockEmitterProducer}
           />
         </fieldset>
       </div>
+      <div className="form__row">
+        <label>
+          <Field
+            disabled={disabled}
+            type="checkbox"
+            name="emitter.isPrivateIndividual"
+            className="td-checkbox"
+            onChange={e => {
+              handleChange(e);
+              setFieldValue("emitter.company.siret", null);
+              setFieldValue("emitter.company.vatNumber", null);
+              setFieldValue("emitter.company.omiNumber", null);
+              setFieldValue("emitter.company.contact", null);
+              setFieldValue("emitter.company.name", null);
+              setFieldValue("emitter.company.address", null);
+              setFieldValue("emitter.company.country", null);
+              setFieldValue("emitter.isForeignShip", false);
+            }}
+          />
+          L'émetteur est un particulier
+        </label>
+        <label>
+          <Field
+            disabled={disabled}
+            type="checkbox"
+            name="emitter.isForeignShip"
+            className="td-checkbox"
+            onChange={e => {
+              handleChange(e);
+              setFieldValue("emitter.company.siret", null);
+              setFieldValue("emitter.company.vatNumber", null);
+              setFieldValue("emitter.company.contact", null);
+              setFieldValue("emitter.company.name", null);
+              setFieldValue("emitter.company.address", null);
+              setFieldValue("emitter.company.country", null);
+              setFieldValue("emitter.isPrivateIndividual", false);
+            }}
+          />
+          L'émetteur est un navire étranger
+        </label>
+      </div>
+      {values.emitter?.type !== "APPENDIX2" &&
+        values.emitter?.isPrivateIndividual && (
+          <div className="form__row">
+            <div className="form__row">
+              <label>
+                Nom et prénom
+                <Field
+                  type="text"
+                  name="emitter.company.name"
+                  className="td-input"
+                  disabled={disabled}
+                />
+              </label>
+            </div>
+            <div className="form__row">
+              <label>
+                Adresse
+                <Field
+                  type="text"
+                  name="emitter.company.address"
+                  className="td-input"
+                  disabled={disabled}
+                />
+              </label>
+            </div>
+            <div className="form__row">
+              <label>
+                Téléphone (optionnel)
+                <Field
+                  type="text"
+                  name="emitter.company.phone"
+                  className="td-input td-input--small"
+                  disabled={disabled}
+                />
+              </label>
+            </div>
+            <div className="form__row">
+              <label>
+                Mail (optionnel)
+                <Field
+                  type="text"
+                  name="emitter.company.mail"
+                  className="td-input td-input--medium"
+                  disabled={disabled}
+                />
+              </label>
+            </div>
+          </div>
+        )}
+      {values.emitter?.type !== "APPENDIX2" && values.emitter?.isForeignShip && (
+        <div className="form__row">
+          <div className="form__row">
+            <label>
+              Numéro OMI (Organisation Maritime Internationale)
+              <Field
+                type="text"
+                name="emitter.company.omiNumber"
+                placeholder="OMI1234567"
+                className="td-input"
+                disabled={disabled}
+                validate={omiNumberValidator}
+              />
+              <RedErrorMessage name="emitter.company.omiNumber" />
+            </label>
+          </div>
+          <div className="form__row">
+            <label>
+              Personne à contacter (optionnel)
+              <Field
+                type="text"
+                name="emitter.company.contact"
+                placeholder="NOM Prénom"
+                className="td-input"
+                disabled={disabled}
+              />
+            </label>
+          </div>
+          <div className="form__row">
+            <label>
+              Adresse (optionnel)
+              <Field
+                type="text"
+                name="emitter.company.address"
+                className="td-input"
+                disabled={disabled}
+              />
+            </label>
+          </div>
+          <div className="form__row">
+            <label>
+              Téléphone (optionnel)
+              <Field
+                type="text"
+                name="emitter.company.phone"
+                className="td-input td-input--small"
+                disabled={disabled}
+              />
+            </label>
+          </div>
+          <div className="form__row">
+            <label>
+              Mail (optionnel)
+              <Field
+                type="text"
+                name="emitter.company.mail"
+                className="td-input td-input--medium"
+                disabled={disabled}
+              />
+            </label>
+          </div>
+        </div>
+      )}
 
-      {values.emitter?.type === "APPENDIX2" ? (
+      {values.emitter?.type === "APPENDIX2" && (
         <div className="tw-my-6">
           <h4 className="form__section-heading">Entreprise émettrice</h4>
           <MyCompanySelector
@@ -112,12 +300,16 @@ export default function Emitter() {
             }}
           />
         </div>
-      ) : (
-        <CompanySelector
-          name="emitter.company"
-          heading="Entreprise émettrice"
-        />
       )}
+
+      {values.emitter?.type !== "APPENDIX2" &&
+        !values.emitter?.isPrivateIndividual &&
+        !values.emitter?.isForeignShip && (
+          <CompanySelector
+            name="emitter.company"
+            heading="Entreprise émettrice"
+          />
+        )}
 
       <WorkSite
         switchLabel="Je souhaite ajouter une adresse de chantier ou de collecte"

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -52,6 +52,7 @@ export function getInitialCompany(company?: FormCompany | null) {
     phone: company?.phone ?? "",
     vatNumber: company?.vatNumber ?? "",
     country: company?.country ?? "",
+    omiNumber: company?.omiNumber ?? "",
   };
 }
 
@@ -113,6 +114,8 @@ export function getInitialState(f?: Form | null): FormInput {
         ? getInitialEmitterWorkSite(f?.emitter?.workSite)
         : null,
       company: getInitialCompany(f?.emitter?.company),
+      isForeignShip: f?.emitter?.isForeignShip ?? false,
+      isPrivateIndividual: f?.emitter?.isPrivateIndividual ?? false,
     },
     recipient: {
       cap: f?.recipient?.cap ?? "",

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -39,6 +39,7 @@ const companySchema: yup.SchemaOf<CompanyInput> = yup.object({
     .string()
     .oneOf([...countries.map(country => country.cca2), null])
     .nullable(),
+  omiNumber: yup.string().nullable(),
 });
 const detenteurSchema: yup.SchemaOf<
   BsffFicheInterventionInput["detenteur"]


### PR DESCRIPTION
# Spécifications

On doit pouvoir identifier les déchets collectés par un particulier ou un navire étranger (sans SIRET) en le visant en tant que producteur sur un BSDD
- ETQ navire, je peux être producteur de déchets, si français => SIRET et pas de changement à l'usage actuel avec les établissements, sinon OMI en champ texte au format "OMI1234567" controlé dans l'input BSDD.
- Quand on vise ce type de producteur, on ne leur demande pas de signature, ni de compte sur TD
- La validation du bordereau vaut pour une signature automatique (cachée) de l'émetteur.
- Le bordereau validé saute directement à la signature transporteur.

- Après Validation d'un bordereau de ce type, il est directement signé par le production, et passe à l'attente de signature Transporteur

# Démo 

https://www.loom.com/share/ece52504c63f463eae7d6e0d3ce2b244

# PDF

## Particuliers

![image](https://user-images.githubusercontent.com/76620/174070859-4a504fd9-dd4a-4267-85b4-9c4cd7ce3700.png)

# Navires
![image](https://user-images.githubusercontent.com/76620/174071391-61c759bc-d31d-4e36-8885-6ee2b3f107c8.png)


# TODO

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro Particuliers](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8005)
- [Ticket Favro Navires](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7603)