### PR TITLE
Fix recettes établissements étrangers

### DIFF
--- a/back/prisma/scripts/clean-transporter-siret-when-vat.ts
+++ b/back/prisma/scripts/clean-transporter-siret-when-vat.ts
@@ -1,0 +1,57 @@
+import { Updater, registerUpdater } from "./helper/helper";
+import prisma from "../../src/prisma";
+
+@registerUpdater(
+  "Clean Transporter SIRET when it's a copy of VAT",
+  "Clean Transporter SIRET after enforcing SIRET validation",
+  true
+)
+export class FixTransporterSiretIsVatUpdater implements Updater {
+  async run() {
+    try {
+      await prisma.$queryRaw`update default$default."Form" set "transporterCompanySiret" = NULL where "transporterCompanySiret" = "transporterCompanyVatNumber" and "transporterCompanySiret" ~ '\\w\\w' and "transporterCompanyVatNumber" != '';`;
+    } catch (err) {
+      console.error(
+        "☠ Something went wrong during the UPDATE of Form.transporterCompanySiret",
+        err
+      );
+      throw new Error();
+    }
+    try {
+      await prisma.$queryRaw`update default$default."Bsvhu" set "transporterCompanySiret" = NULL where "transporterCompanySiret" = "transporterCompanyVatNumber" and "transporterCompanySiret" ~ '\\w\\w' and "transporterCompanyVatNumber" != '';`;
+    } catch (err) {
+      console.error(
+        "☠ Something went wrong during the UPDATE of Bsvhu.transporterCompanySiret",
+        err
+      );
+      throw new Error();
+    }
+    try {
+      await prisma.$queryRaw`update default$default."Bsdasri" set "transporterCompanySiret" = NULL where "transporterCompanySiret" = "transporterCompanyVatNumber" and "transporterCompanySiret" ~ '\\w\\w' and "transporterCompanyVatNumber" != '';`;
+    } catch (err) {
+      console.error(
+        "☠ Something went wrong during the UPDATE of Bsdasri.transporterCompanySiret",
+        err
+      );
+      throw new Error();
+    }
+    try {
+      await prisma.$queryRaw`update default$default."Bsff" set "transporterCompanySiret" = NULL where "transporterCompanySiret" = "transporterCompanyVatNumber" and "transporterCompanySiret" ~ '\\w\\w' and "transporterCompanyVatNumber" != '';`;
+    } catch (err) {
+      console.error(
+        "☠ Something went wrong during the UPDATE of Bsff.transporterCompanySiret",
+        err
+      );
+      throw new Error();
+    }
+    try {
+      await prisma.$queryRaw`update default$default."Bsda" set "transporterCompanySiret" = NULL where "transporterCompanySiret" = "transporterCompanyVatNumber" and "transporterCompanySiret" ~ '\\w\\w' and "transporterCompanyVatNumber" != '';`;
+    } catch (err) {
+      console.error(
+        "☠ Something went wrong during the UPDATE of Bsda.transporterCompanySiret",
+        err
+      );
+      throw new Error();
+    }
+  }
+}

--- a/back/prisma/scripts/fix-vatnumber-bsds.ts
+++ b/back/prisma/scripts/fix-vatnumber-bsds.ts
@@ -6,9 +6,9 @@ import prisma from "../../src/prisma";
 import { Form } from ".prisma/client";
 
 @registerUpdater(
-  "Clean BSD VAT numbers",
+  "Clean BSD SIRET and VAT numbers from bad characters",
   "Clean BSD SIRET and VAT numbers",
-  true
+  false
 )
 export class FixBSDVatUpdater implements Updater {
   async run() {

--- a/back/src/bsdasris/pdf/components/FormCompanyFields.tsx
+++ b/back/src/bsdasris/pdf/components/FormCompanyFields.tsx
@@ -12,17 +12,17 @@ export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
   return (
     <>
       <p>
-        Entreprise{" "}
+        Entreprise {" "}
         <input
           type="checkbox"
-          checked={companyCountry && companyCountry.cca2 === "FR"}
+          checked={companyCountry && companyCountry?.cca2 === "FR"}
           readOnly
         />
         française
         {"  "}
         <input
           type="checkbox"
-          checked={companyCountry && companyCountry.cca2 !== "FR"}
+          checked={companyCountry && companyCountry?.cca2 !== "FR"}
           readOnly
         />{" "}
         étrangère
@@ -40,8 +40,8 @@ export function FormCompanyFields({ company }: FormCompanyFieldsProps) {
         <br />
         Adresse complète : {company?.address}
         <br />
-        {companyCountry == null || companyCountry.cca2 === "FR" ? null : (
-          <span>Pays: {companyCountry.name.common} </span>
+        {companyCountry === null || companyCountry?.cca2 === "FR" ? null : (
+          <span>Pays: {companyCountry?.name.common} </span>
         )}
       </p>
       <p>

--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -75,9 +75,9 @@ export function FormCompanyFields({
         Adresse complète : {company?.address}
         <br />
         Pays (le cas échéant) :{" "}
-        {companyCountry == null || companyCountry.cca2 === "FR"
+        {companyCountry === null || companyCountry?.cca2 === "FR"
           ? null
-          : companyCountry.cca2}
+          : companyCountry?.cca2}
       </p>
       <p>
         Tel : {company?.phone}
@@ -95,28 +95,25 @@ export function FormCompanyFields({
   );
 }
 
-export function getcompanyCountry(company: FormCompany): Country {
+export function getcompanyCountry(company: FormCompany): Country | null {
   // reconnaitre le pays directement dans le champ country
   let companyCountry = company
     ? countries.find(country => country.cca2 === company?.country) ??
       FRENCH_COUNTRY // default
     : null;
 
-  if (company && !companyCountry) {
-    if (isSiret(company.siret)) {
-      // forcer FR si le siret est valide
-      companyCountry = countries.find(country => country.cca2 === "FR");
-    } else if (isVat(company.vatNumber)) {
-      // trouver automatiquement le pays selon le numéro de TVA
-      const vatCountryCode = checkVAT(
-        company.vatNumber.replace(/[\W_\s]/gim, ""),
-        vatCountries
-      )?.country?.isoCode.short;
+  // forcer FR si le siret est valide
+  if (company && isSiret(company.siret)) {
+    companyCountry = countries.find(country => country.cca2 === "FR");
+  } else if (company && isVat(company.vatNumber)) {
+    // trouver automatiquement le pays selon le numéro de TVA
+    const vatCountryCode = checkVAT(
+      company.vatNumber.replace(/[\W_\s]/gim, ""),
+      vatCountries
+    )?.country?.isoCode.short;
 
-      companyCountry = countries.find(
-        country => country.cca2 === vatCountryCode
-      );
-    }
+    companyCountry = countries.find(country => country.cca2 === vatCountryCode);
   }
+
   return companyCountry;
 }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
@@ -167,7 +167,7 @@ export function PrepareSegment({ form, siret }: WorkflowActionProps) {
                 <h4 className="form__section-heading">Siret</h4>
                 <CompanySelector
                   name="transporter.company"
-                  allowForeignCompanies={true}
+                  allowForeignCompanies={false}
                   registeredOnlyCompanies={true}
                   initialAutoSelectFirstCompany={false}
                   onCompanySelected={transporter => {


### PR DESCRIPTION
# Migration données transporterCompanySiret quand il s'agissait de SIRET

- Sinon les BSD existants dans la DB ne pouvaient plus être manipulés car le transporterCompanySiret contenait historiquement des TVA

# Transport multi-modal : désactiver les transporteurs étrangers multi-modal

![image](https://user-images.githubusercontent.com/76620/210838879-f0f8d1a8-9237-430a-b88f-bce825882967.png)


# Fix Signature Transporteur étranger

![image](https://user-images.githubusercontent.com/76620/210837682-f9c687eb-6e62-4a94-bb48-a8da7006129f.png)


# Fix Pays dans les pdf BSDASRI

![image](https://user-images.githubusercontent.com/76620/210828369-44019506-889d-44ee-88f9-28293c9d56e8.png)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro signature transporteur étranger](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10530)
- [Ticket Favro Multi-modal](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10624)
- [Ticket Favro Erreur "IT13029381004" n'est pas un numéro de siret valide](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10447)
- [Ticket Favro Erreur PAYS sur les pdf Bsdasri et autres](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10606)