### PR TITLE
[TRA-10578] Mail à J+7 pour les nouveaux inscrits qui n'ont pas encore créé de MembershipRequest

### DIFF
--- a/back/src/cron.ts
+++ b/back/src/cron.ts
@@ -2,6 +2,7 @@ import * as cron from "cron";
 import cronValidator from "cron-validate";
 import {
   sendFirstOnboardingEmail,
+  sendMembershipRequestDetailsEmail,
   sendSecondOnboardingEmail
 } from "./commands/onboarding.helpers";
 import { initSentry } from "./common/sentry";
@@ -46,6 +47,14 @@ if (CRON_ONBOARDING_SCHEDULE) {
       cronTime: CRON_ONBOARDING_SCHEDULE,
       onTick: async () => {
         await sendSecondOnboardingEmail();
+      },
+      timeZone: "Europe/Paris"
+    }),
+    // new users with no company membership request
+    new cron.CronJob({
+      cronTime: CRON_ONBOARDING_SCHEDULE,
+      onTick: async () => {
+        await sendMembershipRequestDetailsEmail();
       },
       timeZone: "Europe/Paris"
     })

--- a/back/src/mailer/templates/index.ts
+++ b/back/src/mailer/templates/index.ts
@@ -197,3 +197,11 @@ export const finalDestinationModified: MailTemplate<{
   body: mustacheRenderer("destination-finale-modifiee.html"),
   templateId: templateIds.LAYOUT
 };
+
+export const membershipRequestDetailsEmail: MailTemplate<{
+  company: { siret: string; name?: string };
+}> = {
+  subject: "Passez à la prochaine étape sur Trackdéchets",
+  body: mustacheRenderer("membership-request-details.html"),
+  templateId: templateIds.LAYOUT
+};

--- a/back/src/mailer/templates/mustache/membership-request-details.html
+++ b/back/src/mailer/templates/mustache/membership-request-details.html
@@ -1,0 +1,12 @@
+<p>
+Vous avez récemment créé un compte sur Trackdéchets.
+</p>
+<br />
+<p>
+Pour pouvoir créer et signer vos bordereaux de manière dématérialisée, vous devez <a
+href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/sinscrire/rattacher-des-etablissements">rattacher votre compte Trackdéchets à votre établissement</a> en saisissant son numéro SIRET.
+</p>
+<br />
+<p>
+Si votre établissement a déjà été créé sur Trackdéchets, veuillez <a href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/sinscrire/rattacher-des-etablissements/faire-une-demande-de-rattachement">effectuer une demande de rattachement</a>. 
+</p>


### PR DESCRIPTION
# Contexte

Le support aimerait que l'on ajoute des mails automatiques pour traiter les problèmes récurrents et guider un peu mieux les utilisateurs.

Dans cette PR, on envoie un mail à inscription+7j aux nouveaux utilisateurs qui ne font pas partie d'une entreprise et qui n'ont pas envoyé de MembershipRequest, pour leur expliquer comment faire.

# Démo

![image](https://user-images.githubusercontent.com/45355989/217788697-79c1412b-f9c4-4b4f-afd2-278c7b08e5e9.png)

# Ticket Favro

- [Mettre à jour les mails d'onboarding - Février 2023](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10578)
