### PR TITLE
Hotfix multiple prepareSegments

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/prepareSegment.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/prepareSegment.integration.ts
@@ -250,6 +250,41 @@ describe("{ mutation { prepareSegment } }", () => {
 
     expect(markReadyErrors2).toBeUndefined();
     const { mutate: mutate3 } = makeClient(thirdTransporter);
+    // should not allow to prepare befor takeOver segment
+    const { errors: errorToPrepare } = await mutate3<
+      Pick<Mutation, "prepareSegment">
+    >(
+      `mutation  {
+      prepareSegment(id:"${form.id}",
+       siret:"${company3.siret}",
+       nextSegmentInfo: {
+          transporter: {
+            company: {
+              siret: "976345"
+              name: "Nightwatch fight club"
+              address: "The north wall"
+              contact: "John Snow"
+              phone: "0475848484"
+              mail: "toto@mail.com"
+            }
+            isExemptedOfReceipt: true
+          }
+          mode: ROAD
+        }) {
+            id
+            transporter {
+              company {
+                siret
+              }
+            }
+        }
+    }`
+    );
+    expect(errorToPrepare.length).toBe(1);
+    expect(errorToPrepare[0].extensions.code).toBe("FORBIDDEN");
+    expect(errorToPrepare[0].message).toBe(
+      "Vous ne disposez pas des permissions nécessaires"
+    );
     const { errors: takeOverErrors2 } = await mutate3(
       `mutation  {
         takeOverSegment(id:"${data2.prepareSegment.id}",

--- a/back/src/forms/resolvers/mutations/multiModal.ts
+++ b/back/src/forms/resolvers/mutations/multiModal.ts
@@ -152,7 +152,8 @@ export async function prepareSegment(
     : null;
   if (
     !!lastSegment &&
-    (!lastSegment.takenOverAt || lastSegment.transporterCompanySiret !== siret)
+    !lastSegment.takenOverAt &&
+    lastSegment.transporterCompanySiret !== siret
   ) {
     throw new ForbiddenError(SEGMENTS_ALREADY_PREPARED);
   }

--- a/back/src/forms/resolvers/mutations/multiModal.ts
+++ b/back/src/forms/resolvers/mutations/multiModal.ts
@@ -115,6 +115,9 @@ export async function prepareSegment(
   const transportSegments = await prisma.transportSegment.findMany({
     where: {
       form: { id: id }
+    },
+    orderBy: {
+      segmentNumber: "asc"
     }
   });
 
@@ -152,8 +155,7 @@ export async function prepareSegment(
     : null;
   if (
     !!lastSegment &&
-    !lastSegment.takenOverAt &&
-    lastSegment.transporterCompanySiret !== siret
+    (!lastSegment.takenOverAt || lastSegment.transporterCompanySiret !== siret)
   ) {
     throw new ForbiddenError(SEGMENTS_ALREADY_PREPARED);
   }


### PR DESCRIPTION
- [Bug] BSDD : Impossible d'ajouter un nouveau segment de transport multimodal alors que je suis pourtant bien le dernier transporteur : "Il y a d'autres segment après le votre, vous ne pouvez pas ajouter segment"

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10311)
