### PR TITLE
[TRA-10961] ETQ utilisateur je devrais pouvoir remplir les coordonnées d'une entreprise étrangère si elles sont vides

### DIFF
--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -455,7 +455,9 @@ export default function CompanySelector({
                   className="td-input"
                   name={`${field.name}.name`}
                   placeholder="Nom"
-                  disabled={!displayForeignCompanyWithUnknownInfos}
+                  disabled={
+                    !!field.value.name && !displayForeignCompanyWithUnknownInfos
+                  }
                 />
               </label>
 
@@ -468,7 +470,10 @@ export default function CompanySelector({
                   className="td-input"
                   name={`${field.name}.address`}
                   placeholder="Adresse"
-                  disabled={!displayForeignCompanyWithUnknownInfos}
+                  disabled={
+                    !!field.value.address &&
+                    !displayForeignCompanyWithUnknownInfos
+                  }
                 />
               </label>
 

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -73,6 +73,10 @@ export default function CompanySelector({
   const { siret } = useParams<{ siret: string }>();
   const [uniqId] = useState(() => uuidv4());
   const [field] = useField<FormCompany>({ name });
+  const [selectedCompanyDetails, setSelectedCompanyDetails] = useState({
+    name: field.value?.name,
+    address: field.value?.address,
+  });
   const { setFieldError, setFieldValue, setFieldTouched } = useFormikContext();
   // determine if the current Form company is foreign
   const [isForeignCompany, setIsForeignCompany] = useState(
@@ -202,6 +206,11 @@ export default function CompanySelector({
     });
     setFieldTouched(`${field.name}`, true, true);
     onCompanySelected?.(company);
+
+    setSelectedCompanyDetails({
+      name: company.name,
+      address: company.address,
+    });
   }
 
   /**
@@ -456,7 +465,8 @@ export default function CompanySelector({
                   name={`${field.name}.name`}
                   placeholder="Nom"
                   disabled={
-                    !!field.value.name && !displayForeignCompanyWithUnknownInfos
+                    !!selectedCompanyDetails.name &&
+                    !displayForeignCompanyWithUnknownInfos
                   }
                 />
               </label>
@@ -471,7 +481,7 @@ export default function CompanySelector({
                   name={`${field.name}.address`}
                   placeholder="Adresse"
                   disabled={
-                    !!field.value.address &&
+                    !!selectedCompanyDetails.address &&
                     !displayForeignCompanyWithUnknownInfos
                   }
                 />

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -296,6 +296,14 @@ export default function CompanySelector({
     allowForeignCompanies,
   ]);
 
+  // Disable the name field for foreign companies whose name is filled
+  const disableNameField =
+    !!selectedCompanyDetails.name && !displayForeignCompanyWithUnknownInfos;
+
+  // Disable the address field for foreign companies whose address is filled
+  const disableAddressField =
+    !!selectedCompanyDetails.address && !displayForeignCompanyWithUnknownInfos;
+
   return (
     <>
       {favoritesError && (
@@ -464,10 +472,7 @@ export default function CompanySelector({
                   className="td-input"
                   name={`${field.name}.name`}
                   placeholder="Nom"
-                  disabled={
-                    !!selectedCompanyDetails.name &&
-                    !displayForeignCompanyWithUnknownInfos
-                  }
+                  disabled={disableNameField}
                 />
               </label>
 
@@ -480,10 +485,7 @@ export default function CompanySelector({
                   className="td-input"
                   name={`${field.name}.address`}
                   placeholder="Adresse"
-                  disabled={
-                    !!selectedCompanyDetails.address &&
-                    !displayForeignCompanyWithUnknownInfos
-                  }
+                  disabled={disableAddressField}
                 />
               </label>
 


### PR DESCRIPTION
# Contexte

Lors de la validation d'un bordereau par le destinataire, si je choisis un code R12, dans le champ "Destination ultérieure prévue", si je sélectionne une entreprise étrangère dont les coordonnées ne sont pas renseignées, je ne peux pas les renseigner manuellement, les champs sont bloqués:

![image](https://user-images.githubusercontent.com/45355989/216099587-01518efa-5223-4f15-8c57-6f51033b49dc.png)

# Démo de la solution

Entreprise étrangère avec tous les champs renseignés:

![image](https://user-images.githubusercontent.com/45355989/216099896-ec5f3f6f-9315-4f15-a0d8-2c5f51416159.png)

Entreprise étrangère avec adresse manquante:

![image](https://user-images.githubusercontent.com/45355989/216100061-c2aa2b06-0b8a-456b-b654-3d4391c7590c.png)

Entreprise étrangère avec nom manquant:

![image](https://user-images.githubusercontent.com/45355989/216100196-1dce1833-bc53-49f8-976c-b3ae8ce1862e.png)

Entreprise étrangère avec ni nom ni adresse:

![image](https://user-images.githubusercontent.com/45355989/216100332-0751dda6-7a76-4dc4-bbee-e90fb746bdb8.png)



- [[Bug] On ne peut pas renseigner les infos de la Destination ultérieure prévue à l'étranger. les champs sont grisés](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10961)
