### PR TITLE
Généralisation transporteurs étrangers : support transporterCompanyVatNumber on permissions

### DIFF
--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -17,6 +17,7 @@ const bsdaSiretFields = Prisma.validator<Prisma.BsdaArgs>()({
     emitterCompanySiret: true,
     destinationCompanySiret: true,
     transporterCompanySiret: true,
+    transporterCompanyVatNumber: true,
     workerCompanySiret: true,
     brokerCompanySiret: true,
     destinationOperationNextDestinationCompanySiret: true
@@ -44,6 +45,7 @@ export const BSDA_CONTRIBUTORS_FIELDS: Record<string, keyof BsdaContributors> =
     emitter: "emitterCompanySiret",
     destination: "destinationCompanySiret",
     transporter: "transporterCompanySiret",
+    transporterVat: "transporterCompanyVatNumber",
     worker: "workerCompanySiret",
     broker: "brokerCompanySiret",
     nextDestination: "destinationOperationNextDestinationCompanySiret"
@@ -83,7 +85,7 @@ export async function checkIsBsdaContributor(
 export async function isBsdaContributor(user: User, bsda: BsdaContributors) {
   const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
 
-  const formSirets = Object.values(BSDA_CONTRIBUTORS_FIELDS).map(
+  const bsdaSiretOrVat = Object.values(BSDA_CONTRIBUTORS_FIELDS).map(
     field => bsda[field]
   );
 
@@ -94,7 +96,7 @@ export async function isBsdaContributor(user: User, bsda: BsdaContributors) {
 
   return userCompaniesSiretOrVat.some(
     siret =>
-      formSirets.includes(siret) || intermerdiariesSirets?.includes(siret)
+      bsdaSiretOrVat.includes(siret) || intermerdiariesSirets?.includes(siret)
   );
 }
 

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -110,7 +110,7 @@ describe("Query.bsdas", () => {
 
   it.each(
     Object.keys(BSDA_CONTRIBUTORS_FIELDS).filter(
-      key => key !== "nextDestination"
+      key => key !== "nextDestination" && key !== "transporterVat"
     )
   )("should filter bsdas where user appears as %s", async role => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);

--- a/back/src/bsdasris/permissions.ts
+++ b/back/src/bsdasris/permissions.ts
@@ -19,14 +19,15 @@ export async function isDasriContributorHelper(
   dasri: BsdasriSirets
 ) {
   const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
-  const formSirets = [
+  const formSiretsOrVat = [
     dasri.emitterCompanySiret,
     dasri.transporterCompanySiret,
+    dasri.transporterCompanyVatNumber,
     dasri.destinationCompanySiret,
     dasri.ecoOrganismeSiret
   ].filter(Boolean);
 
-  return userCompaniesSiretOrVat.some(siret => formSirets.includes(siret));
+  return userCompaniesSiretOrVat.some(siret => formSiretsOrVat.includes(siret));
 }
 
 // Don't call directly in resolver to handle permissions

--- a/back/src/bsdasris/resolvers/mutations/createBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createBsdasri.ts
@@ -42,6 +42,7 @@ const createBsdasri = async (
     emitterCompanySiret: input.emitter?.company?.siret,
     destinationCompanySiret: input.destination?.company?.siret,
     transporterCompanySiret: input.transporter?.company?.siret,
+    transporterCompanyVatNumber: input.transporter?.company?.vatNumber,
     ecoOrganismeSiret: input.ecoOrganisme?.siret
   };
 

--- a/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
@@ -54,6 +54,7 @@ const createSynthesisBsdasri = async (
   const formSirets = {
     emitterCompanySiret: input.transporter?.company?.siret,
     transporterCompanySiret: input.transporter?.company?.siret,
+    transporterCompanyVatNumber: input.transporter?.company?.vatNumber,
     destinationCompanySiret: input.destination?.company?.siret
   };
 

--- a/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateBsdasri.ts
@@ -20,7 +20,7 @@ import updateBsdasri from "./updateSimpleBsdasri";
 
 /**
  * Bsdasri update mutation
- 
+
  */
 const updateBsdasriResolver = async (
   _: ResolversParentTypes["Mutation"],
@@ -42,6 +42,7 @@ const updateBsdasriResolver = async (
     emitterCompanySiret: dbBsdasri?.emitterCompanySiret,
     destinationCompanySiret: dbBsdasri?.destinationCompanySiret,
     transporterCompanySiret: dbBsdasri?.transporterCompanySiret,
+    transporterCompanyVatNumber: dbBsdasri?.transporterCompanyVatNumber,
     ecoOrganismeSiret: dbBsdasri?.ecoOrganismeSiret
   };
 

--- a/back/src/bsdasris/types.ts
+++ b/back/src/bsdasris/types.ts
@@ -6,7 +6,10 @@ import { Bsdasri } from "@prisma/client";
 
 export type BsdasriSirets = Pick<
   Bsdasri,
-  "emitterCompanySiret" | "destinationCompanySiret" | "transporterCompanySiret"
+  | "emitterCompanySiret"
+  | "destinationCompanySiret"
+  | "transporterCompanySiret"
+  | "transporterCompanyVatNumber"
 > &
   Partial<Pick<Bsdasri, "ecoOrganismeSiret">>;
 

--- a/back/src/bsffs/permissions.ts
+++ b/back/src/bsffs/permissions.ts
@@ -9,19 +9,21 @@ export async function isBsffContributor(
       Bsff,
       | "emitterCompanySiret"
       | "transporterCompanySiret"
+      | "transporterCompanyVatNumber"
       | "destinationCompanySiret"
     >
   >
 ) {
   const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
 
-  const bsffSirets = [
+  const bsffSiretsOrVat = [
     bsff.emitterCompanySiret,
     bsff.transporterCompanySiret,
+    bsff.transporterCompanyVatNumber,
     bsff.destinationCompanySiret
   ].filter(Boolean);
 
-  return userCompaniesSiretOrVat.some(siret => bsffSirets.includes(siret));
+  return userCompaniesSiretOrVat.some(siret => bsffSiretsOrVat.includes(siret));
 }
 
 export async function isFicheInterventionOperateur(
@@ -69,6 +71,7 @@ export async function checkCanWriteBsff(
       Bsff,
       | "emitterCompanySiret"
       | "transporterCompanySiret"
+      | "transporterCompanyVatNumber"
       | "destinationCompanySiret"
     >
   >

--- a/back/src/bsvhu/permissions.ts
+++ b/back/src/bsvhu/permissions.ts
@@ -11,6 +11,7 @@ export async function checkIsBsvhuContributor(
       | "emitterCompanySiret"
       | "destinationCompanySiret"
       | "transporterCompanySiret"
+      | "transporterCompanyVatNumber"
     >
   >,
   errorMsg: string
@@ -27,13 +28,16 @@ export async function checkIsBsvhuContributor(
 export async function isBsvhuContributor(user: User, form: Partial<Bsvhu>) {
   const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
 
-  const formSirets = [
+  const bsvhuSiretsOrVat = [
     form.emitterCompanySiret,
     form.destinationCompanySiret,
-    form.transporterCompanySiret
+    form.transporterCompanySiret,
+    form.transporterCompanyVatNumber
   ];
 
-  return userCompaniesSiretOrVat.some(siret => formSirets.includes(siret));
+  return userCompaniesSiretOrVat.some(siret =>
+    bsvhuSiretsOrVat.includes(siret)
+  );
 }
 
 export async function checkCanDeleteBsdvhu(user: User, form: Bsvhu) {


### PR DESCRIPTION
Fixer la gestion interne des permissions pour les transporteurs étranger avec VAT sur BSDA/NSVHU/BSFF/BSDASRI

- Nécessaire après avoir mergé https://github.com/MTES-MCT/trackdechets/pull/1928/files

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10489)
