### PR TITLE
[Bugfix] La query GQL bsdas ne permet pas de filtrer sur le champ transporter.transport.plates

### DIFF
--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -10,7 +10,8 @@ import {
   toPrismaGenericWhereInput,
   toPrismaEnumFilter,
   toPrismaIdFilter,
-  toPrismaRelationIdFilter
+  toPrismaRelationIdFilter,
+  toPrismaStringNullableListFilter
 } from "../common/where";
 
 function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
@@ -35,6 +36,9 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
     workerCompanySiret: toPrismaStringFilter(where.worker?.company?.siret),
     workerWorkSignatureDate: toPrismaDateFilter(
       where.worker?.work?.signature?.date
+    ),
+    transporterTransportPlates: toPrismaStringNullableListFilter(
+      where.transporter?.transport?.plates
     ),
     destinationCompanySiret: toPrismaStringFilter(
       where.destination?.company?.siret


### PR DESCRIPTION
# Contexte

Un bug a été remonté sur la query `bsdas`, où le champ `transporter.transport.plates` n'est pas pris en compte côté backend pour filtrer les résultats.

J'ai ajouté le champ à la désérialization du `where` pour que ça fonctionne

# Démo

![filtre_bsdas](https://user-images.githubusercontent.com/45355989/215834422-4c8248db-f836-4d09-9e42-07668cc614ab.gif)
