### PR TITLE
Interface d'ajout des intermédiaires sur BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout du code 12 01 16\* pour les BSDAs [PR 1478](https://github.com/MTES-MCT/trackdechets/pull/1478)
 - Ajout d'un filtre sur le type de BSDASRI dans la query `bsdasris` [PR 1479](https://github.com/MTES-MCT/trackdechets/pull/1479)
 - Ajout de la possibilité de rechercher des BSFFs par leurs numéros de contenant (dans l'interface Trackdéchets et par API) [PR 1510](https://github.com/MTES-MCT/trackdechets/pull/1510)
+- Interface d'ajout des intermédiaires sur BSDD [PR 1481](https://github.com/MTES-MCT/trackdechets/pull/1481)
+- La requête `searchCompanies` qui interroge la base SIRENE (via [les données ouvertes de l'INSEE](https://files.data.gouv.fr/insee-sirene/)), reconnaît désormais si `clue` est un numéro de TVA et interroge la base VIES (via [le service la commission européenne](https://ec.europa.eu/taxation_customs/vies/)) pour vérifier son existence et indiquer si l'établissement est inscrit ou non sur Trackdéchets. [PR 1481](https://github.com/MTES-MCT/trackdechets/pull/1481)
+- Ajout de `FormInput.intermediaries: [CompanyInput!]` [PR 1481](https://github.com/MTES-MCT/trackdechets/pull/1481)
 
 #### :bug: Corrections de bugs
 - Correction d'un bug ne permettant pas au destinataire finale de créer un BSDD avec entreposage provisoire [PR 1498](https://github.com/MTES-MCT/trackdechets/pull/1498)

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -70,31 +70,34 @@ export const countries = [
 ];
 
 /**
- * SIRET number validator
+ * Validateur de numéro de SIRETs
  */
 export const isSiret = (clue: string): boolean =>
   !!clue && /^[0-9]{14}$/.test(clue.replace(/\s/g, ""));
 
 /**
- * VAT validator
- * both rules are required, checkVat allows digit-only VAT numbers, may be confusing with SIRET
+ * Validateur de numéro de TVA
  */
 export const isVat = (clue: string): boolean => {
   if (!clue) return false;
-  const isRegexValid = checkVAT(clue.trim(), countries);
+  const cleanClue = clue.replace(/\s/g, "");
+  if (!cleanClue) return false;
+  const isRegexValid = checkVAT(cleanClue, countries);
   return isRegexValid.isValid;
 };
 
 /**
- * French VAT
+ * TVA Français
  */
 export const isFRVat = (clue: string): boolean => {
   if (!clue) return false;
-  return clue.replace(/\s/g, "").slice(0, 2).toUpperCase().startsWith("FR");
+  const cleanClue = clue.replace(/\s/g, "");
+  if (!cleanClue) return false;
+  return cleanClue.slice(0, 2).toUpperCase().startsWith("FR");
 };
 
 /**
- * OMI number is "OMI1234567" (7 numbers)
+ * Le numéro OMI est "OMI1234567" (7 chiffres)
  */
 export const isOmi = (clue: string): boolean => {
   if (!clue) return false;

--- a/back/src/companies/__tests__/search.test.ts
+++ b/back/src/companies/__tests__/search.test.ts
@@ -107,7 +107,7 @@ describe("searchCompanies", () => {
     expect(companies[0]).toStrictEqual(company);
   });
 
-  it("should not call searchCompany when the clue is formatted like a VAT number", async () => {
+  it("should call searchCompany when the clue is formatted like a VAT number", async () => {
     const company = {
       siret: "11111111111111",
       vatNumber: "IT09301420155",
@@ -123,7 +123,7 @@ describe("searchCompanies", () => {
     };
     searchCompanyMock.mockResolvedValue(company);
     await searchCompanies("IT09301420155");
-    expect(searchCompanyMock).toHaveBeenCalledTimes(0);
+    expect(searchCompanyMock).toHaveBeenCalledTimes(1);
   });
 
   it(`should not return closed companies when searching by SIRET`, async () => {

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -8,17 +8,19 @@ import { getInstallation } from "../../database";
 import { searchCompany } from "../../search";
 
 /**
- * This function is used to return public company
- * information for a specific siret or VAT number. It merge info
- * from Sirene or VIES vat database, S3ic database and TD without
- * exposing private TD info like securityCode, users, etc
+ * Recherche et renvoie les données diffusables
+ * sur une entreprise pour un numéro de SIRET ou de TVA
+ * Fusionnant les infos des bases Tracdéchets et S3IC
+ * si elles existent
+ * Renvoie le type CompanyPublic pour la query companyInfos
+ * et le type CompanySearchPrivate pour la query companyPrivateInfos
  *
  * @param siretOrVat
  */
 export async function getCompanyInfos(
   siretOrVat: string
 ): Promise<CompanyPublic | CompanySearchPrivate> {
-  if (siretOrVat === undefined || !siretOrVat.length) {
+  if (!siretOrVat) {
     throw new UserInputError(
       "Paramètre absent. Un numéro SIRET ou de TVA intracommunautaire valide est requis",
       {
@@ -35,10 +37,10 @@ export async function getCompanyInfos(
 }
 
 const companyInfosResolvers: QueryResolvers["companyInfos"] = async (
-  parent,
+  _,
   args
 ) => {
-  if (args.siret === undefined && args.clue === undefined) {
+  if (!args.siret && !args.clue) {
     throw new UserInputError(
       "Paramètre siret et clue absents. Un numéro SIRET ou de TVA intracommunautaire valide est requis",
       {

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -72,6 +72,7 @@ function companyToFavorite(
     contact: company.contact,
     phone: company.contactPhone,
     mail: company.contactEmail,
+    isRegistered: !!company,
     codePaysEtrangerEtablissement: !company.vatNumber
       ? "FR"
       : checkVAT(company.vatNumber, countries)?.country?.isoCode.short,
@@ -85,10 +86,12 @@ function companySearchResultToFavorite(
   return {
     name: companySearchResult.name,
     siret: companySearchResult.siret,
+    vatNumber: companySearchResult.vatNumber,
     address: companySearchResult.address,
     contact: companySearchResult.contact,
     phone: companySearchResult.contactPhone ?? "",
-    mail: companySearchResult.contactEmail ?? ""
+    mail: companySearchResult.contactEmail ?? "",
+    isRegistered: companySearchResult.isRegistered
   };
 }
 

--- a/back/src/companies/typeDefs/company.inputs.graphql
+++ b/back/src/companies/typeDefs/company.inputs.graphql
@@ -1,0 +1,22 @@
+"""
+Basic Company Infos to validate and correct
+"""
+input CompanyValidationInput {
+  """
+  SIRET de l'établissement composé de 14 caractères numériques
+  """
+  siret: String
+
+  """
+  Numéro de TVA intra-communautaire de l'établissement. À renseigner pour
+  les transporteurs étrangers uniquement.
+  """
+  vatNumber: String
+
+  "Nom de l'établissement"
+  name: String
+
+  "Adresse de l'établissement"
+  address: String
+
+}

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -218,6 +218,8 @@ type CompanySearchResult {
   contactEmail: String
   "Numéro de téléphone de contact"
   contactPhone: String
+  "Nom et prénom de contact"
+  contact: String
   "Site web"
   website: String
   """
@@ -467,4 +469,31 @@ type Installation {
 
   "Liste des déclarations GEREP"
   declarations: [Declaration!]
+}
+
+enum EtatAdministratif {
+  A
+  F
+}
+
+enum StatutDiffusionEtablissement {
+  O
+  N
+}
+
+"""
+Informations minimal sur une entreprise identifiée par son siret
+validées par requête à l'INSEE
+"""
+type CompanyValidationInfos {
+  siret: String!
+  vatNumber: String
+  address: String
+  name: String
+  "Enregistré sur Trackdéchets"
+  isRegistered: Boolean!
+  "Statuts de diffusion autorisée ou non selon l'INSEE"
+  statutDiffusionEtablissement: StatutDiffusionEtablissement
+  "Etat ouvert ou fermé selon l'INSEE"
+  etatAdministratif: EtatAdministratif
 }

--- a/back/src/companies/typeDefs/company.queries.graphql
+++ b/back/src/companies/typeDefs/company.queries.graphql
@@ -1,9 +1,9 @@
 type Query {
   """
-  Renvoie des informations publiques sur un établissement
-  extrait de la base SIRENE ou de la base européenne VIES
-  et de la base des installations
-  classées pour la protection de l'environnement (ICPE)
+  Renvoie des informations autorisées à la diffusion publique sur un établissement
+  Les informations proviennent de l'INSEE (Sirene) ou de la base européenne VIES
+  pour les numéros de TVA intracommunautaires (entreprises hors France)
+  ainsi que de la base des installations classées pour la protection de l'environnement (ICPE)
   """
   companyInfos(
     """SIRET de l'établissement, supporte aussi un numéro TVA intracommunautaire"""
@@ -15,6 +15,8 @@ type Query {
   """
   Effectue une recherche floue sur la base SIRENE et enrichie
   avec des informations provenant de Trackdéchets
+  Si vous envoyez un numéro de SIRET ou de TVA la recherche renverra un seul item
+  idendique à celui de la requête companyInfos (ignorant alors le champ department).
   """
   searchCompanies(
     """

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -29,6 +29,11 @@ type CompanyFavorite {
   codePaysEtrangerEtablissement: String
 
   """
+  Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets
+  """
+  isRegistered: Boolean
+
+  """
   Récépissé transporteur associé à cet établissement (le cas échéant)
   """
   transporterReceipt: TransporterReceipt
@@ -199,4 +204,7 @@ type CompanySearchPrivate {
   Si oui on non cet établissement est inscrit sur TD comme AnonymousCompany
   """
   isAnonymousCompany: Boolean
+
+  "Nom du contact"
+  contact: String
 }

--- a/back/src/companies/validateCompany.ts
+++ b/back/src/companies/validateCompany.ts
@@ -1,0 +1,56 @@
+import { UserInputError } from "apollo-server-core";
+import { isObject } from "../forms/workflow/diff";
+import {
+  CompanyValidationInput,
+  CompanyValidationInfos
+} from "../generated/graphql/types";
+import { searchCompany } from "./search";
+
+/**
+ * Validate a Company input and return a partial CompanyInput with info from Sirene data
+ */
+export async function validateCompany(
+  company: CompanyValidationInput,
+  errorPrefix = "Intermédiaires: "
+): Promise<CompanyValidationInfos> {
+  if (!isObject(company) || !Object.keys(company)) {
+    throw new UserInputError(
+      `${errorPrefix}Obligatoirement spécifier un SIRET`
+    );
+  }
+  // validate input because the query accepts both optional siret or vatNumber
+  if (!company.siret) {
+    if (!company.vatNumber) {
+      throw new UserInputError(
+        `${errorPrefix}Obligatoirement spécifier soit un SIRET soit un numéro de TVA intracommunautaire`
+      );
+    } else {
+      throw new UserInputError(
+        `${errorPrefix}Obligatoirement spécifier un SIRET`
+      );
+    }
+  }
+  const { siret, vatNumber } = company;
+  try {
+    const companySearchResult = await searchCompany(siret || vatNumber);
+    return {
+      siret: companySearchResult.siret!, // presence of SIRET is validated in intermediarySchema
+      vatNumber: companySearchResult.vatNumber ?? "",
+      address: companySearchResult?.address ?? company.address,
+      name: companySearchResult?.name ?? company.name,
+      isRegistered: companySearchResult?.isRegistered,
+      statutDiffusionEtablissement:
+        companySearchResult?.statutDiffusionEtablissement,
+      etatAdministratif: companySearchResult?.etatAdministratif as "A" | "F"
+    };
+  } catch (exc) {
+    if (exc instanceof UserInputError) {
+      throw new UserInputError(
+        `${errorPrefix}Numéro de SIRET ou de TVA invalide`,
+        {
+          invalidArgs: ["siret", "vatNumber"]
+        }
+      );
+    }
+  }
+}

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -33,6 +33,19 @@ export function getSiretsByTab(
     {}
   );
 
+  const intermediarySiretsReducer = form.intermediaries.reduce(
+    (acc, intermediary) => {
+      if (!!intermediary.siret) {
+        return {
+          ...acc,
+          [`intermediarySiret${intermediary.siret}`]: intermediary.siret
+        };
+      }
+      return acc;
+    },
+    {}
+  );
+
   const formSirets = {
     emitterCompanySiret: form.emitterCompanySiret,
     recipientCompanySiret: form.recipientCompanySiret,
@@ -43,7 +56,8 @@ export function getSiretsByTab(
     brokerCompanySiret: form.brokerCompanySiret,
     ecoOrganismeSiret: form.ecoOrganismeSiret,
     transporterCompanySiret: form.transporterCompanySiret,
-    ...multimodalTransportersBySegmentId
+    ...multimodalTransportersBySegmentId,
+    ...intermediarySiretsReducer
   };
 
   const siretsByTab = {
@@ -72,7 +86,9 @@ export function getSiretsByTab(
   }
 
   // initialize intermediaries into isFollowFor
-  form.intermediaries.map(({ siret }) => fieldTabs.set(siret, "isFollowFor"));
+  form.intermediaries.forEach(({ siret }) =>
+    setFieldTab(`intermediarySiret${siret}`, "isFollowFor")
+  );
 
   switch (form.status) {
     case Status.DRAFT: {

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -253,7 +253,8 @@ describe("Mutation.createForm", () => {
     });
     expect(errors).toEqual([
       expect.objectContaining({
-        message: "Seul les numéros de TVA en France sont valides",
+        message:
+          "Intermédiaires: seul les numéros de TVA en France sont valides",
         extensions: {
           code: "BAD_USER_INPUT"
         }
@@ -284,7 +285,7 @@ describe("Mutation.createForm", () => {
     });
     expect(errors).toEqual([
       expect.objectContaining({
-        message: "Le N°SIRET est obligatoire pour une entreprise intermédiaire",
+        message: "Intermédiaires: le N° SIRET est obligatoire",
         extensions: {
           code: "BAD_USER_INPUT"
         }

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -306,6 +306,14 @@ input FormInput {
   ecoOrganisme: EcoOrganismeInput
 
   temporaryStorageDetail: TemporaryStorageDetailInput
+
+  """
+  Liste d'entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,
+  mais pas à la responsabilité de la traçabilité (entreprise de travaux, bureau d'étude, maitre d'oeuvre,
+  collectivité, etc.) Il pourra lire ce bordereau, sans étape de signature.
+  L'adresse et la raison sociale seront ignorées car seront automatiquement remplies à partir des données publiques de l'INSEE pour le SIRET
+  """
+  intermediaries: [CompanyInput!]
 }
 
 "Payload de création d'une annexe 2"

--- a/back/src/users/bulk-creation/__tests__/validation.test.ts
+++ b/back/src/users/bulk-creation/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from "yup";
-import { validateCompany, validateRoleGenerator } from "../validations";
+import { companyValidationSchema, validateRoleGenerator } from "../validations";
 import { CompanyType } from "@prisma/client";
 
 const mockCompanyExists = jest.fn();
@@ -31,19 +31,21 @@ describe("company validation", () => {
       siret: "12345678901234",
       companyTypes: ["PRODUCER"]
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
   });
 
   test("missing siret", async () => {
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: null,
         companyTypes: ["PRODUCER"]
       })
     ).rejects.toThrow(ValidationError);
 
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         companyTypes: ["PRODUCER"]
       })
     ).rejects.toThrow(ValidationError);
@@ -51,7 +53,7 @@ describe("company validation", () => {
 
   test("siret does not have lenght 14", async () => {
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "123",
         companyTypes: ["PRODUCER"]
       })
@@ -63,7 +65,7 @@ describe("company validation", () => {
       Promise.reject("SIRET does not exist")
     );
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: ["PRODUCER"]
       })
@@ -73,7 +75,7 @@ describe("company validation", () => {
   test("company already exists in TD", async () => {
     mockCompanyExists.mockResolvedValueOnce(true);
     console.warn = jest.fn();
-    await validateCompany({
+    await companyValidationSchema.validate({
       siret: "12345678901234",
       companyTypes: ["PRODUCER"]
     });
@@ -83,24 +85,24 @@ describe("company validation", () => {
 
   test("missing companyTypes", async () => {
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234"
       })
     ).rejects.toThrow(ValidationError);
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: null
       })
     ).rejects.toThrow(ValidationError);
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: []
       })
     ).rejects.toThrow(ValidationError);
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: [""]
       })
@@ -109,7 +111,7 @@ describe("company validation", () => {
 
   test("companyTypes includes bad value", async () => {
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "123",
         companyTypes: [
           "PRODUCE", // typo here
@@ -126,10 +128,12 @@ describe("company validation", () => {
       companyTypes: ["PRODUCER"],
       contactEmail: "john.snow@trackdechets.fr"
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
     // invalid email
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: ["PRODUCER"],
         contactEmail: "azerty"
@@ -144,10 +148,12 @@ describe("company validation", () => {
       companyTypes: ["PRODUCER"],
       website: "https://trackdechets.beta.gouv.fr"
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
     // invalid URL
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: ["PRODUCER"],
         website: "azerty"
@@ -162,23 +168,29 @@ describe("company validation", () => {
       companyTypes: ["PRODUCER"],
       contactPhone: "0100000000"
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
     company = {
       siret: "12345678901234",
       companyTypes: ["PRODUCER"],
       contactPhone: "01 00 00 00 00"
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
 
     company = {
       siret: "12345678901234",
       companyTypes: ["PRODUCER"],
       contactPhone: "01-00-00-00-00"
     };
-    await expect(validateCompany(company)).resolves.toEqual(company);
+    await expect(companyValidationSchema.validate(company)).resolves.toEqual(
+      company
+    );
     // invalid phone number
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: ["PRODUCER"],
         contactPhone: "01-00-00-00" // missing two digits
@@ -191,7 +203,7 @@ describe("company validation", () => {
       Promise.resolve({ etatAdministratif: "F" })
     );
     await expect(
-      validateCompany({
+      companyValidationSchema.validate({
         siret: "12345678901234",
         companyTypes: ["PRODUCER"]
       })

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -1,7 +1,7 @@
 import parseArgs from "minimist";
 import prisma from "../../prisma";
 import { loadCompanies, loadRoles } from "./loaders";
-import { validateCompany, validateRoleGenerator } from "./validations";
+import { companyValidationSchema, validateRoleGenerator } from "./validations";
 import { sirenify } from "./sirene";
 import { hashPassword, generatePassword } from "../utils";
 import { randomNumber, getUIBaseURL, sanitizeEmail } from "../../utils";
@@ -78,7 +78,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
   for (const company of companiesRows) {
     console.info(`Validate company ${company.siret}`);
     try {
-      const validCompany = await validateCompany(company);
+      const validCompany = await companyValidationSchema.validate(company);
       companies.push(validCompany);
     } catch (err) {
       isValid = false;

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -64,13 +64,6 @@ export const companyValidationSchema = yup.object({
 });
 
 /**
- * Validate company row extracted from etablissements.csv
- */
-export function validateCompany(company): Promise<any> {
-  return companyValidationSchema.validate(company);
-}
-
-/**
  * Validation schema generator for user roles
  * Email adresses should match one entry from utilisateurs.csv
  * SIRET should match one entry from etablissements.csv

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -7145,7 +7145,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -11883,7 +11883,7 @@
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -12798,7 +12798,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
       "version": "4.5.1",
@@ -12837,7 +12837,7 @@
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg=="
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -13614,7 +13614,7 @@
     "postcss-functions": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==",
+      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
       "requires": {
         "glob": "^7.1.2",
         "object-assign": "^4.1.1",
@@ -13782,7 +13782,7 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -15045,7 +15045,7 @@
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
       },

--- a/front/src/common/fragments.ts
+++ b/front/src/common/fragments.ts
@@ -309,6 +309,9 @@ const mutableFieldsFragment = gql`
     transportSegments {
       ...Segment
     }
+    intermediaries {
+      ...CompanyFragment
+    }
   }
   ${traderFragment}
   ${brokerFragment}
@@ -318,6 +321,7 @@ const mutableFieldsFragment = gql`
   ${emitterFragment}
   ${recipientFragment}
   ${segmentFragment}
+  ${companyFragment}
 `;
 
 export const fullFormFragment = gql`
@@ -461,7 +465,7 @@ const wasteAcceptationFragment = gql`
 `;
 
 export const dashboardDasriFragment = gql`
-  fragment DasriFragment on Bsdasri {
+  fragment DashboardDasriFragment on Bsdasri {
     id
     bsdasriStatus: status
     type

--- a/front/src/common/queries.ts
+++ b/front/src/common/queries.ts
@@ -76,7 +76,7 @@ export const GET_BSDS = gql`
             ...FullForm
           }
           ... on Bsdasri {
-            ...DasriFragment
+            ...DashboardDasriFragment
           }
           ... on Bsvhu {
             ...VhuFragment

--- a/front/src/form/bsdd/Recipient.module.scss
+++ b/front/src/form/bsdd/Recipient.module.scss
@@ -16,5 +16,8 @@
     &TextQuote {
       margin: 10px 0;
     }
+    &Select {
+      width: 100%;
+    }
   }
 }

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -99,6 +99,24 @@ export function getInitialEcoOrganisme(ecoOrganisme?: FormEcoOrganisme | null) {
 }
 
 /**
+ * Computes initial values for Form.intermediaries
+ */
+export function getInitialIntermediaries(intermediaries?: FormCompany[]) {
+  return intermediaries
+    ? intermediaries.map(company => ({
+        siret: company?.siret ?? "",
+        name: company?.name ?? "",
+        address: company?.address ?? "",
+        contact: company?.contact ?? "",
+        mail: company?.mail ?? "",
+        phone: company?.phone ?? "",
+        vatNumber: company?.vatNumber ?? "",
+        country: company?.country ?? "",
+      }))
+    : [];
+}
+
+/**
  * Computes initial values of Formik's form by merging
  * default values to the current draft form (if any)
  * @param f current BSD
@@ -173,5 +191,6 @@ export function getInitialState(f?: Form | null): FormInput {
     temporaryStorageDetail: f?.temporaryStorageDetail
       ? getInitialTemporaryStorageDetail(f?.temporaryStorageDetail)
       : null,
+    intermediaries: getInitialIntermediaries(f?.intermediaries),
   };
 }

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -10,6 +10,7 @@ export const FAVORITES = gql`
       contact
       phone
       mail
+      isRegistered
       codePaysEtrangerEtablissement
       transporterReceipt {
         receiptNumber
@@ -80,6 +81,8 @@ export const SEARCH_COMPANIES = gql`
       address
       etatAdministratif
       codePaysEtrangerEtablissement
+      isRegistered
+      contact
       installation {
         codeS3ic
         urlFiche


### PR DESCRIPTION
# Proposition d'UX

Rajouter la possibilité d'ajouter des intermédiaires, au même endroit que le courtier ou le négociant, dans le bas de la page Destination.

- La possibilité d'ajouter plusieurs intermédiaires avec nombre max de 20 (à discuter)
- La possibilité d'en supprimer un
- La possibilité d'ajouter un courtier OU un négociant
- Griser les éléments du menu qui ne sont plus disponibles
- Après validation, un BSD sur lequel un établissement inscrit sur TD est *seulement* intermédiaire s'affiche dans l'onglet "suivi"
- L'intermédiaire qui n'est pas visé comme acteur du bsd peut : valider le bsd et suivre son avancement dans l'onglet suivi, pas de signatures

![image](https://user-images.githubusercontent.com/76620/178005327-ee00d93f-d32f-4da9-af98-4eb86c0e3f4f.png)

# Changements API

- `searchCompanies` : s'adapte à la recherche exacte par numéro de TVA (détection automatique). Ajout dans la réponse de `isRegistered` pour cohérence avec `favorites` et `companyInfos`
- Traduction en français de descriptions de requêtes publiques (et autres fonctions du code back-end)
- `favorites` (privée) et son type de réponse `CompanyFavorite` : ajout de `isRegistered`  et `vatNumber` pour consolidation avec le type `CompanySearchPrivate`
- Refactoring code search.ts pour cohérence de la réponse avec le support de la recherche exacte par numéro de TVA.
- Typage du format d'input `CompanyValidationInput` et `CompanyValidationInfos` pour l'usage dans la fonction back-end de `validateCompany` qui sert à corriger les infos dans `createForm` et `updateForm`
- ajout du champ `contact` sur `CompanySearchPrivate` pour cohérence sur le model `Company` 
- Support `isFollowFor` pour les BSD contenant des intermédiaires.
- Amélioration du texte des erreurs pour l'édition de Form avec intermédiaires.
- Ajout du type d'input `FormInput.intermediaries: [CompanyInput!]` et support dans le schéma de validation des données

# Changements Front

- Recipient.tsx : ajout d'un Select pour ajout d'un courtier/négociant/intermédiaires (max 20 intermédiaires).
- À la sélection d'un entre prise intermédiaires, affichza d'un toaster d'infos si l'entreprise n'est pas inscrite sur TD pour expliquer que "le suivi du bordereau ne sera pas possible sur la plateforme"
- Utilisation de `CompanySelector` pour les intermédaires : des changements ont été nécessaire pour support ce cas.
- `CompanySelector` améliorations code : 
  - suppression `companyInfos` car n'est plus utile pour la recherche exacte pas TVA
  - généralisation du type `CompanySearchPrivate` pour les résultats
  - le cycle "input text" (`useEffect` avec un timeout delai de 300ms) => recherche `searchCompanies` => mise à jour de l'état `searchResults` (dans `useMemo`) => sélection automatique d'un résultat si contraint (`autoSelectCompany` avec `useCallback`)
  - `favoritesQuery` déclenchée manuellement (initial et rafraîchissement si l'input de recherche se vide) et non plus au chargement du composant

# Checklist
- [x] Vérifier les permissions d'accès de suivi au BSDD par l'entreprise intermédiaire losqu'elle est enregistrée sur TD.
- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6959)
