### PR TITLE
HOTFIX - update isDangerous

### DIFF
--- a/back/src/common/constants/WASTES.ts
+++ b/back/src/common/constants/WASTES.ts
@@ -5642,5 +5642,8 @@ export function toWasteTree(
 }
 
 export function isDangerous(wasteCode: string): boolean {
+  if (!wasteCode) {
+    return false;
+  }
   return wasteCode.endsWith("*");
 }


### PR DESCRIPTION

![Capture d’écran 2023-03-30 à 11 18 05](https://user-images.githubusercontent.com/2269165/228790364-2277b715-00a8-43f9-ac11-c9668ec8a869.png)

On a cette erreur Sentry qui a pop up depuis la dernière MEP sans que je n'arrive trop à comprendre pourquoi, ni à reproduire. On dirait que dans certains cas `isDangerous` est appelée côté front avec des valeurs `null` ou `undefined`. Ce fix doit permettre de corriger le problème.
