### PR TITLE
Corrige la disparition intempestive de bouton d'action dasri

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RoutePublishBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RoutePublishBsdasri.tsx
@@ -39,7 +39,7 @@ export function RoutePublishBsdasri() {
       id: formId,
     },
 
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
   });
 
   const [

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -121,7 +121,7 @@ export function RouteSignBsdasri({
     variables: {
       id: formId,
     },
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
   });
   const [updateBsdasri, { error: updateError }] = useMutation<
     Pick<Mutation, "updateBsdasri">,

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
@@ -47,7 +47,7 @@ export function RouteBSDasrisSignEmissionSecretCode() {
       id: formId,
     },
 
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
   });
   const [updateBsdasri, { error: updateError }] = useMutation<
     Pick<Mutation, "updateBsdasri">,

--- a/front/src/dashboard/detail/bsdasri/RouteBSDasrisView.tsx
+++ b/front/src/dashboard/detail/bsdasri/RouteBSDasrisView.tsx
@@ -17,7 +17,7 @@ export function RouteBSDasrisView() {
       id: formId,
     },
     skip: !formId,
-    fetchPolicy: "network-only",
+    fetchPolicy: "no-cache",
   });
 
   if (error) {


### PR DESCRIPTION
Corrige la disparition du bouton d'emport direct.

Sur le dasri, le champ allowDirectTakeOver est ajouté à la volée par la requête dashboard (en utilisant les préférences de l'émetteur).
Les différents modales effectuent une query bsdasri qui ne dispose pas de ce champ. Le valeur de allowDirectTakeOver est donc effacée lors de l'affichage de l'aperçu ou d'une modale de signature. 
Pour éviter d'alourdir l'objet dasri avec ce champ, le fix le plus simple est de na pas mettre à jour le cahce lors de l'affichage des modales.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8302)
