### PR TITLE
Fix transporter with missing fields

### DIFF
--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -468,6 +468,11 @@ export const dashboardFormFragment = gql`
       transporter {
         company {
           siret
+          address
+          name
+          contact
+          phone
+          mail
         }
       }
       wasteDetails {

--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -468,6 +468,7 @@ export const dashboardFormFragment = gql`
       transporter {
         company {
           siret
+          vatNumber
           address
           name
           contact


### PR DESCRIPTION
Fix d'un bug à la complétion du bordereau suite: si un transporteur est déjà renseigné, on ne charge que son siret. Le sélecteur a l'impression qu'une entreprise est donc bien sélectionnée mais les champs comme adresse qui sont requis sont vides.
Ca platen à l'enregistrement.
Il faut charger tous les champs transporteur, pas uniquement le siret.
Voir ticket favro pour plus de détails

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10304)
