### PR TITLE
HOTFIX / Bsda partial intermediaries update

### DIFF
--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -86,8 +86,7 @@ export default async function edit(
     }
   );
 
-  const shouldUpdateIntermediaries =
-    input.intermediaries?.length > 0 || existingBsda.intermediaries?.length > 0;
+  const shouldUpdateIntermediaries = Array.isArray(input.intermediaries);
 
   const updatedBsda = await bsdaRepository.update(
     { id },


### PR DESCRIPTION
Quand on fait un update partiel sans préciser les intermediaries, ca ne doit pas les vider s'il y en a.