### PR TITLE
Fix/Transaction & workflow BSDD

### DIFF
--- a/back/src/forms/repository/form/deleteStaleSegments.ts
+++ b/back/src/forms/repository/form/deleteStaleSegments.ts
@@ -1,0 +1,24 @@
+import { Prisma } from "@prisma/client";
+import { RepositoryFnDeps } from "../types";
+
+export type DeleteFormStaleSegmentsFn = (
+  where: Prisma.FormWhereUniqueInput
+) => Promise<void>;
+
+const buildDeleteFormStaleSegments: (
+  deps: RepositoryFnDeps
+) => DeleteFormStaleSegmentsFn = deps => async where => {
+  const { prisma } = deps;
+
+  const staleSegments = await prisma.form
+    .findUnique({ where })
+    .transportSegments({ where: { takenOverAt: null } });
+
+  if (staleSegments.length > 0) {
+    await prisma.transportSegment.deleteMany({
+      where: { id: { in: staleSegments.map(s => s.id) } }
+    });
+  }
+};
+
+export default buildDeleteFormStaleSegments;

--- a/back/src/forms/repository/form/update.ts
+++ b/back/src/forms/repository/form/update.ts
@@ -1,6 +1,8 @@
 import { Form, Prisma } from "@prisma/client";
+import { eventEmitter, TDEvent } from "../../../events/emitter";
 import { GraphQLContext } from "../../../types";
 import { indexForm } from "../../elastic";
+import { formDiff } from "../../workflow/diff";
 import { LogMetadata, RepositoryFnDeps } from "../types";
 import buildFindFullFormById from "./findFullFormById";
 
@@ -14,10 +16,22 @@ const buildUpdateForm: (deps: RepositoryFnDeps) => UpdateFormFn =
   deps => async (where, data, logMetadata) => {
     const { user, prisma } = deps;
 
+    // retrieves form
+    // for diff calculation
+    const oldForm = await prisma.form.findUnique({
+      where,
+      include: { forwardedIn: true }
+    });
+
     const updatedForm = await prisma.form.update({
       where,
       data
     });
+
+    // retrieves updated temp storage
+    const updatedForwardedIn = await prisma.form
+      .findUnique({ where })
+      .forwardedIn();
 
     await prisma.event.create({
       data: {
@@ -28,6 +42,44 @@ const buildUpdateForm: (deps: RepositoryFnDeps) => UpdateFormFn =
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
+
+    if (oldForm.status !== updatedForm.status) {
+      const newStatus = updatedForm.status;
+      // calculates diff between initial form and updated form
+      const updatedFields = await formDiff(oldForm, {
+        ...updatedForm,
+        forwardedIn: updatedForwardedIn
+      });
+
+      eventEmitter.emit<Form>(TDEvent.TransitionForm, {
+        previousNode: oldForm,
+        node: updatedForm,
+        updatedFields,
+        mutation: "UPDATED"
+      });
+
+      // log status change
+      await prisma.statusLog.create({
+        data: {
+          user: { connect: { id: user.id } },
+          form: { connect: { id: updatedForm.id } },
+          status: newStatus,
+          authType: user.auth,
+          loggedAt: new Date(),
+          updatedFields
+        }
+      });
+
+      await prisma.event.create({
+        data: {
+          streamId: updatedForm.id,
+          actor: user.id,
+          type: "BsddSigned",
+          data: { status: data.status },
+          metadata: { authType: user.auth }
+        }
+      });
+    }
 
     const fullForm = await buildFindFullFormById(deps)(updatedForm.id);
     await indexForm(fullForm, { user } as GraphQLContext);

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -66,17 +66,28 @@ const buildUpdateAppendix2Forms: (
         : Status.AWAITING_GROUP;
 
       if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
-        return transitionForm(user, form, {
-          type: EventType.MarkAsProcessed
-        });
+        return updateForm(
+          { id },
+          {
+            status: transitionForm(form, {
+              type: EventType.MarkAsProcessed
+            })
+          }
+        );
       } else if (
         form.status === Status.AWAITING_GROUP &&
         nextStatus === Status.GROUPED
       ) {
-        return transitionForm(user, form, {
-          type: EventType.MarkAsGrouped,
-          formUpdateInput: { quantityGrouped: quantityGrouped.toNumber() }
-        });
+        return updateForm(
+          { id },
+          {
+            status: transitionForm(form, {
+              type: EventType.MarkAsGrouped,
+              formUpdateInput: { quantityGrouped: quantityGrouped.toNumber() }
+            }),
+            quantityGrouped: quantityGrouped.toNumber()
+          }
+        );
       } else {
         return updateForm(
           { id },

--- a/back/src/forms/repository/index.ts
+++ b/back/src/forms/repository/index.ts
@@ -22,6 +22,7 @@ import {
 } from "./types";
 import buildSetAppendix2 from "./form/setAppendix2";
 import buildUpdateAppendix2Forms from "./form/updateAppendix2Forms";
+import buildDeleteFormStaleSegments from "./form/deleteStaleSegments";
 
 export type FormRepository = FormActions & FormRevisionRequestActions;
 
@@ -78,6 +79,12 @@ export function getFormRepository(
         ? buildUpdateAppendix2Forms({ prisma: transaction, user })(...args)
         : prisma.$transaction(prisma =>
             buildUpdateAppendix2Forms({ prisma, user })(...args)
+          ),
+    deleteStaleSegments: (...args) =>
+      transaction
+        ? buildDeleteFormStaleSegments({ prisma: transaction, user })(...args)
+        : prisma.$transaction(prisma =>
+            buildDeleteFormStaleSegments({ prisma, user })(...args)
           )
   };
 

--- a/back/src/forms/repository/types.ts
+++ b/back/src/forms/repository/types.ts
@@ -17,6 +17,7 @@ import { CreateRevisionRequestFn } from "./formRevisionRequest/createRevisionReq
 import { GetRevisionRequestByIdFn } from "./formRevisionRequest/getRevisionRequestById";
 import { RefuseRevisionRequestFn } from "./formRevisionRequest/refuseRevisionRequestApproval";
 import { UpdateAppendix2Forms } from "./form/updateAppendix2Forms";
+import { DeleteFormStaleSegmentsFn } from "./form/deleteStaleSegments";
 
 export type PrismaTransaction = Omit<
   PrismaClient,
@@ -61,6 +62,7 @@ export type FormActions = {
   removeAppendix2: RemoveAppendix2Fn;
   setAppendix2: SetAppendix2Fn;
   updateAppendix2Forms: UpdateAppendix2Forms;
+  deleteStaleSegments: DeleteFormStaleSegmentsFn;
 };
 
 export type FormRevisionRequestActions = {

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -1082,7 +1082,7 @@ describe("Mutation.markAsSealed", () => {
     });
 
     const { mutate } = makeClient(user);
-    const { data, errors } = await mutate<Pick<Mutation, "markAsSealed">>(
+    const { data } = await mutate<Pick<Mutation, "markAsSealed">>(
       MARK_AS_SEALED,
       {
         variables: {
@@ -1090,7 +1090,7 @@ describe("Mutation.markAsSealed", () => {
         }
       }
     );
-    console.log(errors);
+
     expect(data.markAsSealed.status).toBe("SIGNED_BY_PRODUCER");
   });
 });

--- a/back/src/forms/resolvers/mutations/importPaperForm.ts
+++ b/back/src/forms/resolvers/mutations/importPaperForm.ts
@@ -83,10 +83,16 @@ async function updateForm(
     takenOverAt: flattenedFormInput.sentAt
   };
 
-  return transitionForm(user, form, {
-    type: EventType.ImportPaperForm,
-    formUpdateInput
-  });
+  return getFormRepository(user).update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.ImportPaperForm,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 }
 
 /**

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -1,6 +1,7 @@
 import { Status, WasteAcceptationStatus } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
 import { getFormOrFormNotFound } from "../../database";
 import { expandFormFromDb } from "../../form-converter";
 import { checkCanMarkAsAccepted } from "../../permissions";
@@ -15,7 +16,6 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
   context
 ) => {
   const user = checkIsAuthenticated(context);
-  const formRepository = getFormRepository(user);
   const { id, acceptedInfo } = args;
   const form = await getFormOrFormNotFound({ id });
   await checkCanMarkAsAccepted(user, form);
@@ -40,22 +40,27 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
         signedAt: new Date(acceptedInfo.signedAt)
       };
 
-  const acceptedForm = await formRepository.update(
-    { id: form.id },
-    {
-      status: transitionForm(form, {
-        type: EventType.MarkAsAccepted,
-        formUpdateInput
-      }),
-      ...formUpdateInput
+  return prisma.$transaction(async transaction => {
+    const { update, removeAppendix2 } = getFormRepository(user, transaction);
+    const acceptedForm = await update(
+      { id: form.id },
+      {
+        status: transitionForm(form, {
+          type: EventType.MarkAsAccepted,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
+
+    if (
+      acceptedInfo.wasteAcceptationStatus === WasteAcceptationStatus.REFUSED
+    ) {
+      await removeAppendix2(id);
     }
-  );
 
-  if (acceptedInfo.wasteAcceptationStatus === WasteAcceptationStatus.REFUSED) {
-    await formRepository.removeAppendix2(id);
-  }
-
-  return expandFormFromDb(acceptedForm);
+    return expandFormFromDb(acceptedForm);
+  });
 };
 
 export default markAsAcceptedResolver;

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -40,7 +40,7 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
         signedAt: new Date(acceptedInfo.signedAt)
       };
 
-  return prisma.$transaction(async transaction => {
+  const acceptedForm = await prisma.$transaction(async transaction => {
     const { update, removeAppendix2 } = getFormRepository(user, transaction);
     const acceptedForm = await update(
       { id: form.id },
@@ -59,8 +59,10 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
       await removeAppendix2(id);
     }
 
-    return expandFormFromDb(acceptedForm);
+    return acceptedForm;
   });
+
+  return expandFormFromDb(acceptedForm);
 };
 
 export default markAsAcceptedResolver;

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -72,9 +72,15 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     };
   }
 
+  const appendix2Forms = await getFormRepository(user).findAppendix2FormsById(
+    form.id
+  );
+
   const processedForm = await prisma.$transaction(async transaction => {
-    const { findAppendix2FormsById, updateAppendix2Forms, update } =
-      getFormRepository(user, transaction);
+    const { updateAppendix2Forms, update } = getFormRepository(
+      user,
+      transaction
+    );
 
     const processedForm = await update(
       { id: form.id },
@@ -88,8 +94,6 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     );
 
     // mark appendix2Forms as PROCESSED
-    const appendix2Forms = await findAppendix2FormsById(form.id);
-
     if (appendix2Forms.length > 0) {
       await updateAppendix2Forms(appendix2Forms);
     }

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -71,13 +71,19 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     };
   }
 
-  const processedForm = await transitionForm(user, form, {
-    type: EventType.MarkAsProcessed,
-    formUpdateInput
-  });
-
-  const { findAppendix2FormsById, updateAppendix2Forms } =
+  const { findAppendix2FormsById, updateAppendix2Forms, update } =
     getFormRepository(user);
+
+  const processedForm = await update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsProcessed,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 
   // mark appendix2Forms as PROCESSED
   const appendix2Forms = await findAppendix2FormsById(form.id);

--- a/back/src/forms/resolvers/mutations/markAsReceived.ts
+++ b/back/src/forms/resolvers/mutations/markAsReceived.ts
@@ -62,10 +62,16 @@ const markAsReceivedResolver: MutationResolvers["markAsReceived"] = async (
         currentTransporterSiret: ""
       };
 
-  const receivedForm = await transitionForm(user, form, {
-    type: EventType.MarkAsReceived,
-    formUpdateInput
-  });
+  const receivedForm = await formRepository.update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsReceived,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 
   // check for stale transport segments and delete them
   // quick fix https://trackdechets.zammad.com/#ticket/zoom/1696

--- a/back/src/forms/resolvers/mutations/markAsResealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsResealed.ts
@@ -93,10 +93,16 @@ const markAsResealed: MutationResolvers["markAsResealed"] = async (
     // used to update an already resealed form
     resealedForm = await formRepository.update({ id }, formUpdateInput);
   } else {
-    resealedForm = await transitionForm(user, form, {
-      type: EventType.MarkAsResealed,
-      formUpdateInput
-    });
+    resealedForm = await formRepository.update(
+      { id: form.id },
+      {
+        status: transitionForm(form, {
+          type: EventType.MarkAsResealed,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
   }
 
   return expandFormFromDb(resealedForm);

--- a/back/src/forms/resolvers/mutations/markAsResent.ts
+++ b/back/src/forms/resolvers/mutations/markAsResent.ts
@@ -67,10 +67,16 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
     }
   };
 
-  const resentForm = await transitionForm(user, form, {
-    type: EventType.MarkAsResent,
-    formUpdateInput
-  });
+  const resentForm = await getFormRepository(user).update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsResent,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
   return expandFormFromDb(resentForm);
 };
 

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -54,11 +54,15 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     await beforeSignedByTransporterSchema.validate(futureForm);
   }
 
-  const sealedForm = await transitionForm(user, form, {
-    type: EventType.MarkAsSealed
-  });
-
   const formRepository = getFormRepository(user);
+  const sealedForm = await formRepository.update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsSealed
+      })
+    }
+  );
 
   const appendix2Forms = await formRepository.findAppendix2FormsById(form.id);
   if (appendix2Forms.length > 0) {
@@ -84,10 +88,16 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     (sealedForm.emitterIsForeignShip === true ||
       sealedForm.emitterIsPrivateIndividual === true)
   ) {
-    const updatedForm = await transitionForm(user, sealedForm, {
-      type: EventType.SignedByProducer,
-      formUpdateInput
-    });
+    const updatedForm = await formRepository.update(
+      { id: sealedForm.id },
+      {
+        status: transitionForm(sealedForm, {
+          type: EventType.SignedByProducer,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
     return expandFormFromDb(updatedForm);
   }
 

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -54,10 +54,11 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     await beforeSignedByTransporterSchema.validate(futureForm);
   }
 
-  const emitterCompanyExists =
-    (await prisma.company.count({
-      where: { siret: form.emitterCompanySiret }
-    })) > 0;
+  const emitterCompanyExists = form.emitterCompanySiret
+    ? (await prisma.company.count({
+        where: { siret: form.emitterCompanySiret }
+      })) > 0
+    : false;
 
   const resultingForm = await prisma.$transaction(async transaction => {
     const formRepository = getFormRepository(user, transaction);

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -75,7 +75,7 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     if (form.emitterCompanySiret) {
       // send welcome email to emitter if it is not registered in TD
       const emitterCompanyExists =
-        (await prisma.company.count({
+        (await transaction.company.count({
           where: { siret: form.emitterCompanySiret }
         })) > 0;
 
@@ -113,9 +113,10 @@ async function mailToNonExistentEmitter(
   // check contact email has not been mentionned already
   const contactAlreadyMentionned =
     (await formRepository.count({
+      id: { not: form.id },
       emitterCompanyMail: form.emitterCompanyMail,
       status: { not: Status.DRAFT }
-    })) > 1;
+    })) > 0;
   if (!contactAlreadyMentionned) {
     await sendMail(
       renderMail(contentAwaitsGuest, {

--- a/back/src/forms/resolvers/mutations/markAsSent.ts
+++ b/back/src/forms/resolvers/mutations/markAsSent.ts
@@ -36,13 +36,19 @@ const markAsSentResolver: MutationResolvers["markAsSent"] = async (
     currentTransporterSiret: form.transporterCompanySiret,
     signedByTransporter: false
   };
-  const resentForm = await transitionForm(user, form, {
-    type: EventType.MarkAsSent,
-    formUpdateInput
-  });
-
-  const { findAppendix2FormsById, updateAppendix2Forms } =
+  const { findAppendix2FormsById, updateAppendix2Forms, update } =
     getFormRepository(user);
+
+  const resentForm = await update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsSent,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 
   const appendix2Forms = await findAppendix2FormsById(form.id);
 

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -52,7 +52,7 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
       : {})
   };
 
-  return prisma.$transaction(async transaction => {
+  const tempStoredForm = await prisma.$transaction(async transaction => {
     const formRepository = getFormRepository(user, transaction);
     const tempStoredForm = await formRepository.update(
       { id: form.id },
@@ -75,8 +75,10 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
       await formRepository.removeAppendix2(id);
     }
 
-    return expandFormFromDb(tempStoredForm);
+    return tempStoredForm;
   });
+
+  return expandFormFromDb(tempStoredForm);
 };
 
 export default markAsTempStoredResolver;

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -53,10 +53,16 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
       : {})
   };
 
-  const tempStoredForm = await transitionForm(user, form, {
-    type: EventType.MarkAsTempStored,
-    formUpdateInput
-  });
+  const tempStoredForm = await formRepository.update(
+    { id: form.id },
+    {
+      status: transitionForm(form, {
+        type: EventType.MarkAsTempStored,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 
   // check for stale transport segments and delete them
   // quick fix https://trackdechets.zammad.com/#ticket/zoom/1696

--- a/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
@@ -36,7 +36,7 @@ const markAsTempStorerAcceptedResolver: MutationResolvers["markAsTempStorerAccep
       }
     };
 
-    return prisma.$transaction(async transaction => {
+    const tempStoredForm = await prisma.$transaction(async transaction => {
       const formRepository = getFormRepository(user, transaction);
       const tempStoredForm = await formRepository.update(
         { id: form.id },
@@ -56,8 +56,10 @@ const markAsTempStorerAcceptedResolver: MutationResolvers["markAsTempStorerAccep
         await formRepository.removeAppendix2(id);
       }
 
-      return expandFormFromDb(tempStoredForm);
+      return tempStoredForm;
     });
+
+    return expandFormFromDb(tempStoredForm);
   };
 
 export default markAsTempStorerAcceptedResolver;

--- a/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
@@ -36,10 +36,16 @@ const markAsTempStorerAcceptedResolver: MutationResolvers["markAsTempStorerAccep
       }
     };
 
-    const tempStoredForm = await transitionForm(user, form, {
-      type: EventType.MarkAsTempStorerAccepted,
-      formUpdateInput
-    });
+    const tempStoredForm = await formRepository.update(
+      { id: form.id },
+      {
+        status: transitionForm(form, {
+          type: EventType.MarkAsTempStorerAccepted,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
 
     if (
       tempStorerAcceptedInfo.wasteAcceptationStatus ===

--- a/back/src/forms/resolvers/mutations/signEmissionForm.ts
+++ b/back/src/forms/resolvers/mutations/signEmissionForm.ts
@@ -16,6 +16,7 @@ import {
   wasteDetailsSchema
 } from "../../validation";
 import { FullForm } from "../../types";
+import { getFormRepository } from "../../repository";
 
 const signatures: Partial<
   Record<
@@ -71,10 +72,16 @@ const signatures: Partial<
     await wasteDetailsSchema.validate(futureForm);
     await beforeSignedByTransporterSchema.validate(futureForm);
 
-    const updatedForm = await transitionForm(user, existingForm, {
-      type: EventType.SignedByProducer,
-      formUpdateInput
-    });
+    const updatedForm = await getFormRepository(user).update(
+      { id: existingForm.id },
+      {
+        status: transitionForm(existingForm, {
+          type: EventType.SignedByProducer,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
 
     return expandFormFromDb(updatedForm);
   },
@@ -122,10 +129,16 @@ const signatures: Partial<
     await wasteDetailsSchema.validate(futureFullForm);
     await beforeSignedByTransporterSchema.validate(futureFullForm);
 
-    const updatedForm = await transitionForm(user, existingForm, {
-      type: EventType.SignedByTempStorer,
-      formUpdateInput
-    });
+    const updatedForm = await getFormRepository(user).update(
+      { id: existingForm.id },
+      {
+        status: transitionForm(existingForm, {
+          type: EventType.SignedByTempStorer,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
 
     return expandFormFromDb(updatedForm);
   }

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -11,6 +11,7 @@ import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import { checkCanSignFor } from "../../permissions";
 import { expandFormFromDb } from "../../form-converter";
+import { getFormRepository } from "../../repository";
 
 /**
  * Common function for signing
@@ -36,10 +37,16 @@ const signedByTransporterFn = async (user, args, existingForm) => {
     sentBy: existingForm.emittedBy
   };
 
-  const updatedForm = await transitionForm(user, existingForm, {
-    type: EventType.SignedByTransporter,
-    formUpdateInput
-  });
+  const updatedForm = await getFormRepository(user).update(
+    { id: existingForm.id },
+    {
+      status: transitionForm(existingForm, {
+        type: EventType.SignedByTransporter,
+        formUpdateInput
+      }),
+      ...formUpdateInput
+    }
+  );
 
   return expandFormFromDb(updatedForm);
 };
@@ -98,10 +105,16 @@ const signatures: Partial<
       }
     };
 
-    const updatedForm = await transitionForm(user, existingFullForm, {
-      type: EventType.MarkAsResent,
-      formUpdateInput
-    });
+    const updatedForm = await getFormRepository(user).update(
+      { id: existingFullForm.id },
+      {
+        status: transitionForm(existingFullForm, {
+          type: EventType.MarkAsResent,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
 
     return expandFormFromDb(updatedForm);
   }

--- a/back/src/forms/resolvers/mutations/signedByTransporter.ts
+++ b/back/src/forms/resolvers/mutations/signedByTransporter.ts
@@ -71,6 +71,7 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
     await wasteDetailsSchema.validate(futureForm);
     await beforeSignedByTransporterSchema.validate(futureForm);
 
+    const formRepository = getFormRepository(user);
     if (form.sentAt) {
       // BSD has already been sent, it must be a signature for frame 18
 
@@ -104,10 +105,17 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
           }
         }
       };
-      const resentForm = await transitionForm(user, form, {
-        type: EventType.SignedByTransporter,
-        formUpdateInput
-      });
+
+      const resentForm = await formRepository.update(
+        { id: form.id },
+        {
+          status: transitionForm(form, {
+            type: EventType.SignedByTransporter,
+            formUpdateInput
+          }),
+          ...formUpdateInput
+        }
+      );
 
       return expandFormFromDb(resentForm);
     }
@@ -147,10 +155,16 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
       currentTransporterSiret: form.transporterCompanySiret
     };
 
-    const sentForm = await transitionForm(user, form, {
-      type: EventType.SignedByTransporter,
-      formUpdateInput
-    });
+    const sentForm = await formRepository.update(
+      { id: form.id },
+      {
+        status: transitionForm(form, {
+          type: EventType.SignedByTransporter,
+          formUpdateInput
+        }),
+        ...formUpdateInput
+      }
+    );
 
     return expandFormFromDb(sentForm);
   };

--- a/back/src/forms/workflow/transitionForm.ts
+++ b/back/src/forms/workflow/transitionForm.ts
@@ -1,26 +1,14 @@
-import { Form, Prisma, Status } from "@prisma/client";
-import prisma from "../../prisma";
-import { Event } from "./types";
-import machine from "./machine";
+import { Form, Status } from "@prisma/client";
 import { InvalidTransition } from "../errors";
-import { formDiff } from "./diff";
-import { eventEmitter, TDEvent } from "../../events/emitter";
-import { indexForm } from "../elastic";
-import { getFullForm } from "../database";
-import { GraphQLContext } from "../../types";
-import { persistBsddEvent } from "../../activity-events/bsdd";
+import machine from "./machine";
+import { Event } from "./types";
 
 /**
  * Transition a form from initial state (ex: DRAFT) to next state (ex: SEALED)
+ * and returns the new state.
  * Allowed transitions are defined as a state machine using xstate
- * Data updates are applied along the way and we make sure this transition is
- * logged in the StatusLogs table
  */
-export default async function transitionForm(
-  user: Express.User,
-  form: Form,
-  event: Event
-) {
+export default function transitionForm(form: Form, event: Event): Status {
   const currentStatus = form.status;
 
   // Use state machine to calculate new status
@@ -31,71 +19,5 @@ export default async function transitionForm(
     throw new InvalidTransition();
   }
 
-  const nextStatus = nextState.value as Status;
-
-  const formUpdateInput: Prisma.FormUpdateInput = {
-    status: nextStatus,
-    ...event.formUpdateInput
-  };
-
-  // retrieves temp storage before update
-  // for diff calculation
-  const forwardedIn = await prisma.form
-    .findUnique({ where: { id: form.id } })
-    .forwardedIn();
-
-  // update form
-  const updatedForm = await prisma.form.update({
-    where: { id: form.id },
-    data: formUpdateInput
-  });
-
-  // retrieves updated temp storage
-  const updatedForwardedIn = await prisma.form
-    .findUnique({ where: { id: updatedForm.id } })
-    .forwardedIn();
-
-  // calculates diff between initial form and updated form
-  const updatedFields = await formDiff(
-    { ...form, forwardedIn },
-    { ...updatedForm, forwardedIn: updatedForwardedIn }
-  );
-
-  eventEmitter.emit<Form>(TDEvent.TransitionForm, {
-    previousNode: form,
-    node: updatedForm,
-    updatedFields,
-    mutation: "UPDATED"
-  });
-
-  // log status change
-  await prisma.statusLog.create({
-    data: {
-      user: { connect: { id: user.id } },
-      form: { connect: { id: form.id } },
-      status: nextStatus,
-      authType: user.auth,
-      loggedAt: new Date(),
-      updatedFields
-    }
-  });
-  await persistBsddEvent({
-    streamId: form.id,
-    actor: user.id,
-    type: "BsddUpdated",
-    data: { content: formUpdateInput },
-    metadata: { authType: user.auth }
-  });
-  await persistBsddEvent({
-    streamId: form.id,
-    actor: user.id,
-    type: "BsddSigned",
-    data: { status: nextStatus },
-    metadata: { authType: user.auth }
-  });
-
-  const fullForm = await getFullForm(updatedForm);
-  await indexForm(fullForm, { user } as GraphQLContext);
-
-  return updatedForm;
+  return nextState.value as Status;
 }


### PR DESCRIPTION
Dans `transitionForm`, des bordereaux étaient updatés hors de la transaction. Si la transaction échouaient, ces updates passaient bien en base, créant des données inconsistantes.
Ici, on fait en sorte que toute modification de bsdd passe par le repository et que tout soit fait dans une seule et même transaction.

Pour ex on a eu le bug d'une annexe 2 liée à 321 bordereaux: tous les bordereaux sont passé à GROUPED, mais aucun n'a été rattaché au bordereau de groupement. Ces 321 bordereaux étaient donc "perdus dans les limbes".