### PR TITLE
Ajoute une commande au panneau d'admin  pour reindexer un bsd

### DIFF
--- a/back/src/bsds/resolvers/Mutation.ts
+++ b/back/src/bsds/resolvers/Mutation.ts
@@ -1,5 +1,7 @@
 import { MutationResolvers } from "../../generated/graphql/types";
 import createPdfAccessTokenResolver from "./mutations/createPdfAccessToken";
+import reindexBsd from "./mutations/reindexBsd";
 export const Mutation: MutationResolvers = {
-  createPdfAccessToken: createPdfAccessTokenResolver
+  createPdfAccessToken: createPdfAccessTokenResolver,
+  reindexBsd: reindexBsd
 };

--- a/back/src/bsds/resolvers/mutations/reindexBsd.ts
+++ b/back/src/bsds/resolvers/mutations/reindexBsd.ts
@@ -1,0 +1,16 @@
+import { MutationResolvers } from "../../../generated/graphql/types";
+
+import { checkIsAdmin } from "../../../common/permissions";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { reindex } from "./reindexBsdHelpers";
+
+const reindexBsdResolver: MutationResolvers["reindexBsd"] = async (
+  _,
+  { id: bsdId },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  checkIsAdmin(context);
+  return reindex(bsdId, success => success);
+};
+export default reindexBsdResolver;

--- a/back/src/bsds/resolvers/mutations/reindexBsdHelpers.ts
+++ b/back/src/bsds/resolvers/mutations/reindexBsdHelpers.ts
@@ -1,0 +1,86 @@
+import prisma from "../../../prisma";
+import { indexBsda } from "../../../bsda/elastic";
+import { indexBsdasri } from "../../../bsdasris/elastic";
+import { indexBsff } from "../../../bsffs/elastic";
+import { indexBsvhu } from "../../../bsvhu/elastic";
+import { indexForm } from "../../../forms/elastic";
+import { getFullForm } from "../../../forms/database";
+import { deleteBsd } from "../../../common/elastic";
+import { getReadonlyBsdaRepository } from "../../../bsda/repository";
+
+export async function reindex(bsdId, exitFn) {
+  if (bsdId.startsWith("BSDA-")) {
+    const bsda = await getReadonlyBsdaRepository().findUnique(
+      { id: bsdId },
+      {
+        include: {
+          forwardedIn: { select: { id: true } },
+          groupedIn: { select: { id: true } }
+        }
+      }
+    );
+    if (!!bsda && !bsda.isDeleted) {
+      await indexBsda(bsda);
+    } else {
+      await deleteBsd({ id: bsdId });
+    }
+    return exitFn(true);
+  }
+
+  if (bsdId.startsWith("DASRI-")) {
+    const bsdasri = await prisma.bsdasri.findFirst({
+      where: { id: bsdId, isDeleted: false },
+      include: {
+        grouping: { select: { id: true } },
+        synthesizing: { select: { id: true } }
+      }
+    });
+
+    if (!!bsdasri) {
+      await indexBsdasri(bsdasri);
+    } else {
+      await deleteBsd({ id: bsdId });
+    }
+    return exitFn(true);
+  }
+
+  if (bsdId.startsWith("FF-")) {
+    const bsff = await prisma.bsff.findFirst({
+      where: { id: bsdId, isDeleted: false }
+    });
+
+    if (!!bsff) {
+      await indexBsff(bsff);
+    } else {
+      await deleteBsd({ id: bsdId });
+    }
+    return exitFn(true);
+  }
+
+  if (bsdId.startsWith("VHU-")) {
+    const bsvhu = await prisma.bsvhu.findFirst({
+      where: { id: bsdId, isDeleted: false }
+    });
+
+    if (!!bsvhu) {
+      await indexBsvhu(bsvhu);
+    } else {
+      await deleteBsd({ id: bsdId });
+    }
+    return exitFn(true);
+  }
+
+  if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
+    const bsdd = await prisma.form.findFirst({
+      where: { readableId: bsdId, isDeleted: false }
+    });
+    if (!!bsdd) {
+      const fullBsdd = await getFullForm(bsdd);
+      await indexForm(fullBsdd);
+    } else {
+      await deleteBsd({ id: bsdId });
+    }
+    return exitFn(true);
+  }
+  return exitFn(false);
+}

--- a/back/src/bsds/typeDefs/bsd.mutation.graphql
+++ b/back/src/bsds/typeDefs/bsd.mutation.graphql
@@ -3,7 +3,7 @@ type Mutation {
   Mutation permettant d'obtenir un lien de téléchargement valide 30 minutes.
   A destination des forces de l'ordre qui ne disposent pas d'accès à Trackdéchets, le lien
   est accessible sans authentification, et peut être transmis sous la form de QR-code.
-  La chaîn retournée est l'url de téléchargement.
+  La chaîne retournée est l'url de téléchargement.
   """
   createPdfAccessToken(input: CreatePdfAccessTokenInput!): String!
 }

--- a/back/src/bsds/typeDefs/private/bsd.mutation.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.mutation.graphql
@@ -1,0 +1,4 @@
+type Mutation {
+ 
+  reindexBsd(id: ID!): Boolean!
+}

--- a/back/src/scripts/bin/reindexBsd.ts
+++ b/back/src/scripts/bin/reindexBsd.ts
@@ -1,32 +1,14 @@
 import prisma from "../../prisma";
-import { indexBsda } from "../../bsda/elastic";
-import { indexBsdasri } from "../../bsdasris/elastic";
-import { indexBsff } from "../../bsffs/elastic";
-import { indexBsvhu } from "../../bsvhu/elastic";
-import { indexForm } from "../../forms/elastic";
-import { getFullForm } from "../../forms/database";
-import { deleteBsd, client, index } from "../../common/elastic";
 import { closeQueues } from "../../queue/producers";
-import { getReadonlyBsdaRepository } from "../../bsda/repository";
+import { reindex } from "../../bsds/resolvers/mutations/reindexBsdHelpers";
 
-async function findBsd(id) {
-  return client.search({
-    index: index.alias,
-    body: {
-      query: {
-        match: {
-          readableId: {
-            query: id,
-            operator: "and"
-          }
-        }
-      }
-    }
-  });
-}
-async function exitScript(msg?: string) {
+async function exitScript(success?: boolean) {
   await prisma.$disconnect();
-  console.log(msg || "Done, exiting");
+  console.log(
+    success
+      ? "Done, exiting"
+      : "L'argument ne correspond pas à un ID ou readableId de bsd"
+  );
   await closeQueues();
 }
 
@@ -43,88 +25,6 @@ async function exitScript(msg?: string) {
     );
     return;
   }
-  if (bsdId.startsWith("BSDA-")) {
-    const bsda = await getReadonlyBsdaRepository().findUnique(
-      { id: bsdId },
-      {
-        include: {
-          forwardedIn: { select: { id: true } },
-          groupedIn: { select: { id: true } }
-        }
-      }
-    );
-    if (!!bsda && !bsda.isDeleted) {
-      await indexBsda(bsda);
-    } else {
-      await deleteBsd({ id: bsdId });
-    }
-    await exitScript();
-    return;
-  }
 
-  if (bsdId.startsWith("DASRI-")) {
-    const bsdasri = await prisma.bsdasri.findFirst({
-      where: { id: bsdId, isDeleted: false },
-      include: {
-        grouping: { select: { id: true } },
-        synthesizing: { select: { id: true } }
-      }
-    });
-
-    if (!!bsdasri) {
-      await indexBsdasri(bsdasri);
-    } else {
-      await deleteBsd({ id: bsdId });
-    }
-    await exitScript();
-    return;
-  }
-
-  if (bsdId.startsWith("FF-")) {
-    const bsff = await prisma.bsff.findFirst({
-      where: { id: bsdId, isDeleted: false }
-    });
-
-    if (!!bsff) {
-      await indexBsff(bsff);
-    } else {
-      await deleteBsd({ id: bsdId });
-    }
-    await exitScript();
-    return;
-  }
-
-  if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findFirst({
-      where: { id: bsdId, isDeleted: false }
-    });
-
-    if (!!bsvhu) {
-      await indexBsvhu(bsvhu);
-    } else {
-      await deleteBsd({ id: bsdId });
-    }
-    await exitScript();
-    return;
-  }
-
-  if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
-    const bsdd = await prisma.form.findFirst({
-      where: { readableId: bsdId, isDeleted: false }
-    });
-    if (!!bsdd) {
-      const fullBsdd = await getFullForm(bsdd);
-      await indexForm(fullBsdd);
-    } else {
-      // bsd was not found in db, let's find it in ES and get its db ID
-      const res = await findBsd(bsdId);
-      const indexedId = res?.body?.hits?.hits[0]?._id;
-      if (!!indexedId) {
-        await deleteBsd({ id: indexedId });
-      }
-    }
-    await exitScript();
-    return;
-  }
-  await exitScript("L'argument ne correspond pas à un ID ou readableId de bsd");
+  return reindex(bsdId, exitScript);
 })();

--- a/front/src/admin/Admin.tsx
+++ b/front/src/admin/Admin.tsx
@@ -3,6 +3,7 @@ import routes from "common/routes";
 import React from "react";
 import { NavLink, Switch, Route, Redirect } from "react-router-dom";
 import { CreateAnonymousCompany } from "./anonymousCompany";
+import Reindex from "./reindex/Reindex";
 import CompaniesVerification from "./verification/CompaniesVerification";
 
 /**
@@ -33,6 +34,15 @@ export default function Admin() {
                 Entreprise anonyme
               </NavLink>
             </li>
+            <li className="tw-mb-1">
+              <NavLink
+                to={routes.admin.reindex}
+                className="sidebar__link"
+                activeClassName="sidebar__link--active"
+              >
+                Réindexation
+              </NavLink>
+            </li>
           </ul>
         </>
       </SideMenu>
@@ -43,6 +53,9 @@ export default function Admin() {
           </Route>
           <Route exact path={routes.admin.anonymousCompany}>
             <CreateAnonymousCompany />
+          </Route>
+          <Route exact path={routes.admin.reindex}>
+            <Reindex />
           </Route>
           <Redirect to={routes.admin.verification} />
         </Switch>

--- a/front/src/admin/reindex/Reindex.tsx
+++ b/front/src/admin/reindex/Reindex.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { Formik, Form, Field } from "formik";
+import cogoToast from "cogo-toast";
+import { gql, useMutation } from "@apollo/client";
+import { Mutation, MutationReindexBsdArgs } from "generated/graphql/types";
+import { InlineError } from "common/components/Error";
+
+const REINDEX_BSD = gql`
+  mutation reindexBsd($id: ID!) {
+    reindexBsd(id: $id)
+  }
+`;
+function Reindex() {
+  const [reindexBsd, { loading, error }] = useMutation<
+    Pick<Mutation, "reindexBsd">,
+    MutationReindexBsdArgs
+  >(REINDEX_BSD);
+
+  return (
+    <div className="tw-mx-2">
+      <Formik
+        initialValues={{
+          bsdid: "",
+        }}
+        onSubmit={async (values, { resetForm }) => {
+          const res = await reindexBsd({ variables: { id: values.bsdid } });
+          resetForm();
+          !!res?.data?.reindexBsd
+            ? cogoToast.success(`Réindexation effectuée`, { hideAfter: 3 })
+            : cogoToast.error(
+                `Cet identifiant ne correspond pas à un bordereau`,
+                { hideAfter: 3 }
+              );
+        }}
+      >
+        {() => (
+          <Form>
+            <div className="form__row">
+              <label>
+                ID du bsd à réindexer
+                <Field
+                  name="bsdid"
+                  placeholder="BSD-20211215-12GH0E6TR"
+                  className="td-input"
+                />
+              </label>
+            </div>
+            {error && <InlineError apolloError={error} />}
+            <button
+              type="submit"
+              className="btn btn--primary tw-mt-1"
+              disabled={loading}
+            >
+              {loading ? "Réindexation..." : "Réindexer"}
+            </button>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+}
+
+export default Reindex;

--- a/front/src/common/routes.ts
+++ b/front/src/common/routes.ts
@@ -3,6 +3,7 @@ const routes = {
     index: "/admin",
     verification: "/admin/verification",
     anonymousCompany: "/admin/anonymous-company",
+    reindex: "/admin/reindex",
   },
   login: "/login",
   invite: "/invite",


### PR DESCRIPTION
Ajoute une page réservée aux admins pour réindexer un bsd.

<img width="703" alt="Capture d’écran 2022-09-22 à 23 01 56" src="https://user-images.githubusercontent.com/878396/191851219-ad8fae5f-b5bd-47dd-81ce-abcf9fbd7cdf.png">

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
