### PR TITLE
HOTFIX - `workerIsDisabled` doit être `false` quand une entreprise de travaux est renseignée

### DIFF
--- a/back/prisma/migrations/123_set_worker_is_disabled_false.sql
+++ b/back/prisma/migrations/123_set_worker_is_disabled_false.sql
@@ -1,0 +1,8 @@
+UPDATE
+	"default$default"."Bsda"
+SET
+	"workerIsDisabled" = false
+WHERE
+	"workerIsDisabled" IS NULL
+	AND "workerCompanySiret" IS NOT NULL
+	AND "workerCompanySiret" <> '';

--- a/back/src/bsda/__tests__/factories.ts
+++ b/back/src/bsda/__tests__/factories.ts
@@ -90,6 +90,7 @@ const getBsdaObject = (): Prisma.BsdaCreateInput => ({
   destinationOperationCode: "D 9",
   destinationOperationDate: "2019-11-27T00:00:00.000Z",
 
+  workerIsDisabled: false,
   workerCompanyName: "Entreprise de travaux",
   workerCompanySiret: siretify(4),
   workerCompanyAddress: "1 route du travail, Travaux city",

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -442,7 +442,7 @@ function flattenBsdaTransporterInput({
 
 function flattenBsdaWorkerInput({ worker }: Pick<BsdaInput, "worker">) {
   return {
-    workerIsDisabled: chain(worker, w => w.isDisabled),
+    workerIsDisabled: chain(worker, w => Boolean(w.isDisabled)),
     workerCompanyName: chain(worker, w => chain(w.company, c => c.name)),
     workerCompanySiret: chain(worker, w => chain(w.company, c => c.siret)),
     workerCompanyAddress: chain(worker, w => chain(w.company, c => c.address)),


### PR DESCRIPTION
- L'API BSDA autorise d'envoyer `{ worker { isDisabled: null }, company: { siret: "1111111111111" } }`. 
- Lorsque l'on modifie les infos transport après la signature émetteur depuis l'UI, on envoie `{ isDisabled: false }` (ce qui est normal) mais on a une erreur car cela veut dire que l'on essaye de modifier un champ verrouillé. 
- Ce hotfix vise à corriger les données passées et à faire en sorte que tous les nouveaux BSDAs crées avec une entreprise de travaux renseignée aient bien `workerIsDisabled` à `false`.
- Le fait que ce bug ne soit pas ressorti avant la dernière MEP laisse penser que la vérification sur le verrouillage des champs ne devait pas fonctionner comme attendu sur le BSDA. On a d'ailleurs un [autre bug ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11103) sur le toggle "Adresse chantier" qui se reset lorsque qu'on décoche "Je veux ajouter une adresse chantier" et cause donc une erreur de verrouillage des champs. Ce bug aurait dû ressortir avant. 

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11100)
