### PR TITLE
Améliorations validation input schema dans le frontend company & transporterCompany

### DIFF
--- a/front/src/common/validation/schema.ts
+++ b/front/src/common/validation/schema.ts
@@ -1,22 +1,45 @@
 import { string, object } from "yup";
 import countries from "world-countries";
+import { isVat } from "generated/constants/companySearchHelpers";
 
 export const companySchema = object().shape({
   name: string().required(),
-  siret: string()
-    .when("vatNumber", {
-      is: vatNumber => !vatNumber,
-      then: string().required(
+  siret: string().required(
+    "La sélection d'une entreprise par SIRET ou numéro de TVA (si l'entreprise n'est pas française) est obligatoire"
+  ),
+  vatNumber: string().ensure(),
+  address: string().required(),
+  country: string()
+    .oneOf([
+      ...countries.map(country => country.cca2),
+
+      // .oneOf() has a weird behavior with .nullable(), see:
+      // https://github.com/jquense/yup/issues/104
+      null,
+    ])
+    .nullable(),
+  contact: string().required("Le contact dans l'entreprise est obligatoire"),
+  phone: string().required("Le téléphone de l'entreprise est obligatoire"),
+  mail: string()
+    .email("Le format d'adresse email est incorrect")
+    .required("L'email est obligatoire"),
+});
+
+export const transporterCompanySchema = object().shape({
+  name: string().required(),
+  siret: string().when("vatNumber", {
+    is: vatNumber => !vatNumber,
+    then: schema =>
+      schema.required(
         "La sélection d'une entreprise par SIRET ou numéro de TVA (si l'entreprise n'est pas française) est obligatoire"
       ),
-      otherwise: string().nullable(),
-    })
-    .when("country", {
-      is: country => country == null || country === "FR",
-      then: string().required("La sélection d'une entreprise est obligatoire"),
-      otherwise: string().nullable(),
-    }),
-  vatNumber: string().ensure(),
+    otherwise: schema => schema.nullable(),
+  }),
+  vatNumber: string().test(
+    "is-vat",
+    ({ originalValue }) => `${originalValue} n'est pas un numéro de TVA valide`,
+    value => !value || isVat(value)
+  ),
   address: string().required(),
   country: string()
     .oneOf([

--- a/front/src/common/validation/schema.ts
+++ b/front/src/common/validation/schema.ts
@@ -1,47 +1,21 @@
-import { string, object } from "yup";
+import * as yup from "yup";
 import countries from "world-countries";
-import { isVat } from "generated/constants/companySearchHelpers";
+import { isOmi, isVat } from "generated/constants/companySearchHelpers";
+import { CompanyInput } from "generated/graphql/types";
 
-export const companySchema = object().shape({
-  name: string().required(),
-  siret: string().required(
-    "La sélection d'une entreprise par SIRET ou numéro de TVA (si l'entreprise n'est pas française) est obligatoire"
-  ),
-  vatNumber: string().ensure(),
-  address: string().required(),
-  country: string()
-    .oneOf([
-      ...countries.map(country => country.cca2),
-
-      // .oneOf() has a weird behavior with .nullable(), see:
-      // https://github.com/jquense/yup/issues/104
-      null,
-    ])
-    .nullable(),
-  contact: string().required("Le contact dans l'entreprise est obligatoire"),
-  phone: string().required("Le téléphone de l'entreprise est obligatoire"),
-  mail: string()
-    .email("Le format d'adresse email est incorrect")
-    .required("L'email est obligatoire"),
-});
-
-export const transporterCompanySchema = object().shape({
-  name: string().required(),
-  siret: string().when("vatNumber", {
-    is: vatNumber => !vatNumber,
-    then: schema =>
-      schema.required(
-        "La sélection d'une entreprise par SIRET ou numéro de TVA (si l'entreprise n'est pas française) est obligatoire"
-      ),
-    otherwise: schema => schema.nullable(),
-  }),
-  vatNumber: string().test(
+export const companySchema: yup.SchemaOf<CompanyInput> = yup.object().shape({
+  name: yup.string().required(),
+  siret: yup
+    .string()
+    .required("La sélection d'une entreprise par SIRET est obligatoire"),
+  vatNumber: yup.string().test(
     "is-vat",
     ({ originalValue }) => `${originalValue} n'est pas un numéro de TVA valide`,
     value => !value || isVat(value)
   ),
-  address: string().required(),
-  country: string()
+  address: yup.string().required("L'adresse de l'entreprise est requis"),
+  country: yup
+    .string()
     .oneOf([
       ...countries.map(country => country.cca2),
 
@@ -50,9 +24,37 @@ export const transporterCompanySchema = object().shape({
       null,
     ])
     .nullable(),
-  contact: string().required("Le contact dans l'entreprise est obligatoire"),
-  phone: string().required("Le téléphone de l'entreprise est obligatoire"),
-  mail: string()
+  contact: yup.string().required("Le contact dans l'entreprise est requis"),
+  phone: yup.string().required("Le téléphone de l'entreprise est requis"),
+  mail: yup
+    .string()
     .email("Le format d'adresse email est incorrect")
-    .required("L'email est obligatoire"),
+    .required("L'email de contact est requis"),
+  omiNumber: yup
+    .string()
+    .nullable()
+    .test(
+      "is-omi",
+      ({ originalValue }) => `${originalValue} n'est pas un numéro OMI valide`,
+      value => !value || isOmi(value)
+    ),
 });
+
+export const transporterCompanySchema = companySchema.concat(
+  yup.object().shape({
+    siret: yup.string().when("vatNumber", {
+      is: vatNumber => !vatNumber,
+      then: schema =>
+        schema.required(
+          "La sélection d'une entreprise par SIRET ou numéro de TVA (si l'entreprise n'est pas française) est obligatoire"
+        ),
+      otherwise: schema => schema.nullable(),
+    }),
+    vatNumber: yup.string().test(
+      "is-vat",
+      ({ originalValue }) =>
+        `${originalValue} n'est pas un numéro de TVA valide`,
+      value => !value || isVat(value)
+    ),
+  })
+);

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
@@ -65,7 +65,7 @@ export const transporterSchema = object().shape({
   ),
   validityLimit: date().nullable(true),
   numberPlate: string().nullable(true),
-  company: companySchema, // TransportSegment DOES NOT supports foreign companies
+  company: companySchema, // TransportSegment DOES NOT supports foreign companies yet
 });
 
 const validationSchema = yup.object({ transporter: transporterSchema });

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
@@ -65,7 +65,7 @@ export const transporterSchema = object().shape({
   ),
   validityLimit: date().nullable(true),
   numberPlate: string().nullable(true),
-  company: companySchema,
+  company: companySchema, // TransportSegment DOES NOT supports foreign companies
 });
 
 const validationSchema = yup.object({ transporter: transporterSchema });

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -28,7 +28,10 @@ import {
   isSiret,
   isForeignVat,
 } from "generated/constants/companySearchHelpers";
-import { companySchema } from "common/validation/schema";
+import {
+  companySchema,
+  transporterCompanySchema,
+} from "common/validation/schema";
 
 setLocale({
   mixed: {
@@ -114,7 +117,7 @@ export const transporterSchema = object().shape({
     ),
   validityLimit: date().nullable(true),
   numberPlate: string().nullable(true),
-  company: companySchema,
+  company: transporterCompanySchema,
 });
 
 const packagingInfo: SchemaOf<Omit<PackagingInfo, "__typename">> =

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -10,14 +10,13 @@ import {
   BsffDetenteurInput,
   BsffFicheIntervention,
   BsffFicheInterventionInput,
-  CompanyInput,
   Mutation,
   MutationCreateFicheInterventionBsffArgs,
 } from "generated/graphql/types";
 import * as React from "react";
-import countries from "world-countries";
 import * as yup from "yup";
 import { FicheInterventionFragment } from "common/fragments";
+import { companySchema } from "common/validation/schema";
 
 const CREATE_BSFF_FICHE_INTERVENTION = gql`
   mutation CreateBsffFicheIntervention($input: BsffFicheInterventionInput!) {
@@ -28,23 +27,6 @@ const CREATE_BSFF_FICHE_INTERVENTION = gql`
   ${FicheInterventionFragment}
 `;
 
-const companySchema: yup.SchemaOf<CompanyInput> = yup.object({
-  address: yup.string().required("L'adresse de l'établissement est requis"),
-  contact: yup.string().required("Le contact de l'établissement est requis"),
-  mail: yup.string().required("L'email de contact est requis"),
-  name: yup.string().required("Le nom de l'établissement est requis"),
-  phone: yup
-    .string()
-    .required("Le numéro de téléphone de l'établissement est requis"),
-  siret: yup.string().required("Le numéro SIRET de l'établissement est requis"),
-  vatNumber: yup.string().nullable(),
-  country: yup
-    .string()
-    .oneOf([...countries.map(country => country.cca2), null])
-    .nullable(),
-  omiNumber: yup.string().nullable(),
-  orgId: yup.string().nullable(),
-});
 const detenteurSchema: yup.SchemaOf<BsffFicheInterventionInput["detenteur"]> =
   yup.object({
     isPrivateIndividual: yup.boolean().required(),

--- a/front/src/form/bsff/utils/schema.ts
+++ b/front/src/form/bsff/utils/schema.ts
@@ -1,4 +1,7 @@
-import { companySchema } from "common/validation/schema";
+import {
+  companySchema,
+  transporterCompanySchema,
+} from "common/validation/schema";
 import { BsffPackagingType } from "generated/graphql/types";
 import * as yup from "yup";
 import { OPERATION } from "./constants";
@@ -6,7 +9,7 @@ import { OPERATION } from "./constants";
 export const transporterSchema = yup.object().shape({
   isExemptedOfReceipt: yup.boolean().nullable(true),
   numberPlate: yup.string().nullable(true),
-  company: companySchema,
+  company: transporterCompanySchema,
   recepisse: yup.object({
     number: yup.string().nullable(true),
     department: yup


### PR DESCRIPTION
# Frontend company Schema

- Mauvaise validation dans `front/src/common/validation/schema.ts` : Corrections du `companySchema` (siret obligatoire) et création d'un `transporterCompanySchema` séparé avec VAT OU SIRET obligatoire.
- déduplication du `companySchema` recopié dans Bsff

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
