### PR TITLE
use allSettled to wit for all indexInBulk jobs

### DIFF
--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -579,9 +579,11 @@ async function indexAllBsds(
   }
   if (useQueue && jobs.length) {
     logger.info(`Waiting for all ${jobs.length} jobs in queue to finish`);
-    await Promise.all(
-      jobs.map(async job => {
-        await job.finished();
+    // returned promise fulfills when all of the input's promises settle (resolved or rejected)
+    await Promise.allSettled(
+      jobs.map(job => {
+        // Returns a promise that resolves or rejects when the job completes or fails.
+        job.finished();
       })
     );
   }


### PR DESCRIPTION
- L'autoscaling opérait un scale down trop tôt, les jobs de bulk index ne sont alors pas tous consommés, et les jobs crashent en "out of memory" car BULK_INDEX_BATCH_SIZE trop grand pour la RAM disponible dans l'`indexQueue`


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/49eefb86636fffca4759b9bd?card=tra-10507)
