### PR TITLE
HOTFIX - mauvais update BSDA et conversion décimales

### DIFF
--- a/back/src/bsda/__tests__/converter.test.ts
+++ b/back/src/bsda/__tests__/converter.test.ts
@@ -1,0 +1,60 @@
+import {
+  BsdaInput,
+  BsdaRevisionRequestContentInput
+} from "../../generated/graphql/types";
+import {
+  expandBsdaFromDb,
+  expandBsdaRevisionRequestContent,
+  flattenBsdaInput,
+  flattenBsdaRevisionRequestInput
+} from "../converter";
+
+describe("flattenBsdaInput", () => {
+  it("should convert tonnes to kg and deal with floating point precision", () => {
+    const input: BsdaInput = {
+      weight: { value: 4.06 },
+      destination: { reception: { weight: 4.06 } }
+    };
+    const flattened = flattenBsdaInput(input);
+    expect(flattened).toEqual({
+      weightValue: 4060,
+      destinationReceptionWeight: 4060
+    });
+  });
+});
+
+describe("expandBsdaFromDb", () => {
+  it("should convert kg to tonnes", () => {
+    const dbInput = {
+      weightValue: 4060,
+      destinationReceptionWeight: 4060
+    };
+    const expanded = expandBsdaFromDb(dbInput as any);
+    expect(expanded).toMatchObject({
+      weight: { value: 4.06 },
+      destination: { reception: { weight: 4.06 } }
+    });
+  });
+});
+
+describe("flattenBsdaRevisionRequestInput", () => {
+  it("should convert tonnes to kg and deal with floating point number", () => {
+    const input: BsdaRevisionRequestContentInput = {
+      destination: { reception: { weight: 4.06 } }
+    };
+    const flattened = flattenBsdaRevisionRequestInput(input);
+    expect(flattened).toEqual({ destinationReceptionWeight: 4060 });
+  });
+});
+
+describe("expandBsdaRevisionRequestContent", () => {
+  it("should convert kg to tonnes", () => {
+    const dbInput = {
+      destinationReceptionWeight: 4060
+    };
+    const expanded = expandBsdaRevisionRequestContent(dbInput as any);
+    expect(expanded).toMatchObject({
+      destination: { reception: { weight: 4.06 } }
+    });
+  });
+});

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -46,6 +46,8 @@ import {
 } from "@prisma/client";
 import { BsdElastic } from "../common/elastic";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
+import { Decimal } from "decimal.js-light";
+
 export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
   return {
     id: form.id,
@@ -96,7 +98,9 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
     }),
     weight: nullIfNoValues<BsdaWeight>({
       isEstimate: form.weightIsEstimate,
-      value: form.weightValue ? form.weightValue / 1000 : form.weightValue
+      value: form.weightValue
+        ? new Decimal(form.weightValue).dividedBy(1000).toNumber()
+        : form.weightValue
     }),
     destination: nullIfNoValues<BsdaDestination>({
       company: nullIfNoValues<FormCompany>({
@@ -115,7 +119,9 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
         refusalReason: form.destinationReceptionRefusalReason,
         date: processDate(form.destinationReceptionDate),
         weight: form.destinationReceptionWeight
-          ? form.destinationReceptionWeight / 1000
+          ? new Decimal(form.destinationReceptionWeight)
+              .dividedBy(1000)
+              .toNumber()
           : form.destinationReceptionWeight
       }),
       operation: nullIfNoValues<BsdaOperation>({
@@ -325,7 +331,9 @@ function flattenBsdaDestinationInput({
       chain(d.reception, r => r.date)
     ),
     destinationReceptionWeight: chain(destination, d =>
-      chain(d.reception, r => (r.weight ? r.weight * 1000 : r.weight))
+      chain(d.reception, r =>
+        r.weight ? new Decimal(r.weight).times(1000).toNumber() : r.weight
+      )
     ),
     destinationReceptionAcceptationStatus: chain(destination, d =>
       chain(d.reception, r => r.acceptationStatus)
@@ -493,7 +501,9 @@ function flattenBsdaBrokerInput({ broker }: Pick<BsdaInput, "broker">) {
 function flattenBsdaWeightInput({ weight }: Pick<BsdaInput, "weight">) {
   return {
     weightIsEstimate: chain(weight, q => q.isEstimate),
-    weightValue: chain(weight, q => (q.value ? q.value * 1000 : q.value))
+    weightValue: chain(weight, q =>
+      q.value ? new Decimal(q.value).times(1000).toNumber() : q.value
+    )
   };
 }
 
@@ -596,7 +606,9 @@ export function flattenBsdaRevisionRequestInput(
     destinationCap: chain(reviewContent, r => chain(r.destination, d => d.cap)),
     destinationReceptionWeight: chain(reviewContent, r =>
       chain(r.destination, d =>
-        chain(d.reception, r => (r.weight ? r.weight * 1000 : r.weight))
+        chain(d.reception, r =>
+          r.weight ? new Decimal(r.weight).times(1000).toNumber() : r.weight
+        )
       )
     )
   });
@@ -645,7 +657,9 @@ export function expandBsdaRevisionRequestContent(
       }),
       reception: nullIfNoValues<BsdaRevisionRequestReception>({
         weight: bsdaRevisionRequest.destinationReceptionWeight
-          ? bsdaRevisionRequest.destinationReceptionWeight / 1000
+          ? new Decimal(bsdaRevisionRequest.destinationReceptionWeight)
+              .dividedBy(1000)
+              .toNumber()
           : bsdaRevisionRequest.destinationReceptionWeight
       })
     })

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -83,9 +83,6 @@ export function SignOperation({ siret, bsdaId }: Props) {
                       nextDestination: { company: getInitialCompany() },
                     },
                   },
-                  weight: {
-                    value: null,
-                  },
                 },
                 bsda
               ),
@@ -114,7 +111,7 @@ export function SignOperation({ siret, bsdaId }: Props) {
             {({ isSubmitting, handleReset }) => (
               <Form>
                 <div className="tw-mb-6">
-                  <Operation />
+                  <Operation bsda={bsda} />
                 </div>
 
                 <p>

--- a/front/src/form/bsda/stepper/steps/Operation.tsx
+++ b/front/src/form/bsda/stepper/steps/Operation.tsx
@@ -6,7 +6,11 @@ import { Field, useFormikContext } from "formik";
 import { Bsda } from "generated/graphql/types";
 import React, { useEffect } from "react";
 
-export default function Operation() {
+type Props = {
+  bsda: Bsda;
+};
+
+export default function Operation({ bsda }: Props) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
 
   useEffect(() => {
@@ -91,9 +95,11 @@ export default function Operation() {
 
             <RedErrorMessage name="destination.reception.weight" />
           </div>
-          <p className="tw-text-sm">
-            <em>Quantité prévue: {values.weight?.value} tonnes</em>
-          </p>
+          {bsda.weight?.value && (
+            <p className="tw-text-sm">
+              <em>Quantité prévue: {bsda.weight?.value} tonnes</em>
+            </p>
+          )}
 
           <h4 className="form__section-heading">Opération</h4>
           <div className="form__row">


### PR DESCRIPTION
Deux problèmes en un ici :

- `weightValue` était  renvoyé au moment de l'appel à `updateBsda` avant la signature de l'opération. 
- la valeur de `weightValue` était mal convertie au moment de la comparaison avec les données existantes car `4.06*1000 = 4059.9999999999995 != 4060` et on avait donc une erreur de verrouillage des champs.

---

[Carte bug](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11546)
