### PR TITLE
HOTFIX / Transporteur étranger

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1499,6 +1499,34 @@ describe("Mutation.createForm", () => {
     expect(data?.createForm?.id).toBeDefined();
   });
 
+  it("should be possible to fill TVA number only for a foregin transporter", async () => {
+    const { user, company: emitter } = await userWithCompanyFactory("MEMBER");
+    const { company: transporterCompany } = await userWithCompanyFactory(UserRole.MEMBER, {
+      companyTypes: {
+        set: ["TRANSPORTER"]
+      },
+      vatNumber: "BE0541696005"
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createForm">,
+      MutationCreateFormArgs
+    >(CREATE_FORM, {
+      variables: {
+        createFormInput: {
+          emitter: {
+            company: { siret: emitter.siret }
+          },
+          transporter: {
+            company: { vatNumber: transporterCompany.vatNumber }
+          }
+        }
+      }
+    });
+    expect(data?.createForm?.id).toBeDefined();
+  });
+
   it("should perform form creation in transaction", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const { mutate } = makeClient(user);

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1501,12 +1501,15 @@ describe("Mutation.createForm", () => {
 
   it("should be possible to fill TVA number only for a foregin transporter", async () => {
     const { user, company: emitter } = await userWithCompanyFactory("MEMBER");
-    const { company: transporterCompany } = await userWithCompanyFactory(UserRole.MEMBER, {
-      companyTypes: {
-        set: ["TRANSPORTER"]
-      },
-      vatNumber: "BE0541696005"
-    });
+    const { company: transporterCompany } = await userWithCompanyFactory(
+      UserRole.MEMBER,
+      {
+        companyTypes: {
+          set: ["TRANSPORTER"]
+        },
+        vatNumber: "BE0541696005"
+      }
+    );
 
     const { mutate } = makeClient(user);
     const { data } = await mutate<

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -241,9 +241,6 @@ const recipientCompanySiretSchema = yup
 const transporterCompanySiretSchema = yup
   .string()
   .ensure()
-  .matches(/^$|^\d{14}$/, {
-    message: `Transporteur: ${INVALID_SIRET_LENGTH}`
-  })
   .test(
     "is-transporter-registered-with-right-profile",
     ({ value }) =>


### PR DESCRIPTION
Permettre de créer un bsd avec transporteur étranger. Une validation sur la longueur du champ en trop avait été ajoutée