### PR TITLE
Fix/Recette bsda

### DIFF
--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -28,6 +28,10 @@ export const machine = createMachine<Record<string, never>, Event>(
             target: BsdaStatus.SIGNED_BY_WORKER,
             cond: "canSkipEmissionSignature"
           },
+          TRANSPORT: {
+            target: BsdaStatus.SENT,
+            cond: "isPrivateIndividualWithNoWorkerBsda"
+          },
           OPERATION: [
             {
               target: BsdaStatus.AWAITING_CHILD,
@@ -98,7 +102,9 @@ export const machine = createMachine<Record<string, never>, Event>(
       isGroupingOrForwardingOrWithNoWorkerBsda: (_, event) =>
         event.bsda?.type === BsdaType.GATHERING ||
         event.bsda?.type === BsdaType.RESHIPMENT ||
-        !event.bsda?.workerCompanySiret
+        event.bsda?.workerIsDisabled,
+      isPrivateIndividualWithNoWorkerBsda: (_, event) =>
+        event.bsda?.emitterIsPrivateIndividual && event.bsda?.workerIsDisabled
     }
   }
 );

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -521,6 +521,39 @@ describe("Mutation.Bsda.sign", () => {
 
       expect(data.signBsda.id).toBeTruthy();
     });
+
+    it("should allow transporter to sign an initial bsda if the emitter is a private individual and the worker is disabled", async () => {
+      const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "INITIAL",
+          emitterIsPrivateIndividual: true,
+          workerIsDisabled: true,
+          workerCompanySiret: null,
+          workerCompanyName: null,
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportMode: "ROAD",
+          transporterTransportPlates: ["AA-00-XX"]
+        }
+      });
+
+      const { mutate } = makeClient(transporter.user);
+      const { data } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "TRANSPORT",
+            author: transporter.user.name
+          }
+        }
+      });
+
+      expect(data.signBsda.id).toBeTruthy();
+    });
   });
 
   describe("OPERATION", () => {

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -529,6 +529,7 @@ describe("Mutation.Bsda.sign", () => {
         opt: {
           status: "INITIAL",
           emitterIsPrivateIndividual: true,
+          emitterCompanySiret: null,
           workerIsDisabled: true,
           workerCompanySiret: null,
           workerCompanyName: null,

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -147,7 +147,7 @@ export function Destination({ disabled }) {
           disabled={disabled}
         >
           <option />
-          {isDechetterie ? (
+          {isDechetterie && !hasNextDestination ? (
             <>
               <option value="R 13">
                 R 13 - Opérations de transit incluant le groupement sans


### PR DESCRIPTION
Nouvelles corrections de recette BSDA.
Vues en recette avec Emmanuel & Dané:
- mauvais codes proposés dans le formulaire dans le cas d'une déchetterie avec entreposage provisoire
- il faut laisser le transporteur signer si émetteur particulier & pas de worker