### PR TITLE
Meilleure gestion du nonce de l'open id

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -121,7 +121,7 @@
         "@typescript-eslint/parser": "^5.56.0",
         "concurrently": "^6.4.0",
         "copyfiles": "^2.4.1",
-        "dotenv": "^10.0.0",
+        "dotenv": "^16.0.0",
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-typescript": "^3.5.3",
@@ -5904,15 +5904,6 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/@graphql-tools/prisma-loader/node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@graphql-tools/prisma-loader/node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -11407,12 +11398,12 @@
       "dev": true
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dset": {
@@ -25452,12 +25443,6 @@
             "tslib": "^2.4.0"
           }
         },
-        "dotenv": {
-          "version": "16.0.3",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-          "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
-          "dev": true
-        },
         "tslib": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
@@ -29783,9 +29768,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true
     },
     "dset": {

--- a/back/package.json
+++ b/back/package.json
@@ -166,7 +166,7 @@
     "@typescript-eslint/parser": "^5.56.0",
     "concurrently": "^6.4.0",
     "copyfiles": "^2.4.1",
-    "dotenv": "^10.0.0",
+    "dotenv": "^16.0.0",
     "eslint": "^8.36.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-typescript": "^3.5.3",

--- a/back/prisma/migrations/131_add_grant_nonce.sql
+++ b/back/prisma/migrations/131_add_grant_nonce.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "default$default"."Grant"
+ADD COLUMN
+    "nonce" text;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -560,6 +560,7 @@ model Grant {
   applicationId String
   openIdEnabled Boolean     @default(false)
   scope         String[]    @default([])
+  nonce         String?
   application   Application @relation(fields: [applicationId], references: [id])
   userId        String
   user          User        @relation(fields: [userId], references: [id])

--- a/back/src/oauth/oidc.ts
+++ b/back/src/oauth/oidc.ts
@@ -14,7 +14,7 @@ import {
   PROFILE_SCOPE,
   COMPANIES_SCOPE
 } from "./scopes";
-
+import xss from "xss";
 // Create OpenId Connect server
 export const oidc = createServer();
 
@@ -49,6 +49,7 @@ oidc.grant(
   // @ts-ignore
   grant.code(async (client, redirectUri, user, _ares, _areq, done) => {
     const scope = _areq.scope;
+    const nonce = _ares.nonce;
 
     if (!client.openIdEnabled) {
       return done(
@@ -65,6 +66,7 @@ oidc.grant(
         new AuthorizationError("Scope is mandatory", "invalid_scope")
       );
     }
+
     //missing oid scope item
     if (!scope.includes(OID_SCOPE)) {
       return done(
@@ -89,7 +91,8 @@ oidc.grant(
         expires: 1 * 60, // 1 minute
         openIdEnabled: true,
         redirectUri,
-        scope
+        scope,
+        nonce: xss(nonce)
       }
     });
     done(null, grant.code);

--- a/back/src/oauth/token.ts
+++ b/back/src/oauth/token.ts
@@ -1,4 +1,3 @@
-import { getUid } from "../utils";
 import * as jose from "jose";
 import {
   Grant,
@@ -61,7 +60,7 @@ export const buildIdToken = async (
     ...profile,
     ...email,
     ...companies,
-    nonce: getUid(32)
+    nonce: grant.nonce
   };
 
   const jwt = await new jose.SignJWT(payload)

--- a/back/src/routers/oidc-router.ts
+++ b/back/src/routers/oidc-router.ts
@@ -2,9 +2,9 @@ import prisma from "../prisma";
 import { Router, Request, Response } from "express";
 import { oidc, exchange } from "../oauth/oidc";
 import ensureLoggedIn from "../common/middlewares/ensureLoggedIn";
-import { OAuth2, AuthorizationError } from "oauth2orize";
+import { OAuth2, AuthorizationError, MiddlewareRequest } from "oauth2orize";
 import passport from "passport";
-
+import { getUid } from "../utils";
 export const oidcRouter = Router();
 // OpenID Connect router
 
@@ -48,6 +48,7 @@ oidcRouter.get(
     return done(null, client, redirectUri);
   }),
   (req: Request & { oauth2: OAuth2 }, res: Response) => {
+    // console.log(req.oauth2)
     const payload = {
       transactionID: req.oauth2.transactionID,
       user: {
@@ -57,6 +58,7 @@ oidcRouter.get(
         name: req.oauth2.client.name,
         logoUrl: req.oauth2.client.logoUrl
       },
+
       redirectURI: req.oauth2.redirectURI
     };
     return res.json(payload);
@@ -64,7 +66,14 @@ oidcRouter.get(
   oidc.errorHandler()
 );
 
-oidcRouter.post("/oidc/authorize/decision", ensureLoggedIn, oidc.decision());
+oidcRouter.post(
+  "/oidc/authorize/decision",
+  ensureLoggedIn,
+  oidc.decision(function (req: MiddlewareRequest & Request, done) {
+    const nonce = req?.body?.nonce ?? getUid(32);
+    return done(null, { nonce });
+  })
+);
 
 oidcRouter.post(
   "/oidc/token",

--- a/back/src/routers/oidc-router.ts
+++ b/back/src/routers/oidc-router.ts
@@ -48,7 +48,6 @@ oidcRouter.get(
     return done(null, client, redirectUri);
   }),
   (req: Request & { oauth2: OAuth2 }, res: Response) => {
-    // console.log(req.oauth2)
     const payload = {
       transactionID: req.oauth2.transactionID,
       user: {

--- a/front/src/oauth/OidcDialog.tsx
+++ b/front/src/oauth/OidcDialog.tsx
@@ -3,10 +3,14 @@ import { IconCheckCircle1 } from "common/components/Icons";
 import Loader from "../common/components/Loaders";
 import styles from "./Dialog.module.scss";
 import { useOIDC, AuthorizePayload } from "./use-oidc";
+import * as queryString from "query-string";
 
+import { useLocation } from "react-router-dom";
 export default function OidcDialog() {
   const { VITE_API_ENDPOINT } = import.meta.env;
   const { loading, error, authorizePayload } = useOIDC();
+  const location = useLocation();
+  const { nonce } = queryString.parse(location.search);
 
   const authorizeDecisionUrl = `${VITE_API_ENDPOINT}/oidc/authorize/decision`;
   if (loading) {
@@ -47,6 +51,8 @@ export default function OidcDialog() {
             type="hidden"
             value={transactionID as string}
           ></input>
+
+          {!!nonce && <input name="nonce" type="hidden" value={nonce}></input>}
           <div className={styles.flex}>
             <input
               className="btn btn--primary"


### PR DESCRIPTION
Jusque là le nonce était une simple chaîne aléatoire, dorénavant on se conforme à la spec en passant le nonce de la requête s'il était présent.

L'implémentation actuelle fonctionne avec keycloak.

https://user-images.githubusercontent.com/878396/230876038-7f8811a7-3842-4478-aa74-78791d08de5c.mp4


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
