### PR TITLE
Adaptation sur search sirene pour passage à l'automatisation Airflow

### DIFF
--- a/search/cron.json
+++ b/search/cron.json
@@ -1,8 +1,0 @@
-{
-  "jobs": [
-    {
-      "command": "0 0 3 * * npm run index",
-      "size": "2XL"
-    }
-  ]
-}


### PR DESCRIPTION
# Cron scalingo qui n'est plus utilisé du tout, remplacé par Airflow prochainement
# Le passage à airflow implique une modif du logger de `search/`

- ref PR Airflow https://github.com/MTES-MCT/trackdechets-airflow-workspace/pull/1

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10199)
