### PR TITLE
Sécu / Fix IP

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -146,3 +146,6 @@ ALLOW_TEST_COMPANY=true
 
 # Rate limit the mail queue to respect hosting limit
 QUEUE_MAXRATE_SENDMAIL=60
+
+# Use the address that is at most n number of hops away from the Express application
+TRUST_PROXY_HOPS=1

--- a/back/src/common/middlewares/rateLimiter.ts
+++ b/back/src/common/middlewares/rateLimiter.ts
@@ -9,8 +9,6 @@ type Options = {
   keyGenerator?: (ip: string, request: Request) => string;
 };
 
-const { USE_XFF_HEADER } = process.env;
-
 const RATE_LIMIT_WINDOW_SECONDS = 60;
 const store =
   process.env.NODE_ENV === "test"

--- a/back/src/common/middlewares/rateLimiter.ts
+++ b/back/src/common/middlewares/rateLimiter.ts
@@ -1,6 +1,5 @@
 import rateLimit from "express-rate-limit";
 import { Request } from "express";
-import forwarded from "forwarded";
 import RateLimitRedisStore from "rate-limit-redis";
 import { redisClient } from "../../common/redis";
 
@@ -30,17 +29,7 @@ export function rateLimiterMiddleware(options: Options) {
     max: options.maxRequestsPerWindow,
     store,
     keyGenerator: (request: Request) => {
-      const clientIp = getClientIp(request);
-      return options.keyGenerator(clientIp, request);
+      return options.keyGenerator(request.ip, request);
     }
   });
-}
-
-function getClientIp(request: Request) {
-  if (USE_XFF_HEADER !== "true") {
-    return request.ip;
-  }
-
-  const parsed = forwarded(request);
-  return parsed.slice(-1).pop() ?? request.ip;
 }

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -10,7 +10,6 @@ import redisStore from "connect-redis";
 import cors from "cors";
 import express, { json, static as serveStatic, urlencoded } from "express";
 import session from "express-session";
-import forwarded from "forwarded";
 import depthLimit from "graphql-depth-limit";
 import helmet from "helmet";
 import passport from "passport";
@@ -48,7 +47,8 @@ const {
   SESSION_NAME,
   UI_HOST,
   MAX_REQUESTS_PER_WINDOW = "1000",
-  NODE_ENV
+  NODE_ENV,
+  HAS_OUTSIDE_PROXY
 } = process.env;
 
 const Sentry = initSentry();
@@ -207,8 +207,14 @@ export const sess: session.SessionOptions = {
   }
 };
 
+// The app is always served under one or more reverse proxy:
+// - nginx during local development
+// - Scalingo proxy for live envs
+// - with Baleen, there is a second reverse proxy layer. Hence, the user's ip is 1 hop further
+// For more details, see https://expressjs.com/en/guide/behind-proxies.html.
+app.set("trust proxy", HAS_OUTSIDE_PROXY ? 2 : 1);
+
 if (SESSION_COOKIE_SECURE === "true") {
-  app.set("trust proxy", 1); // trust first proxy
   sess.cookie.secure = true; // serve secure cookies
 }
 
@@ -225,13 +231,7 @@ app.use(oauth2Router);
 app.get("/ping", (_, res) => res.send("Pong!"));
 
 app.get("/ip", (req, res) => {
-  const parsed = forwarded(req);
-
-  return res.send(
-    `IP: ${req.ip} | XFF: ${req.get("X-Forwarded-For")} | parsed: ${parsed
-      .slice(-1)
-      .pop()}`
-  );
+  return res.send(`IP: ${req.ip} | XFF: ${req.get("X-Forwarded-For")}`);
 });
 
 app.get("/userActivation", userActivationHandler);

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -48,7 +48,7 @@ const {
   UI_HOST,
   MAX_REQUESTS_PER_WINDOW = "1000",
   NODE_ENV,
-  HAS_OUTSIDE_PROXY
+  TRUST_PROXY_HOPS
 } = process.env;
 
 const Sentry = initSentry();
@@ -212,7 +212,7 @@ export const sess: session.SessionOptions = {
 // - Scalingo proxy for live envs
 // - with Baleen, there is a second reverse proxy layer. Hence, the user's ip is 1 hop further
 // For more details, see https://expressjs.com/en/guide/behind-proxies.html.
-app.set("trust proxy", HAS_OUTSIDE_PROXY ? 2 : 1);
+app.set("trust proxy", TRUST_PROXY_HOPS ?? 1);
 
 if (SESSION_COOKIE_SECURE === "true") {
   sess.cookie.secure = true; // serve secure cookies


### PR DESCRIPTION
Fix de sécurité.

Si on passe un header X-Forwarded-For on peut bypasser le ratelimit car on ne récupère pas la bonne IP utilisateur.

- [x] Ajouter l'env TRUST_PROXY_HOPS en PROD avant merge