### PR TITLE
Hotfix adresse chantier BSDA lors d'une modification

### DIFF
--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -69,6 +69,13 @@ export default function BsdaStepsList(props: Props) {
       computedState.emitter.pickupSite = null;
     }
 
+    if (
+      computedState.worker?.certification &&
+      existingBsda?.worker?.certification === null
+    ) {
+      computedState.worker.certification = null;
+    }
+
     return computedState;
   }, [formQuery.data]);
 

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -49,17 +49,24 @@ export default function BsdaStepsList(props: Props) {
   });
 
   const formState = useMemo(() => {
+    const existingBsda = formQuery.data?.bsda;
+
     const computedState = prefillTransportMode(
-      getComputedState(initialState, formQuery.data?.bsda)
+      getComputedState(initialState, existingBsda)
     );
 
-    if (formQuery.data?.bsda?.grouping) {
-      computedState.grouping = formQuery.data?.bsda.grouping.map(
-        bsda => bsda.id
-      );
+    if (existingBsda?.grouping) {
+      computedState.grouping = existingBsda.grouping.map(bsda => bsda.id);
     }
-    if (formQuery.data?.bsda?.forwarding) {
-      computedState.forwarding = formQuery.data?.bsda.forwarding.id;
+    if (existingBsda?.forwarding) {
+      computedState.forwarding = existingBsda.forwarding.id;
+    }
+
+    if (
+      computedState.emitter?.pickupSite &&
+      existingBsda?.emitter?.pickupSite === null
+    ) {
+      computedState.emitter.pickupSite = null;
     }
 
     return computedState;


### PR DESCRIPTION
Petit hotfix sur le toggle de l'adresse chantier.
Idéalement il faudrait comme sur le BSDD ne plus passer par `getComputedState` et gérer de façon plus précise la fusion entre les données initiales et les données du BSDA existant mais c'est un changement plus conséquent.


https://user-images.githubusercontent.com/2269165/220879958-792c2fc8-e8a3-4108-a65b-c07cf4a47b8a.mov


---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11103)
