### PR TITLE
Improvements sur l'indexation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2022.09.1] 20/09/2022
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+
+- Amélioration de l'indexation des BSDAs pour éviter des problèmes de désynchronisation du statut [PR 1641](https://github.com/MTES-MCT/trackdechets/pull/1641)
+
 # [2022.08.4] 29/08/2022
 
 #### :rocket: Nouvelles fonctionnalités
@@ -24,7 +40,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :memo: Documentation
 
 #### :house: Interne
- 
+
 # [2022.08.3] 16/08/2022
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -1,6 +1,5 @@
 import { Bsda, BsdaStatus } from "@prisma/client";
 import { BsdElastic, indexBsd, indexBsds } from "../common/elastic";
-import { addToIndexQueue } from "../queue/producers/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 import { getReadonlyBsdaRepository } from "./repository";
@@ -186,10 +185,6 @@ export async function indexAllBsdas(
   }
 
   return indexAllBsdas(idx, { skip: skip + take });
-}
-
-export function addBsdaToIndexQueue(bsda: Bsda) {
-  return addToIndexQueue(toBsdElastic(bsda));
 }
 
 export function indexBsda(bsda: Bsda, ctx?: GraphQLContext) {

--- a/back/src/bsda/repository/bsda/create.ts
+++ b/back/src/bsda/repository/bsda/create.ts
@@ -1,6 +1,6 @@
 import { Bsda, Prisma } from "@prisma/client";
 import { LogMetadata, RepositoryFnDeps } from "../../../forms/repository/types";
-import { addBsdaToIndexQueue } from "../../elastic";
+import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
 
 export type CreateBsdaFn = (
   data: Prisma.BsdaCreateInput,
@@ -23,7 +23,7 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
       }
     });
 
-    prisma.addAfterCommitCallback(() => addBsdaToIndexQueue(bsda));
+    prisma.addAfterCommitCallback(() => enqueueBsdToIndex(bsda.id));
 
     return bsda;
   };

--- a/back/src/bsda/repository/bsda/delete.ts
+++ b/back/src/bsda/repository/bsda/delete.ts
@@ -1,7 +1,6 @@
 import { Bsda, Prisma } from "@prisma/client";
-import { deleteBsd } from "../../../common/elastic";
 import { LogMetadata, RepositoryFnDeps } from "../../../forms/repository/types";
-import { GraphQLContext } from "../../../types";
+import { enqueueBsdToDelete } from "../../../queue/producers/elastic";
 
 export type DeleteBsdaFn = (
   where: Prisma.BsdaWhereUniqueInput,
@@ -33,7 +32,7 @@ export function buildDeleteBsda(deps: RepositoryFnDeps): DeleteBsdaFn {
       }
     });
 
-    await deleteBsd(deletedBsda, { user } as GraphQLContext);
+    prisma.addAfterCommitCallback(() => enqueueBsdToDelete(deletedBsda.id));
 
     return deletedBsda;
   };

--- a/back/src/bsda/repository/bsda/update.ts
+++ b/back/src/bsda/repository/bsda/update.ts
@@ -1,6 +1,6 @@
 import { Bsda, Prisma } from "@prisma/client";
 import { LogMetadata, RepositoryFnDeps } from "../../../forms/repository/types";
-import { addBsdaToIndexQueue } from "../../elastic";
+import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
 
 export type UpdateBsdaFn = (
   where: Prisma.BsdaWhereUniqueInput,
@@ -37,7 +37,7 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
       });
     }
 
-    prisma.addAfterCommitCallback(() => addBsdaToIndexQueue(bsda));
+    prisma.addAfterCommitCallback(() => enqueueBsdToIndex(bsda.id));
 
     return bsda;
   };

--- a/back/src/bsda/repository/revisionRequest/accept.ts
+++ b/back/src/bsda/repository/revisionRequest/accept.ts
@@ -9,7 +9,7 @@ import {
   PrismaTransaction,
   RepositoryFnDeps
 } from "../../../forms/repository/types";
-import { addBsdaToIndexQueue } from "../../elastic";
+import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
@@ -64,12 +64,9 @@ export function buildAcceptRevisionRequestApproval(
       }
     );
 
-    const updatedBsda = await prisma.bsda.findUnique({
-      where: {
-        id: revisionRequest.bsdaId
-      }
-    });
-    prisma.addAfterCommitCallback(() => addBsdaToIndexQueue(updatedBsda));
+    prisma.addAfterCommitCallback(() =>
+      enqueueBsdToIndex(revisionRequest.bsdaId)
+    );
   };
 }
 

--- a/back/src/queue/consumer.ts
+++ b/back/src/queue/consumer.ts
@@ -1,12 +1,14 @@
 import { sendMailJob, indexBsdJob } from "./jobs";
 import { mailQueue } from "./producers/mail";
 import { indexQueue } from "./producers/elastic";
+import { deleteBsdJob } from "./jobs/deleteBsd";
 
 function startConsumers() {
   console.info(`Queues processors started`);
 
   mailQueue.process(sendMailJob);
-  indexQueue.process(indexBsdJob);
+  indexQueue.process("index", indexBsdJob);
+  indexQueue.process("delete", deleteBsdJob);
 }
 
 startConsumers();

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -1,18 +1,17 @@
 import { Job } from "bull";
 import { toBsdElastic } from "../../bsda/elastic";
-import { BsdElastic, indexBsd } from "../../common/elastic";
+import { BsdElastic, deleteBsd } from "../../common/elastic";
 import prisma from "../../prisma";
 
-export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
+export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   const bsdId = job.data;
+
+  await deleteBsd({ id: bsdId });
 
   if (bsdId.startsWith("BSDA-")) {
     const bsda = await prisma.bsda.findUnique({ where: { id: bsdId } });
 
-    const elasticBsda = toBsdElastic(bsda);
-    await indexBsd(elasticBsda);
-
-    return elasticBsda;
+    return toBsdElastic(bsda);
   }
 
   throw new Error("Indexing this type of BSD is not handled by this worker.");

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -1,11 +1,10 @@
 // eslint-disable-next-line import/no-named-as-default
 import Queue, { JobOptions } from "bull";
-import { BsdElastic } from "../../common/elastic";
 
 export type BsdUpdateQueueItem = { sirets: string[]; id: string };
 const { REDIS_URL, NODE_ENV } = process.env;
 
-export const indexQueue = new Queue<BsdElastic>(
+export const indexQueue = new Queue<string>(
   `queue_index_elastic_${NODE_ENV}`,
   REDIS_URL,
   {
@@ -31,22 +30,30 @@ export const updatesQueue = new Queue<BsdUpdateQueueItem>(
 );
 
 indexQueue.on("completed", job => {
-  const { sirets, id } = job.data;
+  const id = job.data;
+  const { sirets } = job.returnvalue;
 
   updatesQueue.add({ sirets, id });
 });
 
 indexQueue.on("failed", (job, err) => {
-  const { id } = job.data;
+  const id = job.data;
 
   console.error(`Indexation job failed for bsd "${id}"`, { id, err });
 });
 
-export async function addToIndexQueue(
-  jobData: BsdElastic,
+export async function enqueueBsdToIndex(
+  bsdId: string,
   options?: JobOptions
 ): Promise<void> {
-  await indexQueue.add(jobData, options);
+  await indexQueue.add("index", bsdId, options);
+}
+
+export async function enqueueBsdToDelete(
+  bsdId: string,
+  options?: JobOptions
+): Promise<void> {
+  await indexQueue.add("delete", bsdId, options);
 }
 
 export function closeIndexAndUpdatesQueue() {


### PR DESCRIPTION
Améliorations sur l'idnexation:
- c'est la queue qui récupère le bsd. Comme ça pas de risque qu'un bsda ancien soit indexé après un bsd plus récent
- la supression de bsd passe également par la queue désormais
