### PR TITLE
Ajout d'index manquants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 - Amélioration de l'indexation des BSDAs pour éviter des problèmes de désynchronisation du statut [PR 1641](https://github.com/MTES-MCT/trackdechets/pull/1641)
+- Ajout d'index manquant [PR 1648](https://github.com/MTES-MCT/trackdechets/pull/1648)
 
 # [2022.08.4] 29/08/2022
 

--- a/back/prisma/migrations/84_add_bsff_packagings_indices.sql
+++ b/back/prisma/migrations/84_add_bsff_packagings_indices.sql
@@ -1,0 +1,2 @@
+-- BsffPackaging
+CREATE INDEX IF NOT EXISTS "_BsffPackagingBsffId" ON "default$default"."BsffPackaging"("bsffId");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -434,6 +434,8 @@ model IntermediaryFormAssociation {
   createdAt DateTime @default(now()) @db.Timestamptz(6)
 
   @@index([formId], map: "_IntermediaryFormAssociationFormIdIdx")
+  @@index([siret], map: "IntermediaryFormAssociationSiretIdx")
+  @@index([vatNumber], map: "IntermediaryFormAssociationVatNumberIdx")
 }
 
 enum RevisionRequestStatus {
@@ -1197,6 +1199,8 @@ model BsffPackaging {
 
   bsff   Bsff   @relation(fields: [bsffId], references: [id], onDelete: Cascade)
   bsffId String
+
+  @@index([bsffId], map: "_BsffPackagingBsffId")
 }
 
 // ----------------


### PR DESCRIPTION
Ajoute 1 index manquants sur:
- BsffPackaging (bsffId)
- et met à jour le schema prisma en ajoutant les index de la migration 68

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
