### PR TITLE
Fix : empty contact infos in Companyselector when selecting a company

### DIFF
--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -131,6 +131,12 @@ export default function CompanySelector({
     (company: CompanyFavorite) => {
       if (disabled) return;
 
+      // empty contact infos
+      setFieldValue(field.name, {
+        contact: null,
+        mail: null,
+        phone: null,
+      });
       // avoid setting same company multiple times
       if (company?.siret && company.siret !== field.value.siret) {
         const fields = {
@@ -160,6 +166,7 @@ export default function CompanySelector({
         setFieldValue(field.name, {
           siret: "",
           name: "",
+          vatNumber: "",
           address: "",
           contact: "",
           mail: "",


### PR DESCRIPTION
# Automatically emptying contact fields when selecting another company, shown below

![image](https://user-images.githubusercontent.com/76620/176406364-c7336ac0-980a-4bed-9041-45e7bbbfbe71.png)
