### PR TITLE
Add email-based rate limits on some gql mutations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Les transporteurs peuvent désormais modifier la date de prise en charge pour les BSDD et BSVHU[PR 1962](https://github.com/MTES-MCT/trackdechets/pull/1962)
+- Ajout de rate limit sur certaines mutations [PR 1948](https://github.com/MTES-MCT/trackdechets/pull/1948)
 
 #### :memo: Documentation
 

--- a/back/src/applications/resolvers/mutations/__tests__/createApplication.integration.ts
+++ b/back/src/applications/resolvers/mutations/__tests__/createApplication.integration.ts
@@ -8,7 +8,7 @@ import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 
 const CREATE_APPLICATION = gql`
-  mutation CreateApplication($input: ApplicationInput!) {
+  mutation CreateApplication($input: CreateApplicationInput!) {
     createApplication(input: $input) {
       id
       clientSecret
@@ -19,7 +19,7 @@ const CREATE_APPLICATION = gql`
 describe("createApplication", () => {
   afterEach(resetDatabase);
 
-  it.skip("should create an application", async () => {
+  it("should create an application", async () => {
     const user = await userFactory();
     const { mutate } = makeClient(user);
 

--- a/back/src/common/middlewares/graphqlRatelimiter.ts
+++ b/back/src/common/middlewares/graphqlRatelimiter.ts
@@ -11,6 +11,14 @@ type Options = {
   maxRequestsPerWindow: number;
 };
 
+/**
+ * Rate limiter middleware, use:
+ * - user email if available
+ * - user ip otherwise
+ * @param rateLimitedQuery
+ * @param options
+ * @returns
+ */
 export function graphqlRateLimiterMiddleware(
   rateLimitedQuery: GqlQueryKey,
   options: Options
@@ -20,7 +28,9 @@ export function graphqlRateLimiterMiddleware(
     rateLimiterMiddleware({
       windowMs: options.windowMs,
       maxRequestsPerWindow: options.maxRequestsPerWindow,
-      keyGenerator: (ip: string) => `gql_${rateLimitedQuery}_${ip}`
+      keyGenerator: (ip: string, req) => {
+        return `gql_${rateLimitedQuery}_${req?.user?.email ?? ip}`;
+      }
     })
   );
 }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11406,7 +11406,7 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -17608,7 +17608,7 @@
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -19125,7 +19125,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
       "version": "4.5.1",
@@ -19181,7 +19181,7 @@
     "num2fraction": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg=="
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -19505,7 +19505,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -19789,7 +19789,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -19982,7 +19982,7 @@
     "postcss-functions": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-      "integrity": "sha512-N5yWXWKA+uhpLQ9ZhBRl2bIAdM6oVJYpDojuI1nF2SzXBimJcdjFwiAouBVbO5VuOF3qA6BSFWFc3wXbbj72XQ==",
+      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
       "requires": {
         "glob": "^7.1.2",
         "object-assign": "^4.1.1",
@@ -20227,7 +20227,7 @@
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
     "process": {
       "version": "0.11.10",
@@ -22325,7 +22325,7 @@
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "requires": {
         "is-arrayish": "^0.3.1"
       },

--- a/front/src/account/accessTokens/AccountAccessTokenCreate.tsx
+++ b/front/src/account/accessTokens/AccountAccessTokenCreate.tsx
@@ -3,7 +3,10 @@ import { Modal, RedErrorMessage } from "common/components";
 import { NewAccessToken } from "generated/graphql/types";
 import { useMutation } from "@apollo/client";
 import { CREATE_ACCESS_TOKEN } from "./queries";
-import { NotificationError } from "common/components/Error";
+import {
+  NotificationError,
+  SimpleNotificationError,
+} from "common/components/Error";
 import { Field, Form, Formik } from "formik";
 import styles from "../fields/AccountField.module.scss";
 import TdTooltip from "common/components/Tooltip";
@@ -71,7 +74,12 @@ export default function AccountAccessTokenCreate({
           </div>
         </Form>
       </Formik>
-      {error && <NotificationError apolloError={error} />}
+      {error && error?.networkError && (
+        <SimpleNotificationError message="Pour des raisons de sécurité la création de jetons est limitée, merci de rééssayer dans une minute." />
+      )}
+      {error && !error?.networkError && (
+        <NotificationError apolloError={error} />
+      )}
     </Modal>
   );
 }

--- a/front/src/account/fields/forms/AccountFormCompanyInviteNewUser.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyInviteNewUser.tsx
@@ -11,6 +11,7 @@ import {
   Mutation,
   MutationInviteUserToCompanyArgs,
 } from "generated/graphql/types";
+import cogoToast from "cogo-toast";
 
 type Props = {
   company: CompanyPrivate;
@@ -49,7 +50,19 @@ export default function AccountFormCompanyInviteNewUser({ company }: Props) {
   const [inviteUserToCompany, { loading }] = useMutation<
     Pick<Mutation, "inviteUserToCompany">,
     MutationInviteUserToCompanyArgs
-  >(INVITE_USER_TO_COMPANY);
+  >(INVITE_USER_TO_COMPANY, {
+    onCompleted: () => {
+      cogoToast.success("Invitation envoyée", { hideAfter: 5 });
+    },
+    onError: () => {
+      cogoToast.error(
+        "L'invitation n'a pas pu être envoyée. Veuillez réessayer dans quelques minutes.",
+        {
+          hideAfter: 5,
+        }
+      );
+    },
+  });
 
   return (
     <Formik

--- a/front/src/account/oauth2/AccountOauth2AppCreateUpdate.tsx
+++ b/front/src/account/oauth2/AccountOauth2AppCreateUpdate.tsx
@@ -15,7 +15,10 @@ import {
 import styles from "./AccountOauth2AppCreateUpdate.module.scss";
 import { useHistory } from "react-router";
 import routes from "common/routes";
-import { NotificationError } from "common/components/Error";
+import {
+  NotificationError,
+  SimpleNotificationError,
+} from "common/components/Error";
 import Tooltip from "common/components/Tooltip";
 import {
   APPLICATION,
@@ -133,7 +136,10 @@ export default function AccountOauth2AppCreateUpdate({
               },
             });
           } else {
-            await createApplication({ variables: { input: values } });
+            const res = await createApplication({
+              variables: { input: values },
+            });
+            console.log(res);
           }
           history.push(routes.account.oauth2.list);
         }}
@@ -293,7 +299,10 @@ export default function AccountOauth2AppCreateUpdate({
           </Form>
         )}
       </Formik>
-      {createApplicationError && (
+      {createApplicationError && createApplicationError?.networkError && (
+        <SimpleNotificationError message="Pour des raisons de sécurité la création d'applications est limitée, merci de rééssayer dans une minute." />
+      )}
+      {createApplicationError && !createApplicationError?.networkError && (
         <NotificationError apolloError={createApplicationError} />
       )}
       {updateApplicationError && (


### PR DESCRIPTION
Ajoute ou modifie des rates limit pour les utilisateurs loggués dont la clé se base sur l'email au lieu de l'ip, les différents rapport YWH ayant démontré que la limitation sur l'ip était aisément contournable. Le risque potentiel est du niveau enquiquinant®

Nouveaux RL : 

- createApplication 3 req par 3 minutes
- createAccessToken 3 req par 3 minutes
- inviteUserToCompany 10 req par 3 minutes

Modifié (anciennement basé sur l'ip, ajd basé sur l'email):

- resendInvitation 10 req par 3 minutes

 
- [x] Mettre à jour le change log

---

- [Ticket Favro]()
