### PR TITLE
Apollo / Bounded cache

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -70,6 +70,7 @@ export const server = new ApolloServer({
   introspection: true, // used to enable the playground in production
   validationRules: [depthLimit(10)],
   csrfPrevention: true, // To prevent "simple requests". See https://www.apollographql.com/docs/apollo-server/security/cors/#preventing-cross-site-request-forgery-csrf
+  cache: "bounded", // Apollo Server's default caching features use an unbounded cache, which is not safe for production use
   context: async ctx => {
     return {
       ...ctx,


### PR DESCRIPTION
Le cache Apollo est unbounded par défaut. Ca pourrait expliquer les problèmes de mémoire qu'on a.
Pour la prod c'est **fortement recommandé** d'être bounded: https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends

Ce cache n'est pas activé pour les réponses (on n'a pas d'annotations pour dans notre schéma) mais persiste les queries pour éviter de parser systématiquement les queries.
Pas certain que ca fasse gagner beaucoup de temps.
Par défaut c'est 30mb de cache. Je teste en bounded comme ca. Si on voit qu'on a une dégradation des perfs à cause du parsing il est possible:
- d'augmenter la taille allouée
- voir même mettre ca sur redis (ce qui permettrait de le partager entre toutes les instances)