### PR TITLE
[TRA-10292|TRA-10337] Les formulaires transporteurs DD & VHU exposent la date de prise en charge

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.1.1] 10/01/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Les transporteurs peuvent désormais modifier la date de prise en charge pour les BSDD et BSVHU[PR 1962](https://github.com/MTES-MCT/trackdechets/pull/1962)
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2022.12.1] 13/12/2022
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -290,6 +290,21 @@ function flattenVhuTransporterInput({
     ),
     transporterRecepisseValidityLimit: chain(transporter, t =>
       chain(t.recepisse, r => r.validityLimit)
+    ),
+    ...flattenTransporterTransportInput(transporter)
+  };
+}
+
+function flattenTransporterTransportInput(input: {
+  transport?: BsvhuTransport;
+}) {
+  if (!input?.transport) {
+    return null;
+  }
+
+  return {
+    transporterTransportTakenOverAt: chain(input.transport, t =>
+      t.takenOverAt ? new Date(t.takenOverAt) : t.takenOverAt
     )
   };
 }

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -299,12 +299,12 @@ function flattenTransporterTransportInput(input: {
   transport?: BsvhuTransport;
 }) {
   if (!input?.transport) {
-    return null;
+    return {};
   }
 
   return {
     transporterTransportTakenOverAt: chain(input.transport, t =>
-      t.takenOverAt ? new Date(t.takenOverAt) : t.takenOverAt
+      t.takenOverAt ? t.takenOverAt : t.takenOverAt
     )
   };
 }

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -303,9 +303,7 @@ function flattenTransporterTransportInput(input: {
   }
 
   return {
-    transporterTransportTakenOverAt: chain(input.transport, t =>
-      t.takenOverAt ? t.takenOverAt : t.takenOverAt
-    )
+    transporterTransportTakenOverAt: chain(input.transport, t => t.takenOverAt)
   };
 }
 

--- a/front/src/common/fragments/bsvhu.ts
+++ b/front/src/common/fragments/bsvhu.ts
@@ -151,6 +151,7 @@ export const FullBsvhuFragment = gql`
         validityLimit
       }
       transport {
+        takenOverAt
         signature {
           author
           date

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -22,6 +22,7 @@ import { FormJourneySummary } from "./FormJourneySummary";
 import { FormWasteTransportSummary } from "./FormWasteTransportSummary";
 import { GET_FORM } from "form/bsdd/utils/queries";
 import Loader from "common/components/Loaders";
+import DateInput from "form/common/components/custom-inputs/DateInput";
 
 const SIGN_TRANSPORT_FORM = gql`
   mutation SignTransportForm(
@@ -37,6 +38,7 @@ const SIGN_TRANSPORT_FORM = gql`
 `;
 
 const validationSchema = yup.object({
+  takenOverAt: yup.date().required("La date de prise en charge est requise"),
   takenOverBy: yup
     .string()
     .ensure()
@@ -90,6 +92,7 @@ function SignTransportFormModal({
       <Formik
         initialValues={{
           takenOverBy: "",
+          takenOverAt: new Date().toISOString(),
           securityCode: "",
           transporterNumberPlate:
             form.stateSummary?.transporterNumberPlate ?? "",
@@ -101,7 +104,7 @@ function SignTransportFormModal({
               variables: {
                 id: form.id,
                 input: {
-                  takenOverAt: new Date().toISOString(),
+                  takenOverAt: values.takenOverAt,
                   takenOverBy: values.takenOverBy,
                   transporterNumberPlate: values.transporterNumberPlate,
                 },
@@ -124,6 +127,20 @@ function SignTransportFormModal({
               que les informations ci-dessus sont correctes. En signant ce
               document, je déclare prendre en charge le déchet.
             </p>
+
+            <div className="form__row">
+              <label className="tw-font-semibold">
+                Date de prise en charge
+                <div className="td-date-wrapper">
+                  <Field
+                    name="takenOverAt"
+                    component={DateInput}
+                    className="td-input"
+                  />
+                </div>
+              </label>
+              <RedErrorMessage name="takenOverAt" />
+            </div>
 
             <div className="form__row">
               <label>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -24,6 +24,8 @@ import { GET_FORM } from "form/bsdd/utils/queries";
 import Loader from "common/components/Loaders";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 
+const TODAY = new Date();
+
 const SIGN_TRANSPORT_FORM = gql`
   mutation SignTransportForm(
     $id: ID!
@@ -38,7 +40,10 @@ const SIGN_TRANSPORT_FORM = gql`
 `;
 
 const validationSchema = yup.object({
-  takenOverAt: yup.date().required("La date de prise en charge est requise"),
+  takenOverAt: yup
+    .date()
+    .required("La date de prise en charge est requise")
+    .max(TODAY, "La date de prise en charge ne peut être dans le futur"),
   takenOverBy: yup
     .string()
     .ensure()
@@ -92,7 +97,7 @@ function SignTransportFormModal({
       <Formik
         initialValues={{
           takenOverBy: "",
-          takenOverAt: new Date().toISOString(),
+          takenOverAt: TODAY.toISOString(),
           securityCode: "",
           transporterNumberPlate:
             form.stateSummary?.transporterNumberPlate ?? "",
@@ -136,6 +141,7 @@ function SignTransportFormModal({
                     name="takenOverAt"
                     component={DateInput}
                     className="td-input"
+                    maxDate={TODAY}
                   />
                 </div>
               </label>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -16,8 +16,13 @@ import { generatePath, Link } from "react-router-dom";
 import * as yup from "yup";
 import { SignBsvhu, SIGN_BSVHU } from "./SignBsvhu";
 
+const TODAY = new Date();
+
 const validationSchema = yup.object({
-  takenOverAt: yup.date().required("La date de prise en charge est requise"),
+  takenOverAt: yup
+    .date()
+    .required("La date de prise en charge est requise")
+    .max(TODAY, "La date de prise en charge ne peut être dans le futur"),
   author: yup
     .string()
     .ensure()
@@ -65,7 +70,7 @@ export function SignTransport({ siret, bsvhuId }: Props) {
           <Formik
             initialValues={{
               author: "",
-              takenOverAt: new Date().toISOString(),
+              takenOverAt: TODAY.toISOString(),
             }}
             validationSchema={validationSchema}
             onSubmit={async values => {
@@ -104,6 +109,7 @@ export function SignTransport({ siret, bsvhuId }: Props) {
                         name="takenOverAt"
                         component={DateInput}
                         className="td-input"
+                        maxDate={TODAY}
                       />
                     </div>
                   </label>

--- a/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
+++ b/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
@@ -162,6 +162,7 @@ function Emitter({ form }: { form: Bsvhu }) {
 }
 
 function Transporter({ form }: { form: Bsvhu }) {
+  console.log("form", form);
   const { transporter, identification, packaging, quantity, weight } = form;
   return (
     <>
@@ -208,7 +209,6 @@ function Transporter({ form }: { form: Bsvhu }) {
           value={transporter?.transport?.takenOverAt}
           label="Emporté le"
         />
-
         <DateRow
           value={transporter?.transport?.signature?.date}
           label="Signé le"

--- a/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
+++ b/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
@@ -162,7 +162,6 @@ function Emitter({ form }: { form: Bsvhu }) {
 }
 
 function Transporter({ form }: { form: Bsvhu }) {
-  console.log("form", form);
   const { transporter, identification, packaging, quantity, weight } = form;
   return (
     <>
@@ -209,6 +208,7 @@ function Transporter({ form }: { form: Bsvhu }) {
           value={transporter?.transport?.takenOverAt}
           label="Emporté le"
         />
+
         <DateRow
           value={transporter?.transport?.signature?.date}
           label="Signé le"


### PR DESCRIPTION
# Contexte

Cette PR a pour objectif de traiter 2 problèmes en parallèle: 
- Les bordereaux DD, lors de la signature du transporteur, fixent la date à now() implicitement, ce qui pose problème si l'appareil de l'utilisateur est desynchronisé
- Les bordereaux VHU, lors de la signature du transporteur, ne renseignent pas le champ de prise en charge (takenOverAt). Il reste vide et appraît vide sur les PDFs.

La solution retenue est, pour les 2 bordereaux, d'afficher explicitement la date dans le formulaire transporteur. L'utilisateur pourra laisser la date par défaut (now()) ou la modifier.

(Document comparatif de la gestion des dates de prise en charge par bordereau [ici](https://docs.google.com/document/d/1BZB7us1-cUg4Li6hyAfs0-OmAMfK1gi6zDvrw74PLy8/edit#)).

# Démo BSDD

![demo_bsdd](https://user-images.githubusercontent.com/45355989/207057956-ebbf126c-c3bb-4a04-ab31-82786bd3a5b7.gif)

Dans le PDF:

![image](https://user-images.githubusercontent.com/45355989/207062166-6163a609-a1a9-458f-b8ec-ae2472365b03.png)

# Démo BSVHU

![demo_vhu](https://user-images.githubusercontent.com/45355989/207062001-7dc97d49-f0aa-493b-ac8b-ff4646177ea9.gif)

Dans le PDF:

![image](https://user-images.githubusercontent.com/45355989/207062307-c25ef794-f326-446f-bab1-23c2908a52f8.png)

# Checklist

- [ ] Mettre à jour le change log
- [x] Testé avec Christian

# Tickets

- [Ticket Favro DD](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0c1de125996523739df4ed8e?card=tra-10337)
- [Ticket Favro VHU](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0c1de125996523739df4ed8e?card=tra-10292)
