### PR TITLE
Favorites / Restauration du fonctionnement & améliorations

### DIFF
--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -145,7 +145,8 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanySiret: emitter.siret,
-        recipientCompanySiret: company.siret
+        recipientCompanySiret: company.siret,
+        recipientsSirets: [company.siret]
       }
     });
 
@@ -275,7 +276,8 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanySiret: company.siret,
-        transporterCompanySiret: transporter.siret
+        transporterCompanySiret: transporter.siret,
+        transportersSirets: [transporter.siret]
       }
     });
 
@@ -443,7 +445,10 @@ describe("query favorites", () => {
 
     await formWithTempStorageFactory({
       ownerId: user.id,
-      opt: { emitterCompanySiret: company.siret },
+      opt: {
+        emitterCompanySiret: company.siret,
+        recipientsSirets: [destination.siret]
+      },
       forwardedInOpts: { recipientCompanySiret: destination.siret }
     });
 
@@ -722,7 +727,7 @@ describe("query favorites", () => {
     ]);
   });
 
-  it.skip("should return the user's company even if there are other results", async () => {
+  it("should return the user's company even if there are other results", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
         set: ["PRODUCER"]
@@ -734,13 +739,15 @@ describe("query favorites", () => {
     const firstForm = await formFactory({
       ownerId: user.id,
       opt: {
-        emitterCompanySiret: emitter1.siret
+        emitterCompanySiret: emitter1.siret,
+        recipientsSirets: [company.siret]
       }
     });
     const secondForm = await formFactory({
       ownerId: user.id,
       opt: {
-        emitterCompanySiret: emitter2.siret
+        emitterCompanySiret: emitter2.siret,
+        recipientsSirets: [company.siret]
       }
     });
 
@@ -768,7 +775,7 @@ describe("query favorites", () => {
     ]);
   });
 
-  it.skip("should return the user's company based on an existing BSD", async () => {
+  it("should return the user's company based on an existing BSD", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
         set: ["PRODUCER"]
@@ -780,13 +787,15 @@ describe("query favorites", () => {
     const firstForm = await formFactory({
       ownerId: user.id,
       opt: {
-        emitterCompanySiret: emitter1.siret
+        emitterCompanySiret: emitter1.siret,
+        recipientsSirets: [company.siret]
       }
     });
     const secondForm = await formFactory({
       ownerId: user.id,
       opt: {
-        emitterCompanySiret: emitter2.siret
+        emitterCompanySiret: emitter2.siret,
+        recipientsSirets: [company.siret]
       }
     });
     await formFactory({
@@ -820,7 +829,7 @@ describe("query favorites", () => {
     ]);
   });
 
-  it.skip("should not return the same company twice", async () => {
+  it("should not return the same company twice", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
         set: ["COLLECTOR"]
@@ -831,14 +840,16 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanyName: "A Name",
-        emitterCompanySiret: emitter.siret
+        emitterCompanySiret: emitter.siret,
+        recipientsSirets: [company.siret]
       }
     });
     await formFactory({
       ownerId: user.id,
       opt: {
         emitterCompanyName: "Another Name",
-        emitterCompanySiret: firstForm.emitterCompanySiret
+        emitterCompanySiret: firstForm.emitterCompanySiret,
+        recipientsSirets: [company.siret]
       }
     });
 
@@ -867,14 +878,16 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         transporterCompanyName: "A Name",
-        transporterCompanyVatNumber: transporter.vatNumber
+        transporterCompanyVatNumber: transporter.vatNumber,
+        recipientsSirets: [company.siret]
       }
     });
     await formFactory({
       ownerId: user.id,
       opt: {
         transporterCompanyName: "Another Name",
-        transporterCompanyVatNumber: transporter.vatNumber
+        transporterCompanyVatNumber: transporter.vatNumber,
+        recipientsSirets: [company.siret]
       }
     });
 
@@ -895,7 +908,7 @@ describe("query favorites", () => {
     );
   });
 
-  it.skip("should suggest a temporary storage detail destination", async () => {
+  it("should suggest a temporary storage detail destination", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
         set: ["PRODUCER"]
@@ -905,6 +918,7 @@ describe("query favorites", () => {
     const form = await formFactory({
       ownerId: user.id,
       opt: {
+        emitterCompanySiret: company.siret,
         recipientCompanySiret: "0".repeat(14),
         recipientIsTempStorage: true,
         forwardedIn: {
@@ -913,7 +927,8 @@ describe("query favorites", () => {
             ownerId: user.id,
             recipientCompanySiret: destination.siret
           }
-        }
+        },
+        recipientsSirets: ["0".repeat(14), destination.siret]
       }
     });
     const forwardedIn = await prisma.form

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -230,8 +230,12 @@ async function getRecentTransporters(defaultWhere: Prisma.FormWhereInput) {
       transporterReceipt: true
     }
   });
-  const transporterSirets = forms.map(f => f.transporterCompanySiret);
-  const transporterVatNumbers = forms.map(f => f.transporterCompanyVatNumber);
+  const transporterSirets = forms
+    .map(f => f.transporterCompanySiret)
+    .filter(s => !["", null].includes(s));
+  const transporterVatNumbers = forms
+    .map(f => f.transporterCompanyVatNumber)
+    .filter(s => !["", null].includes(s));
 
   const companies = await prisma.company.findMany({
     where: {


### PR DESCRIPTION
On remet le fonctionnement des favoris en route en supprimant les jointures restantes sur le where.
Certaines requêtes étaient encore longues. Ex: 
![image](https://user-images.githubusercontent.com/5145523/204308966-c817d458-3dd3-40e1-8291-792caee90f43.png)
