### PR TITLE
Give access to following bsda

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,14 +8,19 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 # [2022.08.1] ~08/08/2022
 
 #### :rocket: Nouvelles fonctionnalités
+
+- Ajout d'un onglet "BSDA suite" sur l'aperçu pour les BSDAs initiaux groupés ou faisant partie d'un bordereau de transit [PR 1577](https://github.com/MTES-MCT/trackdechets/pull/1577)
+
 #### :bug: Corrections de bugs
 
 #### :boom: Breaking changes
+
 #### :nail_care: Améliorations
 
 - Correction du fonctionnement de la validation des champs requis sur le BSFF [PR 1531](https://github.com/MTES-MCT/trackdechets/pull/1531)
 
 #### :memo: Documentation
+
 #### :house: Interne
 
 # [2022.07.5] 25/07/2022
@@ -24,7 +29,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
- 
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations
@@ -35,7 +39,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
--  Import de sociétés anonymes - script [PR 1533](https://github.com/MTES-MCT/trackdechets/pull/1533)
+- Import de sociétés anonymes - script [PR 1533](https://github.com/MTES-MCT/trackdechets/pull/1533)
 
 # [2022.07.4] 21/07/2022
 
@@ -53,7 +57,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
--  Import de sociétés anonymes - script [PR 1533](https://github.com/MTES-MCT/trackdechets/pull/1533)
+- Import de sociétés anonymes - script [PR 1533](https://github.com/MTES-MCT/trackdechets/pull/1533)
 
 # [2022.07.3] 20/07/2022
 
@@ -63,7 +67,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Correction des liens du company selector [PR 1558](https://github.com/MTES-MCT/trackdechets/pull/1558)
 - Correction des favoris transporteur [PR 1559](https://github.com/MTES-MCT/trackdechets/pull/1559)
- 
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/bsda/resolvers/queries/__tests__/bsdaPdf.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdaPdf.integration.ts
@@ -1,0 +1,99 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { ErrorCode } from "../../../../common/errors";
+import { bsdaFactory } from "../../../__tests__/factories";
+import { Query } from "../../../../generated/graphql/types";
+
+import { gql } from "apollo-server-express";
+
+const BSDA_PDF = gql`
+  query BsdaPdf($id: ID!) {
+    bsdaPdf(id: $id) {
+      token
+    }
+  }
+`;
+
+describe("Query.BsdaPdf", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { query } = makeClient();
+    const bsda = await bsdaFactory({
+      opt: {}
+    });
+
+    const { errors } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
+      variables: { id: bsda.id }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+
+  it("should forbid access to user not on the bsd (simple bsda)", async () => {
+    const bsda = await bsdaFactory({
+      opt: {}
+    });
+    const { user } = await userWithCompanyFactory("MEMBER");
+
+    const { query } = makeClient(user);
+    const { errors } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
+      variables: { id: bsda.id }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas autorisé à accéder au bordereau de ce BSDA.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  it("should return a token for requested id", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
+      variables: { id: bsda.id }
+    });
+
+    expect(data.bsdaPdf.token).toBeTruthy();
+  });
+
+  it("should return a token for requested id if current user is not on the bsda but on a parent bsda", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const forwardingBsda = await bsdaFactory({
+      opt: {
+        forwarding: { connect: { id: bsda.id } }
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
+      variables: { id: forwardingBsda.id }
+    });
+
+    expect(data.bsdaPdf.token).toBeTruthy();
+  });
+});

--- a/back/src/bsda/resolvers/queries/bsdaPdf.ts
+++ b/back/src/bsda/resolvers/queries/bsdaPdf.ts
@@ -3,7 +3,7 @@ import { getFileDownload } from "../../../common/fileDownload";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { createPDFResponse } from "../../../common/pdf";
 import { getBsdaOrNotFound } from "../../database";
-import { checkIsBsdaContributor } from "../../permissions";
+import { checkCanAccessBsdaPdf } from "../../permissions";
 import { buildPdf } from "../../pdf/generator";
 import { DownloadHandler } from "../../../routers/downloadRouter";
 import { getBsdaRepository } from "../../repository";
@@ -19,13 +19,9 @@ export const bsdaPdfDownloadHandler: DownloadHandler<QueryBsdaPdfArgs> = {
 
 export default async function bsdaPdf(_, { id }: QueryBsdaPdfArgs, context) {
   const user = checkIsAuthenticated(context);
-  const form = await getBsdaOrNotFound(id);
+  const bsda = await getBsdaOrNotFound(id);
 
-  await checkIsBsdaContributor(
-    user,
-    form,
-    "Vous n'êtes pas autorisé à accéder à ce bordereau"
-  );
+  await checkCanAccessBsdaPdf(user, bsda);
 
   return getFileDownload({
     handler: bsdaPdfDownloadHandler.name,

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -329,7 +329,7 @@ const NextBsda = ({ bsda }: { bsda: Bsda }) => {
   return (
     <div className={styles.detailColumns}>
       <div className={styles.detailGrid}>
-        <dt>Identifiant</dt>
+        <dt>N°</dt>
         <dd>{bsda.id}</dd>
 
         <dt>Code déchet</dt>

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -324,6 +324,36 @@ const NextDestination = ({
   </div>
 );
 
+const NextBsda = ({ bsda }: { bsda: Bsda }) => {
+  const [downloadPdf] = useDownloadPdf({});
+  return (
+    <div className={styles.detailColumns}>
+      <div className={styles.detailGrid}>
+        <dt>Identifiant</dt>
+        <dd>{bsda.id}</dd>
+
+        <dt>Code déchet</dt>
+        <dd>{bsda.waste?.code}</dd>
+
+        <dt>CAP</dt>
+        <dd>{bsda.destination?.cap}</dd>
+
+        <dt>PDF</dt>
+        <dd>
+          <button
+            type="button"
+            className="btn btn--slim btn--small btn--outline-primary"
+            onClick={() => downloadPdf({ variables: { id: bsda.id } })}
+          >
+            <IconPdf size="18px" color="blueLight" />
+            <span>Pdf</span>
+          </button>
+        </dd>
+      </div>
+    </div>
+  );
+};
+
 export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
   const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
@@ -467,6 +497,15 @@ export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
             </Tab>
           )}
 
+          {(form?.forwardedIn?.id || form?.groupedIn?.id) && (
+            <Tab className={styles.detailTab}>
+              <IconBSDa style={{ fontSize: "25px" }} />
+              <span className={styles.detailTabCaption}>
+                <span>BSDA suite</span>
+              </span>
+            </Tab>
+          )}
+
           {!!initialBsdas?.length && (
             <Tab className={styles.detailTab}>
               <IconBSDa style={{ fontSize: "25px" }} />
@@ -519,6 +558,12 @@ export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
                 forwardedIn={form.forwardedIn}
                 groupedIn={form.groupedIn}
               />
+            </TabPanel>
+          )}
+
+          {(form?.forwardedIn?.id || form?.groupedIn?.id) && (
+            <TabPanel className={styles.detailTabPanel}>
+              <NextBsda bsda={form.forwardedIn ?? form.groupedIn!} />
             </TabPanel>
           )}
 

--- a/front/src/form/bsda/stepper/queries.ts
+++ b/front/src/form/bsda/stepper/queries.ts
@@ -176,6 +176,12 @@ export const FullBsdaFragment = gql`
     }
     groupedIn {
       id
+      waste {
+        code
+      }
+      destination {
+        cap
+      }
     }
   }
   ${companyFragment}


### PR DESCRIPTION
On donne sur les bordereaux initiaux accès au bordereau suite via un nouvel onglet dans l'aperçu.

![image](https://user-images.githubusercontent.com/5145523/181732356-3a9692bd-cc44-4149-a506-9a45aa6f4f10.png)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8516)
