### PR TITLE
Perf / Dataloaders pour les events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+- Utilisation de dataloaders pour charger les évènements Psql & Mongo [PR 2107](https://github.com/MTES-MCT/trackdechets/pull/2107)
+
 # [2023.4.2] 24/04/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -136,7 +136,9 @@ describe("ActivityEvent.Bsda", () => {
     const bsdaAfterCreate = await prisma.bsda.findUnique({
       where: { id: bsdaId }
     });
-    const bsdaFromEventsAfterCreate = await getBsdaFromActivityEvents(bsdaId);
+    const bsdaFromEventsAfterCreate = await getBsdaFromActivityEvents({
+      bsdaId
+    });
     expect(bsdaAfterCreate).toMatchObject(bsdaFromEventsAfterCreate);
     expect(bsdaFromEventsAfterCreate.emitterCompanyName).toBe(company.name);
 
@@ -161,7 +163,9 @@ describe("ActivityEvent.Bsda", () => {
     const bsdaAfterUpdate = await prisma.bsda.findUnique({
       where: { id: bsdaId }
     });
-    const bsdaFromEventsAfterUpdate = await getBsdaFromActivityEvents(bsdaId);
+    const bsdaFromEventsAfterUpdate = await getBsdaFromActivityEvents({
+      bsdaId
+    });
     expect(bsdaAfterUpdate).toMatchObject(bsdaFromEventsAfterUpdate);
     expect(bsdaFromEventsAfterUpdate.wasteCode).toBe("06 13 04*");
 
@@ -179,7 +183,9 @@ describe("ActivityEvent.Bsda", () => {
     const bsdaAfterSealed = await prisma.bsda.findUnique({
       where: { id: bsdaId }
     });
-    const bsdaFromEventsAfterSealed = await getBsdaFromActivityEvents(bsdaId);
+    const bsdaFromEventsAfterSealed = await getBsdaFromActivityEvents({
+      bsdaId
+    });
     expect(bsdaAfterSealed).toMatchObject(bsdaFromEventsAfterSealed);
     expect(bsdaFromEventsAfterSealed.status).toBe("SIGNED_BY_PRODUCER");
 
@@ -322,10 +328,10 @@ describe("ActivityEvent.Bsda", () => {
     const bsdaAfterUpdate = await prisma.bsda.findUnique({
       where: { id: bsdaId }
     });
-    const bsdaFromEventsAfterCreate = await getBsdaFromActivityEvents(
+    const bsdaFromEventsAfterCreate = await getBsdaFromActivityEvents({
       bsdaId,
-      now
-    );
+      at: now
+    });
     expect(bsdaFromEventsAfterCreate.wasteCode).toBe("06 07 01*");
     expect(bsdaAfterUpdate!.wasteCode).toBe("06 13 04*");
   });

--- a/back/src/activity-events/bsda/index.ts
+++ b/back/src/activity-events/bsda/index.ts
@@ -1,4 +1,5 @@
 import { Bsda } from "@prisma/client";
+import { AppDataloaders } from "../../types";
 import { aggregateStream } from "../aggregator";
 import { getStream } from "../data";
 import { bsdaReducer } from "./reducer";
@@ -7,8 +8,15 @@ import { BsdaEvent } from "./types";
 export * from "./types";
 export * from "./reducer";
 
-export async function getBsdaFromActivityEvents(bsdaId: string, at?: Date) {
-  const events = await getStream(bsdaId, at ? { until: at } : undefined);
+type BsdaEventsParams = { bsdaId: string; at?: Date };
+
+export async function getBsdaFromActivityEvents(
+  { bsdaId, at }: BsdaEventsParams,
+  options?: { dataloader: AppDataloaders["events"] }
+) {
+  const events = await (options?.dataloader
+    ? options.dataloader.load({ streamId: bsdaId, lte: at })
+    : getStream(bsdaId, at ? { until: at } : undefined));
 
   return aggregateStream<Bsda, BsdaEvent>(events as BsdaEvent[], bsdaReducer);
 }

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -127,7 +127,9 @@ describe("ActivityEvent.Bsdd", () => {
     const formAfterCreate = await prisma.form.findUnique({
       where: { id: formId }
     });
-    const formFromEventsAfterCreate = await getBsddFromActivityEvents(formId);
+    const formFromEventsAfterCreate = await getBsddFromActivityEvents({
+      bsddId: formId
+    });
     expect(formAfterCreate).toMatchObject(formFromEventsAfterCreate);
     expect(formFromEventsAfterCreate.emitterCompanyName).toBe(company.name);
 
@@ -149,7 +151,9 @@ describe("ActivityEvent.Bsdd", () => {
     const formAfterUpdate = await prisma.form.findUnique({
       where: { id: formId }
     });
-    const formFromEventsAfterUpdate = await getBsddFromActivityEvents(formId);
+    const formFromEventsAfterUpdate = await getBsddFromActivityEvents({
+      bsddId: formId
+    });
     expect(formAfterUpdate).toMatchObject(formFromEventsAfterUpdate);
     expect(formFromEventsAfterUpdate.wasteDetailsCode).toBe("01 01 01");
 
@@ -166,7 +170,9 @@ describe("ActivityEvent.Bsdd", () => {
     const formAfterSealed = await prisma.form.findUnique({
       where: { id: formId }
     });
-    const formFromEventsAfterSealed = await getBsddFromActivityEvents(formId);
+    const formFromEventsAfterSealed = await getBsddFromActivityEvents({
+      bsddId: formId
+    });
     expect(formAfterSealed).toMatchObject(formFromEventsAfterSealed);
     expect(formFromEventsAfterSealed.status).toBe("SEALED");
 
@@ -265,10 +271,10 @@ describe("ActivityEvent.Bsdd", () => {
     const formAfterUpdate = await prisma.form.findUniqueOrThrow({
       where: { id: formId }
     });
-    const formFromEventsAfterCreate = await getBsddFromActivityEvents(
-      formId,
-      now
-    );
+    const formFromEventsAfterCreate = await getBsddFromActivityEvents({
+      bsddId: formId,
+      at: now
+    });
     expect(formFromEventsAfterCreate.wasteDetailsCode).toBe("01 03 04*");
     expect(formAfterUpdate.wasteDetailsCode).toBe("01 01 01");
   });

--- a/back/src/activity-events/bsdd/index.ts
+++ b/back/src/activity-events/bsdd/index.ts
@@ -1,10 +1,16 @@
 import { Form } from "@prisma/client";
 import { aggregateStream, getStream, persistEvent } from "..";
+import { AppDataloaders } from "../../types";
 import { bsddReducer } from "./reducer";
 import { BsddEvent, BsddRevisionRequestEvent } from "./types";
 
 export * from "./types";
 export * from "./reducer";
+
+type BsddEventsParams = {
+  bsddId: string;
+  at?: Date;
+};
 
 export function persistBsddEvent(bsddEvent: BsddEvent) {
   return persistEvent(bsddEvent);
@@ -16,8 +22,13 @@ export function persistBsddRevisionRequestEvent(
   return persistEvent(bsddRevisionRequestEvent);
 }
 
-export async function getBsddFromActivityEvents(bsddId: string, at?: Date) {
-  const events = await getStream(bsddId, at ? { until: at } : undefined);
+export async function getBsddFromActivityEvents(
+  { bsddId, at }: BsddEventsParams,
+  options?: { dataloader: AppDataloaders["events"] }
+) {
+  const events = await (options?.dataloader
+    ? options.dataloader.load({ streamId: bsddId, lte: at })
+    : getStream(bsddId, at ? { until: at } : undefined));
 
   return aggregateStream<Form, BsddEvent>(events as BsddEvent[], bsddReducer);
 }

--- a/back/src/activity-events/data.ts
+++ b/back/src/activity-events/data.ts
@@ -2,6 +2,7 @@ import { ActivityEvent } from ".";
 import prisma from "../prisma";
 import { Event, Prisma } from "@prisma/client";
 import { getStreamEvents } from "../events/mongodb";
+import { EventCollection } from "../events/types";
 
 export async function getStream(
   streamId: string,
@@ -32,6 +33,18 @@ export async function getStream(
     data: event.data as Record<string, unknown>,
     metadata: event.metadata as Record<string, unknown>
   }));
+}
+
+export function dbEventToActivityEvent(
+  event: Event | EventCollection
+): ActivityEvent {
+  return {
+    type: event.type,
+    actor: event.actor,
+    streamId: event.streamId,
+    data: event.data as Record<string, unknown>,
+    metadata: event.metadata as Record<string, unknown>
+  };
 }
 
 export function persistEvent(event: ActivityEvent): Promise<Event> {

--- a/back/src/activity-events/dataloader.ts
+++ b/back/src/activity-events/dataloader.ts
@@ -1,0 +1,86 @@
+import DataLoader from "dataloader";
+import { getStreamsEvents } from "../events/mongodb";
+import prisma from "../prisma";
+import { dbEventToActivityEvent } from "./data";
+import { ActivityEvent } from "./types";
+
+type Key = { streamId: string; lte?: Date };
+
+export function createEventsDataLoaders() {
+  return {
+    events: new DataLoader((keys: Key[]) => getStreams(keys), {
+      cacheKeyFn: ({ streamId, lte }: { streamId: string; lte?: Date }) => {
+        return `${streamId}:${lte ? lte.toISOString() : "no-date"}`;
+      }
+    })
+  };
+}
+
+/**
+ * Get events in a single request per DB.
+ * We have to overfetch as:
+ * - each streamId can have a different lte date
+ * - a streamId can appear several times with different lte dates
+ *
+ * The work is then done in JS. This still seems worth it as user with a lot of revisions
+ * can generate hundreds of requests otherwise.
+ *
+ * @param keys The streamId & lte combination
+ * @returns events corresponding to each streamId & lte
+ */
+async function getStreams(keys: Key[]): Promise<ActivityEvent[][]> {
+  const streamIds = keys.map(key => key.streamId);
+
+  const [mongoEvents, psqlEvents] = await Promise.all([
+    getStreamsEvents(streamIds),
+    prisma.event.findMany({
+      where: {
+        streamId: { in: streamIds }
+      }
+    })
+  ]);
+
+  // Initialise response array - each index in the Array of values must correspond to the same index in the Array of keys
+  const eventsByKey: ActivityEvent[][] = keys.map(() => []);
+  // Initialise lookup table to check for duplicates. `.has()` is O(1) on Sets
+  const lookup = keys.map(() => new Set());
+
+  for (const mongoEvent of mongoEvents) {
+    const correspondingKeys = keys.filter(
+      ({ streamId }) => streamId === mongoEvent.streamId
+    );
+
+    for (const key of correspondingKeys) {
+      const index = keys.indexOf(key);
+      if (lteFilter(key.lte, mongoEvent.createdAt)) {
+        eventsByKey[index].push(mongoEvent);
+        lookup[index].add(mongoEvent._id);
+      }
+    }
+  }
+
+  for (const psqlEvent of psqlEvents) {
+    const correspondingKeys = keys.filter(
+      ({ streamId }) => streamId === psqlEvent.streamId
+    );
+
+    for (const key of correspondingKeys) {
+      const index = keys.indexOf(key);
+      // Some events might be already in Mongo but still in Psql (especially during tests),
+      // so we remove duplicates
+      if (
+        !lookup[index].has(psqlEvent.id) &&
+        lteFilter(key.lte, psqlEvent.createdAt)
+      ) {
+        eventsByKey[index].push(dbEventToActivityEvent(psqlEvent));
+      }
+    }
+  }
+
+  return eventsByKey;
+}
+
+function lteFilter(lte: Date | undefined, eventCreatedAt: Date) {
+  if (!lte) return true;
+  return lte >= eventCreatedAt;
+}

--- a/back/src/bsda/resolvers/BsdaRevisionRequest.ts
+++ b/back/src/bsda/resolvers/BsdaRevisionRequest.ts
@@ -31,13 +31,17 @@ const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
     }
     return authoringCompany;
   },
-  bsda: async (parent: BsdaRevisionRequest & { bsdaId: string }) => {
+  bsda: async (
+    parent: BsdaRevisionRequest & { bsdaId: string },
+    _,
+    { dataloaders }
+  ) => {
     const actualBsda = await prisma.bsdaRevisionRequest
       .findUnique({ where: { id: parent.id } })
       .bsda();
     const bsdaFromEvents = await getBsdaFromActivityEvents(
-      parent.bsdaId,
-      parent.createdAt
+      { bsdaId: parent.bsdaId, at: parent.createdAt },
+      { dataloader: dataloaders.events }
     );
     return expandBsdaFromDb({ ...actualBsda, ...bsdaFromEvents });
   }

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -28,6 +28,16 @@ export async function getStreamEvents(streamId: string, lte?: Date) {
   return documents;
 }
 
+export async function getStreamsEvents(streamIds: string[]) {
+  const documents = await eventsCollection
+    .find({
+      streamId: { $in: streamIds }
+    })
+    .toArray();
+
+  return documents;
+}
+
 export async function insertStreamEvents(tdEvents: Event[]) {
   try {
     await eventsCollection.bulkWrite(

--- a/back/src/forms/resolvers/FormRevisionRequest.ts
+++ b/back/src/forms/resolvers/FormRevisionRequest.ts
@@ -32,7 +32,11 @@ const formRevisionRequestResolvers: FormRevisionRequestResolvers = {
     }
     return authoringCompany;
   },
-  form: async (parent: FormRevisionRequest & { bsddId: string }) => {
+  form: async (
+    parent: FormRevisionRequest & { bsddId: string },
+    _,
+    { dataloaders }
+  ) => {
     const fullBsdd = await prisma.bsddRevisionRequest
       .findUnique({ where: { id: parent.id } })
       .bsdd({ include: { forwardedIn: true } });
@@ -42,8 +46,11 @@ const formRevisionRequestResolvers: FormRevisionRequestResolvers = {
     }
 
     const bsdd = await getBsddFromActivityEvents(
-      parent.bsddId,
-      parent.createdAt
+      {
+        bsddId: parent.bsddId,
+        at: parent.createdAt
+      },
+      { dataloader: dataloaders.events }
     );
 
     return expandFormFromDb({

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -32,6 +32,7 @@ import sentryReporter from "./common/plugins/sentryReporter";
 import { redisClient } from "./common/redis";
 import { initSentry } from "./common/sentry";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
+import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { createFormDataLoaders } from "./forms/dataloader";
 import { bullBoardPath, serverAdapter } from "./queue/bull-board";
 import { authRouter } from "./routers/auth-router";
@@ -85,7 +86,8 @@ export const server = new ApolloServer({
       dataloaders: {
         ...createUserDataLoaders(),
         ...createCompanyDataLoaders(),
-        ...createFormDataLoaders()
+        ...createFormDataLoaders(),
+        ...createEventsDataLoaders()
       }
     };
   },

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -1,4 +1,5 @@
 import { ExpressContext } from "apollo-server-express/dist/ApolloServer";
+import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { GqlInfo } from "./common/middlewares/graphqlQueryParser";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
@@ -6,7 +7,8 @@ import { createUserDataLoaders } from "./users/dataloaders";
 
 export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createCompanyDataLoaders> &
-  ReturnType<typeof createFormDataLoaders>;
+  ReturnType<typeof createFormDataLoaders> &
+  ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = ExpressContext & {
   user: Express.User | null;


### PR DESCRIPTION
Utilisation de dataloaders pour les events. On génère actuellement un très grand nombre de requêtes dbs à chaque requête.[ cf exemple](https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20env%3Aproduction%20service%3Aback%20operation_name%3Aexpress.request%20%40http.method%3APOST&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=7288435911078162419&spanType=service-entry&spanViewType=metadata&timeHint=1675242382626&trace=AgAAAYYMOiUi-ZTGUAAAAAAAAAAYAAAAAEFZWU1PaW1RQUFDYWpfVEMwVFFRQVNWbAAAACQAAAAAMDE4NjBjZDQtODhmYi00ZjczLTkxOTktNTJkY2JiOGE5MDdi&traceID=7288435911078162419&start=1675239991184&end=1675326391184&paused=false)
![image](https://user-images.githubusercontent.com/5145523/216270777-16dbb434-21fd-4138-823b-3032d4fe1a71.png)

Ces requêtes DBs sont faites vers Psql & vers Mongo.
Sur la dernière heure, c'est 875K requêtes SQL faites. Et autant vers Mongo. Sur la même période c'est environ 20K appels aux API `revisionRequest`. Avec cette PR on divise donc en gros par 40 le nombre de requêtes faites à la base pour les révisions.

A merger en HOTFIX selon moi vu les difficultées qu'on rencontre avec notre DB en ce moment. Peut être après 1 ou 2j de test en recette pour s'assurer que tout est ok.