### PR TITLE
HOTFIX - Nouvelles modalités de diffusion INSEE

### DIFF
--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -151,10 +151,17 @@ export const makeSearchCompanies =
     // clue can be formatted like a SIRET or a VAT number
     if (isSiret(cleanedClue) || isVat(cleanedClue)) {
       return searchCompany(cleanedClue)
-        .then(c =>
-          // Exclude closed companies
-          [c].filter(c => c.etatAdministratif && c.etatAdministratif === "A")
-        )
+        .then(c => {
+          return (
+            [c]
+              // Exclude closed companies
+              .filter(c => c.etatAdministratif && c.etatAdministratif === "A")
+              // Exclude anonymous company not registered in TD
+              .filter(
+                c => c.statutDiffusionEtablissement === "O" || c.isRegistered
+              )
+          );
+        })
         .catch(_ => []);
     }
     // fuzzy searching only for French companies

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -158,7 +158,7 @@ export const makeSearchCompanies =
               .filter(c => c.etatAdministratif && c.etatAdministratif === "A")
               // Exclude anonymous company not registered in TD
               .filter(
-                c => c.statutDiffusionEtablissement === "O" || c.isRegistered
+                c => c.statutDiffusionEtablissement !== "N" || c.isRegistered
               )
           );
         })

--- a/back/src/companies/sirene/insee/__tests__/client.test.ts
+++ b/back/src/companies/sirene/insee/__tests__/client.test.ts
@@ -67,7 +67,7 @@ describe("searchCompany", () => {
     expect(company).toEqual(expected);
   });
 
-  it("should raise AnonymousCompanyError if non-diffusible", async () => {
+  it("should raise AnonymousCompanyError if partially diffusible", async () => {
     const siret = siretify(6);
 
     axiosGet.mockResolvedValueOnce({
@@ -77,6 +77,50 @@ describe("searchCompany", () => {
         etablissement: {
           siret,
           statutDiffusionEtablissement: "P",
+          uniteLegale: {
+            denominationUniteLegale: "CODE EN STOCK",
+            categorieJuridiqueUniteLegale: "",
+            prenom1UniteLegale: "",
+            nomUniteLegale: ""
+          },
+          adresseEtablissement: {
+            numeroVoieEtablissement: "[ND]",
+            indiceRepetitionEtablissement: "[ND]",
+            typeVoieEtablissement: "[ND]",
+            complementAdresseEtablissement: "[ND]",
+            libelleVoieEtablissement: "[ND]",
+            codePostalEtablissement: "[ND]",
+            libelleCommuneEtablissement: "[ND]",
+            codeCommuneEtablissement: "[ND]"
+          },
+          periodesEtablissement: [
+            {
+              etatAdministratifEtablissement: "A",
+              activitePrincipaleEtablissement: "[ND]"
+            }
+          ]
+        }
+      }
+    });
+
+    expect.assertions(1);
+    try {
+      await searchCompany(siret);
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+
+  it("should raise AnonymousCompanyError if non diffusible", async () => {
+    const siret = siretify(6);
+
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissement: {
+          siret,
+          statutDiffusionEtablissement: "N",
           uniteLegale: {
             denominationUniteLegale: "CODE EN STOCK",
             categorieJuridiqueUniteLegale: "",

--- a/back/src/companies/sirene/insee/__tests__/client.test.ts
+++ b/back/src/companies/sirene/insee/__tests__/client.test.ts
@@ -67,6 +67,50 @@ describe("searchCompany", () => {
     expect(company).toEqual(expected);
   });
 
+  it("should raise AnonymousCompanyError if non-diffusible", async () => {
+    const siret = siretify(6);
+
+    axiosGet.mockResolvedValueOnce({
+      ...axiosResponseDefault,
+      status: 200,
+      data: {
+        etablissement: {
+          siret,
+          statutDiffusionEtablissement: "P",
+          uniteLegale: {
+            denominationUniteLegale: "CODE EN STOCK",
+            categorieJuridiqueUniteLegale: "",
+            prenom1UniteLegale: "",
+            nomUniteLegale: ""
+          },
+          adresseEtablissement: {
+            numeroVoieEtablissement: "[ND]",
+            indiceRepetitionEtablissement: "[ND]",
+            typeVoieEtablissement: "[ND]",
+            complementAdresseEtablissement: "[ND]",
+            libelleVoieEtablissement: "[ND]",
+            codePostalEtablissement: "[ND]",
+            libelleCommuneEtablissement: "[ND]",
+            codeCommuneEtablissement: "[ND]"
+          },
+          periodesEtablissement: [
+            {
+              etatAdministratifEtablissement: "A",
+              activitePrincipaleEtablissement: "[ND]"
+            }
+          ]
+        }
+      }
+    });
+
+    expect.assertions(1);
+    try {
+      await searchCompany(siret);
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+
   it(`should set name for an individual enterprise
       by concatenating first and last name`, async () => {
     axiosGet.mockResolvedValueOnce({

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -50,7 +50,7 @@ function searchResponseToCompany({
     libelleNaf: "",
     statutDiffusionEtablissement:
       etablissement.statutDiffusionEtablissement === "P"
-        ? "N"
+        ? "N" // Patch https://www.insee.fr/fr/information/6683782 for retro-compatibility
         : etablissement.statutDiffusionEtablissement
   };
 

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -100,6 +100,7 @@ export async function searchCompany(
       });
     }
     if (error.response?.status === 403) {
+      // this is not supposed to happen anymore since https://www.insee.fr/fr/information/6683782
       throw new AnonymousCompanyError();
     }
 

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -48,7 +48,10 @@ function searchResponseToCompany({
     name: etablissement.uniteLegale.denominationUniteLegale,
     naf: lastPeriod?.activitePrincipaleEtablissement,
     libelleNaf: "",
-    statutDiffusionEtablissement: etablissement.statutDiffusionEtablissement
+    statutDiffusionEtablissement:
+      etablissement.statutDiffusionEtablissement === "P"
+        ? "N"
+        : etablissement.statutDiffusionEtablissement
   };
 
   if (company.naf) {
@@ -75,26 +78,33 @@ function searchResponseToCompany({
  * Search a company by SIRET
  * @param siret
  */
-export function searchCompany(siret: string): Promise<SireneSearchResult> {
+export async function searchCompany(
+  siret: string
+): Promise<SireneSearchResult> {
   const searchUrl = `${SIRENE_API_BASE_URL}/siret/${siret}`;
 
-  return authorizedAxiosGet<SearchResponseInsee>(searchUrl)
-    .then(r => searchResponseToCompany(r.data))
-    .catch(error => {
-      // The request was made and the server responded with a status code
-      // that falls out of the range of 2xx
-      if (error.response?.status === 404) {
-        // 404 "no results found"
-        throw new UserInputError("Aucun établissement trouvé avec ce SIRET", {
-          invalidArgs: ["siret"]
-        });
-      }
-      if (error.response?.status === 403) {
-        throw new AnonymousCompanyError();
-      }
+  try {
+    const response = await authorizedAxiosGet<SearchResponseInsee>(searchUrl);
+    const company = searchResponseToCompany(response.data);
+    if (company.statutDiffusionEtablissement === "N") {
+      throw new AnonymousCompanyError();
+    }
+    return company;
+  } catch (error) {
+    // The request was made and the server responded with a status code
+    // that falls out of the range of 2xx
+    if (error.response?.status === 404) {
+      // 404 "no results found"
+      throw new UserInputError("Aucun établissement trouvé avec ce SIRET", {
+        invalidArgs: ["siret"]
+      });
+    }
+    if (error.response?.status === 403) {
+      throw new AnonymousCompanyError();
+    }
 
-      throw error;
-    });
+    throw error;
+  }
 }
 
 /**

--- a/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
+++ b/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
@@ -59,7 +59,6 @@ describe("searchCompany", () => {
     expect(company).toEqual(expected);
   });
 
-  // FIXME this case may not even exist in INSEE public data
   it("should raise AnonymousCompanyError if non-diffusible", async () => {
     const siret = siretify(6);
 
@@ -67,7 +66,7 @@ describe("searchCompany", () => {
       body: {
         _source: {
           siret,
-          statutDiffusionEtablissement: "N"
+          statutDiffusionEtablissement: "P"
         }
       }
     });

--- a/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
+++ b/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
@@ -59,7 +59,7 @@ describe("searchCompany", () => {
     expect(company).toEqual(expected);
   });
 
-  it("should raise AnonymousCompanyError if non-diffusible", async () => {
+  it("should raise AnonymousCompanyError if partially diffusible", async () => {
     const siret = siretify(6);
 
     (client.get as jest.Mock).mockResolvedValueOnce({
@@ -67,6 +67,25 @@ describe("searchCompany", () => {
         _source: {
           siret,
           statutDiffusionEtablissement: "P"
+        }
+      }
+    });
+    expect.assertions(1);
+    try {
+      await searchCompany(siret);
+    } catch (e) {
+      expect(e.extensions.code).toEqual(ErrorCode.FORBIDDEN);
+    }
+  });
+
+  it("should raise AnonymousCompanyError if non diffusible", async () => {
+    const siret = siretify(6);
+
+    (client.get as jest.Mock).mockResolvedValueOnce({
+      body: {
+        _source: {
+          siret,
+          statutDiffusionEtablissement: "N"
         }
       }
     });

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -62,7 +62,7 @@ const searchResponseToCompany = (
       : "",
     statutDiffusionEtablissement:
       etablissement.statutDiffusionEtablissement === "P"
-        ? "N"
+        ? "N" // Patch https://www.insee.fr/fr/information/6683782 for retro-compatibility
         : etablissement.statutDiffusionEtablissement,
     // La variable codePaysEtrangerEtablissement commence toujours par 99 si elle est renseignée dans la base sirene INSEE
     // Les 3 caractères suivants sont le code du pays étranger.

--- a/back/src/companies/sirene/trackdechets/types.ts
+++ b/back/src/companies/sirene/trackdechets/types.ts
@@ -2,7 +2,7 @@ export interface SearchStockEtablissement {
   siren: string;
   nic: string;
   siret: string;
-  statutDiffusionEtablissement: "O" | "N";
+  statutDiffusionEtablissement: "O" | "N" | "P";
   dateCreationEtablissement: string;
   trancheEffectifsEtablissement: string;
   anneeEffectifsEtablissement: string;

--- a/back/src/companies/sirene/types.ts
+++ b/back/src/companies/sirene/types.ts
@@ -53,7 +53,7 @@ interface EtablissementInsee {
     codeCommuneEtablissement: string;
   };
   periodesEtablissement: PeriodeEtablissementInsee[];
-  statutDiffusionEtablissement: "O" | "N";
+  statutDiffusionEtablissement: "O" | "N" | "P";
 }
 
 // Response from https://api.insee.fr/entreprises/siret/V3/siret/<VOTRE_SIRET>


### PR DESCRIPTION
Cf https://www.insee.fr/fr/information/6683782 

Depuis le 21 mars, une recherche sur l'API de l'INSEE avec un n°SIRET non diffusible renvoie un résultat avec `statutDiffusionUniteLegale=P` et des "ND" un peu partout au lieu de renvoyer une 403 comme c'était le cas avant. Deux conséquences : 
- Des établissements non diffusibles ont pu s'inscrire directement sans passer par le support 
- Des établissements non diffusibles et non enregistré dans TD ressortent dans les résultats de recherche de l'UI 

![Capture d’écran 2023-03-27 à 14 39 55](https://user-images.githubusercontent.com/2269165/227953049-d8ef9c84-039f-4a36-8174-7c0276c0b6c6.png)

À partir du 1er avril, les établissements non diffusibles seront également présents dans les données data.gouv et vont donc se retrouver dans notre index SIRENE. 

Le fix proposé vise à patcher les résultats de recherche (INSEE et TD) en remplaçant `P` par `N` et à lever des exceptions `AnonymousCompanyError` dès qu'on rencontre `statutDiffusionUniteLegale=N`. Cela devrait permettre de retrouver le comportement antérieur à la mise à jour de l'INSEE. 

Dans un second temps on pourra réfléchir à comment prendre en compte ce nouveau statut de diffusion.

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11509)
