### PR TITLE
Hotfix pagination dashboard

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDList.tsx
+++ b/front/src/dashboard/components/BSDList/BSDList.tsx
@@ -63,7 +63,7 @@ interface BSDListProps {
 }
 
 // Number of bsds per page
-const FIRST = 10;
+const FIRST = 25;
 
 export function BSDList({
   siret,
@@ -112,7 +112,11 @@ export function BSDList({
 
   const refetchWithDefaultWhere = React.useCallback(
     ({ where, ...args }) => {
-      const newVariables = { ...args, where: { ...where, ...defaultWhere } };
+      const newVariables = {
+        ...args,
+        where: { ...where, ...defaultWhere },
+        first: FIRST,
+      };
       setBsdsVariables(newVariables);
       lazyFetchBsds({
         variables: newVariables,

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -12,7 +12,7 @@ import { useDuplicate } from "dashboard/components/BSDList/BSDD/BSDDActions/useD
 
 import { DeleteModal } from "dashboard/components/BSDList/BSDD/BSDDActions/DeleteModal";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
-import classNames from "classnames";
+
 import {
   TransportSegment,
   Form,

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
-import routes from "common/routes";
+
 import {
   FormInput,
   Mutation,
@@ -9,7 +9,7 @@ import {
   QueryFormArgs,
 } from "generated/graphql/types";
 import React, { ReactElement, useMemo, lazy } from "react";
-import { generatePath, useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { getInitialState } from "./utils/initial-state";
 import { formSchema } from "./utils/schema";
 import { CREATE_FORM, GET_FORM, UPDATE_FORM } from "./utils/queries";
@@ -25,7 +25,6 @@ interface Props {
   formId?: string;
 }
 export default function StepsList(props: Props) {
-  const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
 
   const formQuery = useQuery<Pick<Query, "form">, QueryFormArgs>(GET_FORM, {

--- a/front/src/form/common/components/company/MyCompanySelector.tsx
+++ b/front/src/form/common/components/company/MyCompanySelector.tsx
@@ -88,7 +88,6 @@ export default function MyCompanySelector({
 
       if (!companies.map(c => c.siret).includes(field.value.siret)) {
         if (companies.length === 1) {
-          const [company] = companies;
           onCompanySelect(companies[0]);
         } else {
           onCompanySelect(getInitialCompany());


### PR DESCRIPTION
Corrige 2 pb sur la pagination du dashboard:
- lors du remplissage/reset des filtres, la pagination sautait (pb d'update de state dans le front)
- lors de l'appui sur le bouton "charger plus de bsd", le dernier bsd apparaissait en double: les mises à jour récentes de l'index ont introduit un normalizer (dans stringfield) sur le champ id qui lowercase les id, alors que le buildSearchAfter renvoie un id en uppercase

J'en profite pour passer la pagination à 25, on était passé à 10 pour des raisons de perfs, avant d'être full-ES.

Cleanup de petits warnings de lint.

<img width="535" alt="Capture d’écran 2023-03-15 à 15 54 04" src="https://user-images.githubusercontent.com/878396/225453454-b1e98573-eb7d-4881-bebe-f341ceac9e8a.png">



---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10795)
- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11279)