### PR TITLE
Fix bsdd update with temp storage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- Correctif d'un bug empêchant la signature d'un bsd avec entrposage provisoire[PR 1927](https://github.com/MTES-MCT/trackdechets/pull/1927)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -822,6 +822,38 @@ describe("Mutation.updateForm", () => {
     );
   });
 
+  it("should add a temporary storage even if temporaryStorageDetail is empty ", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const updateFormInput = {
+      id: form.id,
+      recipient: {
+        isTempStorage: true
+      }
+    };
+    const { mutate } = makeClient(user);
+    await mutate<Pick<Mutation, "updateForm">>(UPDATE_FORM, {
+      variables: {
+        updateFormInput
+      }
+    });
+
+    const tempStorage = await prisma.form
+      .findUnique({
+        where: { id: form.id }
+      })
+      .forwardedIn();
+
+    expect(tempStorage.readableId).toBe(`${form.readableId}-suite`);
+  });
+
   it("should update the temporary storage", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const form = await formFactory({

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -137,6 +137,14 @@ const updateFormResolver = async (
     };
   }
 
+  if (isOrWillBeTempStorage && !(forwardedIn || temporaryStorageDetail)) {
+    formUpdateInput.forwardedIn = {
+      create: {
+        owner: { connect: { id: user.id } },
+        readableId: `${existingForm.readableId}-suite`
+      }
+    };
+  }
   await checkIsFormContributor(
     user,
     nextFormCompanies,


### PR DESCRIPTION
À la création, si on passe isTempStorage=true, un bsd -suite est créé.
À la modification, si les champs du temp storage sont null, mais sTempStorage=false->true, le bsd -suite n'est pas crée, ce qui bloque les étapes de réception.

Cette PR crée le bsd -suite lors de l'update s'il n'existe pas.

 
- [x] Mettre à jour le change log
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10189)
