### PR TITLE
[Bugfix][TRA-10269] Correction de Helmet pour autoriser les requêtes à des clients tiers

### DIFF
--- a/front/server.js
+++ b/front/server.js
@@ -6,6 +6,18 @@ const fs = require("fs");
 
 const app = express();
 
+const DEFAULT_SRC = [
+  "'self'",
+  "*.trackdechets.beta.gouv.fr",
+  "*.trackdechets.fr",
+];
+
+const CONNECT_SRC = [
+  ...DEFAULT_SRC,
+  "https://api-adresse.data.gouv.fr",
+  "https://sentry.incubateur.net",
+];
+
 app.use(
   helmet({
     frameguard: {
@@ -14,11 +26,8 @@ app.use(
     crossOriginEmbedderPolicy: false,
     contentSecurityPolicy: {
       directives: {
-        defaultSrc: [
-          "'self'",
-          "*.trackdechets.beta.gouv.fr",
-          "*.trackdechets.fr",
-        ],
+        defaultSrc: DEFAULT_SRC,
+        connectSrc: CONNECT_SRC,
         baseUri: "'self'",
         formAction: ["http:"], // allow external redirects for oauth workflow
         fontSrc: ["'self'", "https:", "data:"],
@@ -46,11 +55,11 @@ const indexContent =
       )
     : raw;
 
-app.get("/*", function(req, res) {
+app.get("/*", function (req, res) {
   res.send(indexContent);
 });
 
 const port = process.env.PORT || 3000;
-app.listen(port, function() {
+app.listen(port, function () {
   console.log("Trackdechets front listening on", port);
 });


### PR DESCRIPTION
# Contexte

Lorsqu'on crée un bordereau (de type BSD par exemple), et qu'on entre manuellement une adresse chantier, l'autocomplétion ne fonctionne pas (vérifié sur les environnements Sandbox, Recette & Prod). L'appel à l'API [api-adresse.data.gouv.fr](https://adresse.data.gouv.fr/) n'est pas autorisé à cause de la configuration des CORS.

Cette PR essaie de corriger le bug en ajoutant ladite API au connect-src. Au passage, une autre API a été identifiée et ajoutée, sentry.incubateur.net. Il y en a peut-être encore d'autre!

![cors_bug](https://user-images.githubusercontent.com/45355989/205054268-f00b852b-eb79-4253-bcf0-e29e91768240.gif)

![image](https://user-images.githubusercontent.com/45355989/205054311-a902a6ba-7c38-4906-b5a2-9f793e23ce99.png)

NOTE: vu qu'en local la configuration de démarrage de td-ui est différente de la prod, il est compliqué de reproduire, et donc tester le bug & le fix. J'ai utilisé [Burp Suite](https://portswigger.net/burp) pour faire proxy et modifier les en-têtes de la requête pour l'index.html, cependant en local j'ai aussi dû modifier le Access-Control-Allow-Origin. Il est possible qu'il faille également modifier cette valeur en production. A tester.

# Ticket

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10269)
