### PR TITLE
Recette BSFF

### DIFF
--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -334,19 +334,27 @@ const emitterSchema: FactorySchemaOf<BsdaValidationContext, Emitter> =
             `Émetteur: ${MISSING_COMPANY_CONTACT}`
           )
       }),
-      emitterCompanyPhone: yup
-        .string()
-        .requiredIf(
-          context.emissionSignature,
-          `Émetteur: ${MISSING_COMPANY_PHONE}`
-        ),
+      emitterCompanyPhone: yup.string().when("emitterIsPrivateIndividual", {
+        is: true,
+        then: schema => schema.nullable().notRequired(),
+        otherwise: schema =>
+          schema.requiredIf(
+            context.emissionSignature,
+            `Émetteur: ${MISSING_COMPANY_PHONE}`
+          )
+      }),
       emitterCompanyMail: yup
         .string()
         .email()
-        .requiredIf(
-          context.emissionSignature,
-          `Émetteur: ${MISSING_COMPANY_EMAIL}`
-        ),
+        .when("emitterIsPrivateIndividual", {
+          is: true,
+          then: schema => schema.nullable().notRequired(),
+          otherwise: schema =>
+            schema.requiredIf(
+              context.emissionSignature,
+              `Émetteur: ${MISSING_COMPANY_EMAIL}`
+            )
+        }),
       emitterPickupSiteAddress: yup.string().nullable(),
       emitterPickupSiteCity: yup.string().nullable(),
       emitterPickupSiteInfos: yup.string().nullable(),

--- a/back/src/bsffs/__tests__/validation.test.ts
+++ b/back/src/bsffs/__tests__/validation.test.ts
@@ -567,11 +567,11 @@ describe("ficheInterventionSchema", () => {
     const data = {
       ...ficheIntevention,
       ...privateIndividual,
-      detenteurCompanyMail: null
+      detenteurCompanyAddress: null
     };
     const validateFn = () => ficheInterventionSchema.validate(data);
     await expect(validateFn()).rejects.toThrow(
-      "L'addresse email du détenteur de l'équipement (particulier) est requis"
+      "L'addresse du détenteur de l'équipement (particulier) est requise"
     );
   });
 

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -1025,10 +1025,7 @@ export const ficheInterventionSchema: yup.SchemaOf<
     .ensure()
     .when("detenteurIsPrivateIndividual", {
       is: true,
-      then: schema =>
-        schema.required(
-          "Le numéro de téléphone du détenteur de l'équipement (particulier) est requis"
-        ),
+      then: schema => schema.nullable().notRequired(),
       otherwise: schema =>
         schema.required(
           "Le numéro de téléphone de l'entreprise détentrice de l'équipement est requis"
@@ -1040,10 +1037,7 @@ export const ficheInterventionSchema: yup.SchemaOf<
     .ensure()
     .when("detenteurIsPrivateIndividual", {
       is: true,
-      then: schema =>
-        schema.required(
-          "L'addresse email du détenteur de l'équipement (particulier) est requis"
-        ),
+      then: schema => schema.nullable().notRequired(),
       otherwise: schema =>
         schema.required(
           "L'addresse email de l'entreprise détentrice de l'équipement est requis"

--- a/front/src/form/bsda/stepper/steps/Emitter.tsx
+++ b/front/src/form/bsda/stepper/steps/Emitter.tsx
@@ -92,7 +92,7 @@ export function Emitter({ disabled }) {
           </div>
           <div className="form__row">
             <label>
-              Téléphone
+              Téléphone (optionnel)
               <Field
                 type="text"
                 name="emitter.company.phone"
@@ -103,7 +103,7 @@ export function Emitter({ disabled }) {
           </div>
           <div className="form__row">
             <label>
-              Mail
+              Mail (optionnel)
               <Field
                 type="text"
                 name="emitter.company.mail"

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -60,14 +60,8 @@ const detenteurSchema: yup.SchemaOf<BsffFicheInterventionInput["detenteur"]> =
             .string()
             .ensure()
             .required("L'adresse du détenteur est requise"),
-          mail: yup
-            .string()
-            .ensure()
-            .required("Le courriel du détenteur est requis"),
-          phone: yup
-            .string()
-            .ensure()
-            .required("Le numéro de téléphone du détenteur est requis"),
+          mail: yup.string().nullable().notRequired(),
+          phone: yup.string().nullable().notRequired(),
         }),
     }),
   });
@@ -258,7 +252,7 @@ function PrivateIndividual() {
       </div>
       <div className="form__row">
         <label>
-          Téléphone
+          Téléphone (optionnel)
           <Field
             type="text"
             name="detenteur.company.phone"
@@ -269,7 +263,7 @@ function PrivateIndividual() {
       </div>
       <div className="form__row">
         <label>
-          Mail
+          Mail (optionnel)
           <Field
             type="text"
             name="detenteur.company.mail"


### PR DESCRIPTION
L'adresse email et le numéro de téléphone d'un détenteur particulier sont optionnels.
Au passage, implémentation de ce comportement pour un MOA particulier amiante par soucis d'homogénéité (vu avec Emmanuel).
