### PR TITLE
Mongo / Enhance index

### DIFF
--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -67,7 +67,7 @@ export async function insertStreamEvents(tdEvents: Event[]) {
 // The index is created only if it doesn't already exist.
 async function createIndexes() {
   try {
-    await eventsCollection.createIndex({ streamId: 1 });
+    await eventsCollection.createIndex({ streamId: 1, createdAt: 1 });
   } catch (err) {
     logger.error("Error while creating indexes", err);
   }


### PR DESCRIPTION
Amélioration de l'index Mongo. On filtre soit par streamId, soit par streamId & createdAt. Donc un compound index a plus de sens.

Pour rappel:
> If you sometimes query on only one key and at other times query on that key combined with a second key, then creating a compound index is more efficient than creating a single-key index. MongoDB will use the compound index for both queries. 

Je supprimerai l'index simple à la mano en base. On n'a pas de vrai système de migration pour le moment avec Mongo.