### PR TITLE
Fix bsff packaging nullable acceptation status

### DIFF
--- a/back/src/bsffs/typeDefs/bsff.inputs.graphql
+++ b/back/src/bsffs/typeDefs/bsff.inputs.graphql
@@ -309,18 +309,3 @@ input BsffDetenteurInput {
 input BsffOperateurInput {
   company: CompanyInput!
 }
-
-input BsffPackagingAcceptation {
-  "Poids du contenant. Doit être à 0 dans le cas d'un refus"
-  weight: Float!
-  "Accepté ou refusé"
-  status: WasteAcceptationStatus!
-  "En cas de refus, la raison"
-  refusalReason: String
-  "Code déchet après analyse"
-  wasteCode: String
-  "Dénomination usuelle du déchet après analyse"
-  wasteDescription: String
-  "Signature de la destination lors de l'acceptation ou du refus du déchet."
-  signature: Signature
-}


### PR DESCRIPTION
Message d'erreur ou spinner persistant lors de l'ouverture des modales du bsff.
C'est dû à un champ d’acception qui est requis au lieu d'être optionnel, à cause d'une collision avec un ancienne définition gql.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10248)
