### PR TITLE
BSDA/ Fix signature rules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correction d'un bug qui, dans le cas d'un BSDA avec un particulier, laissait trop longtemps possible la modification de certains champs [PR 1569](https://github.com/MTES-MCT/trackdechets/pull/1569)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/bsda/__tests__/edition-rules.test.ts
+++ b/back/src/bsda/__tests__/edition-rules.test.ts
@@ -18,6 +18,14 @@ describe("Bsda edition rules", () => {
     ).toThrow(SealedFieldsError);
   });
 
+  it("should throw if trying to edit a field sealed not by the required signature type but by a child signature type", () => {
+    expect(() =>
+      checkKeysEditability({ type: BsdaType.GATHERING }, {
+        destinationOperationSignatureDate: new Date()
+      } as BsdaWithGrouping)
+    ).toThrow(SealedFieldsError);
+  });
+
   it("should throw with the flat field path when erroring", () => {
     expect.assertions(1);
     try {

--- a/back/src/bsda/edition-rules.ts
+++ b/back/src/bsda/edition-rules.ts
@@ -12,11 +12,16 @@ type EditableFields<Type> = {
     | ReturnType<typeof ifAwaitingSignature>;
 };
 
-const signatureToFieldMapping: { [key in BsdaSignatureType]: keyof Bsda } = {
-  EMISSION: "emitterEmissionSignatureDate",
-  WORK: "workerWorkSignatureDate",
-  TRANSPORT: "transporterTransportSignatureDate",
-  OPERATION: "destinationOperationSignatureDate"
+const SIGNATURES_HIERARCHY: {
+  [key in BsdaSignatureType]: { field: keyof Bsda; next?: BsdaSignatureType };
+} = {
+  EMISSION: { field: "emitterEmissionSignatureDate", next: "WORK" },
+  WORK: { field: "workerWorkSignatureDate", next: "TRANSPORT" },
+  TRANSPORT: {
+    field: "transporterTransportSignatureDate",
+    next: "OPERATION"
+  },
+  OPERATION: { field: "destinationOperationSignatureDate" }
 };
 
 const bsdaWithGrouping = Prisma.validator<Prisma.BsdaArgs>()({
@@ -72,9 +77,23 @@ const editableFields: EditableFields<BsdaInput> = {
   forwarding: ifAwaitingSignature("EMISSION")
 };
 
-function ifAwaitingSignature(signature: BsdaSignatureType) {
-  const field = signatureToFieldMapping[signature];
-  return (bsda: Bsda) => bsda[field] == null;
+/**
+ * Checks if we still await a signature of the inputed type.
+ * As in some cases a signature nevers gets filled (ex private individual emitter),
+ * we recursively check that any signature coming after the inputed one hasn't
+ * been filled already.
+ *
+ * @param signatureType
+ * @returns boolean
+ */
+function ifAwaitingSignature(signatureType: BsdaSignatureType | undefined) {
+  if (!signatureType) {
+    return () => true;
+  }
+
+  const signature = SIGNATURES_HIERARCHY[signatureType];
+  return (bsda: Bsda) =>
+    bsda[signature.field] == null && ifAwaitingSignature(signature.next)(bsda);
 }
 
 function getDiffInput(updates: BsdaInput, currentForm: BsdaWithGrouping) {


### PR DESCRIPTION
Correction des règles de signature: dans certains cas particuliers des signatures ne sont jamais apposées (ex: émetteur est un particulier et ne signera jamais).
Dans ce cas, les champs bloqués par la signature émetteur n'étaient jamais correctement bloqués.
Pour résoudre ça on défini une hiérarchie de signature, et si une signature n'est pas apposée on vérifie que aucun de ses enfants n'a été apposé non plus.

Bug remonté par Emmanuel (un mail qu'il a reçu)
