### PR TITLE
[Bug] Destination Ultérieure prévue : il ne devrait pas être possible de ne choisir ni SIRET ni nº de TVA intracom

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Cacher l'édition des champs d'adresse d'un transporteur FR, et corriger l'initialisation du pays d'un transporteur dans CompanySelector, et l'affiche dans l'item sélectionné dans la liste [PR 1846](https://github.com/MTES-MCT/trackdechets/pull/1846)
-- Destination Ultérieure prévue : il n'est pas possible de ne choisir ni SIRET ni nº de TVA intracom [PR 1853](https://github.com/MTES-MCT/trackdechets/pull/1846)
+- Destination ultérieure prévue : il n'est pas possible de ne choisir ni SIRET ni nº de TVA intracom [PR 1853](https://github.com/MTES-MCT/trackdechets/pull/1846)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Cacher l'édition des champs d'adresse d'un transporteur FR, et corriger l'initialisation du pays d'un transporteur dans CompanySelector, et l'affiche dans l'item sélectionné dans la liste [PR 1846](https://github.com/MTES-MCT/trackdechets/pull/1846)
+- Destination Ultérieure prévue : il n'est pas possible de ne choisir ni SIRET ni nº de TVA intracom [PR 1853](https://github.com/MTES-MCT/trackdechets/pull/1846)
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -952,6 +952,27 @@ describe("processedInfoSchema", () => {
     expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
   });
 
+  test("nextDestinationCompany SIRET or VAT number is required", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destination ultérieure prévue : Le siret de l'entreprise est obligatoire"
+    );
+  });
+
   test("noTraceability cannot be true when processing operation is not groupement", async () => {
     const processedInfo = {
       processedBy: "John Snow",
@@ -1059,6 +1080,23 @@ describe("processedInfoSchema", () => {
       "transporterCompanyVatNumber n'est pas un numéro de TVA intracommunautaire valide"
     );
   });
+
+  test("transporter SIRET or VAT number is required", async () => {
+    const transporter = {
+      transporterCompanyName: "Thalys",
+      transporterCompanyAddress: "Bruxelles",
+      transporterCompanyContact: "Contact",
+      transporterCompanyPhone: "00 00 00 00 00",
+      transporterCompanyMail: "contact@thalys.com",
+      transporterIsExemptedOfReceipt: true
+    };
+    const validateFn = () => transporterSchemaFn(false).validate(transporter);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Transporteur : Le n°SIRET ou le numéro de TVA intracommunautaire est obligatoire"
+    );
+  });
+
   test("nextDestination should be defined when processing operation is groupement and noTraceability is false", async () => {
     const processedInfo = {
       processedBy: "John Snow",
@@ -1077,7 +1115,7 @@ describe("processedInfoSchema", () => {
         "Destination ultérieure : L'opération de traitement est obligatoire",
         "Destination ultérieure : Le nom de l'entreprise est obligatoire",
         "Destination ultérieure prévue : Le siret de l'entreprise est obligatoire",
-        "Destination ultérieure prévue : Le SIRET n'est pas valide, il doit faire 14 caractères numériques (nextDestinationCompanySiret)",
+        "Destination ultérieure prévue : Le SIRET doit faire 14 caractères numériques",
         "Destination ultérieure : L'adresse de l'entreprise est obligatoire",
         "Destination ultérieure : Le contact dans l'entreprise est obligatoire",
         "Destination ultérieure : Le téléphone de l'entreprise est obligatoire",

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1077,7 +1077,7 @@ describe("processedInfoSchema", () => {
         "Destination ultérieure : L'opération de traitement est obligatoire",
         "Destination ultérieure : Le nom de l'entreprise est obligatoire",
         "Destination ultérieure prévue : Le siret de l'entreprise est obligatoire",
-        "Destination ultérieure prévue : Le SIRET doit faire 14 caractères numériques",
+        "Destination ultérieure prévue : Le SIRET n'est pas valide, il doit faire 14 caractères numériques (nextDestinationCompanySiret)",
         "Destination ultérieure : L'adresse de l'entreprise est obligatoire",
         "Destination ultérieure : Le contact dans l'entreprise est obligatoire",
         "Destination ultérieure : Le téléphone de l'entreprise est obligatoire",

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1089,25 +1089,19 @@ const withNextDestination = (required: boolean) =>
       .requiredIf(required, `Destination ultérieure : ${MISSING_COMPANY_NAME}`),
     nextDestinationCompanySiret: yup
       .string()
-      .when(
-        ["nextDestinationCompanyCountry", "nextDestinationCompanyVatNumber"],
-        {
-          is: (country, tva) =>
-            !tva || ((country == null || country === "FR") && required),
-          then: schema =>
-            schema
+      .when("nextDestinationCompanyVatNumber", (vat, schema) => {
+        return !isVat(vat) && required
+          ? schema
               .ensure()
               .required(
                 `Destination ultérieure prévue : ${MISSING_COMPANY_SIRET}`
               )
-              .test(
-                "is-siret",
-                "Destination ultérieure prévue : Le SIRET n'est pas valide, il doit faire 14 caractères numériques (${path})",
-                value => isSiret(value)
-              ),
-          otherwise: schema => schema.notRequired().nullable()
-        }
-      ),
+              .length(
+                14,
+                `Destination ultérieure prévue : ${INVALID_SIRET_LENGTH}`
+              )
+          : schema.notRequired().nullable();
+      }),
     nextDestinationCompanyVatNumber: yup
       .string()
       .ensure()

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1091,31 +1091,21 @@ const withNextDestination = (required: boolean) =>
       .string()
       .when(
         ["nextDestinationCompanyCountry", "nextDestinationCompanyVatNumber"],
-        ([country, tva], schema) => {
-          if (!tva) {
-            return schema
+        {
+          is: (country, tva) =>
+            !tva || ((country == null || country === "FR") && required),
+          then: schema =>
+            schema
               .ensure()
               .required(
-                `Destination ultérieure prévue : ${MISSING_COMPANY_SIRET_OR_VAT}`
+                `Destination ultérieure prévue : ${MISSING_COMPANY_SIRET}`
               )
               .test(
                 "is-siret",
                 "Destination ultérieure prévue : ${path} n'est pas un numéro de SIRET valide",
                 value => isSiret(value)
-              );
-          }
-          return (country == null || country === "FR") && required
-            ? schema
-                .ensure()
-                .required(
-                  `Destination ultérieure prévue : ${MISSING_COMPANY_SIRET}`
-                )
-                .test(
-                  "is-siret",
-                  "Destination ultérieure prévue : ${path} n'est pas un numéro de SIRET valide",
-                  value => isSiret(value)
-                )
-            : schema.notRequired().nullable();
+              ),
+          otherwise: schema => schema.notRequired().nullable()
         }
       ),
     nextDestinationCompanyVatNumber: yup

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1102,7 +1102,7 @@ const withNextDestination = (required: boolean) =>
               )
               .test(
                 "is-siret",
-                "Destination ultérieure prévue : ${path} n'est pas un numéro de SIRET valide",
+                "Destination ultérieure prévue : Le SIRET n'est pas valide, il doit faire 14 caractères numériques (${path})",
                 value => isSiret(value)
               ),
           otherwise: schema => schema.notRequired().nullable()

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10465,7 +10465,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -16557,7 +16557,7 @@
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -18032,7 +18032,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
     },
     "normalize-url": {
       "version": "4.5.1",
@@ -18088,7 +18088,7 @@
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg=="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -18343,7 +18343,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -18627,7 +18627,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -18794,7 +18794,7 @@
     "postcss-functions": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
+      "integrity": "sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==",
       "requires": {
         "glob": "^7.1.2",
         "object-assign": "^4.1.1",
@@ -19029,7 +19029,7 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
     },
     "process": {
       "version": "0.11.10",
@@ -20732,7 +20732,7 @@
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "requires": {
         "is-arrayish": "^0.3.1"
       },


### PR DESCRIPTION
Comportement attendu

il ne devrait pas être possible de ne choisir ni SIRET ni nº de TVA intracom

Comportement constaté par l'utilisateur

il est possible de ne cocher aucun résultat, et donc de n'avoir aucun SIRET ni nº de TVA d'enregistré dans le champ "Next Destination Company Siret"



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10074)
