### PR TITLE
Fix / BSDA - Erreur 400 avec les conditionnements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Correction d'un bug qui, dans le cas d'un BSDA avec un particulier, laissait trop longtemps possible la modification de certains champs [PR 1569](https://github.com/MTES-MCT/trackdechets/pull/1569)
 - Corrections de bugs sur la révision BSDD & BSDA, dans le cas ou un SIRET avait plusieurs rôles de validation de cette révision. Si le créateur de la révision a l'ensemble des rôles d'approbation, la révision est désormais auto-approuvée [PR 1567](https://github.com/MTES-MCT/trackdechets/pull/1567)
+- Correction d'un bug à l'enregistrement sur le formulaire BSDA si on saisissait un conditionnement sans saisir la quantité associée [PR 1557](https://github.com/MTES-MCT/trackdechets/pull/1557)
 
 #### :boom: Breaking changes
 

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -733,6 +733,15 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
         })
     });
 
+const packagingsSchema = yup.object({
+  type: yup.string().required("Le type de conditionnement est obligatoire"),
+  other: yup.string().optional(),
+  quantity: yup
+    .number()
+    .min(1, "La quantité d'un conditionnement doit être supérieure à 1")
+    .required("La quantité associée à un conditionnement est obligatoire")
+});
+
 const wasteDescriptionSchema: FactorySchemaOf<
   BsdaValidationContext,
   WasteDescription
@@ -755,7 +764,7 @@ const wasteDescriptionSchema: FactorySchemaOf<
     wasteSealNumbers: yup.array().ensure().of(yup.string()) as any,
     wasteAdr: yup.string().nullable(),
     wastePop: yup.boolean().nullable(),
-    packagings: yup.array(),
+    packagings: yup.array().of(packagingsSchema),
     weightIsEstimate: yup
       .boolean()
       .requiredIf(context.workSignature, `Le type de quantité est obligatoire`),

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -738,7 +738,10 @@ const packagingsSchema = yup.object({
   other: yup.string().optional(),
   quantity: yup
     .number()
-    .min(1, "La quantité d'un conditionnement doit être supérieure à 1")
+    .min(
+      1,
+      "La quantité d'un conditionnement doit être supérieure ou égale à 1"
+    )
     .required("La quantité associée à un conditionnement est obligatoire")
 });
 

--- a/front/src/form/bsda/components/packagings/Packagings.tsx
+++ b/front/src/form/bsda/components/packagings/Packagings.tsx
@@ -92,6 +92,16 @@ export default function Packagings({
                           name={`${name}.${idx}.quantity`}
                           placeholder="Nombre"
                           min="1"
+                          onBlur={() => {
+                            // Having an empty quantity is not valid in our gql schema
+                            // So we forbid it with this form
+                            if (
+                              p.quantity == null ||
+                              Number.isNaN(p.quantity)
+                            ) {
+                              setFieldValue(`${name}.${idx}.quantity`, 1);
+                            }
+                          }}
                         />
                       </div>
                     </div>

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -20,6 +20,7 @@ import initialState from "./initial-state";
 import { CREATE_BSDA, UPDATE_BSDA, GET_BSDA } from "./queries";
 import omitDeep from "omit-deep-lodash";
 import { formInputToastError } from "form/common/stepper/toaster";
+import { bsdaValidationSchema } from "./schema";
 
 interface Props {
   children: (bsda: Bsda | undefined) => ReactElement;
@@ -120,7 +121,7 @@ export default function BsdaStepsList(props: Props) {
         formQuery={formQuery}
         onSubmit={onSubmit}
         initialValues={formState}
-        validationSchema={null}
+        validationSchema={bsdaValidationSchema}
         initialStep={props.initialStep}
       />
       {(creating || updating) && <Loader />}

--- a/front/src/form/bsda/stepper/schema.ts
+++ b/front/src/form/bsda/stepper/schema.ts
@@ -1,0 +1,13 @@
+import * as Yup from "yup";
+
+const packagingsSchema = Yup.object({
+  type: Yup.string().required("Le type de conditionnement est obligatoire"),
+  other: Yup.string().optional(),
+  quantity: Yup.number()
+    .min(1, "La quantité d'un conditionnement doit être supérieure à 1")
+    .required("La quantité associée à un conditionnement est obligatoire"),
+});
+
+export const bsdaValidationSchema = Yup.object({
+  packagings: Yup.array().of(packagingsSchema),
+});


### PR DESCRIPTION
Si on ne saisit pas la quantité d'un conditionnement on avait une erreur 400 à l'enregistrement.
En effet la quantité est obligatoire dans notre schéma Gql.
On empêche donc le formulaire de saisir des quantités nulles.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7903)
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8649)
