### PR TITLE
Fix : ne pas afficher 2 fos le meme message "toaster" d'erreur

### DIFF
--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery } from "@apollo/client";
-import cogoToast from "cogo-toast";
 import { Loader } from "common/components";
 import { GET_BSDS } from "common/queries";
 import routes from "common/routes";
@@ -21,6 +20,7 @@ import { generatePath, useHistory, useParams } from "react-router-dom";
 import initialState from "./initial-state";
 import { CREATE_BSDA, UPDATE_BSDA, GET_BSDA } from "./queries";
 import omitDeep from "omit-deep-lodash";
+import { formInputToastError } from "form/common/stepper/toaster";
 
 interface Props {
   children: (bsda: Bsda | undefined) => ReactElement;
@@ -107,15 +107,7 @@ export default function BsdaStepsList(props: Props) {
         });
         history.push(redirectTo);
       })
-      .catch(err => {
-        if (err.graphQLErrors?.length) {
-          err.graphQLErrors.map(err =>
-            cogoToast.error(err.message, { hideAfter: 7 })
-          );
-        } else if (err.message) {
-          cogoToast.error(err.message, { hideAfter: 7 });
-        }
-      });
+      .catch(err => formInputToastError(err));
   }
 
   // As it's a render function, the steps are nested into a `<></>` block

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -6,6 +6,7 @@ import GenericStepList, {
 } from "form/common/stepper/GenericStepList";
 
 import { IStepContainerProps } from "form/common/stepper/Step";
+import { formInputToastError } from "form/common/stepper/toaster";
 import {
   Mutation,
   MutationCreateBsdasriArgs,
@@ -231,13 +232,7 @@ export default function BsdasriStepsList(props: Props) {
         });
         history.push(redirectTo);
       })
-      .catch(err => {
-        err.graphQLErrors.length &&
-          err.graphQLErrors.map(err =>
-            cogoToast.error(err.message, { hideAfter: 7 })
-          );
-        err.message && cogoToast.error(err.message, { hideAfter: 7 });
-      });
+      .catch(err => formInputToastError(err));
   }
 
   // As it's a render function, the steps are nested into a `<></>` block

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -1,5 +1,4 @@
 import { useMutation, useQuery } from "@apollo/client";
-import cogoToast from "cogo-toast";
 import routes from "common/routes";
 import {
   FormInput,
@@ -18,6 +17,7 @@ import { CREATE_FORM, GET_FORM, UPDATE_FORM } from "./utils/queries";
 import { IStepContainerProps } from "../common/stepper/Step";
 import { GET_BSDS } from "common/queries";
 import { Loader } from "common/components";
+import { formInputToastError } from "form/common/stepper/toaster";
 
 interface Props {
   children: ReactElement<IStepContainerProps>[];
@@ -87,13 +87,7 @@ export default function StepsList(props: Props) {
 
     saveForm(formInput)
       .then(_ => history.push(redirectTo))
-      .catch(err => {
-        err.graphQLErrors.length &&
-          err.graphQLErrors.map(err =>
-            cogoToast.error(err.message, { hideAfter: 7 })
-          );
-        err.message && cogoToast.error(err.message, { hideAfter: 7 });
-      });
+      .catch(err => formInputToastError(err));
   }
 
   return (

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery } from "@apollo/client";
-import cogoToast from "cogo-toast";
 import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
 } from "form/common/stepper/GenericStepList";
 import { IStepContainerProps } from "form/common/stepper/Step";
+import { formInputToastError } from "form/common/stepper/toaster";
 import {
   Mutation,
   MutationCreateDraftBsffArgs,
@@ -101,13 +101,7 @@ export default function BsffStepsList(props: Props) {
         });
         history.push(redirectTo);
       })
-      .catch(err => {
-        err.graphQLErrors.length &&
-          err.graphQLErrors.map(err =>
-            cogoToast.error(err.message, { hideAfter: 7 })
-          );
-        err.message && cogoToast.error(err.message, { hideAfter: 7 });
-      });
+      .catch(err => formInputToastError(err));
   }
 
   // As it's a render function, the steps are nested into a `<></>` block

--- a/front/src/form/bsvhu/BsvhuStepList.tsx
+++ b/front/src/form/bsvhu/BsvhuStepList.tsx
@@ -1,10 +1,10 @@
 import { useMutation, useQuery } from "@apollo/client";
-import cogoToast from "cogo-toast";
 import routes from "common/routes";
 import GenericStepList, {
   getComputedState,
 } from "form/common/stepper/GenericStepList";
 import { IStepContainerProps } from "form/common/stepper/Step";
+import { formInputToastError } from "form/common/stepper/toaster";
 import {
   Mutation,
   MutationCreateBsvhuArgs,
@@ -76,13 +76,7 @@ export default function BsvhuStepsList(props: Props) {
         });
         history.push(redirectTo);
       })
-      .catch(err => {
-        err.graphQLErrors.length &&
-          err.graphQLErrors.map(err =>
-            cogoToast.error(err.message, { hideAfter: 7 })
-          );
-        err.message && cogoToast.error(err.message, { hideAfter: 7 });
-      });
+      .catch(err => formInputToastError(err));
   }
 
   // As it's a render function, the steps are nested into a `<></>` block

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -26,7 +26,6 @@ import {
   QueryFavoritesArgs,
   FavoriteType,
   CompanyFavorite,
-  CompanySearchResult,
 } from "generated/graphql/types";
 import CountrySelector from "./CountrySelector";
 import { v4 as uuidv4 } from "uuid";
@@ -177,14 +176,7 @@ export default function CompanySelector({
         onCompanySelected(company);
       }
     },
-    [
-      field.name,
-      field.value.siret,
-      setFieldValue,
-      onCompanySelected,
-      disabled,
-      optional,
-    ]
+    [field.name, setFieldValue, onCompanySelected, disabled]
   );
 
   /**

--- a/front/src/form/common/stepper/toaster.ts
+++ b/front/src/form/common/stepper/toaster.ts
@@ -1,0 +1,17 @@
+import { ApolloError } from "@apollo/client";
+import cogoToast from "cogo-toast";
+
+/**
+ * Common toaster display for ApolloError on form submission
+ */
+export const formInputToastError = (err: ApolloError) => {
+  err.graphQLErrors.length &&
+    err.graphQLErrors.forEach(gqerr => {
+      // avoid duplicate error
+      if (gqerr.message === err.message) {
+        return;
+      }
+      cogoToast.error(gqerr.message, { hideAfter: 7 });
+    });
+  err.message && cogoToast.error(err.message, { hideAfter: 7 });
+};


### PR DESCRIPTION
# Refacto gestion toaster d'erreur

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8477)
