### PR TITLE
Add updated at indices

### DIFF
--- a/back/prisma/migrations/90_add_bsds_updated_at_indices.sql
+++ b/back/prisma/migrations/90_add_bsds_updated_at_indices.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS "_BsdaUpdatedAtIdx" ON "default$default"."Bsda"("updatedAt");
+CREATE INDEX IF NOT EXISTS "_BsdasriUpdatedAtIdx" ON "default$default"."Bsdasri"("updatedAt");
+CREATE INDEX IF NOT EXISTS "_BsffUpdatedAtIdx" ON "default$default"."Bsff"("updatedAt");
+CREATE INDEX IF NOT EXISTS "_BsvhuUpdatedAtIdx" ON "default$default"."Bsvhu"("updatedAt");
+CREATE INDEX IF NOT EXISTS "_FormUpdatedAtIdx" ON "default$default"."Form"("updatedAt");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -830,6 +830,7 @@ model Bsvhu {
   @@index([destinationCompanySiret], map: "_BsvhuDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsvhuTransporterCompanySiretIdx")
   @@index([status], map: "_BsvhuStatusIdx")
+  @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
 }
 
 // ----------------
@@ -971,6 +972,7 @@ model Bsdasri {
   @@index([groupedInId], map: "_BsdasriGroupedInIdIdx")
   @@index([status], map: "_BsdasriStatusIdx")
   @@index([type], map: "_BsdasriTypeIdx")
+  @@index([updatedAt], map: "_BsdasriUpdatedAtIdx")
 }
 
 // ----------------
@@ -1078,6 +1080,7 @@ model Bsff {
   @@index([transporterCompanySiret], map: "_BsffTransporterCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsffDestinationCompanySiretIdx")
   @@index([status], map: "_BsffStatusIdx")
+  @@index([updatedAt], map: "_BsffUpdatedAtIdx")
 }
 
 enum BsffType {
@@ -1303,6 +1306,7 @@ model Bsda {
   @@index([workerCompanySiret], map: "_BsdaWorkerCompanySiretIdx")
   @@index([status], map: "_BsdaStatusIdx")
   @@index([groupedInId], map: "_BsdaGroupedInIdIdx")
+  @@index([updatedAt], map: "_BsdaUpdatedAtIdx")
 }
 
 model BsdaRevisionRequest {


### PR DESCRIPTION
Ajout d'index sur les updatedAt de chaque bsd, en prévision:

- de commande de réindex selectives ou ordonnées
- de l'incitation des utilisateurs à se servir des requêtes forms/bsdas/bsdasris en filtrant sur ce champ pour filtrer les bsds nécessitant des mises à jours

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro]()
