### PR TITLE
Ajoute des champs au scope company du token openid connect

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Ajout de champs au scope company sur le token openId connect [PR 2080](https://github.com/MTES-MCT/trackdechets/pull/2080)
+
 #### :memo: Documentation
 
 - Ajoute les statuts Bsda à la documentation technique [PR 2129](https://github.com/MTES-MCT/trackdechets/pull/2129)

--- a/back/src/__tests__/oidc.integration.ts
+++ b/back/src/__tests__/oidc.integration.ts
@@ -10,7 +10,7 @@ import {
   userFactory,
   userWithCompanyFactory
 } from "./factories";
-
+import { CompanyVerificationStatus } from "@prisma/client";
 import * as jose from "jose";
 
 const request = supertest(app);
@@ -517,7 +517,10 @@ describe("/oidc/token - id/secret auth", () => {
     const application = await applicationFactory(true);
 
     const { user, company } = await userWithCompanyFactory("ADMIN", {
-      vatNumber: "BE0541696005"
+      vatNumber: "ES0541696002",
+      name: "the company",
+      givenName: "happy company",
+      verificationStatus: CompanyVerificationStatus.TO_BE_VERIFIED
     });
 
     const code = getUid(16);
@@ -566,7 +569,16 @@ describe("/oidc/token - id/secret auth", () => {
     expect(payload.name).toBe(undefined);
     expect(payload.phone).toBe(undefined);
     expect(payload.companies).toEqual([
-      { role: "ADMIN", siret: company.siret, vat_number: company.vatNumber }
+      {
+        role: "ADMIN",
+        id: company.id,
+        siret: company.siret,
+        vat_number: "ES0541696002",
+        name: "the company",
+        given_name: "happy company",
+        types: ["PRODUCER", "TRANSPORTER", "WASTEPROCESSOR"],
+        verified: false
+      }
     ]);
   });
 
@@ -996,7 +1008,9 @@ describe("/oidc/token - basic auth", () => {
     const application = await applicationFactory(true);
 
     const { user, company } = await userWithCompanyFactory("ADMIN", {
-      vatNumber: "BE0541696002"
+      vatNumber: "BE0541696002",
+      name: "the company",
+      givenName: "happy company"
     });
 
     const code = getUid(16);
@@ -1048,7 +1062,16 @@ describe("/oidc/token - basic auth", () => {
     expect(payload.name).toBe(undefined);
     expect(payload.phone).toBe(undefined);
     expect(payload.companies).toEqual([
-      { role: "ADMIN", siret: company.siret, vat_number: company.vatNumber }
+      {
+        role: "ADMIN",
+        id: company.id,
+        siret: company.siret,
+        vat_number: "BE0541696002",
+        name: "the company",
+        given_name: "happy company",
+        types: ["PRODUCER", "TRANSPORTER", "WASTEPROCESSOR"],
+        verified: true
+      }
     ]);
   });
 

--- a/back/src/oauth/token.ts
+++ b/back/src/oauth/token.ts
@@ -2,8 +2,9 @@ import { getUid } from "../utils";
 import * as jose from "jose";
 import { Grant, Application, User } from "@prisma/client";
 import prisma from "../prisma";
-
 import { EMAIL_SCOPE, PROFILE_SCOPE, COMPANIES_SCOPE } from "./scopes";
+import { CompanyVerificationStatus } from "@prisma/client";
+
 const { OIDC_PRIVATE_KEY } = process.env;
 
 const TOKEN_SIGNATURE_ALG = "RS256";
@@ -16,9 +17,15 @@ const getCompanies = async userId => {
   });
 
   return associations.map(asso => ({
+    id: asso.company.id,
     role: asso.role,
     siret: asso.company.siret,
-    vat_number: asso.company.vatNumber
+    name: asso.company.name,
+    given_name: asso.company.givenName,
+    vat_number: asso.company.vatNumber,
+    types: asso.company.companyTypes,
+    verified:
+      asso.company.verificationStatus === CompanyVerificationStatus.VERIFIED
   }));
 };
 

--- a/back/src/oauth/token.ts
+++ b/back/src/oauth/token.ts
@@ -1,9 +1,13 @@
 import { getUid } from "../utils";
 import * as jose from "jose";
-import { Grant, Application, User } from "@prisma/client";
+import {
+  Grant,
+  Application,
+  User,
+  CompanyVerificationStatus
+} from "@prisma/client";
 import prisma from "../prisma";
 import { EMAIL_SCOPE, PROFILE_SCOPE, COMPANIES_SCOPE } from "./scopes";
-import { CompanyVerificationStatus } from "@prisma/client";
 
 const { OIDC_PRIVATE_KEY } = process.env;
 

--- a/doc/docs/guides/openidconnect.md
+++ b/doc/docs/guides/openidconnect.md
@@ -102,23 +102,46 @@ La requête doit être authentifiée, 2 méthodes sont possibles:
 - (E) Si la requête est valide et autorisée, le serveur d'autorisation émet un jeton d'identité (ID token). Par exemple
 
 ```
-{
-  name: 'Jean Dupont',
-  phone: '06876543',
-  email: 'foo@barr.fr',
+ {
+  name: "Jean Dupont",
+  phone: "06876543",
+  email: "foo@barr.fr",
   email_verified: true,
   companies: [
-    { role: 'ADMIN', siret: '1234', vat_number: null },
-    { role: 'ADMIN', siret: '5678', vat_number: null },
+    {
+      id: "wxcgh123",
+      role: "ADMIN",
+      siret: "1234",
+      vat_number: null,
+      name: "une entreprise A",
+      given_name: "Succursale Marseille",
+      types: ["PRODUCER"],
+      verified: true
+    },
+
+    {
+      id: "mlkj953",
+      role: "MEMBER",
+      siret: "9876",
+      vat_number: null,
+      name: "une entreprise B",
+      given_name: "Succursale Rouen",
+      types: ["COLLECTOR", "WASTEPROCESSOR"],
+      verified: false
+    }
   ],
-  nonce: 'CYCTdEHKQAqB2ahOVWiOFSMbjdxUhGBb',
+  nonce: "CYCTdEHKQAqB2ahOVWiOFSMbjdxUhGBb",
   iat: 1672650576,
-  iss: 'trackdechets',
-  aud: 'your-app',
+  iss: "trackdechets",
+  aud: "your-app",
   exp: 1672654176,
-  sub: 'ck03yr7q000di0728m7uwhc1i'
-}
+  sub: "ck03yr7q000di0728m7uwhc1i"
+};
 ```
+
+:::caution
+Le champ `sub`correspond à l'User Id de Trackdéchets
+:::
 
 :::caution
 Le token est signé via une clef RSA, il est indispensable de vérifier sa signature l'audience (aud) et issuer (iss) grâce à la clef publique.
@@ -137,7 +160,15 @@ Trackdéchets implémente 3 valeurs standard et une valeur spécifique:
 - openid : obligatoire, requête le `sub`, l'id de l'utilisateur
 - email : requête email et email_verified
 - profile : requête name & phone
-- companies : requête la liste des entreprises de l'utilisateur (role, siret et vat_number si disponible)
+- companies : requête la liste des établissements de l'utilisateur :
+    - id: identifiant unique au sein de Trackdéchets
+    - role : rôle de l'utilisateur, MEMBER ou ADMIN au sein de l'établissement
+    - siret : siret à 14 chiffres pour les entreprises françaises
+    - name : dénomination officielle de l'établissement
+    - given_name : nom usuel donné par l'admin de l'établissement
+    - types : CompanyTypes de l'établissement (eg. ["PRODUCER", "TRANSPORTER", "WASTEPROCESSOR"])
+    - vat_number : numéro de tva si disponible, utilisé pour identifier les entreprises étrangères
+    - verified: true|false, précise si l'établissement est vérifié (la vérification n'est effectuée que sur certains type d'établissements )
 
 :::tip
 Une application Openid de démonstration a été créée à l'adresse [https://openid-demo.trackdechets.beta.gouv.fr/](https://openid-demo.trackdechets.beta.gouv.fr/)


### PR DESCRIPTION
Ajoute les champs demandés par le BRGM au scope company du token d'ID 
 - id: company.id,
 -  name: company.name,
 -  givenName: givenName,
 - types:company.companyTypes
 - verified : établissement vérifié ou non

La maj de la demo est disponible sur une branche dédiée : https://github.com/MTES-MCT/trackdechets-openidconnect-demo/tree/mod/new-company-token-fields

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10661)
