### PR TITLE
Fix emitter types radio buttons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Cacher l'édition des champs d'adresse d'un transporteur FR, et corriger l'initialisation du pays d'un transporteur dans CompanySelector, et l'affiche dans l'item sélectionné dans la liste [PR 1846](https://github.com/MTES-MCT/trackdechets/pull/1846)
 - Destination ultérieure prévue : il n'est pas possible de ne choisir ni SIRET ni nº de TVA intracom [PR 1853](https://github.com/MTES-MCT/trackdechets/pull/1846)
+- Corrige le comportement des boutons radio relatifs au type d'émetteur lorsqu'un écoorganisme est présent  [PR 1856](https://github.com/MTES-MCT/trackdechets/pull/1856)
 
 #### :boom: Breaking changes
 

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -14,14 +14,15 @@ import { RedErrorMessage } from "common/components";
 
 export default function Emitter({ disabled }) {
   const ctx = useFormikContext<Form>();
-
   const { values, handleChange, setFieldValue, initialValues } = ctx;
 
   const hasInitialGrouping = !!initialValues?.grouping?.length; // siret is non editable once bsd contains grouped bsds
   const siretNonEditable = hasInitialGrouping && !!values?.id;
 
-  const [emitterTypeProducerDisabled, setEmitterTypeProducerDisabled] =
-    useState(values.ecoOrganisme?.siret != null);
+  const [
+    emitterTypeProducerDisabled,
+    setEmitterTypeProducerDisabled,
+  ] = useState(values.ecoOrganisme?.siret != null);
 
   const [lockEmitterProducer, setLockEmitterProducer] = useState(
     values.emitter?.isForeignShip || values.emitter?.isPrivateIndividual
@@ -29,8 +30,12 @@ export default function Emitter({ disabled }) {
 
   useEffect(() => {
     if (values.ecoOrganisme?.siret) {
+      // disable PRODUCER radio button
       setEmitterTypeProducerDisabled(true);
-      setFieldValue("emitter.type", "OTHER");
+      if (values?.emitter?.type === "PRODUCER") {
+        // set emitter type to OTHER if value was PRODUCER, else keep value
+        setFieldValue("emitter.type", "OTHER");
+      }
       return;
     }
     setEmitterTypeProducerDisabled(false);


### PR DESCRIPTION
Lors du changement d'onglet du formulaire des bsdd, la valeur du bouton radio repasse sur autre détenteur en cas de présence d'éco-organisme

- [x] Mettre à jour le change log
 ---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10216)
