### PR TITLE
Fix [Bug] contenu des emails automatiques en cas de refus mal généré

### DIFF
--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -1,4 +1,4 @@
-import { Status, WasteAcceptationStatus } from "@prisma/client";
+import { Form, Status, WasteAcceptationStatus } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
@@ -9,6 +9,7 @@ import { getFormRepository } from "../../repository";
 import { acceptedInfoSchema } from "../../validation";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
+import { eventEmitter, TDEvent } from "../../../events/emitter";
 
 const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
   _,
@@ -60,6 +61,13 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
     }
 
     return acceptedForm;
+  });
+
+  eventEmitter.emit<Form>(TDEvent.TransitionForm, {
+    previousNode: null,
+    node: acceptedForm,
+    updatedFields: acceptedInfo,
+    mutation: "UPDATED"
   });
 
   return expandFormFromDb(acceptedForm);

--- a/back/src/forms/resolvers/mutations/markAsReceived.ts
+++ b/back/src/forms/resolvers/mutations/markAsReceived.ts
@@ -88,14 +88,15 @@ const markAsReceivedResolver: MutationResolvers["markAsReceived"] = async (
     ) {
       await formRepository.removeAppendix2(id);
     }
-    // eventEmitter temporary taken out from te repository to fix incomplete refusal email bug
-    eventEmitter.emit<Form>(TDEvent.TransitionForm, {
-      previousNode: null,
-      node: receivedForm,
-      updatedFields: { wasteAcceptationStatus: WasteAcceptationStatus.REFUSED },
-      mutation: "UPDATED"
-    });
     return receivedForm;
+  });
+
+  // eventEmitter temporary taken out from te repository to fix incomplete refusal email bug
+  eventEmitter.emit<Form>(TDEvent.TransitionForm, {
+    previousNode: null,
+    node: receivedForm,
+    updatedFields: receivedInfo,
+    mutation: "UPDATED"
   });
 
   return expandFormFromDb(receivedForm);


### PR DESCRIPTION
Une première tentative de fix avait été faite par Laurent dans https://github.com/MTES-MCT/trackdechets/pull/1579 mais le problème persiste car l'émission de l'événement était toujours dans une transaction (au niveau de `markAsReceived`). Par ailleurs les e-mails n'étaient plus envoyés en cas de refus en deux temps (`markAsReceived` puis `markAsAccepted`).

Si j'ai le temps pendant ce sprint, j'aimerais basculer ces events vers Bull.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8625)
