### PR TITLE
BSDA / Vide le worker

### DIFF
--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -63,6 +63,10 @@ export function Worker({ disabled }) {
               handleChange(e);
               setFieldValue("worker.company.name", null);
               setFieldValue("worker.company.siret", null);
+              setFieldValue("worker.company.contact", null);
+              setFieldValue("worker.company.address", null);
+              setFieldValue("worker.company.mail", null);
+              setFieldValue("worker.company.phone", null);
             }}
           />
           Il n'y a pas d'entreprise de travaux


### PR DESCRIPTION
Quand on enlève le worker d'un bsda, il faut vider tous les champs

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9315)
