### PR TITLE
Logs / Ignore __typename

### DIFF
--- a/back/src/common/middlewares/graphqlQueryParser.ts
+++ b/back/src/common/middlewares/graphqlQueryParser.ts
@@ -31,7 +31,8 @@ function parseGqlDefinition(definition: DefinitionNode) {
   if (definition.kind !== "OperationDefinition") return undefined;
 
   const fieldSelections = definition.selectionSet.selections.filter(
-    (selection): selection is FieldNode => selection.kind === "Field"
+    (selection): selection is FieldNode =>
+      selection.kind === "Field" && selection.name.value !== "__typename"
   );
 
   return fieldSelections.map(field => ({


### PR DESCRIPTION
Amélioration du logging, pour éviter de logger `__typename` comme le nom de l'opération quand ce champ est demandé.
Ex:
![image](https://user-images.githubusercontent.com/5145523/203981484-aab2c9e5-0202-4347-b6a7-7082ad126f3e.png)
