### PR TITLE
Fix recette dasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Corrections de bugs sur la révision BSDD & BSDA, dans le cas ou un SIRET avait plusieurs rôles de validation de cette révision. Si le créateur de la révision a l'ensemble des rôles d'approbation, la révision est désormais auto-approuvée [PR 1567](https://github.com/MTES-MCT/trackdechets/pull/1567)
 - Correction d'un bug à l'enregistrement sur le formulaire BSDA si on saisissait un conditionnement sans saisir la quantité associée [PR 1557](https://github.com/MTES-MCT/trackdechets/pull/1557)
 - Correction d'un bug qui entraînait l'envoi d'un email de refus incomplet [PR 1579](https://github.com/MTES-MCT/trackdechets/pull/1579)
-
+- Correction dasri diverses [PR 1585](https://github.com/MTES-MCT/trackdechets/pull/1585)
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -257,10 +257,6 @@ const computeTotalVolume: computeTotalVolumeFn = packagings => {
 function flattenEcoOrganismeInput(input: {
   ecoOrganisme?: BsdasriEcoOrganismeInput;
 }) {
-  if (!input?.ecoOrganisme) {
-    return null;
-  }
-
   return {
     ecoOrganismeName: chain(input.ecoOrganisme, e => e.name),
     ecoOrganismeSiret: chain(input.ecoOrganisme, e => e.siret)

--- a/back/src/bsdasris/examples/__tests__/examples.integration.ts
+++ b/back/src/bsdasris/examples/__tests__/examples.integration.ts
@@ -55,6 +55,6 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     async () => {
       await testWorkflow(dasriDeSynthese);
     },
-    10000
+    60000
   );
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -218,7 +218,7 @@ describe("Mutation.updateBsdasri", () => {
       where: { id: dasri.id }
     });
     expect(updated.ecoOrganismeSiret).toEqual(ecoOrgCompany.siret);
-    expect(updated.ecoOrganismeName).toEqual(ecoOrgCompany.name);
+    expect(updated.ecoOrganismeName).toEqual("eco-org");
   });
   it("should allow eco organisme fields nulling for INITIAL bsdasris", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -44,7 +44,7 @@ const duplicateBsdasriResolver: MutationResolvers["duplicateBsdasri"] = async (
   );
 
   const newBsdasri = await duplicateBsdasri(user, bsdasri);
-  await indexBsdasri(newBsdasri);
+  await indexBsdasri(newBsdasri, context);
   return expandBsdasriFromDB(newBsdasri);
 };
 

--- a/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/publishBsdasri.ts
@@ -44,7 +44,7 @@ const publishBsdasriResolver: MutationResolvers["publishBsdasri"] = async (
   });
 
   const expandedDasri = expandBsdasriFromDB(publishedBsdasri);
-  await indexBsdasri(publishedBsdasri);
+  await indexBsdasri(publishedBsdasri, context);
   return expandedDasri;
 };
 

--- a/back/src/bsdasris/resolvers/mutations/sign.ts
+++ b/back/src/bsdasris/resolvers/mutations/sign.ts
@@ -219,7 +219,7 @@ const sign = async ({
     await cascadeOnSynthesized({ dasri: updatedDasri });
   }
   const expandedDasri = expandBsdasriFromDB(updatedDasri);
-  await indexBsdasri(updatedDasri);
+  await indexBsdasri(updatedDasri, context);
   return expandedDasri;
 };
 

--- a/back/src/bsdasris/resolvers/mutations/signBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/signBsdasri.ts
@@ -3,11 +3,12 @@ import {
   MutationSignBsdasriArgs,
   MutationResolvers
 } from "../../../generated/graphql/types";
+import { GraphQLContext } from "../../../types";
 
 const signBsdasri: MutationResolvers["signBsdasri"] = async (
   _,
   { id, input }: MutationSignBsdasriArgs,
-  context
+  context: GraphQLContext
 ) => {
   const { author, type } = input;
   return sign({ id, author, type, context });

--- a/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
+++ b/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
@@ -91,7 +91,9 @@ export const checkEmissionSignedWithSecretCode: checkEmitterAllowsSignatureWithC
       });
 
       if (securityCode !== ecoorganismeCompany.securityCode) {
-        throw new UserInputError(errMessage);
+        throw new UserInputError(errMessage, {
+          errorCode: "SECRET_CODE_ERROR"
+        }); // include more spécific error code for UI
       }
     }
     if (emissionSignatureAuthor === "EMITTER") {
@@ -100,7 +102,9 @@ export const checkEmissionSignedWithSecretCode: checkEmitterAllowsSignatureWithC
       });
 
       if (securityCode !== emitterCompany.securityCode) {
-        throw new UserInputError(errMessage);
+        throw new UserInputError(errMessage, {
+          errorCode: "SECRET_CODE_ERROR"
+        }); // include more spécific error code for UI
       }
     }
     return true;

--- a/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
@@ -68,7 +68,7 @@ const updateBsdasriResolver = async (
     });
   }
 
-  return updateBsdasri({ id, input, dbBsdasri, dbGrouping });
+  return updateBsdasri({ id, input, dbBsdasri, dbGrouping, context });
 };
 
 export default updateBsdasriResolver;

--- a/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
@@ -2,7 +2,7 @@ import { expandBsdasriFromDB, flattenBsdasriInput } from "../../converter";
 import { BsdasriStatus, BsdasriType, Bsdasri } from "@prisma/client";
 import prisma from "../../../prisma";
 import { BsdasriInput } from "../../../generated/graphql/types";
-
+import { GraphQLContext } from "../../../types";
 import { validateBsdasri } from "../../validation";
 import { ForbiddenError, UserInputError } from "apollo-server-express";
 import { indexBsdasri } from "../../elastic";
@@ -34,12 +34,14 @@ const updateBsdasri = async ({
   id,
   input,
   dbBsdasri,
-  dbGrouping
+  dbGrouping,
+  context
 }: {
   id: string;
   dbBsdasri: Bsdasri;
   input: BsdasriInput;
   dbGrouping: any;
+  context: GraphQLContext;
 }) => {
   const { grouping: inputGrouping, synthesizing: inputSynthesizing } = input;
   const isGroupingType = dbBsdasri.type === BsdasriType.GROUPING;
@@ -113,7 +115,7 @@ const updateBsdasri = async ({
   });
 
   const expandedDasri = expandBsdasriFromDB(updatedDasri);
-  await indexBsdasri(updatedDasri);
+  await indexBsdasri(updatedDasri, context);
   return expandedDasri;
 };
 

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13571,7 +13571,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/BSDasriActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/BSDasriActions.tsx
@@ -26,6 +26,7 @@ import { Bsdasri, BsdasriStatus, BsdasriType } from "generated/graphql/types";
 import { useDownloadPdf } from "./useDownloadPdf";
 import styles from "../../BSDActions.module.scss";
 import { TableRoadControlButton } from "../../RoadControlButton";
+import { Loader } from "common/components";
 
 interface BSDAsriActionsProps {
   form: Bsdasri;
@@ -34,7 +35,7 @@ interface BSDAsriActionsProps {
 export const BSDAsriActions = ({ form }: BSDAsriActionsProps) => {
   const { siret } = useParams<{ siret: string }>();
   const location = useLocation();
-  const [duplicateBsdasri] = useBsdasriDuplicate({
+  const [duplicateBsdasri, { loading }] = useBsdasriDuplicate({
     variables: { id: form.id },
   });
   const [isDeleting, setIsDeleting] = React.useState(false);
@@ -113,6 +114,7 @@ export const BSDAsriActions = ({ form }: BSDAsriActionsProps) => {
           </>
         )}
       </Menu>
+      {loading && <Loader />}
       {isDeleting && (
         <DeleteBsdasriModal
           isOpen

--- a/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
@@ -48,8 +48,8 @@ export function BsdasriWasteSummary({ bsdasri }: BsdasriWasteSummaryProps) {
         <DataListDescription>
           {!!packagings?.length && (
             <>
-              {packagings.map(packaging => (
-                <div>
+              {packagings.map((packaging, idx) => (
+                <div key={idx}>
                   {packaging.quantity} {packaging.other} {packaging.type} (
                   {packaging.volume} litre(s))
                 </div>

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -17,7 +17,7 @@ import {
 import Loader from "common/components/Loaders";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams, useHistory } from "react-router-dom";
-import { GET_DETAIL_DASRI_WITH_METADATA } from "common/queries";
+import { GET_DETAIL_DASRI_WITH_METADATA, GET_BSDS } from "common/queries";
 
 import EmptyDetail from "dashboard/detail/common/EmptyDetailView";
 import { Formik, Field, Form } from "formik";
@@ -174,6 +174,8 @@ export function RouteSignBsdasri({
               id: bsdasri.id,
               input: { ...signature, type: config.signatureType },
             },
+            refetchQueries: [GET_BSDS],
+            awaitRefetchQueries: true,
           });
           history.goBack();
         }}

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -16,7 +16,7 @@ import {
 } from "dashboard/components/BSDList/BSDasri/types";
 import Loader from "common/components/Loaders";
 import { useQuery, useMutation } from "@apollo/client";
-import { useParams, useHistory } from "react-router-dom";
+import { useParams, useHistory, generatePath } from "react-router-dom";
 import { GET_DETAIL_DASRI_WITH_METADATA, GET_BSDS } from "common/queries";
 
 import EmptyDetail from "dashboard/detail/common/EmptyDetailView";
@@ -34,6 +34,7 @@ import {
   OperationSignatureForm,
   removeSections,
 } from "./PartialForms";
+import routes from "common/routes";
 
 import { BdasriSummary } from "dashboard/components/BSDList/BSDasri/Summary/BsdasriSummary";
 
@@ -112,6 +113,18 @@ export function RouteSignBsdasri({
 }) {
   const { id: formId, siret } = useParams<{ id: string; siret: string }>();
   const history = useHistory();
+  const transporterTab = {
+    pathname: generatePath(routes.dashboard.transport.toCollect, {
+      siret,
+    }),
+  };
+
+  // in most cases, goBack works, but for combined signature (pred+transporter), it leads to an infinite loop
+  // so we explicitly redirect to transporter tab
+  const nextPage =
+    UIsignatureType === BsdasriSignatureType.Transport
+      ? () => history.push(transporterTab)
+      : () => history.goBack();
 
   const { error, data, loading } = useQuery<
     Pick<Query, "bsdasri">,
@@ -177,7 +190,7 @@ export function RouteSignBsdasri({
             refetchQueries: [GET_BSDS],
             awaitRefetchQueries: true,
           });
-          history.goBack();
+          nextPage();
         }}
       >
         {({ isSubmitting, handleReset, errors }) => {
@@ -207,7 +220,7 @@ export function RouteSignBsdasri({
                   className="btn btn--outline-primary"
                   onClick={() => {
                     handleReset();
-                    history.goBack();
+                    nextPage();
                   }}
                 >
                   Annuler

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -91,7 +91,7 @@ const settings: {
   },
 
   [BsdasriSignatureType.Reception]: {
-    getLabel: () => "Signature reception",
+    getLabel: () => "Signature réception",
     signatureType: BsdasriSignatureType.Reception,
     validationText:
       "En signant, je confirme la réception des déchets pour la quantité indiquée dans ce bordereau. La signature est horodatée.",

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
@@ -213,7 +213,7 @@ export function RouteBSDasrisSignEmissionSecretCode() {
           ?.includes("SECRET_CODE_ERROR") && (
           <p className="tw-mt-2 tw-text-red-700">
             Vous devez mettre à jour le bordereau et renseigner les champs
-            nécessaires avant de le signer.vvv
+            nécessaires avant de le signer.
           </p>
         )}
       {updateError && (

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
@@ -206,25 +206,22 @@ export function RouteBSDasrisSignEmissionSecretCode() {
           );
         }}
       </Formik>
-      {(updateError || signError) && (
-        <>
+
+      {signError &&
+        !signError?.graphQLErrors
+          ?.map(err => err?.extensions?.errorCode)
+          ?.includes("SECRET_CODE_ERROR") && (
           <p className="tw-mt-2 tw-text-red-700">
             Vous devez mettre à jour le bordereau et renseigner les champs
-            nécessaires avant de le signer.
+            nécessaires avant de le signer.vvv
           </p>
-          {updateError && (
-            <NotificationError
-              className="action-error"
-              apolloError={updateError}
-            />
-          )}
-          {signError && (
-            <NotificationError
-              className="action-error"
-              apolloError={signError}
-            />
-          )}
-        </>
+        )}
+      {updateError && (
+        <NotificationError className="action-error" apolloError={updateError} />
+      )}
+
+      {signError && (
+        <NotificationError className="action-error" apolloError={signError} />
       )}
     </div>
   );

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
@@ -198,7 +198,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
               state: { background: location },
             }}
           >
-            Signature reception
+            Signature réception
           </ActionLink>
         );
       }

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -74,7 +74,7 @@ const Emitter = ({ form }: { form: Bsdasri }) => {
         ) : null}
         <Company label="Émetteur" company={emitter?.company} />
         <DetailRow value={emitter?.pickupSite?.name} label="Adresse collecte" />
-        <DetailRow value={emitter?.pickupSite?.name} label="Informations" />
+        <DetailRow value={emitter?.pickupSite?.infos} label="Informations" />
         {!!emitter?.pickupSite?.address && (
           <>
             <dt>Adresse</dt>

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -39,6 +39,8 @@ interface Props {
 
 const wasteKey = "waste";
 const ecoOrganismeKey = "ecoOrganisme";
+const emittedByEcoOrganismeKey = "ecoOrganisme.emittedByEcoOrganisme";
+
 const emitterKey = "emitter";
 const transporterKey = "transporter";
 const destinationKey = "destination";
@@ -58,13 +60,14 @@ const getCommonKeys = (bsdasriType: BsdasriType): string[] => {
       transporterCompanyVatNumberKey,
       transporterTransportPackagingsKey,
       transporterTransportVolumeKey,
+      emittedByEcoOrganismeKey,
     ];
   }
   if (bsdasriType === BsdasriType.Grouping) {
-    return [synthesizingKey];
+    return [synthesizingKey, emittedByEcoOrganismeKey];
   }
   if (bsdasriType === BsdasriType.Simple) {
-    return [synthesizingKey, groupingKey];
+    return [synthesizingKey, groupingKey, emittedByEcoOrganismeKey];
   }
   return [];
 };


### PR DESCRIPTION
Correctifs post-recette:

- édition d'un dasri comprenant un eco-organisme - renvoie une 400
- édition d'un dasri comprenant un eco-organisme - impossible de retirer l'éco-organisme
- rafraichissement des onglets après action 
- ne plus afficher "vous devez maj le bordereau" quand c'est le code signature qui est incorrect
- redirection parès la signature combinée pred/transporteur (renvoie sur la signature pred après signature transporteur)
- typo sur le e de réception
 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-8898)
