### PR TITLE
Validation input TVA (vérification si le format est valide)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Vérification des numéros de SIRET en entrée pour tous les types de bordereaux [PR 1928](https://github.com/MTES-MCT/trackdechets/pull/1928)
+- Vérification des numéros de TVA pour les transporteurs de tous les types de bordereaux (vérification si le format est valide et interdiction de tout numéro de TVA français) [PR 1947](https://github.com/MTES-MCT/trackdechets/pull/1947)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -870,7 +870,7 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
         .ensure()
         .test(
           "is-vat",
-          "${path} n'est pas un numéro de TVA intracommunautaire valide",
+          "${path} n'est pas un numéro de TVA étranger valide",
           value => !value || (isVat(value) && !isFRVat(value))
         ),
       transporterCompanyAddress: yup.string().when("type", {

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -11,9 +11,7 @@ import { UserInputError } from "apollo-server-express";
 import * as yup from "yup";
 import { BSDA_WASTE_CODES } from "../common/constants";
 import {
-  isVat,
   isSiret,
-  isFRVat,
   isForeignVat
 } from "../common/constants/companySearchHelpers";
 import configureYup, { FactorySchemaOf } from "../common/yup/configureYup";
@@ -22,7 +20,8 @@ import {
   isCollector,
   isTransporter,
   isWasteCenter,
-  isWasteProcessor
+  isWasteProcessor,
+  transporterCompanyVatNumberSchema
 } from "../companies/validation";
 import {
   INVALID_WASTE_CODE,
@@ -865,14 +864,7 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
             return true;
           }
         ),
-      transporterCompanyVatNumber: yup
-        .string()
-        .ensure()
-        .test(
-          "is-vat",
-          "${path} n'est pas un numéro de TVA étranger valide",
-          value => !value || (isVat(value) && !isFRVat(value))
-        ),
+      transporterCompanyVatNumber: transporterCompanyVatNumberSchema,
       transporterCompanyAddress: yup.string().when("type", {
         is: BsdaType.COLLECTION_2710,
         then: schema => schema.nullable(),

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -1,5 +1,8 @@
 import { WasteAcceptationStatus, Prisma, BsdasriType } from "@prisma/client";
-import { isCollector } from "../companies/validation";
+import {
+  isCollector,
+  transporterCompanyVatNumberSchema
+} from "../companies/validation";
 import * as yup from "yup";
 import {
   DASRI_WASTE_CODES,
@@ -13,11 +16,7 @@ import {
   BsdasriPackagingType,
   BsdasriSignatureType
 } from "../generated/graphql/types";
-import {
-  isVat,
-  isSiret,
-  isFRVat
-} from "../common/constants/companySearchHelpers";
+import { isSiret } from "../common/constants/companySearchHelpers";
 import {
   MISSING_COMPANY_SIRET,
   MISSING_COMPANY_SIRET_OR_VAT
@@ -321,11 +320,6 @@ export const transporterSchema: FactorySchemaOf<
             `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
           );
         }
-        if (context.transportSignature && tva && isFRVat(tva)) {
-          return schema.required(
-            "Transporteur : Le numéro SIRET est obligatoire pour un établissement français"
-          );
-        }
         return schema.nullable().notRequired();
       })
       .test(
@@ -333,14 +327,7 @@ export const transporterSchema: FactorySchemaOf<
         "Transporteur : ${originalValue} n'est pas un numéro de SIRET valide",
         value => !value || isSiret(value)
       ),
-    transporterCompanyVatNumber: yup
-      .string()
-      .ensure()
-      .test(
-        "is-vat",
-        "${path} n'est pas un numéro de TVA étranger valide",
-        value => !value || (isVat(value) && !isFRVat(value))
-      ),
+    transporterCompanyVatNumber: transporterCompanyVatNumberSchema,
     transporterCompanyAddress: yup
       .string()
       .ensure()

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -338,8 +338,8 @@ export const transporterSchema: FactorySchemaOf<
       .ensure()
       .test(
         "is-vat",
-        "${path} n'est pas un numéro de TVA intracommunautaire valide",
-        value => !value || isVat(value)
+        "${path} n'est pas un numéro de TVA étranger valide",
+        value => !value || (isVat(value) && !isFRVat(value))
       ),
     transporterCompanyAddress: yup
       .string()

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -13,7 +13,7 @@ import {
 import { BsffOperationCode, BsffPackaging } from "../generated/graphql/types";
 import { isFinalOperation, OPERATION } from "./constants";
 import prisma from "../prisma";
-import { isVat } from "../common/constants/companySearchHelpers";
+import { isFRVat, isVat } from "../common/constants/companySearchHelpers";
 import configureYup, { FactorySchemaOf } from "../common/yup/configureYup";
 import { BSFF_WASTE_CODES } from "../common/constants";
 import {
@@ -143,8 +143,8 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
         .ensure()
         .test(
           "is-vat",
-          "Transporteur : le numéro de TVA intracommunautaire n'est pas au bon format",
-          value => !value || isVat(value)
+          "Transporteur : le numéro de TVA étranger n'est pas au bon format",
+          value => !value || (isVat(value) && !isFRVat(value))
         ),
       transporterCompanyAddress: yup
         .string()
@@ -412,8 +412,8 @@ const withNextDestination = (required: boolean) =>
       .nullable()
       .test(
         "is-vat",
-        "${path} n'est pas un numéro de TVA intracommunautaire valide",
-        value => !value || isVat(value)
+        "${path} n'est pas un numéro de TVA étranger valide",
+        value => !value || (isVat(value) && !isFRVat(value))
       ),
 
     operationNextDestinationCompanyAddress: yup

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -291,7 +291,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
         .ensure()
         .test(
           "is-vat",
-          "${path} n'est pas un numéro de TVA intracommunautaire valide",
+          "${path} n'est pas un numéro de TVA étranger valide",
           value => !value || (isVat(value) && !isFRVat(value))
         ),
       transporterCompanyAddress: yup

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -17,11 +17,8 @@ import {
 import * as yup from "yup";
 import { FactorySchemaOf } from "../common/yup/configureYup";
 import { BsvhuDestinationType } from "../generated/graphql/types";
-import {
-  isVat,
-  isSiret,
-  isFRVat
-} from "../common/constants/companySearchHelpers";
+import { isSiret } from "../common/constants/companySearchHelpers";
+import { transporterCompanyVatNumberSchema } from "../companies/validation";
 
 type Emitter = Pick<
   Bsvhu,
@@ -286,14 +283,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
           "Transporteur: ${originalValue} n'est pas un numéro de SIRET valide",
           value => !value || isSiret(value)
         ),
-      transporterCompanyVatNumber: yup
-        .string()
-        .ensure()
-        .test(
-          "is-vat",
-          "${path} n'est pas un numéro de TVA étranger valide",
-          value => !value || (isVat(value) && !isFRVat(value))
-        ),
+      transporterCompanyVatNumber: transporterCompanyVatNumberSchema,
       transporterCompanyAddress: yup
         .string()
         .requiredIf(

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -6,7 +6,11 @@ import {
 } from "@prisma/client";
 import { MISSING_COMPANY_SIRET_OR_VAT } from "../forms/errors";
 import prisma from "../prisma";
-import { isFRVat, isSiret } from "../common/constants/companySearchHelpers";
+import {
+  isForeignVat,
+  isFRVat,
+  isSiret
+} from "../common/constants/companySearchHelpers";
 
 export const receiptSchema = yup.object().shape({
   validityLimit: yup.date().required()
@@ -119,10 +123,24 @@ export const transporterCompanySiretSchema = (isDraft: boolean) =>
           `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
         );
       }
-      if (!isDraft && tva && isFRVat(tva)) {
-        return schema.required(
-          "Transporteur : Le numéro SIRET est obligatoire pour un établissement français"
-        );
-      }
       return schema.nullable().notRequired();
     });
+
+export const transporterCompanyVatNumberSchema = yup
+  .string()
+  .ensure()
+  .test(
+    "is-foreign-vat",
+    "Transporteur: ${originalValue} n'est pas un numéro de TVA étranger valide",
+    (value, testContext) => {
+      if (!value) return true;
+      else if (isFRVat(value)) {
+        return testContext.createError({
+          message:
+            "Transporteur : Le numéro SIRET est obligatoire pour un établissement français"
+        });
+      } else if (isForeignVat(value)) {
+        return true;
+      }
+    }
+  );

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -137,7 +137,7 @@ export const transporterCompanyVatNumberSchema = yup
       else if (isFRVat(value)) {
         return testContext.createError({
           message:
-            "Transporteur : Le numéro SIRET est obligatoire pour un établissement français"
+            "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
         });
       } else if (isForeignVat(value)) {
         return true;

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1080,7 +1080,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => transporterSchemaFn(false).validate(transporter);
 
     await expect(validateFn()).rejects.toThrow(
-      "Transporteur : Le numéro SIRET est obligatoire pour un établissement français"
+      "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
     );
   });
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1098,7 +1098,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => transporterSchemaFn(false).validate(transporter);
 
     await expect(validateFn()).rejects.toThrow(
-      "transporterCompanyVatNumber n'est pas un numéro de TVA étranger valide"
+      "Transporteur: invalid n'est pas un numéro de TVA étranger valide"
     );
   });
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1098,7 +1098,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => transporterSchemaFn(false).validate(transporter);
 
     await expect(validateFn()).rejects.toThrow(
-      "transporterCompanyVatNumber n'est pas un numéro de TVA intracommunautaire valide"
+      "transporterCompanyVatNumber n'est pas un numéro de TVA étranger valide"
     );
   });
 

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1559,7 +1559,8 @@ describe("Mutation.createForm", () => {
           code: "BAD_USER_INPUT"
         }
       })
-    ]);  });
+    ]);
+  });
 
   it("should be possible to fill TVA number only for a foreign transporter", async () => {
     const { user, company: emitter } = await userWithCompanyFactory("MEMBER");
@@ -1634,7 +1635,7 @@ describe("Mutation.createForm", () => {
 
     const intermediaryCreation = toIntermediaryCompany(company);
 
-    const { data, errors } = await mutate<
+    const { data } = await mutate<
       Pick<Mutation, "createForm">,
       MutationCreateFormArgs
     >(CREATE_FORM, {

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -535,7 +535,7 @@ describe("Mutation markAsResealed", () => {
     ]);
   }, 10000);
 
-  it("should work when a transporter vat number is present", async () => {
+  it("should not work when a transporter french vat number is present along with a SIRET", async () => {
     const owner = await userFactory();
     const { user, company: collector } = await userWithCompanyFactory(
       "MEMBER",
@@ -561,7 +561,7 @@ describe("Mutation markAsResealed", () => {
       }
     });
 
-    const { data } = await mutate<
+    const { errors } = await mutate<
       Pick<Mutation, "markAsResealed">,
       MutationMarkAsResealedArgs
     >(
@@ -599,8 +599,14 @@ describe("Mutation markAsResealed", () => {
       }
     );
 
-    expect(
-      data.markAsResealed.temporaryStorageDetail.transporter.company.vatNumber
-    ).toEqual("FR87850019464");
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement",
+        extensions: {
+          code: "BAD_USER_INPUT"
+        }
+      })
+    ]);
   });
 });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -681,8 +681,8 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
         .ensure()
         .test(
           "is-vat",
-          "${path} n'est pas un numéro de TVA intracommunautaire valide",
-          value => !value || isVat(value)
+          "${path} n'est pas un numéro de TVA étranger valide",
+          value => !value || (isVat(value) && !isFRVat(value))
         ),
       transporterCompanyAddress: yup
         .string()

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -50,7 +50,8 @@ import { validateCompany } from "../companies/validateCompany";
 import { Decimal } from "decimal.js-light";
 import {
   destinationCompanySiretSchema,
-  transporterCompanySiretSchema
+  transporterCompanySiretSchema,
+  transporterCompanyVatNumberSchema
 } from "../companies/validation";
 // set yup default error messages
 configureYup();
@@ -676,14 +677,7 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
         .ensure()
         .requiredIf(!isDraft, `Transporteur: ${MISSING_COMPANY_NAME}`),
       transporterCompanySiret: transporterCompanySiretSchema(isDraft),
-      transporterCompanyVatNumber: yup
-        .string()
-        .ensure()
-        .test(
-          "is-vat",
-          "${path} n'est pas un numéro de TVA étranger valide",
-          value => !value || (isVat(value) && !isFRVat(value))
-        ),
+      transporterCompanyVatNumber: transporterCompanyVatNumberSchema,
       transporterCompanyAddress: yup
         .string()
         .ensure()
@@ -1027,7 +1021,7 @@ const withNextDestination = (required: boolean) =>
       .ensure()
       .test(
         "is-vat",
-        "${path} n'est pas un numéro de TVA intracommunautaire valide",
+        "Destination ultérieure prévue : ${originalValue} n'est pas un numéro de TVA intracommunautaire valide",
         value => !value || isVat(value)
       ),
     nextDestinationCompanyAddress: yup

--- a/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
@@ -10,7 +10,6 @@ import {
   BsdasriEcoOrganisme,
 } from "../../../../generated/graphql/types";
 import TdSwitch from "common/components/Switch";
-import { string } from "yup";
 
 const GET_ECO_ORGANISMES = gql`
   {


### PR DESCRIPTION
## Validation `vatNumber` (de formattage seulement) sur tous les inputs Transporter. Interdisant tout numéro FR...

- Refacto schema validation vatNumber sur tous les BSD, création d'un [`transporterCompanyVatNumberSchema`](https://github.com/MTES-MCT/trackdechets/pull/1947/files#diff-33a79722c5d5b78ab3fb9e787a8a9b25cc904335e3cd8580419e568725a72011R129) exporté
- Certaines suppressions de doublons de validation [comme ici](https://github.com/MTES-MCT/trackdechets/pull/1947/files#diff-f10cc9c79394f2b463df47ec95d1257c94885ce2c4646664d4fee95ba3b4a55cL321)
- Améliorations des messages d'erreur de validaiton TVA : "Destination ultérieure : ${originalValue} n'est pas..." à la place de "${path} n'est pas un numéro de TVA", car {path} n'indique pas la valeur non-valide, mais seulement le nom du champ.
- Amélioration message d'erreur [pour un numéro de TVA FR interdit](https://github.com/MTES-MCT/trackdechets/pull/1947/files#diff-2f99408c45c909f46352172e8fbc30081b5e9c6e58d608767b015366309d21daR1079)

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro "exclure FR VAT"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9311)
