### PR TITLE
Fixes BSDA transporter error message

### DIFF
--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -33,6 +33,7 @@ export function Transporter({ disabled }) {
         name="transporter.company"
         heading="Entreprise de transport"
         allowForeignCompanies={true}
+        isBsdaTransporter={true}
         registeredOnlyCompanies={true}
         onCompanySelected={transporter => {
           if (transporter.transporterReceipt) {

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -53,6 +53,7 @@ interface CompanySelectorProps {
   disabled?: boolean;
   optionalMail?: boolean;
   skipFavorite?: boolean;
+  isBsdaTransporter?: boolean;
   // whether the company is optional
   optional?: boolean;
 }
@@ -67,6 +68,7 @@ export default function CompanySelector({
   disabled,
   optionalMail = false,
   skipFavorite = false,
+  isBsdaTransporter = false,
   optional = false,
 }: CompanySelectorProps) {
   const { siret } = useParams<{ siret: string }>();
@@ -380,7 +382,11 @@ export default function CompanySelector({
             <SimpleNotificationError
               message={
                 <>
-                  <span>La sélection d'un établissement est obligatoire</span>
+                  <span>
+                    {isBsdaTransporter
+                      ? "La sélection d'un transporteur sera obligatoire avant la signature de l'entreprise de travaux"
+                      : "La sélection d'un établissement est obligatoire"}
+                  </span>
                 </>
               }
             />


### PR DESCRIPTION
Personnalisation du message d'erreur lors de l'absence de sélection d'un transporteur pour les BSDA.


- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9406)
