### PR TITLE
Correctif reindexBSd and deleteBsd

### DIFF
--- a/back/src/bsds/indexation/reindexBsdHelpers.ts
+++ b/back/src/bsds/indexation/reindexBsdHelpers.ts
@@ -83,7 +83,7 @@ export async function reindex(bsdId, exitFn) {
       const fullBsdd = await getFullForm(bsdd);
       await indexForm(fullBsdd);
     } else {
-      await deleteBsd({ id: bsdId });
+      await deleteBsd({ readableId: bsdId });
     }
     return exitFn(true);
   }

--- a/back/src/bsffs/resolvers/mutations/deleteBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/deleteBsff.ts
@@ -41,7 +41,7 @@ const deleteBsff: MutationResolvers["deleteBsff"] = async (
     });
   });
 
-  await elastic.deleteBsd(updatedBsff, context);
+  await elastic.deleteBsd({ id: updatedBsff.id }, context);
 
   return expandBsffFromDB(updatedBsff);
 };

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -379,6 +379,17 @@ function refresh(ctx?: GraphQLContext): Partial<RequestParams.Index> {
 }
 
 /**
+ * Set refresh parameter to `wait_for` when user is logged in from UI
+ * It allows to refresh the BSD list in real time after a create, update or delete operation from UI
+ * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
+ */
+function refreshForDelete(ctx?: GraphQLContext): { refresh: boolean } {
+  return ctx?.user?.auth === AuthType.Session
+    ? { refresh: true }
+    : { refresh: false };
+}
+
+/**
  * Create/update a document in Elastic Search.
  */
 export function indexBsd(bsd: BsdElastic, ctx?: GraphQLContext) {
@@ -430,7 +441,7 @@ export function deleteBsd<T extends { id?: string; readableId?: string }>(
       {
         index: index.alias,
         type: index.type,
-        ...(refresh(ctx) as { refresh: any }), // Partial<RequestParams.Index> is not allowed here
+        ...refreshForDelete(ctx),
         body: {
           query: {
             match: {

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -421,10 +421,27 @@ export function indexBsds(indexName: string, bsds: BsdElastic[]) {
 /**
  * Delete a document in Elastic Search.
  */
-export function deleteBsd<T extends { id: string }>(
-  { id }: T,
+export function deleteBsd<T extends { id?: string; readableId?: string }>(
+  { id, readableId }: T,
   ctx?: GraphQLContext
 ) {
+  if (readableId && !id) {
+    return client.delete_by_query(
+      {
+        index: index.alias,
+        type: index.type,
+        ...(refresh(ctx) as { refresh: any }), // Partial<RequestParams.Index> is not allowed here
+        body: {
+          query: {
+            match: {
+              readableId
+            }
+          }
+        }
+      },
+      { ignore: [404] }
+    );
+  }
   return client.delete(
     {
       index: index.alias,

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1059,7 +1059,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => processedInfoSchema.validate(processedInfo);
 
     await expect(validateFn()).rejects.toThrow(
-      "Destination ultérieure : le code du pays de l'entreprise ne peut pas différent de FR"
+      "Destination ultérieure : le code du pays de l'entreprise ne peut pas être différent de FR"
     );
   });
 

--- a/back/src/forms/repository/form/delete.ts
+++ b/back/src/forms/repository/form/delete.ts
@@ -38,7 +38,9 @@ const buildDeleteForm: (deps: RepositoryFnDeps) => DeleteFormFn =
       }
     });
 
-    await deleteBsd(deletedForm, { user } as GraphQLContext);
+    await deleteBsd({ readableId: deletedForm.readableId }, {
+      user
+    } as GraphQLContext);
 
     // disconnect appendix2 forms if any
     const removeAppendix2 = buildRemoveAppendix2({ prisma, user });

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -8,8 +8,11 @@ import prisma from "../../prisma";
 
 export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   const bsdId = job.data;
-
-  await deleteBsd({ id: bsdId });
+  if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
+    await deleteBsd({ readableId: bsdId });
+  } else {
+    await deleteBsd({ id: bsdId });
+  }
 
   if (bsdId.startsWith("BSDA-")) {
     const bsda = await prisma.bsda.findUnique({


### PR DESCRIPTION
- Index DeleteBsd ne fonctionnait pas car on passait readable Id en argument, mais on supprimait par "Form.id".

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10060)
