### PR TITLE
BSDA / Case chantier affichée par défaut

### DIFF
--- a/front/src/form/bsda/stepper/initial-state.ts
+++ b/front/src/form/bsda/stepper/initial-state.ts
@@ -4,13 +4,14 @@ import {
   BsdaType,
   TransportMode,
 } from "generated/graphql/types";
+import { getInitialEmitterPickupSite } from "./steps/Emitter";
 
 const initialState = {
   type: BsdaType.OtherCollections,
   emitter: {
     company: getInitialCompany(),
     isPrivateIndividual: false,
-    pickupSite: null,
+    pickupSite: getInitialEmitterPickupSite(),
   },
   waste: {
     code: "",


### PR DESCRIPTION
On affiche les champs de la case chantier par défaut à la création d'un bsda

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8798)
