### PR TITLE
BSFF - Restriction sur les champs pouvant être modifiés après signature via `updateBsff`

### DIFF
--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -253,35 +253,48 @@ export function expandBsffFromDB(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
 export function flattenBsffPackagingInput(
   input: GraphQL.UpdateBsffPackagingInput
 ) {
-  return {
-    acceptationDate: input.acceptation?.date,
-    acceptationWeight: input.acceptation?.weight,
-    acceptationStatus: input.acceptation?.status,
-    acceptationRefusalReason: input.acceptation?.refusalReason,
-    acceptationWasteCode: input.acceptation?.wasteCode,
-    acceptationWasteDescription: input.acceptation?.wasteDescription,
-    operationDate: input.operation?.date,
-    operationNoTraceability: input.operation?.noTraceability,
-    operationCode: input.operation?.code,
-    operationDescription: input.operation?.description,
-    operationNextDestinationPlannedOperationCode:
-      input.operation?.nextDestination?.plannedOperationCode,
-    operationNextDestinationCap: input.operation?.nextDestination?.cap,
-    operationNextDestinationCompanyName:
-      input.operation?.nextDestination?.company?.name,
-    operationNextDestinationCompanySiret:
-      input.operation?.nextDestination?.company?.siret,
-    operationNextDestinationCompanyVatNumber:
-      input.operation?.nextDestination?.company?.vatNumber,
-    operationNextDestinationCompanyAddress:
-      input.operation?.nextDestination?.company?.address,
-    operationNextDestinationCompanyContact:
-      input.operation?.nextDestination?.company?.contact,
-    operationNextDestinationCompanyPhone:
-      input.operation?.nextDestination?.company?.phone,
-    operationNextDestinationCompanyMail:
-      input.operation?.nextDestination?.company?.mail
-  };
+  return safeInput({
+    acceptationDate: chain(input.acceptation, a => a.date),
+    acceptationWeight: chain(input.acceptation, a => a.weight),
+    acceptationStatus: chain(input.acceptation, a => a.status),
+    acceptationRefusalReason: chain(input.acceptation, a => a.refusalReason),
+    acceptationWasteCode: chain(input.acceptation, a => a.wasteCode),
+    acceptationWasteDescription: chain(
+      input.acceptation,
+      a => a.wasteDescription
+    ),
+    operationDate: chain(input.operation, o => o.date),
+    operationNoTraceability: chain(input.operation, o => o.noTraceability),
+    operationCode: chain(input.operation, o => o.code),
+    operationDescription: chain(input.operation, o => o.description),
+    operationNextDestinationPlannedOperationCode: chain(input.operation, o =>
+      chain(o.nextDestination, nd => nd.plannedOperationCode)
+    ),
+    operationNextDestinationCap: chain(input.operation, o =>
+      chain(o.nextDestination, nd => nd.cap)
+    ),
+    operationNextDestinationCompanyName: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.name))
+    ),
+    operationNextDestinationCompanySiret: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.siret))
+    ),
+    operationNextDestinationCompanyVatNumber: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.vatNumber))
+    ),
+    operationNextDestinationCompanyAddress: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.address))
+    ),
+    operationNextDestinationCompanyContact: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.contact))
+    ),
+    operationNextDestinationCompanyPhone: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.phone))
+    ),
+    operationNextDestinationCompanyMail: chain(input.operation, o =>
+      chain(o.nextDestination, nd => chain(nd.company, c => c.mail))
+    )
+  });
 }
 
 export function expandBsffPackagingFromDB(

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -301,7 +301,7 @@ describe("Mutation.updateBsff", () => {
         }
       }
     };
-    const { data, errors } = await mutate<
+    const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
     >(UPDATE_BSFF, {
@@ -311,12 +311,12 @@ describe("Mutation.updateBsff", () => {
       }
     });
 
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff.emitter.company).toEqual(
+    expect(errors).toEqual([
       expect.objectContaining({
-        name: bsff.emitterCompanyName
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : emitterCompanyName"
       })
-    );
+    ]);
   });
 
   it("should allow updating waste and quantity if emitter didn't sign", async () => {
@@ -379,7 +379,7 @@ describe("Mutation.updateBsff", () => {
         isEstimate: false
       }
     };
-    const { data, errors } = await mutate<
+    const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
     >(UPDATE_BSFF, {
@@ -389,20 +389,12 @@ describe("Mutation.updateBsff", () => {
       }
     });
 
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff).toEqual(
+    expect(errors).toEqual([
       expect.objectContaining({
-        waste: {
-          code: bsff.wasteCode,
-          description: bsff.wasteDescription,
-          adr: input.waste.adr
-        },
-        weight: {
-          value: bsff.weightValue,
-          isEstimate: bsff.weightIsEstimate
-        }
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : wasteDescription, weightValue"
       })
-    );
+    ]);
   });
 
   it("should not update packagings after emitter signature", async () => {
@@ -417,26 +409,26 @@ describe("Mutation.updateBsff", () => {
 
     const { mutate } = makeClient(emitter.user);
 
-    await mutate<Pick<Mutation, "updateBsff">, MutationUpdateBsffArgs>(
-      UPDATE_BSFF,
-      {
-        variables: {
-          id: bsff.id,
-          input: {
-            packagings: [
-              { type: "BOUTEILLE", weight: 1, volume: 1, numero: "cont2" }
-            ]
-          }
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          packagings: [
+            { type: "BOUTEILLE", weight: 1, volume: 1, numero: "cont2" }
+          ]
         }
       }
-    );
-
-    const updatedBsff = await prisma.bsff.findUnique({
-      where: { id: bsff.id },
-      include: { packagings: true }
     });
 
-    expect(bsff.packagings[0].id).toEqual(updatedBsff.packagings[0].id);
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : packagings"
+      })
+    ]);
   });
 
   it("should allow updating transporter if they didn't sign", async () => {
@@ -493,7 +485,7 @@ describe("Mutation.updateBsff", () => {
         }
       }
     };
-    const { data, errors } = await mutate<
+    const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
     >(UPDATE_BSFF, {
@@ -503,84 +495,12 @@ describe("Mutation.updateBsff", () => {
       }
     });
 
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff.transporter.company).toEqual(
+    expect(errors).toEqual([
       expect.objectContaining({
-        name: bsff.transporterCompanyName
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : transporterCompanyName"
       })
-    );
-  });
-
-  it("should allow updating destination if they didn't sign", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffAfterTransport({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      destination: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
-    const { data, errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff.destination.company).toEqual(
-      expect.objectContaining({ name: input.destination.company.name })
-    );
-  });
-
-  it("should not update a transporter if signed already", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffAfterTransport({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      transporter: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
-    const { data, errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff.transporter.company).toEqual(
-      expect.objectContaining({
-        name: bsff.transporterCompanyName
-      })
-    );
+    ]);
   });
 
   it("should update the list of grouped BSFFs", async () => {

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -383,7 +383,7 @@ describe("Mutation.updateBsff", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés :" +
           " emitterCompanyName, emitterCompanyAddress, emitterCompanyContact, emitterCompanyPhone," +
           " emitterCompanyMail, destinationCompanyName, destinationCompanySiret," +
           " destinationCompanyAddress, destinationCompanyContact, destinationCompanyPhone," +
@@ -460,7 +460,7 @@ describe("Mutation.updateBsff", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés :" +
           " transporterTransportPlates, transporterTransportTakenOverAt"
       })
     ]);
@@ -522,7 +522,7 @@ describe("Mutation.updateBsff", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : destinationReceptionDate"
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés : destinationReceptionDate"
       })
     ]);
   });

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -405,6 +405,40 @@ describe("Mutation.updateBsff", () => {
     );
   });
 
+  it("should not update packagings after emitter signature", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsffAfterEmission({
+      emitter,
+      transporter,
+      destination
+    });
+
+    const { mutate } = makeClient(emitter.user);
+
+    await mutate<Pick<Mutation, "updateBsff">, MutationUpdateBsffArgs>(
+      UPDATE_BSFF,
+      {
+        variables: {
+          id: bsff.id,
+          input: {
+            packagings: [
+              { type: "BOUTEILLE", weight: 1, volume: 1, numero: "cont2" }
+            ]
+          }
+        }
+      }
+    );
+
+    const updatedBsff = await prisma.bsff.findUnique({
+      where: { id: bsff.id },
+      include: { packagings: true }
+    });
+
+    expect(bsff.packagings[0].id).toEqual(updatedBsff.packagings[0].id);
+  });
+
   it("should allow updating transporter if they didn't sign", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const transporter = await userWithCompanyFactory(UserRole.ADMIN);

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -371,8 +371,8 @@ describe("Mutation.updateBsff", () => {
           },
           packagings: [
             {
-              type: BsffPackagingType.BOUTEILLE,
-              numero: "123",
+              type: BsffPackagingType.CITERNE,
+              numero: "updated-numero",
               weight: 1,
               volume: 1
             }
@@ -387,9 +387,17 @@ describe("Mutation.updateBsff", () => {
           " emitterCompanyName, emitterCompanyAddress, emitterCompanyContact, emitterCompanyPhone," +
           " emitterCompanyMail, destinationCompanyName, destinationCompanySiret," +
           " destinationCompanyAddress, destinationCompanyContact, destinationCompanyPhone," +
-          " destinationCompanyMail, wasteCode, wasteDescription, wasteAdr, weightValue, packagings"
+          " destinationCompanyMail, wasteCode, wasteDescription, wasteAdr, weightValue"
       })
     ]);
+
+    const updatedBsff = await prisma.bsff.findUnique({
+      where: { id: bsff.id },
+      include: { packagings: true }
+    });
+
+    // check packagings update has been ignored
+    expect(updatedBsff.packagings[0].numero).toEqual("1234");
   });
 
   test("after emitter signature > it should be possible to update trasport fields", async () => {

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -8,6 +8,7 @@ import { gql } from "apollo-server-core";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { BSFF_WASTE_CODES } from "../../../../common/constants";
 import {
+  BsffOperationCode,
   Mutation,
   MutationUpdateBsffArgs
 } from "../../../../generated/graphql/types";
@@ -28,6 +29,7 @@ import {
   createBsffAfterOperation,
   createBsffAfterTransport,
   createBsffBeforeEmission,
+  createBsffAfterReception,
   createFicheIntervention
 } from "../../../__tests__/factories";
 
@@ -247,168 +249,12 @@ describe("Mutation.updateBsff", () => {
     ]);
   });
 
-  it("should allow updating emitter if they didn't sign", async () => {
+  test("before emitter signature > it should be possible to update any field", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const transporter = await userWithCompanyFactory(UserRole.ADMIN);
     const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffBeforeEmission({
-      emitter,
-      transporter,
-      destination
-    });
-
+    const bsff = await createBsffBeforeEmission({ emitter });
     const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      emitter: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
-    const { data, errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff.emitter.company).toEqual(
-      expect.objectContaining({ name: input.emitter.company.name })
-    );
-  });
-
-  it("should not update emitter if they signed already", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffAfterEmission({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      emitter: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
-    const { errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : emitterCompanyName"
-      })
-    ]);
-  });
-
-  it("should allow updating waste and quantity if emitter didn't sign", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffBeforeEmission({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      waste: {
-        code: BSFF_WASTE_CODES[0],
-        description: "R10",
-        adr: "Mention ADR"
-      },
-      weight: {
-        value: 1,
-        isEstimate: false
-      }
-    };
-    const { data, errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toBeUndefined();
-    expect(data.updateBsff).toEqual(expect.objectContaining(input));
-  });
-
-  it("should not update waste and quantity if emitter signed already", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffAfterEmission({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      waste: {
-        code: BSFF_WASTE_CODES[0],
-        description: "R10",
-        adr: "Mention ADR"
-      },
-      weight: {
-        value: 6,
-        isEstimate: false
-      }
-    };
-    const { errors } = await mutate<
-      Pick<Mutation, "updateBsff">,
-      MutationUpdateBsffArgs
-    >(UPDATE_BSFF, {
-      variables: {
-        id: bsff.id,
-        input
-      }
-    });
-
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : wasteDescription, weightValue"
-      })
-    ]);
-  });
-
-  it("should not update packagings after emitter signature", async () => {
-    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
-    const destination = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsffAfterEmission({
-      emitter,
-      transporter,
-      destination
-    });
-
-    const { mutate } = makeClient(emitter.user);
-
     const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
@@ -416,22 +262,137 @@ describe("Mutation.updateBsff", () => {
       variables: {
         id: bsff.id,
         input: {
+          emitter: {
+            company: {
+              name: emitter.company.name,
+              siret: emitter.company.siret,
+              address: emitter.company.address,
+              contact: emitter.user.name,
+              mail: emitter.user.email,
+              phone: emitter.company.contactPhone
+            }
+          },
+          transporter: {
+            company: {
+              name: transporter.company.name,
+              siret: transporter.company.siret,
+              address: transporter.company.address,
+              contact: transporter.user.name,
+              mail: transporter.user.email,
+              phone: transporter.company.contactPhone
+            }
+          },
+          destination: {
+            company: {
+              name: destination.company.name,
+              siret: destination.company.siret,
+              address: destination.company.address,
+              contact: destination.user.name,
+              mail: destination.user.email,
+              phone: destination.company.contactPhone
+            },
+            plannedOperationCode: "R12" as BsffOperationCode
+          },
+          waste: {
+            code: BSFF_WASTE_CODES[0],
+            adr: "Mention ADR",
+            description: "R410"
+          },
+          weight: {
+            value: 1,
+            isEstimate: true
+          },
           packagings: [
-            { type: "BOUTEILLE", weight: 1, volume: 1, numero: "cont2" }
+            {
+              type: BsffPackagingType.BOUTEILLE,
+              numero: "123",
+              weight: 1,
+              volume: 1
+            }
           ]
         }
       }
     });
+    expect(errors).toBeUndefined();
+  });
 
+  test("after emitter signature > it should not be possible to update sealed fields", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsffAfterEmission({ emitter });
+    const { mutate } = makeClient(emitter.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          emitter: {
+            company: {
+              name: "Émetteur 2",
+              siret: emitter.company.siret,
+              address: "Adresse 2",
+              contact: "Contact 2",
+              mail: "Email 2",
+              phone: "0202020202"
+            }
+          },
+          transporter: {
+            company: {
+              name: "Transporteur 2",
+              siret: transporter.company.siret,
+              address: "Adresse 2",
+              contact: "Contact 2",
+              mail: "Email 2",
+              phone: "0202020202"
+            }
+          },
+          destination: {
+            company: {
+              name: "Destination 2",
+              siret: destination.company.siret,
+              address: "Adresse 2",
+              contact: "COntact 2",
+              mail: "Email 2",
+              phone: "0202020202"
+            },
+            plannedOperationCode: "D10" as BsffOperationCode
+          },
+          waste: {
+            code: "14 06 03*",
+            adr: "ADR",
+            description: "HFC"
+          },
+          weight: {
+            value: 2,
+            isEstimate: false
+          },
+          packagings: [
+            {
+              type: BsffPackagingType.BOUTEILLE,
+              numero: "123",
+              weight: 1,
+              volume: 1
+            }
+          ]
+        }
+      }
+    });
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : packagings"
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          " emitterCompanyName, emitterCompanyAddress, emitterCompanyContact, emitterCompanyPhone," +
+          " emitterCompanyMail, destinationCompanyName, destinationCompanySiret," +
+          " destinationCompanyAddress, destinationCompanyContact, destinationCompanyPhone," +
+          " destinationCompanyMail, wasteCode, wasteDescription, wasteAdr, weightValue, packagings"
       })
     ]);
   });
 
-  it("should allow updating transporter if they didn't sign", async () => {
+  test("after emitter signature > it should be possible to update trasport fields", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const transporter = await userWithCompanyFactory(UserRole.ADMIN);
     const destination = await userWithCompanyFactory(UserRole.ADMIN);
@@ -440,33 +401,28 @@ describe("Mutation.updateBsff", () => {
       transporter,
       destination
     });
-
-    const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      transporter: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
-    const { data, errors } = await mutate<
+    const { mutate } = makeClient(transporter.user);
+    const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
     >(UPDATE_BSFF, {
       variables: {
         id: bsff.id,
-        input
+        input: {
+          transporter: {
+            transport: {
+              takenOverAt: "2022-11-02" as any,
+              mode: "ROAD",
+              plates: ["BG-007-FR"]
+            }
+          }
+        }
       }
     });
-
     expect(errors).toBeUndefined();
-    expect(data.updateBsff.transporter.company).toEqual(
-      expect.objectContaining(input.transporter.company)
-    );
   });
 
-  it("should not update transporter if they signed already", async () => {
+  test("after transporter signature > it should not be possible to update sealed fields", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const transporter = await userWithCompanyFactory(UserRole.ADMIN);
     const destination = await userWithCompanyFactory(UserRole.ADMIN);
@@ -475,30 +431,90 @@ describe("Mutation.updateBsff", () => {
       transporter,
       destination
     });
-
     const { mutate } = makeClient(emitter.user);
-
-    const input = {
-      transporter: {
-        company: {
-          name: "Another name"
-        }
-      }
-    };
     const { errors } = await mutate<
       Pick<Mutation, "updateBsff">,
       MutationUpdateBsffArgs
     >(UPDATE_BSFF, {
       variables: {
         id: bsff.id,
-        input
+        input: {
+          transporter: {
+            transport: {
+              takenOverAt: "2022-11-02" as any,
+              mode: "ROAD",
+              plates: ["BG-007-FR"]
+            }
+          }
+        }
       }
     });
-
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : transporterCompanyName"
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          " transporterTransportPlates, transporterTransportTakenOverAt"
+      })
+    ]);
+  });
+
+  test("after transporter signature > it should be possible to update reception fields", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsffAfterTransport({
+      emitter,
+      transporter,
+      destination
+    });
+    const { mutate } = makeClient(transporter.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          destination: {
+            reception: {
+              date: "2022-11-03" as any
+            }
+          }
+        }
+      }
+    });
+    expect(errors).toBeUndefined();
+  });
+
+  test("after reception signature > it should not be possible to update sealed fields", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsffAfterReception({
+      emitter,
+      transporter,
+      destination
+    });
+    const { mutate } = makeClient(emitter.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          destination: {
+            reception: {
+              date: "2022-11-03" as any
+            }
+          }
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : destinationReceptionDate"
       })
     ]);
   });

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
@@ -6,7 +6,11 @@ import {
 } from "../../../../generated/graphql/types";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
-import { createBsffAfterReception } from "../../../__tests__/factories";
+import {
+  createBsffAfterOperation,
+  createBsffAfterReception,
+  createBsffBeforeOperation
+} from "../../../__tests__/factories";
 import prisma from "../../../../prisma";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 
@@ -21,7 +25,7 @@ const UPDATE_BSFF_PACKAGING = gql`
 describe("Mutation.updateBsffPackaging", () => {
   afterEach(resetDatabase);
 
-  it("should update a bsff packaging", async () => {
+  test("before acceptation > it should be possible to update acceptation fields", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
@@ -90,6 +94,185 @@ describe("Mutation.updateBsffPackaging", () => {
       expect.objectContaining({
         message:
           "Seul le destinataire du BSFF peut modifier les informations d'acceptation et d'opération sur un contenant"
+      })
+    ]);
+  });
+
+  test("before acceptation > it should be possible to update acceptation fields", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsffAfterReception({
+      emitter,
+      transporter,
+      destination
+    });
+
+    const packagingId = bsff.packagings[0].id;
+
+    const { mutate } = makeClient(destination.user);
+    await mutate<
+      Pick<Mutation, "updateBsffPackaging">,
+      MutationUpdateBsffPackagingArgs
+    >(UPDATE_BSFF_PACKAGING, {
+      variables: {
+        id: packagingId,
+        input: {
+          acceptation: {
+            date: "2022-11-04" as any,
+            weight: 1,
+            status: "ACCEPTED",
+            wasteCode: "14 06 01*",
+            wasteDescription: "R404A"
+          }
+        }
+      }
+    });
+
+    const updatedPackaging = await prisma.bsffPackaging.findUnique({
+      where: { id: packagingId }
+    });
+    expect(updatedPackaging.acceptationStatus).toEqual(
+      WasteAcceptationStatus.ACCEPTED
+    );
+  });
+
+  test("after acceptation > it should not be possible to update sealed fields", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsffBeforeOperation({
+      emitter,
+      transporter,
+      destination
+    });
+
+    const packagingId = bsff.packagings[0].id;
+
+    const { mutate } = makeClient(destination.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsffPackaging">,
+      MutationUpdateBsffPackagingArgs
+    >(UPDATE_BSFF_PACKAGING, {
+      variables: {
+        id: packagingId,
+        input: {
+          acceptation: {
+            date: "2022-11-04" as any,
+            weight: 2,
+            status: "ACCEPTED",
+            wasteCode: "14 06 02*",
+            wasteDescription: "HFC"
+          }
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés" +
+          " : acceptationDate, acceptationWeight, acceptationWasteCode, acceptationWasteDescription"
+      })
+    ]);
+  });
+
+  test("before operation > it should be possible to update operation fields", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+    const nextDestination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsffBeforeOperation({
+      emitter,
+      transporter,
+      destination
+    });
+
+    const packagingId = bsff.packagings[0].id;
+
+    const { mutate } = makeClient(destination.user);
+    await mutate<
+      Pick<Mutation, "updateBsffPackaging">,
+      MutationUpdateBsffPackagingArgs
+    >(UPDATE_BSFF_PACKAGING, {
+      variables: {
+        id: packagingId,
+        input: {
+          operation: {
+            date: "2022-11-05" as any,
+            code: "D13",
+            description: "Regroupement",
+            nextDestination: {
+              plannedOperationCode: "R2",
+              cap: "CAP 2",
+              company: {
+                siret: nextDestination.company.siret,
+                name: "Traiteur & Co",
+                address: "1 avenue des roses 67100 Strasbourg",
+                contact: "Thomas Largeron",
+                phone: "03 00 00 00 00",
+                mail: "thomas.largeron@traiteur.fr"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const updatedPackaging = await prisma.bsffPackaging.findUnique({
+      where: { id: packagingId }
+    });
+    expect(updatedPackaging.operationCode).toEqual("D13");
+  });
+
+  test("after operation > it should not be possible to update sealed fields", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+    const nextDestination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsffAfterOperation({
+      emitter,
+      transporter,
+      destination
+    });
+
+    const packagingId = bsff.packagings[0].id;
+
+    const { mutate } = makeClient(destination.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsffPackaging">,
+      MutationUpdateBsffPackagingArgs
+    >(UPDATE_BSFF_PACKAGING, {
+      variables: {
+        id: packagingId,
+        input: {
+          operation: {
+            date: "2022-11-05" as any,
+            code: "D13",
+            description: "Regroupement",
+            nextDestination: {
+              plannedOperationCode: "R2",
+              cap: "CAP 2",
+              company: {
+                siret: nextDestination.company.siret,
+                name: "Traiteur & Co",
+                address: "1 avenue des roses 67100 Strasbourg",
+                contact: "Thomas Largeron",
+                phone: "03 00 00 00 00",
+                mail: "thomas.largeron@traiteur.fr"
+              }
+            }
+          }
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          " operationDate, operationCode, operationDescription, operationNextDestinationPlannedOperationCode," +
+          " operationNextDestinationCap, operationNextDestinationCompanyName, operationNextDestinationCompanySiret," +
+          " operationNextDestinationCompanyAddress, operationNextDestinationCompanyContact," +
+          " operationNextDestinationCompanyPhone, operationNextDestinationCompanyMail"
       })
     ]);
   });

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
@@ -170,7 +170,7 @@ describe("Mutation.updateBsffPackaging", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés" +
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés" +
           " : acceptationDate, acceptationWeight, acceptationWasteCode, acceptationWasteDescription"
       })
     ]);
@@ -268,7 +268,7 @@ describe("Mutation.updateBsffPackaging", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été vérouillés via signature et ne peuvent plus être modifiés :" +
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés :" +
           " operationDate, operationCode, operationDescription, operationNextDestinationPlannedOperationCode," +
           " operationNextDestinationCap, operationNextDestinationCompanyName, operationNextDestinationCompanySiret," +
           " operationNextDestinationCompanyAddress, operationNextDestinationCompanyContact," +

--- a/back/src/bsffs/resolvers/mutations/updateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsff.ts
@@ -1,5 +1,4 @@
 import { ForbiddenError, UserInputError } from "apollo-server-express";
-import omit from "object.omit";
 import { Prisma, BsffType } from "@prisma/client";
 import {
   BsffSignatureType,
@@ -56,7 +55,7 @@ const updateBsff: MutationResolvers["updateBsff"] = async (
     );
   }
 
-  const flatInput = { ...flattenBsffInput(input) };
+  const flatInput = flattenBsffInput(input);
 
   const sealedFieldErrors: string[] = [];
 
@@ -238,7 +237,7 @@ type EditableFields = keyof Omit<
  * Defines until which signature editable fields can be modified
  * The typing Record<EditableFields, BsffSignatureType> ensure that
  * the typing will break anytime we add a field to the Bsff model so that
- * we think of adding ther new field edition rule
+ * we think of adding a new edition rule
  */
 const editionRules: Record<EditableFields, BsffSignatureType> = {
   type: "EMISSION",

--- a/back/src/bsffs/resolvers/mutations/updateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsff.ts
@@ -254,7 +254,7 @@ const editableFieldsAfterTransport = editableFieldsAfterEmission.filter(
 export class SealedFieldError extends ForbiddenError {
   constructor(fields: string[]) {
     super(
-      `Des champs ont été vérouillés via signature et ne peuvent plus être modifiés : ${fields.join(
+      `Des champs ont été verrouillés via signature et ne peuvent plus être modifiés : ${fields.join(
         ", "
       )}`
     );

--- a/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
@@ -51,7 +51,7 @@ const updateBsffPackaging: MutationResolvers["updateBsffPackaging"] = async (
 
   if (existingBsffPackaging.operationSignatureDate) {
     // do not allow any fields to be updated after operation signature
-    for (const field in Object.keys(flatInput)) {
+    for (const field of Object.keys(flatInput)) {
       sealedFieldErrors.push(field);
     }
   }
@@ -123,5 +123,5 @@ const editionRules: Record<EditableFields, BsffSignatureType> = {
 const editableFields = Object.keys(editionRules) as string[];
 
 const editableFieldsAfterAcceptation = editableFields.filter(
-  field => editionRules[field] !== "OPERATION"
+  field => editionRules[field] !== "ACCEPTATION"
 );

--- a/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
@@ -1,4 +1,7 @@
-import { MutationResolvers } from "../../../generated/graphql/types";
+import {
+  BsffSignatureType,
+  MutationResolvers
+} from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import {
   flattenBsffPackagingInput,
@@ -8,6 +11,8 @@ import { getBsffPackagingOrNotFound } from "../../database";
 import { getCachedUserSiretOrVat } from "../../../common/redis/users";
 import { UserInputError } from "apollo-server-core";
 import { getBsffPackagingRepository } from "../../repository";
+import { Prisma } from "@prisma/client";
+import { SealedFieldError } from "./updateBsff";
 
 const updateBsffPackaging: MutationResolvers["updateBsffPackaging"] = async (
   _,
@@ -29,16 +34,94 @@ const updateBsffPackaging: MutationResolvers["updateBsffPackaging"] = async (
     );
   }
 
+  const flatInput = flattenBsffPackagingInput(input);
+
+  const sealedFieldErrors: string[] = [];
+
+  if (existingBsffPackaging.acceptationSignatureDate) {
+    for (const field of Object.keys(flatInput)) {
+      if (
+        !editableFieldsAfterAcceptation.includes(field) &&
+        existingBsffPackaging[field] !== flatInput[field]
+      ) {
+        sealedFieldErrors.push(field);
+      }
+    }
+  }
+
+  if (existingBsffPackaging.operationSignatureDate) {
+    // do not allow any fields to be updated after operation signature
+    for (const field in Object.keys(flatInput)) {
+      sealedFieldErrors.push(field);
+    }
+  }
+
+  if (sealedFieldErrors.length > 0) {
+    throw new SealedFieldError(sealedFieldErrors);
+  }
+
   const { update: updateBsffPackaging } = getBsffPackagingRepository(
     context.user
   );
 
   const updatedBsffPackaging = await updateBsffPackaging({
     where: { id },
-    data: flattenBsffPackagingInput(input)
+    data: flatInput
   });
 
   return expandBsffPackagingFromDB(updatedBsffPackaging);
 };
 
 export default updateBsffPackaging;
+
+// Fields that can be updated via `updateBsffPackaging`
+type EditableFields = keyof Omit<
+  Prisma.BsffPackagingUpdateInput,
+  | "id"
+  | "type"
+  | "other"
+  | "volume"
+  | "weight"
+  | "numero"
+  | "bsff"
+  | "nextPackaging"
+  | "previousPackagings"
+  | "acceptationSignatureAuthor"
+  | "acceptationSignatureDate"
+  | "operationSignatureAuthor"
+  | "operationSignatureDate"
+>;
+
+/**
+ * Defines until which signature editable fields can be modified
+ * The typing Record<EditableFields, BsffSignatureType> ensure that
+ * the typing will break anytime we add a field to the BsffPackaging model so that
+ * we think of adding ther new field edition rule
+ */
+const editionRules: Record<EditableFields, BsffSignatureType> = {
+  acceptationDate: "ACCEPTATION",
+  acceptationStatus: "ACCEPTATION",
+  acceptationWeight: "ACCEPTATION",
+  acceptationRefusalReason: "ACCEPTATION",
+  acceptationWasteCode: "ACCEPTATION",
+  acceptationWasteDescription: "ACCEPTATION",
+  operationDate: "OPERATION",
+  operationCode: "OPERATION",
+  operationDescription: "OPERATION",
+  operationNoTraceability: "OPERATION",
+  operationNextDestinationPlannedOperationCode: "OPERATION",
+  operationNextDestinationCap: "OPERATION",
+  operationNextDestinationCompanyName: "OPERATION",
+  operationNextDestinationCompanySiret: "OPERATION",
+  operationNextDestinationCompanyVatNumber: "OPERATION",
+  operationNextDestinationCompanyAddress: "OPERATION",
+  operationNextDestinationCompanyContact: "OPERATION",
+  operationNextDestinationCompanyPhone: "OPERATION",
+  operationNextDestinationCompanyMail: "OPERATION"
+};
+
+const editableFields = Object.keys(editionRules) as string[];
+
+const editableFieldsAfterAcceptation = editableFields.filter(
+  field => editionRules[field] !== "OPERATION"
+);

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/BsffActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/BsffActions.tsx
@@ -93,7 +93,7 @@ export const BsffActions = ({ form }: BsffActionsProps) => {
                 <IconPdf size="24px" color="blueLight" />
                 Pdf
               </MenuItem>
-              {![BsffStatus.Processed, BsffStatus.Refused].includes(
+              {[BsffStatus.Initial, BsffStatus.SignedByEmitter].includes(
                 form.bsffStatus
               ) &&
                 canWrite && (

--- a/front/src/form/bsff/Destination.tsx
+++ b/front/src/form/bsff/Destination.tsx
@@ -41,7 +41,12 @@ export default function Destination({ disabled }) {
       <div className="form__row">
         <label>
           Numéro de CAP (optionnel)
-          <Field type="text" name="destination.cap" className="td-input" />
+          <Field
+            type="text"
+            name="destination.cap"
+            disabled={disabled}
+            className="td-input"
+          />
         </label>
       </div>
     </>

--- a/front/src/form/bsff/Emitter.tsx
+++ b/front/src/form/bsff/Emitter.tsx
@@ -89,6 +89,7 @@ export default function Emitter({ disabled }) {
                   )
                 )
               }
+              disabled={disabled}
             />
           )}
         />

--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -283,6 +283,7 @@ interface FicheInterventionListProps {
   initialOperateurCompany: BsffFicheInterventionInput["operateur"]["company"];
   onAddFicheIntervention: (ficheIntervention: BsffFicheIntervention) => void;
   onRemoveFicheIntervention: (ficheIntervention: BsffFicheIntervention) => void;
+  disabled: boolean;
 }
 
 export function FicheInterventionList({
@@ -291,6 +292,7 @@ export function FicheInterventionList({
   initialOperateurCompany,
   onAddFicheIntervention,
   onRemoveFicheIntervention,
+  disabled,
 }: FicheInterventionListProps) {
   const [isModalOpen, setIsModalOpen] = React.useState(false);
 
@@ -364,33 +366,34 @@ export function FicheInterventionList({
           </div>
         </div>
       ))}
+      {!disabled && (
+        <button
+          type="button"
+          className="btn btn--outline-primary"
+          onClick={() => {
+            companySchema
+              .validate(initialOperateurCompany)
+              .then(() => {
+                if (ficheInterventions.length >= max) {
+                  window.alert(
+                    `Vous ne pouvez pas ajouter plus de ${max} fiche(s) d'intervention avec ce type de BSFF.`
+                  );
+                  return;
+                }
 
-      <button
-        type="button"
-        className="btn btn--outline-primary"
-        onClick={() => {
-          companySchema
-            .validate(initialOperateurCompany)
-            .then(() => {
-              if (ficheInterventions.length >= max) {
+                setIsModalOpen(true);
+              })
+              .catch(() => {
                 window.alert(
-                  `Vous ne pouvez pas ajouter plus de ${max} fiche(s) d'intervention avec ce type de BSFF.`
+                  `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
                 );
                 return;
-              }
-
-              setIsModalOpen(true);
-            })
-            .catch(() => {
-              window.alert(
-                `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
-              );
-              return;
-            });
-        }}
-      >
-        Ajouter une fiche d'intervention
-      </button>
+              });
+          }}
+        >
+          Ajouter une fiche d'intervention
+        </button>
+      )}
 
       {isModalOpen && (
         <AddFicheInterventionModal

--- a/front/src/form/bsff/WasteInfo.tsx
+++ b/front/src/form/bsff/WasteInfo.tsx
@@ -70,7 +70,12 @@ export default function WasteInfo({ disabled }) {
       <div className="form__row">
         <label>
           Code déchet
-          <Field as="select" name="waste.code" className="td-select">
+          <Field
+            as="select"
+            name="waste.code"
+            className="td-select"
+            disabled={disabled}
+          >
             <option />
             {BSFF_WASTES.map(item => (
               <option value={item.code} key={item.code}>


### PR DESCRIPTION
- Amélioration de la mutation `updateBsff` pour ne pas autoriser la modification de champs scellés par signature.
- Désactive certains inputs front lorsqu'il y a déjà eu des signatures.

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [[Bug] BSFF : le bouton d'ajout de FI laisse croire, à tort, qu'on peut ajouter une FI après signature du BSFF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10733)
- [BSFF - Il ne devrait pas être possible de modifier les contenants après signature de l'émetteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10735)
