### PR TITLE
BSDA / Champ isExempted manquant

### DIFF
--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -182,7 +182,8 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
       recepisse: nullIfNoValues<BsdaRecepisse>({
         department: form.transporterRecepisseDepartment,
         number: form.transporterRecepisseNumber,
-        validityLimit: form.transporterRecepisseValidityLimit
+        validityLimit: form.transporterRecepisseValidityLimit,
+        isExempted: form.transporterRecepisseIsExempted
       }),
       transport: nullIfNoValues<BsdaTransport>({
         mode: form.transporterTransportMode,


### PR DESCRIPTION
Le champ `isExempted` sur le recepisse transporteur n'était jamais rendu en lecture sur le BSDA.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
