### PR TITLE
[TRA-10450] Ajout de valeurs maximales pour les poids

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Les transporteurs peuvent désormais modifier la date de prise en charge pour les BSDD et BSVHU [PR 1962](https://github.com/MTES-MCT/trackdechets/pull/1962)
 - Ajout de rate limit sur certaines mutations [PR 1948](https://github.com/MTES-MCT/trackdechets/pull/1948)
 - Les destinataires des BSDD peuvent désormais choisir l'option R0 (réemploi/réutilisation) [PR 1971](https://github.com/MTES-MCT/trackdechets/pull/1971)
+- Limite les valeurs de poids à 40 tonnes lorsque le transport se fait par route et à 50 000 T tout mode de transport confondu [PR 1995](https://github.com/MTES-MCT/trackdechets/pull/1995)
 
 #### :memo: Documentation
 

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -11,7 +11,8 @@ import {
   UserRole,
   User,
   Prisma,
-  Company
+  Company,
+  TransportMode
 } from "@prisma/client";
 import prisma from "../prisma";
 import { hashToken } from "../utils";
@@ -230,6 +231,7 @@ const formdata = {
   transporterCompanySiret: siretify(1),
   transporterDepartment: "86",
   transporterIsExemptedOfReceipt: false,
+  transporterTransportMode: TransportMode.ROAD,
   transporterNumberPlate: "aa22",
   transporterReceipt: "33AA",
   transporterValidityLimit: "2019-11-27T00:00:00.000Z",

--- a/back/src/bsffs/__tests__/validation.test.ts
+++ b/back/src/bsffs/__tests__/validation.test.ts
@@ -254,7 +254,7 @@ describe("wasteDetailsSchema", () => {
       });
 
     await expect(validateFn()).rejects.toThrow(
-      "Conditionnements : le poids doit être supérieur à 0"
+      "Conditionnement : le poids doit être supérieur à 0"
     );
   });
 
@@ -339,7 +339,7 @@ describe("acceptationSchema", () => {
     };
     const validateFn = () => acceptationSchema.validate(data);
     await expect(validateFn()).rejects.toThrow(
-      "Vous devez saisir une quantité reçue supérieure à 0"
+      "Acceptation : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
     );
   });
 
@@ -373,7 +373,7 @@ describe("acceptationSchema", () => {
     };
     const validateFn = () => acceptationSchema.validate(data);
     await expect(validateFn()).rejects.toThrow(
-      "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé"
+      "Acceptation : le poids doit être égal à 0 lorsque le déchet est refusé"
     );
   });
 

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -19,6 +19,7 @@ import { FactorySchemaOf } from "../common/yup/configureYup";
 import { BsvhuDestinationType } from "../generated/graphql/types";
 import { isSiret } from "../common/constants/companySearchHelpers";
 import { transporterCompanyVatNumberSchema } from "../companies/validation";
+import { weight, WeightUnits } from "../common/validation";
 
 type Emitter = Pick<
   Bsvhu,
@@ -153,11 +154,11 @@ const destinationSchema: FactorySchemaOf<VhuValidationContext, Destination> =
           context.emissionSignature,
           `Destinataire: le type de destination est obligatoire`
         ),
-      destinationReceptionWeight: yup
-        .number()
+      destinationReceptionWeight: weight(WeightUnits.Kilogramme)
+        .label("Destinataire")
         .requiredIf(
           context.operationSignature,
-          `Destinataire: le poids reçu est obligatoire`
+          "${path}: le poids reçu est obligatoire"
         ),
       destinationReceptionRefusalReason: yup.string().nullable(),
       destinationAgrementNumber: yup
@@ -338,11 +339,11 @@ const quantitySchema: FactorySchemaOf<VhuValidationContext, Quantity> =
 
 const weightSchema: FactorySchemaOf<VhuValidationContext, Weight> = context =>
   yup.object({
-    weightValue: yup
-      .number()
+    weightValue: weight(WeightUnits.Kilogramme)
+      .label("Déchet")
       .requiredIf(
         context.emissionSignature,
-        `Déchet: le poids est obligatoire`
+        "${path}: le poids est obligatoire"
       ),
     weightIsEstimate: yup.boolean().nullable()
   });

--- a/back/src/common/__tests__/validation.integration.ts
+++ b/back/src/common/__tests__/validation.integration.ts
@@ -1,0 +1,136 @@
+import { weight, weightConditions, WeightUnits } from "../validation";
+import * as yup from "yup";
+
+describe("weight validation", () => {
+  test("a negative number should be an invalid weight", async () => {
+    const schema = yup.object({ weight: weight().label("Émetteur") });
+
+    const validateFn = () => schema.validate({ weight: -1 });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Émetteur : le poids doit être supérieur ou égal à 0"
+    );
+  });
+
+  test("null should be valid", async () => {
+    const schema = yup.object({ weight: weight().label("Émetteur") });
+    expect(await schema.isValid({ weight: null })).toEqual(true);
+  });
+
+  test("undefined should be valid", async () => {
+    const schema = yup.object({ weight: weight().label("Émetteur") });
+    expect(await schema.isValid({ weight: undefined })).toEqual(true);
+  });
+
+  test("null should not be valid when marking the weight required", async () => {
+    const schema = yup.object({
+      weight: weight().label("Émetteur").required()
+    });
+    expect(await schema.isValid({ weight: null })).toEqual(false);
+  });
+
+  test("null should not be valid when marking the weight required", async () => {
+    const schema = yup.object({
+      weight: weight().label("Émetteur").required()
+    });
+    expect(await schema.isValid({ weight: undefined })).toEqual(false);
+  });
+
+  test("0 should be a valid weight", async () => {
+    const schema = yup.object({ weight: weight().label("Émetteur") });
+    expect(await schema.isValid({ weight: 0 })).toEqual(true);
+  });
+
+  test("a positive number should be a valid weight", async () => {
+    const schema = yup.object({ weight: weight().label("Émetteur") });
+    expect(await schema.isValid({ weight: 1.1 })).toEqual(true);
+  });
+
+  test("a weight in T should not be greater than 50 000 T", async () => {
+    const schema = yup.object({
+      weight: weight(WeightUnits.Tonne).label("Émetteur")
+    });
+    const validateFn = () => schema.validate({ weight: 50001 });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Émetteur : le poids doit être inférieur à 50000 tonnes"
+    );
+  });
+
+  test("a weight in kilogramme should not be greater than 50 000 T", async () => {
+    const schema = yup.object({
+      weight: weight(WeightUnits.Kilogramme).label("Émetteur")
+    });
+    const validateFn = () => schema.validate({ weight: 50000001 });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Émetteur : le poids doit être inférieur à 50000 tonnes"
+    );
+  });
+
+  test("a weight should be equal to 0 when acceptation status is REFUSED", async () => {
+    const schema = yup.object({
+      wasteAcceptationStatus: yup.string(),
+      weight: weight()
+        .label("Destinataire")
+        .when("wasteAcceptationStatus", weightConditions.wasteAcceptationStatus)
+    });
+    const validateFn = () =>
+      schema.validate({ weight: 1, wasteAcceptationStatus: "REFUSED" });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destinataire : le poids doit être égal à 0 lorsque le déchet est refusé"
+    );
+  });
+
+  test("a weight should be positive when acceptation status is ACCEPTED", async () => {
+    const schema = yup.object({
+      wasteAcceptationStatus: yup.string(),
+      weight: weight()
+        .label("Destinataire")
+        .when("wasteAcceptationStatus", weightConditions.wasteAcceptationStatus)
+    });
+    const validateFn = () =>
+      schema.validate({ weight: 0, wasteAcceptationStatus: "ACCEPTED" });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destinataire : le poids doit être supérieur à 0 lorsque le déchet est accepté"
+    );
+  });
+
+  test("a weight in tonne should not be greater than 40 T when the transport mode is ROAD", async () => {
+    const schema = yup.object({
+      transportMode: yup.string(),
+      weight: weight(WeightUnits.Tonne)
+        .label("Destinataire")
+        .when(
+          "transportMode",
+          weightConditions.transportMode(WeightUnits.Tonne)
+        )
+    });
+    const validateFn = () =>
+      schema.validate({ weight: 50, transportMode: "ROAD" });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destinataire : le poids doit être inférieur à 40 tonnes lorsque le transport se fait par la route"
+    );
+  });
+
+  test("a weight in kilogramme should not be greater than 40 T when the transport mode is ROAD", async () => {
+    const schema = yup.object({
+      transportMode: yup.string(),
+      weight: weight(WeightUnits.Kilogramme)
+        .label("Destinataire")
+        .when(
+          "transportMode",
+          weightConditions.transportMode(WeightUnits.Kilogramme)
+        )
+    });
+    const validateFn = () =>
+      schema.validate({ weight: 50000, transportMode: "ROAD" });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destinataire : le poids doit être inférieur à 40 tonnes lorsque le transport se fait par la route"
+    );
+  });
+});

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -1,0 +1,67 @@
+import { TransportMode, WasteAcceptationStatus } from "@prisma/client";
+import * as yup from "yup";
+import { ConditionBuilder, ConditionConfig } from "yup/lib/Condition";
+
+// Poids maximum en tonnes tout mode de transport confondu
+const MAX_WEIGHT_TONNES = 50000;
+
+// Poids maximum en tonnes quand le transport se fait sur route
+const MAX_WEIGHT_BY_ROAD_TONNES = 40;
+
+export enum WeightUnits {
+  Tonne,
+  Kilogramme
+}
+
+export const weight = (unit = WeightUnits.Kilogramme) =>
+  yup
+    .number()
+    .nullable()
+    .min(0, "${path} : le poids doit être supérieur ou égal à 0")
+    .max(
+      unit == WeightUnits.Kilogramme
+        ? MAX_WEIGHT_TONNES * 1000
+        : MAX_WEIGHT_TONNES,
+      `\${path} : le poids doit être inférieur à ${MAX_WEIGHT_TONNES} tonnes`
+    );
+
+// Differents conditions than can be applied to a weight based on the
+// value of other sibling fields
+type WeightConditions = {
+  wasteAcceptationStatus: ConditionBuilder<yup.NumberSchema>;
+  transportMode: (unit: WeightUnits) => ConditionConfig<yup.NumberSchema>;
+};
+
+export const weightConditions: WeightConditions = {
+  wasteAcceptationStatus: (status, weight) => {
+    if (status === WasteAcceptationStatus.REFUSED) {
+      return weight.test({
+        name: "is-0",
+        test: weight => weight === 0,
+        message:
+          "${path} : le poids doit être égal à 0 lorsque le déchet est refusé"
+      });
+    } else if (
+      [
+        WasteAcceptationStatus.ACCEPTED,
+        WasteAcceptationStatus.PARTIALLY_REFUSED
+      ]
+    ) {
+      return weight.positive(
+        "${path} : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
+      );
+    }
+    return weight;
+  },
+  transportMode: unit => ({
+    is: TransportMode.ROAD,
+    then: weight =>
+      weight.max(
+        unit == WeightUnits.Kilogramme
+          ? MAX_WEIGHT_BY_ROAD_TONNES * 1000
+          : MAX_WEIGHT_BY_ROAD_TONNES,
+        `\${path} : le poids doit être inférieur à ${MAX_WEIGHT_BY_ROAD_TONNES}` +
+          ` tonnes lorsque le transport se fait par la route`
+      )
+  })
+};

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -596,7 +596,7 @@ describe("receivedInfosSchema", () => {
           quantityReceived: 0
         });
       await expect(validateFn()).rejects.toThrow(
-        "Vous devez saisir une quantité reçue supérieure à 0."
+        "Réception : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
       );
     });
   });
@@ -631,7 +631,7 @@ describe("receivedInfosSchema", () => {
       const validateFn = () =>
         receivedInfoSchema.validate({ ...receivedInfo, quantityReceived: 1.0 });
       await expect(validateFn()).rejects.toThrow(
-        "Vous devez saisir une quantité égale à 0 lorsque le déchet est refusé"
+        "Réception : le poids doit être égal à 0 lorsque le déchet est refusé"
       );
     });
   });
@@ -666,7 +666,7 @@ describe("receivedInfosSchema", () => {
       const validateFn = () =>
         receivedInfoSchema.validate({ ...receivedInfo, quantityReceived: 0 });
       await expect(validateFn()).rejects.toThrow(
-        "Vous devez saisir une quantité reçue supérieure à 0."
+        "Réception : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
       );
     });
   });

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1660,4 +1660,30 @@ describe("Mutation.createForm", () => {
     expect(form.transportersSirets).toContain(company.siret);
     expect(form.intermediariesSirets).toContain(company.siret);
   });
+
+  it("should not be possible de set a weight > 50 T when transport mode is ROAD", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporter = await companyFactory();
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createForm">,
+      MutationCreateFormArgs
+    >(CREATE_FORM, {
+      variables: {
+        createFormInput: {
+          wasteDetails: { quantity: 50 },
+          emitter: {
+            company: { siret: company.siret }
+          },
+          transporter: { mode: "ROAD", company: { siret: transporter.siret } }
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Déchet : le poids doit être inférieur à 40 tonnes lorsque le transport se fait par la route"
+      })
+    ]);
+  });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
@@ -727,4 +727,38 @@ describe("Test Form reception", () => {
       })
     ]);
   });
+
+  it("should throw an error if transport mode is road and quantity accepted > 40T", async () => {
+    const { emitterCompany, recipient, recipientCompany, form } =
+      await prepareDB();
+
+    expect(form.transporterTransportMode).toEqual("ROAD");
+
+    await prepareRedis({
+      emitterCompany,
+      recipientCompany
+    });
+
+    const { mutate } = makeClient(recipient);
+
+    const { errors } = await mutate(MARK_AS_RECEIVED, {
+      variables: {
+        id: form.id,
+        receivedInfo: {
+          receivedBy: "Bill",
+          receivedAt: "2019-01-17T10:22:00+0100",
+          signedAt: "2019-01-17T10:22:00+0100",
+          wasteAcceptationStatus: "ACCEPTED",
+          quantityReceived: 50
+        }
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Réception : le poids doit être inférieur à 40 tonnes lorsque le transport se fait par la route"
+      })
+    ]);
+  });
 });

--- a/back/src/forms/resolvers/mutations/markAsReceived.ts
+++ b/back/src/forms/resolvers/mutations/markAsReceived.ts
@@ -29,6 +29,8 @@ const markAsReceivedResolver: MutationResolvers["markAsReceived"] = async (
   const form = await getFormOrFormNotFound({ id });
   await checkCanMarkAsReceived(user, form);
 
+  let transporterTransportMode = form.transporterTransportMode;
+
   if (form.recipientIsTempStorage === true) {
     // this form can be mark as received only if it has been
     // taken over by the transporter after temp storage
@@ -39,9 +41,14 @@ const markAsReceivedResolver: MutationResolvers["markAsReceived"] = async (
     if (!forwardedIn?.emittedAt) {
       throw new TemporaryStorageCannotReceive();
     }
+
+    transporterTransportMode = forwardedIn.transporterTransportMode;
   }
 
-  await receivedInfoSchema.validate(receivedInfo);
+  await receivedInfoSchema.validate({
+    ...receivedInfo,
+    transporterTransportMode
+  });
 
   const formUpdateInput: Prisma.FormUpdateInput = form.forwardedInId
     ? {

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -28,7 +28,10 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
     throw new DestinationCannotTempStore();
   }
 
-  await receivedInfoSchema.validate(tempStoredInfos);
+  await receivedInfoSchema.validate({
+    ...tempStoredInfos,
+    transporterTransportMode: form.transporterTransportMode
+  });
 
   const { quantityType, ...tmpStoredInfos } = tempStoredInfos;
 

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsReceived.tsx
@@ -1,29 +1,12 @@
 import React from "react";
-import {
-  Mutation,
-  MutationMarkAsReceivedArgs,
-  Query,
-  QueryFormArgs,
-} from "generated/graphql/types";
-import { gql, useMutation, useLazyQuery } from "@apollo/client";
-import { statusChangeFragment } from "common/fragments";
+import { Query, QueryFormArgs } from "generated/graphql/types";
+import { useLazyQuery } from "@apollo/client";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
 import { ActionButton, Loader } from "common/components";
 import { IconWaterDam } from "common/components/Icons";
 import ReceivedInfo from "./ReceivedInfo";
-import { NotificationError } from "common/components/Error";
-import { GET_BSDS } from "common/queries";
 import { GET_FORM } from "form/bsdd/utils/queries";
-
-const MARK_AS_RECEIVED = gql`
-  mutation MarkAsReceived($id: ID!, $receivedInfo: ReceivedFormInput!) {
-    markAsReceived(id: $id, receivedInfo: $receivedInfo) {
-      ...StatusChange
-    }
-  }
-  ${statusChangeFragment}
-`;
 
 export default function MarkAsReceived({ form }: WorkflowActionProps) {
   const [getBsdd, { data }] = useLazyQuery<Pick<Query, "form">, QueryFormArgs>(
@@ -36,16 +19,6 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
       fetchPolicy: "network-only",
     }
   );
-  const [markAsReceived, { loading, error }] = useMutation<
-    Pick<Mutation, "markAsReceived">,
-    MutationMarkAsReceivedArgs
-  >(MARK_AS_RECEIVED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
-    onError: () => {
-      // The error is handled in the UI
-    },
-  });
 
   const actionLabel = "Valider la réception";
 
@@ -73,24 +46,9 @@ export default function MarkAsReceived({ form }: WorkflowActionProps) {
             <div>
               <ReceivedInfo
                 form={data.form}
-                onSubmit={values => {
-                  markAsReceived({
-                    variables: {
-                      id: data.form.id,
-                      receivedInfo: values,
-                    },
-                  });
-                  close();
-                }}
                 close={close}
+                isTempStorage={false}
               />
-              {error && (
-                <NotificationError
-                  className="action-error"
-                  apolloError={error}
-                />
-              )}
-              {loading && <Loader />}
             </div>
           );
         }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStored.tsx
@@ -1,31 +1,13 @@
 import React from "react";
-import {
-  Mutation,
-  MutationMarkAsTempStoredArgs,
-  QuantityType,
-  WasteAcceptationStatus,
-  Query,
-  QueryFormArgs,
-} from "generated/graphql/types";
-import { gql, useMutation, useLazyQuery } from "@apollo/client";
-import { statusChangeFragment } from "common/fragments";
+import { Query, QueryFormArgs } from "generated/graphql/types";
+import { useLazyQuery } from "@apollo/client";
 import { WorkflowActionProps } from "./WorkflowAction";
 import { TdModalTrigger } from "common/components/Modal";
 import { ActionButton, Loader } from "common/components";
 import { IconWarehouseStorage } from "common/components/Icons";
 import ReceivedInfo from "./ReceivedInfo";
 import { NotificationError } from "common/components/Error";
-import { GET_BSDS } from "common/queries";
 import { GET_FORM } from "form/bsdd/utils/queries";
-
-const MARK_AS_TEMP_STORED = gql`
-  mutation MarkAsTempStored($id: ID!, $tempStoredInfos: TempStoredFormInput!) {
-    markAsTempStored(id: $id, tempStoredInfos: $tempStoredInfos) {
-      ...StatusChange
-    }
-  }
-  ${statusChangeFragment}
-`;
 
 export default function MarkAsTempStored({ form }: WorkflowActionProps) {
   const [getBsdd, { error: bsddGetError, data, loading: bsddGetLoading }] =
@@ -36,16 +18,6 @@ export default function MarkAsTempStored({ form }: WorkflowActionProps) {
       },
       fetchPolicy: "network-only",
     });
-  const [markAsTempStored, { loading, error }] = useMutation<
-    Pick<Mutation, "markAsTempStored">,
-    MutationMarkAsTempStoredArgs
-  >(MARK_AS_TEMP_STORED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
-    onError: () => {
-      // The error is handled in the UI
-    },
-  });
 
   const actionLabel = "Valider l'entreposage provisoire";
 
@@ -78,35 +50,11 @@ export default function MarkAsTempStored({ form }: WorkflowActionProps) {
           }
           if (!!data?.form) {
             return (
-              <div>
-                <ReceivedInfo
-                  form={data?.form}
-                  close={close}
-                  onSubmit={values => {
-                    return markAsTempStored({
-                      variables: {
-                        id: form.id,
-                        tempStoredInfos: {
-                          ...values,
-                          quantityType:
-                            values.quantityType ?? QuantityType.Real,
-                          quantityReceived: values.quantityReceived ?? 0,
-                          wasteAcceptationStatus:
-                            values.wasteAcceptationStatus ??
-                            WasteAcceptationStatus.Accepted,
-                        },
-                      },
-                    });
-                  }}
-                />
-                {error && (
-                  <NotificationError
-                    className="action-error"
-                    apolloError={error}
-                  />
-                )}
-                {loading && <Loader />}
-              </div>
+              <ReceivedInfo
+                form={data?.form}
+                close={close}
+                isTempStorage={true}
+              />
             );
           }
         }}

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Field, Form, Formik, FormikConfig } from "formik";
+import { Field, Form, Formik } from "formik";
 import { startOfDay } from "date-fns";
 import { parseDate } from "common/datetime";
 import * as yup from "yup";
-import { RedErrorMessage } from "common/components";
+import { Loader, RedErrorMessage } from "common/components";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import {
@@ -15,7 +15,14 @@ import {
   FormStatus,
   Form as TdForm,
   QuantityType,
+  MutationMarkAsReceivedArgs,
+  Mutation,
+  MutationMarkAsTempStoredArgs,
 } from "generated/graphql/types";
+import { gql, useMutation } from "@apollo/client";
+import { statusChangeFragment } from "common/fragments";
+import { GET_BSDS } from "common/queries";
+import { NotificationError } from "common/components/Error";
 
 export const textConfig: {
   [id: string]: {
@@ -76,190 +83,276 @@ const validationSchema = (form: TdForm) =>
       .transform(value => startOfDay(parseDate(value))),
   });
 
+const MARK_AS_RECEIVED = gql`
+  mutation MarkAsReceived($id: ID!, $receivedInfo: ReceivedFormInput!) {
+    markAsReceived(id: $id, receivedInfo: $receivedInfo) {
+      ...StatusChange
+    }
+  }
+  ${statusChangeFragment}
+`;
+
+const MARK_AS_TEMP_STORED = gql`
+  mutation MarkAsTempStored($id: ID!, $tempStoredInfos: TempStoredFormInput!) {
+    markAsTempStored(id: $id, tempStoredInfos: $tempStoredInfos) {
+      ...StatusChange
+    }
+  }
+  ${statusChangeFragment}
+`;
+
 /**
  * Reception info form shared between markAsReceived and markAsTempStored
  */
 export default function ReceivedInfo({
   form,
   close,
-  onSubmit,
+  isTempStorage,
 }: {
   form: TdForm;
-  onSubmit: FormikConfig<ReceivedInfoValues>["onSubmit"];
   close: () => void;
+  isTempStorage: boolean;
 }) {
+  const [
+    markAsReceived,
+    { loading: loadingMarkAsReceived, error: errorMarkAsReceived },
+  ] = useMutation<Pick<Mutation, "markAsReceived">, MutationMarkAsReceivedArgs>(
+    MARK_AS_RECEIVED,
+    {
+      refetchQueries: [GET_BSDS],
+      awaitRefetchQueries: true,
+      onError: () => {
+        // The error is handled in the UI
+      },
+      onCompleted: close,
+    }
+  );
+
+  const [
+    markAsTempStored,
+    { loading: loadingMarkAsTempStored, error: errorMarkAsTempStored },
+  ] = useMutation<
+    Pick<Mutation, "markAsTempStored">,
+    MutationMarkAsTempStoredArgs
+  >(MARK_AS_TEMP_STORED, {
+    refetchQueries: [GET_BSDS],
+    awaitRefetchQueries: true,
+    onError: () => {
+      // The error is handled in the UI
+    },
+  });
+
   return (
-    <Formik<ReceivedInfoValues>
-      initialValues={{
-        receivedBy: "",
-        receivedAt: new Date().toISOString(),
-        signedAt: new Date().toISOString(),
-        quantityReceived: null,
-        wasteAcceptationStatus: null,
-        wasteRefusalReason: "",
-        ...(form.recipient?.isTempStorage &&
-          form.status === FormStatus.Sent && {
-            quantityType: QuantityType.Real,
-          }),
-      }}
-      onSubmit={onSubmit}
-      validationSchema={() => validationSchema(form)}
-    >
-      {({ values, isSubmitting, handleReset, setFieldValue }) => (
-        <Form>
-          <div className="form__row">
-            <label>
-              Date de présentation
-              <Field
-                component={DateInput}
-                minDate={parseDate(form.takenOverAt!)}
-                name="receivedAt"
-                className="td-input"
-              />
-            </label>
-            <RedErrorMessage name="receivedAt" />
-          </div>
-          <div className="form__row">
+    <>
+      <Formik<ReceivedInfoValues>
+        initialValues={{
+          receivedBy: "",
+          receivedAt: new Date().toISOString(),
+          signedAt: new Date().toISOString(),
+          quantityReceived: null,
+          wasteAcceptationStatus: null,
+          wasteRefusalReason: "",
+          ...(form.recipient?.isTempStorage &&
+            form.status === FormStatus.Sent && {
+              quantityType: QuantityType.Real,
+            }),
+        }}
+        onSubmit={values =>
+          isTempStorage
+            ? markAsTempStored({
+                variables: {
+                  id: form.id,
+                  tempStoredInfos: {
+                    ...values,
+                    quantityType: values.quantityType ?? QuantityType.Real,
+                    quantityReceived: values.quantityReceived ?? 0,
+                    wasteAcceptationStatus:
+                      values.wasteAcceptationStatus ??
+                      WasteAcceptationStatus.Accepted,
+                  },
+                },
+              })
+            : markAsReceived({
+                variables: {
+                  id: form.id,
+                  receivedInfo: values,
+                },
+              })
+        }
+        validationSchema={() => validationSchema(form)}
+      >
+        {({ values, isSubmitting, handleReset, setFieldValue }) => (
+          <Form>
             <div className="form__row">
-              <fieldset className="form__radio-group">
-                <h4 className="tw-mr-2">Lot accepté: </h4>
+              <label>
+                Date de présentation
                 <Field
-                  name="wasteAcceptationStatus"
-                  id={WasteAcceptationStatus.Accepted}
-                  label="Oui"
-                  component={InlineRadioButton}
-                  onChange={() => {
-                    // clear wasteRefusalReason if waste is accepted
-                    setFieldValue("wasteRefusalReason", "");
-                    setFieldValue(
-                      "wasteAcceptationStatus",
-                      WasteAcceptationStatus.Accepted
-                    );
-                  }}
+                  component={DateInput}
+                  minDate={parseDate(form.takenOverAt!)}
+                  name="receivedAt"
+                  className="td-input"
+                />
+              </label>
+              <RedErrorMessage name="receivedAt" />
+            </div>
+            <div className="form__row">
+              <div className="form__row">
+                <fieldset className="form__radio-group">
+                  <h4 className="tw-mr-2">Lot accepté: </h4>
+                  <Field
+                    name="wasteAcceptationStatus"
+                    id={WasteAcceptationStatus.Accepted}
+                    label="Oui"
+                    component={InlineRadioButton}
+                    onChange={() => {
+                      // clear wasteRefusalReason if waste is accepted
+                      setFieldValue("wasteRefusalReason", "");
+                      setFieldValue(
+                        "wasteAcceptationStatus",
+                        WasteAcceptationStatus.Accepted
+                      );
+                    }}
+                  />
+                  <Field
+                    name="wasteAcceptationStatus"
+                    id={WasteAcceptationStatus.Refused}
+                    label="Non"
+                    component={InlineRadioButton}
+                    onChange={() => {
+                      setFieldValue("quantityReceived", 0);
+                      setFieldValue(
+                        "wasteAcceptationStatus",
+                        WasteAcceptationStatus.Refused
+                      );
+                    }}
+                  />
+                  <Field
+                    name="wasteAcceptationStatus"
+                    id={WasteAcceptationStatus.PartiallyRefused}
+                    label="Partiellement"
+                    component={InlineRadioButton}
+                  />
+                </fieldset>
+                <RedErrorMessage name="wasteAcceptationStatus" />
+              </div>
+            </div>
+            <div className="form__row">
+              <label>
+                Poids à l'arrivée
+                <Field
+                  component={NumberInput}
+                  name="quantityReceived"
+                  placeholder="En tonnes"
+                  className="td-input"
+                  disabled={
+                    values.wasteAcceptationStatus ===
+                    WasteAcceptationStatus.Refused
+                  }
+                />
+                <span>
+                  Poids indicatif émis: {form.stateSummary?.quantity} tonnes
+                </span>
+              </label>
+              <RedErrorMessage name="quantityReceived" />
+            </div>
+            {form.recipient?.isTempStorage && form.status === FormStatus.Sent && (
+              <fieldset className="form__row">
+                <legend>Cette quantité est</legend>
+                <Field
+                  name="quantityType"
+                  id="REAL"
+                  label="Réelle"
+                  component={RadioButton}
                 />
                 <Field
-                  name="wasteAcceptationStatus"
-                  id={WasteAcceptationStatus.Refused}
-                  label="Non"
-                  component={InlineRadioButton}
-                  onChange={() => {
-                    setFieldValue("quantityReceived", 0);
-                    setFieldValue(
-                      "wasteAcceptationStatus",
-                      WasteAcceptationStatus.Refused
-                    );
-                  }}
-                />
-                <Field
-                  name="wasteAcceptationStatus"
-                  id={WasteAcceptationStatus.PartiallyRefused}
-                  label="Partiellement"
-                  component={InlineRadioButton}
+                  name="quantityType"
+                  id="ESTIMATED"
+                  label="Estimée"
+                  component={RadioButton}
                 />
               </fieldset>
-              <RedErrorMessage name="wasteAcceptationStatus" />
-            </div>
-          </div>
-          <div className="form__row">
-            <label>
-              Poids à l'arrivée
-              <Field
-                component={NumberInput}
-                name="quantityReceived"
-                placeholder="En tonnes"
-                className="td-input"
-                disabled={
-                  values.wasteAcceptationStatus ===
-                  WasteAcceptationStatus.Refused
-                }
-              />
-              <span>
-                Poids indicatif émis: {form.stateSummary?.quantity} tonnes
-              </span>
-            </label>
-            <RedErrorMessage name="quantityReceived" />
-          </div>
-          {form.recipient?.isTempStorage && form.status === FormStatus.Sent && (
-            <fieldset className="form__row">
-              <legend>Cette quantité est</legend>
-              <Field
-                name="quantityType"
-                id="REAL"
-                label="Réelle"
-                component={RadioButton}
-              />
-              <Field
-                name="quantityType"
-                id="ESTIMATED"
-                label="Estimée"
-                component={RadioButton}
-              />
-            </fieldset>
-          )}
-          {/* Display wasteRefusalReason field if waste is refused or partially refused*/}
-          {values.wasteAcceptationStatus &&
-            [
-              WasteAcceptationStatus.Refused.toString(),
-              WasteAcceptationStatus.PartiallyRefused.toString(),
-            ].includes(values.wasteAcceptationStatus) && (
-              <div className="form__row">
-                <label>
-                  {textConfig[values.wasteAcceptationStatus].refusalReasonText}
-                  <Field name="wasteRefusalReason" className="td-input" />
-                </label>
-                <RedErrorMessage name="wasteRefusalReason" />
-              </div>
             )}
-          <div className="form__row">
-            <label>
-              Nom du responsable
-              <Field
-                type="text"
-                name="receivedBy"
-                placeholder="NOM Prénom"
-                className="td-input"
-              />
-            </label>
-            <RedErrorMessage name="receivedBy" />
-          </div>
-          <div className="form__row">
-            <label>
-              Date d'acceptation
-              <Field
-                component={DateInput}
-                minDate={parseDate(values.receivedAt)}
-                name="signedAt"
-                className="td-input"
-              />
-            </label>
-            <RedErrorMessage name="signedAt" />
-          </div>
-          <p>
+            {/* Display wasteRefusalReason field if waste is refused or partially refused*/}
             {values.wasteAcceptationStatus &&
-              textConfig[values.wasteAcceptationStatus].validationText}
-          </p>
-          <div className="form__actions">
-            <button
-              type="button"
-              className="btn btn--outline-primary"
-              onClick={() => {
-                handleReset();
-                close();
-              }}
-            >
-              Annuler
-            </button>
+              [
+                WasteAcceptationStatus.Refused.toString(),
+                WasteAcceptationStatus.PartiallyRefused.toString(),
+              ].includes(values.wasteAcceptationStatus) && (
+                <div className="form__row">
+                  <label>
+                    {
+                      textConfig[values.wasteAcceptationStatus]
+                        .refusalReasonText
+                    }
+                    <Field name="wasteRefusalReason" className="td-input" />
+                  </label>
+                  <RedErrorMessage name="wasteRefusalReason" />
+                </div>
+              )}
+            <div className="form__row">
+              <label>
+                Nom du responsable
+                <Field
+                  type="text"
+                  name="receivedBy"
+                  placeholder="NOM Prénom"
+                  className="td-input"
+                />
+              </label>
+              <RedErrorMessage name="receivedBy" />
+            </div>
+            <div className="form__row">
+              <label>
+                Date d'acceptation
+                <Field
+                  component={DateInput}
+                  minDate={parseDate(values.receivedAt)}
+                  name="signedAt"
+                  className="td-input"
+                />
+              </label>
+              <RedErrorMessage name="signedAt" />
+            </div>
+            <p>
+              {values.wasteAcceptationStatus &&
+                textConfig[values.wasteAcceptationStatus].validationText}
+            </p>
+            <div className="form__actions">
+              <button
+                type="button"
+                className="btn btn--outline-primary"
+                onClick={() => {
+                  handleReset();
+                  close();
+                }}
+              >
+                Annuler
+              </button>
 
-            <button
-              type="submit"
-              className="btn btn--primary"
-              disabled={isSubmitting}
-            >
-              Je valide la réception
-            </button>
-          </div>
-        </Form>
+              <button
+                type="submit"
+                className="btn btn--primary"
+                disabled={isSubmitting}
+              >
+                Je valide la réception
+              </button>
+            </div>
+          </Form>
+        )}
+      </Formik>
+      {errorMarkAsReceived && (
+        <NotificationError
+          className="action-error"
+          apolloError={errorMarkAsReceived}
+        />
       )}
-    </Formik>
+      {errorMarkAsTempStored && (
+        <NotificationError
+          className="action-error"
+          apolloError={errorMarkAsTempStored}
+        />
+      )}
+      {(loadingMarkAsReceived || loadingMarkAsTempStored) && <Loader />}
+    </>
   );
 }

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -10,6 +10,7 @@ import {
   Trader,
   Broker,
   WorkSite,
+  TransportMode,
 } from "generated/graphql/types";
 
 /**
@@ -150,7 +151,7 @@ export function getInitialState(f?: Form | null): FormInput {
       numberPlate: f?.transporter?.numberPlate ?? "",
       customInfo: f?.transporter?.customInfo ?? null,
       company: getInitialCompany(f?.transporter?.company),
-      mode: f?.transporter?.mode,
+      mode: f?.transporter?.mode ?? TransportMode.Road,
     },
     trader: f?.trader
       ? {


### PR DESCRIPTION
Exemple ici sur le poids à réception BSDD mais on retrouve le même fonctionnement partout : 

https://user-images.githubusercontent.com/2269165/208942129-1cf2dca3-620b-45fc-8e24-96a287d95199.mov



- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10450)
