### PR TITLE
Perfs / Speed up markAsSealed

### DIFF
--- a/back/prisma/migrations/105_add_form_emitter_mail_indice.sql
+++ b/back/prisma/migrations/105_add_form_emitter_mail_indice.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "_FormEmitterCompanyMailIdx" ON "default$default"."Form"("emitterCompanyMail");

--- a/back/src/forms/repository/form/findFirst.ts
+++ b/back/src/forms/repository/form/findFirst.ts
@@ -1,0 +1,16 @@
+import { Form, Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+export type FindFirstFormFn = (
+  where: Prisma.FormWhereInput,
+  options?: Omit<Prisma.FormFindFirstArgs, "where">
+) => Promise<Form>;
+
+const buildFindFirstForm: (deps: ReadRepositoryFnDeps) => FindFirstFormFn =
+  ({ prisma }) =>
+  (where, options?) => {
+    const input = { where, ...options };
+    return prisma.form.findFirst(input);
+  };
+
+export default buildFindFirstForm;

--- a/back/src/forms/repository/index.ts
+++ b/back/src/forms/repository/index.ts
@@ -9,6 +9,7 @@ import buildCreateForm from "./form/create";
 import buildDeleteForm from "./form/delete";
 import buildDeleteFormStaleSegments from "./form/deleteStaleSegments";
 import buildFindAppendix2FormsById from "./form/findAppendix2FormsById";
+import buildFindFirstForm from "./form/findFirst";
 import buildFindForwardedInById from "./form/findForwardedInById";
 import buildFindFullFormById from "./form/findFullFormById";
 import buildFindUniqueForm from "./form/findUnique";
@@ -30,6 +31,7 @@ export type FormRepository = FormActions & FormRevisionRequestActions;
 export function getReadOnlyFormRepository() {
   return {
     findUnique: buildFindUniqueForm({ prisma }),
+    findFirst: buildFindFirstForm({ prisma }),
     findFullFormById: buildFindFullFormById({ prisma }),
     findAppendix2FormsById: buildFindAppendix2FormsById({ prisma }),
     findForwardedInById: buildFindForwardedInById({ prisma }),

--- a/back/src/forms/repository/types.ts
+++ b/back/src/forms/repository/types.ts
@@ -4,6 +4,7 @@ import { CreateFormFn } from "./form/create";
 import { DeleteFormFn } from "./form/delete";
 import { DeleteFormStaleSegmentsFn } from "./form/deleteStaleSegments";
 import { FindAppendix2FormsByIdFn } from "./form/findAppendix2FormsById";
+import { FindFirstFormFn } from "./form/findFirst";
 import { FindForwardedInByIdFn } from "./form/findForwardedInById";
 import { FindFullFormByIdFn } from "./form/findFullFormById";
 import { FindUniqueFormFn } from "./form/findUnique";
@@ -31,6 +32,7 @@ export type FullForm = Prisma.FormGetPayload<typeof formWithLinkedObjects>;
 
 export type FormActions = {
   findUnique: FindUniqueFormFn;
+  findFirst: FindFirstFormFn;
   findFullFormById: FindFullFormByIdFn;
   findAppendix2FormsById: FindAppendix2FormsByIdFn;
   findForwardedInById: FindForwardedInByIdFn;

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -112,12 +112,14 @@ async function mailToNonExistentEmitter(
   formRepository: FormRepository
 ) {
   // check contact email has not been mentionned already
-  const contactAlreadyMentionned =
-    (await formRepository.count({
+  const contactAlreadyMentionned = await formRepository.findFirst(
+    {
       id: { not: form.id },
       emitterCompanyMail: form.emitterCompanyMail,
       status: { not: Status.DRAFT }
-    })) > 0;
+    },
+    { select: { id: true } }
+  );
   if (!contactAlreadyMentionned) {
     await sendMail(
       renderMail(contentAwaitsGuest, {


### PR DESCRIPTION
Dans les requêtes les plus longues, `markAsSealed` ressort à cause d'un count sans index.
Cette PR corrige ça

![image](https://user-images.githubusercontent.com/5145523/204007463-8f3e59b9-b953-4ab6-830d-b5908a19f549.png)
