### PR TITLE
Recette - gestion des établissements

### DIFF
--- a/back/src/users/resolvers/queries/membershipRequest.ts
+++ b/back/src/users/resolvers/queries/membershipRequest.ts
@@ -49,7 +49,7 @@ const invitationRequestResolver: QueryResolvers["membershipRequest"] = async (
   const isRequester = user.email === email;
 
   if (!isRequester) {
-    const admins = await getCompanyAdminUsers(company.siret);
+    const admins = await getCompanyAdminUsers(company.orgId);
     if (!admins.map(u => u.id).includes(user.id)) {
       // user is neither requester nor admin of the company, throw error
       throw new ForbiddenError(
@@ -63,7 +63,7 @@ const invitationRequestResolver: QueryResolvers["membershipRequest"] = async (
     sentTo: invitationRequest.sentTo,
     status: invitationRequest.status,
     email,
-    siret: company.siret,
+    siret: company.orgId,
     name: company.name
   };
 };


### PR DESCRIPTION
La query `membershipRequest` appelait `getCompanyAdminUsers` en utilisant le `siret` plutôt que l'`orgId`. Du coup ça pétait lorsque la query était appelé par un transporteur étranger.

<img width="1262" alt="Capture d’écran 2023-01-31 à 11 46 05" src="https://user-images.githubusercontent.com/2269165/215739340-9ca9e439-30c8-47d2-988b-f652c99fffac.png">

---

- [Cahier de recette](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10671)
