### PR TITLE
[TRA-11187] Make bsdd waste detail name mandatory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Tous BSD - transport - Ne plus proposer de champs de récépissés modifiables mais automatiquement remplir celles enregistrées dans le compte Trackdéchets de l'établissement. Informer du récépissé dans les modales de signature transporteur [PR 2205](https://github.com/MTES-MCT/trackdechets/pull/2205).
+- Le champ wasteDetails.name (appellation du déchet) devient obigatoire sur le Bsdd à partir de l'étape SEALED [PR 2317](https://github.com/MTES-MCT/trackdechets/pull/2317).
 
 ### :bug: Corrections de bugs
 

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -285,6 +285,7 @@ export const forwardedInData: Partial<Prisma.FormCreateInput> = {
   recipientCap: "CAP",
   recipientProcessingOperation: "R 1",
   wasteDetailsCode: "05 01 04*",
+  wasteDetailsName: "Déchets divers",
   wasteDetailsIsDangerous: true,
   wasteDetailsOnuCode: "2003",
   wasteDetailsPackagingInfos: [{ type: "CITERNE", quantity: 1 }],

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -326,7 +326,6 @@ describe("ActivityEvent.Bsda", () => {
       bsdaId,
       now
     );
-    console.log(bsdaFromEventsAfterCreate);
     expect(bsdaFromEventsAfterCreate.wasteCode).toBe("06 07 01*");
     expect(bsdaAfterUpdate!.wasteCode).toBe("06 13 04*");
   });

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -326,6 +326,7 @@ describe("ActivityEvent.Bsda", () => {
       bsdaId,
       now
     );
+    console.log(bsdaFromEventsAfterCreate);
     expect(bsdaFromEventsAfterCreate.wasteCode).toBe("06 07 01*");
     expect(bsdaAfterUpdate!.wasteCode).toBe("06 13 04*");
   });

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -108,6 +108,7 @@ describe("ActivityEvent.Bsdd", () => {
           },
           wasteDetails: {
             code: "01 03 04*",
+            name: "stériles acidogènes",
             onuCode: "AAA",
             packagingInfos: [
               { type: "FUT", quantity: 1 },

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -48,6 +48,7 @@ const formData: Partial<Form> = {
   transporterCompanyPhone: "03",
   transporterCompanyMail: "t@t.fr",
   wasteDetailsCode: "16 06 01*",
+  wasteDetailsName: "Déchets divers",
   wasteDetailsOnuCode: "AAA",
   wasteDetailsPackagingInfos: [
     { type: "FUT", other: null, quantity: 1 },

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -82,6 +82,7 @@ describe("mutation / importPaperForm", () => {
         },
         wasteDetails: {
           code: "01 03 04*",
+          name: "Déchets divers",
           quantity: 1.0,
           quantityType: QuantityType.REAL,
           packagingInfos: [{ type: "BENNE" as Packagings, quantity: 1 }],
@@ -390,6 +391,7 @@ describe("mutation / importPaperForm", () => {
         transporterCompanyContact: "Mr Transporteur",
         transporterCompanyMail: "trasnporteur@trackdechets.fr",
         wasteDetailsCode: "01 03 04*",
+        wasteDetailsName: "stériles acidogènes",
         wasteDetailsQuantity: 1.0,
         wasteDetailsQuantityType: QuantityType.ESTIMATED,
         wasteDetailsPackagingInfos: [{ type: "BENNE", quantity: 1 }],

--- a/back/src/forms/resolvers/mutations/__tests__/signEmissionForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/signEmissionForm.integration.ts
@@ -365,7 +365,6 @@ describe("signEmissionForm", () => {
         recipientCompanyName: temporaryStorage.company.name
       }
     });
-
     const emittedAt = new Date("2018-12-11T00:00:00.000Z");
 
     const { mutate } = makeClient(temporaryStorage.user);

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -575,7 +575,7 @@ input WasteDetailsInput {
   """
   code: String
 
-  "Dénomination usuelle"
+  "Dénomination usuelle. Obligatoire"
   name: String
 
   "Code ONU. Obligatoire pour les déchets dangereux. Merci d'indiquer 'non soumis' si nécessaire."

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -651,6 +651,9 @@ const fullWasteDetailsSchemaFn: FactorySchemaOf<
         .string()
         .requiredIf(!isDraft, "Le code déchet est obligatoire")
         .oneOf([...BSDD_WASTE_CODES, "", null], INVALID_WASTE_CODE),
+      wasteDetailsName: yup
+        .string()
+        .requiredIf(!isDraft, "L'appellation du déchet est obligatoire."),
       wasteDetailsPackagingInfos: yup
         .array()
         .requiredIf(!isDraft, "Le détail du conditionnement est obligatoire")

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -68,7 +68,7 @@ export default connect<{}, Values>(function WasteInfo(props) {
 
       <div className="form__row">
         <label>
-          Votre appellation du déchet (optionnel)
+          Votre appellation du déchet
           <Tooltip
             msg="L'appellation du déchet est propre à votre entreprise pour vous aider
           à retrouver facilement le déchet concerné."


### PR DESCRIPTION
Le champ appellation du déchet devient obligatoire (au-delà du stade brouillon).

C'est un breaking change, annoncé dans la dernière NL tech.

<img width="557" alt="Capture d’écran 2023-04-18 à 09 17 23" src="https://user-images.githubusercontent.com/878396/232701131-c955450a-11ba-4b75-95e5-924044867bad.png">


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11187)
