### PR TITLE
Remet en place verifyCompanyByAdmin et ajout de test

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/verifyCompanyByAdmin.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/verifyCompanyByAdmin.integration.ts
@@ -100,4 +100,40 @@ describe("mutation verifyCompanyByAdmin", () => {
     expect(verifiedCompany.verificationComment).toEqual(verificationComment);
     expect(verifiedCompany.verifiedAt).not.toBeNull();
   });
+
+  it("should verify a foreign company, set verification mode and verificationComment", async () => {
+    const admin = await userFactory({ isAdmin: true });
+
+    const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+      verificationStatus: CompanyVerificationStatus.TO_BE_VERIFIED,
+      siret: null,
+      vatNumber: "BE0541696002"
+    });
+
+    const { mutate } = makeClient(admin);
+
+    const verificationComment = "The admin is the director of the company";
+
+    await mutate(VERIFY_COMPANY_BY_ADMIN, {
+      variables: {
+        input: {
+          siret: company.orgId,
+          verificationComment
+        }
+      }
+    });
+
+    const verifiedCompany = await prisma.company.findUnique({
+      where: { orgId: company.orgId }
+    });
+
+    expect(verifiedCompany.verificationStatus).toEqual(
+      CompanyVerificationStatus.VERIFIED
+    );
+    expect(verifiedCompany.verificationMode).toEqual(
+      CompanyVerificationMode.MANUAL
+    );
+    expect(verifiedCompany.verificationComment).toEqual(verificationComment);
+    expect(verifiedCompany.verifiedAt).not.toBeNull();
+  });
 });

--- a/front/src/admin/verification/actions/CompanyVerifyModal.tsx
+++ b/front/src/admin/verification/actions/CompanyVerifyModal.tsx
@@ -10,7 +10,6 @@ import {
   MutationVerifyCompanyByAdminArgs,
 } from "generated/graphql/types";
 import { NotificationError } from "common/components/Error";
-import { isSiret } from "generated/constants/companySearchHelpers";
 
 type VerifyModalProps = {
   isOpen: boolean;
@@ -54,23 +53,14 @@ export default function CompanyVerifyModal({
   });
 
   function onSubmit(values: Values) {
-    if (isSiret(company.siret!)) {
-      return verifyCompanyByAdmin({
-        variables: {
-          input: {
-            siret: company.siret!,
-            verificationComment: values.verificationComment,
-          },
+    return verifyCompanyByAdmin({
+      variables: {
+        input: {
+          siret: company.orgId!,
+          verificationComment: values.verificationComment,
         },
-      });
-    } else {
-      cogoToast.error(
-        "La vérification n'a pas pu être envoyée, l'établissement ne possède pas de SIRET valide",
-        {
-          hideAfter: 5,
-        }
-      );
-    }
+      },
+    });
   }
 
   return (
@@ -82,7 +72,7 @@ export default function CompanyVerifyModal({
       ariaLabel="Vérifier l'établissment"
     >
       <div className={styles.VerifyModal}>
-        <h2 className="td-modal-title">Vérifier l'établissment</h2>
+        <h2 className="td-modal-title">Vérifier l'établissement</h2>
         <Formik<Values>
           initialValues={{ verificationComment: "" }}
           onSubmit={onSubmit}


### PR DESCRIPTION
# ETQ admin, je peux vérifier manuellement une entreprise étrangère, après clic sur le bouton, le tableau m'indique la confirmation "vérifié manuellement"

![image](https://user-images.githubusercontent.com/76620/213236952-ed37038a-14f3-40c6-8a5e-6b4a37ba117b.png)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/49eefb86636fffca4759b9bd?card=tra-10690)
