### PR TITLE
FIX/BSDDs fantômes

### DIFF
--- a/back/src/forms/repository/form/create.ts
+++ b/back/src/forms/repository/form/create.ts
@@ -3,9 +3,7 @@ import {
   LogMetadata,
   RepositoryFnDeps
 } from "../../../common/repository/types";
-import { GraphQLContext } from "../../../types";
-import { indexForm } from "../../elastic";
-import buildFindFullFormById from "./findFullFormById";
+import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
 
 export type CreateFormFn = (
   data: Prisma.FormCreateInput,
@@ -39,8 +37,7 @@ const buildCreateForm: (deps: RepositoryFnDeps) => CreateFormFn =
       }
     });
 
-    const fullForm = await buildFindFullFormById(deps)(form.id);
-    await indexForm(fullForm, { user } as GraphQLContext);
+    prisma.addAfterCommitCallback(() => enqueueBsdToIndex(form.readableId));
 
     return form;
   };


### PR DESCRIPTION
Migration des appels d'indexation synchrones restants vers du async. On a encore des cas de fantomes à cause de ça.