### PR TITLE
Fix : interdire la création d'établissement étranger sans nom ni adresse

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -30,6 +30,7 @@ const CREATE_COMPANY = `
       vatNumber
       gerepId
       name
+      address
       companyTypes
       ecoOrganismeAgreements
       transporterReceipt {
@@ -62,6 +63,7 @@ describe("Mutation.createCompany", () => {
       orgId: "12345678912345",
       gerepId: "1234",
       companyName: "Acme",
+      address: "3 rue des granges",
       companyTypes: ["PRODUCER"]
     };
 
@@ -117,6 +119,7 @@ describe("Mutation.createCompany", () => {
       orgId: "12345678912345",
       gerepId: "1234",
       companyName: "Acme",
+      address: "3 rue des granges",
       companyTypes: ["PRODUCER"],
       allowBsdasriTakeOverWithoutSignature: true
     };
@@ -179,6 +182,7 @@ describe("Mutation.createCompany", () => {
     const companyInput = {
       orgId: "12345678912345",
       companyName: "Acme",
+      address: "3 rue des granges",
       companyTypes: ["TRANSPORTER"],
       transporterReceiptId: transporterReceipt.id
     };
@@ -222,6 +226,7 @@ describe("Mutation.createCompany", () => {
     const companyInput = {
       orgId: "12345678912345",
       companyName: "Acme",
+      address: "3 rue des granges",
       companyTypes: ["TRADER"],
       traderReceiptId: traderReceipt.id
     };
@@ -262,6 +267,7 @@ describe("Mutation.createCompany", () => {
       orgId: company.siret,
       gerepId: company.gerepId,
       companyName: company.name,
+      address: "3 rue des granges",
       companyTypes: company.companyTypes
     };
 
@@ -293,6 +299,8 @@ describe("Mutation.createCompany", () => {
       variables: {
         companyInput: {
           orgId: "1".repeat(14),
+          companyName: "UN BEL ECO ORGANISME",
+          address: "3 rue des granges",
           companyTypes: ["ECO_ORGANISME"]
         }
       }
@@ -311,6 +319,8 @@ describe("Mutation.createCompany", () => {
 
     const companyInput = {
       orgId: "1".repeat(14),
+      companyName: "UN BEL ECO ORGANISME",
+      address: "3 rue des granges",
       companyTypes: ["ECO_ORGANISME"]
     };
     searchSirene.mockResolvedValueOnce({
@@ -345,6 +355,8 @@ describe("Mutation.createCompany", () => {
 
     const companyInput = {
       orgId: "1".repeat(14),
+      companyName: "UN BEL ECO ORGANISME",
+      address: "3 rue des granges",
       companyTypes: ["ECO_ORGANISME"],
       ecoOrganismeAgreements: ["https://legifrance.com/agreement"]
     };
@@ -381,6 +393,8 @@ describe("Mutation.createCompany", () => {
 
     const companyInput = {
       orgId: "1".repeat(14),
+      companyName: "UN BEL ECO ORGANISME",
+      address: "3 rue des granges",
       companyTypes: ["PRODUCER"],
       ecoOrganismeAgreements: ["https://legifrance.com/agreement"]
     };
@@ -436,6 +450,7 @@ describe("Mutation.createCompany", () => {
       orgId: "12345678912345",
       gerepId: "1234",
       companyName: "Acme",
+      address: "3 rue des granges",
       companyTypes: [CompanyType.WASTEPROCESSOR]
     };
 
@@ -461,10 +476,12 @@ describe("Mutation.createCompany", () => {
     process.env = OLD_ENV;
   }, 30000);
 
-  it("should allow to create a TRANSPORTER company with VAT number only", async () => {
+  it("should allow to create a TRANSPORTER company with VAT number", async () => {
     const user = await userFactory();
     const companyInput = {
       orgId: "RO17579668",
+      companyName: "Acme in EU",
+      address: "Transporter street",
       companyTypes: ["TRANSPORTER"]
     };
 
@@ -481,8 +498,9 @@ describe("Mutation.createCompany", () => {
         companyTypes: ["TRANSPORTER"],
         ecoOrganismeAgreements: [],
         gerepId: null,
-        name: null,
+        name: "Acme in EU",
         siret: "RO17579668",
+        address: "Transporter street",
         traderReceipt: null,
         transporterReceipt: null,
         vatNumber: "RO17579668"
@@ -499,6 +517,8 @@ describe("Mutation.createCompany", () => {
       }
       const companyInput = {
         orgId: "RO17579668",
+        companyName: "Acme in EU",
+        address: "Transporter street",
         companyTypes: [type]
       };
 

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -11,7 +11,11 @@ import * as COMPANY_TYPES from "../../../common/constants/COMPANY_TYPES";
 import { renderMail } from "../../../mailer/templates/renderers";
 import { verificationProcessInfo } from "../../../mailer/templates";
 import { deleteCachedUserCompanies } from "../../../common/redis/users";
-import { isFRVat, isSiret, isVat } from "../../../common/constants/companySearchHelpers";
+import {
+  isFRVat,
+  isSiret,
+  isVat
+} from "../../../common/constants/companySearchHelpers";
 import { whereSiretOrVatNumber } from "../CompanySearchResult";
 import { searchCompany } from "../../search";
 import {

--- a/back/src/companies/typeDefs/private/company.inputs.graphql
+++ b/back/src/companies/typeDefs/private/company.inputs.graphql
@@ -230,13 +230,13 @@ input PrivateCompanyInput {
   codeNaf: String
 
   "Nom de l'établissement"
-  companyName: String
+  companyName: String!
 
   "Nom d'usage de l'établissement"
   givenName: String
 
   "Adresse de l'établissement"
-  address: String
+  address: String!
 
   """
   Récipissé transporteur (le cas échéant, pour les profils transporteur)

--- a/front/src/account/AccountCompanyAdd.tsx
+++ b/front/src/account/AccountCompanyAdd.tsx
@@ -26,7 +26,11 @@ import AccountCompanyAddVhuAgrement from "./accountCompanyAdd/AccountCompanyAddV
 import { InlineRadioButton } from "form/common/components/custom-inputs/RadioButton";
 import classNames from "classnames";
 import { MY_COMPANIES } from "./AccountCompanyList";
-import { isSiret, isVat } from "generated/constants/companySearchHelpers";
+import {
+  isFRVat,
+  isSiret,
+  isVat,
+} from "generated/constants/companySearchHelpers";
 const CREATE_COMPANY = gql`
   mutation CreateCompany($companyInput: PrivateCompanyInput!) {
     createCompany(companyInput: $companyInput) {
@@ -406,6 +410,12 @@ export default function AccountCompanyAdd() {
             const isBroker_ = isBroker(values.companyTypes);
 
             return {
+              ...(!values.companyName && {
+                companyName: "Champ obligatoire",
+              }),
+              ...(!values.address && {
+                address: "Champ obligatoire",
+              }),
               ...(values.willManageDasris &&
                 values.allowBsdasriTakeOverWithoutSignature === null && {
                   allowBsdasriTakeOverWithoutSignature:
@@ -418,11 +428,11 @@ export default function AccountCompanyAdd() {
                 isAllowed:
                   "Vous devez certifier être autorisé à créer ce compte pour votre entreprise",
               }),
-              ...(!isSiret(values.siret) &&
-                !isVat(values.vatNumber) && {
-                  siret:
-                    "Le SIRET ou le numéro de TVA intracommunautaire doit être valides.",
-                }),
+              ...((isFRVat(values.vatNumber) ||
+                (!isSiret(values.siret) && !isVat(values.vatNumber))) && {
+                siret:
+                  "Le SIRET ou le numéro de TVA intracommunautaire doit être valides.",
+              }),
               ...(anyTransporterReceipField &&
                 isTransporter_ &&
                 !values.transporterReceiptNumber && {
@@ -490,11 +500,15 @@ export default function AccountCompanyAdd() {
 
                 <div className={styles.field__value}>
                   {companyInfos?.name || (
-                    <Field
-                      type="text"
-                      name="companyName"
-                      className={`td-input ${styles.textField}`}
-                    />
+                    <>
+                      <Field
+                        type="text"
+                        name="companyName"
+                        className={`td-input ${styles.textField}`}
+                        disabled={!!companyInfos?.name}
+                      />
+                      <RedErrorMessage name="companyName" />
+                    </>
                   )}
                 </div>
               </div>
@@ -534,12 +548,15 @@ export default function AccountCompanyAdd() {
                 <label className={`text-right ${styles.bold}`}>Adresse</label>
                 <div className={styles.field__value}>
                   {companyInfos?.address || (
-                    <Field
-                      type="text"
-                      name="address"
-                      className={`td-input ${styles.textField}`}
-                      disabled={!!companyInfos?.address}
-                    />
+                    <>
+                      <Field
+                        type="text"
+                        name="address"
+                        className={`td-input ${styles.textField}`}
+                        disabled={!!companyInfos?.address}
+                      />
+                      <RedErrorMessage name="address" />
+                    </>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
# [Bug] Transporteur étranger ne devrait pas pouvoir s'inscrire sans renseigner Raison sociale + Adresse

![image](https://user-images.githubusercontent.com/76620/189932264-f0d32045-3f5f-40b8-b2a4-779783b6cbb3.png)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente


- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8775)
