### PR TITLE
Enhance / Perfs annexe 2

### DIFF
--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -101,7 +101,7 @@ describe("expandFormFromDb", () => {
       signedAt: null,
       quantityReceived: null,
       processingOperationDone: null,
-      quantityGrouped: 0,
+      quantityGrouped: null,
       processingOperationDescription: null,
       processedBy: null,
       processedAt: null,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -621,7 +621,7 @@ export async function expandFormFromDb(form: any): Promise<GraphQLForm> {
     quantityReceived: forwardedIn
       ? forwardedIn.quantityReceived
       : form.quantityReceived,
-    quantityGrouped: form.quantityGrouped,
+    quantityGrouped: null,
     processingOperationDone: forwardedIn
       ? forwardedIn.processingOperationDone
       : form.processingOperationDone,

--- a/back/src/forms/repository/form/setAppendix2.ts
+++ b/back/src/forms/repository/form/setAppendix2.ts
@@ -45,7 +45,11 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
     });
 
     // update or create new appendix2
-    const formGroupementToCreate = [];
+    const formGroupementToCreate: {
+      nextFormId: string;
+      initialFormId: string;
+      quantity: number;
+    }[] = [];
     const formGroupementToUpdate: {
       initialFormId: string;
       quantity: number;

--- a/back/src/forms/repository/form/setAppendix2.ts
+++ b/back/src/forms/repository/form/setAppendix2.ts
@@ -50,7 +50,8 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
       initialFormId: string;
       quantity: number;
     }[] = [];
-    appendix2.map(({ form: initialForm, quantity }) => {
+
+    for (const { form: initialForm, quantity } of appendix2) {
       if (currentAppendix2Forms.map(f => f.id).includes(initialForm.id)) {
         formGroupementToUpdate.push({
           initialFormId: initialForm.id,
@@ -63,7 +64,7 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
           quantity: quantity
         });
       }
-    });
+    }
 
     if (formGroupementToCreate.length > 0) {
       await prisma.formGroupement.createMany({
@@ -89,7 +90,7 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
           prisma.formGroupement.updateMany({
             where: {
               nextFormId: form.id,
-              initialFormId: initialFormId
+              initialFormId
             },
             data: { quantity }
           })

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -3,103 +3,99 @@ import { Decimal } from "decimal.js-light";
 import { RepositoryFnDeps } from "../../../common/repository/types";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
-import buildUpdateForm from "./update";
+import buildUpdateManyForms from "./updateMany";
 
-export type UpdateAppendix2Forms = (forms: Form[]) => Promise<Form[]>;
+export type UpdateAppendix2Forms = (forms: Form[]) => Promise<void>;
 
 const buildUpdateAppendix2Forms: (
   deps: RepositoryFnDeps
 ) => UpdateAppendix2Forms = deps => async forms => {
   const { user, prisma } = deps;
-  const updateForm = buildUpdateForm({ prisma, user });
+  const updateManyForms = buildUpdateManyForms({ prisma, user });
 
-  return Promise.all(
-    forms.map(async form => {
-      if (
-        ![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)
-      ) {
-        return form;
-      }
-      const { id, quantityReceived } = form;
+  const formIds = forms.map(form => form.id);
+  const formGroupements = await prisma.formGroupement.findMany({
+    where: { initialFormId: { in: formIds } },
+    include: { nextForm: { select: { status: true } } }
+  });
 
-      const quantityGrouped = new Decimal(
-        (
-          await prisma.formGroupement.aggregate({
-            _sum: { quantity: true },
-            where: { initialFormId: id }
-          })
-        )._sum.quantity ?? 0
-      ).toDecimalPlaces(6); // set precision to gramme
+  const formUpdatesByStatus = new Map<Status, string[]>();
+  for (const form of forms) {
+    if (![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)) {
+      continue;
+    }
+    const { id, quantityReceived } = form;
 
-      const groupementForms = (
-        await prisma.formGroupement.findMany({
-          where: { initialFormId: id },
-          include: { nextForm: { select: { status: true } } }
-        })
-      ).map(g => g.nextForm);
+    const quantityGrouped = new Decimal(
+      formGroupements
+        .filter(grp => grp.initialFormId === id)
+        .map(grp => grp.quantity)
+        .reduce((prev, cur) => prev + cur, 0) ?? 0
+    ).toDecimalPlaces(6); // set precision to gramme
 
-      const groupedInTotality =
-        quantityGrouped.greaterThanOrEqualTo(quantityReceived); // case > should not happen
+    const groupementForms = formGroupements
+      .filter(grp => grp.initialFormId === id)
+      .map(g => g.nextForm);
 
-      const allSealed =
-        groupementForms.length &&
-        groupedInTotality &&
-        groupementForms.reduce(
-          (acc, form) => acc && form.status !== Status.DRAFT,
-          true
-        );
+    const groupedInTotality =
+      quantityGrouped.greaterThanOrEqualTo(quantityReceived); // case > should not happen
 
-      const allProcessed =
-        groupementForms.length &&
-        groupedInTotality &&
-        groupementForms.reduce(
-          (acc, form) =>
-            acc &&
-            [
-              Status.PROCESSED,
-              Status.NO_TRACEABILITY,
-              Status.FOLLOWED_WITH_PNTTD
-            ].includes(form.status as any),
-          true
-        );
+    const allSealed =
+      groupementForms.length &&
+      groupedInTotality &&
+      groupementForms.reduce(
+        (acc, form) => acc && form.status !== Status.DRAFT,
+        true
+      );
 
-      const nextStatus = allProcessed
-        ? Status.PROCESSED
-        : allSealed
-        ? Status.GROUPED
-        : Status.AWAITING_GROUP;
+    const allProcessed =
+      groupementForms.length &&
+      groupedInTotality &&
+      groupementForms.reduce(
+        (acc, form) =>
+          acc &&
+          [
+            Status.PROCESSED,
+            Status.NO_TRACEABILITY,
+            Status.FOLLOWED_WITH_PNTTD
+          ].includes(form.status as any),
+        true
+      );
 
-      if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
-        return updateForm(
-          { id },
-          {
-            status: transitionForm(form, {
-              type: EventType.MarkAsProcessed
-            })
-          }
-        );
-      } else if (
-        form.status === Status.AWAITING_GROUP &&
-        nextStatus === Status.GROUPED
-      ) {
-        return updateForm(
-          { id },
-          {
-            status: transitionForm(form, {
-              type: EventType.MarkAsGrouped,
-              formUpdateInput: { quantityGrouped: quantityGrouped.toNumber() }
-            }),
-            quantityGrouped: quantityGrouped.toNumber()
-          }
-        );
-      } else {
-        return updateForm(
-          { id },
-          { status: nextStatus, quantityGrouped: quantityGrouped.toNumber() }
-        );
-      }
-    })
-  );
+    const nextStatus = allProcessed
+      ? Status.PROCESSED
+      : allSealed
+      ? Status.GROUPED
+      : Status.AWAITING_GROUP;
+
+    if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
+      const status = transitionForm(form, {
+        type: EventType.MarkAsProcessed
+      });
+
+      formUpdatesByStatus.set(status, [...formUpdatesByStatus.get(status), id]);
+    } else if (
+      form.status === Status.AWAITING_GROUP &&
+      nextStatus === Status.GROUPED
+    ) {
+      const status = transitionForm(form, {
+        type: EventType.MarkAsGrouped
+      });
+      formUpdatesByStatus.set(status, [...formUpdatesByStatus.get(status), id]);
+    } else {
+      formUpdatesByStatus.set(nextStatus, [
+        ...formUpdatesByStatus.get(nextStatus),
+        id
+      ]);
+    }
+  }
+
+  const promises = [];
+  for (const [status, ids] of formUpdatesByStatus.entries()) {
+    promises.push(updateManyForms(ids, { status }));
+  }
+
+  await Promise.all(promises);
 };
 
 export default buildUpdateAppendix2Forms;

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -73,7 +73,10 @@ const buildUpdateAppendix2Forms: (
         type: EventType.MarkAsProcessed
       });
 
-      formUpdatesByStatus.set(status, [...formUpdatesByStatus.get(status), id]);
+      formUpdatesByStatus.set(status, [
+        ...(formUpdatesByStatus.get(status) ?? []),
+        id
+      ]);
     } else if (
       form.status === Status.AWAITING_GROUP &&
       nextStatus === Status.GROUPED
@@ -81,10 +84,13 @@ const buildUpdateAppendix2Forms: (
       const status = transitionForm(form, {
         type: EventType.MarkAsGrouped
       });
-      formUpdatesByStatus.set(status, [...formUpdatesByStatus.get(status), id]);
+      formUpdatesByStatus.set(status, [
+        ...(formUpdatesByStatus.get(status) ?? []),
+        id
+      ]);
     } else {
       formUpdatesByStatus.set(nextStatus, [
-        ...formUpdatesByStatus.get(nextStatus),
+        ...(formUpdatesByStatus.get(nextStatus) ?? []),
         id
       ]);
     }

--- a/back/src/forms/repository/form/updateMany.ts
+++ b/back/src/forms/repository/form/updateMany.ts
@@ -22,17 +22,15 @@ const buildUpdateManyForms: (deps: RepositoryFnDeps) => UpdateManyFormFn =
       data
     });
 
-    for (const id of ids) {
-      await prisma.event.create({
-        data: {
-          streamId: id,
-          actor: user.id,
-          type: "BsddUpdated",
-          data: { content: data } as Prisma.InputJsonObject,
-          metadata: { ...logMetadata, authType: user.auth }
-        }
-      });
-    }
+    await prisma.event.createMany({
+      data: ids.map(id => ({
+        streamId: id,
+        actor: user.id,
+        type: "BsddUpdated",
+        data: { content: data } as Prisma.InputJsonObject,
+        metadata: { ...logMetadata, authType: user.auth }
+      }))
+    });
 
     await Promise.all(
       ids.map(async id => {

--- a/back/src/forms/resolvers/Form.ts
+++ b/back/src/forms/resolvers/Form.ts
@@ -5,6 +5,7 @@ import transportSegments from "./forms/transportSegments";
 import groupedIn from "./forms/groupedIn";
 import grouping from "./forms/grouping";
 import intermediaries from "./forms/intermediary";
+import quantityGrouped from "./forms/quantityGrouped";
 
 const formResolvers: FormResolvers = {
   appendix2Forms,
@@ -13,7 +14,8 @@ const formResolvers: FormResolvers = {
   transportSegments,
   groupedIn,
   grouping,
-  intermediaries
+  intermediaries,
+  quantityGrouped
 };
 
 export default formResolvers;

--- a/back/src/forms/resolvers/forms/quantityGrouped.ts
+++ b/back/src/forms/resolvers/forms/quantityGrouped.ts
@@ -1,0 +1,19 @@
+import { FormResolvers } from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+
+const quantityGrouped: FormResolvers["quantityGrouped"] = async form => {
+  const formGroupements = await prisma.form
+    .findUnique({
+      where: { id: form.id }
+    })
+    .groupedIn();
+
+  if (formGroupements) {
+    return formGroupements
+      .map(grp => grp.quantity)
+      .reduce((prev, cur) => prev + cur, 0);
+  }
+  return null;
+};
+
+export default quantityGrouped;

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -947,12 +947,6 @@ describe("Mutation.createForm", () => {
     expect(groupementForm2.grouping).toEqual([
       { form: { id: initialForm.id }, quantity: 0.5 }
     ]);
-
-    const updatedInitialForm = await prisma.form.findUnique({
-      where: { id: initialForm.id }
-    });
-
-    expect(updatedInitialForm.quantityGrouped).toEqual(1);
   });
 
   it("should fail when adding the same form twice to the same groupement form", async () => {
@@ -1350,8 +1344,7 @@ describe("Mutation.createForm", () => {
       opt: {
         status: Status.AWAITING_GROUP,
         recipientCompanySiret: ttr.siret,
-        quantityReceived: 1,
-        quantityGrouped: 0.2
+        quantityReceived: 1
       }
     });
 
@@ -1390,14 +1383,6 @@ describe("Mutation.createForm", () => {
         form: expect.objectContaining({ id: appendix2.id })
       })
     ]);
-
-    const updatedAppendix2 = await prisma.form.findUnique({
-      where: { id: appendix2.id }
-    });
-
-    expect(updatedAppendix2.quantityGrouped).toEqual(
-      updatedAppendix2.quantityReceived
-    );
   });
 
   it("should set isDangerous to `true` when specifying a waste code ending with *", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
@@ -200,7 +200,6 @@ describe("Mutation.deleteForm", () => {
     });
     expect(disconnectedAppendix2.groupedIn).toEqual([]);
     expect(disconnectedAppendix2.status).toEqual("AWAITING_GROUP");
-    expect(disconnectedAppendix2.quantityGrouped).toEqual(0);
   });
 
   it("should delete bsd suite", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -1708,14 +1708,6 @@ describe("Mutation.updateForm", () => {
     expect(data.updateForm.grouping).toEqual([
       expect.objectContaining({ form: { id: appendix2Form.id }, quantity: 0.8 })
     ]);
-
-    const updatedAppendix2Form = await prisma.form.findFirst({
-      where: { id: appendix2Form.id }
-    });
-
-    expect(updatedAppendix2Form.quantityGrouped).toEqual(
-      updatedAppendix2Form.quantityReceived
-    );
   });
 
   it("should not be possible to set isDangerous=false with a waste code containing an *", async () => {


### PR DESCRIPTION
PR pour tenter d'améliorer les perfs, en se basant sur le constat suivant:
![image](https://user-images.githubusercontent.com/5145523/194091928-a4a8fce0-87d4-45ba-a420-46b119dd47cc.png)
On a énormément d'appels qui sont faits par bordereau. Il faudrait que tout ce qui peut être fait en groupe le soit.

A voir ce que ca donne.
A noter que pour éviter des updates, on renormalise en bougeant le calcul de `quantityGrouped` dans un resolver