### PR TITLE
Do not wrap all mutation code in transaction (`createForm` and `updateForm`)

### DIFF
--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -28,153 +28,159 @@ const createFormResolver = async (
   { createFormInput }: MutationCreateFormArgs,
   context: GraphQLContext
 ) => {
-  const newForm = await prisma.$transaction(async transaction => {
-    const user = checkIsAuthenticated(context);
+  const user = checkIsAuthenticated(context);
 
-    const {
-      appendix2Forms,
-      grouping,
-      temporaryStorageDetail,
-      intermediaries,
-      ...formContent
-    } = createFormInput;
+  const {
+    appendix2Forms,
+    grouping,
+    temporaryStorageDetail,
+    intermediaries,
+    ...formContent
+  } = createFormInput;
 
-    if (appendix2Forms && grouping) {
-      throw new UserInputError(
-        "Vous pouvez renseigner soit `appendix2Forms` soit `grouping` mais pas les deux"
-      );
-    }
-
-    if (
-      formContent.wasteDetails?.code &&
-      isDangerous(formContent.wasteDetails?.code) &&
-      formContent.wasteDetails.isDangerous === undefined
-    ) {
-      formContent.wasteDetails.isDangerous = true;
-    }
-
-    const formCompanies: FormCompanies = {
-      emitterCompanySiret: formContent.emitter?.company?.siret,
-      recipientCompanySiret: formContent.recipient?.company?.siret,
-      transporterCompanySiret: formContent.transporter?.company?.siret,
-      traderCompanySiret: formContent.trader?.company?.siret,
-      brokerCompanySiret: formContent.broker?.company?.siret,
-      ecoOrganismeSiret: formContent.ecoOrganisme?.siret,
-      ...(temporaryStorageDetail?.destination?.company?.siret
-        ? {
-            destinationCompanySiret:
-              temporaryStorageDetail.destination.company.siret
-          }
-        : {}),
-      ...(intermediaries?.length
-        ? {
-            intermediariesVatNumbers: intermediaries?.map(
-              intermediary => intermediary.vatNumber ?? null
-            ),
-            intermediariesSirets: intermediaries?.map(
-              intermediary => intermediary.siret ?? null
-            )
-          }
-        : {})
-    };
-
-    await checkIsFormContributor(
-      user,
-      formCompanies,
-      "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
+  if (appendix2Forms && grouping) {
+    throw new UserInputError(
+      "Vous pouvez renseigner soit `appendix2Forms` soit `grouping` mais pas les deux"
     );
+  }
 
-    const form = flattenFormInput(formContent);
+  if (
+    formContent.wasteDetails?.code &&
+    isDangerous(formContent.wasteDetails?.code) &&
+    formContent.wasteDetails.isDangerous === undefined
+  ) {
+    formContent.wasteDetails.isDangerous = true;
+  }
 
-    const readableId = getReadableId();
+  const formCompanies: FormCompanies = {
+    emitterCompanySiret: formContent.emitter?.company?.siret,
+    recipientCompanySiret: formContent.recipient?.company?.siret,
+    transporterCompanySiret: formContent.transporter?.company?.siret,
+    traderCompanySiret: formContent.trader?.company?.siret,
+    brokerCompanySiret: formContent.broker?.company?.siret,
+    ecoOrganismeSiret: formContent.ecoOrganisme?.siret,
+    ...(temporaryStorageDetail?.destination?.company?.siret
+      ? {
+          destinationCompanySiret:
+            temporaryStorageDetail.destination.company.siret
+        }
+      : {}),
+    ...(intermediaries?.length
+      ? {
+          intermediariesVatNumbers: intermediaries?.map(
+            intermediary => intermediary.vatNumber ?? null
+          ),
+          intermediariesSirets: intermediaries?.map(
+            intermediary => intermediary.siret ?? null
+          )
+        }
+      : {})
+  };
 
-    const formCreateInput: Prisma.FormCreateInput = {
-      ...form,
-      readableId,
-      owner: { connect: { id: user.id } }
-    };
+  await checkIsFormContributor(
+    user,
+    formCompanies,
+    "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
+  );
 
-    await draftFormSchema.validate(formCreateInput);
+  const form = flattenFormInput(formContent);
 
-    if (temporaryStorageDetail) {
-      if (formContent.recipient?.isTempStorage !== true) {
-        // The user is trying to set a temporary storage without
-        // recipient.isTempStorage=true, throw error
-        throw new MissingTempStorageFlag();
+  const readableId = getReadableId();
+
+  const formCreateInput: Prisma.FormCreateInput = {
+    ...form,
+    readableId,
+    owner: { connect: { id: user.id } }
+  };
+
+  await draftFormSchema.validate(formCreateInput);
+
+  if (temporaryStorageDetail) {
+    if (formContent.recipient?.isTempStorage !== true) {
+      // The user is trying to set a temporary storage without
+      // recipient.isTempStorage=true, throw error
+      throw new MissingTempStorageFlag();
+    }
+    formCreateInput.forwardedIn = {
+      create: {
+        owner: { connect: { id: user.id } },
+        readableId: `${readableId}-suite`,
+        ...flattenTemporaryStorageDetailInput(temporaryStorageDetail)
       }
+    };
+  } else {
+    if (formContent.recipient?.isTempStorage === true) {
+      // Recipient is temp storage but no details provided
+      // Create empty temporary storage details
       formCreateInput.forwardedIn = {
         create: {
           owner: { connect: { id: user.id } },
-          readableId: `${readableId}-suite`,
-          ...flattenTemporaryStorageDetailInput(temporaryStorageDetail)
+          readableId: `${readableId}-suite`
         }
       };
-    } else {
-      if (formContent.recipient?.isTempStorage === true) {
-        // Recipient is temp storage but no details provided
-        // Create empty temporary storage details
-        formCreateInput.forwardedIn = {
-          create: {
-            owner: { connect: { id: user.id } },
-            readableId: `${readableId}-suite`
-          }
-        };
+    }
+  }
+
+  if (intermediaries) {
+    formCreateInput.intermediaries = {
+      createMany: {
+        data: await validateIntermediariesInput(intermediaries),
+        skipDuplicates: true
       }
+    };
+  }
+
+  let appendix2: { quantity: number; form: Form }[] = null;
+
+  if (grouping) {
+    appendix2 = await Promise.all(
+      grouping.map(async ({ form, quantity }) => {
+        const foundForm = await getFormOrFormNotFound(form);
+        return {
+          form: foundForm,
+          quantity:
+            quantity ??
+            new Decimal(foundForm.quantityReceived)
+              .minus(foundForm.quantityGrouped)
+              .toNumber()
+        };
+      })
+    );
+  } else if (appendix2Forms) {
+    appendix2 = await Promise.all(
+      appendix2Forms.map(async ({ id }) => {
+        const initialForm = await getFormOrFormNotFound({ id });
+        return {
+          form: initialForm,
+          quantity: initialForm.quantityReceived
+        };
+      })
+    );
+  }
+
+  const newForm = await prisma.$transaction(
+    async transaction => {
+      const { create, setAppendix2 } = getFormRepository(user, transaction);
+      const newForm = await create(formCreateInput);
+      await setAppendix2({
+        form: newForm,
+        appendix2
+      });
+      return newForm;
+    },
+    {
+      maxWait: 10000, // default 2000
+      timeout: 20000 // default 5000
     }
+  );
 
-    if (intermediaries) {
-      formCreateInput.intermediaries = {
-        createMany: {
-          data: await validateIntermediariesInput(intermediaries),
-          skipDuplicates: true
-        }
-      };
-    }
-
-    const formRepository = getFormRepository(user, transaction);
-    const newForm = await formRepository.create(formCreateInput);
-
-    let appendix2: { quantity: number; form: Form }[] = null;
-
-    if (grouping) {
-      appendix2 = await Promise.all(
-        grouping.map(async ({ form, quantity }) => {
-          const foundForm = await getFormOrFormNotFound(form);
-          return {
-            form: foundForm,
-            quantity:
-              quantity ??
-              new Decimal(foundForm.quantityReceived)
-                .minus(foundForm.quantityGrouped)
-                .toNumber()
-          };
-        })
-      );
-    } else if (appendix2Forms) {
-      appendix2 = await Promise.all(
-        appendix2Forms.map(async ({ id }) => {
-          const initialForm = await getFormOrFormNotFound({ id });
-          return {
-            form: initialForm,
-            quantity: initialForm.quantityReceived
-          };
-        })
-      );
-    }
-
-    await formRepository.setAppendix2({
-      form: newForm,
-      appendix2
-    });
-
-    eventEmitter.emit(TDEvent.CreateForm, {
-      previousNode: null,
-      node: newForm,
-      updatedFields: {},
-      mutation: "CREATED"
-    });
-    return newForm;
+  eventEmitter.emit(TDEvent.CreateForm, {
+    previousNode: null,
+    node: newForm,
+    updatedFields: {},
+    mutation: "CREATED"
   });
+
   return expandFormFromDb(newForm);
 };
 

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -158,21 +158,15 @@ const createFormResolver = async (
     );
   }
 
-  const newForm = await prisma.$transaction(
-    async transaction => {
-      const { create, setAppendix2 } = getFormRepository(user, transaction);
-      const newForm = await create(formCreateInput);
-      await setAppendix2({
-        form: newForm,
-        appendix2
-      });
-      return newForm;
-    },
-    {
-      maxWait: 10000, // default 2000
-      timeout: 20000 // default 5000
-    }
-  );
+  const newForm = await prisma.$transaction(async transaction => {
+    const { create, setAppendix2 } = getFormRepository(user, transaction);
+    const newForm = await create(formCreateInput);
+    await setAppendix2({
+      form: newForm,
+      appendix2
+    });
+    return newForm;
+  });
 
   eventEmitter.emit(TDEvent.CreateForm, {
     previousNode: null,

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -244,21 +244,15 @@ const updateFormResolver = async (
     );
   }
 
-  const updatedForm = await prisma.$transaction(
-    async transaction => {
-      const { update, setAppendix2 } = getFormRepository(user, transaction);
-      const updatedForm = await update({ id }, formUpdateInput);
-      await setAppendix2({
-        form: updatedForm,
-        appendix2
-      });
-      return updatedForm;
-    },
-    {
-      maxWait: 10000, // default 2000
-      timeout: 20000 // default 5000
-    }
-  );
+  const updatedForm = await prisma.$transaction(async transaction => {
+    const { update, setAppendix2 } = getFormRepository(user, transaction);
+    const updatedForm = await update({ id }, formUpdateInput);
+    await setAppendix2({
+      form: updatedForm,
+      appendix2
+    });
+    return updatedForm;
+  });
 
   return expandFormFromDb(updatedForm);
 };


### PR DESCRIPTION
Premier quick win pour réduire le nombre d'erreurs liées à des transactions fermées qui remontent dans sentry.
PR plus complète de refactoring à venir par Orion.

### createForm.ts

```ts
  const newForm = await prisma.$transaction(async transaction => {
    const { create, setAppendix2 } = getFormRepository(user, transaction);
    const newForm = await create(formCreateInput);
    await setAppendix2({
      form: newForm,
      appendix2
    });
    return newForm;
  });
```


### updateForm.ts

```ts
  const updatedForm = await prisma.$transaction(async transaction => {
    const { update, setAppendix2 } = getFormRepository(user, transaction);
    const updatedForm = await update({ id }, formUpdateInput);
    await setAppendix2({
      form: updatedForm,
      appendix2
    });
    return updatedForm;
  });
```
