### PR TITLE
Fix/force reindex

### DIFF
--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -626,7 +626,7 @@ export async function indexAllBsds(index: string, bsdType?: BsdType) {
   }
   if (!bsdType || bsdType === "BSDA") {
     console.log("Indexing Bsdas");
-    await await indexAllBsdas(index);
+    await indexAllBsdas(index);
   }
   if (!bsdType || bsdType === "BSFF") {
     console.log("Indexing Bsffs");

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -350,7 +350,7 @@ export const index: BsdIndex = {
   // Doing so will cause all BSDs to be reindexed in Elastic Search
   // when running the appropriate script
 
-  index: "bsds_0.2.6",
+  index: "bsds_0.2.5",
 
   // The next major version of Elastic Search doesn't use "type" anymore
   // so while it's required for the current version, we are not using it too much

--- a/back/src/scripts/bin/indexElasticSearch.helpers.ts
+++ b/back/src/scripts/bin/indexElasticSearch.helpers.ts
@@ -136,10 +136,15 @@ export async function indexElasticSearch({
   } else {
     const { index: oldIndex } = catAliasesResponse.body[0];
     if (oldIndex === newIndex) {
-      if (force) {
+      if (force && !bsdTypeToIndex) {
         console.log(
           `The -f flag was passed, documents are being reindexed in place.`
         );
+        await bumpIndex(index.index, {
+          ...index,
+          index: `${index.index}_force_${Date.now()}`
+        });
+      } else if (force && bsdTypeToIndex) {
         await reindexInPlace(index, bsdTypeToIndex);
       } else {
         console.log(

--- a/back/src/scripts/bin/indexElasticSearch.helpers.ts
+++ b/back/src/scripts/bin/indexElasticSearch.helpers.ts
@@ -136,15 +136,10 @@ export async function indexElasticSearch({
   } else {
     const { index: oldIndex } = catAliasesResponse.body[0];
     if (oldIndex === newIndex) {
-      if (force && !bsdTypeToIndex) {
+      if (force) {
         console.log(
           `The -f flag was passed, documents are being reindexed in place.`
         );
-        await bumpIndex(index.index, {
-          ...index,
-          index: `${index.index}_force_${Date.now()}`
-        });
-      } else if (force && bsdTypeToIndex) {
         await reindexInPlace(index, bsdTypeToIndex);
       } else {
         console.log(

--- a/back/src/scripts/build/scalingo.sh
+++ b/back/src/scripts/build/scalingo.sh
@@ -10,5 +10,4 @@ npm prune --production
 if [ -z "${STARTUP_FILE}" ] || [ "$STARTUP_FILE" = "dist/src/index.js" ]; then
     cd dist
     npm run migrate
-    npm run index-elastic-search
 fi


### PR DESCRIPTION
# Rend l'indexation post-MEP manuelle (pour le moment)

```
npm run index-elastic-search:dev -- -f

> back@1.0.0 index-elastic-search:dev
> ts-node -r dotenv/config ./src/scripts/bin/indexElasticSearch.ts

The -f flag was passed, documents are being reindexed in place.
Creating the new index "bsds_0.2.5_force_1663920331562".
All the documents are being indexed in the new index "bsds_0.2.5_force_1663920331562" while the alias "bsds" still points to the old index.
Indexing Bsdds
prisma:info Starting a postgresql pool with 9 connections.
Indexing Bsdasris
Indexing Bsvhus
Indexing Bsdas
Indexing Bsffs
All documents have been indexed, the alias "bsds" will now point to the new index "bsds_0.2.5_force_1663920331562".
There are no references to the old index anymore, it's now being deleted.
All done, exiting.
```


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
