### PR TITLE
[TRA-9429][BSDD] Lorsque l'émetteur est un particulier, le cadre 9 ne devrait pas se remplir automatiquement avec le nom du propriétaire de la clé d'API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+
 # [2023.4.2] 24/04/2023
 
 #### :rocket: Nouvelles fonctionnalités
@@ -11,6 +12,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Envoi d'un mail aux administrateurs d'une entreprise ayant ignoré une RevisionRequest pendant 5 jours (BSD + BSDA) [PR 2288](https://github.com/MTES-MCT/trackdechets/pull/2288)
 
 #### :bug: Corrections de bugs
+
+- Lorsque l'émetteur est un particulier, le champ `emittedBy` ne devrait pas se remplir automatiquement avec le nom de l'utilisateur appelant la mutation `markAsSealed`. Le champ se remplit désormais avec la valeur "Signature auto (particulier)". [PR 2316](https://github.com/MTES-MCT/trackdechets/pull/2316)
 
 #### :boom: Breaking changes
 
@@ -35,8 +38,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Tous BSD - transport - Le récépissé transporteur du BSFF est obligatoire, sauf exemption à cocher [PR 2205](https://github.com/MTES-MCT/trackdechets/pull/2205).
 
 #### :nail_care: Améliorations
+
 - Améliorations sur l'annexe 1 [PR 2274](https://github.com/MTES-MCT/trackdechets/pull/2274)
-  - Ajout du code déchet 15 02 02*
+  - Ajout du code déchet 15 02 02\*
   - Ajout de la propriété `receivedSignatureAutomations` sur l'objet `CompanyPrivate` pour lister les entreprises qui ont activé la signature automatique
   - Correction de bugs sur le PDF d'un bordereau de tournée
   - Correction d'un bug à la signature des annexes 1 émises par des particuliers

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -1163,16 +1163,18 @@ describe("Mutation.markAsSealed", () => {
     });
 
     const { mutate } = makeClient(user);
-    const { data } = await mutate<Pick<Mutation, "markAsSealed">>(
-      MARK_AS_SEALED,
-      {
-        variables: {
-          id: form.id
-        }
+    await mutate<Pick<Mutation, "markAsSealed">>(MARK_AS_SEALED, {
+      variables: {
+        id: form.id
       }
-    );
+    });
 
-    expect(data.markAsSealed.status).toBe("SIGNED_BY_PRODUCER");
+    const updatedForm = await prisma.form.findUnique({
+      where: { id: form.id }
+    });
+    expect(updatedForm.status).toEqual("SIGNED_BY_PRODUCER");
+    expect(updatedForm.emittedAt).not.toBeNull();
+    expect(updatedForm.emittedBy).toEqual("Signature auto (particulier)");
   });
 
   it("should throw an error if any SIRET does not exists", async () => {

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -42,7 +42,7 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     // pre-validate when signature by producer will be by-passed at the end of this mutation
     formUpdateInput = {
       emittedAt: new Date(),
-      emittedBy: user.name,
+      emittedBy: "Signature auto (particulier)",
       emittedByEcoOrganisme: false,
       // required for machine to authorize signature
       emitterIsForeignShip: form.emitterIsForeignShip,

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -42,7 +42,9 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
     // pre-validate when signature by producer will be by-passed at the end of this mutation
     formUpdateInput = {
       emittedAt: new Date(),
-      emittedBy: "Signature auto (particulier)",
+      emittedBy: form.emitterIsPrivateIndividual
+        ? "Signature auto (particulier)"
+        : "Signature auto (navire étranger)",
       emittedByEcoOrganisme: false,
       // required for machine to authorize signature
       emitterIsForeignShip: form.emitterIsForeignShip,


### PR DESCRIPTION

![Capture d’écran 2023-04-14 à 17 16 55](https://user-images.githubusercontent.com/2269165/232470252-58b0450f-7755-4770-b09b-17f0fc65c931.png)

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-9429)
