### PR TITLE
Mem leak / Ajout d'une route

### DIFF
--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -1,0 +1,50 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
+import { Request, Response } from "express";
+import { createWriteStream } from "fs";
+import v8 from "v8";
+import logger from "./logger";
+
+export async function heapSnapshotToS3Router(req: Request, res: Response) {
+  if (process.env.DEBUG_HEAPDUMP !== "active") {
+    return res.send("Inactive");
+  }
+  const snapshotStream = v8.getHeapSnapshot();
+  // It's important that the filename end with `.heapsnapshot`,
+  // otherwise Chrome DevTools won't open it.
+  const fileName = `${process.env.DD_ENV}_${
+    process.env.CONTAINER
+  }_${Date.now()}.heapsnapshot`;
+  const fileStream = createWriteStream(fileName);
+  snapshotStream.pipe(fileStream);
+
+  res.send(fileName);
+  res.status(202);
+
+  try {
+    const parallelUploads3 = new Upload({
+      client: new S3Client({
+        endpoint: process.env.S3_ENDPOINT,
+        region: process.env.S3_REGION,
+        credentials: {
+          accessKeyId: process.env.S3_ACCESS_KEY_ID,
+          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+        }
+      }),
+      params: {
+        Bucket: process.env.S3_BUCKET,
+        Key: fileName,
+        Body: snapshotStream
+      },
+      leavePartsOnError: false
+    });
+
+    parallelUploads3.on("httpUploadProgress", progress => {
+      logger.info(progress);
+    });
+
+    await parallelUploads3.done();
+  } catch (e) {
+    logger.error("Error while uploading heapdump", e);
+  }
+}

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -40,6 +40,7 @@ import { resolvers, typeDefs } from "./schema";
 import { userActivationHandler } from "./users/activation";
 import { createUserDataLoaders } from "./users/dataloaders";
 import { getUIBaseURL } from "./utils";
+import { heapSnapshotToS3Router } from "./logging/heapSnapshot";
 
 const {
   SESSION_SECRET,
@@ -267,6 +268,8 @@ function ensureLoggedInAndAdmin() {
   };
 }
 app.use(bullBoardPath, ensureLoggedInAndAdmin(), serverAdapter.getRouter());
+// TEMP until memory leaks are fixed
+app.get("/heap", ensureLoggedInAndAdmin(), heapSnapshotToS3Router);
 
 // Apply passport auth middlewares to the graphQL endpoint
 app.use(graphQLPath, passportBearerMiddleware);

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -269,7 +269,7 @@ function ensureLoggedInAndAdmin() {
 }
 app.use(bullBoardPath, ensureLoggedInAndAdmin(), serverAdapter.getRouter());
 // TEMP until memory leaks are fixed
-app.get("/heap", ensureLoggedInAndAdmin(), heapSnapshotToS3Router);
+app.post("/heap", ensureLoggedInAndAdmin(), heapSnapshotToS3Router);
 
 // Apply passport auth middlewares to the graphQL endpoint
 app.use(graphQLPath, passportBearerMiddleware);


### PR DESCRIPTION
Ajout d'une route pour trigger manuellement des heapdump exportés vers S3.
Ca permettre d'en faire en prod.
Ceux de sandbox ne donnent pas grand chose: il n'est pas certain que le comportement mémoire de la sandbox soit indentique à celui de la prod.
Cf https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9092