### PR TITLE
Fixes ENV variable to be exposed to Vite

### DIFF
--- a/front/src/layout/LayoutContainer.tsx
+++ b/front/src/layout/LayoutContainer.tsx
@@ -72,7 +72,7 @@ export default withRouter(function LayoutContainer({ history }) {
   const isDevelopment = DEV;
 
   if (!isDevelopment) {
-    const plausibleDomain = import.meta.env.PLAUSIBLE_DOMAIN;
+    const plausibleDomain = import.meta.env.VITE_PLAUSIBLE_DOMAIN;
 
     if (plausibleDomain) {
       const { enableAutoPageviews } = Plausible({


### PR DESCRIPTION
Quick fix recette : la var d'ENV a besoin du prefix pour être exposée par VITE.