### PR TITLE
Fix / favorites (transporter)

### DIFF
--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -185,18 +185,23 @@ async function getRecentTransporters(defaultWhere: Prisma.FormWhereInput) {
   const forms = await prisma.form.findMany({
     ...defaultArgs,
     where: {
-      ...defaultWhere,
-      OR: [
+      // `defaultWhere` uses an `OR` already. We need a `AND` to avoid overwriting it.
+      AND: [
+        defaultWhere,
         {
-          NOT: [
-            { transporterCompanySiret: null },
-            { transporterCompanySiret: "" }
-          ]
-        },
-        {
-          NOT: [
-            { transporterCompanyVatNumber: null },
-            { transporterCompanyVatNumber: "" }
+          OR: [
+            {
+              NOT: [
+                { transporterCompanySiret: null },
+                { transporterCompanySiret: "" }
+              ]
+            },
+            {
+              NOT: [
+                { transporterCompanyVatNumber: null },
+                { transporterCompanyVatNumber: "" }
+              ]
+            }
           ]
         }
       ]


### PR DESCRIPTION
Fix favoris transport.
La clause OR était overwrited, donc on avait n'importe quel transporteur qui s'affichait.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8778)
