### PR TITLE
Ajout d'index manquants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@
 
    ```bash
    docker exec -it $(docker ps -aqf "name=trackdechets_td-api") bash
-   npx prisma db push --preview-feature
+   npx prisma db push
    ```
 
 6. Initialiser l'index Elastic Search.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,21 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2022.08.2] ~30/08/2022
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+- Ajout d'index db supplémentaires [PR 1592](https://github.com/MTES-MCT/trackdechets/pull/1592)
+
 # [2022.08.1] ~08/08/2022
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/prisma/migrations/82_missing_indices.sql
+++ b/back/prisma/migrations/82_missing_indices.sql
@@ -1,0 +1,24 @@
+-- Bsdasris
+CREATE INDEX IF NOT EXISTS "_BsdasriEcoOrganismeSiretIdx" ON "default$default"."Bsdasri"("ecoOrganismeSiret");
+CREATE INDEX IF NOT EXISTS "_BsdasriSynthesizedInIdIdx" ON "default$default"."Bsdasri"("synthesizedInId");
+CREATE INDEX IF NOT EXISTS "_BsdasriGroupedInIdIdx" ON "default$default"."Bsdasri"("groupedInId");
+CREATE INDEX IF NOT EXISTS "_BsdasriTypeIdx" ON "default$default"."Bsdasri"("type");
+CREATE INDEX IF NOT EXISTS "_BsdasriIsDraftIdx" ON default$default."Bsdasri" ("isDraft") WHERE "Bsdasri"."isDraft"=true;
+CREATE INDEX IF NOT EXISTS "_BsdasriIsDeletedIdx" ON default$default."Bsdasri"("isDeleted") WHERE "Bsdasri"."isDeleted"=true;
+ 
+-- Bsda
+CREATE INDEX IF NOT EXISTS "_BsdaGroupedInIdIdx" ON "default$default"."Bsda"("groupedInId");
+CREATE INDEX IF NOT EXISTS "_BsdaIsDeletedIdx" ON default$default."Bsda"("isDeleted") WHERE "Bsda"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsdaIsDraftIdx" ON default$default."Bsda" ("isDraft") WHERE "Bsda"."isDeleted"=true;
+
+-- Bsff
+CREATE INDEX IF NOT EXISTS "_BsffIsDeletedIdx" ON default$default."Bsff"("isDeleted") WHERE "Bsff"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsffIsDraftIdx" ON default$default."Bsff"("isDeleted") WHERE "Bsff"."isDeleted"=true;
+
+-- Bsvhu
+CREATE INDEX IF NOT EXISTS "_BsvhuIsDeletedIdx" ON default$default."Bsvhu" ("isDeleted") WHERE "Bsvhu"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsvhuIsDraftIdx" ON default$default."Bsvhu"("isDeleted") WHERE "Bsvhu"."isDeleted"=true;
+
+-- Form
+CREATE INDEX IF NOT EXISTS "_FormEcoOrganismeSiretIdx" ON "default$default"."Form"("ecoOrganismeSiret");
+CREATE INDEX IF NOT EXISTS "_FormIsDeletedIdx" ON default$default."Form"("isDeleted") WHERE "Form"."isDeleted"=true;

--- a/back/prisma/migrations/82_missing_indices.sql
+++ b/back/prisma/migrations/82_missing_indices.sql
@@ -9,15 +9,15 @@ CREATE INDEX IF NOT EXISTS "_BsdasriIsDeletedIdx" ON default$default."Bsdasri"("
 -- Bsda
 CREATE INDEX IF NOT EXISTS "_BsdaGroupedInIdIdx" ON "default$default"."Bsda"("groupedInId");
 CREATE INDEX IF NOT EXISTS "_BsdaIsDeletedIdx" ON default$default."Bsda"("isDeleted") WHERE "Bsda"."isDeleted"=true;
-CREATE INDEX IF NOT EXISTS "_BsdaIsDraftIdx" ON default$default."Bsda" ("isDraft") WHERE "Bsda"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsdaIsDraftIdx" ON default$default."Bsda"("isDraft") WHERE "Bsda"."isDraft"=true;
 
 -- Bsff
 CREATE INDEX IF NOT EXISTS "_BsffIsDeletedIdx" ON default$default."Bsff"("isDeleted") WHERE "Bsff"."isDeleted"=true;
-CREATE INDEX IF NOT EXISTS "_BsffIsDraftIdx" ON default$default."Bsff"("isDeleted") WHERE "Bsff"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsffIsDraftIdx" ON default$default."Bsff"("isDraft") WHERE "Bsff"."isDraft"=true;
 
 -- Bsvhu
 CREATE INDEX IF NOT EXISTS "_BsvhuIsDeletedIdx" ON default$default."Bsvhu" ("isDeleted") WHERE "Bsvhu"."isDeleted"=true;
-CREATE INDEX IF NOT EXISTS "_BsvhuIsDraftIdx" ON default$default."Bsvhu"("isDeleted") WHERE "Bsvhu"."isDeleted"=true;
+CREATE INDEX IF NOT EXISTS "_BsvhuIsDraftIdx" ON default$default."Bsvhu"("isDraft") WHERE "Bsvhu"."isDraft"=true;
 
 -- Form
 CREATE INDEX IF NOT EXISTS "_FormEcoOrganismeSiretIdx" ON "default$default"."Form"("ecoOrganismeSiret");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -395,11 +395,14 @@ model Form {
   forwardedInId String? @unique
   forwardedIn   Form?   @relation("BsddForwarding", fields: [forwardedInId], references: [id])
 
+  // partial index _FormIsDeletedIdx see migration82_missing_indices.sql
+
   @@index([emitterCompanySiret], map: "_FormEmitterCompanySiretIdx")
   @@index([recipientCompanySiret], map: "_FormRecipientCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_FormTransporterCompanySiretIdx")
   @@index([traderCompanySiret], map: "_FormTraderCompanySiretIdx")
   @@index([brokerCompanySiret], map: "_FormBrokerCompanySiretIdx")
+  @@index([ecoOrganismeSiret], map: "_FormEcoOrganismeSiretIdx")
   @@index([status], map: "_FormStatusIdx")
 }
 
@@ -700,7 +703,6 @@ model TransportSegment {
   formId                          String
   form                            Form           @relation(fields: [formId], references: [id])
 
-
   @@index([formId], map: "_TransportSegmentFormIdIdx")
   @@index([transporterCompanySiret], map: "_TransportSegmentTransporterCompanySiretIdx")
 }
@@ -874,6 +876,8 @@ model Bsvhu {
   destinationOperationSignatureAuthor                 String?
   destinationOperationSignatureDate                   DateTime? @db.Timestamptz(6)
 
+  // partial indices _BsvhuIsDeletedIdx,_BsvhuIsDraftIdx  see migration82_missing_indices.sql
+
   @@index([emitterCompanySiret], map: "_BvhuEmitterCompanySirettIdx")
   @@index([destinationCompanySiret], map: "_BsvhuDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsvhuTransporterCompanySiretIdx")
@@ -1008,10 +1012,17 @@ model Bsdasri {
   synthesizing                                Bsdasri[]               @relation("BsdasriSynthesizing")
   synthesizedIn                               Bsdasri?                @relation("BsdasriSynthesizing", fields: [synthesizedInId], references: [id])
   synthesizedInId                             String?
+
+  // partial indices _BsdasriTypeIdx, _BsdasriIsDraftIdx, _BsdasriIsDeletedIdx see migration82_missing_indices.sql
+
   @@index([emitterCompanySiret], map: "_BsdasriEmitterCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsdasriTransporterCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsdasriDestinationCompanySiretIdx")
+  @@index([ecoOrganismeSiret], map: "_BsdasriEcoOrganismeSiretIdx")
+  @@index([synthesizedInId], map: "_BsdasriSynthesizedInIdIdx")
+  @@index([groupedInId], map: "_BsdasriGroupedInIdIdx")
   @@index([status], map: "_BsdasriStatusIdx")
+  @@index([type], map: "_BsdasriTypeIdx")
 }
 
 // ----------------
@@ -1120,6 +1131,8 @@ model Bsff {
 
   packagings BsffPackaging[]
 
+  // partial _BsffIsDeletedIdx, _BsffIsDraftIdx index see migration82_missing_indices.sql
+
   @@index([emitterCompanySiret], map: "_BsffEmitterCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsffTransporterCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsffDestinationCompanySiretIdx")
@@ -1176,13 +1189,13 @@ model BsffFicheIntervention {
 }
 
 model BsffPackaging {
-  id        String   @id @default(cuid())
-  name      String
-  volume    Float?
-  weight    Float
-  numero    String
+  id     String @id @default(cuid())
+  name   String
+  volume Float?
+  weight Float
+  numero String
 
-  bsff   Bsff @relation(fields: [bsffId], references: [id], onDelete: Cascade)
+  bsff   Bsff   @relation(fields: [bsffId], references: [id], onDelete: Cascade)
   bsffId String
 }
 
@@ -1342,12 +1355,16 @@ model Bsda {
   childBsdaId String?
 
   BsdaRevisionRequest BsdaRevisionRequest[]
+
+  // partial indices _BsdaIsDeletedIdx, _BsdaIsDraftIdx see migration82_missing_indices.sql
+
   @@index([emitterCompanySiret], map: "_BsdaEmitterCompanySiretIdx")
   @@index([brokerCompanySiret], map: "_BsdaBrokerCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsdaDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsdaTransporterCompanySiretIdx")
   @@index([workerCompanySiret], map: "_BsdaWorkerCompanySiretIdx")
   @@index([status], map: "_BsdaStatusIdx")
+  @@index([groupedInId], map: "_BsdaGroupedInIdIdx")
 }
 
 model BsdaRevisionRequest {
@@ -1382,7 +1399,6 @@ model BsdaRevisionRequest {
   brokerRecepisseNumber        String?
   brokerRecepisseDepartment    String?
   brokerRecepisseValidityLimit DateTime? @db.Timestamptz(6)
-
 
   emitterPickupSiteName       String?
   emitterPickupSiteAddress    String?


### PR DESCRIPTION
## Ajout de quelques index:

Prisma ne supportant pas la création d'indexs partiels, ceux-ci sont uniquement présents dans le fichier de migration et indiqués en commentaires dans le fichier de schema.

### Bsdd:
 - ecoOrganismeSiret
 - isDeleted (partiel)

### Dasri
- ecoOrganismeSiret, synthesizedInId, groupedInId, type
- isDraft, isDeleted (partiels)

### Bsff
- isDraft, isDeleted (partiels)

### Bsvhu
- isDraft, isDeleted (partiels)

### Bsda
- isDraft, isDeleted (partiels)

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---


