### PR TITLE
 [Bug] [BSDD+BSDA+BVHU+BSDASRI] il ne devrait pas être possible de modifier l'adresse (et raison sociale) du Transporteur s'il est français

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Cacher l'édition des champs d'adresse d'un transporteur FR, et corriger l'initialisation du pays d'un transporteur dans CompanySelector, et l'affiche dans l'item sélectionné dans la liste [PR 1846](https://github.com/MTES-MCT/trackdechets/pull/1846)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -97,6 +97,18 @@ export const isFRVat = (clue: string): boolean => {
 };
 
 /**
+ * TVA Non-Français
+ */
+export const isForeignVat = (clue: string): boolean => {
+  if (!clue) return false;
+  const cleanClue = clue.replace(/\s/g, "");
+  if (!cleanClue) return false;
+  return (
+    isVat(cleanClue) && !cleanClue.slice(0, 2).toUpperCase().startsWith("FR")
+  );
+};
+
+/**
  * Le numéro OMI est "OMI1234567" (7 chiffres)
  */
 export const isOmi = (clue: string): boolean => {

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -16,7 +16,10 @@ import { applyAuthStrategies, AuthType } from "../../../auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../database";
 import { checkIsCompanyMember } from "../../../users/permissions";
-import { countries } from "../../../common/constants/companySearchHelpers";
+import {
+  countries,
+  isForeignVat
+} from "../../../common/constants/companySearchHelpers";
 import { checkVAT } from "jsvat";
 import { searchCompany } from "../../search";
 import { CompanySearchResult } from "../../types";
@@ -73,7 +76,7 @@ function companyToFavorite(
     phone: company.contactPhone,
     mail: company.contactEmail,
     isRegistered: !!company,
-    codePaysEtrangerEtablissement: !company.vatNumber
+    codePaysEtrangerEtablissement: !isForeignVat(company.vatNumber)
       ? "FR"
       : checkVAT(company.vatNumber, countries)?.country?.isoCode.short,
     transporterReceipt: company.transporterReceipt
@@ -384,7 +387,7 @@ const favoritesResolver: QueryResolvers["favorites"] = async (
         ) == null
       ) {
         // compute codePaysEtrangerEtablissement
-        cur.codePaysEtrangerEtablissement = !cur.vatNumber
+        cur.codePaysEtrangerEtablissement = !isForeignVat(cur.vatNumber)
           ? "FR"
           : checkVAT(cur.vatNumber, countries)?.country?.isoCode.short;
         return prev.concat([cur]);

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -19,7 +19,12 @@ interface CompanyResultsProps<T> {
 
 type CompanyResultBase = Pick<
   CompanySearchResult,
-  "siret" | "name" | "address" | "isRegistered" | "vatNumber"
+  | "siret"
+  | "name"
+  | "address"
+  | "isRegistered"
+  | "vatNumber"
+  | "codePaysEtrangerEtablissement"
 >;
 
 export function isSelected<T extends CompanyResultBase>(
@@ -97,6 +102,9 @@ export function CompanyResult<T extends CompanyResultBase>({
         <p>
           {item.siret?.length ? item.siret : item.vatNumber} -{" "}
           {item.address ? item.address : "[Adresse inconnue]"}
+          {item.codePaysEtrangerEtablissement
+            ? ` - ${item.codePaysEtrangerEtablissement}`
+            : ""}
         </p>
         <p>
           <a

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -76,16 +76,15 @@ export default function CompanySelector({
   const [field] = useField<FormCompany>({ name });
   const { setFieldError, setFieldValue, setFieldTouched } = useFormikContext();
   const [isForeignCompany, setIsForeignCompany] = useState(
-    `${field.name}.country` !== "FR"
+    field.value.country && field.value.country !== "FR"
   );
-
+  console.log(`${field.name}.country`);
   const departmentInputRef = useRef<HTMLInputElement>(null);
   const clueInputRef = useRef<HTMLInputElement>(null);
   const [mustBeRegistered, setMustBeRegistered] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<CompanySearchResult[]>([]);
   const [toggleManualForeignCompanyForm, setToggleManualForeignCompanyForm] =
     useState<boolean>(false);
-
   // Favortite type is deduced from the field prefix (transporter, emitter, etc)
   const favoriteType = constantCase(field.name.split(".")[0]) as FavoriteType;
   const {
@@ -218,9 +217,8 @@ export default function CompanySelector({
         .filter(company => company.etatAdministratif === "A")
         .map(company => ({
           ...company,
-          codePaysEtrangerEtablissement: company.codePaysEtrangerEtablissement
-            ? company.codePaysEtrangerEtablissement
-            : "FR",
+          codePaysEtrangerEtablissement:
+            company.codePaysEtrangerEtablissement || "FR",
         })) ?? [];
 
     const results = [...reshapedSearchResults, ...reshapedFavorites];
@@ -414,9 +412,11 @@ export default function CompanySelector({
             vatNumber: field.value.vatNumber,
             name: field.value.name,
             address: field.value.address,
-            // complete with isRegistered
+            // complete with companyPrivateInfos data
             ...(selectedData?.companyPrivateInfos && {
               isRegistered: selectedData?.companyPrivateInfos.isRegistered,
+              codePaysEtrangerEtablissement:
+                selectedData?.companyPrivateInfos.codePaysEtrangerEtablissement,
             }),
           }}
         />
@@ -525,9 +525,8 @@ function favoriteToCompanySearchResult(
     brokerReceipt: company.brokerReceipt,
     vhuAgrementDemolisseur: company.vhuAgrementDemolisseur,
     vhuAgrementBroyeur: company.vhuAgrementBroyeur,
-    codePaysEtrangerEtablissement: company.codePaysEtrangerEtablissement
-      ? company.codePaysEtrangerEtablissement
-      : "FR",
+    codePaysEtrangerEtablissement:
+      company.codePaysEtrangerEtablissement || "FR",
     contact: company.contact,
     contactPhone: company.phone,
     contactEmail: company.mail,

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -152,6 +152,7 @@ export const COMPANY_PRIVATE_INFOS = gql`
       isRegistered
       isAnonymousCompany
       companyTypes
+      codePaysEtrangerEtablissement
       installation {
         codeS3ic
         urlFiche
@@ -189,6 +190,7 @@ export const COMPANY_SELECTOR_PRIVATE_INFOS = gql`
       isRegistered
       isAnonymousCompany
       companyTypes
+      codePaysEtrangerEtablissement
     }
   }
 `;


### PR DESCRIPTION
# Quand le BSD a été signé par le producteur, et que je clique sur Actions > Modifier, je ne devrais pas pouvoir modifier l'adresse/le pays / la raison sociale du transporteur s'il est français (= visé avec son SIRET).
# BSDD : Lorsque la destination ultérieure prévue est en France, certains champs ne devraient pas s'afficher (comme Pays de l'entreprise, adresse etc...)

- Pour cacher l'édition des champs d'adresse d'un transporteur FR
- Plus : Fixer Problème avec l'identification ou l'initialisation du pays d'un transporteur 

![image](https://user-images.githubusercontent.com/76620/200887176-68187e92-1ea2-479c-8838-24a35381db75.png)

---
- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro Adresses Transporteurs français](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8835)
- [Ticket Favro Destination ultérieure](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8794)
