### PR TITLE
Support Redis clusters in bull Queue

### DIFF
--- a/back/src/queue/producers/company.ts
+++ b/back/src/queue/producers/company.ts
@@ -8,14 +8,16 @@ const queueNameCompany = QUEUE_NAME_COMPANY || "queue_company";
 export type GeocodeJobData = { siret: string; address?: string };
 export type SetDepartementJobData = { siret: string; codeCommune?: string };
 
+const geocodeCompanyQueueName = `${queueNameCompany}_geocode`;
 /**
  * This queue is used to off load retrieving latitude and longitude info for a company
  */
 export const geocodeCompanyQueue = new Queue(
-  `${queueNameCompany}_geocode`,
+  geocodeCompanyQueueName,
   `${REDIS_URL}`,
 
   {
+    prefix: `{${geocodeCompanyQueueName}}`,
     // prevent hitting api-adresse.data.gouv.fr limit
     limiter: {
       max: 15,
@@ -30,10 +32,13 @@ export const geocodeCompanyQueue = new Queue(
 /**
  * This queue is used to off load retrieving departement info for a company
  */
+
+const setCompanyDepartementQueueName = `${queueNameCompany}_set_departement`;
 export const setCompanyDepartementQueue = new Queue(
-  `${queueNameCompany}_set_departement`,
+  setCompanyDepartementQueueName,
   `${REDIS_URL}`,
   {
+    prefix: `{${setCompanyDepartementQueueName}}`,
     // prevent hitting geo.api.gouv.fr limit
     limiter: {
       max: 2,

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -8,24 +8,25 @@ const { REDIS_URL, NODE_ENV } = process.env;
 export const INDEX_JOB_NAME = "index";
 export const DELETE_JOB_NAME = "delete";
 
-export const indexQueue = new Queue<string>(
-  `queue_index_elastic_${NODE_ENV}`,
-  REDIS_URL,
-  {
-    defaultJobOptions: {
-      attempts: 3,
-      backoff: { type: "fixed", delay: 100 },
-      removeOnComplete: 10_000,
-      timeout: 10000
-    }
+const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+
+export const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL, {
+  prefix: `{${INDEX_QUEUE_NAME}}`,
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
   }
-);
+});
 
 const INDEX_REFRESH_INTERVAL = 1000;
+const updatesQueueName = `queue_updates_elastic_${NODE_ENV}`;
 export const updatesQueue = new Queue<BsdUpdateQueueItem>(
-  `queue_updates_elastic_${NODE_ENV}`,
+  updatesQueueName,
   REDIS_URL,
   {
+    prefix: `{${updatesQueueName}}`,
     defaultJobOptions: {
       delay: INDEX_REFRESH_INTERVAL, // We delay processing to make sure updates have been refreshed in ES
       removeOnComplete: 100

--- a/back/src/queue/producers/mail.ts
+++ b/back/src/queue/producers/mail.ts
@@ -8,6 +8,7 @@ const { REDIS_URL, QUEUE_NAME_SENDMAIL } = process.env;
  * Connect to mailQueue once for the server
  */
 export const mailQueue = new Queue(`${QUEUE_NAME_SENDMAIL}`, `${REDIS_URL}`, {
+  prefix: `{${QUEUE_NAME_SENDMAIL}}`,
   defaultJobOptions: {
     removeOnComplete: 10_000
   },


### PR DESCRIPTION
# Redis cluster fur bull queues

Bull internals require atomic operations that span different keys. This behavior breaks Redis's rules for cluster configurations. However, it is still possible to use a cluster environment by using the proper bull prefix option as a cluster "hash tag". Hash tags are used to guarantee that certain keys are placed in the same hash slot, read more about hash tags in the [redis cluster tutorial](https://redis.io/topics/cluster-tutorial). A hash tag is defined with brackets. I.e. a key that has a substring inside brackets will use that substring to determine in which hash slot the key will be placed.

In summary, to make bull compatible with Redis cluster, use a queue prefix inside brackets. For example:
```
const queue = new Queue('cluster', {
  prefix: '{myprefix}'
});
```

If you use several queues in the same cluster, you should use different prefixes so that the queues are evenly placed in the cluster nodes.

source : https://github.com/OptimalBits/bull/blob/b6d530f72a774be0fd4936ddb4ad9df3b183f4b6/PATTERNS.md#redis-cluster

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/49eefb86636fffca4759b9bd?card=tra-8110)
