### PR TITLE
Recette BSFF

### DIFF
--- a/back/src/bsffs/resolvers/queries/bsffPdf.ts
+++ b/back/src/bsffs/resolvers/queries/bsffPdf.ts
@@ -34,7 +34,10 @@ export const bsffPdfDownloadHandler: DownloadHandler<QueryBsffPdfArgs> = {
     const previousBsffIds = [...new Set(previousPackagings.map(p => p.bsffId))];
     const previousBsffs = await prisma.bsff.findMany({
       where: { id: { in: previousBsffIds } },
-      include: { packagings: true }
+      include: {
+        // includes only packagings in the dependency graph of the BSFF
+        packagings: { where: { id: { in: previousPackagings.map(p => p.id) } } }
+      }
     });
     const readableStream = await buildPdf({ ...bsff, previousBsffs });
     readableStream.pipe(createPDFResponse(res, bsff.id));

--- a/front/src/common/fragments/bsff.ts
+++ b/front/src/common/fragments/bsff.ts
@@ -241,13 +241,15 @@ export const PreviousBsffPackagingFragment = gql`
   fragment PreviousBsffPackaging on BsffPackaging {
     id
     numero
+    type
+    other
     weight
     volume
-    name
     bsffId
     acceptation {
       wasteCode
       wasteDescription
+      weight
     }
     bsff {
       id

--- a/front/src/dashboard/components/BSDList/BSFF/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/index.tsx
@@ -8,6 +8,7 @@ import { WorkflowAction } from "./WorkflowAction";
 import { bsffVerboseStatuses } from "form/bsff/utils/constants";
 import { UpdateTransporterCustomInfo } from "./BsffActions/UpdateTransporterCustomInfo";
 import { UpdateTransporterPlates } from "./BsffActions/UpdateTransporterPlates";
+import { BsffStatus } from "generated/graphql/types";
 
 export const COLUMNS: Record<
   string,
@@ -63,7 +64,9 @@ export const COLUMNS: Record<
     Cell: ({ value, row }) => (
       <>
         <span style={{ marginRight: "0.5rem" }}>{value}</span>
-        <UpdateTransporterCustomInfo bsff={row.original} />
+        {[BsffStatus.Initial, BsffStatus.SignedByEmitter].includes(
+          row.original.bsffStatus
+        ) && <UpdateTransporterCustomInfo bsff={row.original} />}
       </>
     ),
   },
@@ -74,7 +77,9 @@ export const COLUMNS: Record<
     Cell: ({ value, row }) => (
       <>
         <span style={{ marginRight: "0.5rem" }}>{value.join(", ")}</span>
-        <UpdateTransporterPlates bsff={row.original} />
+        {[BsffStatus.Initial, BsffStatus.SignedByEmitter].includes(
+          row.original.bsffStatus
+        ) && <UpdateTransporterPlates bsff={row.original} />}
       </>
     ),
   },

--- a/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
+++ b/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
@@ -148,7 +148,7 @@ export function BsffDetailContent({ form: bsff }: Props) {
             </Tab>
             <Tab className={styles.detailTab}>
               <IconBSFF />
-              <span className={styles.detailTabCaption}>Contenants</span>
+              <span className={styles.detailTabCaption}>Contenant(s)</span>
             </Tab>
           </TabList>
           {/* Tabs content */}

--- a/front/src/form/bsff/WasteInfo.tsx
+++ b/front/src/form/bsff/WasteInfo.tsx
@@ -17,7 +17,13 @@ export default function WasteInfo({ disabled }) {
   useEffect(() => {
     if ([BsffType.Reexpedition, BsffType.Groupement].includes(values.type)) {
       if (!values.id || hasPreviousPackagingsChanged) {
-        setFieldValue("packagings", values.previousPackagings);
+        setFieldValue(
+          "packagings",
+          values.previousPackagings.map(p => ({
+            ...p,
+            weight: p.acceptation?.weight ?? p.weight,
+          }))
+        );
       }
     }
   }, [


### PR DESCRIPTION
- [Les numéros de contenants des BSFF initiaux n'apparaissent pas sur le PDF en cas de reconditionnement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11039)
- [Les boutons d'édition du champ libre transporteur et de la plaque d'immatriculation ne devraient plus apparaitre lorsque le BSFF a été signé par le transporteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11038)
- [Prendre en compte le poids accepté en cas de regroupement et réexpédition](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11039)
- [[Bug] Aperçu : BSFF de reconditionnement : pas de "s" à contenant](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11056)

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
