### PR TITLE
Scrolle en haut de page en cas d'erreur sur la page d'inscription

### DIFF
--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -64,6 +64,8 @@ export default function Signup() {
         setErrorMessage(
           _.message || "Une erreur est survenue, veuillez réessayer."
         );
+        // error message might be off-screen, let's scroll to top
+        window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
         setSubmitting(false);
       });
   };
@@ -94,7 +96,6 @@ export default function Signup() {
   const formContent = (
     <form onSubmit={handleSubmit}>
       <Container className={styles.centralContainer} spacing="pt-10w">
-        {alert}
         <Row justifyContent="center" spacing="mb-2w">
           <Col spacing="m-auto">
             <Title as="h1" look="h3" spacing="mb-1w">
@@ -105,6 +106,7 @@ export default function Signup() {
               est préalable à l'enregistrement ou au rattachement d'une
               entreprise dans Trackdéchets.
             </Text>
+            {alert}
             <Text as="p" className="fr-text--bold">
               Vos informations :
             </Text>


### PR DESCRIPTION
Sur un écran de faible hauteur, le message d'erreur n'est pas très visible.


Cette pr ajoute un smooth scroll vers le haut en cas d'erreur pour permettre à l'utilisateur d'en prendre connaissance.


https://user-images.githubusercontent.com/878396/207104646-42b1ce5c-d532-408d-9da8-b4d625fb7a29.mov


---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10377)
