### PR TITLE
Hotfix BSDA / Packagings schema & nextDestination

### DIFF
--- a/front/src/form/bsda/stepper/schema.ts
+++ b/front/src/form/bsda/stepper/schema.ts
@@ -2,7 +2,14 @@ import * as Yup from "yup";
 
 const packagingsSchema = Yup.object({
   type: Yup.string().required("Le type de conditionnement est obligatoire"),
-  other: Yup.string().optional(),
+  other: Yup.string()
+    .label("Détail du conditionnement")
+    .when("type", {
+      is: "OTHER",
+      then: schema =>
+        schema.required("Vous devez saisir la description du conditionnement"),
+      otherwise: schema => schema.optional().nullable(),
+    }),
   quantity: Yup.number()
     .min(1, "La quantité d'un conditionnement doit être supérieure à 1")
     .required("La quantité associée à un conditionnement est obligatoire"),

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -7,7 +7,7 @@ import { getInitialCompany } from "form/bsdd/utils/initial-state";
 export function Destination({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
   const hasNextDestination = Boolean(
-    values.destination?.operation?.nextDestination
+    values.destination?.operation?.nextDestination?.company
   );
   const isDechetterie = values?.type === BsdaType.Collection_2710;
 


### PR DESCRIPTION
Hotfix BSDA

- problème sur le schéma packagings (message d'erreur qui n'a pas lieu d'être)
- problème sur le nextDestination si on a un code de traitement saisi sans entreprise