### PR TITLE
Ne pas afficher le champ des scellés dans les révisions bsdas si aucune modification n'est demandée.

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsda/approve/BsdaApproveRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsda/approve/BsdaApproveRevision.tsx
@@ -240,7 +240,10 @@ function booleanFormatter(entity: boolean | undefined): React.ReactNode {
 }
 
 function sealNumbersFormatter(entity: string[] | undefined): React.ReactNode {
-  if (!entity) return null;
+  // prisma does not allow nullable lists so we can't tell apart `no change requested` vs `change to empty array`
+  // this is not an issue on this field as we do not want to set sealNumbers to [] on a reivsion
+  // so we consider empty arrays as falsy, they are ignored when reivsion is applied
+  if (!entity || !entity?.length) return null;
 
   return entity.join(", ");
 }


### PR DESCRIPTION
Fix suite cahier de recette bsda

Les révisions bsda permettent de modifier les numéros de scellés. Si on ne demande pas de révision, un array vide [] est stocké en db, prisma n'autorisant pas les null sur ces champs.

Le champ des scellés apparaissait ainsi comme "à modifier" dans l'affichage des révisions. 
Par ailleurs, il n'est pas permis de réviser un bsda pour n'avoir aucun numéro de scellé.

Cette PR corrige le problème, le champ n'apparaît pas si aucune modification n'est demandée.

![image](https://user-images.githubusercontent.com/878396/220090442-4c75fe46-2e3f-4453-8fd4-b08e2fe8288a.png)
---
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11036)
