### PR TITLE
Heap snapshot - Switch to  signals

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -1,6 +1,7 @@
 import { app, startApolloServer } from "./server";
 import { closeQueues } from "./queue/producers";
 import { cleanGqlCaches } from "./temp-memory";
+import { heapSnapshotToS3Router } from "./logging/heapSnapshot";
 
 const port = process.env.API_PORT || 80;
 
@@ -17,6 +18,8 @@ async function start() {
 
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+
+  process.on("SIGUSR1", heapSnapshotToS3Router);
 }
 
 if (process.env.TZ !== "Europe/Paris") {

--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -35,7 +35,9 @@ export async function heapSnapshotToS3Router() {
     });
 
     parallelUploads3.on("httpUploadProgress", progress => {
-      console.log(`Uploaded: ${Math.round((progress.loaded * 100) / progress.total)}%`);
+      console.log(
+        `Uploaded: ${Math.round((progress.loaded * 100) / progress.total)}%`
+      );
     });
 
     await parallelUploads3.done();

--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -1,28 +1,16 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
-import { Request, Response } from "express";
 import { createWriteStream } from "fs";
 import v8 from "v8";
-import logger from "./logger";
 
-export async function heapSnapshotToS3Router(req: Request, res: Response) {
-  if (process.env.DEBUG_HEAPDUMP !== "active") {
-    return res.send("Inactive");
-  }
-
-  // Once we have a first snapshot, we need the second one to be from the same container
-  if (req.params.container && req.params.container !== process.env.CONTAINER) {
-    return res.send("Wrong container, try again");
-  }
-
+export async function heapSnapshotToS3Router() {
   // It's important that the filename end with `.heapsnapshot`,
   // otherwise Chrome DevTools won't open it.
   const fileName = `${process.env.DD_ENV}_${
     process.env.CONTAINER
   }_${Date.now()}.heapsnapshot`;
 
-  // Return early so that the heavy work is done in background (avoiding the 1min HTTP timeout)
-  res.status(202).send(fileName);
+  console.info(`Taking a heap snapshot named "${fileName}"...`);
 
   const fileStream = createWriteStream(fileName);
   const snapshotStream = v8.getHeapSnapshot();
@@ -47,11 +35,11 @@ export async function heapSnapshotToS3Router(req: Request, res: Response) {
     });
 
     parallelUploads3.on("httpUploadProgress", progress => {
-      logger.info(progress);
+      console.log(`Uploaded: ${Math.round((progress.loaded * 100) / progress.total)}%`);
     });
 
     await parallelUploads3.done();
   } catch (e) {
-    logger.error("Error while uploading heapdump", e);
+    console.error("Error while uploading heapdump", e);
   }
 }

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -32,7 +32,6 @@ import { redisClient } from "./common/redis";
 import { initSentry } from "./common/sentry";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
-import { heapSnapshotToS3Router } from "./logging/heapSnapshot";
 import { bullBoardPath, serverAdapter } from "./queue/bull-board";
 import { authRouter } from "./routers/auth-router";
 import { downloadRouter } from "./routers/downloadRouter";
@@ -322,8 +321,6 @@ function ensureLoggedInAndAdmin() {
   };
 }
 app.use(bullBoardPath, ensureLoggedInAndAdmin(), serverAdapter.getRouter());
-// TEMP until memory leaks are fixed
-app.post("/heap/:container?", ensureLoggedInAndAdmin(), heapSnapshotToS3Router);
 
 // Apply passport auth middlewares to the graphQL endpoint
 app.use(graphQLPath, passportBearerMiddleware);


### PR DESCRIPTION
Utilisation des signals unix plutot que d'une route pour générer les snapshots de la heap.
Pour prendre un snapshot de web-5 on fait `scalingo -a trackdechets-env-api send-signal --signal SIGUSR1 web-5`

C'est arrivé récemment sur Scalingo et ça permet de:
- target un container en particulier
- évite d'avoir à exposer une route
- évite toutees les problématiques d'authentification
- évite les timeout quand le snapshot est long à prendre

Doc et présentation de la feature ici: https://scalingo.com/blog/unix-signal-support-for-apps