### PR TITLE
BSDA / Suppression après signature émetteur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout d'un onglet "BSDA suite" sur l'aperçu pour les BSDAs initiaux groupés ou faisant partie d'un bordereau de transit [PR 1577](https://github.com/MTES-MCT/trackdechets/pull/1577)
+- Ajout de la possibilité pour l'émetteur d'un BSDA de supprimer le bordereau après qu'il ait signé, si aucun autre acteur n'a encore signé [PR 1571](https://github.com/MTES-MCT/trackdechets/pull/1571)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -80,7 +80,15 @@ export async function checkCanDeleteBsda(user: User, bsda: Bsda) {
     "Vous n'êtes pas autorisé à supprimer ce bordereau."
   );
 
-  if (bsda.status !== BsdaStatus.INITIAL) {
+  const userSirets = await getCachedUserSirets(user.id);
+  const isBsdaEmitter = userSirets.some(
+    siret => bsda.emitterCompanySiret === siret
+  );
+
+  if (
+    bsda.status !== BsdaStatus.INITIAL &&
+    (!isBsdaEmitter || bsda.status !== BsdaStatus.SIGNED_BY_PRODUCER)
+  ) {
     throw new ForbiddenError(
       "Seuls les bordereaux en brouillon ou n'ayant pas encore été signés peuvent être supprimés"
     );

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
@@ -105,7 +105,9 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
                 <IconDuplicateFile size="24px" color="blueLight" />
                 Dupliquer
               </MenuItem>
-              {form["bsdaStatus"] === BsdaStatus.Initial ? (
+              {form["bsdaStatus"] === BsdaStatus.Initial ||
+              (form["bsdaStatus"] === BsdaStatus.SignedByProducer &&
+                form.emitter?.company?.siret === siret) ? (
                 <MenuItem onSelect={() => setIsDeleting(true)}>
                   <IconTrash color="blueLight" size="24px" />
                   Supprimer


### PR DESCRIPTION
Possibilité de supprimer un bsda après signature émetteur, si je suis moi même l'émetteur.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7216)
