### PR TITLE
[TRA-10777] Le takenOverAt dans les formulaires transporteurs BSFF devrait se mettre à jour

### DIFF
--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -17,18 +17,17 @@ import { SignBsff } from "./SignBsff";
 import { GET_BSDS } from "common/queries";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 
-const TODAY = new Date();
-
-const validationSchema = yup.object({
-  takenOverAt: yup
-    .date()
-    .required("La date de prise en charge est requise")
-    .max(TODAY, "La date de prise en charge ne peut être dans le futur"),
-  signatureAuthor: yup
-    .string()
-    .ensure()
-    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-});
+const getValidationSchema = (today: Date) =>
+  yup.object({
+    takenOverAt: yup
+      .date()
+      .required("La date de prise en charge est requise")
+      .max(today, "La date de prise en charge ne peut être dans le futur"),
+    signatureAuthor: yup
+      .string()
+      .ensure()
+      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+  });
 
 interface SignTransportFormProps {
   bsff: Bsff;
@@ -45,6 +44,9 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
   >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+
+  const TODAY = new Date();
+  const validationSchema = getValidationSchema(TODAY);
 
   return (
     <Formik


### PR DESCRIPTION
# Contexte

Cette PR corrige un bug remonté où la date de signature du transporteur, dans les formulaires BSFF, ne se met pas à jour. Aussi longtemps qu'un transporteur garde son application ouverte, la date ne changera pas (à moins qu'il ne la change manuellement).

Solution: rendre la date dynamique, à minima à chaque ouverture de la fenêtre de signature transporteur

# Ticket Favro

- [[Bug] La date du jour dans la modale Transporteur devrait s'actualiser et non reprendre une date antérieure si mon appli était déjà ouverte hier (BSDD, et sûrement BSVHU)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10777)
