### PR TITLE
Do not use offset pagination in bulk index job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,12 +364,12 @@ Toutes ces migrations sont jouées avec la commande `npm run update:dev`. (sans 
 Depuis un one-off container de taille XL
 
 - Réindexation globale sans downtime en utilisant les workers d'indexation
-  La réidexation ne sera déclenchée que si la version du mapping ES a changé
+  La réindexation ne sera déclenchée que si la version du mapping ES a changé
 
 `FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk -- --useQueue`
 
 - Réindexation globale sans downtime depuis la console (le travail ne sera pas parallélisé)
-  La réidexation ne sera déclenchée que si la version du mapping ES a changé
+  La réindexation ne sera déclenchée que si la version du mapping ES a changé
 
 `FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,6 +359,42 @@ Attention, contrairement aux scripts SQL ces migrations ne sont pas jouées une 
 
 Toutes ces migrations sont jouées avec la commande `npm run update:dev`. (sans le suffixe `:dev` en production)
 
+## Réindexation Elasticsearch
+
+Depuis un one-off container de taille XL
+
+- Réindexation globale sans downtime en utilisant les workers d'indexation
+  La réidexation ne sera déclenchée que si la version du mapping ES a changé
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk -- --useQueue`
+
+- Réindexation globale sans downtime depuis la console (le travail ne sera pas parallélisé)
+  La réidexation ne sera déclenchée que si la version du mapping ES a changé
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk`
+
+- Réindexation globale sans downtime en utilisant les workers d'indexation
+  Le paramètre -f permet de forcer la réindexation même si le mapping n'a pas changé
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk -- --useQueue -f`
+
+- Réindexation globale sans downtime depuis la console (le travail ne sera pas parallélisé)
+  Le paramètre -f permet de forcer la réindexation même si le mapping n'a pas changé
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-all-bsds-bulk -- -f`
+
+- Réindexation de tous les bordereaux d'un certain type (en place)
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-partial-in-place BSFF`
+
+- Réindexation de tous les bordereaux d'un certain type (en supprimant tous les bordereaux de ce type avant)
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-partial-in-place -- -f BSFF`
+
+- Réindexation de tous les bordereaux depuis une certaine date (en place)
+
+`FORCE_LOGGER_CONSOLE=true npm run reindex-partial-in-place -- --since 2023-03-01`
+
 ## Guides
 
 ### Mettre à jour le changelog
@@ -455,7 +491,6 @@ Voilà la procédure pour ajouter une icône au fichier `Icons.tsx` :
 
 Pour s'y retrouver plus facilement, suivre la convention de nommage en place et utiliser le nom donné par streamlineicons.
 
-
 ### Clefs de signature token OpenID
 
 Une clef de signature RSA est nécessaire pour signer les tokens d'identité d'Openid.
@@ -465,9 +500,9 @@ Une clef de signature RSA est nécessaire pour signer les tokens d'identité d'O
    openssl rsa -in keypair.pem -pubout -out publickey.crt
    openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in keypair.pem -out pkcs8.key
 ```
+
 Le contenu de pkcs8.key va dans la vairable d'env OIDC_PRIVATE_KEY.
 Le contenu de publickey.crt est destiné aux applications clientes d'OpenId connect.
-
 
 ### Reindexer un bordereau individuel
 

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -1,0 +1,392 @@
+import { ApiResponse } from "@elastic/elasticsearch";
+import { SearchResponse } from "@elastic/elasticsearch/api/types";
+import {
+  refreshElasticSearch,
+  resetDatabase
+} from "../../../../integration-tests/helper";
+import { bsdaFactory } from "../../../bsda/__tests__/factories";
+import { bsdasriFactory } from "../../../bsdasris/__tests__/factories";
+import { createBsff } from "../../../bsffs/__tests__/factories";
+import { bsvhuFactory } from "../../../bsvhu/__tests__/factories.vhu";
+import { BsdElastic, client, index } from "../../../common/elastic";
+import { formFactory, userFactory } from "../../../__tests__/factories";
+import {
+  getBsdIdentifiers,
+  indexAllBsds,
+  indexAllBsdTypeConcurrently,
+  indexAllBsdTypeSync,
+  processBsdIdentifiersByChunk
+} from "../bulkIndexBsds";
+
+describe("processBsdIdentifiersByChunk", () => {
+  it("should process every chunk", async () => {
+    const ids = ["1", "2", "3", "4", "5"];
+    const fn = jest.fn();
+    await processBsdIdentifiersByChunk(ids, fn, 2);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenNthCalledWith(1, ["1", "2"]);
+    expect(fn).toHaveBeenNthCalledWith(2, ["3", "4"]);
+    expect(fn).toHaveBeenNthCalledWith(3, ["5"]);
+  });
+});
+
+describe("getBsdIdentifiers", () => {
+  afterEach(resetDatabase);
+
+  it("should return all identifiers of a bsd type", async () => {
+    const user = await userFactory();
+
+    const form = await formFactory({ ownerId: user.id });
+    const ids = await getBsdIdentifiers("bsdd");
+    expect(ids).toEqual([form.id]);
+  });
+
+  it("should not return identifiers updated before since paramater", async () => {
+    const user = await userFactory();
+
+    // should not be returned
+    await formFactory({
+      ownerId: user.id,
+      opt: { updatedAt: new Date("2023-01-01") }
+    });
+    const form2 = await formFactory({
+      ownerId: user.id,
+      opt: { updatedAt: new Date("2023-02-01") }
+    });
+    const ids = await getBsdIdentifiers("bsdd", new Date("2023-02-01"));
+    expect(ids).toEqual([form2.id]);
+  });
+});
+
+describe("indexAllBsdTypeSync", () => {
+  afterEach(resetDatabase);
+
+  it("should index BSDDs synchronously", async () => {
+    const user = await userFactory();
+    const bsdds = await Promise.all([
+      formFactory({ ownerId: user.id }),
+      formFactory({ ownerId: user.id }),
+      formFactory({ ownerId: user.id })
+    ]);
+
+    await indexAllBsdTypeSync({ bsdName: "bsdd", index: index.alias });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdds.length);
+    for (const hit of hits) {
+      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSDAs synchronously", async () => {
+    const bsdas = await Promise.all([
+      bsdaFactory({}),
+      bsdaFactory({}),
+      bsdaFactory({})
+    ]);
+
+    await indexAllBsdTypeSync({ bsdName: "bsda", index: index.alias });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdas.length);
+    for (const hit of hits) {
+      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSDASRIs synchronously", async () => {
+    const bsdasris = await Promise.all([
+      bsdasriFactory({}),
+      bsdasriFactory({}),
+      bsdasriFactory({})
+    ]);
+
+    await indexAllBsdTypeSync({ bsdName: "bsdasri", index: index.alias });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdasris.length);
+    for (const hit of hits) {
+      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSFFs synchronously", async () => {
+    const bsffs = await Promise.all([
+      createBsff({}),
+      createBsff({}),
+      createBsff({})
+    ]);
+
+    await indexAllBsdTypeSync({ bsdName: "bsff", index: index.alias });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsffs.length);
+    for (const hit of hits) {
+      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSVHUs synchronously", async () => {
+    const bsvhus = await Promise.all([
+      bsvhuFactory({}),
+      bsvhuFactory({}),
+      bsvhuFactory({})
+    ]);
+    await indexAllBsdTypeSync({ bsdName: "bsvhu", index: index.alias });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsvhus.length);
+    for (const hit of hits) {
+      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source.id);
+    }
+  });
+});
+
+describe("indexAllBsdTypeConcurrently", () => {
+  afterEach(resetDatabase);
+
+  it("should index BSDDs using the index queue", async () => {
+    const user = await userFactory();
+    const bsdds = await Promise.all([
+      formFactory({ ownerId: user.id }),
+      formFactory({ ownerId: user.id }),
+      formFactory({ ownerId: user.id })
+    ]);
+
+    const jobs = await indexAllBsdTypeConcurrently({
+      bsdName: "bsdd",
+      index: index.alias
+    });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    expect(jobs.length).toEqual(1);
+    expect(jobs[0].status).toEqual("fulfilled");
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdds.length);
+    for (const hit of hits) {
+      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSDAs using the index queue", async () => {
+    const bsdas = await Promise.all([
+      bsdaFactory({}),
+      bsdaFactory({}),
+      bsdaFactory({})
+    ]);
+
+    const jobs = await indexAllBsdTypeConcurrently({
+      bsdName: "bsda",
+      index: index.alias
+    });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    expect(jobs.length).toEqual(1);
+    expect(jobs[0].status).toEqual("fulfilled");
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdas.length);
+    for (const hit of hits) {
+      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSDASRIs using the index queue", async () => {
+    const bsdasris = await Promise.all([
+      bsdasriFactory({}),
+      bsdasriFactory({}),
+      bsdasriFactory({})
+    ]);
+
+    const jobs = await indexAllBsdTypeConcurrently({
+      bsdName: "bsdasri",
+      index: index.alias
+    });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    expect(jobs.length).toEqual(1);
+    expect(jobs[0].status).toEqual("fulfilled");
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsdasris.length);
+    for (const hit of hits) {
+      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSFFs using the index queue", async () => {
+    const bsffs = await Promise.all([
+      createBsff({}),
+      createBsff({}),
+      createBsff({})
+    ]);
+
+    const jobs = await indexAllBsdTypeConcurrently({
+      bsdName: "bsff",
+      index: index.alias
+    });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    expect(jobs.length).toEqual(1);
+    expect(jobs[0].status).toEqual("fulfilled");
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsffs.length);
+    for (const hit of hits) {
+      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index BSVHUs using the index queue", async () => {
+    const bsvhus = await Promise.all([
+      bsvhuFactory({}),
+      bsvhuFactory({}),
+      bsvhuFactory({})
+    ]);
+    const jobs = await indexAllBsdTypeConcurrently({
+      bsdName: "bsvhu",
+      index: index.alias
+    });
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    expect(jobs.length).toEqual(1);
+    expect(jobs[0].status).toEqual("fulfilled");
+    const hits = body.hits.hits;
+    expect(hits).toHaveLength(bsvhus.length);
+    for (const hit of hits) {
+      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source.id);
+    }
+  });
+});
+
+describe("indexAllBsds", () => {
+  afterEach(resetDatabase);
+
+  it("should index all BSDs synchronously", async () => {
+    const user = await userFactory();
+    const form = await formFactory({ ownerId: user.id });
+    const bsda = await bsdaFactory({});
+    const bsdasri = await bsdasriFactory({});
+    const bsff = await createBsff({});
+    const bsvhu = await bsvhuFactory({});
+    const bsds = [form, bsda, bsdasri, bsff, bsvhu];
+
+    await formFactory({ ownerId: user.id });
+
+    await indexAllBsds(index.alias, false);
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+
+    expect(hits).toHaveLength(bsds.length);
+    for (const hit of hits) {
+      expect(bsds.map(bsd => bsd.id)).toContain(hit._source.id);
+    }
+  });
+
+  it("should index all BSDs in index queue", async () => {
+    const user = await userFactory();
+    const form = await formFactory({ ownerId: user.id });
+    const bsda = await bsdaFactory({});
+    const bsdasri = await bsdasriFactory({});
+    const bsff = await createBsff({});
+    const bsvhu = await bsvhuFactory({});
+    const bsds = [form, bsda, bsdasri, bsff, bsvhu];
+
+    await indexAllBsds(index.alias, true);
+    await refreshElasticSearch();
+
+    const { body }: ApiResponse<SearchResponse<BsdElastic>> =
+      await client.search({
+        index: index.alias,
+        body: {
+          query: { match_all: {} }
+        }
+      });
+    const hits = body.hits.hits;
+
+    expect(hits).toHaveLength(bsds.length);
+    for (const hit of hits) {
+      expect(bsds.map(bsd => bsd.id)).toContain(hit._source.id);
+    }
+  });
+});

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -343,8 +343,6 @@ describe("indexAllBsds", () => {
     const bsvhu = await bsvhuFactory({});
     const bsds = [form, bsda, bsdasri, bsff, bsvhu];
 
-    await formFactory({ ownerId: user.id });
-
     await indexAllBsds(index.alias, false);
     await refreshElasticSearch();
 

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -32,18 +32,13 @@ export const INDEX_DATETIME_SEPARATOR = "===";
 type IndexAllFnSignature = {
   bsdName: string;
   index: string;
-  skip: number;
-  total: number;
   since: Date;
 };
 
 export type FindManyAndIndexBsdsFnSignature = {
   bsdName: string;
   index: string;
-  skip: number;
-  total: number;
-  since: Date;
-  take: number;
+  ids: string[];
 };
 
 const bsdNameToBsdElasticFns = {
@@ -454,47 +449,113 @@ export async function addReindexAllInBulkJob(
 }
 
 /**
+ * Retrieves all BSD identifiers for a given BSD type
+ */
+async function getBsdIdentifiers(
+  bsdName: string,
+  since?: Date
+): Promise<string[]> {
+  const prismaModelDelegate = prismaModels[bsdName];
+
+  const bsds = await prismaModelDelegate.findMany({
+    where: {
+      isDeleted: false,
+      ...(since ? { updatedAt: { gte: since } } : {})
+    },
+    select: { id: true }
+  });
+
+  return bsds.map(bsd => bsd.id);
+}
+
+async function processBsdIdentifiersByChunk(
+  ids: string[],
+  fn: (chunk: string[]) => Promise<any>
+) {
+  const chunkSize = parseInt(process.env.BULK_INDEX_BATCH_SIZE, 10) || 100;
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    const chunk = ids.slice(i, i + chunkSize);
+    await fn(chunk);
+  }
+}
+
+/**
  * Index in chunks all BSDs of a given type in a synchronous manner
  */
 async function indexAllBsdTypeSync({
   bsdName,
   index,
-  skip,
-  total,
   since
 }: IndexAllFnSignature): Promise<IndexAllFnSignature | void> {
-  const take = parseInt(process.env.BULK_INDEX_BATCH_SIZE, 10) || 100;
+  const ids = await getBsdIdentifiers(bsdName, since);
 
-  const continueChunks = await findManyAndIndexBsds({
-    bsdName,
-    index,
-    skip,
-    total,
-    take,
-    since
-  });
+  logger.info(`Starting synchronous indexation of ${ids.length} ${bsdName}`);
 
-  if (!continueChunks) {
-    return;
-  }
-  // synchronous indexation takes place in the database order
-  return indexAllBsdTypeSync({
-    bsdName,
-    index,
-    skip: skip + take,
-    total,
-    since
+  processBsdIdentifiersByChunk(ids, async chunk => {
+    await findManyAndIndexBsds({
+      bsdName,
+      index,
+      ids: chunk
+    });
   });
 }
 
-async function getIndexTypeCount(bsdName: string, since: Date) {
-  const prismaModelDelegate = prismaModels[bsdName];
-  return prismaModelDelegate.count({
-    where: {
-      isDeleted: false,
-      ...(since ? { updatedAt: { gte: since } } : {})
-    }
+/**
+ * Index in chunks all BSDs of a given type by adding jobs
+ * to the job queue
+ */
+async function indexAllBsdTypeConcurrently({
+  bsdName,
+  index,
+  since
+}: IndexAllFnSignature) {
+  const jobs: Job<string>[] = [];
+
+  const data = [];
+
+  const ids = await getBsdIdentifiers(bsdName, since);
+  logger.info(`Starting indexation of ${ids.length} ${bsdName}`);
+
+  processBsdIdentifiersByChunk(ids, async chunk => {
+    data.push({
+      name: "indexChunk",
+      data: JSON.stringify({
+        bsdName,
+        index,
+        ids: chunk
+      }),
+      opts: {
+        lifo: true,
+        stackTraceLimit: 100,
+        attempts: 1,
+        timeout: 600_000 // 10 min
+      }
+    });
   });
+
+  // control concurrency of addBulk
+  const chunkSize = parseInt(process.env.BULK_INDEX_BATCH_ADD, 10) || 5;
+  for (let i = 0; i < data.length; i += chunkSize) {
+    const chunk = data.slice(i, i + chunkSize);
+    // all jobs are succesfully added in bulk or all jobs will fail
+    const bulkJobs = await indexQueue.addBulk(chunk);
+    jobs.push(...bulkJobs);
+  }
+
+  logger.info(
+    `Added ${data.length} bulk jobs to index chunks of "${bsdName}" to index "${index}"`
+  );
+
+  if (jobs.length) {
+    logger.info(`Waiting for all ${jobs.length} jobs in queue to finish`);
+    // returned promise fulfills when all of the input's promises settle (resolved or rejected)
+    return Promise.allSettled(
+      jobs.map(job => {
+        // Returns a promise that resolves or rejects when the job completes or fails.
+        return job.finished();
+      })
+    );
+  }
 }
 
 /**
@@ -506,87 +567,44 @@ async function indexAllBsds(
   bsdType?: BsdType,
   updatedSince?: Date
 ): Promise<void> {
-  let since: Date;
-  const jobs: Job<string>[] = [];
+  const startDate = new Date();
+
   const allBsdTypes: BsdType[] = ["BSDD", "BSDA", "BSDASRI", "BSVHU", "BSFF"];
 
   for (const loopType of allBsdTypes) {
     if (!bsdType || bsdType === loopType) {
       const bsdName = loopType.toLowerCase();
-      // initialize the total counter
-      const total = await getIndexTypeCount(bsdName, updatedSince);
-      logger.info(`Starting indexation of ${total} ${loopType}`);
+
       if (!useQueue) {
-        since = new Date();
         await indexAllBsdTypeSync({
           bsdName,
           index,
-          skip: 0,
-          total,
-          since: updatedSince ?? undefined
-        });
-        logger.info(
-          `Catching-up indexation of ${bsdName} updated in database since ${since.toISOString()}`
-        );
-        const totalSince = await getIndexTypeCount(bsdName, since);
-        await indexAllBsdTypeSync({
-          bsdName,
-          index,
-          skip: 0,
-          total: totalSince,
-          since
+          since: updatedSince
         });
       } else {
-        const take = parseInt(process.env.BULK_INDEX_BATCH_SIZE, 10) || 100;
-        const data = [];
-        for (
-          let incrementalSkip = 0;
-          incrementalSkip < total;
-          incrementalSkip += take
-        ) {
-          data.push({
-            name: "indexChunk",
-            data: JSON.stringify({
-              bsdName,
-              index,
-              skip: incrementalSkip,
-              total,
-              take,
-              since
-            }),
-            opts: {
-              lifo: true,
-              stackTraceLimit: 100,
-              attempts: 1,
-              timeout: 600_000 // 10 min
-            }
-          });
-        }
-        // control concurrency of addBulk
-        const chunkSize = parseInt(process.env.BULK_INDEX_BATCH_ADD, 10) || 5;
-        for (let i = 0; i < data.length; i += chunkSize) {
-          const chunk = data.slice(i, i + chunkSize);
-          // all jobs are succesfully added in bulk or all jobs will fail
-          const bulkJobs = await indexQueue.addBulk(chunk);
-          jobs.push(...bulkJobs);
-        }
-
-        logger.info(
-          `Added ${data.length} bulk jobs to index chunks of "${loopType}" to index "${index}"`
-        );
+        await indexAllBsdTypeConcurrently({
+          bsdName,
+          index,
+          since: updatedSince
+        });
       }
     }
   }
-  if (useQueue && jobs.length) {
-    logger.info(`Waiting for all ${jobs.length} jobs in queue to finish`);
-    // returned promise fulfills when all of the input's promises settle (resolved or rejected)
-    await Promise.allSettled(
-      jobs.map(job => {
-        // Returns a promise that resolves or rejects when the job completes or fails.
-        job.finished();
-      })
-    );
+
+  logger.info(
+    `Catching-up indexation of BSDs updated in database since ${startDate.toISOString()}`
+  );
+  for (const loopType of allBsdTypes) {
+    if (!bsdType || bsdType === loopType) {
+      const bsdName = loopType.toLowerCase();
+      await indexAllBsdTypeSync({
+        bsdName,
+        index,
+        since: startDate
+      });
+    }
   }
+
   logger.info("All types of BSD have been indexed");
 }
 
@@ -596,11 +614,8 @@ async function indexAllBsds(
 export async function findManyAndIndexBsds({
   bsdName,
   index,
-  skip,
-  take,
-  total,
-  since
-}: FindManyAndIndexBsdsFnSignature): Promise<boolean> {
+  ids
+}: FindManyAndIndexBsdsFnSignature): Promise<void> {
   const prismaModelDelegate = prismaModels[bsdName];
   const toBsdElasticFn = bsdNameToBsdElasticFns[bsdName];
   if (!toBsdElasticFn || !prismaModelDelegate) {
@@ -609,42 +624,14 @@ export async function findManyAndIndexBsds({
     throw new Error(msg);
   }
   const bsds = await prismaModelDelegate.findMany({
-    skip,
-    take,
-    // orderBy gives consistency in SELECT with OFFSET and LIMIT.
-    // Job queue is LIFO so the last inserted should be the first job processed
-    // All BSD have an SQL INDEX on updatedAt
-    orderBy: { updatedAt: "desc" },
-    where: {
-      isDeleted: false,
-      ...(since
-        ? { OR: [{ updatedAt: { gte: since } }, { createdAt: { gte: since } }] }
-        : {})
-    },
+    where: { id: { in: ids } },
     ...prismaFindManyOptions[bsdName]
   });
 
-  if (bsds.length === 0) {
-    logger.info(`No ${bsdName} to index, exit`, since);
-    return false;
-  }
-
   await indexBsds(
     index,
-    bsds.map(form => toBsdElasticFn(form))
+    bsds.map(bsd => toBsdElasticFn(bsd))
   );
 
-  if (bsds.length < take) {
-    logger.info(
-      `Indexed ${bsdName} the last/unique batch from cursor ${skip} to ${total} on total of ${total}`
-    );
-    return false;
-  } else {
-    logger.info(
-      `Indexed ${bsdName} batch from cursor ${skip} to ${
-        skip + take
-      } on total of ${total}`
-    );
-  }
-  return true;
+  logger.info(`Indexed ${bsdName} batch of ${bsds.length}`);
 }

--- a/back/src/queue/jobs/indexAllBsds.ts
+++ b/back/src/queue/jobs/indexAllBsds.ts
@@ -44,14 +44,9 @@ async function getBearerToken(scalingoToken) {
  */
 export async function indexChunkBsdJob(job: Job<string>) {
   try {
-    const {
-      bsdName,
-      index,
-      skip,
-      total,
-      take,
-      since
-    }: FindManyAndIndexBsdsFnSignature = JSON.parse(job.data);
+    const { bsdName, index, ids }: FindManyAndIndexBsdsFnSignature = JSON.parse(
+      job.data
+    );
     logger.info(
       `Started job indexChunk for the following bsd and index names : "${bsdName}", "${index}"`
     );
@@ -59,10 +54,7 @@ export async function indexChunkBsdJob(job: Job<string>) {
     await findManyAndIndexBsds({
       bsdName,
       index,
-      skip,
-      total,
-      take,
-      since
+      ids
     });
     return null;
   } catch (error) {


### PR DESCRIPTION
La réindexation utilisait une pagination par offset pour parcourir tous les bordereaux. Or Prisma spécifie bien : 

![Capture d’écran 2023-03-09 à 15 05 39](https://user-images.githubusercontent.com/2269165/224049423-99126fed-11ef-411f-8d4d-44092b2fbeb0.png)

J'ai fait des tests en local et effectivement dès que l'on dépasse quelques centaines de milliers de bordereaux, l'obtention de chaque chunk prend quelques secondes ce qui doit considérablement ralentir le process.

La solution proposée ici est de construire les chunks après avoir récupéré la liste de tous les identifiants pour un type de bordereau donnée. En locale, c'était de loin le mode de pagination le plus rapide. 

J'ai au passage ajouté pas mal de tests et ajouté de la documentation sur les différentes commandes de réindexation. 

### Benchmark d'une réindexation totale avec la config suivante : PostgreSQL 8G, ES 8G, 2 workers 2XL 

- pagination avec les identifiants (proposée dans cette PR): 43 minutes 
- pagination avec offset (fonctionnement initial) : 2 heures 20 minutes

Dans la pagination avec offset on a des chunks qui mettent plus de 5 minutes a être traitées (celles pour lesquelles le paramètre `skip` est élevé): 

![Capture d’écran 2023-03-13 à 16 26 03](https://user-images.githubusercontent.com/2269165/224748246-78263019-ba52-4d69-9133-979d8389261b.png)


--- 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
