### PR TITLE
RFC - Réflexions sur la validation

### DIFF
--- a/back/src/bsda/edition.ts
+++ b/back/src/bsda/edition.ts
@@ -245,7 +245,7 @@ async function getUpdatedFields(
   return Object.keys(diff);
 }
 
-const SIGNATURES_HIERARCHY: {
+export const SIGNATURES_HIERARCHY: {
   [key in BsdaSignatureType]: { field: keyof Bsda; next?: BsdaSignatureType };
 } = {
   EMISSION: { field: "emitterEmissionSignatureDate", next: "WORK" },

--- a/back/src/bsda/repository/bsda/findMany.ts
+++ b/back/src/bsda/repository/bsda/findMany.ts
@@ -1,16 +1,17 @@
 import { Bsda, Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
-export type FindManyBsdaFn = (
+export type FindManyBsdaFn = <Args extends Prisma.BsdaArgs>(
   where: Prisma.BsdaWhereInput,
-  options?: Omit<Prisma.BsdaFindManyArgs, "where">
-) => Promise<Bsda[]>;
+  options?: Args
+) => Promise<Prisma.BsdaGetPayload<Args>[]>;
 
 export function buildFindManyBsda({
   prisma
 }: ReadRepositoryFnDeps): FindManyBsdaFn {
-  return (where, options?) => {
+  return async <Args>(where, options?) => {
     const input = { where, ...options };
-    return prisma.bsda.findMany(input);
+    const bsdas = await prisma.bsda.findMany(input);
+    return bsdas as Prisma.BsdaGetPayload<Args>[];
   };
 }

--- a/back/src/bsda/repository/bsda/findUnique.ts
+++ b/back/src/bsda/repository/bsda/findUnique.ts
@@ -9,7 +9,7 @@ export type FindUniqueBsdaFn = <Args extends Prisma.BsdaArgs>(
 export function buildFindUniqueBsda({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsdaFn {
-  return async <Args>(where, options?) => {
+  return async <Args extends Prisma.BsdaArgs>(where, options?) => {
     const input = { where, ...options };
     const bsda = await prisma.bsda.findUnique(input);
     return bsda as Prisma.BsdaGetPayload<Args>;

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -1,6 +1,5 @@
 import { UserInputError } from "apollo-server-express";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
 import {
   BsdaInput,
   MutationCreateBsdaArgs
@@ -12,10 +11,9 @@ import {
   expandBsdaFromDb,
   flattenBsdaInput
 } from "../../converter";
-import { getBsdaOrNotFound } from "../../database";
 import { checkIsBsdaContributor } from "../../permissions";
 import { getBsdaRepository } from "../../repository";
-import { validateBsda } from "../../validation";
+import { getContextualBsdaSchema } from "../../validation/validate";
 
 type CreateBsda = {
   isDraft: boolean;
@@ -34,29 +32,12 @@ export default async function create(
 export async function genericCreate({ isDraft, input, context }: CreateBsda) {
   const user = checkIsAuthenticated(context);
 
-  const bsda = flattenBsdaInput(input);
-
-  await checkIsBsdaContributor(
-    user,
-    { ...bsda, intermediaries: input.intermediaries },
-    "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
-  );
-
-  const isForwarding = Boolean(input.forwarding);
-  const isGrouping = input.grouping?.length > 0;
-
-  if ([isForwarding, isGrouping].filter(b => b).length > 1) {
-    throw new UserInputError(
-      "Les opérations d'entreposage provisoire et groupement ne sont pas compatibles entre elles"
-    );
-  }
-
   const companies = await getUserCompanies(user.id);
   const destinationCompany = companies.find(
     company => company.siret === input.destination?.company?.siret
   );
   if (
-    bsda.type === "COLLECTION_2710" &&
+    input.type === "COLLECTION_2710" &&
     !destinationCompany?.companyTypes.includes("WASTE_CENTER")
   ) {
     throw new UserInputError(
@@ -64,48 +45,39 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     );
   }
 
-  const bsdaRepository = getBsdaRepository(user);
-  const forwardedBsda = isForwarding
-    ? await getBsdaOrNotFound(input.forwarding)
-    : null;
-  const groupedBsdas = isGrouping
-    ? await bsdaRepository.findMany({ id: { in: input.grouping } })
-    : [];
+  const unparsedBsda = flattenBsdaInput(input);
 
-  const previousBsdas = [
-    ...(isForwarding ? [forwardedBsda] : []),
-    ...(isGrouping ? groupedBsdas : [])
-  ];
-  const hasIntermediaries = input.intermediaries?.length > 0;
-
-  await validateBsda(
-    bsda,
-    { previousBsdas, intermediaries: input.intermediaries },
-    {
-      emissionSignature: !isDraft
-    }
+  await checkIsBsdaContributor(
+    user,
+    { ...unparsedBsda, intermediaries: input.intermediaries },
+    "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
   );
 
-  const newBsda = await bsdaRepository.create({
-    ...bsda,
-    id: getReadableId(ReadableIdPrefix.BSDA),
-    isDraft,
-    ...(isForwarding && {
-      forwarding: { connect: { id: input.forwarding } }
-    }),
-    ...(isGrouping && {
-      grouping: { connect: groupedBsdas.map(({ id }) => ({ id })) }
-    }),
-    ...(hasIntermediaries && {
-      intermediariesOrgIds: input.intermediaries
-        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
-        .filter(Boolean),
-      intermediaries: {
-        createMany: {
-          data: companyToIntermediaryInput(input.intermediaries)
+  const bsda = await getContextualBsdaSchema({
+    currentSignatureType: !isDraft ? "EMISSION" : undefined
+  }).parseAsync({ ...unparsedBsda, isDraft });
+
+  const forwarding = Boolean(bsda.forwarding)
+    ? { connect: { id: bsda.forwarding } }
+    : undefined;
+  const grouping =
+    bsda.grouping && bsda.grouping.length > 0
+      ? { connect: bsda.grouping.map(id => ({ id })) }
+      : undefined;
+  const intermediaries =
+    bsda.intermediaries && bsda.intermediaries.length > 0
+      ? {
+          createMany: {
+            data: companyToIntermediaryInput(bsda.intermediaries)
+          }
         }
-      }
-    })
+      : undefined;
+
+  const newBsda = await getBsdaRepository(user).create({
+    ...bsda,
+    forwarding,
+    grouping,
+    intermediaries
   });
 
   return expandBsdaFromDb(newBsda);

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -38,8 +38,8 @@ import prisma from "../prisma";
 
 configureYup();
 
-export const PARTIAL_OPERATIONS = ["R 13", "D 15"];
-export const OPERATIONS = ["R 5", "D 5", "D 9", ...PARTIAL_OPERATIONS];
+export const PARTIAL_OPERATIONS = ["R 13", "D 15"] as const;
+export const OPERATIONS = ["R 5", "D 5", "D 9", ...PARTIAL_OPERATIONS] as const;
 type Emitter = Pick<
   Bsda,
   | "emitterIsPrivateIndividual"
@@ -264,7 +264,11 @@ async function validatePreviousBsdas(
       ]);
     }
 
-    if (!PARTIAL_OPERATIONS.includes(previousBsda.destinationOperationCode)) {
+    if (
+      !PARTIAL_OPERATIONS.some(
+        op => op === previousBsda.destinationOperationCode
+      )
+    ) {
       return acc.concat([
         `Le bordereau n°${previousBsda.id} a déclaré un traitement qui ne permet pas de lui donner la suite voulue.`
       ]);

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -1,0 +1,309 @@
+import { Bsda, BsdaType, Prisma, WasteAcceptationStatus } from "@prisma/client";
+import { RefinementCtx, z } from "zod";
+import { BsdaSignatureType } from "../../generated/graphql/types";
+import { PARTIAL_OPERATIONS } from "../validation";
+import { ZodBsda } from "./schema";
+
+type EditableBsdaFields = Required<
+  Omit<
+    Prisma.BsdaCreateInput,
+    | "id"
+    | "createdAt"
+    | "updatedAt"
+    | "isDraft"
+    | "isDeleted"
+    | "status"
+    | "emitterEmissionSignatureDate"
+    | "emitterEmissionSignatureAuthor"
+    | "transporterTransportSignatureAuthor"
+    | "transporterTransportSignatureDate"
+    | "workerWorkSignatureAuthor"
+    | "workerWorkSignatureDate"
+    | "destinationOperationSignatureAuthor"
+    | "destinationOperationSignatureDate"
+    | "groupedInId"
+    | "forwardingId"
+    | "groupedIn"
+    | "forwardedIn"
+    | "BsdaRevisionRequest"
+    | "intermediariesOrgIds"
+  >
+>;
+
+export const editionRules: {
+  [Key in keyof EditableBsdaFields]: {
+    sealedBy: BsdaSignatureType; // The type of signature that seals the field
+    isRequired: boolean | ((val: ZodBsda) => boolean); // Field must be filled. The rule can depend on other fields
+    isForbidden?: (val: ZodBsda, isRequired: boolean) => boolean; // Field must not set. The rule can depend on other fields or the result of `isRequired` as fields are often either required or forbiden
+    superRefine?: (val: ZodBsda, ctx: RefinementCtx) => void; // For other custom rules, we use a refine
+  };
+} = {
+  type: { sealedBy: "EMISSION", isRequired: true },
+  emitterIsPrivateIndividual: { sealedBy: "EMISSION", isRequired: true },
+  emitterCompanyName: {
+    sealedBy: "EMISSION",
+    isRequired: true
+  },
+  emitterCompanySiret: {
+    sealedBy: "EMISSION",
+    isRequired: bsda => !bsda.emitterIsPrivateIndividual,
+    isForbidden: isNotRequired
+  },
+  emitterCompanyAddress: {
+    sealedBy: "EMISSION",
+    isRequired: true
+  },
+  emitterCompanyContact: {
+    sealedBy: "EMISSION",
+    isRequired: bsda => !bsda.emitterIsPrivateIndividual
+  },
+  emitterCompanyPhone: {
+    sealedBy: "EMISSION",
+    isRequired: bsda => !bsda.emitterIsPrivateIndividual
+  },
+  emitterCompanyMail: {
+    sealedBy: "EMISSION",
+    isRequired: bsda => !bsda.emitterIsPrivateIndividual
+  },
+  emitterCustomInfo: { sealedBy: "EMISSION", isRequired: false },
+  emitterPickupSiteName: { sealedBy: "EMISSION", isRequired: false },
+  emitterPickupSiteAddress: { sealedBy: "EMISSION", isRequired: false },
+  emitterPickupSiteCity: { sealedBy: "EMISSION", isRequired: false },
+  emitterPickupSitePostalCode: {
+    sealedBy: "EMISSION",
+    isRequired: false
+  },
+  emitterPickupSiteInfos: { sealedBy: "EMISSION", isRequired: false },
+  ecoOrganismeName: { sealedBy: "TRANSPORT", isRequired: true },
+  ecoOrganismeSiret: { sealedBy: "TRANSPORT", isRequired: true },
+  destinationCompanyName: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanySiret: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanyAddress: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanyContact: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanyPhone: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanyMail: { sealedBy: "EMISSION", isRequired: true },
+  destinationCustomInfo: { sealedBy: "OPERATION", isRequired: true },
+  destinationCap: {
+    sealedBy: "EMISSION",
+    isRequired: bsda =>
+      [BsdaType.COLLECTION_2710, BsdaType.GATHERING, BsdaType.RESHIPMENT].every(
+        type => bsda.type !== type
+      ) &&
+      PARTIAL_OPERATIONS.every(
+        op => bsda.destinationPlannedOperationCode !== op
+      )
+  },
+  destinationPlannedOperationCode: {
+    sealedBy: "EMISSION",
+    isRequired: true
+  },
+  destinationReceptionDate: { sealedBy: "OPERATION", isRequired: true },
+  destinationReceptionWeight: { sealedBy: "OPERATION", isRequired: true },
+  destinationReceptionAcceptationStatus: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationReceptionRefusalReason: {
+    sealedBy: "OPERATION",
+    isRequired: isNotRefusedOrPartiallyRefused
+  },
+  destinationOperationCode: {
+    sealedBy: "OPERATION",
+    isRequired: isNotRefused
+  },
+  destinationOperationDescription: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationDate: {
+    sealedBy: "OPERATION",
+    isRequired: isNotRefused,
+    superRefine: (val, ctx) => {
+      if (
+        val.destinationReceptionDate &&
+        val.destinationOperationDate &&
+        val.destinationOperationDate <= val.destinationReceptionDate
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `La date d'opération doit être postérieure à la date de réception`
+        });
+      }
+    }
+  },
+  destinationOperationNextDestinationCompanyName: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanySiret: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanyVatNumber: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanyAddress: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanyContact: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanyPhone: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCompanyMail: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  destinationOperationNextDestinationCap: {
+    sealedBy: "OPERATION",
+    isRequired: bsda =>
+      Boolean(bsda.destinationOperationNextDestinationCompanySiret)
+  },
+  destinationOperationNextDestinationPlannedOperationCode: {
+    sealedBy: "OPERATION",
+    isRequired: true
+  },
+  transporterCompanyName: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanySiret: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanyAddress: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanyContact: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanyPhone: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanyMail: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterCompanyVatNumber: {
+    sealedBy: "TRANSPORT",
+    isRequired: true
+  },
+  transporterCustomInfo: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterRecepisseIsExempted: {
+    sealedBy: "TRANSPORT",
+    isRequired: true
+  },
+  transporterRecepisseNumber: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterRecepisseDepartment: {
+    sealedBy: "TRANSPORT",
+    isRequired: true
+  },
+  transporterRecepisseValidityLimit: {
+    sealedBy: "TRANSPORT",
+    isRequired: true
+  },
+  transporterTransportMode: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterTransportPlates: { sealedBy: "TRANSPORT", isRequired: true },
+  transporterTransportTakenOverAt: {
+    sealedBy: "TRANSPORT",
+    isRequired: true
+  },
+  workerIsDisabled: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker
+  },
+  workerCompanyName: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker,
+    isForbidden: isNotRequired
+  },
+  workerCompanySiret: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker,
+    isForbidden: isNotRequired
+  },
+  workerCompanyAddress: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker
+  },
+  workerCompanyContact: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker
+  },
+  workerCompanyPhone: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker
+  },
+  workerCompanyMail: {
+    sealedBy: "EMISSION",
+    isRequired: hasNoWorker
+  },
+  workerWorkHasEmitterPaperSignature: {
+    sealedBy: "WORK",
+    isRequired: true
+  },
+  workerCertificationHasSubSectionFour: {
+    sealedBy: "WORK",
+    isRequired: false
+  },
+  workerCertificationHasSubSectionThree: {
+    sealedBy: "WORK",
+    isRequired: false
+  },
+  workerCertificationCertificationNumber: {
+    sealedBy: "WORK",
+    isRequired: bsda => Boolean(bsda.workerCertificationHasSubSectionThree),
+    isForbidden: isNotRequired
+  },
+  workerCertificationValidityLimit: {
+    sealedBy: "WORK",
+    isRequired: bsda => Boolean(bsda.workerCertificationHasSubSectionThree),
+    isForbidden: isNotRequired
+  },
+  workerCertificationOrganisation: {
+    sealedBy: "WORK",
+    isRequired: bsda => Boolean(bsda.workerCertificationHasSubSectionThree),
+    isForbidden: isNotRequired
+  },
+  brokerCompanyName: { sealedBy: "EMISSION", isRequired: false },
+  brokerCompanySiret: { sealedBy: "EMISSION", isRequired: false },
+  brokerCompanyAddress: { sealedBy: "EMISSION", isRequired: false },
+  brokerCompanyContact: { sealedBy: "EMISSION", isRequired: false },
+  brokerCompanyPhone: { sealedBy: "EMISSION", isRequired: false },
+  brokerCompanyMail: { sealedBy: "EMISSION", isRequired: false },
+  brokerRecepisseNumber: { sealedBy: "EMISSION", isRequired: false },
+  brokerRecepisseDepartment: { sealedBy: "EMISSION", isRequired: false },
+  brokerRecepisseValidityLimit: {
+    sealedBy: "EMISSION",
+    isRequired: false
+  },
+  wasteCode: { sealedBy: "EMISSION", isRequired: true },
+  wasteAdr: { sealedBy: "WORK", isRequired: true },
+  wasteFamilyCode: { sealedBy: "WORK", isRequired: true },
+  wasteMaterialName: { sealedBy: "WORK", isRequired: true },
+  wasteConsistence: { sealedBy: "WORK", isRequired: true },
+  wasteSealNumbers: { sealedBy: "WORK", isRequired: true },
+  wastePop: { sealedBy: "WORK", isRequired: true },
+  packagings: { sealedBy: "WORK", isRequired: true },
+  weightIsEstimate: { sealedBy: "WORK", isRequired: true },
+  weightValue: { sealedBy: "WORK", isRequired: true },
+  grouping: { sealedBy: "EMISSION", isRequired: false },
+  forwarding: { sealedBy: "EMISSION", isRequired: false },
+  intermediaries: { sealedBy: "TRANSPORT", isRequired: false }
+};
+
+function hasNoWorker(bsda: ZodBsda) {
+  return (
+    [BsdaType.RESHIPMENT, BsdaType.GATHERING, BsdaType.COLLECTION_2710].every(
+      type => type !== bsda.type
+    ) && !bsda.workerIsDisabled
+  );
+}
+
+function isNotRefusedOrPartiallyRefused(bsda: ZodBsda) {
+  return (
+    bsda.destinationReceptionAcceptationStatus !==
+      WasteAcceptationStatus.PARTIALLY_REFUSED && isNotRefused(bsda)
+  );
+}
+
+function isNotRefused(bsda: ZodBsda) {
+  return (
+    bsda.destinationReceptionAcceptationStatus !==
+    WasteAcceptationStatus.REFUSED
+  );
+}
+
+function isNotRequired(_, isRequired: boolean) {
+  return !isRequired;
+}

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -1,0 +1,169 @@
+import {
+  Bsda,
+  BsdaStatus,
+  BsdaType,
+  BsdaConsistence,
+  WasteAcceptationStatus,
+  TransportMode
+} from "@prisma/client";
+import { z } from "zod";
+import { BSDA_WASTE_CODES } from "../../common/constants";
+import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
+import { OPERATIONS } from "../validation";
+
+export const rawBsdaSchema = z
+  .object({
+    id: z.string().default(() => getReadableId(ReadableIdPrefix.BSDA)),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    isDraft: z.boolean().default(false),
+    isDeleted: z.boolean().default(false),
+    status: z.nativeEnum(BsdaStatus).default(BsdaStatus.INITIAL),
+    type: z.nativeEnum(BsdaType),
+    emitterIsPrivateIndividual: z.boolean().nullish(),
+    emitterCompanyName: z.string().nullish(),
+    emitterCompanySiret: z.string().length(14).nullish(),
+    emitterCompanyAddress: z.string().nullish(),
+    emitterCompanyContact: z.string().nullish(),
+    emitterCompanyPhone: z.string().nullish(),
+    emitterCompanyMail: z.string().nullish(),
+    emitterCustomInfo: z.string().nullish(),
+    emitterPickupSiteName: z.string().nullish(),
+    emitterPickupSiteAddress: z.string().nullish(),
+    emitterPickupSiteCity: z.string().nullish(),
+    emitterPickupSitePostalCode: z.string().nullish(),
+    emitterPickupSiteInfos: z.string().nullish(),
+    emitterEmissionSignatureAuthor: z.string().nullish(),
+    emitterEmissionSignatureDate: z.coerce.date().nullish(),
+    ecoOrganismeName: z.string().nullish(),
+    ecoOrganismeSiret: z.string().nullish(),
+    wasteCode: z.enum(BSDA_WASTE_CODES).nullish(),
+    wasteFamilyCode: z.string().nullish(),
+    wasteMaterialName: z.string().nullish(),
+    wasteConsistence: z.nativeEnum(BsdaConsistence).nullish(),
+    wasteSealNumbers: z.array(z.string()).default([]),
+    wasteAdr: z.string().nullish(),
+    wastePop: z.coerce.boolean(),
+    packagings: z
+      .array(
+        z.object({
+          type: z.enum([
+            "BIG_BAG",
+            "CONTENEUR_BAG",
+            "DEPOT_BAG",
+            "OTHER",
+            "PALETTE_FILME",
+            "SAC_RENFORCE"
+          ]),
+          other: z.string(),
+          quantity: z.number()
+        })
+      )
+      .default([]),
+    weightIsEstimate: z.coerce.boolean().nullish(),
+    weightValue: z.number().nullish(),
+    brokerCompanyName: z.string().nullish(),
+    brokerCompanySiret: z.string().nullish(),
+    brokerCompanyAddress: z.string().nullish(),
+    brokerCompanyContact: z.string().nullish(),
+    brokerCompanyPhone: z.string().nullish(),
+    brokerCompanyMail: z.string().nullish(),
+    brokerRecepisseNumber: z.string().nullish(),
+    brokerRecepisseDepartment: z.string().nullish(),
+    brokerRecepisseValidityLimit: z.coerce.date().nullish(),
+    destinationCompanyName: z.string().nullish(),
+    destinationCompanySiret: z.string().nullish(),
+    destinationCompanyAddress: z.string().nullish(),
+    destinationCompanyContact: z.string().nullish(),
+    destinationCompanyPhone: z.string().nullish(),
+    destinationCompanyMail: z.string().nullish(),
+    destinationCap: z.string().nullish(),
+    destinationPlannedOperationCode: z.enum(OPERATIONS).nullish(),
+    destinationCustomInfo: z.string().nullish(),
+    destinationReceptionDate: z.coerce.date().nullish(),
+    destinationReceptionWeight: z.number().nullish(),
+    destinationReceptionAcceptationStatus: z
+      .nativeEnum(WasteAcceptationStatus)
+      .nullish(),
+    destinationReceptionRefusalReason: z.string().nullish(),
+    destinationOperationCode: z.enum(OPERATIONS).nullish(),
+    destinationOperationDescription: z.string().nullish(),
+    destinationOperationDate: z.coerce.date().max(new Date()).nullish(),
+    destinationOperationSignatureAuthor: z.string().nullish(),
+    destinationOperationSignatureDate: z.coerce.date().nullish(),
+    destinationOperationNextDestinationCompanySiret: z.string().nullish(),
+    destinationOperationNextDestinationCompanyVatNumber: z.string().nullish(),
+    destinationOperationNextDestinationCompanyName: z.string().nullish(),
+    destinationOperationNextDestinationCompanyAddress: z.string().nullish(),
+    destinationOperationNextDestinationCompanyContact: z.string().nullish(),
+    destinationOperationNextDestinationCompanyPhone: z.string().nullish(),
+    destinationOperationNextDestinationCompanyMail: z.string().nullish(),
+    destinationOperationNextDestinationCap: z.string().nullish(),
+    destinationOperationNextDestinationPlannedOperationCode: z
+      .string()
+      .nullish(),
+    transporterCompanyName: z.string().nullish(),
+    transporterCompanySiret: z.string().nullish(),
+    transporterCompanyAddress: z.string().nullish(),
+    transporterCompanyContact: z.string().nullish(),
+    transporterCompanyPhone: z.string().nullish(),
+    transporterCompanyMail: z.string().nullish(),
+    transporterCompanyVatNumber: z.string().nullish(),
+    transporterCustomInfo: z.string().nullish(),
+    transporterRecepisseIsExempted: z.coerce.boolean().nullish(),
+    transporterRecepisseNumber: z.string().nullish(),
+    transporterRecepisseDepartment: z.string().nullish(),
+    transporterRecepisseValidityLimit: z.coerce.date().nullish(),
+    transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
+    transporterTransportPlates: z.array(z.string()),
+    transporterTransportTakenOverAt: z.coerce.date().nullish(),
+    transporterTransportSignatureAuthor: z.string().nullish(),
+    transporterTransportSignatureDate: z.coerce.date().nullish(),
+    workerIsDisabled: z.coerce.boolean().nullish(),
+    workerCompanyName: z.string().nullish(),
+    workerCompanySiret: z.string().nullish(),
+    workerCompanyAddress: z.string().nullish(),
+    workerCompanyContact: z.string().nullish(),
+    workerCompanyPhone: z.string().nullish(),
+    workerCompanyMail: z.string().nullish(),
+    workerCertificationHasSubSectionFour: z.coerce.boolean().nullish(),
+    workerCertificationHasSubSectionThree: z.coerce.boolean().nullish(),
+    workerCertificationCertificationNumber: z.string().nullish(),
+    workerCertificationValidityLimit: z.coerce.date().nullish(),
+    workerCertificationOrganisation: z
+      .enum(["AFNOR Certification", "GLOBAL CERTIFICATION", "QUALIBAT"])
+      .nullish(),
+    workerWorkHasEmitterPaperSignature: z.coerce.boolean().nullish(),
+    workerWorkSignatureAuthor: z.string().nullish(),
+    workerWorkSignatureDate: z.coerce.date().nullish(),
+    grouping: z.array(z.string()).optional(),
+    forwarding: z.string().optional(),
+    intermediaries: z
+      .array(
+        z.object({
+          siret: z.string().nullish(),
+          vatNumber: z.string().nullish(),
+          contact: z.string().nullish(),
+          address: z.string().nullish(),
+          name: z.string().nullish(),
+          phone: z.string().nullish(),
+          mail: z.string().nullish(),
+          country: z.string().nullish(),
+          omiNumber: z.string().nullish(),
+          orgId: z.string().nullish()
+        })
+      )
+      .nullish(),
+    intermediariesOrgIds: z.array(z.string()).nullish()
+  })
+  .transform(val => {
+    val.intermediariesOrgIds = val.intermediaries
+      ?.flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+      .filter(Boolean) as string[];
+
+    // Here would be a
+
+    return val;
+  });
+
+export type ZodBsda = z.infer<typeof rawBsdaSchema>;

--- a/back/src/bsda/validation/utils.ts
+++ b/back/src/bsda/validation/utils.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { rawBsdaSchema, ZodBsda } from "./schema";
+
+export function someFieldIsNotNullish<Field extends keyof ZodBsda>(
+  bsda: ZodBsda,
+  fields: readonly Field[]
+) {
+  return fields.some(field => bsda[field]);
+}
+
+export function someFieldIsNullish<Field extends keyof ZodBsda>(
+  bsda: ZodBsda,
+  fields: readonly Field[]
+) {
+  return fields.some(field => !bsda[field]);
+}

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -1,0 +1,258 @@
+import { Bsda, BsdaStatus } from "@prisma/client";
+import { RefinementCtx, z } from "zod";
+import { BsdaSignatureType } from "../../generated/graphql/types";
+import { SIGNATURES_HIERARCHY } from "../edition";
+import { getReadonlyBsdaRepository } from "../repository";
+import { PARTIAL_OPERATIONS } from "../validation";
+import { editionRules } from "./rules";
+import { rawBsdaSchema, ZodBsda } from "./schema";
+
+type BsdaValidationContext = {
+  skipPreviousBsdas?: boolean;
+  currentSignatureType: BsdaSignatureType | undefined;
+};
+
+export function getContextualBsdaSchema(
+  validationContext: BsdaValidationContext
+) {
+  return rawBsdaSchema.superRefine(async (val, ctx) => {
+    const arrayOfRules = Object.entries(editionRules);
+
+    for (const [field, rule] of arrayOfRules) {
+      // Some signatures may be skipped, so always check all the hierarchy
+      const signaturesToCheck = getSignaturesLeadingToTarget(
+        validationContext.currentSignatureType
+      );
+
+      // At first we apply refinement rules
+      if (rule.superRefine instanceof Function) {
+        rule.superRefine(val, ctx);
+      }
+
+      // Then we apply the required / no value rules. We skip those rules if the fields are not sealed yet
+      if (!signaturesToCheck.includes(rule.sealedBy)) {
+        continue;
+      }
+
+      const fieldIsRequired =
+        rule.isRequired instanceof Function
+          ? rule.isRequired(val)
+          : rule.isRequired;
+
+      if (fieldIsRequired && !val[field]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `TODO type & message => il faut une valeur`
+        });
+      }
+
+      if (rule.isForbidden?.(val, fieldIsRequired) && val[field]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `TODO type & message => pas de valeur attendue mais on en a une`
+        });
+      }
+    }
+
+    const isForwarding = Boolean(val.forwarding);
+    const isGrouping = Boolean(val.grouping?.length);
+
+    if ([isForwarding, isGrouping].filter(b => b).length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Les opérations d'entreposage provisoire et groupement ne sont pas compatibles entre elles"
+      });
+    }
+
+    if (!validationContext.skipPreviousBsdas) {
+      await validatePreviousBsdas(val, ctx);
+    }
+
+    await validateIntermediaries(val.intermediaries, ctx);
+  });
+}
+
+function getSignaturesLeadingToTarget(
+  targetSignature: BsdaSignatureType | undefined
+) {
+  if (!targetSignature) return [];
+
+  const signaturesLeadingToTarget: BsdaSignatureType[] = [];
+  let currentSignature: BsdaSignatureType = "EMISSION";
+
+  while (currentSignature !== targetSignature) {
+    signaturesLeadingToTarget.push(currentSignature);
+
+    const nextSignature = SIGNATURES_HIERARCHY[currentSignature].next;
+    if (!nextSignature) {
+      throw new Error(
+        `Signature hierarchy error. ${currentSignature} has no next singature but target isn't reached yet.`
+      );
+    }
+    currentSignature = nextSignature;
+  }
+
+  return signaturesLeadingToTarget;
+}
+
+async function validateIntermediaries(
+  intermediaries: ZodBsda["intermediaries"] | undefined,
+  ctx: RefinementCtx
+) {
+  if (!intermediaries || intermediaries.length === 0) {
+    return;
+  }
+
+  if (intermediaries.length > 3) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "Intermédiaires: impossible d'ajouter plus de 3 intermédiaires sur un BSDA",
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  const intermediaryIdentifiers = intermediaries.map(
+    c => c.siret || c.vatNumber
+  );
+  const hasDuplicate =
+    new Set(intermediaryIdentifiers).size !== intermediaryIdentifiers.length;
+  if (hasDuplicate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "Intermédiaires: impossible d'ajouter le même établissement en intermédiaire plusieurs fois",
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  for (const intermediary of intermediaries) {
+    //await validateCompany(intermediary);
+  }
+}
+
+async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
+  if (!["GATHERING", "RESHIPMENT"].includes(bsda.type)) {
+    return;
+  }
+
+  const { findMany } = getReadonlyBsdaRepository();
+  const previousIds = [bsda.forwarding, ...(bsda.grouping ?? [])].filter(
+    Boolean
+  ) as string[];
+  const previousBsdas = await findMany(
+    { id: { in: previousIds } },
+    {
+      include: {
+        forwardedIn: true,
+        groupedIn: true
+      }
+    }
+  );
+
+  if (previousBsdas.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "Un bordereau de groupement ou de réexpédition doit obligatoirement être associé à au moins un bordereau.",
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  const previousBsdasWithDestination = previousBsdas.filter(
+    previousBsda => previousBsda.destinationCompanySiret
+  );
+  if (
+    bsda.emitterCompanySiret &&
+    previousBsdasWithDestination.some(
+      previousBsda =>
+        previousBsda.destinationCompanySiret !== bsda.emitterCompanySiret
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Certains des bordereaux à associer ne sont pas en la possession du nouvel émetteur.`,
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  const nextDestinations = previousBsdas.map(
+    bsda => bsda.destinationOperationNextDestinationCompanySiret
+  );
+  if (!nextDestinations.every(siret => siret === nextDestinations[0])) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Certains des bordereaux à associer ont des exutoires différents. Ils ne peuvent pas être groupés ensemble.`,
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  const firstPreviousBsdaWithDestination = previousBsdasWithDestination[0];
+  if (
+    previousBsdasWithDestination.some(
+      previousBsda =>
+        previousBsda.destinationCompanySiret !==
+        firstPreviousBsdaWithDestination.destinationCompanySiret
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Certains des bordereaux à associer ne sont pas en possession du même établissement.`,
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
+  for (const previousBsda of previousBsdas) {
+    if (previousBsda.status === BsdaStatus.PROCESSED) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Le bordereau n°${previousBsda.id} a déjà reçu son traitement final.`,
+        fatal: true
+      });
+      continue;
+    }
+
+    if (previousBsda.status !== BsdaStatus.AWAITING_CHILD) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Le bordereau n°${previousBsda.id} n'a pas toutes les signatures requises.`,
+        fatal: true
+      });
+      continue;
+    }
+
+    const { forwardedIn, groupedIn } = previousBsda;
+    // nextBsdas of previous
+    const nextBsdas = [forwardedIn, groupedIn].filter(Boolean) as Bsda[];
+    if (
+      nextBsdas.length > 0 &&
+      !nextBsdas.map(bsda => bsda.id).includes(bsda.id)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Le bordereau n°${previousBsda.id} a déjà été réexpédié ou groupé.`,
+        fatal: true
+      });
+      continue;
+    }
+
+    if (
+      !PARTIAL_OPERATIONS.some(
+        op => op === previousBsda.destinationOperationCode
+      )
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Le bordereau n°${previousBsda.id} a déclaré un traitement qui ne permet pas de lui donner la suite voulue.`,
+        fatal: true
+      });
+    }
+  }
+}

--- a/back/src/common/constants/WASTES.ts
+++ b/back/src/common/constants/WASTES.ts
@@ -5537,7 +5537,7 @@ const bsdaOnlyWasteCodes = [
   "16 02 12*",
   "17 06 01*",
   "17 06 05*"
-];
+] as const;
 const bsdasriOnlyWasteCodes = ["18 01 03*", "18 02 02*"];
 
 export const BSDA_WASTE_CODES = [
@@ -5560,7 +5560,7 @@ export const BSDA_WASTE_CODES = [
   "17 06 03*",
   "17 08 01*",
   "17 09 03*"
-];
+] as const;
 
 export const BSFF_WASTE_CODES = [
   ...bsffOnlyWasteCodes,
@@ -5583,7 +5583,7 @@ export const ALL_WASTES = flatten(ALL_WASTES_TREE);
 export const BSDD_WASTES = flatten(BSDD_WASTES_TREE);
 
 export const BSDA_WASTES = ALL_WASTES.filter(w =>
-  BSDA_WASTE_CODES.includes(w.code)
+  BSDA_WASTE_CODES.some(code => w.code === code)
 );
 
 export const BSFF_WASTES = ALL_WASTES.filter(w =>


### PR DESCRIPTION
Avec cette PR, je voudrais ouvrir le débat sur la maniètre dont est faite la validation (et tout ce qui va autour) dans notre code.

> Le code associé n'est pas à review, mais plutot à but illustratif. Il représente l'exploration que j'ai faite sur le BSDA en m'essayant à un début de refactor du BSDA.

L'idée ici est de réfléchir à une meilleure manière de valider nos données, et de s'assurer de manière générale qu'on a des données typées et correctement formattées dans l'ensemble de notre application. Ce n'est donc pas **uniquement** la validation et les schémas Yup

Voici ce que j'identifie comme pain points dans notre fonctionnement actuel (il n'y a pas d'ordre particulier, les numéros sont là pour les référencer plus tard) :
1. dans les resolvers on travaille parfois avec des input types, parfois avec des types "flatten" adaptés à la db. On devrait avoir un type unique dans le back. Celui de la db à priori, et ne jamais manipuler dans notre code métier les types graphql
2. la validation des données se fait un peu dans Yup, un peu dans les resolvers directement, un peu dans des fichiers common. Idem pour les valeurs par défaut, chaque resolver les déclare au besoin et ce n'est pas associé au schéma. On devrait être capable de tout centraliser
3. si on veut changer des données à la volée sur un input, on doit wrapper les inputs dans des appels [comme ici pour les sirets](https://github.com/MTES-MCT/trackdechets/pull/2171). La "validation" au sens large pourrait tout à fait prendre en compte ces manipulations et réunir validation et autofill
4. les fichiers de validation Yup sont de plus en plus difficiles à maintenir, avec des `.when(x.when(x.when()))` imbriqués. C'est souvent difficile de comprendre vraiment quand un champ est required ou pas et quelles règles s'appliquent
5. les règles d'édition et de validation recoupent la même information (si emitter est required à la signature EMISSION, c'est qu'en fait il sera vérouillé à cette même signature EMISSION) mais se trouvent dans deux endroits différents. Et qui n'ont aucun lien entre eux

> En voyez vous d'autres ? Etes-vous d'accord avec ces points ?

Il me semble que globalement chaque resolver devrait commencer par quelque chose comme ça:

```javascript
const unsafeObj = flatten(input);
const obj = await schema.parseAsync(unsafeObj);
```

On commence toujours par appliquer `flatten()` sur l'input au lieu de parfois le faire tardivement. On pourrait même imaginer que ca soit fait dans une étape de preprocess, genre un middleware chargé de `flatten` automatiquement les inputs. C'est sans douteoverkill, mais c'est l'idée: essayons de toujours travailler avec un seul et même type en back (c'est le point 1 plus haut).

Ensuite, on ne fait plus de la validation mais du parsing. C'est le ["parse don't validate"](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/) dont on entend parler de temps en temps et qui me semble important. C'est à dire que notre moulinette de validation doit avoir la capacité de modifier nos données d'entrées (`result=parse(input)` vs `validate(input)`). Concrètement, je pense qu'on devrait mettre beaucoup plus de choses dans cette moulinette pour y centraliser validation + remplissage auto + valeurs par défauts. Même pourquoi pas adaptation de l'objet vers un objet compatible Prisma.

Ex:
```javascript
// J'utilise zod (https://github.com/colinhacks/zod) dans les exemples car c'est avec cette lib que j'ai expérimenté
const schema = z.schema({
  // les valeurs hors input devraient probablement apparaitre dans ce schéma
  id: z.string().default(() => getReadableId(ReadableIdPrefix.BSDA)), // on gère directement toutes les valeurs par défaut de ce genre d'objet au lieu de mettre ces lignes dans le resolver lors de la création
  isDeleted: z.boolean().default(false),
  status: z.nativeEnum(BsdaStatus).default(BsdaStatus.INITIAL),
  ...

  // valeurs dans l'input
  emitterIsPrivateIndividual: z.boolean().default(false), // Si aucune valeur n'est passée, ayons un `false` en DB plutôt qu'un `null` qui n'a pas vraiment de sens
  grouping: z.array(z.string()).nullish().transform(val => val?.length ? { connect: bsda.grouping.map(id => ({ id })) } : undefined) // On peut même faire le mapping vers le type Prisma directement. Ou alors on considère que ce n'est pas du métier et ça doit reste en dehors du schéma, dans le resolver. A réfléchir. Mais c'est possible
  ...
}).transform(val => {
    // Et on peut précompléter directement dans ce schéma tout ce qui est champ calculé
    val.intermediariesOrgIds = val.intermediaries
      ?.flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
      .filter(Boolean);

    return val;
  });
```

Ce schéma peut ainsi centraliser toutes les règles métiers associées au type, donner de meilleurs défauts (eg false vs null), et aller aussi loin que l'on veut dans le fait de sortir un type "Prisma compatible". Et à noter ce type de sortie est strictement typé, en prenant en compte les transformation appliquées. Ca permet je crois de résoudre les points 2 & 3.

Pour le point 4, je pense qu'il faudrait bannir l'utilisation de `.when()` qui est problématique en terme de lisibilité du schéma. Zod [n'a volontairement pas ajouté cette méthode](https://github.com/colinhacks/zod/issues/1394#issuecomment-1346013265). De même il n'y a pas de contexte de validation directement intégré à Zod. A nous de construire le schéma avec notre contexte. Ces contraintes me semblent saines et peuvent à mon sens permettre un code plus clair et lisible.
C'est avec ces contraintes et en écrivant le schéma différemment qu'on rejoint le point 5: la colocation des règles de validation et des règles de vérouillage de signature.

Pour faire ça, on peut commencer par déclarer sur le schéma tous les fields qui *peuvent* être optionnels, en optionnel. Plus de `requiredIf`, `.when(x then nullable())`. Tout est nullable s'il faut pouvoir être dans un cas nullable (`nullish` probablement, c'est à dire soit `null` soit `undefined`).

Ensuite, sur les r_gles d42dition on peut passer de ça:
```javascript
const editionRules= {
  type: "EMISSION",
  emitterIsPrivateIndividual: "EMISSION",
  emitterCompanyName: "EMISSION",
  ...
}
```

A ça:
```javascript
const editionRules= {
  type: {sealedBy: "EMISSION", isRequired: true }, // Je suis vérouillé par signature EMISSION, à partir de cette signature je suis obligatoire
  emitterCompanySiret: { // Vérouillé par EMISSION. **Doit avoir une valeur** si ce n'est pas un particulier, et ne **doit pas avoir de valeur** si s'en est un. 
    sealedBy: "EMISSION",
    isRequired: bsda => !bsda.emitterIsPrivateIndividual,
    isForbidden: isNotRequired
  },
destinationOperationDate: { // Parfois le when n'est pas pour dire si c'est obligatoire ou non mais pour comparer avec d'autres valeurs. On remplace par une étape de `refine`, qui peut soit être ici soit directement dans le fichier schéma.
    sealedBy: "OPERATION",
    isRequired: isNotRefused,
    superRefine: (val, ctx) => {
      if (
        val.destinationReceptionDate &&
        val.destinationOperationDate &&
        val.destinationOperationDate <= val.destinationReceptionDate
      ) {
        ctx.addIssue({
          code: z.ZodIssueCode.custom,
          message: `La date d'opération doit être postérieure à la date de réception`
        });
      }
    }
  }
  ...
}
```

L'intérêt que je vois à ça c'est la colocation de données liées, et une maitenabilité il me semble bien meilleure. En un coup d'oeil, je sais quand mon champ est required, par quoi il est vérouillé, quand il doit être vide, et même ses relations métiers avec les autres champs.

Ces règles sont automatiquement appliquées au schéma global avec une implémentation comme ce qui a été fait [dans le fichier `validate.ts`](https://github.com/MTES-MCT/trackdechets/pull/2178/files#diff-2cefa38b414c2cbc570d76e5115138600280360ea9461320878ecf09842a4173). L'idée est qu'on prend un schéma, des règles et un contexte de validation, on mélange tout ça et on obtient un parsing + validation adapté à notre situation.

Voilà pour l'état de ma réflexion. Je serais intéressé par vous outputs. L'idée n'est pas de se lancer dans un tel refactor tant qu'on ne s'est pas mis d'accord sur 1 l'intérêt de ce changement, et 2 la manière de le mener.

A vos commentaires / avis / jet de tomates 🍅 !