### PR TITLE
Fix / Fix appendix 2 query

### DIFF
--- a/back/src/forms/resolvers/queries/appendixForms.ts
+++ b/back/src/forms/resolvers/queries/appendixForms.ts
@@ -20,7 +20,7 @@ const appendixFormsResolver: QueryResolvers["appendixForms"] = async (
         { status: "AWAITING_GROUP" },
         {
           OR: [
-            { recipientCompanySiret: siret },
+            { recipientCompanySiret: siret, forwardedIn: null },
             {
               recipientIsTempStorage: true,
               forwardedIn: { recipientCompanySiret: siret }


### PR DESCRIPTION
Correction d'un bug sur la query annexe2.
En cas d'entreposage provisoire on avait des bordereaux qui remontaient alors qu'on n'avait pas le droit de les utiliser (si je suis entreposage provisoire je ne peux pas utiliser le bordereau. Seul la destination finale peut)