### PR TITLE
Tech/ Move CORS middleware

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -124,6 +124,18 @@ if (Sentry) {
   app.use(Sentry.Handlers.requestHandler());
 }
 
+/**
+ * Set the following headers for cross-domain cookie
+ * Access-Control-Allow-Credentials: true
+ * Access-Control-Allow-Origin: $UI_DOMAIN
+ */
+app.use(
+  cors({
+    origin: UI_BASE_URL,
+    credentials: true
+  })
+);
+
 const RATE_LIMIT_WINDOW_SECONDS = 60;
 
 app.use(
@@ -185,18 +197,6 @@ app.use(
 app.use(loggingMiddleware(graphQLPath));
 
 app.use(graphQLPath, timeoutMiddleware());
-
-/**
- * Set the following headers for cross-domain cookie
- * Access-Control-Allow-Credentials: true
- * Access-Control-Allow-Origin: $UI_DOMAIN
- */
-app.use(
-  cors({
-    origin: UI_BASE_URL,
-    credentials: true
-  })
-);
 
 // configure session for passport local strategy
 const RedisStore = redisStore(session);


### PR DESCRIPTION
On met le middleware de cors plus haut dans la liste pour:
- jetter immédiatement ceux qui n'auraient pas le droit de query l'API
- pour les requêtes OPTIONS ne pas jouer tout un tas de middleware inutile (et qui tombent en erreur pour certains)
![image](https://user-images.githubusercontent.com/5145523/231471579-e60a03c5-4933-4635-bfa9-6997232905ce.png)

