### PR TITLE
Prévient une xss sur le champ company website

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Prévention des injections SSTI [PR 1924](https://github.com/MTES-MCT/trackdechets/pull/1924)
-
+- Prévention d'injection XSS sur le champ website [PR 1934](https://github.com/MTES-MCT/trackdechets/pull/1934)
 #### :memo: Documentation
 
 #### :house: Interne

--- a/back/src/companies/resolvers/mutations/updateCompany.ts
+++ b/back/src/companies/resolvers/mutations/updateCompany.ts
@@ -9,6 +9,7 @@ import { applyAuthStrategies, AuthType } from "../../../auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { convertUrls, getCompanyOrCompanyNotFound } from "../../database";
 import { checkIsCompanyAdmin } from "../../../users/permissions";
+import * as yup from "yup";
 
 export async function updateCompanyFn({
   id,
@@ -67,6 +68,13 @@ export async function updateCompanyFn({
         }
       : {})
   };
+
+  const companySchema = yup.object().shape({
+    website: yup.string().url("L'url est invalide")
+  });
+  // A string like javascript:alert("p0wned") might be reflected on company public page
+  // this is not filtered by the xss middleware
+  await companySchema.validate(data);
 
   const company = await prisma.company.update({
     where: { id },

--- a/front/src/company/CompanyContact.tsx
+++ b/front/src/company/CompanyContact.tsx
@@ -37,13 +37,7 @@ export default function CompanyContact({ company }: Props) {
       <div className="company__item">
         <label className="company__item-key">Site internet</label>
         <span className="company__item-value" style={{ fontStyle: "italic" }}>
-          {company.website ? (
-            <a href={company.website} target="__blank">
-              {company.website}
-            </a>
-          ) : (
-            "Inconnu"
-          )}
+          {company.website ? company.website : "Inconnu"}
         </span>
       </div>
       {company.ecoOrganismeAgreements &&


### PR DESCRIPTION
Le champ website est protégé en front pour n'accepter que des urls valides, mais il est facile de le contourner en tweakant la requête. 
cf. https://recette.trackdechets.fr/company/51212357100022 
Un utilisateur qui cliquerait sur le champ website de la fiche inspection serait vulnérable

Cette PR:
- ajoute une validation backend (déjà présente en front) sur ce champ
- affiche le website comme un span (et pas un lien) sur la fiche

 
- [ ] Mettre à jour le change log
 
---

- [Ticket Favro]()
