### PR TITLE
Activation de strictNullCheck, round 2

### DIFF
--- a/back/prisma/scripts/add-address-lat-long.ts
+++ b/back/prisma/scripts/add-address-lat-long.ts
@@ -18,6 +18,7 @@ export class AddAddressLatLongUpdater implements Updater {
       const companies = await prisma.company.findMany();
       for (const company of companies) {
         try {
+          if (!company.siret) continue;
           // TODO index geocoding directly in trackdechets/search module by fetching geocoded SIRENE fron data.gouv.fr
           const companyInfo = await searchCompany(company.siret);
           const { latitude, longitude } = await geocode(companyInfo.address);

--- a/back/prisma/scripts/fix-empty-company-name.ts
+++ b/back/prisma/scripts/fix-empty-company-name.ts
@@ -21,6 +21,7 @@ export class FixNameAddressCompanyUpdater implements Updater {
       });
       for (const company of companies) {
         try {
+          if (!company.siret) continue;
           const companyInfo = await searchCompany(company.siret);
           await prisma.company.update({
             data: {

--- a/back/prisma/scripts/fix-vatnumber-bsds.ts
+++ b/back/prisma/scripts/fix-vatnumber-bsds.ts
@@ -68,7 +68,7 @@ export class FixBSDVatUpdater implements Updater {
             cleanTransportersSirets = transportersSirets.map(siret => {
               if (siret === transporterCompanySiret) return cleanSiret;
               else return siret;
-            });
+            }).filter(Boolean);
           }
 
           await prisma.form.update({
@@ -108,7 +108,7 @@ export class FixBSDVatUpdater implements Updater {
         await prisma.bsda.update({
           data: {
             transporterCompanyVatNumber:
-              bsda.transporterCompanyVatNumber.replace(/[\W_]+/g, ""),
+              bsda.transporterCompanyVatNumber!.replace(/[\W_]+/g, ""),
             ...(bsda.transporterCompanySiret &&
             bsda.transporterCompanyVatNumber === bsda.transporterCompanySiret
               ? {

--- a/back/prisma/scripts/set-contacts.ts
+++ b/back/prisma/scripts/set-contacts.ts
@@ -1,3 +1,4 @@
+import { User } from "@prisma/client";
 import axios from "axios";
 import { addContact } from "../../src/mailer/mailing";
 import prisma from "../../src/prisma";
@@ -22,7 +23,7 @@ export class SetContactsUpdater implements Updater {
             "http://td-mail/contact"
           );
 
-          const contactsToCreate = [];
+          const contactsToCreate: User[] = [];
           for (const user of users) {
             // As soon as one of the user is in the 10 latest contacts, stop picking users
             if (

--- a/back/src/__tests__/auth.test.ts
+++ b/back/src/__tests__/auth.test.ts
@@ -96,9 +96,9 @@ describe("applyAuthStrategies", () => {
     };
     const context: GraphQLContext = {
       user: { ...(user as User), auth: AuthType.Session },
-      req: null,
-      res: null,
-      dataloaders: null
+      req: null as any,
+      res: null as any,
+      dataloaders: null as any
     };
     applyAuthStrategies(context, [AuthType.Session]);
     expect(context.user).not.toBeNull();
@@ -114,9 +114,9 @@ describe("applyAuthStrategies", () => {
     };
     const context: GraphQLContext = {
       user: { ...(user as User), auth: AuthType.Bearer },
-      req: null,
-      res: null,
-      dataloaders: null
+      req: null as any,
+      res: null as any,
+      dataloaders: null as any
     };
     applyAuthStrategies(context, [AuthType.Session]);
     expect(context.user).toBeNull();

--- a/back/src/__tests__/captcha.integration.ts
+++ b/back/src/__tests__/captcha.integration.ts
@@ -178,7 +178,9 @@ describe("POST /login", () => {
     // should send trackdechets.connect.sid cookie
     expect(login.header["set-cookie"]).toHaveLength(1);
     const cookieRegExp = new RegExp(
-      `${sess.name}=(.+); Domain=${sess.cookie.domain}; Path=/; Expires=.+; HttpOnly`
+      `${sess.name}=(.+); Domain=${
+        sess.cookie!.domain
+      }; Path=/; Expires=.+; HttpOnly`
     );
     const sessionCookie = login.header["set-cookie"][0];
     expect(sessionCookie).toMatch(cookieRegExp);

--- a/back/src/__tests__/factories.integration.ts
+++ b/back/src/__tests__/factories.integration.ts
@@ -25,7 +25,7 @@ describe("Test Factories", () => {
     const company = await companyFactory();
 
     expect(company.id).toBeTruthy();
-    expect(company.siret.length).toBe(14);
+    expect(company.siret!.length).toBe(14);
   });
 
   test("should create a user with a company", async () => {
@@ -49,7 +49,7 @@ describe("Test Factories", () => {
       }
     });
 
-    const companyAssociations = usr.companyAssociations;
+    const companyAssociations = usr!.companyAssociations;
     expect(companyAssociations.length).toBe(1);
     expect([...companyAssociations[0].company.companyTypes]).toMatchObject([
       "PRODUCER",
@@ -82,7 +82,7 @@ describe("Test Factories", () => {
       }
     });
 
-    const companyAssociations = usr.companyAssociations;
+    const companyAssociations = usr!.companyAssociations;
     expect(companyAssociations.length).toBe(1);
     expect(companyAssociations[0].company.siret).toBe(company.siret);
 
@@ -159,5 +159,5 @@ test("should create a transport segment", async () => {
   const segments = await prisma.form
     .findUnique({ where: { id: frm.id } })
     .transportSegments();
-  expect(segments.length).toEqual(1);
+  expect(segments!.length).toEqual(1);
 });

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -453,7 +453,7 @@ export const ecoOrganismeFactory = async ({
 };
 
 export const toIntermediaryCompany = (company: Company, contact = "toto") => ({
-  siret: company.siret,
+  siret: company.siret!,
   name: company.name,
   address: company.address,
   contact

--- a/back/src/__tests__/oidc.integration.ts
+++ b/back/src/__tests__/oidc.integration.ts
@@ -191,7 +191,7 @@ describe("/oidc/authorize/decision", () => {
       }
     });
 
-    expect(grant.scope).toEqual(["openid", "profile", "email", "companies"]);
+    expect(grant!.scope).toEqual(["openid", "profile", "email", "companies"]);
   });
 
   it("should forbid funny scope values", async () => {
@@ -319,7 +319,7 @@ describe("/oidc/token - id/secret auth", () => {
 
     await prisma.grant.create({
       data: {
-        user: { connect: { id: application.adminId } },
+        user: { connect: { id: application.adminId! } },
         code: getUid(16),
         application: { connect: { id: application.id } },
         expires: 1 * 60, // 1 minute
@@ -343,7 +343,7 @@ describe("/oidc/token - id/secret auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -396,7 +396,7 @@ describe("/oidc/token - id/secret auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -454,7 +454,7 @@ describe("/oidc/token - id/secret auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -512,7 +512,7 @@ describe("/oidc/token - id/secret auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -739,7 +739,7 @@ describe("/oidc/token - basic auth", () => {
 
     await prisma.grant.create({
       data: {
-        user: { connect: { id: application.adminId } },
+        user: { connect: { id: application.adminId! } },
         code: getUid(16),
         application: { connect: { id: application.id } },
         expires: 1 * 60, // 1 minute
@@ -767,7 +767,7 @@ describe("/oidc/token - basic auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -822,7 +822,7 @@ describe("/oidc/token - basic auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -883,7 +883,7 @@ describe("/oidc/token - basic auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -945,7 +945,7 @@ describe("/oidc/token - basic auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 
@@ -1003,7 +1003,7 @@ describe("/oidc/token - basic auth", () => {
     const spki = process.env.OIDC_PUBLIC_KEY;
     const alg = "RS256";
 
-    const publicKey = await jose.importSPKI(spki, alg);
+    const publicKey = await jose.importSPKI(spki!, alg);
 
     const application = await applicationFactory(true);
 

--- a/back/src/__tests__/testClient.ts
+++ b/back/src/__tests__/testClient.ts
@@ -5,7 +5,7 @@ import { server } from "../server";
 /**
  * Instantiate test client
  */
-function makeClient(user?: Express.User) {
+function makeClient(user?: Express.User | null) {
   const { mutate, query, setOptions } = createTestClient({
     apolloServer: server
   });

--- a/back/src/__tests__/testWorkflow.ts
+++ b/back/src/__tests__/testWorkflow.ts
@@ -14,7 +14,7 @@ async function testWorkflow(workflow: Workflow) {
     });
     if (workflowCompany.companyTypes.includes("ECO_ORGANISME")) {
       // create ecoOrganisme to allow its user to perform api calls
-      await ecoOrganismeFactory({ siret: company.siret, handleBsdasri: true });
+      await ecoOrganismeFactory({ siret: company.siret!, handleBsdasri: true });
     }
 
     context = { ...context, [workflowCompany.name]: { ...company, user } };
@@ -34,6 +34,7 @@ async function testWorkflow(workflow: Workflow) {
           variables: step.variables(context)
         });
       }
+      throw new Error();
     })();
 
     expect(errors).toBeUndefined();

--- a/back/src/activity-events/bsda/reducer.ts
+++ b/back/src/activity-events/bsda/reducer.ts
@@ -49,7 +49,7 @@ export function bsdaReducer(
       const { ...bsda } = event.data.content;
       return {
         ...currentState,
-        ...fixMissTypings(bsda as Prisma.BsdaCreateInput)
+        ...fixMissTypings(bsda as Partial<Prisma.BsdaCreateInput>)
       };
 
     default:
@@ -58,7 +58,9 @@ export function bsdaReducer(
 }
 
 function fixMissTypings(
-  update: Omit<Prisma.BsdaCreateInput, "updatedAt" | "createdAt" | "grouping">
+  update: Partial<
+    Omit<Prisma.BsdaCreateInput, "updatedAt" | "createdAt" | "grouping">
+  >
 ) {
   const patch = {
     ...update,

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -189,7 +189,7 @@ describe("ActivityEvent.Bsdd", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteDetailsCode: "01 03 08",
         comment: ""
       }
@@ -261,7 +261,7 @@ describe("ActivityEvent.Bsdd", () => {
     });
 
     // We should now be able to get the bsdd at different stages
-    const formAfterUpdate = await prisma.form.findUnique({
+    const formAfterUpdate = await prisma.form.findUniqueOrThrow({
       where: { id: formId }
     });
     const formFromEventsAfterCreate = await getBsddFromActivityEvents(

--- a/back/src/applications/resolvers/mutations/__tests__/deleteApplication.integration.ts
+++ b/back/src/applications/resolvers/mutations/__tests__/deleteApplication.integration.ts
@@ -20,8 +20,8 @@ describe("mutation deleteApplication", () => {
 
   it("should delete an application and revoke all associated tokens", async () => {
     const application = await applicationFactory();
-    const admin = await prisma.user.findFirst({
-      where: { id: application.adminId }
+    const admin = await prisma.user.findFirstOrThrow({
+      where: { id: application.adminId! }
     });
     const user = await userFactory();
     let applicationAccessToken = await prisma.accessToken.create({
@@ -36,10 +36,10 @@ describe("mutation deleteApplication", () => {
       where: { id: application.id }
     });
     expect(deletedApplication).toEqual(null);
-    applicationAccessToken = await prisma.accessToken.findFirst({
+    applicationAccessToken = await prisma.accessToken.findFirstOrThrow({
       where: { id: applicationAccessToken.id }
     });
-    personnalAccessToken = await prisma.accessToken.findFirst({
+    personnalAccessToken = await prisma.accessToken.findFirstOrThrow({
       where: { id: personnalAccessToken.id }
     });
     expect(applicationAccessToken.isRevoked).toEqual(true);

--- a/back/src/applications/resolvers/mutations/updateApplication.ts
+++ b/back/src/applications/resolvers/mutations/updateApplication.ts
@@ -1,5 +1,6 @@
 import { ForbiddenError } from "apollo-server-core";
 import { applyAuthStrategies, AuthType } from "../../../auth";
+import { removeEmptyKeys } from "../../../common/converter";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
@@ -28,7 +29,7 @@ const updateApplicationResolver: MutationResolvers["updateApplication"] =
 
     const updatedApplication = await prisma.application.update({
       where: { id: existingApplication.id },
-      data: input
+      data: removeEmptyKeys(input)
     });
 
     return updatedApplication;

--- a/back/src/applications/resolvers/queries/myApplications.ts
+++ b/back/src/applications/resolvers/queries/myApplications.ts
@@ -2,6 +2,7 @@ import { QueryResolvers } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import prisma from "../../../prisma";
 import { applyAuthStrategies, AuthType } from "../../../auth";
+import { UserInputError } from "apollo-server-core";
 
 const myApplications: QueryResolvers["myApplications"] = async (
   _,
@@ -10,7 +11,15 @@ const myApplications: QueryResolvers["myApplications"] = async (
 ) => {
   applyAuthStrategies(context, [AuthType.Session]);
   const user = checkIsAuthenticated(context);
-  return prisma.user.findUnique({ where: { id: user.id } }).applications();
+  const applications = await prisma.user
+    .findUnique({ where: { id: user.id } })
+    .applications();
+
+  if (!applications) {
+    throw new UserInputError("Aucune application pour cet utilisateur.");
+  }
+
+  return applications;
 };
 
 export default myApplications;

--- a/back/src/bsda/__tests__/bsdaFactories.integration.ts
+++ b/back/src/bsda/__tests__/bsdaFactories.integration.ts
@@ -16,7 +16,9 @@ describe("Bsda factories", () => {
       opt: {
         emitterCompanySiret: otherCompany.siret,
         intermediaries: {
-          create: [{ siret: company.siret, name: company.name, contact: "joe" }]
+          create: [
+            { siret: company.siret!, name: company.name, contact: "joe" }
+          ]
         }
       }
     });

--- a/back/src/bsda/__tests__/edition.integration.ts
+++ b/back/src/bsda/__tests__/edition.integration.ts
@@ -106,7 +106,7 @@ describe("edition rules", () => {
     await prisma.intermediaryBsdaAssociation.create({
       data: {
         bsdaId: bsda.id,
-        siret: intermediary.siret,
+        siret: intermediary.siret!,
         name: intermediary.name,
         contact: "contact"
       }
@@ -215,7 +215,7 @@ describe("edition rules", () => {
     await prisma.intermediaryBsdaAssociation.create({
       data: {
         bsdaId: bsda.id,
-        siret: intermediary.siret,
+        siret: intermediary.siret!,
         name: intermediary.name,
         contact: "contact"
       }

--- a/back/src/bsda/__tests__/sirenify.integration.ts
+++ b/back/src/bsda/__tests__/sirenify.integration.ts
@@ -28,12 +28,12 @@ describe("sirenify", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destinataire"),
-      [worker.company.siret]: searchResult("courtier"),
-      [intermediary1.company.siret]: searchResult("intermédiaire 1"),
-      [intermediary2.company.siret]: searchResult("intermédiaire 2")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire"),
+      [worker.company.siret!]: searchResult("courtier"),
+      [intermediary1.company.siret!]: searchResult("intermédiaire 1"),
+      [intermediary2.company.siret!]: searchResult("intermédiaire 2")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -90,41 +90,41 @@ describe("sirenify", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
-    expect(sirenified.worker.company.name).toEqual(
-      searchResults[worker.company.siret].name
+    expect(sirenified.worker!.company!.name).toEqual(
+      searchResults[worker.company.siret!].name
     );
-    expect(sirenified.worker.company.address).toEqual(
-      searchResults[worker.company.siret].address
+    expect(sirenified.worker!.company!.address).toEqual(
+      searchResults[worker.company.siret!].address
     );
-    expect(sirenified.intermediaries[0].name).toEqual(
-      searchResults[intermediary1.company.siret].name
+    expect(sirenified.intermediaries![0].name).toEqual(
+      searchResults[intermediary1.company.siret!].name
     );
-    expect(sirenified.intermediaries[0].address).toEqual(
-      searchResults[intermediary1.company.siret].address
+    expect(sirenified.intermediaries![0].address).toEqual(
+      searchResults[intermediary1.company.siret!].address
     );
-    expect(sirenified.intermediaries[1].name).toEqual(
-      searchResults[intermediary2.company.siret].name
+    expect(sirenified.intermediaries![1].name).toEqual(
+      searchResults[intermediary2.company.siret!].name
     );
-    expect(sirenified.intermediaries[1].address).toEqual(
-      searchResults[intermediary2.company.siret].address
+    expect(sirenified.intermediaries![1].address).toEqual(
+      searchResults[intermediary2.company.siret!].address
     );
   });
 
@@ -145,12 +145,12 @@ describe("sirenify", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destinataire"),
-      [worker.company.siret]: searchResult("courtier"),
-      [intermediary1.company.siret]: searchResult("intermédiaire 1"),
-      [intermediary2.company.siret]: searchResult("intermédiaire 2")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire"),
+      [worker.company.siret!]: searchResult("courtier"),
+      [intermediary1.company.siret!]: searchResult("intermédiaire 1"),
+      [intermediary2.company.siret!]: searchResult("intermédiaire 2")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -193,41 +193,41 @@ describe("sirenify", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
-    expect(sirenified.worker.company.name).toEqual(
-      searchResults[worker.company.siret].name
+    expect(sirenified.worker!.company!.name).toEqual(
+      searchResults[worker.company.siret!].name
     );
-    expect(sirenified.worker.company.address).toEqual(
-      searchResults[worker.company.siret].address
+    expect(sirenified.worker!.company!.address).toEqual(
+      searchResults[worker.company.siret!].address
     );
-    expect(sirenified.intermediaries[0].name).toEqual(
-      searchResults[intermediary1.company.siret].name
+    expect(sirenified.intermediaries![0].name).toEqual(
+      searchResults[intermediary1.company.siret!].name
     );
-    expect(sirenified.intermediaries[0].address).toEqual(
-      searchResults[intermediary1.company.siret].address
+    expect(sirenified.intermediaries![0].address).toEqual(
+      searchResults[intermediary1.company.siret!].address
     );
-    expect(sirenified.intermediaries[1].name).toEqual(
-      searchResults[intermediary2.company.siret].name
+    expect(sirenified.intermediaries![1].name).toEqual(
+      searchResults[intermediary2.company.siret!].name
     );
-    expect(sirenified.intermediaries[1].address).toEqual(
-      searchResults[intermediary2.company.siret].address
+    expect(sirenified.intermediaries![1].address).toEqual(
+      searchResults[intermediary2.company.siret!].address
     );
   });
 });

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -605,7 +605,10 @@ export function flattenBsdaRevisionRequestInput(
         chain(d.reception, r => (r.weight ? r.weight * 1000 : r.weight))
       )
     ),
-    isCanceled: chain(reviewContent, c => chain(c, r => r.isCanceled))
+    isCanceled: undefinedOrDefault(
+      chain(reviewContent, c => chain(c, r => r.isCanceled)),
+      false
+    )
   });
 }
 

--- a/back/src/bsda/database.ts
+++ b/back/src/bsda/database.ts
@@ -39,7 +39,7 @@ export async function getPreviousBsdas(
     .findRelatedEntity({ id: bsda.id })
     .grouping(bsdaWithItermediaries);
 
-  return [forwardedBsda, ...groupedBsdas].filter(
+  return [forwardedBsda, ...(groupedBsdas ?? [])].filter(
     Boolean
   ) as Prisma.BsdaGetPayload<typeof bsdaWithItermediaries>[];
 }

--- a/back/src/bsda/edition.ts
+++ b/back/src/bsda/edition.ts
@@ -142,7 +142,8 @@ export async function checkEditionRules(
   }
 
   const userSirets = user?.id ? await getCachedUserSiretOrVat(user.id) : [];
-  const isEmitter = userSirets.includes(bsda.emitterCompanySiret);
+  const isEmitter =
+    bsda.emitterCompanySiret && userSirets.includes(bsda.emitterCompanySiret);
 
   if (bsda.status === "SIGNED_BY_PRODUCER" && isEmitter) {
     return true;
@@ -155,7 +156,7 @@ export async function checkEditionRules(
   // Inner function used to recursively checks that the diff
   // does not contain any fields sealed by signature
   function checkSealedFields(
-    signatureType: BsdaSignatureType,
+    signatureType: BsdaSignatureType | null,
     editableFields: string[]
   ) {
     if (signatureType === null) {
@@ -229,7 +230,7 @@ async function getUpdatedFields(
       return { ...acc, [field]: bsda[field] };
     }, {}),
     ...(input.grouping ? { grouping: grouping?.map(g => g.id) } : {}),
-    ...(input.forwarding ? { forwarding: forwarding.id } : {}),
+    ...(input.forwarding ? { forwarding: forwarding?.id } : {}),
     ...(input.intermediaries
       ? {
           intermediaries: intermediaries?.map(inter => {

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -14,6 +14,13 @@ export type BsdaToElastic = Bsda & {
   intermediaries: IntermediaryBsdaAssociation[];
 };
 
+type WhereKeys =
+  | "isDraftFor"
+  | "isForActionFor"
+  | "isFollowFor"
+  | "isArchivedFor"
+  | "isToCollectFor"
+  | "isCollectedFor";
 // | state              | emitter         | worker          | transporter | destination     | nextDestination | intermediary |
 // | ------------------ | --------------- | --------------- | ----------- | --------------- | --------------- | ------------ |
 // | INITIAL (draft)    | draft           | draft           | draft       | draft           | follow          | follow       |
@@ -24,18 +31,8 @@ export type BsdaToElastic = Bsda & {
 // | PROCESSED          | archive         | archive         | archive     | archive         | follow          | archive      |
 // | REFUSED            | archive         | archive         | archive     | archive         | follow          | archive      |
 // | AWAITING_CHILD     | follow          | follow          | follow      | follow          | follow          | follow       |
-function getWhere(
-  bsda: BsdaToElastic
-): Pick<
-  BsdElastic,
-  | "isDraftFor"
-  | "isForActionFor"
-  | "isFollowFor"
-  | "isArchivedFor"
-  | "isToCollectFor"
-  | "isCollectedFor"
-> {
-  const where = {
+function getWhere(bsda: BsdaToElastic): Pick<BsdElastic, WhereKeys> {
+  const where: Record<WhereKeys, string[]> = {
     isDraftFor: [],
     isForActionFor: [],
     isFollowFor: [],
@@ -174,11 +171,13 @@ export function toBsdElastic(bsda: BsdaToElastic): BsdElastic {
     emitterCompanySiret: bsda.emitterCompanySiret ?? "",
     emitterCompanyAddress: bsda.emitterCompanyAddress ?? "",
     emitterPickupSiteName: bsda.emitterPickupSiteName ?? "",
-    emitterPickupSiteAddress: buildAddress([
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupSiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     emitterCustomInfo: bsda.emitterCustomInfo ?? "",
     workerCompanyName: bsda.workerCompanyName ?? "",
     workerCompanySiret: bsda.workerCompanySiret ?? "",

--- a/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
+++ b/back/src/bsda/examples/workflows/collecteChantierTransporteurEtranger.ts
@@ -31,7 +31,7 @@ const workflow: Workflow = {
     { name: "traiteur", companyTypes: ["WASTEPROCESSOR"] }
   ],
   steps: [
-    createBsda("producteur", fixtures),
+    createBsda("producteur", fixtures as any),
     signBsda("producteur", "EMISSION"),
     updateBsda("worker", fixtures.workerSignatureUpdateInput),
     signBsda("worker", "WORK"),

--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -91,21 +91,27 @@ export const machine = createMachine<Record<string, never>, Event>(
         event.bsda?.destinationReceptionAcceptationStatus ===
         BsdaStatus.REFUSED,
       canSkipEmissionSignature: (_, event) =>
-        event.bsda?.workerWorkHasEmitterPaperSignature ||
-        event.bsda?.emitterIsPrivateIndividual,
+        Boolean(
+          event.bsda?.workerWorkHasEmitterPaperSignature ||
+            event.bsda?.emitterIsPrivateIndividual
+        ),
       isCollectedBy2710: (_, event) =>
         event.bsda?.type === BsdaType.COLLECTION_2710,
       isCollectedBy2710AndGroupingOrReshipmentOperation: (_, event) =>
         event.bsda?.type === BsdaType.COLLECTION_2710 &&
-        PARTIAL_OPERATIONS.includes(event.bsda?.destinationOperationCode),
+        !!event.bsda?.destinationOperationCode &&
+        PARTIAL_OPERATIONS.includes(event.bsda.destinationOperationCode),
       isGroupingOrReshipmentOperation: (_, event) =>
+        !!event.bsda?.destinationOperationCode &&
         PARTIAL_OPERATIONS.includes(event.bsda?.destinationOperationCode),
       isGroupingOrForwardingOrWithNoWorkerBsda: (_, event) =>
         event.bsda?.type === BsdaType.GATHERING ||
         event.bsda?.type === BsdaType.RESHIPMENT ||
-        event.bsda?.workerIsDisabled,
+        Boolean(event.bsda?.workerIsDisabled),
       isPrivateIndividualWithNoWorkerBsda: (_, event) =>
-        event.bsda?.emitterIsPrivateIndividual && event.bsda?.workerIsDisabled
+        Boolean(
+          event.bsda?.emitterIsPrivateIndividual && event.bsda?.workerIsDisabled
+        )
     }
   }
 );

--- a/back/src/bsda/pdf/components/BsdaPdf.tsx
+++ b/back/src/bsda/pdf/components/BsdaPdf.tsx
@@ -100,7 +100,7 @@ export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
             <p>
               <input
                 type="checkbox"
-                checked={bsda?.emitter?.isPrivateIndividual}
+                checked={Boolean(bsda?.emitter?.isPrivateIndividual)}
                 readOnly
               />{" "}
               Le MO ou le détenteur est un particulier
@@ -164,7 +164,7 @@ export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
             <p>
               <strong>2.2 Numéros de scellés :</strong>
             </p>
-            <p>{bsda?.waste?.sealNumbers.join(", ")}</p>
+            <p>{bsda?.waste?.sealNumbers?.join(", ")}</p>
           </div>
         </div>
 
@@ -268,7 +268,7 @@ export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
               <p>
                 <input
                   type="checkbox"
-                  checked={bsda?.worker?.work?.hasEmitterPaperSignature}
+                  checked={Boolean(bsda?.worker?.work?.hasEmitterPaperSignature)}
                   readOnly
                 />{" "}
                 je certifie disposer d’une version papier, signée du MOA et de

--- a/back/src/bsda/pdf/components/Company.tsx
+++ b/back/src/bsda/pdf/components/Company.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { FormCompany } from "../../../generated/graphql/types";
 
 type Props = {
-  company?: FormCompany;
+  company?: FormCompany | null;
 };
 
 export function CompanyDescription({ company }: Props) {

--- a/back/src/bsda/pdf/components/PickupSite.tsx
+++ b/back/src/bsda/pdf/components/PickupSite.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { BsdaPickupSite } from "../../../generated/graphql/types";
 
 type Props = {
-  pickupSite?: BsdaPickupSite;
+  pickupSite?: BsdaPickupSite | null;
 };
 
 export function PickupSite({ pickupSite }: Props) {

--- a/back/src/bsda/pdf/components/Recepisse.tsx
+++ b/back/src/bsda/pdf/components/Recepisse.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { formatDate } from "../../../common/pdf";
 import { BsdaRecepisse } from "../../../generated/graphql/types";
 
-type Props = { recepisse: BsdaRecepisse };
+type Props = { recepisse: BsdaRecepisse | null | undefined };
 
 export function Recepisse({ recepisse }: Props) {
   return (

--- a/back/src/bsda/pdf/components/Signature.tsx
+++ b/back/src/bsda/pdf/components/Signature.tsx
@@ -3,7 +3,7 @@ import { formatDate, SignatureStamp } from "../../../common/pdf";
 import { Signature } from "../../../generated/graphql/types";
 
 type Props = {
-  signature: Signature;
+  signature: Signature | null| undefined;
 };
 export function Signature({ signature }: Props) {
   return (

--- a/back/src/bsda/pdf/components/WasteDescription.tsx
+++ b/back/src/bsda/pdf/components/WasteDescription.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { BsdaWaste } from "../../../generated/graphql/types";
 
 type Props = {
-  waste?: BsdaWaste;
+  waste?: BsdaWaste | null;
 };
 
 export function WasteDescription({ waste }: Props) {

--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -6,9 +6,9 @@ import {
 } from "../../../generated/graphql/types";
 
 type Props = {
-  waste?: BsdaWaste;
-  packagings?: BsdaPackaging[];
-  weight?: BsdaWeight;
+  waste?: BsdaWaste | null;
+  packagings?: BsdaPackaging[] | null;
+  weight?: BsdaWeight | null;
 };
 
 const CONSISTANCE = {
@@ -25,7 +25,12 @@ export function WasteDetails({ waste, packagings, weight }: Props) {
         Quantité en tonnes : {weight?.value}{" "}
         <input type="checkbox" checked={!weight?.isEstimate} readOnly /> Réelle
         <br />
-        <input type="checkbox" checked={weight?.isEstimate} readOnly /> Estimée
+        <input
+          type="checkbox"
+          checked={Boolean(weight?.isEstimate)}
+          readOnly
+        />{" "}
+        Estimée
       </p>
     </>
   );

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -26,11 +26,19 @@ const bsdaSiretFields = Prisma.validator<Prisma.BsdaArgs>()({
 });
 type BsdaFlatSiretsFields = Prisma.BsdaGetPayload<typeof bsdaSiretFields>;
 
+type BsdaContributorsIntermediaryFields = Pick<
+  IntermediaryBsdaAssociation,
+  "siret" | "vatNumber"
+>;
 type BsdaContributors = Partial<BsdaFlatSiretsFields> &
   Partial<{
-    intermediaries: Partial<
-      Pick<IntermediaryBsdaAssociation, "siret" | "vatNumber">
-    >[];
+    intermediaries:
+      | {
+          [P in keyof BsdaContributorsIntermediaryFields]?:
+            | BsdaContributorsIntermediaryFields[P]
+            | null;
+        }[]
+      | null;
   }>;
 
 export const BSDA_REVISION_REQUESTER_FIELDS: Record<

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -12,16 +12,15 @@ import {
 import { GenericWaste } from "../registry/types";
 import { extractPostalCode } from "../utils";
 
-export function getRegistryFields(
-  bsda: Bsda
-): Pick<
-  BsdElastic,
+type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-> {
-  const registryFields = {
+  | "isManagedWasteFor";
+export function getRegistryFields(
+  bsda: Bsda
+): Pick<BsdElastic, RegistryFields> {
+  const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
@@ -35,14 +34,18 @@ export function getRegistryFields(
     if (bsda.workerCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.workerCompanySiret);
     }
-    registryFields.isTransportedWasteFor.push(getTransporterCompanyOrgId(bsda));
+
+    const transporterCompanyOrgId = getTransporterCompanyOrgId(bsda);
+    if (transporterCompanyOrgId) {
+      registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
+    }
     if (bsda.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
     }
   }
 
   // There is no signature at reception on the BSDA so we use the operation signature
-  if (bsda.destinationOperationSignatureDate) {
+  if (bsda.destinationOperationSignatureDate && bsda.destinationCompanySiret) {
     registryFields.isIncomingWasteFor.push(bsda.destinationCompanySiret);
   }
 
@@ -121,12 +124,14 @@ export function toIncomingWaste(
     emitterCompanySiret: bsda.emitterCompanySiret,
     emitterCompanyAddress: bsda.emitterCompanyAddress,
     ...initialEmitter,
-    emitterPickupsiteAddress: buildAddress([
-      bsda.emitterPickupSiteName,
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupsiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteName,
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     traderCompanyName: null,
     traderCompanySiret: null,
     traderRecepisseNumber: null,
@@ -189,12 +194,14 @@ export function toOutgoingWaste(
     emitterCompanyName: bsda.emitterCompanyName,
     emitterCompanySiret: bsda.emitterCompanySiret,
     emitterCompanyAddress: bsda.emitterCompanyAddress,
-    emitterPickupsiteAddress: buildAddress([
-      bsda.emitterPickupSiteName,
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupsiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteName,
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     ...initialEmitter,
     traderCompanyName: null,
     traderCompanySiret: null,
@@ -261,12 +268,14 @@ export function toTransportedWaste(
     emitterCompanyAddress: bsda.emitterCompanyAddress,
     emitterCompanyName: bsda.emitterCompanyName,
     emitterCompanySiret: bsda.emitterCompanySiret,
-    emitterPickupsiteAddress: buildAddress([
-      bsda.emitterPickupSiteName,
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupsiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteName,
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     traderCompanyName: null,
     traderCompanySiret: null,
     traderRecepisseNumber: null,
@@ -331,12 +340,14 @@ export function toManagedWaste(
     emitterCompanyAddress: bsda.emitterCompanyAddress,
     emitterCompanyName: bsda.emitterCompanyName,
     emitterCompanySiret: bsda.emitterCompanySiret,
-    emitterPickupsiteAddress: buildAddress([
-      bsda.emitterPickupSiteName,
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupsiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteName,
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     ...initialEmitter,
     transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterCompanyName: bsda.transporterCompanyName,
@@ -400,12 +411,14 @@ export function toAllWaste(
     emitterCompanyAddress: bsda.emitterCompanyAddress,
     emitterCompanyName: bsda.emitterCompanyName,
     emitterCompanySiret: bsda.emitterCompanySiret,
-    emitterPickupsiteAddress: buildAddress([
-      bsda.emitterPickupSiteName,
-      bsda.emitterPickupSiteAddress,
-      bsda.emitterPickupSitePostalCode,
-      bsda.emitterPickupSiteCity
-    ]),
+    emitterPickupsiteAddress: buildAddress(
+      [
+        bsda.emitterPickupSiteName,
+        bsda.emitterPickupSiteAddress,
+        bsda.emitterPickupSitePostalCode,
+        bsda.emitterPickupSiteCity
+      ].filter(Boolean)
+    ),
     ...initialEmitter,
     transporterCompanyAddress: bsda.transporterCompanyAddress,
     transporterCompanyName: bsda.transporterCompanyName,

--- a/back/src/bsda/repository/bsda/findRelatedEntity.ts
+++ b/back/src/bsda/repository/bsda/findRelatedEntity.ts
@@ -2,7 +2,7 @@ import { Bsda, Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
 type ChainableBsda = Pick<
-  Prisma.Prisma__BsdaClient<Bsda>,
+  Prisma.Prisma__BsdaClient<Bsda | null, null>,
   "forwardedIn" | "forwarding" | "groupedIn" | "grouping" | "intermediaries"
 >;
 

--- a/back/src/bsda/repository/bsda/findUnique.ts
+++ b/back/src/bsda/repository/bsda/findUnique.ts
@@ -9,7 +9,7 @@ export type FindUniqueBsdaFn = <Args extends Prisma.BsdaArgs>(
 export function buildFindUniqueBsda({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsdaFn {
-  return async <Args>(where, options?) => {
+  return async <Args extends Prisma.BsdaArgs>(where, options?) => {
     const input = { where, ...options };
     const bsda = await prisma.bsda.findUnique(input);
     return bsda as Prisma.BsdaGetPayload<Args>;

--- a/back/src/bsda/repository/revisionRequest/accept.ts
+++ b/back/src/bsda/repository/revisionRequest/accept.ts
@@ -18,7 +18,7 @@ import { ForbiddenError } from "apollo-server-core";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
-  { comment }: { comment?: string },
+  { comment }: { comment?: string | null },
   logMetadata?: LogMetadata
 ) => Promise<void>;
 
@@ -155,6 +155,12 @@ export async function approveAndApplyRevisionRequest(
     updatedRevisionRequest,
     prisma
   );
+
+  if (!updateData) {
+    throw new Error(
+      `Empty BSDA revision cannot be applied. Id #${updatedRevisionRequest.id}, BSDA id #${updatedRevisionRequest.bsdaId}`
+    );
+  }
 
   const updatedBsda = await prisma.bsda.update({
     where: { id: updatedRevisionRequest.bsdaId },

--- a/back/src/bsda/repository/revisionRequest/findUnique.ts
+++ b/back/src/bsda/repository/revisionRequest/findUnique.ts
@@ -4,7 +4,7 @@ import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 export type FindUniqueRevisionRequestFn = (
   where: Prisma.BsdaRevisionRequestWhereUniqueInput,
   options?: Omit<Prisma.BsdaRevisionRequestFindUniqueArgs, "where">
-) => Promise<BsdaRevisionRequest>;
+) => Promise<BsdaRevisionRequest | null>;
 
 export function buildFindUniqueRevisionRequest({
   prisma

--- a/back/src/bsda/repository/revisionRequest/refuse.ts
+++ b/back/src/bsda/repository/revisionRequest/refuse.ts
@@ -9,7 +9,7 @@ import {
 
 export type RefuseRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
-  { comment }: { comment?: string },
+  { comment }: { comment?: string | null },
   logMetadata?: LogMetadata
 ) => Promise<void>;
 

--- a/back/src/bsda/resolvers/Bsda.ts
+++ b/back/src/bsda/resolvers/Bsda.ts
@@ -31,7 +31,7 @@ export const Bsda: BsdaResolvers = {
     const grouping = await getReadonlyBsdaRepository()
       .findRelatedEntity({ id })
       .grouping();
-    return grouping.map(bsda => toInitialBsda(expandBsdaFromDb(bsda)));
+    return grouping?.map(bsda => toInitialBsda(expandBsdaFromDb(bsda))) ?? [];
   },
   groupedIn: async (bsda, _, ctx) => {
     // use ES indexed field when requested from dashboard

--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -77,7 +77,7 @@ export const Metadata: BsdaMetadataResolvers = {
       } = prismaForm;
       try {
         await validateBsda(
-          bsda,
+          bsda as any,
           { previousBsdas: [], intermediaries: [] },
           context
         );

--- a/back/src/bsda/resolvers/BsdaRevisionRequest.ts
+++ b/back/src/bsda/resolvers/BsdaRevisionRequest.ts
@@ -12,7 +12,7 @@ import {
 const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   approvals: async parent => {
     return prisma.bsdaRevisionRequest
-      .findUnique({ where: { id: parent.id } })
+      .findUniqueOrThrow({ where: { id: parent.id } })
       .approvals();
   },
   content: parent => {
@@ -20,7 +20,7 @@ const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   },
   authoringCompany: parent => {
     return prisma.bsdaRevisionRequest
-      .findUnique({ where: { id: parent.id } })
+      .findUniqueOrThrow({ where: { id: parent.id } })
       .authoringCompany();
   },
   bsda: async (parent: BsdaRevisionRequest & { bsdaId: string }) => {

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -151,8 +151,8 @@ describe("Mutation.Bsda.create", () => {
     expect(data.createBsda.id).toMatch(
       new RegExp(`^BSDA-[0-9]{8}-[A-Z0-9]{9}$`)
     );
-    expect(data.createBsda.destination.company.siret).toBe(
-      input.destination.company.siret
+    expect(data.createBsda.destination!.company!.siret).toBe(
+      input.destination!.company!.siret
     );
     // check input is sirenified
     expect(sirenifyMock).toHaveBeenCalledTimes(1);
@@ -220,8 +220,8 @@ describe("Mutation.Bsda.create", () => {
     expect(data.createBsda.id).toMatch(
       new RegExp(`^BSDA-[0-9]{8}-[A-Z0-9]{9}$`)
     );
-    expect(data.createBsda.destination.company.siret).toBe(
-      input.destination.company.siret
+    expect(data.createBsda.destination!.company!.siret).toBe(
+      input.destination!.company!.siret
     );
   });
 
@@ -286,8 +286,8 @@ describe("Mutation.Bsda.create", () => {
     expect(data.createBsda.id).toMatch(
       new RegExp(`^BSDA-[0-9]{8}-[A-Z0-9]{9}$`)
     );
-    expect(data.createBsda.destination.company.siret).toBe(
-      input.destination.company.siret
+    expect(data.createBsda.destination!.company!.siret).toBe(
+      input.destination!.company!.siret
     );
   });
 
@@ -365,7 +365,7 @@ describe("Mutation.Bsda.create", () => {
       }
     });
 
-    expect(data.createBsda.transporter.transport.plates.length).toBe(2);
+    expect(data.createBsda.transporter!.transport!.plates!.length).toBe(2);
   });
 
   it("should fail creating the form if more than 2 plates are submitted", async () => {
@@ -922,7 +922,7 @@ describe("Mutation.Bsda.create", () => {
     });
 
     expect(data.createBsda.id).toBeDefined();
-    expect(data.createBsda.intermediaries.length).toBe(1);
+    expect(data.createBsda.intermediaries!.length).toBe(1);
   });
 
   it("should fail if creating a bsda with the same intermediary several times", async () => {

--- a/back/src/bsda/resolvers/mutations/__tests__/createDraft.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/createDraft.integration.ts
@@ -130,7 +130,7 @@ describe("Mutation.Bsda.createDraft", () => {
       }
     );
 
-    expect(data.createDraftBsda.destination.company).toMatchObject(
+    expect(data.createDraftBsda.destination!.company).toMatchObject(
       input.destination.company
     );
   });
@@ -160,7 +160,7 @@ describe("Mutation.Bsda.createDraft", () => {
       }
     );
     expect(errors).toBeUndefined();
-    const bsda = await prisma.bsda.findUnique({
+    const bsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: data.createDraftBsda.id }
     });
     expect(bsda.workerIsDisabled).toEqual(false);

--- a/back/src/bsda/resolvers/mutations/__tests__/delete.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/delete.integration.ts
@@ -180,7 +180,7 @@ describe("Mutation.deleteBsda", () => {
 
     expect(data.deleteBsda.id).toBeTruthy();
 
-    const updatedForwarded = await prisma.bsda.findUnique({
+    const updatedForwarded = await prisma.bsda.findUniqueOrThrow({
       where: { id: forwardedBsda.id },
       include: { forwarding: true }
     });
@@ -206,7 +206,7 @@ describe("Mutation.deleteBsda", () => {
       }
     );
 
-    const deletedBsda = await prisma.bsda.findUnique({
+    const deletedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
     expect(deletedBsda.isDeleted).toBe(true);

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -759,11 +759,11 @@ describe("Mutation.Bsda.sign", () => {
       expect(errors).toBeUndefined();
       expect(data.signBsda.id).toBeTruthy();
 
-      const newBsda1 = await prisma.bsda.findUnique({
+      const newBsda1 = await prisma.bsda.findUniqueOrThrow({
         where: { id: bsda1.id }
       });
       expect(newBsda1.status).toEqual(BsdaStatus.PROCESSED);
-      const newBsda2 = await prisma.bsda.findUnique({
+      const newBsda2 = await prisma.bsda.findUniqueOrThrow({
         where: { id: bsda2.id }
       });
       expect(newBsda2.status).toEqual(BsdaStatus.PROCESSED);
@@ -899,13 +899,13 @@ describe("Mutation.Bsda.sign", () => {
       expect(errors).toBeUndefined();
       expect(data.signBsda.id).toBeTruthy();
 
-      const newGrouped1 = await prisma.bsda.findUnique({
+      const newGrouped1 = await prisma.bsda.findUniqueOrThrow({
         where: { id: grouped1.id }
       });
       expect(newGrouped1.status).toEqual(BsdaStatus.AWAITING_CHILD);
       expect(newGrouped1.groupedInId).toBe(null);
 
-      const newGrouped2 = await prisma.bsda.findUnique({
+      const newGrouped2 = await prisma.bsda.findUniqueOrThrow({
         where: { id: grouped2.id }
       });
       expect(newGrouped2.status).toEqual(BsdaStatus.AWAITING_CHILD);
@@ -963,7 +963,7 @@ describe("Mutation.Bsda.sign", () => {
       expect(errors).toBeUndefined();
       expect(data.signBsda.id).toBeTruthy();
 
-      const newForwarding = await prisma.bsda.findUnique({
+      const newForwarding = await prisma.bsda.findUniqueOrThrow({
         where: { id: forwarding.id }
       });
       expect(newForwarding.status).toEqual(BsdaStatus.REFUSED);

--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -313,7 +313,7 @@ describe("Mutation.updateBsda", () => {
       }
     });
 
-    expect(data.updateBsda.transporter.recepisse.number).toEqual(
+    expect(data.updateBsda.transporter!.recepisse!.number).toEqual(
       "Num recepisse"
     );
   });
@@ -466,7 +466,7 @@ describe("Mutation.updateBsda", () => {
     expect(errors).toBeUndefined();
 
     const actualForwarded = await prisma.bsda
-      .findUnique({ where: { id: bsda.id } })
+      .findUniqueOrThrow({ where: { id: bsda.id } })
       .forwarding();
 
     expect(actualForwarded.id).toEqual(newForwarded.id);
@@ -550,7 +550,7 @@ describe("Mutation.updateBsda", () => {
         emitterCompanySiret: company.siret,
         intermediaries: {
           create: {
-            siret: company.siret,
+            siret: company.siret!,
             name: company.name,
             address: company.address,
             contact: "John Doe"
@@ -581,8 +581,8 @@ describe("Mutation.updateBsda", () => {
       }
     });
 
-    expect(data.updateBsda.intermediaries.length).toBe(1);
-    expect(data.updateBsda.intermediaries[0].siret).toBe(otherCompany.siret);
+    expect(data.updateBsda.intermediaries!.length).toBe(1);
+    expect(data.updateBsda.intermediaries![0].siret).toBe(otherCompany.siret);
   });
 
   it("should ignore intermediaries update if the value hasn't changed", async () => {
@@ -595,7 +595,7 @@ describe("Mutation.updateBsda", () => {
         transporterTransportSignatureDate: new Date(),
         intermediaries: {
           create: {
-            siret: company.siret,
+            siret: company.siret!,
             name: company.name,
             address: company.address,
             contact: "John Doe"
@@ -628,7 +628,7 @@ describe("Mutation.updateBsda", () => {
       }
     });
 
-    expect(data.updateBsda.intermediaries.length).toBe(1);
+    expect(data.updateBsda.intermediaries!.length).toBe(1);
   });
 
   it("should reject if updating intermediaries when its value is locked", async () => {
@@ -644,7 +644,7 @@ describe("Mutation.updateBsda", () => {
         transporterTransportSignatureDate: new Date(),
         intermediaries: {
           create: {
-            siret: company.siret,
+            siret: company.siret!,
             name: company.name,
             address: company.address,
             contact: "John Doe"

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -45,7 +45,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
   );
 
   const isForwarding = Boolean(input.forwarding);
-  const isGrouping = input.grouping?.length > 0;
+  const isGrouping = input.grouping && input.grouping.length > 0;
 
   if ([isForwarding, isGrouping].filter(b => b).length > 1) {
     throw new UserInputError(
@@ -68,17 +68,18 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
 
   const bsdaRepository = getBsdaRepository(user);
   const forwardedBsda = isForwarding
-    ? await getBsdaOrNotFound(input.forwarding)
+    ? await getBsdaOrNotFound(input.forwarding!)
     : null;
   const groupedBsdas = isGrouping
-    ? await bsdaRepository.findMany({ id: { in: input.grouping } })
+    ? await bsdaRepository.findMany({ id: { in: input.grouping! } })
     : [];
 
   const previousBsdas = [
     ...(isForwarding ? [forwardedBsda] : []),
     ...(isGrouping ? groupedBsdas : [])
-  ];
-  const hasIntermediaries = input.intermediaries?.length > 0;
+  ].filter(Boolean);
+  const hasIntermediaries =
+    input.intermediaries && input.intermediaries.length > 0;
 
   await validateBsda(
     bsda,
@@ -93,18 +94,21 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     id: getReadableId(ReadableIdPrefix.BSDA),
     isDraft,
     ...(isForwarding && {
-      forwarding: { connect: { id: input.forwarding } }
+      forwarding: { connect: { id: input.forwarding! } }
     }),
     ...(isGrouping && {
       grouping: { connect: groupedBsdas.map(({ id }) => ({ id })) }
     }),
     ...(hasIntermediaries && {
-      intermediariesOrgIds: input.intermediaries
-        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+      intermediariesOrgIds: input
+        .intermediaries!.flatMap(intermediary => [
+          intermediary.siret,
+          intermediary.vatNumber
+        ])
         .filter(Boolean),
       intermediaries: {
         createMany: {
-          data: companyToIntermediaryInput(input.intermediaries)
+          data: companyToIntermediaryInput(input.intermediaries!)
         }
       }
     })

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -73,6 +73,7 @@ function duplicateBsda({
     id: getReadableId(ReadableIdPrefix.BSDA),
     status: BsdaStatus.INITIAL,
     isDraft: true,
+    packagings: rest.packagings ?? Prisma.JsonNull,
     ...(intermediaries && {
       intermediaries: {
         createMany: {

--- a/back/src/bsda/resolvers/mutations/publish.ts
+++ b/back/src/bsda/resolvers/mutations/publish.ts
@@ -33,7 +33,7 @@ export default async function create(
   const previousBsdas = await getPreviousBsdas(existingBsda);
   const { intermediaries, ...bsda } = existingBsda;
   await validateBsda(
-    bsda,
+    bsda as any,
     { previousBsdas, intermediaries },
     { emissionSignature: true }
   );

--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
@@ -51,7 +51,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -84,7 +84,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -112,7 +112,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -145,7 +145,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -177,7 +177,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -232,7 +232,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "Made up code" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -263,7 +263,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -294,7 +294,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -326,7 +326,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -358,7 +358,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { isCanceled: true, waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -391,7 +391,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
           bsdaId: bsda.id,
           content: { waste: { code: "16 01 11*" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -428,7 +428,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
             bsdaId: bsda.id,
             content: { isCanceled: true },
             comment: "A comment",
-            authoringCompanySiret: company.siret
+            authoringCompanySiret: company.siret!
           }
         }
       });
@@ -465,7 +465,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
             bsdaId: bsda.id,
             content: { isCanceled: true },
             comment: "A comment",
-            authoringCompanySiret: company.siret
+            authoringCompanySiret: company.siret!
           }
         }
       });

--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -92,7 +92,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: company.id,
-        approvals: { create: { approverSiret: companyOfSomeoneElse.siret } },
+        approvals: { create: { approverSiret: companyOfSomeoneElse.siret! } },
         comment: ""
       }
     });
@@ -124,7 +124,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: "",
         wasteCode: "10 13 09*"
       }
@@ -158,8 +158,8 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
         authoringCompanyId: secondCompany.id,
         approvals: {
           create: [
-            { approverSiret: company.siret },
-            { approverSiret: thirdCompany.siret }
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
           ]
         },
         comment: ""
@@ -180,13 +180,13 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
     expect(
       data.submitBsdaRevisionRequestApproval.approvals.find(
         val => val.approverSiret === company.siret
-      ).status
+      )!.status
     ).toBe("ACCEPTED");
 
     expect(
-      data.submitBsdaRevisionRequestApproval.approvals.find(
+      data.submitBsdaRevisionRequestApproval.approvals!.find(
         val => val.approverSiret === thirdCompany.siret
-      ).status
+      )!.status
     ).toBe("PENDING");
   });
 
@@ -206,8 +206,8 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
         authoringCompanyId: secondCompany.id,
         approvals: {
           create: [
-            { approverSiret: company.siret },
-            { approverSiret: thirdCompany.siret }
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
           ]
         },
         comment: ""
@@ -226,13 +226,13 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
     expect(
       data.submitBsdaRevisionRequestApproval.approvals.find(
         val => val.approverSiret === company.siret
-      ).status
+      )!.status
     ).toBe("REFUSED");
     expect(data.submitBsdaRevisionRequestApproval.status).toBe("REFUSED");
     expect(
       data.submitBsdaRevisionRequestApproval.approvals.find(
         val => val.approverSiret === thirdCompany.siret
-      ).status
+      )!.status
     ).toBe("CANCELED");
   });
 
@@ -251,7 +251,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: ""
       }
     });
@@ -284,7 +284,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteCode: "01 03 08",
         comment: ""
       }
@@ -300,7 +300,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -323,7 +323,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteCode: "01 03 08",
         comment: ""
       }
@@ -339,7 +339,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -365,7 +365,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         destinationOperationCode: "R 13",
         comment: "Operation code error"
       }
@@ -381,7 +381,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -407,7 +407,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         destinationOperationCode: "R 5",
         comment: "Operation code error"
       }
@@ -423,7 +423,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -449,7 +449,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         destinationOperationCode: "R 13",
         comment: "Operation code error"
       }
@@ -465,7 +465,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -490,7 +490,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       data: {
         bsdaId: bsda.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: "Cancel",
         isCanceled: true
       }
@@ -506,7 +506,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsda = await prisma.bsda.findUnique({
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
 
@@ -533,7 +533,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
         data: {
           bsdaId: bsda.id,
           authoringCompanyId: companyOfSomeoneElse.id,
-          approvals: { create: { approverSiret: company.siret } },
+          approvals: { create: { approverSiret: company.siret! } },
           comment: "Cancel",
           isCanceled: true
         }
@@ -603,7 +603,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
         bsdaId: bsda.id,
         authoringCompanyId: emitter.id,
         approvals: {
-          create: [{ approverSiret: destination.siret }]
+          create: [{ approverSiret: destination.siret! }]
         },
         comment: "Cancel",
         isCanceled: true
@@ -622,19 +622,19 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
 
     expect(errors).toBeUndefined();
 
-    const newGrouped1AfterRevision = await prisma.bsda.findUnique({
+    const newGrouped1AfterRevision = await prisma.bsda.findUniqueOrThrow({
       where: { id: grouped1.id }
     });
     expect(newGrouped1AfterRevision.status).toEqual(BsdaStatus.SENT);
     expect(newGrouped1AfterRevision.groupedInId).toBe(null);
 
-    const newGrouped2AfterRevision = await prisma.bsda.findUnique({
+    const newGrouped2AfterRevision = await prisma.bsda.findUniqueOrThrow({
       where: { id: grouped2.id }
     });
     expect(newGrouped2AfterRevision.status).toEqual(BsdaStatus.SENT);
     expect(newGrouped2AfterRevision.groupedInId).toBe(null);
 
-    const newBsdaAfterRevision = await prisma.bsda.findUnique({
+    const newBsdaAfterRevision = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsda.id }
     });
     expect(newBsdaAfterRevision.status).toEqual(BsdaStatus.CANCELED);

--- a/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
@@ -87,6 +87,12 @@ export async function createBsdaRevisionRequest(
     bsda,
     authoringCompanySiret
   );
+
+  if (!authoringCompany.siret) {
+    throw new Error(
+      `Authoring company ${authoringCompany.id} has no siret. Cannot create BSDA revision request.`
+    );
+  }
   const approversSirets = await getApproversSirets(
     bsda,
     authoringCompany.siret

--- a/back/src/bsda/resolvers/mutations/revisionRequest/submitRevisionRequestApproval.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/submitRevisionRequestApproval.ts
@@ -76,8 +76,8 @@ async function getCurrentApproverSiret(
     .map(approvals => approvals.approverSiret);
 
   const userCompanies = await getUserCompanies(user.id);
-  const approvingCompaniesCandidate = userCompanies.find(company =>
-    remainingApproverSirets.includes(company.siret)
+  const approvingCompaniesCandidate = userCompanies.find(
+    company => company.siret && remainingApproverSirets.includes(company.siret)
   );
 
   if (!approvingCompaniesCandidate) {

--- a/back/src/bsda/resolvers/queries/__tests__/bsda.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsda.integration.ts
@@ -46,7 +46,9 @@ describe("Query.Bsda", () => {
       opt: {
         emitterCompanySiret: otherCompany.siret,
         intermediaries: {
-          create: [{ siret: company.siret, name: company.name, contact: "joe" }]
+          create: [
+            { siret: company.siret!, name: company.name, contact: "joe" }
+          ]
         }
       }
     });

--- a/back/src/bsda/resolvers/queries/__tests__/bsdaPdf.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdaPdf.integration.ts
@@ -107,7 +107,9 @@ describe("Query.BsdaPdf", () => {
       opt: {
         emitterCompanySiret: otherCompany.siret,
         intermediaries: {
-          create: [{ siret: company.siret, name: company.name, contact: "joe" }]
+          create: [
+            { siret: company.siret!, name: company.name, contact: "joe" }
+          ]
         }
       }
     });

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -54,7 +54,9 @@ describe("Query.bsdas", () => {
       opt: {
         emitterCompanySiret: otherCompany.siret,
         intermediaries: {
-          create: [{ siret: company.siret, name: company.name, contact: "joe" }]
+          create: [
+            { siret: company.siret!, name: company.name, contact: "joe" }
+          ]
         }
       }
     });

--- a/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -46,7 +46,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
       data: {
         bsdaId: bsda1.id,
         authoringCompanyId: otherCompany.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: ""
       }
     });
@@ -54,7 +54,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
       data: {
         bsdaId: bsda2.id,
         authoringCompanyId: company.id,
-        approvals: { create: { approverSiret: otherCompany.siret } },
+        approvals: { create: { approverSiret: otherCompany.siret! } },
         comment: ""
       }
     });
@@ -66,7 +66,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
         authoringCompanyId: company.id,
         approvals: {
           create: {
-            approverSiret: otherCompany.siret,
+            approverSiret: otherCompany.siret!,
             status: "ACCEPTED"
           }
         },
@@ -79,7 +79,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
         authoringCompanyId: company.id,
         approvals: {
           create: {
-            approverSiret: otherCompany.siret,
+            approverSiret: otherCompany.siret!,
             status: "REFUSED"
           }
         },

--- a/back/src/bsda/resolvers/queries/bsdaPdf.ts
+++ b/back/src/bsda/resolvers/queries/bsdaPdf.ts
@@ -6,12 +6,12 @@ import { getBsdaOrNotFound } from "../../database";
 import { checkCanAccessBsdaPdf } from "../../permissions";
 import { buildPdf } from "../../pdf/generator";
 import { DownloadHandler } from "../../../routers/downloadRouter";
-import { getBsdaRepository } from "../../repository";
+import { getReadonlyBsdaRepository } from "../../repository";
 
 export const bsdaPdfDownloadHandler: DownloadHandler<QueryBsdaPdfArgs> = {
   name: "bsdaPdf",
-  handler: async (req, res, { id }) => {
-    const bsda = await getBsdaRepository(req.user).findUnique({ id });
+  handler: async (_, res, { id }) => {
+    const bsda = await getReadonlyBsdaRepository().findUnique({ id });
     const readableStream = await buildPdf(bsda);
     readableStream.pipe(createPDFResponse(res, bsda.id));
   }

--- a/back/src/bsda/resolvers/queries/revisionRequests.ts
+++ b/back/src/bsda/resolvers/queries/revisionRequests.ts
@@ -23,9 +23,9 @@ export async function bsdaRevisionRequests(
   await checkIsCompanyMember({ id: user.id }, { orgId: siret });
   const company = await getCompanyOrCompanyNotFound({ orgId: siret });
 
-  const pageSize = Math.max(Math.min(first, MAX_SIZE), MIN_SIZE);
+  const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
 
-  const { status } = inputWhere;
+  const { status } = inputWhere ?? {};
   const where = {
     OR: [
       { authoringCompanyId: company.id },

--- a/back/src/bsda/sirenify.ts
+++ b/back/src/bsda/sirenify.ts
@@ -31,10 +31,10 @@ const accessors = (input: BsdaInput) => [
     })
   },
   ...(input.intermediaries ?? []).map((_, idx) => ({
-    getter: () => input.intermediaries[idx],
+    getter: () => input.intermediaries![idx],
     setter: (input: BsdaInput, companyInput: CompanyInput) => ({
       ...input,
-      intermediaries: input.intermediaries.map((current, i) =>
+      intermediaries: input.intermediaries!.map((current, i) =>
         i === idx ? companyInput : current
       )
     })

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -335,7 +335,7 @@ type BsdaRevisionRequest {
   bsda: Bsda!
 
   "Date de création de la demande"
-  createdAt: DateTime
+  createdAt: DateTime!
 
   "Entreprise à l'origine de la demande de révision"
   authoringCompany: FormCompany!

--- a/back/src/bsda/typeDefs/bsda.queries.graphql
+++ b/back/src/bsda/typeDefs/bsda.queries.graphql
@@ -48,7 +48,7 @@ type Query {
   Ce token doit être transmis à la route /download pour obtenir le fichier.
   Il est valable 10 secondes
   """
-  bsdaPdf("ID d'un bordereau" id: ID): FileDownload!
+  bsdaPdf("ID d'un bordereau" id: ID!): FileDownload!
 
   """
   Renvoie les demandes de révisions Bsda associées à un SIRET (demandes soumises et approbations requises)

--- a/back/src/bsda/validation.ts
+++ b/back/src/bsda/validation.ts
@@ -137,7 +137,7 @@ export async function validateBsda(
     intermediaries
   }: {
     previousBsdas: Bsda[];
-    intermediaries: CompanyInput[];
+    intermediaries: CompanyInput[] | null | undefined;
   },
   context: BsdaValidationContext
 ) {
@@ -153,7 +153,7 @@ async function validatePreviousBsdas(
   bsda: Partial<Prisma.BsdaCreateInput>,
   previousBsdas: Bsda[]
 ) {
-  if (!["GATHERING", "RESHIPMENT"].includes(bsda.type)) {
+  if (!bsda.type || !["GATHERING", "RESHIPMENT"].includes(bsda.type)) {
     return;
   }
 
@@ -225,6 +225,7 @@ async function validatePreviousBsdas(
     // nextBsdas of previous
     const nextBsdas = [forwardedIn, groupedIn].filter(Boolean);
     if (
+      bsda.id &&
       nextBsdas.length > 0 &&
       !nextBsdas.map(bsda => bsda.id).includes(bsda.id)
     ) {
@@ -233,7 +234,10 @@ async function validatePreviousBsdas(
       ]);
     }
 
-    if (!PARTIAL_OPERATIONS.includes(previousBsda.destinationOperationCode)) {
+    if (
+      previousBsda.destinationOperationCode &&
+      !PARTIAL_OPERATIONS.includes(previousBsda.destinationOperationCode)
+    ) {
       return acc.concat([
         `Le bordereau n°${previousBsda.id} a déclaré un traitement qui ne permet pas de lui donner la suite voulue.`
       ]);

--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -9,9 +9,9 @@ import {
   toPrismaNestedWhereInput,
   toPrismaGenericWhereInput,
   toPrismaEnumFilter,
-  toPrismaIdFilter,
   toPrismaRelationIdFilter,
-  toPrismaStringNullableListFilter
+  toPrismaStringNullableListFilter,
+  toPrismaStringNullableFilter
 } from "../common/where";
 
 function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
@@ -54,7 +54,7 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
     ),
     destinationCustomInfo: toPrismaStringFilter(where.destination?.customInfo),
     brokerCompanySiret: toPrismaStringFilter(where.broker?.company?.siret),
-    groupedInId: toPrismaIdFilter(where.groupedIn),
+    groupedInId: toPrismaStringNullableFilter(where.groupedIn),
     forwardedIn: toPrismaRelationIdFilter(where.forwardedIn) as Prisma.XOR<
       Prisma.BsdaRelationFilter,
       Prisma.BsdaWhereInput

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -83,7 +83,7 @@ describe("indexAllBsdTypeSync", () => {
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdds.length);
     for (const hit of hits) {
-      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source.id);
+      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source!.id);
     }
   });
 
@@ -107,7 +107,7 @@ describe("indexAllBsdTypeSync", () => {
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdas.length);
     for (const hit of hits) {
-      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source.id);
+      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source!.id);
     }
   });
 
@@ -131,7 +131,7 @@ describe("indexAllBsdTypeSync", () => {
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdasris.length);
     for (const hit of hits) {
-      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source.id);
+      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source!.id);
     }
   });
 
@@ -155,7 +155,7 @@ describe("indexAllBsdTypeSync", () => {
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsffs.length);
     for (const hit of hits) {
-      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source.id);
+      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source!.id);
     }
   });
 
@@ -178,7 +178,7 @@ describe("indexAllBsdTypeSync", () => {
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsvhus.length);
     for (const hit of hits) {
-      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source.id);
+      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source!.id);
     }
   });
 });
@@ -207,12 +207,12 @@ describe("indexAllBsdTypeConcurrently", () => {
           query: { match_all: {} }
         }
       });
-    expect(jobs.length).toEqual(1);
-    expect(jobs[0].status).toEqual("fulfilled");
+    expect(jobs!.length).toEqual(1);
+    expect(jobs![0].status).toEqual("fulfilled");
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdds.length);
     for (const hit of hits) {
-      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source.id);
+      expect(bsdds.map(bsdd => bsdd.id)).toContain(hit._source!.id);
     }
   });
 
@@ -236,12 +236,12 @@ describe("indexAllBsdTypeConcurrently", () => {
           query: { match_all: {} }
         }
       });
-    expect(jobs.length).toEqual(1);
-    expect(jobs[0].status).toEqual("fulfilled");
+    expect(jobs!.length).toEqual(1);
+    expect(jobs![0].status).toEqual("fulfilled");
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdas.length);
     for (const hit of hits) {
-      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source.id);
+      expect(bsdas.map(bsda => bsda.id)).toContain(hit._source!.id);
     }
   });
 
@@ -265,12 +265,12 @@ describe("indexAllBsdTypeConcurrently", () => {
           query: { match_all: {} }
         }
       });
-    expect(jobs.length).toEqual(1);
-    expect(jobs[0].status).toEqual("fulfilled");
+    expect(jobs!.length).toEqual(1);
+    expect(jobs![0].status).toEqual("fulfilled");
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsdasris.length);
     for (const hit of hits) {
-      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source.id);
+      expect(bsdasris.map(bsdasri => bsdasri.id)).toContain(hit._source!.id);
     }
   });
 
@@ -294,12 +294,12 @@ describe("indexAllBsdTypeConcurrently", () => {
           query: { match_all: {} }
         }
       });
-    expect(jobs.length).toEqual(1);
-    expect(jobs[0].status).toEqual("fulfilled");
+    expect(jobs!.length).toEqual(1);
+    expect(jobs![0].status).toEqual("fulfilled");
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsffs.length);
     for (const hit of hits) {
-      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source.id);
+      expect(bsffs.map(bsff => bsff.id)).toContain(hit._source!.id);
     }
   });
 
@@ -322,12 +322,12 @@ describe("indexAllBsdTypeConcurrently", () => {
           query: { match_all: {} }
         }
       });
-    expect(jobs.length).toEqual(1);
-    expect(jobs[0].status).toEqual("fulfilled");
+    expect(jobs!.length).toEqual(1);
+    expect(jobs![0].status).toEqual("fulfilled");
     const hits = body.hits.hits;
     expect(hits).toHaveLength(bsvhus.length);
     for (const hit of hits) {
-      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source.id);
+      expect(bsvhus.map(bsvhu => bsvhu.id)).toContain(hit._source!.id);
     }
   });
 });
@@ -358,7 +358,7 @@ describe("indexAllBsds", () => {
 
     expect(hits).toHaveLength(bsds.length);
     for (const hit of hits) {
-      expect(bsds.map(bsd => bsd.id)).toContain(hit._source.id);
+      expect(bsds.map(bsd => bsd.id)).toContain(hit._source!.id);
     }
   });
 
@@ -385,7 +385,7 @@ describe("indexAllBsds", () => {
 
     expect(hits).toHaveLength(bsds.length);
     for (const hit of hits) {
-      expect(bsds.map(bsd => bsd.id)).toContain(hit._source.id);
+      expect(bsds.map(bsd => bsd.id)).toContain(hit._source!.id);
     }
   });
 });

--- a/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
+++ b/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
@@ -139,7 +139,7 @@ describe("Mutation.creatPdfAccessToken", () => {
       }
     );
 
-    const token = await prisma.pdfAccessToken.findFirst({
+    const token = await prisma.pdfAccessToken.findFirstOrThrow({
       where: { bsdType: BsdType.BSDD, userId: user.id, bsdId: bsdd.id }
     });
 
@@ -225,7 +225,7 @@ describe("Mutation.creatPdfAccessToken", () => {
       }
     );
 
-    const token = await prisma.pdfAccessToken.findFirst({
+    const token = await prisma.pdfAccessToken.findFirstOrThrow({
       where: { bsdType: BsdType.BSDA, userId: user.id, bsdId: bsda.id }
     });
 
@@ -310,7 +310,7 @@ describe("Mutation.creatPdfAccessToken", () => {
       }
     );
 
-    const token = await prisma.pdfAccessToken.findFirst({
+    const token = await prisma.pdfAccessToken.findFirstOrThrow({
       where: { bsdType: BsdType.BSDASRI, userId: user.id, bsdId: dasri.id }
     });
 
@@ -390,7 +390,7 @@ describe("Mutation.creatPdfAccessToken", () => {
       }
     );
 
-    const token = await prisma.pdfAccessToken.findFirst({
+    const token = await prisma.pdfAccessToken.findFirstOrThrow({
       where: { bsdType: BsdType.BSFF, userId: user.id, bsdId: bsff.id }
     });
 
@@ -476,7 +476,7 @@ describe("Mutation.creatPdfAccessToken", () => {
       }
     );
 
-    const token = await prisma.pdfAccessToken.findFirst({
+    const token = await prisma.pdfAccessToken.findFirstOrThrow({
       where: { bsdType: BsdType.BSVHU, userId: user.id, bsdId: vhu.id }
     });
 

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -189,7 +189,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -211,7 +211,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -228,7 +228,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [worker.company.siret]
+              isDraftFor: [worker.company.siret!]
             }
           }
         }
@@ -245,7 +245,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [transporter.company.siret]
+              isDraftFor: [transporter.company.siret!]
             }
           }
         }
@@ -262,7 +262,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [destination.company.siret]
+              isDraftFor: [destination.company.siret!]
             }
           }
         }
@@ -297,7 +297,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [emitter.company.siret]
+              isForActionFor: [emitter.company.siret!]
             }
           }
         }
@@ -315,7 +315,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [worker.company.siret]
+              isFollowFor: [worker.company.siret!]
             }
           }
         }
@@ -333,7 +333,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [transporter.company.siret]
+              isFollowFor: [transporter.company.siret!]
             }
           }
         }
@@ -351,7 +351,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [transporter.company.siret]
+              isFollowFor: [transporter.company.siret!]
             }
           }
         }
@@ -387,7 +387,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -405,7 +405,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [worker.company.siret]
+              isForActionFor: [worker.company.siret!]
             }
           }
         }
@@ -423,7 +423,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [transporter.company.siret]
+              isFollowFor: [transporter.company.siret!]
             }
           }
         }
@@ -441,7 +441,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -477,7 +477,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -495,7 +495,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [worker.company.siret]
+              isFollowFor: [worker.company.siret!]
             }
           }
         }
@@ -513,7 +513,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -531,7 +531,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -567,7 +567,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -585,7 +585,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [worker.company.siret]
+              isFollowFor: [worker.company.siret!]
             }
           }
         }
@@ -603,7 +603,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isCollectedFor: [transporter.company.siret]
+              isCollectedFor: [transporter.company.siret!]
             }
           }
         }
@@ -621,7 +621,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [destination.company.siret]
+              isForActionFor: [destination.company.siret!]
             }
           }
         }
@@ -657,7 +657,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -675,7 +675,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [worker.company.siret]
+              isArchivedFor: [worker.company.siret!]
             }
           }
         }
@@ -693,7 +693,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -711,7 +711,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }
@@ -757,7 +757,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -775,7 +775,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [worker.company.siret]
+              isFollowFor: [worker.company.siret!]
             }
           }
         }
@@ -793,7 +793,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [transporter.company.siret]
+              isFollowFor: [transporter.company.siret!]
             }
           }
         }
@@ -811,7 +811,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -860,7 +860,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -878,7 +878,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [worker.company.siret]
+              isArchivedFor: [worker.company.siret!]
             }
           }
         }
@@ -896,7 +896,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -914,7 +914,7 @@ describe("Query.bsds.bsda base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -188,7 +188,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -210,7 +210,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -227,7 +227,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [transporter.company.siret]
+              isDraftFor: [transporter.company.siret!]
             }
           }
         }
@@ -244,7 +244,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [destination.company.siret]
+              isDraftFor: [destination.company.siret!]
             }
           }
         }
@@ -279,7 +279,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [emitter.company.siret]
+              isForActionFor: [emitter.company.siret!]
             }
           }
         }
@@ -297,7 +297,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -315,7 +315,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -351,7 +351,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -369,7 +369,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -387,7 +387,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -423,7 +423,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -441,7 +441,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isCollectedFor: [transporter.company.siret]
+              isCollectedFor: [transporter.company.siret!]
             }
           }
         }
@@ -459,7 +459,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [destination.company.siret]
+              isForActionFor: [destination.company.siret!]
             }
           }
         }
@@ -495,7 +495,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -513,7 +513,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [transporter.company.siret]
+              isFollowFor: [transporter.company.siret!]
             }
           }
         }
@@ -531,7 +531,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [destination.company.siret]
+              isForActionFor: [destination.company.siret!]
             }
           }
         }
@@ -567,7 +567,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -585,7 +585,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -603,7 +603,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }
@@ -632,7 +632,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -650,7 +650,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -668,7 +668,7 @@ describe("Query.bsds.dasris base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }
@@ -786,7 +786,7 @@ describe("Query.bsds.dasris mutations", () => {
     expect(data.bsds.edges).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ node: { id: dasri.id } }),
-        expect.objectContaining({ node: { id: duplicateBsdasri.id } })
+        expect.objectContaining({ node: { id: duplicateBsdasri!.id } })
       ])
     );
   });

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
@@ -183,7 +183,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -223,7 +223,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -274,7 +274,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [emitter.company.siret]
+              isForActionFor: [emitter.company.siret!]
             }
           }
         }
@@ -292,7 +292,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -341,7 +341,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [recipient.company.siret]
+              isForActionFor: [recipient.company.siret!]
             }
           }
         }
@@ -359,7 +359,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isCollectedFor: [transporter.company.siret]
+              isCollectedFor: [transporter.company.siret!]
             }
           }
         }
@@ -409,7 +409,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [recipient.company.siret]
+              isForActionFor: [recipient.company.siret!]
             }
           }
         }
@@ -457,7 +457,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [recipient.company.siret]
+              isArchivedFor: [recipient.company.siret!]
             }
           }
         }
@@ -475,7 +475,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -493,7 +493,7 @@ describe("Query.bsds workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -551,7 +551,7 @@ describe("Query.bsds edge cases", () => {
       {
         variables: {
           where: {
-            isCollectedFor: [recipientAndTransporter.company.siret]
+            isCollectedFor: [recipientAndTransporter.company.siret!]
           }
         }
       }
@@ -566,7 +566,7 @@ describe("Query.bsds edge cases", () => {
     res = await recipientQuery<Pick<Query, "bsds">, QueryBsdsArgs>(GET_BSDS, {
       variables: {
         where: {
-          isForActionFor: [recipientAndTransporter.company.siret]
+          isForActionFor: [recipientAndTransporter.company.siret!]
         }
       }
     });

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -188,7 +188,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [emitter.company.siret]
+              isDraftFor: [emitter.company.siret!]
             }
           }
         }
@@ -205,7 +205,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [transporter.company.siret]
+              isDraftFor: [transporter.company.siret!]
             }
           }
         }
@@ -222,7 +222,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isDraftFor: [destination.company.siret]
+              isDraftFor: [destination.company.siret!]
             }
           }
         }
@@ -257,7 +257,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [emitter.company.siret]
+              isForActionFor: [emitter.company.siret!]
             }
           }
         }
@@ -275,7 +275,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -293,7 +293,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -329,7 +329,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -347,7 +347,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isToCollectFor: [transporter.company.siret]
+              isToCollectFor: [transporter.company.siret!]
             }
           }
         }
@@ -365,7 +365,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [destination.company.siret]
+              isFollowFor: [destination.company.siret!]
             }
           }
         }
@@ -401,7 +401,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isFollowFor: [emitter.company.siret]
+              isFollowFor: [emitter.company.siret!]
             }
           }
         }
@@ -419,7 +419,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isCollectedFor: [transporter.company.siret]
+              isCollectedFor: [transporter.company.siret!]
             }
           }
         }
@@ -437,7 +437,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isForActionFor: [destination.company.siret]
+              isForActionFor: [destination.company.siret!]
             }
           }
         }
@@ -484,7 +484,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -502,7 +502,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -520,7 +520,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }
@@ -549,7 +549,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [emitter.company.siret]
+              isArchivedFor: [emitter.company.siret!]
             }
           }
         }
@@ -567,7 +567,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [transporter.company.siret]
+              isArchivedFor: [transporter.company.siret!]
             }
           }
         }
@@ -585,7 +585,7 @@ describe("Query.bsds.vhus base workflow", () => {
         {
           variables: {
             where: {
-              isArchivedFor: [destination.company.siret]
+              isArchivedFor: [destination.company.siret!]
             }
           }
         }

--- a/back/src/bsffs/repository/index.ts
+++ b/back/src/bsffs/repository/index.ts
@@ -9,6 +9,7 @@ import { buildCreateBsff } from "./bsff/create";
 import { buildUpdateBsff } from "./bsff/update";
 import { buildUpdateBsffPackaging } from "./bsffPackaging/update";
 import {
+  PrismaTransaction,
   RepositoryFnBuilder,
   RepositoryTransaction
 } from "../../common/repository/types";
@@ -39,7 +40,7 @@ export type BsffRepository = BsffActions;
 export type BsffPackagingRepository = BsffPackagingActions;
 export type BsffFicheInterventionRepository = BsffFicheInterventionActions;
 
-export function getReadonlyBsffRepository(transaction?: RepositoryTransaction) {
+export function getReadonlyBsffRepository(transaction?: PrismaTransaction) {
   const deps = { prisma: transaction ?? prisma };
   return {
     count: buildCountBsff(deps),
@@ -52,7 +53,7 @@ export function getReadonlyBsffRepository(transaction?: RepositoryTransaction) {
 }
 
 export function getReadonlyBsffPackagingRepository(
-  transaction?: RepositoryTransaction
+  transaction?: PrismaTransaction
 ) {
   const deps = { prisma: transaction ?? prisma };
   return {
@@ -68,7 +69,7 @@ export function getReadonlyBsffPackagingRepository(
 }
 
 export function getReadonlyBsffFicheInterventionRepository(
-  transaction?: RepositoryTransaction
+  transaction?: PrismaTransaction
 ) {
   const deps = { prisma: transaction ?? prisma };
   return {

--- a/back/src/bsvhu/__tests__/sirenify.integration.ts
+++ b/back/src/bsvhu/__tests__/sirenify.integration.ts
@@ -25,9 +25,9 @@ describe("sirenify", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destinataire")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -63,23 +63,23 @@ describe("sirenify", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
   });
 
@@ -97,9 +97,9 @@ describe("sirenify", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destinataire")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -129,23 +129,23 @@ describe("sirenify", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
   });
 });

--- a/back/src/bsvhu/edition.ts
+++ b/back/src/bsvhu/edition.ts
@@ -97,7 +97,8 @@ export async function checkEditionRules(
   }
 
   const userSirets = user?.id ? await getCachedUserSiretOrVat(user.id) : [];
-  const isEmitter = userSirets.includes(bsvhu.emitterCompanySiret);
+  const isEmitter =
+    bsvhu.emitterCompanySiret && userSirets.includes(bsvhu.emitterCompanySiret);
 
   if (bsvhu.status === "SIGNED_BY_PRODUCER" && isEmitter) {
     return true;
@@ -110,7 +111,7 @@ export async function checkEditionRules(
   // Inner function used to recursively checks that the diff
   // does not contain any fields sealed by signature
   function checkSealedFields(
-    signatureType: SignatureTypeInput,
+    signatureType: SignatureTypeInput | null,
     editableFields: string[]
   ) {
     if (signatureType === null) {

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -4,6 +4,14 @@ import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 
+type WhereKeys =
+  | "isDraftFor"
+  | "isForActionFor"
+  | "isFollowFor"
+  | "isArchivedFor"
+  | "isToCollectFor"
+  | "isCollectedFor";
+
 // | state              | emitter | transporter | destination |
 // |--------------------|---------|-------------|-------------|
 // | initial (draft)    | draft   | draft       | draft       |
@@ -13,18 +21,8 @@ import { getRegistryFields } from "./registry";
 // | processed          | archive | archive     | archive     |
 // | refused            | archive | archive     | archive     |
 
-function getWhere(
-  bsvhu: Bsvhu
-): Pick<
-  BsdElastic,
-  | "isDraftFor"
-  | "isForActionFor"
-  | "isFollowFor"
-  | "isArchivedFor"
-  | "isToCollectFor"
-  | "isCollectedFor"
-> {
-  const where = {
+function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
+  const where: Record<WhereKeys, string[]> = {
     isDraftFor: [],
     isForActionFor: [],
     isFollowFor: [],
@@ -33,7 +31,7 @@ function getWhere(
     isCollectedFor: []
   };
 
-  const formSirets: Record<string, string | null | undefined> = {
+  const formSirets: Partial<Record<keyof Bsvhu, string | null | undefined>> = {
     emitterCompanySiret: bsvhu.emitterCompanySiret,
     destinationCompanySiret: bsvhu.destinationCompanySiret,
     transporterCompanySiret: getTransporterCompanyOrgId(bsvhu)
@@ -165,7 +163,7 @@ export function toBsdElastic(bsvhu: Bsvhu): BsdElastic {
     destinationOperationCode: bsvhu.destinationOperationCode ?? "",
 
     emitterEmissionDate: bsvhu.emitterEmissionSignatureDate?.getTime(),
-    workerWorkDate: null,
+    workerWorkDate: undefined,
     transporterTransportTakenOverAt:
       bsvhu.transporterTransportTakenOverAt?.getTime(),
     destinationReceptionDate: bsvhu.destinationReceptionDate?.getTime(),

--- a/back/src/bsvhu/examples/workflows/vhuVersBroyeurTransporteurEtranger.ts
+++ b/back/src/bsvhu/examples/workflows/vhuVersBroyeurTransporteurEtranger.ts
@@ -21,7 +21,7 @@ const workflow: Workflow = {
     { name: "broyeur", companyTypes: ["WASTE_VEHICLES", "WASTEPROCESSOR"] }
   ],
   steps: [
-    createBsvhu("producteur", fixtures),
+    createBsvhu("producteur", fixtures as any),
     signForProducer("producteur"),
     signTransport("transporteur"),
     updateDestination("broyeur"),

--- a/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
+++ b/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
@@ -85,7 +85,7 @@ export function BsvhuPdf({ bsvhu, qrCode }: Props) {
               </div>
             </div>
             <p className="mb-3">
-              Nom de la personne à contacter : {bsvhu.emitter.company.contact}
+              Nom de la personne à contacter : {bsvhu.emitter?.company?.contact}
             </p>
           </div>
           {/* End Emitter */}
@@ -367,12 +367,12 @@ export function BsvhuPdf({ bsvhu, qrCode }: Props) {
                 NOM (Raison sociale) : {bsvhu?.destination?.company?.name}
               </p>
               <p className="mb-3">
-                Adresse : {bsvhu?.destination.company.address}
+                Adresse : {bsvhu?.destination?.company?.address}
               </p>
               <div className="Flex">
-                <p className="mb-3">Tel : {bsvhu.destination.company.phone}</p>
+                <p className="mb-3">Tel : {bsvhu.destination?.company?.phone}</p>
                 <p className="mb-3 ml-12">
-                  Mail : {bsvhu.destination.company.mail}
+                  Mail : {bsvhu.destination?.company?.mail}
                 </p>
               </div>
             </div>

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -10,16 +10,15 @@ import {
 import { GenericWaste } from "../registry/types";
 import { getWasteDescription } from "./utils";
 
-export function getRegistryFields(
-  bsvhu: Bsvhu
-): Pick<
-  BsdElastic,
+type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-> {
-  const registryFields = {
+  | "isManagedWasteFor";
+export function getRegistryFields(
+  bsvhu: Bsvhu
+): Pick<BsdElastic, RegistryFields> {
+  const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
@@ -30,11 +29,18 @@ export function getRegistryFields(
     bsvhu.emitterEmissionSignatureDate &&
     bsvhu.transporterTransportSignatureDate
   ) {
-    registryFields.isOutgoingWasteFor.push(bsvhu.emitterCompanySiret);
-    registryFields.isTransportedWasteFor.push(bsvhu.transporterCompanySiret);
+    if (bsvhu.emitterCompanySiret) {
+      registryFields.isOutgoingWasteFor.push(bsvhu.emitterCompanySiret);
+    }
+    if (bsvhu.transporterCompanySiret) {
+      registryFields.isTransportedWasteFor.push(bsvhu.transporterCompanySiret);
+    }
   }
 
-  if (bsvhu.destinationOperationSignatureDate) {
+  if (
+    bsvhu.destinationOperationSignatureDate &&
+    bsvhu.destinationCompanySiret
+  ) {
     registryFields.isIncomingWasteFor.push(bsvhu.destinationCompanySiret);
   }
 

--- a/back/src/bsvhu/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/create.integration.ts
@@ -155,7 +155,7 @@ describe("Mutation.Vhu.create", () => {
     expect(data.createBsvhu.id).toMatch(
       new RegExp(`^VHU-[0-9]{8}-[A-Z0-9]{9}$`)
     );
-    expect(data.createBsvhu.destination.company.siret).toBe(
+    expect(data.createBsvhu.destination!.company!.siret).toBe(
       input.destination.company.siret
     );
     // check input is sirenified

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createDraft.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createDraft.integration.ts
@@ -128,7 +128,7 @@ describe("Mutation.Vhu.createDraft", () => {
       }
     );
 
-    expect(data.createDraftBsvhu.destination.company).toMatchObject(
+    expect(data.createDraftBsvhu.destination!.company).toMatchObject(
       input.destination.company
     );
     // check input is sirenified

--- a/back/src/bsvhu/resolvers/mutations/__tests__/deleteBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/deleteBsvhu.integration.ts
@@ -131,7 +131,7 @@ describe("Mutation.deleteBsdasri", () => {
 
     expect(errors).toBeUndefined();
 
-    const deletedBsvhu = await prisma.bsvhu.findUnique({
+    const deletedBsvhu = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: bsvhu.id }
     });
 
@@ -193,7 +193,7 @@ describe("Mutation.deleteBsdasri", () => {
 
     expect(data.deleteBsvhu.id).toBe(vhu.id);
 
-    const bsdvhu = await prisma.bsvhu.findUnique({
+    const bsdvhu = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: vhu.id }
     });
     expect(bsdvhu.isDeleted).toEqual(true);

--- a/back/src/bsvhu/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/sign.integration.ts
@@ -59,8 +59,8 @@ describe("Mutation.Vhu.sign", () => {
       }
     });
 
-    expect(data.signBsvhu.emitter.emission.signature.author).toBe(user.name);
-    expect(data.signBsvhu.emitter.emission.signature.date).not.toBeNull();
+    expect(data.signBsvhu.emitter!.emission!.signature!.author).toBe(user.name);
+    expect(data.signBsvhu.emitter!.emission!.signature!.date).not.toBeNull();
   });
 
   it("should use the provided date for the signature if  given", async () => {
@@ -80,7 +80,7 @@ describe("Mutation.Vhu.sign", () => {
       }
     });
 
-    expect(data.signBsvhu.emitter.emission.signature.author).toBe(user.name);
-    expect(data.signBsvhu.emitter.emission.signature.date).toBe(date);
+    expect(data.signBsvhu.emitter!.emission!.signature!.author).toBe(user.name);
+    expect(data.signBsvhu.emitter!.emission!.signature!.date).toBe(date);
   });
 });

--- a/back/src/bsvhu/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/update.integration.ts
@@ -130,7 +130,7 @@ describe("Mutation.Vhu.update", () => {
       }
     );
 
-    expect(data.updateBsvhu.weight.value).toBe(4);
+    expect(data.updateBsvhu.weight!.value).toBe(4);
     // check input is sirenified
     expect(sirenifyMock).toHaveBeenCalledTimes(1);
   });
@@ -156,7 +156,7 @@ describe("Mutation.Vhu.update", () => {
       }
     );
 
-    expect(data.updateBsvhu.emitter.agrementNumber).toBe("new agrement");
+    expect(data.updateBsvhu.emitter!.agrementNumber).toBe("new agrement");
   });
 
   it("should disallow emitter fields update after emitter signature", async () => {
@@ -224,7 +224,7 @@ describe("Mutation.Vhu.update", () => {
       }
     );
 
-    expect(data.updateBsvhu.transporter.company.vatNumber).toBe(
+    expect(data.updateBsvhu.transporter!.company!.vatNumber).toBe(
       foreignTransporter.vatNumber
     );
   });

--- a/back/src/bsvhu/resolvers/queries/bsvhuPdf.ts
+++ b/back/src/bsvhu/resolvers/queries/bsvhuPdf.ts
@@ -20,7 +20,7 @@ export const bsvhuPdfDownloadHandler: DownloadHandler<QueryBsvhuPdfArgs> = {
   }
 };
 
-const formPdfResolver: QueryResolvers["formPdf"] = async (
+const formPdfResolver: QueryResolvers["bsvhuPdf"] = async (
   _,
   { id }: QueryBsvhuPdfArgs,
   context

--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -101,7 +101,7 @@ input BsvhuEmitterInput {
 
 input BsvhuIdentificationInput {
   "Numéros d'identification"
-  numbers: [String]
+  numbers: [String!]
   "Type de numéros d'indentification"
   type: BsvhuIdentificationType
 }

--- a/back/src/bsvhu/typeDefs/bsvhu.queries.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.queries.graphql
@@ -55,5 +55,5 @@ type Query {
   Ce token doit être transmis à la route /download pour obtenir le fichier.
   Il est valable 10 secondes
   """
-  bsvhuPdf("ID d'un bordereau" id: ID): FileDownload!
+  bsvhuPdf("ID d'un bordereau" id: ID!): FileDownload!
 }

--- a/back/src/bsvhu/utils.ts
+++ b/back/src/bsvhu/utils.ts
@@ -1,4 +1,4 @@
-export function getWasteDescription(wasteCode: string) {
+export function getWasteDescription(wasteCode: string | null) {
   return wasteCode === "16 01 06"
     ? "Véhicules hors d'usage ne contenant ni liquides ni autres composants dangereux"
     : wasteCode === "16 01 04*"

--- a/back/src/commands/onboarding.helpers.ts
+++ b/back/src/commands/onboarding.helpers.ts
@@ -32,14 +32,14 @@ export const xDaysAgo = (baseDate: Date, daysAgo: number): Date => {
   return new Date(clonedDate.toDateString());
 };
 
-type getRecentlyJoinedUsersParams = {
+type GetRecentlyJoinedUsersParams = {
   daysAgo: number;
   retrieveCompanies?: boolean;
 };
 export const getRecentlyAssociatedUsers = async ({
   daysAgo,
   retrieveCompanies = false
-}: getRecentlyJoinedUsersParams) => {
+}: GetRecentlyJoinedUsersParams) => {
   const now = new Date();
 
   const associatedDateGt = xDaysAgo(now, daysAgo);

--- a/back/src/common/__tests__/cache.integration.ts
+++ b/back/src/common/__tests__/cache.integration.ts
@@ -37,8 +37,8 @@ describe("Test Caching", () => {
     const userCompaniesSiretOrVat = await getCachedUserSiretOrVat(user.id);
 
     expect(userCompaniesSiretOrVat.length).toEqual(2);
-    expect(userCompaniesSiretOrVat.includes(company.siret)).toBe(true);
-    expect(userCompaniesSiretOrVat.includes(otherCompany.siret)).toBe(true);
+    expect(userCompaniesSiretOrVat.includes(company.siret!)).toBe(true);
+    expect(userCompaniesSiretOrVat.includes(otherCompany.siret!)).toBe(true);
 
     // redis key exists now
     exists = await redisClient.exists(key);

--- a/back/src/common/__tests__/fileDownload.test.ts
+++ b/back/src/common/__tests__/fileDownload.test.ts
@@ -10,7 +10,7 @@ jest.mock("../redis", () => ({
 
 describe("getFileDownload", () => {
   it("should set token in cache", async () => {
-    await getFileDownload({ handler: "formPdf", params: null });
+    await getFileDownload({ handler: "formPdf", params: null as any });
 
     expect(setInCacheMock).toHaveBeenCalled();
   });
@@ -18,7 +18,7 @@ describe("getFileDownload", () => {
   it("should return token and link", async () => {
     const response = await getFileDownload({
       handler: "formPdf",
-      params: null
+      params: null as any
     });
 
     expect(response.token).not.toBeNull();
@@ -26,8 +26,14 @@ describe("getFileDownload", () => {
   });
 
   it("should return different tokens every time", async () => {
-    const res1 = await getFileDownload({ handler: "formPdf", params: null });
-    const res2 = await getFileDownload({ handler: "formPdf", params: null });
+    const res1 = await getFileDownload({
+      handler: "formPdf",
+      params: null as any
+    });
+    const res2 = await getFileDownload({
+      handler: "formPdf",
+      params: null as any
+    });
 
     expect(res1.token).not.toBe(res2.token);
   });

--- a/back/src/common/__tests__/redis.test.ts
+++ b/back/src/common/__tests__/redis.test.ts
@@ -33,21 +33,21 @@ const dbGetterMock = id => {
 describe("cachedGet", () => {
   test("should be able to get numeric key in cache", async () => {
     const foo = () => null;
-    const res = await cachedGet(foo, "foo", 1000);
+    const res = await cachedGet(foo as any, "foo", 1000);
 
     expect(res).toBe("redisBar");
   });
 
   test("should be able to get string key in cache", async () => {
     const foo = () => null;
-    const res = await cachedGet(foo, "foo", "1000");
+    const res = await cachedGet(foo as any, "foo", "1000");
 
     expect(res).toBe("redisBar");
   });
 
   test("should be able to get json in cache", async () => {
     const foo = () => null;
-    const res = await cachedGet<{ name: string }>(foo, "foo", "2000", {
+    const res = await cachedGet<{ name: string }>(foo as any, "foo", "2000", {
       parser: JSON
     });
 

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -106,7 +106,10 @@ export const cleanClue = (clue: string): string =>
  * @param allowTestCompany For the frontend to pass ALLOW_TEST_COMPANY
  * @returns
  */
-export const isSiret = (clue: string, allowTestCompany?: boolean): boolean => {
+export const isSiret = (
+  clue: string | null | undefined,
+  allowTestCompany?: boolean
+): boolean => {
   const allowTest =
     allowTestCompany !== undefined ? allowTestCompany : ALLOW_TEST_COMPANY;
   if (!clue || !/^[0-9]{14}$/.test(clue) || /^0{14}$/.test(clue)) {
@@ -129,7 +132,7 @@ export const isSiret = (clue: string, allowTestCompany?: boolean): boolean => {
 /**
  * Validateur de numéro de TVA
  */
-export const isVat = (clue: string): boolean => {
+export const isVat = (clue: string | null | undefined): boolean => {
   if (!clue || clue.match(BAD_CHARACTERS_REGEXP) !== null) return false;
   const isRegexValid = checkVAT(clue, countries);
   return isRegexValid.isValid;
@@ -138,15 +141,15 @@ export const isVat = (clue: string): boolean => {
 /**
  * TVA Français
  */
-export const isFRVat = (clue: string): boolean => {
-  if (!isVat(clue)) return false;
+export const isFRVat = (clue: string | null | undefined): boolean => {
+  if (!clue || !isVat(clue)) return false;
   return clue.slice(0, 2).toUpperCase().startsWith("FR");
 };
 
 /**
  * TVA Non-Français
  */
-export const isForeignVat = (clue: string): boolean => {
+export const isForeignVat = (clue: string | null | undefined): boolean => {
   if (!isVat(clue)) return false;
   return !isFRVat(clue);
 };

--- a/back/src/common/converter.ts
+++ b/back/src/common/converter.ts
@@ -27,6 +27,20 @@ export function safeInput<T extends Record<string, unknown>>(
 }
 
 /**
+ * Discard undefined or null fields in an object
+ */
+export function removeEmptyKeys<T extends Record<string, unknown>>(
+  obj: T
+): { [K in keyof T]: NonNullable<T[K]> } {
+  return Object.keys(obj).reduce((acc, curr) => {
+    return {
+      ...acc,
+      ...(obj[curr] != null ? { [curr]: obj[curr] } : {})
+    };
+  }, {} as any);
+}
+
+/**
  * Removes keys that are either null or an empty array from an object
  */
 export function removeEmpty<T extends Record<string, unknown>>(

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -71,13 +71,13 @@ export interface BsdElastic {
 
   destinationOperationCode: string;
 
-  emitterEmissionDate: number;
-  workerWorkDate: number;
-  transporterTransportTakenOverAt: number;
-  destinationReceptionDate: number;
-  destinationAcceptationDate: number;
-  destinationAcceptationWeight: number;
-  destinationOperationDate: number;
+  emitterEmissionDate: number | undefined;
+  workerWorkDate: number | undefined;
+  transporterTransportTakenOverAt: number | undefined;
+  destinationReceptionDate: number | undefined;
+  destinationAcceptationDate: number | undefined;
+  destinationAcceptationWeight: number | null;
+  destinationOperationDate: number | undefined;
 
   isDraftFor: string[];
   isForActionFor: string[];

--- a/back/src/common/middlewares/__tests__/errorHandler.test.ts
+++ b/back/src/common/middlewares/__tests__/errorHandler.test.ts
@@ -11,7 +11,7 @@ afterAll(() => {
 describe("errorHandler", () => {
   const OLD_ENV = process.env;
 
-  let request = null;
+  let request;
 
   function setup() {
     const app = express();

--- a/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlQueryParser.test.ts
@@ -31,9 +31,9 @@ describe("graphqlQueryParserMiddleware", () => {
     const req = { body: { query: "{me {id}}" } } as Request;
     middleware(req, res, next);
 
-    expect(req.gqlInfos.length).toBe(1);
-    expect(req.gqlInfos[0].operation).toBe("query");
-    expect(req.gqlInfos[0].name).toBe("me");
+    expect(req.gqlInfos!.length).toBe(1);
+    expect(req.gqlInfos![0].operation).toBe("query");
+    expect(req.gqlInfos![0].name).toBe("me");
   });
 
   it("should return several operations info", async () => {
@@ -42,10 +42,10 @@ describe("graphqlQueryParserMiddleware", () => {
     } as Request;
     middleware(req, res, next);
 
-    expect(req.gqlInfos.length).toBe(2);
-    expect(req.gqlInfos[0].operation).toBe("query");
-    expect(req.gqlInfos[0].name).toBe("me");
-    expect(req.gqlInfos[1].operation).toBe("mutation");
-    expect(req.gqlInfos[1].name).toBe("sign");
+    expect(req.gqlInfos!.length).toBe(2);
+    expect(req.gqlInfos![0].operation).toBe("query");
+    expect(req.gqlInfos![0].name).toBe("me");
+    expect(req.gqlInfos![1].operation).toBe("mutation");
+    expect(req.gqlInfos![1].name).toBe("sign");
   });
 });

--- a/back/src/common/pagination.ts
+++ b/back/src/common/pagination.ts
@@ -6,17 +6,17 @@ const DEFAULT_PAGINATE_BY = 50;
 const MAX_PAGINATE_BY = 500;
 
 export type GraphqlPaginationArgs = {
-  skip?: number;
-  first?: number;
-  after?: string;
-  last?: number;
-  before?: string;
+  skip?: number | null;
+  first?: number | null;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
 };
 
 // https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination
 export type PrismaPaginationArgs = {
   skip?: number;
-  take?: number;
+  take: number;
   cursor?: { id: string };
 };
 
@@ -143,7 +143,7 @@ export function getPrismaPaginationArgs(
     ...(after ? { cursor: { id: after }, skip: 1 } : {}),
     ...(last ? { take: -last } : {}),
     ...(before ? { cursor: { id: before }, skip: 1 } : {})
-  };
+  } as PrismaPaginationArgs;
 }
 
 export function validateGqlPaginationArgs({
@@ -157,7 +157,7 @@ export function validateGqlPaginationArgs({
   // validate number formats
   getValidationSchema(maxPaginateBy).validateSync({ first, last });
 
-  if (first & last) {
+  if (first && last) {
     throw new UserInputError(
       "L'utilisation simultanée de `first` et `last` n'est pas supportée"
     );

--- a/back/src/common/pdf/pdf.ts
+++ b/back/src/common/pdf/pdf.ts
@@ -10,7 +10,7 @@ import {
 } from "gotenberg-js-client";
 
 export const toPDF = pipe(
-  gotenberg(process.env.GOTENBERG_URL),
+  gotenberg(process.env.GOTENBERG_URL!),
   convert,
   html,
   to({

--- a/back/src/common/post/backends/mysendingbox/index.ts
+++ b/back/src/common/post/backends/mysendingbox/index.ts
@@ -5,7 +5,7 @@ const MY_SENDING_BOX_URL = "https://api.MySendingBox.fr";
 const { MY_SENDING_BOX_API_KEY } = process.env;
 
 const config = {
-  auth: { username: MY_SENDING_BOX_API_KEY, password: "" }
+  auth: { username: MY_SENDING_BOX_API_KEY!, password: "" }
 };
 
 const mysendingboxBackend = {

--- a/back/src/common/post/index.ts
+++ b/back/src/common/post/index.ts
@@ -27,6 +27,11 @@ function truncate(s: string) {
 }
 
 export async function sendVerificationCodeLetter(company: Company) {
+  if (!company.siret) {
+    throw new Error(
+      `Cannot send verification code letter, company ${company.id} hyas no siret`
+    );
+  }
   const sireneInfo = await searchCompany(company.siret);
   const admin = await prisma.companyAssociation
     .findFirst({
@@ -38,8 +43,8 @@ export async function sendVerificationCodeLetter(company: Company) {
     return sendLetter({
       description: "Code de vérification",
       to: {
-        address_line1: truncate(sireneInfo.addressVoie),
-        address_city: truncate(sireneInfo.addressCity),
+        address_line1: truncate(sireneInfo.addressVoie ?? ""),
+        address_city: truncate(sireneInfo.addressCity ?? ""),
         address_postalcode: sireneInfo.addressPostalCode,
         address_country: "France",
         company: truncate(company.name),

--- a/back/src/common/redis/captcha.ts
+++ b/back/src/common/redis/captcha.ts
@@ -18,7 +18,7 @@ export async function doesUserLoginNeedsCaptcha(
   userEmail: string
 ): Promise<boolean> {
   const key = getUserLoginFailedKey(userEmail);
-  const redisValue = await redisClient.get(key).catch(_ => 0);
+  const redisValue = (await redisClient.get(key).catch(_ => 0)) ?? 0;
   // Captcha is displayed a the N+1th attempt, so we substract 1
   return +redisValue >= FAILED_ATTEMPTS_BEFORE_CAPTCHA - 1;
 }

--- a/back/src/common/redis/users.ts
+++ b/back/src/common/redis/users.ts
@@ -60,7 +60,7 @@ export async function getCachedUserSiretOrVat(
     ...companies.map(c => c.siret),
     ...companies.map(c => c.vatNumber)
   ];
-  const cleanIds = ids.filter(id => !!id);
+  const cleanIds = ids.filter(Boolean);
   await setCachedUserCompanyId(userId, cleanIds);
   return cleanIds;
 }
@@ -89,7 +89,7 @@ export async function storeUserSessionsId(
 
 export async function getUserSessions(userId: string): Promise<string[]> {
   if (!userId) {
-    return;
+    return [];
   }
   return redisClient.smembers(genUserSessionsIdsKey(userId));
 }

--- a/back/src/common/repository/__tests__/helper.integration.ts
+++ b/back/src/common/repository/__tests__/helper.integration.ts
@@ -11,9 +11,10 @@ describe("Repository.helper", () => {
     const siret = "1".padStart(14);
     await runInTransaction(transaction => {
       transaction.addAfterCommitCallback(async () => {
-        const companyCreatedInTransaction = await prisma.company.findUnique({
-          where: { siret }
-        });
+        const companyCreatedInTransaction =
+          await prisma.company.findUniqueOrThrow({
+            where: { siret }
+          });
 
         expect(companyCreatedInTransaction.siret).toBe(siret);
       });
@@ -40,9 +41,10 @@ describe("Repository.helper", () => {
       });
 
       transaction.addAfterCommitCallback(async () => {
-        const companyCreatedInTransaction = await prisma.company.findUnique({
-          where: { siret }
-        });
+        const companyCreatedInTransaction =
+          await prisma.company.findUniqueOrThrow({
+            where: { siret }
+          });
 
         expect(companyCreatedInTransaction.siret).toBe(siret);
       });

--- a/back/src/common/repository/helper.ts
+++ b/back/src/common/repository/helper.ts
@@ -11,7 +11,7 @@ type RepositoryContext = {
 
 // See https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions-in-preview
 export const PRISMA_TRANSACTION_TIMEOUT =
-  parseInt(process.env.PRISMA_TRANSACTION_TIMEOUT, 10) || 5000;
+  parseInt(process.env.PRISMA_TRANSACTION_TIMEOUT!, 10) || 5000;
 
 /**
  * Wrapper to provide a transaction if not provided from context

--- a/back/src/common/repository/types.ts
+++ b/back/src/common/repository/types.ts
@@ -5,11 +5,12 @@ export type PrismaTransaction = Omit<
   "$connect" | "$disconnect" | "$on" | "$transaction" | "$use"
 >;
 export type RepositoryTransaction = PrismaTransaction & {
-  addAfterCommitCallback?: (callback: () => void | Promise<void>) => void;
+  addAfterCommitCallback: (callback: () => void | Promise<void>) => void;
 };
 
-export type ReadRepositoryFnDeps = { prisma: RepositoryTransaction };
-export type WriteRepositoryFnDeps = ReadRepositoryFnDeps & {
+export type ReadRepositoryFnDeps = { prisma: PrismaTransaction };
+export type WriteRepositoryFnDeps = {
+  prisma: RepositoryTransaction;
   user: Express.User;
 };
 export type RepositoryFnDeps = WriteRepositoryFnDeps;

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -313,10 +313,10 @@ export const intermediarySchema: yup.SchemaOf<CompanyInput> = yup.object({
  * Validate Intermediary Input
  */
 export async function validateIntermediariesInput(
-  intermediaries: CompanyInput[]
+  intermediaries: CompanyInput[] | null | undefined
 ): Promise<CompanyInput[]> {
   if (!intermediaries || intermediaries.length === 0) {
-    return intermediaries;
+    return [];
   }
 
   if (intermediaries.length > 3) {

--- a/back/src/common/yup/configureYup.ts
+++ b/back/src/common/yup/configureYup.ts
@@ -4,7 +4,7 @@ import { SSTI_CHARS } from "../constants";
 /* eslint-disable */
 declare module "yup" {
   interface BaseSchema<TCast = any, TContext = AnyObject, TOutput = any> {
-    requiredIf<T>(condition: boolean, message?: string): this;
+    requiredIf<T>(condition: boolean | undefined, message?: string): this;
     isSafeSSTI<T>(): this;
   }
 }

--- a/back/src/companies/__tests__/database.integration.ts
+++ b/back/src/companies/__tests__/database.integration.ts
@@ -21,14 +21,14 @@ describe("getInvitedUsers", () => {
     await prisma.userAccountHash.create({
       data: {
         email: "john.snow@trackdechets.fr",
-        companySiret: company.siret,
+        companySiret: company.siret!,
         hash: "hash1",
         role: "MEMBER",
         acceptedAt: new Date()
       }
     });
     const invitedUsers = await getCompanyInvitedUsers(
-      company.siret,
+      company.siret!,
       dataloaders
     );
     expect(invitedUsers).toEqual([]);
@@ -39,13 +39,13 @@ describe("getInvitedUsers", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: "john.snow@trackdechets.fr",
-        companySiret: company.siret,
+        companySiret: company.siret!,
         hash: "hash2",
         role: "MEMBER"
       }
     });
     const invitedUsers = await getCompanyInvitedUsers(
-      company.siret,
+      company.siret!,
       dataloaders
     );
     expect(invitedUsers).toHaveLength(1);

--- a/back/src/companies/__tests__/database.test.ts
+++ b/back/src/companies/__tests__/database.test.ts
@@ -19,7 +19,7 @@ const ASSOCIATIONS = [
 
 jest.mock("../../prisma", () => ({
   company: {
-    findUnique: jest.fn(() => ({
+    findUniqueOrThrow: jest.fn(() => ({
       companyAssociations: () => Promise.resolve(ASSOCIATIONS)
     }))
   }

--- a/back/src/companies/__tests__/search.test.ts
+++ b/back/src/companies/__tests__/search.test.ts
@@ -84,7 +84,7 @@ describe("searchCompany", () => {
         ...createInput
       }
     });
-    const testCompany = await searchCompany(siret);
+    const testCompany = await searchCompany(siret!);
     expect(siret).toEqual(testCompany.siret);
     expect("FR").toEqual(testCompany.codePaysEtrangerEtablissement);
     process.env = OLD_ENV;
@@ -98,7 +98,7 @@ describe("searchCompany", () => {
         ...createInput
       }
     });
-    const testCompany = await searchCompany(siret);
+    const testCompany = await searchCompany(siret!);
     expect(siret).toEqual(testCompany.siret);
     expect("FR").toEqual(testCompany.codePaysEtrangerEtablissement);
   });

--- a/back/src/companies/__tests__/sirenify.test.ts
+++ b/back/src/companies/__tests__/sirenify.test.ts
@@ -147,6 +147,6 @@ describe("searchCompanyFailFast", () => {
   it("should return result if searchCompany takes less than 1 second to respond", async () => {
     searchCompanySpy.mockResolvedValue(searchResult);
     const r = await searchCompanyFailFast("85001946400021");
-    expect(r.name).toEqual("CODE EN STOCK");
+    expect(r!.name).toEqual("CODE EN STOCK");
   });
 });

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -22,22 +22,17 @@ import { AppDataloaders } from "../types";
 export async function getCompanyOrCompanyNotFound({
   id,
   orgId,
-  siret,
-  vatNumber
+  siret
 }: Prisma.CompanyWhereUniqueInput) {
   if (!id && !siret && !orgId) {
-    throw new UserInputError(
-      "You should specify an id or a siret or a VAT number"
-    );
+    throw new UserInputError("You should specify an id or a siret or an orgId");
   }
   let where: Prisma.CompanyWhereUniqueInput;
   if (id) {
     where = { id };
   } else if (siret) {
     where = { siret };
-  } else if (vatNumber) {
-    where = { vatNumber };
-  } else if (orgId) {
+  } else {
     where = { orgId };
   }
   const company = await prisma.company.findUnique({
@@ -79,7 +74,7 @@ export function getInstallation(siret: string) {
  * Returns list of rubriques of an ICPE
  * @param codeS3ic
  */
-export function getRubriques(codeS3ic: string) {
+export function getRubriques(codeS3ic: string | null | undefined) {
   if (codeS3ic) {
     return prisma.rubrique.findMany({ where: { codeS3ic } });
   }
@@ -90,7 +85,7 @@ export function getRubriques(codeS3ic: string) {
  * Returns list of GEREP declarations of an ICPE
  * @param codeS3ic
  */
-export function getDeclarations(codeS3ic: string) {
+export function getDeclarations(codeS3ic: string | null | undefined) {
   if (codeS3ic) {
     return prisma.declaration.findMany({ where: { codeS3ic } });
   }
@@ -108,7 +103,7 @@ export function getDeclarations(codeS3ic: string) {
  */
 export async function getUserRole(userId: string, orgId: string) {
   const associations = await prisma.company
-    .findUnique({ where: { orgId } })
+    .findUniqueOrThrow({ where: { orgId } })
     .companyAssociations({ where: { userId } });
 
   if (associations.length > 0) {
@@ -151,19 +146,20 @@ export async function getCompanyUsers(
  * Returns company members that already have an account in TD
  * @param siret
  */
-export function getCompanyActiveUsers(orgId: string): Promise<CompanyMember[]> {
-  return prisma.company
-    .findUnique({ where: { orgId } })
-    .companyAssociations({ include: { user: true } })
-    .then(associations =>
-      associations.map(a => {
-        return {
-          ...a.user,
-          role: a.role,
-          isPendingInvitation: false
-        };
-      })
-    );
+export async function getCompanyActiveUsers(
+  orgId: string
+): Promise<CompanyMember[]> {
+  const associations = await prisma.company
+    .findUniqueOrThrow({ where: { orgId } })
+    .companyAssociations({ include: { user: true } });
+
+  return associations.map(a => {
+    return {
+      ...a.user,
+      role: a.role,
+      isPendingInvitation: false
+    };
+  });
 }
 
 /**
@@ -284,14 +280,10 @@ export async function getWorkerCertificationOrNotFound({
 
 export function convertUrls<T extends Partial<Company>>(
   company: T
-): T & { ecoOrganismeAgreements: URL[]; signatureAutomations: [] } {
-  if (!company) {
-    return null;
-  }
-
+): T & { ecoOrganismeAgreements?: URL[]; signatureAutomations: [] } {
   return {
     ...company,
-    ...(company?.ecoOrganismeAgreements && {
+    ...(company.ecoOrganismeAgreements && {
       ecoOrganismeAgreements: company.ecoOrganismeAgreements.map(
         a => new URL(a)
       )

--- a/back/src/companies/resolvers/CompanyMember.ts
+++ b/back/src/companies/resolvers/CompanyMember.ts
@@ -2,7 +2,7 @@ import { CompanyMemberResolvers } from "../../generated/graphql/types";
 
 const companyMemberResolvers: CompanyMemberResolvers = {
   isMe: (parent, _, context) => {
-    return parent.id === context.user.id;
+    return context.user && parent.id === context.user.id;
   }
 };
 

--- a/back/src/companies/resolvers/CompanyPrivate.ts
+++ b/back/src/companies/resolvers/CompanyPrivate.ts
@@ -4,12 +4,12 @@ import { getCompanyUsers, getUserRole } from "../database";
 
 const companyPrivateResolvers: CompanyPrivateResolvers = {
   users: async (parent, _, context) => {
-    const userId = context.user.id;
+    const userId = context.user!.id;
     const userRole = await getUserRole(userId, parent.orgId);
     if (userRole !== "ADMIN") {
       return [
         {
-          ...context.user,
+          ...context.user!,
           role: userRole,
           isPendingInvitation: false
         }
@@ -19,7 +19,7 @@ const companyPrivateResolvers: CompanyPrivateResolvers = {
     return getCompanyUsers(parent.orgId, context.dataloaders);
   },
   userRole: (parent, _, context) => {
-    const userId = context.user.id;
+    const userId = context.user!.id;
     return getUserRole(userId, parent.orgId);
   },
   transporterReceipt: parent => {

--- a/back/src/companies/resolvers/CompanySearchResult.ts
+++ b/back/src/companies/resolvers/CompanySearchResult.ts
@@ -12,6 +12,7 @@ export const whereSiretOrVatNumber = (parent: CompanyBaseIdentifiers) => {
   } else if (!!parent.vatNumber) {
     return { vatNumber: parent.vatNumber };
   }
+  throw new Error(`No siret or vatNumber provided to company filter`);
 };
 
 const companySearchResultResolvers: CompanySearchResultResolvers = {

--- a/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createCompany.integration.ts
@@ -114,7 +114,7 @@ describe("Mutation.createCompany", () => {
       })) != null;
     expect(newCompanyAssociationExists).toBe(true);
 
-    const refreshedUser = await prisma.user.findUnique({
+    const refreshedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -173,7 +173,7 @@ describe("Mutation.createCompany", () => {
       })) != null;
     expect(newCompanyAssociationExists).toBe(true);
 
-    const refreshedUser = await prisma.user.findUnique({
+    const refreshedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -216,13 +216,13 @@ describe("Mutation.createCompany", () => {
       }
     );
 
-    expect(data.createCompany.transporterReceipt.receiptNumber).toEqual(
+    expect(data.createCompany.transporterReceipt!.receiptNumber).toEqual(
       transporterReceipt.receiptNumber
     );
-    expect(data.createCompany.transporterReceipt.validityLimit).toEqual(
+    expect(data.createCompany.transporterReceipt!.validityLimit).toEqual(
       transporterReceipt.validityLimit.toISOString()
     );
-    expect(data.createCompany.transporterReceipt.department).toEqual(
+    expect(data.createCompany.transporterReceipt!.department).toEqual(
       transporterReceipt.department
     );
   });
@@ -263,13 +263,13 @@ describe("Mutation.createCompany", () => {
     );
 
     // check the traderReceipt was created in db
-    expect(data.createCompany.traderReceipt.receiptNumber).toEqual(
+    expect(data.createCompany.traderReceipt!.receiptNumber).toEqual(
       traderReceipt.receiptNumber
     );
-    expect(data.createCompany.traderReceipt.validityLimit).toEqual(
+    expect(data.createCompany.traderReceipt!.validityLimit).toEqual(
       traderReceipt.validityLimit.toISOString()
     );
-    expect(data.createCompany.traderReceipt.department).toEqual(
+    expect(data.createCompany.traderReceipt!.department).toEqual(
       traderReceipt.department
     );
   });
@@ -288,7 +288,7 @@ describe("Mutation.createCompany", () => {
     };
 
     searchCompany.mockResolvedValueOnce({
-      orgId: company.siret,
+      orgId: company.siret!,
       siret: company.siret,
       etatAdministratif: "A"
     });
@@ -487,14 +487,14 @@ describe("Mutation.createCompany", () => {
     });
     expect(errors).toBeUndefined();
 
-    const company = await prisma.company.findUnique({
+    const company = await prisma.company.findUniqueOrThrow({
       where: { siret: companyInput.siret }
     });
 
     expect(sendMailSpy).toHaveBeenCalledWith(
       renderMail(verificationProcessInfo, {
         to: [{ email: user.email, name: user.name }],
-        variables: { company }
+        variables: { company: company as any }
       })
     );
 

--- a/back/src/companies/resolvers/mutations/__tests__/sendVerificationCodeLetter.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/sendVerificationCodeLetter.integration.ts
@@ -71,8 +71,8 @@ describe("mutation sendVerificationCodeLetter", () => {
       variables: { input: { siret: company.siret } }
     });
     expect(sendVerificationCodeLetterSpy).toHaveBeenCalledWith(company);
-    const updatedCompany = await prisma.company.findUnique({
-      where: { siret: company.siret }
+    const updatedCompany = await prisma.company.findUniqueOrThrow({
+      where: { siret: company.siret! }
     });
     expect(updatedCompany.verificationStatus).toEqual(
       CompanyVerificationStatus.LETTER_SENT

--- a/back/src/companies/resolvers/mutations/__tests__/updateBrokerReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateBrokerReceipt.integration.ts
@@ -49,7 +49,7 @@ describe("{ mutation { updateBrokerReceipt } }", () => {
     expect(data.updateBrokerReceipt).toEqual(update);
 
     // check record was modified in db
-    const { id, ...updated } = await prisma.brokerReceipt.findUnique({
+    const { id, ...updated } = await prisma.brokerReceipt.findUniqueOrThrow({
       where: { id: createdReceipt.id }
     });
     expect(updated.receiptNumber).toEqual(update.receiptNumber);

--- a/back/src/companies/resolvers/mutations/__tests__/updateCompany.test.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateCompany.test.ts
@@ -3,7 +3,9 @@ import { MutationUpdateCompanyArgs } from "../../../../generated/graphql/types";
 
 const updateCompanyMock = jest.fn();
 jest.mock("../../../../prisma", () => ({
-  company: { update: jest.fn((...args) => updateCompanyMock(...args)) }
+  company: {
+    update: jest.fn((...args) => updateCompanyMock(...args))
+  }
 }));
 
 describe("updateCompany", () => {
@@ -11,6 +13,8 @@ describe("updateCompany", () => {
     updateCompanyMock.mockReset();
   });
   it("should call prisma.updateCompany with proper data", async () => {
+    updateCompanyMock.mockResolvedValue({});
+
     let payload: MutationUpdateCompanyArgs = {
       id: "85001946400013",
       gerepId: "gerepId"

--- a/back/src/companies/resolvers/mutations/__tests__/updateTraderReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateTraderReceipt.integration.ts
@@ -49,7 +49,7 @@ describe("{ mutation { updateTraderReceipt } }", () => {
     expect(data.updateTraderReceipt).toEqual(update);
 
     // check record was modified in db
-    const { id, ...updated } = await prisma.traderReceipt.findUnique({
+    const { id, ...updated } = await prisma.traderReceipt.findUniqueOrThrow({
       where: { id: createdReceipt.id }
     });
     expect(updated.receiptNumber).toEqual(update.receiptNumber);

--- a/back/src/companies/resolvers/mutations/__tests__/updateTransporterReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateTransporterReceipt.integration.ts
@@ -51,9 +51,10 @@ describe("{ mutation { updateTransporterReceipt } }", () => {
     expect(data.updateTransporterReceipt).toEqual(update);
 
     // check record was modified in db
-    const { id, ...updated } = await prisma.transporterReceipt.findUnique({
-      where: { id: createdReceipt.id }
-    });
+    const { id, ...updated } =
+      await prisma.transporterReceipt.findUniqueOrThrow({
+        where: { id: createdReceipt.id }
+      });
     expect(updated.receiptNumber).toEqual(update.receiptNumber);
     expect(updated.validityLimit.toISOString()).toEqual(update.validityLimit);
     expect(updated.department).toEqual(update.department);

--- a/back/src/companies/resolvers/mutations/__tests__/updateVhuAgrement.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateVhuAgrement.integration.ts
@@ -48,7 +48,7 @@ describe("{ mutation { updateVhuAgrement } }", () => {
     expect(data.updateVhuAgrement).toEqual(update);
 
     // check record was modified in db
-    const { id, ...updated } = await prisma.vhuAgrement.findUnique({
+    const { id, ...updated } = await prisma.vhuAgrement.findUniqueOrThrow({
       where: { id: createdAgrement.id }
     });
     expect(updated.agrementNumber).toEqual(update.agrementNumber);

--- a/back/src/companies/resolvers/mutations/__tests__/updateWorkerCertification.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateWorkerCertification.integration.ts
@@ -51,9 +51,10 @@ describe("{ mutation { updateworkerCertification } }", () => {
     expect(data.updateWorkerCertification).toEqual(update);
 
     // check record was modified in db
-    const { id, ...updated } = await prisma.workerCertification.findUnique({
-      where: { id: createdCertification.id }
-    });
+    const { id, ...updated } =
+      await prisma.workerCertification.findUniqueOrThrow({
+        where: { id: createdCertification.id }
+      });
     expect(updated.certificationNumber).toEqual(update.certificationNumber);
   });
 });

--- a/back/src/companies/resolvers/mutations/__tests__/verifyCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/verifyCompany.integration.ts
@@ -139,8 +139,8 @@ describe("mutation verifyCompany", () => {
     expect(data.verifyCompany.verificationStatus).toEqual(
       CompanyVerificationStatus.VERIFIED
     );
-    const updatedCompany = await prisma.company.findUnique({
-      where: { siret: company.siret }
+    const updatedCompany = await prisma.company.findUniqueOrThrow({
+      where: { siret: company.siret! }
     });
     expect(updatedCompany.verificationStatus).toEqual(
       CompanyVerificationStatus.VERIFIED
@@ -154,7 +154,9 @@ describe("mutation verifyCompany", () => {
     expect(sendMailSpy).toHaveBeenCalledWith(
       renderMail(verificationDone, {
         to: [{ email: user.email, name: user.name }],
-        variables: { company: updatedCompany }
+        variables: {
+          company: updatedCompany as any
+        }
       })
     );
   });

--- a/back/src/companies/resolvers/mutations/__tests__/verifyCompanyByAdmin.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/verifyCompanyByAdmin.integration.ts
@@ -87,8 +87,8 @@ describe("mutation verifyCompanyByAdmin", () => {
       }
     });
 
-    const verifiedCompany = await prisma.company.findUnique({
-      where: { siret: company.siret }
+    const verifiedCompany = await prisma.company.findUniqueOrThrow({
+      where: { siret: company.siret! }
     });
 
     expect(verifiedCompany.verificationStatus).toEqual(
@@ -123,7 +123,7 @@ describe("mutation verifyCompanyByAdmin", () => {
       }
     });
 
-    const verifiedCompany = await prisma.company.findUnique({
+    const verifiedCompany = await prisma.company.findUniqueOrThrow({
       where: { orgId: company.orgId }
     });
 

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -66,7 +66,7 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
   const vatNumber = companyInput.vatNumber
     ? cleanClue(companyInput.vatNumber)
     : null;
-  const orgId = siret ?? vatNumber;
+  const orgId = siret ?? (vatNumber as string);
 
   if (isVat(vatNumber)) {
     if (isFRVat(vatNumber)) {
@@ -140,7 +140,9 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
     ecoOrganismeAgreements: {
       set: ecoOrganismeAgreements
     },
-    allowBsdasriTakeOverWithoutSignature,
+    allowBsdasriTakeOverWithoutSignature: Boolean(
+      allowBsdasriTakeOverWithoutSignature
+    ),
     contact,
     contactEmail,
     contactPhone
@@ -208,7 +210,7 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
       );
     }
   }
-  if (company.siret) {
+  if (company.siret && company.address && companyInfo.codeCommune) {
     // Fill latitude, longitude and departement asynchronously
     addToGeocodeCompanyQueue({
       siret: company.siret,

--- a/back/src/companies/resolvers/mutations/createTestCompany.ts
+++ b/back/src/companies/resolvers/mutations/createTestCompany.ts
@@ -52,7 +52,7 @@ const createTestCompany: MutationResolvers["createTestCompany"] = async (
       orgId: createInput.siret
     }
   });
-  return company.siret;
+  return company.siret!;
 };
 
 export default createTestCompany;

--- a/back/src/companies/resolvers/mutations/renewSecurityCodeService.ts
+++ b/back/src/companies/resolvers/mutations/renewSecurityCodeService.ts
@@ -39,9 +39,8 @@ export async function renewSecurityCodeFn(
 
   const currentSecurityCode = company.securityCode;
 
-  let newSecurityCode = null;
-
-  while (!newSecurityCode || newSecurityCode === currentSecurityCode) {
+  let newSecurityCode = currentSecurityCode;
+  while (newSecurityCode === currentSecurityCode) {
     newSecurityCode = randomNumber(4);
   }
 

--- a/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/favorites.integration.ts
@@ -148,7 +148,7 @@ describe("query favorites", () => {
       opt: {
         emitterCompanySiret: emitter.siret,
         recipientCompanySiret: company.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
 
@@ -279,7 +279,7 @@ describe("query favorites", () => {
       opt: {
         emitterCompanySiret: company.siret,
         transporterCompanySiret: transporter.siret,
-        transportersSirets: [transporter.siret]
+        transportersSirets: [transporter.siret!]
       }
     });
 
@@ -449,7 +449,7 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanySiret: company.siret,
-        recipientsSirets: [destination.siret]
+        recipientsSirets: [destination.siret!]
       },
       forwardedInOpts: { recipientCompanySiret: destination.siret }
     });
@@ -592,7 +592,7 @@ describe("query favorites", () => {
     });
 
     const traderSirene: CompanySearchResult = {
-      orgId: trader.siret,
+      orgId: trader.siret!,
       siret: trader.siret,
       address: "rue des 4 chemins",
       name: "Négociant",
@@ -658,7 +658,7 @@ describe("query favorites", () => {
 
     const brokerSirene: CompanySearchResult = {
       siret: broker.siret,
-      orgId: broker.siret,
+      orgId: broker.siret!,
       address: "rue des 4 chemins",
       name: "Courtier",
       isRegistered: true,
@@ -746,14 +746,14 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanySiret: emitter1.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
     const secondForm = await formFactory({
       ownerId: user.id,
       opt: {
         emitterCompanySiret: emitter2.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
 
@@ -794,14 +794,14 @@ describe("query favorites", () => {
       ownerId: user.id,
       opt: {
         emitterCompanySiret: emitter1.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
     const secondForm = await formFactory({
       ownerId: user.id,
       opt: {
         emitterCompanySiret: emitter2.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
     await formFactory({
@@ -847,7 +847,7 @@ describe("query favorites", () => {
       opt: {
         emitterCompanyName: "A Name",
         emitterCompanySiret: emitter.siret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
     await formFactory({
@@ -855,7 +855,7 @@ describe("query favorites", () => {
       opt: {
         emitterCompanyName: "Another Name",
         emitterCompanySiret: firstForm.emitterCompanySiret,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
 
@@ -885,7 +885,7 @@ describe("query favorites", () => {
       opt: {
         transporterCompanyName: "A Name",
         transporterCompanyVatNumber: transporter.vatNumber,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
     await formFactory({
@@ -893,7 +893,7 @@ describe("query favorites", () => {
       opt: {
         transporterCompanyName: "Another Name",
         transporterCompanyVatNumber: transporter.vatNumber,
-        recipientsSirets: [company.siret]
+        recipientsSirets: [company.siret!]
       }
     });
 
@@ -935,11 +935,11 @@ describe("query favorites", () => {
             recipientCompanySiret: destination.siret
           }
         },
-        recipientsSirets: [recipientCompanySiret, destination.siret]
+        recipientsSirets: [recipientCompanySiret, destination.siret!]
       }
     });
     const forwardedIn = await prisma.form
-      .findUnique({ where: { id: form.id } })
+      .findUniqueOrThrow({ where: { id: form.id } })
       .forwardedIn();
 
     const { query } = makeClient({ ...user, auth: AuthType.Session });

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -47,7 +47,7 @@ export async function getCompanyInfos(
     contactPhone: searchResult.contactPhone,
     website: searchResult.website,
     isRegistered: searchResult.isRegistered,
-    companyTypes: searchResult.companyTypes,
+    companyTypes: searchResult.companyTypes ?? [],
     ecoOrganismeAgreements: searchResult.ecoOrganismeAgreements ?? [],
     allowBsdasriTakeOverWithoutSignature:
       searchResult.allowBsdasriTakeOverWithoutSignature,
@@ -75,7 +75,7 @@ const companyInfosResolvers: QueryResolvers["companyInfos"] = async (
     );
   }
   const companyInfos = (await getCompanyInfos(
-    !!args.siret ? args.siret : args.clue
+    !!args.siret ? args.siret : args.clue!
   )) as CompanyPublic;
   if (companyInfos.statutDiffusionEtablissement !== "N") {
     return companyInfos;

--- a/back/src/companies/resolvers/queries/favorites.ts
+++ b/back/src/companies/resolvers/queries/favorites.ts
@@ -79,7 +79,7 @@ function companyToFavorite(
     isRegistered: !!company,
     codePaysEtrangerEtablissement: !isForeignVat(company.vatNumber)
       ? "FR"
-      : checkVAT(company.vatNumber, countries)?.country?.isoCode.short,
+      : checkVAT(company.vatNumber ?? "", countries)?.country?.isoCode.short,
     transporterReceipt: company.transporterReceipt
   };
 }
@@ -116,7 +116,7 @@ async function getRecentEmitters(
     },
     select: { emitterCompanySiret: true }
   });
-  const emitterSirets = forms.map(f => f.emitterCompanySiret);
+  const emitterSirets = forms.map(f => f.emitterCompanySiret).filter(Boolean);
   const companies = await prisma.company.findMany({
     where: { siret: { in: emitterSirets } }
   });
@@ -135,7 +135,9 @@ async function getRecentRecipients(
     select: { recipientCompanySiret: true }
   });
 
-  const recipientSirets = forms.map(f => f.recipientCompanySiret);
+  const recipientSirets = forms
+    .map(f => f.recipientCompanySiret)
+    .filter(Boolean);
   const companies = await prisma.company.findMany({
     where: { siret: { in: recipientSirets } }
   });
@@ -185,7 +187,7 @@ async function getRecentNextDestinations(
   });
 
   const nextDestinationSirets = [
-    ...new Set(forms.map(f => f.nextDestinationCompanySiret))
+    ...new Set(forms.map(f => f.nextDestinationCompanySiret).filter(Boolean))
   ];
   const favorites = await Promise.all(
     nextDestinationSirets.map(async siret => {
@@ -234,10 +236,10 @@ async function getRecentTransporters(defaultWhere: Prisma.FormWhereInput) {
   });
   const transporterSirets = forms
     .map(f => f.transporterCompanySiret)
-    .filter(s => !["", null].includes(s));
+    .filter(Boolean);
   const transporterVatNumbers = forms
     .map(f => f.transporterCompanyVatNumber)
-    .filter(s => !["", null].includes(s));
+    .filter(Boolean);
 
   const companies = await prisma.company.findMany({
     where: {
@@ -262,7 +264,9 @@ async function getRecentTraders(
     select: { traderCompanySiret: true }
   });
 
-  const traderSirets = [...new Set(forms.map(f => f.traderCompanySiret))];
+  const traderSirets = [
+    ...new Set(forms.map(f => f.traderCompanySiret).filter(Boolean))
+  ];
   const favorites = await Promise.all(
     traderSirets.map(async siret => {
       try {
@@ -270,7 +274,7 @@ async function getRecentTraders(
         const favorite = companySearchResultToFavorite(company);
         const traderReceipt = await prisma.company
           .findUnique({
-            where: { siret: favorite.siret }
+            where: { orgId: favorite.orgId }
           })
           .traderReceipt();
         return { ...favorite, traderReceipt };
@@ -295,7 +299,9 @@ async function getRecentBrokers(
     select: { brokerCompanySiret: true }
   });
 
-  const brokerSirets = [...new Set(forms.map(f => f.brokerCompanySiret))];
+  const brokerSirets = [
+    ...new Set(forms.map(f => f.brokerCompanySiret).filter(Boolean))
+  ];
   const favorites = await Promise.all(
     brokerSirets.map(async siret => {
       try {
@@ -303,7 +309,7 @@ async function getRecentBrokers(
         const favorite = companySearchResultToFavorite(company);
         const brokerReceipt = await prisma.company
           .findUnique({
-            where: { siret: favorite.siret }
+            where: { orgId: favorite.orgId }
           })
           .brokerReceipt();
         return { ...favorite, brokerReceipt };
@@ -384,13 +390,16 @@ const favoritesResolver: QueryResolvers["favorites"] = async (
   const company = await getCompanyOrCompanyNotFound({ orgId: siret });
   await checkIsCompanyMember({ id: user.id }, { orgId: company.orgId });
 
-  const recentPartners = await getRecentPartners(company.siret, type);
+  const recentPartners = company.siret
+    ? await getRecentPartners(company.siret, type)
+    : [];
   const favorites: CompanyFavorite[] = recentPartners.map(recentPartner => {
     return {
       ...recentPartner,
       codePaysEtrangerEtablissement: !isForeignVat(recentPartner.vatNumber)
         ? "FR"
-        : checkVAT(recentPartner.vatNumber, countries)?.country?.isoCode.short
+        : checkVAT(recentPartner.vatNumber ?? "", countries)?.country?.isoCode
+            .short
     };
   });
 

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -17,6 +17,7 @@ import {
 import { SireneSearchResult } from "./sirene/types";
 import { CompanyVatSearchResult } from "./vat/vies/types";
 import { AnonymousCompanyError } from "./sirene/errors";
+import { removeEmptyKeys } from "../common/converter";
 
 interface SearchCompaniesDeps {
   searchCompany: (clue: string) => Promise<CompanySearchResult>;
@@ -30,7 +31,7 @@ const SIRET_OR_VAT_ERROR =
  */
 async function findCompanyAndMergeInfos(
   cleanClue: string,
-  companyInfo: SireneSearchResult | CompanyVatSearchResult
+  companyInfo: SireneSearchResult | CompanyVatSearchResult | null
 ): Promise<CompanySearchResult> {
   const where = {
     where: { orgId: cleanClue }
@@ -60,7 +61,9 @@ async function findCompanyAndMergeInfos(
     trackdechetsId: trackdechetsCompanyInfo?.id,
     companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
     orgId: cleanClue,
-    ...convertUrls(trackdechetsCompanyInfo),
+    ...(trackdechetsCompanyInfo != null && {
+      ...convertUrls(trackdechetsCompanyInfo)
+    }),
     // override database infos with Sirene or VAT search
     ...companyInfo
   };
@@ -100,7 +103,7 @@ export async function searchCompany(
   // Anonymous Company search
   if (anonymousCompany) {
     const companyInfo: SireneSearchResult = {
-      ...anonymousCompany,
+      ...removeEmptyKeys(anonymousCompany),
       statutDiffusionEtablissement: cleanedClue.startsWith(TEST_COMPANY_PREFIX)
         ? "O"
         : "N",
@@ -127,13 +130,15 @@ export async function searchCompany(
     if (company.isRegistered === true) {
       // shorcut to return the result directly from database
       const { country } = checkVAT(cleanedClue, countries);
-      return {
-        codePaysEtrangerEtablissement: country.isoCode.short,
-        statutDiffusionEtablissement: "O",
-        etatAdministratif: "A",
-        vatNumber: cleanedClue,
-        ...company
-      };
+      if (country) {
+        return {
+          codePaysEtrangerEtablissement: country.isoCode.short,
+          statutDiffusionEtablissement: "O",
+          etatAdministratif: "A",
+          vatNumber: cleanedClue,
+          ...company
+        };
+      }
     }
     const companyInfo = await searchVatFrOnlyOrNotFound(cleanedClue);
     return {
@@ -141,12 +146,17 @@ export async function searchCompany(
       ...companyInfo
     };
   }
+
+  throw new Error(`Unhandled search company case for clue ${clue}`);
 }
 
 // used for dependency injection in tests to easily mock `searchCompany`
 export const makeSearchCompanies =
   ({ searchCompany }: SearchCompaniesDeps) =>
-  (clue: string, department?: string): Promise<CompanySearchResult[]> => {
+  (
+    clue: string,
+    department?: string | null
+  ): Promise<CompanySearchResult[]> => {
     const cleanedClue = cleanClue(clue);
     // clue can be formatted like a SIRET or a VAT number
     if (isSiret(cleanedClue) || isVat(cleanedClue)) {
@@ -166,12 +176,15 @@ export const makeSearchCompanies =
     }
     // fuzzy searching only for French companies
     return decoratedSearchCompanies(clue, department).then(async results => {
-      let existingCompanies = [];
+      if (!results) {
+        return [];
+      }
+      let existingCompanies: string[] = [];
       if (results.length) {
         existingCompanies = (
           await prisma.company.findMany({
             where: {
-              orgId: { in: results.map(r => r.siret) }
+              orgId: { in: results.map(r => r.siret!) }
             },
             select: {
               orgId: true
@@ -182,8 +195,8 @@ export const makeSearchCompanies =
 
       return results.map(company => ({
         ...company,
-        orgId: company.siret,
-        isRegistered: existingCompanies.includes(company.siret)
+        orgId: company.siret!,
+        isRegistered: existingCompanies.includes(company.siret!)
       }));
     });
   };
@@ -193,7 +206,7 @@ export const makeSearchCompanies =
  */
 async function searchSireneOrNotFound(
   siret: string
-): Promise<SireneSearchResult> {
+): Promise<SireneSearchResult | null> {
   try {
     return await redundantCachedSearchSirene(siret);
   } catch (err) {
@@ -204,7 +217,7 @@ async function searchSireneOrNotFound(
     });
     if (anonymousCompany) {
       return {
-        ...anonymousCompany,
+        ...removeEmptyKeys(anonymousCompany),
         // required to avoid leaking anonymous data to the public
         statutDiffusionEtablissement: "N",
         etatAdministratif: "A",
@@ -241,7 +254,7 @@ interface PartialCompanyVatSearchResult
  */
 async function searchVatFrOnlyOrNotFound(
   vatNumber: string
-): Promise<PartialCompanyVatSearchResult> {
+): Promise<PartialCompanyVatSearchResult | null> {
   if (isFRVat(vatNumber)) {
     throw new UserInputError(
       "Une entreprise française doit être identifiée par son SIRET et pas par sa TVA intracommunautaire",
@@ -251,11 +264,13 @@ async function searchVatFrOnlyOrNotFound(
     );
   }
   // throws UserInputError if not found
-  const viesResult = await searchVat(vatNumber);
+  const viesResult: PartialCompanyVatSearchResult | null = await searchVat(
+    vatNumber
+  );
   // delete name and adresse if === ""
   // in order to avoid db name and adresse to be replaced with empty string from the VIES api
-  if (viesResult.name === "") delete viesResult.name;
-  if (viesResult.address === "") delete viesResult.address;
+  if (viesResult && viesResult.name === "") delete viesResult.name;
+  if (viesResult && viesResult.address === "") delete viesResult.address;
   return viesResult;
 }
 

--- a/back/src/companies/sirene/__tests__/index.integration.ts
+++ b/back/src/companies/sirene/__tests__/index.integration.ts
@@ -4,6 +4,7 @@ import { searchCompany } from "../../search";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import { AnonymousCompanyError } from "../errors";
 import { siretify } from "../../../__tests__/factories";
+import { removeEmptyKeys } from "../../../common/converter";
 
 const searchCompanySpy = jest.spyOn(searchCompanyDecorated, "default");
 // Mock the fact a siret is not found in SIRENE API's
@@ -34,6 +35,6 @@ describe("searchCompany", () => {
       }
     });
     const searchResult = await searchCompany(siret);
-    expect(searchResult).toMatchObject(anonymousCompany);
+    expect(searchResult).toMatchObject(removeEmptyKeys(anonymousCompany));
   });
 });

--- a/back/src/companies/sirene/insee/__tests__/client.test.ts
+++ b/back/src/companies/sirene/insee/__tests__/client.test.ts
@@ -49,7 +49,7 @@ describe("searchCompany", () => {
           ]
         }
       }
-    });
+    } as any);
 
     const company = await searchCompany(siret);
     const expected = {
@@ -101,7 +101,7 @@ describe("searchCompany", () => {
           ]
         }
       }
-    });
+    } as any);
 
     expect.assertions(1);
     try {
@@ -145,7 +145,7 @@ describe("searchCompany", () => {
           ]
         }
       }
-    });
+    } as any);
 
     expect.assertions(1);
     try {
@@ -185,7 +185,7 @@ describe("searchCompany", () => {
           ]
         }
       }
-    });
+    } as any);
     const company = await searchCompany("34393738900041");
     expect(company.name).toEqual("JOHN SNOW");
   });
@@ -257,7 +257,7 @@ describe("searchCompanies", () => {
           }
         ]
       }
-    });
+    } as any);
     const companies = await searchCompanies("code en stock");
     expect(companies).toHaveLength(1);
     const expected = {
@@ -330,7 +330,7 @@ describe("searchCompanies", () => {
           }
         ]
       }
-    });
+    } as any);
 
     const companies = await searchCompanies("boulangerie", "07");
     expect(companies).toHaveLength(1);

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -131,7 +131,7 @@ export function searchCompanies(
   department?: string
 ): Promise<SireneSearchResult[]> {
   // list of filters to pass as "q" arguments
-  const filters = [];
+  const filters: string[] = [];
 
   const today = format(new Date(), "yyyy-MM-dd");
 

--- a/back/src/companies/sirene/insee/token.ts
+++ b/back/src/companies/sirene/insee/token.ts
@@ -34,7 +34,7 @@ async function renewToken(): Promise<void> {
 /**
  * Retrives token from redis cache
  */
-export async function getToken(): Promise<string> {
+export async function getToken(): Promise<string | null> {
   return redisClient.get(INSEE_TOKEN_KEY);
 }
 

--- a/back/src/companies/sirene/ratelimit.ts
+++ b/back/src/companies/sirene/ratelimit.ts
@@ -46,11 +46,11 @@ type ThrottleDecoratorArgs = {
   requestsPerSeconds?: number;
 };
 
-export function backoffIfTestEnvs<T>(fn: (...args) => Promise<T>) {
-  const backoff = async (...args): Promise<T> => {
+export function backoffIfTestEnvs<T>(fn: (...args) => Promise<T | null>) {
+  const backoff = async (...args): Promise<T | null> => {
     if (process.env.NODE_ENV === "test") {
       // do not call the APIs when running tests
-      return;
+      return null;
     } else {
       return fn(...args);
     }

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -37,7 +37,7 @@ const searchCompanyProviders = [
 /**
  * Apply throttle, redundant and cache decorators to searchCompany functions
  */
-const decoratedSearchCompany = cache<SireneSearchResult>(
+const decoratedSearchCompany = cache<SireneSearchResult | null>(
   redundant(...searchCompanyProviders)
 );
 

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -13,7 +13,7 @@ import {
 import client from "./esClient";
 
 const { ResponseError } = errors;
-const index = process.env.TD_COMPANY_ELASTICSEARCH_INDEX;
+const index = process.env.TD_COMPANY_ELASTICSEARCH_INDEX!;
 
 /**
  * Specific Error class
@@ -144,6 +144,9 @@ export const searchCompany = async (
       id: siret,
       index
     });
+    if (!response.body._source) {
+      throw new Error(`No _source in ES body for id ${siret} & index ${index}`);
+    }
     const company = searchResponseToCompany(response.body._source);
     if (company.statutDiffusionEtablissement === "N") {
       throw new AnonymousCompanyError();
@@ -200,7 +203,7 @@ export const searchCompanies = (
     }
   ];
 
-  if (department?.length >= 2 && department?.length <= 3) {
+  if (department && department.length >= 2 && department.length <= 3) {
     // this might a french department code
     must.push({
       wildcard: { codePostalEtablissement: `${department}*` }

--- a/back/src/companies/sirene/trackdechets/esClient.ts
+++ b/back/src/companies/sirene/trackdechets/esClient.ts
@@ -4,7 +4,7 @@ import { Client } from "@elastic/elasticsearch";
 
 const certPath = path.join(__dirname, "es.cert");
 
-let ssl = undefined;
+let ssl;
 
 if (fs.existsSync(certPath)) {
   ssl = { ca: fs.readFileSync(certPath, "utf-8") };

--- a/back/src/companies/sirene/utils.ts
+++ b/back/src/companies/sirene/utils.ts
@@ -10,8 +10,8 @@ export function libelleFromCodeNaf(codeNaf: string) {
 /**
  * Build a full address string from its base components
  */
-export function buildAddress(addressComponents: string[]) {
-  return addressComponents.filter(x => !!x).join(" ");
+export function buildAddress(addressComponents: (string | null)[]) {
+  return addressComponents.filter(Boolean).join(" ");
 }
 
 export function safeParseFloat(f: string) {

--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -18,7 +18,7 @@ const SIRENIFY_BYPASS_USER_EMAILS =
  * defines a getter and a setter for a nested company input
  */
 type CompanyInputAccessor<T> = {
-  getter: () => CompanyInput;
+  getter: () => CompanyInput | null | undefined;
   setter: (input: T, companyInput: CompanyInput) => T;
 };
 
@@ -56,7 +56,9 @@ export default function buildSirenify<T>(
     // check if we found a corresponding companySearchResult based on siret
     const companySearchResults = await Promise.all(
       companyInputs.map(companyInput =>
-        companyInput ? searchCompanyFailFast(companyInput.siret) : null
+        companyInput && companyInput.siret
+          ? searchCompanyFailFast(companyInput.siret)
+          : null
       )
     );
 
@@ -89,7 +91,7 @@ export default function buildSirenify<T>(
 
 export async function searchCompanyFailFast(
   siret: string
-): Promise<CompanySearchResult> {
+): Promise<CompanySearchResult | null> {
   // make sure we do not wait more thant 1s here to avoid bottlenecks
   const raceWith = new Promise<null>(resolve =>
     setTimeout(resolve, 1000, null)

--- a/back/src/companies/vat/index.ts
+++ b/back/src/companies/vat/index.ts
@@ -14,10 +14,12 @@ const throttledSearchVat = backoffIfTestEnvs<CompanyVatSearchResult>(
   })
 );
 
-const decoratedSearchVat = cache<CompanyVatSearchResult>(throttledSearchVat);
+const decoratedSearchVat = cache<CompanyVatSearchResult | null>(
+  throttledSearchVat
+);
 
 interface SearchVatDeps {
-  searchVat: (vat: string) => Promise<CompanyVatSearchResult>;
+  searchVat: (vat: string) => Promise<CompanyVatSearchResult | null>;
 }
 
 export const makeSearchVat =

--- a/back/src/companies/vat/vies/client.ts
+++ b/back/src/companies/vat/vies/client.ts
@@ -62,8 +62,8 @@ export const client = async (
   }
 
   const payload = {
-    vatNumber: value.slice(2),
-    countryCode: country.isoCode.short
+    vatNumber: value!.slice(2),
+    countryCode: country!.isoCode.short
   };
 
   const soapClient = await createClientAsync(viesUrl);
@@ -80,15 +80,15 @@ export const client = async (
     }
 
     // auto-correct VIES "unknown data"
-    const address = viesResult.address === "---" ? "" : viesResult.address;
-    const name = viesResult.name === "---" ? "" : viesResult.name;
+    const address = viesResult.address === "---" ? "" : viesResult.address!;
+    const name = viesResult.name === "---" ? "" : viesResult.name!;
 
     return {
       vatNumber: vatNumber,
       address: address,
       name: name,
       // Compat mapping avec SireneSearchResult
-      codePaysEtrangerEtablissement: country.isoCode.short,
+      codePaysEtrangerEtablissement: country!.isoCode.short,
       statutDiffusionEtablissement: "O",
       etatAdministratif: "A"
     };

--- a/back/src/cron.ts
+++ b/back/src/cron.ts
@@ -16,7 +16,7 @@ const {
   PROFESSIONAL_SECOND_ONBOARDING_TEMPLATE_ID
 } = process.env;
 
-let jobs = [];
+let jobs: cron.CronJob[] = [];
 
 if (CRON_ONBOARDING_SCHEDULE) {
   validateOnbardingCronSchedule(CRON_ONBOARDING_SCHEDULE);
@@ -83,12 +83,13 @@ const Sentry = initSentry();
 
 if (Sentry) {
   jobs.forEach(job => {
-    const onTick = job.onTick;
-    job.onTick = async () => {
-      try {
-        await onTick();
-      } catch (err) {
-        Sentry.captureException(err);
+    job.fireOnTick = async function () {
+      for (let i = this._callbacks.length - 1; i >= 0; i--) {
+        try {
+          await this._callbacks[i].call(this.context, this.onComplete);
+        } catch (err) {
+          Sentry.captureException(err);
+        }
       }
     };
   });

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -8,7 +8,7 @@ const { MONGO_URL } = process.env;
 
 const EVENTS_COLLECTION = "events";
 
-const mongodbClient = new MongoClient(MONGO_URL);
+const mongodbClient = new MongoClient(MONGO_URL!);
 
 const database = mongodbClient.db();
 const eventsCollection =

--- a/back/src/forms/__tests__/sirenify.integration.ts
+++ b/back/src/forms/__tests__/sirenify.integration.ts
@@ -33,14 +33,14 @@ describe("sirenifyFormInput", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [recipient.company.siret]: searchResult("destinataire"),
-      [broker.company.siret]: searchResult("courtier"),
-      [trader.company.siret]: searchResult("négociant"),
-      [exutoire.company.siret]: searchResult("destinataire final"),
-      [intermediary1.company.siret]: searchResult("intermédiaire 1"),
-      [intermediary2.company.siret]: searchResult("intermédiaire 2")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [recipient.company.siret!]: searchResult("destinataire"),
+      [broker.company.siret!]: searchResult("courtier"),
+      [trader.company.siret!]: searchResult("négociant"),
+      [exutoire.company.siret!]: searchResult("destinataire final"),
+      [intermediary1.company.siret!]: searchResult("intermédiaire 1"),
+      [intermediary2.company.siret!]: searchResult("intermédiaire 2")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -110,53 +110,53 @@ describe("sirenifyFormInput", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.recipient.company.name).toEqual(
-      searchResults[recipient.company.siret].name
+    expect(sirenified.recipient!.company!.name).toEqual(
+      searchResults[recipient.company.siret!].name
     );
-    expect(sirenified.recipient.company.address).toEqual(
-      searchResults[recipient.company.siret].address
+    expect(sirenified.recipient!.company!.address).toEqual(
+      searchResults[recipient.company.siret!].address
     );
-    expect(sirenified.broker.company.name).toEqual(
-      searchResults[broker.company.siret].name
+    expect(sirenified.broker!.company!.name).toEqual(
+      searchResults[broker.company.siret!].name
     );
-    expect(sirenified.broker.company.address).toEqual(
-      searchResults[broker.company.siret].address
+    expect(sirenified.broker!.company!.address).toEqual(
+      searchResults[broker.company.siret!].address
     );
-    expect(sirenified.trader.company.name).toEqual(
-      searchResults[trader.company.siret].name
+    expect(sirenified.trader!.company!.name).toEqual(
+      searchResults[trader.company.siret!].name
     );
-    expect(sirenified.trader.company.address).toEqual(
-      searchResults[trader.company.siret].address
-    );
-    expect(sirenified.temporaryStorageDetail.destination.company.name).toEqual(
-      searchResults[exutoire.company.siret].name
+    expect(sirenified.trader!.company!.address).toEqual(
+      searchResults[trader.company.siret!].address
     );
     expect(
-      sirenified.temporaryStorageDetail.destination.company.address
-    ).toEqual(searchResults[exutoire.company.siret].address);
-    expect(sirenified.intermediaries[0].name).toEqual(
-      searchResults[intermediary1.company.siret].name
+      sirenified.temporaryStorageDetail!.destination!.company!.name
+    ).toEqual(searchResults[exutoire.company.siret!].name);
+    expect(
+      sirenified.temporaryStorageDetail!.destination!.company!.address
+    ).toEqual(searchResults[exutoire.company.siret!].address);
+    expect(sirenified.intermediaries![0].name).toEqual(
+      searchResults[intermediary1.company.siret!].name
     );
-    expect(sirenified.intermediaries[0].address).toEqual(
-      searchResults[intermediary1.company.siret].address
+    expect(sirenified.intermediaries![0].address).toEqual(
+      searchResults[intermediary1.company.siret!].address
     );
-    expect(sirenified.intermediaries[1].name).toEqual(
-      searchResults[intermediary2.company.siret].name
+    expect(sirenified.intermediaries![1].name).toEqual(
+      searchResults[intermediary2.company.siret!].name
     );
-    expect(sirenified.intermediaries[1].address).toEqual(
-      searchResults[intermediary2.company.siret].address
+    expect(sirenified.intermediaries![1].address).toEqual(
+      searchResults[intermediary2.company.siret!].address
     );
   });
 
@@ -179,14 +179,14 @@ describe("sirenifyFormInput", () => {
     }
 
     const searchResults = {
-      [emitter.company.siret]: searchResult("émetteur"),
-      [transporter.company.siret]: searchResult("transporteur"),
-      [recipient.company.siret]: searchResult("destinataire"),
-      [broker.company.siret]: searchResult("courtier"),
-      [trader.company.siret]: searchResult("négociant"),
-      [exutoire.company.siret]: searchResult("destinataire final"),
-      [intermediary1.company.siret]: searchResult("intermédiaire 1"),
-      [intermediary2.company.siret]: searchResult("intermédiaire 2")
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [recipient.company.siret!]: searchResult("destinataire"),
+      [broker.company.siret!]: searchResult("courtier"),
+      [trader.company.siret!]: searchResult("négociant"),
+      [exutoire.company.siret!]: searchResult("destinataire final"),
+      [intermediary1.company.siret!]: searchResult("intermédiaire 1"),
+      [intermediary2.company.siret!]: searchResult("intermédiaire 2")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -242,53 +242,53 @@ describe("sirenifyFormInput", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.emitter.company.name).toEqual(
-      searchResults[emitter.company.siret].name
+    expect(sirenified.emitter!.company!.name).toEqual(
+      searchResults[emitter.company.siret!].name
     );
-    expect(sirenified.emitter.company.address).toEqual(
-      searchResults[emitter.company.siret].address
+    expect(sirenified.emitter!.company!.address).toEqual(
+      searchResults[emitter.company.siret!].address
     );
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.recipient.company.name).toEqual(
-      searchResults[recipient.company.siret].name
+    expect(sirenified.recipient!.company!.name).toEqual(
+      searchResults[recipient.company.siret!].name
     );
-    expect(sirenified.recipient.company.address).toEqual(
-      searchResults[recipient.company.siret].address
+    expect(sirenified.recipient!.company!.address).toEqual(
+      searchResults[recipient.company.siret!].address
     );
-    expect(sirenified.broker.company.name).toEqual(
-      searchResults[broker.company.siret].name
+    expect(sirenified.broker!.company!.name).toEqual(
+      searchResults[broker.company.siret!].name
     );
-    expect(sirenified.broker.company.address).toEqual(
-      searchResults[broker.company.siret].address
+    expect(sirenified.broker!.company!.address).toEqual(
+      searchResults[broker.company.siret!].address
     );
-    expect(sirenified.trader.company.name).toEqual(
-      searchResults[trader.company.siret].name
+    expect(sirenified.trader!.company!.name).toEqual(
+      searchResults[trader.company.siret!].name
     );
-    expect(sirenified.trader.company.address).toEqual(
-      searchResults[trader.company.siret].address
-    );
-    expect(sirenified.temporaryStorageDetail.destination.company.name).toEqual(
-      searchResults[exutoire.company.siret].name
+    expect(sirenified.trader!.company!.address).toEqual(
+      searchResults[trader.company.siret!].address
     );
     expect(
-      sirenified.temporaryStorageDetail.destination.company.address
-    ).toEqual(searchResults[exutoire.company.siret].address);
-    expect(sirenified.intermediaries[0].name).toEqual(
-      searchResults[intermediary1.company.siret].name
+      sirenified.temporaryStorageDetail!.destination!.company!.name
+    ).toEqual(searchResults[exutoire.company.siret!].name);
+    expect(
+      sirenified.temporaryStorageDetail!.destination!.company!.address
+    ).toEqual(searchResults[exutoire.company.siret!].address);
+    expect(sirenified.intermediaries![0].name).toEqual(
+      searchResults[intermediary1.company.siret!].name
     );
-    expect(sirenified.intermediaries[0].address).toEqual(
-      searchResults[intermediary1.company.siret].address
+    expect(sirenified.intermediaries![0].address).toEqual(
+      searchResults[intermediary1.company.siret!].address
     );
-    expect(sirenified.intermediaries[1].name).toEqual(
-      searchResults[intermediary2.company.siret].name
+    expect(sirenified.intermediaries![1].name).toEqual(
+      searchResults[intermediary2.company.siret!].name
     );
-    expect(sirenified.intermediaries[1].address).toEqual(
-      searchResults[intermediary2.company.siret].address
+    expect(sirenified.intermediaries![1].address).toEqual(
+      searchResults[intermediary2.company.siret!].address
     );
   });
 });
@@ -309,8 +309,8 @@ describe("sirenifyResealedFormInput", () => {
     }
 
     const searchResults = {
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destination")
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destination")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -339,17 +339,17 @@ describe("sirenifyResealedFormInput", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
   });
 
@@ -366,8 +366,8 @@ describe("sirenifyResealedFormInput", () => {
     }
 
     const searchResults = {
-      [transporter.company.siret]: searchResult("transporteur"),
-      [destination.company.siret]: searchResult("destination")
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destination")
     };
 
     searchCompanySpy.mockImplementation((clue: string) => {
@@ -392,17 +392,17 @@ describe("sirenifyResealedFormInput", () => {
       auth: AuthType.Bearer
     } as Express.User);
 
-    expect(sirenified.transporter.company.name).toEqual(
-      searchResults[transporter.company.siret].name
+    expect(sirenified.transporter!.company!.name).toEqual(
+      searchResults[transporter.company.siret!].name
     );
-    expect(sirenified.transporter.company.address).toEqual(
-      searchResults[transporter.company.siret].address
+    expect(sirenified.transporter!.company!.address).toEqual(
+      searchResults[transporter.company.siret!].address
     );
-    expect(sirenified.destination.company.name).toEqual(
-      searchResults[destination.company.siret].name
+    expect(sirenified.destination!.company!.name).toEqual(
+      searchResults[destination.company.siret!].name
     );
-    expect(sirenified.destination.company.address).toEqual(
-      searchResults[destination.company.siret].address
+    expect(sirenified.destination!.company!.address).toEqual(
+      searchResults[destination.company.siret!].address
     );
   });
 });

--- a/back/src/forms/repository/formRevisionRequest/countRevisionRequest.ts
+++ b/back/src/forms/repository/formRevisionRequest/countRevisionRequest.ts
@@ -1,12 +1,12 @@
 import { Prisma } from "@prisma/client";
-import { RepositoryFnDeps } from "../../../common/repository/types";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
 export type CountRevisionRequestsFn = (
   where: Prisma.BsddRevisionRequestWhereInput
 ) => Promise<number>;
 
 const buildCountRevisionRequests: (
-  deps: RepositoryFnDeps
+  deps: ReadRepositoryFnDeps
 ) => CountRevisionRequestsFn =
   ({ prisma }) =>
   where => {

--- a/back/src/forms/repository/formRevisionRequest/getRevisionRequestById.ts
+++ b/back/src/forms/repository/formRevisionRequest/getRevisionRequestById.ts
@@ -1,13 +1,13 @@
 import { BsddRevisionRequest, Prisma } from "@prisma/client";
-import { RepositoryFnDeps } from "../../../common/repository/types";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
 export type GetRevisionRequestByIdFn = (
   id: string,
   options?: Omit<Prisma.BsddRevisionRequestFindUniqueArgs, "where">
-) => Promise<BsddRevisionRequest>;
+) => Promise<BsddRevisionRequest | null>;
 
 const buildGetRevisionRequestById: (
-  deps: RepositoryFnDeps
+  deps: ReadRepositoryFnDeps
 ) => GetRevisionRequestByIdFn =
   ({ prisma }) =>
   async (id, options) => {

--- a/back/src/forms/repository/index.ts
+++ b/back/src/forms/repository/index.ts
@@ -67,8 +67,8 @@ export function getFormRepository(
 
   const formRevisionRequestActions: FormRevisionRequestActions = {
     // READ operations
-    getRevisionRequestById: buildGetRevisionRequestById({ prisma, user }),
-    countRevisionRequests: buildCountRevisionRequests({ prisma, user }),
+    getRevisionRequestById: buildGetRevisionRequestById({ prisma }),
+    countRevisionRequests: buildCountRevisionRequests({ prisma }),
     // WRITE operations - wrapped into a transaction
     cancelRevisionRequest: useTransaction(buildCancelRevisionRequest),
     createRevisionRequest: useTransaction(buildCreateRevisionRequest),

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -226,7 +226,7 @@ describe("Mutation.createForm", () => {
       }
     });
     expect(errors).toBeUndefined();
-    expect(data.createForm.recipient.processingOperation).toEqual("R1");
+    expect(data.createForm.recipient!.processingOperation).toEqual("R1");
   });
 
   it("should allow an intermediary company to create a form", async () => {
@@ -357,7 +357,7 @@ describe("Mutation.createForm", () => {
     await prisma.ecoOrganisme.create({
       data: {
         address: "",
-        siret: eo.siret,
+        siret: eo.siret!,
         name: eo.name
       }
     });
@@ -374,7 +374,7 @@ describe("Mutation.createForm", () => {
       }
     });
 
-    expect(data.createForm.ecoOrganisme.siret).toBe(eo.siret);
+    expect(data.createForm.ecoOrganisme!.siret).toBe(eo.siret);
   });
 
   it("should return an error when trying to create a form with a non-existing eco-organisme", async () => {
@@ -431,7 +431,7 @@ describe("Mutation.createForm", () => {
       variables: { createFormInput }
     });
 
-    expect(data.createForm.emitter.workSite).toMatchObject(
+    expect(data.createForm.emitter!.workSite).toMatchObject(
       createFormInput.emitter.workSite
     );
   });
@@ -464,7 +464,7 @@ describe("Mutation.createForm", () => {
       variables: { createFormInput }
     });
 
-    expect(data.createForm.temporaryStorageDetail.destination).toMatchObject(
+    expect(data.createForm.temporaryStorageDetail!.destination).toMatchObject(
       createFormInput.temporaryStorageDetail.destination
     );
   });
@@ -524,10 +524,10 @@ describe("Mutation.createForm", () => {
       variables: { createFormInput }
     });
 
-    expect(data.createForm.wasteDetails.parcelNumbers[0]).toMatchObject(
+    expect(data.createForm.wasteDetails!.parcelNumbers![0]).toMatchObject(
       parcelNumbers[0]
     );
-    expect(data.createForm.wasteDetails.parcelNumbers[1]).toMatchObject(
+    expect(data.createForm.wasteDetails!.parcelNumbers![1]).toMatchObject(
       parcelNumbers[1]
     );
   });
@@ -585,7 +585,7 @@ describe("Mutation.createForm", () => {
       }
     });
 
-    expect(data.createForm.recipient.company).toMatchObject(
+    expect(data.createForm.recipient!.company).toMatchObject(
       createFormInput.recipient.company
     );
   });
@@ -793,7 +793,7 @@ describe("Mutation.createForm", () => {
           createFormInput
         }
       });
-      const form = await prisma.form.findUnique({
+      const form = await prisma.form.findUniqueOrThrow({
         where: { id: data.createForm.id }
       });
       expect(form.transporterValidityLimit).toEqual(validityLimit);
@@ -825,7 +825,7 @@ describe("Mutation.createForm", () => {
       { type: "FUT", other: null, quantity: 1 },
       { type: "AUTRE", other: "Contenant", quantity: 1 }
     ];
-    expect(data.createForm.wasteDetails.packagingInfos).toMatchObject(
+    expect(data.createForm.wasteDetails!.packagingInfos).toMatchObject(
       expectedPackagingInfos
     );
   });
@@ -916,7 +916,7 @@ describe("Mutation.createForm", () => {
     });
 
     expect(errors).toEqual(undefined);
-    expect(data.createForm.appendix2Forms[0].id).toBe(appendix2.id);
+    expect(data.createForm.appendix2Forms![0].id).toBe(appendix2.id);
   });
 
   it("should allow creating a form with an appendix 2 (using CreateFormInput.grouping)", async () => {
@@ -1067,7 +1067,7 @@ describe("Mutation.createForm", () => {
           grouping: {
             create: {
               initialFormId: appendix2.id,
-              quantity: appendix2.quantityReceived
+              quantity: appendix2.quantityReceived!
             }
           }
         }
@@ -1520,7 +1520,7 @@ describe("Mutation.createForm", () => {
         }
       }
     });
-    expect(data.createForm.wasteDetails.isDangerous).toEqual(true);
+    expect(data.createForm.wasteDetails!.isDangerous).toEqual(true);
   });
 
   it("should set isDangerous to `false` when specifying a waste code without *", async () => {
@@ -1539,7 +1539,7 @@ describe("Mutation.createForm", () => {
         }
       }
     });
-    expect(data.createForm.wasteDetails.isDangerous).toEqual(false);
+    expect(data.createForm.wasteDetails!.isDangerous).toEqual(false);
   });
 
   it("should throw an exception if trying to set `isDangerous=false` with a code containing *", async () => {
@@ -1582,7 +1582,7 @@ describe("Mutation.createForm", () => {
         }
       }
     });
-    expect(data.createForm.wasteDetails.isDangerous).toBe(true);
+    expect(data.createForm.wasteDetails!.isDangerous).toBe(true);
   });
 
   it("should not be possible to fill both a SIRET number and a FR TVA number for transporter", async () => {
@@ -1705,7 +1705,7 @@ describe("Mutation.createForm", () => {
       }
     });
 
-    const form = await prisma.form.findUnique({
+    const form = await prisma.form.findUniqueOrThrow({
       where: { id: data.createForm.id }
     });
 
@@ -1759,7 +1759,7 @@ describe("Mutation.createForm", () => {
         }
       });
 
-      const form = await prisma.form.findUnique({
+      const form = await prisma.form.findUniqueOrThrow({
         where: { id: data.createForm.id }
       });
 
@@ -1834,7 +1834,7 @@ describe("Mutation.createForm", () => {
       });
 
       expect(data.createForm.id).toBeDefined();
-      expect(data.createForm.grouping.length).toBe(2);
+      expect(data.createForm.grouping!.length).toBe(2);
     });
 
     it("should seal grouped appendix 1 items when necessary", async () => {
@@ -1894,14 +1894,14 @@ describe("Mutation.createForm", () => {
         }
       });
 
-      expect(data.createForm.grouping.length).toBe(2);
+      expect(data.createForm.grouping!.length).toBe(2);
 
-      const newAppendix1_1 = await prisma.form.findUnique({
+      const newAppendix1_1 = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_1.id }
       });
       expect(newAppendix1_1.status).toBe(Status.SEALED);
 
-      const newAppendix1_2 = await prisma.form.findUnique({
+      const newAppendix1_2 = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_2.id }
       });
       expect(newAppendix1_2.status).toBe(Status.SEALED);

--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -55,7 +55,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -84,7 +84,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -116,7 +116,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { isCanceled: true, quantityReceived: 10 },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -148,7 +148,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { isCanceled: false },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -181,7 +181,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { quantityReceived: 10 },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -212,7 +212,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { wasteDetails: { code: "01 03 08" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -265,7 +265,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { wasteDetails: { code: "01 03 08" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -297,7 +297,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { wasteDetails: { code: "01 03 08" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -352,7 +352,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { wasteDetails: { code: "Made up code" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -383,7 +383,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: { wasteDetails: { code: "01 03 08" } },
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -414,7 +414,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -445,7 +445,7 @@ describe("Mutation.createFormRevisionRequest", () => {
           formId: bsdd.id,
           content: {},
           comment: "A comment",
-          authoringCompanySiret: company.siret
+          authoringCompanySiret: company.siret!
         }
       }
     });
@@ -482,7 +482,7 @@ describe("Mutation.createFormRevisionRequest", () => {
             formId: bsdd.id,
             content: { isCanceled: true },
             comment: "A comment",
-            authoringCompanySiret: company.siret
+            authoringCompanySiret: company.siret!
           }
         }
       });
@@ -519,7 +519,7 @@ describe("Mutation.createFormRevisionRequest", () => {
             formId: bsdd.id,
             content: { isCanceled: true },
             comment: "A comment",
-            authoringCompanySiret: company.siret
+            authoringCompanySiret: company.siret!
           }
         }
       });

--- a/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteForm.integration.ts
@@ -43,7 +43,9 @@ describe("Mutation.deleteForm", () => {
         })
       })
     ]);
-    const intactForm = await prisma.form.findUnique({ where: { id: form.id } });
+    const intactForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id }
+    });
     expect(intactForm.isDeleted).toBe(false);
   });
 
@@ -67,7 +69,9 @@ describe("Mutation.deleteForm", () => {
         })
       })
     ]);
-    const intactForm = await prisma.form.findUnique({ where: { id: form.id } });
+    const intactForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id }
+    });
     expect(intactForm.isDeleted).toBe(false);
   });
 
@@ -92,7 +96,9 @@ describe("Mutation.deleteForm", () => {
       })
     ]);
 
-    const intactForm = await prisma.form.findUnique({ where: { id: form.id } });
+    const intactForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id }
+    });
     expect(intactForm.isDeleted).toBe(false);
   });
 
@@ -113,7 +119,7 @@ describe("Mutation.deleteForm", () => {
 
       expect(data.deleteForm.id).toBeTruthy();
 
-      const deletedForm = await prisma.form.findUnique({
+      const deletedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
       expect(deletedForm.isDeleted).toBe(true);
@@ -137,7 +143,7 @@ describe("Mutation.deleteForm", () => {
 
       expect(data.deleteForm.id).toBeTruthy();
 
-      const deletedForm = await prisma.form.findUnique({
+      const deletedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
       expect(deletedForm.isDeleted).toBe(true);
@@ -169,7 +175,7 @@ describe("Mutation.deleteForm", () => {
         grouping: {
           create: {
             initialFormId: appendix2.id,
-            quantity: appendix2.quantityReceived
+            quantity: appendix2.quantityReceived!
           }
         }
       }
@@ -187,14 +193,14 @@ describe("Mutation.deleteForm", () => {
 
     expect(data.deleteForm.id).toBeTruthy();
 
-    const deletedForm = await prisma.form.findUnique({
+    const deletedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { grouping: true }
     });
     expect(deletedForm.isDeleted).toBe(true);
     expect(deletedForm.grouping).toEqual([]);
 
-    const disconnectedAppendix2 = await prisma.form.findUnique({
+    const disconnectedAppendix2 = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id },
       include: { groupedIn: true }
     });
@@ -213,8 +219,8 @@ describe("Mutation.deleteForm", () => {
     await mutate<Pick<Mutation, "deleteForm">>(DELETE_FORM, {
       variables: { id: form.id }
     });
-    const updatedForwardedInForm = await prisma.form.findUnique({
-      where: { id: forwardedIn.id }
+    const updatedForwardedInForm = await prisma.form.findUniqueOrThrow({
+      where: { id: forwardedIn!.id }
     });
     expect(updatedForwardedInForm.isDeleted).toEqual(true);
   });

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -306,7 +306,9 @@ describe("Mutation.duplicateForm", () => {
       wasteDetailsName,
       wasteDetailsConsistence,
       ...rest
-    } = await prisma.form.findUnique({ where: { id: form.id } }).forwardedIn();
+    } = await prisma.form
+      .findUniqueOrThrow({ where: { id: form.id } })
+      .forwardedIn();
 
     const { mutate } = makeClient(user);
     const { data } = await mutate<Pick<Mutation, "duplicateForm">>(
@@ -317,7 +319,7 @@ describe("Mutation.duplicateForm", () => {
         }
       }
     );
-    const duplicatedForm = await prisma.form.findUnique({
+    const duplicatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: data.duplicateForm.id }
     });
     const duplicatedForwardedIn = await prisma.form
@@ -558,7 +560,7 @@ describe("Mutation.duplicateForm", () => {
         }
       }
     );
-    const duplicatedForm = await prisma.form.findUnique({
+    const duplicatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: data.duplicateForm.id }
     });
     expect(duplicatedForm.nextDestinationProcessingOperation).toBeNull();

--- a/back/src/forms/resolvers/mutations/__tests__/editSegment.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/editSegment.integration.ts
@@ -63,7 +63,7 @@ describe("{ mutation { editSegment } }", () => {
           }`
     );
 
-    const editedSegment = await prisma.transportSegment.findUnique({
+    const editedSegment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: segment.id }
     });
     expect(editedSegment.transporterCompanySiret).toBe(editSegmentSiret);
@@ -113,7 +113,7 @@ describe("{ mutation { editSegment } }", () => {
           }`
     );
 
-    const editedSegment = await prisma.transportSegment.findUnique({
+    const editedSegment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: segment.id }
     });
     expect(editedSegment.transporterCompanySiret).toBe(editSegmentSiret);
@@ -165,7 +165,7 @@ describe("{ mutation { editSegment } }", () => {
           }`
     );
 
-    const editedSegment = await prisma.transportSegment.findUnique({
+    const editedSegment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: segment.id }
     });
 

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -129,7 +129,7 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.recipient.company.siret = company.siret;
+      input.recipient!.company!.siret = company.siret;
 
       const { data } = await mutate<Pick<Mutation, "importPaperForm">>(
         IMPORT_PAPER_FORM,
@@ -168,9 +168,9 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.recipient.company.siret = company.siret;
+      input.recipient!.company!.siret = company.siret;
       // invalidate input
-      input.emitter.type = null;
+      input.emitter!.type = null;
 
       const { errors } = await mutate<Pick<Mutation, "importPaperForm">>(
         IMPORT_PAPER_FORM,
@@ -198,8 +198,8 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.emitter.type = "OTHER";
-      input.recipient.company.siret = company.siret;
+      input.emitter!.type = "OTHER";
+      input.recipient!.company!.siret = company.siret;
       input.ecoOrganisme = {
         siret: ecoOrganisme.siret,
         name: ecoOrganisme.name
@@ -230,8 +230,8 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.emitter.type = "OTHER";
-      input.recipient.company.siret = company.siret;
+      input.emitter!.type = "OTHER";
+      input.recipient!.company!.siret = company.siret;
       input.ecoOrganisme = {
         siret: siretify(3),
         name: "Some Eco-Organisme"
@@ -264,7 +264,7 @@ describe("mutation / importPaperForm", () => {
         const processedAt = new Date("2021-01-04");
 
         const input = await getImportPaperFormInput();
-        input.recipient.company.siret = company.siret;
+        input.recipient!.company!.siret = company.siret;
         input.signingInfo.sentAt = format(sentAt, f) as any;
         input.receivedInfo.receivedAt = format(receivedAt, f) as any;
         input.receivedInfo.signedAt = format(signedAt, f) as any;
@@ -280,7 +280,7 @@ describe("mutation / importPaperForm", () => {
         expect(data.importPaperForm.status).toEqual(Status.PROCESSED);
         expect(data.importPaperForm.isImportedFromPaper).toEqual(true);
 
-        const form = await prisma.form.findUnique({
+        const form = await prisma.form.findUniqueOrThrow({
           where: { id: data.importPaperForm.id }
         });
         expect(form.status).toEqual(Status.PROCESSED);
@@ -297,7 +297,7 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.recipient.company.siret = company.siret;
+      input.recipient!.company!.siret = company.siret;
       input.processedInfo.processingOperationDone = "D 13";
       input.processedInfo.nextDestination = {
         company: {
@@ -328,7 +328,7 @@ describe("mutation / importPaperForm", () => {
       const { mutate } = makeClient(user);
 
       const input = await getImportPaperFormInput();
-      input.recipient.company.siret = company.siret;
+      input.recipient!.company!.siret = company.siret;
       input.processedInfo.noTraceability = true;
       input.processedInfo.processingOperationDone = "R 13";
       input.processedInfo.nextDestination = {
@@ -448,7 +448,7 @@ describe("mutation / importPaperForm", () => {
           }
         }
       });
-      const updatedForm = await prisma.form.findUnique({
+      const updatedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
 
@@ -545,7 +545,7 @@ describe("mutation / importPaperForm", () => {
           }
         }
       });
-      const updatedForm = await prisma.form.findUnique({
+      const updatedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
       expect(updatedForm.status).toEqual("PROCESSED");
@@ -804,7 +804,7 @@ describe("mutation / importPaperForm", () => {
         }
       });
 
-      const updatedForm = await prisma.form.findUnique({
+      const updatedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
       expect(updatedForm.status).toEqual(Status.NO_TRACEABILITY);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
@@ -83,7 +83,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const acceptedForm = await prisma.form.findUnique({
+    const acceptedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -131,7 +131,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted, still sent
     expect(frm.status).toBe("RECEIVED");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -170,7 +170,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted, still sent
     expect(frm.status).toBe("RECEIVED");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -208,7 +208,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     // form was refused
     expect(frm.status).toBe("REFUSED");
@@ -261,7 +261,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     // form is still sent
     expect(frm.status).toBe("RECEIVED");
@@ -307,7 +307,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted
     expect(frm.status).toBe("ACCEPTED");
     expect(frm.wasteAcceptationStatus).toBe("PARTIALLY_REFUSED");
@@ -366,7 +366,7 @@ describe("Test Form reception", () => {
         }
       });
 
-      const acceptedForm = await prisma.form.findUnique({
+      const acceptedForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
 
@@ -419,8 +419,8 @@ describe("Test Form reception", () => {
         grouping: {
           createMany: {
             data: [
-              { initialFormId: form1.id, quantity: form1.quantityReceived },
-              { initialFormId: form2.id, quantity: form2.quantityReceived }
+              { initialFormId: form1.id, quantity: form1.quantityReceived! },
+              { initialFormId: form2.id, quantity: form2.quantityReceived! }
             ]
           }
         }
@@ -445,17 +445,17 @@ describe("Test Form reception", () => {
       }
     );
 
-    const updatedForm1 = await prisma.form.findUnique({
+    const updatedForm1 = await prisma.form.findUniqueOrThrow({
       where: { id: form1.id }
     });
-    const updatedForm2 = await prisma.form.findUnique({
+    const updatedForm2 = await prisma.form.findUniqueOrThrow({
       where: { id: form2.id }
     });
     expect(updatedForm1.status).toEqual("AWAITING_GROUP");
     expect(updatedForm2.status).toEqual("AWAITING_GROUP");
 
     const groupement = await prisma.form
-      .findUnique({
+      .findUniqueOrThrow({
         where: { id: groupementForm.id }
       })
       .grouping({ include: { initialForm: true } });
@@ -588,7 +588,7 @@ describe("Test Form reception", () => {
 
       expect(data.markAsAccepted.status).toBe(Status.ACCEPTED);
 
-      const refreshedItem = await prisma.form.findUnique({
+      const refreshedItem = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_item.id }
       });
       expect(refreshedItem.status).toBe(Status.ACCEPTED);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -92,7 +92,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("PROCESSED");
@@ -133,7 +133,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const updatedForm = await prisma.form.findFirst({
+    const updatedForm = await prisma.form.findFirstOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -178,7 +178,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const updatedForm = await prisma.form.findFirst({
+    const updatedForm = await prisma.form.findFirstOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -225,7 +225,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const updatedForm = await prisma.form.findFirst({
+    const updatedForm = await prisma.form.findFirstOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -260,14 +260,14 @@ describe("mutation.markAsProcessed", () => {
       variables: {
         id: form.id,
         processedInfo: {
-          processingOperationDone: processingOperation.code,
+          processingOperationDone: processingOperation!.code,
           processedBy: "A simple bot",
           processedAt: "2018-12-11T00:00:00.000Z"
         }
       }
     });
     expect(processingOperationDescription).toBe(
-      processingOperation.description
+      processingOperation!.description
     );
   });
 
@@ -298,7 +298,7 @@ describe("mutation.markAsProcessed", () => {
     expect(errors[0].message).toBe(
       "Cette opération d’élimination / valorisation n'existe pas."
     );
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("ACCEPTED");
@@ -348,7 +348,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("AWAITING_GROUP");
@@ -439,7 +439,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
@@ -483,7 +483,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
@@ -518,7 +518,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
@@ -605,7 +605,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -650,7 +650,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -695,16 +695,16 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
 
     expect(resultingForm.status).toBe("FOLLOWED_WITH_PNTTD");
-    expect(resultingForm.forwardedIn.nextDestinationCompanyVatNumber).toEqual(
+    expect(resultingForm.forwardedIn!.nextDestinationCompanyVatNumber).toEqual(
       "IE9513674T"
     );
-    expect(resultingForm.forwardedIn.nextDestinationCompanyCountry).toBe("IE");
+    expect(resultingForm.forwardedIn!.nextDestinationCompanyCountry).toBe("IE");
   });
 
   it("should disallow a missing siret for any next destination", async () => {
@@ -769,7 +769,7 @@ describe("mutation.markAsProcessed", () => {
         grouping: {
           create: {
             initialFormId: appendix2.id,
-            quantity: appendix2.quantityReceived
+            quantity: appendix2.quantityReceived!
           }
         }
       }
@@ -789,7 +789,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const appendix2grouped = await prisma.form.findUnique({
+    const appendix2grouped = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id }
     });
     expect(appendix2grouped.status).toEqual("PROCESSED");
@@ -834,7 +834,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const appendix2grouped = await prisma.form.findUnique({
+    const appendix2grouped = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id }
     });
     expect(appendix2grouped.status).toEqual("AWAITING_GROUP");
@@ -866,7 +866,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe(Status.PROCESSED);
@@ -904,7 +904,7 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    expect(data.markAsProcessed.nextDestination.company).toBeNull();
+    expect(data.markAsProcessed.nextDestination!.company).toBeNull();
   });
 
   test("nextDestination.company should be mandatory when noTraceability is not true", async () => {
@@ -1005,7 +1005,7 @@ describe("mutation.markAsProcessed", () => {
       variables: {
         id: form.id,
         processedInfo: {
-          processingOperationDone: processingOperation.code,
+          processingOperationDone: processingOperation!.code,
           processedBy: "A simple bot",
           processedAt: "2018-12-11T00:00:00.000Z"
         }

--- a/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
@@ -74,7 +74,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     expect(frm.status).toBe("RECEIVED");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -123,7 +123,7 @@ describe("Test Form reception", () => {
 
     expect(errors).toBeUndefined();
 
-    const receivedForm = await prisma.form.findUnique({
+    const receivedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -161,7 +161,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     expect(frm.status).toBe("ACCEPTED");
     expect(frm.wasteAcceptationStatus).toBe("ACCEPTED");
@@ -202,7 +202,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted, still sent
     expect(frm.status).toBe("SENT");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -233,7 +233,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted, still sent
     expect(frm.status).toBe("SENT");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -264,7 +264,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     // form was refused
     expect(frm.status).toBe("REFUSED");
@@ -309,7 +309,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     // form is still sent
     expect(frm.status).toBe("SENT");
@@ -348,7 +348,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
     // form was not accepted
     expect(frm.status).toBe("ACCEPTED");
     expect(frm.wasteAcceptationStatus).toBe("PARTIALLY_REFUSED");
@@ -399,7 +399,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({
+    const frm = await prisma.form.findUniqueOrThrow({
       where: { id: alreadyReceivedForm.id }
     });
     // form is not updated by the last mutation
@@ -441,7 +441,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     expect(frm.status).toBe("SENT");
     expect(frm.wasteAcceptationStatus).toBe(null);
@@ -491,7 +491,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     expect(frm.status).toBe("ACCEPTED");
     expect(frm.wasteAcceptationStatus).toBe("ACCEPTED");
@@ -560,7 +560,7 @@ describe("Test Form reception", () => {
       }
     });
 
-    const frm = await prisma.form.findUnique({ where: { id: form.id } });
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
 
     expect(frm.status).toBe("ACCEPTED");
 
@@ -634,7 +634,9 @@ describe("Test Form reception", () => {
         }
       });
 
-      const frm = await prisma.form.findUnique({ where: { id: form.id } });
+      const frm = await prisma.form.findUniqueOrThrow({
+        where: { id: form.id }
+      });
 
       expect(frm.status).toBe(Status.RECEIVED);
       expect(frm.receivedAt).toEqual(receivedAt);
@@ -685,8 +687,8 @@ describe("Test Form reception", () => {
         grouping: {
           createMany: {
             data: [
-              { initialFormId: form1.id, quantity: form1.quantityReceived },
-              { initialFormId: form2.id, quantity: form2.quantityReceived }
+              { initialFormId: form1.id, quantity: form1.quantityReceived! },
+              { initialFormId: form2.id, quantity: form2.quantityReceived! }
             ]
           }
         }
@@ -711,10 +713,10 @@ describe("Test Form reception", () => {
       }
     );
 
-    const updatedForm1 = await prisma.form.findUnique({
+    const updatedForm1 = await prisma.form.findUniqueOrThrow({
       where: { id: form1.id }
     });
-    const updatedForm2 = await prisma.form.findUnique({
+    const updatedForm2 = await prisma.form.findUniqueOrThrow({
       where: { id: form2.id }
     });
     expect(updatedForm1.status).toEqual("AWAITING_GROUP");
@@ -923,7 +925,7 @@ describe("Test Form reception", () => {
 
       expect(data.markAsReceived.status).toBe(Status.ACCEPTED);
 
-      const refreshedItem = await prisma.form.findUnique({
+      const refreshedItem = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_item.id }
       });
       expect(refreshedItem.status).toBe(Status.ACCEPTED);
@@ -978,7 +980,7 @@ describe("Test Form reception", () => {
 
       expect(data.markAsReceived.status).toBe(Status.RECEIVED);
 
-      const refreshedItem = await prisma.form.findUnique({
+      const refreshedItem = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_item.id }
       });
       expect(refreshedItem.status).toBe(Status.RECEIVED);
@@ -1066,17 +1068,17 @@ describe("Test Form reception", () => {
       });
       expect(links.length).toBe(1);
 
-      const refreshedItem1 = await prisma.form.findUnique({
+      const refreshedItem1 = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_1.id }
       });
       expect(refreshedItem1.status).toBe(Status.RECEIVED);
 
-      const refreshedItem2 = await prisma.form.findUnique({
+      const refreshedItem2 = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_2.id }
       });
       expect(refreshedItem2.isDeleted).toBe(true);
 
-      const refreshedItem3 = await prisma.form.findUnique({
+      const refreshedItem3 = await prisma.form.findUniqueOrThrow({
         where: { id: appendix1_3.id }
       });
       expect(refreshedItem3.isDeleted).toBe(true);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -75,7 +75,7 @@ describe("Mutation markAsResealed", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("RESEALED");
@@ -141,24 +141,24 @@ describe("Mutation markAsResealed", () => {
       }
     );
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
     expect(resealedForm.status).toEqual("RESEALED");
-    expect(resealedForm.forwardedIn.emitterCompanySiret).toEqual(
+    expect(resealedForm.forwardedIn!.emitterCompanySiret).toEqual(
       collector.siret
     );
-    expect(resealedForm.forwardedIn.recipientCompanySiret).toEqual(
+    expect(resealedForm.forwardedIn!.recipientCompanySiret).toEqual(
       destination.siret
     );
-    expect(resealedForm.forwardedIn.transporterCompanySiret).toEqual(
+    expect(resealedForm.forwardedIn!.transporterCompanySiret).toEqual(
       transporter.siret
     );
-    expect(resealedForm.forwardedIn.readableId).toEqual(
+    expect(resealedForm.forwardedIn!.readableId).toEqual(
       `${form.readableId}-suite`
     );
-    expect(resealedForm.forwardedIn.status).toEqual("SEALED");
+    expect(resealedForm.forwardedIn!.status).toEqual("SEALED");
   });
 
   test("it should fail if temporary storage detail is incomplete", async () => {
@@ -199,7 +199,7 @@ describe("Mutation markAsResealed", () => {
       "Destinataire: Le siret de l'entreprise est obligatoire"
     );
     expect(errors[0].extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("TEMP_STORER_ACCEPTED");
@@ -243,7 +243,7 @@ describe("Mutation markAsResealed", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("RESEALED");
@@ -286,12 +286,12 @@ describe("Mutation markAsResealed", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
     expect(resealedForm.status).toEqual("RESEALED");
-    expect(resealedForm.forwardedIn.transporterCompanySiret).toEqual(
+    expect(resealedForm.forwardedIn!.transporterCompanySiret).toEqual(
       transporter.siret
     );
   });
@@ -381,7 +381,7 @@ describe("Mutation markAsResealed", () => {
       }
     });
     const tempStorage = await prisma.form
-      .findUnique({
+      .findUniqueOrThrow({
         where: { id: form.id }
       })
       .forwardedIn();
@@ -442,7 +442,7 @@ describe("Mutation markAsResealed", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("RESEALED");

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResent.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResent.integration.ts
@@ -89,7 +89,7 @@ describe("Mutation markAsResent", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("RESENT");
@@ -138,7 +138,7 @@ describe("Mutation markAsResent", () => {
       "Destinataire: Le siret de l'entreprise est obligatoire"
     );
     expect(errors[0].extensions.code).toEqual(ErrorCode.BAD_USER_INPUT);
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("TEMP_STORER_ACCEPTED");
@@ -188,7 +188,7 @@ describe("Mutation markAsResent", () => {
       }
     });
 
-    const resealedForm = await prisma.form.findUnique({
+    const resealedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resealedForm.status).toEqual("RESENT");

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -159,7 +159,7 @@ describe("Mutation.markAsSealed", () => {
         }[role]);
 
       const { user, company } = await userWithCompanyFactory("MEMBER", {
-        companyTypes: { set: [companyType(role)] }
+        companyTypes: { set: [companyType(role) as CompanyType] }
       });
 
       let form = await formFactory({
@@ -192,7 +192,7 @@ describe("Mutation.markAsSealed", () => {
         }
       });
 
-      form = await prisma.form.findUnique({
+      form = await prisma.form.findUniqueOrThrow({
         where: { id: form.id },
         include: { forwardedIn: true }
       });
@@ -222,7 +222,7 @@ describe("Mutation.markAsSealed", () => {
     const eo = await prisma.ecoOrganisme.create({
       data: {
         name: "An EO",
-        siret: ecoOrganismeCompany.siret,
+        siret: ecoOrganismeCompany.siret!,
         address: "An address"
       }
     });
@@ -246,7 +246,7 @@ describe("Mutation.markAsSealed", () => {
       }
     });
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -261,7 +261,7 @@ describe("Mutation.markAsSealed", () => {
     await prisma.ecoOrganisme.create({
       data: {
         name: eo.name,
-        siret: eo.siret,
+        siret: eo.siret!,
         address: "An address"
       }
     });
@@ -285,7 +285,7 @@ describe("Mutation.markAsSealed", () => {
       }
     });
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -300,7 +300,7 @@ describe("Mutation.markAsSealed", () => {
     await prisma.ecoOrganisme.create({
       data: {
         name: eo.name,
-        siret: eo.siret,
+        siret: eo.siret!,
         address: "An address"
       }
     });
@@ -325,7 +325,7 @@ describe("Mutation.markAsSealed", () => {
       }
     });
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -340,7 +340,7 @@ describe("Mutation.markAsSealed", () => {
     await prisma.ecoOrganisme.create({
       data: {
         name: eo.name,
-        siret: eo.siret,
+        siret: eo.siret!,
         address: "An address"
       }
     });
@@ -364,7 +364,7 @@ describe("Mutation.markAsSealed", () => {
       }
     });
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -395,7 +395,7 @@ describe("Mutation.markAsSealed", () => {
     });
     expect(errors[0].extensions.code).toBe("FORBIDDEN");
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toEqual("DRAFT");
@@ -430,7 +430,7 @@ describe("Mutation.markAsSealed", () => {
       "Émetteur: Le contact dans l'entreprise est obligatoire";
     expect(errors[0].message).toBe(errMessage);
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -477,7 +477,7 @@ describe("Mutation.markAsSealed", () => {
           "Le code déchet n'est pas reconnu comme faisant partie de la liste officielle du code de l'environnement."
         )
       );
-      form = await prisma.form.findUnique({
+      form = await prisma.form.findUniqueOrThrow({
         where: { id: form.id },
         include: { forwardedIn: true }
       });
@@ -671,7 +671,7 @@ describe("Mutation.markAsSealed", () => {
         grouping: {
           create: {
             initialFormId: appendix2.id,
-            quantity: appendix2.quantityReceived
+            quantity: appendix2.quantityReceived!
           }
         }
       }
@@ -683,7 +683,7 @@ describe("Mutation.markAsSealed", () => {
       variables: { id: form.id }
     });
 
-    const appendix2grouped = await prisma.form.findUnique({
+    const appendix2grouped = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id }
     });
     expect(appendix2grouped.status).toEqual("GROUPED");
@@ -928,12 +928,12 @@ describe("Mutation.markAsSealed", () => {
     expect(sendMailSpy).toHaveBeenCalledWith(
       renderMail(contentAwaitsGuest, {
         to: [
-          { email: form.emitterCompanyMail, name: form.emitterCompanyContact }
+          { email: form.emitterCompanyMail!, name: form.emitterCompanyContact! }
         ],
         variables: {
           company: {
-            siret: form.emitterCompanySiret,
-            name: form.emitterCompanyName
+            siret: form.emitterCompanySiret!,
+            name: form.emitterCompanyName!
           }
         }
       })
@@ -1242,7 +1242,7 @@ describe("Mutation.markAsSealed", () => {
         }[role]);
 
       const { user, company } = await userWithCompanyFactory("MEMBER", {
-        companyTypes: { set: [companyType(role)] }
+        companyTypes: { set: [companyType(role) as CompanyType] }
       });
       const { siret: recipientCompanySiret } = await destinationFactory();
 

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
@@ -117,7 +117,7 @@ describe("{ mutation { markAsTempStored } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -171,7 +171,7 @@ describe("{ mutation { markAsTempStored } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -220,7 +220,7 @@ describe("{ mutation { markAsTempStored } }", () => {
       }
     });
 
-    const updatedForm = await prisma.form.findUnique({
+    const updatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -264,7 +264,7 @@ describe("{ mutation { markAsTempStored } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -369,7 +369,7 @@ describe("{ mutation { markAsTempStored } }", () => {
         }
       });
 
-      const formAfterMutation = await prisma.form.findUnique({
+      const formAfterMutation = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
 
@@ -424,11 +424,11 @@ describe("{ mutation { markAsTempStored } }", () => {
             data: [
               {
                 initialFormId: form1.id,
-                quantity: form1.quantityReceived
+                quantity: form1.quantityReceived!
               },
               {
                 initialFormId: form2.id,
-                quantity: form2.quantityReceived
+                quantity: form2.quantityReceived!
               }
             ]
           }
@@ -455,17 +455,17 @@ describe("{ mutation { markAsTempStored } }", () => {
       }
     });
 
-    const updatedForm1 = await prisma.form.findUnique({
+    const updatedForm1 = await prisma.form.findUniqueOrThrow({
       where: { id: form1.id }
     });
-    const updatedForm2 = await prisma.form.findUnique({
+    const updatedForm2 = await prisma.form.findUniqueOrThrow({
       where: { id: form2.id }
     });
     expect(updatedForm1.status).toEqual("AWAITING_GROUP");
     expect(updatedForm2.status).toEqual("AWAITING_GROUP");
 
     const groupement = await prisma.form
-      .findUnique({
+      .findUniqueOrThrow({
         where: { id: groupementForm.id }
       })
       .grouping({ include: { initialForm: true } });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
@@ -124,7 +124,7 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -179,7 +179,7 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -241,7 +241,7 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
       }
     });
 
-    const formAfterMutation = await prisma.form.findUnique({
+    const formAfterMutation = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -293,8 +293,8 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
         grouping: {
           createMany: {
             data: [
-              { initialFormId: form1.id, quantity: form1.quantityReceived },
-              { initialFormId: form2.id, quantity: form2.quantityReceived }
+              { initialFormId: form1.id, quantity: form1.quantityReceived! },
+              { initialFormId: form2.id, quantity: form2.quantityReceived! }
             ]
           }
         }
@@ -320,17 +320,17 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
       }
     });
 
-    const updatedForm1 = await prisma.form.findUnique({
+    const updatedForm1 = await prisma.form.findUniqueOrThrow({
       where: { id: form1.id }
     });
-    const updatedForm2 = await prisma.form.findUnique({
+    const updatedForm2 = await prisma.form.findUniqueOrThrow({
       where: { id: form2.id }
     });
     expect(updatedForm1.status).toEqual("AWAITING_GROUP");
     expect(updatedForm2.status).toEqual("AWAITING_GROUP");
 
     const groupement = await prisma.form
-      .findUnique({
+      .findUniqueOrThrow({
         where: { id: groupementForm.id }
       })
       .grouping({ include: { initialForm: true } });

--- a/back/src/forms/resolvers/mutations/__tests__/markSegmentAsReadyToTakeOver.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markSegmentAsReadyToTakeOver.integration.ts
@@ -60,9 +60,10 @@ describe("{ mutation { markSegmentAsReadyToTakeOver} }", () => {
         }`
     );
 
-    const readyToTakeOverSegment = await prisma.transportSegment.findUnique({
-      where: { id: segment.id }
-    });
+    const readyToTakeOverSegment =
+      await prisma.transportSegment.findUniqueOrThrow({
+        where: { id: segment.id }
+      });
     expect(readyToTakeOverSegment.readyToTakeOver).toBe(true);
   });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/prepareSegment.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/prepareSegment.integration.ts
@@ -60,7 +60,7 @@ describe("{ mutation { prepareSegment } }", () => {
       }`
     );
 
-    const segment = await prisma.transportSegment.findUnique({
+    const segment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: data.prepareSegment.id }
     });
 
@@ -109,7 +109,7 @@ describe("{ mutation { prepareSegment } }", () => {
       }`
     );
 
-    const segment = await prisma.transportSegment.findUnique({
+    const segment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: data.prepareSegment.id }
     });
 
@@ -186,8 +186,10 @@ describe("{ mutation { prepareSegment } }", () => {
       }`
     );
 
-    expect(data.prepareSegment.transporter.company.siret).toBe(company2.siret);
-    const segment = await prisma.transportSegment.findFirst({
+    expect(data.prepareSegment.transporter!.company!.siret).toBe(
+      company2.siret
+    );
+    const segment = await prisma.transportSegment.findFirstOrThrow({
       where: { form: { id: form.id } }
     });
 
@@ -241,7 +243,9 @@ describe("{ mutation { prepareSegment } }", () => {
       }`
     );
 
-    expect(data2.prepareSegment.transporter.company.siret).toBe(company3.siret);
+    expect(data2.prepareSegment.transporter!.company!.siret).toBe(
+      company3.siret
+    );
     const { errors: markReadyErrors2 } = await mutate2(
       `mutation  {
         markSegmentAsReadyToTakeOver(id:"${data2.prepareSegment.id}") {
@@ -328,7 +332,7 @@ describe("{ mutation { prepareSegment } }", () => {
       }`
     );
     expect(errors).toBeUndefined();
-    expect(data3.prepareSegment.transporter.company.siret).toBe(
+    expect(data3.prepareSegment.transporter!.company!.siret).toBe(
       transporterCompanySiret
     );
   });

--- a/back/src/forms/resolvers/mutations/__tests__/signTransportForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signTransportForm.integration.ts
@@ -482,7 +482,7 @@ describe("signTransportForm", () => {
 
       expect(data.signTransportForm.status).toBe(Status.SENT);
 
-      const appendix1Container = await prisma.form.findUnique({
+      const appendix1Container = await prisma.form.findUniqueOrThrow({
         where: { id: container.id }
       });
       expect(appendix1Container.status).toBe(Status.SENT);
@@ -552,7 +552,7 @@ describe("signTransportForm", () => {
       });
 
       expect(data.signTransportForm.status).toBe(Status.SENT);
-      const appendix1Container = await prisma.form.findUnique({
+      const appendix1Container = await prisma.form.findUniqueOrThrow({
         where: { id: container.id }
       });
       expect(appendix1Container.status).toBe(Status.SENT);
@@ -664,7 +664,7 @@ describe("signTransportForm", () => {
 
       expect(data.signTransportForm.status).toBe(Status.SENT);
 
-      const appendix1Container = await prisma.form.findUnique({
+      const appendix1Container = await prisma.form.findUniqueOrThrow({
         where: { id: container.id }
       });
       expect(appendix1Container.status).toBe(Status.SENT);
@@ -721,7 +721,7 @@ describe("signTransportForm", () => {
 
       expect(data.signTransportForm.status).toBe(Status.SENT);
 
-      const appendix1Container = await prisma.form.findUnique({
+      const appendix1Container = await prisma.form.findUniqueOrThrow({
         where: { id: container.id }
       });
       expect(appendix1Container.status).toBe(Status.SENT);

--- a/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signedByTransporter.integration.ts
@@ -67,7 +67,7 @@ describe("Mutation.signedByTransporter", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(resultingForm.status).toBe("SENT");
@@ -499,7 +499,7 @@ describe("Mutation.signedByTransporter", () => {
       }
     });
 
-    const resultingForm = await prisma.form.findUnique({
+    const resultingForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     const resultingFullForm = await getFullForm(resultingForm);
@@ -559,7 +559,7 @@ describe("Mutation.signedByTransporter", () => {
         }
       );
 
-      const resultingForm = await prisma.form.findUnique({
+      const resultingForm = await prisma.form.findUniqueOrThrow({
         where: { id: form.id }
       });
       expect(resultingForm.status).toEqual(Status.SENT);

--- a/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
@@ -101,7 +101,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: company.id,
-        approvals: { create: { approverSiret: companyOfSomeoneElse.siret } },
+        approvals: { create: { approverSiret: companyOfSomeoneElse.siret! } },
         comment: ""
       }
     });
@@ -134,7 +134,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: ""
       }
     });
@@ -168,8 +168,8 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
         authoringCompanyId: secondCompany.id,
         approvals: {
           create: [
-            { approverSiret: company.siret },
-            { approverSiret: thirdCompany.siret }
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
           ]
         },
         comment: ""
@@ -190,13 +190,13 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
     expect(
       data.submitFormRevisionRequestApproval.approvals.find(
         val => val.approverSiret === company.siret
-      ).status
+      )!.status
     ).toBe("ACCEPTED");
 
     expect(
       data.submitFormRevisionRequestApproval.approvals.find(
         val => val.approverSiret === thirdCompany.siret
-      ).status
+      )!.status
     ).toBe("PENDING");
   });
 
@@ -217,8 +217,8 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
         authoringCompanyId: secondCompany.id,
         approvals: {
           create: [
-            { approverSiret: company.siret },
-            { approverSiret: thirdCompany.siret }
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
           ]
         },
         comment: ""
@@ -237,7 +237,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
     expect(
       data.submitFormRevisionRequestApproval.approvals.find(
         val => val.approverSiret === company.siret
-      ).status
+      )!.status
     ).toBe("REFUSED");
     expect(data.submitFormRevisionRequestApproval.status).toBe("REFUSED");
   });
@@ -258,7 +258,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         comment: ""
       }
     });
@@ -292,7 +292,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteDetailsCode: "01 03 08",
         comment: ""
       }
@@ -308,7 +308,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: bsdd.id }
     });
 
@@ -338,7 +338,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: exutoire.id,
-        approvals: { create: { approverSiret: emitter.siret } },
+        approvals: { create: { approverSiret: emitter.siret! } },
         recipientCap: "TTR CAP",
         processingOperationDone: "R 3",
         quantityReceived: 50,
@@ -359,20 +359,20 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: bsdd.id },
       include: { forwardedIn: true }
     });
 
     expect(updatedBsdd.recipientCap).toEqual("TTR CAP");
-    expect(updatedBsdd.forwardedIn.recipientCap).toEqual("EXUTOIRE CAP");
+    expect(updatedBsdd.forwardedIn!.recipientCap).toEqual("EXUTOIRE CAP");
     expect(updatedBsdd.quantityReceived).toEqual(40);
-    expect(updatedBsdd.forwardedIn.processingOperationDone).toBe("R 3");
-    expect(updatedBsdd.forwardedIn.processingOperationDescription).toBe(
+    expect(updatedBsdd.forwardedIn!.processingOperationDone).toBe("R 3");
+    expect(updatedBsdd.forwardedIn!.processingOperationDescription).toBe(
       "Recyclage"
     );
-    expect(updatedBsdd.forwardedIn.wasteDetailsQuantity).toEqual(40);
-    expect(updatedBsdd.forwardedIn.quantityReceived).toBe(50);
+    expect(updatedBsdd.forwardedIn!.wasteDetailsQuantity).toEqual(40);
+    expect(updatedBsdd.forwardedIn!.quantityReceived).toBe(50);
   });
 
   it("should not edit bsdd when refused", async () => {
@@ -392,7 +392,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         wasteDetailsCode: "01 03 08",
         comment: ""
       }
@@ -408,7 +408,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: bsdd.id }
     });
 
@@ -434,7 +434,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         processingOperationDone: "R 13",
         comment: ""
       }
@@ -450,7 +450,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: bsdd.id }
     });
 
@@ -476,7 +476,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: bsdd.id,
         authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         processingOperationDone: "D 5",
         comment: ""
       }
@@ -492,7 +492,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: bsdd.id }
     });
 
@@ -518,7 +518,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
         grouping: {
           create: {
             initialFormId: appendix2.id,
-            quantity: appendix2.quantityReceived
+            quantity: appendix2.quantityReceived!
           }
         }
       }
@@ -545,7 +545,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const appendix2grouped = await prisma.form.findUnique({
+    const appendix2grouped = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id }
     });
     expect(appendix2grouped.status).toEqual("GROUPED");
@@ -554,7 +554,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       data: {
         bsddId: form.id,
         authoringCompanyId: company.id,
-        approvals: { create: { approverSiret: company.siret } },
+        approvals: { create: { approverSiret: company.siret! } },
         isCanceled: true,
         comment: "test cancel"
       }
@@ -570,7 +570,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       }
     });
 
-    const updatedBsdd = await prisma.form.findUnique({
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
       where: { id: appendix2.id }
     });
 
@@ -602,7 +602,7 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
           isCanceled: true,
           bsddId: bsdd.id,
           authoringCompanyId: companyOfSomeoneElse.id,
-          approvals: { create: { approverSiret: company.siret } },
+          approvals: { create: { approverSiret: company.siret! } },
           comment: ""
         }
       });

--- a/back/src/forms/resolvers/mutations/__tests__/takeOverSegment.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/takeOverSegment.integration.ts
@@ -68,17 +68,17 @@ describe("{ mutation { takeOverSegment } }", () => {
     );
 
     // segment take over fields are filled
-    const takenOverSegment = await prisma.transportSegment.findUnique({
+    const takenOverSegment = await prisma.transportSegment.findUniqueOrThrow({
       where: { id: segment.id }
     });
 
-    expect(takenOverSegment.takenOverAt.toISOString()).toBe(
+    expect(takenOverSegment.takenOverAt!.toISOString()).toBe(
       "2020-04-28T00:00:00.000Z"
     );
     expect(takenOverSegment.takenOverBy).toBe("transporter suivant");
 
     // form next and currentTransporterSiret have been updated
-    const udpatedForm = await prisma.form.findUnique({
+    const udpatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
     expect(udpatedForm.currentTransporterSiret).toBe(

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -346,7 +346,7 @@ describe("Mutation.updateForm", () => {
       data: {
         address: "",
         name: eo.name,
-        siret: eo.siret
+        siret: eo.siret!
       }
     });
     const form = await formFactory({
@@ -448,7 +448,7 @@ describe("Mutation.updateForm", () => {
       data: {
         address: "",
         name: originalEO.name,
-        siret: originalEO.siret
+        siret: originalEO.siret!
       }
     });
     const form = await formFactory({
@@ -469,7 +469,7 @@ describe("Mutation.updateForm", () => {
       data: {
         address: "",
         name: newEO.name,
-        siret: newEO.siret
+        siret: newEO.siret!
       }
     });
 
@@ -489,7 +489,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.ecoOrganisme.siret).toBe(newEO.siret);
+    expect(data.updateForm.ecoOrganisme!.siret).toBe(newEO.siret);
   });
 
   it("should remove the eco-organisme", async () => {
@@ -503,7 +503,7 @@ describe("Mutation.updateForm", () => {
       data: {
         address: "",
         name: eo.name,
-        siret: eo.siret
+        siret: eo.siret!
       }
     });
     const form = await formFactory({
@@ -810,7 +810,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.temporaryStorageDetail.destination).toMatchObject(
+    expect(data.updateForm.temporaryStorageDetail!.destination).toMatchObject(
       updateFormInput.temporaryStorageDetail.destination
     );
   });
@@ -839,7 +839,7 @@ describe("Mutation.updateForm", () => {
     });
 
     const tempStorage = await prisma.form
-      .findUnique({
+      .findUniqueOrThrow({
         where: { id: form.id }
       })
       .forwardedIn();
@@ -880,7 +880,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.temporaryStorageDetail.destination).toMatchObject(
+    expect(data.updateForm.temporaryStorageDetail!.destination).toMatchObject(
       updateFormInput.temporaryStorageDetail.destination
     );
   });
@@ -942,7 +942,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.recipient.company).toMatchObject(
+    expect(data.updateForm.recipient!.company).toMatchObject(
       updateFormInput.recipient.company
     );
   });
@@ -975,7 +975,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.recipient.company).toMatchObject(
+    expect(data.updateForm.recipient!.company).toMatchObject(
       updateFormInput.recipient.company
     );
   });
@@ -1079,7 +1079,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1097,13 +1097,13 @@ describe("Mutation.updateForm", () => {
     });
 
     // Old appendix form is back to AWAITING_GROUP
-    const oldAppendix2Form = await prisma.form.findUnique({
+    const oldAppendix2Form = await prisma.form.findUniqueOrThrow({
       where: { id: appendixForm.id }
     });
     expect(oldAppendix2Form.status).toBe("AWAITING_GROUP");
 
     // New appendix form is now GROUPED
-    const newAppendix2Form = await prisma.form.findUnique({
+    const newAppendix2Form = await prisma.form.findUniqueOrThrow({
       where: { id: toBeAppendixForm.id }
     });
     expect(newAppendix2Form.status).toBe("GROUPED");
@@ -1130,7 +1130,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1147,7 +1147,7 @@ describe("Mutation.updateForm", () => {
         }
       }
     });
-    expect(data.updateForm.wasteDetails.code).toEqual("01 03 04*");
+    expect(data.updateForm.wasteDetails!.code).toEqual("01 03 04*");
   });
   it("should be impossible to update emitter siret on a form containing appendix 2", async () => {
     const { user: transporterUser, company: transporter } =
@@ -1176,7 +1176,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1226,7 +1226,7 @@ describe("Mutation.updateForm", () => {
           grouping: {
             create: {
               initialFormId: initialAppendix2.id,
-              quantity: initialAppendix2.quantityReceived
+              quantity: initialAppendix2.quantityReceived!
             }
           }
         }
@@ -1279,7 +1279,7 @@ describe("Mutation.updateForm", () => {
           grouping: {
             create: {
               initialFormId: initialAppendix2.id,
-              quantity: initialAppendix2.quantityReceived
+              quantity: initialAppendix2.quantityReceived!
             }
           }
         }
@@ -1335,7 +1335,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1480,7 +1480,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1524,7 +1524,7 @@ describe("Mutation.updateForm", () => {
         grouping: {
           create: {
             initialFormId: appendixForm.id,
-            quantity: appendixForm.quantityReceived
+            quantity: appendixForm.quantityReceived!
           }
         }
       }
@@ -1790,7 +1790,7 @@ describe("Mutation.updateForm", () => {
     const { data } = await mutate<Pick<Mutation, "updateForm">>(UPDATE_FORM, {
       variables: { updateFormInput }
     });
-    expect(data.updateForm.wasteDetails.isDangerous).toBe(true);
+    expect(data.updateForm.wasteDetails!.isDangerous).toBe(true);
   });
 
   it("should perform update in transaction", async () => {
@@ -1829,7 +1829,7 @@ describe("Mutation.updateForm", () => {
       })
     ]);
 
-    const updatedForm = await prisma.form.findUnique({
+    const updatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id }
     });
 
@@ -1865,7 +1865,7 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    const updatedForm = await prisma.form.findUnique({
+    const updatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: data.updateForm.id }
     });
 
@@ -1967,9 +1967,9 @@ describe("Mutation.updateForm", () => {
       }
     });
 
-    expect(data.updateForm.grouping.length).toBe(1);
+    expect(data.updateForm.grouping!.length).toBe(1);
 
-    const updatedAppendix1_1 = await prisma.form.findUnique({
+    const updatedAppendix1_1 = await prisma.form.findUniqueOrThrow({
       where: { id: appendix1_1.id },
       include: { groupedIn: true }
     });

--- a/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateTransporterFields.integration.ts
@@ -39,7 +39,7 @@ describe("Forms -> updateTransporterFields mutation", () => {
   `;
       await mutate(mutation);
 
-      form = await prisma.form.findUnique({
+      form = await prisma.form.findUniqueOrThrow({
         where: { id: form.id },
         include: { forwardedIn: true }
       });
@@ -72,7 +72,7 @@ describe("Forms -> updateTransporterFields mutation", () => {
   `;
       await mutate(mutation);
 
-      form = await prisma.form.findUnique({
+      form = await prisma.form.findUniqueOrThrow({
         where: { id: form.id },
         include: { forwardedIn: true }
       });
@@ -106,7 +106,7 @@ describe("Forms -> updateTransporterFields mutation", () => {
       "Ce champ n'est pas modifiable sur un bordereau qui n'est pas en statut scellé ou signé par le producteur"
     );
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });
@@ -141,7 +141,7 @@ describe("Forms -> updateTransporterFields mutation", () => {
       "Vous n'êtes pas transporteur de ce bordereau."
     );
 
-    form = await prisma.form.findUnique({
+    form = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { forwardedIn: true }
     });

--- a/back/src/forms/resolvers/queries/formsRegister.ts
+++ b/back/src/forms/resolvers/queries/formsRegister.ts
@@ -44,7 +44,7 @@ const formsRegisterResolver: QueryResolvers["formsRegister"] = async (
   const wasteRegistryArgs:
     | QueryWastesRegistryCsvArgs
     | QueryWastesRegistryXlsArgs = {
-    registryType: exportTypeToRegisterType[args.exportType],
+    registryType: exportTypeToRegisterType[args.exportType ?? "ALL"],
     sirets: args.sirets,
     where: {
       bsdType: { _eq: "BSDD" },

--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -22,8 +22,8 @@ export async function heapSnapshotToS3Router() {
         endpoint: process.env.S3_ENDPOINT,
         region: process.env.S3_REGION,
         credentials: {
-          accessKeyId: process.env.S3_ACCESS_KEY_ID,
-          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY
+          accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+          secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!
         }
       }),
       params: {
@@ -35,9 +35,11 @@ export async function heapSnapshotToS3Router() {
     });
 
     parallelUploads3.on("httpUploadProgress", progress => {
-      console.log(
-        `Uploaded: ${Math.round((progress.loaded * 100) / progress.total)}%`
-      );
+      if (progress.loaded && progress.total) {
+        console.log(
+          `Uploaded: ${Math.round((progress.loaded * 100) / progress.total)}%`
+        );
+      }
     });
 
     await parallelUploads3.done();

--- a/back/src/mailer/backends/sendInBlueBackend.ts
+++ b/back/src/mailer/backends/sendInBlueBackend.ts
@@ -1,4 +1,4 @@
-import { Mail, Contact } from "../types";
+import { Mail, Contact, Recipient } from "../types";
 import axios from "axios";
 import * as Sentry from "@sentry/node";
 import logger from "../../logging/logger";
@@ -19,7 +19,7 @@ const SIB_CONTACT_URL = `${SIB_BASE_URL}/contacts`;
 export const MESSAGE_VERSIONS_BULK_LIMIT = 950;
 
 const headers = {
-  "api-key": SIB_APIKEY,
+  "api-key": SIB_APIKEY!,
   "Content-Type": "application/json"
 };
 const sendInBlueBackend = {
@@ -72,7 +72,7 @@ const sendInBlueBackend = {
     });
     return req
       .then(() => {
-        const allRecipients = [];
+        const allRecipients: Recipient[] = [];
 
         if (mail.to) {
           allRecipients.push(...mail.to);
@@ -99,7 +99,7 @@ const sendInBlueBackend = {
           Sentry.captureException(err, {
             tags: {
               Mailer: "SendInBlue",
-              Recipients: mail.to.map(el => el.email).join(" ")
+              Recipients: mail.to?.map(el => el.email).join(" ")
             }
           });
         } else {

--- a/back/src/mailer/helpers.ts
+++ b/back/src/mailer/helpers.ts
@@ -3,7 +3,9 @@ const unwantedChars = /\*|\//g;
  * Remove * and / special chars appearing on some individual companies
  * @param name string
  */
-export const cleanupSpecialChars = (name: string): string => {
+export const cleanupSpecialChars = (
+  name: string | null | undefined
+): string => {
   if (!name) {
     return "";
   }
@@ -35,12 +37,12 @@ export const toFrFormat = (date: Date): string => {
 /**
  * Will split an array into smaller arrays of max size maxChunkSize
  */
-export const splitArrayIntoChunks = (arr: any[], maxChunkSize: number) => {
+export const splitArrayIntoChunks = <T>(arr: T[], maxChunkSize: number) => {
   if (!arr.length) {
     return [[]];
   }
 
-  const result = [];
+  const result: T[][] = [];
 
   for (let i = 0; i < arr.length; i += maxChunkSize) {
     const chunk = arr.slice(i, i + maxChunkSize);

--- a/back/src/mailer/index.ts
+++ b/back/src/mailer/index.ts
@@ -6,7 +6,7 @@ const backends = {
   sendinblue: sendInBlueBackend
 };
 
-export const backend = backends[process.env.EMAIL_BACKEND];
+export const backend = backends[process.env.EMAIL_BACKEND!];
 
 if (!backend) {
   throw new Error("Invalid email backend configuration: EMAIL_BACKEND");

--- a/back/src/mailer/templates/__tests__/templates.test.ts
+++ b/back/src/mailer/templates/__tests__/templates.test.ts
@@ -90,13 +90,13 @@ describe("templates", () => {
       to
     });
     expect(rendered.body).toContain(form.recipientCompanyName);
-    expect(rendered.body).toContain(toFrFormat(form.receivedAt));
+    expect(rendered.body).toContain(toFrFormat(form.receivedAt!));
     expect(rendered.body).toContain(form.emitterCompanyName);
     expect(rendered.body).toContain(form.emitterCompanyAddress);
     expect(rendered.body).toContain(form.readableId);
     expect(rendered.body).toContain(form.wasteDetailsName);
     expect(rendered.body).toContain(form.wasteDetailsCode);
-    expect(rendered.body).toContain(form.wasteDetailsQuantity.toString());
+    expect(rendered.body).toContain(form.wasteDetailsQuantity!.toString());
     expect(rendered.body).toContain(form.wasteRefusalReason);
     expect(rendered.body).toContain(form.transporterCompanyName);
     expect(rendered.body).toContain(form.sentBy);
@@ -172,13 +172,13 @@ describe("templates", () => {
       to
     });
     expect(rendered.body).toContain(form.recipientCompanyName);
-    expect(rendered.body).toContain(toFrFormat(form.receivedAt));
+    expect(rendered.body).toContain(toFrFormat(form.receivedAt!));
     expect(rendered.body).toContain(form.emitterCompanyName);
     expect(rendered.body).toContain(form.emitterCompanyAddress);
     expect(rendered.body).toContain(form.readableId);
     expect(rendered.body).toContain(form.wasteDetailsName);
     expect(rendered.body).toContain(form.wasteDetailsCode);
-    expect(rendered.body).toContain(form.wasteDetailsQuantity.toString());
+    expect(rendered.body).toContain(form.wasteDetailsQuantity!.toString());
     expect(rendered.body).toContain(form.wasteRefusalReason);
     expect(rendered.body).toContain(form.transporterCompanyName);
     expect(rendered.body).toContain(form.sentBy);

--- a/back/src/mailer/templates/index.ts
+++ b/back/src/mailer/templates/index.ts
@@ -98,7 +98,7 @@ export const formPartiallyRefused: MailTemplate<{ form: Form }> = {
           form.transporterCompanyName
         ),
         quantityPartiallyRefused:
-          form.wasteDetailsQuantity - form.quantityReceived,
+          form.wasteDetailsQuantity! - form.quantityReceived!,
         receivedAt: form.receivedAt
           ? toFrFormat(new Date(form.receivedAt))
           : "",

--- a/back/src/mailer/templates/provider/templateIds.ts
+++ b/back/src/mailer/templates/provider/templateIds.ts
@@ -14,17 +14,17 @@ type templateInterface = {
 };
 
 const templateIds: templateInterface = {
-  [TemplateNames.LAYOUT]: parseInt(process.env.MAIN_TEMPLATE_ID, 10),
+  [TemplateNames.LAYOUT]: parseInt(process.env.MAIN_TEMPLATE_ID!, 10),
   [TemplateNames.FIRST_ONBOARDING]: parseInt(
-    process.env.FIRST_ONBOARDING_TEMPLATE_ID,
+    process.env.FIRST_ONBOARDING_TEMPLATE_ID!,
     10
   ),
   [TemplateNames.PRODUCER_SECOND_ONBOARDING]: parseInt(
-    process.env.PRODUCER_SECOND_ONBOARDING_TEMPLATE_ID,
+    process.env.PRODUCER_SECOND_ONBOARDING_TEMPLATE_ID!,
     10
   ),
   [TemplateNames.PROFESSIONAL_SECOND_ONBOARDING]: parseInt(
-    process.env.PROFESSIONAL_SECOND_ONBOARDING_TEMPLATE_ID,
+    process.env.PROFESSIONAL_SECOND_ONBOARDING_TEMPLATE_ID!,
     10
   )
 };

--- a/back/src/mailer/templates/renderers.ts
+++ b/back/src/mailer/templates/renderers.ts
@@ -56,9 +56,8 @@ export function renderMail<V>(
 ): Mail {
   const { prepareVariables } = mailTemplate;
 
-  const preparedVariables = prepareVariables
-    ? prepareVariables(variables)
-    : variables;
+  const preparedVariables =
+    prepareVariables && variables ? prepareVariables(variables) : variables;
 
   const vars = { ...preparedVariables, ...context };
 

--- a/back/src/oauth/oauth2.ts
+++ b/back/src/oauth/oauth2.ts
@@ -114,6 +114,6 @@ oauth2server.exchange(
     // Add custom params
     const params = { user: { name: grant.user.name, email: grant.user.email } };
 
-    return done(null, clearToken, null, params);
+    return done(null, clearToken, undefined, params);
   })
 );

--- a/back/src/oauth/token.ts
+++ b/back/src/oauth/token.ts
@@ -42,7 +42,7 @@ export const buildIdToken = async (
   grant: Grant & { application: Application; user: User }
 ): Promise<string> => {
   const privateKey = await jose.importPKCS8(
-    OIDC_PRIVATE_KEY,
+    OIDC_PRIVATE_KEY!,
     TOKEN_SIGNATURE_ALG
   );
 

--- a/back/src/prisma.ts
+++ b/back/src/prisma.ts
@@ -51,7 +51,7 @@ prisma.$on("query", e => {
 
 function getDbUrl() {
   try {
-    const dbUrl = new URL(process.env.DATABASE_URL);
+    const dbUrl = new URL(process.env.DATABASE_URL!);
     dbUrl.searchParams.set("schema", "default$default");
 
     return unescape(dbUrl.href); // unescape needed because of the `$`

--- a/back/src/queue/consumerIndexation.ts
+++ b/back/src/queue/consumerIndexation.ts
@@ -12,7 +12,7 @@ function startConsumers() {
 
   indexQueue.process(
     "indexChunk",
-    parseInt(process.env.BULK_INDEX_JOB_CONCURRENCY, 10) || 1,
+    parseInt(process.env.BULK_INDEX_JOB_CONCURRENCY!, 10) || 1,
     indexChunkBsdJob
   );
   indexQueue.process("indexAllInBulk", indexAllInBulk);

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -13,7 +13,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   await deleteBsd({ id: bsdId });
 
   if (bsdId.startsWith("BSDA-")) {
-    const bsda = await prisma.bsda.findUnique({
+    const bsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsdId },
       include: { intermediaries: true }
     });
@@ -22,19 +22,23 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("DASRI-")) {
-    const bsdasri = await prisma.bsdasri.findUnique({ where: { id: bsdId } });
+    const bsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdId }
+    });
 
     return toBsdasriElastic(bsdasri);
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUnique({ where: { id: bsdId } });
+    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsdId }
+    });
 
     return toBsvhuElastic(bsvhu);
   }
 
   if (bsdId.startsWith("FF-")) {
-    const bsff = await prisma.bsff.findUnique({
+    const bsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsdId },
       include: { packagings: true, ficheInterventions: true }
     });

--- a/back/src/queue/jobs/geocode.ts
+++ b/back/src/queue/jobs/geocode.ts
@@ -6,7 +6,7 @@ import { Company } from "@prisma/client";
 
 export async function geocodeJob(
   job: Job<GeocodeJobData>
-): Promise<Pick<Company, "siret" | "latitude" | "longitude">> {
+): Promise<Pick<Company, "siret" | "latitude" | "longitude"> | null> {
   const { latitude, longitude } = await geocode(job.data.address);
   if (latitude && longitude) {
     return prisma.company.update({

--- a/back/src/queue/jobs/indexAllBsds.ts
+++ b/back/src/queue/jobs/indexAllBsds.ts
@@ -137,7 +137,7 @@ export async function indexAllInBulk(job: Job<string>) {
             {
               name: BULK_INDEX_SCALINGO_CONTAINER_NAME,
               amount:
-                parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP, 10) || 4,
+                parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_UP!, 10) || 4,
               size: BULK_INDEX_SCALINGO_CONTAINER_SIZE_UP || "2XL"
             }
           ]
@@ -202,7 +202,7 @@ async function scaleDownScalingo() {
       containers: [
         {
           name: BULK_INDEX_SCALINGO_CONTAINER_NAME,
-          amount: parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN, 10) || 1,
+          amount: parseInt(BULK_INDEX_SCALINGO_CONTAINER_AMOUNT_DOWN!, 10) || 1,
           size: BULK_INDEX_SCALINGO_CONTAINER_SIZE_DOWN || "M"
         }
       ]

--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -11,7 +11,7 @@ export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
   const bsdId = job.data;
 
   if (bsdId.startsWith("BSDA-")) {
-    const bsda = await prisma.bsda.findUnique({
+    const bsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsdId },
       include: {
         // required for dashboard queries
@@ -27,7 +27,7 @@ export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
     return elasticBsda;
   }
   if (bsdId.startsWith("BSD-") || bsdId.startsWith("TD-")) {
-    const fullForm = await prisma.form.findUnique({
+    const fullForm = await prisma.form.findUniqueOrThrow({
       where: { readableId: bsdId },
       include: {
         forwardedIn: true,
@@ -40,7 +40,7 @@ export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("DASRI-")) {
-    const bsdasri = await prisma.bsdasri.findUnique({
+    const bsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: bsdId },
       include: {
         // required for dashboard queries
@@ -56,7 +56,7 @@ export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUnique({
+    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: bsdId }
     });
 
@@ -67,7 +67,7 @@ export async function indexBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("FF-")) {
-    const bsff = await prisma.bsff.findUnique({
+    const bsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsdId },
       include: { packagings: true, ficheInterventions: true }
     });

--- a/back/src/queue/jobs/sendmail.ts
+++ b/back/src/queue/jobs/sendmail.ts
@@ -9,6 +9,6 @@ export async function sendMailJob(job: Job<Mail>) {
   try {
     return sendMailSync(job.data);
   } catch (err) {
-    Sentry.captureException(err);
+    Sentry?.captureException(err);
   }
 }

--- a/back/src/queue/jobs/setDepartement.ts
+++ b/back/src/queue/jobs/setDepartement.ts
@@ -7,7 +7,7 @@ import { Company } from "@prisma/client";
 
 export async function setDepartementJob(
   job: Job<SetDepartementJobData>
-): Promise<Pick<Company, "siret" | "codeDepartement">> {
+): Promise<Pick<Company, "siret" | "codeDepartement"> | null> {
   if (!job.data.siret?.length) {
     return null;
   }
@@ -19,7 +19,7 @@ export async function setDepartementJob(
       return null;
     }
   }
-  const codeDepartement = await getDepartement(codeCommune);
+  const codeDepartement = await getDepartement(codeCommune!);
   if (codeDepartement) {
     return prisma.company.update({
       where: { siret: job.data.siret },

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -8,7 +8,7 @@ const { REDIS_URL, NODE_ENV } = process.env;
 export const INDEX_JOB_NAME = "index";
 export const DELETE_JOB_NAME = "delete";
 export const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
-export const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL, {
+export const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
   defaultJobOptions: {
     attempts: 3,
     backoff: { type: "fixed", delay: 100 },
@@ -21,7 +21,7 @@ const INDEX_REFRESH_INTERVAL = 1000;
 // Updates queue, used by the notifier. Items are enqueued once indexation is done
 export const updatesQueue = new Queue<BsdUpdateQueueItem>(
   `queue_updates_elastic_${NODE_ENV}`,
-  REDIS_URL,
+  REDIS_URL!,
   {
     defaultJobOptions: {
       delay: INDEX_REFRESH_INTERVAL, // We delay processing to make sure updates have been refreshed in ES

--- a/back/src/queue/producers/events.ts
+++ b/back/src/queue/producers/events.ts
@@ -8,7 +8,7 @@ const { REDIS_URL, NODE_ENV } = process.env;
 // Events sync queue. Items are enqueued once indexation is done
 export const syncEventsQueue = new Queue<void>(
   `queue_sync_events_${NODE_ENV}`,
-  REDIS_URL,
+  REDIS_URL!,
   {
     defaultJobOptions: {
       removeOnComplete: 1000

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -111,7 +111,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
 
@@ -133,7 +133,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [ttr.company.siret]);
+    const bsds = await searchBsds("INCOMING", [ttr.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
 
@@ -156,8 +156,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn.id]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
   });
 
   it("it should not list a BSDD in destination's incoming wastes before it has been received", async () => {
@@ -175,7 +175,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
   });
 
@@ -189,7 +189,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should not list a BSDD in destination's incoming wastes before it has been received", async () => {
@@ -202,7 +202,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDA in destination's incoming wastes once it has been received", async () => {
@@ -215,7 +215,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should not list a BSDA in destination's incoming wastes before it has been received", async () => {
@@ -228,7 +228,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDASRI in destination's incoming wastes once it has been received", async () => {
@@ -241,7 +241,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should not list a BSDASRI in destination's incoming wastes before it has been received", async () => {
@@ -253,7 +253,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSVHU in destination's incoming wastes once it has been received", async () => {
@@ -266,7 +266,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should not list a BSVHU in destination's incoming wastes before it has been received", async () => {
@@ -278,7 +278,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSFF in destination's incoming wastes once it has been received", async () => {
@@ -289,7 +289,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
   it("should not list a BSFF in destination's incoming wastes before it has been received", async () => {
@@ -300,7 +300,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret]);
+    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
   });
 
@@ -316,7 +316,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should not list a BSDD in emitter's outgoing wastes before it has been sent", async () => {
@@ -329,7 +329,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDD in ttr's outgoing wastes once it has been sent after temporary storage", async () => {
@@ -353,8 +353,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [ttr.company.siret]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn.id]);
+    const bsds = await searchBsds("OUTGOING", [ttr.company.siret!]);
+    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
   });
   it("should list a BSDA in emitter's outgoing wastes once it has been sent", async () => {
     const bsda = await bsdaFactory({
@@ -366,7 +366,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should not list a BSDA in emitter's outgoing wastes before it has been sent", async () => {
@@ -379,7 +379,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDA in worker's outgoing wastes once it has been sent", async () => {
@@ -392,7 +392,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [worker.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should not list a BSDA in worker's outgoing wastes before it has been sent", async () => {
@@ -405,7 +405,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [worker.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDASRI in emitter's outgoing wastes once it has been sent", async () => {
@@ -418,7 +418,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should not list a BSDASRI in emitter's outgoing wastes before it has been sent", async () => {
@@ -431,7 +431,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSVHU in emitter's outgoing wastes once it has been sent", async () => {
@@ -444,7 +444,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should not list a BSVHU in emitter's outgoing wastes before it has been sent", async () => {
@@ -457,7 +457,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSFF in emitter's outgoing wastes once it has been sent", async () => {
@@ -468,7 +468,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
 
@@ -485,14 +485,14 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         destination
       },
       {
-        detenteurCompanySirets: [detenteur.company.siret],
+        detenteurCompanySirets: [detenteur.company.siret!],
         ficheInterventions: { connect: { id: ficheIntervention.id } }
       }
     );
 
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [detenteur.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [detenteur.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
 
@@ -504,7 +504,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret]);
+    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
   });
 
@@ -520,7 +520,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should not list a BSDD in transporter' transported wastes before it has been taken over", async () => {
@@ -533,7 +533,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDD in transporter's transported wastes once it has been resent after temp storage", async () => {
@@ -555,8 +555,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn.id]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
+    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
   });
   it("should list a BSDA in transporter's transported wastes once it has been taken over", async () => {
     const bsda = await bsdaFactory({
@@ -568,7 +568,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should not list a BSDA in transporter'transported wastes before it has been taken over", async () => {
@@ -581,7 +581,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSDASRI in transporter's transported wastes once it has been taken over", async () => {
@@ -594,7 +594,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should not list a BSDASRI in transporter'transported wastes before it has been taken over", async () => {
@@ -607,7 +607,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSVHU in transporter's transported wastes once it has been taken over", async () => {
@@ -620,7 +620,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should not list a BSVHU in transporter'transported wastes before it has been delivered", async () => {
@@ -633,7 +633,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
   });
   it("should list a BSFF in transporter's transported wastes once it has been taken over", async () => {
@@ -644,7 +644,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
   it("should not list a BSFF in transporter'transported wastes before it has been taken over", async () => {
@@ -655,7 +655,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret]);
+    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
   });
 
@@ -670,7 +670,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [trader.company.siret]);
+    const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in broker's managed wastes after it has been sent", async () => {
@@ -683,7 +683,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret]);
+    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should not list a BSDD in trader's managed wastes before it has been sent", async () => {
@@ -696,7 +696,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [trader.company.siret]);
+    const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
   });
   it("should not list a BSDD in broker's managed wastes before it has been sent", async () => {
@@ -709,7 +709,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret]);
+    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
   });
   it("should list a BSDA in broker's managed wastes after it has been sent", async () => {
@@ -722,7 +722,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret]);
+    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should not list a BSDA in broker's managed wastes before it has been sent", async () => {
@@ -735,7 +735,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret]);
+    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
   });
   // REGISTRE EXHAUSTIF
@@ -749,7 +749,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret]);
+    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in transporter's all wastes", async () => {
@@ -762,7 +762,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in destination's all wastes", async () => {
@@ -776,7 +776,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in trader's all wastes", async () => {
@@ -789,7 +789,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [trader.company.siret]);
+    const bsds = await searchBsds("ALL", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in broker's all wastes", async () => {
@@ -801,7 +801,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [broker.company.siret]);
+    const bsds = await searchBsds("ALL", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in ttr's all wastes", async () => {
@@ -816,7 +816,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [ttr.company.siret]);
+    const bsds = await searchBsds("ALL", [ttr.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
   });
   it("should list a BSDD in transporter after temp storage 's all wastes", async () => {
@@ -830,10 +830,10 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
     expect(ids).toContain(form.id);
-    expect(ids).toContain(form.forwardedIn.id);
+    expect(ids).toContain(form.forwardedIn!.id);
   });
   it("should list a BSDD in final destination's all wastes", async () => {
     const form = await formWithTempStorageFactory({
@@ -846,10 +846,10 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
 
     await indexForm(await getFullForm(form));
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
     expect(ids).toContain(form.id);
-    expect(ids).toContain(form.forwardedIn.id);
+    expect(ids).toContain(form.forwardedIn!.id);
   });
   it("should list a BSDA in emitter's all wastes", async () => {
     const bsda = await bsdaFactory({
@@ -861,7 +861,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret]);
+    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should list a BSDA in transporter's all wastes", async () => {
@@ -874,7 +874,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should list a BSDA in destination's all wastes", async () => {
@@ -888,7 +888,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should list a BSDA in broker's all wastes", async () => {
@@ -901,7 +901,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsda({ ...bsda, intermediaries: [] });
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [broker.company.siret]);
+    const bsds = await searchBsds("ALL", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
   });
   it("should list a BSDASRI in emitter's all wastes", async () => {
@@ -914,7 +914,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret]);
+    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should list a BSDASRI in transporter's all wastes", async () => {
@@ -927,7 +927,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should list a BSDASRI in destination's all wastes", async () => {
@@ -941,7 +941,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsdasri(bsdasri);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
   });
   it("should list a BSVHU in emitter's all wastes", async () => {
@@ -954,7 +954,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret]);
+    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should list a BSVHU in transporter's all wastes", async () => {
@@ -967,7 +967,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should list a BSVHU in destination's all wastes", async () => {
@@ -981,7 +981,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     });
     await indexBsvhu(bsvhu);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
   });
   it("should list a BSFF in emitter's all wastes", async () => {
@@ -998,7 +998,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     );
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret]);
+    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
   it("should list a BSFF in transporter's all wastes", async () => {
@@ -1015,7 +1015,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     );
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret]);
+    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
   it("should list a BSFF in destination's all wastes", async () => {
@@ -1033,7 +1033,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     );
     await indexBsff(bsff);
     await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret]);
+    const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
   });
 });

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -137,11 +137,11 @@ describe("wastesReader", () => {
     // read forms by chunk of 4
     const reader = wastesReader({
       registryType: "INCOMING",
-      sirets: [destination.company.siret],
+      sirets: [destination.company.siret!],
       chunk: 4
     });
 
-    const incomingWastes = [];
+    const incomingWastes: any[] = [];
 
     reader.on("data", chunk => {
       incomingWastes.push(chunk);

--- a/back/src/registry/__tests__/where.integration.ts
+++ b/back/src/registry/__tests__/where.integration.ts
@@ -128,7 +128,7 @@ describe("toElasticFilter", () => {
     const bsds = await searchBsds(where);
 
     expect(bsds.map(bsd => bsd.id)).toEqual(
-      where.bsdType._in.map(t => BSDS[t].id)
+      where.bsdType!._in!.map(t => BSDS[t].id)
     );
   });
 

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -15,9 +15,7 @@ type Column = {
     ManagedWaste &
     AllWaste);
   label: string;
-  format?: (
-    v: string | boolean | number | Date | string[]
-  ) => string | number | null;
+  format?: (v: unknown) => string | number | null;
 };
 
 const formatDate = (d: Date | null) => d?.toISOString().slice(0, 10) ?? "";

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -10,7 +10,7 @@ import { toElasticFilter } from "./where";
 export function buildQuery(
   registryType: WasteRegistryType,
   sirets: string[],
-  where: WasteRegistryWhere
+  where: WasteRegistryWhere | undefined | null
 ): estypes.QueryDslQueryContainer {
   const elasticKey: { [key in WasteRegistryType]: keyof BsdElastic } = {
     OUTGOING: "isOutgoingWasteFor",
@@ -43,7 +43,7 @@ type ElasticPaginationArgs = {
 export async function searchBsds(
   registryType: WasteRegistryType,
   sirets: string[],
-  where: WasteRegistryWhere,
+  where: WasteRegistryWhere | undefined | null,
   { size, sort, search_after }: ElasticPaginationArgs
 ): Promise<estypes.SearchHitsMetadata<BsdElastic>> {
   const sortKey = Object.keys(sort[0])[0];

--- a/back/src/registry/permissions.ts
+++ b/back/src/registry/permissions.ts
@@ -6,7 +6,11 @@ export const REGISTRY_WHITE_LIST_IP =
   ) ?? [];
 
 export function checkIsRegistreNational(user: Express.User) {
-  if (user.isRegistreNational && REGISTRY_WHITE_LIST_IP.includes(user.ip)) {
+  if (
+    user.isRegistreNational &&
+    user.ip &&
+    REGISTRY_WHITE_LIST_IP.includes(user.ip)
+  ) {
     return true;
   }
   return false;

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
@@ -118,7 +118,7 @@ describe("query { wastesRegistryCsv }", () => {
           : registryType === "MANAGED"
           ? traderFormFactory
           : emitterFormFactory;
-      const form = await customFormFactory(user.id, company.siret);
+      const form = await customFormFactory(user.id, company.siret!);
       await indexForm(await getFullForm(form));
       await refreshElasticSearch();
       const { query } = makeClient(user);
@@ -142,7 +142,7 @@ describe("query { wastesRegistryCsv }", () => {
 
       expect(res.status).toBe(200);
 
-      const rows = [];
+      const rows: any[] = [];
 
       parseString(res.text, { headers: true, delimiter: ";" })
         .on("data", row => rows.push(row))

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
@@ -119,7 +119,7 @@ describe("query { wastesRegistryXls }", () => {
           : registryType === "TRADED"
           ? traderFormFactory
           : emitterFormFactory;
-      const form = await customFormFactory(user.id, company.siret);
+      const form = await customFormFactory(user.id, company.siret!);
       await indexForm(await getFullForm(form));
       await refreshElasticSearch();
       const { query } = makeClient(user);

--- a/back/src/registry/streams.ts
+++ b/back/src/registry/streams.ts
@@ -20,7 +20,7 @@ export class WasteReader extends Readable {
 export interface WasteReaderArgs {
   registryType: WasteRegistryType;
   sirets: string[];
-  where?: WasteRegistryWhere;
+  where?: WasteRegistryWhere | null;
   chunk?: number;
 }
 

--- a/back/src/routers/__tests__/road-control-pdf-router.integration.ts
+++ b/back/src/routers/__tests__/road-control-pdf-router.integration.ts
@@ -38,7 +38,7 @@ describe("Road control pdf Router", () => {
       res.header.location.startsWith(`http://${API_HOST}/download?token=`)
     ).toBe(true);
 
-    const tkn = await prisma.pdfAccessToken.findUnique({
+    const tkn = await prisma.pdfAccessToken.findUniqueOrThrow({
       where: {
         id: token.id
       }

--- a/back/src/scalars/__tests__/scalars.test.ts
+++ b/back/src/scalars/__tests__/scalars.test.ts
@@ -63,7 +63,7 @@ describe("DateTime", () => {
 
   it("should format date to ISO string", async () => {
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual(bar.toISOString());
+    expect(data!.foo.bar).toEqual(bar.toISOString());
   });
 
   it.each(
@@ -169,37 +169,37 @@ describe("String", () => {
   it("should not modify valid string", async () => {
     resolveFooMock.mockReturnValue({ bar: "bar" });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual("bar");
+    expect(data!.foo.bar).toEqual("bar");
   });
 
   it("should not modify a null value", async () => {
     resolveFooMock.mockReturnValue({ bar: null });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual(null);
+    expect(data!.foo.bar).toEqual(null);
   });
 
   it("should not modify an empty string", async () => {
     resolveFooMock.mockReturnValue({ bar: "" });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual("");
+    expect(data!.foo.bar).toEqual("");
   });
 
   it("should remove <script> tag", async () => {
     resolveFooMock.mockReturnValue({ bar: "<script>oué</script>" });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual("oué");
+    expect(data!.foo.bar).toEqual("oué");
   });
 
   it("should remove forbidden opening tag only", async () => {
     resolveFooMock.mockReturnValue({ bar: "<script>yes" });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual("yes");
+    expect(data!.foo.bar).toEqual("yes");
   });
 
   it("should escape < and >", async () => {
     resolveFooMock.mockReturnValue({ bar: "> <" });
     const { data } = await server.executeOperation({ query: FOO_QUERY });
-    expect(data.foo.bar).toEqual("&gt; &lt;");
+    expect(data!.foo.bar).toEqual("&gt; &lt;");
   });
 
   it("should leave incoming data untouched", async () => {

--- a/back/src/scripts/bin/deduplicateCompanyAssociations.helpers.ts
+++ b/back/src/scripts/bin/deduplicateCompanyAssociations.helpers.ts
@@ -13,7 +13,7 @@ export default async function deduplicateCompanyAssociations() {
   // Duplicate may originate from bulk import script
   const duplicates: Duplicate[] =
     await prisma.$queryRaw`select "companyId", "userId", COUNT("companyId") from default$default."CompanyAssociation" group by   "companyId", "userId" having COUNT(*) > 1;`;
-  let associationsToDelete = [];
+  let associationsToDelete: string[] = [];
   for (const duplicate of duplicates) {
     const asso = await prisma.companyAssociation.findMany({
       where: {

--- a/back/src/scripts/bin/fillCompanyAddresses.ts
+++ b/back/src/scripts/bin/fillCompanyAddresses.ts
@@ -21,6 +21,7 @@ function sleep(ms) {
     });
     let counter = 0;
     for (const company of companies) {
+      if (!company.siret) continue;
       counter++;
 
       console.log(`Processing company ${counter}`);

--- a/back/src/scripts/prisma/__tests__/acceptPendingInvitations.integration.ts
+++ b/back/src/scripts/prisma/__tests__/acceptPendingInvitations.integration.ts
@@ -18,13 +18,13 @@ describe("acceptPendingInvitations", () => {
       const invitation = await prisma.userAccountHash.create({
         data: {
           email: "john.snow@trackdechets.fr",
-          companySiret: company.siret,
+          companySiret: company.siret!,
           role: "MEMBER",
           hash: "hash1"
         }
       });
       await acceptPendingInvitations();
-      const untouchedInvitation = await prisma.userAccountHash.findUnique({
+      const untouchedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
         where: {
           id: invitation.id
         }
@@ -42,7 +42,7 @@ describe("acceptPendingInvitations", () => {
       const invitation = await prisma.userAccountHash.create({
         data: {
           email: user.email,
-          companySiret: company.siret,
+          companySiret: company.siret!,
           role: "MEMBER",
           hash: "hash2"
         }
@@ -66,13 +66,13 @@ describe("acceptPendingInvitations", () => {
       const invitation = await prisma.userAccountHash.create({
         data: {
           email: user.email,
-          companySiret: company.siret,
+          companySiret: company.siret!,
           role: "MEMBER",
           hash: "hash3"
         }
       });
       await acceptPendingInvitations();
-      const acceptedInvitation = await prisma.userAccountHash.findUnique({
+      const acceptedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
         where: {
           id: invitation.id
         }

--- a/back/src/scripts/prisma/__tests__/decodeAmpersandsInCompanyNames.integration.ts
+++ b/back/src/scripts/prisma/__tests__/decodeAmpersandsInCompanyNames.integration.ts
@@ -12,10 +12,10 @@ describe("decodeAmpersandsInCompanyNames", () => {
     });
     const company2 = await companyFactory({ name: "TRAITEUER SAS" });
     await decodeAmpersandsInCompanyNames();
-    const updatedCompany1 = await prisma.company.findUnique({
+    const updatedCompany1 = await prisma.company.findUniqueOrThrow({
       where: { id: company1.id }
     });
-    const updatedCompany2 = await prisma.company.findUnique({
+    const updatedCompany2 = await prisma.company.findUniqueOrThrow({
       where: { id: company2.id }
     });
     expect(updatedCompany1.name).toEqual("TRANSPORTS MARCEL & FILS");

--- a/back/src/scripts/prisma/__tests__/hashTokens.integration.ts
+++ b/back/src/scripts/prisma/__tests__/hashTokens.integration.ts
@@ -29,7 +29,7 @@ describe("hashTokens", () => {
     // run the migration function
     await hashTokens();
     // let's retrieve the previously unhashed token by its hashed value
-    const newlyHashedToken = await prisma.accessToken.findUnique({
+    const newlyHashedToken = await prisma.accessToken.findUniqueOrThrow({
       where: { token: hashToken(unHashedToken.token) }
     });
     expect(newlyHashedToken.id).not.toBeNull();

--- a/back/src/scripts/prisma/__tests__/mergeUsers.integration.ts
+++ b/back/src/scripts/prisma/__tests__/mergeUsers.integration.ts
@@ -25,7 +25,7 @@ describe("mergeUsers", () => {
 
     await mergeUsers(user, heir);
 
-    const updatedForm = await prisma.form.findUnique({
+    const updatedForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: { owner: { select: { id: true } } }
     });
@@ -44,7 +44,7 @@ describe("mergeUsers", () => {
 
     await mergeUsers(user, heir);
 
-    const updatedStatusLog = await prisma.statusLog.findUnique({
+    const updatedStatusLog = await prisma.statusLog.findUniqueOrThrow({
       where: { id: statusLog.id },
       include: { user: { select: { id: true } } }
     });
@@ -96,7 +96,7 @@ describe("mergeUsers", () => {
 
     await mergeUsers(user, heir);
 
-    const updatedAccessToken = await prisma.accessToken.findUnique({
+    const updatedAccessToken = await prisma.accessToken.findUniqueOrThrow({
       where: { token: hashToken(accessToken) },
       include: { user: { select: { id: true } } }
     });
@@ -116,7 +116,7 @@ describe("mergeUsers", () => {
 
     await mergeUsers(user, heir);
 
-    const updatedApplication = await prisma.application.findUnique({
+    const updatedApplication = await prisma.application.findUniqueOrThrow({
       where: {
         id: application.id
       },

--- a/back/src/scripts/prisma/__tests__/set-company-name.integration.ts
+++ b/back/src/scripts/prisma/__tests__/set-company-name.integration.ts
@@ -26,7 +26,7 @@ describe.skip("setCompanyName", () => {
     // LP, name is not set
     const lp = await companyFactory({
       siret: siretify(2),
-      name: null
+      name: null as any
     });
     const resp1 = { status: 200, data: { name: "LP" } };
     (axios.get as jest.Mock).mockResolvedValueOnce(resp1);
@@ -35,7 +35,7 @@ describe.skip("setCompanyName", () => {
     // Code en stock, name is not set
     const codeEnStock = await companyFactory({
       siret,
-      name: null
+      name: null as any
     });
     const resp2 = { status: 200, data: { name: "CODE EN STOCK" } };
     (axios.get as jest.Mock).mockResolvedValueOnce(resp2);
@@ -43,7 +43,7 @@ describe.skip("setCompanyName", () => {
     // Unknown SIRET, name is not set
     const unknown = await companyFactory({
       siret: "xxxxxxxxxxxxxx",
-      name: null
+      name: null as any
     });
 
     // expect insee service to retunr 404
@@ -53,29 +53,29 @@ describe.skip("setCompanyName", () => {
     await setCompanyName();
 
     // Frontier name was already set, it should be unchanged
-    const frontierUpdated = await prisma.company.findUnique({
-      where: { siret: frontier.siret }
+    const frontierUpdated = await prisma.company.findUniqueOrThrow({
+      where: { siret: frontier.siret! }
     });
     expect(frontierUpdated.name).toEqual(frontier.name);
 
     // LP name should be set
-    const lpUpdated = await prisma.company.findUnique({
-      where: { siret: lp.siret }
+    const lpUpdated = await prisma.company.findUniqueOrThrow({
+      where: { siret: lp.siret! }
     });
     expect(lpUpdated.name).toEqual("LP");
 
     // Code en Stock name should be set
-    const codeEnStockUpdated = await prisma.company.findUnique({
+    const codeEnStockUpdated = await prisma.company.findUniqueOrThrow({
       where: {
-        siret: codeEnStock.siret
+        siret: codeEnStock.siret!
       }
     });
     expect(codeEnStockUpdated.name).toEqual("CODE EN STOCK");
 
     // Unknown company name should not be set
-    const unknownUpdated = await prisma.company.findUnique({
+    const unknownUpdated = await prisma.company.findUniqueOrThrow({
       where: {
-        siret: unknown.siret
+        siret: unknown.siret!
       }
     });
     expect(unknownUpdated.name).toBeNull();

--- a/back/src/scripts/prisma/__tests__/updateBsddTakenOverAt.integration.ts
+++ b/back/src/scripts/prisma/__tests__/updateBsddTakenOverAt.integration.ts
@@ -49,19 +49,19 @@ describe("updateBsddTakenOverAt", () => {
     });
     expect(count).toEqual(1);
 
-    const updatedForm1 = await prisma.form.findUnique({
+    const updatedForm1 = await prisma.form.findUniqueOrThrow({
       where: { id: form1.id }
     });
 
     expect(updatedForm1.takenOverAt).toEqual(updatedForm1.emittedAt);
 
-    const updatedForm2 = await prisma.form.findUnique({
+    const updatedForm2 = await prisma.form.findUniqueOrThrow({
       where: { id: form2.id }
     });
 
     expect(updatedForm2.takenOverAt).not.toEqual(updatedForm2.emittedAt);
 
-    const updatedForm3 = await prisma.form.findUnique({
+    const updatedForm3 = await prisma.form.findUniqueOrThrow({
       where: { id: form3.id }
     });
 

--- a/back/src/scripts/prisma/__tests__/updateBsvhuTakenOverAt.integration.ts
+++ b/back/src/scripts/prisma/__tests__/updateBsvhuTakenOverAt.integration.ts
@@ -44,7 +44,7 @@ describe("updateBsvhuTakenOverAt", () => {
     });
     expect(count).toEqual(1);
 
-    const updatedBsvhu1 = await prisma.bsvhu.findUnique({
+    const updatedBsvhu1 = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: bsvhu1.id }
     });
 
@@ -52,7 +52,7 @@ describe("updateBsvhuTakenOverAt", () => {
       updatedBsvhu1.emitterEmissionSignatureDate
     );
 
-    const updatedBsvhu2 = await prisma.bsvhu.findUnique({
+    const updatedBsvhu2 = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: bsvhu2.id }
     });
 
@@ -60,7 +60,7 @@ describe("updateBsvhuTakenOverAt", () => {
       updatedBsvhu2.emitterEmissionSignatureDate
     );
 
-    const updatedBsvhu3 = await prisma.bsvhu.findUnique({
+    const updatedBsvhu3 = await prisma.bsvhu.findUniqueOrThrow({
       where: { id: bsvhu3.id }
     });
 

--- a/back/src/scripts/prisma/set-company-name.ts
+++ b/back/src/scripts/prisma/set-company-name.ts
@@ -7,9 +7,12 @@ function sleep(ms) {
 
 export async function setCompanyName() {
   // filter companies where name field is not set
-  const companies = await prisma.company.findMany({ where: { name: null } });
+  const companies = await prisma.company.findMany({
+    where: { name: null as any }
+  });
 
   for (const company of companies) {
+    if (!company.siret) continue;
     console.log(`Setting name for company ${company.siret}`);
 
     try {
@@ -17,7 +20,7 @@ export async function setCompanyName() {
 
       await prisma.company.update({
         data: {
-          name: companyInfo.name
+          name: companyInfo.name!
         },
         where: {
           id: company.id

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -152,7 +152,7 @@ app.use(
           "https:",
           "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='"
         ],
-        connectSrc: [process.env.API_HOST],
+        connectSrc: [process.env.API_HOST!],
         formAction: ["self"],
         upgradeInsecureRequests: NODE_ENV === "production" ? [] : null
       }
@@ -204,7 +204,7 @@ const RedisStore = redisStore(session);
 export const sess: session.SessionOptions = {
   store: new RedisStore({ client: redisClient }),
   name: SESSION_NAME || "trackdechets.connect.sid",
-  secret: SESSION_SECRET,
+  secret: SESSION_SECRET!,
   resave: false,
   saveUninitialized: false,
   cookie: {
@@ -221,7 +221,7 @@ export const sess: session.SessionOptions = {
 // For more details, see https://expressjs.com/en/guide/behind-proxies.html.
 app.set("trust proxy", TRUST_PROXY_HOPS ? parseInt(TRUST_PROXY_HOPS, 10) : 1);
 
-if (SESSION_COOKIE_SECURE === "true") {
+if (SESSION_COOKIE_SECURE === "true" && sess.cookie) {
   sess.cookie.secure = true; // serve secure cookies
 }
 
@@ -237,8 +237,8 @@ app.use(oauth2Router);
 app.use(oidcRouter);
 
 const USERS_BLACKLIST_ENV = process.env.USERS_BLACKLIST;
-let blacklist = [];
-if (USERS_BLACKLIST_ENV?.length > 0) {
+let blacklist: string[] = [];
+if (USERS_BLACKLIST_ENV && USERS_BLACKLIST_ENV.length > 0) {
   blacklist = USERS_BLACKLIST_ENV.split(",");
 }
 

--- a/back/src/users/__tests__/activation.integration.ts
+++ b/back/src/users/__tests__/activation.integration.ts
@@ -22,7 +22,7 @@ describe("user activation", () => {
     const userActivationHash = await createActivationHash(user);
     await request.get(`/userActivation?hash=${userActivationHash.hash}`);
 
-    const refreshedUser = await prisma.user.findUnique({
+    const refreshedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -51,7 +51,7 @@ describe("user activation", () => {
     });
     await request.get(`/userActivation?hash=${hash}`);
 
-    const refreshedUser = await prisma.user.findUnique({
+    const refreshedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 

--- a/back/src/users/__tests__/database.integration.ts
+++ b/back/src/users/__tests__/database.integration.ts
@@ -67,7 +67,7 @@ describe("associateUserToCompany", () => {
     const company = await companyFactory();
 
     await associateUserToCompany(user.id, company.siret, "MEMBER");
-    const refreshedUser = await prisma.user.findUnique({
+    const refreshedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
     const fullUser = await getFullUser(refreshedUser);

--- a/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
+++ b/back/src/users/bulk-creation/__tests__/bulk-create.integration.ts
@@ -105,7 +105,7 @@ describe("bulk create users and companies from csv files", () => {
     await expectNumberOfRecords(2, 3, 4);
 
     // check fields are OK for first user
-    const john = await prisma.user.findUnique({
+    const john = await prisma.user.findUniqueOrThrow({
       where: { email: "john.snow@trackdechets.fr" }
     });
     expect(john.name).toEqual("john.snow@trackdechets.fr");
@@ -114,7 +114,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(john.firstAssociationDate).toBeTruthy();
 
     // check fields are OK for first company
-    const codeEnStock = await prisma.company.findUnique({
+    const codeEnStock = await prisma.company.findUniqueOrThrow({
       where: { siret: "85001946400013" }
     });
     expect(codeEnStock.name).toEqual("NAME FROM SIRENE");
@@ -127,7 +127,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(codeEnStock.contact).toEqual("Marcel Machin");
 
     // check fields are OK for second company
-    const frontier = await prisma.company.findUnique({
+    const frontier = await prisma.company.findUniqueOrThrow({
       where: { siret: "81343950200028" }
     });
     expect(frontier.name).toEqual("NAME FROM SIRENE");
@@ -164,7 +164,7 @@ describe("bulk create users and companies from csv files", () => {
 
     await expectNumberOfRecords(2, 3, 4);
     const { firstAssociationDate, updatedAt, ...dbJohn } =
-      await prisma.user.findUnique({
+      await prisma.user.findUniqueOrThrow({
         where: { email: "john.snow@trackdechets.fr" }
       });
 
@@ -203,7 +203,7 @@ describe("bulk create users and companies from csv files", () => {
 
     // Code en Stock should be untouched
     expect(
-      await prisma.company.findUnique({ where: { siret: codeEnStock.siret } })
+      await prisma.company.findUnique({ where: { siret: codeEnStock.siret! } })
     ).toEqual(codeEnStock);
     // Association should be there
     const associations = await prisma.companyAssociation.findMany({
@@ -220,7 +220,7 @@ describe("bulk create users and companies from csv files", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: "john.snow@trackdechets.fr",
-        companySiret: company.siret,
+        companySiret: company.siret!,
         role: "MEMBER",
         hash: "hash"
       }
@@ -231,7 +231,7 @@ describe("bulk create users and companies from csv files", () => {
     await expectNumberOfRecords(3, 3, 5);
 
     // John Snow user should be created
-    const john = await prisma.user.findUnique({
+    const john = await prisma.user.findUniqueOrThrow({
       where: { email: "john.snow@trackdechets.fr" }
     });
 
@@ -244,7 +244,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(associations[0].role).toEqual("MEMBER");
 
     // invitation should be marked as joined
-    const updatedInvitation = await prisma.userAccountHash.findUnique({
+    const updatedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
       where: {
         id: invitation.id
       }
@@ -258,7 +258,7 @@ describe("bulk create users and companies from csv files", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: "john.snow@trackdechets.fr",
-        companySiret: company.siret,
+        companySiret: company.siret!,
         role: "MEMBER",
         hash: "hash"
       }
@@ -267,7 +267,7 @@ describe("bulk create users and companies from csv files", () => {
     await bulkCreateIdempotent();
     await expectNumberOfRecords(2, 3, 4);
 
-    const john = await prisma.user.findUnique({
+    const john = await prisma.user.findUniqueOrThrow({
       where: { email: "john.snow@trackdechets.fr" }
     });
 
@@ -279,7 +279,7 @@ describe("bulk create users and companies from csv files", () => {
     expect(associations[0].role).toEqual("MEMBER");
 
     // invitation should be marked as joined
-    const updatedInvitation = await prisma.userAccountHash.findUnique({
+    const updatedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
       where: {
         id: invitation.id
       }

--- a/back/src/users/bulk-creation/index.ts
+++ b/back/src/users/bulk-creation/index.ts
@@ -15,10 +15,11 @@ import {
 } from "../database";
 import templateIds from "../../mailer/templates/provider/templateIds";
 import {
+  CompanyType,
   CompanyVerificationMode,
   CompanyVerificationStatus
 } from "@prisma/client";
-import { CompanyRow } from "./types";
+import { CompanyInfo, CompanyRow, RoleRow } from "./types";
 
 function printHelp() {
   console.log(`
@@ -90,7 +91,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
 
   // validate roles
   const validateRole = validateRoleGenerator(companies);
-  const roles = [];
+  const roles: RoleRow[] = [];
 
   for (const role of rolesRows) {
     try {
@@ -132,7 +133,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
     process.exit(1);
   }
 
-  const sirenifiedCompanies = [];
+  const sirenifiedCompanies: (CompanyRow & CompanyInfo)[] = [];
 
   // add sirene information
   for (const c of companies) {
@@ -165,7 +166,9 @@ export async function bulkCreate(opts: Opts): Promise<void> {
           codeNaf: company.codeNaf,
           gerepId: company.gerepId,
           name: company.name,
-          companyTypes: { set: company.companyTypes },
+          companyTypes: {
+            set: company.companyTypes as CompanyType[]
+          },
           securityCode: randomNumber(4),
           givenName: company.givenName,
           contactEmail: company.contactEmail,
@@ -188,7 +191,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
     // check for existing user
     let user = await prisma.user.findUnique({ where: { email } });
 
-    let newUser = null;
+    let newUser: { password: string } | null = null;
 
     if (!user) {
       // No user matches this email. Creates a new one
@@ -216,13 +219,13 @@ export async function bulkCreate(opts: Opts): Promise<void> {
       usersWithRoles[email].map(async ({ role, siret }) => {
         try {
           const association = await associateUserToCompany(
-            user.id,
+            user!.id,
             siret,
             role
           );
-          if (!user.firstAssociationDate) {
+          if (!user!.firstAssociationDate) {
             await prisma.user.update({
-              where: { id: user.id },
+              where: { id: user!.id },
               data: { firstAssociationDate: new Date() }
             });
           }
@@ -232,7 +235,7 @@ export async function bulkCreate(opts: Opts): Promise<void> {
             // association already exist, return it
             const existingAssociations =
               await prisma.companyAssociation.findMany({
-                where: { company: { siret }, user: { id: user.id } }
+                where: { company: { siret }, user: { id: user!.id } }
               });
             return existingAssociations[0];
           }

--- a/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
@@ -132,11 +132,11 @@ describe("mutation acceptMembershipRequest", () => {
         }
       );
       expect(data.acceptMembershipRequest.users).toHaveLength(2);
-      const members = data.acceptMembershipRequest.users.map(u => u.email);
+      const members = data.acceptMembershipRequest.users!.map(u => u.email);
       expect(members).toContain(user.email);
 
       const acceptedMembershipRequest =
-        await prisma.membershipRequest.findUnique({
+        await prisma.membershipRequest.findUniqueOrThrow({
           where: {
             id: membershipRequest.id
           }

--- a/back/src/users/resolvers/mutations/__tests__/anonymizeUser.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/anonymizeUser.integration.ts
@@ -16,7 +16,9 @@ import { USER_SESSIONS_CACHE_KEY } from "../../../../common/redis/users";
 
 const request = supertest(app);
 const cookieRegExp = new RegExp(
-  `${sess.name}=(.+); Domain=${sess.cookie.domain}; Path=/; Expires=.+; HttpOnly`
+  `${sess.name}=(.+); Domain=${
+    sess.cookie!.domain
+  }; Path=/; Expires=.+; HttpOnly`
 );
 
 jest.spyOn(utils, "getUIBaseURL").mockReturnValue("*");
@@ -54,7 +56,7 @@ describe("disconnectDeletedUser Middleware", () => {
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     const { sessionCookie } = await logIn(app, user.email, "pass");
-    const cookieValue = sessionCookie.match(cookieRegExp)[1];
+    const cookieValue = sessionCookie.match(cookieRegExp)![1];
 
     // should be logged-in
     const res = await request
@@ -96,7 +98,7 @@ describe("disconnectDeletedUser Middleware", () => {
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     const { sessionCookie } = await logIn(app, user.email, "pass");
-    const cookieValue = sessionCookie.match(cookieRegExp)[1];
+    const cookieValue = sessionCookie.match(cookieRegExp)![1];
 
     // should be logged-in
     const res = await request

--- a/back/src/users/resolvers/mutations/__tests__/changePassword.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/changePassword.integration.ts
@@ -46,7 +46,7 @@ describe("mutation changePassword", () => {
       }
     );
     expect(data.changePassword.id).toEqual(user.id);
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
     expect(await compare(newPassword, updatedUser.password)).toEqual(true);

--- a/back/src/users/resolvers/mutations/__tests__/createAccessToken.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/createAccessToken.integration.ts
@@ -28,7 +28,7 @@ describe("mutation createAccessToken", () => {
     >(CREATE_ACCESS_TOKEN, {
       variables: { input: { description: "TEST" } }
     });
-    const accessToken = await prisma.accessToken.findFirst({
+    const accessToken = await prisma.accessToken.findFirstOrThrow({
       where: { id: data.createAccessToken.id }
     });
     expect(accessToken).not.toBeNull();

--- a/back/src/users/resolvers/mutations/__tests__/createPasswordResetRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/createPasswordResetRequest.integration.ts
@@ -45,7 +45,7 @@ describe("mutation createPasswordResetRequest", () => {
     );
     expect(data.createPasswordResetRequest).toEqual(true);
 
-    const resetHash = await prisma.userResetPasswordHash.findFirst({
+    const resetHash = await prisma.userResetPasswordHash.findFirstOrThrow({
       where: { userId: user.id }
     });
 

--- a/back/src/users/resolvers/mutations/__tests__/deleteInvitation.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/deleteInvitation.integration.ts
@@ -19,7 +19,7 @@ describe("mutation deleteInvitation", () => {
     const accountHash = await createUserAccountHash(
       usrToInvite.email,
       "MEMBER",
-      company.siret
+      company.siret!
     );
 
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });

--- a/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
@@ -6,7 +6,7 @@ import prisma from "../../../../prisma";
 import { ErrorCode } from "../../../../common/errors";
 
 const EDIT_PROFILE = `
-  mutation EditProfile($name: String, $phone: String){
+  mutation EditProfile($name: String!, $phone: String){
     editProfile(name: $name, phone: $phone){
       name
       email
@@ -23,7 +23,7 @@ describe("mutation editProfile", () => {
     const name = "New Name";
     const phone = "01234567891";
     await mutate(EDIT_PROFILE, { variables: { name, phone } });
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
     expect(updatedUser.name).toEqual(name);

--- a/back/src/users/resolvers/mutations/__tests__/editProfile.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/editProfile.test.ts
@@ -14,19 +14,11 @@ describe("editProfile", () => {
     mockUpdateUser.mockReset();
   });
 
-  it("should allow setting fields to empty string", async () => {
-    await editProfile("userId", { name: "" });
+  it("should allow setting fields", async () => {
+    await editProfile("userId", { name: "John Doe" });
     expect(mockUpdateUser).toHaveBeenCalledWith({
       where: { id: "userId" },
-      data: { name: "" }
-    });
-  });
-
-  it("should allow setting fields to null value", async () => {
-    await editProfile("userId", { name: null });
-    expect(mockUpdateUser).toHaveBeenCalledWith({
-      where: { id: "userId" },
-      data: { name: null }
+      data: { name: "John Doe" }
     });
   });
 });

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
@@ -41,17 +41,17 @@ describe("mutation inviteUserToCompany", () => {
         variables: { email: user.email, siret: company.siret, role: "MEMBER" }
       }
     );
-    expect(data.inviteUserToCompany.users.length).toBe(2);
+    expect(data.inviteUserToCompany.users!.length).toBe(2);
     expect(data.inviteUserToCompany.users).toEqual(
       expect.arrayContaining([{ email: admin.email }, { email: user.email }])
     );
     const companyAssociations = await prisma.user
-      .findUnique({ where: { id: user.id } })
+      .findUniqueOrThrow({ where: { id: user.id } })
       .companyAssociations();
     expect(companyAssociations).toHaveLength(1);
     expect(companyAssociations[0].role).toEqual("MEMBER");
     const userCompany = await prisma.companyAssociation
-      .findUnique({
+      .findUniqueOrThrow({
         where: {
           id: companyAssociations[0].id
         }
@@ -78,7 +78,7 @@ describe("mutation inviteUserToCompany", () => {
 
     // Check userAccountHash has been successfully created
     const hashes = await prisma.userAccountHash.findMany({
-      where: { email: invitedUserEmail, companySiret: company.siret }
+      where: { email: invitedUserEmail, companySiret: company.siret! }
     });
     expect(hashes.length).toEqual(1);
 

--- a/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/joinWithInvite.integration.ts
@@ -47,7 +47,7 @@ describe("joinWithInvite mutation", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: invitee,
-        companySiret: company.siret,
+        companySiret: company.siret!,
         role: "MEMBER",
         hash: "hash",
         acceptedAt: new Date()
@@ -71,7 +71,7 @@ describe("joinWithInvite mutation", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: invitee,
-        companySiret: company.siret,
+        companySiret: company.siret!,
         role: "MEMBER",
         hash: "hash"
       }
@@ -91,7 +91,7 @@ describe("joinWithInvite mutation", () => {
     expect(data.joinWithInvite.email).toEqual(invitee);
 
     // should mark invitation as joined
-    const updatedInvitation = await prisma.userAccountHash.findUnique({
+    const updatedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
       where: {
         id: invitation.id
       }
@@ -108,7 +108,7 @@ describe("joinWithInvite mutation", () => {
       })) != null;
     expect(isCompanyMember).toEqual(true);
 
-    const createdUser = await prisma.user.findUnique({
+    const createdUser = await prisma.user.findUniqueOrThrow({
       where: { email: invitee }
     });
     expect(createdUser.activatedAt).toBeTruthy();
@@ -123,7 +123,7 @@ describe("joinWithInvite mutation", () => {
     const invitation1 = await prisma.userAccountHash.create({
       data: {
         email: invitee,
-        companySiret: company1.siret,
+        companySiret: company1.siret!,
         role: "MEMBER",
         hash: "hash1"
       }
@@ -132,7 +132,7 @@ describe("joinWithInvite mutation", () => {
     const invitation2 = await prisma.userAccountHash.create({
       data: {
         email: invitee,
-        companySiret: company2.siret,
+        companySiret: company2.siret!,
         role: "MEMBER",
         hash: "hash2"
       }
@@ -146,14 +146,16 @@ describe("joinWithInvite mutation", () => {
       }
     });
 
-    const updatedInvitation2 = await prisma.userAccountHash.findUnique({
+    const updatedInvitation2 = await prisma.userAccountHash.findUniqueOrThrow({
       where: {
         id: invitation2.id
       }
     });
     expect(updatedInvitation2.acceptedAt).not.toBeNull();
 
-    const user = await prisma.user.findUnique({ where: { email: invitee } });
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email: invitee }
+    });
     const companies = await getUserCompanies(user.id);
 
     expect(companies.length).toEqual(2);
@@ -171,7 +173,7 @@ describe("joinWithInvite mutation", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: invitee,
-        companySiret: company.siret,
+        companySiret: company.siret!,
         role: "MEMBER",
         hash: "hash"
       }

--- a/back/src/users/resolvers/mutations/__tests__/refuseMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/refuseMembershipRequest.integration.ts
@@ -131,11 +131,12 @@ describe("mutation refuseMembershipRequest", () => {
       }
     );
     expect(data.refuseMembershipRequest.users).toHaveLength(1);
-    const refusedMembershipRequest = await prisma.membershipRequest.findUnique({
-      where: {
-        id: membershipRequest.id
-      }
-    });
+    const refusedMembershipRequest =
+      await prisma.membershipRequest.findUniqueOrThrow({
+        where: {
+          id: membershipRequest.id
+        }
+      });
     expect(refusedMembershipRequest.status).toEqual("REFUSED");
     expect(refusedMembershipRequest.statusUpdatedBy).toEqual(user.email);
     const associationExists =

--- a/back/src/users/resolvers/mutations/__tests__/removeUserFromCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/removeUserFromCompany.integration.ts
@@ -38,13 +38,13 @@ describe("mutation removeUserFromCompany", () => {
         role: "MEMBER"
       }
     });
-    let isMember = await isMemberFn(user.id, company.siret);
+    let isMember = await isMemberFn(user.id, company.siret!);
     expect(isMember).toEqual(true);
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
     await mutate(REMOVE_USER_FROM_COMPANY, {
       variables: { userId: user.id, siret: company.siret }
     });
-    isMember = await isMemberFn(user.id, company.siret);
+    isMember = await isMemberFn(user.id, company.siret!);
     expect(isMember).toEqual(false);
   });
 

--- a/back/src/users/resolvers/mutations/__tests__/resendInvitation.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/resendInvitation.integration.ts
@@ -27,7 +27,7 @@ describe("mutation resendInvitation", () => {
     const invitation = await createUserAccountHash(
       usrToInvite,
       "MEMBER",
-      company.siret
+      company.siret!
     );
 
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });

--- a/back/src/users/resolvers/mutations/__tests__/resetPassword.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/resetPassword.integration.ts
@@ -153,7 +153,7 @@ describe("mutation resetPassword", () => {
       await redisClient.exists(genUserSessionsIdsKey(user.id))
     ).toBeFalsy();
 
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -195,7 +195,7 @@ describe("mutation resetPassword", () => {
     });
     expect(resetHashExists).toEqual(1);
 
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -236,7 +236,7 @@ describe("mutation resetPassword", () => {
     });
     expect(resetHashExists).toEqual(1);
 
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
@@ -278,7 +278,7 @@ describe("mutation resetPassword", () => {
     });
     expect(resetHashExists).toEqual(1);
 
-    const updatedUser = await prisma.user.findUnique({
+    const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 

--- a/back/src/users/resolvers/mutations/__tests__/revokeAccessToken.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/revokeAccessToken.integration.ts
@@ -27,7 +27,7 @@ describe("mutation revokeAccessToken", () => {
     expect(accessToken.isRevoked).toEqual(false);
     const { mutate } = makeClient(user);
     await mutate(REVOKE_ACCESS_TOKEN, { variables: { id: accessToken.id } });
-    const revokedAccessToken = await prisma.accessToken.findFirst({
+    const revokedAccessToken = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken.id }
     });
     expect(revokedAccessToken.isRevoked).toEqual(true);

--- a/back/src/users/resolvers/mutations/__tests__/revokeAllAccessTokens.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/revokeAllAccessTokens.integration.ts
@@ -44,16 +44,16 @@ describe("mutation revokeAllAccessTokens", () => {
     expect(accessToken4.isRevoked).toEqual(false);
     const { mutate } = makeClient(user);
     await mutate(REVOKE_ALL_ACCESS_TOKENS);
-    accessToken1 = await prisma.accessToken.findFirst({
+    accessToken1 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken1.id }
     });
-    accessToken2 = await prisma.accessToken.findFirst({
+    accessToken2 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken2.id }
     });
-    accessToken3 = await prisma.accessToken.findFirst({
+    accessToken3 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken3.id }
     });
-    accessToken4 = await prisma.accessToken.findFirst({
+    accessToken4 = await prisma.accessToken.findFirstOrThrow({
       where: { id: accessToken4.id }
     });
     expect(accessToken1.isRevoked).toEqual(true);

--- a/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
@@ -59,25 +59,25 @@ describe("mutation sendMembershipRequest", () => {
         variables: { siret: company.siret }
       }
     );
-    const { id, status, sentTo, email, siret } = data.sendMembershipRequest;
+    const { id, status, sentTo, email, siret } = data.sendMembershipRequest!;
     expect(status).toEqual("PENDING");
     // emails should be hidden
     expect(sentTo).toEqual(["jo****@trackdechets.fr"]);
     expect(email).toEqual(requester.email);
     expect(siret).toEqual(company.siret);
-    const membershipRequest = await prisma.membershipRequest.findUnique({
+    const membershipRequest = await prisma.membershipRequest.findUniqueOrThrow({
       where: { id }
     });
 
     // check relation to user was created
     const linkedUser = await prisma.membershipRequest
-      .findUnique({ where: { id } })
+      .findUniqueOrThrow({ where: { id } })
       .user();
     expect(linkedUser.id).toEqual(requester.id);
 
     // check relation to company was created
     const linkedCompany = await prisma.membershipRequest
-      .findUnique({ where: { id } })
+      .findUniqueOrThrow({ where: { id } })
       .company();
     expect(linkedCompany.id).toEqual(company.id);
 
@@ -129,25 +129,25 @@ describe("mutation sendMembershipRequest", () => {
         variables: { siret: company.siret }
       }
     );
-    const { id, status, sentTo, email, siret } = data.sendMembershipRequest;
+    const { id, status, sentTo, email, siret } = data.sendMembershipRequest!;
     expect(status).toEqual("PENDING");
     // emails should be hidden
     expect(sentTo).toEqual([`admin${userIndex}@trackdechets.fr`]);
     expect(email).toEqual(requester.email);
     expect(siret).toEqual(company.siret);
-    const membershipRequest = await prisma.membershipRequest.findUnique({
+    const membershipRequest = await prisma.membershipRequest.findUniqueOrThrow({
       where: { id }
     });
 
     // check relation to user was created
     const linkedUser = await prisma.membershipRequest
-      .findUnique({ where: { id } })
+      .findUniqueOrThrow({ where: { id } })
       .user();
     expect(linkedUser.id).toEqual(requester.id);
 
     // check relation to company was created
     const linkedCompany = await prisma.membershipRequest
-      .findUnique({ where: { id } })
+      .findUniqueOrThrow({ where: { id } })
       .company();
     expect(linkedCompany.id).toEqual(company.id);
 

--- a/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
@@ -62,7 +62,7 @@ describe("Mutation.signup", () => {
 
     expect(data.signup).toEqual(user);
 
-    const newUser = await prisma.user.findUnique({
+    const newUser = await prisma.user.findUniqueOrThrow({
       where: { email: user.email }
     });
     expect(newUser.email).toEqual(user.email);
@@ -235,7 +235,7 @@ describe("Mutation.signup", () => {
     const invitation = await prisma.userAccountHash.create({
       data: {
         email: user.email,
-        companySiret: company.siret,
+        companySiret: company.siret!,
         hash: "hash",
         role: "MEMBER"
       }
@@ -252,11 +252,11 @@ describe("Mutation.signup", () => {
       }
     });
 
-    const newUser = await prisma.user.findUnique({
+    const newUser = await prisma.user.findUniqueOrThrow({
       where: { email: user.email }
     });
 
-    const updatedInvitation = await prisma.userAccountHash.findUnique({
+    const updatedInvitation = await prisma.userAccountHash.findUniqueOrThrow({
       where: {
         id: invitation.id
       }

--- a/back/src/users/resolvers/mutations/editProfile.ts
+++ b/back/src/users/resolvers/mutations/editProfile.ts
@@ -19,7 +19,7 @@ export async function editProfileFn(
   payload: MutationEditProfileArgs
 ) {
   const editProfileSchema = yup.object({
-    name: yup.string().ensure().isSafeSSTI(),
+    name: yup.string().required().isSafeSSTI(),
     phone: yup.string()
   });
   editProfileSchema.validateSync(payload);

--- a/back/src/users/resolvers/mutations/sendMembershipRequest.ts
+++ b/back/src/users/resolvers/mutations/sendMembershipRequest.ts
@@ -60,7 +60,7 @@ const sendMembershipRequestResolver: MutationResolvers["sendMembershipRequest"] 
     });
 
     // send membership request to all admins of the company
-    const recipients = admins.map(a => ({ email: a.email, name: a.name }));
+    const recipients = admins.map(a => ({ email: a.email, name: a.name! }));
 
     await sendMail(
       renderMail(membershipRequestMail, {

--- a/back/src/users/resolvers/queries/__tests__/authorizedApplications.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/authorizedApplications.integration.ts
@@ -75,7 +75,7 @@ describe("query authorizedApplications", () => {
       expect.objectContaining({ id: application2.id, name: application2.name })
     ]);
     expect(data.authorizedApplications[0].lastConnection).toEqual(
-      accessToken2.lastUsed.toISOString()
+      accessToken2!.lastUsed!.toISOString()
     );
   });
 });

--- a/back/src/users/resolvers/queries/__tests__/invitation.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/invitation.integration.ts
@@ -31,10 +31,10 @@ describe("query / invitation", () => {
     const { data } = await query<Pick<Query, "invitation">>(INVITATION, {
       variables: { hash: userAccountHash.hash }
     });
-    expect(data.invitation.email).toEqual(userAccountHash.email);
-    expect(data.invitation.companySiret).toEqual(userAccountHash.companySiret);
-    expect(data.invitation.role).toEqual(userAccountHash.role);
-    expect(data.invitation.email).toEqual(userAccountHash.email);
+    expect(data.invitation!.email).toEqual(userAccountHash.email);
+    expect(data.invitation!.companySiret).toEqual(userAccountHash.companySiret);
+    expect(data.invitation!.role).toEqual(userAccountHash.role);
+    expect(data.invitation!.email).toEqual(userAccountHash.email);
   });
 
   it("should return error if invitation does not exist", async () => {

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -33,7 +33,7 @@ type Mutation {
   USAGE INTERNE
   Met à jour les informations de l'utilisateur
   """
-  editProfile(name: String, phone: String): User!
+  editProfile(name: String!, phone: String): User!
 
   """
   USAGE INTERNE

--- a/back/src/utils.ts
+++ b/back/src/utils.ts
@@ -108,7 +108,7 @@ export function base32Encode(n: number): string {
  */
 export const hashToken = (token: string) =>
   crypto
-    .createHmac("sha256", process.env.API_TOKEN_SECRET)
+    .createHmac("sha256", process.env.API_TOKEN_SECRET!)
     .update(token)
     .digest("hex");
 


### PR DESCRIPTION
Nouveau round de correction des erreurs à l'activation du `strictNullCheck`.

On part de 2.7K erreurs.
Dernier pointage: `Found 1045 errors in 191 files.`

Focus dans cette PR:
- [x] erreurs `/bsda`
- [x] erreurs `/bsds`
- [x] erreurs `/bsvhu`
- [x] erreurs `/common` 
- [x] erreurs `/users` 
- [x] erreurs `/registry` 

Statistiques sur les erreurs par dossier racine. En précisant à chaque fois le nombre d'erreur dans les fichiers métiers et dans les fichiers de tests:

```json
{
    "activity-events": {
        "files": 1,
        "tests": 0,
        "total": 1
    },
    "bsda": {
        "files": 9,
        "tests": 0,
        "total": 9
    },
    "bsdasris": {
        "files": 110,
        "tests": 139,
        "total": 249
    },
    "bsds": {
        "files": 1,
        "tests": 0,
        "total": 1
    },
    "bsffs": {
        "files": 117,
        "tests": 138,
        "total": 255
    },
    "bsvhu": {
        "files": 10,
        "tests": 0,
        "total": 10
    },
    "commands": {
        "files": 1,
        "tests": 2,
        "total": 3
    },
    "common": {
        "files": 1,
        "tests": 0,
        "total": 1
    },
    "companies": {
        "files": 17,
        "tests": 0,
        "total": 17
    },
    "forms": {
        "files": 281,
        "tests": 201,
        "total": 482
    },
    "mailer": {
        "files": 1,
        "tests": 0,
        "total": 1
    },
    "notifier": {
        "files": 3,
        "tests": 0,
        "total": 3
    },
    "queue": {
        "files": 2,
        "tests": 0,
        "total": 2
    },
    "registry": {
        "files": 1,
        "tests": 0,
        "total": 1
    },
    "routers": {
        "files": 2,
        "tests": 0,
        "total": 2
    },
    "scripts": {
        "files": 1,
        "tests": 1,
        "total": 2
    },
    "users": {
        "files": 6,
        "tests": 0,
        "total": 6
    }
}
```
