### PR TITLE
Correctifs pdf bsff

### DIFF
--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -129,7 +129,7 @@ function BsffEmitterType({ bsff }: Pick<Props, "bsff">) {
         <p>
           <input
             type="checkbox"
-            checked={bsff.type === BsffType.COLLECTE_PETITES_QUANTITES}
+            defaultChecked={bsff.type === BsffType.COLLECTE_PETITES_QUANTITES}
             readOnly
           />{" "}
           Un opérateur qui collecte des déchets dangereux de fluides
@@ -139,7 +139,7 @@ function BsffEmitterType({ bsff }: Pick<Props, "bsff">) {
         <p>
           <input
             type="checkbox"
-            checked={bsff.type === BsffType.TRACER_FLUIDE}
+            defaultChecked={bsff.type === BsffType.TRACER_FLUIDE}
             readOnly
           />{" "}
           Un autre détenteur de déchets
@@ -147,7 +147,7 @@ function BsffEmitterType({ bsff }: Pick<Props, "bsff">) {
         <p>
           <input
             type="checkbox"
-            checked={bsff.type === BsffType.GROUPEMENT}
+            defaultChecked={bsff.type === BsffType.GROUPEMENT}
             readOnly
           />{" "}
           Une installation dans le cadre d'un regroupement
@@ -155,7 +155,7 @@ function BsffEmitterType({ bsff }: Pick<Props, "bsff">) {
         <p>
           <input
             type="checkbox"
-            checked={bsff.type === BsffType.REEXPEDITION}
+            defaultChecked={bsff.type === BsffType.REEXPEDITION}
             readOnly
           />{" "}
           Une installation dans le cadre d'une réexpédition
@@ -163,7 +163,7 @@ function BsffEmitterType({ bsff }: Pick<Props, "bsff">) {
         <p>
           <input
             type="checkbox"
-            checked={bsff.type === BsffType.RECONDITIONNEMENT}
+            defaultChecked={bsff.type === BsffType.RECONDITIONNEMENT}
             readOnly
           />{" "}
           Une installation dans le cadre d'un reconditionnement
@@ -288,7 +288,7 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
             <span>
               <input
                 type="checkbox"
-                checked={!bsff.weight?.isEstimate}
+                defaultChecked={!bsff.weight?.isEstimate}
                 readOnly
               />{" "}
               Réelle
@@ -296,7 +296,7 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
             <span>
               <input
                 type="checkbox"
-                checked={bsff.weight?.isEstimate}
+                defaultChecked={bsff.weight?.isEstimate}
                 readOnly
               />{" "}
               Estimée
@@ -347,9 +347,9 @@ function BsffTransporter({ bsff }: Pick<Props, "bsff">) {
             {bsff.transporter?.company?.siret &&
             !bsff.transporter?.recepisse ? (
               <p>
-                <input type="checkbox" checked readOnly /> Je déclare être
-                exempté de récépissé au titre de l'article R.541-50 du code de
-                l'environnement
+                <input type="checkbox" defaultChecked readOnly /> Je déclare
+                être exempté de récépissé au titre de l'article R.541-50 du code
+                de l'environnement
               </p>
             ) : (
               <p>
@@ -410,9 +410,10 @@ function BsffPackagingAcceptation({
       )}
 
       <div>
-        Contenant accepté : <input type="checkbox" checked={isAccepted} /> Oui
+        Contenant accepté :{" "}
+        <input type="checkbox" defaultChecked={isAccepted} /> Oui
         {"  "}
-        <input type="checkbox" checked={isRefused} /> Non
+        <input type="checkbox" defaultChecked={isRefused} /> Non
       </div>
       <div>
         Description du déchet : {packaging?.acceptation?.wasteCode}{" "}
@@ -463,18 +464,34 @@ function BsffOnePackagingOperation({
       </p>
       <div>
         Récupération ou régénération des solvants{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "R2"} />{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "R2"}
+        />{" "}
         R 2
       </div>
       <div>
+        Recyclage ou récupération des substances organiques{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "R3"}
+        />{" "}
+        R 3
+      </div>
+      <div>
         Recyclage ou récupération d’autres matières inorganiques{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "R5"} />{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "R5"}
+        />{" "}
         R 5
       </div>
       <div>
-        Recyclage ou récupération des substances organiques R 3 Incinération à
-        terre{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "D10"} />{" "}
+        Incinération à terre{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "D10"}
+        />{" "}
         D 10
       </div>
       <div>
@@ -482,10 +499,13 @@ function BsffOnePackagingOperation({
         Groupement de contenants{" "}
         <input
           type="checkbox"
-          checked={packaging?.operation?.code === "R12"}
+          defaultChecked={packaging?.operation?.code === "R12"}
         />{" "}
         R12{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "D13"} />{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "D13"}
+        />{" "}
         D 13
       </div>
       <div>
@@ -493,10 +513,13 @@ function BsffOnePackagingOperation({
         Reconditionnement dans un nouveau contenant{" "}
         <input
           type="checkbox"
-          checked={packaging?.operation?.code === "R12"}
+          defaultChecked={packaging?.operation?.code === "R12"}
         />{" "}
         R 12{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "D14"} />{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "D14"}
+        />{" "}
         D 14
       </div>
       <div>
@@ -504,10 +527,13 @@ function BsffOnePackagingOperation({
         Entreposage provisoire avant réexpédition{" "}
         <input
           type="checkbox"
-          checked={packaging?.operation?.code === "R13"}
+          defaultChecked={packaging?.operation?.code === "R13"}
         />{" "}
         R13{" "}
-        <input type="checkbox" checked={packaging?.operation?.code === "D15"} />{" "}
+        <input
+          type="checkbox"
+          defaultChecked={packaging?.operation?.code === "D15"}
+        />{" "}
         D 15
       </div>
       <div> Date de réalisation : {formatDate(packaging?.operation?.date)}</div>
@@ -557,8 +583,10 @@ function BsffPackagingOperation({ packaging }: { packaging: BsffPackaging }) {
     <div>
       <div>Nom du responsable : {packaging?.operation?.signature?.author}</div>
       <div>
-        Code D/R : {packaging?.operation?.code} (
-        {packaging?.operation?.description})
+        Code D/R : {packaging?.operation?.code}{" "}
+        {packaging?.operation?.description &&
+          `(
+        ${packaging?.operation?.description})`}
       </div>
       {packaging?.operation?.noTraceability && (
         <div>Rupture de traçabilité autorisée par arrêté préfectoral</div>

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -19,7 +19,6 @@ import {
 } from "../../generated/graphql/types";
 import { BSFF_WASTES } from "../../common/constants";
 import { extractPostalCode } from "../../utils";
-import { boolean } from "yup";
 
 type Props = {
   bsff: Bsff & { packagings: BsffPackaging[] } & {

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { BsffPackagingType, BsffType } from "@prisma/client";
+import {
+  BsffPackagingType,
+  BsffType,
+  WasteAcceptationStatus
+} from "@prisma/client";
 import {
   Document,
   formatDate,
@@ -15,6 +19,7 @@ import {
 } from "../../generated/graphql/types";
 import { BSFF_WASTES } from "../../common/constants";
 import { extractPostalCode } from "../../utils";
+import { boolean } from "yup";
 
 type Props = {
   bsff: Bsff & { packagings: BsffPackaging[] } & {
@@ -731,7 +736,21 @@ function PreviousBsffsTable({ bsff }: Pick<Props, "bsff">) {
             <tr key={previous.id}>
               <td>{previous.id}</td>
               <td>{previous.destination?.cap}</td>
-              <td>{previous.weight?.value}</td>
+              <td>
+                {/*  sum acceptation.weight if all packagings are accepted, else use previous bsff expected weight*/}
+                {previous.packagings
+                  .map(
+                    p =>
+                      p.acceptation?.status === WasteAcceptationStatus.ACCEPTED
+                  )
+                  .every(Boolean)
+                  ? Math.round(
+                      previous.packagings
+                        .map(p => p.acceptation.weight)
+                        .reduce((acc, el) => acc + el, 0) * 100
+                    ) / 100
+                  : previous.weight?.value}
+              </td>
               <td>
                 {previous.packagings
                   .map(p => p.numero)

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/WorkflowAction.tsx
@@ -8,7 +8,8 @@ import { SignReception } from "./SignReception";
 import { SignBsffOperationOnePackaging } from "./SignOperation";
 import { SignBsffAcceptationOnePackaging } from "./SignAcceptation";
 import { SignPackagings } from "./SignPackagings";
-import { useParams } from "react-router-dom";
+import { useParams, useRouteMatch } from "react-router-dom";
+import routes from "common/routes";
 
 export interface WorkflowActionProps {
   form: BsffFragment;
@@ -18,6 +19,8 @@ export function WorkflowAction(props: WorkflowActionProps) {
   const { siret } = useParams<{ siret: string }>();
   const { form } = props;
 
+  const isActTab = !!useRouteMatch(routes.dashboard.bsds.act);
+  const isToCollectTab = !!useRouteMatch(routes.dashboard.transport.toCollect);
   const emitterSiret = form.bsffEmitter?.company?.siret;
   const transporterSiret = form.bsffTransporter?.company?.siret;
   const destinationSiret = form.bsffDestination?.company?.siret;
@@ -31,19 +34,19 @@ export function WorkflowAction(props: WorkflowActionProps) {
 
   switch (form.bsffStatus) {
     case BsffStatus.Initial:
-      if (siret !== emitterSiret) return null;
+      if (siret !== emitterSiret || !isActTab) return null;
       return <SignEmission bsffId={form.id} />;
 
     case BsffStatus.SignedByEmitter:
-      if (siret !== transporterSiret) return null;
+      if (siret !== transporterSiret || !isToCollectTab) return null;
       return <SignTransport bsffId={form.id} />;
 
     case BsffStatus.Sent:
-      if (siret !== destinationSiret) return null;
+      if (siret !== destinationSiret || !isActTab) return null;
       return <SignReception bsffId={form.id} />;
 
     case BsffStatus.Received:
-      if (siret !== destinationSiret) return null;
+      if (siret !== destinationSiret || !isActTab) return null;
       if (form.packagings?.length === 1) {
         return <SignBsffAcceptationOnePackaging bsffId={form.id} />;
       }


### PR DESCRIPTION
 Petits correctifs sur le pdf:
- passe les checked en defaultChecked pour supprimer les warnings
- supprime le parenthèses lorsque l'operation description est vide
- ordonne R2, R3, R5
- ajoute la checkbox manquante sur la ligne R3 (cadre 9, lors d'un seul packaging sur le bsff)
- affiche la somme des quatités acceptées dans le tableaux des bsds regroupés plutôt que la quantité prévue
- au passage on masque les boutons de workflow sauvages qui apparaissent ailleurs que dans les onglets actions ou à collecter

## Codes déchets

### Avant
<img width="484" alt="Capture d’écran 2023-02-16 à 09 48 08" src="https://user-images.githubusercontent.com/878396/219320254-2a8aaa54-bda6-4b47-b512-331cb9583949.png">

### Après
<img width="526" alt="Capture d’écran 2023-02-16 à 10 06 41" src="https://user-images.githubusercontent.com/878396/219321516-127bb21e-986a-4e88-9e49-842f02d0d027.png">

## Quantité de fluides

### Avant
<img width="569" alt="Capture d’écran 2023-02-16 à 16 02 54" src="https://user-images.githubusercontent.com/878396/219412641-ffe9bfba-049c-4d47-a424-aedb73ee84a6.png">


### Après

<img width="1335" alt="bsff" src="https://user-images.githubusercontent.com/878396/219414058-dd91ff69-49ed-4e04-bd8e-a60486b0300a.png">

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-10625)

