### PR TITLE
Support autoscaling in reindexAllInBulk queueing system

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -133,6 +133,16 @@ BULK_INDEX_BATCH_SIZE=100
 BULK_INDEX_BATCH_ADD=2
 # Bull job worker concurrency setting
 BULK_INDEX_JOB_CONCURRENCY=1
+# Autoscaling bulk index workers
+BULK_INDEX_SCALINGO_CONTAINER_NAME=indexqueue
+BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING=false|true
+# Size containers according to BULK_INDEX_JOB_CONCURRENCY and BULK_INDEX_BATCH_SIZE
+BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP=2XL
+BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN=M
+# Size concurrency according to ElasticSearch cluster RAM and CPU
+BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP=4
+BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN=1
+
 
 # Gotenberg URL
 GOTENBERG_URL=https://gotenberg.service.url
@@ -166,3 +176,8 @@ TRUST_PROXY_HOPS=1
 
 # Nombre maximal de BSDDs initiaux autorisés sur une annexe 2
 BSDD_MAX_APPENDIX2=250
+
+# Scalingo API
+SCALINGO_API_URL=api.osc-secnum-fr1.scalingo.com
+SCALINGO_APP_NAME=trackdechets-recette-api
+SCALINGO_API_TOKEN=mytoken

--- a/.env.model
+++ b/.env.model
@@ -180,4 +180,4 @@ BSDD_MAX_APPENDIX2=250
 # Scalingo API
 SCALINGO_API_URL=api.osc-secnum-fr1.scalingo.com
 SCALINGO_APP_NAME=trackdechets-recette-api
-SCALINGO_API_TOKEN=mytoken
+SCALINGO_TOKEN=mytoken

--- a/back/src/queue/jobs/indexAllBsds.ts
+++ b/back/src/queue/jobs/indexAllBsds.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { Job } from "bull";
 import { BsdIndex } from "../../common/elastic";
 import {
@@ -47,12 +48,87 @@ export async function indexAllInBulk(job: Job<string>) {
     const { index, force }: { index: BsdIndex; force: boolean } = JSON.parse(
       job.data
     );
+    const {
+      SCALINGO_API_URL,
+      SCALINGO_APP_NAME,
+      SCALINGO_API_TOKEN,
+      BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING,
+      BULK_INDEX_SCALINGO_CONTAINER_NAME,
+      BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP,
+      BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN,
+      BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP,
+      BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN
+    } = process.env;
+
+    if (BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING === "true") {
+      // scale-up indexqueue workers
+      try {
+        const resp = await axios({
+          method: "post",
+          url: `https://${SCALINGO_API_URL}/v1/apps/${SCALINGO_APP_NAME}/scale`,
+          data: {
+            containers: [
+              {
+                name: BULK_INDEX_SCALINGO_CONTAINER_NAME,
+                amount:
+                  parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP, 10) || 4,
+                size: BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP || "2XL"
+              }
+            ]
+          },
+          headers: {
+            Authorization: `Bearer ${SCALINGO_API_TOKEN}`
+          }
+        });
+        logger.info(
+          `Scaled-up indexqueue workers to ${BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP} ${BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP}`,
+          resp.data
+        );
+      } catch (e) {
+        logger.error(
+          `Failed to scale-up indexqueue workers, please take a manual action instead`,
+          e
+        );
+      }
+    }
+
     // will index all BSD without downtime, only if need because of a mapping change
     await reindexAllBsdsInBulk({
       index,
       force,
       useQueue: true
     });
+    if (BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING === "true") {
+      // scale-down indexqueue workers
+      try {
+        const resp = await axios({
+          method: "post",
+          url: `https://${SCALINGO_API_URL}/v1/apps/${SCALINGO_APP_NAME}/scale`,
+          data: {
+            containers: [
+              {
+                name: BULK_INDEX_SCALINGO_CONTAINER_NAME,
+                amount:
+                  parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN, 10) || 1,
+                size: BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN || "M"
+              }
+            ]
+          },
+          headers: {
+            Authorization: `Bearer ${SCALINGO_API_TOKEN}`
+          }
+        });
+        logger.info(
+          `Scaled-down indexqueue workers to ${BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN} ${BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN}`,
+          resp.data
+        );
+      } catch (e) {
+        logger.error(
+          `Failed to scale-up indexqueue workers, please take a manual action instead`,
+          e
+        );
+      }
+    }
     return null;
   } catch (error) {
     logger.error(`Error in indexAllInBulk.`, error);

--- a/back/src/queue/jobs/indexAllBsds.ts
+++ b/back/src/queue/jobs/indexAllBsds.ts
@@ -51,7 +51,7 @@ export async function indexAllInBulk(job: Job<string>) {
     const {
       SCALINGO_API_URL,
       SCALINGO_APP_NAME,
-      SCALINGO_API_TOKEN,
+      SCALINGO_TOKEN,
       BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING,
       BULK_INDEX_SCALINGO_CONTAINER_NAME,
       BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP,
@@ -77,7 +77,7 @@ export async function indexAllInBulk(job: Job<string>) {
             ]
           },
           headers: {
-            Authorization: `Bearer ${SCALINGO_API_TOKEN}`
+            Authorization: `Bearer ${SCALINGO_TOKEN}`
           }
         });
         logger.info(
@@ -115,7 +115,7 @@ export async function indexAllInBulk(job: Job<string>) {
             ]
           },
           headers: {
-            Authorization: `Bearer ${SCALINGO_API_TOKEN}`
+            Authorization: `Bearer ${SCALINGO_TOKEN}`
           }
         });
         logger.info(

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -7,20 +7,15 @@ const { REDIS_URL, NODE_ENV } = process.env;
 
 export const INDEX_JOB_NAME = "index";
 export const DELETE_JOB_NAME = "delete";
-
-// Indexation queue. BSD ids are pushed into it when an indexation is needed
-export const indexQueue = new Queue<string>(
-  `queue_index_elastic_${NODE_ENV}`,
-  REDIS_URL,
-  {
-    defaultJobOptions: {
-      attempts: 3,
-      backoff: { type: "fixed", delay: 100 },
-      removeOnComplete: 10_000,
-      timeout: 10000
-    }
+export const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+export const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL, {
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
   }
-);
+});
 
 const INDEX_REFRESH_INTERVAL = 1000;
 // Updates queue, used by the notifier. Items are enqueued once indexation is done

--- a/back/src/scripts/bin/reindexAllInBulk.ts
+++ b/back/src/scripts/bin/reindexAllInBulk.ts
@@ -10,7 +10,7 @@ if (STARTUP_FILE && STARTUP_FILE !== "dist/src/index.js") {
       "Starting reindexAllInBulk with --dev bypassing api deployment protection"
     );
   } else {
-    logger.info(
+    logger.error(
       "Abort reindexAllInBulk: not in a TD api deployment ($STARTUP_FILE is not targeting the api server index.js)"
     );
     process.exit(0);
@@ -46,6 +46,7 @@ async function exitScript() {
       });
     }
   } catch (error) {
+    logger.error("Error in reindexAllInBulk script, exiting", error);
     throw new Error(`Error in reindexAllInBulk script : ${error}`);
   } finally {
     await exitScript();


### PR DESCRIPTION
Permet d'augmenter et gérer automatiquement le nombre et la taille des containers de workers d'index-queue quand certaines vars d'env sont définies 

 - `BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING` => active ou désactive toute la feature d'autoscaling, ce qui permettra de quand même gérer manuellement si besoin

```
BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING=false|true
BULK_INDEX_SCALINGO_CONTAINER_NAME=indexqueue
# Size containers according to BULK_INDEX_JOB_CONCURRENCY and BULK_INDEX_BATCH_SIZE
BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP=2XL
BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN=M
# Size concurrency according to ElasticSearch cluster RAM and CPU
BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP=4
BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN=1
```

- Ce à quoi s'ajoute de nouvelles vars pour l'api scalingo

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/49eefb86636fffca4759b9bd?card=tra-10062)
