### PR TITLE
Display security warning for token and update doc

### DIFF
--- a/front/src/account/accessTokens/AccountNewAccessToken.tsx
+++ b/front/src/account/accessTokens/AccountNewAccessToken.tsx
@@ -4,6 +4,7 @@ import { IconCheckCircle1, IconCopyPaste } from "common/components/Icons";
 import { NewAccessToken } from "generated/graphql/types";
 import AccountAccessTokenRevoke from "./AccountAccessTokenRevoke";
 import styles from "./AccountAccessToken.module.scss";
+import { DEVELOPERS_DOCUMENTATION_URL } from "common/config";
 
 type AccountNewAccessTokenProps = {
   accessToken: NewAccessToken;
@@ -24,8 +25,15 @@ export default function AccountNewAccessToken({
           Vous ne serez plus en mesure de le consulter ultérieurement.
         </p>
         <strong>
-          🚨 Ce jeton est confidentiel, ne le diffusez pas, et consultez nos
-          recommendations de sécurité dans la documentation.
+          🚨 Ce jeton est confidentiel, ne le diffusez pas, et consultez nos{" "}
+          <a
+            href={`${DEVELOPERS_DOCUMENTATION_URL}/tutoriels/quickstart/access-token`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            recommandations de sécurité{" "}
+          </a>
+          dans la documentation.
         </strong>
       </div>
       <div className={`${styles.token} ${styles.newToken}`}>


### PR DESCRIPTION
Ajoute:
-  un texte enjoignant l'utilisateur à prendre soin de ses token (cf leak sur le forum)
- quelque lignes de doc pour préciser les bons headers à passer dans les requêtes

 
