### PR TITLE
Fixes form getting cleared after adding a foreign company VAT

### DIFF
--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -69,12 +69,7 @@ export default function CompanySelector({
   const { siret } = useParams<{ siret: string }>();
   const [uniqId] = useState(() => uuidv4());
   const [field] = useField<FormCompany>({ name });
-  const {
-    setFieldError,
-    setFieldValue,
-    setFieldTouched,
-    resetForm,
-  } = useFormikContext();
+  const { setFieldError, setFieldValue, setFieldTouched } = useFormikContext();
   const { values } = useFormikContext<FormCompany>();
   const [clue, setClue] = useState("");
   const [department, setDepartement] = useState<null | string>(null);
@@ -109,7 +104,6 @@ export default function CompanySelector({
           cogoToast.error(
             "Cet établissement n'est pas enregistré sur Trackdéchets, nous ne pouvons l'ajouter dans ce formulaire"
           );
-          resetCompany();
           return;
         }
         if (companyInfos.name === "---") {
@@ -124,13 +118,6 @@ export default function CompanySelector({
     },
     fetchPolicy: "no-cache",
   });
-
-  const resetCompany = useCallback(() => {
-    resetForm();
-    if (onCompanySelected) {
-      onCompanySelected({});
-    }
-  }, [resetForm, onCompanySelected]);
 
   const selectCompany = useCallback(
     (company: CompanyFavorite) => {


### PR DESCRIPTION
Fix retour de recette.

[Lien Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8346)

On nettoyait le form lorsque l'utilisateur entrait le numéro de TVA d'une entreprise non inscrite sur TD ; cela marchait par la grâce de Dieu, mais il n'y a plus de form dans le form et pas vraiment d'intérêt à nettoyer quoi que ce soit ; le message d'erreur étant suffisant. 