### PR TITLE
Mauvaise navigation entre les onglets

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction de la navigation entre les onglets du tableau de bord lors de certaines actions [PR 1469](https://github.com/MTES-MCT/trackdechets/pull/1469)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -16,8 +16,7 @@ import {
 } from "dashboard/components/BSDList/BSDasri/types";
 import Loader from "common/components/Loaders";
 import { useQuery, useMutation } from "@apollo/client";
-import routes from "common/routes";
-import { useParams, useHistory, generatePath } from "react-router-dom";
+import { useParams, useHistory } from "react-router-dom";
 import { GET_DETAIL_DASRI_WITH_METADATA } from "common/queries";
 
 import EmptyDetail from "dashboard/detail/common/EmptyDetailView";
@@ -144,12 +143,6 @@ export function RouteSignBsdasri({
 
   const config = settings[UIsignatureType];
 
-  const actionTab = {
-    pathname: generatePath(routes.dashboard.bsds.act, {
-      siret,
-    }),
-  };
-
   const formState = prefillWasteDetails(
     getComputedState(getInitialState(), bsdasri)
   );
@@ -182,7 +175,7 @@ export function RouteSignBsdasri({
               input: { ...signature, type: config.signatureType },
             },
           });
-          history.push(actionTab);
+          history.goBack();
         }}
       >
         {({ isSubmitting, handleReset, errors }) => {
@@ -212,7 +205,7 @@ export function RouteSignBsdasri({
                   className="btn btn--outline-primary"
                   onClick={() => {
                     handleReset();
-                    history.push(actionTab);
+                    history.goBack();
                   }}
                 >
                   Annuler

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { Loader } from "common/components";
 import { GET_BSDS } from "common/queries";
-import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
 } from "form/common/stepper/GenericStepList";
@@ -16,7 +15,7 @@ import {
   BsdaInput,
 } from "generated/graphql/types";
 import React, { ReactElement, useMemo } from "react";
-import { generatePath, useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import initialState from "./initial-state";
 import { CREATE_BSDA, UPDATE_BSDA, GET_BSDA } from "./queries";
 import omitDeep from "omit-deep-lodash";
@@ -102,10 +101,7 @@ export default function BsdaStepsList(props: Props) {
     const { id, ...input } = values;
     saveForm(input)
       .then(_ => {
-        const redirectTo = generatePath(routes.dashboard.bsds.drafts, {
-          siret,
-        });
-        history.push(redirectTo);
+        history.goBack();
       })
       .catch(err => formInputToastError(err));
   }

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -34,7 +34,6 @@ const prefillTransportMode = state => {
   return state;
 };
 export default function BsdaStepsList(props: Props) {
-  const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
 
   const formQuery = useQuery<Pick<Query, "bsda">, QueryBsdaArgs>(GET_BSDA, {

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -110,7 +110,6 @@ const removeSections = (
   return omitDeep(input, mapping[status]);
 };
 export default function BsdasriStepsList(props: Props) {
-  const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
 
   const formQuery = useQuery<Pick<Query, "bsdasri">, QueryBsdasriArgs>(

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
 import cogoToast from "cogo-toast";
-import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
 } from "form/common/stepper/GenericStepList";
@@ -21,7 +20,7 @@ import {
 } from "generated/graphql/types";
 import omitDeep from "omit-deep-lodash";
 import React, { ReactElement, useMemo } from "react";
-import { generatePath, useHistory, useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import getInitialState from "./utils/initial-state";
 import {
   CREATE_DRAFT_BSDASRI,
@@ -226,11 +225,7 @@ export default function BsdasriStepsList(props: Props) {
 
     saveForm(input, type)
       .then(_ => {
-        // TODO  redirect to the correct dashboard
-        const redirectTo = generatePath(routes.dashboard.bsds.drafts, {
-          siret,
-        });
-        history.push(redirectTo);
+        history.goBack();
       })
       .catch(err => formInputToastError(err));
   }

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery } from "@apollo/client";
-import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
 } from "form/common/stepper/GenericStepList";
@@ -16,7 +15,7 @@ import {
   BsffType,
 } from "generated/graphql/types";
 import React, { ReactElement, useMemo } from "react";
-import { generatePath, useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import initialState from "./utils/initial-state";
 import {
   CREATE_DRAFT_BSFF,
@@ -30,7 +29,6 @@ interface Props {
 }
 
 export default function BsffStepsList(props: Props) {
-  const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
 
   const formQuery = useQuery<Pick<Query, "bsff">, QueryBsffArgs>(
@@ -96,10 +94,7 @@ export default function BsffStepsList(props: Props) {
           : [],
     })
       .then(_ => {
-        const redirectTo = generatePath(routes.dashboard.bsds.drafts, {
-          siret,
-        });
-        history.push(redirectTo);
+        history.goBack();
       })
       .catch(err => formInputToastError(err));
   }


### PR DESCRIPTION
Lors de l'appel à certaines mutations, on redirige systématiquement sur le même onglet c'est dépendant du contexte. L'idée serait donc de systématiquement utiliser `history.goBack()`. Je suis preneur si vous avez une meilleure solution.

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7269)
