### PR TITLE
Allow http redirects for chrome with csp headers

### DIFF
--- a/front/server.js
+++ b/front/server.js
@@ -20,11 +20,7 @@ app.use(
           "*.trackdechets.fr",
         ],
         baseUri: "'self'",
-        formAction: [
-          "'self'",
-          "*.trackdechets.beta.gouv.fr",
-          "*.trackdechets.fr",
-        ],
+        formAction: ["http:"], // allow external redirects for oauth workflow
         fontSrc: ["'self'", "https:", "data:"],
         frameAncestors: "'none'",
         frameSrc: ["'self'"],


### PR DESCRIPTION
La mise à jour récente des headers csp interdit à chrome et safari d'e suivre les redirections vers des sites tiers, ce qui est le cas sur le processus d'oauth.
Cette PR assouplit les headers.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
