### PR TITLE
BSFF - Drop not null constraint on optional field

### DIFF
--- a/back/prisma/migrations/112_bsff_drop_detenteur_contact_not_null.sql
+++ b/back/prisma/migrations/112_bsff_drop_detenteur_contact_not_null.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "default$default"."BsffFicheIntervention"
+ALTER COLUMN
+    "detenteurCompanyContact" DROP NOT NULL;


### PR DESCRIPTION
Ajout d'une migration oubliée pour rendre optionnel en base le champ `BsffFicheIntervention.detenteurCompanyContact` en accord avec les modifs du schéma prisma. 
La migration a été appliquée manuellement sur tous les environnements mais il faut quand même l'ajouter dans le code pour rester sync (c'est idempotent).
