### PR TITLE
Fix Recette Transporteur étrangers

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessed.tsx
@@ -181,7 +181,6 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
           <CompanySelector
             name="nextDestination.company"
             allowForeignCompanies={true}
-            forceManualForeignCompanyForm={true}
             skipFavorite={noTraceability === true}
             optional={noTraceability === true}
           />

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
@@ -202,7 +202,6 @@ function NextDestinationField(props) {
       <CompanySelector
         name="nextDestination.company"
         allowForeignCompanies={true}
-        forceManualForeignCompanyForm={true}
         skipFavorite={true}
       />
     </div>

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -83,8 +83,8 @@ export default function CompanySelector({
   const [mustBeRegistered, setMustBeRegistered] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<CompanySearchResult[]>([]);
   const [
-    toggleForeignCompanyWithUnknownInfos,
-    setToggleForeignCompanyWithUnknownInfos,
+    displayForeignCompanyWithUnknownInfos,
+    setDisplayForeignCompanyWithUnknownInfos,
   ] = useState<boolean>(false);
 
   // Favortite type is deduced from the field prefix (transporter, emitter, etc)
@@ -158,7 +158,7 @@ export default function CompanySelector({
       );
     }
     // Assure la mise à jour des variables d'etat d'affichage des sous-parties du Form
-    setToggleForeignCompanyWithUnknownInfos(
+    setDisplayForeignCompanyWithUnknownInfos(
       isForeignVat(company.vatNumber!!) &&
         (company.name === "---" || company.name === "")
     );
@@ -168,7 +168,7 @@ export default function CompanySelector({
     const fields: FormCompany = {
       siret: company.siret,
       vatNumber: company.vatNumber,
-      name: company.name ?? "",
+      name: company.name && company.name !== "---" ? company.name : "",
       address: company.address ?? "",
       contact: company.contact ?? "",
       phone: company.contactPhone ?? "",
@@ -361,7 +361,7 @@ export default function CompanySelector({
             />
           </div>
         </div>
-        {toggleForeignCompanyWithUnknownInfos === true && (
+        {displayForeignCompanyWithUnknownInfos && (
           <SimpleNotificationError
             message={
               <>
@@ -424,51 +424,50 @@ export default function CompanySelector({
           }}
         />
         <div className="form__row">
-          {allowForeignCompanies &&
-            (isForeignCompany || toggleForeignCompanyWithUnknownInfos) && (
-              <>
-                <label>
-                  Nom de l'entreprise
-                  <Field
-                    type="text"
-                    className="td-input"
-                    name={`${field.name}.name`}
-                    placeholder="Nom"
-                    disabled={disabled}
-                  />
-                </label>
+          {allowForeignCompanies && isForeignCompany && (
+            <>
+              <label>
+                Nom de l'entreprise
+                <Field
+                  type="text"
+                  className="td-input"
+                  name={`${field.name}.name`}
+                  placeholder="Nom"
+                  disabled={disabled}
+                />
+              </label>
 
-                <RedErrorMessage name={`${field.name}.name`} />
+              <RedErrorMessage name={`${field.name}.name`} />
 
-                <label>
-                  Adresse de l'entreprise
-                  <Field
-                    type="text"
-                    className="td-input"
-                    name={`${field.name}.address`}
-                    placeholder="Adresse"
-                    disabled={disabled}
-                  />
-                </label>
+              <label>
+                Adresse de l'entreprise
+                <Field
+                  type="text"
+                  className="td-input"
+                  name={`${field.name}.address`}
+                  placeholder="Adresse"
+                  disabled={disabled}
+                />
+              </label>
 
-                <RedErrorMessage name={`${field.name}.address`} />
-                <label>
-                  Pays de l'entreprise
-                  <Field name={`${field.name}.country`} disabled={disabled}>
-                    {({ field, form }) => (
-                      <CountrySelector
-                        {...field}
-                        onChange={code => form.setFieldValue(field.name, code)}
-                        value={field.value}
-                        placeholder="Pays"
-                      />
-                    )}
-                  </Field>
-                </label>
+              <RedErrorMessage name={`${field.name}.address`} />
+              <label>
+                Pays de l'entreprise
+                <Field name={`${field.name}.country`} disabled={disabled}>
+                  {({ field, form }) => (
+                    <CountrySelector
+                      {...field}
+                      onChange={code => form.setFieldValue(field.name, code)}
+                      value={field.value}
+                      placeholder="Pays"
+                    />
+                  )}
+                </Field>
+              </label>
 
-                <RedErrorMessage name={`${field.name}.country`} />
-              </>
-            )}
+              <RedErrorMessage name={`${field.name}.country`} />
+            </>
+          )}
           <label>
             Personne à contacter
             <Field

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -47,8 +47,6 @@ interface CompanySelectorProps {
   name: string;
   onCompanySelected?: (company: CompanySearchResult) => void;
   allowForeignCompanies?: boolean;
-  // force l'affichage d'un formulaire pour entrer manuellement les coordonnées
-  forceManualForeignCompanyForm?: boolean;
   registeredOnlyCompanies?: boolean;
   heading?: string;
   disabled?: boolean;
@@ -63,7 +61,6 @@ export default function CompanySelector({
   name,
   onCompanySelected,
   allowForeignCompanies = false,
-  forceManualForeignCompanyForm = false,
   registeredOnlyCompanies = false,
   heading,
   disabled,
@@ -85,8 +82,10 @@ export default function CompanySelector({
   const clueInputRef = useRef<HTMLInputElement>(null);
   const [mustBeRegistered, setMustBeRegistered] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<CompanySearchResult[]>([]);
-  const [toggleManualForeignCompanyForm, setToggleManualForeignCompanyForm] =
-    useState<boolean>(false);
+  const [
+    toggleForeignCompanyWithUnknownInfos,
+    setToggleForeignCompanyWithUnknownInfos,
+  ] = useState<boolean>(false);
 
   // Favortite type is deduced from the field prefix (transporter, emitter, etc)
   const favoriteType = constantCase(field.name.split(".")[0]) as FavoriteType;
@@ -159,7 +158,7 @@ export default function CompanySelector({
       );
     }
     // Assure la mise à jour des variables d'etat d'affichage des sous-parties du Form
-    setToggleManualForeignCompanyForm(
+    setToggleForeignCompanyWithUnknownInfos(
       isForeignVat(company.vatNumber!!) &&
         (company.name === "---" || company.name === "")
     );
@@ -362,7 +361,7 @@ export default function CompanySelector({
             />
           </div>
         </div>
-        {toggleManualForeignCompanyForm === true && (
+        {toggleForeignCompanyWithUnknownInfos === true && (
           <SimpleNotificationError
             message={
               <>
@@ -426,9 +425,7 @@ export default function CompanySelector({
         />
         <div className="form__row">
           {allowForeignCompanies &&
-            (isForeignCompany ||
-              forceManualForeignCompanyForm ||
-              toggleManualForeignCompanyForm) && (
+            (isForeignCompany || toggleForeignCompanyWithUnknownInfos) && (
               <>
                 <label>
                   Nom de l'entreprise


### PR DESCRIPTION
# Paramètre `forceManualForeignCompanyForm` devenu inutile : on affiche tjs les champs d'edition pour une etnreprise étrangère

![image](https://user-images.githubusercontent.com/76620/203027379-c32749de-4deb-4330-b964-e4135d3db494.png)

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-8794)
