### PR TITLE
Correctifs Validation Destination ultérieure et gestion "country"

### DIFF
--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1020,7 +1020,7 @@ describe("processedInfoSchema", () => {
     expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
   });
 
-  test("nextDestinationCompany SIRET or VAT number is required", async () => {
+  test("nextDestinationCompany SIRET is required when no other identication is given", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),
@@ -1038,6 +1038,50 @@ describe("processedInfoSchema", () => {
 
     await expect(validateFn()).rejects.toThrow(
       "Destination ultérieure prévue : Le siret de l'entreprise est obligatoire"
+    );
+  });
+
+  test("nextDestinationCompany return an error when SIRET is given and country is not FR", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanySiret: siretify(1),
+      nextDestinationCompanyCountry: "IE",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destination ultérieure : le code du pays de l'entreprise ne peut pas différent de FR"
+    );
+  });
+
+  test("nextDestinationCompany return an error when VAT is given and country is FR", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyVatNumber: "BE0541696005",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destination ultérieure : le code du pays de l'entreprise ne correspond pas au numéro de TVA entré"
     );
   });
 

--- a/back/src/forms/resolvers/FormCompany.ts
+++ b/back/src/forms/resolvers/FormCompany.ts
@@ -1,12 +1,28 @@
+import { checkVAT } from "jsvat";
+import {
+  countries as vatCountries,
+  isVat,
+  isSiret
+} from "../../common/constants/companySearchHelpers";
 import { FormCompanyResolvers } from "../../generated/graphql/types";
 
 const formCompanyResolvers: FormCompanyResolvers = {
   country: parent => {
-    if (parent.vatNumber) {
-      return parent.country ?? "FR";
+    if (isVat(parent.vatNumber)) {
+      // ignore parent.country
+      const vatCountryCode = checkVAT(
+        parent.vatNumber.replace(/[\W_\s]/gim, ""),
+        vatCountries
+      )?.country?.isoCode.short;
+      return vatCountryCode ? vatCountryCode : parent.country ?? "FR";
     }
-    if (parent.siret) {
+    if (isSiret(parent.siret)) {
+      // ignore parent.country
       return "FR";
+    }
+    if (parent.country) {
+      // only parent.country
+      return parent.country;
     }
     return null;
   },

--- a/back/src/forms/resolvers/__tests__/FormCompany.integration.ts
+++ b/back/src/forms/resolvers/__tests__/FormCompany.integration.ts
@@ -1,0 +1,72 @@
+import { CompanyType, Status, UserRole } from "@prisma/client";
+import { Query } from "../../../generated/graphql/types";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+
+const FORM = `
+  query Form($id: ID!) {
+    form(id: $id) {
+      emitter {
+        company {
+          country
+        }
+      }
+      recipient {
+        company {
+          country
+        }
+      }
+      transporter {
+        company {
+          country
+        }
+      }
+      nextDestination {
+        company {
+          country
+        }
+      }
+    }
+  }`;
+
+describe("FormCompany resolver", () => {
+  afterAll(resetDatabase);
+
+  it("should return the right country for a Company", async () => {
+    const { user: emitterUser, company: emitter } =
+      await userWithCompanyFactory(UserRole.MEMBER, {
+        companyTypes: { set: [CompanyType.PRODUCER] }
+      });
+
+    const { user: destinationUser, company: destination } =
+      await userWithCompanyFactory(UserRole.MEMBER, {
+        companyTypes: { set: [CompanyType.WASTEPROCESSOR] }
+      });
+
+    const form = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        status: Status.SEALED,
+        emitterCompanySiret: emitter.siret,
+        recipientCompanySiret: destination.siret,
+        transporterCompanyVatNumber: "BE0541696005",
+        quantityReceived: 1,
+        nextDestinationCompanyVatNumber: "BE0541696005"
+      }
+    });
+    const { query } = makeClient(destinationUser);
+    const { data } = await query<Pick<Query, "form">>(FORM, {
+      variables: {
+        id: form.id
+      }
+    });
+    expect(data.form.emitter.company.country).toBe("FR");
+    expect(data.form.recipient.company.country).toBe("FR");
+    expect(data.form.transporter.company.country).toBe("BE");
+    expect(data.form.nextDestination.company.country).toBe("BE");
+  });
+});

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -489,6 +489,41 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
+  it("should allow empty company as nextDestination when NO_TRACEABILITY is true", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "ACCEPTED",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: "D 13",
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z",
+          noTraceability: true,
+          nextDestination: {
+            processingOperation: "D 1",
+            company: null
+          }
+        }
+      }
+    });
+
+    const resultingForm = await prisma.form.findUnique({
+      where: { id: form.id }
+    });
+    expect(resultingForm.status).toBe("NO_TRACEABILITY");
+  });
+
   it("should set country to FR by default", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -11,6 +11,12 @@ import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import machine from "../../workflow/machine";
 import { runInTransaction } from "../../../common/repository/helper";
+import { checkVAT } from "jsvat";
+import {
+  countries,
+  isSiret,
+  isVat
+} from "../../../common/constants/companySearchHelpers";
 
 const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   parent,
@@ -37,13 +43,27 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   formUpdateInput.processingOperationDescription =
     processedInfo.processingOperationDescription || operation?.description;
 
+  // auto-fill nextDestinationCompanyCountry
   if (
-    formUpdateInput.nextDestinationCompanySiret &&
+    isSiret(formUpdateInput.nextDestinationCompanySiret as string) &&
     !formUpdateInput.nextDestinationCompanyCountry
   ) {
     // only default to "FR" if there's an actual nextDestination
     // otherwise keep it empty to avoid filling a field for an object that doesn't exist
     formUpdateInput.nextDestinationCompanyCountry = "FR";
+  }
+  if (
+    isVat(formUpdateInput.nextDestinationCompanyVatNumber as string) &&
+    !formUpdateInput.nextDestinationCompanyCountry
+  ) {
+    const vatCountryCode = checkVAT(
+      (formUpdateInput.nextDestinationCompanyVatNumber as string).replace(
+        /[\W_\s]/gim,
+        ""
+      ),
+      countries
+    )?.country?.isoCode.short;
+    formUpdateInput.nextDestinationCompanyCountry = vatCountryCode;
   }
 
   if (form.status === Status.TEMP_STORER_ACCEPTED) {

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -415,7 +415,8 @@ input InternationalCompanyInput {
   Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise :
   https://fr.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
-  En l'absence de code, l'entreprise est considérée comme résidant en France.
+  En l'absence de code, le pays est FR si un siret est donné, ou détecté depuis le numéro de TVA si vztNumber est donné.
+  Une incohérence du pays avec le siret ou le numéro pays détecté du numéro de TVA résultera en une erreur type BAD_USER_INPUT.
   """
   country: String
 

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -415,7 +415,7 @@ input InternationalCompanyInput {
   Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise :
   https://fr.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
-  En l'absence de code, le pays est FR si un siret est donné, ou détecté depuis le numéro de TVA si vztNumber est donné.
+  En l'absence de code, le pays est FR si un siret est donné, ou détecté depuis le numéro de TVA si vatNumber est donné.
   Une incohérence du pays avec le siret ou le numéro pays détecté du numéro de TVA résultera en une erreur type BAD_USER_INPUT.
   """
   country: String

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1037,7 +1037,7 @@ const withNextDestination = (required: boolean) =>
         return isSiret(siret) && required
           ? schema.test(
               "is-fr-country-valid",
-              "Destination ultérieure : le code du pays de l'entreprise ne peut pas différent de FR",
+              "Destination ultérieure : le code du pays de l'entreprise ne peut pas être différent de FR",
               value => !value || value === "FR"
             )
           : schema;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1012,10 +1012,16 @@ const withNextDestination = (required: boolean) =>
         required,
         `Destination ultérieure : ${MISSING_COMPANY_ADDRESS}`
       ),
-    nextDestinationCompanyCountry: yup.string().oneOf(
-      countries.map(country => country.cca2),
-      "Destination ultérieure : le code ISO 3166-1 alpha-2 du pays de l'entreprise n'est pas reconnu"
-    ),
+    nextDestinationCompanyCountry: yup
+      .string()
+      .requiredIf(
+        required,
+        `Destination ultérieure : le code ISO 3166-1 alpha-2 du pays est obligatoire`
+      )
+      .oneOf(
+        countries.map(country => country.cca2),
+        "Destination ultérieure : le code ISO 3166-1 alpha-2 du pays de l'entreprise n'est pas reconnu"
+      ),
     nextDestinationCompanyContact: yup
       .string()
       .ensure()


### PR DESCRIPTION
# Nombreuses incohérences sur la gestion des entrées `nextDestination`

- Permet de valider un traitement ulterieur sans etablissement quand on coche la rupture de traçabilité.

https://www.loom.com/share/9a186b8728ac471794c2f4c985c3d9a4

- Fix le FormCompany resolver qui renvoyait de fausses valeurs sur `country`.
- Solidifie la validation de nextDestination : erreurs quand `nextDestinationCompanyCountry` ne correspond pas soit à "FR" quand `nextDestinationCompanySiret` est envoyé soit au pays déduit du numéro de TVA quand`nextDestinationCompanyVatNumber` est envoyé
- remplit automatiquement le `nextDestinationCompanyCountry` en fonction du siret ou vat

- N'est pas traité ici : l'ajout d'un champ "numéro de document de transfert" cf https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8478

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10656)
- [Favro sur nextDestinationCompanyCountry](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10569)
