### PR TITLE
[TRA-10364] ETQ émetteur d'un bsd, je ne dois pas pouvoir ajouter un transporteur ou un destinataire non inscrit sur TD ( BSDASRI, BSVHU)

### DIFF
--- a/back/src/bsda/__tests__/validation.integration.ts
+++ b/back/src/bsda/__tests__/validation.integration.ts
@@ -1,47 +1,159 @@
-import { ValidationError } from "yup";
-import { siretify } from "../../__tests__/factories";
-import { validateBsda } from "../validation";
+import { Bsda, BsdaType } from "@prisma/client";
+import { resetDatabase } from "../../../integration-tests/helper";
+import { companyFactory } from "../../__tests__/factories";
+import { bsdaSchema } from "../validation";
 
 import { bsdaFactory } from "./factories";
 
 describe("BSDA validation", () => {
-  it("should validate without recipisse when it's a foreign transport", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        transporterCompanyVatNumber: "BE0541696005",
-        transporterCompanyName: "transporteur BE"
-      }
-    });
-    delete bsda.transporterRecepisseDepartment;
-    delete bsda.transporterRecepisseNumber;
-    delete bsda.transporterRecepisseIsExempted;
+  afterAll(resetDatabase);
 
-    await validateBsda(
-      bsda,
-      { previousBsdas: [], intermediaries: [] },
-      {
-        transportSignature: true
-      }
-    );
+  let bsda: Bsda;
+
+  beforeAll(async () => {
+    bsda = await bsdaFactory({});
   });
 
-  it("should not validate without recipisse when it's a french transport", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        transporterCompanySiret: siretify(1),
-        transporterCompanyName: "transporteur FR"
-      }
+  describe("BSDA should be valid", () => {
+    test("when there is a foreign transporter and recepisse fields are null", async () => {
+      expect(
+        await bsdaSchema({}).isValid({
+          ...bsda,
+          transporterCompanyVatNumber: "BE0541696005",
+          transporterCompanyName: "transporteur BE",
+          transporterRecepisseDepartment: null,
+          transporterRecepisseNumber: null,
+          transporterRecepisseIsExempted: null
+        })
+      ).toEqual(true);
     });
-    delete bsda.transporterRecepisseDepartment;
-    delete bsda.transporterRecepisseNumber;
-    await expect(() =>
-      validateBsda(
-        bsda,
-        { previousBsdas: [], intermediaries: [] },
-        {
-          transportSignature: true
-        }
-      )
-    ).rejects.toThrow(ValidationError);
+
+    test("when a foreign transporter vat number is specified and transporter siret is null", async () => {
+      const data = {
+        ...bsda,
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: "IT13029381004"
+      };
+
+      const isValid = await bsdaSchema({}).isValid(data);
+      expect(isValid).toBe(true);
+    });
+  });
+
+  describe("BSDA should not be valid", () => {
+    test("when emitter siret is not valid", async () => {
+      const data = {
+        ...bsda,
+        emitterCompanySiret: "1"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur: 1 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when transporter siret is not valid", async () => {
+      const data = {
+        ...bsda,
+        transporterCompanySiret: "1"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur: 1 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when transporter VAT number is FR", async () => {
+      const data = {
+        ...bsda,
+        transporterCompanyVatNumber: "FR35552049447"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
+      );
+    });
+
+    test("when transporter is not registered in Trackdéchets", async () => {
+      const data = {
+        ...bsda,
+        transporterCompanySiret: "85001946400021"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+      );
+    });
+
+    test("when transporter is registered with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const data = {
+        ...bsda,
+        transporterCompanySiret: company.siret
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        `Le transporteur saisi sur le bordereau (SIRET: ${company.siret}) n'est pas inscrit sur Trackdéchets en tant qu'entreprise de transport.` +
+          " Cette entreprise ne peut donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette entreprise pour" +
+          " qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+      );
+    });
+
+    test("when destination siret is not valid", async () => {
+      const data = {
+        ...bsda,
+        destinationCompanySiret: "1"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Destination: 1 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when destination is not registered in Trackdéchets", async () => {
+      const data = {
+        ...bsda,
+        destinationCompanySiret: "85001946400021"
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Destination : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+      );
+    });
+
+    test("when destination is registered with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const data = {
+        ...bsda,
+        destinationCompanySiret: company.siret
+      };
+      const validateFn = () => bsdaSchema({}).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET \"${company.siret}\" n'est pas inscrite` +
+          " sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut donc" +
+          " pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il" +
+          " modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+      );
+    });
+
+    test("when there is a french transporter and recepisse fields are null", async () => {
+      const transporterCompany = await companyFactory({
+        companyTypes: ["TRANSPORTER"]
+      });
+      const data = {
+        ...bsda,
+        type: BsdaType.OTHER_COLLECTIONS,
+        transporterCompanySiret: transporterCompany.siret,
+        transporterCompanyVatNumber: null,
+        transporterRecepisseIsExempted: false,
+        transporterRecepisseNumber: null,
+        transporterRecepisseDepartment: null
+      };
+      const validateFn = () =>
+        bsdaSchema({ transportSignature: true }).validate(data);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur: le numéro de récépissé est obligatoire"
+      );
+    });
   });
 });

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -15,6 +15,7 @@ import {
   siret,
   siretConditions,
   siretTests,
+  vatNumberTests,
   weight,
   weightConditions,
   WeightUnits
@@ -755,7 +756,9 @@ const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =
                 "Impossible de saisir le SIRET d'un transporteur pour ce type de bordereau"
               )
         }),
-      transporterCompanyVatNumber: foreignVatNumber.label("Transporteur"),
+      transporterCompanyVatNumber: foreignVatNumber
+        .label("Transporteur")
+        .test(vatNumberTests.isRegisteredTransporter),
       transporterCompanyAddress: yup.string().when("type", {
         is: BsdaType.COLLECTION_2710,
         then: schema => schema.nullable(),

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
@@ -30,7 +30,7 @@ describe("Mutation.createDasri", () => {
   it("should build a synthesis dasri", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: {
-        set: ["COLLECTOR"]
+        set: ["COLLECTOR", "TRANSPORTER"]
       }
     });
 

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
@@ -76,6 +76,7 @@ describe("Mutation.createDraftBsdasri", () => {
 
   it("create a draft dasri with an emitter and a destination", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const destination = await companyFactory();
 
     const input = {
       emitter: {
@@ -85,7 +86,7 @@ describe("Mutation.createDraftBsdasri", () => {
       },
       destination: {
         company: {
-          siret: siretify(1)
+          siret: destination.siret
         }
       }
     };

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -23,6 +23,7 @@ import {
   siret,
   siretConditions,
   siretTests,
+  vatNumberTests,
   weight,
   weightConditions,
   WeightUnits
@@ -310,7 +311,9 @@ export const transporterSchema: FactorySchemaOf<
       )
       .when("transporterCompanyVatNumber", siretConditions.companyVatNumber)
       .test(siretTests.isRegistered("TRANSPORTER")),
-    transporterCompanyVatNumber: foreignVatNumber.label("Transporteur"),
+    transporterCompanyVatNumber: foreignVatNumber
+      .label("Transporteur")
+      .test(vatNumberTests.isRegisteredTransporter),
     transporterCompanyAddress: yup
       .string()
       .ensure()

--- a/back/src/bsds/typeDefs/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/bsd.inputs.graphql
@@ -3,13 +3,20 @@ Payload d'un établissement
 """
 input CompanyInput {
   """
-  SIRET de l'établissement composé de 14 caractères numériques
+  SIRET de l'établissement composé de 14 caractères numériques.
+
+  Un établissement visé sur un bordereau en tant que transporteur doit être inscrit sur Trackdéchets avec le profil Transporteur.
+  Un établissement visé sur un bordereau en tant qu'installation de destination doit être inscrit sur Trackdéchets avec un profil d'installation
+  de transit ou de traitement.
   """
   siret: String
 
   """
   Numéro de TVA intra-communautaire de l'établissement. À renseigner pour
   les transporteurs étrangers uniquement.
+
+  Un transporteur étranger visé sur un bordereau par son numéro de TVA intra-communautaire doit être inscrit sur Trackdéchets
+  avec le profil Transporteur.
   """
   vatNumber: String
 

--- a/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
@@ -236,7 +236,7 @@ describe("Mutation.createBsff", () => {
       expect.objectContaining({
         message:
           "Erreur de validation des données. Des champs sont manquants ou mal formatés : \n" +
-          `Le transporteur qui a été renseigné sur le bordereau (SIRET: ${siret}) n'est pas inscrit sur Trackdéchets`
+          `Transporteur : l'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`
       })
     ]);
   });
@@ -273,7 +273,7 @@ describe("Mutation.createBsff", () => {
       expect.objectContaining({
         message:
           "Erreur de validation des données. Des champs sont manquants ou mal formatés : \n" +
-          `L'installation de destination avec le SIRET ${siret} n'est pas inscrite sur Trackdéchets`
+          `Destination : l'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`
       })
     ]);
   });

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -20,6 +20,7 @@ import {
   siret,
   siretConditions,
   siretTests,
+  vatNumberTests,
   weight,
   weightConditions,
   WeightUnits
@@ -145,7 +146,9 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
         )
         .when("transporterCompanyVatNumber", siretConditions.companyVatNumber)
         .test(siretTests.isRegistered("TRANSPORTER")),
-      transporterCompanyVatNumber: foreignVatNumber.label("Transporteur"),
+      transporterCompanyVatNumber: foreignVatNumber
+        .label("Transporteur")
+        .test(vatNumberTests.isRegisteredTransporter),
       transporterCompanyAddress: yup
         .string()
         .requiredIf(

--- a/back/src/bsvhu/__tests__/factories.vhu.ts
+++ b/back/src/bsvhu/__tests__/factories.vhu.ts
@@ -5,17 +5,25 @@ import {
 } from "@prisma/client";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import prisma from "../../prisma";
-import { siretify } from "../../__tests__/factories";
+import { companyFactory, siretify } from "../../__tests__/factories";
 
 export const bsvhuFactory = async ({
   opt = {}
 }: {
   opt?: Partial<Prisma.BsvhuCreateInput>;
 }) => {
-  const formParams = { ...getVhuFormdata(), ...opt };
+  const transporterCompany = await companyFactory({
+    companyTypes: ["TRANSPORTER"]
+  });
+  const destinationCompany = await companyFactory({
+    companyTypes: ["WASTEPROCESSOR"]
+  });
   return prisma.bsvhu.create({
     data: {
-      ...formParams
+      ...getVhuFormdata(),
+      transporterCompanySiret: transporterCompany.siret,
+      destinationCompanySiret: destinationCompany.siret,
+      ...opt
     }
   });
 };

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -1,37 +1,234 @@
-import { ValidationError } from "yup";
-import { siretify } from "../../__tests__/factories";
+import { Bsvhu } from "@prisma/client";
+import { resetDatabase } from "../../../integration-tests/helper";
+import { companyFactory } from "../../__tests__/factories";
 import { validateBsvhu } from "../validation";
 
 import { bsvhuFactory } from "./factories.vhu";
 
 describe("BSVHU validation", () => {
-  it("should validate without recipisse when it's a foreign transport", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        transporterCompanyVatNumber: "BE0541696005",
-        transporterCompanyName: "transporteur BE"
-      }
-    });
-    delete bsvhu.transporterRecepisseDepartment;
-    delete bsvhu.transporterRecepisseNumber;
+  afterAll(resetDatabase);
 
-    await validateBsvhu(bsvhu, {
-      transportSignature: true
+  let bsvhu: Bsvhu;
+
+  beforeAll(async () => {
+    const emitterCompany = await companyFactory({ companyTypes: ["PRODUCER"] });
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const destinationCompany = await companyFactory({
+      companyTypes: ["WASTEPROCESSOR"]
+    });
+
+    bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        transporterCompanySiret: transporterCompany.siret,
+        destinationCompanySiret: destinationCompany.siret
+      }
     });
   });
-  it("should not validate without recipisse when it's a foreign transport", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        transporterCompanySiret: siretify(1),
-        transporterCompanyName: "transporteur FR"
+
+  describe("BSVHU should be valid", () => {
+    test("when there is a foreign transporter vatNumber and transporter siret is null", async () => {
+      const data = {
+        ...bsvhu,
+        transporterCompanyVatNumber: "BE0541696005",
+        transporterCompanySiret: null
+      };
+      const validated = await validateBsvhu(data, {
+        transportSignature: true
+      });
+      expect(validated).toBeDefined();
+    });
+
+    test("when there is a foreign transporter and recepisse fields are null", async () => {
+      const data = {
+        ...bsvhu,
+        transporterCompanyVatNumber: "BE0541696005",
+        transporterRecepisseDepartment: null,
+        transporterRecepisseNumber: null
+      };
+      const validated = await validateBsvhu(data, {
+        transportSignature: true
+      });
+      expect(validated).toBeDefined();
+    });
+  });
+
+  describe("BSVHU should not be valid", () => {
+    test("when emitter siret is not valid", async () => {
+      const data = {
+        ...bsvhu,
+        emitterCompanySiret: "1"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Émetteur: 1 n'est pas un numéro de SIRET valide"
+        ]);
       }
     });
-    delete bsvhu.transporterRecepisseDepartment;
-    delete bsvhu.transporterRecepisseNumber;
-    await expect(() =>
-      validateBsvhu(bsvhu, {
-        transportSignature: true
-      })
-    ).rejects.toThrow(ValidationError);
+
+    test("when transporter siret is not valid", async () => {
+      const data = {
+        ...bsvhu,
+        transporterCompanySiret: "1"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Transporteur: 1 n'est pas un numéro de SIRET valide",
+          "Transporteur : l'établissement avec le SIRET 1 n'est pas inscrit sur Trackdéchets"
+        ]);
+      }
+    });
+
+    test("when transporter is not registered in Trackdéchets", async () => {
+      const data = {
+        ...bsvhu,
+        transporterCompanySiret: "85001946400021"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Transporteur : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+        ]);
+      }
+    });
+
+    test("when transporter is registered with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const data = {
+        ...bsvhu,
+        transporterCompanySiret: company.siret
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          `Le transporteur saisi sur le bordereau (SIRET: ${company.siret}) n'est pas inscrit sur Trackdéchets` +
+            " en tant qu'entreprise de transport. Cette entreprise ne peut donc pas être visée sur le bordereau." +
+            " Veuillez vous rapprocher de l'administrateur de cette entreprise pour qu'il modifie le profil de" +
+            " l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+        ]);
+      }
+    });
+
+    test("when transporter vatNumber is FR", async () => {
+      const data = {
+        ...bsvhu,
+        transporterCompanyVatNumber: "FR35552049447"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
+        ]);
+      }
+    });
+
+    test("when destination siret is not valid", async () => {
+      const data = {
+        ...bsvhu,
+        destinationCompanySiret: "1"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Destination: 1 n'est pas un numéro de SIRET valide",
+          "Destination : l'établissement avec le SIRET 1 n'est pas inscrit sur Trackdéchets"
+        ]);
+      }
+    });
+
+    test("when destination is not registered in Trackdéchets", async () => {
+      const data = {
+        ...bsvhu,
+        destinationCompanySiret: "85001946400021"
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Destination : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+        ]);
+      }
+    });
+
+    test("when destination is registered with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const data = {
+        ...bsvhu,
+        destinationCompanySiret: company.siret
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET \"${company.siret}\" n'est pas inscrite` +
+            " sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut donc pas" +
+            " être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+        ]);
+      }
+    });
+
+    test("when transporter is french but recepisse fields are missing", async () => {
+      const data = {
+        ...bsvhu,
+        transporterRecepisseDepartment: null,
+        transporterRecepisseNumber: null,
+        transporterRecepisseValidityLimit: null
+      };
+      expect.assertions(1);
+
+      try {
+        await validateBsvhu(data, {
+          transportSignature: true
+        });
+      } catch (err) {
+        expect(err.errors).toEqual([
+          "Transporteur: le département associé au récépissé est obligatoire",
+          "Transporteur: le numéro de récépissé est obligatoire",
+          "Transporteur: la date de validité de récépissé est obligatoire"
+        ]);
+      }
+    });
   });
 });

--- a/back/src/bsvhu/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/create.integration.ts
@@ -2,6 +2,7 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import { Mutation } from "../../../../generated/graphql/types";
 import {
+  companyFactory,
   siretify,
   userFactory,
   userWithCompanyFactory
@@ -93,6 +94,9 @@ describe("Mutation.Vhu.create", () => {
 
   it("should allow creating a valid form for the producer signature", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const destinationCompany = await companyFactory({
+      companyTypes: ["WASTEPROCESSOR"]
+    });
 
     const input = {
       emitter: {
@@ -121,7 +125,7 @@ describe("Mutation.Vhu.create", () => {
         type: "BROYEUR",
         plannedOperationCode: "R 12",
         company: {
-          siret: siretify(1),
+          siret: destinationCompany.siret,
           name: "destination",
           address: "address",
           contact: "contactEmail",
@@ -150,6 +154,9 @@ describe("Mutation.Vhu.create", () => {
 
   it("should fail if a required field like the emitter agrement is missing", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const destinationCompany = await companyFactory({
+      companyTypes: ["WASTEPROCESSOR"]
+    });
 
     const input = {
       emitter: {
@@ -177,7 +184,7 @@ describe("Mutation.Vhu.create", () => {
         type: "BROYEUR",
         plannedOperationCode: "R 12",
         company: {
-          siret: siretify(1),
+          siret: destinationCompany.siret,
           name: "destination",
           address: "address",
           contact: "contactEmail",

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createDraft.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createDraft.integration.ts
@@ -2,6 +2,7 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import { Mutation } from "../../../../generated/graphql/types";
 import {
+  companyFactory,
   siretify,
   userFactory,
   userWithCompanyFactory
@@ -93,6 +94,9 @@ describe("Mutation.Vhu.createDraft", () => {
 
   it("create a form with an emitter and a destination", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const destination = await companyFactory({
+      companyTypes: ["WASTEPROCESSOR"]
+    });
 
     const input = {
       emitter: {
@@ -102,7 +106,7 @@ describe("Mutation.Vhu.createDraft", () => {
       },
       destination: {
         company: {
-          siret: siretify(3)
+          siret: destination.siret
         }
       }
     };

--- a/back/src/bsvhu/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/update.integration.ts
@@ -2,6 +2,7 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import { bsvhuFactory } from "../../../__tests__/factories.vhu";
 import {
+  companyFactory,
   userFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
@@ -184,6 +185,11 @@ describe("Mutation.Vhu.update", () => {
 
   it("should allow transporter fields update after emitter signature", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const foreignTransporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"],
+      orgId: "NL004983269B01",
+      vatNumber: "NL004983269B01"
+    });
     const form = await bsvhuFactory({
       opt: {
         emitterCompanySiret: company.siret,
@@ -195,7 +201,7 @@ describe("Mutation.Vhu.update", () => {
     const { mutate } = makeClient(user);
     const input = {
       transporter: {
-        company: { vatNumber: "NL004983269B01" }
+        company: { vatNumber: foreignTransporter.vatNumber }
       }
     };
     const { data } = await mutate<Pick<Mutation, "updateBsvhu">>(
@@ -206,7 +212,7 @@ describe("Mutation.Vhu.update", () => {
     );
 
     expect(data.updateBsvhu.transporter.company.vatNumber).toBe(
-      "NL004983269B01"
+      foreignTransporter.vatNumber
     );
   });
 });

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -23,6 +23,7 @@ import {
   siret,
   siretConditions,
   siretTests,
+  vatNumberTests,
   weight,
   WeightUnits
 } from "../common/validation";
@@ -277,7 +278,9 @@ const transporterSchema: FactorySchemaOf<VhuValidationContext, Transporter> =
           `Transporteur: ${MISSING_COMPANY_SIRET}`
         )
         .when("transporterCompanyVatNumber", siretConditions.companyVatNumber),
-      transporterCompanyVatNumber: foreignVatNumber.label("Transporteur"),
+      transporterCompanyVatNumber: foreignVatNumber
+        .label("Transporteur")
+        .test(vatNumberTests.isRegisteredTransporter),
       transporterCompanyAddress: yup
         .string()
         .requiredIf(

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -1,6 +1,19 @@
-import { TransportMode, WasteAcceptationStatus } from "@prisma/client";
+import {
+  CompanyVerificationStatus,
+  TransportMode,
+  WasteAcceptationStatus
+} from "@prisma/client";
 import * as yup from "yup";
 import { ConditionBuilder, ConditionConfig } from "yup/lib/Condition";
+import {
+  isCollector,
+  isTransporter,
+  isWasteCenter,
+  isWasteProcessor,
+  isWasteVehicles
+} from "../companies/validation";
+import prisma from "../prisma";
+import { isForeignVat, isSiret, isVat } from "./constants/companySearchHelpers";
 
 // Poids maximum en tonnes tout mode de transport confondu
 const MAX_WEIGHT_TONNES = 50000;
@@ -80,3 +93,143 @@ export const weightConditions: WeightConditions = {
       )
   })
 };
+
+export const siret = yup
+  .string()
+  .nullable() // makes sure `null` does not throw a type error
+  .test(
+    "is-siret",
+    "${path}: ${originalValue} n'est pas un numéro de SIRET valide",
+    value => !value || isSiret(value)
+  );
+
+// Differents conditions than can be applied to a siret number based on the
+// value of other sibling fields
+type SiretConditions = {
+  isForeignShip: ConditionBuilder<yup.StringSchema>;
+  isPrivateIndividual: ConditionBuilder<yup.StringSchema>;
+  companyVatNumber: ConditionBuilder<yup.StringSchema>;
+};
+
+// Different tests that can be applied to a siret number
+type SiretTests = {
+  isRegistered: (
+    role?: "DESTINATION" | "TRANSPORTER"
+  ) => yup.TestConfig<string>;
+};
+
+export const siretConditions: SiretConditions = {
+  isForeignShip: (isForeignShip: boolean, schema: yup.StringSchema) => {
+    if (isForeignShip === true) {
+      return schema
+        .notRequired()
+        .test(
+          "is-null-or-undefined-when-is-foreign-ship",
+          "Émetteur : vous ne pouvez pas enregistrer un numéro de SIRET en cas d'émetteur navire étranger",
+          value => !value
+        );
+    }
+    return schema;
+  },
+  isPrivateIndividual: (
+    isPrivateIndividual: boolean,
+    schema: yup.StringSchema
+  ) => {
+    if (isPrivateIndividual === true) {
+      return schema
+        .notRequired()
+        .test(
+          "is-null-or-undefined-when-is-private-individual",
+          "${path} : vous ne pouvez pas renseigner de n°SIRET lorsque l'émetteur ou le détenteur est un particulier",
+          value => !value
+        );
+    }
+    return schema;
+  },
+  companyVatNumber: (vatNumber, schema) => {
+    if (isForeignVat(vatNumber)) {
+      return schema.notRequired();
+    }
+    return schema;
+  }
+};
+
+const { VERIFY_COMPANY } = process.env;
+
+export const siretTests: SiretTests = {
+  isRegistered: role => ({
+    name: "is-registered-with-right-profile",
+    message: ({ path, value }) =>
+      `${path} : l'établissement avec le SIRET ${value} n'est pas inscrit sur Trackdéchets`,
+    test: async (siret, ctx) => {
+      if (!siret) return true;
+      const company = await prisma.company.findUnique({
+        where: { siret }
+      });
+      if (company === null) {
+        return false;
+      }
+      if (role === "DESTINATION") {
+        if (
+          !(
+            isCollector(company) ||
+            isWasteProcessor(company) ||
+            isWasteCenter(company) ||
+            isWasteVehicles(company)
+          )
+        ) {
+          return ctx.createError({
+            message:
+              `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET "${siret}" n'est pas inscrite` +
+              ` sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut` +
+              ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
+              ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
+          });
+        }
+        if (
+          VERIFY_COMPANY === "true" &&
+          company.verificationStatus !== CompanyVerificationStatus.VERIFIED
+        ) {
+          return ctx.createError({
+            message:
+              `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue` +
+              ` avec le SIRET ${siret} n'a pas encore été vérifié. Cette installation ne peut pas être visée sur le bordereau bordereau.`
+          });
+        }
+      }
+      if (role === "TRANSPORTER" && !isTransporter(company)) {
+        return ctx.createError({
+          message:
+            `Le transporteur saisi sur le bordereau (SIRET: ${siret}) n'est pas inscrit sur Trackdéchets` +
+            ` en tant qu'entreprise de transport. Cette entreprise ne peut donc pas être visée sur le bordereau.` +
+            ` Veuillez vous rapprocher de l'administrateur de cette entreprise pour qu'il modifie le profil` +
+            ` de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
+        });
+      }
+      return true;
+    }
+  })
+};
+
+export const vatNumber = yup
+  .string()
+  .nullable()
+  .test(
+    "is-vat",
+    "${path}: ${originalValue} n'est pas un numéro de TVA valide",
+    value => {
+      if (!value) {
+        return true;
+      }
+      return isVat(value);
+    }
+  );
+
+export const foreignVatNumber = vatNumber.test(
+  "is-foreign-vat",
+  "${path} : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement",
+  value => {
+    if (!value) return true;
+    return isForeignVat(value);
+  }
+);

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -1,16 +1,5 @@
 import * as yup from "yup";
-import {
-  Company,
-  CompanyType,
-  CompanyVerificationStatus
-} from "@prisma/client";
-import { MISSING_COMPANY_SIRET_OR_VAT } from "../forms/errors";
-import prisma from "../prisma";
-import {
-  isForeignVat,
-  isFRVat,
-  isSiret
-} from "../common/constants/companySearchHelpers";
+import { Company, CompanyType } from "@prisma/client";
 
 export const receiptSchema = yup.object().shape({
   validityLimit: yup.date().required()
@@ -28,119 +17,10 @@ export function isWasteCenter(company: Company) {
   return company.companyTypes.includes(CompanyType.WASTE_CENTER);
 }
 
+export function isWasteVehicles(company: Company) {
+  return company.companyTypes.includes(CompanyType.WASTE_VEHICLES);
+}
+
 export function isTransporter(company: Company) {
   return company.companyTypes.includes(CompanyType.TRANSPORTER);
 }
-
-const { VERIFY_COMPANY } = process.env;
-
-export const destinationCompanySiretSchema = yup
-  .string()
-  .ensure()
-  .test(
-    "is-siret",
-    "Destination: ${originalValue} n'est pas un numéro de SIRET valide",
-    value => !value || isSiret(value)
-  )
-  .test(
-    "is-recipient-registered-with-right-profile",
-    ({ value }) =>
-      `L'installation de destination avec le SIRET ${value} n'est pas inscrite sur Trackdéchets`,
-    async (siret, ctx) => {
-      if (!siret) return true;
-
-      const company = await prisma.company.findUnique({
-        where: { siret }
-      });
-      if (!company) {
-        return false;
-      }
-
-      if (!(isCollector(company) || isWasteProcessor(company))) {
-        throw ctx.createError({
-          message:
-            `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET "${siret}" n'est pas inscrite` +
-            ` sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut` +
-            ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
-            ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
-        });
-      }
-
-      if (
-        VERIFY_COMPANY === "true" &&
-        company.verificationStatus !== CompanyVerificationStatus.VERIFIED
-      ) {
-        throw ctx.createError({
-          message:
-            `Le compte de l'installation de destination ou d’entreposage ou de reconditionnement prévue` +
-            ` avec le SIRET ${siret} n'a pas encore été vérifié. Cette installation ne peut pas être visée sur le bordereau bordereau.`
-        });
-      }
-
-      return true;
-    }
-  );
-
-export const transporterCompanySiretSchema = (isDraft: boolean) =>
-  yup
-    .string()
-    .ensure()
-    .test(
-      "is-transporter-registered-with-right-profile",
-      ({ value }) =>
-        `Le transporteur qui a été renseigné sur le bordereau (SIRET: ${value}) n'est pas inscrit sur Trackdéchets`,
-      async (siret, ctx) => {
-        if (!siret) return true;
-
-        const company = await prisma.company.findUnique({
-          where: { siret }
-        });
-        if (!company) {
-          return false;
-        }
-
-        if (!isTransporter(company)) {
-          throw ctx.createError({
-            message:
-              `Le transporteur saisi sur le bordereau (SIRET: ${siret}) n'est pas inscrit sur Trackdéchets` +
-              ` en tant qu'entreprise de transport. Cette entreprise ne peut donc pas être visée sur le bordereau.` +
-              ` Veuillez vous rapprocher de l'administrateur de cette entreprise pour qu'il modifie le profil` +
-              ` de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
-          });
-        }
-
-        return true;
-      }
-    )
-    .test(
-      "is-siret",
-      "Transporteur : ${originalValue} n'est pas un numéro de SIRET valide",
-      value => !value || isSiret(value)
-    )
-    .when("transporterCompanyVatNumber", (tva, schema) => {
-      if ((!tva || !isForeignVat(tva)) && !isDraft) {
-        return schema.required(
-          `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`
-        );
-      }
-      return schema.nullable().notRequired();
-    });
-
-export const transporterCompanyVatNumberSchema = yup
-  .string()
-  .ensure()
-  .test(
-    "is-foreign-vat",
-    "Transporteur: ${originalValue} n'est pas un numéro de TVA étranger valide",
-    (value, testContext) => {
-      if (!value) return true;
-      else if (isFRVat(value)) {
-        return testContext.createError({
-          message:
-            "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
-        });
-      } else if (isForeignVat(value)) {
-        return true;
-      }
-    }
-  );

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1,9 +1,4 @@
-import {
-  CompanyType,
-  CompanyVerificationStatus,
-  EmitterType,
-  Form
-} from "@prisma/client";
+import { EmitterType, Form } from "@prisma/client";
 import {
   draftFormSchema,
   sealedFormSchema,
@@ -13,30 +8,13 @@ import {
   transporterSchemaFn
 } from "../validation";
 import { ReceivedFormInput } from "../../generated/graphql/types";
-import { siretify } from "../../__tests__/factories";
-
-jest.mock("../../prisma", () => ({
-  company: {
-    findUnique: jest.fn(() =>
-      Promise.resolve({
-        companyTypes: [
-          CompanyType.COLLECTOR,
-          CompanyType.WASTEPROCESSOR,
-          CompanyType.TRANSPORTER
-        ],
-        verificationStatus: CompanyVerificationStatus.VERIFIED
-      })
-    )
-  },
-  ecoOrganisme: {
-    findFirst: jest.fn(() => Promise.resolve(null))
-  }
-}));
+import { companyFactory, siretify } from "../../__tests__/factories";
+import { resetDatabase } from "../../../integration-tests/helper";
 
 const siret1 = siretify(1);
 const siret2 = siretify(2);
 const siret3 = siretify(3);
-const form: Partial<Form> = {
+const formData: Partial<Form> = {
   id: "cjplbvecc000d0766j32r19am",
   readableId: "BSD-20210101-AAAAAAAA",
   status: "DRAFT",
@@ -82,15 +60,34 @@ const form: Partial<Form> = {
 };
 
 describe("sealedFormSchema", () => {
+  let sealedForm: Partial<Form>;
+
+  afterAll(resetDatabase);
+  beforeAll(async () => {
+    const emitterCompany = await companyFactory({ companyTypes: ["PRODUCER"] });
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const destinationCompany = await companyFactory({
+      companyTypes: ["WASTEPROCESSOR"]
+    });
+    sealedForm = {
+      ...formData,
+      emitterCompanySiret: emitterCompany.siret,
+      transporterCompanySiret: transporterCompany.siret,
+      recipientCompanySiret: destinationCompany.siret
+    };
+  });
+
   describe("form can be sealed", () => {
     test("when fully filled", async () => {
-      const isValid = await sealedFormSchema.isValid(form);
+      const isValid = await sealedFormSchema.isValid(sealedForm);
       expect(isValid).toEqual(true);
     });
 
     test("with empty strings for optionnal fields", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         transporterNumberPlate: ""
       };
       const isValid = await sealedFormSchema.isValid(testForm);
@@ -99,7 +96,7 @@ describe("sealedFormSchema", () => {
 
     test("with null values for optionnal fields", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         transporterNumberPlate: null
       };
       const isValid = await sealedFormSchema.isValid(testForm);
@@ -108,7 +105,7 @@ describe("sealedFormSchema", () => {
 
     test("with transporter receipt exemption R.541-50 ticked and no transportation infos", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         transporterIsExemptedOfReceipt: true,
         transporterReceipt: null,
         transporterDepartment: null
@@ -120,7 +117,7 @@ describe("sealedFormSchema", () => {
 
     test("with foreign transporter receipt no need for exemption R.541-50", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         transporterCompanyVatNumber: "BE0541696005",
         transporterIsExemptedOfReceipt: null,
         transporterReceipt: null,
@@ -137,7 +134,7 @@ describe("sealedFormSchema", () => {
 
     test("when there is an eco-organisme and emitter type is OTHER", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         emitterType: "OTHER",
         ecoOrganisme: { id: "an_id" }
       };
@@ -150,7 +147,7 @@ describe("sealedFormSchema", () => {
 
     test("when there is no eco-organisme and emitter type is OTHER", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         emitterType: "OTHER",
         ecoOrganisme: null
       };
@@ -165,7 +162,7 @@ describe("sealedFormSchema", () => {
       "when emitterType is (%p)",
       async emitterType => {
         const testForm = {
-          ...form,
+          ...sealedForm,
           emitterType
         };
 
@@ -176,46 +173,10 @@ describe("sealedFormSchema", () => {
 
     test("when emitterIsForeignShip is true without emitter company siret", async () => {
       const partialForm: Partial<Form> = {
-        id: "cjplbvecc000d0766j32r19am",
-        readableId: "BSD-20210101-AAAAAAAA",
-        status: "SEALED",
-        emitterType: "PRODUCER",
+        ...sealedForm,
         emitterIsForeignShip: true,
-        emitterWorkSiteName: "",
-        emitterWorkSiteAddress: "",
-        emitterWorkSiteCity: "",
-        emitterWorkSitePostalCode: "",
-        emitterWorkSiteInfos: "",
-        emitterCompanyName: "A company 2",
-        emitterCompanyAddress: "8 rue du Général de Gaulle",
-        emitterCompanyOmiNumber: "OMI1234567",
-        recipientCap: "1234",
-        recipientProcessingOperation: "D 6",
-        recipientCompanyName: "A company 3",
-        recipientCompanySiret: siret2,
-        recipientCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCompanyContact: "Destination",
-        recipientCompanyPhone: "02",
-        recipientCompanyMail: "d@d.fr",
-        transporterReceipt: "sdfg",
-        transporterDepartment: "82",
-        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
-        transporterCompanyName: "A company 4",
-        transporterCompanySiret: siret3,
-        transporterCompanyAddress: "8 rue du Général de Gaulle",
-        transporterCompanyContact: "Transporteur",
-        transporterCompanyPhone: "03",
-        transporterCompanyMail: "t@t.fr",
-        wasteDetailsCode: "01 03 04*",
-        wasteDetailsOnuCode: "AAA",
-        wasteDetailsPackagingInfos: [
-          { type: "FUT", other: null, quantity: 1 },
-          { type: "GRV", other: null, quantity: 1 }
-        ],
-        wasteDetailsQuantity: 1.5,
-        wasteDetailsQuantityType: "REAL",
-        wasteDetailsConsistence: "SOLID",
-        wasteDetailsPop: false
+        emitterCompanySiret: undefined,
+        emitterCompanyOmiNumber: "OMI1234567"
       };
       await sealedFormSchema.validate(partialForm);
       const isValid = await sealedFormSchema.isValid(partialForm);
@@ -223,45 +184,10 @@ describe("sealedFormSchema", () => {
     });
     test("when emitterIsPrivateIndividual is true without emitter company siret", async () => {
       const partialForm: Partial<Form> = {
-        id: "cjplbvecc000d0766j32r19am",
-        readableId: "BSD-20210101-AAAAAAAA",
-        status: "SEALED",
-        emitterType: "PRODUCER",
+        ...sealedForm,
         emitterIsPrivateIndividual: true,
-        emitterWorkSiteName: "",
-        emitterWorkSiteAddress: "",
-        emitterWorkSiteCity: "",
-        emitterWorkSitePostalCode: "",
-        emitterWorkSiteInfos: "",
-        emitterCompanyName: "A company 2",
-        emitterCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCap: "1234",
-        recipientProcessingOperation: "D 6",
-        recipientCompanyName: "A company 3",
-        recipientCompanySiret: siret2,
-        recipientCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCompanyContact: "Destination",
-        recipientCompanyPhone: "02",
-        recipientCompanyMail: "d@d.fr",
-        transporterReceipt: "sdfg",
-        transporterDepartment: "82",
-        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
-        transporterCompanyName: "A company 4",
-        transporterCompanySiret: siret3,
-        transporterCompanyAddress: "8 rue du Général de Gaulle",
-        transporterCompanyContact: "Transporteur",
-        transporterCompanyPhone: "03",
-        transporterCompanyMail: "t@t.fr",
-        wasteDetailsCode: "01 03 04*",
-        wasteDetailsOnuCode: "AAA",
-        wasteDetailsPackagingInfos: [
-          { type: "FUT", other: null, quantity: 1 },
-          { type: "GRV", other: null, quantity: 1 }
-        ],
-        wasteDetailsQuantity: 1.5,
-        wasteDetailsQuantityType: "REAL",
-        wasteDetailsConsistence: "SOLID",
-        wasteDetailsPop: false
+        emitterCompanySiret: null,
+        emitterCompanyContact: null
       };
       await sealedFormSchema.validate(partialForm);
       const isValid = await sealedFormSchema.isValid(partialForm);
@@ -271,7 +197,7 @@ describe("sealedFormSchema", () => {
     test("when is grouped and R0 is selected", async () => {
       // Given
       const processedInfo = {
-        ...form,
+        ...sealedForm,
         processedAt: new Date(),
         processedBy: "John Snow",
         emitterType: EmitterType.APPENDIX2,
@@ -285,163 +211,247 @@ describe("sealedFormSchema", () => {
       // Then
       expect(isValid).toBeTruthy();
     });
+
+    test("when transporterVatNumber is defined and transporterCompanySiret is nullish", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: "ESA15022510"
+      };
+      await sealedFormSchema.validate(partialForm);
+      const isValid = await sealedFormSchema.isValid(partialForm);
+      expect(isValid).toEqual(true);
+    });
+
+    test("when there is 2 bennes", async () => {
+      const testForm = {
+        ...sealedForm,
+        wasteDetailsPackagingInfos: [
+          { type: "BENNE", other: null, quantity: 2 }
+        ]
+      };
+
+      const isValid = await sealedFormSchema.isValid(testForm);
+      expect(isValid).toEqual(true);
+    });
+
+    test("when there is 2 citernes", async () => {
+      const testForm = {
+        ...sealedForm,
+        wasteDetailsPackagingInfos: [
+          { type: "CITERNE", other: null, quantity: 2 }
+        ]
+      };
+
+      const isValid = await sealedFormSchema.isValid(testForm);
+      expect(isValid).toEqual(true);
+    });
+
+    test("when there is more than 2 bennes", async () => {
+      const testForm = {
+        ...sealedForm,
+        wasteDetailsPackagingInfos: [
+          { type: "BENNE", other: null, quantity: 3 }
+        ]
+      };
+      const validateFn = () => sealedFormSchema.validate(testForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Le nombre de benne ou de citerne ne peut être supérieur à 2."
+      );
+    });
+
+    test("when there is more than 2 citernes", async () => {
+      const testForm = {
+        ...sealedForm,
+        wasteDetailsPackagingInfos: [
+          { type: "CITERNE", other: null, quantity: 3 }
+        ]
+      };
+
+      const validateFn = () => sealedFormSchema.validate(testForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Le nombre de benne ou de citerne ne peut être supérieur à 2."
+      );
+    });
+
+    test("when there is no waste details quantity", async () => {
+      const testForm = {
+        ...sealedForm,
+        wasteDetailsQuantity: null
+      };
+
+      const isValid = await sealedFormSchema.isValid(testForm);
+      expect(isValid).toEqual(false);
+    });
   });
 
   describe("form cannot be sealed", () => {
+    test("when emitterCompanySiret is not well formatted", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        emitterCompanySiret: "123"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur: 123 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when transporterCompanySiret is not well formatted", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: "123"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur: 123 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when transporter is not registered in Trackdéchets", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: "85001946400021"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+      );
+    });
+
+    test("when transporter is registered in Trackdéchets with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: company.siret
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        `Le transporteur saisi sur le bordereau (SIRET: ${company.siret}) n'est pas inscrit sur Trackdéchets` +
+          " en tant qu'entreprise de transport. Cette entreprise ne peut donc pas être visée sur le bordereau." +
+          " Veuillez vous rapprocher de l'administrateur de cette entreprise pour qu'il modifie le profil de" +
+          " l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+      );
+    });
+
+    test("when recipientCompanySiret is not well formatted", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        recipientCompanySiret: "123"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Destinataire: 123 n'est pas un numéro de SIRET valide"
+      );
+    });
+
+    test("when recipient is not registered in Trackdéchets", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        recipientCompanySiret: "85001946400021"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Destinataire : l'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+      );
+    });
+
+    test("when recipient is registered in Trackdéchets with wrong profile", async () => {
+      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        recipientCompanySiret: company.siret
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET \"${company.siret}\" n'est` +
+          " pas inscrite sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement." +
+          " Cette installation ne peut donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur" +
+          " de cette installation pour qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+      );
+    });
+
     test("when emitterIsForeignShip is true without emitterCompanyOmiNumber", async () => {
       const partialForm: Partial<Form> = {
-        id: "cjplbvecc000d0766j32r19am",
-        readableId: "BSD-20210101-AAAAAAAA",
-        status: "SEALED",
-        emitterType: "PRODUCER",
+        ...sealedForm,
         emitterIsForeignShip: true,
-        emitterWorkSiteName: "",
-        emitterWorkSiteAddress: "",
-        emitterWorkSiteCity: "",
-        emitterWorkSitePostalCode: "",
-        emitterWorkSiteInfos: "",
-        emitterCompanyName: "A company 2",
-        emitterCompanySiret: siret1,
-        emitterCompanyContact: "Emetteur",
-        emitterCompanyPhone: "01",
-        emitterCompanyAddress: "8 rue du Général de Gaulle",
-        emitterCompanyMail: "e@e.fr",
-        recipientCap: "1234",
-        recipientProcessingOperation: "D 6",
-        recipientCompanyName: "A company 3",
-        recipientCompanySiret: siret2,
-        recipientCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCompanyContact: "Destination",
-        recipientCompanyPhone: "02",
-        recipientCompanyMail: "d@d.fr",
-        transporterReceipt: "sdfg",
-        transporterDepartment: "82",
-        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
-        transporterCompanyName: "A company 4",
-        transporterCompanySiret: siret3,
-        transporterCompanyAddress: "8 rue du Général de Gaulle",
-        transporterCompanyContact: "Transporteur",
-        transporterCompanyPhone: "03",
-        transporterCompanyMail: "t@t.fr",
-        wasteDetailsCode: "01 03 04*",
-        wasteDetailsOnuCode: "AAA",
-        wasteDetailsPackagingInfos: [
-          { type: "FUT", other: null, quantity: 1 },
-          { type: "GRV", other: null, quantity: 1 }
-        ],
-        wasteDetailsQuantity: 1.5,
-        wasteDetailsQuantityType: "REAL",
-        wasteDetailsConsistence: "SOLID",
-        wasteDetailsPop: false
+        emitterCompanySiret: null,
+        emitterCompanyOmiNumber: null
       };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur: Le numéro OMI (Organisation maritime international) de l'entreprise est obligatoire"
+      );
+    });
+
+    test("when emitterIsForeignShip and siret is defined", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        emitterIsForeignShip: true,
+        emitterCompanySiret: siret1,
+        emitterCompanyOmiNumber: "OMI1234567"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur : vous ne pouvez pas enregistrer un numéro de SIRET en cas d'émetteur navire étranger"
+      );
+
       const isValid = await sealedFormSchema.isValid(partialForm);
       expect(isValid).toEqual(false);
     });
+
     test("when emitterIsForeignShip is true with invalid emitterCompanyOmiNumber", async () => {
       const partialForm: Partial<Form> = {
-        id: "cjplbvecc000d0766j32r19am",
-        readableId: "BSD-20210101-AAAAAAAA",
-        status: "SEALED",
-        emitterType: "PRODUCER",
+        ...sealedForm,
         emitterIsForeignShip: true,
-        emitterWorkSiteName: "",
-        emitterWorkSiteAddress: "",
-        emitterWorkSiteCity: "",
-        emitterWorkSitePostalCode: "",
-        emitterWorkSiteInfos: "",
-        emitterCompanyName: "A company 2",
-        emitterCompanySiret: siret1,
-        emitterCompanyContact: "Emetteur",
-        emitterCompanyPhone: "01",
-        emitterCompanyAddress: "8 rue du Général de Gaulle",
-        emitterCompanyMail: "e@e.fr",
-        emitterCompanyOmiNumber: "OMI123",
-        recipientCap: "1234",
-        recipientProcessingOperation: "D 6",
-        recipientCompanyName: "A company 3",
-        recipientCompanySiret: siret2,
-        recipientCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCompanyContact: "Destination",
-        recipientCompanyPhone: "02",
-        recipientCompanyMail: "d@d.fr",
-        transporterReceipt: "sdfg",
-        transporterDepartment: "82",
-        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
-        transporterCompanyName: "A company 4",
-        transporterCompanySiret: siret3,
-        transporterCompanyAddress: "8 rue du Général de Gaulle",
-        transporterCompanyContact: "Transporteur",
-        transporterCompanyPhone: "03",
-        transporterCompanyMail: "t@t.fr",
-        wasteDetailsCode: "01 03 04*",
-        wasteDetailsOnuCode: "AAA",
-        wasteDetailsPackagingInfos: [
-          { type: "FUT", other: null, quantity: 1 },
-          { type: "GRV", other: null, quantity: 1 }
-        ],
-        wasteDetailsQuantity: 1.5,
-        wasteDetailsQuantityType: "REAL",
-        wasteDetailsConsistence: "SOLID",
-        wasteDetailsPop: false
+        emitterCompanySiret: null,
+        emitterCompanyOmiNumber: "foo"
       };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur: Le numéro OMI (Organisation maritime international) de l'entreprise doit se composer des trois lettres OMI suivies de 7 chiffres (ex. OMI1234567)"
+      );
+
       const isValid = await sealedFormSchema.isValid(partialForm);
       expect(isValid).toEqual(false);
     });
 
     test("when emitterIsForeignShip and emitterIsPrivateIndividual both true", async () => {
       const partialForm: Partial<Form> = {
-        id: "cjplbvecc000d0766j32r19am",
-        readableId: "BSD-20210101-AAAAAAAA",
-        status: "SEALED",
-        emitterType: "PRODUCER",
+        ...sealedForm,
         emitterIsForeignShip: true,
+        emitterCompanySiret: null,
         emitterIsPrivateIndividual: true,
-        emitterWorkSiteName: "",
-        emitterWorkSiteAddress: "",
-        emitterWorkSiteCity: "",
-        emitterWorkSitePostalCode: "",
-        emitterWorkSiteInfos: "",
-        emitterCompanyName: "A company 2",
-        emitterCompanySiret: siret1,
-        emitterCompanyContact: "Emetteur",
-        emitterCompanyPhone: "01",
-        emitterCompanyAddress: "8 rue du Général de Gaulle",
-        emitterCompanyMail: "e@e.fr",
-        emitterCompanyOmiNumber: "OMI1234567",
-        recipientCap: "1234",
-        recipientProcessingOperation: "D 6",
-        recipientCompanyName: "A company 3",
-        recipientCompanySiret: siret2,
-        recipientCompanyAddress: "8 rue du Général de Gaulle",
-        recipientCompanyContact: "Destination",
-        recipientCompanyPhone: "02",
-        recipientCompanyMail: "d@d.fr",
-        transporterReceipt: "sdfg",
-        transporterDepartment: "82",
-        transporterValidityLimit: new Date("2018-12-11T00:00:00.000Z"),
-        transporterCompanyName: "A company 4",
-        transporterCompanySiret: siret3,
-        transporterCompanyAddress: "8 rue du Général de Gaulle",
-        transporterCompanyContact: "Transporteur",
-        transporterCompanyPhone: "03",
-        transporterCompanyMail: "t@t.fr",
-        wasteDetailsCode: "01 03 04*",
-        wasteDetailsOnuCode: "AAA",
-        wasteDetailsPackagingInfos: [
-          { type: "FUT", other: null, quantity: 1 },
-          { type: "GRV", other: null, quantity: 1 }
-        ],
-        wasteDetailsQuantity: 1.5,
-        wasteDetailsQuantityType: "REAL",
-        wasteDetailsConsistence: "SOLID",
-        wasteDetailsPop: false
+        emitterCompanyOmiNumber: "OMI1234567"
       };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur: Impossible de définir un  numéro OMI avec un émetteur particulier"
+      );
+
       const isValid = await sealedFormSchema.isValid(partialForm);
       expect(isValid).toEqual(false);
     });
+
+    test("when emitterIsPrivateIndividual and siret is defined", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        emitterIsPrivateIndividual: true,
+        emitterCompanyContact: null,
+        emitterCompanySiret: siret1
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+
+      await expect(validateFn()).rejects.toThrow(
+        "Émetteur : vous ne pouvez pas renseigner de n°SIRET lorsque l'émetteur ou le détenteur est un particulier"
+      );
+    });
     test("when there is no receipt exemption and no receipt", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         transporterIsExemptedOfReceipt: false,
         transporterReceipt: null
       };
@@ -452,7 +462,7 @@ describe("sealedFormSchema", () => {
 
     test("when there is an eco-organisme but emitter type is not OTHER", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         emitterType: "PRODUCER",
         ecoOrganismeSiret: siretify(5),
         ecoOrganismeName: "Some eco-organisme"
@@ -466,7 +476,7 @@ describe("sealedFormSchema", () => {
 
     test("when there is 1 citerne and another packaging", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         wasteDetailsPackagingInfos: [
           { type: "CITERNE", other: null, quantity: 1 },
           { type: "GRV", other: null, quantity: 1 }
@@ -479,7 +489,7 @@ describe("sealedFormSchema", () => {
 
     test("when there is 1 benne and another packaging", async () => {
       const testForm = {
-        ...form,
+        ...sealedForm,
         wasteDetailsPackagingInfos: [
           { type: "BENNE", other: null, quantity: 1 },
           { type: "GRV", other: null, quantity: 1 }
@@ -495,7 +505,7 @@ describe("sealedFormSchema", () => {
 
       // Given
       const processedInfo = {
-        ...form,
+        ...sealedForm,
         processedAt: new Date(),
         processedBy: "John Snow",
         emitterType: EmitterType.APPENDIX1,
@@ -513,63 +523,45 @@ describe("sealedFormSchema", () => {
         ]);
       }
     });
-  });
 
-  test("when there is 2 bennes", async () => {
-    const testForm = {
-      ...form,
-      wasteDetailsPackagingInfos: [{ type: "BENNE", other: null, quantity: 2 }]
-    };
+    test("when there is nor transporterCompanySiret nor transporterCompanyVatNumber", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: null
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
 
-    const isValid = await sealedFormSchema.isValid(testForm);
-    expect(isValid).toEqual(true);
-  });
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur : Le n°SIRET ou le numéro de TVA intracommunautaire est obligatoire"
+      );
+    });
 
-  test("when there is 2 citernes", async () => {
-    const testForm = {
-      ...form,
-      wasteDetailsPackagingInfos: [
-        { type: "CITERNE", other: null, quantity: 2 }
-      ]
-    };
+    test("when the transporterCompanyVatNumber is invalid", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: "invalid"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
 
-    const isValid = await sealedFormSchema.isValid(testForm);
-    expect(isValid).toEqual(true);
-  });
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur: invalid n'est pas un numéro de TVA valide"
+      );
+    });
 
-  test("when there is more than 2 bennes", async () => {
-    const testForm = {
-      ...form,
-      wasteDetailsPackagingInfos: [{ type: "BENNE", other: null, quantity: 3 }]
-    };
-    const validateFn = () => sealedFormSchema.validate(testForm);
-    await expect(validateFn()).rejects.toThrow(
-      "Le nombre de benne ou de citerne ne peut être supérieur à 2."
-    );
-  });
+    test("when the transporterCompanyVatNumber is FR", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: "FR35552049447"
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
 
-  test("when there is more than 2 citernes", async () => {
-    const testForm = {
-      ...form,
-      wasteDetailsPackagingInfos: [
-        { type: "CITERNE", other: null, quantity: 3 }
-      ]
-    };
-
-    const validateFn = () => sealedFormSchema.validate(testForm);
-    await expect(validateFn()).rejects.toThrow(
-      "Le nombre de benne ou de citerne ne peut être supérieur à 2."
-    );
-  });
-
-  test("when there is no waste details quantity", async () => {
-    const testForm = {
-      ...form,
-      wasteDetailsQuantity: null
-    };
-
-    const isValid = await sealedFormSchema.isValid(testForm);
-    expect(isValid).toEqual(false);
+      await expect(validateFn()).rejects.toThrow(
+        "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
+      );
+    });
   });
 });
 
@@ -1146,9 +1138,12 @@ describe("processedInfoSchema", () => {
   });
 
   test("transporter vatNumber is optional when a valid SIRET is present", async () => {
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
     const transporter = {
       transporterCompanyName: "Code en Stock",
-      transporterCompanySiret: siretify(1),
+      transporterCompanySiret: transporterCompany.siret,
       transporterCompanyAddress: "Marseille",
       transporterCompanyContact: "Contact",
       transporterCompanyPhone: "00 00 00 00 00",
@@ -1189,7 +1184,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => transporterSchemaFn(false).validate(transporter);
 
     await expect(validateFn()).rejects.toThrow(
-      "Transporteur: invalid n'est pas un numéro de TVA étranger valide"
+      "Transporteur: invalid n'est pas un numéro de TVA valide"
     );
   });
 
@@ -1210,9 +1205,13 @@ describe("processedInfoSchema", () => {
   });
 
   test("SIRET for la poste is valid", async () => {
+    const transporterCompany = await companyFactory({
+      siret: "35600000040773",
+      companyTypes: ["TRANSPORTER"]
+    });
     const transporter = {
       transporterCompanyName: "la poste",
-      transporterCompanySiret: "35600000040773",
+      transporterCompanySiret: transporterCompany.siret,
       transporterCompanyAddress: "paris",
       transporterCompanyContact: "Contact",
       transporterCompanyPhone: "00 00 00 00 00",
@@ -1228,15 +1227,18 @@ describe("processedInfoSchema", () => {
       transporterCompanyName: "la poste",
       transporterCompanyPhone: "00 00 00 00 00",
       transporterCompanySiret: "35600000040773",
-      transporterCompanyVatNumber: "",
       transporterIsExemptedOfReceipt: true
     });
   });
 
   test("SIRET for any valid SIRET is valid", async () => {
+    const transporterCompany = await companyFactory({
+      siret: "35600000000048",
+      companyTypes: ["TRANSPORTER"]
+    });
     const transporter = {
       transporterCompanyName: "la poste siege",
-      transporterCompanySiret: "35600000000048",
+      transporterCompanySiret: transporterCompany.siret,
       transporterCompanyAddress: "paris",
       transporterCompanyContact: "Contact",
       transporterCompanyPhone: "00 00 00 00 00",
@@ -1251,8 +1253,7 @@ describe("processedInfoSchema", () => {
       transporterCompanyMail: "contact@laposte.com",
       transporterCompanyName: "la poste siege",
       transporterCompanyPhone: "00 00 00 00 00",
-      transporterCompanySiret: "35600000000048",
-      transporterCompanyVatNumber: "",
+      transporterCompanySiret: transporterCompany.siret,
       transporterIsExemptedOfReceipt: true
     });
   });

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -601,7 +601,7 @@ describe("Mutation.createForm", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `L'installation de destination avec le SIRET ${siret} n'est pas inscrite sur Trackdéchets`,
+        message: `Destinataire : l'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`,
         extensions: expect.objectContaining({
           code: ErrorCode.BAD_USER_INPUT
         })
@@ -634,7 +634,7 @@ describe("Mutation.createForm", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `Le transporteur qui a été renseigné sur le bordereau (SIRET: ${siret}) n'est pas inscrit sur Trackdéchets`,
+        message: `Transporteur : l'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`,
         extensions: expect.objectContaining({
           code: ErrorCode.BAD_USER_INPUT
         })

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -475,7 +475,7 @@ describe("Mutation markAsResealed", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `L'installation de destination avec le SIRET ${recipientCompanySiret} n'est pas inscrite sur Trackdéchets`
+        message: `Destinataire : l'établissement avec le SIRET ${recipientCompanySiret} n'est pas inscrit sur Trackdéchets`
       })
     ]);
   });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -702,7 +702,7 @@ describe("Mutation.markAsSealed", () => {
       expect.objectContaining({
         message: [
           "Erreur, impossible de valider le bordereau car des champs obligatoires ne sont pas renseignés.",
-          `Erreur(s): L'installation de destination avec le SIRET ${recipientCompanySiret} n'est pas inscrite sur Trackdéchets`
+          `Erreur(s): Destinataire : l'établissement avec le SIRET ${recipientCompanySiret} n'est pas inscrit sur Trackdéchets`
         ].join("\n")
       })
     ]);
@@ -769,7 +769,7 @@ describe("Mutation.markAsSealed", () => {
     });
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `L'installation de destination avec le SIRET ${recipientCompanySiret} n'est pas inscrite sur Trackdéchets`
+        message: `Destination finale : l'établissement avec le SIRET ${recipientCompanySiret} n'est pas inscrit sur Trackdéchets`
       })
     ]);
   });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -57,6 +57,7 @@ import {
   siretConditions,
   siretTests,
   vatNumber,
+  vatNumberTests,
   weight,
   weightConditions,
   WeightUnits
@@ -681,7 +682,9 @@ export const transporterSchemaFn: FactorySchemaOf<boolean, Transporter> =
           siretConditions.companyVatNumber
         )
         .requiredIf(!isDraft, `Transporteur : ${MISSING_COMPANY_SIRET_OR_VAT}`),
-      transporterCompanyVatNumber: foreignVatNumber.label("Transporteur"),
+      transporterCompanyVatNumber: foreignVatNumber
+        .label("Transporteur")
+        .test(vatNumberTests.isRegisteredTransporter),
       transporterCompanyAddress: yup
         .string()
         .ensure()
@@ -1188,6 +1191,7 @@ export async function validateForwardedInCompanies(form: Form): Promise<void> {
   if (forwardedIn?.transporterCompanyVatNumber) {
     await foreignVatNumber
       .label("Transporteur après entreposage provisoire")
+      .test(vatNumberTests.isRegisteredTransporter)
       .validate(forwardedIn?.transporterCompanyVatNumber);
   }
 }

--- a/front/src/form/bsdasri/steps/Destination.tsx
+++ b/front/src/form/bsdasri/steps/Destination.tsx
@@ -34,6 +34,7 @@ export default function Destination({ status, stepName, disabled = false }) {
           name="destination.company"
           heading="Installation destinataire"
           disabled={receptionDisabled}
+          registeredOnlyCompanies={true}
           optionalMail={true}
         />
       </div>

--- a/front/src/form/bsvhu/Destination.tsx
+++ b/front/src/form/bsvhu/Destination.tsx
@@ -60,6 +60,7 @@ export default function Destination({ disabled }) {
         disabled={disabled}
         name="destination.company"
         heading="Installation de destination"
+        registeredOnlyCompanies={true}
         onCompanySelected={destination => {
           const agrementNumber =
             values.destination?.type === "BROYEUR"


### PR DESCRIPTION
- ETQ émetteur d'un bordereau, tout type confondu :
  - je ne dois pas pouvoir renseigner un transporteur non inscrit sur Trackdéchets
  - je ne dois pas pouvoir renseigner un transporteur inscrit sur Trackdéchets mais sans le profil Transporteur    
  - je ne dois pas pouvoir renseigner une installation de destination non inscrite sur Trackdéchets
  - je ne dois pas pouvoir renseigner une installation de destination inscrite sur Trackdéchets mais n'ayant pas un profil d'installation de traitement ou de tri, transit, regroupement

Ce comportement était déjà présent sur le BSDD, BSDA et BSFF mais pas sur le BSDASRI et BSVHU. J'en ai profité pour factoriser tout le code ayant trait à la validation des n°SIRET dans le fichier `common/validation.ts`.

--- 


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10364)
