### PR TITLE
Correctifs Recette Transporter étrangers

### DIFF
--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -66,7 +66,7 @@ export const companyFactory = async (
   const siret = opts.siret ? opts.siret : siretify(companyIndex);
   return prisma.company.create({
     data: {
-      orgId: siret,
+      orgId: !opts.vatNumber?.length ? siret : opts.vatNumber,
       siret,
       companyTypes: {
         set: ["PRODUCER", "TRANSPORTER", "WASTEPROCESSOR"]

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -45,6 +45,7 @@ import {
   BsdaRevisionRequest
 } from "@prisma/client";
 import { BsdElastic } from "../common/elastic";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
   return {
     id: form.id,
@@ -183,7 +184,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
     transporter: nullIfNoValues<BsdaTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
-        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
+        orgId: getTransporterCompanyOrgId(form),
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -183,6 +183,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
     transporter: nullIfNoValues<BsdaTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
+        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -1,4 +1,5 @@
 import { Bsda, BsdaStatus, IntermediaryBsdaAssociation } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic, indexBsd } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
@@ -55,7 +56,7 @@ function getWhere(
     emitterCompanySiret: bsda.emitterCompanySiret,
     workerCompanySiret: bsda.workerCompanySiret,
     destinationCompanySiret: bsda.destinationCompanySiret,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     brokerCompanySiret: bsda.brokerCompanySiret,
     destinationOperationNextDestinationCompanySiret:
       bsda.destinationOperationNextDestinationCompanySiret,
@@ -158,6 +159,7 @@ export function toBsdElastic(bsda: BsdaToElastic): BsdElastic {
     emitterCompanySiret: bsda.emitterCompanySiret ?? "",
     transporterCompanyName: bsda.transporterCompanyName ?? "",
     transporterCompanySiret: bsda.transporterCompanySiret ?? "",
+    transporterCompanyVatNumber: bsda.transporterCompanyVatNumber ?? "",
     transporterTakenOverAt: bsda.transporterTransportTakenOverAt?.getTime(),
     transporterCustomInfo: bsda.transporterCustomInfo ?? "",
     transporterNumberPlate: bsda.transporterTransportPlates,

--- a/back/src/bsda/examples/__tests__/examples.integration.ts
+++ b/back/src/bsda/examples/__tests__/examples.integration.ts
@@ -1,13 +1,14 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import collecteChantierWorkflow from "../workflows/collecteChantier";
+import collecteChantierTransporteurEtranger from "../workflows/collecteChantierTransporteurEtranger";
 import collecteChantierParticulierWorkflow from "../workflows/collecteChantierParticulier";
 import groupementWorkflow from "../workflows/groupement";
 
 describe("Exemples de circuit du bordereau de suivi amiante", () => {
   afterEach(resetDatabase);
 
-  test(
+  it(
     collecteChantierWorkflow.title,
     async () => {
       await testWorkflow(collecteChantierWorkflow);
@@ -15,7 +16,15 @@ describe("Exemples de circuit du bordereau de suivi amiante", () => {
     60000
   );
 
-  test(
+  it(
+    collecteChantierTransporteurEtranger.title,
+    async () => {
+      await testWorkflow(collecteChantierTransporteurEtranger);
+    },
+    60000
+  );
+
+  it(
     collecteChantierParticulierWorkflow.title,
     async () => {
       await testWorkflow(collecteChantierParticulierWorkflow);
@@ -23,7 +32,7 @@ describe("Exemples de circuit du bordereau de suivi amiante", () => {
     60000
   );
 
-  test(
+  it(
     groupementWorkflow.title,
     async () => {
       await testWorkflow(groupementWorkflow);

--- a/back/src/bsda/examples/fixtures.ts
+++ b/back/src/bsda/examples/fixtures.ts
@@ -2,7 +2,7 @@
  * Fixtures used as building blocks of mutations inputs
  */
 
-function emitterCompanyInput(siret: string) {
+export function emitterCompanyInput(siret: string) {
   return {
     siret,
     name: "Déchets & Co",
@@ -13,14 +13,14 @@ function emitterCompanyInput(siret: string) {
   };
 }
 
-const pickupSiteInput = {
+export const pickupSiteInput = {
   address: "5 rue du chantier",
   postalCode: "75010",
   city: "Paris",
   infos: "Site de stockage de boues"
 };
 
-function emitterInput(siret: string) {
+export function emitterInput(siret: string) {
   return {
     isPrivateIndividual: false,
     company: emitterCompanyInput(siret),
@@ -28,7 +28,7 @@ function emitterInput(siret: string) {
   };
 }
 
-function privateIndividualEmitterInput() {
+export function privateIndividualEmitterInput() {
   return {
     isPrivateIndividual: true,
     company: {
@@ -41,7 +41,7 @@ function privateIndividualEmitterInput() {
   };
 }
 
-function packagingsInput() {
+export function packagingsInput() {
   return [
     {
       type: "BIG_BAG",
@@ -50,7 +50,7 @@ function packagingsInput() {
   ];
 }
 
-function wasteInput() {
+export function wasteInput() {
   return {
     code: "16 01 11*",
     consistence: "SOLIDE",
@@ -61,14 +61,14 @@ function wasteInput() {
   };
 }
 
-function weightInput() {
+export function weightInput() {
   return {
     isEstimate: true,
     value: 2.3
   };
 }
 
-function transporterCompanyInput(siret: string) {
+export function transporterCompanyInput(siret: string) {
   return {
     siret,
     name: "Transport & Co",
@@ -85,14 +85,14 @@ const recepisseInput = {
   validityLimit: "2020-06-30"
 };
 
-function transporterInput(siret: string) {
+export function transporterInput(siret: string) {
   return {
     company: transporterCompanyInput(siret),
     recepisse: recepisseInput
   };
 }
 
-function traiteurCompanyInput(siret: string) {
+export function traiteurCompanyInput(siret: string) {
   return {
     siret,
     name: "Traiteur & Co",
@@ -103,7 +103,7 @@ function traiteurCompanyInput(siret: string) {
   };
 }
 
-function destinationInput(siret: string) {
+export function destinationInput(siret: string) {
   return {
     company: traiteurCompanyInput(siret),
     plannedOperationCode: "D 5",
@@ -111,13 +111,13 @@ function destinationInput(siret: string) {
   };
 }
 
-function workerInput(siret: string) {
+export function workerInput(siret: string) {
   return {
     company: workerCompanyInput(siret)
   };
 }
 
-function workerCompanyInput(siret: string) {
+export function workerCompanyInput(siret: string) {
   return {
     siret,
     name: "Entreprise de travaux & Co",
@@ -128,15 +128,15 @@ function workerCompanyInput(siret: string) {
   };
 }
 
-function emitterSignatureUpdateInput() {
+export function emitterSignatureUpdateInput() {
   return {};
 }
 
-function workerSignatureUpdateInput() {
+export function workerSignatureUpdateInput() {
   return {};
 }
 
-function transporterSignatureUpdateInput() {
+export function transporterSignatureUpdateInput() {
   return {
     transporter: {
       transport: {
@@ -148,7 +148,7 @@ function transporterSignatureUpdateInput() {
   };
 }
 
-function destinationSignatureUpdateInput() {
+export function destinationSignatureUpdateInput() {
   return {
     destination: {
       reception: {
@@ -164,7 +164,7 @@ function destinationSignatureUpdateInput() {
   };
 }
 
-function transporterToGroupInput(siret: string) {
+export function transporterToGroupInput(siret: string) {
   return {
     company: transporterCompanyInput(siret),
     recepisse: recepisseInput,
@@ -176,7 +176,7 @@ function transporterToGroupInput(siret: string) {
   };
 }
 
-function destinationToGroupInput(siret: string) {
+export function destinationToGroupInput(siret: string) {
   return {
     company: traiteurCompanyInput(siret),
     plannedOperationCode: "D 15",

--- a/back/src/bsda/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsda/examples/fixturesForeignTransporter.ts
@@ -1,0 +1,58 @@
+import {
+  emitterCompanyInput,
+  emitterInput,
+  privateIndividualEmitterInput,
+  transporterToGroupInput,
+  traiteurCompanyInput,
+  destinationInput,
+  destinationToGroupInput,
+  packagingsInput,
+  wasteInput,
+  weightInput,
+  workerInput,
+  pickupSiteInput,
+  emitterSignatureUpdateInput,
+  workerSignatureUpdateInput,
+  transporterSignatureUpdateInput,
+  destinationSignatureUpdateInput
+} from "./fixtures";
+
+function transporterCompanyInput(vatNumber: string) {
+  return {
+    siret: null,
+    vatNumber,
+    name: "Transport & Co",
+    address: "1 rue des 6 chemins, 07100 ANNONAY",
+    contact: "Claire Dupuis",
+    mail: "claire.dupuis@transportco.fr",
+    phone: "04 00 00 00 00"
+  };
+}
+
+function transporterInput(vatNumber: string) {
+  return {
+    company: transporterCompanyInput(vatNumber),
+    recepisse: null
+  };
+}
+
+export default {
+  emitterCompanyInput,
+  emitterInput,
+  privateIndividualEmitterInput,
+  transporterCompanyInput,
+  transporterInput,
+  transporterToGroupInput,
+  traiteurCompanyInput,
+  destinationInput,
+  destinationToGroupInput,
+  packagingsInput,
+  wasteInput,
+  weightInput,
+  workerInput,
+  pickupSiteInput,
+  emitterSignatureUpdateInput,
+  workerSignatureUpdateInput,
+  transporterSignatureUpdateInput,
+  destinationSignatureUpdateInput
+};

--- a/back/src/bsda/examples/steps/createBsda.ts
+++ b/back/src/bsda/examples/steps/createBsda.ts
@@ -1,8 +1,11 @@
 import { WorkflowStep } from "../../../common/workflow";
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import mutations from "../mutations";
 
-export function createBsda(company: string): WorkflowStep {
+export function createBsda(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Les informations du BSDA sont remplies. Cette action peut-être effectuée
     par n'importe quel établissement apparaissant sur le BSDA. À ce stade il est toujours possible
@@ -13,7 +16,11 @@ export function createBsda(company: string): WorkflowStep {
         emitter: fixtures.emitterInput(producteur.siret),
         worker: fixtures.workerInput(worker.siret),
         destination: fixtures.destinationInput(traiteur.siret),
-        transporter: fixtures.transporterInput(transporteur.siret),
+        transporter: fixtures.transporterInput(
+          transporteur.siret?.length
+            ? transporteur.siret
+            : transporteur.vatNumber
+        ),
         waste: fixtures.wasteInput(),
         packagings: fixtures.packagingsInput(),
         weight: fixtures.weightInput()
@@ -26,7 +33,10 @@ export function createBsda(company: string): WorkflowStep {
   };
 }
 
-export function createPrivateIndividualBsda(company: string): WorkflowStep {
+export function createPrivateIndividualBsda(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Les informations du BSDA sont remplies. L'émetteur est ici un particulier. Il n'aura pas à signer le bordereau sur Trackdéchets.
     La création du BSDA peut-être effectuée
@@ -51,7 +61,10 @@ export function createPrivateIndividualBsda(company: string): WorkflowStep {
   };
 }
 
-export function create2710Bsda(company: string): WorkflowStep {
+export function create2710Bsda(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Les informations du BSDA sont remplies. Cette action est effectuée
     par la déchetterie. À ce stade il est toujours possible

--- a/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
+++ b/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
@@ -43,7 +43,7 @@ const workflow: Workflow = {
   docContext: {
     producteur: { siret: "SIRET_PRODUCTEUR" },
     worker: { siret: "SIRET_WORKER" },
-    transporteur: { siret: "VAT_TRANSPORTEUR" },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
     traiteur: { siret: "SIRET_TRAITEUR" },
     bsda: { id: "ID_BSD" }
   },

--- a/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
+++ b/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
@@ -1,0 +1,60 @@
+import { Workflow } from "../../../common/workflow";
+import fixtures from "../fixturesForeignTransporter";
+import { createBsda } from "../steps/createBsda";
+import { signBsda } from "../steps/signBsda";
+import { updateBsda } from "../steps/updateBsda";
+
+const workflow: Workflow = {
+  title: "Collecte d'amiante sur un chantier avec transporteur étranger",
+  description: `L’entreprise “Gedésamiante” intervient chez son client et maître d’ouvrage “Tolamianté”.
+  “Gedésamiante” décide de faire le BSDA pour son client.
+  Il va renseigner les informations du maître d’ouvrage, des déchets, de l’installation de destination et de son entreprise.
+  Le maître d’ouvrage peut signer dans le champs 1.1
+  L’entreprise de travaux finalise les conditionnement et peut ajuster les quantités. Elle peut ajouter les scellés si ce n’est pas déjà fait.
+  Quand elle signe en cadre 5.2, elle fige les informations jusqu’à ce cadre.
+  Le transporteur identifié sur le BSDA peut alors venir sur le chantier, vérifier les conditionnements et scellés, compléter la partie le concernant si besoin (nom, date, immatriculation etc) et signer l'enlèvement pour acheminer le déchets vers l’installation de destination prévue.
+  L’installation de destination accepte le lot, effectue une pesée qu’elle renseigne.
+  Elle indique en cadre 8 l’opération réalisée, ajoute la date et signe sur Trackdéchets.
+  Le BSDA est disponible sur la plateforme pour tous les acteurs.
+  `,
+  companies: [
+    { name: "producteur", companyTypes: ["PRODUCER"] },
+    { name: "worker", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: {
+        vatNumber: "BE0541696005",
+        siret: null
+      }
+    },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createBsda("producteur", fixtures),
+    signBsda("producteur", "EMISSION"),
+    updateBsda("worker", fixtures.workerSignatureUpdateInput),
+    signBsda("worker", "WORK"),
+    updateBsda("transporteur", fixtures.transporterSignatureUpdateInput),
+    signBsda("transporteur", "TRANSPORT"),
+    updateBsda("traiteur", fixtures.destinationSignatureUpdateInput),
+    signBsda("traiteur", "OPERATION")
+  ],
+  docContext: {
+    producteur: { siret: "SIRET_PRODUCTEUR" },
+    worker: { siret: "SIRET_WORKER" },
+    transporteur: { siret: "VAT_TRANSPORTEUR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsda: { id: "ID_BSD" }
+  },
+  chart: `
+    graph LR
+    AO(NO STATE) -->|createForm| A
+    A(INITIAL) -->|signBsda| B(SIGNED_BY_PRODUCER)
+    B -->|signBsda| C(SIGNED_BY_WORKER)
+    C --> |signBsda| D(SENT)
+    D --> |signBsda| E(PROCESSED)
+    `
+};
+
+export default workflow;

--- a/back/src/bsda/examples/workflows/index.ts
+++ b/back/src/bsda/examples/workflows/index.ts
@@ -1,9 +1,11 @@
 import collecteChantier from "./collecteChantier";
+import collecteChantierTransporteurEtranger from "./collecteChantierTransporteurEtranger";
 import collecteChantierParticulier from "./collecteChantierParticulier";
 import groupement from "./groupement";
 
 export default {
   collecteChantier,
+  collecteChantierTransporteurEtranger,
   collecteChantierParticulier,
   groupement
 };

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -1,4 +1,5 @@
 import { Bsda } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic } from "../common/elastic";
 import { buildAddress } from "../companies/sirene/utils";
 import {
@@ -34,7 +35,7 @@ export function getRegistryFields(
     if (bsda.workerCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.workerCompanySiret);
     }
-    registryFields.isTransportedWasteFor.push(bsda.transporterCompanySiret);
+    registryFields.isTransportedWasteFor.push(getTransporterCompanyOrgId(bsda));
     if (bsda.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
     }
@@ -133,7 +134,7 @@ export function toIncomingWaste(
     brokerCompanySiret: bsda.brokerCompanySiret,
     brokerRecepisseNumber: null,
     transporterCompanyName: bsda.transporterCompanyName,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     transporterRecepisseNumber: bsda.transporterRecepisseNumber,
     destinationOperationCode: bsda.destinationOperationCode,
     destinationCustomInfo: bsda.destinationCustomInfo,
@@ -200,7 +201,7 @@ export function toOutgoingWaste(
     traderRecepisseNumber: null,
     transporterCompanyAddress: null,
     transporterCompanyName: bsda.transporterCompanyName,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
     transporterRecepisseNumber: bsda.transporterRecepisseNumber,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,
@@ -249,7 +250,7 @@ export function toTransportedWaste(
     destinationReceptionDate: bsda.destinationReceptionDate,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,
     transporterCompanyName: bsda.transporterCompanyName,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterNumberPlates: bsda.transporterTransportPlates,
     ...initialEmitter,
@@ -335,7 +336,7 @@ export function toManagedWaste(
     ...initialEmitter,
     transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterCompanyName: bsda.transporterCompanyName,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     transporterRecepisseNumber: bsda.transporterRecepisseNumber,
     emitterCompanyMail: bsda.emitterCompanyMail,
     transporterCompanyMail: bsda.transporterCompanyMail,
@@ -402,7 +403,7 @@ export function toAllWaste(
     ...initialEmitter,
     transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterCompanyName: bsda.transporterCompanyName,
-    transporterCompanySiret: bsda.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
     transporterRecepisseNumber: bsda.transporterRecepisseNumber,
     transporterNumberPlates: bsda.transporterTransportPlates,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,

--- a/back/src/bsda/resolvers/Bsda.ts
+++ b/back/src/bsda/resolvers/Bsda.ts
@@ -51,13 +51,7 @@ export const Bsda: BsdaResolvers = {
       .findRelatedEntity({ id: bsda.id })
       .intermediaries();
 
-    if (intermediaries) {
-      return intermediaries.map(intermediary => ({
-        orgId: intermediary.siret,
-        ...intermediary
-      }));
-    }
-    return null;
+    return intermediaries ?? null;
   },
   metadata: bsda => {
     return {

--- a/back/src/bsda/resolvers/Bsda.ts
+++ b/back/src/bsda/resolvers/Bsda.ts
@@ -51,7 +51,13 @@ export const Bsda: BsdaResolvers = {
       .findRelatedEntity({ id: bsda.id })
       .intermediaries();
 
-    return intermediaries ?? null;
+    if (intermediaries) {
+      return intermediaries.map(intermediary => ({
+        orgId: intermediary.siret,
+        ...intermediary
+      }));
+    }
+    return null;
   },
   metadata: bsda => {
     return {

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -22,6 +22,7 @@ import { machine } from "../../machine";
 import { getBsdaRepository } from "../../repository";
 import { runInTransaction } from "../../../common/repository/helper";
 import { validateBsda } from "../../validation";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 type SignatureTypeInfos = {
   dbDateKey: keyof Bsda;
@@ -144,7 +145,7 @@ const signatureTypeMapping: Record<BsdaSignatureType, SignatureTypeInfos> = {
   TRANSPORT: {
     dbDateKey: "transporterTransportSignatureDate",
     dbAuthorKey: "transporterTransportSignatureAuthor",
-    getAuthorizedSiret: form => form.transporterCompanySiret
+    getAuthorizedSiret: form => getTransporterCompanyOrgId(form)
   }
 };
 

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -19,7 +19,6 @@ export default async function edit(
   context: GraphQLContext
 ) {
   const user = checkIsAuthenticated(context);
-
   const existingBsda = await getBsdaOrNotFound(id, {
     include: { intermediaries: true, grouping: true, forwarding: true }
   });

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -816,20 +816,13 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
               ),
           otherwise: schema =>
             schema.when("transporterCompanyVatNumber", (tva, schema) => {
-              if (!tva) {
-                return schema
-                  .nullable()
-                  .requiredIf(
-                    context.transportSignature,
-                    `Transporteur: ${MISSING_COMPANY_SIRET}`
-                  );
-              }
-              return schema
-                .nullable()
-                .requiredIf(
+              if (!isForeignVat(tva)) {
+                return schema.requiredIf(
                   context.workSignature,
                   `Transporteur: ${MISSING_COMPANY_SIRET}`
                 );
+              }
+              return schema.nullable().notRequired();
             })
         })
         .test(

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -816,7 +816,7 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
               ),
           otherwise: schema =>
             schema.when("transporterCompanyVatNumber", (tva, schema) => {
-              if (!isForeignVat(tva)) {
+              if (!tva || !isForeignVat(tva)) {
                 return schema.requiredIf(
                   context.workSignature,
                   `Transporteur: ${MISSING_COMPANY_SIRET}`

--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -25,6 +25,9 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
     transporterCompanySiret: toPrismaStringFilter(
       where.transporter?.company?.siret
     ),
+    transporterCompanyVatNumber: toPrismaStringFilter(
+      where.transporter?.company?.vatNumber
+    ),
     transporterTransportSignatureDate: toPrismaDateFilter(
       where.transporter?.transport?.signature?.date
     ),

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -41,6 +41,7 @@ import {
 import { BsdElastic } from "../common/elastic";
 import { Prisma, Bsdasri, BsdasriStatus } from "@prisma/client";
 import { Decimal } from "decimal.js-light";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 
 export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
   return {
@@ -101,9 +102,7 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
     transporter: nullIfNoValues<BsdasriTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: bsdasri.transporterCompanyName,
-        orgId:
-          bsdasri.transporterCompanySiret ??
-          bsdasri.transporterCompanyVatNumber,
+        orgId: getTransporterCompanyOrgId(bsdasri),
         siret: bsdasri.transporterCompanySiret,
         vatNumber: bsdasri.transporterCompanyVatNumber,
         address: bsdasri.transporterCompanyAddress,

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -101,6 +101,7 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
     transporter: nullIfNoValues<BsdasriTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: bsdasri.transporterCompanyName,
+        orgId: bsdasri.transporterCompanySiret ?? bsdasri.transporterCompanyVatNumber,
         siret: bsdasri.transporterCompanySiret,
         vatNumber: bsdasri.transporterCompanyVatNumber,
         address: bsdasri.transporterCompanyAddress,

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -101,7 +101,9 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
     transporter: nullIfNoValues<BsdasriTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: bsdasri.transporterCompanyName,
-        orgId: bsdasri.transporterCompanySiret ?? bsdasri.transporterCompanyVatNumber,
+        orgId:
+          bsdasri.transporterCompanySiret ??
+          bsdasri.transporterCompanyVatNumber,
         siret: bsdasri.transporterCompanySiret,
         vatNumber: bsdasri.transporterCompanyVatNumber,
         address: bsdasri.transporterCompanyAddress,

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -4,6 +4,7 @@ import { BsdElastic, indexBsd } from "../common/elastic";
 import { DASRI_WASTE_CODES_MAPPING } from "../common/constants/DASRI_CONSTANTS";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 
 // | state              | emitter | transporter | recipient |
 // |--------------------|---------|-------------|-----------|
@@ -40,7 +41,7 @@ function getWhere(
   const formSirets: Record<string, string | null | undefined> = {
     emitterCompanySiret: bsdasri.emitterCompanySiret,
     destinationCompanySiret: bsdasri.destinationCompanySiret,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     ecoOrganismeSiret: bsdasri.ecoOrganismeSiret
   };
 
@@ -127,6 +128,7 @@ export function toBsdElastic(bsdasri: Bsdasri): BsdElastic {
     emitterCompanySiret: bsdasri.emitterCompanySiret ?? "",
     transporterCompanyName: bsdasri.transporterCompanyName ?? "",
     transporterCompanySiret: bsdasri.transporterCompanySiret ?? "",
+    transporterCompanyVatNumber: bsdasri.transporterCompanyVatNumber ?? "",
     transporterTakenOverAt: bsdasri.transporterTakenOverAt?.getTime(),
     transporterCustomInfo: bsdasri.transporterCustomInfo ?? "",
     destinationCompanyName: bsdasri.destinationCompanyName ?? "",

--- a/back/src/bsdasris/examples/__tests__/examples.integration.ts
+++ b/back/src/bsdasris/examples/__tests__/examples.integration.ts
@@ -1,6 +1,7 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import acheminementDirect from "../workflows/acheminementDirect";
+import acheminementDirectTransporteurEtranger from "../workflows/acheminementDirectTransporteurEtranger";
 import emportDirect from "../workflows/emportDirect";
 import dasriDeSynthese from "../workflows/dasriDeSynthese";
 import dasriDeGroupement from "../workflows/dasriDeGroupement";
@@ -11,7 +12,7 @@ import signatureCodeSecretEcoOrganisme from "../workflows/signatureCodeSecretEco
 describe("Exemples de circuit du bordereau de suivi DASRI", () => {
   afterEach(resetDatabase);
 
-  test(
+  it(
     signatureCodeSecretEcoOrganisme.title,
     async () => {
       await testWorkflow(signatureCodeSecretEcoOrganisme);
@@ -19,7 +20,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
     signatureCodeSecret.title,
     async () => {
       await testWorkflow(signatureCodeSecret);
@@ -27,7 +28,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
     acheminementDirectEcoOrganisme.title,
     async () => {
       await testWorkflow(acheminementDirectEcoOrganisme);
@@ -35,7 +36,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
     acheminementDirect.title,
     async () => {
       await testWorkflow(acheminementDirect);
@@ -43,7 +44,15 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
+    acheminementDirectTransporteurEtranger.title,
+    async () => {
+      await testWorkflow(acheminementDirectTransporteurEtranger);
+    },
+    60000
+  );
+
+  it(
     emportDirect.title,
     async () => {
       await testWorkflow(emportDirect);
@@ -51,7 +60,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
     dasriDeSynthese.title,
     async () => {
       await testWorkflow(dasriDeSynthese);
@@ -59,7 +68,7 @@ describe("Exemples de circuit du bordereau de suivi DASRI", () => {
     60000
   );
 
-  test(
+  it(
     dasriDeGroupement.title,
     async () => {
       await testWorkflow(dasriDeGroupement);

--- a/back/src/bsdasris/examples/fixtures.ts
+++ b/back/src/bsdasris/examples/fixtures.ts
@@ -1,10 +1,10 @@
-const wasteInput = {
+export const wasteInput = {
   waste: {
     code: "18 01 03*",
     adr: "non soumis"
   }
 };
-function emitterCompanyInput(siret: string) {
+export function emitterCompanyInput(siret: string) {
   return {
     siret,
     name: "Hopital Saint Denis",
@@ -15,27 +15,27 @@ function emitterCompanyInput(siret: string) {
   };
 }
 
-function emitterInput(siret: string) {
+export function emitterInput(siret: string) {
   return {
     company: emitterCompanyInput(siret)
   };
 }
 
-const emissionInput = {
+export const emissionInput = {
   weight: {
     value: 1,
     isEstimate: false
   },
   packagings: [{ type: "BOITE_CARTON", quantity: 1, volume: 1 }]
 };
-function ecoorganismeInput(siret: string) {
+export function ecoorganismeInput(siret: string) {
   return {
     siret,
     name: "Eco-organisme"
   };
 }
 
-function transporteurCompanyInput(siret: string) {
+export function transporteurCompanyInput(siret: string) {
   return {
     siret,
     name: "Transport Inc",
@@ -46,20 +46,20 @@ function transporteurCompanyInput(siret: string) {
   };
 }
 
-const recepisseInput = {
+export const recepisseInput = {
   number: "KIH-458-87",
   department: "07",
   validityLimit: "2022-01-01"
 };
 
-function transporterInput(siret: string) {
+export function transporterInput(siret: string) {
   return {
     company: transporteurCompanyInput(siret),
     recepisse: recepisseInput
   };
 }
 
-const transportInput = {
+export const transportInput = {
   acceptation: { status: "ACCEPTED" },
 
   weight: {
@@ -71,7 +71,7 @@ const transportInput = {
   takenOverAt: "2022-04-27"
 };
 
-const synthesisTransportInput = {
+export const synthesisTransportInput = {
   acceptation: { status: "ACCEPTED" },
 
   weight: {
@@ -81,7 +81,7 @@ const synthesisTransportInput = {
 
   takenOverAt: "2022-04-27"
 };
-function destinationCompanyInput(siret: string) {
+export function destinationCompanyInput(siret: string) {
   return {
     siret,
     name: "Traiteur Inc",
@@ -92,13 +92,13 @@ function destinationCompanyInput(siret: string) {
   };
 }
 
-function destinationInput(siret: string) {
+export function destinationInput(siret: string) {
   return {
     company: destinationCompanyInput(siret)
   };
 }
 
-const receptionInput = {
+export const receptionInput = {
   acceptation: { status: "ACCEPTED" },
 
   volume: 1,
@@ -107,7 +107,7 @@ const receptionInput = {
   date: "2021-04-27"
 };
 
-const operationInput = {
+export const operationInput = {
   weight: {
     value: 1
   },
@@ -115,7 +115,7 @@ const operationInput = {
   date: "2020-04-28"
 };
 
-const operationForGroupingInput = {
+export const operationForGroupingInput = {
   weight: {
     value: 1
   },

--- a/back/src/bsdasris/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsdasris/examples/fixturesForeignTransporter.ts
@@ -1,0 +1,50 @@
+import {
+  wasteInput,
+  emitterCompanyInput,
+  emitterInput,
+  emissionInput,
+  ecoorganismeInput,
+  transportInput,
+  synthesisTransportInput,
+  destinationCompanyInput,
+  destinationInput,
+  receptionInput,
+  operationInput,
+  operationForGroupingInput
+} from "./fixtures";
+
+export function transporteurCompanyInput(vatNumber: string) {
+  return {
+    siret: null,
+    vatNumber,
+    name: "Transport Inc",
+    address: "6 rue des 7 chemins, 07100 ANNONAY",
+    mail: "contact@transport.co",
+    phone: "07 00 00 00 00",
+    contact: "John Antoine"
+  };
+}
+
+export function transporterInput(vatNumber: string) {
+  return {
+    company: transporteurCompanyInput(vatNumber),
+    recepisse: null
+  };
+}
+
+export default {
+  wasteInput,
+  emitterCompanyInput,
+  emitterInput,
+  emissionInput,
+  ecoorganismeInput,
+  transporteurCompanyInput,
+  transporterInput,
+  transportInput,
+  synthesisTransportInput,
+  destinationCompanyInput,
+  destinationInput,
+  receptionInput,
+  operationInput,
+  operationForGroupingInput
+};

--- a/back/src/bsdasris/examples/steps/createBsdasri.ts
+++ b/back/src/bsdasris/examples/steps/createBsdasri.ts
@@ -1,8 +1,11 @@
 import mutations from "../mutations";
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import { WorkflowStep } from "../../../common/workflow";
 
-export function createBsdasri(company: string): WorkflowStep {
+export function createBsdasri(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Les informations du BSDASRI (PRED, transporteur, destinataire, déchets) sont remplies.`,
     mutation: mutations.createBsdasri,
@@ -14,7 +17,11 @@ export function createBsdasri(company: string): WorkflowStep {
           emission: fixtures.emissionInput
         },
         destination: fixtures.destinationInput(traiteur.siret),
-        transporter: fixtures.transporterInput(transporteur.siret)
+        transporter: fixtures.transporterInput(
+          transporteur.siret?.length
+            ? transporteur.siret
+            : transporteur.vatNumber
+        )
       }
     }),
     expected: { status: "INITIAL" },

--- a/back/src/bsdasris/examples/workflows/acheminementDirectTransporteurEtranger.ts
+++ b/back/src/bsdasris/examples/workflows/acheminementDirectTransporteurEtranger.ts
@@ -1,0 +1,52 @@
+import fixtures from "../fixturesForeignTransporter";
+import { createBsdasri } from "../steps/createBsdasri";
+import { signForProducer } from "../steps/signForProducer";
+import { signOperation } from "../steps/signOperation";
+import { signReception } from "../steps/signReception";
+import { signTransport } from "../steps/signTransport";
+import { updateReception } from "../steps/updateReception";
+import { updateOperation } from "../steps/updateOperation";
+import { updateTransport } from "../steps/updateTransport";
+
+export default {
+  title: `Acheminement direct de la personne responsable de l'élimination
+ des déchets PRED vers l'installation destinataire par un transporteur étranger`,
+  companies: [
+    { name: "pred", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: {
+        siret: null,
+        vatNumber: "BE0541696005"
+      }
+    },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createBsdasri("pred", fixtures),
+    signForProducer("pred"),
+    updateTransport("transporteur"),
+    signTransport("transporteur"),
+    updateReception("traiteur"),
+    signReception("traiteur"),
+    updateOperation("traiteur"),
+    signOperation("traiteur")
+  ],
+  docContext: {
+    pred: { siret: "SIRET_PRODUCTEUR", securityCode: "XXXX" },
+    transporteur: { siret: "SIRET_TRANSPORTEUR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsd: { id: "ID_BSD" }
+  },
+  chart: `
+graph LR
+AO(NO STATE) -->|createBsdasri| A(INITIAL)
+A -->|"signBsdasri (EMISSION)"| B(SIGNED_BY_PRODUCER)
+B -->|updateBsdasri| B
+B -->|"signBsdasri (TRANSPORT)"| C(SENT)
+C -->|updateBsdasri| C
+C -->|"signBsdasri (RECEPTION)"| D(RECEIVED)
+D -->|updateBsdasri| D
+D -->|"signBsdasri (OPERATION)"| PROCESSED`
+};

--- a/back/src/bsdasris/examples/workflows/acheminementDirectTransporteurEtranger.ts
+++ b/back/src/bsdasris/examples/workflows/acheminementDirectTransporteurEtranger.ts
@@ -35,7 +35,7 @@ export default {
   ],
   docContext: {
     pred: { siret: "SIRET_PRODUCTEUR", securityCode: "XXXX" },
-    transporteur: { siret: "SIRET_TRANSPORTEUR" },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
     traiteur: { siret: "SIRET_TRAITEUR" },
     bsd: { id: "ID_BSD" }
   },

--- a/back/src/bsdasris/examples/workflows/index.ts
+++ b/back/src/bsdasris/examples/workflows/index.ts
@@ -1,4 +1,5 @@
 import acheminementDirect from "./acheminementDirect";
+import acheminementDirectTransporteurEtranger from "./acheminementDirectTransporteurEtranger";
 import emportDirect from "./emportDirect";
 import dasriDeGroupement from "./dasriDeGroupement";
 import dasriDeSynthese from "./dasriDeSynthese";
@@ -8,6 +9,7 @@ import signatureCodeSecretEcoOrganisme from "./signatureCodeSecretEcoOrganisme";
 
 export default {
   acheminementDirect,
+  acheminementDirectTransporteurEtranger,
   ecoOrganisme,
   signatureCodeSecret,
   signatureCodeSecretEcoOrganisme,

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -1,4 +1,5 @@
 import { Bsdasri } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic } from "../common/elastic";
 import { buildAddress } from "../companies/sirene/utils";
 import {
@@ -33,7 +34,9 @@ export function getRegistryFields(
     bsdasri.transporterTransportSignatureDate
   ) {
     registryFields.isOutgoingWasteFor.push(bsdasri.emitterCompanySiret);
-    registryFields.isTransportedWasteFor.push(bsdasri.transporterCompanySiret);
+    registryFields.isTransportedWasteFor.push(
+      getTransporterCompanyOrgId(bsdasri)
+    );
   }
 
   if (bsdasri.destinationReceptionSignatureDate) {
@@ -119,7 +122,7 @@ export function toIncomingWaste(
     brokerCompanySiret: null,
     brokerRecepisseNumber: null,
     transporterCompanyName: bsdasri.transporterCompanyName,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     transporterRecepisseNumber: bsdasri.transporterRecepisseNumber,
     destinationOperationCode: bsdasri.destinationOperationCode,
     destinationCustomInfo: bsdasri.destinationCustomInfo,
@@ -177,7 +180,7 @@ export function toOutgoingWaste(
     traderRecepisseNumber: null,
     transporterCompanyAddress: null,
     transporterCompanyName: bsdasri.transporterCompanyName,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     transporterTakenOverAt: bsdasri.transporterTakenOverAt,
     transporterRecepisseNumber: bsdasri.transporterRecepisseNumber,
     weight: bsdasri.emitterWasteWeightValue
@@ -221,7 +224,7 @@ export function toTransportedWaste(
       ? bsdasri.emitterWasteWeightValue / 1000
       : bsdasri.emitterWasteWeightValue,
     transporterCompanyName: bsdasri.transporterCompanyName,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     transporterCompanyAddress: bsdasri.transporterCompanyAddress,
     transporterNumberPlates: bsdasri.transporterTransportPlates,
     ...initialEmitter,
@@ -302,7 +305,7 @@ export function toManagedWaste(
     ...initialEmitter,
     transporterCompanyAddress: bsdasri.transporterCompanyAddress,
     transporterCompanyName: bsdasri.transporterCompanyName,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     transporterRecepisseNumber: bsdasri.transporterRecepisseNumber,
     emitterCompanyMail: bsdasri.emitterCompanyMail,
     transporterCompanyMail: bsdasri.transporterCompanyMail,
@@ -360,7 +363,7 @@ export function toAllWaste(
     ...initialEmitter,
     transporterCompanyAddress: bsdasri.transporterCompanyAddress,
     transporterCompanyName: bsdasri.transporterCompanyName,
-    transporterCompanySiret: bsdasri.transporterCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsdasri),
     transporterRecepisseNumber: bsdasri.transporterRecepisseNumber,
     transporterNumberPlates: bsdasri.transporterTransportPlates,
     weight: bsdasri.emitterWasteWeightValue

--- a/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
@@ -66,7 +66,8 @@ const createSynthesisBsdasri = async (
 
   const dasrisToAssociate = await getEligibleDasrisForSynthesis(
     synthesizing,
-    input.transporter.company.siret
+    null,
+    input.transporter.company
   );
 
   const aggregatedPackagings = aggregatePackagings(dasrisToAssociate);

--- a/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
+++ b/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
@@ -1,16 +1,25 @@
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
 import { BsdasriValidationContext } from "../../validation";
 
-import { BsdasriSignatureType } from "../../../generated/graphql/types";
+import {
+  BsdasriSignatureInput,
+  BsdasriSignatureType,
+  SignatureAuthor
+} from "../../../generated/graphql/types";
 import { UserInputError } from "apollo-server-express";
 import { Bsdasri, BsdasriStatus, BsdasriType } from "@prisma/client";
 
 import { BsdasriEventType } from "../../workflow/types";
 import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
-type checkEmitterAllowsDirectTakeOverFn = ({
-  signatureParams: BsdasriSignatureInfos,
-  bsdasri: Bsdasri
-}) => Promise<boolean>;
+
+interface checkEmitterAllowsDirectTakeOverProps {
+  signatureParams: BsdasriSignatureInfos;
+  bsdasri: Bsdasri;
+}
+
+type checkEmitterAllowsDirectTakeOverFn = (
+  input: checkEmitterAllowsDirectTakeOverProps
+) => Promise<boolean>;
 /**
  * Dasri can be taken over by transporter directly if:
  * - without emitter signature if emitter explicitly allows this in company preferences
@@ -49,12 +58,15 @@ export const checkDirectakeOverIsAllowed: checkEmitterAllowsDirectTakeOverFn =
     return false;
   };
 
-type checkEmitterAllowsSignatureWithCodeFn = ({
-  signatureParams: BsdasriSignatureInfos,
-  bsdasri: Dasri,
-  securityCode: number,
-  emissionSignatureAuthor: SignatureAuthor
-}) => Promise<boolean>;
+interface checkEmitterAllowsSignatureWithCodeProps {
+  signatureParams: BsdasriSignatureInfos;
+  bsdasri: Bsdasri;
+  securityCode: number;
+  emissionSignatureAuthor: SignatureAuthor;
+}
+type checkEmitterAllowsSignatureWithCodeFn = (
+  input: checkEmitterAllowsSignatureWithCodeProps
+) => Promise<boolean>;
 /**
  * Dasri takeOver can be processed on the transporter device
  * To perform this, we expect a INITIAL -> SIGNED_BY_PRODUCER signature, then a SIGNED_BY_PRODUCER -> SENT one
@@ -186,10 +198,12 @@ export const dasriSignatureMapping: Record<
   }
 };
 
-type getFieldsUpdateFn = ({
-  bsdasri: Dasri,
-  input: BsdasriSignatureInput
-}) => Partial<Bsdasri>;
+interface getFieldsUpdateProps {
+  bsdasri: Bsdasri;
+  input: BsdasriSignatureInput;
+}
+
+type getFieldsUpdateFn = (input: getFieldsUpdateProps) => Partial<Bsdasri>;
 
 /**
  * A few fields obey to a custom logic

--- a/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
+++ b/back/src/bsdasris/resolvers/mutations/signatureUtils.ts
@@ -6,6 +6,7 @@ import { UserInputError } from "apollo-server-express";
 import { Bsdasri, BsdasriStatus, BsdasriType } from "@prisma/client";
 
 import { BsdasriEventType } from "../../workflow/types";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 type checkEmitterAllowsDirectTakeOverFn = ({
   signatureParams: BsdasriSignatureInfos,
   bsdasri: Bsdasri
@@ -155,7 +156,7 @@ export const dasriSignatureMapping: Record<
     eventType: BsdasriEventType.SignEmissionWithSecretCode,
     validationContext: { emissionSignature: true },
     signatoryField: "emissionSignatory",
-    authorizedSirets: bsdasri => [bsdasri.transporterCompanySiret] // transporter can sign with emitter secret code (trs device)
+    authorizedSirets: bsdasri => [getTransporterCompanyOrgId(bsdasri)] // transporter can sign with emitter secret code (trs device)
   },
   TRANSPORT: {
     author: "transporterTransportSignatureAuthor",
@@ -164,7 +165,7 @@ export const dasriSignatureMapping: Record<
     validationContext: { emissionSignature: true, transportSignature: true }, // validate emission in case of direct takeover
 
     signatoryField: "transportSignatory",
-    authorizedSirets: bsdasri => [bsdasri.transporterCompanySiret]
+    authorizedSirets: bsdasri => [getTransporterCompanyOrgId(bsdasri)]
   },
 
   RECEPTION: {

--- a/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
@@ -87,10 +87,7 @@ const updateSynthesisBsdasri = async ({
       el => !dbSynthesizing.map(el => el.id).includes(el)
     );
     // check associated dasris meet eligibility criteria
-    await getEligibleDasrisForSynthesis(
-      newDasrisToAssociate,
-      dbBsdasri.transporterCompanySiret
-    );
+    await getEligibleDasrisForSynthesis(newDasrisToAssociate, dbBsdasri);
   }
 
   const bsdasriReadonlyRepository = getReadonlyBsdasriRepository();

--- a/back/src/bsdasris/resolvers/mutations/utils.ts
+++ b/back/src/bsdasris/resolvers/mutations/utils.ts
@@ -3,10 +3,12 @@ import { UserInputError } from "apollo-server-express";
 import { BsdasriStatus, BsdasriType, Bsdasri } from "@prisma/client";
 import { DASRI_GROUPING_OPERATIONS_CODES } from "../../../common/constants";
 import { getReadonlyBsdasriRepository } from "../../repository";
+import { CompanyInput } from "../../../generated/graphql/types";
 
 export const getEligibleDasrisForSynthesis = async (
   synthesizingIds: string[],
-  emitterSiret: string
+  bsdasri: Bsdasri,
+  company?: CompanyInput
 ): Promise<Bsdasri[]> => {
   if (!synthesizingIds) {
     return;
@@ -30,7 +32,18 @@ export const getEligibleDasrisForSynthesis = async (
     grouping: { none: {} },
     synthesizedIn: null,
     synthesizing: { none: {} },
-    transporterCompanySiret: emitterSiret
+    OR: [
+      {
+        transporterCompanySiret: bsdasri
+          ? bsdasri.transporterCompanySiret
+          : company.siret
+      },
+      {
+        transporterCompanyVatNumber: bsdasri
+          ? bsdasri.transporterCompanyVatNumber
+          : company.vatNumber
+      }
+    ]
   });
 
   const foundIds = found.map(el => el.id);

--- a/back/src/bsdasris/resolvers/queries/bsdasris.ts
+++ b/back/src/bsdasris/resolvers/queries/bsdasris.ts
@@ -24,6 +24,7 @@ const bsdasrisResolver: QueryResolvers["bsdasris"] = async (
     OR: [
       { emitterCompanySiret: { in: userCompaniesSiretOrVat } },
       { transporterCompanySiret: { in: userCompaniesSiretOrVat } },
+      { transporterCompanyVatNumber: { in: userCompaniesSiretOrVat } },
       { destinationCompanySiret: { in: userCompaniesSiretOrVat } },
       { ecoOrganismeSiret: { in: userCompaniesSiretOrVat } }
     ]

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -16,7 +16,11 @@ import {
   BsdasriPackagingType,
   BsdasriSignatureType
 } from "../generated/graphql/types";
-import { isSiret } from "../common/constants/companySearchHelpers";
+import {
+  isForeignVat,
+  isSiret,
+  isVat
+} from "../common/constants/companySearchHelpers";
 import {
   MISSING_COMPANY_SIRET,
   MISSING_COMPANY_SIRET_OR_VAT
@@ -317,8 +321,9 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!tva && context.transportSignature) {
-          return schema.required(
+        if (!isForeignVat(tva)) {
+          return schema.requiredIf(
+            context.transportSignature,
             `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
           );
         }
@@ -356,7 +361,7 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!tva) {
+        if (!isVat(tva)) {
           return schema.requiredIf(
             context.transportSignature,
             `Transporteur: le numéro de récépissé est obligatoire`
@@ -369,25 +374,25 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!tva) {
+        if (!isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature,
             `Transporteur: le département associé au récépissé est obligatoire`
           );
         }
-        return schema.notRequired();
+        return schema.nullable().notRequired();
       }),
 
     transporterRecepisseValidityLimit: yup
       .date()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!tva) {
+        if (!isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature || requiredForSynthesis,
             "La date de validité du récépissé est obligatoire"
           );
         }
-        return schema.notRequired();
+        return schema.nullable().notRequired();
       })
   });
 };

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -18,8 +18,7 @@ import {
 } from "../generated/graphql/types";
 import {
   isForeignVat,
-  isSiret,
-  isVat
+  isSiret
 } from "../common/constants/companySearchHelpers";
 import {
   MISSING_COMPANY_SIRET,

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -321,7 +321,7 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!isForeignVat(tva)) {
+        if (!tva || !isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature,
             `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
@@ -361,7 +361,7 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!isVat(tva)) {
+        if (!tva || !isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature,
             `Transporteur: le numéro de récépissé est obligatoire`
@@ -374,7 +374,7 @@ export const transporterSchema: FactorySchemaOf<
       .string()
       .ensure()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!isForeignVat(tva)) {
+        if (!tva || !isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature,
             `Transporteur: le département associé au récépissé est obligatoire`
@@ -386,7 +386,7 @@ export const transporterSchema: FactorySchemaOf<
     transporterRecepisseValidityLimit: yup
       .date()
       .when("transporterCompanyVatNumber", (tva, schema) => {
-        if (!isForeignVat(tva)) {
+        if (!tva || !isForeignVat(tva)) {
           return schema.requiredIf(
             context.transportSignature || requiredForSynthesis,
             "La date de validité du récépissé est obligatoire"

--- a/back/src/bsdasris/where.ts
+++ b/back/src/bsdasris/where.ts
@@ -52,6 +52,9 @@ function toPrismaBsdasriWhereInput(
     transporterCompanySiret: toPrismaStringFilter(
       where?.transporter?.company?.siret
     ),
+    transporterCompanyVatNumber: toPrismaStringFilter(
+      where?.transporter?.company?.vatNumber
+    ),
     transporterTransportSignatureDate: toPrismaDateFilter(
       where?.transporter?.transport?.signature?.date
     ),

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -196,6 +196,7 @@ export function expandBsffFromDB(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
     transporter: nullIfNoValues<GraphQL.BsffTransporter>({
       company: nullIfNoValues<GraphQL.FormCompany>({
         name: prismaBsff.transporterCompanyName,
+        orgId: prismaBsff.transporterCompanySiret ?? prismaBsff.transporterCompanyVatNumber,
         siret: prismaBsff.transporterCompanySiret,
         vatNumber: prismaBsff.transporterCompanyVatNumber,
         address: prismaBsff.transporterCompanyAddress,

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -196,7 +196,9 @@ export function expandBsffFromDB(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
     transporter: nullIfNoValues<GraphQL.BsffTransporter>({
       company: nullIfNoValues<GraphQL.FormCompany>({
         name: prismaBsff.transporterCompanyName,
-        orgId: prismaBsff.transporterCompanySiret ?? prismaBsff.transporterCompanyVatNumber,
+        orgId:
+          prismaBsff.transporterCompanySiret ??
+          prismaBsff.transporterCompanyVatNumber,
         siret: prismaBsff.transporterCompanySiret,
         vatNumber: prismaBsff.transporterCompanyVatNumber,
         address: prismaBsff.transporterCompanyAddress,

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -8,6 +8,7 @@ import {
 import * as GraphQL from "../generated/graphql/types";
 import { BsdElastic } from "../common/elastic";
 import { BsffPackaging, BsffPackagingType } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 
 function flattenEmitterInput(input: { emitter?: GraphQL.BsffEmitter }) {
   return {
@@ -196,9 +197,7 @@ export function expandBsffFromDB(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
     transporter: nullIfNoValues<GraphQL.BsffTransporter>({
       company: nullIfNoValues<GraphQL.FormCompany>({
         name: prismaBsff.transporterCompanyName,
-        orgId:
-          prismaBsff.transporterCompanySiret ??
-          prismaBsff.transporterCompanyVatNumber,
+        orgId: getTransporterCompanyOrgId(prismaBsff),
         siret: prismaBsff.transporterCompanySiret,
         vatNumber: prismaBsff.transporterCompanyVatNumber,
         address: prismaBsff.transporterCompanyAddress,

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -4,6 +4,7 @@ import { BsdElastic, indexBsd } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 import { toBsffDestination } from "./compat";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 
 export function toBsdElastic(
   bsff: Bsff & { packagings: BsffPackaging[] }
@@ -21,6 +22,7 @@ export function toBsdElastic(
     emitterCompanySiret: bsff.emitterCompanySiret ?? "",
     transporterCompanyName: bsff.transporterCompanyName ?? "",
     transporterCompanySiret: bsff.transporterCompanySiret ?? "",
+    transporterCompanyVatNumber: bsff.transporterCompanyVatNumber ?? "",
     transporterTakenOverAt:
       bsff.transporterTransportTakenOverAt?.getTime() ??
       bsff.transporterTransportSignatureDate?.getTime(),
@@ -59,7 +61,7 @@ export function toBsdElastic(
   if (bsff.isDraft) {
     bsd.isDraftFor.push(
       bsff.emitterCompanySiret,
-      bsff.transporterCompanySiret,
+      getTransporterCompanyOrgId(bsff),
       bsff.destinationCompanySiret
     );
   } else {
@@ -68,13 +70,13 @@ export function toBsdElastic(
       case BsffStatus.INITIAL: {
         bsd.isForActionFor.push(bsff.emitterCompanySiret);
         bsd.isFollowFor.push(
-          bsff.transporterCompanySiret,
+          getTransporterCompanyOrgId(bsff),
           bsff.destinationCompanySiret
         );
         break;
       }
       case BsffStatus.SIGNED_BY_EMITTER: {
-        bsd.isToCollectFor.push(bsff.transporterCompanySiret);
+        bsd.isToCollectFor.push(getTransporterCompanyOrgId(bsff));
         bsd.isFollowFor.push(
           bsff.emitterCompanySiret,
           bsff.destinationCompanySiret
@@ -82,7 +84,7 @@ export function toBsdElastic(
         break;
       }
       case BsffStatus.SENT: {
-        bsd.isCollectedFor.push(bsff.transporterCompanySiret);
+        bsd.isCollectedFor.push(getTransporterCompanyOrgId(bsff));
         bsd.isFollowFor.push(bsff.emitterCompanySiret);
         bsd.isForActionFor.push(bsff.destinationCompanySiret);
         break;
@@ -92,7 +94,7 @@ export function toBsdElastic(
       case BsffStatus.ACCEPTED: {
         bsd.isFollowFor.push(
           bsff.emitterCompanySiret,
-          bsff.transporterCompanySiret
+          getTransporterCompanyOrgId(bsff)
         );
         bsd.isForActionFor.push(bsff.destinationCompanySiret);
         break;
@@ -100,7 +102,7 @@ export function toBsdElastic(
       case BsffStatus.INTERMEDIATELY_PROCESSED: {
         bsd.isFollowFor.push(
           bsff.emitterCompanySiret,
-          bsff.transporterCompanySiret,
+          getTransporterCompanyOrgId(bsff),
           bsff.destinationCompanySiret
         );
         break;
@@ -109,7 +111,7 @@ export function toBsdElastic(
       case BsffStatus.PROCESSED: {
         bsd.isArchivedFor.push(
           bsff.emitterCompanySiret,
-          bsff.transporterCompanySiret,
+          getTransporterCompanyOrgId(bsff),
           bsff.destinationCompanySiret
         );
         break;

--- a/back/src/bsffs/examples/__tests__/examples.integration.ts
+++ b/back/src/bsffs/examples/__tests__/examples.integration.ts
@@ -1,12 +1,13 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import collectePetitesQuantitesWorkflow from "../workflows/collecteFluidesParOperateur";
+import collectePetitesQuantitesTransporteurEtrangerWorkflow from "../workflows/collecteFluidesParOperateurTransporteurEtranger";
 import groupementWorkflow from "../workflows/groupement";
 
 describe("Exemples de circuit du bordereau de suivi BSFF", () => {
   afterEach(resetDatabase);
 
-  test(
+  it(
     collectePetitesQuantitesWorkflow.title,
     async () => {
       await testWorkflow(collectePetitesQuantitesWorkflow);
@@ -14,7 +15,15 @@ describe("Exemples de circuit du bordereau de suivi BSFF", () => {
     60000
   );
 
-  test(
+  it(
+    collectePetitesQuantitesTransporteurEtrangerWorkflow.title,
+    async () => {
+      await testWorkflow(collectePetitesQuantitesTransporteurEtrangerWorkflow);
+    },
+    60000
+  );
+
+  it(
     groupementWorkflow.title,
     async () => {
       await testWorkflow(groupementWorkflow);

--- a/back/src/bsffs/examples/fixtures.ts
+++ b/back/src/bsffs/examples/fixtures.ts
@@ -1,4 +1,4 @@
-function detenteurInput(siret: string) {
+export function detenteurInput(siret: string) {
   return {
     company: {
       siret,
@@ -11,11 +11,11 @@ function detenteurInput(siret: string) {
   };
 }
 
-function operateurInput(siret: string) {
+export function operateurInput(siret: string) {
   return { company: operateurCompanyInput(siret) };
 }
 
-function operateurCompanyInput(siret: string) {
+export function operateurCompanyInput(siret: string) {
   return {
     siret,
     name: "Les gentlemen du froid",
@@ -26,7 +26,7 @@ function operateurCompanyInput(siret: string) {
   };
 }
 
-function transporterInput(siret: string) {
+export function transporterInput(siret: string) {
   return {
     company: {
       siret,
@@ -44,7 +44,7 @@ function transporterInput(siret: string) {
   };
 }
 
-function ttrInput(siret: string) {
+export function ttrInput(siret: string) {
   return {
     company: {
       siret,
@@ -59,7 +59,7 @@ function ttrInput(siret: string) {
   };
 }
 
-function traiteurCompanyInput(siret: string) {
+export function traiteurCompanyInput(siret: string) {
   return {
     siret,
     name: "Traiteur & Co",
@@ -70,7 +70,7 @@ function traiteurCompanyInput(siret: string) {
   };
 }
 
-function nextDestinationInput(siret: string) {
+export function nextDestinationInput(siret: string) {
   return {
     plannedOperationCode: "R2",
     cap: "CAP 2",
@@ -78,7 +78,7 @@ function nextDestinationInput(siret: string) {
   };
 }
 
-function traiteurInput(siret: string) {
+export function traiteurInput(siret: string) {
   return {
     cap: "CAP",
     plannedOperationCode: "R2",

--- a/back/src/bsffs/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsffs/examples/fixturesForeignTransporter.ts
@@ -1,0 +1,31 @@
+import {
+  detenteurInput,
+  nextDestinationInput,
+  operateurInput,
+  traiteurInput,
+  ttrInput
+} from "./fixtures";
+
+export function transporterInput(vatNumber: string) {
+  return {
+    company: {
+      siret: null,
+      vatNumber,
+      name: "Transport & Co",
+      address: "1 rue des 6 chemins, 07100 ANNONAY",
+      contact: "Claire Dupuis",
+      mail: "claire.dupuis@transportco.fr",
+      phone: "04 00 00 00 00"
+    },
+    recepisse: null
+  };
+}
+
+export default {
+  detenteurInput,
+  operateurInput,
+  transporterInput,
+  ttrInput,
+  traiteurInput,
+  nextDestinationInput
+};

--- a/back/src/bsffs/examples/steps/createBsff.ts
+++ b/back/src/bsffs/examples/steps/createBsff.ts
@@ -1,8 +1,11 @@
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import { WorkflowStep } from "../../../common/workflow";
 import mutations from "../mutations";
 
-export function createBsff(company: string): WorkflowStep {
+export function createBsff(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `L'opérateur crée un BSFF`,
     mutation: mutations.createBsff,
@@ -23,7 +26,11 @@ export function createBsff(company: string): WorkflowStep {
             value: 1,
             isEstimate: true
           },
-          transporter: fixtures.transporterInput(transporteur.siret),
+          transporter: fixtures.transporterInput(
+            transporteur.siret?.length
+              ? transporteur.siret
+              : transporteur.vatNumber
+          ),
           destination: fixtures.ttrInput(ttr.siret),
           ficheInterventions: ficheInterventions.map(fi => fi.id)
         }

--- a/back/src/bsffs/examples/workflows/collecteFluidesParOperateurTransporteurEtranger.ts
+++ b/back/src/bsffs/examples/workflows/collecteFluidesParOperateurTransporteurEtranger.ts
@@ -76,7 +76,7 @@ const workflow: Workflow = {
     detenteur1: { siret: "SIRET_DETENTEUR_1" },
     detenteur2: { siret: "SIRET_DETENTEUR_2" },
     operateur: { siret: "SIRET_OPERATEUR" },
-    transporteur: { siret: "SIRET_TRANSPORTEUR" },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
     ttr: { siret: "SIRET_TTR" },
     traiteur: { siret: "SIRET_TRAITEUR" },
     bsff: { id: "ID_BSFF" },

--- a/back/src/bsffs/examples/workflows/collecteFluidesParOperateurTransporteurEtranger.ts
+++ b/back/src/bsffs/examples/workflows/collecteFluidesParOperateurTransporteurEtranger.ts
@@ -1,0 +1,104 @@
+import fixtures from "../fixturesForeignTransporter";
+import { Workflow } from "../../../common/workflow";
+import { createFicheIntervention } from "../steps/createFicheIntervention";
+import { createBsff } from "../steps/createBsff";
+import { signEmission } from "../steps/signEmission";
+import { updateTransport } from "../steps/updateTransport";
+import { signTransport } from "../steps/signTransport";
+import { updateReception } from "../steps/updateReception";
+import { signReception } from "../steps/signReception";
+import { updateAcceptation } from "../steps/updateAcceptation";
+import { signAcceptation } from "../steps/signAcceptation";
+import { updateOperationD13 } from "../steps/updateOperation";
+import { signOperation } from "../steps/signOperation";
+
+const workflow: Workflow = {
+  title: "Collecte de fluides par un opérateur avec un transporteur étranger",
+  description:
+    "Un opérateur qui collecte des fluides lors d'opérations sur les équipements de ses" +
+    " clients. Il établit une ou des fiches d’intervention pour les détenteurs d’équipements. \n \n" +
+    " Lorsqu’il souhaite renvoyer le(s) contenant(s) à son fournisseur, l’opérateur crée un" +
+    " bordereau FF sur Trackdéchets. Il rapporte les renseignements clés des FI sur ce" +
+    " bordereau, ainsi que les informations des contenants." +
+    " Lorsque le bordereau est finalisé, il permet d’accompagner le ou les contenants de fluides." +
+    " Un bordereau doit servir de traçabilité pour un même fluide (pas de mélange)." +
+    " Le bordereau est signé par l’opérateur, le transporteur et l’entreprise de destination finale qui" +
+    " indique l’opération réalisée. Le BSFF est mis à disposition sur (ou via) Trackdéchets, à" +
+    " toutes les entreprises visées sur le bordereau. \n",
+  companies: [
+    { name: "detenteur1", companyTypes: ["PRODUCER"] },
+    { name: "detenteur2", companyTypes: ["PRODUCER"] },
+    { name: "operateur", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: {
+        siret: null,
+        vatNumber: "BE0541696005"
+      }
+    },
+    { name: "ttr", companyTypes: ["COLLECTOR"] },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    {
+      ...createFicheIntervention("operateur", {
+        detenteur: "detenteur1",
+        numero: "FI-1"
+      }),
+      description:
+        "L'opérateur renseigne les informations d'une première fiche d'intervention"
+    },
+    {
+      ...createFicheIntervention("operateur", {
+        detenteur: "detenteur2",
+        numero: "FI-2"
+      }),
+      description:
+        "L'opérateur renseigne les informations d'une deuxième fiche d'intervention. " +
+        "Cette étape peut être répétée autant de fois que l'on veut pour renseigner N fiches d'intervention"
+    },
+    {
+      ...createBsff("operateur", fixtures),
+      description: `L'opérateur crée un BSFF en liant les fiches d'intervention par leur identifiant Trackdéchets`
+    },
+    signEmission("operateur"),
+    updateTransport("transporteur"),
+    signTransport("transporteur"),
+    updateReception("ttr"),
+    signReception("ttr"),
+    updateAcceptation("ttr", { packagingIdx: 0 }),
+    signAcceptation("ttr"),
+    updateOperationD13("ttr", { packagingIdx: 0 }),
+    signOperation("ttr")
+  ],
+  docContext: {
+    detenteur1: { siret: "SIRET_DETENTEUR_1" },
+    detenteur2: { siret: "SIRET_DETENTEUR_2" },
+    operateur: { siret: "SIRET_OPERATEUR" },
+    transporteur: { siret: "SIRET_TRANSPORTEUR" },
+    ttr: { siret: "SIRET_TTR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsff: { id: "ID_BSFF" },
+    ficheInterventions: [{ id: "ID_FI_1" }, { id: "ID_FI_2" }],
+    packagings: [{ id: "ID_PACKAGING_1" }]
+  },
+  chart: `
+graph LR
+AO(NO STATE) -->|createFicheInterventionBsff| B(FI CREATED)
+AO(NO STATE) -->|createFicheInterventionBsff| B
+B -->|createBsff| C(INITIAL)
+C -->|updateBsff|C
+C -->|"signBsff(EMISSION)"|D(SIGNED_BY_EMITTER)
+D -->|updateBsff|D
+D -->|"signBsff(TRANSPORT)"|F(SENT)
+F -->|updateBsff|F
+G(SENT) -->|"signBsff(RECEPTION)"|H(RECEIVED)
+H -->|updateBsffPackaging|H
+H -->|"signBsff(ACCEPTATION)"|I(ACCEPTED)
+I -->|updateBsffPackaging|I
+I -->|"signBsff(OPERATION)"|J(INTERMEDIATELY_PROCESSED)
+`
+};
+
+export default workflow;

--- a/back/src/bsffs/examples/workflows/index.ts
+++ b/back/src/bsffs/examples/workflows/index.ts
@@ -1,7 +1,9 @@
+import collecteFluidesParOperateurTransporteurEtranger from "./collecteFluidesParOperateurTransporteurEtranger";
 import collecteFluidesParOperateur from "./collecteFluidesParOperateur";
 import groupement from "./groupement";
 
 export default {
+  collecteFluidesParOperateurTransporteurEtranger,
   collecteFluidesParOperateur,
   groupement
 };

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -1,4 +1,5 @@
 import { Bsff, BsffPackaging, BsffType } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic } from "../common/elastic";
 import {
   AllWaste,
@@ -39,7 +40,7 @@ export function getRegistryFields(
       bsff.emitterCompanySiret,
       ...bsff.detenteurCompanySirets
     );
-    registryFields.isTransportedWasteFor.push(bsff.transporterCompanySiret);
+    registryFields.isTransportedWasteFor.push(getTransporterCompanyOrgId(bsff));
   }
 
   if (bsff.destinationReceptionSignatureDate) {

--- a/back/src/bsffs/resolvers/mutations/signBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/signBsff.ts
@@ -27,6 +27,7 @@ import { isFinalOperation } from "../../constants";
 import { getStatus } from "../../compat";
 import { runInTransaction } from "../../../common/repository/helper";
 import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 async function checkIsAllowed(
   siret: string | null,
@@ -42,7 +43,7 @@ async function checkIsAllowed(
   if (securityCode) {
     const count = await prisma.company.count({
       where: {
-        siret,
+        orgId: siret,
         securityCode
       }
     });
@@ -54,7 +55,7 @@ async function checkIsAllowed(
       where: {
         userId: user.id,
         company: {
-          siret
+          orgId: siret
         }
       }
     });
@@ -99,7 +100,7 @@ const signatures: Record<
     existingBsff
   ) => {
     await checkIsAllowed(
-      existingBsff.transporterCompanySiret,
+      getTransporterCompanyOrgId(existingBsff),
       user,
       securityCode
     );

--- a/back/src/bsffs/resolvers/mutations/signBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/signBsff.ts
@@ -28,6 +28,8 @@ import { getStatus } from "../../compat";
 import { runInTransaction } from "../../../common/repository/helper";
 import { enqueueBsdToIndex } from "../../../queue/producers/elastic";
 import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
+import { getCachedUserSiretOrVat } from "../../../common/redis/users";
+import { checkSecurityCode } from "../../../forms/permissions";
 
 async function checkIsAllowed(
   siret: string | null,
@@ -41,25 +43,14 @@ async function checkIsAllowed(
   }
 
   if (securityCode) {
-    const count = await prisma.company.count({
-      where: {
-        orgId: siret,
-        securityCode
-      }
-    });
-    if (count <= 0) {
+    try {
+      await checkSecurityCode(siret, securityCode);
+    } catch (e) {
       throw new UserInputError(`Le code de sécurité est incorrect.`);
     }
   } else {
-    const count = await prisma.companyAssociation.count({
-      where: {
-        userId: user.id,
-        company: {
-          orgId: siret
-        }
-      }
-    });
-    if (count <= 0) {
+    const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
+    if (!userCompaniesSiretOrVat.includes(siret)) {
       throw new UserInputError(
         `Vous n'êtes pas autorisé à signer pour cet acteur.`
       );

--- a/back/src/bsffs/resolvers/queries/bsffPackagings.ts
+++ b/back/src/bsffs/resolvers/queries/bsffPackagings.ts
@@ -22,6 +22,7 @@ const bsffPackagings: QueryResolvers["bsffPackagings"] = async (
       OR: [
         { emitterCompanySiret: { in: userCompaniesSiretOrVat } },
         { transporterCompanySiret: { in: userCompaniesSiretOrVat } },
+        { transporterCompanyVatNumber: { in: userCompaniesSiretOrVat } },
         { destinationCompanySiret: { in: userCompaniesSiretOrVat } }
       ]
     }

--- a/back/src/bsffs/resolvers/queries/bsffs.ts
+++ b/back/src/bsffs/resolvers/queries/bsffs.ts
@@ -21,6 +21,7 @@ const bsffs: QueryResolvers["bsffs"] = async (
     OR: [
       { emitterCompanySiret: { in: userCompaniesSiretOrVat } },
       { transporterCompanySiret: { in: userCompaniesSiretOrVat } },
+      { transporterCompanyVatNumber: { in: userCompaniesSiretOrVat } },
       { destinationCompanySiret: { in: userCompaniesSiretOrVat } },
       { detenteurCompanySirets: { hasSome: userCompaniesSiretOrVat } }
     ]

--- a/back/src/bsffs/where.ts
+++ b/back/src/bsffs/where.ts
@@ -23,6 +23,9 @@ function toPrismaBsffSimpleWhereInput(where: BsffWhere): Prisma.BsffWhereInput {
     transporterCompanySiret: toPrismaStringFilter(
       where.transporter?.company?.siret
     ),
+    transporterCompanyVatNumber: toPrismaStringFilter(
+      where.transporter?.company?.vatNumber
+    ),
     transporterTransportSignatureDate: toPrismaDateFilter(
       where.transporter?.transport?.signature?.date
     ),

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -109,6 +109,7 @@ export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
     transporter: nullIfNoValues<BsvhuTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
+        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
         siret: form.transporterCompanySiret,
         address: form.transporterCompanyAddress,
         contact: form.transporterCompanyContact,

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -26,6 +26,7 @@ import {
   Bsvhu as PrismaVhuForm,
   WasteAcceptationStatus
 } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 
 export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
   return {
@@ -109,7 +110,7 @@ export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
     transporter: nullIfNoValues<BsvhuTransporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
-        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
+        orgId: getTransporterCompanyOrgId(form),
         siret: form.transporterCompanySiret,
         address: form.transporterCompanyAddress,
         contact: form.transporterCompanyContact,

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,5 +1,6 @@
 import { BsvhuStatus, Bsvhu } from "@prisma/client";
 import { BsdElastic, indexBsd } from "../common/elastic";
+import { transporterCompanyVatNumberSchema } from "../companies/validation";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 
@@ -35,7 +36,8 @@ function getWhere(
   const formSirets: Record<string, string | null | undefined> = {
     emitterCompanySiret: bsvhu.emitterCompanySiret,
     destinationCompanySiret: bsvhu.destinationCompanySiret,
-    transporterCompanySiret: bsvhu.transporterCompanySiret
+    transporterCompanySiret: bsvhu.transporterCompanySiret,
+    transporterCompanyVatNumber: bsvhu.transporterCompanyVatNumber
   };
 
   const siretsFilters = new Map<string, keyof typeof where>(
@@ -113,6 +115,7 @@ export function toBsdElastic(bsvhu: Bsvhu): BsdElastic {
     emitterCompanySiret: bsvhu.emitterCompanySiret ?? "",
     transporterCompanyName: bsvhu.transporterCompanyName ?? "",
     transporterCompanySiret: bsvhu.transporterCompanySiret ?? "",
+    transporterCompanyVatNumber: bsvhu.transporterCompanyVatNumber ?? "",
     transporterTakenOverAt: bsvhu.transporterTransportTakenOverAt?.getTime(),
     destinationCompanyName: bsvhu.destinationCompanyName ?? "",
     destinationCompanySiret: bsvhu.destinationCompanySiret ?? "",

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,6 +1,5 @@
 import { BsvhuStatus, Bsvhu } from "@prisma/client";
 import { BsdElastic, indexBsd } from "../common/elastic";
-import { transporterCompanyVatNumberSchema } from "../companies/validation";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 

--- a/back/src/bsvhu/examples/__tests__/examples.integration.ts
+++ b/back/src/bsvhu/examples/__tests__/examples.integration.ts
@@ -1,14 +1,23 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import vhuVersBroyeurWorkflow from "../workflows/vhuVersBroyeur";
+import vhuVersBroyeurTransporteurEtrangerWorkflow from "../workflows/vhuVersBroyeurTransporteurEtranger";
 
 describe("Exemples de circuit du bordereau de suivi VHU", () => {
   afterEach(resetDatabase);
 
-  test(
+  it(
     vhuVersBroyeurWorkflow.title,
     async () => {
       await testWorkflow(vhuVersBroyeurWorkflow);
+    },
+    60000
+  );
+
+  it(
+    vhuVersBroyeurTransporteurEtrangerWorkflow.title,
+    async () => {
+      await testWorkflow(vhuVersBroyeurTransporteurEtrangerWorkflow);
     },
     60000
   );

--- a/back/src/bsvhu/examples/fixtures.ts
+++ b/back/src/bsvhu/examples/fixtures.ts
@@ -1,4 +1,4 @@
-function emitterCompanyInput(siret: string) {
+export function emitterCompanyInput(siret: string) {
   return {
     siret,
     name: "Casse auto",
@@ -9,14 +9,14 @@ function emitterCompanyInput(siret: string) {
   };
 }
 
-function emitterInput(siret: string) {
+export function emitterInput(siret: string) {
   return {
     agrementNumber: "1234",
     company: emitterCompanyInput(siret)
   };
 }
 
-const wasteDetailsInput = {
+export const wasteDetailsInput = {
   wasteCode: "16 01 06",
   packaging: "UNITE",
   identification: {
@@ -30,7 +30,7 @@ const wasteDetailsInput = {
   }
 };
 
-function transporterCompanyInput(siret: string) {
+export function transporterCompanyInput(siret: string) {
   return {
     siret,
     name: "Transport Inc",
@@ -41,19 +41,19 @@ function transporterCompanyInput(siret: string) {
   };
 }
 
-const receiptInput = {
+export const receiptInput = {
   number: "recepisse number",
   department: "75",
   validityLimit: "2020-06-30"
 };
 
-function transporterInput(siret: string) {
+export function transporterInput(siret: string) {
   return {
     company: transporterCompanyInput(siret)
   };
 }
 
-function broyeurCompanyInput(siret: string) {
+export function broyeurCompanyInput(siret: string) {
   return {
     siret,
     name: "Broyeur du Sud Est",
@@ -64,7 +64,7 @@ function broyeurCompanyInput(siret: string) {
   };
 }
 
-function broyeurInput(siret: string) {
+export function broyeurInput(siret: string) {
   return {
     type: "BROYEUR",
     agrementNumber: "456",
@@ -73,12 +73,12 @@ function broyeurInput(siret: string) {
   };
 }
 
-const receptionInput = {
+export const receptionInput = {
   weight: 1.4,
   acceptationStatus: "ACCEPTED"
 };
 
-const operationInput = {
+export const operationInput = {
   date: "2021-04-27",
   code: "R 12"
 };

--- a/back/src/bsvhu/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsvhu/examples/fixturesForeignTransporter.ts
@@ -1,0 +1,42 @@
+import {
+  emitterCompanyInput,
+  emitterInput,
+  wasteDetailsInput,
+  broyeurCompanyInput,
+  broyeurInput,
+  receptionInput,
+  operationInput
+} from "./fixtures";
+
+export const receiptInput = null;
+
+function transporterCompanyInput(vatNumber: string) {
+  return {
+    siret: null,
+    vatNumber,
+    name: "Transport Inc",
+    address: "1 rue des 6 chemins, 07100 Annonay",
+    contact: "Jean Dupont",
+    phone: "01 00 00 00 00",
+    mail: "transport.dupont@transporter.fr"
+  };
+}
+
+function transporterInput(vatNumber: string) {
+  return {
+    company: transporterCompanyInput(vatNumber)
+  };
+}
+
+export default {
+  emitterCompanyInput,
+  emitterInput,
+  wasteDetailsInput,
+  transporterCompanyInput,
+  transporterInput,
+  receiptInput,
+  broyeurCompanyInput,
+  broyeurInput,
+  receptionInput,
+  operationInput
+};

--- a/back/src/bsvhu/examples/steps/createBsvhu.ts
+++ b/back/src/bsvhu/examples/steps/createBsvhu.ts
@@ -1,8 +1,11 @@
 import mutations from "../mutations";
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import { WorkflowStep } from "../../../common/workflow";
 
-export function createBsvhu(company: string): WorkflowStep {
+export function createBsvhu(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Création du BSVHU`,
     mutation: mutations.createBsvhu,
@@ -10,7 +13,11 @@ export function createBsvhu(company: string): WorkflowStep {
       input: {
         emitter: fixtures.emitterInput(producteur.siret),
         ...fixtures.wasteDetailsInput,
-        transporter: fixtures.transporterInput(transporteur.siret),
+        transporter: fixtures.transporterInput(
+          transporteur.siret?.length
+            ? transporteur.siret
+            : transporteur.vatNumber
+        ),
         destination: fixtures.broyeurInput(broyeur.siret)
       }
     }),

--- a/back/src/bsvhu/examples/workflows/index.ts
+++ b/back/src/bsvhu/examples/workflows/index.ts
@@ -1,5 +1,7 @@
 import vhuVersBroyeur from "./vhuVersBroyeur";
+import vhuVersBroyeurTransporteurEtranger from "./vhuVersBroyeurTransporteurEtranger";
 
 export default {
-  vhuVersBroyeur
+  vhuVersBroyeur,
+  vhuVersBroyeurTransporteurEtranger
 };

--- a/back/src/bsvhu/examples/workflows/vhuVersBroyeurTransporteurEtranger.ts
+++ b/back/src/bsvhu/examples/workflows/vhuVersBroyeurTransporteurEtranger.ts
@@ -1,0 +1,46 @@
+import { Workflow } from "../../../common/workflow";
+import { createBsvhu } from "../steps/createBsvhu";
+import { signForProducer } from "../steps/signForProducer";
+import { signOperation } from "../steps/signOperation";
+import { signTransport } from "../steps/signTransport";
+import { updateDestination } from "../steps/updateDestination";
+import fixtures from "../fixturesForeignTransporter";
+
+const workflow: Workflow = {
+  title: `Acheminement d'un centre VHU vers un broyeur par un transporteur étranger`,
+  companies: [
+    { name: "producteur", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: {
+        vatNumber: "BE0541696005",
+        siret: null
+      }
+    },
+    { name: "broyeur", companyTypes: ["WASTE_VEHICLES", "WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createBsvhu("producteur", fixtures),
+    signForProducer("producteur"),
+    signTransport("transporteur"),
+    updateDestination("broyeur"),
+    signOperation("broyeur")
+  ],
+  docContext: {
+    producteur: { siret: "SIRET_PRODUCTEUR", securityCode: "XXXX" },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
+    broyeur: { siret: "SIRET_BROYEUR" },
+    bsd: { id: "ID_BSD" }
+  },
+  chart: `
+graph LR
+AO(NO STATE) -->|createBsvhu| A(INITIAL)
+A -->|"signBsvhu (EMISSION)"| B(SIGNED_BY_PRODUCTER)
+B -->|updateBsvhu| B
+B -->|"signBsvhu (TRANSPORT)"| C(SENT)
+C -->|updateBsvhu| C
+C -->|"signBsvhu (OPERATION)"| D(PROCESSED)`
+};
+
+export default workflow;

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -13,6 +13,7 @@ import { AlreadySignedError, InvalidSignatureError } from "../../errors";
 import { machine } from "../../machine";
 import { validateBsvhu } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 type SignatureTypeInfos = {
   dbDateKey: keyof Bsvhu;
@@ -92,7 +93,7 @@ const signatureTypeMapping: Record<SignatureTypeInput, SignatureTypeInfos> = {
   TRANSPORT: {
     dbDateKey: "transporterTransportSignatureDate",
     dbAuthorKey: "transporterTransportSignatureAuthor",
-    getAuthorizedSiret: form => form.transporterCompanySiret
+    getAuthorizedSiret: form => getTransporterCompanyOrgId(form)
   }
 };
 

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -17,7 +17,10 @@ import {
 import * as yup from "yup";
 import { FactorySchemaOf } from "../common/yup/configureYup";
 import { BsvhuDestinationType } from "../generated/graphql/types";
-import { isSiret } from "../common/constants/companySearchHelpers";
+import {
+  isForeignVat,
+  isSiret
+} from "../common/constants/companySearchHelpers";
 import { transporterCompanyVatNumberSchema } from "../companies/validation";
 import { weight, WeightUnits } from "../common/validation";
 
@@ -236,7 +239,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
       transporterRecepisseDepartment: yup
         .string()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!tva) {
+          if (!isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: le département associé au récépissé est obligatoire`
@@ -247,7 +250,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
       transporterRecepisseNumber: yup
         .string()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!tva) {
+          if (!isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: le numéro de récépissé est obligatoire`
@@ -271,7 +274,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
         .string()
         .ensure()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!tva) {
+          if (!isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: ${MISSING_COMPANY_SIRET}`

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -260,10 +260,15 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
         }),
       transporterRecepisseValidityLimit: yup
         .date()
-        .requiredIf(
-          context.transportSignature,
-          `Transporteur: ${MISSING_COMPANY_NAME}`
-        ) as any,
+        .when("transporterCompanyVatNumber", (tva, schema) => {
+          if (!tva || !isForeignVat(tva)) {
+            return schema.requiredIf(
+              context.transportSignature,
+              `Transporteur: la date de validité de récépissé est obligatoire`
+            );
+          }
+          return schema.nullable().notRequired();
+        }),
       transporterCompanyName: yup
         .string()
         .requiredIf(

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -239,7 +239,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
       transporterRecepisseDepartment: yup
         .string()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!isForeignVat(tva)) {
+          if (!tva || !isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: le département associé au récépissé est obligatoire`
@@ -250,7 +250,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
       transporterRecepisseNumber: yup
         .string()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!isForeignVat(tva)) {
+          if (!tva || !isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: le numéro de récépissé est obligatoire`
@@ -274,7 +274,7 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
         .string()
         .ensure()
         .when("transporterCompanyVatNumber", (tva, schema) => {
-          if (!isForeignVat(tva)) {
+          if (!tva || !isForeignVat(tva)) {
             return schema.requiredIf(
               context.transportSignature,
               `Transporteur: ${MISSING_COMPANY_SIRET}`

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -123,7 +123,7 @@ export const isSiret = (clue: string, allowTestCompany = false): boolean => {
  * Validateur de numéro de TVA
  */
 export const isVat = (clue: string): boolean => {
-  if (!clue) return false;
+  if (!clue || !clue.length) return false;
   if (clue.match(/[\W_]/gim) !== null) return false;
   const cleanClue = clue.replace(/[\W_]+/g, "");
   if (!cleanClue) return false;

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -160,3 +160,14 @@ export const isOmi = (clue: string): boolean => {
   const clean = clue.replace(/[\W_]+/g, "");
   return clean.match(/^OMI[0-9]{7}$/gim) !== null;
 };
+
+/**
+ * Works with any BSD in order to provide a default orgId
+ */
+export const getTransporterCompanyOrgId = (form: {
+  transporterCompanySiret: string;
+  transporterCompanyVatNumber: string;
+}): string =>
+  form.transporterCompanySiret?.length
+    ? form.transporterCompanySiret
+    : form.transporterCompanyVatNumber;

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -118,7 +118,7 @@ export const transporterCompanySiretSchema = (isDraft: boolean) =>
       value => !value || isSiret(value)
     )
     .when("transporterCompanyVatNumber", (tva, schema) => {
-      if (!tva && !isDraft) {
+      if (!isForeignVat(tva) && !isDraft) {
         return schema.required(
           `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
         );

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -118,7 +118,7 @@ export const transporterCompanySiretSchema = (isDraft: boolean) =>
       value => !value || isSiret(value)
     )
     .when("transporterCompanyVatNumber", (tva, schema) => {
-      if (!isForeignVat(tva) && !isDraft) {
+      if ((!tva || !isForeignVat(tva)) && !isDraft) {
         return schema.required(
           `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
         );

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -47,6 +47,7 @@ describe("expandFormFromDb", () => {
       transporter: {
         company: {
           name: form.transporterCompanyName,
+          orgId: form.transporterCompanySiret,
           siret: form.transporterCompanySiret,
           vatNumber: form.transporterCompanyVatNumber,
           address: form.transporterCompanyAddress,
@@ -158,6 +159,7 @@ describe("expandFormFromDb", () => {
       transporter: {
         company: {
           name: forwardedIn.transporterCompanyName,
+          orgId: forwardedIn.transporterCompanySiret,
           siret: forwardedIn.transporterCompanySiret,
           vatNumber: forwardedIn.transporterCompanyVatNumber,
           address: forwardedIn.transporterCompanyAddress,

--- a/back/src/forms/__tests__/permissions.integration.ts
+++ b/back/src/forms/__tests__/permissions.integration.ts
@@ -360,6 +360,15 @@ describe("checkSecurityCode", () => {
     expect(check).toEqual(true);
   });
 
+  test("securityCode is valid for foreign transporter", async () => {
+    const company = await companyFactory({
+      siret: null,
+      vatNumber: "BE0541696005"
+    });
+    const check = await checkSecurityCode(company.orgId, company.securityCode);
+    expect(check).toEqual(true);
+  });
+
   test("securityCode is invalid", async () => {
     const company = await companyFactory();
     const checkFn = () => checkSecurityCode(company.siret, 1258478956);

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -6,6 +6,7 @@ import {
   TransportSegment as PrismaTransportSegment
 } from "@prisma/client";
 import DataLoader from "dataloader";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import {
   chain,
   nullIfNoValues,
@@ -548,7 +549,7 @@ export async function expandFormFromDb(
     transporter: nullIfNoValues<Transporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
-        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
+        orgId: getTransporterCompanyOrgId(form),
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,
@@ -725,9 +726,7 @@ export async function expandFormFromDb(
           transporter: nullIfNoValues<Transporter>({
             company: nullIfNoValues<FormCompany>({
               name: forwardedIn.transporterCompanyName,
-              orgId:
-                forwardedIn.transporterCompanySiret ??
-                forwardedIn.transporterCompanyVatNumber,
+              orgId: getTransporterCompanyOrgId(forwardedIn),
               siret: forwardedIn.transporterCompanySiret,
               vatNumber: forwardedIn.transporterCompanyVatNumber,
               address: forwardedIn.transporterCompanyAddress,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -548,7 +548,7 @@ export async function expandFormFromDb(
     transporter: nullIfNoValues<Transporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
-        orgId: form.transporterCompanyName ?? form.transporterCompanyVatNumber,
+        orgId: form.transporterCompanySiret ?? form.transporterCompanyVatNumber,
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -548,7 +548,7 @@ export async function expandFormFromDb(
     transporter: nullIfNoValues<Transporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
-        orgId: form.traderCompanySiret ?? form.transporterCompanyVatNumber,
+        orgId: form.transporterCompanyName ?? form.transporterCompanyVatNumber,
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -548,6 +548,7 @@ export async function expandFormFromDb(
     transporter: nullIfNoValues<Transporter>({
       company: nullIfNoValues<FormCompany>({
         name: form.transporterCompanyName,
+        orgId: form.traderCompanySiret ?? form.transporterCompanyVatNumber,
         siret: form.transporterCompanySiret,
         vatNumber: form.transporterCompanyVatNumber,
         address: form.transporterCompanyAddress,
@@ -724,6 +725,9 @@ export async function expandFormFromDb(
           transporter: nullIfNoValues<Transporter>({
             company: nullIfNoValues<FormCompany>({
               name: forwardedIn.transporterCompanyName,
+              orgId:
+                forwardedIn.transporterCompanySiret ??
+                forwardedIn.transporterCompanyVatNumber,
               siret: forwardedIn.transporterCompanySiret,
               vatNumber: forwardedIn.transporterCompanyVatNumber,
               address: forwardedIn.transporterCompanyAddress,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -51,6 +51,8 @@ export function getSiretsByTab(
     forwardedInDestinationCompanySiret: form.forwardedIn?.recipientCompanySiret,
     forwardedInTransporterCompanySiret:
       form.forwardedIn?.transporterCompanySiret,
+    forwardedInTransporterCompanyVatNumber:
+      form.forwardedIn?.transporterCompanyVatNumber,
     traderCompanySiret: form.traderCompanySiret,
     brokerCompanySiret: form.brokerCompanySiret,
     ecoOrganismeSiret: form.ecoOrganismeSiret,

--- a/back/src/forms/examples/__tests__/examples.integration.ts
+++ b/back/src/forms/examples/__tests__/examples.integration.ts
@@ -1,15 +1,18 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
 import testWorkflow from "../../../__tests__/testWorkflow";
 import acheminementDirectWorkflow from "../workflows/acheminementDirect";
+import acheminementDirectTransporterEtrangerWorkflow from "../workflows/acheminementDirectTransporteurEtranger";
 import multiModalWorkflow from "../workflows/multiModal";
 import entreposageProvisoireWorkflow from "../workflows/entreposageProvisoire";
+import entreposageProvisoireTransporterEtrangerWorkflow from "../workflows/entreposageProvisoireTransporteurEtranger";
 import importBsdPapier from "../workflows/importBsdPapier";
 import regroupement from "../workflows/regroupement";
+import regroupementTransporterEtranger from "../workflows/regroupementTransporteurEtranger";
 
 describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () => {
   afterEach(resetDatabase);
 
-  test(
+  it(
     acheminementDirectWorkflow.title,
     async () => {
       await testWorkflow(acheminementDirectWorkflow);
@@ -17,7 +20,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
     60000
   );
 
-  test(
+  it(
     entreposageProvisoireWorkflow.title,
     async () => {
       await testWorkflow(entreposageProvisoireWorkflow);
@@ -25,7 +28,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
     60000
   );
 
-  test(
+  it(
     regroupement.title,
     async () => {
       await testWorkflow(regroupement);
@@ -33,7 +36,31 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
     60000
   );
 
-  test(
+  it(
+    acheminementDirectTransporterEtrangerWorkflow.title,
+    async () => {
+      await testWorkflow(acheminementDirectTransporterEtrangerWorkflow);
+    },
+    60000
+  );
+
+  it(
+    entreposageProvisoireTransporterEtrangerWorkflow.title,
+    async () => {
+      await testWorkflow(entreposageProvisoireTransporterEtrangerWorkflow);
+    },
+    60000
+  );
+
+  it(
+    regroupementTransporterEtranger.title,
+    async () => {
+      await testWorkflow(regroupementTransporterEtranger);
+    },
+    60000
+  );
+
+  it(
     multiModalWorkflow.title,
     async () => {
       await testWorkflow(multiModalWorkflow);
@@ -41,7 +68,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets dangereux", () 
     60000
   );
 
-  test(
+  it(
     importBsdPapier.title,
     async () => {
       await testWorkflow(importBsdPapier);

--- a/back/src/forms/examples/fixtures.ts
+++ b/back/src/forms/examples/fixtures.ts
@@ -2,7 +2,7 @@
  * Fixtures used as building blocks of mutations inputs
  */
 
-function emitterCompanyInput(siret: string) {
+export function emitterCompanyInput(siret: string) {
   return {
     siret,
     name: "Déchets & Co",
@@ -13,14 +13,14 @@ function emitterCompanyInput(siret: string) {
   };
 }
 
-const workSiteInput = {
+export const workSiteInput = {
   address: "5 rue du chantier",
   postalCode: "75010",
   city: "Paris",
   infos: "Site de stockage de boues"
 };
 
-function emitterInput(siret: string) {
+export function emitterInput(siret: string) {
   return {
     type: "PRODUCER",
     workSite: workSiteInput,
@@ -28,7 +28,7 @@ function emitterInput(siret: string) {
   };
 }
 
-function transporterCompanyInput(siret: string) {
+export function transporterCompanyInput(siret: string) {
   return {
     siret,
     name: "Transport & Co",
@@ -39,7 +39,7 @@ function transporterCompanyInput(siret: string) {
   };
 }
 
-function transporter2CompanyInput(siret: string) {
+export function transporter2CompanyInput(siret: string) {
   return {
     siret,
     name: "Fret & Co",
@@ -50,21 +50,21 @@ function transporter2CompanyInput(siret: string) {
   };
 }
 
-const receiptInput = {
+export const receiptInput = {
   receipt: "12379",
   department: "07",
   validityLimit: "2020-06-30",
   numberPlate: "AD-007-TS"
 };
 
-function transporterInput(siret: string) {
+export function transporterInput(siret: string) {
   return {
     company: transporterCompanyInput(siret),
     ...receiptInput
   };
 }
 
-function traiteurCompanyInput(siret: string) {
+export function traiteurCompanyInput(siret: string) {
   return {
     siret,
     name: "Traiteur & Co",
@@ -75,7 +75,7 @@ function traiteurCompanyInput(siret: string) {
   };
 }
 
-function ttrCompanyInput(siret: string) {
+export function ttrCompanyInput(siret: string) {
   return {
     siret,
     name: "Entreposage & Co",
@@ -86,7 +86,7 @@ function ttrCompanyInput(siret: string) {
   };
 }
 
-function recipientInput(siret: string) {
+export function recipientInput(siret: string) {
   return {
     processingOperation: "D 10",
     cap: "CAP",
@@ -94,7 +94,7 @@ function recipientInput(siret: string) {
   };
 }
 
-function recipientIsTempStorageInput(siret: string) {
+export function recipientIsTempStorageInput(siret: string) {
   return {
     processingOperation: "D 13",
     cap: "CAP",
@@ -103,7 +103,7 @@ function recipientIsTempStorageInput(siret: string) {
   };
 }
 
-function ttrInput(siret: string) {
+export function ttrInput(siret: string) {
   return {
     processingOperation: "D 13",
     cap: "CAP",
@@ -111,7 +111,7 @@ function ttrInput(siret: string) {
   };
 }
 
-const wasteDetailsInput = {
+export const wasteDetailsInput = {
   code: "06 05 02*",
   onuCode: "Non Soumis",
   name: "Boues",
@@ -121,7 +121,7 @@ const wasteDetailsInput = {
   consistence: "LIQUID"
 };
 
-function signEmissionFormInput() {
+export function signEmissionFormInput() {
   return {
     quantity: 1,
     onuCode: "non soumis",
@@ -132,14 +132,14 @@ function signEmissionFormInput() {
   };
 }
 
-function signTransportFormInput() {
+export function signTransportFormInput() {
   return {
     takenOverAt: "2020-04-03T14:48:00",
     takenOverBy: "Isabelle Guichard"
   };
 }
 
-const receivedInfoInput = {
+export const receivedInfoInput = {
   wasteAcceptationStatus: "ACCEPTED",
   receivedBy: "Antoine Derieux",
   receivedAt: "2020-04-05T11:18:00",
@@ -147,14 +147,14 @@ const receivedInfoInput = {
   quantityReceived: 1
 };
 
-const processedInfoInput = {
+export const processedInfoInput = {
   processingOperationDone: "D 10",
   processingOperationDescription: "Incinération",
   processedBy: "Alfred Dujardin",
   processedAt: "2020-04-15T10:22:00"
 };
 
-function awaitingGroupInfoInput(nextDestinationSiret: string) {
+export function awaitingGroupInfoInput(nextDestinationSiret: string) {
   return {
     processingOperationDone: "D 13",
     processingOperationDescription: "Regroupement",
@@ -167,7 +167,7 @@ function awaitingGroupInfoInput(nextDestinationSiret: string) {
   };
 }
 
-const tempStoredInfosInput = {
+export const tempStoredInfosInput = {
   wasteAcceptationStatus: "ACCEPTED",
   receivedBy: "John Arnold",
   receivedAt: "2020-05-03T09:00:00",
@@ -176,13 +176,13 @@ const tempStoredInfosInput = {
   quantityType: "REAL"
 };
 
-function resealedInfosInput(siret: string) {
+export function resealedInfosInput(siret: string) {
   return {
     transporter: transporterInput(siret)
   };
 }
 
-function nextSegmentInfoInput(siret: string) {
+export function nextSegmentInfoInput(siret: string) {
   return {
     transporter: {
       company: transporter2CompanyInput(siret),
@@ -192,7 +192,7 @@ function nextSegmentInfoInput(siret: string) {
   };
 }
 
-const takeOverInfoInput = {
+export const takeOverInfoInput = {
   takenOverAt: "2020-04-04T09:00:00.000Z",
   takenOverBy: "Transporteur 2"
 };

--- a/back/src/forms/examples/fixturesForeignTransporter.ts
+++ b/back/src/forms/examples/fixturesForeignTransporter.ts
@@ -1,0 +1,72 @@
+import {
+  emitterCompanyInput,
+  emitterInput,
+  receiptInput,
+  traiteurCompanyInput,
+  recipientInput,
+  ttrCompanyInput,
+  recipientIsTempStorageInput,
+  ttrInput,
+  wasteDetailsInput,
+  workSiteInput,
+  signEmissionFormInput,
+  signTransportFormInput,
+  receivedInfoInput,
+  processedInfoInput,
+  awaitingGroupInfoInput,
+  tempStoredInfosInput,
+  nextSegmentInfoInput,
+  takeOverInfoInput
+} from "./fixtures";
+
+export function transporterCompanyInput(vatNumber: string) {
+  return {
+    siret: null,
+    vatNumber,
+    name: "Transport & Co",
+    address: "1 rue des 6 chemins, 07100 ANNONAY",
+    contact: "Claire Dupuis",
+    mail: "claire.dupuis@transportco.fr",
+    phone: "04 00 00 00 00"
+  };
+}
+
+export function transporterInput(vatNumber: string) {
+  return {
+    company: transporterCompanyInput(vatNumber),
+    receipt: null,
+    department: null,
+    validityLimit: null,
+    numberPlate: null
+  };
+}
+
+export function resealedInfosInput(vatNumber: string) {
+  return {
+    transporter: transporterInput(vatNumber)
+  };
+}
+
+export default {
+  emitterCompanyInput,
+  emitterInput,
+  transporterCompanyInput,
+  transporterInput,
+  traiteurCompanyInput,
+  recipientInput,
+  ttrCompanyInput,
+  recipientIsTempStorageInput,
+  ttrInput,
+  wasteDetailsInput,
+  workSiteInput,
+  receiptInput,
+  signEmissionFormInput,
+  signTransportFormInput,
+  receivedInfoInput,
+  processedInfoInput,
+  awaitingGroupInfoInput,
+  tempStoredInfosInput,
+  resealedInfosInput,
+  nextSegmentInfoInput,
+  takeOverInfoInput
+};

--- a/back/src/forms/examples/steps/createForm.ts
+++ b/back/src/forms/examples/steps/createForm.ts
@@ -1,8 +1,11 @@
 import mutations from "../mutations";
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import { WorkflowStep } from "../../../common/workflow";
 
-export function createForm(company: string): WorkflowStep {
+export function createForm(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Les informations du BSDD sont remplies. Cette action peut-être effectuée
   par n'importe quel établissement apparaissant sur le BSDD. À ce stade il est toujours possible
@@ -40,21 +43,31 @@ export function createFormMultiModal(company: string): WorkflowStep {
 }
 
 /** Creates a form that will be grouped */
-export function createInitialForm(company: string): WorkflowStep {
+export function createInitialForm(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     ...createForm(company),
     variables: ({ producteur, transporteur, ttr }) => ({
       createFormInput: {
         emitter: fixtures.emitterInput(producteur.siret),
         recipient: fixtures.ttrInput(ttr.siret),
-        transporter: fixtures.transporterInput(transporteur.siret),
+        transporter: fixtures.transporterInput(
+          transporteur.siret?.length
+            ? transporteur.siret
+            : transporteur.vatNumber
+        ),
         wasteDetails: fixtures.wasteDetailsInput
       }
     })
   };
 }
 
-export function createGroupementForm(company: string): WorkflowStep {
+export function createGroupementForm(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     ...createForm(company),
     description:
@@ -72,7 +85,11 @@ export function createGroupementForm(company: string): WorkflowStep {
             company: fixtures.ttrCompanyInput(ttr.siret)
           },
           recipient: fixtures.recipientInput(traiteur.siret),
-          transporter: fixtures.transporterInput(transporteur2.siret),
+          transporter: fixtures.transporterInput(
+            transporteur2.siret?.length
+              ? transporteur2.siret
+              : transporteur2.vatNumber
+          ),
           wasteDetails: fixtures.wasteDetailsInput,
           grouping: [
             {
@@ -86,14 +103,21 @@ export function createGroupementForm(company: string): WorkflowStep {
   };
 }
 
-export function createFormTempStorage(company: string): WorkflowStep {
+export function createFormTempStorage(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     ...createForm(company),
     variables: ({ producteur, ttr, transporteur1, traiteur }) => ({
       createFormInput: {
         emitter: fixtures.emitterInput(producteur.siret),
         recipient: fixtures.recipientIsTempStorageInput(ttr.siret),
-        transporter: fixtures.transporterInput(transporteur1.siret),
+        transporter: fixtures.transporterInput(
+          transporteur1.siret?.length
+            ? transporteur1.siret
+            : transporteur1.vatNumber
+        ),
         wasteDetails: fixtures.wasteDetailsInput,
         temporaryStorageDetail: {
           destination: fixtures.recipientInput(traiteur.siret)

--- a/back/src/forms/examples/steps/createForm.ts
+++ b/back/src/forms/examples/steps/createForm.ts
@@ -12,7 +12,11 @@ export function createForm(company: string): WorkflowStep {
       createFormInput: {
         emitter: fixtures.emitterInput(producteur.siret),
         recipient: fixtures.recipientInput(traiteur.siret),
-        transporter: fixtures.transporterInput(transporteur.siret),
+        transporter: fixtures.transporterInput(
+          transporteur.siret?.length
+            ? transporteur.siret
+            : transporteur.vatNumber
+        ),
         wasteDetails: fixtures.wasteDetailsInput
       }
     }),

--- a/back/src/forms/examples/steps/markAsResealed.ts
+++ b/back/src/forms/examples/steps/markAsResealed.ts
@@ -1,14 +1,21 @@
 import mutations from "../mutations";
-import fixtures from "../fixtures";
+import defaultFixtures from "../fixtures";
 import { WorkflowStep } from "../../../common/workflow";
 
-export function markAsResealed(company: string): WorkflowStep {
+export function markAsResealed(
+  company: string,
+  fixtures = defaultFixtures
+): WorkflowStep {
   return {
     description: `Complète et valide les cadres 13 à 19`,
     mutation: mutations.markAsResealed,
     variables: ({ bsd, transporteur2 }) => ({
       id: bsd.id,
-      resealedInfos: fixtures.resealedInfosInput(transporteur2.siret)
+      resealedInfos: fixtures.resealedInfosInput(
+        transporteur2.siret?.length
+          ? transporteur2.siret
+          : transporteur2.vatNumber
+      )
     }),
     expected: { status: "RESEALED" },
     data: response => response.markAsResealed,

--- a/back/src/forms/examples/workflows/acheminementDirectTransporteurEtranger.ts
+++ b/back/src/forms/examples/workflows/acheminementDirectTransporteurEtranger.ts
@@ -1,0 +1,52 @@
+import { Workflow } from "../../../common/workflow";
+import { createForm } from "../steps/createForm";
+import { markAsSealed } from "../steps/markAsSealed";
+import { markAsReceived } from "../steps/markAsReceived";
+import { markAsProcessed } from "../steps/markAsProcessed";
+import { signEmissionForm } from "../steps/signEmissionForm";
+import { signTransportForm } from "../steps/signTransportForm";
+import fixtures from "../fixturesForeignTransporter";
+
+const workflow: Workflow = {
+  title:
+    "Acheminement direct du producteur à l'installation de traitement avec un transporteur étranger",
+  description: `Les informations du BSDD sont remplies par le producteur du déchet.
+  L'émetteur signe l'envoi suivit par le transporteur étranger puis le déchet est accepté
+  et traité à l'installation de destination.`,
+  companies: [
+    { name: "producteur", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: {
+        siret: null,
+        vatNumber: "BE0541696005"
+      }
+    },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createForm("producteur", fixtures),
+    markAsSealed("producteur"),
+    signEmissionForm("producteur"),
+    signTransportForm("transporteur"),
+    markAsReceived("traiteur"),
+    markAsProcessed("traiteur")
+  ],
+  docContext: {
+    producteur: { siret: "SIRET_PRODUCTEUR", securityCode: 1234 },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsd: { id: "ID_BSD" }
+  },
+  chart: `
+graph LR
+NO_STATE(NO STATE) --> |createForm| DRAFT
+DRAFT --> |markAsSealed| SEALED
+SEALED --> |signEmissionForm| SIGNED_BY_PRODUCER
+SIGNED_BY_PRODUCER --> |signTransportForm| SENT
+SENT --> |markAsReceived| ACCEPTED
+ACCEPTED --> |markAsProcessed| PROCESSED`
+};
+
+export default workflow;

--- a/back/src/forms/examples/workflows/entreposageProvisoireTransporteurEtranger.ts
+++ b/back/src/forms/examples/workflows/entreposageProvisoireTransporteurEtranger.ts
@@ -1,0 +1,76 @@
+import { createFormTempStorage } from "../steps/createForm";
+import { markAsSealed } from "../steps/markAsSealed";
+import { markAsTempStored } from "../steps/markAsTempStored";
+import { markAsResealed } from "../steps/markAsResealed";
+import { markAsReceived } from "../steps/markAsReceived";
+import { markAsProcessed } from "../steps/markAsProcessed";
+import { Workflow } from "../../../common/workflow";
+import {
+  signEmissionForm,
+  signEmissionFormAfterTempStorage
+} from "../steps/signEmissionForm";
+import {
+  signTransportForm,
+  signTransportFormAfterTempStorage
+} from "../steps/signTransportForm";
+import fixtures from "../fixturesForeignTransporter";
+
+const workflow: Workflow = {
+  title: "Entreposage provisoire avec transporteur étranger",
+  description: `Les informations principales du BSDD sont remplies par l'émetteur du bordereau
+en précisant isTempStorage=true dans les informations de destination. Le destinataire correspond à
+l'installation d'entreposage provisoire. L'émetteur signe l'envoi, suivit du transporteur étranger.
+L'installation d'entreposage provisoire accepte les déchets et complète les informations du
+second transporteur et de la destination finale (si ce n'est pas déjà fait par l'émetteur).
+L'installation d'entreposage provisoire signe l'envoi, suivit du transporteur n°2 étranger. L'installation
+de destination finale accepte le déchet et valide le traitement.`,
+  companies: [
+    { name: "producteur", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur1",
+      companyTypes: ["TRANSPORTER"],
+      opt: { siret: null, vatNumber: "BE0541696005" }
+    },
+    { name: "ttr", companyTypes: ["COLLECTOR"] },
+    {
+      name: "transporteur2",
+      companyTypes: ["TRANSPORTER"],
+      opt: { siret: null, vatNumber: "IT13029381004" }
+    },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createFormTempStorage("producteur", fixtures),
+    markAsSealed("producteur"),
+    signEmissionForm("producteur"),
+    signTransportForm("transporteur1"),
+    markAsTempStored("ttr"),
+    markAsResealed("ttr", fixtures),
+    signEmissionFormAfterTempStorage("ttr"),
+    signTransportFormAfterTempStorage("transporteur2"),
+    markAsReceived("traiteur"),
+    markAsProcessed("traiteur")
+  ],
+  docContext: {
+    producteur: { siret: "SIRET_PRODUCTEUR" },
+    transporteur1: { siret: "SIRET_TRANSPORTEUR_1" },
+    ttr: { siret: "SIRET_TTR", securityCode: "XXXX" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    transporteur2: { siret: "SIRET_TRANSPORTEUR_2" },
+    bsd: { id: "ID_BSD" }
+  },
+  chart: `
+graph LR
+NO_STATE(NO STATE) --> |createForm| DRAFT
+DRAFT --> |markAsSealed| SEALED
+SEALED --> |signEmissionForm| SIGNED_BY_PRODUCER
+SIGNED_BY_PRODUCER --> |signTransportForm| SENT
+SENT --> |markAsTempStored| TEMP_STORER_ACCEPTED
+TEMP_STORER_ACCEPTED2(TEMP_STORER_ACCEPTED) --> |markAsResealed| RESEALED
+RESEALED --> |signEmissionForm| SIGNED_BY_TEMP_STORER
+SIGNED_BY_TEMP_STORER --> |signTransportForm| RESENT
+RESENT --> |markAsReceived| RECEIVED
+RECEIVED --> |markAsProcessed| PROCESSED`
+};
+
+export default workflow;

--- a/back/src/forms/examples/workflows/index.ts
+++ b/back/src/forms/examples/workflows/index.ts
@@ -1,13 +1,19 @@
 import acheminementDirect from "./acheminementDirect";
+import acheminementDirectTransporteurEtranger from "./acheminementDirectTransporteurEtranger";
 import entreposageProvisoire from "./entreposageProvisoire";
+import entreposageProvisoireTransporteurEtranger from "./entreposageProvisoireTransporteurEtranger";
 import importBsdPapier from "./importBsdPapier";
 import multiModal from "./multiModal";
 import regroupement from "./regroupement";
+import regroupementTransporteurEtranger from "./regroupementTransporteurEtranger";
 
 export default {
   acheminementDirect,
+  acheminementDirectTransporteurEtranger,
   entreposageProvisoire,
+  entreposageProvisoireTransporteurEtranger,
   importBsdPapier,
   multiModal,
-  regroupement
+  regroupement,
+  regroupementTransporteurEtranger
 };

--- a/back/src/forms/examples/workflows/regroupementTransporteurEtranger.ts
+++ b/back/src/forms/examples/workflows/regroupementTransporteurEtranger.ts
@@ -1,0 +1,62 @@
+import { Workflow } from "../../../common/workflow";
+import { createInitialForm, createGroupementForm } from "../steps/createForm";
+import { markAsSealed } from "../steps/markAsSealed";
+import { markAsReceived } from "../steps/markAsReceived";
+import { markAsAwaitingGroup } from "../steps/markAsProcessed";
+import { signEmissionForm } from "../steps/signEmissionForm";
+import { signTransportForm } from "../steps/signTransportForm";
+import fixtures from "../fixturesForeignTransporter";
+
+const workflow: Workflow = {
+  title:
+    "Émission d’un BSDD de regroupement, pour la personne ayant transformé ou réalisé un" +
+    " traitement dont la provenance des déchets reste identifiable avec un transporteur étranger",
+  description:
+    "Installation recevant des déchets et les réexpédiant, après" +
+    " avoir procédé à leur déconditionnement et reconditionnement, voire leur" +
+    " sur-conditionnement, pour constituer des lots de taille plus importante. Les opérations de" +
+    " déconditionnement / reconditionnement ne doivent pas conduire au mélange de déchets de" +
+    " nature et catégorie différentes. Par exemple, la mise en balle de déchets non dangereux" +
+    " (filmage, compactage, ...) est une opération de regroupement.`",
+  companies: [
+    { name: "producteur", companyTypes: ["PRODUCER"] },
+    {
+      name: "transporteur",
+      companyTypes: ["TRANSPORTER"],
+      opt: { siret: null, vatNumber: "BE0541696005" }
+    },
+    { name: "ttr", companyTypes: ["COLLECTOR"] },
+    {
+      name: "transporteur2",
+      companyTypes: ["TRANSPORTER"],
+      opt: { siret: null, vatNumber: "RO17579668" }
+    },
+    { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
+  ],
+  steps: [
+    createInitialForm("producteur", fixtures),
+    markAsSealed("producteur"),
+    signEmissionForm("producteur"),
+    signTransportForm("transporteur"),
+    markAsReceived("ttr"),
+    markAsAwaitingGroup("ttr"),
+    createGroupementForm("ttr", fixtures)
+  ],
+  docContext: {
+    producteur: { siret: "SIRET_PRODUCTEUR", securityCode: 1234 },
+    transporteur: { vatNumber: "VAT_TRANSPORTEUR" },
+    transporteur2: { vatNumber: "VAT_TRANSPORTEUR_2" },
+    ttr: { siret: "SIRET_TTR" },
+    traiteur: { siret: "SIRET_TRAITEUR" },
+    bsd: { id: "ID_BSD" },
+    initialBsd: { id: "ID_INITIAL_BSD", quantityReceived: 1.0 }
+  },
+  chart: `
+graph LR
+ACCEPTED --> |markAsProcessed sur le BSD initial| AWAITING_GROUP
+AWAITING_GROUP --> |markAsSealed sur le BSD de regroupement | GROUPED
+GROUPED --> |markAsProcessed  sur le BSD de regroupement | PROCESSED
+`
+};
+
+export default workflow;

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -6,6 +6,7 @@ import { generateBsddPdfToBase64 } from "../pdf";
 import DREALS from "../../common/constants/DREALS";
 import { formNotAccepted, formPartiallyRefused } from "../../mailer/templates";
 import { renderMail } from "../../mailer/templates/renderers";
+import { getTransporterCompanyOrgId } from "../../common/constants/companySearchHelpers";
 
 const { NOTIFY_DREAL_WHEN_FORM_DECLINED } = process.env;
 
@@ -98,7 +99,7 @@ export async function renderFormRefusedEmail(
               transporterIsExemptedOfReceipt:
                 forwardedIn.transporterIsExemptedOfReceipt,
               transporterCompanyName: forwardedIn.transporterCompanyName,
-              transporterCompanySiret: forwardedIn.transporterCompanySiret,
+              transporterCompanySiret: getTransporterCompanyOrgId(forwardedIn),
               transporterReceipt: forwardedIn.transporterReceipt,
               sentBy: forwardedIn.sentBy,
               quantityReceived: forwardedIn.quantityReceived
@@ -111,7 +112,7 @@ export async function renderFormRefusedEmail(
               transporterIsExemptedOfReceipt:
                 form.transporterIsExemptedOfReceipt,
               transporterCompanyName: form.transporterCompanyName,
-              transporterCompanySiret: form.transporterCompanySiret,
+              transporterCompanySiret: getTransporterCompanyOrgId(form),
               transporterReceipt: form.transporterReceipt,
               sentBy: form.sentBy,
               quantityReceived: form.quantityReceived

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -492,7 +492,7 @@ export async function checkCanImportForm(user: User, form: Form) {
 
 export async function checkSecurityCode(siret: string, securityCode: number) {
   const exists = await prisma.company.findFirst({
-    where: { siret, securityCode }
+    where: { orgId: siret, securityCode }
   });
   if (!exists) {
     throw new InvaliSecurityCode();

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -1,4 +1,5 @@
 import { Form, TransportSegment } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic } from "../common/elastic";
 import { buildAddress } from "../companies/sirene/utils";
 import {
@@ -33,9 +34,7 @@ export function getRegistryFields(
 
   if (form.receivedAt) {
     registryFields.isIncomingWasteFor.push(form.recipientCompanySiret);
-    registryFields.isTransportedWasteFor.push(
-      getTransporterCompanyOrgIdform(form)
-    );
+    registryFields.isTransportedWasteFor.push(getTransporterCompanyOrgId(form));
 
     if (form.transportSegments?.length) {
       for (const transportSegment of form.transportSegments) {
@@ -458,7 +457,3 @@ export function toAllWaste(
     transporter3CompanyMail: bsdd.transporter3CompanyMail
   };
 }
-function getTransporterCompanyOrgIdform(form: Form & { transportSegments: TransportSegment[]; }): any {
-  throw new Error("Function not implemented.");
-}
-

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -33,7 +33,9 @@ export function getRegistryFields(
 
   if (form.receivedAt) {
     registryFields.isIncomingWasteFor.push(form.recipientCompanySiret);
-    registryFields.isTransportedWasteFor.push(form.transporterCompanySiret);
+    registryFields.isTransportedWasteFor.push(
+      getTransporterCompanyOrgIdform(form)
+    );
 
     if (form.transportSegments?.length) {
       for (const transportSegment of form.transportSegments) {
@@ -456,3 +458,7 @@ export function toAllWaste(
     transporter3CompanyMail: bsdd.transporter3CompanyMail
   };
 }
+function getTransporterCompanyOrgIdform(form: Form & { transportSegments: TransportSegment[]; }): any {
+  throw new Error("Function not implemented.");
+}
+

--- a/back/src/forms/repository/form/update.ts
+++ b/back/src/forms/repository/form/update.ts
@@ -94,6 +94,7 @@ export function checkIfHasPossibleSiretChange(data: Prisma.FormUpdateInput) {
   return Boolean(
     data.recipientCompanySiret ||
       data.transporterCompanySiret ||
+      data.transporterCompanyVatNumber ||
       data.intermediaries ||
       data.transportSegments ||
       data.forwardedIn

--- a/back/src/forms/resolvers/forms/intermediary.ts
+++ b/back/src/forms/resolvers/forms/intermediary.ts
@@ -9,13 +9,7 @@ const intermediaryCompaniesResolver: FormResolvers["intermediaries"] =
       })
       .intermediaries();
 
-    if (intermediaries) {
-      return intermediaries.map(intermediary => ({
-        orgId: intermediary.siret,
-        ...intermediary
-      }));
-    }
-    return null;
+    return intermediaries ?? null;
   };
 
 export default intermediaryCompaniesResolver;

--- a/back/src/forms/resolvers/forms/intermediary.ts
+++ b/back/src/forms/resolvers/forms/intermediary.ts
@@ -10,7 +10,10 @@ const intermediaryCompaniesResolver: FormResolvers["intermediaries"] =
       .intermediaries();
 
     if (intermediaries) {
-      return intermediaries;
+      return intermediaries.map(intermediary => ({
+        orgId: intermediary.siret,
+        ...intermediary
+      }));
     }
     return null;
   };

--- a/back/src/forms/resolvers/mutations/markAsSent.ts
+++ b/back/src/forms/resolvers/mutations/markAsSent.ts
@@ -8,6 +8,7 @@ import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import { runInTransaction } from "../../../common/repository/helper";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 const markAsSentResolver: MutationResolvers["markAsSent"] = async (
   parent,
@@ -34,7 +35,7 @@ const markAsSentResolver: MutationResolvers["markAsSent"] = async (
   const formUpdateInput = {
     ...sentInfo,
     sentAt: new Date(sentInfo.sentAt),
-    currentTransporterSiret: form.transporterCompanySiret,
+    currentTransporterSiret: getTransporterCompanyOrgId(form),
     signedByTransporter: false
   };
 

--- a/back/src/forms/resolvers/mutations/multiModal.ts
+++ b/back/src/forms/resolvers/mutations/multiModal.ts
@@ -29,6 +29,9 @@ const SEGMENT_ALREADY_SEALED = "Ce segment de transport est déjà scellé";
 const SEGMENTS_ALREADY_PREPARED =
   "Il y a d'autres segments après le vôtre, vous ne pouvez pas ajouter de segment";
 
+const MISSING_COMPANY_SIRET =
+  "Le siret est obligatoire. Les entreprises étrangères ne sont pas supportées pour le moment.";
+
 const segmentSchema = Yup.object<any>().shape({
   // id: Yup.string().label("Identifiant (id)").required(),
   mode: Yup.string().label("Mode de transport").required(),
@@ -101,7 +104,7 @@ export async function prepareSegment(
   const nextSegmentPayload = flattenTransportSegmentInput(nextSegmentInfo);
 
   if (!nextSegmentPayload.transporterCompanySiret) {
-    throw new ForbiddenError("Le siret est obligatoire");
+    throw new ForbiddenError(MISSING_COMPANY_SIRET);
   }
   const formRepository = getFormRepository(user);
   // get form and segments
@@ -161,7 +164,7 @@ export async function prepareSegment(
   }
 
   if (!nextSegmentPayload.transporterCompanySiret) {
-    throw new UserInputError("Le siret est obligatoire");
+    throw new UserInputError(MISSING_COMPANY_SIRET);
   }
 
   const segmentInput = {

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -12,13 +12,14 @@ import { EventType } from "../../workflow/types";
 import { checkCanSignFor } from "../../permissions";
 import { expandFormFromDb } from "../../converter";
 import { getFormRepository } from "../../repository";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 /**
  * Common function for signing
  */
 const signedByTransporterFn = async (user, args, existingForm) => {
   await checkCanSignFor(
-    existingForm.transporterCompanySiret,
+    getTransporterCompanyOrgId(existingForm),
     user,
     args.securityCode
   );

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -82,7 +82,7 @@ const signatures: Partial<
     const existingFullForm = await getFullForm(existingForm);
 
     await checkCanSignFor(
-      existingFullForm.forwardedIn.transporterCompanySiret,
+      getTransporterCompanyOrgId(existingFullForm.forwardedIn),
       user,
       args.securityCode
     );

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -29,7 +29,7 @@ const signedByTransporterFn = async (user, args, existingForm) => {
     transporterNumberPlate:
       args.input.transporterNumberPlate ?? existingForm.transporterNumberPlate,
 
-    currentTransporterSiret: existingForm.transporterCompanySiret,
+    currentTransporterSiret: getTransporterCompanyOrgId(existingForm),
 
     // The following fields are deprecated
     // but we need to fill them until we remove them completely

--- a/back/src/forms/resolvers/mutations/signedByTransporter.ts
+++ b/back/src/forms/resolvers/mutations/signedByTransporter.ts
@@ -19,6 +19,7 @@ import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import { Prisma } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
 
 const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
   async (parent, args, context) => {
@@ -152,7 +153,7 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
       takenOverBy: user.name,
 
       ...wasteDetails,
-      currentTransporterSiret: form.transporterCompanySiret
+      currentTransporterSiret: getTransporterCompanyOrgId(form)
     };
 
     const sentForm = await formRepository.update(

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1198,6 +1198,14 @@ export async function validateForwardedInCompanies(form: Form): Promise<void> {
       forwardedIn.transporterCompanySiret
     );
   }
+  if (
+    forwardedIn?.transporterCompanyVatNumber?.length &&
+    !isForeignVat(forwardedIn?.transporterCompanyVatNumber)
+  ) {
+    throw new UserInputError(
+      "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
+    );
+  }
 }
 
 /**

--- a/back/src/queue/__tests__/sendmail.integration.ts
+++ b/back/src/queue/__tests__/sendmail.integration.ts
@@ -35,7 +35,7 @@ describe("Test the mail job queue", () => {
       templateId: templateIds.LAYOUT
     };
     const drainedPromise = new Promise<void>(resolve =>
-      mailQueue.once("global:drained", resolve)
+      mailQueue.once("drained", resolve)
     );
     // add to the queue
     await sendMail(mail);

--- a/back/src/queue/__tests__/sendmail.integration.ts
+++ b/back/src/queue/__tests__/sendmail.integration.ts
@@ -26,7 +26,7 @@ describe("Test the mail job queue", () => {
     return mailQueue.clean(1000);
   });
 
-  test("sendMailJob to the consumer that sends the mail using axios", async () => {
+  test("sendMailJob to the consumer that sends the mail via the mail queue", async () => {
     // create the fake email
     const mail: Mail = {
       to: [{ email: "test@trackdechets.local", name: "test" }],
@@ -52,6 +52,8 @@ describe("Test the mail job queue", () => {
         job.finished();
       })
     );
+    expect(mockedSendMailBackend).toHaveBeenCalledTimes(1);
+    expect(mockedSendMailBackend).toHaveBeenCalledWith({});
 
     const [{ data }] = await mailQueue.getCompleted();
     // assert parameters values

--- a/back/src/users/permissions.ts
+++ b/back/src/users/permissions.ts
@@ -4,9 +4,9 @@ import { NotCompanyAdmin, NotCompanyMember } from "../common/errors";
 import { getCachedUserSiretOrVat } from "../common/redis/users";
 
 export async function checkIsCompanyAdmin(user: User, company: Company) {
-  const admins = await getCompanyAdminUsers(company.siret);
+  const admins = await getCompanyAdminUsers(company.orgId);
   if (!admins.map(u => u.id).includes(user.id)) {
-    throw new NotCompanyAdmin(company.siret);
+    throw new NotCompanyAdmin(company.orgId);
   }
   return true;
 }

--- a/front/src/account/AccountCompanyMember.tsx
+++ b/front/src/account/AccountCompanyMember.tsx
@@ -125,7 +125,7 @@ export default function AccountCompanyMember({ company, user }: Props) {
               className="btn btn--primary"
               onClick={() => {
                 removeUserFromCompany({
-                  variables: { siret: company.siret!, userId: user.id },
+                  variables: { siret: company.orgId!, userId: user.id },
                 });
               }}
             >

--- a/front/src/account/AccountCompanyMember.tsx
+++ b/front/src/account/AccountCompanyMember.tsx
@@ -141,7 +141,7 @@ export default function AccountCompanyMember({ company, user }: Props) {
                 disabled={deleteLoading}
                 onClick={() => {
                   deleteInvitation({
-                    variables: { email: user.email, siret: company.siret! },
+                    variables: { email: user.email, siret: company.orgId! },
                   });
                 }}
               >
@@ -157,7 +157,7 @@ export default function AccountCompanyMember({ company, user }: Props) {
                 disabled={resendLoading}
                 onClick={() => {
                   resendInvitation({
-                    variables: { email: user.email, siret: company.siret },
+                    variables: { email: user.email, siret: company.orgId },
                   });
                 }}
               >

--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -369,13 +369,7 @@ export const detailFormFragment = gql`
     }
     quantityGrouped
     intermediaries {
-      name
-      siret
-      vatNumber
-      phone
-      contact
-      mail
-      address
+      ...CompanyFragment
     }
   }
   ${transporterFormFragment}

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -161,8 +161,8 @@ function SignTransportFormModal({
             </div>
 
             {![
-              form.transporter?.company?.siret,
-              form.temporaryStorageDetail?.transporter?.company?.siret,
+              form.transporter?.company?.orgId,
+              form.temporaryStorageDetail?.transporter?.company?.orgId,
             ].includes(siret) && (
               <div className="form__row">
                 <label>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -34,7 +34,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
         [
           form.emitter?.company?.siret,
           form.ecoOrganisme?.siret,
-          form.transporter?.company?.siret,
+          form.transporter?.company?.orgId,
         ].includes(siret)
       ) {
         return <SignEmissionForm {...props} />;
@@ -42,7 +42,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return null;
     }
     case FormStatus.SignedByProducer: {
-      if ([form.transporter?.company?.siret].includes(siret)) {
+      if ([form.transporter?.company?.orgId].includes(siret)) {
         return <SignTransportForm {...props} />;
       }
       return null;
@@ -113,7 +113,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return null;
     }
     case FormStatus.SignedByTempStorer: {
-      if (siret === form.temporaryStorageDetail?.transporter?.company?.siret) {
+      if (siret === form.temporaryStorageDetail?.transporter?.company?.orgId) {
         return <SignTransportForm {...props} />;
       }
       return null;

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -42,7 +42,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return null;
     }
     case FormStatus.SignedByProducer: {
-      if ([form.transporter?.company?.orgId].includes(siret)) {
+      if (form.transporter?.company?.orgId === siret) {
         return <SignTransportForm {...props} />;
       }
       return null;
@@ -105,7 +105,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       if (
         [
           form.recipient?.company?.siret,
-          form.temporaryStorageDetail?.transporter?.company?.siret,
+          form.temporaryStorageDetail?.transporter?.company?.orgId,
         ].includes(siret)
       ) {
         return <SignEmissionForm {...props} />;

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/BsdaJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/BsdaJourneySummary.tsx
@@ -55,7 +55,7 @@ export function BsdaJourneySummary({ bsda }: Props) {
           <JourneyStopName>Transporteur</JourneyStopName>
           <JourneyStopDescription>
             {bsda.transporter?.company?.name} (
-            {bsda.transporter?.company?.siret})
+            {bsda.transporter?.company?.orgId})
             <br />
             {bsda.transporter?.company?.address}
           </JourneyStopDescription>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/WorkflowAction.tsx
@@ -27,7 +27,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       if (
         form.emitter?.isPrivateIndividual &&
         form.worker?.isDisabled &&
-        siret === form.transporter?.company?.siret
+        siret === form.transporter?.company?.orgId
       ) {
         return <SignTransport {...props} bsdaId={form.id} />;
       }
@@ -46,7 +46,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
         form["bsdaType"] === "RESHIPMENT" ||
         form.worker?.isDisabled
       ) {
-        return siret === form.transporter?.company?.siret ? (
+        return siret === form.transporter?.company?.orgId ? (
           <SignTransport {...props} bsdaId={form.id} />
         ) : null;
       }
@@ -54,7 +54,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return <SignWork {...props} bsdaId={form.id} />;
 
     case BsdaStatus.SignedByWorker:
-      if (siret !== form.transporter?.company?.siret) return null;
+      if (siret !== form.transporter?.company?.orgId) return null;
       return <SignTransport {...props} bsdaId={form.id} />;
 
     case BsdaStatus.Sent:

--- a/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriJourneySummary.tsx
@@ -35,7 +35,7 @@ export function BsdasriJourneySummary({ bsdasri }: BsdasriJourneySummaryProps) {
         <JourneyStopName>Transporteur</JourneyStopName>
         <JourneyStopDescription>
           {bsdasri.transporter?.company?.name} (
-          {bsdasri.transporter?.company?.siret})
+          {bsdasri.transporter?.company?.orgId})
           <br />
           {bsdasri.transporter?.company?.address}
         </JourneyStopDescription>

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/WorkflowAction.tsx
@@ -43,7 +43,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
   const isSimple = form.type === BsdasriType.Simple;
   const isEmitter = siret === form.emitter?.company?.siret;
   const isEcoOrganisme = siret === form.ecoOrganisme?.siret;
-  const isTransporter = siret === form.transporter?.company?.siret;
+  const isTransporter = siret === form.transporter?.company?.orgId;
   const isDestination = siret === form.destination?.company?.siret;
 
   if (isAssociatedToSynthesis) {

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffJourneySummary.tsx
@@ -34,7 +34,7 @@ export function BsffJourneySummary({ bsff }: BsffJourneySummaryProps) {
       >
         <JourneyStopName>Transporteur</JourneyStopName>
         <JourneyStopDescription>
-          {bsff.transporter?.company?.name} ({bsff.transporter?.company?.siret})
+          {bsff.transporter?.company?.name} ({bsff.transporter?.company?.orgId})
           <br />
           {bsff.transporter?.company?.address}
         </JourneyStopDescription>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/BsvhuJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/BsvhuJourneySummary.tsx
@@ -35,7 +35,7 @@ export function BsvhuJourneySummary({ bsvhu }: Props) {
         <JourneyStopName>Transporteur</JourneyStopName>
         <JourneyStopDescription>
           {bsvhu.transporter?.company?.name} (
-          {bsvhu.transporter?.company?.siret})
+          {bsvhu.transporter?.company?.orgId})
           <br />
           {bsvhu.transporter?.company?.address}
         </JourneyStopDescription>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/WorkflowAction.tsx
@@ -22,7 +22,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       return <SignEmission {...props} bsvhuId={form.id} />;
 
     case BsvhuStatus.SignedByProducer:
-      if (siret !== form.transporter?.company?.siret) return null;
+      if (siret !== form.transporter?.company?.orgId) return null;
       return <SignTransport {...props} bsvhuId={form.id} />;
 
     case BsvhuStatus.Sent:

--- a/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
+++ b/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
@@ -61,7 +61,7 @@ export function BsffDetailContent({ form: bsff }: Props) {
 
   const isBsffContributor = [
     bsff.emitter?.company?.siret,
-    bsff.transporter?.company?.siret,
+    bsff.transporter?.company?.orgId,
     bsff?.destination?.company?.siret,
   ]
     .filter(Boolean)
@@ -233,7 +233,7 @@ export function BsffDetailContent({ form: bsff }: Props) {
               },
               bsffTransporter: {
                 company: {
-                  siret: bsff.transporter?.company?.siret ?? undefined,
+                  siret: bsff.transporter?.company?.orgId ?? undefined,
                   name: bsff.transporter?.company?.name ?? undefined,
                 },
               },

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -41,6 +41,7 @@ export function Destination({ disabled }) {
       (values.intermediaries ?? []).concat([
         {
           siret: "",
+          orgId: "",
           name: "",
           address: "",
           contact: "",

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -48,6 +48,7 @@ const identificationKey = "identification";
 const synthesizingKey = "synthesizing";
 const groupingKey = "grouping";
 const transporterCompanySiretKey = "transporter.company.siret";
+const transporterCompanyOrgIdKey = "transporter.company.orgId";
 const transporterCompanyVatNumberKey = "transporter.company.vatNumber";
 const transporterTransportPackagingsKey = "transporter.transport.packagings";
 const transporterTransportVolumeKey = "transporter.transport.volume";
@@ -57,6 +58,7 @@ const getCommonKeys = (bsdasriType: BsdasriType): string[] => {
     return [
       groupingKey,
       transporterCompanySiretKey,
+      transporterCompanyOrgIdKey,
       transporterCompanyVatNumberKey,
       transporterTransportPackagingsKey,
       transporterTransportVolumeKey,

--- a/front/src/form/bsdasri/FormContainer.tsx
+++ b/front/src/form/bsdasri/FormContainer.tsx
@@ -42,7 +42,7 @@ export default function FormContainer() {
             const TransporterComponent =
               state === "INITIAL" &&
               !bsdasri?.isDraft &&
-              siret === bsdasri?.transporter?.company?.siret
+              siret === bsdasri?.transporter?.company?.orgId
                 ? TransporterShowingTakeOverFields
                 : Transporter;
             // associated bsd can't be edited

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -136,6 +136,7 @@ export default function Transporter({
 const COMPANY_INFOS = gql`
   query CompanyInfos($siret: String!) {
     companyInfos(siret: $siret) {
+      orgId
       siret
       vatNumber
       name
@@ -222,8 +223,7 @@ function CurrentCompanyWidget({ disabled = false }) {
           <div className={companyStyles.content}>
             <h6>{data?.companyInfos?.name}</h6>
             <p>
-              {data?.companyInfos?.siret || data?.companyInfos?.vatNumber} -{" "}
-              {data?.companyInfos?.address}
+              {data?.companyInfos?.orgId} - {data?.companyInfos?.address}
             </p>
           </div>
         </div>

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -18,6 +18,7 @@ const COMPANY_INFOS = gql`
   query CompanyInfos($siret: String!) {
     companyInfos(siret: $siret) {
       siret
+      vatNumber
       name
       address
       companyTypes
@@ -74,7 +75,7 @@ export function Type({ disabled }: Props) {
     Pick<Query, "companyInfos">,
     QueryCompanyInfosArgs
   >(COMPANY_INFOS, {
-    variables: { siret },
+    variables: { clue: siret },
     fetchPolicy: "no-cache",
   });
 
@@ -94,8 +95,10 @@ export function Type({ disabled }: Props) {
       setFieldValue("emitter.company.address", data?.companyInfos.address);
       setFieldValue("emitter.company.name", data?.companyInfos.name);
       setFieldValue("transporter.company.siret", data?.companyInfos.siret);
-      // TODO
-      // setFieldValue("transporter.company.vatNumber", data?.companyInfos.vatNumber);
+      setFieldValue(
+        "transporter.company.vatNumber",
+        data?.companyInfos.vatNumber
+      );
       setFieldValue("transporter.company.address", data?.companyInfos.address);
       setFieldValue("transporter.company.name", data?.companyInfos.name);
       setFieldValue("grouping", []);

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -17,6 +17,7 @@ type Props = { disabled: boolean };
 const COMPANY_INFOS = gql`
   query CompanyInfos($siret: String!) {
     companyInfos(siret: $siret) {
+      orgId
       siret
       vatNumber
       name
@@ -75,7 +76,7 @@ export function Type({ disabled }: Props) {
     Pick<Query, "companyInfos">,
     QueryCompanyInfosArgs
   >(COMPANY_INFOS, {
-    variables: { clue: siret },
+    variables: { siret },
     fetchPolicy: "no-cache",
   });
 

--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -77,6 +77,7 @@ export default function Recipient() {
       values.intermediaries.concat([
         {
           siret: "",
+          orgId: "",
           name: "",
           address: "",
           contact: "",

--- a/front/src/form/bsdd/Transporter.tsx
+++ b/front/src/form/bsdd/Transporter.tsx
@@ -63,7 +63,7 @@ export default function Transporter() {
                   !values.transporter.isExemptedOfReceipt
                 )
               }
-              disabled={values.transporter.company?.siret === null}
+              disabled={values.transporter.company?.orgId === null}
               label="Le transporteur déclare être exempté de récépissé conformément aux
             dispositions de l'article R.541-50 du code de l'environnement."
             />

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -106,6 +106,7 @@ export function getInitialEcoOrganisme(ecoOrganisme?: FormEcoOrganisme | null) {
 export function getInitialIntermediaries(intermediaries?: FormCompany[]) {
   return intermediaries
     ? intermediaries.map(company => ({
+        orgId: company?.orgId ?? "",
         siret: company?.siret ?? "",
         name: company?.name ?? "",
         address: company?.address ?? "",

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -55,7 +55,7 @@ export default function BsffStepsList(props: Props) {
         transporter: {
           ...transporter,
           isExemptedOfRecepisse:
-            !!bsff?.transporter?.company?.siret &&
+            !!bsff?.transporter?.company?.orgId &&
             bsff?.transporter?.recepisse === null,
         },
       };

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -15,7 +15,7 @@ import {
   isForeignVat,
 } from "generated/constants/companySearchHelpers";
 import { checkVAT } from "jsvat";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 
 import { debounce } from "common/helper";
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
@@ -70,16 +70,19 @@ export default function CompanySelector({
   optional = false,
   initialAutoSelectFirstCompany = true,
 }: CompanySelectorProps) {
+  // siret is the current active company
   const { siret } = useParams<{ siret: string }>();
   const [uniqId] = useState(() => uuidv4());
   const [field] = useField<FormCompany>({ name });
   const { setFieldError, setFieldValue, setFieldTouched } = useFormikContext();
+  // determine if the current Form company is foreign
   const [isForeignCompany, setIsForeignCompany] = useState(
     (field.value.country && field.value.country !== "FR") ||
       isForeignVat(field.value.vatNumber!!)
   );
 
   const departmentInputRef = useRef<HTMLInputElement>(null);
+  // this ref lets us transmit the input to both search input and department input
   const clueInputRef = useRef<HTMLInputElement>(null);
   const [mustBeRegistered, setMustBeRegistered] = useState<boolean>(false);
   const [searchResults, setSearchResults] = useState<CompanySearchResult[]>([]);
@@ -88,13 +91,10 @@ export default function CompanySelector({
     setDisplayForeignCompanyWithUnknownInfos,
   ] = useState<boolean>(false);
 
-  // Initialize with either orgId (present in ForCompany but not in Intermediaries)
-  const [orgId, setOrgId] = useState<string | null>(
-    field.value.orgId ?? field.value.siret ?? null
-  );
   // Listen for changes in field.value.siret and field.value.orgId
-  useEffect(() => {
-    setOrgId(field.value.orgId ?? field.value.siret ?? null);
+  let orgId = field.value.orgId ?? field.value.siret ?? null;
+  useMemo(() => {
+    orgId = field.value.orgId ?? field.value.siret ?? null;
   }, [field.value.siret, field.value.orgId]);
   // Favortite type is deduced from the field prefix (transporter, emitter, etc)
   const favoriteType = constantCase(field.name.split(".")[0]) as FavoriteType;

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -91,11 +91,12 @@ export default function CompanySelector({
     setDisplayForeignCompanyWithUnknownInfos,
   ] = useState<boolean>(false);
 
-  // Listen for changes in field.value.siret and field.value.orgId
-  let orgId = field.value.orgId ?? field.value.siret ?? null;
-  useMemo(() => {
-    orgId = field.value.orgId ?? field.value.siret ?? null;
-  }, [field.value.siret, field.value.orgId]);
+  // Memoize for changes in field.value.siret and field.value.orgId
+  // To support both FormCompany and Intermediary (that don't have orgId)
+  const orgId = useMemo(
+    () => field.value.orgId ?? field.value.siret ?? null,
+    [field.value.siret, field.value.orgId]
+  );
   // Favortite type is deduced from the field prefix (transporter, emitter, etc)
   const favoriteType = constantCase(field.name.split(".")[0]) as FavoriteType;
   const {

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -146,10 +146,6 @@ export default function CompanySelector({
       clue: orgId!,
     },
     skip: !orgId,
-    onCompleted: () => {
-      // do not intialize the field with an error
-      setFieldTouched(`${field.name}.siret`);
-    },
   });
 
   /**
@@ -388,13 +384,15 @@ export default function CompanySelector({
               <>
                 <span>
                   Cet établissement existe mais nous ne pouvons pas remplir
-                  automatiquement le formulaire
+                  automatiquement le formulaire car les informations sont
+                  cachées par le service de recherche administratif externe à
+                  Trackdéchets
                 </span>
               </>
             }
           />
         )}
-        {!isLoadingFavorites && !orgId && !optional && (
+        {!isLoadingFavorites && !isLoadingSearch && !orgId && !optional && (
           <SimpleNotificationError
             message={
               <>

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -38,6 +38,9 @@ export const FAVORITES = gql`
   }
 `;
 
+/**
+ * TODO Clean up query, barely used anymore
+ */
 export const COMPANY_INFOS = gql`
   query CompanyInfos($siret: String!, $clue: String) {
     companyInfos(siret: $siret, clue: $clue) {


### PR DESCRIPTION
# Contexte

- Pour renforcer la validation des siret en entrée partout (ce qui a déjà été fait), il a fallu permettre d'avoir des siret null quand il s'agissait de transporteurs étrangers
- pour pouvoir support des transporterCompanySiret null ou vides, il fallait aussi renforcer la validation des transporterCompanyVatNumber, ce qui a déjà été fait
- pour finir le support des transporteurs étrangers partout, il fallait tester et fixer tous les workflow de tous les types de BSD comme par ailleurs, ce qui a déjà été fait était de rendre Company.siret nullable au même titre que Company.vatNumber. Pareillement nous avions déjà introduit sur `dev` un identifiant universel Company.orgId pour avoir toujours un des 2 identifiants présents

# Support de SIRET optionnel pour les transporteurs étrangers back&front

- Ajouts de tests workflow d'integration (`examples`) pour tous les types de BSD
- Ajout d'orgId dans tous les graphql `converter` pour les `transporter.company`
- Création d'une fonction getTransporterCompanyOrgId(form) pour récupérer l'un ou l'autre des identifiants (vat|siret) partout où cela est nécessaire (`common/constants/companySearchHelpers.ts`)
- Mise à jour indexation de tous types de bsd `elastic.ts`
- mise à jour de tous les `registry.ts`, support de la récupération registres pour les entreprises n'ayant plus qu'un numéro de TVA et pas de SIRET
- Mise à jour des permissions cassées (se basant sur transporter siret) dans les mutations
- Fixes pour la validation `transporterCompanySiret` de tous les types de bordereaux
- Ajout de filtres "where" pour les queries du BSDA `transporterCompanyVatNumber`
- Support `transporterCompanyVatNumber` dans les resolvers BSDASRI
- Fix permissions signBsff et optimisation (remplacement prisma par redis avec usage de `getCachedUserSiretOrVat`)
- Fix `checkSecurityCode`
- Fix BSDD Form email pour éviter les transporterCompanySiret vides (simple remplacement par TVA si besoin). Les templates emails restent inchangés
- Fixes BSDD form update :
  - ajout de `transporterCompanyVatNumber` dans `checkIfHasPossibleSiretChange`
  - `currentTransporterSiret` peut contenir si besoin `transporterCompanyVatNumber`
  - fix validation forwardedIn.transporterCompanySiret
- Fix `checkIsCompanyAdmin`
-
# Front

- Support orgId dans `CompanySelector.tsx` => possible support de Company tranporters & Intermediary identiques
- Support orgId à la place de siret (excepté TransportSegments qui n'ont pas de support TVA pour le moment)
- Bug : bouton signature transporter absent

![image](https://user-images.githubusercontent.com/76620/211055894-e2ab1d50-a18a-480c-8dda-a0e799b2e6a4.png)

- fix intermediaries qui ne s'affichait plus, ajout `orgId` à la volée de la lecture des données. Changement du fragment GQL intermediaries `front/src/common/fragments/bsdd.ts` pour à l'avenir générer renvoyer ce orgId  la volée côté serveur.

![image](https://user-images.githubusercontent.com/76620/211053272-d67adb25-ce29-413a-9ed2-bf3a57d5595f.png)

- Fix formulaires d'édition d'établissements du compte.
- Fix gestion d'Invitation de membre aux établissements
- Fix Front BSDARI qui ne supportait pas l'écriture de vatNumber en cas de sélection d'un transporteur étranger `front/src/form/bsdasri/steps/Type.tsx` 

# Annexes

- Fix types dans back/src/bsdasris/resolvers/mutations/signatureUtils.ts

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10530)
