### PR TITLE
[TRA-10649] La fenêtre d'acceptation de révision devrait contenir un comentaire, lors d'une demande d'annulation

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddApproveRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddApproveRevision.tsx
@@ -105,12 +105,20 @@ export function BsddApproveRevision({ review }: Props) {
 export function DisplayRevision({ review }: Props) {
   if (review.content.isCanceled) {
     return (
-      <div>
-        <p className="tw-pb-6">
-          L'entreprise <strong>{review.authoringCompany.name}</strong> a demandé
-          l'annulation du bordereau <strong>#{review.form.readableId}</strong>
-        </p>
-      </div>
+      <>
+        <div>
+          <p className="tw-pb-6">
+            L'entreprise <strong>{review.authoringCompany.name}</strong> a
+            demandé l'annulation du bordereau{" "}
+            <strong>#{review.form.readableId}</strong>
+          </p>
+        </div>
+
+        <div className="tw-flex tw-py-2">
+          <p className="tw-w-1/4 tw-font-bold">Commentaire</p>
+          <p className="tw-w-3/4">{review.comment}</p>
+        </div>
+      </>
     );
   }
 


### PR DESCRIPTION
# Contexte

La modal de révision, lors d'une demande d'annulation, n'affichait pas le commentaire. Petit fix pour ajouter le commentaire:

![image](https://user-images.githubusercontent.com/45355989/215731800-ac86d0c7-1bed-467a-8970-592356edc8db.png)

# Ticket

[[BSDD] En tant qu'émetteur ou destinataire, je peux annuler un BSDD via l'interface](https://favro.com/widget/ab14a4f0460a99a9d64d4945/342a3d609040b799619919f3?card=tra-10649)
