### PR TITLE
Recette refonte company selector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,13 +17,16 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout de `FormInput.intermediaries: [CompanyInput!]` [PR 1481](https://github.com/MTES-MCT/trackdechets/pull/1481)
 
 #### :bug: Corrections de bugs
+
 - Correction d'un bug ne permettant pas au destinataire finale de créer un BSDD avec entreposage provisoire [PR 1498](https://github.com/MTES-MCT/trackdechets/pull/1498)
 - Correction de la navigation entre les onglets du tableau de bord lors de certaines actions [PR 1469](https://github.com/MTES-MCT/trackdechets/pull/1469)
 
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations
+
 - Gestion des volumes représentés par des nombres décimaux sur les BSDASRIs [PR 1506](https://github.com/MTES-MCT/trackdechets/pull/1506)
+- Interface de recherche d'établissements : améliorations de design général, et support des entreprises étrangères par recherche de TVA inclus directement dans le champs de recherche textuel des entreprises françaises. Suppression du sélecteur "Entreprise étrangère".
 
 #### :memo: Documentation
 

--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import countries, { Country } from "world-countries";
 import { checkVAT } from "jsvat";
-import { countries as vatCountries } from "../../../common/constants/companySearchHelpers";
+import {
+  countries as vatCountries,
+  isVat
+} from "../../../common/constants/companySearchHelpers";
 import { FormCompany } from "../../../generated/graphql/types";
 
 const FRENCH_COUNTRY = countries.find(country => country.cca2 === "FR");
@@ -17,15 +20,18 @@ export function FormCompanyFields({
   isForeignShip,
   isPrivateIndividual
 }: FormCompanyFieldsProps) {
-  let companyCountry: Country = null;
+  let companyCountry: Country = FRENCH_COUNTRY;
 
   if (company) {
-    companyCountry =
-      countries.find(country => country.cca2 === company?.country) ??
-      FRENCH_COUNTRY;
-    if (company.vatNumber) {
-      const vatCountryCode = checkVAT(company.vatNumber.trim(), vatCountries)
-        ?.country?.isoCode.short;
+    companyCountry = countries.find(
+      country => country.cca2 === company?.country
+    );
+    // trouver automatiquement le pays avec le vatNumber s'il n'est pas renseigné.
+    if (isVat(company.vatNumber)) {
+      const vatCountryCode = checkVAT(
+        company.vatNumber.replace(/\s/g, ""),
+        vatCountries
+      )?.country?.isoCode.short;
 
       companyCountry = countries.find(
         country => country.cca2 === vatCountryCode
@@ -40,10 +46,7 @@ export function FormCompanyFields({
           type="checkbox"
           checked={
             !isForeignShip &&
-            !company?.vatNumber &&
-            company?.siret &&
-            companyCountry &&
-            companyCountry.cca2 === "FR"
+            (!!company?.siret || companyCountry?.cca2 === "FR")
           }
           readOnly
         />{" "}
@@ -53,9 +56,7 @@ export function FormCompanyFields({
           type="checkbox"
           checked={
             isForeignShip ||
-            (company?.vatNumber &&
-              companyCountry &&
-              companyCountry.cca2 !== "FR")
+            (!!company?.vatNumber && companyCountry?.cca2 !== "FR")
           }
           readOnly
         />{" "}

--- a/back/src/companies/resolvers/queries/__tests__/companyInfos.test.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyInfos.test.ts
@@ -71,7 +71,22 @@ describe("companyInfos with SIRET", () => {
       companyTypes: [],
       installation: {
         codeS3ic: "0055.14316"
-      }
+      },
+      address: undefined,
+      allowBsdasriTakeOverWithoutSignature: undefined,
+      brokerReceipt: undefined,
+      codeCommune: undefined,
+      codePaysEtrangerEtablissement: undefined,
+      contact: undefined,
+      etatAdministratif: undefined,
+      libelleNaf: undefined,
+      naf: undefined,
+      statutDiffusionEtablissement: undefined,
+      traderReceipt: undefined,
+      transporterReceipt: undefined,
+      vatNumber: undefined,
+      vhuAgrementBroyeur: undefined,
+      vhuAgrementDemolisseur: undefined
     });
   });
 
@@ -89,7 +104,25 @@ describe("companyInfos with SIRET", () => {
       isRegistered: false,
       companyTypes: [],
       ecoOrganismeAgreements: [],
-      installation: undefined
+      installation: undefined,
+      address: undefined,
+      allowBsdasriTakeOverWithoutSignature: undefined,
+      brokerReceipt: undefined,
+      codeCommune: undefined,
+      codePaysEtrangerEtablissement: undefined,
+      contact: undefined,
+      contactEmail: undefined,
+      contactPhone: undefined,
+      etatAdministratif: undefined,
+      libelleNaf: undefined,
+      naf: undefined,
+      statutDiffusionEtablissement: undefined,
+      traderReceipt: undefined,
+      transporterReceipt: undefined,
+      vatNumber: undefined,
+      vhuAgrementBroyeur: undefined,
+      vhuAgrementDemolisseur: undefined,
+      website: undefined
     });
   });
 });
@@ -129,6 +162,7 @@ describe("companyInfos search with a VAT number", () => {
     const company = await getCompanyInfos("IT09301420155");
 
     expect(company).toStrictEqual({
+      siret: undefined,
       vatNumber: "IT09301420155",
       name: "Code en stock",
       address: "une adresse",
@@ -140,7 +174,18 @@ describe("companyInfos search with a VAT number", () => {
       ecoOrganismeAgreements: [],
       companyTypes: [],
       installation: undefined,
-      statutDiffusionEtablissement: "O"
+      statutDiffusionEtablissement: "O",
+      allowBsdasriTakeOverWithoutSignature: undefined,
+      brokerReceipt: undefined,
+      codeCommune: undefined,
+      contact: undefined,
+      etatAdministratif: undefined,
+      libelleNaf: undefined,
+      naf: undefined,
+      traderReceipt: undefined,
+      transporterReceipt: undefined,
+      vhuAgrementBroyeur: undefined,
+      vhuAgrementDemolisseur: undefined
     });
   });
 
@@ -155,6 +200,7 @@ describe("companyInfos search with a VAT number", () => {
     const company = await getCompanyInfos("IT09301420155");
 
     expect(company).toStrictEqual({
+      siret: undefined,
       vatNumber: "IT09301420155",
       name: "Code en stock",
       address: "une adresse",
@@ -163,7 +209,21 @@ describe("companyInfos search with a VAT number", () => {
       companyTypes: [],
       ecoOrganismeAgreements: [],
       installation: undefined,
-      statutDiffusionEtablissement: "O"
+      statutDiffusionEtablissement: "O",
+      allowBsdasriTakeOverWithoutSignature: undefined,
+      brokerReceipt: undefined,
+      codeCommune: undefined,
+      contact: undefined,
+      contactPhone: undefined,
+      contactEmail: undefined,
+      etatAdministratif: undefined,
+      libelleNaf: undefined,
+      naf: undefined,
+      traderReceipt: undefined,
+      transporterReceipt: undefined,
+      vhuAgrementBroyeur: undefined,
+      vhuAgrementDemolisseur: undefined,
+      website: undefined
     });
   });
 });

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -1,7 +1,6 @@
 import { UserInputError } from "apollo-server-express";
 import {
   CompanyPublic,
-  CompanySearchPrivate,
   QueryResolvers
 } from "../../../generated/graphql/types";
 import { getInstallation } from "../../database";
@@ -19,7 +18,7 @@ import { searchCompany } from "../../search";
  */
 export async function getCompanyInfos(
   siretOrVat: string
-): Promise<CompanyPublic | CompanySearchPrivate> {
+): Promise<CompanyPublic> {
   if (!siretOrVat) {
     throw new UserInputError(
       "Paramètre absent. Un numéro SIRET ou de TVA intracommunautaire valide est requis",
@@ -29,13 +28,39 @@ export async function getCompanyInfos(
     );
   }
   const searchResult = await searchCompany(siretOrVat);
+
   return {
-    ...searchResult,
+    siret: searchResult.siret,
+    vatNumber: searchResult.vatNumber,
+    codePaysEtrangerEtablissement: searchResult.codePaysEtrangerEtablissement,
+    etatAdministratif: searchResult.etatAdministratif,
+    statutDiffusionEtablissement: searchResult.statutDiffusionEtablissement,
+    address: searchResult.address,
+    codeCommune: searchResult.codeCommune,
+    name: searchResult.name,
+    naf: searchResult.naf,
+    libelleNaf: searchResult.libelleNaf,
+    installation: await getInstallation(siretOrVat),
+    contact: searchResult.contact,
+    contactEmail: searchResult.contactEmail,
+    contactPhone: searchResult.contactPhone,
+    website: searchResult.website,
+    isRegistered: searchResult.isRegistered,
+    companyTypes: searchResult.companyTypes,
     ecoOrganismeAgreements: searchResult.ecoOrganismeAgreements ?? [],
-    installation: await getInstallation(siretOrVat)
+    allowBsdasriTakeOverWithoutSignature:
+      searchResult.allowBsdasriTakeOverWithoutSignature,
+    transporterReceipt: searchResult.transporterReceipt,
+    traderReceipt: searchResult.traderReceipt,
+    brokerReceipt: searchResult.brokerReceipt,
+    vhuAgrementDemolisseur: searchResult.vhuAgrementDemolisseur,
+    vhuAgrementBroyeur: searchResult.vhuAgrementBroyeur
   };
 }
 
+/**
+ * Public Query
+ */
 const companyInfosResolvers: QueryResolvers["companyInfos"] = async (
   _,
   args

--- a/back/src/companies/resolvers/queries/searchCompanies.ts
+++ b/back/src/companies/resolvers/queries/searchCompanies.ts
@@ -1,28 +1,16 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
-import prisma from "../../../prisma";
 import { searchCompanies } from "../../search";
 
 const searchCompaniesResolver: QueryResolvers["searchCompanies"] = async (
   _,
   { clue, department },
   context
-) => {
-  return searchCompanies(clue, department).then(async results => {
-    let existingCompanies = [];
-    if (results.length) {
-      existingCompanies = await prisma.company.findMany({
-        where: {
-          siret: { in: results.map(r => r.siret) }
-        }
-      });
-    }
-
-    return results.map(async company => ({
+) =>
+  searchCompanies(clue, department).then(async results =>
+    results.map(async company => ({
       ...company,
-      isRegistered: existingCompanies.includes(company.siret),
       installation: await context.dataloaders.installations.load(company.siret)
-    }));
-  });
-};
+    }))
+  );
 
 export default searchCompaniesResolver;

--- a/back/src/companies/sirene/types.ts
+++ b/back/src/companies/sirene/types.ts
@@ -1,14 +1,34 @@
-import { CompanySearchResult } from "../types";
+import { StatutDiffusionEtablissement } from "../../generated/graphql/types";
 
-export type SireneSearchResult = Omit<
-  CompanySearchResult,
-  | "id"
-  | "isRegistered"
-  | "companyTypes"
-  | "contact"
-  | "contactEmail"
-  | "contactPhone"
->;
+/**
+ * Interface des résultats sur la base Sirene INSEE
+ */
+export interface SireneSearchResult {
+  addressVoie?: string;
+  addressPostalCode?: string;
+  addressCity?: string;
+  /** Adresse de l'établissement */
+  address?: string;
+  /** Code commune de l'établissement */
+  codeCommune?: string;
+  /** Code pays de l'établissement */
+  codePaysEtrangerEtablissement?: string;
+
+  /** État administratif de l'établissement. A = Actif, F = Fermé */
+  etatAdministratif?: string;
+  /** Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets */
+  isRegistered?: boolean;
+  /** Libellé NAF */
+  libelleNaf?: string;
+  /** Code NAF */
+  naf?: string;
+  /** Nom de l'établissement */
+  name?: string;
+  /** SIRET de l'établissement */
+  siret?: string;
+  /** Statut de diffusion des informations de l'établisement selon l'INSEE */
+  statutDiffusionEtablissement?: StatutDiffusionEtablissement;
+}
 
 // Response from https://api.entreprise.data.gouv.fr/api/sirene/v3/etablissements/<VOTRE_SIRET>
 export interface SearchResponseDataGouv {

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -200,6 +200,12 @@ type CompanySearchResult {
   etatAdministratif: String
   "Adresse de l'établissement"
   address: String
+  "Nom de la voie de l'adresse de l'établissement"
+  addressVoie: String
+  "Code Postal de l'adresse de l'établissement"
+  addressPostalCode: String
+  "Ville de l'adresse de l'établissement"
+  addressCity: String
   "Code commune de l'établissement"
   codeCommune: String
   "Nom de l'établissement"
@@ -265,6 +271,10 @@ type CompanySearchResult {
   Agrément VHU broyeur (le cas échéant, pour les profils VHU)
   """
   vhuAgrementBroyeur: VhuAgrement
+  """
+  Statut de diffusion des informations de l'établisement selon l'INSEE
+  """
+  statutDiffusionEtablissement: StatutDiffusionEtablissement
 }
 
 """

--- a/back/src/companies/types.ts
+++ b/back/src/companies/types.ts
@@ -1,28 +1,5 @@
-import { CompanyType } from "../generated/graphql/types";
+export { CompanySearchResult } from "../generated/graphql/types";
 
-// return type for functions searchCompany and searchCompanies
-export interface CompanySearchResult extends CompanyBaseIdentifiers {
-  address: string;
-  name: string;
-  // Ouvert "A", Fermé "F" (INSEE)
-  etatAdministratif?: string;
-  codeCommune?: string;
-  naf?: string;
-  libelleNaf?: string;
-  addressVoie?: string;
-  addressCity?: string;
-  addressPostalCode?: string;
-  // Enregistré sur TD
-  isRegistered: boolean;
-  companyTypes: CompanyType[];
-  ecoOrganismeAgreements?: URL[];
-  contact: string;
-  contactEmail: string;
-  contactPhone: string;
-  // diffusible ou non-diffusible légalement (INSEE)
-  statutDiffusionEtablissement: "O" | "N";
-  codePaysEtrangerEtablissement?: string;
-}
 /**
  * Company interface only with identifiers
  * used with Company types derivatives


### PR DESCRIPTION
- [x] Fix PDF Destination ultérieure
- [x] Fix recherche Destination ultérieure BSDD pour les entre prises étrangères
- [x] Nettoyage du type et données de réponse de `getCompanyInfos()` car multi-forme auparavant et créant confusion
- [x] Nettoyage données de réponse de query `companyPrivateInfos` car données du type `CompanyPrivateInfos` manquantes dans la fonction
- [x] Ajout d'un check authentifié sur la query auparavant publique `searchCompanies`, refacto du calcul `isRegistered` dans la fonction base `searchCompanies()`
- [x] Correction du caccul de `isRegistered` et mise en cohérence des types `CompanySearchResult` (CompanySearchResult[]` comme type de réponse de la query `searchCompanies`) pour répondre à la définition de query
- [x] Nettoyage et précision de types : `SireneSearchResult`, `CompanySearchResult` et suppression de l'interface TS `interface CompanySearchResult` au profit du type GQL correspondant
- [x] Correctifs bugs `CompanySelector.tsx`, suppression complexité de la sélection automatique d'un résultat, correction absence [message d'erreur non-inscrits TD interdit](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7281) `setMustBeRegistered`, amélioration du debounce de requete, suppression onBlur inutil

# Checklist
- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-6959)
- [Autre ticket bug Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-7281)
