### PR TITLE
Fix transporter autocomplete on synthesis dasri

### DIFF
--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -142,6 +142,7 @@ const COMPANY_INFOS = gql`
       name
       address
       companyTypes
+      contact
       contactEmail
       contactPhone
       transporterReceipt {
@@ -171,7 +172,12 @@ function CurrentCompanyWidget({ disabled = false }) {
           data?.companyInfos?.contactEmail
         );
       }
-
+      if (!values?.transporter?.company?.contact) {
+        setFieldValue(
+          `transporter.company.contact`,
+          data?.companyInfos?.contact
+        );
+      }
       if (!values?.transporter?.company?.phone) {
         setFieldValue(
           `transporter.company.phone`,


### PR DESCRIPTION
Lors de la création du dasri de synthèse, le transporteur ne peut être que l'utilisateur courant, il est géré par un composant react spécifique. Ce composant ne préremplissait pas le champ contact. 
Cette PR corrige le problème.

 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11032)
