### PR TITLE
HotFix exit reindex scripts

### DIFF
--- a/back/package.json
+++ b/back/package.json
@@ -15,7 +15,7 @@
     "migrate:dev": "ts-node -r dotenv/config prisma/migrate.ts",
     "check:migrations": "pg-validate-migrations ./prisma/migrations",
     "test": "jest",
-    "preintegration-tests": "prisma db push && npm run generate:graphql && npm run reindex-all-bsds-bulk:dev -- --dev",
+    "preintegration-tests": "prisma db push && npm run generate:graphql && npm run reindex-all-bsds-bulk:dev",
     "integration-tests": "jest --config ./integration-tests/jest.config.js -i --forceExit",
     "types": "tsc --noEmit",
     "generate": "npm run generate:prisma && npm run generate:graphql",

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -428,14 +428,16 @@ export async function reindexAllBsdsInBulk({
 export async function addReindexAllInBulkJob(
   force: boolean
 ): Promise<Job<string>> {
-  logger.info(`Enqueuing indexation of all bsds in bulk without downtime`);
+  logger.info(
+    `Enqueuing job indexAllInBulk for the indexation of all bsds in bulk without downtime`
+  );
   // default options can be overwritten by the calling function
   const jobOptions: JobOptions = {
     lifo: true,
     attempts: 1,
     timeout: 36_000_000 // 10h
   };
-  return indexQueue.add(
+  const job = await indexQueue.add(
     "indexAllInBulk",
     JSON.stringify({
       index: defaultIndexConfig,
@@ -443,6 +445,11 @@ export async function addReindexAllInBulkJob(
     }),
     jobOptions
   );
+  const isActive = await job.isActive();
+  logger.info(
+    `Done enqueuing job indexAllInBulk: Job ${job.id}, is currently active ? ${isActive}`
+  );
+  return job;
 }
 
 /**

--- a/back/src/logging/logger.ts
+++ b/back/src/logging/logger.ts
@@ -18,9 +18,7 @@ const logger = createLogger({
   exitOnError: false,
   format: format.combine(format.errors({ stack: true }), format.json()),
   transports: [
-    !LOG_TO_CONSOLE && !LOG_TO_HTTP
-      ? new transports.File({ filename: LOG_PATH })
-      : LOG_TO_CONSOLE
+    LOG_TO_CONSOLE
       ? new transports.Console({
           // Simple `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
           format: format.simple()

--- a/back/src/queue/producers/index.ts
+++ b/back/src/queue/producers/index.ts
@@ -1,6 +1,11 @@
+import { closeCompanyQueues } from "./company";
 import { closeIndexAndUpdatesQueue } from "./elastic";
 import { closeMailQueue } from "./mail";
 
 export function closeQueues() {
-  return Promise.all([closeIndexAndUpdatesQueue(), closeMailQueue()]);
+  return Promise.all([
+    closeIndexAndUpdatesQueue(),
+    closeMailQueue(),
+    closeCompanyQueues()
+  ]);
 }

--- a/back/src/scripts/bin/reindexAllInBulk.ts
+++ b/back/src/scripts/bin/reindexAllInBulk.ts
@@ -28,7 +28,6 @@ async function exitScript() {
   logger.info("Done reindexAllInBulk script, exiting");
   await prisma.$disconnect();
   await closeQueues();
-  process.exit(0);
 }
 
 (async function () {

--- a/back/src/scripts/bin/reindexAllInBulk.ts
+++ b/back/src/scripts/bin/reindexAllInBulk.ts
@@ -28,6 +28,7 @@ async function exitScript() {
   logger.info("Done reindexAllInBulk script, exiting");
   await prisma.$disconnect();
   await closeQueues();
+  process.exit(0);
 }
 
 (async function () {
@@ -37,14 +38,13 @@ async function exitScript() {
     const useQueue = process.argv.includes("--useQueue");
     if (useQueue) {
       await addReindexAllInBulkJob(force);
-      await exitScript();
-      return;
+    } else {
+      // will index all BSD without downtime, only if need because of a mapping change
+      await reindexAllBsdsInBulk({
+        force,
+        useQueue: false
+      });
     }
-    // will index all BSD without downtime, only if need because of a mapping change
-    await reindexAllBsdsInBulk({
-      force,
-      useQueue: false
-    });
   } catch (error) {
     throw new Error(`Error in reindexAllInBulk script : ${error}`);
   } finally {

--- a/back/src/scripts/bin/reindexPartialInPlace.ts
+++ b/back/src/scripts/bin/reindexPartialInPlace.ts
@@ -13,6 +13,7 @@ async function exitScript() {
   logger.info("Finished reindex-partial-in-place script, exiting");
   await prisma.$disconnect();
   await closeQueues();
+  process.exit(0);
 }
 
 (async function () {
@@ -42,7 +43,6 @@ async function exitScript() {
   try {
     if (bsdTypesToIndex.length > 1) {
       logger.info("You can only specify one bsd type to index");
-      await exitScript();
       return;
     }
 
@@ -52,7 +52,6 @@ async function exitScript() {
       logger.info(
         "You can target whether one bsd type OR a date '--since YYYY-MM-DD' to target the re-indexation in place"
       );
-      await exitScript();
       return;
     }
     if (force) {
@@ -60,7 +59,6 @@ async function exitScript() {
         logger.info(
           "You can only force delete existing bsd when passing a BSD type as a command argument"
         );
-        await exitScript();
         return;
       }
       await prompts({
@@ -81,6 +79,7 @@ async function exitScript() {
   } catch (error) {
     logger.info("reindex-partial-in-place failed, error:", error);
   } finally {
+    logger.info("Finished reindex-partial-in-place script, exiting");
     await exitScript();
   }
 })();


### PR DESCRIPTION
- Simplifie logger options
- Clean package.json
- ajout process.exit() dans scripts de reindexation
  - code testé sur scalingo en one-off en copiant le diff localement, et j'ai eu une réindexation OK, et le script rend la main

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
