### PR TITLE
[TRA-10450-Recette] Add env variable `MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER`

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -184,3 +184,7 @@ SCALINGO_TOKEN=mytoken
 # OPENID JWT
 OIDC_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----…"
 
+# Permet de définir une date avant laquelle la validation 
+# des poids max en cas de transport routier ne s'applique pas
+MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER=
+

--- a/.env.model
+++ b/.env.model
@@ -186,5 +186,5 @@ OIDC_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----…"
 
 # Permet de définir une date avant laquelle la validation 
 # des poids max en cas de transport routier ne s'applique pas
-MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER=
+MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER=2023-01-11T00:00:00.000Z
 

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -118,7 +118,11 @@ input BsdaInput {
   waste: BsdaWasteInput
   "Conditionnement"
   packagings: [BsdaPackagingInput!]
-  "Quantité en tonnes, réelle ou estimée"
+  """
+  Poids en tonnes, réel ou estimé.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   weight: BsdaWeightInput
 
   "Installation de destination"
@@ -199,7 +203,11 @@ input BsdaPackagingInput {
 input BsdaWeightInput {
   "Type de quantité (réelle ou estimé)"
   isEstimate: Boolean
-  "Quantité en tonne"
+  """
+  Poids en tonne.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   value: Float
 }
 
@@ -221,7 +229,11 @@ input BsdaDestinationInput {
 input BsdaReceptionInput {
   "Date de présentation sur site"
   date: DateTime
-  "Quantité présentée en tonnes"
+  """
+  Quantité présentée en tonnes
+
+  Doit être inférieure à 40T en cas de transport routier et inférieure à 50 000 T tout type de transport confondu.
+  """
   weight: Float
   "Lot accepté, accepté partiellement ou refusé"
   acceptationStatus: WasteAcceptationStatus

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -982,7 +982,7 @@ const wasteDescriptionSchema: FactorySchemaOf<
     weightValue: weight(WeightUnits.Kilogramme)
       .label("Déchet")
       .when(
-        "transporterTransportMode",
+        ["transporterTransportMode", "createdAt"],
         weightConditions.transportMode(WeightUnits.Kilogramme)
       )
       .requiredIf(context.workSignature, `La quantité est obligatoire`)

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -125,7 +125,11 @@ input BsdasriWasteInput {
 }
 
 input BsdasriEmissionInput {
-  "Quantité en kilogrammes"
+  """
+  Poids en kilogrammes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   weight: BsdasriWeightInput
   packagings: [BsdasriPackagingsInput!]
 }
@@ -147,14 +151,22 @@ input BsdasriEcoOrganismeInput {
 }
 
 input BsdasriWeightInput {
-  "Poids en kilogrammes"
+  """
+  Poids en kilogrammes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   value: Float
   "Le poids est il une estimation"
   isEstimate: Boolean
 }
 
 input BsdasriRealWeightInput {
-  "Poids en kilogrammes"
+  """
+  Poids en kilogrammes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   value: Float!
 }
 input BsdasriAcceptationInput {
@@ -167,7 +179,11 @@ input BsdasriAcceptationInput {
 }
 
 input BsdasriTransportInput {
-  "Poids"
+  """
+  Poids en kilogrammes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   weight: BsdasriWeightInput
   packagings: [BsdasriPackagingsInput!]
   takenOverAt: DateTime
@@ -220,6 +236,11 @@ input BsdasriReceptionInput {
 }
 
 input BsdasriOperationInput {
+  """
+  Poids en kilogrammes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   weight: BsdasriRealWeightInput
   """
   Code de traitement

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -238,7 +238,7 @@ export const emissionSchema: FactorySchemaOf<
           )
       })
       .when(
-        "transporterTransportMode",
+        ["transporterTransportMode", "createdAt"],
         weightConditions.transportMode(WeightUnits.Kilogramme)
       )
       .positive("Le poids de déchet émis doit être supérieur à 0"),
@@ -459,7 +459,7 @@ export const transportSchema: FactorySchemaOf<
           )
       })
       .when(
-        "transporterTransportMode",
+        ["transporterTransportMode", "createdAt"],
         weightConditions.transportMode(WeightUnits.Kilogramme)
       )
       .positive("Le poids de déchets transportés doit être supérieur à 0"),

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -241,7 +241,7 @@ export const wasteDetailsSchemaFn: FactorySchemaOf<boolean, WasteDetails> =
       weightValue: weight(WeightUnits.Kilogramme)
         .label("Déchet")
         .when(
-          "transporterTransportMode",
+          ["transporterTransportMode", "createdAt"],
           weightConditions.transportMode(WeightUnits.Kilogramme)
         )
         .positive("Le poids doit être supérieur à 0")

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -1661,7 +1661,7 @@ describe("Mutation.createForm", () => {
     expect(form.intermediariesSirets).toContain(company.siret);
   });
 
-  it("should not be possible de set a weight > 50 T when transport mode is ROAD", async () => {
+  it("should not be possible de set a weight > 40 T when transport mode is ROAD", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const transporter = await companyFactory();
     const { mutate } = makeClient(user);

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -1883,4 +1883,71 @@ describe("Mutation.updateForm", () => {
     expect(updatedForm.transportersSirets).toContain(company.siret);
     expect(updatedForm.intermediariesSirets).toContain(company.siret);
   });
+
+  it("should not be possible to update a weight > 40 T when transport mode is ROAD", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const { mutate } = makeClient(user);
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SEALED",
+        emitterCompanySiret: company.siret,
+        emitterType: EmitterType.APPENDIX2,
+        wasteDetailsCode: "01 03 04*",
+        transporterTransportMode: "ROAD"
+      }
+    });
+    const { errors } = await mutate<
+      Pick<Mutation, "updateForm">,
+      MutationUpdateFormArgs
+    >(UPDATE_FORM, {
+      variables: {
+        updateFormInput: {
+          id: form.id,
+          wasteDetails: { quantity: 50 }
+        }
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Déchet : le poids doit être inférieur à 40 tonnes lorsque le transport se fait par la route"
+      })
+    ]);
+  });
+
+  it(
+    "should be possible to update a form where transport is ROAD and wasteDetailsQuantity is > 40T " +
+      "if it was created before (<=) process.env.MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER",
+    async () => {
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+      const { mutate } = makeClient(user);
+      const form = await formFactory({
+        ownerId: user.id,
+        opt: {
+          createdAt: new Date(0), // same as default value for MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER
+          status: "SEALED",
+          emitterCompanySiret: company.siret,
+          emitterType: EmitterType.APPENDIX2,
+          wasteDetailsCode: "01 03 04*",
+          transporterTransportMode: "ROAD",
+          wasteDetailsQuantity: 50
+        }
+      });
+      const { errors } = await mutate<
+        Pick<Mutation, "updateForm">,
+        MutationUpdateFormArgs
+      >(UPDATE_FORM, {
+        variables: {
+          updateFormInput: {
+            id: form.id,
+            wasteDetails: { consistence: "SOLID" }
+          }
+        }
+      });
+
+      expect(errors).toBeUndefined();
+    }
+  );
 });

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -11,7 +11,11 @@ input SignEmissionFormInput {
   "Conditionnements"
   packagingInfos: [PackagingInfoInput!]
 
-  "Quantité en tonnes"
+  """
+  Poids en tonnes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   quantity: Float!
 
   "Code ONU"
@@ -67,7 +71,11 @@ input TransporterSignatureFormInput {
   "DEPRECATED - Conditionnement"
   packagings: [Packagings]
 
-  "Quantité en tonnes"
+  """
+  Poids en tonnes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   quantity: Float!
 
   "Code ONU"
@@ -97,8 +105,11 @@ input AcceptedFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 10).
-   Doit être supérieure à 0 lorsque le déchet est accepté.
-   Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être supérieure à 0 lorsque le déchet est accepté.
+  Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 }
@@ -122,8 +133,11 @@ input ReceivedFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 10).
-   Doit être supérieure à 0 lorsque le déchet est accepté.
-   Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être supérieure à 0 lorsque le déchet est accepté.
+  Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float
 }
@@ -575,7 +589,11 @@ input WasteDetailsInput {
   "DEPRECATED - Nombre de colis"
   numberOfPackages: Int
 
-  "Quantité en tonnes"
+  """
+  Poids en tonnes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   quantity: Float
 
   "Réelle ou estimée"
@@ -640,7 +658,11 @@ input WasteDetailsRepackagingInput {
   "Conditionnements"
   packagingInfos: [PackagingInfoInput!]
 
-  "Quantité en tonnes"
+  """
+  Poids en tonnes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   quantity: Float
 
   "Réelle ou estimée"
@@ -662,8 +684,11 @@ input TempStorerAcceptedFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 13)
-   Doit être supérieure à 0 lorsque le déchet est accepté.
-   Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être supérieure à 0 lorsque le déchet est accepté.
+  Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 
@@ -689,8 +714,11 @@ input TempStoredFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 13)
-   Doit être supérieure à 0 lorsque le déchet est accepté.
-   Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être supérieure à 0 lorsque le déchet est accepté.
+  Doit être égale à 0 lorsque le déchet est refusé.
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 
@@ -708,7 +736,11 @@ input WasteDetailsRepackagingInput {
   "Conditionnements"
   packagingInfos: [PackagingInfoInput!]
 
-  "Quantité en tonnes"
+  """
+  Poids en tonnes
+
+  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  """
   quantity: Float
 
   "Réelle ou estimée"

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -640,7 +640,7 @@ const wasteDetailsSchemaFn: FactorySchemaOf<boolean, WasteDetails> = isDraft =>
     wasteDetailsQuantity: weight(WeightUnits.Tonne)
       .label("Déchet")
       .when(
-        "transporterTransportMode",
+        ["transporterTransportMode", "createdAt"],
         weightConditions.transportMode(WeightUnits.Tonne)
       )
       .requiredIf(!isDraft, "La quantité du déchet en tonnes est obligatoire"),


### PR DESCRIPTION
- Ajout d'une variable d'env permettant de valider les poids en transport routier seulement pour les bordereaux ayant une date de création ultérieure. Cela va permettre d'éviter de nombreux problèmes de validation après la MEP sur des bordereaux en transit avec des valeurs de poids incohérentes. 
- Ajout de docstring en bonus

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10450)
