### PR TITLE
Dénormalisation Bsdasri

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-[2023.2.1] 21/02/2023
+# [2023.2.1] 21/02/2023
 #### :rocket: Nouvelles fonctionnalités
 
 #### :bug: Corrections de bugs
@@ -19,7 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajoute les statuts Bsda à la documentation technique [PR 2129](https://github.com/MTES-MCT/trackdechets/pull/2129)
 
 #### :house: Interne
-
+- Dénormalisation du bsdasri [PR 2090](https://github.com/MTES-MCT/trackdechets/pull/2090)
 
 # [2023.1.4] 31/01/2023
 

--- a/back/prisma/migrations/119_dasri_denormalized_sirets.sql
+++ b/back/prisma/migrations/119_dasri_denormalized_sirets.sql
@@ -1,0 +1,7 @@
+ALTER TABLE
+    "default$default"."Bsdasri"
+ADD
+    COLUMN "synthesisEmitterSirets" text[] DEFAULT '{}';
+
+-- GIN index for array
+CREATE INDEX IF NOT EXISTS "_BsdasriSynthesisEmitterSiretsIdx" ON "default$default"."Bsdasri" USING GIN ("synthesisEmitterSirets");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -405,6 +405,7 @@ model Form {
 
   // partial index _FormIsDeletedIdx see migration82_missing_indices.sql
   // partial index _FormRecipientIsTempStorageIdx see 99_add_form_indices.sql
+  // gin indices see 104_denormalize_indexes.sql
 
   @@index([emitterCompanySiret], map: "_FormEmitterCompanySiretIdx")
   @@index([recipientCompanySiret], map: "_FormRecipientCompanySiretIdx")
@@ -994,7 +995,11 @@ model Bsdasri {
   synthesizedIn                               Bsdasri?                @relation("BsdasriSynthesizing", fields: [synthesizedInId], references: [id])
   synthesizedInId                             String?
 
+  // Denormalized fields, storing associated dasri sirets to speed up some queries
+  synthesisEmitterSirets String[] @default([])
+
   // partial indices _BsdasriTypeIdx, _BsdasriIsDraftIdx, _BsdasriIsDeletedIdx see migration82_missing_indices.sql
+  // gin index see 119_dasri_denormalized_sirets.sql
 
   @@index([emitterCompanySiret], map: "_BsdasriEmitterCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsdasriTransporterCompanySiretIdx")

--- a/back/prisma/scripts/denormalize-dasris.ts
+++ b/back/prisma/scripts/denormalize-dasris.ts
@@ -1,0 +1,35 @@
+import prisma from "../../src/prisma";
+import { registerUpdater, Updater } from "./helper/helper";
+
+@registerUpdater(
+  "Denormalize dasris",
+  "Denormalize synthesis dasris by caching child bsd emitter sirets",
+  true
+)
+export class UpdateBsdasrisSyntesizedEmitters implements Updater {
+  async run() {
+    console.info("Denormalize dasris...");
+    const synthesizedBsdasris = await prisma.bsdasri.findMany({
+      where: { type: "SYNTHESIS" },
+      include: { synthesizing: true }
+    });
+
+    for (const bsd of synthesizedBsdasris) {
+      if (!bsd.synthesizing?.length) {
+        continue;
+      }
+
+      await prisma.bsdasri.update({
+        where: { id: bsd.id },
+        data: {
+          synthesisEmitterSirets: [
+            ...new Set(
+              bsd.synthesizing.map(associated => associated.emitterCompanySiret)
+            )
+          ].filter(Boolean)
+        }
+      });
+    }
+    console.info("All done.");
+  }
+}

--- a/back/src/bsdasris/__tests__/factories.integration.ts
+++ b/back/src/bsdasris/__tests__/factories.integration.ts
@@ -1,6 +1,10 @@
 import { resetDatabase } from "../../../integration-tests/helper";
-import { bsdasriFactory } from "./factories";
-
+import { bsdasriFactory, initialData } from "./factories";
+import { BsdasriType } from "@prisma/client";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../__tests__/factories";
 describe("Test Factories", () => {
   afterEach(resetDatabase);
 
@@ -12,5 +16,28 @@ describe("Test Factories", () => {
     expect(dasri.id).toBeTruthy();
     expect(dasri.status).toEqual("INITIAL");
     expect(dasri.isDraft).toEqual(false);
+  });
+
+  test("should denormalize synthesis bsdasri", async () => {
+    const { company: initialCompany } = await userWithCompanyFactory("MEMBER");
+
+    const mainCompany = await companyFactory();
+
+    const initialBsdasri = await bsdasriFactory({
+      opt: {
+        ...initialData(initialCompany)
+      }
+    });
+    const synthesisBsdasri = await bsdasriFactory({
+      opt: {
+        type: BsdasriType.SYNTHESIS,
+        ...initialData(mainCompany),
+        synthesizing: { connect: [{ id: initialBsdasri.id }] }
+      }
+    });
+
+    expect(synthesisBsdasri.synthesisEmitterSirets).toEqual([
+      initialCompany.siret
+    ]);
   });
 });

--- a/back/src/bsdasris/__tests__/permissions.integration.ts
+++ b/back/src/bsdasris/__tests__/permissions.integration.ts
@@ -65,6 +65,7 @@ describe("Dasri permission helpers", () => {
       expect(err.extensions.code).toEqual(ErrorCode.FORBIDDEN);
     }
   });
+
   it("should grant synthesis dasri reading access to user whose siret is emitter on the associated form", async () => {
     const { user, company: initialCompany } = await userWithCompanyFactory(
       "MEMBER"

--- a/back/src/bsdasris/repository/bsdasri/findMany.ts
+++ b/back/src/bsdasris/repository/bsdasri/findMany.ts
@@ -11,6 +11,7 @@ export function buildFindManyBsdasri({
 }: ReadRepositoryFnDeps): FindManyBsdasriFn {
   return (where, options?) => {
     const input = { where, ...options };
+
     return prisma.bsdasri.findMany(input);
   };
 }

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
@@ -10,6 +10,7 @@ import makeClient from "../../../../__tests__/testClient";
 import { Mutation } from "../../../../generated/graphql/types";
 import { fullGroupingBsdasriFragment } from "../../../fragments";
 import { gql } from "apollo-server-express";
+import prisma from "../../../../prisma";
 
 const CREATE_DASRI = gql`
   ${fullGroupingBsdasriFragment}
@@ -163,6 +164,10 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
     expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+    const created = await prisma.bsdasri.findUnique({
+      where: { id: data.createBsdasri.id }
+    });
+    expect(created.synthesisEmitterSirets).toEqual([]);
   });
 
   it("create a dasri with a default transport mode", async () => {

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
@@ -133,6 +133,11 @@ describe("Mutation.createDasri", () => {
     expect(created.emitterWasteVolume).toEqual(totalVolume);
     expect(created.transporterWastePackagings).toEqual(packaging);
     expect(created.transporterWasteVolume).toEqual(totalVolume);
+    // synthesized emitter sirets are denormalized in `synthesisEmitterSirets`
+    expect(created.synthesisEmitterSirets).toEqual([
+      toAssociate1.emitterCompanySiret,
+      toAssociate2.emitterCompanySiret
+    ]);
   });
 
   it("should forbid to mix grouping and synthesis arguments", async () => {

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmissionWithSecretCode.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmissionWithSecretCode.integration.ts
@@ -32,7 +32,7 @@ describe("Mutation.signBsdasri emission with secret code", () => {
     const { user: transporter, company: transporterCompany } =
       await userWithCompanyFactory("MEMBER");
 
-    let dasri = await bsdasriFactory({
+    const dasri = await bsdasriFactory({
       opt: {
         ...initialData(emitterCompany),
         status: BsdasriStatus.INITIAL,
@@ -64,10 +64,10 @@ describe("Mutation.signBsdasri emission with secret code", () => {
         })
       })
     ]);
-    dasri = await prisma.bsdasri.findUnique({
+    const updatedDasri = await prisma.bsdasri.findUnique({
       where: { id: dasri.id }
     });
-    expect(dasri.status).toEqual("INITIAL");
+    expect(updatedDasri.status).toEqual("INITIAL");
   });
 
   it("should put emission signature on a dasri when correct code is provided", async () => {

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -331,7 +331,7 @@ describe("Mutation.updateBsdasri", () => {
   });
   it("should allow transporter and destination fields update after emission signature", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    let dasri = await bsdasriFactory({
+    const dasri = await bsdasriFactory({
       opt: {
         status: BsdasriStatus.SIGNED_BY_PRODUCER,
         emitterCompanySiret: company.siret,
@@ -362,13 +362,15 @@ describe("Mutation.updateBsdasri", () => {
       variables: { id: dasri.id, input }
     });
 
-    dasri = await prisma.bsdasri.findUnique({
+    const updatedDasri = await prisma.bsdasri.findUnique({
       where: { id: dasri.id }
     });
 
-    expect(dasri.destinationCompanyMail).toEqual("recipient@test.test");
-    expect(dasri.transporterCompanyMail).toEqual("transporter@test.test");
-    expect(dasri.type).toBe("SIMPLE");
+    expect(updatedDasri.destinationCompanyMail).toEqual("recipient@test.test");
+    expect(updatedDasri.transporterCompanyMail).toEqual(
+      "transporter@test.test"
+    );
+    expect(updatedDasri.type).toBe("SIMPLE");
   });
 
   it("should disallow emitter and transporter fields update after transport signature", async () => {
@@ -565,7 +567,7 @@ describe("Mutation.updateBsdasri", () => {
 
   it("should allow operation fields update after reception signature", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    let dasri = await bsdasriFactory({
+    const dasri = await bsdasriFactory({
       opt: {
         status: BsdasriStatus.RECEIVED,
         emitterCompanySiret: company.siret,
@@ -586,9 +588,9 @@ describe("Mutation.updateBsdasri", () => {
       variables: { id: dasri.id, input }
     });
 
-    dasri = await prisma.bsdasri.findUnique({
+    const updatedDasri = await prisma.bsdasri.findUnique({
       where: { id: dasri.id }
     });
-    expect(dasri.destinationOperationCode).toEqual("D10");
+    expect(updatedDasri.destinationOperationCode).toEqual("D10");
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
@@ -129,7 +129,11 @@ describe("Mutation.updateBsdasri", () => {
       aggregatedPackagings
     );
     expect(updatedDasri.transporterWasteVolume).toEqual(summedVolume);
+
+    // synthesized emitter sirets are denormalized in `synthesisEmitterSirets`
+    expect(updatedDasri.synthesisEmitterSirets).toEqual([emitterCompanySiret]);
   });
+
   it("should forbid empty associated bsds fields on INITIAL synthesis dasri", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
 

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -12,7 +12,6 @@ import { checkIsBsdasriContributor } from "../../permissions";
 import { ForbiddenError } from "apollo-server-express";
 import { getBsdasriRepository } from "../../repository";
 
-import { indexBsdasri } from "../../elastic";
 /**
  *
  * Duplicate a bsdasri
@@ -45,7 +44,6 @@ const duplicateBsdasriResolver: MutationResolvers["duplicateBsdasri"] = async (
   );
 
   const newBsdasri = await duplicateBsdasri(user, bsdasri);
-  await indexBsdasri(newBsdasri, context);
   return expandBsdasriFromDB(newBsdasri);
 };
 
@@ -96,7 +94,7 @@ function duplicateBsdasri(
     groupedInId,
     synthesizedInId,
     identificationNumbers,
-
+    synthesisEmitterSirets,
     ...fieldsToCopy
   }: Bsdasri
 ) {

--- a/back/src/bsdasris/resolvers/queries/__tests__/bsdasriPdf.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/bsdasriPdf.integration.ts
@@ -133,6 +133,7 @@ describe("Query.BsdasriPdf", () => {
         synthesizing: { connect: [{ id: initialBsdasri.id }] }
       }
     });
+    // user from inital company tries to access pdf
     const { query } = makeClient(user);
 
     const { data } = await query<Pick<Query, "bsdasriPdf">>(BSDASRI_PDF, {


### PR DESCRIPTION
Même principe que pour le bsdd, mais se limite à dénormaliser les sirets des bsds associés dans le cas d'une synthèse, seul cas actuellement où l'on doit effectuer des requêtes  sur ces sirets 

 
- [x] Mettre à jour le change log
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10396)
