### PR TITLE
ES / Add updatedAt

### DIFF
--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -135,6 +135,7 @@ export function toBsdElastic(bsda: Bsda): BsdElastic {
     customId: "",
     readableId: bsda.id,
     createdAt: bsda.createdAt.getTime(),
+    updatedAt: bsda.updatedAt.getTime(),
     emitterCompanyName: bsda.emitterCompanyName ?? "",
     emitterCompanySiret: bsda.emitterCompanySiret ?? "",
     transporterCompanyName: bsda.transporterCompanyName ?? "",

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -139,6 +139,7 @@ export function toBsdElastic(bsdasri: Bsdasri): BsdElastic {
     wasteDescription: DASRI_WASTE_CODES_MAPPING[bsdasri.wasteCode],
     transporterNumberPlate: bsdasri.transporterTransportPlates,
     createdAt: bsdasri.createdAt.getTime(),
+    updatedAt: bsdasri.updatedAt.getTime(),
     ...where,
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsdasri),

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -14,6 +14,7 @@ export function toBsdElastic(
     readableId: bsff.id,
     customId: "",
     createdAt: bsff.createdAt.getTime(),
+    updatedAt: bsff.updatedAt.getTime(),
     emitterCompanyName: bsff.emitterCompanyName ?? "",
     emitterCompanySiret: bsff.emitterCompanySiret ?? "",
     transporterCompanyName: bsff.transporterCompanyName ?? "",

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -109,6 +109,7 @@ function toBsdElastic(bsvhu: Bsvhu): BsdElastic {
     readableId: bsvhu.id,
     customId: "",
     createdAt: bsvhu.createdAt.getTime(),
+    updatedAt: bsvhu.updatedAt.getTime(),
     emitterCompanyName: bsvhu.emitterCompanyName ?? "",
     emitterCompanySiret: bsvhu.emitterCompanySiret ?? "",
     transporterCompanyName: bsvhu.transporterCompanyName ?? "",

--- a/back/src/common/__tests__/elastic.integration.ts
+++ b/back/src/common/__tests__/elastic.integration.ts
@@ -27,6 +27,7 @@ const defaultOpts: BsdElastic = {
   destinationOperationCode: "D10",
   destinationOperationDate: null,
   createdAt: new Date().getMilliseconds(),
+  updatedAt: new Date().getMilliseconds(),
   isDraftFor: [],
   isForActionFor: [],
   isFollowFor: [],

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -455,8 +455,9 @@ export function indexBsd(bsd: BsdElastic, ctx?: GraphQLContext) {
     index: index.index,
     type: index.type,
     id: bsd.id,
-
     body: bsd,
+    version_type: "external",
+    version: bsd.updatedAt,
     ...refresh(ctx)
   });
 }

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -29,6 +29,7 @@ export interface BsdElastic {
   type: BsdType;
   id: string;
   createdAt: number;
+  updatedAt: number;
   readableId: string;
   customId: string;
   emitterCompanyName: string;
@@ -279,6 +280,9 @@ const properties: Record<keyof BsdElastic, Record<string, unknown>> = {
     }
   },
   createdAt: {
+    type: "date"
+  },
+  updatedAt: {
     type: "date"
   },
   isDraftFor: {

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -456,7 +456,7 @@ export function indexBsd(bsd: BsdElastic, ctx?: GraphQLContext) {
     type: index.type,
     id: bsd.id,
     body: bsd,
-    version_type: "external",
+    version_type: "external_gte",
     version: bsd.updatedAt,
     ...refresh(ctx)
   });

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -213,6 +213,7 @@ function toBsdElastic(form: FullForm & { forwarding?: Form }): BsdElastic {
     readableId: form.readableId,
     customId: form.customId,
     createdAt: form.createdAt.getTime(),
+    updatedAt: form.updatedAt.getTime(),
     emitterCompanyName: form.emitterCompanyName ?? "",
     emitterCompanySiret: form.emitterCompanySiret ?? "",
     transporterCompanyName: form.transporterCompanyName ?? "",


### PR DESCRIPTION
Ajout de la date d'update du bsd dans ES.
Permettra de débug quelle version du bordereau est actuellement dans ES.

On en profite également pour ajouter `updatedAt` comme discriminant de version. Cela afin d'éviter qu'une idexation antérieure mais plus longue ne vienne écraser une indexation plus rapide ayant été enqueue après.

Il y a un nouveau champ, donc peut être attendre les modifs sur l'indexation avant de merger cette PR.