### PR TITLE
Release 2023.01.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,24 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.1.2] 12/01/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+- Correction bug de suppression d'un BSDD de l'index ES [PR 2050](https://github.com/MTES-MCT/trackdechets/pull/2050)
+- Correctifs validation de Destination ultérieure et correction des réponses du champ Form "company.country" [PR 2046](https://github.com/MTES-MCT/trackdechets/pull/2046)
+
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2023.1.1] 10/01/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-# [2023.1.2] 12/01/2023
+# [2023.1.2] 16/01/2023
 
 #### :rocket: Nouvelles fonctionnalités
 
@@ -14,6 +14,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Correction bug de suppression d'un BSDD de l'index ES [PR 2050](https://github.com/MTES-MCT/trackdechets/pull/2050)
 - Correctifs validation de Destination ultérieure et correction des réponses du champ Form "company.country" [PR 2046](https://github.com/MTES-MCT/trackdechets/pull/2046)
 - Correction de la validation SIRET pour le groupe La Poste
+- Corrections affichage d'erreurs de validation sur company selector [PR 2052](https://github.com/MTES-MCT/trackdechets/pull/2052)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Correction bug de suppression d'un BSDD de l'index ES [PR 2050](https://github.com/MTES-MCT/trackdechets/pull/2050)
 - Correctifs validation de Destination ultérieure et correction des réponses du champ Form "company.country" [PR 2046](https://github.com/MTES-MCT/trackdechets/pull/2046)
-
+- Correction de la validation SIRET pour le groupe La Poste
 
 #### :boom: Breaking changes
 

--- a/back/src/bsds/indexation/reindexBsdHelpers.ts
+++ b/back/src/bsds/indexation/reindexBsdHelpers.ts
@@ -83,7 +83,7 @@ export async function reindex(bsdId, exitFn) {
       const fullBsdd = await getFullForm(bsdd);
       await indexForm(fullBsdd);
     } else {
-      await deleteBsd({ id: bsdId });
+      await deleteBsd({ readableId: bsdId });
     }
     return exitFn(true);
   }

--- a/back/src/bsffs/resolvers/mutations/deleteBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/deleteBsff.ts
@@ -41,7 +41,7 @@ const deleteBsff: MutationResolvers["deleteBsff"] = async (
     });
   });
 
-  await elastic.deleteBsd(updatedBsff, context);
+  await elastic.deleteBsd({ id: updatedBsff.id }, context);
 
   return expandBsffFromDB(updatedBsff);
 };

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -111,12 +111,11 @@ export const isSiret = (clue: string, allowTestCompany = false): boolean => {
   ) {
     return true;
   }
-  const luhnValid = luhnCheck(clue);
-  if (luhnValid) {
-    return true;
+  // La Poste groupe specific rule (except for headquarters 35600000000048 that pass luhnChack)
+  if (clue.startsWith("356000000") && clue !== "35600000000048") {
+    return clue.split("").reduce((a, b) => a + parseInt(b, 10), 0) % 5 === 0;
   }
-  // try with "5" (default is 10) for La Poste Groupe SIRET
-  return luhnCheck(clue, 5);
+  return luhnCheck(clue);
 };
 
 /**

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -383,11 +383,9 @@ function refresh(ctx?: GraphQLContext): Partial<RequestParams.Index> {
  * It allows to refresh the BSD list in real time after a create, update or delete operation from UI
  * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
  */
-function refreshForDelete(ctx?: GraphQLContext): { refresh: boolean } {
-  return ctx?.user?.auth === AuthType.Session
-    ? { refresh: true }
-    : { refresh: false };
-}
+const refreshForDelete = (ctx?: GraphQLContext): { refresh: boolean } => ({
+  refresh: ctx?.user?.auth === AuthType.Session
+});
 
 /**
  * Create/update a document in Elastic Search.

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1209,6 +1209,54 @@ describe("processedInfoSchema", () => {
     );
   });
 
+  test("SIRET for la poste is valid", async () => {
+    const transporter = {
+      transporterCompanyName: "la poste",
+      transporterCompanySiret: "35600000040773",
+      transporterCompanyAddress: "paris",
+      transporterCompanyContact: "Contact",
+      transporterCompanyPhone: "00 00 00 00 00",
+      transporterCompanyMail: "contact@laposte.com",
+      transporterIsExemptedOfReceipt: true
+    };
+    const validateFn = () => transporterSchemaFn(false).validate(transporter);
+
+    await expect(validateFn()).resolves.toMatchObject({
+      transporterCompanyAddress: "paris",
+      transporterCompanyContact: "Contact",
+      transporterCompanyMail: "contact@laposte.com",
+      transporterCompanyName: "la poste",
+      transporterCompanyPhone: "00 00 00 00 00",
+      transporterCompanySiret: "35600000040773",
+      transporterCompanyVatNumber: "",
+      transporterIsExemptedOfReceipt: true
+    });
+  });
+
+  test("SIRET for any valid SIRET is valid", async () => {
+    const transporter = {
+      transporterCompanyName: "la poste siege",
+      transporterCompanySiret: "35600000000048",
+      transporterCompanyAddress: "paris",
+      transporterCompanyContact: "Contact",
+      transporterCompanyPhone: "00 00 00 00 00",
+      transporterCompanyMail: "contact@laposte.com",
+      transporterIsExemptedOfReceipt: true
+    };
+    const validateFn = () => transporterSchemaFn(false).validate(transporter);
+
+    await expect(validateFn()).resolves.toMatchObject({
+      transporterCompanyAddress: "paris",
+      transporterCompanyContact: "Contact",
+      transporterCompanyMail: "contact@laposte.com",
+      transporterCompanyName: "la poste siege",
+      transporterCompanyPhone: "00 00 00 00 00",
+      transporterCompanySiret: "35600000000048",
+      transporterCompanyVatNumber: "",
+      transporterIsExemptedOfReceipt: true
+    });
+  });
+
   test("nextDestination should be defined when processing operation is groupement and noTraceability is false", async () => {
     const processedInfo = {
       processedBy: "John Snow",

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1059,7 +1059,7 @@ describe("processedInfoSchema", () => {
     const validateFn = () => processedInfoSchema.validate(processedInfo);
 
     await expect(validateFn()).rejects.toThrow(
-      "Destination ultérieure : le code du pays de l'entreprise ne peut pas différent de FR"
+      "Destination ultérieure : le code du pays de l'entreprise ne peut pas être différent de FR"
     );
   });
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1020,7 +1020,7 @@ describe("processedInfoSchema", () => {
     expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
   });
 
-  test("nextDestinationCompany SIRET or VAT number is required", async () => {
+  test("nextDestinationCompany SIRET is required when no other identication is given", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),
@@ -1038,6 +1038,50 @@ describe("processedInfoSchema", () => {
 
     await expect(validateFn()).rejects.toThrow(
       "Destination ultérieure prévue : Le siret de l'entreprise est obligatoire"
+    );
+  });
+
+  test("nextDestinationCompany return an error when SIRET is given and country is not FR", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanySiret: siretify(1),
+      nextDestinationCompanyCountry: "IE",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destination ultérieure : le code du pays de l'entreprise ne peut pas différent de FR"
+    );
+  });
+
+  test("nextDestinationCompany return an error when VAT is given and country is FR", async () => {
+    const processedInfo = {
+      processedBy: "John Snow",
+      processedAt: new Date(),
+      processingOperationDone: "D 13",
+      processingOperationDescription: "Regroupement",
+      nextDestinationProcessingOperation: "D 8",
+      nextDestinationCompanyName: "Exutoire",
+      nextDestinationCompanyAddress: "4 rue du déchet",
+      nextDestinationCompanyCountry: "FR",
+      nextDestinationCompanyVatNumber: "BE0541696005",
+      nextDestinationCompanyContact: "Arya Stark",
+      nextDestinationCompanyPhone: "06 XX XX XX XX",
+      nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+    };
+    const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Destination ultérieure : le code du pays de l'entreprise ne correspond pas au numéro de TVA entré"
     );
   });
 

--- a/back/src/forms/__tests__/validation.test.ts
+++ b/back/src/forms/__tests__/validation.test.ts
@@ -1020,7 +1020,7 @@ describe("processedInfoSchema", () => {
     expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
   });
 
-  test("nextDestinationCompany SIRET is required when no other identication is given", async () => {
+  test("nextDestinationCompany SIRET is required when no other identification is given", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),
@@ -1063,7 +1063,7 @@ describe("processedInfoSchema", () => {
     );
   });
 
-  test("nextDestinationCompany return an error when VAT is given and country is FR", async () => {
+  test("nextDestinationCompany return an error when a foreign VAT is given and country is FR", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),

--- a/back/src/forms/repository/form/delete.ts
+++ b/back/src/forms/repository/form/delete.ts
@@ -38,7 +38,9 @@ const buildDeleteForm: (deps: RepositoryFnDeps) => DeleteFormFn =
       }
     });
 
-    await deleteBsd(deletedForm, { user } as GraphQLContext);
+    await deleteBsd({ readableId: deletedForm.readableId }, {
+      user
+    } as GraphQLContext);
 
     // disconnect appendix2 forms if any
     const removeAppendix2 = buildRemoveAppendix2({ prisma, user });

--- a/back/src/forms/resolvers/FormCompany.ts
+++ b/back/src/forms/resolvers/FormCompany.ts
@@ -1,12 +1,28 @@
+import { checkVAT } from "jsvat";
+import {
+  countries as vatCountries,
+  isVat,
+  isSiret
+} from "../../common/constants/companySearchHelpers";
 import { FormCompanyResolvers } from "../../generated/graphql/types";
 
 const formCompanyResolvers: FormCompanyResolvers = {
   country: parent => {
-    if (parent.vatNumber) {
-      return parent.country ?? "FR";
+    if (isVat(parent.vatNumber)) {
+      // ignore parent.country
+      const vatCountryCode = checkVAT(
+        parent.vatNumber.replace(/[\W_\s]/gim, ""),
+        vatCountries
+      )?.country?.isoCode.short;
+      return vatCountryCode ? vatCountryCode : parent.country ?? "FR";
     }
-    if (parent.siret) {
+    if (isSiret(parent.siret)) {
+      // ignore parent.country
       return "FR";
+    }
+    if (parent.country) {
+      // only parent.country
+      return parent.country;
     }
     return null;
   },

--- a/back/src/forms/resolvers/__tests__/FormCompany.integration.ts
+++ b/back/src/forms/resolvers/__tests__/FormCompany.integration.ts
@@ -1,0 +1,72 @@
+import { CompanyType, Status, UserRole } from "@prisma/client";
+import { Query } from "../../../generated/graphql/types";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import {
+  formFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+
+const FORM = `
+  query Form($id: ID!) {
+    form(id: $id) {
+      emitter {
+        company {
+          country
+        }
+      }
+      recipient {
+        company {
+          country
+        }
+      }
+      transporter {
+        company {
+          country
+        }
+      }
+      nextDestination {
+        company {
+          country
+        }
+      }
+    }
+  }`;
+
+describe("FormCompany resolver", () => {
+  afterAll(resetDatabase);
+
+  it("should return the right country for a Company", async () => {
+    const { user: emitterUser, company: emitter } =
+      await userWithCompanyFactory(UserRole.MEMBER, {
+        companyTypes: { set: [CompanyType.PRODUCER] }
+      });
+
+    const { user: destinationUser, company: destination } =
+      await userWithCompanyFactory(UserRole.MEMBER, {
+        companyTypes: { set: [CompanyType.WASTEPROCESSOR] }
+      });
+
+    const form = await formFactory({
+      ownerId: emitterUser.id,
+      opt: {
+        status: Status.SEALED,
+        emitterCompanySiret: emitter.siret,
+        recipientCompanySiret: destination.siret,
+        transporterCompanyVatNumber: "BE0541696005",
+        quantityReceived: 1,
+        nextDestinationCompanyVatNumber: "BE0541696005"
+      }
+    });
+    const { query } = makeClient(destinationUser);
+    const { data } = await query<Pick<Query, "form">>(FORM, {
+      variables: {
+        id: form.id
+      }
+    });
+    expect(data.form.emitter.company.country).toBe("FR");
+    expect(data.form.recipient.company.country).toBe("FR");
+    expect(data.form.transporter.company.country).toBe("BE");
+    expect(data.form.nextDestination.company.country).toBe("BE");
+  });
+});

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -489,7 +489,42 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  it("should set country to FR by default", async () => {
+  it("should allow empty company as nextDestination when NO_TRACEABILITY is true", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "ACCEPTED",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: "D 13",
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z",
+          noTraceability: true,
+          nextDestination: {
+            processingOperation: "D 1",
+            company: null
+          }
+        }
+      }
+    });
+
+    const resultingForm = await prisma.form.findUnique({
+      where: { id: form.id }
+    });
+    expect(resultingForm.status).toBe("NO_TRACEABILITY");
+  });
+
+  it("should set nextDestinationCompanyCountry to FR by default is a SIRET is defined", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -579,6 +614,51 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.nextDestinationCompanyCountry).toBe("IE");
   });
 
+  it("should mark a form FOLLOWED_WITH_PNTTD with foreign next destination and auto-guess the country", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "ACCEPTED",
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: "D 14",
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z",
+          nextDestination: {
+            processingOperation: "D 1",
+            company: {
+              mail: "m@m.fr",
+              siret: null,
+              vatNumber: "IE9513674T",
+              name: "IE company",
+              phone: "0101010101",
+              contact: "The famous bot",
+              address: "A beautiful place..."
+            }
+          }
+        }
+      }
+    });
+
+    const resultingForm = await prisma.form.findUnique({
+      where: { id: form.id }
+    });
+
+    expect(resultingForm.status).toBe("FOLLOWED_WITH_PNTTD");
+    expect(resultingForm.nextDestinationCompanyVatNumber).toEqual("IE9513674T");
+    expect(resultingForm.nextDestinationCompanyCountry).toBe("IE");
+  });
+
   it("should mark a form with temp storage FOLLOWED_WITH_PNTTD with foreign next destination", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formWithTempStorageFactory({
@@ -627,7 +707,7 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.forwardedIn.nextDestinationCompanyCountry).toBe("IE");
   });
 
-  it("should disallow a missing siret for a french next destination", async () => {
+  it("should disallow a missing siret for any next destination", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -651,7 +731,6 @@ describe("mutation.markAsProcessed", () => {
             processingOperation: "D 1",
             company: {
               mail: "m@m.fr",
-              country: "FR",
               name: "company",
               phone: "0101010101",
               contact: "The famous bot",

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -11,6 +11,12 @@ import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import machine from "../../workflow/machine";
 import { runInTransaction } from "../../../common/repository/helper";
+import { checkVAT } from "jsvat";
+import {
+  countries,
+  isSiret,
+  isVat
+} from "../../../common/constants/companySearchHelpers";
 
 const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   parent,
@@ -37,13 +43,27 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   formUpdateInput.processingOperationDescription =
     processedInfo.processingOperationDescription || operation?.description;
 
+  // auto-fill nextDestinationCompanyCountry
   if (
-    formUpdateInput.nextDestinationCompanySiret &&
+    isSiret(formUpdateInput.nextDestinationCompanySiret as string) &&
     !formUpdateInput.nextDestinationCompanyCountry
   ) {
     // only default to "FR" if there's an actual nextDestination
     // otherwise keep it empty to avoid filling a field for an object that doesn't exist
     formUpdateInput.nextDestinationCompanyCountry = "FR";
+  }
+  if (
+    isVat(formUpdateInput.nextDestinationCompanyVatNumber as string) &&
+    !formUpdateInput.nextDestinationCompanyCountry
+  ) {
+    const vatCountryCode = checkVAT(
+      (formUpdateInput.nextDestinationCompanyVatNumber as string).replace(
+        /[\W_\s]/gim,
+        ""
+      ),
+      countries
+    )?.country?.isoCode.short;
+    formUpdateInput.nextDestinationCompanyCountry = vatCountryCode;
   }
 
   if (form.status === Status.TEMP_STORER_ACCEPTED) {

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -415,7 +415,8 @@ input InternationalCompanyInput {
   Code ISO 3166-1 alpha-2 du pays d'origine de l'entreprise :
   https://fr.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
-  En l'absence de code, l'entreprise est considérée comme résidant en France.
+  En l'absence de code, le pays est FR si un siret est donné, ou détecté depuis le numéro de TVA si vatNumber est donné.
+  Une incohérence du pays avec le siret ou le numéro pays détecté du numéro de TVA résultera en une erreur type BAD_USER_INPUT.
   """
   country: String
 

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -45,7 +45,8 @@ import {
   isSiret,
   isFRVat,
   isOmi,
-  isForeignVat
+  isForeignVat,
+  countries as vatCountries
 } from "../common/constants/companySearchHelpers";
 import { validateCompany } from "../companies/validateCompany";
 import { Decimal } from "decimal.js-light";
@@ -55,6 +56,7 @@ import {
   transporterCompanyVatNumberSchema
 } from "../companies/validation";
 import { weight, weightConditions, WeightUnits } from "../common/validation";
+import { checkVAT } from "jsvat";
 // set yup default error messages
 configureYup();
 
@@ -1012,10 +1014,34 @@ const withNextDestination = (required: boolean) =>
         required,
         `Destination ultérieure : ${MISSING_COMPANY_ADDRESS}`
       ),
-    nextDestinationCompanyCountry: yup.string().oneOf(
-      countries.map(country => country.cca2),
-      "Destination ultérieure : le code ISO 3166-1 alpha-2 du pays de l'entreprise n'est pas reconnu"
-    ),
+    nextDestinationCompanyCountry: yup
+      .string()
+      .ensure()
+      .oneOf(
+        ["", ...countries.map(country => country.cca2)],
+        "Destination ultérieure : le code ISO 3166-1 alpha-2 du pays de l'entreprise n'est pas reconnu"
+      )
+      .when("nextDestinationCompanyVatNumber", (vat, schema) => {
+        return isVat(vat) && required
+          ? schema.test(
+              "is-country-valid",
+              "Destination ultérieure : le code du pays de l'entreprise ne correspond pas au numéro de TVA entré",
+              value =>
+                !value ||
+                checkVAT(vat.replace(/[\W_\s]/gim, ""), vatCountries)?.country
+                  ?.isoCode.short === value.replace(/[\W_\s]/gim, "")
+            )
+          : schema;
+      })
+      .when("nextDestinationCompanySiret", (siret, schema) => {
+        return isSiret(siret) && required
+          ? schema.test(
+              "is-fr-country-valid",
+              "Destination ultérieure : le code du pays de l'entreprise ne peut pas être différent de FR",
+              value => !value || value === "FR"
+            )
+          : schema;
+      }),
     nextDestinationCompanyContact: yup
       .string()
       .ensure()

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -8,8 +8,11 @@ import prisma from "../../prisma";
 
 export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   const bsdId = job.data;
-
-  await deleteBsd({ id: bsdId });
+  if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
+    await deleteBsd({ readableId: bsdId });
+  } else {
+    await deleteBsd({ id: bsdId });
+  }
 
   if (bsdId.startsWith("BSDA-")) {
     const bsda = await prisma.bsda.findUnique({

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealed.tsx
@@ -248,6 +248,7 @@ const emptyState = {
     numberPlate: "",
     company: {
       siret: "",
+      vatNumber: "",
       name: "",
       address: "",
       contact: "",

--- a/front/src/form/bsda/stepper/initial-state.ts
+++ b/front/src/form/bsda/stepper/initial-state.ts
@@ -45,7 +45,6 @@ const initialState = {
   transporter: {
     company: {
       ...getInitialCompany(),
-      vatNumber: "",
     },
     recepisse: {
       number: "",

--- a/front/src/form/bsdd/Transporter.tsx
+++ b/front/src/form/bsdd/Transporter.tsx
@@ -21,7 +21,6 @@ export default function Transporter() {
       <h4 className="form__section-heading">Transporteur</h4>
       <CompanySelector
         name="transporter.company"
-        optional={true}
         allowForeignCompanies={true}
         registeredOnlyCompanies={true}
         onCompanySelected={transporter => {

--- a/front/src/form/bsff/utils/initial-state.ts
+++ b/front/src/form/bsff/utils/initial-state.ts
@@ -9,7 +9,6 @@ const initialState = {
   transporter: {
     company: {
       ...getInitialCompany(),
-      vatNumber: "",
     },
     isExemptedOfRecepisse: false,
     recepisse: {

--- a/front/src/form/bsvhu/utils/initial-state.ts
+++ b/front/src/form/bsvhu/utils/initial-state.ts
@@ -41,7 +41,6 @@ export default {
   transporter: {
     company: {
       ...getInitialCompany(),
-      vatNumber: "",
     },
     recepisse: {
       number: "",

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -97,7 +97,7 @@ export default function CompanySelector({
     () => field.value.orgId ?? field.value.siret ?? null,
     [field.value.siret, field.value.orgId]
   );
-  // Favortite type is deduced from the field prefix (transporter, emitter, etc)
+  // Favorite type is deduced from the field prefix (transporter, emitter, etc)
   const favoriteType = constantCase(field.name.split(".")[0]) as FavoriteType;
   const {
     loading: isLoadingFavorites,
@@ -155,7 +155,11 @@ export default function CompanySelector({
   function selectCompany(company?: CompanySearchResult) {
     if (disabled) return;
     // empty the  selected company when null
-    if (!company) return setFieldValue(field.name, getInitialCompany());
+    if (!company) {
+      setFieldValue(field.name, getInitialCompany());
+      setFieldTouched(`${field.name}`, true, true);
+      return;
+    }
 
     // Side effects
     const notVoidCompany = Object.keys(company).length !== 0; // unselect returns emtpy object {}
@@ -200,7 +204,7 @@ export default function CompanySelector({
     Object.keys(fields).forEach(key => {
       setFieldValue(`${field.name}.${key}`, fields[key]);
     });
-
+    setFieldTouched(`${field.name}`, true, true);
     onCompanySelected?.(company);
   }
 


### PR DESCRIPTION
Dupliquée de https://github.com/MTES-MCT/trackdechets/pull/2051 enlevant les autres PR mergées plus tard

# Bugfix Release

- Correction bug de suppression d'un BSDD de l'index ES [PR 2050](https://github.com/MTES-MCT/trackdechets/pull/2050)
- Correctifs validation de Destination ultérieure et correction des réponses du champ Form "company.country" [PR 2046](https://github.com/MTES-MCT/trackdechets/pull/2046)
- Correction de la validation SIRET pour le groupe La Poste
- Corrections affichage d'erreurs de validation sur company selector #2052 


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro bug reindex bsdd](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10060)
- [Ticket Favro bug nextDestination country](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10060)
- [Ticket Favro bug Message d'erreur lorsqu'on ne renseigne pas la destination finale en cas de rupture de traçabilité](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10656)
- [Ticket Bug Form Company country resolver](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10569)
- [Ticket Favro]()
