### PR TITLE
HOTFIX - impossible de valider une réception avec une quantité à 0

### DIFF
--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -55,7 +55,7 @@ export const weightConditions: WeightConditions = {
       [
         WasteAcceptationStatus.ACCEPTED,
         WasteAcceptationStatus.PARTIALLY_REFUSED
-      ]
+      ].includes(status)
     ) {
       return weight.positive(
         "${path} : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"


### PR DESCRIPTION
https://trackdechets.zammad.com/#ticket/zoom/21911

Dû à l'oubli d'un `includes` dans une condition
