### PR TITLE
Add/Index mongo sur l'acteur

### DIFF
--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -68,6 +68,7 @@ export async function insertStreamEvents(tdEvents: Event[]) {
 async function createIndexes() {
   try {
     await eventsCollection.createIndex({ streamId: 1, createdAt: 1 });
+    await eventsCollection.createIndex({ actor: 1 });
   } catch (err) {
     logger.error("Error while creating indexes", err);
   }


### PR DESCRIPTION
Pour faciliter la vie du support qui fait régulièrement des requêtes sur l'acteur. Ce n'est pas utilisé par l'app.