### PR TITLE
BSDA / Pas d'entreprise de travaux

### DIFF
--- a/back/prisma/migrations/83_bsda_worker_disabled.sql
+++ b/back/prisma/migrations/83_bsda_worker_disabled.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "default$default"."Bsda" ADD COLUMN "workerIsDisabled" BOOLEAN;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1330,6 +1330,8 @@ model Bsda {
   transporterTransportSignatureAuthor String?
   transporterTransportSignatureDate   DateTime?      @db.Timestamptz(6)
 
+  workerIsDisabled Boolean?
+
   workerCompanyName    String?
   workerCompanySiret   String?
   workerCompanyAddress String?

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -137,6 +137,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
       })
     }),
     worker: nullIfNoValues<BsdaWorker>({
+      isDisabled: Boolean(form.workerIsDisabled),
       company: nullIfNoValues<FormCompany>({
         name: form.workerCompanyName,
         siret: form.workerCompanySiret,
@@ -410,6 +411,7 @@ function flattenBsdaTransporterInput({
 
 function flattenBsdaWorkerInput({ worker }: Pick<BsdaInput, "worker">) {
   return {
+    workerIsDisabled: chain(worker, w => w.isDisabled),
     workerCompanyName: chain(worker, w => chain(w.company, c => c.name)),
     workerCompanySiret: chain(worker, w => chain(w.company, c => c.siret)),
     workerCompanyAddress: chain(worker, w => chain(w.company, c => c.address)),

--- a/back/src/bsda/edition-rules.ts
+++ b/back/src/bsda/edition-rules.ts
@@ -67,6 +67,7 @@ const editableFields: EditableFields<BsdaInput> = {
   packagings: ifAwaitingSignature("WORK"),
   weight: ifAwaitingSignature("WORK"),
   worker: {
+    isDisabled: ifAwaitingSignature("EMISSION"),
     company: ifAwaitingSignature("EMISSION"),
     work: ifAwaitingSignature("WORK")
   },
@@ -86,7 +87,9 @@ const editableFields: EditableFields<BsdaInput> = {
  * @param signatureType
  * @returns boolean
  */
-function ifAwaitingSignature(signatureType: BsdaSignatureType | undefined) {
+function ifAwaitingSignature(
+  signatureType: BsdaSignatureType | undefined
+): (bsda?: Bsda) => boolean {
   if (!signatureType) {
     return () => true;
   }

--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -47,7 +47,7 @@ export const machine = createMachine<Record<string, never>, Event>(
           },
           TRANSPORT: {
             target: BsdaStatus.SENT,
-            cond: "isGroupingOrForwardingBsda"
+            cond: "isGroupingOrForwardingOrWithNoWorkerBsda"
           }
         }
       },
@@ -95,9 +95,10 @@ export const machine = createMachine<Record<string, never>, Event>(
         PARTIAL_OPERATIONS.includes(event.bsda?.destinationOperationCode),
       isGroupingOrReshipmentOperation: (_, event) =>
         PARTIAL_OPERATIONS.includes(event.bsda?.destinationOperationCode),
-      isGroupingOrForwardingBsda: (_, event) =>
+      isGroupingOrForwardingOrWithNoWorkerBsda: (_, event) =>
         event.bsda?.type === BsdaType.GATHERING ||
-        event.bsda?.type === BsdaType.RESHIPMENT
+        event.bsda?.type === BsdaType.RESHIPMENT ||
+        !event.bsda?.workerCompanySiret
     }
   }
 );

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -487,6 +487,40 @@ describe("Mutation.Bsda.sign", () => {
         })
       ]);
     });
+
+    it("should allow transporter to sign bsda signed by emitter only if worker is disabled", async () => {
+      const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          emitterEmissionSignatureAuthor: "Emétteur",
+          emitterEmissionSignatureDate: new Date(),
+          workerIsDisabled: true,
+          workerCompanySiret: null,
+          workerCompanyName: null,
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportMode: "ROAD",
+          transporterTransportPlates: ["AA-00-XX"]
+        }
+      });
+
+      const { mutate } = makeClient(transporter.user);
+      const { data } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "TRANSPORT",
+            author: transporter.user.name
+          }
+        }
+      });
+
+      expect(data.signBsda.id).toBeTruthy();
+    });
   });
 
   describe("OPERATION", () => {

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -243,6 +243,8 @@ input BsdaNextDestinationInput {
 }
 
 input BsdaWorkerInput {
+  "Indique si une entreprise de travaux est présente sur le BSDA (pour le cas d'un émetteur qui démonte lui même son amiante par ex)"
+  isDisabled: Boolean
   "Entreprise de travaux"
   company: CompanyInput
   "Déclaration générale"

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -221,6 +221,9 @@ type BsdaNextDestination {
 }
 
 type BsdaWorker {
+  "Indique si une entreprise de travaux est présente sur le BSDA (pour le cas d'un émetteur qui démonte lui même son amiante par ex)"
+  isDisabled: Boolean!
+  
   "Entreprise de travaux"
   company: FormCompany
   "Déclaration générale"

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -300,13 +300,14 @@ const emitterSchema: FactorySchemaOf<BsdaValidationContext, Emitter> =
 
 const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
   yup.object({
-    workerCompanyName: yup.string().when("type", {
-      is: value =>
+    workerIsDisabled: yup.boolean().nullable(),
+    workerCompanyName: yup.string().when(["type", "workerIsDisabled"], {
+      is: (type, isDisabled) =>
         [
           BsdaType.RESHIPMENT,
           BsdaType.GATHERING,
           BsdaType.COLLECTION_2710
-        ].includes(value),
+        ].includes(type) || isDisabled,
       then: schema =>
         schema
           .nullable()
@@ -320,13 +321,13 @@ const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
           `Entreprise de travaux: ${MISSING_COMPANY_NAME}`
         )
     }),
-    workerCompanySiret: yup.string().when("type", {
-      is: value =>
+    workerCompanySiret: yup.string().when(["type", "workerIsDisabled"], {
+      is: (type, isDisabled) =>
         [
           BsdaType.RESHIPMENT,
           BsdaType.GATHERING,
           BsdaType.COLLECTION_2710
-        ].includes(value),
+        ].includes(type) || isDisabled,
       then: schema =>
         schema
           .nullable()
@@ -342,13 +343,13 @@ const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
             `Entreprise de travaux: ${MISSING_COMPANY_SIRET}`
           )
     }),
-    workerCompanyAddress: yup.string().when("type", {
-      is: value =>
+    workerCompanyAddress: yup.string().when(["type", "workerIsDisabled"], {
+      is: (type, isDisabled) =>
         [
           BsdaType.RESHIPMENT,
           BsdaType.GATHERING,
           BsdaType.COLLECTION_2710
-        ].includes(value),
+        ].includes(type) || isDisabled,
       then: schema => schema.nullable(),
       otherwise: schema =>
         schema.requiredIf(
@@ -356,13 +357,13 @@ const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
           `Entreprise de travaux: ${MISSING_COMPANY_ADDRESS}`
         )
     }),
-    workerCompanyContact: yup.string().when("type", {
-      is: value =>
+    workerCompanyContact: yup.string().when(["type", "workerIsDisabled"], {
+      is: (type, isDisabled) =>
         [
           BsdaType.RESHIPMENT,
           BsdaType.GATHERING,
           BsdaType.COLLECTION_2710
-        ].includes(value),
+        ].includes(type) || isDisabled,
       then: schema => schema.nullable(),
       otherwise: schema =>
         schema.requiredIf(
@@ -370,13 +371,13 @@ const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
           `Entreprise de travaux: ${MISSING_COMPANY_CONTACT}`
         )
     }),
-    workerCompanyPhone: yup.string().when("type", {
-      is: value =>
+    workerCompanyPhone: yup.string().when(["type", "workerIsDisabled"], {
+      is: (type, isDisabled) =>
         [
           BsdaType.RESHIPMENT,
           BsdaType.GATHERING,
           BsdaType.COLLECTION_2710
-        ].includes(value),
+        ].includes(type) || isDisabled,
       then: schema => schema.nullable(),
       otherwise: schema =>
         schema.requiredIf(
@@ -387,13 +388,13 @@ const workerSchema: FactorySchemaOf<BsdaValidationContext, Worker> = context =>
     workerCompanyMail: yup
       .string()
       .email()
-      .when("type", {
-        is: value =>
+      .when(["type", "workerIsDisabled"], {
+        is: (type, isDisabled) =>
           [
             BsdaType.RESHIPMENT,
             BsdaType.GATHERING,
             BsdaType.COLLECTION_2710
-          ].includes(value),
+          ].includes(type) || isDisabled,
         then: schema => schema.nullable(),
         otherwise: schema =>
           schema.requiredIf(


### PR DESCRIPTION
Dans le cas d'un émetteur qui dépose lui même son amiante, il faut pouvoir zapper l'entreprise de travaux.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8372)
