### PR TITLE
Fix / BSDA refusal

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -1,4 +1,4 @@
-import { BsdaStatus, UserRole } from "@prisma/client";
+import { BsdaStatus, UserRole, WasteAcceptationStatus } from "@prisma/client";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import {
@@ -768,6 +768,138 @@ describe("Mutation.Bsda.sign", () => {
           message: "Le conditionnement est obligatoire"
         })
       ]);
+    });
+
+    it("should release initial BSDAs when grouping BSDA is refused", async () => {
+      const { company: emitter } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { company: transporter } = await userWithCompanyFactory(
+        UserRole.ADMIN
+      );
+      const { user, company: destination } = await userWithCompanyFactory(
+        UserRole.ADMIN
+      );
+      const { company: ttr1 } = await userWithCompanyFactory(UserRole.ADMIN);
+
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: ttr1.siret,
+          transporterCompanySiret: transporter.siret,
+          destinationCompanySiret: destination.siret,
+          status: BsdaStatus.SENT,
+          destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
+          destinationReceptionRefusalReason: "Invalid bsda, cant accept",
+          destinationReceptionWeight: 0,
+          destinationOperationCode: null
+        }
+      });
+
+      const grouped1 = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: emitter.siret,
+          transporterCompanySiret: transporter.siret,
+          destinationCompanySiret: ttr1.siret,
+          destinationOperationCode: "R 13",
+          status: BsdaStatus.AWAITING_CHILD,
+          groupedIn: { connect: { id: bsda.id } }
+        }
+      });
+      const grouped2 = await bsdaFactory({
+        opt: {
+          status: BsdaStatus.AWAITING_CHILD,
+          emitterCompanySiret: emitter.siret,
+          transporterCompanySiret: transporter.siret,
+          destinationCompanySiret: ttr1.siret,
+          destinationOperationCode: "R 13",
+          groupedIn: { connect: { id: bsda.id } }
+        }
+      });
+
+      const { mutate } = makeClient(user);
+      const { data, errors } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "OPERATION",
+            author: user.name
+          }
+        }
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data.signBsda.id).toBeTruthy();
+
+      const newGrouped1 = await prisma.bsda.findUnique({
+        where: { id: grouped1.id }
+      });
+      expect(newGrouped1.status).toEqual(BsdaStatus.AWAITING_CHILD);
+      expect(newGrouped1.groupedInId).toBe(null);
+
+      const newGrouped2 = await prisma.bsda.findUnique({
+        where: { id: grouped2.id }
+      });
+      expect(newGrouped2.status).toEqual(BsdaStatus.AWAITING_CHILD);
+      expect(newGrouped2.groupedInId).toBe(null);
+    });
+
+    it("should release forwarded BSDA when forwarding BSDA is refused", async () => {
+      const { company: emitter } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { company: transporter } = await userWithCompanyFactory(
+        UserRole.ADMIN
+      );
+      const { user, company: destination } = await userWithCompanyFactory(
+        UserRole.ADMIN
+      );
+      const { company: ttr1 } = await userWithCompanyFactory(UserRole.ADMIN);
+
+      const forwarded = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: emitter.siret,
+          transporterCompanySiret: transporter.siret,
+          destinationCompanySiret: ttr1.siret,
+          status: BsdaStatus.AWAITING_CHILD,
+          destinationOperationCode: "R 13"
+        }
+      });
+
+      const forwarding = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: emitter.siret,
+          transporterCompanySiret: transporter.siret,
+          destinationCompanySiret: destination.siret,
+          destinationReceptionWeight: 0,
+          destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
+          destinationReceptionRefusalReason: "Invalid bsda, cant accept",
+          destinationOperationCode: null,
+          status: BsdaStatus.SENT,
+          forwarding: { connect: { id: forwarded.id } }
+        }
+      });
+
+      const { mutate } = makeClient(user);
+      const { data, errors } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: forwarding.id,
+          input: {
+            type: "OPERATION",
+            author: user.name
+          }
+        }
+      });
+
+      expect(errors).toBeUndefined();
+      expect(data.signBsda.id).toBeTruthy();
+
+      const newForwarding = await prisma.bsda.findUnique({
+        where: { id: forwarding.id }
+      });
+      expect(newForwarding.status).toEqual(BsdaStatus.REFUSED);
+      expect(newForwarding.forwardingId).toBe(null);
     });
   });
 });

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -83,7 +83,8 @@ export default async function sign(
         [signatureTypeInfos.dbAuthorKey]: input.author,
         [signatureTypeInfos.dbDateKey]: new Date(input.date ?? Date.now()),
         isDraft: false,
-        status: newStatus as BsdaStatus
+        status: newStatus as BsdaStatus,
+        ...(newStatus === BsdaStatus.REFUSED && { forwardingId: null })
       }
     );
 
@@ -96,6 +97,15 @@ export default async function sign(
         {
           status: BsdaStatus.PROCESSED
         }
+      );
+    }
+
+    if (newStatus === BsdaStatus.REFUSED) {
+      await bsdaRepository.updateMany(
+        {
+          groupedInId: signedBsda.id
+        },
+        { groupedInId: null }
       );
     }
 

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -531,7 +531,7 @@ const destinationSchema: FactorySchemaOf<BsdaValidationContext, Destination> =
             schema
               .oneOf(
                 [null, ""],
-                "Le code d'opétation ne doit pas être renseigné lorsque le déchet est refusé"
+                "Le code d'opération ne doit pas être renseigné lorsque le déchet est refusé"
               )
               .nullable(),
           otherwise: schema =>


### PR DESCRIPTION
Fix d'un bug sur le BSDA: quand on refuse un bsda qui groupe ou forward des bsdas, il faut les "libérer"

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8857)
