### PR TITLE
FIX Mongo

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -40,7 +40,7 @@ PRISMA_TRANSACTION_TIMEOUT=5000
 REDIS_URL=redis://user:password@some-redis-service.com:1234/
 
 # Mongodb configuration
-MONGO_URL=mongodb://USER:PWD@HOST:PORT/DB_NAME
+MONGO_URL=mongodb://USER:PWD@HOST:PORT/EXISTING_DB_NAME_OR_EMPTY_FOR_DEFAULT
 
 # Developement only
 # On Linux:

--- a/.env.model
+++ b/.env.model
@@ -40,7 +40,7 @@ PRISMA_TRANSACTION_TIMEOUT=5000
 REDIS_URL=redis://user:password@some-redis-service.com:1234/
 
 # Mongodb configuration
-MONGODB_URL=mongodb://USER:PWD@HOST:PORT
+MONGO_URL=mongodb://USER:PWD@HOST:PORT/DB_NAME
 
 # Developement only
 # On Linux:

--- a/back/integration-tests/.integration-tests-env
+++ b/back/integration-tests/.integration-tests-env
@@ -1,7 +1,7 @@
 NODE_ENV=test
 DATABASE_URL=postgresql://test:no_pass@postgres:5432/prisma?schema=default$default
 REDIS_URL=redis://redis:6379
-MONGODB_URL=mongodb://test:no_pass@mongodb:27017
+MONGO_URL=mongodb://test:no_pass@mongodb:27017/td_events
 SESSION_SECRET=any_secret
 API_TOKEN_SECRET=any_secret
 API_HOST=api.trackdechets.local

--- a/back/integration-tests/.integration-tests-env
+++ b/back/integration-tests/.integration-tests-env
@@ -1,7 +1,7 @@
 NODE_ENV=test
 DATABASE_URL=postgresql://test:no_pass@postgres:5432/prisma?schema=default$default
 REDIS_URL=redis://redis:6379
-MONGO_URL=mongodb://test:no_pass@mongodb:27017/td_events
+MONGO_URL=mongodb://test:no_pass@mongodb:27017
 SESSION_SECRET=any_secret
 API_TOKEN_SECRET=any_secret
 API_HOST=api.trackdechets.local

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -4,14 +4,13 @@ import { EventCollection } from "./types";
 import { WriteErrors } from "./writeErrors";
 import logger from "../logging/logger";
 
-const { MONGODB_URL } = process.env;
+const { MONGO_URL } = process.env;
 
-const DB_NAME = "td_events";
 const EVENTS_COLLECTION = "events";
 
-export const mongodbClient = new MongoClient(MONGODB_URL);
+export const mongodbClient = new MongoClient(MONGO_URL);
 
-const database = mongodbClient.db(DB_NAME);
+const database = mongodbClient.db();
 const eventsCollection =
   database.collection<EventCollection>(EVENTS_COLLECTION);
 

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -8,7 +8,7 @@ const { MONGO_URL } = process.env;
 
 const EVENTS_COLLECTION = "events";
 
-export const mongodbClient = new MongoClient(MONGO_URL);
+const mongodbClient = new MongoClient(MONGO_URL);
 
 const database = mongodbClient.db();
 const eventsCollection =


### PR DESCRIPTION
Corrections Mongo:
- par défaut Scalingo crée une variable `MONGO_URL` et non `MONGODB_URL`. C'est donc plus simple d'utiliser leur naming
- il crée également une DB par défaut, et on n'a pas les droits sur les autres dbs. Donc on utilise leur DB à eux, passée dans la connection string.

2 modifs à faire en local donc:
- changer MONGODB_URL en MONGO_URL
- ajouter une db. Le nom configuré en local était `db_events`. Je vous suggère de garder le même si vous avez déjà des évènements en local :) Par contre si vous n'avez jamais set up mongo laissez la db name vide et il utilisera celle par défaut (`test`). Il plante s'il essaye de se connecter à une db qui n'existe pas