### PR TITLE
Recette BSDD - Correction du state machine

### DIFF
--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -1,4 +1,4 @@
-import { Status, WasteAcceptationStatus } from "@prisma/client";
+import { Prisma, Status, WasteAcceptationStatus } from "@prisma/client";
 import { Machine } from "xstate";
 import { PROCESSING_OPERATIONS_GROUPEMENT_CODES } from "../../common/constants";
 import { Event, EventType } from "./types";
@@ -227,50 +227,73 @@ const machine = Machine<any, Event>(
   {
     guards: {
       isExemptOfTraceability: (_, event) => {
-        const update =
-          event.formUpdateInput?.forwardedIn?.update ?? event?.formUpdateInput;
-        return update?.noTraceability === true;
+        function guard(update: Prisma.FormUpdateInput) {
+          if (!update) return false;
+          return update.noTraceability === true;
+        }
+        return (
+          guard(event.formUpdateInput) ||
+          guard(event.formUpdateInput?.forwardedIn?.update)
+        );
       },
       awaitsGroup: (_, event) => {
-        const update =
-          event.formUpdateInput?.forwardedIn?.update ?? event.formUpdateInput;
+        function guard(update: Prisma.FormUpdateInput) {
+          if (!update) return false;
+          return (
+            PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
+              update.processingOperationDone as string
+            ) &&
+            (!update.nextDestinationCompanyCountry ||
+              update.nextDestinationCompanyCountry === "FR") &&
+            !(update.noTraceability === true)
+          );
+        }
         return (
-          PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
-            update?.processingOperationDone as string
-          ) &&
-          (!update?.nextDestinationCompanyCountry ||
-            update?.nextDestinationCompanyCountry === "FR") &&
-          !(update?.noTraceability === true)
+          guard(event.formUpdateInput) ||
+          guard(event.formUpdateInput?.forwardedIn?.update)
         );
       },
       isFollowedWithPnttd: (_, event) => {
-        const update =
-          event.formUpdateInput?.forwardedIn?.update ?? event.formUpdateInput;
+        function guard(update: Prisma.FormUpdateInput) {
+          if (!update) return false;
+          return (
+            PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
+              update.processingOperationDone as string
+            ) &&
+            !!update.nextDestinationCompanyCountry &&
+            update.nextDestinationCompanyCountry !== "FR" &&
+            !(update.noTraceability === true)
+          );
+        }
         return (
-          PROCESSING_OPERATIONS_GROUPEMENT_CODES.includes(
-            update?.processingOperationDone as string
-          ) &&
-          !!update?.nextDestinationCompanyCountry &&
-          update?.nextDestinationCompanyCountry !== "FR" &&
-          !(update?.noTraceability === true)
+          guard(event.formUpdateInput) ||
+          guard(event.formUpdateInput?.forwardedIn?.update)
         );
       },
-      isFormRefused: (_, event) =>
-        event.formUpdateInput?.wasteAcceptationStatus === "REFUSED" ||
-        event.formUpdateInput?.forwardedIn?.update?.wasteAcceptationStatus ===
-          "REFUSED",
-      isFormAccepted: (_, event) =>
-        [
-          WasteAcceptationStatus.ACCEPTED,
-          WasteAcceptationStatus.PARTIALLY_REFUSED
-        ].includes(event.formUpdateInput?.wasteAcceptationStatus as any) ||
-        [
-          WasteAcceptationStatus.ACCEPTED,
-          WasteAcceptationStatus.PARTIALLY_REFUSED
-        ].includes(
-          event.formUpdateInput?.forwardedIn?.update
-            ?.wasteAcceptationStatus as any
-        )
+      isFormRefused: (_, event) => {
+        function guard(update: Prisma.FormUpdateInput) {
+          if (!update) return false;
+          return update.wasteAcceptationStatus === "REFUSED";
+        }
+
+        return (
+          guard(event.formUpdateInput) ||
+          guard(event.formUpdateInput?.forwardedIn?.update)
+        );
+      },
+      isFormAccepted: (_, event) => {
+        function guard(update: Prisma.FormUpdateInput) {
+          if (!update) return false;
+          return [
+            WasteAcceptationStatus.ACCEPTED,
+            WasteAcceptationStatus.PARTIALLY_REFUSED
+          ].includes(update.wasteAcceptationStatus as any);
+        }
+        return (
+          guard(event.formUpdateInput) ||
+          guard(event.formUpdateInput?.forwardedIn?.update)
+        );
+      }
     }
   }
 );

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -1,6 +1,5 @@
 import { Status, WasteAcceptationStatus } from "@prisma/client";
 import { Machine } from "xstate";
-import updateApplicationResolver from "../../applications/resolvers/mutations/updateApplication";
 import { PROCESSING_OPERATIONS_GROUPEMENT_CODES } from "../../common/constants";
 import { Event, EventType } from "./types";
 

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -255,19 +255,22 @@ const machine = Machine<any, Event>(
           !(update?.noTraceability === true)
         );
       },
-      isFormRefused: (_, event) => {
-        const update =
-          event.formUpdateInput?.forwardedIn?.update ?? event.formUpdateInput;
-        return update?.wasteAcceptationStatus === "REFUSED";
-      },
-      isFormAccepted: (_, event) => {
-        const update =
-          event.formUpdateInput?.forwardedIn?.update ?? event.formUpdateInput;
-        return [
+      isFormRefused: (_, event) =>
+        event.formUpdateInput?.wasteAcceptationStatus === "REFUSED" ||
+        event.formUpdateInput?.forwardedIn?.update?.wasteAcceptationStatus ===
+          "REFUSED",
+      isFormAccepted: (_, event) =>
+        [
           WasteAcceptationStatus.ACCEPTED,
           WasteAcceptationStatus.PARTIALLY_REFUSED
-        ].includes(update?.wasteAcceptationStatus as any);
-      }
+        ].includes(event.formUpdateInput?.wasteAcceptationStatus as any) ||
+        [
+          WasteAcceptationStatus.ACCEPTED,
+          WasteAcceptationStatus.PARTIALLY_REFUSED
+        ].includes(
+          event.formUpdateInput?.forwardedIn?.update
+            ?.wasteAcceptationStatus as any
+        )
     }
   }
 );


### PR DESCRIPTION
Les mauvaises transitions suivantes étaient possibles : 

1 - `TEMP_STORER_ACCEPTED` => `markAsProcessed` (avec code regroupement et destination ult. étranger) => `PROCESSED` 
2 - `ACCEPTED` => `markAsProcessed` par la dest. finale après entr. prvoisoire (avec code regroupement et destination ult. étrangé)  => `AWAITING_GROUP`

Le premier cas était possible car le guard `isFollowedWithPnttd` n'était pas présent dans la transition `TEMP_STORER_ACCEPTED` => `markAsProcessed`. Le deuxième cas était possible car les changements sur `forwardedIn` n'était pas correctement pris en compte dans le guard `isFollowedWithPnttd`. 

Petit refacto des `guards` au passage pour éviter de dupliquer les conditions entre `event.formUpdateInput` et `event.formUpdateInput?.forwardedIn?.update` ce qui a été probablement la source d'erreur du problème 2.

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

### Fix 1

https://user-images.githubusercontent.com/2269165/210972202-18abe84c-4ff9-4965-b7c6-07862ce25f4c.mov


### Fix 2 

https://user-images.githubusercontent.com/2269165/210973836-d4ea7cb7-39cf-4d39-a283-df35ee0c8d9f.mov





- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10523)
