### PR TITLE
Recette - Fix le numéro de TVA ne s'affiche pas sur le PDF en cas de destination ultérieure à l'étranger

### DIFF
--- a/back/prisma/migrations/92_add_next_destination_vatnumber.sql
+++ b/back/prisma/migrations/92_add_next_destination_vatnumber.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "default$default"."Form"
+    ADD COLUMN "nextDestinationCompanyVatNumber" VARCHAR(30);

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -363,6 +363,8 @@ model Form {
   nextDestinationCompanyContact      String?
   nextDestinationCompanyPhone        String?
   nextDestinationCompanyMail         String?
+  nextDestinationCompanyCountry      String?
+  nextDestinationCompanyVatNumber    String?
   emitterWorkSiteName                String?
   emitterWorkSiteAddress             String?
   emitterWorkSiteCity                String?
@@ -373,8 +375,6 @@ model Form {
   signedAt                           DateTime?               @db.Timestamptz(6)
   currentTransporterSiret            String?
   nextTransporterSiret               String?
-  nextDestinationCompanyCountry      String?
-  nextDestinationCompanyVatNumber    String?
   isImportedFromPaper                Boolean                 @default(false)
   ecoOrganismeName                   String?
   ecoOrganismeSiret                  String?

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -374,6 +374,7 @@ model Form {
   currentTransporterSiret            String?
   nextTransporterSiret               String?
   nextDestinationCompanyCountry      String?
+  nextDestinationCompanyVatNumber    String?
   isImportedFromPaper                Boolean                 @default(false)
   ecoOrganismeName                   String?
   ecoOrganismeSiret                  String?

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -308,6 +308,9 @@ function flattenNextDestinationInput(input: {
     ),
     nextDestinationCompanyPhone: chain(input.nextDestination, nd =>
       chain(nd.company, c => c.phone)
+    ),
+    nextDestinationCompanyVatNumber: chain(input.nextDestination, nd =>
+      chain(nd.company, c => c.vatNumber)
     )
   };
 }
@@ -641,6 +644,7 @@ export async function expandFormFromDb(form: any): Promise<GraphQLForm> {
           company: nullIfNoValues<FormCompany>({
             name: forwardedIn.nextDestinationCompanyName,
             siret: forwardedIn.nextDestinationCompanySiret,
+            vatNumber: forwardedIn.nextDestinationCompanyVatNumber,
             address: forwardedIn.nextDestinationCompanyAddress,
             country: forwardedIn.nextDestinationCompanyCountry,
             contact: forwardedIn.nextDestinationCompanyContact,
@@ -653,6 +657,7 @@ export async function expandFormFromDb(form: any): Promise<GraphQLForm> {
           company: nullIfNoValues<FormCompany>({
             name: form.nextDestinationCompanyName,
             siret: form.nextDestinationCompanySiret,
+            vatNumber: form.nextDestinationCompanyVatNumber,
             address: form.nextDestinationCompanyAddress,
             country: form.nextDestinationCompanyCountry,
             contact: form.nextDestinationCompanyContact,

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -378,9 +378,9 @@ describe("mutation.markAsProcessed", () => {
             company: {
               mail: "m@m.fr",
               siret: null,
-              vatNumber: "DE12345678",
-              country: "DE",
-              name: "DE company",
+              vatNumber: "IE9513674T",
+              country: "IE",
+              name: "IE company",
               phone: "0101010101",
               contact: "The famous bot",
               address: "A beautiful place..."
@@ -465,9 +465,9 @@ describe("mutation.markAsProcessed", () => {
             company: {
               mail: "m@m.fr",
               siret: null,
-              vatNumber: "DE12345678",
-              country: "DE",
-              name: "DE company",
+              vatNumber: "IE9513674T",
+              country: "IE",
+              name: "IE company",
               phone: "0101010101",
               contact: "The famous bot",
               address: "A beautiful place..."
@@ -482,8 +482,8 @@ describe("mutation.markAsProcessed", () => {
     });
 
     expect(resultingForm.status).toBe("FOLLOWED_WITH_PNTTD");
-    expect(resultingForm.nextDestinationCompanyVatNumber).toEqual("DE12345678");
-    expect(resultingForm.nextDestinationCompanyCountry).toBe("DE");
+    expect(resultingForm.nextDestinationCompanyVatNumber).toEqual("IE9513674T");
+    expect(resultingForm.nextDestinationCompanyCountry).toBe("IE");
   });
 
   it("should disallow a missing siret for a french next destination", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -480,7 +480,9 @@ describe("mutation.markAsProcessed", () => {
     const resultingForm = await prisma.form.findUnique({
       where: { id: form.id }
     });
+
     expect(resultingForm.status).toBe("FOLLOWED_WITH_PNTTD");
+    expect(resultingForm.nextDestinationCompanyVatNumber).toEqual("DE12345678");
     expect(resultingForm.nextDestinationCompanyCountry).toBe("DE");
   });
 

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -196,6 +196,7 @@ type ProcessedInfo = Pick<
   | "nextDestinationCompanyContact"
   | "nextDestinationCompanyPhone"
   | "nextDestinationCompanyMail"
+  | "nextDestinationCompanyVatNumber"
 >;
 
 // *************************************************************
@@ -1101,6 +1102,14 @@ const withNextDestination = (required: boolean) =>
               )
           : schema.notRequired().nullable();
       }),
+    nextDestinationCompanyVatNumber: yup
+      .string()
+      .ensure()
+      .test(
+        "is-vat",
+        "${path} n'est pas un numéro de TVA intracommunautaire valide",
+        value => !value || isVat(value)
+      ),
     nextDestinationCompanyAddress: yup
       .string()
       .ensure()
@@ -1143,6 +1152,10 @@ const withoutNextDestination = yup.object().shape({
     .ensure()
     .max(0, EXTRANEOUS_NEXT_DESTINATION),
   nextDestinationCompanySiret: yup
+    .string()
+    .ensure()
+    .max(0, EXTRANEOUS_NEXT_DESTINATION),
+  nextDestinationCompanyVatNumber: yup
     .string()
     .ensure()
     .max(0, EXTRANEOUS_NEXT_DESTINATION),

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -271,17 +271,12 @@ export default function MarkAsProcessed({ form }: WorkflowActionProps) {
                   noTraceability: null,
                 }}
                 onSubmit={({ nextDestination, ...values }) => {
-                  const cleanedNextDestination = nextDestination;
-                  if (cleanedNextDestination?.company) {
-                    // clean vatNumber that may have been added by CompanySelector
-                    delete cleanedNextDestination.company["vatNumber"];
-                  }
                   return markAsProcessed({
                     variables: {
                       id: data?.form.id,
                       processedInfo: {
                         ...values,
-                        nextDestination: cleanedNextDestination,
+                        nextDestination,
                       },
                     },
                   });


### PR DESCRIPTION
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-8400)

Source du problème : 
- On n'avait pas pensé à ajouter un champ en base `nextDestinationCompanyVatNumber` lorsqu'on est passé au sélecteur d'entreprise qui permet de sélectionner un numéro de TVA intracom dans la section "Destination ultérieure".
- On a corrigé un problème d'erreur 400 (surement lié à l'absence du champ en base) en virant le `vatNumber` des données qui sont envoyées par le front : https://github.com/MTES-MCT/trackdechets/pull/1699 


