### PR TITLE
Hotfix/refresh

### DIFF
--- a/front/src/dashboard/components/BSDList/useNotifier.ts
+++ b/front/src/dashboard/components/BSDList/useNotifier.ts
@@ -11,7 +11,7 @@ export function useNotifier(siret: string, callback: () => Promise<any>) {
     const source = new EventSource(`${host}/updates/${siret}`);
 
     source.addEventListener("open", callback);
-    source.addEventListener("message", callback);
+    source.addEventListener("update", callback);
 
     return () => {
       source.close();

--- a/front/src/dashboard/components/BSDList/useNotifier.ts
+++ b/front/src/dashboard/components/BSDList/useNotifier.ts
@@ -1,20 +1,42 @@
-import { useEffect } from "react";
+import { QueryBsdsArgs } from "generated/graphql/types";
+import { useState, useEffect } from "react";
 
 const host = import.meta.env.VITE_NOTIFIER_ENDPOINT;
 
-export function useNotifier(siret: string, callback: () => Promise<any>) {
+export function useNotifier(
+  siret: string,
+  callback: (variables?: QueryBsdsArgs | undefined) => void
+) {
+  if (!callback) {
+    throw new Error("Cannot call useNotifier without callback");
+  }
+
+  const [source, setSource] = useState<EventSource | undefined>();
+
   useEffect(() => {
-    if (!callback) {
-      throw new Error("Cannot call useNotifier without callback");
-    }
-
-    const source = new EventSource(`${host}/updates/${siret}`);
-
-    source.addEventListener("open", callback);
-    source.addEventListener("update", callback);
+    const eventSource = new EventSource(`${host}/updates/${siret}`);
+    setSource(eventSource);
 
     return () => {
-      source.close();
+      setSource(undefined);
+      eventSource.close();
     };
-  }, [siret, callback]);
+  }, [siret]);
+
+  // Use separate effects for connection and events to avoid having to memoize the callback
+  useEffect(() => {
+    if (!source) {
+      return;
+    }
+
+    function onUpdate() {
+      callback();
+    }
+    source.addEventListener("open", onUpdate);
+    source.addEventListener("update", onUpdate);
+
+    return () => {
+      source.removeEventListener("update", onUpdate);
+    };
+  }, [source, callback]);
 }

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -277,7 +277,6 @@ const EcoOrganisme = ({ ecoOrganisme }) => (
 type BSDDetailContentProps = {
   form: Form;
   children?: React.ReactNode;
-  refetch?: () => void;
 };
 
 const GroupedIn = ({ form }: { form: Form }) => {
@@ -407,7 +406,6 @@ const Appendix2 = ({
 export default function BSDDetailContent({
   form,
   children = null,
-  refetch,
 }: BSDDetailContentProps) {
   const { siret } = useParams<{ siret: string }>();
   const history = useHistory();

--- a/front/src/dashboard/detail/bsdd/RouteBSDDsView.tsx
+++ b/front/src/dashboard/detail/bsdd/RouteBSDDsView.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router-dom";
 import { GET_DETAIL_FORM } from "common/queries";
 import { InlineError } from "common/components/Error";
 import EmptyDetail from "dashboard/detail/common/EmptyDetailView";
+
 export function RouteBSDDsView() {
   const { id: formId } = useParams<{ id: string }>();
   const { error, data, loading } = useQuery<Pick<Query, "form">, QueryFormArgs>(


### PR DESCRIPTION
Hotfix pour https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8962

En qques mots:
- la connexion semble interrompue après 1min d'inactivité, donnant des `net::ERR_HTTP2_PROTOCOL_ERROR 200`. Pour éviter ça on envoie des messages `keep alive` (de simples commentaires en fait)
- le refresh récupère désormais les filtres appliqués au dashboard