### PR TITLE
Utilise les sirets en cache pour la query statusLogs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2022.08.4] ~29/08/2022
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Utilisation des sirets en cache pour la query formsLifeCycle [PR 1609](https://github.com/MTES-MCT/trackdechets/pull/1609)
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2022.08.3] 16/08/2022
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/forms/resolvers/queries/formsLifeCycle.ts
+++ b/back/src/forms/resolvers/queries/formsLifeCycle.ts
@@ -4,6 +4,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { QueryResolvers } from "../../../generated/graphql/types";
 import { getFormsRightFilter } from "../../database";
 import { getConnection } from "../../../common/pagination";
+import { getCachedUserSirets } from "../../../common/redis/users";
 
 const PAGINATE_BY = 100;
 
@@ -14,23 +15,16 @@ const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
-  const userCompanies = await prisma.companyAssociation
-    .findMany({
-      where: { user: { id: user.id } },
-      include: {
-        company: { select: { id: true, siret: true } }
-      }
-    })
-    .then(associations => associations.map(a => a.company));
+  const userSirets = await getCachedUserSirets(user.id);
 
   // User must be associated with a company
-  if (!userCompanies.length) {
+  if (!userSirets.length) {
     throw new ForbiddenError(
       "Vous n'êtes pas autorisé à consulter le cycle de vie des bordereaux."
     );
   }
   // If user is associated with several companies, siret is mandatory
-  if (userCompanies.length > 1 && !siret) {
+  if (userSirets.length > 1 && !siret) {
     throw new UserInputError(
       "Vous devez préciser pour quel siret vous souhaitez consulter",
       {
@@ -39,16 +33,15 @@ const formsLifeCycleResolver: QueryResolvers["formsLifeCycle"] = async (
     );
   }
   // If requested siret does not belong to user, raise an error
-  if (!!siret && !userCompanies.map(c => c.siret).includes(siret)) {
+  if (!!siret && !userSirets.includes(siret)) {
     throw new ForbiddenError(
       "Vous n'avez pas le droit d'accéder au siret précisé"
     );
   }
-  // Select user company matching siret or get the first
-  const selectedCompany =
-    userCompanies.find(uc => uc.siret === siret) || userCompanies.shift();
+  // Select user company siret matching siret or get the first
+  const selectedSiret = siret || userSirets.shift();
 
-  const formsFilter = getFormsRightFilter(selectedCompany.siret);
+  const formsFilter = getFormsRightFilter(selectedSiret);
 
   const gqlPaginationArgs = {
     after: cursorAfter,


### PR DESCRIPTION
La query effectuait encore systématiquement la requête des compagnies associées à l’utilisateur en db

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
