### PR TITLE
[TRA-10658] Modification du numéro de contenant par le destinataire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :rocket: Nouvelles fonctionnalités
 
+- ETQ destinataire d'un BSFF, je peux modifier le numéro de contenant lors de l'acceptation [PR 2208](https://github.com/MTES-MCT/trackdechets/pull/2208)
+
 #### :bug: Corrections de bugs
 
 #### :boom: Breaking changes

--- a/back/prisma/migrations/127_bsff_add_acceptation_numero.sql
+++ b/back/prisma/migrations/127_bsff_add_acceptation_numero.sql
@@ -1,7 +1,12 @@
 ALTER TABLE
   "default$default"."BsffPackaging"
 ADD
-  COLUMN "emissionNumero" TEXT;
+  COLUMN "emissionNumero" VARCHAR(100);
+
+ALTER TABLE
+  "default$default"."BsffPackaging"
+ALTER COLUMN
+  "numero" TYPE VARCHAR(100);
 
 UPDATE
   "default$default"."BsffPackaging"

--- a/back/prisma/migrations/127_bsff_add_acceptation_numero.sql
+++ b/back/prisma/migrations/127_bsff_add_acceptation_numero.sql
@@ -1,0 +1,16 @@
+ALTER TABLE
+  "default$default"."BsffPackaging"
+ADD
+  COLUMN "emissionNumero" TEXT;
+
+UPDATE
+  "default$default"."BsffPackaging"
+SET
+  "emissionNumero" = "numero";
+
+ALTER TABLE
+  "default$default"."BsffPackaging"
+ALTER COLUMN
+  "emissionNumero"
+SET
+  NOT NULL;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1167,12 +1167,13 @@ model BsffFicheIntervention {
 }
 
 model BsffPackaging {
-  id     String            @id @default(cuid())
-  type   BsffPackagingType
-  other  String?
-  volume Float?
-  weight Float
-  numero String
+  id             String            @id @default(cuid())
+  type           BsffPackagingType
+  other          String?
+  volume         Float?
+  weight         Float
+  emissionNumero String
+  numero         String
 
   acceptationDate             DateTime?               @db.Timestamptz(6)
   acceptationWeight           Float?

--- a/back/src/bsffs/__tests__/compat.integration.ts
+++ b/back/src/bsffs/__tests__/compat.integration.ts
@@ -22,12 +22,14 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1
             },
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1
             }
@@ -58,6 +60,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -67,6 +70,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -100,6 +104,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -110,6 +115,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -144,6 +150,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -154,6 +161,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -187,6 +195,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -199,6 +208,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -211,6 +221,7 @@ describe("toBsffDestination", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -251,6 +262,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -259,6 +271,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -283,6 +296,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -292,6 +306,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -317,6 +332,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -325,6 +341,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -348,6 +365,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -356,6 +374,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -379,6 +398,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -387,6 +407,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -410,6 +431,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -419,6 +441,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -443,6 +466,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -452,6 +476,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -475,6 +500,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -484,6 +510,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -507,6 +534,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -516,6 +544,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -540,6 +569,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -549,6 +579,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -569,6 +600,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont3",
+              emissionNumero: "cont3",
               weight: 2,
               volume: 2,
               operationSignatureDate: new Date(),
@@ -597,6 +629,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -606,6 +639,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 1,
               volume: 1,
               operationSignatureDate: new Date(),
@@ -626,6 +660,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont3",
+              emissionNumero: "cont3",
               weight: 2,
               volume: 2,
               operationSignatureDate: new Date(),
@@ -655,6 +690,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont1",
+              emissionNumero: "cont1",
               weight: 1,
               volume: 1,
               acceptationSignatureDate: new Date(),
@@ -680,6 +716,7 @@ describe("getStatus", () => {
             {
               type: BsffPackagingType.BOUTEILLE,
               numero: "cont2",
+              emissionNumero: "cont2",
               weight: 2,
               volume: 2,
               acceptationSignatureDate: new Date(),

--- a/back/src/bsffs/__tests__/factories.ts
+++ b/back/src/bsffs/__tests__/factories.ts
@@ -84,6 +84,7 @@ export function createBsffPackaging(
   return {
     type: BsffPackagingType.BOUTEILLE,
     numero: "1234",
+    emissionNumero: "1234",
     weight: 1,
     volume: 1,
     ...args,
@@ -148,7 +149,6 @@ export function createBsffPackagingBeforeTransport(
       type: "AUTRE",
       other: "BOUTEILLE de récup",
       operationSignatureAuthor: "John Snow",
-      numero: "01",
       weight: 1,
       volume: 1,
       ...args

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -254,6 +254,7 @@ export function flattenBsffPackagingInput(
   input: GraphQL.UpdateBsffPackagingInput
 ) {
   return safeInput({
+    numero: input.numero,
     acceptationDate: chain(input.acceptation, a => a.date),
     acceptationWeight: chain(input.acceptation, a => a.weight),
     acceptationStatus: chain(input.acceptation, a => a.status),

--- a/back/src/bsffs/database.ts
+++ b/back/src/bsffs/database.ts
@@ -232,5 +232,5 @@ export function getPackagingCreateInput(
           }
         }
       ]
-    : bsff.packagings.map(p => ({ ...p, emissionNumero: p.numero })) ?? [];
+    : bsff.packagings?.map(p => ({ ...p, emissionNumero: p.numero })) ?? [];
 }

--- a/back/src/bsffs/database.ts
+++ b/back/src/bsffs/database.ts
@@ -213,6 +213,7 @@ export function getPackagingCreateInput(
         type: p.type,
         other: p.other,
         numero: p.numero,
+        emissionNumero: p.numero,
         volume: p.volume,
         weight: p.acceptationWeight,
         previousPackagings: { connect: { id: p.id } }
@@ -224,11 +225,12 @@ export function getPackagingCreateInput(
           other: bsff.packagings[0].other,
           volume: bsff.packagings[0].volume,
           numero: bsff.packagings[0].numero,
+          emissionNumero: bsff.packagings[0].numero,
           weight: bsff.packagings[0].weight,
           previousPackagings: {
             connect: previousPackagings.map(p => ({ id: p.id }))
           }
         }
       ]
-    : bsff.packagings ?? [];
+    : bsff.packagings.map(p => ({ ...p, emissionNumero: p.numero })) ?? [];
 }

--- a/back/src/bsffs/edition/__tests__/bsffPackagingEdition.test.ts
+++ b/back/src/bsffs/edition/__tests__/bsffPackagingEdition.test.ts
@@ -51,6 +51,7 @@ describe("edition", () => {
     };
 
     const input: Required<UpdateBsffPackagingInput> = {
+      numero: "1234",
       acceptation,
       operation
     };

--- a/back/src/bsffs/edition/bsffPackagingEdition.ts
+++ b/back/src/bsffs/edition/bsffPackagingEdition.ts
@@ -19,7 +19,7 @@ type EditableBsffPackagingFields = Required<
     | "other"
     | "volume"
     | "weight"
-    | "numero"
+    | "emissionNumero"
     | "acceptationSignatureAuthor"
     | "acceptationSignatureDate"
     | "operationSignatureAuthor"
@@ -35,6 +35,7 @@ type EditableBsffPackagingFields = Required<
 export const editionRules: {
   [key in keyof EditableBsffPackagingFields]: BsffSignatureType;
 } = {
+  numero: "ACCEPTATION",
   acceptationDate: "ACCEPTATION",
   acceptationStatus: "ACCEPTATION",
   acceptationWeight: "ACCEPTATION",

--- a/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
@@ -236,6 +236,7 @@ describe("Mutation.deleteBsff", () => {
           create: initialBsff.packagings.map(p => ({
             type: p.type,
             numero: p.numero,
+            emissionNumero: p.numero,
             volume: p.volume,
             weight: p.acceptationWeight,
             previousPackagings: { connect: { id: p.id } }
@@ -303,6 +304,7 @@ describe("Mutation.deleteBsff", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "cont1",
+            emissionNumero: "cont1",
             weight: 1,
             volume: 1,
             previousPackagings: {
@@ -372,6 +374,7 @@ describe("Mutation.deleteBsff", () => {
           create: {
             type: initialBsff.packagings[0].type,
             numero: initialBsff.packagings[0].numero,
+            emissionNumero: initialBsff.packagings[0].numero,
             weight: initialBsff.packagings[0].acceptationWeight,
             volume: initialBsff.packagings[0].volume,
             previousPackagings: {

--- a/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
@@ -108,6 +108,7 @@ describe("publishBsff", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "123",
+            emissionNumero: "123",
             weight: 1,
             volume: 1
           }

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -86,7 +86,12 @@ describe("Mutation.updateBsff", () => {
       { emitter },
       {
         packagings: {
-          create: { type: BsffPackagingType.BOUTEILLE, weight: 1, numero: "1" }
+          create: {
+            type: BsffPackagingType.BOUTEILLE,
+            weight: 1,
+            numero: "1",
+            emissionNumero: "1"
+          }
         },
         isDraft: true
       }
@@ -710,6 +715,7 @@ describe("Mutation.updateBsff", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "numero",
+            emissionNumero: "numero",
             volume: 1,
             weight: 1,
             previousPackagings: {

--- a/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsffPackaging.ts
@@ -31,6 +31,12 @@ const updateBsffPackaging: MutationResolvers["updateBsffPackaging"] = async (
     );
   }
 
+  if (input.numero === null || input.numero === "") {
+    throw new UserInputError(
+      "Le numéro de contenant ne peut pas être nul ou vide"
+    );
+  }
+
   const sirenifiedInput = await sirenifyBsffPackagingInput(input, user);
   const flatInput = flattenBsffPackagingInput(sirenifiedInput);
 

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
@@ -188,6 +188,7 @@ describe("Query.bsffs", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "AAAAA",
+            emissionNumero: "AAAAA",
             weight: 1
           }
         }
@@ -200,6 +201,7 @@ describe("Query.bsffs", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "BBBBB",
+            emissionNumero: "BBBBB",
             weight: 1
           }
         }
@@ -212,6 +214,7 @@ describe("Query.bsffs", () => {
           create: {
             type: BsffPackagingType.BOUTEILLE,
             numero: "CCCCC",
+            emissionNumero: "CCCCC",
             weight: 1
           }
         }

--- a/back/src/bsffs/typeDefs/bsff.inputs.graphql
+++ b/back/src/bsffs/typeDefs/bsff.inputs.graphql
@@ -200,6 +200,8 @@ input BsffPackagingInput {
 }
 
 input UpdateBsffPackagingInput {
+  "Permet au destintaire du contenant de rectifier le numéro du contenant en cas d'erreur de saisie"
+  numero: String
   "Informations sur l'acceptation du contenant sur l'installation de destination"
   acceptation: BsffPackagingAcceptationInput
   "Informations sur le traitement effectué par contenant"

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignAcceptation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignAcceptation.tsx
@@ -37,6 +37,7 @@ import { BsffPackagingSummary } from "./BsffPackagingSummary";
 
 const getValidationSchema = (today: Date) =>
   yup.object({
+    numero: yup.string(),
     analysisWasteCode: yup.string().required(),
     analysisWasteDescription: yup.string().required(),
     acceptationDate: yup
@@ -178,6 +179,7 @@ export function SignBsffAcceptationOnePackagingModalContent({
       )}
       <Formik
         initialValues={{
+          numero: packaging.numero,
           analysisWasteCode:
             packaging?.acceptation?.wasteCode ?? bsff.waste?.code ?? "",
           analysisWasteDescription:
@@ -197,6 +199,7 @@ export function SignBsffAcceptationOnePackagingModalContent({
             variables: {
               id: packaging.id,
               input: {
+                numero: values.numero,
                 acceptation: {
                   wasteCode: values.analysisWasteCode,
                   wasteDescription: values.analysisWasteDescription,
@@ -250,6 +253,14 @@ export function SignBsffAcceptationOnePackagingModalContent({
                 <Field className="td-input" name="analysisWasteDescription" />
               </label>
               <RedErrorMessage name="analysisWasteDescription" />
+            </div>
+            <div className="form__row">
+              <label>
+                Numéro du contenant{" "}
+                <TdTooltip msg="Permet de rectifier le numéro du contenant en cas de saisie erronée par l'émetteur du BSFF" />
+                <Field className="td-input" name="numero" />
+              </label>
+              <RedErrorMessage name="numero" />
             </div>
             <div className="form__row">
               <label>


### PR DESCRIPTION
Permet au destinataire du BSFF de modifier les numéros de contenant avant l'acceptation du contenant. Cela permet de corriger des erreurs de saisie lors de l'émission du BSFF. Le numéro de contenant initial est stocké dans un nouveau champ `emissionNumero`. 

https://user-images.githubusercontent.com/2269165/226303796-a60b3131-107d-4985-84a0-68d94621112d.mov



- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10658)
