### PR TITLE
PDF / A4 au lieu de Letter

### DIFF
--- a/back/src/common/pdf/pdf.ts
+++ b/back/src/common/pdf/pdf.ts
@@ -17,7 +17,10 @@ export const toPDF = pipe(
     marginTop: 0.2,
     marginBottom: 0.2,
     marginLeft: 0.2,
-    marginRight: 0.2
+    marginRight: 0.2,
+    // A4 - default is Letter
+    paperWidth: 8.27,
+    paperHeight: 11.7
   }),
   adjust({ headers: { "X-Auth-Token": process.env.GOTENBERG_TOKEN ?? "" } }),
   please


### PR DESCRIPTION
Changement de format vers A4.
Cf https://forum.trackdechets.beta.gouv.fr/t/pourquoi-generer-des-pdf-au-format-letter-au-lieu-de-a4/1173/2
