### PR TITLE
Better track psql

### DIFF
--- a/back/datadog/conf.d/postgres.yaml
+++ b/back/datadog/conf.d/postgres.yaml
@@ -11,3 +11,7 @@ instances:
     tags:
       - service.name:postgres
       - env:%%env_DD_ENV%%
+    relations:
+      - relation_regex: '.*'
+        schemas:
+        - 'default$default'


### PR DESCRIPTION
Meilleur tracking psql.
Avec cette config, le dashboard https://app.datadoghq.eu/dash/integration/28/postgres---overview devrait en théorie être complet (2/3 vide actuellement).
C'est le support DD qui me recommande ce changement: https://help.datadoghq.com/hc/en-us/requests/1016560