### PR TITLE
API : il ne devrait pas être possible de  créer un établissement ni de valider un BSDD avec un SIRET qui est fermé selon l'insee

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Amélioration de la recherche par numéro de TVA et accélération requêtes pour les établissement déjà enregistrés [PR 1988](https://github.com/MTES-MCT/trackdechets/pull/1988)
+- API : il n'est plus possible de créer un établissement ni de valider un BSDD avec un SIRET qui est fermé ou introuvable selon l'insee [PR 2003](https://github.com/MTES-MCT/trackdechets/pull/2003)
 
 # [2023.1.3] 19/01/2023
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Amélioration de la recherche par numéro de TVA et accélération requêtes pour les établissement déjà enregistrés [PR 1988](https://github.com/MTES-MCT/trackdechets/pull/1988)
-- API : il n'est plus possible de créer un établissement ni de valider un BSDD avec un SIRET qui est fermé ou introuvable selon l'insee [PR 2003](https://github.com/MTES-MCT/trackdechets/pull/2003)
+- Interdire la possibilité de créer un SIRET fermé selon l'INSEE, ni de valider ou re-valider (`markAsSealed` et `markAsResealed`) un BSDD avec un SIRET qui est fermé. Amélioration de l'affichage de la page publique `/company/1234` [PR 2003](https://github.com/MTES-MCT/trackdechets/pull/2003)
 
 # [2023.1.3] 19/01/2023
 

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -172,3 +172,12 @@ export const getTransporterCompanyOrgId = (form: {
     ? form.transporterCompanySiret
     : form.transporterCompanyVatNumber;
 };
+
+/**
+ * Check for etatAdministratif
+ */
+export const isClosedCompany = (companyInfos: any) =>
+  companyInfos.etatAdministratif === "F";
+
+export const CLOSED_COMPANY_ERROR =
+  "Impossible de créer un établissement fermé selon l'INSEE";

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -622,8 +622,7 @@ describe("Mutation.createCompany", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message:
-          "Impossible de créer un établissement identifié par un numéro de TVA français, merci d'indiquer un SIRET"
+        message: "Impossible de créer un établissement fermé selon l'INSEE"
       })
     ]);
   });

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -596,6 +596,7 @@ describe("Mutation.createCompany", () => {
       })
     ]);
   });
+
   it("should return an error when creating a closed company ", async () => {
     const user = await userFactory();
     const orgId = siretify(8);
@@ -606,7 +607,7 @@ describe("Mutation.createCompany", () => {
     });
 
     const companyInput = {
-      orgId: "FR87850019464",
+      siret: orgId,
       companyName: "Acme in FR",
       address: "une adresse",
       companyTypes: [CompanyType.TRANSPORTER]

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -596,4 +596,34 @@ describe("Mutation.createCompany", () => {
       })
     ]);
   });
+  it("should return an error when creating a closed company ", async () => {
+    const user = await userFactory();
+    const orgId = siretify(8);
+    searchCompany.mockResolvedValueOnce({
+      orgId,
+      siret: orgId,
+      etatAdministratif: "F"
+    });
+
+    const companyInput = {
+      orgId: "FR87850019464",
+      companyName: "Acme in FR",
+      address: "une adresse",
+      companyTypes: [CompanyType.TRANSPORTER]
+    };
+
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate(CREATE_COMPANY, {
+      variables: {
+        companyInput
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Impossible de créer un établissement identifié par un numéro de TVA français, merci d'indiquer un SIRET"
+      })
+    ]);
+  });
 });

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -13,9 +13,11 @@ import { verificationProcessInfo } from "../../../mailer/templates";
 import { deleteCachedUserCompanies } from "../../../common/redis/users";
 import {
   cleanClue,
+  isClosedCompany,
   isFRVat,
   isSiret,
-  isVat
+  isVat,
+  CLOSED_COMPANY_ERROR
 } from "../../../common/constants/companySearchHelpers";
 import { searchCompany } from "../../search";
 import {
@@ -97,6 +99,10 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
 
   // check if orgId exists in public databases or in AnonymousCompany
   const companyInfo = await searchCompany(orgId);
+
+  if (isClosedCompany(companyInfo)) {
+    throw new UserInputError(CLOSED_COMPANY_ERROR);
+  }
 
   if (companyTypes.includes("ECO_ORGANISME") && siret) {
     const ecoOrganismeExists = await prisma.ecoOrganisme.findUnique({

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -12,8 +12,7 @@ import {
   isFRVat,
   TEST_COMPANY_PREFIX,
   countries,
-  cleanClue,
-  isClosedCompany
+  cleanClue
 } from "../common/constants/companySearchHelpers";
 import { SireneSearchResult } from "./sirene/types";
 import { CompanyVatSearchResult } from "./vat/vies/types";
@@ -153,7 +152,7 @@ export const makeSearchCompanies =
       return searchCompany(cleanedClue)
         .then(c =>
           // Exclude closed companies
-          [c].filter(c => c.etatAdministratif && !isClosedCompany(c))
+          [c].filter(c => c.etatAdministratif && c.etatAdministratif === "A")
         )
         .catch(_ => []);
     }
@@ -190,7 +189,7 @@ async function searchSireneOrNotFound(
   siret: string
 ): Promise<SireneSearchResult> {
   try {
-    return redundantCachedSearchSirene(siret);
+    return await redundantCachedSearchSirene(siret);
   } catch (err) {
     // The SIRET was not found in public data
     // Try searching the anonymous companies

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -12,7 +12,8 @@ import {
   isFRVat,
   TEST_COMPANY_PREFIX,
   countries,
-  cleanClue
+  cleanClue,
+  isClosedCompany
 } from "../common/constants/companySearchHelpers";
 import { SireneSearchResult } from "./sirene/types";
 import { CompanyVatSearchResult } from "./vat/vies/types";
@@ -152,7 +153,7 @@ export const makeSearchCompanies =
       return searchCompany(cleanedClue)
         .then(c =>
           // Exclude closed companies
-          [c].filter(c => c.etatAdministratif && c.etatAdministratif === "A")
+          [c].filter(c => c.etatAdministratif && !isClosedCompany(c))
         )
         .catch(_ => []);
     }
@@ -189,7 +190,7 @@ async function searchSireneOrNotFound(
   siret: string
 ): Promise<SireneSearchResult> {
   try {
-    return await redundantCachedSearchSirene(siret);
+    return redundantCachedSearchSirene(siret);
   } catch (err) {
     // The SIRET was not found in public data
     // Try searching the anonymous companies

--- a/back/src/companies/validateCompany.ts
+++ b/back/src/companies/validateCompany.ts
@@ -7,7 +7,8 @@ import {
 import { searchCompany } from "./search";
 
 /**
- * Validate a Company input and return a partial CompanyInput with info from Sirene data
+ * Validate a Company input
+ * auto-complete information with info from INSEE Sirene
  */
 export async function validateCompany(
   company: CompanyValidationInput,

--- a/back/src/forms/resolvers/mutations/markAsResealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsResealed.ts
@@ -5,7 +5,8 @@ import { expandFormFromDb, flattenFormInput } from "../../converter";
 import { checkCanMarkAsResealed } from "../../permissions";
 import {
   validateForwardedInCompanies,
-  sealedFormSchema
+  sealedFormSchema,
+  checkForClosedCompanies
 } from "../../validation";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
@@ -89,9 +90,14 @@ const markAsResealed: MutationResolvers["markAsResealed"] = async (
             update: { ...updateInput, status: Status.SEALED }
           }
         };
+  /**
+   * Check for closed companies or throw an exception
+   */
+  if (process.env.VERIFY_COMPANY === "true") {
+    await checkForClosedCompanies(form.id);
+  }
 
   let resealedForm: Form | null = null;
-
   if (form.status === Status.RESEALED) {
     // by pass xstate transition because markAsResealed is
     // used to update an already resealed form

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -7,7 +7,8 @@ import {
   beforeSignedByTransporterSchema,
   checkCanBeSealed,
   validateForwardedInCompanies,
-  wasteDetailsSchema
+  wasteDetailsSchema,
+  checkForClosedCompanies
 } from "../../validation";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
@@ -60,6 +61,13 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
         where: { siret: form.emitterCompanySiret }
       })) > 0
     : false;
+
+  /**
+   * Check for closed companies or throw an exception
+   */
+  if (process.env.VERIFY_COMPANY === "true") {
+    await checkForClosedCompanies(form.id);
+  }
 
   const resultingForm = await runInTransaction(async transaction => {
     const formRepository = getFormRepository(user, transaction);

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -3,6 +3,7 @@ import * as yup from "yup";
 import prisma from "../../prisma";
 import { CompanyRow } from "./types";
 import { searchCompany } from "../../companies/search";
+import { isClosedCompany } from "../../common/constants/companySearchHelpers";
 
 /**
  * Validation schema for company
@@ -18,7 +19,7 @@ export const companyValidationSchema = yup.object({
       async value => {
         try {
           const company = await searchCompany(value);
-          if (company.etatAdministratif === "F") {
+          if (isClosedCompany(company)) {
             return false;
           }
           return true;

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -1,5 +1,4 @@
 import { ApolloError, gql, useLazyQuery, useMutation } from "@apollo/client";
-import cogoToast from "cogo-toast";
 import { Field, Form, Formik } from "formik";
 import React, { useState } from "react";
 import { COMPANY_PRIVATE_INFOS } from "form/common/components/company/query";
@@ -22,7 +21,6 @@ import {
   TextInput,
   Alert,
 } from "@dataesr/react-dsfr";
-import { GraphQLError } from "graphql";
 
 type IProps = {
   onCompanyInfos: (companyInfos) => void;

--- a/front/src/company/Company.tsx
+++ b/front/src/company/Company.tsx
@@ -66,7 +66,10 @@ export default function CompanyInfo() {
 
   // Retrieves geo information from api-adresse.data.gouv.fr
   useEffect(() => {
-    if (data?.companyInfos.statutDiffusionEtablissement === "N") {
+    if (
+      data?.companyInfos.statutDiffusionEtablissement === "N" ||
+      data?.companyInfos.name === ""
+    ) {
       setNonDiffusible(true);
     }
     if (data?.companyInfos?.address) {

--- a/front/src/company/Company.tsx
+++ b/front/src/company/Company.tsx
@@ -41,6 +41,7 @@ const COMPANY_INFOS = gql`
       }
       ecoOrganismeAgreements
       statutDiffusionEtablissement
+      etatAdministratif
     }
   }
 `;
@@ -118,6 +119,7 @@ export default function CompanyInfo() {
 
           <CompanyRegistration
             isRegistered={company.isRegistered}
+            etatAdministratif={company.etatAdministratif}
             companyTypes={company.companyTypes}
           />
 

--- a/front/src/company/CompanyRegistration.tsx
+++ b/front/src/company/CompanyRegistration.tsx
@@ -3,13 +3,20 @@ import { CompanySearchResult } from "generated/graphql/types";
 import routes from "common/routes";
 import { COMPANY_TYPES } from "login/CompanyType";
 
-type Props = Pick<CompanySearchResult, "isRegistered" | "companyTypes">;
+type Props = Pick<
+  CompanySearchResult,
+  "isRegistered" | "companyTypes" | "etatAdministratif"
+>;
 
 export default function CompanyRegistration(props: Props) {
   return (
     <div className="columns">
       <div
-        className={`notification ${props.isRegistered ? "success" : "warning"}`}
+        className={`notification ${
+          props.isRegistered || props.etatAdministratif?.toUpperCase() !== "F"
+            ? "notification--success"
+            : "notification--error"
+        }`}
         style={{ width: "100%" }}
       >
         {props.isRegistered ? (
@@ -25,7 +32,7 @@ export default function CompanyRegistration(props: Props) {
               ))}
             </ul>
           </>
-        ) : (
+        ) : props.etatAdministratif?.toUpperCase() !== "F" ? (
           <>
             <span>
               Cette entreprise n'est pas encore inscrite sur Trackdéchets
@@ -35,6 +42,11 @@ export default function CompanyRegistration(props: Props) {
               Il s'agit de votre entreprise ? Mettez à jour vos informations en{" "}
               <a href={routes.signup.index}>vous inscrivant</a>
             </span>
+          </>
+        ) : (
+          <>
+            <span>Cet établissement est fermé</span>
+            <br />
           </>
         )}
       </div>

--- a/front/src/company/CompanyRegistration.tsx
+++ b/front/src/company/CompanyRegistration.tsx
@@ -10,12 +10,10 @@ type Props = Pick<
 
 export default function CompanyRegistration(props: Props) {
   return (
-    <div className="columns">
+    <div className="rows">
       <div
         className={`notification ${
-          props.isRegistered || props.etatAdministratif?.toUpperCase() !== "F"
-            ? "notification--success"
-            : "notification--error"
+          props.isRegistered ? "notification--success" : "notification--error"
         }`}
         style={{ width: "100%" }}
       >
@@ -32,7 +30,7 @@ export default function CompanyRegistration(props: Props) {
               ))}
             </ul>
           </>
-        ) : props.etatAdministratif?.toUpperCase() !== "F" ? (
+        ) : (
           <>
             <span>
               Cette entreprise n'est pas encore inscrite sur Trackdéchets
@@ -43,13 +41,16 @@ export default function CompanyRegistration(props: Props) {
               <a href={routes.signup.index}>vous inscrivant</a>
             </span>
           </>
-        ) : (
-          <>
-            <span>Cet établissement est fermé</span>
-            <br />
-          </>
         )}
       </div>
+      {props.etatAdministratif?.toUpperCase() === "F" && (
+        <div
+          className={`notification notification--error`}
+          style={{ width: "100%" }}
+        >
+          <span>Cet établissement est fermé selon l'INSEE</span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- Ajout de la validation dans `markAsSealed` et `markAsResealed` avec activation de la fonction par var d'env `VALIDATE_COMPANY` déjà existante en prod
 - Fonction de validation des SIRET actifs = `checkForClosedCompanies`

- Ajout de la validation dans `createCompany` et adaptations dans le front d'ajout d'établissement

# BAD_USER_INPUT retournée par l'api en cas d'établissement fermé

![image](https://user-images.githubusercontent.com/76620/213751268-f5a76fb0-5650-4d72-be0d-752fe2b3be14.png)

# Amélioration page publique Company infos

![image](https://user-images.githubusercontent.com/76620/214080618-374cfb55-a571-46ae-8f75-8987f6bb39b3.png)

![image](https://user-images.githubusercontent.com/76620/214080887-8ea218a6-a509-4b2e-880e-ddd46110648a.png)

![image](https://user-images.githubusercontent.com/76620/214081006-080b6775-4101-474a-86fa-62bffe186253.png)

![image](https://user-images.githubusercontent.com/76620/214081216-86aca351-fe9d-40ac-ae80-93c7313b7398.png)


----

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8408)
