### PR TITLE
Fix Cannot convert object to primitive value

### DIFF
--- a/back/src/forms/workflow/__tests__/diff.test.ts
+++ b/back/src/forms/workflow/__tests__/diff.test.ts
@@ -99,6 +99,7 @@ describe("isString", () => {
 describe("arrayEquals", () => {
   test("arrays are equal", () => {
     expect(arraysEqual([1, 2], [1, 2])).toEqual(true);
+    expect(arraysEqual([1, 2], [2, 1])).toEqual(true);
     expect(arraysEqual([], [])).toEqual(true);
     expect(arraysEqual(null, null)).toEqual(true);
     expect(arraysEqual(undefined, undefined)).toEqual(true);
@@ -111,6 +112,44 @@ describe("arrayEquals", () => {
     expect(arraysEqual([1, 2], null)).toEqual(false);
     expect(arraysEqual(undefined, [2, 3])).toEqual(false);
     expect(arraysEqual([1, 2], undefined)).toEqual(false);
+  });
+
+  test("arrays of objects are equal", () => {
+    expect(
+      arraysEqual(
+        [
+          { a: "a", b: "b" },
+          { c: "c", d: "d" }
+        ],
+        [
+          { a: "a", b: "b" },
+          { c: "c", d: "d" }
+        ]
+      )
+    ).toEqual(true);
+  });
+
+  test.skip("arrays of objects in different order are equal", () => {
+    // waiting for fix - using default Array.sort on array of objects does not work
+    expect(
+      arraysEqual(
+        [
+          { a: "a", b: "b" },
+          { c: "c", d: "d" }
+        ],
+        [
+          { c: "c", d: "d" },
+          { a: "a", b: "b" }
+        ]
+      )
+    ).toEqual(true);
+  });
+
+  test("arrays of [Object: null prototype] are equals", () => {
+    const a = Object.create(null);
+    const b = Object.create(null);
+    a.b = b;
+    expect(arraysEqual([a, a], [a, a])).toEqual(true);
   });
 });
 

--- a/back/src/forms/workflow/diff.ts
+++ b/back/src/forms/workflow/diff.ts
@@ -23,8 +23,12 @@ export function arraysEqual(a, b) {
   if (a == null || b == null) return false;
   if (a.length !== b.length) return false;
 
-  const sortedA = [...a].sort();
-  const sortedB = [...b].sort();
+  const sortedA = [...a]
+    .map(item => (isObject(item) ? { ...item } : item))
+    .sort();
+  const sortedB = [...b]
+    .map(item => (isObject(item) ? { ...item } : item))
+    .sort();
 
   for (let i = 0; i < sortedA.length; ++i) {
     if (isObject(sortedA[i])) {


### PR DESCRIPTION
Il semblerait que `graphql` parse les arguments comme étant des [Object: null prototype]. Ces objets n'ont pas de fonction `toString` et on avait une erreur dans `arraysEqual` en appelant `sort`.

> Par défaut, le tri s'effectue sur les éléments du tableau convertis en chaînes de caractères

Cf https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort

Au passage je me suis aperçu que le sort ne fonctionnait pas sur les objets ce qui n'est pas dramatique mais j'ai quand même ajouté un failing test skipped pour gérer ce cas plus tard.



https://sentry.incubateur.net/organizations/betagouv/issues/23617/events/017f495f01c9409bb6f8ffa1a22e3497/?environment=production&project=19
