### PR TITLE
Forms /No join hasNextStep

### DIFF
--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -120,9 +120,10 @@ function getHasNextStepFilter(siret: string, hasNextStep?: boolean | null) {
               },
               {
                 AND: [
-                  {
-                    forwardedIn: { recipientCompanySiret: siret } // installation de destination finale
-                  },
+                  // Installation de destination finale
+                  // No join equivalent to {forwardedIn: { recipientCompanySiret: siret }}
+                  { recipientsSirets: { has: siret } },
+                  { recipientCompanySiret: { not: siret } },
                   {
                     status: {
                       in: [


### PR DESCRIPTION
On tire partie de la dénormalisation pour éviter un join dans le cas du filtre hasNextStep.
On pourrait aller plus loin et le précalculer, mais c'est un premier quick win.