### PR TITLE
Close modal window after bsdd reception

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Résolution de l'erreur avec Bsdasri quand `transporterTransportMode` envoyé `None` [PR 1854](https://github.com/MTES-MCT/trackdechets/pull/1854)
 - Destination ultérieure prévue : il n'est pas possible de ne choisir ni SIRET ni nº de TVA intracom [PR 1853](https://github.com/MTES-MCT/trackdechets/pull/1846)
 - BSFF - Les BSFFs groupés / reconditionnés / réexpédiés ne passent pas en "traité" lorsqu'il y a eu plusieurs intermédiaires [PR 1739](https://github.com/MTES-MCT/trackdechets/pull/1739)
+- BSDD - Correction de l'affichage de la modale de réception après un refus [PR 1865](https://github.com/MTES-MCT/trackdechets/pull/1865)
 
 #### :boom: Breaking changes
 

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
@@ -74,12 +74,13 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
               <ReceivedInfo
                 form={data.form}
                 onSubmit={values => {
-                  return markAsReceived({
+                  markAsReceived({
                     variables: {
                       id: data.form.id,
                       receivedInfo: values,
                     },
                   });
+                  close();
                 }}
                 close={close}
               />

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PackagingAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PackagingAction.tsx
@@ -1,6 +1,5 @@
 import { ActionButton, Modal } from "common/components";
 import { IconCheckCircle1 } from "common/components/Icons";
-import { formatDate } from "common/datetime";
 import {
   Bsff,
   BsffPackaging,


### PR DESCRIPTION
Quand un destinataire a plusieurs bsdds à recevoir dans son dashboard, en cas de refus, la modale reste ouverte

 
- [x] Mettre à jour le change log
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10222)
