### PR TITLE
BSDA / Pas d'adresse chantier dans un groupement

### DIFF
--- a/front/src/form/bsda/stepper/steps/Emitter.tsx
+++ b/front/src/form/bsda/stepper/steps/Emitter.tsx
@@ -113,14 +113,16 @@ export function Emitter({ disabled }) {
         />
       )}
 
-      <WorkSite
-        switchLabel="Je souhaite ajouter une adresse de chantier ou de collecte"
-        headingTitle="Adresse chantier"
-        designation="du chantier ou lieu de collecte"
-        getInitialEmitterWorkSiteFn={getInitialEmitterPickupSite}
-        disabled={disabled}
-        modelKey="pickupSite"
-      />
+      {!isValidBsdaSuite && (
+        <WorkSite
+          switchLabel="Je souhaite ajouter une adresse de chantier ou de collecte"
+          headingTitle="Adresse chantier"
+          designation="du chantier ou lieu de collecte"
+          getInitialEmitterWorkSiteFn={getInitialEmitterPickupSite}
+          disabled={disabled}
+          modelKey="pickupSite"
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Si c'est un groupement ou transit, on n'affiche pas la possibilité d'ajouter une adresse chantier

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7802)
