### PR TITLE
Hotfix / Events & erreur quand duplicat

### DIFF
--- a/back/prisma/scripts/migrate-bsff-acceptation-destination.ts
+++ b/back/prisma/scripts/migrate-bsff-acceptation-destination.ts
@@ -4,7 +4,7 @@ import { registerUpdater, Updater } from "./helper/helper";
 @registerUpdater(
   "Update BSFF acceptation, operation, grouping, forwarding and repackaging",
   "Update BSFF acceptation, operation, grouping, forwarding and repackaging",
-  true
+  false
 )
 
 /**

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -1,4 +1,4 @@
-import { MongoClient } from "mongodb";
+import { MongoBulkWriteError, MongoClient } from "mongodb";
 import { Event } from "@prisma/client";
 import { EventCollection } from "./types";
 import { WriteErrors } from "./writeErrors";
@@ -29,35 +29,37 @@ export async function getStreamEvents(streamId: string, lte?: Date) {
 }
 
 export async function insertStreamEvents(tdEvents: Event[]) {
-  const writeResult = await eventsCollection.bulkWrite(
-    tdEvents.map(fullEvent => {
-      const { id, ...evt } = fullEvent;
-      return {
-        insertOne: {
-          document: { _id: id, ...evt }
-        }
-      };
-    }),
-    // During an ordered bulk write, if an error occurs during the processing of an operation,
-    // MongoDB returns without processing the remaining operations in the list.
-    // In contrast, when ordered is false, MongoDB continues to process remaining write operations in the list.
-    { ordered: false }
-  );
-
-  // We ignore duplicate key errors - if the event is already in Mongo it's fine
-  // Eg: Error during bulkWrite, BulkWriteError: E11000 duplicate key error collection: ...
-  const writeErrors = writeResult.getWriteErrors();
-  const DUPLICATE_KEY_ERROR_CODE = 11000;
-  const errors = writeErrors.filter(
-    error => error.code !== DUPLICATE_KEY_ERROR_CODE
-  );
-
-  if (errors.length) {
-    logger.error(
-      `${errors.length} unexpected error(s) occured during insertion in Mongo`,
-      errors
+  try {
+    await eventsCollection.bulkWrite(
+      tdEvents.map(fullEvent => {
+        const { id, ...evt } = fullEvent;
+        return {
+          insertOne: {
+            document: { _id: id, ...evt }
+          }
+        };
+      }),
+      // During an ordered bulk write, if an error occurs during the processing of an operation,
+      // MongoDB returns without processing the remaining operations in the list.
+      // In contrast, when ordered is false, MongoDB continues to process remaining write operations in the list.
+      { ordered: false }
     );
-    throw new WriteErrors(errors);
+  } catch (error) {
+    if (!(error instanceof MongoBulkWriteError)) {
+      logger.error("Unknown error during insertion in Mongo", error);
+      throw error;
+    }
+
+    const DUPLICATE_KEY_ERROR_CODE = 11000;
+    // We ignore duplicate key errors - if the event is already in Mongo it's fine
+    // Eg: Error during bulkWrite, BulkWriteError: E11000 duplicate key error collection: ...
+    if (error.code !== DUPLICATE_KEY_ERROR_CODE) {
+      logger.error(
+        `Unexpected error(s) occured during insertion in Mongo`,
+        error.result
+      );
+      throw new WriteErrors(error.writeErrors);
+    }
   }
 }
 


### PR DESCRIPTION
En cas de duplicat le script doit être résilient.
En fait il throw en cas d'erreur, et ne retourne pas le résultat tel quel meme avec unordered.