### PR TITLE
Recette : correction email de refus et MarkAsResealed

### DIFF
--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -53,7 +53,11 @@ export function FormCompanyFields({
       <p>
         <input
           type="checkbox"
-          checked={!isForeignShip && companyCountry?.cca2 === "FR"}
+          checked={
+            !!company?.siret?.length &&
+            !isForeignShip &&
+            companyCountry?.cca2 === "FR"
+          }
           readOnly
         />{" "}
         Entreprise française

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -10,7 +10,7 @@ import { renderMail } from "../../mailer/templates/renderers";
 const { NOTIFY_DREAL_WHEN_FORM_DECLINED } = process.env;
 
 export async function renderFormRefusedEmail(
-  form: Form & { forwarding?: Form },
+  form: Form,
   notifyDreal = NOTIFY_DREAL_WHEN_FORM_DECLINED === "true"
 ): Promise<Mail> {
   if (form.emitterIsPrivateIndividual || form.emitterIsForeignShip) {
@@ -32,7 +32,7 @@ export async function renderFormRefusedEmail(
     : form.wasteAcceptationStatus;
 
   const attachmentData = {
-    file: await generateBsddPdfToBase64(form.forwarding ?? form),
+    file: await generateBsddPdfToBase64(form),
     name: `${form.readableId}.pdf`
   };
 
@@ -98,6 +98,8 @@ export async function renderFormRefusedEmail(
               transporterIsExemptedOfReceipt:
                 forwardedIn.transporterIsExemptedOfReceipt,
               transporterCompanyName: forwardedIn.transporterCompanyName,
+              transporterCompanySiret: forwardedIn.transporterCompanySiret,
+              transporterReceipt: forwardedIn.transporterReceipt,
               sentBy: forwardedIn.sentBy,
               quantityReceived: forwardedIn.quantityReceived
             }
@@ -109,6 +111,8 @@ export async function renderFormRefusedEmail(
               transporterIsExemptedOfReceipt:
                 form.transporterIsExemptedOfReceipt,
               transporterCompanyName: form.transporterCompanyName,
+              transporterCompanySiret: form.transporterCompanySiret,
+              transporterReceipt: form.transporterReceipt,
               sentBy: form.sentBy,
               quantityReceived: form.quantityReceived
             })

--- a/back/src/mailer/templates/mustache/refus-partiel-dechet.html
+++ b/back/src/mailer/templates/mustache/refus-partiel-dechet.html
@@ -17,11 +17,10 @@
       {{^form.wasteRefusalReason}}<span>Non précisé</span>{{/form.wasteRefusalReason}}
     </li>
   </ul>
-  <li>Transporteur :
-    {{#form.transporterIsExemptedOfReceipt}}
-    <b>Exemption relevant de l'article R.541-50 du code de l'Environnement</b>{{/form.transporterIsExemptedOfReceipt}}
+  <li>Transporteur : {{form.transporterCompanyName}} ({{form.transporterCompanySiret}}). {{#form.transporterIsExemptedOfReceipt}}
+    <span> Récépissé transport : Exemption relevant de l'article R.541-50 du code de l'Environnement</span>{{/form.transporterIsExemptedOfReceipt}}
     {{^form.transporterIsExemptedOfReceipt}}
-    <b>{{form.transporterCompanyName}}</b>
+    <span> Récépissé transport : {{form.transporterReceipt}}</span>
     {{/form.transporterIsExemptedOfReceipt}}
   </li>
   <li>Responsable du site : {{form.sentBy}}</li>

--- a/back/src/mailer/templates/mustache/refus-total-dechet.html
+++ b/back/src/mailer/templates/mustache/refus-total-dechet.html
@@ -16,11 +16,10 @@
       {{^form.wasteRefusalReason}}<span>Non précisé</span>{{/form.wasteRefusalReason}}
     </li>
   </ul>
-  <li>Transporteur :
-    {{#form.transporterIsExemptedOfReceipt}}
-    <b>Exemption relevant de l'article R.541-50 du code de l'Environnement</b>{{/form.transporterIsExemptedOfReceipt}}
+  <li>Transporteur : {{form.transporterCompanyName}} ({{form.transporterCompanySiret}}). {{#form.transporterIsExemptedOfReceipt}}
+    <span> Récépissé transport : Exemption relevant de l'article R.541-50 du code de l'Environnement</span>{{/form.transporterIsExemptedOfReceipt}}
     {{^form.transporterIsExemptedOfReceipt}}
-    <b>{{form.transporterCompanyName}}</b>
+    <span> Récépissé transport : {{form.transporterReceipt}}</span>
     {{/form.transporterIsExemptedOfReceipt}}
   </li>
   <li>Responsable du site : {{form.sentBy}}</li>

--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -401,6 +401,11 @@ export const dashboardFormFragment = gql`
     wasteDetails {
       code
       name
+      packagingInfos {
+        type
+        other
+        quantity
+      }
     }
     emitter {
       type
@@ -451,7 +456,23 @@ export const dashboardFormFragment = gql`
       destination {
         company {
           siret
+          address
+          name
+          contact
+          phone
+          mail
         }
+        cap
+        processingOperation
+      }
+      wasteDetails {
+        packagingInfos {
+          type
+          other
+          quantity
+        }
+        quantity
+        quantityType
       }
     }
     transportSegments {


### PR DESCRIPTION
- modification contenu email de refus
- modification des données dans `GET_FORMS` utilisées dans `MarkAsResealed`
- suppression de la case FR coché par défaut sur le pdf

---

- [Ticket mail de refus](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8625&referrer=emailNotification)
- [Cahier recette](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-9303&referrer=emailNotification)
