### PR TITLE
fix recherche par TVA avec nom/adresse inconnus

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,13 +21,15 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug ne permettant pas au destinataire finale de créer un BSDD avec entreposage provisoire [PR 1498](https://github.com/MTES-MCT/trackdechets/pull/1498)
 - Correction de la navigation entre les onglets du tableau de bord lors de certaines actions [PR 1469](https://github.com/MTES-MCT/trackdechets/pull/1469)
 - Correction d'un bug affichant une mauvaise adresse et raison sociale dans le module de recherche d'entreprise sur l'interface Trackdéchets [PR 1501](https://github.com/MTES-MCT/trackdechets/pull/1501)
+- - On visualise mieux quand la recherche par TVA donne des informations manquantes pour un TVA qui existe et on doit pouvoir éditer manuellement les coordonnées d'un établissement étranger aux coordonnées inconnues donc ouverture automatique du formulaire à la selection du résultat inconnus [PR 1543](https://github.com/MTES-MCT/trackdechets/pull/1543)
 
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations
 
 - Gestion des volumes représentés par des nombres décimaux sur les BSDASRIs [PR 1506](https://github.com/MTES-MCT/trackdechets/pull/1506)
-- Interface de recherche d'établissements : améliorations de design général, et support des entreprises étrangères par recherche de TVA inclus directement dans le champs de recherche textuel des entreprises françaises. Suppression du sélecteur "Entreprise étrangère".
+- Interface de recherche d'établissements : améliorations de design général, et support des entreprises étrangères par recherche de TVA inclus directement dans le champs de recherche textuel des entreprises françaises. Suppression du sélecteur "Entreprise étrangère". [PR 1481](https://github.com/MTES-MCT/trackdechets/pull/1481) et suivantes : [PR 1539](https://github.com/MTES-MCT/trackdechets/pull/1539), [PR 1538](https://github.com/MTES-MCT/trackdechets/pull/1538), [PR 1528](https://github.com/MTES-MCT/trackdechets/pull/1528)
+- Affichage des inscriptions sur Trackdéchets dans la liste des résultats de recherche [PR 1541](https://github.com/MTES-MCT/trackdechets/pull/1541)
 - Meilleure validation des numéros de téléphone étrangers dans le compte utilisateur [PR 1544](https://github.com/MTES-MCT/trackdechets/pull/1544)
 
 #### :memo: Documentation

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction d'un bug ne permettant pas au destinataire finale de créer un BSDD avec entreposage provisoire [PR 1498](https://github.com/MTES-MCT/trackdechets/pull/1498)
 - Correction de la navigation entre les onglets du tableau de bord lors de certaines actions [PR 1469](https://github.com/MTES-MCT/trackdechets/pull/1469)
 - Correction d'un bug affichant une mauvaise adresse et raison sociale dans le module de recherche d'entreprise sur l'interface Trackdéchets [PR 1501](https://github.com/MTES-MCT/trackdechets/pull/1501)
-- - On visualise mieux quand la recherche par TVA donne des informations manquantes pour un TVA qui existe et on doit pouvoir éditer manuellement les coordonnées d'un établissement étranger aux coordonnées inconnues donc ouverture automatique du formulaire à la selection du résultat inconnus [PR 1543](https://github.com/MTES-MCT/trackdechets/pull/1543)
+- On visualise mieux quand la recherche par TVA donne des informations manquantes pour un numéro de TVA qui existe et on doit pouvoir éditer manuellement les coordonnées d'un établissement étranger aux coordonnées inconnues donc ouverture automatique du formulaire à la sélection du résultat inconnu [PR 1543](https://github.com/MTES-MCT/trackdechets/pull/1543)
 
 #### :boom: Breaking changes
 

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -43,7 +43,9 @@ export default function CompanyResults<
           >
             <div className={styles.content}>
               <h6 className="tw-flex tw-items-center tw-align-middle">
-                <div className="tw-mt-1">{item.name}</div>
+                <div className="tw-mt-1">
+                  {item.name ? item.name : "[Nom inconnu]"}
+                </div>
                 {item.isRegistered === true && (
                   <div className="tw-ml-1">
                     <IconTrackDechetsCheck />
@@ -51,7 +53,8 @@ export default function CompanyResults<
                 )}
               </h6>
               <p>
-                {item.siret} - {item.address}
+                {item.siret} -{" "}
+                {item.address ? item.address : "[Adresse inconnue]"}
               </p>
               <p>
                 <a

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Tooltip } from "@reach/tooltip";
 
 import {
   IconCheckCircle1,

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -242,8 +242,10 @@ export default function CompanySelector({
    * Parse and merge data from searchCompanies and favoritesData
    */
   useEffect(() => {
-    if (disabled || !searchData) return;
-    let mergedResults: CompanySearchResult[] = searchData.searchCompanies
+    if (disabled) return;
+    let mergedResults:
+      | CompanySearchResult[]
+      | undefined = searchData?.searchCompanies
       .map(
         ({
           siret,

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -309,13 +309,7 @@ export default function CompanySelector({
       mergedResults = [];
     }
     setSearchResults(mergedResults);
-  }, [
-    disabled,
-    searchData?.searchCompanies,
-    favoritesData,
-    setSearchResults,
-    skipFavorite,
-  ]);
+  }, [disabled, searchData, favoritesData, setSearchResults, skipFavorite]);
 
   /**
    * Démarre la requete avec un délai

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -80,6 +80,10 @@ export default function CompanySelector({
   const [department, setDepartement] = useState<null | string>(null);
   const [mustBeRegistered, setMustBeRegistered] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<CompanySearchResult[]>([]);
+  const [
+    toggleManualForeignCompanyForm,
+    setToggleManualForeignCompanyForm,
+  ] = useState<boolean>(false);
   const timeout = useRef<number | null>();
 
   /**
@@ -158,7 +162,7 @@ export default function CompanySelector({
         }),
         country: company.codePaysEtrangerEtablissement,
       };
-      if (company.name === "---") {
+      if (company.name === "---" || company.name === "") {
         cogoToast.error(
           "Cet établissement existe mais nous ne pouvons remplir automatiquement le formulaire"
         );
@@ -172,7 +176,10 @@ export default function CompanySelector({
           fields.country = vatCountryCode;
         }
       }
-
+      setToggleManualForeignCompanyForm(
+        company.codePaysEtrangerEtablissement !== "FR" &&
+          (company.name === "---" || company.name === "")
+      );
       setIsForeignCompany(company.codePaysEtrangerEtablissement !== "FR");
       Object.keys(fields).forEach(key => {
         setFieldValue(`${field.name}.${key}`, fields[key]);
@@ -187,6 +194,7 @@ export default function CompanySelector({
       field.name,
       setFieldValue,
       setIsForeignCompany,
+      setToggleManualForeignCompanyForm,
       onCompanySelected,
       disabled,
       registeredOnlyCompanies,
@@ -495,7 +503,9 @@ export default function CompanySelector({
 
         <div className="form__row">
           {allowForeignCompanies &&
-            (isForeignCompany || forceManualForeignCompanyForm) && (
+            (isForeignCompany ||
+              forceManualForeignCompanyForm ||
+              toggleManualForeignCompanyForm) && (
               <>
                 <label>
                   Nom de l'entreprise


### PR DESCRIPTION
# Permet la saisie manuelle des coordonnées quand l'api de recherche TVA renvoie des coordonnées vides pour des TVA existants

- On doit visualiser mieux quand la recherche par TVA donne des informations manquantes pour un TVA qui existe.
- On doit pouvoir éditer manuellement les coordonnées d'un établissement étranger aux coordonnées inconnues donc ouverture automatique et requise du formulaire en base à la selection du résultat au nom inconnu

---

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-8364)
