### PR TITLE
Affiche correctement les caractères spéciaux

### DIFF
--- a/front/src/common/components/xss.ts
+++ b/front/src/common/components/xss.ts
@@ -1,0 +1,20 @@
+const entities = { "&gt;": "\u003E", "&lt;": "\u003C" };
+
+/**
+ *
+ * Allow to properly display xss filtered chars (cirrently < and > )without using back or front hazardous methods
+ *
+ */
+export const entitiesToEscapedUnicode = (
+  escapedString: string | undefined | null
+): string => {
+  if (escapedString === undefined || escapedString === null) {
+    return "";
+  }
+  let escapedUnicode = escapedString;
+  Object.keys(entities).map(
+    key =>
+      (escapedUnicode = escapedUnicode.replace(new RegExp(key), entities[key]))
+  );
+  return escapedUnicode;
+};

--- a/front/src/dashboard/components/BSDList/BSDD/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/index.tsx
@@ -15,6 +15,7 @@ import TransporterInfoEdit from "./TransporterInfoEdit";
 import { WorkflowAction } from "./WorkflowAction";
 import { useQuery } from "@apollo/client";
 import { COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS } from "form/common/components/company/query";
+import { entitiesToEscapedUnicode } from "common/components/xss";
 
 export const COLUMNS: Record<
   string,
@@ -68,9 +69,11 @@ export const COLUMNS: Record<
   },
   waste: {
     accessor: form =>
-      [form.wasteDetails?.code, form.wasteDetails?.name]
-        .filter(Boolean)
-        .join(" "),
+      entitiesToEscapedUnicode(
+        [form.wasteDetails?.code, form.wasteDetails?.name]
+          .filter(Boolean)
+          .join(" ")
+      ),
   },
   transporterCustomInfo: {
     accessor: form => form.stateSummary?.transporterCustomInfo ?? "",

--- a/front/src/dashboard/components/BSDList/BSDa/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/index.tsx
@@ -8,6 +8,7 @@ import { useParams } from "react-router-dom";
 import { ActionButtonContext } from "common/components/ActionButton";
 import { WorkflowAction } from "./WorkflowAction/WorkflowAction";
 import { TransporterInfoEdit } from "./WorkflowAction/TransporterInfoEdit";
+import { entitiesToEscapedUnicode } from "common/components/xss";
 
 const bsdaVerboseStatuses: Record<BsdaStatus, string> = {
   INITIAL: "Initial",
@@ -60,9 +61,11 @@ export const COLUMNS: Record<
   },
   waste: {
     accessor: bsda =>
-      [bsda?.waste?.["bsdaCode"], bsda?.waste?.materialName]
-        .filter(Boolean)
-        .join(" - "),
+      entitiesToEscapedUnicode(
+        [bsda?.waste?.["bsdaCode"], bsda?.waste?.materialName]
+          .filter(Boolean)
+          .join(" - ")
+      ),
   },
   transporterCustomInfo: {
     accessor: bsda => bsda.transporter?.customInfo,

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffPackagingSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffPackagingSummary.tsx
@@ -6,7 +6,7 @@ import {
   DataListTerm,
   DataListDescription,
 } from "common/components";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 interface BsffPackagingSummaryProps {
   bsff: Bsff;
   packaging: BsffPackaging;
@@ -36,7 +36,7 @@ export function BsffPackagingSummary({
         <DataListTerm>Nature du fluide</DataListTerm>
         <DataListDescription>
           {packaging?.acceptation?.wasteDescription ??
-            (bsff.waste?.description || "inconnue")}
+            (entitiesToEscapedUnicode(bsff.waste?.description) || "inconnue")}
         </DataListDescription>
       </DataListItem>
       <DataListItem>

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/BsffWasteSummary.tsx
@@ -7,7 +7,7 @@ import {
   DataListDescription,
 } from "common/components";
 import { PACKAGINGS_NAMES } from "form/bsff/components/packagings/Packagings";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 interface BsffWasteSummaryProps {
   bsff: Bsff;
 }
@@ -31,7 +31,7 @@ export function BsffWasteSummary({ bsff }: BsffWasteSummaryProps) {
             <DataListTerm>Dénomination usuelle</DataListTerm>
             <DataListDescription>
               {bsff.packagings[0].acceptation?.wasteDescription ??
-                (bsff.waste?.description || "inconnue")}
+                (entitiesToEscapedUnicode(bsff.waste?.description) || "inconnue")}
             </DataListDescription>
           </DataListItem>
         </>

--- a/front/src/dashboard/components/BSDList/BSFF/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/index.tsx
@@ -9,7 +9,7 @@ import { bsffVerboseStatuses } from "form/bsff/utils/constants";
 import { UpdateTransporterCustomInfo } from "./BsffActions/UpdateTransporterCustomInfo";
 import { UpdateTransporterPlates } from "./BsffActions/UpdateTransporterPlates";
 import { BsffStatus } from "generated/graphql/types";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 export const COLUMNS: Record<
   string,
   {
@@ -57,7 +57,9 @@ export const COLUMNS: Record<
   },
   waste: {
     accessor: bsff =>
-      [bsff.waste?.code, bsff.waste?.description].filter(Boolean).join(" "),
+      entitiesToEscapedUnicode(
+        [bsff.waste?.code, bsff.waste?.description].filter(Boolean).join(" ")
+      ),
   },
   transporterCustomInfo: {
     accessor: bsff => bsff.bsffTransporter?.customInfo ?? "",

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -30,7 +30,7 @@ import QRCodeIcon from "react-qr-code";
 import { generatePath, useHistory, useParams } from "react-router-dom";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import { InitialBsdas } from "./InitialBsdas";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 type CompanyProps = {
   company?: FormCompany | null;
   label: string;
@@ -470,7 +470,7 @@ export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
             <dt>Code déchet</dt>
             <dd>{form.waste?.code}</dd>
             <dt>Description du déchet</dt>
-            <dd>{form.waste?.materialName}</dd>
+            <dd>{entitiesToEscapedUnicode(form.waste?.materialName)}</dd>
             <dt>Code famille</dt>
             <dd>{form.waste?.familyCode}</dd>
             <dt>

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -65,7 +65,7 @@ import { format } from "date-fns";
 import { isSiret } from "generated/constants/companySearchHelpers";
 import { Appendix1ProducerForm } from "form/bsdd/appendix1Producer/form";
 import { gql, useQuery } from "@apollo/client";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 type CompanyProps = {
   company?: FormCompany | null;
   label: string;
@@ -641,7 +641,10 @@ export default function BSDDetailContent({
                   form.wasteDetails?.isDangerous &&
                   " (dangereux)"}
               </dd>
-              <DetailRow value={form.wasteDetails?.name} label="Nom usuel" />
+              <DetailRow
+                value={entitiesToEscapedUnicode(form.wasteDetails?.name)}
+                label="Nom usuel"
+              />
               <dt>Quantité</dt>
               <dd>{form.stateSummary?.quantity ?? "?"} tonnes</dd>
               <PackagingRow

--- a/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
+++ b/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
@@ -39,7 +39,7 @@ import {
 } from "common/components";
 import { formatDate } from "common/datetime";
 import { PACKAGINGS_NAMES } from "form/bsff/components/packagings/Packagings";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 type CompanyProps = {
   company?: FormCompany | null;
   label: string;
@@ -115,7 +115,8 @@ export function BsffDetailContent({ form: bsff }: Props) {
               <DetailRow value={totalWeight} label="Poids total" units="kg" />
               <dt>Déchet</dt>
               <dd>
-                {bsff.waste?.code} {bsff.waste?.description}
+                {bsff.waste?.code}{" "}
+                {entitiesToEscapedUnicode(bsff.waste?.description)}
               </dd>
             </div>
           </div>

--- a/front/src/form/bsff/components/PreviousPackagingsPicker.tsx
+++ b/front/src/form/bsff/components/PreviousPackagingsPicker.tsx
@@ -21,7 +21,7 @@ import {
 } from "common/components";
 import { OPERATION } from "../utils/constants";
 import { useTable, Column, useFilters } from "react-table";
-
+import { entitiesToEscapedUnicode } from "common/components/xss";
 interface PreviousBsffsPickerProps {
   bsff: Bsff;
   onAddOrRemove: () => void;
@@ -58,10 +58,10 @@ export function PreviousPackagingsPicker({
           `${
             bsffPackaging?.acceptation?.wasteCode ??
             bsffPackaging.bsff?.waste?.code
-          } - ${
+          } - ${entitiesToEscapedUnicode(
             bsffPackaging?.acceptation?.wasteDescription ??
-            bsffPackaging.bsff?.waste?.description
-          }`,
+              bsffPackaging.bsff?.waste?.description
+          )}`,
         canFilter: true,
         filter: "text",
       },


### PR DESCRIPTION
Certains caractères spéciaux sont échappés dans le back pour prévenir les injections xss. Certains utilisateurs les emploient nénamoins, notamment <>, et React affiche des \&gt; , \&lt; etc

Pour éviter d'ouvrir la boite de pandore avec des dangerouslySetInnerHTML ou  de réintroduire des cractères dangereux, cette pr introduit un utilitaire qui transforme les caractères échappés en reference unicode (\&gt; -> "\u003E")

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
