### PR TITLE
FIX / Ratelimit bypass

### DIFF
--- a/back/src/routers/auth-router.ts
+++ b/back/src/routers/auth-router.ts
@@ -5,7 +5,7 @@ import { ADMIN_IS_PERSONIFYING } from "../auth";
 import nocache from "../common/middlewares/nocache";
 import { rateLimiterMiddleware } from "../common/middlewares/rateLimiter";
 import { sess } from "../server";
-import { getUIBaseURL } from "../utils";
+import { getUIBaseURL, sanitizeEmail } from "../utils";
 
 const UI_BASE_URL = getUIBaseURL();
 
@@ -18,8 +18,10 @@ authRouter.post(
   rateLimiterMiddleware({
     windowMs,
     maxRequestsPerWindow,
-    keyGenerator: (ip, request) =>
-      `login_${ip}_${request.body?.email ?? "void"}`
+    keyGenerator: (ip, request) => {
+      const { email } = request.body;
+      return `login_${ip}_${email ? sanitizeEmail(email) : "void"}`;
+    }
   }),
   (req, res, next) => {
     passport.authenticate("local", (err, user, info) => {

--- a/back/src/users/resolvers/mutations/login.ts
+++ b/back/src/users/resolvers/mutations/login.ts
@@ -3,6 +3,7 @@ import { compare } from "bcrypt";
 import { UserInputError, ForbiddenError } from "apollo-server-express";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { createAccessToken } from "../../database";
+import { sanitizeEmail } from "../../../utils";
 
 /**
  * DEPRECATED
@@ -15,7 +16,9 @@ const loginResolver: MutationResolvers["login"] = async (
   parent,
   { email, password }
 ) => {
-  const user = await prisma.user.findUnique({ where: { email: email.trim() } });
+  const user = await prisma.user.findUnique({
+    where: { email: sanitizeEmail(email) }
+  });
   if (!user) {
     throw new UserInputError(`Aucun utilisateur trouvé avec l'email ${email}`, {
       invalidArgs: ["email"]


### PR DESCRIPTION
Nouvelle remontée comme quoi on peut bypasser le ratelimit email / password.
Il faut que dans la clef Redis la valeur de l'email soit la même que ce qui est query en base. Ca pouvait sinon être bypass en insérant des espaces à la fin.