### PR TITLE
HOTFIX - Traite `null` comme une chaine de caractère vide dans les règles d'édition

### DIFF
--- a/back/src/bsda/__tests__/edition.integration.ts
+++ b/back/src/bsda/__tests__/edition.integration.ts
@@ -40,6 +40,36 @@ describe("edition rules", () => {
     );
   });
 
+  it("should be possible to set a sealed field to null if it was empty", async () => {
+    const bsda = await bsdaFactory({
+      opt: {
+        status: "SIGNED_BY_PRODUCER",
+        emitterEmissionSignatureDate: new Date(),
+        emitterPickupSiteAddress: ""
+      }
+    });
+
+    const checked = await checkEditionRules(bsda, {
+      emitter: { pickupSite: { address: null } }
+    });
+    expect(checked).toBe(true);
+  });
+
+  it("should be possible to set a sealed field to an empty string if it was null", async () => {
+    const bsda = await bsdaFactory({
+      opt: {
+        status: "SIGNED_BY_PRODUCER",
+        emitterEmissionSignatureDate: new Date(),
+        emitterPickupSiteAddress: null
+      }
+    });
+
+    const checked = await checkEditionRules(bsda, {
+      emitter: { pickupSite: { address: "" } }
+    });
+    expect(checked).toBe(true);
+  });
+
   it("should be possible for the emitter to update a field sealed by emission signature", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const bsda = await bsdaFactory({

--- a/back/src/forms/workflow/__tests__/diff.test.ts
+++ b/back/src/forms/workflow/__tests__/diff.test.ts
@@ -1,4 +1,11 @@
-import { isObject, isArray, arraysEqual, objectDiff } from "../diff";
+import {
+  isObject,
+  isArray,
+  arraysEqual,
+  objectDiff,
+  isString,
+  stringEqual
+} from "../diff";
 
 describe("isObject", () => {
   test("object is object", () => {
@@ -54,6 +61,41 @@ describe("isArray", () => {
   });
 });
 
+describe("isString", () => {
+  test("string is string", () => {
+    expect(isString("a")).toEqual(true);
+    expect(isString("")).toEqual(true);
+  });
+
+  test("array is not string", () => {
+    expect(isString(["a", "b"])).toEqual(false);
+  });
+
+  test("object not string", () => {
+    expect(isString({ a: "a" })).toEqual(false);
+  });
+
+  test("date is not string", () => {
+    expect(isString(new Date())).toEqual(false);
+  });
+
+  test("boolean is not string", () => {
+    expect(isString(true)).toEqual(false);
+  });
+
+  test("number is not string", () => {
+    expect(isString(1)).toEqual(false);
+  });
+
+  test("null is not string", () => {
+    expect(isString(null)).toEqual(false);
+  });
+
+  test("undefined is not string", () => {
+    expect(isString(undefined)).toEqual(false);
+  });
+});
+
 describe("arrayEquals", () => {
   test("arrays are equal", () => {
     expect(arraysEqual([1, 2], [1, 2])).toEqual(true);
@@ -69,6 +111,23 @@ describe("arrayEquals", () => {
     expect(arraysEqual([1, 2], null)).toEqual(false);
     expect(arraysEqual(undefined, [2, 3])).toEqual(false);
     expect(arraysEqual([1, 2], undefined)).toEqual(false);
+  });
+});
+
+describe("stringEqual", () => {
+  test("strings are equal", () => {
+    expect(stringEqual("", null)).toBe(true);
+    expect(stringEqual(null, "")).toBe(true);
+    expect(stringEqual("", undefined)).toBe(true);
+    expect(stringEqual(undefined, "")).toBe(true);
+    expect(stringEqual("", "")).toBe(true);
+    expect(stringEqual("a", "a")).toBe(true);
+  });
+
+  test("strings are not equal", () => {
+    expect(stringEqual("a", "b")).toBe(false);
+    expect(stringEqual("a", "")).toBe(false);
+    expect(stringEqual("a", null)).toBe(false);
   });
 });
 
@@ -190,5 +249,23 @@ describe("dateDiff", () => {
 
     const diff = objectDiff(o1, o2);
     expect(diff).toEqual({ a: date2 });
+  });
+
+  test("diff with empty string", () => {
+    // same date but different object
+    const string1 = "";
+    const string2 = null;
+
+    const o1 = {
+      a: string1
+    };
+
+    const o2 = {
+      a: string2
+    };
+
+    expect(objectDiff(o1, o2)).toEqual({});
+    expect(objectDiff(o2, o1)).toEqual({});
+    expect(objectDiff(o1, { a: "another" })).toEqual({ a: "another" });
   });
 });

--- a/back/src/forms/workflow/__tests__/diff.test.ts
+++ b/back/src/forms/workflow/__tests__/diff.test.ts
@@ -252,7 +252,6 @@ describe("dateDiff", () => {
   });
 
   test("diff with empty string", () => {
-    // same date but different object
     const string1 = "";
     const string2 = null;
 

--- a/back/src/forms/workflow/diff.ts
+++ b/back/src/forms/workflow/diff.ts
@@ -10,6 +10,10 @@ export function isObject(obj) {
   return {}.toString.apply(obj) === "[object Object]";
 }
 
+export function isString(obj) {
+  return {}.toString.call(obj) === "[object String]";
+}
+
 export function isEmpty(obj) {
   return Object.keys(obj).length === 0;
 }
@@ -29,6 +33,10 @@ export function arraysEqual(a, b) {
     } else if (sortedA[i] !== sortedB[i]) return false;
   }
   return true;
+}
+
+export function stringEqual(s1: string, s2: string) {
+  return (s1 ?? "") === (s2 ?? "");
 }
 
 export function objectDiff(o1, o2) {
@@ -51,6 +59,15 @@ export function objectDiff(o1, o2) {
     }
     if (isDate(o2[key])) {
       if (o1[key] && isEqual(o2[key], o1[key])) {
+        return diff;
+      }
+      return {
+        ...diff,
+        [key]: o2[key]
+      };
+    }
+    if (isString(o2[key]) || isString(o1[key])) {
+      if (stringEqual(o1[key], o2[key])) {
         return diff;
       }
       return {


### PR DESCRIPTION
`nullIfNoValues` dans les converter considère que "" est la même chose que `null`. Du coup le front récupère potentiellement des valeurs nulles là où on a des chaines de caractère vides en DB et renvoie donc null lors d'un update. Si le champ est verrouillée par les règles d'édition, ça pète une erreur alors que l'utilisateur n'a rien changé dans le formulaire.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
