### PR TITLE
[TRA-10777] Le takenOverAt dans les formulaires transporteurs BSDD & BSVHU devrait se mettre à jour

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -24,8 +24,6 @@ import { GET_FORM } from "form/bsdd/utils/queries";
 import Loader from "common/components/Loaders";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 
-const TODAY = new Date();
-
 const SIGN_TRANSPORT_FORM = gql`
   mutation SignTransportForm(
     $id: ID!
@@ -39,20 +37,21 @@ const SIGN_TRANSPORT_FORM = gql`
   ${fullFormFragment}
 `;
 
-const validationSchema = yup.object({
-  takenOverAt: yup
-    .date()
-    .required("La date de prise en charge est requise")
-    .max(TODAY, "La date de prise en charge ne peut être dans le futur"),
-  takenOverBy: yup
-    .string()
-    .ensure()
-    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  securityCode: yup
-    .string()
-    .nullable()
-    .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
-});
+const getValidationSchema = (today: Date) =>
+  yup.object({
+    takenOverAt: yup
+      .date()
+      .required("La date de prise en charge est requise")
+      .max(today, "La date de prise en charge ne peut être dans le futur"),
+    takenOverBy: yup
+      .string()
+      .ensure()
+      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+    securityCode: yup
+      .string()
+      .nullable()
+      .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
+  });
 interface SignTransportFormModalProps {
   title: string;
   siret: string;
@@ -90,6 +89,12 @@ function SignTransportFormModal({
     );
   }
   const form = data?.form;
+
+  const TODAY = new Date();
+  const validationSchema = getValidationSchema(TODAY);
+
+  console.log("TODAY", TODAY);
+
   return (
     <Modal onClose={onClose} ariaLabel={title} isOpen>
       <h2 className="td-modal-title">{title}</h2>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportForm.tsx
@@ -93,8 +93,6 @@ function SignTransportFormModal({
   const TODAY = new Date();
   const validationSchema = getValidationSchema(TODAY);
 
-  console.log("TODAY", TODAY);
-
   return (
     <Modal onClose={onClose} ariaLabel={title} isOpen>
       <h2 className="td-modal-title">{title}</h2>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -16,18 +16,17 @@ import { generatePath, Link } from "react-router-dom";
 import * as yup from "yup";
 import { SignBsvhu, SIGN_BSVHU } from "./SignBsvhu";
 
-const TODAY = new Date();
-
-const validationSchema = yup.object({
-  takenOverAt: yup
-    .date()
-    .required("La date de prise en charge est requise")
-    .max(TODAY, "La date de prise en charge ne peut être dans le futur"),
-  author: yup
-    .string()
-    .ensure()
-    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-});
+const getValidationSchema = (today: Date) =>
+  yup.object({
+    takenOverAt: yup
+      .date()
+      .required("La date de prise en charge est requise")
+      .max(today, "La date de prise en charge ne peut être dans le futur"),
+    author: yup
+      .string()
+      .ensure()
+      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+  });
 
 type Props = { siret: string; bsvhuId: string };
 export function SignTransport({ siret, bsvhuId }: Props) {
@@ -43,6 +42,9 @@ export function SignTransport({ siret, bsvhuId }: Props) {
     );
 
   const loading = loadingUpdate || loadingSign;
+
+  const TODAY = new Date();
+  const validationSchema = getValidationSchema(TODAY);
 
   return (
     <SignBsvhu title="Signer l'enlèvement" bsvhuId={bsvhuId}>

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -43,13 +43,13 @@ export function SignTransport({ siret, bsvhuId }: Props) {
 
   const loading = loadingUpdate || loadingSign;
 
-  const TODAY = new Date();
-  const validationSchema = getValidationSchema(TODAY);
-
   return (
     <SignBsvhu title="Signer l'enlèvement" bsvhuId={bsvhuId}>
-      {({ bsvhu, onClose }) =>
-        bsvhu.metadata?.errors.some(
+      {({ bsvhu, onClose }) => {
+        const TODAY = new Date();
+        const validationSchema = getValidationSchema(TODAY);
+
+        return bsvhu.metadata?.errors.some(
           error => error.requiredFor === SignatureTypeInput.Transport
         ) ? (
           <>
@@ -169,8 +169,8 @@ export function SignTransport({ siret, bsvhuId }: Props) {
               </Form>
             )}
           </Formik>
-        )
-      }
+        );
+      }}
     </SignBsvhu>
   );
 }


### PR DESCRIPTION
# Contexte

Cette PR corrige un bug remonté où la date de signature du transporteur, dans les formulaires BSDD & BSVHU, ne se met pas à jour. Aussi longtemps qu'un transporteur garde son application ouverte, la date ne changera pas (à moins qu'il ne la change manuellement).

Solution: rendre la date dynamique, à minima à chaque ouverture de la fenêtre de signature transporteur

# Ticket Favro

[[Bug] La date du jour dans la modale Transporteur devrait s'actualiser et non reprendre une date antérieure si mon appli était déjà ouverte hier (BSDD, et sûrement BSVHU)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10777)
