### PR TITLE
Fix Error on declined form subscription TypeError: _a.hasOwnProperty is not a function

### DIFF
--- a/back/src/events/forms.ts
+++ b/back/src/events/forms.ts
@@ -27,7 +27,7 @@ export async function formsEventCallback(payload: TDEventPayload<Form>) {
  */
 export async function mailWhenFormIsDeclined(payload: TDEventPayload<Form>) {
   if (
-    !payload.updatedFields?.hasOwnProperty("wasteAcceptationStatus") ||
+    !("wasteAcceptationStatus" in (payload.updatedFields ?? {})) ||
     !payload.node ||
     !["REFUSED", "PARTIALLY_REFUSED"].includes(
       payload.node.wasteAcceptationStatus


### PR DESCRIPTION
Cf sentry
Erreur apparue suite à https://github.com/MTES-MCT/trackdechets/pull/1638