### PR TITLE
Champ nextDestination.company.country NULL via l'API mais rempli sur le PDF, correction gestion country dans nextDestination

### DIFF
--- a/back/src/forms/resolvers/FormCompany.ts
+++ b/back/src/forms/resolvers/FormCompany.ts
@@ -1,12 +1,25 @@
+import { checkVAT } from "jsvat";
+import {
+  countries as vatCountries,
+  isSiret,
+  isVat
+} from "../../common/constants/companySearchHelpers";
 import { FormCompanyResolvers } from "../../generated/graphql/types";
 
 const formCompanyResolvers: FormCompanyResolvers = {
   country: parent => {
-    if (parent.vatNumber) {
-      return parent.country ?? "FR";
+    if (isVat(parent.vatNumber)) {
+      const vatCountryCode = checkVAT(
+        parent.vatNumber.replace(/[\W_\s]/gim, ""),
+        vatCountries
+      )?.country?.isoCode.short;
+      return vatCountryCode ? vatCountryCode : parent.country ?? "FR";
     }
-    if (parent.siret) {
+    if (isSiret(parent.siret)) {
       return "FR";
+    }
+    if (parent.country) {
+      return parent.country;
     }
     return null;
   },

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -1,6 +1,10 @@
 import { Prisma, Status, WasteAcceptationStatus } from "@prisma/client";
 import { Machine } from "xstate";
 import { PROCESSING_OPERATIONS_GROUPEMENT_CODES } from "../../common/constants";
+import {
+  isForeignVat,
+  isSiret
+} from "../../common/constants/companySearchHelpers";
 import { Event, EventType } from "./types";
 
 /**
@@ -243,8 +247,7 @@ const machine = Machine<any, Event>(
             PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
               update.processingOperationDone as string
             ) &&
-            (!update.nextDestinationCompanyCountry ||
-              update.nextDestinationCompanyCountry === "FR") &&
+            !isForeignNextDestination(update) &&
             !(update.noTraceability === true)
           );
         }
@@ -260,8 +263,7 @@ const machine = Machine<any, Event>(
             PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
               update.processingOperationDone as string
             ) &&
-            !!update.nextDestinationCompanyCountry &&
-            update.nextDestinationCompanyCountry !== "FR" &&
+            isForeignNextDestination(update) &&
             !(update.noTraceability === true)
           );
         }
@@ -298,4 +300,24 @@ const machine = Machine<any, Event>(
   }
 );
 
+function isForeignNextDestination(update: Prisma.FormUpdateInput) {
+  if (
+    update.nextDestinationCompanyVatNumber &&
+    isForeignVat(update.nextDestinationCompanyVatNumber as string)
+  ) {
+    return true;
+  }
+  if (
+    update.nextDestinationCompanySiret &&
+    isSiret(update.nextDestinationCompanySiret as string)
+  ) {
+    return false;
+  }
+  if (
+    !!update.nextDestinationCompanyCountry &&
+    update.nextDestinationCompanyCountry !== "FR"
+  ) {
+    return true;
+  }
+}
 export default machine;


### PR DESCRIPTION
# Reproduction bug

- mutation markAsProcessed avec les arguments suivants dans nextDestination.company :

> vatNumber: "DE116150985"
> siret: null
> et pas de country

- Résultats : le retour de la mutation, ainsi que la query form renvoient un country: 
- "FR" pour la nextDestination : KO, le pays déduit devrait être "DE"
- le statut est "AWAITING_GROUP", au lieu de FOLLOWED_WITH_PNTTD : KO

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10569)
