### PR TITLE
Prise en compte des erreurs 404 de notre index SIRENE

### DIFF
--- a/back/src/companies/sirene/__tests__/redundancy.test.ts
+++ b/back/src/companies/sirene/__tests__/redundancy.test.ts
@@ -1,8 +1,6 @@
 import { redundant } from "../redundancy";
 import { ErrorCode } from "../../../common/errors";
-import { AnonymousCompanyError } from "../errors";
-import { ProviderErrors } from "../trackdechets/types";
-import { UserInputError } from "apollo-server-express";
+import { AnonymousCompanyError, SiretNotFoundError } from "../errors";
 
 const fn1 = jest.fn();
 const fn2 = jest.fn();
@@ -42,20 +40,16 @@ describe("redundant", () => {
     expect(fn2).not.toHaveBeenCalled();
   });
 
-  it("should not call fallback function when the first function throws UserInputError", async () => {
+  it("should not call fallback function when the first function throws SiretNotFoundError", async () => {
     const fn = redundant(fn1, fn2);
 
     // test fn1 throws UserInputError
-    fn1.mockRejectedValueOnce(
-      new UserInputError(ProviderErrors.SiretNotFound, {
-        invalidArgs: ["siret"]
-      })
-    );
+    fn1.mockRejectedValueOnce(new SiretNotFoundError());
 
     try {
       await fn("foo");
     } catch (err) {
-      expect(err).toBeInstanceOf(UserInputError);
+      expect(err).toBeInstanceOf(SiretNotFoundError);
     }
 
     // fn2 should not be called

--- a/back/src/companies/sirene/errors.ts
+++ b/back/src/companies/sirene/errors.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from "apollo-server-express";
+import { ForbiddenError, UserInputError } from "apollo-server-express";
 
 export class AnonymousCompanyError extends ForbiddenError {
   constructor() {
@@ -6,5 +6,13 @@ export class AnonymousCompanyError extends ForbiddenError {
       `Les informations de cet établissement ne sont pas disponibles car son propriétaire` +
         ` a choisi de ne pas les rendre publiques lors de son enregistrement au Répertoire des Entreprises et des Établissements (SIRENE)`
     );
+  }
+}
+
+export class SiretNotFoundError extends UserInputError {
+  constructor() {
+    super("Aucun établissement trouvé avec ce SIRET", {
+      invalidArgs: ["siret"]
+    });
   }
 }

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -4,9 +4,8 @@ import {
   SireneSearchResult
 } from "../types";
 import { libelleFromCodeNaf, buildAddress } from "../utils";
-import { UserInputError } from "apollo-server-express";
 import { authorizedAxiosGet } from "./token";
-import { AnonymousCompanyError } from "../errors";
+import { AnonymousCompanyError, SiretNotFoundError } from "../errors";
 import { format } from "date-fns";
 
 const SIRENE_API_BASE_URL = "https://api.insee.fr/entreprises/sirene/V3";
@@ -95,9 +94,7 @@ export async function searchCompany(
     // that falls out of the range of 2xx
     if (error.response?.status === 404) {
       // 404 "no results found"
-      throw new UserInputError("Aucun établissement trouvé avec ce SIRET", {
-        invalidArgs: ["siret"]
-      });
+      throw new SiretNotFoundError();
     }
     if (error.response?.status === 403) {
       // this is not supposed to happen anymore since https://www.insee.fr/fr/information/6683782

--- a/back/src/companies/sirene/redundancy.ts
+++ b/back/src/companies/sirene/redundancy.ts
@@ -1,6 +1,5 @@
-import { UserInputError } from "apollo-server-express";
 import type { AsyncReturnType } from "type-fest";
-import { AnonymousCompanyError } from "./errors";
+import { AnonymousCompanyError, SiretNotFoundError } from "./errors";
 
 /**
  * Loop over the functions until one of them returns a result
@@ -15,12 +14,13 @@ export function redundant<F extends (...args: any[]) => any>(...fns: F[]) {
         return response;
       } catch (error) {
         // fail fast for user-input errors
-        if (error instanceof AnonymousCompanyError) {
+        if (
+          error instanceof SiretNotFoundError ||
+          error instanceof AnonymousCompanyError
+        ) {
           throw error;
         }
-        if (error instanceof UserInputError) {
-          throw error;
-        }
+
         if (firstError == null) {
           firstError = error;
         }

--- a/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
+++ b/back/src/companies/sirene/trackdechets/__tests__/client.test.ts
@@ -1,13 +1,10 @@
 import { ApiResponse, errors } from "@elastic/elasticsearch";
-import {
-  searchCompany,
-  searchCompanies,
-  CompanyNotFoundInTrackdechetsSearch
-} from "../client";
+import { searchCompany, searchCompanies } from "../client";
 import { ErrorCode } from "../../../../common/errors";
 import client from "../esClient";
 import { SearchHit } from "../types";
 import { siretify } from "../../../../__tests__/factories";
+import { SiretNotFoundError } from "../../errors";
 
 const { ResponseError } = errors;
 
@@ -180,15 +177,13 @@ describe("searchCompany", () => {
     expect(company.name).toEqual("CODE EN STOCK (CES)");
   });
 
-  it("should raise CompanyNotFound if error 404 (siret not found)", async () => {
+  it("should raise SiretNotFound if error 404 (siret not found)", async () => {
     (client.get as jest.Mock).mockRejectedValueOnce(
       new ResponseError({
         statusCode: 404
       } as unknown as ApiResponse)
     );
-    expect(searchCompany("xxxxxxxxxxxxxx")).rejects.toThrow(
-      CompanyNotFoundInTrackdechetsSearch
-    );
+    expect(searchCompany("xxxxxxxxxxxxxx")).rejects.toThrow(SiretNotFoundError);
   });
 
   it(`should escalate other types of errors

--- a/back/src/companies/sirene/trackdechets/types.ts
+++ b/back/src/companies/sirene/trackdechets/types.ts
@@ -112,11 +112,3 @@ export interface SearchHit {
   _score: number;
   _source: SearchStockEtablissement;
 }
-
-/**
- * Public API error code names
- */
-export enum ProviderErrors {
-  SiretNotFound = "Nous n'avons pas trouvé ce SIRET dans notre base de données, cherchons sur l'Api publique Sirene de l'INSEE",
-  ServerError = "Erreur inconnue"
-}

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -35,16 +35,8 @@ sendMailSpy.mockImplementation(() => Promise.resolve());
 
 // Mock external search services
 import * as search from "../../../../companies/sirene/searchCompany";
+import { MARK_AS_SEALED } from "./mutations";
 const searchCompanyMock = jest.spyOn(search, "default");
-
-export const MARK_AS_SEALED = `
-  mutation MarkAsSealed($id: ID!) {
-    markAsSealed(id: $id) {
-      id
-      status
-    }
-  }
-`;
 
 const formdataForPrivateOrShip = {
   brokerCompanyAddress: "",

--- a/back/src/forms/resolvers/mutations/__tests__/mutations.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/mutations.ts
@@ -1,0 +1,29 @@
+export const MARK_AS_SEALED = `
+  mutation MarkAsSealed($id: ID!) {
+    markAsSealed(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+export const SIGN_EMISSION_FORM = `
+  mutation SignEmissionForm($id: ID!, $input: SignEmissionFormInput!, $securityCode: Int) {
+    signEmissionForm(id: $id, input: $input, securityCode: $securityCode) {
+      id
+      status
+      signedByTransporter
+      sentAt
+      sentBy
+      emittedAt
+      emittedBy
+      emittedByEcoOrganisme
+      temporaryStorageDetail {
+        signedAt
+        signedBy
+        emittedAt
+        emittedBy
+      }
+    }
+  }
+`;

--- a/back/src/forms/resolvers/mutations/__tests__/signEmissionForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signEmissionForm.integration.ts
@@ -12,27 +12,7 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import getReadableId from "../../../readableId";
-
-export const SIGN_EMISSION_FORM = `
-  mutation SignEmissionForm($id: ID!, $input: SignEmissionFormInput!, $securityCode: Int) {
-    signEmissionForm(id: $id, input: $input, securityCode: $securityCode) {
-      id
-      status
-      signedByTransporter
-      sentAt
-      sentBy
-      emittedAt
-      emittedBy
-      emittedByEcoOrganisme
-      temporaryStorageDetail {
-        signedAt
-        signedBy
-        emittedAt
-        emittedBy
-      }
-    }
-  }
-`;
+import { SIGN_EMISSION_FORM } from "./mutations";
 
 describe("signEmissionForm", () => {
   afterEach(resetDatabase);

--- a/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
@@ -14,8 +14,7 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 import { Status } from "@prisma/client";
 import { NON_CANCELLABLE_BSDD_STATUSES } from "../createFormRevisionRequest";
-import { MARK_AS_SEALED } from "./markAsSealed.integration";
-import { SIGN_EMISSION_FORM } from "./signEmissionForm.integration";
+import { MARK_AS_SEALED, SIGN_EMISSION_FORM } from "./mutations";
 
 const SUBMIT_BSDD_REVISION_REQUEST_APPROVAL = `
   mutation SubmitFormRevisionRequestApproval($id: ID!, $isApproved: Boolean!) {
@@ -37,7 +36,7 @@ const SUBMIT_BSDD_REVISION_REQUEST_APPROVAL = `
 `;
 
 describe("Mutation.submitFormRevisionRequestApproval", () => {
-  afterEach(() => resetDatabase());
+  afterEach(resetDatabase);
 
   it("should fail if revisionRequest doesnt exist", async () => {
     const { user } = await userWithCompanyFactory("ADMIN");


### PR DESCRIPTION
## NE PAS FUSIONNER AVANT LA MAJ SIRENE DU 01/04/23 - Vérifier au préalable que les établissements non diffusibles sont bien répertoriés dans l'index

Suite aux nouvelles [modalités de diffusion des établissements](https://www.insee.fr/fr/information/6683782) les établissements "non diffusibles" seront présents dans les fichiers stocks importés de [data.gouv](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/). Cela veut donc dire qu'en cas d'erreur 404 sur notre index maison, on n'aura plus besoin de faire un appel supplémentaire à l'API INSEE pour savoir si l'établissement est non diffusible. 
