### PR TITLE
Message d'erreur plus explicite à la création d'un BSDD de groupement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,9 +20,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
  
 - Affiche les adresses emails des administrateurs d'un établissement lors d'une demande de rattachement si l'email du requérant appartient au même nom de domaine [PR 1429](https://github.com/MTES-MCT/trackdechets/pull/1429)
-
 - Ajout de suggestions lors de l'ajout d'un établissement fermé. [PR 1463](https://github.com/MTES-MCT/trackdechets/pull/1463)
 - Ajout de la possibilité de filtrer par numéro SIRET de l'émetteur ou du destinataire dans le tableau de bord [PR 1456](https://github.com/MTES-MCT/trackdechets/pull/1456)
+- Affichage d'un message d'erreur plus explicite à la création d'un BSDD de groupement  [PR 1461](https://github.com/MTES-MCT/trackdechets/pull/1461)
 
 #### :memo: Documentation
 #### :house: Interne

--- a/back/src/forms/repository/form/setAppendix2.ts
+++ b/back/src/forms/repository/form/setAppendix2.ts
@@ -88,6 +88,20 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
       );
     }
 
+    // check each form appears in only one form fraction
+    const formIds = appendix2.map(({ form }) => form.id);
+    const duplicates = formIds.filter(
+      (id, index) => formIds.indexOf(id) !== index
+    );
+    if (duplicates.length > 0) {
+      throw new UserInputError(
+        `Impossible d'associer plusieurs fractions du même bordereau initial sur un même bordereau` +
+          ` de regroupement. Identifiant du ou des bordereaux initiaux concernés : ${duplicates.join(
+            ", "
+          )}`
+      );
+    }
+
     // check quantity grouped in each grouped form is not greater than quantity received
     for (const { form: initialForm, quantity } of appendix2) {
       if (quantity <= 0) {


### PR DESCRIPTION
On avait une erreur serveur si on essayait d'ajouter plusieurs fractions du même bordereau initial sur un bordereau de regroupement.

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8321)
