### PR TITLE
Refacto - Préparation en vue d'activer strictNullCheck

### DIFF
--- a/back/integration-tests/helper.ts
+++ b/back/integration-tests/helper.ts
@@ -6,7 +6,7 @@ import { app } from "../src/server";
 import { client as elasticSearch, index } from "../src/common/elastic";
 import { indexQueue } from "../src/queue/producers/elastic";
 
-let httpServerInstance: HttpServer | HttpsServer = null;
+let httpServerInstance: HttpServer | HttpsServer | null = null;
 
 export function startServer() {
   if (!httpServerInstance) {
@@ -16,11 +16,11 @@ export function startServer() {
 }
 
 export async function closeServer() {
-  if (!httpServerInstance) {
-    return Promise.resolve();
-  }
-
   return new Promise<void>(resolve => {
+    if (!httpServerInstance) {
+      return resolve();
+    }
+
     httpServerInstance.close(() => {
       httpServerInstance = null;
       resolve();

--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -23,6 +23,7 @@
         "@prisma/client": "^4.6.1",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.6",
+        "@total-typescript/ts-reset": "^0.4.2",
         "apollo-server-core": "^3.10.1",
         "apollo-server-express": "^3.10.1",
         "apollo-server-plugin-base": "^3.6.2",
@@ -6013,6 +6014,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@total-typescript/ts-reset": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.4.2.tgz",
+      "integrity": "sha512-vqd7ZUDSrXFVT1n8b2kc3LnklncDQFPvR58yUS1kEP23/nHPAO9l1lMjUfnPrXYYk4Hj54rrLKMW5ipwk7k09A=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -24364,6 +24370,11 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
+    },
+    "@total-typescript/ts-reset": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.4.2.tgz",
+      "integrity": "sha512-vqd7ZUDSrXFVT1n8b2kc3LnklncDQFPvR58yUS1kEP23/nHPAO9l1lMjUfnPrXYYk4Hj54rrLKMW5ipwk7k09A=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",

--- a/back/package.json
+++ b/back/package.json
@@ -67,6 +67,7 @@
     "@prisma/client": "^4.6.1",
     "@sentry/integrations": "^6.19.7",
     "@sentry/node": "^6.19.6",
+    "@total-typescript/ts-reset": "^0.4.2",
     "apollo-server-core": "^3.10.1",
     "apollo-server-express": "^3.10.1",
     "apollo-server-plugin-base": "^3.6.2",

--- a/back/prisma/migrations/126_non_nullable_fields.sql
+++ b/back/prisma/migrations/126_non_nullable_fields.sql
@@ -1,0 +1,5 @@
+-- User name
+ALTER TABLE "default$default"."User" ALTER COLUMN "name" SET NOT NULL;
+
+-- Company name
+ALTER TABLE "default$default"."Company" ALTER COLUMN "name" SET NOT NULL;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -184,7 +184,7 @@ model Company {
   verificationMode                     CompanyVerificationMode?
   verificationComment                  String?
   verifiedAt                           DateTime?                 @db.Timestamptz(6)
-  name                                 String?
+  name                                 String
   address                              String?
   codeDepartement                      String?
   longitude                            Float?
@@ -709,7 +709,7 @@ model User {
   email                 String                  @unique
   password              String
   passwordVersion       Int
-  name                  String?
+  name                  String
   phone                 String?
   createdAt             DateTime                @default(now()) @db.Timestamptz(6)
   updatedAt             DateTime                @updatedAt @db.Timestamptz(6)

--- a/back/prisma/scripts/denormalize-dasris.ts
+++ b/back/prisma/scripts/denormalize-dasris.ts
@@ -26,7 +26,7 @@ export class UpdateBsdasrisSyntesizedEmitters implements Updater {
             ...new Set(
               bsd.synthesizing.map(associated => associated.emitterCompanySiret)
             )
-          ].filter(Boolean)
+          ].filter(Boolean) as string[]
         }
       });
     }

--- a/back/prisma/scripts/fix-vatnumber-bsds.ts
+++ b/back/prisma/scripts/fix-vatnumber-bsds.ts
@@ -63,7 +63,7 @@ export class FixBSDVatUpdater implements Updater {
           ) {
             cleanSiret = transporterCompanySiret.replace(/[\W_]+/g, "");
           }
-          let cleanTransportersSirets = [];
+          let cleanTransportersSirets: string[] = [];
           if (!!transportersSirets) {
             cleanTransportersSirets = transportersSirets.map(siret => {
               if (siret === transporterCompanySiret) return cleanSiret;

--- a/back/prisma/scripts/init-bsda-activity-logs.ts
+++ b/back/prisma/scripts/init-bsda-activity-logs.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import prisma from "../../src/prisma";
 import { registerUpdater, Updater } from "./helper/helper";
 
@@ -32,7 +33,7 @@ export class InitBsdaActivityLogs implements Updater {
         `🔢 There are ${bsdasCount} bsdas to process. Chunk size is ${CHUNK_SIZE}`
       );
 
-      let cursor = null;
+      let cursor: string | null = null;
       for (let i = 0; i < bsdasCount; i += CHUNK_SIZE) {
         const chunkBsdas = await prisma.bsda.findMany({
           where,
@@ -49,7 +50,7 @@ export class InitBsdaActivityLogs implements Updater {
             streamId: bsda.id,
             type: "BsdaCreated",
             actor: "script",
-            data: JSON.parse(JSON.stringify(bsda)),
+            data: JSON.parse(JSON.stringify(bsda)) as Prisma.InputJsonValue,
             metadata: { fake: true, origin: "initial migration" }
           }))
         });

--- a/back/prisma/scripts/init-form-activity-logs.ts
+++ b/back/prisma/scripts/init-form-activity-logs.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import prisma from "../../src/prisma";
 import { registerUpdater, Updater } from "./helper/helper";
 
@@ -32,7 +33,7 @@ export class LoadAnonymousCompaniesUpdater implements Updater {
         `🔢 There are ${formsCount} forms to process. Chunk size is ${CHUNK_SIZE}`
       );
 
-      let cursor = null;
+      let cursor: string | null = null;
       for (let i = 0; i < formsCount; i += CHUNK_SIZE) {
         const chunkForms = await prisma.form.findMany({
           where,
@@ -50,7 +51,7 @@ export class LoadAnonymousCompaniesUpdater implements Updater {
             type: "BsddCreated",
             actor: "script",
             data: {
-              content: JSON.parse(JSON.stringify(form))
+              content: JSON.parse(JSON.stringify(form)) as Prisma.InputJsonValue
             },
             metadata: { fake: true, origin: "initial migration" }
           }))

--- a/back/prisma/scripts/load-anonymous-companies.ts
+++ b/back/prisma/scripts/load-anonymous-companies.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import { Updater, registerUpdater } from "./helper/helper";
 import prisma from "../../src/prisma";
+import { Prisma } from "@prisma/client";
 
 @registerUpdater(
   "Load anonymous companies",
@@ -17,7 +18,9 @@ export class LoadAnonymousCompaniesUpdater implements Updater {
       const fixturePath =
         "./src/companies/sirene/fixtures/anonymousCompanies.json";
 
-      const data = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+      const data = JSON.parse(
+        fs.readFileSync(fixturePath, "utf8")
+      ) as Prisma.AnonymousCompanyCreateInput[];
 
       for (const companyInput of data) {
         await prisma.anonymousCompany.create({ data: companyInput });

--- a/back/src/__tests__/apollo-integration-testing.ts
+++ b/back/src/__tests__/apollo-integration-testing.ts
@@ -50,7 +50,11 @@ export type TestQuery = <
 >(
   operation: StringOrAst,
   options?: Options<V>
-) => Promise<ExecutionResult<T>>;
+) => Promise<
+  Required<{
+    [P in keyof ExecutionResult<T>]: NonNullable<ExecutionResult<T>[P]>;
+  }>
+>; // TODO to ease strictNullChecks migration, assert that all ExecutionResult results have a value for now
 
 export type TestSetOptions = (options: {
   request?: RequestOptions;

--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -26,7 +26,9 @@ describe("POST /login", () => {
     // should send trackdechets.connect.sid cookie
     expect(login.header["set-cookie"]).toHaveLength(1);
     const cookieRegExp = new RegExp(
-      `${sess.name}=(.+); Domain=${sess.cookie.domain}; Path=/; Expires=.+; HttpOnly`
+      `${sess.name}=(.+); Domain=${
+        sess.cookie!.domain
+      }; Path=/; Expires=.+; HttpOnly`
     );
     const sessionCookie = login.header["set-cookie"][0];
     expect(sessionCookie).toMatch(cookieRegExp);
@@ -259,7 +261,7 @@ describe("Authentification with token", () => {
       me: { email: user.email }
     });
 
-    const dbToken = await prisma.accessToken.findUnique({
+    const dbToken = await prisma.accessToken.findUniqueOrThrow({
       where: { token: hashToken(accessToken) }
     });
     expect(dbToken.lastUsed).not.toBeNull();
@@ -307,7 +309,7 @@ describe("Authentification with token", () => {
     });
 
     // should update lastUsed field
-    const accessToken = await prisma.accessToken.findUnique({
+    const accessToken = await prisma.accessToken.findUniqueOrThrow({
       where: { token: hashToken(token) }
     });
     expect(accessToken.lastUsed).not.toBeNull();

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -43,7 +43,7 @@ export const userFactory = async (
  * @param index numerical index
  */
 export function siretify(index: number | undefined) {
-  if (index === null || index > 9) {
+  if (!index || index > 9) {
     return faker.helpers.replaceCreditCardSymbols(
       Math.floor(Number(crypto.randomBytes(1))) + "############L"
     );
@@ -433,7 +433,7 @@ export const applicationFactory = async (openIdEnabled?: boolean) => {
 };
 
 export const ecoOrganismeFactory = async ({
-  siret = null,
+  siret,
   handleBsdasri = false
 }: {
   siret?: string;

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -202,7 +202,7 @@ describe("ActivityEvent.Bsda", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteCode: "01 03 08",
         comment: ""
       }
@@ -327,6 +327,6 @@ describe("ActivityEvent.Bsda", () => {
       now
     );
     expect(bsdaFromEventsAfterCreate.wasteCode).toBe("06 07 01*");
-    expect(bsdaAfterUpdate.wasteCode).toBe("06 13 04*");
+    expect(bsdaAfterUpdate!.wasteCode).toBe("06 13 04*");
   });
 });

--- a/back/src/applications/database.ts
+++ b/back/src/applications/database.ts
@@ -7,7 +7,7 @@ import { ApplicationNotFound } from "./errors";
  */
 export async function getApplicationOrApplicationNotFound({
   id
-}: Prisma.ApplicationWhereUniqueInput) {
+}: Required<Prisma.ApplicationWhereUniqueInput>) {
   const application = await prisma.application.findUnique({
     where: { id }
   });

--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -160,7 +160,7 @@ passport.serializeUser((user: User, done) => {
 
 passport.deserializeUser((id: string, done) => {
   prisma.user
-    .findUnique({ where: { id } })
+    .findUniqueOrThrow({ where: { id } })
     .then(user => done(null, { ...user, auth: AuthType.Session }))
     .catch(err => done(err));
 });
@@ -252,7 +252,7 @@ async function passportCallback(
   callback?: () => Promise<any>
 ) {
   if (user) {
-    req.logIn(user, { session: false }, null);
+    req.logIn(user, { session: false }, () => undefined);
     if (callback) {
       await callback();
     }
@@ -307,7 +307,7 @@ export function applyAuthStrategies(
   context: GraphQLContext,
   strategies: AuthType[]
 ) {
-  if (context.user && !strategies.includes(context.user.auth)) {
+  if (context.user && !strategies.includes(context.user.auth!)) {
     context.user = null;
   }
   return context;
@@ -318,5 +318,5 @@ export function applyAuthStrategies(
  *
  */
 export function isSessionUser(context: GraphQLContext): boolean {
-  return context.user && context.user.auth === AuthType.Session;
+  return !!context.user && context.user.auth === AuthType.Session;
 }

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -210,7 +210,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
       })
     }),
     grouping: [],
-    metadata: null
+    metadata: undefined as any
   };
 }
 export function expandBsdaFromElastic(
@@ -218,9 +218,6 @@ export function expandBsdaFromElastic(
 ): GraphqlBsda & { groupedIn?: string; forwardedIn?: string } {
   const expanded = expandBsdaFromDb(bsda);
 
-  if (!expanded) {
-    return null;
-  }
   // pass down related field to sub-resolvers
   return {
     ...expanded,
@@ -235,7 +232,7 @@ type FlattenedBsdaInput = Partial<
 
 export function flattenBsdaInput(formInput: BsdaInput) {
   return safeInput<FlattenedBsdaInput>({
-    type: chain(formInput, f => f.type),
+    type: formInput?.type ?? undefined,
     ...flattenBsdaEmitterInput(formInput),
     ...flattenBsdaEcoOrganismeInput(formInput),
     ...flattenBsdaDestinationInput(formInput),
@@ -431,8 +428,9 @@ function flattenBsdaTransporterInput({
     transporterTransportMode: chain(transporter, t =>
       chain(t.transport, tr => tr.mode)
     ),
-    transporterTransportPlates: chain(transporter, t =>
-      chain(t.transport, tr => tr.plates)
+    transporterTransportPlates: undefinedOrDefault(
+      chain(transporter, t => chain(t.transport, tr => tr.plates)),
+      []
     ),
     transporterTransportTakenOverAt: chain(transporter, t =>
       chain(t.transport, tr => tr.takenOverAt)
@@ -508,10 +506,14 @@ function flattenBsdaWasteInput({ waste }: Pick<BsdaInput, "waste">) {
     wasteMaterialName:
       chain(waste, w => w.materialName) ?? chain(waste, w => w.name),
     wasteConsistence: chain(waste, w => w.consistence),
-    wasteSealNumbers: chain(waste, w =>
-      w.sealNumbers === null ? undefined : w.sealNumbers
+    wasteSealNumbers: undefinedOrDefault(
+      chain(waste, w => w.sealNumbers),
+      []
     ),
-    wastePop: chain(waste, w => w.pop)
+    wastePop: undefinedOrDefault(
+      chain(waste, w => w.pop),
+      false
+    )
   };
 }
 
@@ -528,7 +530,7 @@ export function toInitialBsda(bsda: GraphqlBsda): GraphQLInitialBsda {
     waste: bsda.waste,
     weight: bsda.weight,
     destination: bsda.destination,
-    packagings: bsda.packagings
+    packagings: bsda.packagings ?? []
   };
 }
 
@@ -582,11 +584,15 @@ export function flattenBsdaRevisionRequestInput(
     wasteMaterialName: chain(reviewContent, r =>
       chain(r.waste, w => w.materialName)
     ),
-    wasteSealNumbers: chain(reviewContent, r =>
-      chain(r.waste, w => (w.sealNumbers === null ? undefined : w.sealNumbers))
+    wasteSealNumbers: undefinedOrDefault(
+      chain(reviewContent, r => chain(r.waste, w => w.sealNumbers)),
+      []
     ),
     wastePop: chain(reviewContent, r => chain(r.waste, w => w.pop)),
-    packagings: chain(reviewContent, r => r.packagings),
+    packagings: undefinedOrDefault(
+      chain(reviewContent, r => r.packagings),
+      []
+    ),
     destinationOperationCode: chain(reviewContent, r =>
       chain(r.destination, d => chain(d.operation, o => o.code))
     ),
@@ -659,11 +665,11 @@ export function companyToIntermediaryInput(
 
   return companies.map(company => {
     return {
-      name: company.name,
-      siret: company.siret,
+      name: company.name!,
+      siret: company.siret!,
       vatNumber: company.vatNumber,
       address: company.address,
-      contact: company.contact,
+      contact: company.contact!,
       phone: company.phone,
       mail: company.mail
     };

--- a/back/src/bsda/typeDefs/bsda.mutations.graphql
+++ b/back/src/bsda/typeDefs/bsda.mutations.graphql
@@ -2,22 +2,22 @@ type Mutation {
   """
   Crée un Bsda
   """
-  createBsda(input: BsdaInput!): Bsda
+  createBsda(input: BsdaInput!): Bsda!
 
   """
   Crée un Bsda en brouillon
   """
-  createDraftBsda(input: BsdaInput!): Bsda
+  createDraftBsda(input: BsdaInput!): Bsda!
 
   """
   Met à jour un Bsda
   """
-  updateBsda(id: ID!, input: BsdaInput!): Bsda
+  updateBsda(id: ID!, input: BsdaInput!): Bsda!
 
   """
   Permet de publier un brouillon pour le marquer comme prêt à être envoyé
   """
-  publishBsda(id: ID!): Bsda
+  publishBsda(id: ID!): Bsda!
 
   """
   Signe un Bsda.
@@ -112,24 +112,24 @@ type Mutation {
   }
   ```
   """
-  signBsda(id: ID!, input: BsdaSignatureInput!): Bsda
+  signBsda(id: ID!, input: BsdaSignatureInput!): Bsda!
 
   """
   Duplique un Bsda
   """
-  duplicateBsda("ID d'un BSDA" id: ID!): Bsda
+  duplicateBsda("ID d'un BSDA" id: ID!): Bsda!
 
   """
   Supprime un Bsda
   """
-  deleteBsda("ID d'un BSDA" id: ID!): Bsda
+  deleteBsda("ID d'un BSDA" id: ID!): Bsda!
 
   """
   Crée une demande de révision sur un Bsda existant
   """
   createBsdaRevisionRequest(
     input: CreateBsdaRevisionRequestInput!
-  ): BsdaRevisionRequest
+  ): BsdaRevisionRequest!
 
   """
   Annule une demande de révision de Bsda.
@@ -138,7 +138,7 @@ type Mutation {
   cancelBsdaRevisionRequest(
     "Identifiant de la demande de révision"
     id: ID!
-  ): Boolean
+  ): Boolean!
 
   """
   Répond à une demande d'approbation d'une révision.
@@ -152,5 +152,5 @@ type Mutation {
     isApproved: Boolean!
     "Commentaire facultatif"
     comment: String
-  ): BsdaRevisionRequest
+  ): BsdaRevisionRequest!
 }

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasri.integration.ts
@@ -163,8 +163,8 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.status).toEqual("INITIAL");
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
-    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
-    const created = await prisma.bsdasri.findUnique({
+    expect(data.createBsdasri.emitter!.company!.siret).toEqual(company.siret);
+    const created = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: data.createBsdasri.id }
     });
     expect(created.synthesisEmitterSirets).toEqual([]);
@@ -237,7 +237,7 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.status).toEqual("INITIAL");
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
-    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+    expect(data.createBsdasri.emitter!.company!.siret).toEqual(company.siret);
   });
 });
 
@@ -377,7 +377,7 @@ describe("Mutation.createDasri validation scenarii", () => {
     expect(data.createBsdasri.isDraft).toEqual(false);
     expect(data.createBsdasri.status).toEqual("INITIAL");
 
-    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+    expect(data.createBsdasri.emitter!.company!.siret).toEqual(company.siret);
   });
 
   it("Transport weight isEstimate is required when value is provided", async () => {
@@ -575,7 +575,7 @@ describe("Mutation.createDasri validation scenarii", () => {
         }
       }
     );
-    expect(data.createBsdasri.identification.numbers).toEqual([
+    expect(data.createBsdasri.identification!.numbers).toEqual([
       "GRV-XY12345",
       "GRV-VB45678"
     ]);
@@ -641,7 +641,9 @@ describe("Mutation.createDasri validation scenarii", () => {
         }
       }
     );
-    expect(data.createBsdasri.transporter.transport.plates.length).toEqual(2);
+    expect(data.createBsdasri.transporter!.transport!.plates!.length).toEqual(
+      2
+    );
   });
 
   it("should fail creating the form if more than 2 plates are submitted", async () => {
@@ -773,7 +775,7 @@ describe("Mutation.createDasri validation scenarii", () => {
     expect(data.createBsdasri.isDraft).toEqual(false);
     expect(data.createBsdasri.status).toEqual("INITIAL");
 
-    expect(data.createBsdasri.emitter.company.siret).toEqual(company.siret);
+    expect(data.createBsdasri.emitter!.company!.siret).toEqual(company.siret);
   });
 
   it("should convert 18 01 02* to 18 02 02*", async () => {
@@ -812,7 +814,7 @@ describe("Mutation.createDasri validation scenarii", () => {
       }
     );
 
-    expect(data.createBsdasri.waste.code).toEqual("18 02 02*");
+    expect(data.createBsdasri.waste!.code).toEqual("18 02 02*");
   });
 
   it("should allow decimal volume", async () => {

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriEcoOrganisme.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriEcoOrganisme.integration.ts
@@ -174,7 +174,7 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.status).toEqual("INITIAL");
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
-    expect(data.createBsdasri.ecoOrganisme.siret).toEqual(ecoOrg.siret);
+    expect(data.createBsdasri.ecoOrganisme?.siret).toEqual(ecoOrg.siret);
   });
   it("create a dasri with an eco-organisme and an unregistered emitter(eco-org user)", async () => {
     const ecoOrg = await ecoOrganismeFactory({ handleBsdasri: true });
@@ -224,8 +224,8 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.status).toEqual("INITIAL");
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
-    expect(data.createBsdasri.ecoOrganisme.siret).toEqual(ecoOrg.siret);
-    expect(data.createBsdasri.emitter.company.siret).toEqual(siret);
+    expect(data.createBsdasri.ecoOrganisme?.siret).toEqual(ecoOrg.siret);
+    expect(data.createBsdasri.emitter?.company?.siret).toEqual(siret);
   });
   it("create a dasri with an eco-organism (emitter user)", async () => {
     const ecoOrg = await ecoOrganismeFactory({ handleBsdasri: true });
@@ -275,9 +275,9 @@ describe("Mutation.createDasri", () => {
     expect(data.createBsdasri.status).toEqual("INITIAL");
     expect(data.createBsdasri.type).toEqual("SIMPLE");
 
-    expect(data.createBsdasri.emitter.company.siret).toEqual(
+    expect(data.createBsdasri.emitter?.company?.siret).toEqual(
       otherCompany.siret
     );
-    expect(data.createBsdasri.ecoOrganisme.siret).toEqual(ecoOrg.siret);
+    expect(data.createBsdasri.ecoOrganisme?.siret).toEqual(ecoOrg.siret);
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
@@ -97,22 +97,22 @@ describe("Mutation.createDasri", () => {
         }
       }
     );
-    expect(data.createBsdasri.synthesizing.map(bsd => bsd.id)).toEqual([
+    expect(data.createBsdasri.synthesizing?.map(bsd => bsd.id)).toEqual([
       toAssociate1.id,
       toAssociate2.id
     ]);
     expect(data.createBsdasri.type).toEqual("SYNTHESIS");
-    const grouped1 = await prisma.bsdasri.findUnique({
+    const grouped1 = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: toAssociate1.id }
     });
-    const grouped2 = await prisma.bsdasri.findUnique({
+    const grouped2 = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: toAssociate2.id }
     });
     expect(grouped1.synthesizedInId).toEqual(data.createBsdasri.id);
 
     expect(grouped2.synthesizedInId).toEqual(data.createBsdasri.id);
 
-    const created = await prisma.bsdasri.findUnique({
+    const created = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: data.createBsdasri.id }
     });
     const packaging = [

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriOperation.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriOperation.integration.ts
@@ -57,7 +57,7 @@ describe("Mutation.signBsdasri operation", () => {
       })
     ]);
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("RECEIVED");
@@ -91,7 +91,7 @@ describe("Mutation.signBsdasri operation", () => {
       }
     });
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("PROCESSED");
@@ -133,7 +133,7 @@ describe("Mutation.signBsdasri operation", () => {
       }
     });
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("AWAITING_GROUP");
@@ -181,7 +181,7 @@ describe("Mutation.signBsdasri operation", () => {
         })
       })
     ]);
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("RECEIVED");
@@ -221,7 +221,7 @@ describe("Mutation.signBsdasri operation", () => {
       }
     });
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("AWAITING_GROUP");

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
@@ -99,7 +99,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
       }
     });
 
-    const takenOverDasri = await prisma.bsdasri.findUnique({
+    const takenOverDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(takenOverDasri.status).toEqual("SENT");
@@ -108,7 +108,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
     expect(takenOverDasri.transportSignatoryId).toEqual(transporter.id);
 
     // signature data are cascaded on synthesizeBsdasri
-    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUnique({
+    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
 
@@ -223,7 +223,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
       }
     });
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("RECEIVED");
@@ -234,7 +234,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
     expect(receivedDasri.receptionSignatoryId).toEqual(recipient.id);
 
     // signature data are cascaded on synthesizeBsdasri
-    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUnique({
+    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
 
@@ -354,7 +354,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
       }
     });
 
-    const receivedDasri = await prisma.bsdasri.findUnique({
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
     expect(receivedDasri.status).toEqual("PROCESSED");
@@ -367,7 +367,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
     expect(receivedDasri.operationSignatoryId).toEqual(recipient.id);
 
     // signature data are cascaded on synthesizeBsdasri
-    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUnique({
+    const updatedSynthesizeBsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id }
     });
 

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
@@ -104,7 +104,7 @@ describe("Mutation.updateBsdasri", () => {
       }
     });
 
-    const updatedDasri = await prisma.bsdasri.findUnique({
+    const updatedDasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: dasri.id },
       include: {
         synthesizing: { select: { id: true } }
@@ -345,7 +345,7 @@ describe("Mutation.updateBsdasri", () => {
         }
       });
 
-      const updatedDasri = await prisma.bsdasri.findUnique({
+      const updatedDasri = await prisma.bsdasri.findUniqueOrThrow({
         where: { id: dasri.id },
         include: {
           synthesizing: { select: { id: true } }

--- a/back/src/bsds/indexation/reindexBsdHelpers.ts
+++ b/back/src/bsds/indexation/reindexBsdHelpers.ts
@@ -76,7 +76,7 @@ export async function reindex(bsdId, exitFn) {
   }
 
   if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
-    const bsdd = await prisma.form.findFirst({
+    const bsdd = await prisma.form.findFirstOrThrow({
       where: { readableId: bsdId }
     });
     if (bsdd.isDeleted) {

--- a/back/src/bsds/where.ts
+++ b/back/src/bsds/where.ts
@@ -15,7 +15,7 @@ import { BsdWhere } from "../generated/graphql/types";
 import { QueryDslQueryContainer } from "@elastic/elasticsearch/api/types";
 import { transportPlateFilter } from "../common/elastic";
 
-export function toElasticSimpleQuery(where: BsdWhere): QueryDslQueryContainer {
+export function toElasticSimpleQuery(where: BsdWhere) {
   return {
     bool: {
       must: [
@@ -182,7 +182,7 @@ export function toElasticSimpleQuery(where: BsdWhere): QueryDslQueryContainer {
           where.destination?.operation?.date
         ),
         toElasticStringListQuery("sirets", where.sirets)
-      ].filter(f => !!f)
+      ].filter(Boolean)
     }
   };
 }
@@ -214,10 +214,7 @@ export function toElasticQuery(where: BsdWhere): QueryDslQueryContainer {
     if (_and) {
       return {
         bool: {
-          must: [
-            ...(simpleQuery.bool.must as QueryDslQueryContainer[]),
-            ...arrayToInner(_and)
-          ],
+          must: [...simpleQuery.bool.must, ...arrayToInner(_and)],
           should: []
         }
       };

--- a/back/src/bsffs/compat.ts
+++ b/back/src/bsffs/compat.ts
@@ -10,7 +10,7 @@ import { UserInputError } from "apollo-server-core";
 import { RepositoryFnDeps } from "../common/repository/types";
 import { BsffPackagingInput } from "../generated/graphql/types";
 import { isFinalOperation } from "./constants";
-import { getBsffPackagingRepository } from "./repository";
+import { getReadonlyBsffPackagingRepository } from "./repository";
 
 type BsffDestination = {
   receptionWeight: number;
@@ -125,7 +125,7 @@ export async function getStatus(
 ) {
   const prisma = ctx?.prisma ?? prismaClient;
 
-  const { findNextPackagings } = getBsffPackagingRepository(ctx?.user, prisma);
+  const { findNextPackagings } = getReadonlyBsffPackagingRepository(prisma);
 
   const packagingsSimple =
     bsff.packagings ??

--- a/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
@@ -54,7 +54,7 @@ describe("bsffRepository.delete", () => {
 
     await deleteBsff({ where: { id: bsff.id } });
 
-    const deletedBsff = await prisma.bsff.findUnique({
+    const deletedBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsff.id }
     });
     expect(deletedBsff.isDeleted).toBe(true);

--- a/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
@@ -55,7 +55,7 @@ describe("bsffRepository.update", () => {
       data: { wasteCode: "14 06 02*" }
     });
 
-    const updatedBsff = await prisma.bsff.findUnique({
+    const updatedBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsff.id }
     });
     expect(updatedBsff.wasteCode).toEqual("14 06 02*");

--- a/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
@@ -180,7 +180,7 @@ describe("Mutation.deleteBsff", () => {
 
     expect(errors).toBeUndefined();
 
-    const deletedBsff = await prisma.bsff.findUnique({
+    const deletedBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsff.id }
     });
 
@@ -245,7 +245,7 @@ describe("Mutation.deleteBsff", () => {
       include: { packagings: true }
     });
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });
@@ -271,7 +271,7 @@ describe("Mutation.deleteBsff", () => {
       }
     );
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });
@@ -314,7 +314,7 @@ describe("Mutation.deleteBsff", () => {
       include: { packagings: true }
     });
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });
@@ -340,7 +340,7 @@ describe("Mutation.deleteBsff", () => {
       }
     );
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });
@@ -383,7 +383,7 @@ describe("Mutation.deleteBsff", () => {
       include: { packagings: true }
     });
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });
@@ -409,7 +409,7 @@ describe("Mutation.deleteBsff", () => {
       }
     );
 
-    initialBsff = await prisma.bsff.findUnique({
+    initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
       include: { packagings: true }
     });

--- a/back/src/bsffs/resolvers/mutations/signBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/signBsff.ts
@@ -35,7 +35,7 @@ import {
 async function checkIsAllowed(
   siret: string | null,
   user: Express.User,
-  securityCode: number | null
+  securityCode: number | null | undefined
 ) {
   if (siret == null) {
     throw new UserInputError(
@@ -308,8 +308,10 @@ const signatures: Record<
         data: { status }
       });
 
-      const finalOperationPackagings = packagings.filter(p =>
-        isFinalOperation(p.operationCode, p.operationNoTraceability)
+      const finalOperationPackagings = packagings.filter(
+        p =>
+          p.operationCode &&
+          isFinalOperation(p.operationCode, p.operationNoTraceability)
       );
 
       const previousPackagings = await findPreviousPackagings(

--- a/back/src/bsffs/where.ts
+++ b/back/src/bsffs/where.ts
@@ -9,7 +9,9 @@ import {
   toPrismaGenericWhereInput
 } from "../common/where";
 
-function toPrismaBsffSimpleWhereInput(where: BsffWhere): Prisma.BsffWhereInput {
+function toPrismaBsffSimpleWhereInput(
+  where: BsffWhere
+): Prisma.BsffWhereInput | undefined {
   if (!where) {
     return undefined;
   }
@@ -43,7 +45,7 @@ function toPrismaBsffSimpleWhereInput(where: BsffWhere): Prisma.BsffWhereInput {
 }
 export function toPrismaBsffWhereInput(
   where: BsffWhere
-): Prisma.BsffWhereInput {
+): Prisma.BsffWhereInput | undefined {
   if (!where) {
     return undefined;
   }

--- a/back/src/bsvhu/permissions.ts
+++ b/back/src/bsvhu/permissions.ts
@@ -49,6 +49,7 @@ export async function checkCanDeleteBsdvhu(user: User, bsvhu: Bsvhu) {
 
   const isUserOnlySignatory = async () =>
     bsvhu.status === BsvhuStatus.SIGNED_BY_PRODUCER &&
+    bsvhu.emitterCompanySiret &&
     (await getCachedUserSiretOrVat(user.id)).includes(
       bsvhu.emitterCompanySiret
     );

--- a/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
@@ -2,22 +2,22 @@ type Mutation {
   """
   Crée un BSVHU
   """
-  createBsvhu(input: BsvhuInput!): Bsvhu
+  createBsvhu(input: BsvhuInput!): Bsvhu!
 
   """
   Crée un BSVHU en brouillon
   """
-  createDraftBsvhu(input: BsvhuInput!): Bsvhu
+  createDraftBsvhu(input: BsvhuInput!): Bsvhu!
 
   """
   Met à jour un BSVHU
   """
-  updateBsvhu(id: ID!, input: BsvhuInput!): Bsvhu
+  updateBsvhu(id: ID!, input: BsvhuInput!): Bsvhu!
 
   """
   Permet de publier un brouillon pour le marquer comme prêt à être envoyé
   """
-  publishBsvhu(id: ID!): Bsvhu
+  publishBsvhu(id: ID!): Bsvhu!
 
   """
   Signe un BSVHU.
@@ -93,15 +93,15 @@ type Mutation {
   }
   ```
   """
-  signBsvhu(id: ID!, input: BsvhuSignatureInput!): Bsvhu
+  signBsvhu(id: ID!, input: BsvhuSignatureInput!): Bsvhu!
 
   """
   Duplique un BSVHU
   """
-  duplicateBsvhu("ID d'un BSD VHU" id: ID!): Bsvhu
+  duplicateBsvhu("ID d'un BSD VHU" id: ID!): Bsvhu!
 
   """
   Supprime un BSVHU
   """
-  deleteBsvhu("ID d'un BSD VHU" id: ID!): Bsvhu
+  deleteBsvhu("ID d'un BSD VHU" id: ID!): Bsvhu!
 }

--- a/back/src/captcha/captchaGen.ts
+++ b/back/src/captcha/captchaGen.ts
@@ -180,8 +180,8 @@ export async function captchaSound(captchaToken, res) {
   const captchaArray = captchaString.toLowerCase().split("");
   const letters = Array.from(new Set(captchaArray)); // remove duplicates
 
-  const audio = [];
-  const playList = [];
+  const audio: string[] = [];
+  const playList: number[] = [];
 
   for (const letter of letters) {
     const contents = fs.readFileSync(

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -164,8 +164,8 @@ export const isOmi = (clue: string): boolean => {
  * Works with any BSD in order to provide a default orgId
  */
 export const getTransporterCompanyOrgId = (form: {
-  transporterCompanySiret: string;
-  transporterCompanyVatNumber: string;
+  transporterCompanySiret: string | null;
+  transporterCompanyVatNumber: string | null;
 }): string | null => {
   if (!form) return null;
   return form.transporterCompanySiret?.length

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -366,7 +366,7 @@ export function indexBsds(indexName: string, bsds: BsdElastic[]) {
 /**
  * Delete a document in Elastic Search.
  */
-export function deleteBsd<T extends { id?: string }>(
+export function deleteBsd<T extends { id: string }>(
   { id }: T,
   ctx?: GraphQLContext
 ) {

--- a/back/src/common/middlewares/loggingMiddleware.ts
+++ b/back/src/common/middlewares/loggingMiddleware.ts
@@ -25,8 +25,8 @@ export default function (graphQLPath: string) {
       requestMetadata.graphql_variables = req.body?.variables;
       requestMetadata.graphql_query = req.body?.query;
 
-      requestMetadata.graphql_operation = req.gqlInfos[0]?.operation;
-      requestMetadata.graphql_selection_name = req.gqlInfos[0]?.name;
+      requestMetadata.graphql_operation = req.gqlInfos?.[0]?.operation;
+      requestMetadata.graphql_selection_name = req.gqlInfos?.[0]?.name;
     }
 
     logger.info(message, requestMetadata);

--- a/back/src/common/middlewares/rateLimiter.ts
+++ b/back/src/common/middlewares/rateLimiter.ts
@@ -19,7 +19,7 @@ const store =
       });
 
 export function rateLimiterMiddleware(options: Options) {
-  options.keyGenerator = options.keyGenerator ?? (ip => ip);
+  const keyGenerator = options.keyGenerator ?? (ip => ip);
 
   return rateLimit({
     message: `Quota de ${options.maxRequestsPerWindow} requêtes par minute excédé pour cette adresse IP, merci de réessayer plus tard.`,
@@ -27,7 +27,7 @@ export function rateLimiterMiddleware(options: Options) {
     max: options.maxRequestsPerWindow,
     store,
     keyGenerator: (request: Request) => {
-      return options.keyGenerator(request.ip, request);
+      return keyGenerator(request.ip, request);
     }
   });
 }

--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -43,7 +43,9 @@ export function FormCompanyFields({
         <input
           type="checkbox"
           checked={
-            company?.vatNumber?.length > 0 && companyCountry?.cca2 !== "FR"
+            !!company?.vatNumber &&
+            company.vatNumber.length > 0 &&
+            companyCountry?.cca2 !== "FR"
           }
           readOnly
         />{" "}
@@ -96,23 +98,20 @@ export function FormCompanyFields({
   );
 }
 
-export function getcompanyCountry(company: FormCompany): Country | null {
-  // reconnaitre le pays directement dans le champ country
-  let companyCountry = company
-    ? countries.find(country => country.cca2 === company?.country) ??
-      FRENCH_COUNTRY // default
-    : null;
+export function getcompanyCountry(company: FormCompany | undefined): Country | undefined {
+  if (!company) return FRENCH_COUNTRY; // default
 
   // forcer FR si le siret est valide
-  if (company && isSiret(company.siret)) {
-    companyCountry = countries.find(country => country.cca2 === "FR");
-  } else if (company && isVat(company.vatNumber)) {
+  if (company.siret && isSiret(company.siret)) {
+    return countries.find(country => country.cca2 === "FR");
+  } else if (company.vatNumber && isVat(company.vatNumber)) {
     // trouver automatiquement le pays selon le numéro de TVA
     const vatCountryCode = checkVAT(cleanClue(company.vatNumber), vatCountries)
       ?.country?.isoCode.short;
 
-    companyCountry = countries.find(country => country.cca2 === vatCountryCode);
+    return countries.find(country => country.cca2 === vatCountryCode);
   }
 
-  return companyCountry;
+  // reconnaitre le pays directement dans le champ country
+  return countries.find(country => country.cca2 === company.country);
 }

--- a/back/src/common/pdf/generatePdf.tsx
+++ b/back/src/common/pdf/generatePdf.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import { toPDF } from "./pdf";
 import { CSS_PATHS } from "./components";
 
-export function formatDate(date?: Date) {
+export function formatDate(date?: Date | null) {
   return date ? format(date, "dd/MM/yyyy") : "__/__/____";
 }
 

--- a/back/src/common/repository/__tests__/helper.integration.ts
+++ b/back/src/common/repository/__tests__/helper.integration.ts
@@ -22,6 +22,7 @@ describe("Repository.helper", () => {
         data: {
           orgId: siret,
           siret,
+          name: "",
           securityCode: 1,
           verificationCode: "1111"
         }
@@ -49,6 +50,7 @@ describe("Repository.helper", () => {
       return transaction.company.create({
         data: {
           orgId: siret,
+          name: "",
           siret,
           securityCode: 1,
           verificationCode: "1111"

--- a/back/src/common/where.ts
+++ b/back/src/common/where.ts
@@ -22,10 +22,10 @@ export type NestedWhere<W> = {
 };
 
 export type GenericWhere = {
-  id?: IdFilter;
-  isDraft?: boolean;
-  createdAt?: DateFilter;
-  updatedAt?: DateFilter;
+  id?: IdFilter | null;
+  isDraft?: boolean | null;
+  createdAt?: DateFilter | null;
+  updatedAt?: DateFilter | null;
 };
 
 export class NestingWhereError extends UserInputError {
@@ -56,11 +56,10 @@ const cleanMerge = <A, B>(arr1: A[], arr2: B[]): (A | B)[] | undefined => {
  * Recursively compose where input with OR, AND and NOT logic
  * until depth limit is reached
  */
-export function toPrismaNestedWhereInput<W extends NestedWhere<W>, P>(
-  where: W,
-  converter: (where: W) => P,
-  depthLimit = 2
-) {
+export function toPrismaNestedWhereInput<
+  W extends NestedWhere<W>,
+  P extends Record<string, unknown>
+>(where: W, converter: (where: W) => P, depthLimit = 2) {
   function inner(where: W, depth = 0): Partial<P> {
     if (depth >= depthLimit) {
       throw new NestingWhereError(depthLimit);
@@ -77,8 +76,8 @@ export function toPrismaNestedWhereInput<W extends NestedWhere<W>, P>(
 
     return safeInput<P>({
       ...converted,
-      AND: cleanMerge(arrayToInner(_and), converted["AND"] || []),
-      OR: cleanMerge(arrayToInner(_or), converted["OR"] || []),
+      AND: cleanMerge(arrayToInner(_and), (converted["AND"] as string[]) || []),
+      OR: cleanMerge(arrayToInner(_or), (converted["OR"] as string[]) || []),
       NOT: where?._not ? inner(where._not, depth + 1) : undefined
     });
   }
@@ -100,8 +99,8 @@ export function toPrismaGenericWhereInput(where: GenericWhere) {
 }
 
 export function toPrismaDateFilter(
-  dateFilter: DateFilter | undefined
-): Prisma.DateTimeFilter {
+  dateFilter: DateFilter | null | undefined
+): Prisma.DateTimeFilter | undefined {
   if (!dateFilter) {
     return undefined;
   }
@@ -115,7 +114,7 @@ export function toPrismaDateFilter(
   });
 }
 
-export function toPrismaEnumFilter<E>(enumFilter: EnumFilter<E>) {
+export function toPrismaEnumFilter<E>(enumFilter: EnumFilter<E> | undefined) {
   if (!enumFilter) {
     return undefined;
   }
@@ -125,7 +124,7 @@ export function toPrismaEnumFilter<E>(enumFilter: EnumFilter<E>) {
   });
 }
 
-export function toPrismaIdFilter(idFilter: IdFilter | undefined) {
+export function toPrismaIdFilter(idFilter: IdFilter | null | undefined) {
   if (!idFilter) {
     return undefined;
   }
@@ -135,7 +134,9 @@ export function toPrismaIdFilter(idFilter: IdFilter | undefined) {
   });
 }
 
-export function toPrismaRelationIdFilter(idFilter: IdFilter | undefined) {
+export function toPrismaRelationIdFilter(
+  idFilter: IdFilter | null | undefined
+) {
   if (!idFilter) {
     return undefined;
   }
@@ -153,8 +154,8 @@ export function toPrismaRelationIdFilter(idFilter: IdFilter | undefined) {
 }
 
 export function toPrismaStringFilter(
-  stringFilter: StringFilter | undefined
-): Prisma.StringFilter {
+  stringFilter: StringFilter | null | undefined
+): Prisma.StringFilter | undefined {
   if (!stringFilter) {
     return undefined;
   }
@@ -168,8 +169,8 @@ export function toPrismaStringFilter(
 
 /** Converter */
 export function toPrismaStringNullableListFilter(
-  stringNullableListFilter: StringNullableListFilter | undefined
-): Prisma.StringNullableListFilter {
+  stringNullableListFilter: StringNullableListFilter | null | undefined
+): Prisma.StringNullableListFilter | undefined {
   if (!stringNullableListFilter) {
     return undefined;
   }
@@ -222,9 +223,9 @@ function ngramMatch(fieldName: string, value: string): QueryDslQueryContainer {
 
 export function toElasticTextQuery(
   fieldName: string,
-  textFilter: TextFilter | undefined,
+  textFilter: TextFilter | null | undefined,
   maxLength = 50
-): QueryDslQueryContainer {
+): QueryDslQueryContainer | undefined {
   if (!textFilter) {
     return undefined;
   }
@@ -251,9 +252,9 @@ export function toElasticTextQuery(
 
 export function toElasticStringQuery(
   fieldName: string,
-  stringFilter: StringFilter | undefined,
+  stringFilter: StringFilter | null | undefined,
   maxLength = 50
-): QueryDslQueryContainer {
+): QueryDslQueryContainer | undefined {
   if (!stringFilter) {
     return undefined;
   }
@@ -281,10 +282,10 @@ export function toElasticStringQuery(
 
 export function toElasticStringListQuery(
   fieldName: string,
-  stringListFilter: StringNullableListFilter | undefined,
+  stringListFilter: StringNullableListFilter | null | undefined,
   maxLength = 50,
   filter = (s: string) => s // optional pre-processing function
-): QueryDslQueryContainer {
+): QueryDslQueryContainer | undefined {
   if (!stringListFilter) {
     return undefined;
   }
@@ -338,8 +339,8 @@ export function toElasticStringListQuery(
 
 export function toElasticDateQuery(
   fieldName: string,
-  dateFilter: DateFilter | undefined
-): QueryDslQueryContainer {
+  dateFilter: DateFilter | null | undefined
+): QueryDslQueryContainer | undefined {
   if (!dateFilter) {
     return undefined;
   }

--- a/back/src/companies/geo/geocode.ts
+++ b/back/src/companies/geo/geocode.ts
@@ -13,7 +13,13 @@ type Feature = {
   properties?: { score: number };
 };
 
-export default async function geocode(address: string): Promise<GeoInfo> {
+export default async function geocode(
+  address: string | null | undefined
+): Promise<GeoInfo> {
+  if (!address) {
+    return { longitude: null, latitude: null };
+  }
+
   try {
     const response = await axios.get<{ features: Feature[] }>(API_ADRESSE_URL, {
       params: { q: address }
@@ -24,7 +30,8 @@ export default async function geocode(address: string): Promise<GeoInfo> {
         const feature = features[0];
         if (
           feature.geometry?.type === "Point" &&
-          feature.properties?.score > 0.6
+          feature.properties?.score &&
+          feature.properties.score > 0.6
         ) {
           const coordinates = feature.geometry.coordinates;
           return { longitude: coordinates[0], latitude: coordinates[1] };

--- a/back/src/companies/typeDefs/private/company.mutations.graphql
+++ b/back/src/companies/typeDefs/private/company.mutations.graphql
@@ -58,7 +58,7 @@ type Mutation {
   """
   createTransporterReceipt(
     input: CreateTransporterReceiptInput!
-  ): TransporterReceipt
+  ): TransporterReceipt!
 
   """
   USAGE INTERNE
@@ -66,7 +66,7 @@ type Mutation {
   """
   updateTransporterReceipt(
     input: UpdateTransporterReceiptInput!
-  ): TransporterReceipt
+  ): TransporterReceipt!
 
   """
   USAGE INTERNE
@@ -74,61 +74,61 @@ type Mutation {
   """
   deleteTransporterReceipt(
     input: DeleteTransporterReceiptInput!
-  ): TransporterReceipt
+  ): TransporterReceipt!
 
   """
   USAGE INTERNE
   Crée un récépissé négociant
   """
-  createTraderReceipt(input: CreateTraderReceiptInput!): TraderReceipt
+  createTraderReceipt(input: CreateTraderReceiptInput!): TraderReceipt!
 
   """
   USAGE INTERNE
   Édite les informations d'un récépissé négociant
   """
-  updateTraderReceipt(input: UpdateTraderReceiptInput!): TraderReceipt
+  updateTraderReceipt(input: UpdateTraderReceiptInput!): TraderReceipt!
 
   """
   USAGE INTERNE
   Supprime un récépissé négociant
   """
-  deleteTraderReceipt(input: DeleteTraderReceiptInput!): TraderReceipt
+  deleteTraderReceipt(input: DeleteTraderReceiptInput!): TraderReceipt!
 
   """
   USAGE INTERNE
   Crée un récépissé courtier
   """
-  createBrokerReceipt(input: CreateBrokerReceiptInput!): BrokerReceipt
+  createBrokerReceipt(input: CreateBrokerReceiptInput!): BrokerReceipt!
 
   """
   USAGE INTERNE
   Édite les informations d'un récépissé courtier
   """
-  updateBrokerReceipt(input: UpdateBrokerReceiptInput!): BrokerReceipt
+  updateBrokerReceipt(input: UpdateBrokerReceiptInput!): BrokerReceipt!
 
   """
   USAGE INTERNE
   Supprime un récépissé courtier
   """
-  deleteBrokerReceipt(input: DeleteBrokerReceiptInput!): BrokerReceipt
+  deleteBrokerReceipt(input: DeleteBrokerReceiptInput!): BrokerReceipt!
 
   """
   USAGE INTERNE
   Crée un agrément VHU
   """
-  createVhuAgrement(input: CreateVhuAgrementInput!): VhuAgrement
+  createVhuAgrement(input: CreateVhuAgrementInput!): VhuAgrement!
 
   """
   USAGE INTERNE
   Édite un agrément VHU
   """
-  updateVhuAgrement(input: UpdateVhuAgrementInput!): VhuAgrement
+  updateVhuAgrement(input: UpdateVhuAgrementInput!): VhuAgrement!
 
   """
   USAGE INTERNE
   Supprime un agrément VHU
   """
-  deleteVhuAgrement(input: DeleteVhuAgrementInput!): VhuAgrement
+  deleteVhuAgrement(input: DeleteVhuAgrementInput!): VhuAgrement!
 
   """
   USAGE INTERNE
@@ -136,7 +136,7 @@ type Mutation {
   """
   createWorkerCertification(
     input: CreateWorkerCertificationInput!
-  ): WorkerCertification
+  ): WorkerCertification!
 
   """
   USAGE INTERNE
@@ -144,7 +144,7 @@ type Mutation {
   """
   updateWorkerCertification(
     input: UpdateWorkerCertificationInput!
-  ): WorkerCertification
+  ): WorkerCertification!
 
   """
   USAGE INTERNE
@@ -152,7 +152,7 @@ type Mutation {
   """
   deleteWorkerCertification(
     input: DeleteWorkerCertificationInput!
-  ): WorkerCertification
+  ): WorkerCertification!
 
   """
   USAGE INTERNE

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -494,7 +494,7 @@ export async function expandFormFromDb(
   form: any,
   dataloader?: DataLoader<string, Form, string>
 ): Promise<GraphQLForm> {
-  let forwardedIn: Form;
+  let forwardedIn: Form | null;
   // if form is rawBsd, forwardedIn is already computed
   if (form?.forwardedIn) {
     forwardedIn = form.forwardedIn;
@@ -762,7 +762,7 @@ export async function expandFormFromDb(
 
 export async function expandFormFromElastic(
   form: BsdElastic["rawBsd"]
-): Promise<GraphQLForm> {
+): Promise<GraphQLForm | null> {
   const expanded = await expandFormFromDb(form);
 
   if (!expanded) {
@@ -789,7 +789,8 @@ export async function expandInitialFormFromDb(
     quantityGrouped
   } = await expandFormFromDb(prismaForm, dataloader);
 
-  const hasPickupSite = emitter?.workSite?.postalCode?.length > 0;
+  const hasPickupSite =
+    emitter?.workSite?.postalCode && emitter.workSite.postalCode.length > 0;
 
   return {
     id,

--- a/back/src/forms/typeDefs/bsdd.mutations.graphql
+++ b/back/src/forms/typeDefs/bsdd.mutations.graphql
@@ -12,7 +12,7 @@ type Mutation {
   ): Form!
 
   "DEPRECATED - Sauvegarde un BSD (création ou modification, si `FormInput` contient un ID)"
-  saveForm("Payload du BSD" formInput: FormInput!): Form
+  saveForm("Payload du BSD" formInput: FormInput!): Form!
     @deprecated(reason: "Utiliser createForm / updateForm selon le besoin")
 
   """
@@ -26,13 +26,13 @@ type Mutation {
     transporterNumberPlate: String
     "Champ libre, utilisable par exemple pour noter les tournées des transporteurs"
     transporterCustomInfo: String
-  ): Form
+  ): Form!
 
   "Supprime un BSD"
-  deleteForm("ID d'un BSD" id: ID!): Form
+  deleteForm("ID d'un BSD" id: ID!): Form!
 
   "Duplique un BSD"
-  duplicateForm("ID d'un BSD" id: ID!): Form
+  duplicateForm("ID d'un BSD" id: ID!): Form!
 
   """
   Finalise un BSD
@@ -92,7 +92,7 @@ type Mutation {
   Lorsqu'un courtier ou un négociant est présent sur le BSDD, les informations de contact,
   ainsi que le numéro, la limite de validité et le département du récépissé sont obligatoires.
   """
-  markAsSealed("ID d'un BSD" id: ID!): Form
+  markAsSealed("ID d'un BSD" id: ID!): Form!
 
   "Valide l'acceptation du BSD"
   markAsAccepted(
@@ -100,7 +100,7 @@ type Mutation {
     id: ID!
     "Informations liées à l'arrivée"
     acceptedInfo: AcceptedFormInput!
-  ): Form
+  ): Form!
 
   "Valide la réception d'un BSD"
   markAsReceived(
@@ -108,7 +108,7 @@ type Mutation {
     id: ID!
     "Informations liées à la réception"
     receivedInfo: ReceivedFormInput!
-  ): Form
+  ): Form!
 
   "Valide le traitement d'un BSD"
   markAsProcessed(
@@ -116,7 +116,7 @@ type Mutation {
     id: ID!
     "Informations liées au traitement"
     processedInfo: ProcessedFormInput!
-  ): Form
+  ): Form!
 
   """
   Permet de signer pour le détenteur du déchet afin de le transférer au transporteur.
@@ -160,22 +160,22 @@ type Mutation {
     id: ID!
     "Informations liées aux signatures transporteur et émetteur (case 8 et 9)"
     signingInfo: TransporterSignatureFormInput!
-  ): Form @deprecated(reason: "Remplacé par signEmission et signTransport")
+  ): Form! @deprecated(reason: "Remplacé par signEmission et signTransport")
 
   "Valide la réception d'un BSD d'un entreposage provisoire ou reconditionnement"
-  markAsTempStored(id: ID!, tempStoredInfos: TempStoredFormInput!): Form
+  markAsTempStored(id: ID!, tempStoredInfos: TempStoredFormInput!): Form!
 
   "Valide l'acceptation ou le refus d'un BSD d'un entreposage provisoire ou reconditionnement"
   markAsTempStorerAccepted(
     id: ID!
     tempStorerAcceptedInfo: TempStorerAcceptedFormInput!
-  ): Form
+  ): Form!
 
   "Valide la complétion des cadres 14 à 19 lors d'un entreposage provisoire ou reconditionnement"
-  markAsResealed(id: ID!, resealedInfos: ResealedFormInput!): Form
+  markAsResealed(id: ID!, resealedInfos: ResealedFormInput!): Form!
 
   "Valide l'envoi du BSD après un entreposage provisoire ou reconditionnement"
-  markAsResent(id: ID!, resentInfos: ResentFormInput!): Form
+  markAsResent(id: ID!, resentInfos: ResentFormInput!): Form!
     @deprecated(
       reason: "Utiliser la mutation signedByTransporter permettant d'apposer les signatures du collecteur-transporteur (case 18) et de l'exploitant du site d'entreposage provisoire ou de reconditionnement (case 19)"
     )
@@ -186,34 +186,34 @@ type Mutation {
   être en mesure de retrouver le bordereau papier correspondant à un bordereau numérique. Le champ `customId`
   de l'input peut-être utilisé pour faire le lien.
   """
-  importPaperForm(input: ImportPaperFormInput!): Form
+  importPaperForm(input: ImportPaperFormInput!): Form!
 
   "Prépare un nouveau segment de transport multimodal"
   prepareSegment(
     id: ID!
     siret: String!
     nextSegmentInfo: NextSegmentInfoInput!
-  ): TransportSegment
+  ): TransportSegment!
 
   "Marque un segment de transport comme prêt à être emporté"
-  markSegmentAsReadyToTakeOver(id: ID!): TransportSegment
+  markSegmentAsReadyToTakeOver(id: ID!): TransportSegment!
 
   "Marque un segment comme pris en charge par le nouveau transporteur"
-  takeOverSegment(id: ID!, takeOverInfo: TakeOverInput!): TransportSegment
+  takeOverSegment(id: ID!, takeOverInfo: TakeOverInput!): TransportSegment!
 
   "Édite un segment existant"
   editSegment(
     id: ID!
     siret: String!
     nextSegmentInfo: NextSegmentInfoInput!
-  ): TransportSegment
+  ): TransportSegment!
 
   """
   Crée une demande de révision sur un BSDD existant
   """
   createFormRevisionRequest(
     input: CreateFormRevisionRequestInput!
-  ): FormRevisionRequest
+  ): FormRevisionRequest!
 
   """
   Annule une demande de révision de BSDD.
@@ -222,7 +222,7 @@ type Mutation {
   cancelFormRevisionRequest(
     "Identifiant de la demande de révision"
     id: ID!
-  ): Boolean
+  ): Boolean!
 
   """
   Répond à une demande d'approbation d'une révision.
@@ -236,5 +236,5 @@ type Mutation {
     isApproved: Boolean!
     "Commentaire facultatif"
     comment: String
-  ): FormRevisionRequest
+  ): FormRevisionRequest!
 }

--- a/back/src/queue/jobs/indexAllBsds.ts
+++ b/back/src/queue/jobs/indexAllBsds.ts
@@ -44,9 +44,9 @@ async function getBearerToken(scalingoToken) {
  */
 export async function indexChunkBsdJob(job: Job<string>) {
   try {
-    const { bsdName, index, ids }: FindManyAndIndexBsdsFnSignature = JSON.parse(
+    const { bsdName, index, ids } = JSON.parse(
       job.data
-    );
+    ) as FindManyAndIndexBsdsFnSignature;
     logger.info(
       `Started job indexChunk for the following bsd and index names : "${bsdName}", "${index}"`
     );
@@ -121,9 +121,10 @@ const sleepUntil = async (
  */
 export async function indexAllInBulk(job: Job<string>) {
   try {
-    const { index, force }: { index: BsdIndex; force: boolean } = JSON.parse(
-      job.data
-    );
+    const { index, force } = JSON.parse(job.data) as {
+      index: BsdIndex;
+      force: boolean;
+    };
     let operationsUrl;
     if (BULK_INDEX_SCALINGO_ACTIVE_AUTOSCALING === "true") {
       const { token: bearerToken } = await getBearerToken(SCALINGO_TOKEN);

--- a/back/src/registry/streams.ts
+++ b/back/src/registry/streams.ts
@@ -11,7 +11,7 @@ export interface WasteReaderOptions extends ReadableOptions {
   read?(this: WasteReader, size: number): void;
 }
 export class WasteReader extends Readable {
-  after: string;
+  after: string | null;
   constructor(opts?: WasteReaderOptions) {
     super(opts);
     this.after = null;

--- a/back/src/reset.d.ts
+++ b/back/src/reset.d.ts
@@ -1,0 +1,1 @@
+import "@total-typescript/ts-reset";

--- a/back/src/routers/downloadRouter.ts
+++ b/back/src/routers/downloadRouter.ts
@@ -97,7 +97,7 @@ export async function downloadRouter(req: Request, res: Response) {
     return res.status(403).send("Token invalide ou expiré.");
   }
 
-  const { handler, params }: FileDownloadPayload = JSON.parse(redisValue);
+  const { handler, params } = JSON.parse(redisValue) as FileDownloadPayload;
 
   const handlerFn = downloadHandlers[handler];
 

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -18,6 +18,7 @@ import {
   CompanyVerificationMode,
   CompanyVerificationStatus
 } from "@prisma/client";
+import { CompanyRow } from "./types";
 
 function printHelp() {
   console.log(`
@@ -73,7 +74,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
 
   let isValid = true;
 
-  const companies = [];
+  const companies: CompanyRow[] = [];
 
   // perform validation
   for (const company of companiesRows) {

--- a/back/src/users/bulk-creation/loaders.ts
+++ b/back/src/users/bulk-creation/loaders.ts
@@ -13,7 +13,7 @@ export function readCsv<Row>(
   csvpath: string,
   transform?: (row: any) => Row
 ): Promise<Row[]> {
-  const rows = [];
+  const rows: Row[] = [];
   return new Promise((resolve, reject) => {
     fs.createReadStream(csvpath)
       .pipe(csv({ separator }))

--- a/back/src/users/bulk-creation/validations.ts
+++ b/back/src/users/bulk-creation/validations.ts
@@ -16,7 +16,7 @@ export const companyValidationSchema = yup.object({
     .test(
       "sirene-validation-failed",
       "Siret ${value} was not found in SIRENE database or company is closed",
-      async value => {
+      async (value: string) => {
         try {
           const company = await searchCompany(value);
           if (isClosedCompany(company)) {

--- a/back/src/users/clearUserSessions.ts
+++ b/back/src/users/clearUserSessions.ts
@@ -11,7 +11,7 @@ import { getUserSessions, genUserSessionsIdsKey } from "../common/redis/users";
 export async function clearUserSessions(userId: string): Promise<void> {
   const sessions = await getUserSessions(userId);
 
-  sessions.forEach(sessionId => sess.store.destroy(sessionId));
+  sessions.forEach(sessionId => sess.store?.destroy(sessionId));
 
   await redisClient.del(genUserSessionsIdsKey(userId));
 }

--- a/back/src/users/resolvers/User.ts
+++ b/back/src/users/resolvers/User.ts
@@ -13,7 +13,7 @@ const userResolvers: UserResolvers = {
       const companyPrivate: CompanyPrivate = convertUrls(company);
 
       const { codeNaf: naf, address } = company;
-      const libelleNaf = naf in nafCodes ? nafCodes[naf] : "";
+      const libelleNaf = naf && naf in nafCodes ? nafCodes[naf] : "";
 
       return { ...companyPrivate, naf, libelleNaf, address };
     });

--- a/back/src/users/resolvers/mutations/__tests__/revokeAuthorizedApplication.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/revokeAuthorizedApplication.integration.ts
@@ -58,16 +58,16 @@ describe("mutation revokeAuthorizedApplication", () => {
     >(REVOKE_AUTHORIZED_APPLICATION, {
       variables: { id: application.id }
     });
-    accessToken1 = await prisma.accessToken.findFirst({
+    accessToken1 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken1.id }
     });
-    accessToken2 = await prisma.accessToken.findFirst({
+    accessToken2 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken2.id }
     });
-    accessToken3 = await prisma.accessToken.findFirst({
+    accessToken3 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken3.id }
     });
-    accessToken4 = await prisma.accessToken.findFirst({
+    accessToken4 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken4.id }
     });
     expect(accessToken1.isRevoked).toEqual(true);

--- a/back/src/users/resolvers/mutations/anonymizeUser.ts
+++ b/back/src/users/resolvers/mutations/anonymizeUser.ts
@@ -10,7 +10,7 @@ import { clearUserSessions } from "../../clearUserSessions";
 import { getUid } from "../../../utils";
 
 export async function checkCompanyAssociations(user: User): Promise<string[]> {
-  const errors = [];
+  const errors: string[] = [];
   const companyAssociations = await prisma.companyAssociation.findMany({
     where: {
       user: {
@@ -53,7 +53,7 @@ export async function checkCompanyAssociations(user: User): Promise<string[]> {
 }
 
 export async function checkApplications(user: User): Promise<string[]> {
-  const errors = [];
+  const errors: string[] = [];
   const applications = await prisma.application.findMany({
     where: {
       adminId: user.id

--- a/back/src/users/resolvers/mutations/changePassword.ts
+++ b/back/src/users/resolvers/mutations/changePassword.ts
@@ -21,6 +21,9 @@ export async function changePasswordFn(
   currentSessionId: string
 ) {
   const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) {
+    throw new Error(`Cannot find user ${userId}`);
+  }
   const passwordValid = await compare(oldPassword, user.password);
   if (!passwordValid) {
     throw new UserInputError("L'ancien mot de passe est incorrect.", {

--- a/back/src/users/resolvers/mutations/createAccessToken.ts
+++ b/back/src/users/resolvers/mutations/createAccessToken.ts
@@ -14,7 +14,7 @@ const createAccessTokenResolver: MutationResolvers["createAccessToken"] =
     return {
       id: accessToken.id,
       token: accessToken.token,
-      description: accessToken.description
+      description: accessToken.description ?? ""
     };
   };
 

--- a/back/src/users/resolvers/mutations/deleteInvitation.ts
+++ b/back/src/users/resolvers/mutations/deleteInvitation.ts
@@ -26,7 +26,7 @@ const deleteInvitationResolver: MutationResolvers["deleteInvitation"] = async (
   const dbCompany = await prisma.company.findUnique({
     where: { orgId: siret }
   });
-  return convertUrls(dbCompany);
+  return convertUrls(dbCompany!);
 };
 
 export default deleteInvitationResolver;

--- a/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/refuseMembershipRequest.ts
@@ -26,6 +26,12 @@ const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipReques
       .findUnique({ where: { id: membershipRequest.id } })
       .company();
 
+    if (!company) {
+      throw new Error(
+        `Cannot find company for membershipRequest ${membershipRequest.id}`
+      );
+    }
+
     // check authenticated user is admin of the company
     await checkIsCompanyAdmin(user, company);
 
@@ -51,6 +57,9 @@ const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipReques
     const requester = await prisma.membershipRequest
       .findUnique({ where: { id } })
       .user();
+    if (!requester) {
+      throw new Error(`Cannot find requester for membershipRequest ${id}`);
+    }
     const mail = renderMail(membershipRequestRefused, {
       to: [{ email: requester.email, name: requester.name }],
       variables: { companyName: company.name, companySiret: company.siret }
@@ -60,7 +69,7 @@ const refuseMembershipRequestResolver: MutationResolvers["refuseMembershipReques
     const dbCompany = await prisma.company.findUnique({
       where: { id: company.id }
     });
-    return convertUrls(dbCompany);
+    return convertUrls(dbCompany!);
   };
 
 export default refuseMembershipRequestResolver;

--- a/back/src/users/resolvers/mutations/removeUserFromCompany.ts
+++ b/back/src/users/resolvers/mutations/removeUserFromCompany.ts
@@ -31,7 +31,7 @@ const removeUserFromCompanyResolver: MutationResolvers["removeUserFromCompany"] 
       where: { orgId: siret }
     });
 
-    return convertUrls(dbCompany);
+    return convertUrls(dbCompany!);
   };
 
 export default removeUserFromCompanyResolver;

--- a/back/src/users/resolvers/mutations/resetPassword.ts
+++ b/back/src/users/resolvers/mutations/resetPassword.ts
@@ -36,6 +36,11 @@ const resetPasswordResolver: MutationResolvers["resetPassword"] = async (
   const user = await prisma.user.findUnique({
     where: { id: resetHash.userId }
   });
+  if (!user) {
+    throw new Error(
+      `Cannot find user ${resetHash.userId} for resetHash ${resetHash.id}`
+    );
+  }
   checkPasswordCriteria(trimmedPassword);
 
   await updateUserPassword({ userId: user.id, trimmedPassword });

--- a/back/src/users/resolvers/mutations/revokeAuthorizedApplication.ts
+++ b/back/src/users/resolvers/mutations/revokeAuthorizedApplication.ts
@@ -15,6 +15,10 @@ const revokeAuthorizedApplicationResolver: MutationResolvers["revokeAuthorizedAp
         where: { id: application.id }
       })
       .admin();
+    if (!owner) {
+      throw new Error(`Cannot find admin for application ${application.id}`);
+    }
+
     const accessTokens = await prisma.accessToken.findMany({
       where: { userId: user.id, applicationId: id }
     });

--- a/back/src/users/resolvers/mutations/signup.ts
+++ b/back/src/users/resolvers/mutations/signup.ts
@@ -32,7 +32,7 @@ function validateArgs(args: MutationSignupArgs) {
       password: yup
         .string()
         .required("Vous devez saisir un mot de passe.")
-        .test("new-user-password-meets-criteria", "", function (password) {
+        .test("new-user-password-meets-criteria", "", (password: string) => {
           checkPasswordCriteria(password);
           return true;
         })

--- a/back/src/users/resolvers/queries/__tests__/membershipRequest.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/membershipRequest.integration.ts
@@ -32,7 +32,7 @@ describe("query membershipRequest", () => {
       MEMBERSHIP_REQUEST
     );
     expect(errors).toHaveLength(1);
-    expect(errors[0].extensions.code).toEqual(ErrorCode.UNAUTHENTICATED);
+    expect(errors[0].extensions?.code).toEqual(ErrorCode.UNAUTHENTICATED);
   });
 
   it("should return an error when trying to pass both id and siret", async () => {
@@ -65,17 +65,18 @@ describe("query membershipRequest", () => {
     );
   });
 
-  it("should return null when no request found for authenticated user and siret", async () => {
+  it("should throw when no request found for authenticated user and siret", async () => {
     const user = await userFactory();
     const company = await companyFactory();
     const { query } = makeClient(user);
-    const { data } = await query<Pick<Query, "membershipRequest">>(
+    const { errors } = await query<Pick<Query, "membershipRequest">>(
       MEMBERSHIP_REQUEST,
       {
         variables: { siret: company.siret }
       }
     );
-    expect(data.membershipRequest).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe("Demande de rattachement non trouvée");
   });
 
   it("should return an invitation request by id", async () => {

--- a/back/src/users/resolvers/queries/__tests__/myCompanies.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/myCompanies.integration.ts
@@ -65,8 +65,8 @@ describe("query { myCompanies }", () => {
     );
     const { query } = makeClient(user1);
     const { data } = await query<Pick<Query, "myCompanies">>(MY_COMPANIES);
-    expect(data.myCompanies.totalCount).toEqual(1);
-    expect(data.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(data!.myCompanies.totalCount).toEqual(1);
+    expect(data!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company1.id
     ]);
   }, 20000);
@@ -87,12 +87,12 @@ describe("query { myCompanies }", () => {
         variables: { first: 3 }
       }
     );
-    expect(page1.myCompanies.totalCount).toEqual(4);
-    expect(page1.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
-    expect(page1.myCompanies.pageInfo.hasNextPage).toEqual(true);
-    expect(page1.myCompanies.pageInfo.endCursor).toEqual(company3.id);
-    expect(page1.myCompanies.pageInfo.startCursor).toEqual(company1.id);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(4);
+    expect(page1!.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
+    expect(page1!.myCompanies.pageInfo.hasNextPage).toEqual(true);
+    expect(page1!.myCompanies.pageInfo.endCursor).toEqual(company3.id);
+    expect(page1!.myCompanies.pageInfo.startCursor).toEqual(company1.id);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company1.id,
       company2.id,
       company3.id
@@ -100,15 +100,15 @@ describe("query { myCompanies }", () => {
     const { data: page2 } = await query<Pick<Query, "myCompanies">>(
       MY_COMPANIES,
       {
-        variables: { first: 3, after: page1.myCompanies.pageInfo.endCursor }
+        variables: { first: 3, after: page1!.myCompanies.pageInfo.endCursor }
       }
     );
-    expect(page2.myCompanies.totalCount).toEqual(4);
-    expect(page2.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
-    expect(page2.myCompanies.pageInfo.hasNextPage).toEqual(false);
-    expect(page2.myCompanies.pageInfo.endCursor).toEqual(company4.id);
-    expect(page2.myCompanies.pageInfo.startCursor).toEqual(company4.id);
-    expect(page2.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page2!.myCompanies.totalCount).toEqual(4);
+    expect(page2!.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
+    expect(page2!.myCompanies.pageInfo.hasNextPage).toEqual(false);
+    expect(page2!.myCompanies.pageInfo.endCursor).toEqual(company4.id);
+    expect(page2!.myCompanies.pageInfo.startCursor).toEqual(company4.id);
+    expect(page2!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company4.id
     ]);
   }, 20000);
@@ -131,12 +131,12 @@ describe("query { myCompanies }", () => {
       }
     );
 
-    expect(page1.myCompanies.totalCount).toEqual(4);
-    expect(page1.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
-    expect(page1.myCompanies.pageInfo.hasNextPage).toEqual(false);
-    expect(page1.myCompanies.pageInfo.endCursor).toEqual(company4.id);
-    expect(page1.myCompanies.pageInfo.startCursor).toEqual(company2.id);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(4);
+    expect(page1!.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
+    expect(page1!.myCompanies.pageInfo.hasNextPage).toEqual(false);
+    expect(page1!.myCompanies.pageInfo.endCursor).toEqual(company4.id);
+    expect(page1!.myCompanies.pageInfo.startCursor).toEqual(company2.id);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company2.id,
       company3.id,
       company4.id
@@ -144,16 +144,16 @@ describe("query { myCompanies }", () => {
     const { data: page2 } = await query<Pick<Query, "myCompanies">>(
       MY_COMPANIES,
       {
-        variables: { last: 3, before: page1.myCompanies.pageInfo.startCursor }
+        variables: { last: 3, before: page1!.myCompanies.pageInfo.startCursor }
       }
     );
 
-    expect(page2.myCompanies.totalCount).toEqual(4);
-    expect(page2.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
-    expect(page2.myCompanies.pageInfo.hasNextPage).toEqual(true);
-    expect(page2.myCompanies.pageInfo.endCursor).toEqual(company1.id);
-    expect(page2.myCompanies.pageInfo.startCursor).toEqual(company1.id);
-    expect(page2.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page2!.myCompanies.totalCount).toEqual(4);
+    expect(page2!.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
+    expect(page2!.myCompanies.pageInfo.hasNextPage).toEqual(true);
+    expect(page2!.myCompanies.pageInfo.endCursor).toEqual(company1.id);
+    expect(page2!.myCompanies.pageInfo.startCursor).toEqual(company1.id);
+    expect(page2!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company1.id
     ]);
   }, 20000);
@@ -229,8 +229,8 @@ describe("query { myCompanies }", () => {
       }
     );
 
-    expect(page1.myCompanies.totalCount).toEqual(1);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(1);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company2.id
     ]);
   }, 20000);
@@ -252,8 +252,8 @@ describe("query { myCompanies }", () => {
       }
     );
 
-    expect(page1.myCompanies.totalCount).toEqual(1);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(1);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company2.id
     ]);
   }, 20000);
@@ -275,8 +275,8 @@ describe("query { myCompanies }", () => {
       }
     );
 
-    expect(page1.myCompanies.totalCount).toEqual(1);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(1);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company3.id
     ]);
   }, 20000);
@@ -298,8 +298,8 @@ describe("query { myCompanies }", () => {
       }
     );
 
-    expect(page1.myCompanies.totalCount).toEqual(1);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(1);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company2.id
     ]);
   }, 20000);
@@ -321,12 +321,12 @@ describe("query { myCompanies }", () => {
         variables: { first: 3, search: "Lorient" }
       }
     );
-    expect(page1.myCompanies.totalCount).toEqual(4);
-    expect(page1.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
-    expect(page1.myCompanies.pageInfo.hasNextPage).toEqual(true);
-    expect(page1.myCompanies.pageInfo.endCursor).toEqual(company3.id);
-    expect(page1.myCompanies.pageInfo.startCursor).toEqual(company1.id);
-    expect(page1.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page1!.myCompanies.totalCount).toEqual(4);
+    expect(page1!.myCompanies.pageInfo.hasPreviousPage).toEqual(false);
+    expect(page1!.myCompanies.pageInfo.hasNextPage).toEqual(true);
+    expect(page1!.myCompanies.pageInfo.endCursor).toEqual(company3.id);
+    expect(page1!.myCompanies.pageInfo.startCursor).toEqual(company1.id);
+    expect(page1!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company1.id,
       company2.id,
       company3.id
@@ -336,17 +336,17 @@ describe("query { myCompanies }", () => {
       {
         variables: {
           first: 3,
-          after: page1.myCompanies.pageInfo.endCursor,
+          after: page1!.myCompanies.pageInfo.endCursor,
           search: "Lorient"
         }
       }
     );
-    expect(page2.myCompanies.totalCount).toEqual(4);
-    expect(page2.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
-    expect(page2.myCompanies.pageInfo.hasNextPage).toEqual(false);
-    expect(page2.myCompanies.pageInfo.endCursor).toEqual(company4.id);
-    expect(page2.myCompanies.pageInfo.startCursor).toEqual(company4.id);
-    expect(page2.myCompanies.edges.map(({ node }) => node.id)).toEqual([
+    expect(page2!.myCompanies.totalCount).toEqual(4);
+    expect(page2!.myCompanies.pageInfo.hasPreviousPage).toEqual(true);
+    expect(page2!.myCompanies.pageInfo.hasNextPage).toEqual(false);
+    expect(page2!.myCompanies.pageInfo.endCursor).toEqual(company4.id);
+    expect(page2!.myCompanies.pageInfo.startCursor).toEqual(company4.id);
+    expect(page2!.myCompanies.edges.map(({ node }) => node.id)).toEqual([
       company4.id
     ]);
   }, 20000);

--- a/back/src/users/resolvers/queries/__tests__/passwordResetRequest.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/passwordResetRequest.integration.ts
@@ -30,7 +30,7 @@ describe("passwordResetRequest", () => {
         variables: { hash: "abcdef" }
       }
     );
-    expect(data.passwordResetRequest).toEqual(resetHash.id);
+    expect(data!.passwordResetRequest).toEqual(resetHash.id);
   });
 
   it("querying an inexistant hash", async () => {
@@ -50,7 +50,7 @@ describe("passwordResetRequest", () => {
         variables: { hash: "xyz" }
       }
     );
-    expect(data.passwordResetRequest).toEqual(null);
+    expect(data!.passwordResetRequest).toEqual(null);
   });
 
   it("querying an expired hash", async () => {
@@ -70,6 +70,6 @@ describe("passwordResetRequest", () => {
         variables: { hash: "abcdef" }
       }
     );
-    expect(data.passwordResetRequest).toEqual(null);
+    expect(data!.passwordResetRequest).toEqual(null);
   });
 });

--- a/back/src/users/resolvers/queries/authorizedApplications.ts
+++ b/back/src/users/resolvers/queries/authorizedApplications.ts
@@ -26,15 +26,14 @@ const authorizedApplicationsResolver: QueryResolvers["authorizedApplications"] =
     const authorizedApplicationsById = accessTokens.reduce(
       (acc, accessToken) => {
         const application = accessToken.application;
+        if (!application) return acc;
+
         if (acc[application.id]) {
           const current = acc[application.id];
           let lastConnection = current.lastConnection;
-          if (accessToken.lastUsed) {
+          if (lastConnection && accessToken.lastUsed) {
             lastConnection = new Date(
-              Math.max(
-                lastConnection?.getTime(),
-                accessToken.lastUsed?.getTime()
-              )
+              Math.max(lastConnection.getTime(), accessToken.lastUsed.getTime())
             );
           }
           return { ...acc, [application.id]: { ...current, lastConnection } };
@@ -46,7 +45,9 @@ const authorizedApplicationsResolver: QueryResolvers["authorizedApplications"] =
               name: application.name,
               admin: application.admin?.email,
               logoUrl: application.logoUrl,
-              lastConnection: new Date(accessToken.lastUsed)
+              lastConnection: accessToken.lastUsed
+                ? new Date(accessToken.lastUsed)
+                : undefined
             }
           };
         }

--- a/back/src/users/resolvers/queries/myCompanies.ts
+++ b/back/src/users/resolvers/queries/myCompanies.ts
@@ -23,7 +23,7 @@ const myCompaniesResolver: QueryResolvers["myCompanies"] = async (
   const me = checkIsAuthenticated(context);
 
   const { search, ...paginationArgs } = args;
-  if (!!search && context.user.auth !== AuthType.Session) {
+  if (!!search && context.user?.auth !== AuthType.Session) {
     throw new UserInputError(
       `Le paramètre de recherche "search" est réservé à usage interne et n'est pas disponible via l'api.`
     );
@@ -88,7 +88,7 @@ const myCompaniesResolver: QueryResolvers["myCompanies"] = async (
     formatNode: (company: Company) => {
       const companyPrivate: CompanyPrivate = convertUrls(company);
       const { codeNaf: naf, address } = company;
-      const libelleNaf = naf in nafCodes ? nafCodes[naf] : "";
+      const libelleNaf = naf && naf in nafCodes ? nafCodes[naf] : "";
       return { ...companyPrivate, naf, libelleNaf, address };
     },
     ...paginationArgs

--- a/back/src/users/resolvers/queries/warningMessage.ts
+++ b/back/src/users/resolvers/queries/warningMessage.ts
@@ -5,7 +5,7 @@ const warningMessageResolver: QueryResolvers["warningMessage"] = async (
   args,
   context
 ) => {
-  return context.req.session.warningMessage;
+  return context.req.session.warningMessage ?? "";
 };
 
 export default warningMessageResolver;

--- a/back/src/users/typeDefs/user.queries.graphql
+++ b/back/src/users/typeDefs/user.queries.graphql
@@ -17,7 +17,7 @@ type Query {
     before: ID
     "USAGE INTERNE - Filtre par nom, siret ou numéro de TVA - chaîne comprise entre 3 et 30 caractères"
     search: String
-  ): CompanyPrivateConnection
+  ): CompanyPrivateConnection!
 
   """
   Récupère une demande de rattachement effectuée par l'utilisateur courant
@@ -27,5 +27,5 @@ type Query {
   permet notamment de suivre l'état d'avancement de la demande de rattachement
   (en attente, accepté, refusé)
   """
-  membershipRequest(id: ID, siret: String): MembershipRequest
+  membershipRequest(id: ID, siret: String): MembershipRequest!
 }

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -115,7 +115,7 @@ export const hashToken = (token: string) =>
 /**
  *Try extracting a valid postal code
  */
-export function extractPostalCode(address: string) {
+export function extractPostalCode(address: string | null | undefined) {
   if (address) {
     const matches = address.match(/([0-9]{5})/);
     if (matches && matches.length > 0) {


### PR DESCRIPTION
WIP pour activer les `strictNullCheck`.
On partait de 5K+ erreurs dans 500+ fichiers.

Etat avec cette PR:
> Found 2618 errors in 418 files

**Il y a de vrai changements !**. Essentiellement des champs qui ne sont plus optionnels en DB et des retours de mutations qui ne le sont plus non plus.
Pour la DB, j'ai checké en prod tous les champs sont remplis.
Pour les retours d'API, ça fait plus de sens. On n'a pas de rasion de retourner `null` à priori dans nos mutations. En cas de problème on lève une erreur. Est-ce considéré comme un breaking change par contre ?