### PR TITLE
Améliore validation téléphones du compte

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Gestion des volumes représentés par des nombres décimaux sur les BSDASRIs [PR 1506](https://github.com/MTES-MCT/trackdechets/pull/1506)
 - Interface de recherche d'établissements : améliorations de design général, et support des entreprises étrangères par recherche de TVA inclus directement dans le champs de recherche textuel des entreprises françaises. Suppression du sélecteur "Entreprise étrangère".
+- Meilleure validation des numéros de téléphone étrangers dans le compte utilisateur [PR 1544](https://github.com/MTES-MCT/trackdechets/pull/1544)
 
 #### :memo: Documentation
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -12022,6 +12022,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.8.tgz",
+      "integrity": "sha512-MGgHrKRGE7sg7y0DikHybRDgTXcYv4HL+WwhDm5UAiChCNb5tcy5OEaU8XTTt5bDBwhZGCJNxoGMVBpZ4RfhIg=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",

--- a/front/package.json
+++ b/front/package.json
@@ -24,6 +24,7 @@
     "graphql": "^16.0.2",
     "graphql-anywhere": "^4.2.7",
     "jsvat": "^2.5.3",
+    "libphonenumber-js": "^1.10.8",
     "local-storage": "^2.0.0",
     "mapbox-gl": "^1.11.1",
     "object.omit": "^3.0.0",

--- a/front/src/account/fields/AccountFieldCompanyContactPhone.tsx
+++ b/front/src/account/fields/AccountFieldCompanyContactPhone.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { gql } from "@apollo/client";
+import { isValidPhoneNumber, getCountries } from "libphonenumber-js";
 import AccountField from "./AccountField";
 import AccountFieldNotEditable from "./AccountFieldNotEditable";
 import AccountFormSimpleInput from "./forms/AccountFormSimpleInput";
@@ -35,13 +36,21 @@ const UPDATE_CONTACT_PHONE = gql`
   }
 `;
 
+const countries = getCountries().map(country => country);
+
 const yupSchema = object().shape({
   contactPhone: string()
     .trim()
-    .matches(/^(0[1-9])(?:[ _.-]?(\d{2})){4}$/, {
-      message: "Le numéro de téléphone est invalide",
-      excludeEmptyString: true,
-    }),
+    .test(
+      "is-valid-phone",
+      "Merci de renseigner un numéro de téléphone valide",
+      value =>
+        !!value &&
+        ((!value.startsWith("0") &&
+          countries.some(country => isValidPhoneNumber(value!, country))) ||
+          (value.startsWith("0") &&
+            /^(0[1-9])(?:[ _.-]?(\d{2})){4}$/.test(value)))
+    ),
 });
 
 export default function AccountFielCompanyContactPhone({ company }: Props) {

--- a/front/src/account/fields/AccountFieldCompanyContactPhone.tsx
+++ b/front/src/account/fields/AccountFieldCompanyContactPhone.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { gql } from "@apollo/client";
-import { isValidPhoneNumber, getCountries } from "libphonenumber-js";
 import AccountField from "./AccountField";
 import AccountFieldNotEditable from "./AccountFieldNotEditable";
 import AccountFormSimpleInput from "./forms/AccountFormSimpleInput";
@@ -10,6 +9,7 @@ import {
   UserRole,
   MutationUpdateCompanyArgs,
 } from "generated/graphql/types";
+import { validatePhoneNumber } from "common/helper";
 
 type Props = {
   company: CompanyPrivate;
@@ -36,20 +36,13 @@ const UPDATE_CONTACT_PHONE = gql`
   }
 `;
 
-const countries = getCountries().map(country => country);
-
 const yupSchema = object().shape({
   contactPhone: string()
     .trim()
     .test(
       "is-valid-phone",
       "Merci de renseigner un numéro de téléphone valide",
-      value =>
-        !!value &&
-        ((!value.startsWith("0") &&
-          countries.some(country => isValidPhoneNumber(value!, country))) ||
-          (value.startsWith("0") &&
-            /^(0[1-9])(?:[ _.-]?(\d{2})){4}$/.test(value)))
+      validatePhoneNumber
     ),
 });
 

--- a/front/src/account/fields/AccountFieldPhone.tsx
+++ b/front/src/account/fields/AccountFieldPhone.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { gql } from "@apollo/client";
-import { getCountries, isValidPhoneNumber } from "libphonenumber-js";
 import AccountField from "./AccountField";
 import AccountFormSimpleInput from "./forms/AccountFormSimpleInput";
 import { object, string } from "yup";
 import { User, MutationEditProfileArgs } from "generated/graphql/types";
+import { validatePhoneNumber } from "common/helper";
 
 type Me = Pick<User, "phone">;
 
@@ -30,20 +30,13 @@ const UPDATE_PHONE = gql`
   }
 `;
 
-const countries = getCountries().map(country => country);
-
 const yupSchema = object().shape({
   phone: string()
     .trim()
     .test(
       "is-valid-phone",
       "Merci de renseigner un numéro de téléphone valide",
-      value =>
-        !!value &&
-        ((!value.startsWith("0") &&
-          countries.some(country => isValidPhoneNumber(value!, country))) ||
-          (value.startsWith("0") &&
-            /^(0[1-9])(?:[ _.-]?(\d{2})){4}$/.test(value)))
+      validatePhoneNumber
     ),
 });
 

--- a/front/src/account/fields/AccountFieldPhone.tsx
+++ b/front/src/account/fields/AccountFieldPhone.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { gql } from "@apollo/client";
+import { getCountries, isValidPhoneNumber } from "libphonenumber-js";
 import AccountField from "./AccountField";
 import AccountFormSimpleInput from "./forms/AccountFormSimpleInput";
 import { object, string } from "yup";
@@ -29,13 +30,21 @@ const UPDATE_PHONE = gql`
   }
 `;
 
+const countries = getCountries().map(country => country);
+
 const yupSchema = object().shape({
   phone: string()
     .trim()
-    .matches(/^(0[1-9])(?:[ _.-]?(\d{2})){4}$/, {
-      message: "Le numéro de téléphone est invalide",
-      excludeEmptyString: true,
-    }),
+    .test(
+      "is-valid-phone",
+      "Merci de renseigner un numéro de téléphone valide",
+      value =>
+        !!value &&
+        ((!value.startsWith("0") &&
+          countries.some(country => isValidPhoneNumber(value!, country))) ||
+          (value.startsWith("0") &&
+            /^(0[1-9])(?:[ _.-]?(\d{2})){4}$/.test(value)))
+    ),
 });
 
 export default function AccountFieldPhone({ me }: Props) {

--- a/front/src/common/helper.ts
+++ b/front/src/common/helper.ts
@@ -1,5 +1,6 @@
 import { DocumentNode } from "graphql";
 import { ApolloError, DataProxy } from "@apollo/client";
+import { getCountries, isValidPhoneNumber } from "libphonenumber-js";
 
 export const capitalize = (str: string) =>
   str.charAt(0).toUpperCase() + str.slice(1);
@@ -142,3 +143,12 @@ export const sortCompaniesByName = values => {
     return aName.localeCompare(bName);
   });
 };
+
+const countries = getCountries().map(country => country);
+
+export const validatePhoneNumber = value =>
+  !!value &&
+  ((!value.startsWith("0") &&
+    value.startsWith("+") &&
+    countries.some(country => isValidPhoneNumber(value!, country))) ||
+    (value.startsWith("0") && /^(0[1-9])(?:[ _.-]?(\d{2})){4}$/.test(value)));


### PR DESCRIPTION
## ETQ transporteur étranger, je peux renseigner mon nº de téléphone (pour qu'il soit ensuite auto-rempli dans les BSD qui me visent)

- support des numéros étrangers avec https://catamphetamine.gitlab.io/libphonenumber-js/
- mais restrictions spéciales pour garder les numéro en "0" (pas possible d'autre chiffre que 0 en début de numéro, seul des "+" peuvent être valides comme numéro étranger ou français.

https://www.loom.com/share/69cda48bf4a54cfcb3545c14ebb5e97d

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a)
