### PR TITLE
[TRA-9116][BUGFIX] La fenêtre de consultation de révision devrait afficher les quantités égales à zéro

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/RevisionField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/RevisionField.tsx
@@ -12,9 +12,6 @@ export function RevisionField({
   reviewValue,
   formatter = value => value,
 }: Props) {
-  console.log("bsddvalue", bsddValue);
-  console.log("reviewValue", reviewValue);
-
   const formattedBsddValue = useMemo(
     () => formatter(bsddValue),
     [formatter, bsddValue]

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/RevisionField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/RevisionField.tsx
@@ -12,6 +12,9 @@ export function RevisionField({
   reviewValue,
   formatter = value => value,
 }: Props) {
+  console.log("bsddvalue", bsddValue);
+  console.log("reviewValue", reviewValue);
+
   const formattedBsddValue = useMemo(
     () => formatter(bsddValue),
     [formatter, bsddValue]
@@ -21,7 +24,8 @@ export function RevisionField({
     [formatter, reviewValue]
   );
 
-  if (!formattedReviewValue) return null;
+  if (formattedReviewValue === null || formattedReviewValue === undefined)
+    return null;
 
   return (
     <div className="tw-py-2 tw-border-t-2">


### PR DESCRIPTION
# Contexte

Lorsqu'on formule une demande de révision et que des quantités égales à zéro sont impliquées, les messages ne s'affichent pas correctement:

![image](https://user-images.githubusercontent.com/45355989/217495843-e38c607c-2a07-48b4-812e-cb5a898e594b.png)

![image](https://user-images.githubusercontent.com/45355989/217495867-cef1c7d1-b9fc-4d59-924d-c001c5e5dfa1.png)

# Ticket Favro

- [[Bug] la fenêtre de consultation de la révision n'affiche pas la valeur modifiée quand on passe à 0kg (et cas inverse, can l'ancienne valeur était 0kg)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-9116)
