### PR TITLE
Perfs/Appendix 2 

### DIFF
--- a/back/prisma/migrations/93_delete_form_quantity_grouped.sql
+++ b/back/prisma/migrations/93_delete_form_quantity_grouped.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "default$default"."Form"
+    DROP COLUMN IF EXISTS "quantityGrouped";

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -383,8 +383,6 @@ model Form {
   transportSegments TransportSegment[]
   groupedIn         FormGroupement[]   @relation("GroupedIn")
   grouping          FormGroupement[]   @relation("Grouping")
-  // quantité affectée à des bordereaux de regroupement
-  quantityGrouped   Float              @default(0)
 
   ownerId              String
   owner                User                          @relation(fields: [ownerId], references: [id])

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -101,7 +101,7 @@ describe("expandFormFromDb", () => {
       signedAt: null,
       quantityReceived: null,
       processingOperationDone: null,
-      quantityGrouped: 0,
+      quantityGrouped: null,
       processingOperationDescription: null,
       processedBy: null,
       processedAt: null,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -624,7 +624,7 @@ export async function expandFormFromDb(form: any): Promise<GraphQLForm> {
     quantityReceived: forwardedIn
       ? forwardedIn.quantityReceived
       : form.quantityReceived,
-    quantityGrouped: form.quantityGrouped,
+    quantityGrouped: null,
     processingOperationDone: forwardedIn
       ? forwardedIn.processingOperationDone
       : form.processingOperationDone,

--- a/back/src/forms/dataloader.ts
+++ b/back/src/forms/dataloader.ts
@@ -1,0 +1,51 @@
+import { FormGroupement } from "@prisma/client";
+import DataLoader from "dataloader";
+import prisma from "../prisma";
+
+export function createFormDataLoaders() {
+  return {
+    forwardedIns: new DataLoader((formIds: string[]) =>
+      getForwardedIns(formIds)
+    ),
+    formGoupements: new DataLoader((formIds: string[]) =>
+      getFormGroupements(formIds)
+    )
+  };
+}
+
+async function getForwardedIns(formIds: string[]) {
+  const initialForms = await prisma.form.findMany({
+    where: {
+      id: { in: formIds }
+    },
+    include: { forwardedIn: true }
+  });
+
+  return formIds.map(
+    formId =>
+      initialForms.find(initialForm => initialForm.id === formId).forwardedIn ??
+      null
+  );
+}
+
+async function getFormGroupements(formIds: string[]) {
+  const groupements = await prisma.formGroupement.findMany({
+    where: {
+      initialFormId: { in: formIds }
+    }
+  });
+
+  const groupementsGroupedByInitialFormId: { [id: string]: FormGroupement[] } =
+    formIds.reduce((prev, cur) => {
+      prev[cur] = [];
+      return prev;
+    }, {});
+
+  for (const groupement of groupements) {
+    groupementsGroupedByInitialFormId[groupement.initialFormId].push(
+      groupement
+    );
+  }
+
+  return formIds.map(formId => groupementsGroupedByInitialFormId[formId]);
+}

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -3,103 +3,105 @@ import { Decimal } from "decimal.js-light";
 import { RepositoryFnDeps } from "../../../common/repository/types";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
-import buildUpdateForm from "./update";
+import buildUpdateManyForms from "./updateMany";
 
-export type UpdateAppendix2Forms = (forms: Form[]) => Promise<Form[]>;
+export type UpdateAppendix2Forms = (forms: Form[]) => Promise<void>;
 
 const buildUpdateAppendix2Forms: (
   deps: RepositoryFnDeps
 ) => UpdateAppendix2Forms = deps => async forms => {
   const { user, prisma } = deps;
-  const updateForm = buildUpdateForm({ prisma, user });
+  const updateManyForms = buildUpdateManyForms({ prisma, user });
 
-  return Promise.all(
-    forms.map(async form => {
-      if (
-        ![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)
-      ) {
-        return form;
-      }
-      const { id, quantityReceived } = form;
+  const formIds = forms.map(form => form.id);
+  const formGroupements = await prisma.formGroupement.findMany({
+    where: { initialFormId: { in: formIds } },
+    include: { nextForm: { select: { status: true } } }
+  });
 
-      const quantityGrouped = new Decimal(
-        (
-          await prisma.formGroupement.aggregate({
-            _sum: { quantity: true },
-            where: { initialFormId: id }
-          })
-        )._sum.quantity ?? 0
-      ).toDecimalPlaces(6); // set precision to gramme
+  const formUpdatesByStatus = new Map<Status, string[]>();
+  for (const form of forms) {
+    if (![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)) {
+      continue;
+    }
+    const { id, quantityReceived } = form;
 
-      const groupementForms = (
-        await prisma.formGroupement.findMany({
-          where: { initialFormId: id },
-          include: { nextForm: { select: { status: true } } }
-        })
-      ).map(g => g.nextForm);
+    const quantityGrouped = new Decimal(
+      formGroupements
+        .filter(grp => grp.initialFormId === id)
+        .map(grp => grp.quantity)
+        .reduce((prev, cur) => prev + cur, 0) ?? 0
+    ).toDecimalPlaces(6); // set precision to gramme
 
-      const groupedInTotality =
-        quantityGrouped.greaterThanOrEqualTo(quantityReceived); // case > should not happen
+    const groupementForms = formGroupements
+      .filter(grp => grp.initialFormId === id)
+      .map(g => g.nextForm);
 
-      const allSealed =
-        groupementForms.length &&
-        groupedInTotality &&
-        groupementForms.reduce(
-          (acc, form) => acc && form.status !== Status.DRAFT,
-          true
-        );
+    const groupedInTotality =
+      quantityGrouped.greaterThanOrEqualTo(quantityReceived); // case > should not happen
 
-      const allProcessed =
-        groupementForms.length &&
-        groupedInTotality &&
-        groupementForms.reduce(
-          (acc, form) =>
-            acc &&
-            [
-              Status.PROCESSED,
-              Status.NO_TRACEABILITY,
-              Status.FOLLOWED_WITH_PNTTD
-            ].includes(form.status as any),
-          true
-        );
+    const allSealed =
+      groupementForms.length &&
+      groupedInTotality &&
+      groupementForms.reduce(
+        (acc, form) => acc && form.status !== Status.DRAFT,
+        true
+      );
 
-      const nextStatus = allProcessed
-        ? Status.PROCESSED
-        : allSealed
-        ? Status.GROUPED
-        : Status.AWAITING_GROUP;
+    const allProcessed =
+      groupementForms.length &&
+      groupedInTotality &&
+      groupementForms.reduce(
+        (acc, form) =>
+          acc &&
+          [
+            Status.PROCESSED,
+            Status.NO_TRACEABILITY,
+            Status.FOLLOWED_WITH_PNTTD
+          ].includes(form.status as any),
+        true
+      );
 
-      if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
-        return updateForm(
-          { id },
-          {
-            status: transitionForm(form, {
-              type: EventType.MarkAsProcessed
-            })
-          }
-        );
-      } else if (
-        form.status === Status.AWAITING_GROUP &&
-        nextStatus === Status.GROUPED
-      ) {
-        return updateForm(
-          { id },
-          {
-            status: transitionForm(form, {
-              type: EventType.MarkAsGrouped,
-              formUpdateInput: { quantityGrouped: quantityGrouped.toNumber() }
-            }),
-            quantityGrouped: quantityGrouped.toNumber()
-          }
-        );
-      } else {
-        return updateForm(
-          { id },
-          { status: nextStatus, quantityGrouped: quantityGrouped.toNumber() }
-        );
-      }
-    })
-  );
+    const nextStatus = allProcessed
+      ? Status.PROCESSED
+      : allSealed
+      ? Status.GROUPED
+      : Status.AWAITING_GROUP;
+
+    if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
+      const status = transitionForm(form, {
+        type: EventType.MarkAsProcessed
+      });
+
+      formUpdatesByStatus.set(status, [
+        ...(formUpdatesByStatus.get(status) ?? []),
+        id
+      ]);
+    } else if (
+      form.status === Status.AWAITING_GROUP &&
+      nextStatus === Status.GROUPED
+    ) {
+      const status = transitionForm(form, {
+        type: EventType.MarkAsGrouped
+      });
+      formUpdatesByStatus.set(status, [
+        ...(formUpdatesByStatus.get(status) ?? []),
+        id
+      ]);
+    } else {
+      formUpdatesByStatus.set(nextStatus, [
+        ...(formUpdatesByStatus.get(nextStatus) ?? []),
+        id
+      ]);
+    }
+  }
+
+  const promises = [];
+  for (const [status, ids] of formUpdatesByStatus.entries()) {
+    promises.push(updateManyForms(ids, { status }));
+  }
+
+  await Promise.all(promises);
 };
 
 export default buildUpdateAppendix2Forms;

--- a/back/src/forms/repository/form/updateMany.ts
+++ b/back/src/forms/repository/form/updateMany.ts
@@ -22,17 +22,15 @@ const buildUpdateManyForms: (deps: RepositoryFnDeps) => UpdateManyFormFn =
       data
     });
 
-    for (const id of ids) {
-      await prisma.event.create({
-        data: {
-          streamId: id,
-          actor: user.id,
-          type: "BsddUpdated",
-          data: { content: data } as Prisma.InputJsonObject,
-          metadata: { ...logMetadata, authType: user.auth }
-        }
-      });
-    }
+    await prisma.event.createMany({
+      data: ids.map(id => ({
+        streamId: id,
+        actor: user.id,
+        type: "BsddUpdated",
+        data: { content: data } as Prisma.InputJsonObject,
+        metadata: { ...logMetadata, authType: user.auth }
+      }))
+    });
 
     await Promise.all(
       ids.map(async id => {

--- a/back/src/forms/resolvers/Appendix2Form.ts
+++ b/back/src/forms/resolvers/Appendix2Form.ts
@@ -1,6 +1,7 @@
 import { Appendix2FormResolvers } from "../../generated/graphql/types";
 import prisma from "../../prisma";
 import { isFormContributor } from "../permissions";
+import quantityGrouped from "./forms/quantityGrouped";
 
 const appendix2FormResolvers: Appendix2FormResolvers = {
   emitter: async (parent, _, { user }) => {
@@ -9,7 +10,8 @@ const appendix2FormResolvers: Appendix2FormResolvers = {
       return null;
     }
     return parent.emitter;
-  }
+  },
+  quantityGrouped
 };
 
 export default appendix2FormResolvers;

--- a/back/src/forms/resolvers/Form.ts
+++ b/back/src/forms/resolvers/Form.ts
@@ -5,6 +5,7 @@ import transportSegments from "./forms/transportSegments";
 import groupedIn from "./forms/groupedIn";
 import grouping from "./forms/grouping";
 import intermediaries from "./forms/intermediary";
+import quantityGrouped from "./forms/quantityGrouped";
 
 const formResolvers: FormResolvers = {
   appendix2Forms,
@@ -13,7 +14,8 @@ const formResolvers: FormResolvers = {
   transportSegments,
   groupedIn,
   grouping,
-  intermediaries
+  intermediaries,
+  quantityGrouped
 };
 
 export default formResolvers;

--- a/back/src/forms/resolvers/forms/appendix2Forms.ts
+++ b/back/src/forms/resolvers/forms/appendix2Forms.ts
@@ -5,11 +5,13 @@ import { getFormRepository } from "../../repository";
 const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async (
   form,
   _,
-  { user }
+  { user, dataloaders }
 ) => {
   const { findAppendix2FormsById } = getFormRepository(user);
   const appendix2Forms = await findAppendix2FormsById(form.id);
-  return appendix2Forms.map(expandAppendix2FormFromDb);
+  return appendix2Forms.map(form =>
+    expandAppendix2FormFromDb(form, dataloaders.forwardedIns)
+  );
 };
 
 export default appendix2FormsResolver;

--- a/back/src/forms/resolvers/forms/grouping.ts
+++ b/back/src/forms/resolvers/forms/grouping.ts
@@ -14,7 +14,10 @@ const groupingResolver: FormResolvers["grouping"] = async (
   return Promise.all(
     formGroupements.map(async ({ quantity, initialForm }) => ({
       quantity,
-      form: await expandAppendix2FormFromDb(initialForm, context.dataloaders.forwardedIns)
+      form: await expandAppendix2FormFromDb(
+        initialForm,
+        context.dataloaders.forwardedIns
+      )
     }))
   );
 };

--- a/back/src/forms/resolvers/forms/grouping.ts
+++ b/back/src/forms/resolvers/forms/grouping.ts
@@ -2,7 +2,11 @@ import { FormResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
 import { expandAppendix2FormFromDb } from "../../converter";
 
-const groupingResolver: FormResolvers["grouping"] = async form => {
+const groupingResolver: FormResolvers["grouping"] = async (
+  form,
+  _,
+  context
+) => {
   const formGroupements = await prisma.formGroupement.findMany({
     where: { nextFormId: form.id },
     include: { initialForm: true }
@@ -10,7 +14,7 @@ const groupingResolver: FormResolvers["grouping"] = async form => {
   return Promise.all(
     formGroupements.map(async ({ quantity, initialForm }) => ({
       quantity,
-      form: await expandAppendix2FormFromDb(initialForm)
+      form: await expandAppendix2FormFromDb(initialForm, context.dataloaders.forwardedIns)
     }))
   );
 };

--- a/back/src/forms/resolvers/forms/quantityGrouped.ts
+++ b/back/src/forms/resolvers/forms/quantityGrouped.ts
@@ -1,12 +1,13 @@
 import { FormResolvers } from "../../../generated/graphql/types";
-import prisma from "../../../prisma";
 
-const quantityGrouped: FormResolvers["quantityGrouped"] = async form => {
-  const formGroupements = await prisma.form
-    .findUnique({
-      where: { id: form.id }
-    })
-    .groupedIn();
+const quantityGrouped: FormResolvers["quantityGrouped"] = async (
+  form,
+  _,
+  context
+) => {
+  const formGroupements = await context.dataloaders.formGoupements.load(
+    form.id
+  );
 
   if (formGroupements) {
     return formGroupements

--- a/back/src/forms/resolvers/forms/quantityGrouped.ts
+++ b/back/src/forms/resolvers/forms/quantityGrouped.ts
@@ -1,10 +1,11 @@
-import { FormResolvers } from "../../../generated/graphql/types";
+import { Decimal } from "decimal.js-light";
+import { GraphQLContext } from "../../../types";
 
-const quantityGrouped: FormResolvers["quantityGrouped"] = async (
-  form,
+export default async function quantityGrouped(
+  form: { id: string },
   _,
-  context
-) => {
+  context: GraphQLContext
+) {
   const formGroupements = await context.dataloaders.formGoupements.load(
     form.id
   );
@@ -12,9 +13,9 @@ const quantityGrouped: FormResolvers["quantityGrouped"] = async (
   if (formGroupements) {
     return formGroupements
       .map(grp => grp.quantity)
-      .reduce((prev, cur) => prev + cur, 0);
+      .reduce((prev, cur) => prev.add(cur), new Decimal(0))
+      .toNumber();
   }
-  return null;
-};
 
-export default quantityGrouped;
+  return null;
+}

--- a/back/src/forms/resolvers/forms/quantityGrouped.ts
+++ b/back/src/forms/resolvers/forms/quantityGrouped.ts
@@ -1,0 +1,19 @@
+import { FormResolvers } from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+
+const quantityGrouped: FormResolvers["quantityGrouped"] = async form => {
+  const formGroupements = await prisma.form
+    .findUnique({
+      where: { id: form.id }
+    })
+    .groupedIn();
+
+  if (formGroupements) {
+    return formGroupements
+      .map(grp => grp.quantity)
+      .reduce((prev, cur) => prev + cur, 0);
+  }
+  return null;
+};
+
+export default quantityGrouped;

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -947,12 +947,6 @@ describe("Mutation.createForm", () => {
     expect(groupementForm2.grouping).toEqual([
       { form: { id: initialForm.id }, quantity: 0.5 }
     ]);
-
-    const updatedInitialForm = await prisma.form.findUnique({
-      where: { id: initialForm.id }
-    });
-
-    expect(updatedInitialForm.quantityGrouped).toEqual(1);
   });
 
   it("should fail when adding the same form twice to the same groupement form", async () => {
@@ -1350,8 +1344,7 @@ describe("Mutation.createForm", () => {
       opt: {
         status: Status.AWAITING_GROUP,
         recipientCompanySiret: ttr.siret,
-        quantityReceived: 1,
-        quantityGrouped: 0.2
+        quantityReceived: 1
       }
     });
 
@@ -1390,14 +1383,30 @@ describe("Mutation.createForm", () => {
         form: expect.objectContaining({ id: appendix2.id })
       })
     ]);
+  });
 
-    const updatedAppendix2 = await prisma.form.findUnique({
-      where: { id: appendix2.id }
+  it("should not be possible to add more than 250 BSDDs on appendix2", async () => {
+    const { user, company: ttr } = await userWithCompanyFactory("MEMBER");
+    const createFormInput: CreateFormInput = {
+      emitter: {
+        type: "APPENDIX2",
+        company: {
+          siret: ttr.siret
+        }
+      },
+      grouping: Array.from(Array(300).keys()).map(n => ({
+        form: { id: `id_${n}` }
+      }))
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createForm">>(CREATE_FORM, {
+      variables: { createFormInput }
     });
-
-    expect(updatedAppendix2.quantityGrouped).toEqual(
-      updatedAppendix2.quantityReceived
-    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: `Vous ne pouvez pas regrouper plus de 250 BSDDs initiaux`
+      })
+    ]);
   });
 
   it("should set isDangerous to `true` when specifying a waste code ending with *", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
@@ -200,7 +200,6 @@ describe("Mutation.deleteForm", () => {
     });
     expect(disconnectedAppendix2.groupedIn).toEqual([]);
     expect(disconnectedAppendix2.status).toEqual("AWAITING_GROUP");
-    expect(disconnectedAppendix2.quantityGrouped).toEqual(0);
   });
 
   it("should delete bsd suite", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
@@ -177,7 +177,7 @@ describe("Mutation.deleteForm", () => {
 
     await prisma.form.update({
       where: { id: appendix2.id },
-      data: { status: "GROUPED", quantityGrouped: appendix2.quantityReceived }
+      data: { status: "GROUPED" }
     });
 
     const { mutate } = makeClient(ttrUser);

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -1667,8 +1667,7 @@ describe("Mutation.updateForm", () => {
       opt: {
         status: "AWAITING_GROUP",
         recipientCompanySiret: ttr.siret,
-        quantityReceived: 1,
-        quantityGrouped: 0.2
+        quantityReceived: 1
       }
     });
 

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -1708,14 +1708,6 @@ describe("Mutation.updateForm", () => {
     expect(data.updateForm.grouping).toEqual([
       expect.objectContaining({ form: { id: appendix2Form.id }, quantity: 0.8 })
     ]);
-
-    const updatedAppendix2Form = await prisma.form.findFirst({
-      where: { id: appendix2Form.id }
-    });
-
-    expect(updatedAppendix2Form.quantityGrouped).toEqual(
-      updatedAppendix2Form.quantityReceived
-    );
   });
 
   it("should not be possible to set isDangerous=false with a waste code containing an *", async () => {

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -40,7 +40,6 @@ function getDuplicateFormInput(
     signedAt,
     signedBy,
     quantityReceived,
-    quantityGrouped,
     processedBy,
     processedAt,
     processingOperationDone,

--- a/back/src/forms/resolvers/queries/__tests__/appendixforms.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/appendixforms.integration.ts
@@ -78,8 +78,7 @@ describe("Test appendixForms", () => {
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: ttrCompany.siret,
         status: "AWAITING_GROUP",
-        quantityReceived: 1,
-        quantityGrouped: 1
+        quantityReceived: 1
       }
     });
 
@@ -109,8 +108,7 @@ describe("Test appendixForms", () => {
         emitterCompanySiret: emitterCompany.siret,
         recipientCompanySiret: ttrCompany.siret,
         status: "AWAITING_GROUP",
-        quantityReceived: 1,
-        quantityGrouped: 0.5
+        quantityReceived: 1
       }
     });
 

--- a/back/src/forms/resolvers/queries/appendixForms.ts
+++ b/back/src/forms/resolvers/queries/appendixForms.ts
@@ -30,16 +30,25 @@ const appendixFormsResolver: QueryResolvers["appendixForms"] = async (
         { isDeleted: false },
         { forwarding: null }
       ]
+    },
+    include: {
+      groupedIn: true
     }
   });
 
   return Promise.all(
     queriedForms
-      .filter(
-        f =>
+      .filter(f => {
+        const quantityGrouped = f.groupedIn.reduce(
+          (sum, grp) => sum.add(grp.quantity),
+          new Decimal(0)
+        );
+
+        return (
           f.quantityReceived > 0 &&
-          new Decimal(f.quantityReceived).greaterThan(f.quantityGrouped)
-      )
+          new Decimal(f.quantityReceived).greaterThan(quantityGrouped)
+        );
+      })
       .map(f => expandFormFromDb(f))
   );
 };

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -30,6 +30,7 @@ import sentryReporter from "./common/plugins/sentryReporter";
 import { redisClient } from "./common/redis";
 import { initSentry } from "./common/sentry";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
+import { createFormDataLoaders } from "./forms/dataloader";
 import { bullBoardPath, serverAdapter } from "./queue/bull-board";
 import { authRouter } from "./routers/auth-router";
 import { downloadRouter } from "./routers/downloadRouter";
@@ -72,7 +73,11 @@ export const server = new ApolloServer({
       ...ctx,
       // req.user is made available by passport
       user: ctx.req?.user ?? null,
-      dataloaders: { ...createUserDataLoaders(), ...createCompanyDataLoaders() }
+      dataloaders: {
+        ...createUserDataLoaders(),
+        ...createCompanyDataLoaders(),
+        ...createFormDataLoaders()
+      }
     };
   },
   formatError: err => {

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -1,10 +1,12 @@
 import { ExpressContext } from "apollo-server-express/dist/ApolloServer";
 import { GqlInfo } from "./common/middlewares/graphqlQueryParser";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
+import { createFormDataLoaders } from "./forms/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 
 export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
-  ReturnType<typeof createCompanyDataLoaders>;
+  ReturnType<typeof createCompanyDataLoaders> &
+  ReturnType<typeof createFormDataLoaders>;
 
 export type GraphQLContext = ExpressContext & {
   user: Express.User | null;


### PR DESCRIPTION
Reprise de [la PR sur les perfs pour l'annexe 2](https://github.com/MTES-MCT/trackdechets/pull/1748), avec correction des problèmes détectés (mauvais affichage des quantités sur l'UI) et suppression de la colonne `quantityGrouped` sur la table `Form`.
En local j'ai pu créer une annexe 2 avec 1000 bordereaux annexés sans problème. Je n'ai pas essayé plus donc je ne connais pas la limite théorique.

Je n'ai pas de flame graph à montrer en local, car DD n'est pas pluggé dessus. 
Il y aura probablement des améliorations encore possibles. Mais ca semble mettre un vrai coup de boost aux perfs pour cette mutation. Et ca renormalise le schéma sql par la même occasion.

A bien recetter tout de même.