### PR TITLE
Add a load more button to revisions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -27,6 +27,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction du fonctionnement de la validation des champs requis sur le BSFF [PR 1531](https://github.com/MTES-MCT/trackdechets/pull/1531)
 - Ajout d'un "rate limit" sur le formulaire de connexion pour éviter les attaques par "brute force" [PR 1565](https://github.com/MTES-MCT/trackdechets/pull/1565)
 - Multiples améliorations BSDA: inversion de la destination finale & initiale sur le formulaire UI, correction d'un bug sur l'aperçu qui indiquait un bordereau comme de réexpédition par erreur, amélioration de la visibilité du destinataire final lors d'un groupement, ajout de détails sur les BSDAs associés dans les onglets de signature, PDF  et aperçu [PR 1551](https://github.com/MTES-MCT/trackdechets/pull/1551)
+- Ajout d'un bouton pour charger les révisions non affichées [PR 1587](https://github.com/MTES-MCT/trackdechets/pull/1587)
 
 #### :memo: Documentation
 

--- a/front/src/dashboard/components/RevisionRequestList/bsda/query.ts
+++ b/front/src/dashboard/components/RevisionRequestList/bsda/query.ts
@@ -104,12 +104,16 @@ const reviewFragment = gql`
 `;
 
 export const GET_BSDA_REVISION_REQUESTS = gql`
-  query BsdaRevisionRequests($siret: String!) {
-    bsdaRevisionRequests(siret: $siret) {
+  query BsdaRevisionRequests($siret: String!, $after: String) {
+    bsdaRevisionRequests(siret: $siret, after: $after) {
       edges {
         node {
           ...BsdaRevisionRequestFragment
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/query.ts
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/query.ts
@@ -101,12 +101,16 @@ const reviewFragment = gql`
 `;
 
 export const GET_FORM_REVISION_REQUESTS = gql`
-  query FormRevisionRequests($siret: String!) {
-    formRevisionRequests(siret: $siret) {
+  query FormRevisionRequests($siret: String!, $after: String) {
+    formRevisionRequests(siret: $siret, after: $after) {
       edges {
         node {
           ...FormRevisionRequestFragment
         }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
       }
     }
   }

--- a/front/src/dashboard/components/RevisionRequestList/fetchMore.ts
+++ b/front/src/dashboard/components/RevisionRequestList/fetchMore.ts
@@ -1,0 +1,18 @@
+const buildUpdateQueryFn = (name: string) => {
+  const updateQueryFn = (prev, { fetchMoreResult }) => {
+    if (fetchMoreResult == null) {
+      return prev;
+    }
+
+    return {
+      ...prev,
+      [name]: {
+        ...prev[name],
+        ...fetchMoreResult[name],
+        edges: prev[name].edges.concat(fetchMoreResult[name].edges),
+      },
+    };
+  };
+  return updateQueryFn;
+};
+export default buildUpdateQueryFn;


### PR DESCRIPTION
Les révisions ne disposaient pas de bouton dans l'UI pour charger les révisions non affichées.
Fix d'un petit glitch de pagination au passage.

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8934)
