### PR TITLE
Corrige et hamonise l'ordre des boutons d'actions

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
@@ -53,6 +53,12 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
     canDeleteAndUpdate = siret === signedBySiret;
   }
 
+  const canRequestRevision = ![
+    FormStatus.Draft,
+    FormStatus.Sealed,
+    FormStatus.Refused,
+  ].includes(form.status);
+
   return (
     <>
       <Menu>
@@ -77,6 +83,8 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                 styles.BSDDActionsMenu
               )}
             >
+              <TableRoadControlButton siret={siret} form={form} />
+
               <MenuLink
                 as={Link}
                 to={{
@@ -90,7 +98,6 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                 <IconView color="blueLight" size="24px" />
                 Aperçu
               </MenuLink>
-              <TableRoadControlButton siret={siret} form={form} />
 
               {form.status !== FormStatus.Draft && (
                 <MenuItem onSelect={() => downloadPdf()}>
@@ -98,12 +105,14 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                   Pdf
                 </MenuItem>
               )}
+
+              <MenuItem onSelect={() => duplicateForm()}>
+                <IconDuplicateFile size="24px" color="blueLight" />
+                Dupliquer
+              </MenuItem>
+
               {canDeleteAndUpdate && (
                 <>
-                  <MenuItem onSelect={() => setIsDeleting(true)}>
-                    <IconTrash color="blueLight" size="24px" />
-                    Supprimer
-                  </MenuItem>
                   <MenuLink
                     as={Link}
                     to={generatePath(routes.dashboard.bsdds.edit, {
@@ -116,11 +125,8 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                   </MenuLink>
                 </>
               )}
-              {![
-                FormStatus.Draft,
-                FormStatus.Sealed,
-                FormStatus.Refused,
-              ].includes(form.status) && (
+
+              {canRequestRevision && (
                 <MenuLink
                   as={Link}
                   to={{
@@ -135,10 +141,15 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                   Révision
                 </MenuLink>
               )}
-              <MenuItem onSelect={() => duplicateForm()}>
-                <IconDuplicateFile size="24px" color="blueLight" />
-                Dupliquer
-              </MenuItem>
+
+              {canDeleteAndUpdate && (
+                <>
+                  <MenuItem onSelect={() => setIsDeleting(true)}>
+                    <IconTrash color="blueLight" size="24px" />
+                    Supprimer
+                  </MenuItem>
+                </>
+              )}
             </MenuList>
           </>
         )}

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/BSDaActions.tsx
@@ -66,6 +66,8 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
                 styles.BSDDActionsMenu
               )}
             >
+              <TableRoadControlButton siret={siret} form={form} />
+
               <MenuLink
                 as={Link}
                 to={{
@@ -80,14 +82,18 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
                 Aperçu
               </MenuLink>
 
-              <TableRoadControlButton siret={siret} form={form} />
-
               {!form.isDraft && (
                 <MenuItem onSelect={() => downloadPdf()}>
                   <IconPdf size="24px" color="blueLight" />
                   Pdf
                 </MenuItem>
               )}
+
+              <MenuItem onSelect={() => duplicateBsda()}>
+                <IconDuplicateFile size="24px" color="blueLight" />
+                Dupliquer
+              </MenuItem>
+
               {![
                 BsdaStatus.Processed,
                 BsdaStatus.Refused,
@@ -106,10 +112,7 @@ export const BSDaActions = ({ form }: BSdaActionsProps) => {
                   </MenuLink>
                 </>
               )}
-              <MenuItem onSelect={() => duplicateBsda()}>
-                <IconDuplicateFile size="24px" color="blueLight" />
-                Dupliquer
-              </MenuItem>
+
               {form["bsdaStatus"] === BsdaStatus.Initial ||
               (form["bsdaStatus"] === BsdaStatus.SignedByProducer &&
                 form.emitter?.company?.siret === siret) ? (

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/BSDasriActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/BSDasriActions.tsx
@@ -65,12 +65,15 @@ export const BSDAsriActions = ({ form }: BSDAsriActionsProps) => {
                 <IconChevronDown size="14px" color="blueLight" />
               )}
             </MenuButton>
+
             <MenuList
               className={classNames(
                 "fr-raw-link fr-raw-list",
                 styles.BSDDActionsMenu
               )}
             >
+              <TableRoadControlButton siret={siret} form={form} />
+
               <MenuLink
                 as={Link}
                 to={{
@@ -85,20 +88,20 @@ export const BSDAsriActions = ({ form }: BSDAsriActionsProps) => {
                 Aperçu
               </MenuLink>
 
-              <TableRoadControlButton siret={siret} form={form} />
-
-              {canDelete && (
-                <MenuItem onSelect={() => setIsDeleting(true)}>
-                  <IconTrash color="blueLight" size="24px" />
-                  Supprimer
-                </MenuItem>
-              )}
               {!form.isDraft && (
                 <MenuItem onSelect={() => downloadPdf()}>
                   <IconPdf size="24px" color="blueLight" />
                   Pdf
                 </MenuItem>
               )}
+
+              {form.type === BsdasriType.Simple && (
+                <MenuItem onSelect={() => duplicateBsdasri()}>
+                  <IconDuplicateFile size="24px" color="blueLight" />
+                  Dupliquer
+                </MenuItem>
+              )}
+
               {![BsdasriStatus.Processed, BsdasriStatus.Refused].includes(
                 status
               ) && (
@@ -115,10 +118,11 @@ export const BSDAsriActions = ({ form }: BSDAsriActionsProps) => {
                   </MenuLink>
                 </>
               )}
-              {form.type === BsdasriType.Simple && (
-                <MenuItem onSelect={() => duplicateBsdasri()}>
-                  <IconDuplicateFile size="24px" color="blueLight" />
-                  Dupliquer
+
+              {canDelete && (
+                <MenuItem onSelect={() => setIsDeleting(true)}>
+                  <IconTrash color="blueLight" size="24px" />
+                  Supprimer
                 </MenuItem>
               )}
             </MenuList>

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/BsffActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/BsffActions.tsx
@@ -73,6 +73,8 @@ export const BsffActions = ({ form }: BsffActionsProps) => {
                 styles.BSDDActionsMenu
               )}
             >
+              <TableRoadControlButton siret={siret} form={form} />
+
               <MenuLink
                 as={Link}
                 to={{
@@ -86,12 +88,19 @@ export const BsffActions = ({ form }: BsffActionsProps) => {
                 <IconView color="blueLight" size="24px" />
                 Aperçu
               </MenuLink>
-              <TableRoadControlButton siret={siret} form={form} />
 
-              <MenuItem onSelect={() => downloadPdf()}>
-                <IconPdf size="24px" color="blueLight" />
-                Pdf
+              {!form.isDraft && (
+                <MenuItem onSelect={() => downloadPdf()}>
+                  <IconPdf size="24px" color="blueLight" />
+                  Pdf
+                </MenuItem>
+              )}
+
+              <MenuItem onSelect={() => duplicateBsff()}>
+                <IconDuplicateFile size="24px" color="blueLight" />
+                Dupliquer
               </MenuItem>
+
               {[BsffStatus.Initial, BsffStatus.SignedByEmitter].includes(
                 form.bsffStatus
               ) && (
@@ -108,11 +117,6 @@ export const BsffActions = ({ form }: BsffActionsProps) => {
                   </MenuLink>
                 </>
               )}
-
-              <MenuItem onSelect={() => duplicateBsff()}>
-                <IconDuplicateFile size="24px" color="blueLight" />
-                Dupliquer
-              </MenuItem>
 
               {canDelete && (
                 <MenuItem onSelect={() => setIsDeleting(true)}>

--- a/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/BSVhuActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/BSVhuActions.tsx
@@ -74,6 +74,8 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
                 styles.BSDDActionsMenu
               )}
             >
+              <TableRoadControlButton siret={siret} form={form} />
+
               <MenuLink
                 as={Link}
                 to={{
@@ -87,7 +89,6 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
                 <IconView color="blueLight" size="24px" />
                 Aperçu
               </MenuLink>
-              <TableRoadControlButton siret={siret} form={form} />
 
               {!form.isDraft && (
                 <MenuItem onSelect={() => downloadPdf()}>
@@ -95,6 +96,10 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
                   Pdf
                 </MenuItem>
               )}
+              <MenuItem onSelect={() => duplicateBsvhu()}>
+                <IconDuplicateFile size="24px" color="blueLight" />
+                Dupliquer
+              </MenuItem>
               {![BsvhuStatus.Processed, BsvhuStatus.Refused].includes(
                 status
               ) && (
@@ -111,10 +116,7 @@ export const BSVhuActions = ({ form }: BSVhuActionsProps) => {
                   </MenuLink>
                 </>
               )}
-              <MenuItem onSelect={() => duplicateBsvhu()}>
-                <IconDuplicateFile size="24px" color="blueLight" />
-                Dupliquer
-              </MenuItem>
+
               {canDelete && (
                 <MenuItem onSelect={() => setIsDeleting(true)}>
                   <IconTrash color="blueLight" size="24px" />

--- a/front/src/dashboard/components/BSDList/RoadControlButton.tsx
+++ b/front/src/dashboard/components/BSDList/RoadControlButton.tsx
@@ -53,9 +53,11 @@ export const TableRoadControlButton = ({ siret, form }) => {
       }}
     >
       <IconQrCode color="blueLight" size="24px" />
-      Contrôle
-      <br />
-      routier
+      <span className="tw-m-1 tw-leading-tight tw-text-center">
+        Contrôle
+        <br />
+        routier
+      </span>
     </MenuLink>
   );
 };


### PR DESCRIPTION
Relevé par la team UX, quelques incohérences/inconsistances du menu déroulant.

- On utilise donc l'ordre préconisé (selon disponibilité des actions):
     - Contrôle routier (transporteur uniquement)
     - Aperçu ; 
     - PDF ; 
     - Dupliquer ; 
     - Modifier ; 
     - Réviser ; 
     - Supprimer
-  on désactive le pdf bsff sur les brouillons
- améliorations centrage et espacement du texte du bouton de contrôle routier


<img width="111" alt="Capture d’écran 2023-02-16 à 11 40 50" src="https://user-images.githubusercontent.com/878396/219344874-09ff9ddf-40d5-4e4a-be53-7be8c265f7af.png">

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11052)
