### PR TITLE
Recette Navires étrangers et particuliers

### DIFF
--- a/back/src/events/forms.ts
+++ b/back/src/events/forms.ts
@@ -36,6 +36,9 @@ export async function mailWhenFormIsDeclined(payload: TDEventPayload<Form>) {
     return;
   }
   const form = await prisma.form.findUnique({ where: { id: payload.node.id } });
+  if (form.emitterIsPrivateIndividual || form.emitterIsForeignShip) {
+    return;
+  }
   // build pdf as a base64 string
   const { NOTIFY_DREAL_WHEN_FORM_DECLINED } = process.env;
 

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -144,6 +144,11 @@ async function checkIfUserCanRequestRevisionOnBsdd(
   forwardedIn?: Form
 ): Promise<void> {
   await checkCanRequestRevision(user, bsdd, forwardedIn);
+  if (bsdd.emitterIsPrivateIndividual || bsdd.emitterIsForeignShip) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur ce bordereau car l'émetteur est un particulier ou un navire étranger."
+    );
+  }
   if (Status.DRAFT === bsdd.status || Status.SEALED === bsdd.status) {
     throw new ForbiddenError(
       "Impossible de créer une révision sur ce bordereau. Vous pouvez le modifier directement, aucune signature bloquante n'a encore été apposée."

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -90,8 +90,8 @@ export default function Emitter({ disabled }) {
         <div className="form__row notification notification--warning">
           Lorsqu'un particulier ou un navire étranger est émetteur du déchet, le
           type d'émetteur est verrouillé à "Producteur". La signature de
-          l'émetteur ne sera pas requise et après validation, le bordereau
-          passera à l'attente de la signature par le transporteur.
+          l'émetteur ne sera pas requise et après validation du bordereau la
+          première signature attendue sera celle du transporteur.
         </div>
       )}
       <div className="form__row">


### PR DESCRIPTION
- wording sur UI
- Interdire les requêtes de révision pour ce cas
- Ne pas envoyer d'email (cc DREAL) en cas de refus du destinataire.


- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7603)
