### PR TITLE
[tra-11088] Bsda - exutoire doit avoir le bon rôle

### DIFF
--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -90,6 +90,7 @@ type Destination = Pick<
   | "destinationOperationDescription"
   | "destinationOperationDate"
   | "destinationOperationNextDestinationCap"
+  | "destinationOperationNextDestinationCompanySiret"
 >;
 
 type Transporter = Pick<
@@ -653,7 +654,11 @@ const destinationSchema: FactorySchemaOf<BsdaValidationContext, Destination> =
               `Entreprise de destination ultérieure prévue: CAP obligatoire`
             ),
           otherwise: schema => schema.nullable()
-        })
+        }),
+      destinationOperationNextDestinationCompanySiret: siret
+        .label("Entreprise de destination ultérieure prévue")
+        .test(siretTests.isRegistered("DESTINATION"))
+        .nullable()
     });
 
 const transporterSchema: FactorySchemaOf<BsdaValidationContext, Transporter> =


### PR DESCRIPTION
[Bug] On ne devrait pas pouvoir renseigner un établissement n'ayant pas le profil Installation de traitement dans la partie Exutoire final du BSDA initial

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11088)
