### PR TITLE
Inclut un access_token dans la réponse du protocole openId Connect

### DIFF
--- a/back/src/__tests__/oidc.integration.ts
+++ b/back/src/__tests__/oidc.integration.ts
@@ -373,10 +373,10 @@ describe("/oidc/token - id/secret auth", () => {
 
     expect(res.status).toEqual(200);
 
-    const { idToken } = res.body;
+    const { id_token } = res.body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -428,10 +428,10 @@ describe("/oidc/token - id/secret auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -486,10 +486,10 @@ describe("/oidc/token - id/secret auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -549,10 +549,10 @@ describe("/oidc/token - id/secret auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -799,10 +799,10 @@ describe("/oidc/token - basic auth", () => {
 
     expect(res.status).toEqual(200);
 
-    const { idToken } = res.body;
+    const { id_token } = res.body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -857,10 +857,10 @@ describe("/oidc/token - basic auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -920,10 +920,10 @@ describe("/oidc/token - basic auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -977,10 +977,10 @@ describe("/oidc/token - basic auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",
@@ -1042,10 +1042,10 @@ describe("/oidc/token - basic auth", () => {
 
     const body = res.body;
 
-    const { idToken } = body;
+    const { id_token } = body;
 
     const { payload, protectedHeader } = await jose.jwtVerify(
-      idToken,
+      id_token,
       publicKey,
       {
         issuer: "trackdechets",

--- a/back/src/oauth/oidc.ts
+++ b/back/src/oauth/oidc.ts
@@ -169,5 +169,5 @@ export const exchange = async (req, res, next) => {
   // openid connect grants are not meant to be reused
   await prisma.grant.delete({ where: { id: grant.id } });
 
-  return res.send({ idToken: jwt });
+  return res.send({ id_token: jwt, access_token: "" });
 };


### PR DESCRIPTION
En absence de besoin exprimé, l'access_token n'était pas renvoyé par le protocol openID connect.
Il s'avère que ce champ manquant est requis par l'implémentation du client (keycloak).
A sa demande, on ajoute un access_token vide dans la réponse et on renomme idToken en id_token, conformément à la spec.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
