### PR TITLE
Flaky tests

### DIFF
--- a/back/src/bsffs/repository/bsff/__tests__/create.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/create.integration.ts
@@ -1,6 +1,5 @@
 import { userFactory } from "../../../../__tests__/factories";
 import { AuthType } from "../../../../auth";
-import prisma from "../../../../prisma";
 import getReadableId, { ReadableIdPrefix } from "../../../../forms/readableId";
 import { getBsffRepository } from "../..";
 import {
@@ -10,6 +9,7 @@ import {
 import { ApiResponse } from "@elastic/elasticsearch";
 import { SearchResponse } from "@elastic/elasticsearch/api/types";
 import { client, BsdElastic, index } from "../../../../common/elastic";
+import { getStream } from "../../../../activity-events";
 
 describe("bsffRepository.create", () => {
   afterEach(resetDatabase);
@@ -24,7 +24,7 @@ describe("bsffRepository.create", () => {
     const bsff = await createBsff({
       data: { id: getReadableId(ReadableIdPrefix.FF), wasteDescription: "HFC" }
     });
-    const events = await prisma.event.findMany();
+    const events = await getStream(bsff.id);
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       streamId: bsff.id,

--- a/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
@@ -16,6 +16,7 @@ import {
   indexBsd
 } from "../../../../common/elastic";
 import { toBsdElastic } from "../../../elastic";
+import { getStream } from "../../../../activity-events";
 
 describe("bsffRepository.delete", () => {
   afterEach(resetDatabase);
@@ -58,7 +59,7 @@ describe("bsffRepository.delete", () => {
     });
     expect(deletedBsff.isDeleted).toBe(true);
 
-    const events = await prisma.event.findMany();
+    const events = await getStream(deletedBsff.id);
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       streamId: bsff.id,

--- a/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
@@ -16,6 +16,7 @@ import {
   indexBsd
 } from "../../../../common/elastic";
 import { toBsdElastic } from "../../../elastic";
+import { getStream } from "../../../../activity-events";
 
 describe("bsffRepository.update", () => {
   afterEach(resetDatabase);
@@ -59,7 +60,7 @@ describe("bsffRepository.update", () => {
     });
     expect(updatedBsff.wasteCode).toEqual("14 06 02*");
 
-    const events = await prisma.event.findMany();
+    const events = await getStream(updatedBsff.id);
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       streamId: bsff.id,

--- a/back/src/queue/__tests__/sendmail.integration.ts
+++ b/back/src/queue/__tests__/sendmail.integration.ts
@@ -54,7 +54,7 @@ describe("Test the mail job queue", () => {
     expect(data.body).toContain(
       "Bonjour, ceci est un email de test de Trackdéchets."
     );
-  });
+  }, 60000);
 
   it("fallback to sendMailSync when queue is broken which directly call axios.post", async () => {
     // mocking the redis queue is down

--- a/back/src/scripts/prisma/__tests__/updateBsddTakenOverAt.integration.ts
+++ b/back/src/scripts/prisma/__tests__/updateBsddTakenOverAt.integration.ts
@@ -1,4 +1,5 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
+import { getStream } from "../../../activity-events";
 import prisma from "../../../prisma";
 import {
   formFactory,
@@ -66,7 +67,7 @@ describe("updateBsddTakenOverAt", () => {
 
     expect(updatedForm3.takenOverAt).not.toEqual(updatedForm3.emittedAt);
 
-    const events = await prisma.event.findMany();
+    const events = await getStream(form1.id);
 
     expect(events).toHaveLength(1);
 

--- a/back/src/scripts/prisma/__tests__/updateBsvhuTakenOverAt.integration.ts
+++ b/back/src/scripts/prisma/__tests__/updateBsvhuTakenOverAt.integration.ts
@@ -1,4 +1,5 @@
 import { resetDatabase } from "../../../../integration-tests/helper";
+import { getStream } from "../../../activity-events";
 import { bsvhuFactory } from "../../../bsvhu/__tests__/factories.vhu";
 import prisma from "../../../prisma";
 import { userWithCompanyFactory } from "../../../__tests__/factories";
@@ -67,7 +68,7 @@ describe("updateBsvhuTakenOverAt", () => {
       updatedBsvhu3.emitterEmissionSignatureDate
     );
 
-    const events = await prisma.event.findMany();
+    const events = await getStream(bsvhu1.id);
 
     expect(events).toHaveLength(1);
 

--- a/front/src/common/hooks/useOnClickOutsideRefTarget.ts
+++ b/front/src/common/hooks/useOnClickOutsideRefTarget.ts
@@ -16,7 +16,7 @@ const useOnClickOutsideRefTarget = ({ onClickOutside }) => {
     return () => {
       document.removeEventListener("mousedown", clickEvent!);
     };
-  }, []);
+  }, [onClickOutside]);
   return { targetRef };
 };
 

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -12,7 +12,6 @@ import {
   isFRVat,
   isVat,
   isForeignVat,
-  isSiret,
 } from "generated/constants/companySearchHelpers";
 import { checkVAT } from "jsvat";
 import React, { useMemo, useRef, useState } from "react";


### PR DESCRIPTION
- Usage de `getStream` plutôt que `prisma.event.findMany` dans certains tests. En effet `getStream` est conçu pour aller lire à la fois dans Postgres et Mongo pour récupérer les événements de façon consistante. 
- augmentation du timeout sur `sendmail.integration.ts` qui est souvent en timeout. Si ça ne passe toujours pas à 60s il faudra creuser pour comprendre ce qu'il se passe.
