### PR TITLE
Ajout d'un index sur `StatusLog.loggedAt`

### DIFF
--- a/back/prisma/migrations/132_create_index_statuslog_loggedAt.sql
+++ b/back/prisma/migrations/132_create_index_statuslog_loggedAt.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "_StatusLogLoggedAtIdx" ON "default$default"."StatusLog"("loggedAt");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -633,6 +633,7 @@ model StatusLog {
 
   @@index([userId], map: "_StatusLogUserIdIdx")
   @@index([formId], map: "_StatusLogFormIdIdx")
+  @@index([loggedAt], map: "_StatusLogLoggedAtIdx")
 }
 
 model TraderReceipt {


### PR DESCRIPTION
On n'avait pas d'index sur ce champ filtrable via la query `formLifeCycle` et sur laquelle des problèmes de performances ont été constatées. 


