### PR TITLE
FIX / Registre BSDA

### DIFF
--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -160,7 +160,9 @@ export function toBsdElastic(bsda: BsdaToElastic): BsdElastic {
     transporterCompanyName: bsda.transporterCompanyName ?? "",
     transporterCompanySiret: bsda.transporterCompanySiret ?? "",
     transporterCompanyVatNumber: bsda.transporterCompanyVatNumber ?? "",
-    transporterTakenOverAt: bsda.transporterTransportTakenOverAt?.getTime(),
+    transporterTakenOverAt:
+      bsda.transporterTransportTakenOverAt?.getTime() ??
+      bsda.transporterTransportSignatureDate?.getTime(),
     transporterCustomInfo: bsda.transporterCustomInfo ?? "",
     transporterNumberPlate: bsda.transporterTransportPlates,
     destinationCompanyName: bsda.destinationCompanyName ?? "",

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -202,7 +202,9 @@ export function toOutgoingWaste(
     transporterCompanyAddress: null,
     transporterCompanyName: bsda.transporterCompanyName,
     transporterCompanySiret: getTransporterCompanyOrgId(bsda),
-    transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
+    transporterTakenOverAt:
+      bsda.transporterTransportTakenOverAt ??
+      bsda.transporterTransportSignatureDate,
     transporterRecepisseNumber: bsda.transporterRecepisseNumber,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,
     emitterCustomInfo: bsda.emitterCustomInfo,
@@ -246,7 +248,9 @@ export function toTransportedWaste(
 
   return {
     ...genericWaste,
-    transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
+    transporterTakenOverAt:
+      bsda.transporterTransportTakenOverAt ??
+      bsda.transporterTransportSignatureDate,
     destinationReceptionDate: bsda.destinationReceptionDate,
     weight: bsda.weightValue ? bsda.weightValue / 1000 : bsda.weightValue,
     transporterCompanyName: bsda.transporterCompanyName,
@@ -380,7 +384,9 @@ export function toAllWaste(
   return {
     ...genericWaste,
     createdAt: bsda.createdAt,
-    transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
+    transporterTakenOverAt:
+      bsda.transporterTransportTakenOverAt ??
+      bsda.transporterTransportSignatureDate,
     destinationReceptionDate: bsda.destinationReceptionDate,
     brokerCompanyName: bsda.brokerCompanyName,
     brokerCompanySiret: bsda.brokerCompanySiret,


### PR DESCRIPTION
Quand on query le registre depuis l'interface ca fait une requete ES avec un filtre sur takenOverAt. Or cette date n'est souvent pas remplie sur le BSDA. On met donc un fallback sur la date de signature transporteur.

**Il faudra une réindexation des bsdas pour que la modif soit rétro active !**

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10028)
