### PR TITLE
Doc/bsda deprecated object

### DIFF
--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -135,8 +135,8 @@ type BsdaEmission {
 type BsdaWaste {
   "Rubrique Déchet"
   code: String
-  "Dénomination usuelle"
-  name: String
+  "DEPRECATED - Dénomination usuelle"
+  name: String @deprecated(reason: "Utiliser materialName")
   "Code famille"
   familyCode: String
   "Nom du matériau"


### PR DESCRIPTION
On avait un champ deprecated marqué comme tel sur l'input mais pas sur l'object.
Pour plus de clarté dans la doc on l'ajoute sur l'object.
cf https://forum.trackdechets.beta.gouv.fr/t/denomination-usuelle-du-dechet/741/4