### PR TITLE
[TRA-11138][Bugfix] Révision : il ne devrait pas être possible de soumettre une demande de révision sans avoir spécifié de champ

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -126,6 +126,38 @@ describe("Mutation.createFormRevisionRequest", () => {
     );
   });
 
+  it("should fail if revision has no modifications", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: company.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: bsdd.id,
+          content: { isCanceled: false },
+          comment: "A comment",
+          authoringCompanySiret: company.siret
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      `Impossible de créer une révision sans modifications.`
+    );
+  });
+
   it("should fail if the bsdd is canceled", async () => {
     const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
     const { user, company } = await userWithCompanyFactory("ADMIN");

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -209,7 +209,9 @@ async function getFlatContent(
 ): Promise<RevisionRequestContent> {
   const flatContent = flattenBsddRevisionRequestInput(content);
 
-  if (Object.keys(flatContent).length === 0) {
+  const { isCanceled, ...revisionFields } = flatContent;
+
+  if (!isCanceled && Object.keys(revisionFields).length === 0) {
     throw new UserInputError(
       "Impossible de créer une révision sans modifications."
     );
@@ -221,7 +223,7 @@ async function getFlatContent(
     );
   }
 
-  if (flatContent.isCanceled && Object.values(flatContent).length > 1) {
+  if (flatContent.isCanceled && Object.values(revisionFields).length > 0) {
     throw new UserInputError(
       "Impossible d'annuler et de modifier un bordereau."
     );


### PR DESCRIPTION
# Contexte

Aujourd'hui il est possible de créer une `RevisionRequest` en précisant juste un commentaire, mais sans sélectionner aucun critère de modification. On a donc en base plein de `RevisionRequest` qui ne servent à rien puisqu'elles ne réclament aucun changement effectif.

### Source du bug

Le problème vient du fait que le code regardait si le front envoyait au moins une clé:
```javascript
if (Object.keys(flatContent).length === 0) {
    throw new UserInputError(
      "Impossible de créer une révision sans modifications."
    );
}
```

Or avec la modification des annulations (via révision), on envoie toujours au moins une clé, `isCanceled`. Il n'y avait pas de test pour couvrir le use-case, donc il a cassé silencieusement. 

J'ai donc ajouté un test et modifié le code de la façon suivante:
```javascript
const { isCanceled, ...revisionFields } = flatContent;

if (!isCanceled && Object.keys(revisionFields).length === 0) {
    throw new UserInputError(
      "Impossible de créer une révision sans modifications."
    );
}
```

L'erreur s'affiche dans le front:
![image](https://user-images.githubusercontent.com/45355989/223760680-a13ccc71-d734-4fe9-841f-21d50d13037a.png)

# Ticket

[[Bug] Révision : il ne devrait pas être possible de soumettre une demande de révision sans avoir spécifié le.s champ.s à réviser (BSDD)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/06a754d25e59c3fbd50a14e6?card=tra-11138)
