### PR TITLE
Le destinataire d'un BSVHU ne peut entrer un poids de zéro en cas d'acception (partielle ou totale)

### DIFF
--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -25,6 +25,7 @@ import {
   siretTests,
   vatNumberTests,
   weight,
+  weightConditions,
   WeightUnits
 } from "../common/validation";
 
@@ -158,6 +159,10 @@ const destinationSchema: FactorySchemaOf<VhuValidationContext, Destination> =
         ),
       destinationReceptionWeight: weight(WeightUnits.Kilogramme)
         .label("Destinataire")
+        .when(
+          "destinationReceptionAcceptationStatus",
+          weightConditions.wasteAcceptationStatus
+        )
         .requiredIf(
           context.operationSignature,
           "${path}: le poids reçu est obligatoire"

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -25,11 +25,11 @@ const validationSchema = yup.object({
 
 type Props = { siret: string; bsvhuId: string };
 export function SignOperation({ siret, bsvhuId }: Props) {
-  const [updateBsvhu] =
+  const [updateBsvhu, { error: updateError }] =
     useMutation<Pick<Mutation, "updateBsvhu">, MutationUpdateBsvhuArgs>(
       UPDATE_VHU_FORM
     );
-  const [signBsvhu, { loading, error }] = useMutation<
+  const [signBsvhu, { loading, error: signError }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
   >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
@@ -104,7 +104,12 @@ export function SignOperation({ siret, bsvhuId }: Props) {
                 <RedErrorMessage name="author" />
               </div>
 
-              {error && <div className="error-message">{error.message}</div>}
+              {updateError && (
+                <div className="error-message">{updateError.message}</div>
+              )}
+              {signError && (
+                <div className="error-message">{signError.message}</div>
+              )}
 
               <div className="form__actions">
                 <button


### PR DESCRIPTION
# Contexte

En l'état nous acceptons un poids de 0 à la réception d'un BSVHU. Pour les BSDs par exemple ce n'est pas autorisé. 

Le fix reprend donc le même code que pour les BSDs.

# Démo

![image](https://user-images.githubusercontent.com/45355989/224339254-c54c6622-656e-414f-b8ad-ee147385dea5.png)

# Ticket Favro

[Cahier de recette VHU](https://favro.com/organization/ab14a4f0460a99a9d64d4945/02f1ec52bd91efc0adb3c38b?card=tra-11040)
