### PR TITLE
Fix mauvaise raison sociale et adresse dans les favoris

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Corrections d'édition d'un BSDD avec un transporteur étranger [PR 1491](https://github.com/MTES-MCT/trackdechets/pull/1491), [PR 1494](https://github.com/MTES-MCT/trackdechets/pull/1494) et [PR 1497](https://github.com/MTES-MCT/trackdechets/pull/1497)
 - Corrections de textes divers [PR 1477](https://github.com/MTES-MCT/trackdechets/pull/1477) et [PR 1475](https://github.com/MTES-MCT/trackdechets/pull/1475)
 - Correction "Select all" BSDD avec appendice 2, quantités groupées corrigées [PR 1493](https://github.com/MTES-MCT/trackdechets/pull/1493)
+- Correction de mauvaises raisons sociales et adresses affichées dans le sélecteur d'entreprises [PR 1501](https://github.com/MTES-MCT/trackdechets/pull/1501)
 
 #### :boom: Breaking changes
 

--- a/back/prisma/migrations/78_add_company_contact.sql
+++ b/back/prisma/migrations/78_add_company_contact.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "default$default"."Company" ADD COLUMN "contact" CHAR(100);
+ALTER TABLE "default$default"."Company" ADD COLUMN "contact" TEXT;

--- a/back/prisma/migrations/78_add_company_contact.sql
+++ b/back/prisma/migrations/78_add_company_contact.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "default$default"."Company" ADD COLUMN "contact" CHAR(100);

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -186,6 +186,7 @@ model Company {
   gerepId                              String?
   codeNaf                              String?
   givenName                            String?
+  contact                              String?
   contactEmail                         String?
   contactPhone                         String?
   website                              String?

--- a/back/src/companies/resolvers/mutations/updateCompany.ts
+++ b/back/src/companies/resolvers/mutations/updateCompany.ts
@@ -14,6 +14,7 @@ export async function updateCompanyFn({
   siret,
   companyTypes,
   gerepId,
+  contact,
   contactEmail,
   contactPhone,
   website,
@@ -29,6 +30,7 @@ export async function updateCompanyFn({
   const data = {
     ...(companyTypes != null ? { companyTypes: { set: companyTypes } } : {}),
     ...(gerepId != null ? { gerepId } : {}),
+    ...(contact != null ? { contact } : {}),
     ...(contactEmail != null ? { contactEmail } : {}),
     ...(contactPhone != null ? { contactPhone } : {}),
     ...(website != null ? { website } : {}),

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -497,7 +497,8 @@ describe("query favorites", () => {
       companyTypes: ["WASTEPROCESSOR"],
       statutDiffusionEtablissement: "O",
       contactEmail: "contact@traiteur.co",
-      contactPhone: "00 00 00 00 00"
+      contactPhone: "00 00 00 00 00",
+      contact: "John Snow"
     };
     searchCompanySpy.mockResolvedValueOnce(destination);
 
@@ -584,7 +585,8 @@ describe("query favorites", () => {
       companyTypes: ["TRADER"],
       statutDiffusionEtablissement: "O",
       contactEmail: "contact@trader.co",
-      contactPhone: "00 00 00 00 00"
+      contactPhone: "00 00 00 00 00",
+      contact: "John Snow"
     };
     searchCompanySpy.mockResolvedValueOnce(traderSirene);
 
@@ -647,7 +649,8 @@ describe("query favorites", () => {
       companyTypes: ["BROKER"],
       statutDiffusionEtablissement: "O",
       contactEmail: "contact@broker.co",
-      contactPhone: "00 00 00 00 00"
+      contactPhone: "00 00 00 00 00",
+      contact: "John Snow"
     };
     searchCompanySpy.mockResolvedValueOnce(brokerSirene);
 

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -162,7 +162,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: emitter.contactEmail,
         phone: emitter.contactPhone,
-        contact: "",
+        contact: emitter.contact,
         codePaysEtrangerEtablissement: "FR"
       })
     ]);
@@ -224,7 +224,7 @@ describe("query favorites", () => {
         mail: recipient.contactEmail,
         phone: recipient.contactPhone,
         codePaysEtrangerEtablissement: "FR",
-        contact: ""
+        contact: recipient.contact
       })
     ]);
   });
@@ -293,7 +293,7 @@ describe("query favorites", () => {
         mail: transporter.contactEmail,
         phone: transporter.contactPhone,
         codePaysEtrangerEtablissement: "FR",
-        contact: "",
+        contact: transporter.contact,
         transporterReceipt: expect.objectContaining({
           receiptNumber: "receipt"
         })
@@ -336,7 +336,7 @@ describe("query favorites", () => {
         mail: transporter.contactEmail,
         phone: transporter.contactPhone,
         codePaysEtrangerEtablissement: "IT",
-        contact: ""
+        contact: transporter.contact
       })
     ]);
   });
@@ -397,7 +397,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: tempStorer.contactEmail,
         phone: tempStorer.contactPhone,
-        contact: "",
+        contact: tempStorer.contact,
         codePaysEtrangerEtablissement: "FR"
       })
     ]);
@@ -458,7 +458,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: destination.contactEmail,
         phone: destination.contactPhone,
-        contact: "",
+        contact: destination.contact,
         codePaysEtrangerEtablissement: "FR"
       })
     ]);
@@ -532,7 +532,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: destination.contactEmail,
         phone: destination.contactPhone,
-        contact: "",
+        contact: destination.contact,
         codePaysEtrangerEtablissement: "FR"
       })
     ]);
@@ -620,7 +620,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: traderSirene.contactEmail,
         phone: traderSirene.contactPhone,
-        contact: "",
+        contact: traderSirene.contact,
         codePaysEtrangerEtablissement: "FR",
         traderReceipt: {
           receiptNumber: "receipt"
@@ -684,7 +684,7 @@ describe("query favorites", () => {
         vatNumber: null,
         mail: brokerSirene.contactEmail,
         phone: brokerSirene.contactPhone,
-        contact: "",
+        contact: brokerSirene.contact,
         codePaysEtrangerEtablissement: "FR",
         brokerReceipt: {
           receiptNumber: "receipt"

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -496,8 +496,8 @@ describe("query favorites", () => {
       isRegistered: true,
       companyTypes: ["WASTEPROCESSOR"],
       statutDiffusionEtablissement: "O",
-      email: "contact@traiteur.co",
-      phone: "00 00 00 00 00"
+      contactEmail: "contact@traiteur.co",
+      contactPhone: "00 00 00 00 00"
     };
     searchCompanySpy.mockResolvedValueOnce(destination);
 
@@ -529,8 +529,8 @@ describe("query favorites", () => {
         name: destination.name,
         address: destination.address,
         vatNumber: null,
-        mail: destination.email,
-        phone: destination.phone,
+        mail: destination.contactEmail,
+        phone: destination.contactPhone,
         contact: "",
         codePaysEtrangerEtablissement: "FR"
       })
@@ -583,8 +583,8 @@ describe("query favorites", () => {
       isRegistered: true,
       companyTypes: ["TRADER"],
       statutDiffusionEtablissement: "O",
-      email: "contact@trader.co",
-      phone: "00 00 00 00 00"
+      contactEmail: "contact@trader.co",
+      contactPhone: "00 00 00 00 00"
     };
     searchCompanySpy.mockResolvedValueOnce(traderSirene);
 
@@ -616,8 +616,8 @@ describe("query favorites", () => {
         name: traderSirene.name,
         address: traderSirene.address,
         vatNumber: null,
-        mail: traderSirene.email,
-        phone: traderSirene.phone,
+        mail: traderSirene.contactEmail,
+        phone: traderSirene.contactPhone,
         contact: "",
         codePaysEtrangerEtablissement: "FR",
         traderReceipt: {
@@ -646,8 +646,8 @@ describe("query favorites", () => {
       isRegistered: true,
       companyTypes: ["BROKER"],
       statutDiffusionEtablissement: "O",
-      email: "contact@broker.co",
-      phone: "00 00 00 00 00"
+      contactEmail: "contact@broker.co",
+      contactPhone: "00 00 00 00 00"
     };
     searchCompanySpy.mockResolvedValueOnce(brokerSirene);
 
@@ -679,8 +679,8 @@ describe("query favorites", () => {
         name: brokerSirene.name,
         address: brokerSirene.address,
         vatNumber: null,
-        mail: brokerSirene.email,
-        phone: brokerSirene.phone,
+        mail: brokerSirene.contactEmail,
+        phone: brokerSirene.contactPhone,
         contact: "",
         codePaysEtrangerEtablissement: "FR",
         brokerReceipt: {

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -116,15 +116,13 @@ async function getRecentEmitters(
 }
 
 async function getRecentRecipients(
-  defaultWhere: Prisma.FormWhereInput,
-  recipientIsTempStorage: boolean
+  defaultWhere: Prisma.FormWhereInput
 ): Promise<CompanyFavorite[]> {
   const forms = await prisma.form.findMany({
     ...defaultArgs,
     where: {
       ...defaultWhere,
-      NOT: [{ recipientCompanySiret: null }, { recipientCompanySiret: "" }],
-      recipientIsTempStorage
+      NOT: [{ recipientCompanySiret: null }, { recipientCompanySiret: "" }]
     },
     select: { recipientCompanySiret: true }
   });
@@ -334,9 +332,11 @@ async function getRecentPartners(
     case "EMITTER":
       return getRecentEmitters(defaultWhere);
     case "RECIPIENT":
-      return getRecentRecipients(defaultWhere, false);
+      return getRecentRecipients(defaultWhere);
     case "TEMPORARY_STORAGE_DETAIL":
-      return getRecentRecipients(defaultWhere, true);
+      // do not differenciate between recipient and temp storage
+      // because the front never set type = TEMPORARY_STORAGE_DETAIL
+      return getRecentRecipients(defaultWhere);
     case "TRANSPORTER":
       return getRecentTransporters(defaultWhere);
     case "DESTINATION":

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -87,8 +87,8 @@ function companySearchResultToFavorite(
     siret: companySearchResult.siret,
     address: companySearchResult.address,
     contact: "",
-    phone: companySearchResult.phone ?? "",
-    mail: companySearchResult.email ?? ""
+    phone: companySearchResult.contactPhone ?? "",
+    mail: companySearchResult.contactEmail ?? ""
   };
 }
 

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -69,7 +69,7 @@ function companyToFavorite(
     siret: company.siret,
     vatNumber: company.vatNumber,
     address: company.address,
-    contact: "",
+    contact: company.contact,
     phone: company.contactPhone,
     mail: company.contactEmail,
     codePaysEtrangerEtablissement: !company.vatNumber
@@ -86,7 +86,7 @@ function companySearchResultToFavorite(
     name: companySearchResult.name,
     siret: companySearchResult.siret,
     address: companySearchResult.address,
-    contact: "",
+    contact: companySearchResult.contact,
     phone: companySearchResult.contactPhone ?? "",
     mail: companySearchResult.contactEmail ?? ""
   };

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -80,6 +80,7 @@ export async function searchCompany(
       address: true,
       vatNumber: true,
       companyTypes: true,
+      contact: true,
       contactEmail: true,
       contactPhone: true,
       website: true,

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -93,8 +93,6 @@ export async function searchCompany(
     ecoOrganismeAgreements: [],
     isRegistered: trackdechetsCompanyInfo != null,
     companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
-    phone: trackdechetsCompanyInfo?.contactPhone,
-    email: trackdechetsCompanyInfo?.contactEmail,
     ...convertUrls(trackdechetsCompanyInfo),
     ...companyInfo
   };

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -93,6 +93,8 @@ export async function searchCompany(
     ecoOrganismeAgreements: [],
     isRegistered: trackdechetsCompanyInfo != null,
     companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
+    phone: trackdechetsCompanyInfo?.contactPhone,
+    email: trackdechetsCompanyInfo?.contactEmail,
     ...convertUrls(trackdechetsCompanyInfo),
     ...companyInfo
   };

--- a/back/src/companies/sirene/types.ts
+++ b/back/src/companies/sirene/types.ts
@@ -2,7 +2,7 @@ import { CompanySearchResult } from "../types";
 
 export type SireneSearchResult = Omit<
   CompanySearchResult,
-  "id" | "isRegistered" | "companyTypes"
+  "id" | "isRegistered" | "companyTypes" | "contactEmail" | "contactPhone"
 >;
 
 // Response from https://api.entreprise.data.gouv.fr/api/sirene/v3/etablissements/<VOTRE_SIRET>

--- a/back/src/companies/sirene/types.ts
+++ b/back/src/companies/sirene/types.ts
@@ -2,7 +2,12 @@ import { CompanySearchResult } from "../types";
 
 export type SireneSearchResult = Omit<
   CompanySearchResult,
-  "id" | "isRegistered" | "companyTypes" | "contactEmail" | "contactPhone"
+  | "id"
+  | "isRegistered"
+  | "companyTypes"
+  | "contact"
+  | "contactEmail"
+  | "contactPhone"
 >;
 
 // Response from https://api.entreprise.data.gouv.fr/api/sirene/v3/etablissements/<VOTRE_SIRET>

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -15,6 +15,9 @@ type CompanyPrivate {
   "État du processus de vérification de l'établissement"
   verificationStatus: CompanyVerificationStatus!
 
+  "Prénom et nom du contact"
+  contact: String
+
   "Email de contact (visible sur la fiche entreprise)"
   contactEmail: String
 
@@ -132,7 +135,8 @@ type CompanyPublic {
   associé à cet établissement
   """
   installation: Installation
-
+  "Prénom et nom du contact"
+  contact: String
   "Email de contact"
   contactEmail: String
   "Numéro de téléphone de contact"

--- a/back/src/companies/typeDefs/private/company.mutations.graphql
+++ b/back/src/companies/typeDefs/private/company.mutations.graphql
@@ -14,6 +14,8 @@ type Mutation {
     siret: String!
     "Identifiant GEREP"
     gerepId: String
+    "Prénom et nom du contact dans l'entreprise"
+    contact: String
     "Email de contact"
     contactEmail: String
     "Numéro de téléphone de contact"

--- a/back/src/companies/types.ts
+++ b/back/src/companies/types.ts
@@ -16,6 +16,7 @@ export interface CompanySearchResult extends CompanyBaseIdentifiers {
   isRegistered: boolean;
   companyTypes: CompanyType[];
   ecoOrganismeAgreements?: URL[];
+  contact: string;
   contactEmail: string;
   contactPhone: string;
   // diffusible ou non-diffusible légalement (INSEE)

--- a/back/src/companies/types.ts
+++ b/back/src/companies/types.ts
@@ -16,8 +16,8 @@ export interface CompanySearchResult extends CompanyBaseIdentifiers {
   isRegistered: boolean;
   companyTypes: CompanyType[];
   ecoOrganismeAgreements?: URL[];
-  email?: string;
-  phone?: string;
+  contactEmail: string;
+  contactPhone: string;
   // diffusible ou non-diffusible légalement (INSEE)
   statutDiffusionEtablissement: "O" | "N";
   codePaysEtrangerEtablissement?: string;

--- a/back/src/companies/types.ts
+++ b/back/src/companies/types.ts
@@ -16,6 +16,8 @@ export interface CompanySearchResult extends CompanyBaseIdentifiers {
   isRegistered: boolean;
   companyTypes: CompanyType[];
   ecoOrganismeAgreements?: URL[];
+  email?: string;
+  phone?: string;
   // diffusible ou non-diffusible légalement (INSEE)
   statutDiffusionEtablissement: "O" | "N";
   codePaysEtrangerEtablissement?: string;

--- a/back/src/events/__tests__/rejected-form.test.ts
+++ b/back/src/events/__tests__/rejected-form.test.ts
@@ -160,7 +160,8 @@ const insee1: CompanySearchResult = {
   companyTypes: [],
   statutDiffusionEtablissement: "O",
   contactEmail: "",
-  contactPhone: ""
+  contactPhone: "",
+  contact: ""
 };
 const insee2: CompanySearchResult = {
   siret: "12346085500055",
@@ -176,7 +177,8 @@ const insee2: CompanySearchResult = {
   companyTypes: [],
   statutDiffusionEtablissement: "O",
   contactEmail: "",
-  contactPhone: ""
+  contactPhone: "",
+  contact: ""
 };
 
 // Mock pdf generator

--- a/back/src/events/__tests__/rejected-form.test.ts
+++ b/back/src/events/__tests__/rejected-form.test.ts
@@ -158,7 +158,9 @@ const insee1: CompanySearchResult = {
   codeCommune: "66001",
   isRegistered: true,
   companyTypes: [],
-  statutDiffusionEtablissement: "O"
+  statutDiffusionEtablissement: "O",
+  contactEmail: "",
+  contactPhone: ""
 };
 const insee2: CompanySearchResult = {
   siret: "12346085500055",
@@ -172,7 +174,9 @@ const insee2: CompanySearchResult = {
   codeCommune: "77001",
   isRegistered: true,
   companyTypes: [],
-  statutDiffusionEtablissement: "O"
+  statutDiffusionEtablissement: "O",
+  contactEmail: "",
+  contactPhone: ""
 };
 
 // Mock pdf generator

--- a/front/src/account/AccountCompany.tsx
+++ b/front/src/account/AccountCompany.tsx
@@ -6,7 +6,7 @@ import AccountCompanyMenu from "./AccountCompanyMenu";
 import AccountCompanyInfo from "./AccountCompanyInfo";
 import AccountCompanySecurity from "./AccountCompanySecurity";
 import AccountCompanyMemberList from "./AccountCompanyMemberList";
-import AccountCompanyPage from "./AccountCompanyPage";
+import AccountCompanyContact from "./AccountCompanyContact";
 import AccountCompanyAdvanced from "./AccountCompanyAdvanced";
 import styles from "./AccountCompany.module.scss";
 import { CompanyPrivate, UserRole } from "generated/graphql/types";
@@ -19,7 +19,7 @@ export enum Link {
   Info = "Information",
   Signature = "Signature",
   Members = "Membres",
-  CompanyPage = "Fiche Entreprise",
+  Contact = "Contact",
   Advanced = "Avancé",
 }
 
@@ -33,12 +33,12 @@ AccountCompany.fragments = {
       ...AccountCompanyInfoFragment
       ...AccountCompanySecurityFragment
       ...AccountCompanyMemberListFragment
-      ...AccountCompanyPageFragment
+      ...AccountCompanyContactFragment
     }
     ${AccountCompanyInfo.fragments.company}
     ${AccountCompanySecurity.fragments.company}
     ${AccountCompanyMemberList.fragments.company}
-    ${AccountCompanyPage.fragments.company}
+    ${AccountCompanyContact.fragments.company}
   `,
 };
 
@@ -65,9 +65,9 @@ export default function AccountCompany({ company }: Props) {
     />
   );
 
-  const page = (
-    <AccountCompanyPage
-      company={filter(AccountCompanyPage.fragments.company, company)}
+  const contact = (
+    <AccountCompanyContact
+      company={filter(AccountCompanyContact.fragments.company, company)}
     />
   );
 
@@ -89,8 +89,8 @@ export default function AccountCompany({ company }: Props) {
     case Link.Members:
       activeContent = members;
       break;
-    case Link.CompanyPage:
-      activeContent = page;
+    case Link.Contact:
+      activeContent = contact;
       break;
     case Link.Advanced:
       activeContent = advanced;
@@ -98,8 +98,8 @@ export default function AccountCompany({ company }: Props) {
   }
 
   const links = isAdmin
-    ? [Link.Info, Link.Signature, Link.Members, Link.CompanyPage, Link.Advanced]
-    : [Link.Info, Link.Signature, Link.CompanyPage];
+    ? [Link.Info, Link.Signature, Link.Members, Link.Contact, Link.Advanced]
+    : [Link.Info, Link.Signature, Link.Contact];
 
   return (
     <div className={["panel", styles.company].join(" ")}>

--- a/front/src/account/AccountCompanyContact.tsx
+++ b/front/src/account/AccountCompanyContact.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { gql } from "@apollo/client";
 import { filter } from "graphql-anywhere";
+import AccountFieldCompanyContact from "./fields/AccountFieldCompanyContact";
 import AccountFieldCompanyContactEmail from "./fields/AccountFieldCompanyContactEmail";
 import AccountFieldCompanyContactPhone from "./fields/AccountFieldCompanyContactPhone";
 import AccountFieldCompanyWebsite from "./fields/AccountFieldCompanyWebsite";
@@ -13,16 +14,18 @@ type Props = {
   company: CompanyPrivate;
 };
 
-AccountCompanyPage.fragments = {
+AccountCompanyContact.fragments = {
   company: gql`
-    fragment AccountCompanyPageFragment on CompanyPrivate {
+    fragment AccountCompanyContactFragment on CompanyPrivate {
       siret
       companyTypes
+      ...AccountFieldCompanyContactFragment
       ...AccountFieldCompanyContactEmailFragment
       ...AccountFieldCompanyContactPhoneFragment
       ...AccountFieldCompanyWebsiteFragment
       ...AccountFieldCompanyAgreementsFragment
     }
+    ${AccountFieldCompanyContact.fragments.company}
     ${AccountFieldCompanyContactEmail.fragments.company}
     ${AccountFieldCompanyContactPhone.fragments.company}
     ${AccountFieldCompanyWebsite.fragments.company}
@@ -30,7 +33,7 @@ AccountCompanyPage.fragments = {
   `,
 };
 
-export default function AccountCompanyPage({ company }: Props) {
+export default function AccountCompanyContact({ company }: Props) {
   const companyPage =
     `${import.meta.env.VITE_URL_SCHEME}://` +
     `${import.meta.env.VITE_HOSTNAME}` +
@@ -43,8 +46,13 @@ export default function AccountCompanyPage({ company }: Props) {
         <a href={companyPage} target="_blank" rel="noopener noreferrer">
           fiche entreprise
         </a>{" "}
-        et sont consultables par n'importe qui.
+        et sont consultables par n'importe qui. Elles sont également utilisées
+        pour compléter automatiquement les informations de contact sur les
+        bordereaux lorsque votre n°SIRET est visé.
       </div>
+      <AccountFieldCompanyContact
+        company={filter(AccountFieldCompanyContact.fragments.company, company)}
+      />
       <AccountFieldCompanyContactEmail
         company={filter(
           AccountFieldCompanyContactEmail.fragments.company,

--- a/front/src/account/fields/AccountFieldCompanyContact.tsx
+++ b/front/src/account/fields/AccountFieldCompanyContact.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { gql } from "@apollo/client";
+import AccountField from "./AccountField";
+import AccountFieldNotEditable from "./AccountFieldNotEditable";
+import AccountFormSimpleInput from "./forms/AccountFormSimpleInput";
+import { object, string } from "yup";
+import {
+  CompanyPrivate,
+  UserRole,
+  MutationUpdateCompanyArgs,
+} from "generated/graphql/types";
+
+type Props = {
+  company: CompanyPrivate;
+};
+
+AccountFielCompanyContact.fragments = {
+  company: gql`
+    fragment AccountFieldCompanyContactFragment on CompanyPrivate {
+      id
+      siret
+      contact
+      userRole
+    }
+  `,
+};
+
+const UPDATE_CONTACT = gql`
+  mutation UpdateCompany($siret: String!, $contact: String!) {
+    updateCompany(siret: $siret, contact: $contact) {
+      id
+      siret
+      contact
+    }
+  }
+`;
+
+const yupSchema = object().shape({
+  contact: string().max(100),
+});
+
+export default function AccountFielCompanyContact({ company }: Props) {
+  const fieldName = "contact";
+  const fieldLabel = "Prénom et nom du contact";
+
+  return (
+    <>
+      {company.userRole === UserRole.Admin ? (
+        <AccountField
+          name={fieldName}
+          label={fieldLabel}
+          value={company.contact}
+          renderForm={toggleEdition => (
+            <AccountFormSimpleInput<Partial<MutationUpdateCompanyArgs>>
+              name="contact"
+              type="text"
+              value={company.contact}
+              placeHolder={fieldLabel}
+              mutation={UPDATE_CONTACT}
+              mutationArgs={{ siret: company.siret }}
+              yupSchema={yupSchema}
+              toggleEdition={() => {
+                toggleEdition();
+              }}
+            />
+          )}
+        />
+      ) : (
+        <AccountFieldNotEditable
+          name={fieldName}
+          label={fieldLabel}
+          value={company.contact}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Problème
Si des mauvaises données (adresse, raison sociale, contact) sont injectées dans la table `Form` par API, ces données sont ensuite remontées dans les favoris. 

## Solution 
- Aller chercher uniquement les n°SIRET dans la table `Form`.
- Pour les acteurs du bordereau qui doivent signer (émetteur, transporteur, destinataire), aller chercher les infos directement dans la table `Company`. Si un établissement présent sur un bordereau n'est pas inscrit sur TD, ne pas le faire remonter dans les favoris. Un champ `contact` a été ajouté au modèle `Company` pour l'auto-complétion du champ contact. Il faudra prévoir une communication ad hoc pour inviter les utilisateurs à compléter ce champ
- Pour les acteurs du bordereau qui ne doivent pas signer (négociant, courtier, destination ultérieure), aller chercher les infos dans notre base SIRENE

https://user-images.githubusercontent.com/2269165/176866886-2ccad921-4f6d-40b8-ade8-697493dfe894.mp4

--- 

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7393)
