### PR TITLE
Hotfix - Cannot convert undefined or null to object

### DIFF
--- a/back/src/common/constants/__tests__/formHelpers.test.ts
+++ b/back/src/common/constants/__tests__/formHelpers.test.ts
@@ -1,16 +1,40 @@
-import { packagingsEqual } from "../formHelpers";
+import { objectsEqual, packagingsEqual } from "../formHelpers";
+
+describe("objectEquals", () => {
+  test("empty objects", () => {
+    expect(objectsEqual({}, {})).toEqual(true);
+    expect(objectsEqual({}, { type: "FUT", quantity: 1 })).toEqual(false);
+  });
+
+  test("null values", () => {
+    expect(objectsEqual(null, null)).toEqual(true);
+    expect(objectsEqual(null, { type: "FUT", quantity: 1 })).toEqual(false);
+    expect(objectsEqual({ type: "FUT", quantity: 1 }, null)).toEqual(false);
+  });
+
+  test("undefined values", () => {
+    expect(objectsEqual(undefined, undefined)).toEqual(true);
+    expect(objectsEqual({ type: "FUT", quantity: 1 }, undefined)).toEqual(
+      false
+    );
+    expect(objectsEqual(undefined, { type: "FUT", quantity: 1 })).toEqual(
+      false
+    );
+  });
+});
 
 describe("packagingEquals", () => {
   test("empty packaging", () => {
     expect(packagingsEqual([], [])).toEqual(true);
     expect(packagingsEqual([{ type: "FUT", quantity: 1 }], [])).toEqual(false);
   });
-  test("null packaging", () => {
-    expect(packagingsEqual(null, null)).toEqual(true);
-    expect(packagingsEqual([{ type: "FUT", quantity: 1 }], null)).toEqual(
-      false
-    );
+
+  test("undefined key in packaging", () => {
+    expect(
+      packagingsEqual([{ type: "FUT", quantity: 1 }], [{ type: "FUT" }])
+    ).toEqual(false);
   });
+
   test("different packagings", () => {
     expect(
       packagingsEqual(

--- a/back/src/common/constants/formHelpers.ts
+++ b/back/src/common/constants/formHelpers.ts
@@ -1,11 +1,12 @@
 export const isBsddTransporterFieldEditable = status =>
   ["SEALED", "SIGNED_BY_PRODUCER"].includes(status);
 
-const objectsEqual = (o1, o2) =>
-  typeof o1 === "object" && Object.keys(o1).length > 0
+export const objectsEqual = (o1, o2) => {
+  return isObject(o1) && isObject(o2)
     ? Object.keys(o1).length === Object.keys(o2).length &&
-      Object.keys(o1).every(p => objectsEqual(o1[p], o2[p]))
+        Object.keys(o1).every(p => objectsEqual(o1[p], o2[p]))
     : o1 === o2;
+};
 
 const arraysEqual = (a1, a2) =>
   a1.length === a2.length && a1.every((o, idx) => objectsEqual(o, a2[idx]));
@@ -15,3 +16,7 @@ export const packagingsEqual = (p1, p2) =>
     (p1 ?? []).sort((p11, p12) => p11.type.localeCompare(p12.type)),
     (p2 ?? []).sort((p21, p22) => p21.type.localeCompare(p22.type))
   );
+
+function isObject(o) {
+  return typeof o === "object" && !Array.isArray(o) && o !== null;
+}


### PR DESCRIPTION
https://sentry.incubateur.net/organizations/betagouv/issues/3379/?project=19&query=is%3Aunresolved

`typeof null === "object"` renvoie `true` ce qui posait un problème lors de l'appel à `Object.keys`
