### PR TITLE
[TRA-11644] Permettre de filtrer sur un numéro de bordereau dans les queries permettant de lister les  demandes de révision `formRevisionRequests` et `bsdaRevisionRequests`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -47,6 +47,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
   - Correction d'un bug à la signature des annexes 1 émises par des particuliers
   - Désactivation du bouton de création de révision sur les annexes 1: seul le borereau de tournée peut être révisé
   - Ajout des champs consistance du déchet et CAP sur le bordereau de tournée
+- Ajout d'un filtre par numéro de bordereau sur les queries `formRevisionRequests` et `bsdaRevisionsRequests` [PR 2319](https://github.com/MTES-MCT/trackdechets/pull/2319)
 
 - Modification des mails d'onboarding (modification du contenu et des triggers) [PR 2212](https://github.com/MTES-MCT/trackdechets/pull/2212):
   - Le premier mail d'onboarding est envoyé:

--- a/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -1,13 +1,16 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import { Query } from "../../../../generated/graphql/types";
+import {
+  Query,
+  QueryBsdaRevisionRequestsArgs
+} from "../../../../generated/graphql/types";
 import prisma from "../../../../prisma";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdaFactory } from "../../../__tests__/factories";
 
 const BSDA_REVISION_REQUESTS = `
-  query BsdaRevisionRequests($siret: String!) {
-    bsdaRevisionRequests(siret: $siret) {
+  query BsdaRevisionRequests($siret: String!, $where:BsdaRevisionRequestWhere) {
+    bsdaRevisionRequests(siret: $siret, where: $where) {
       totalCount
       pageInfo {
         hasNextPage
@@ -112,6 +115,98 @@ describe("Mutation.bsdaRevisionRequests", () => {
 
     expect(errors[0].message).toBe(
       `Vous n'êtes pas membre de l'entreprise portant le siret "${company.siret}".`
+    );
+  });
+
+  it("should filter based on status", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsda = await bsdaFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    // should be included
+    const bsda1RevisionRequest = await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    // should not be included
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "REFUSED"
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<
+      Pick<Query, "bsdaRevisionRequests">,
+      QueryBsdaRevisionRequestsArgs
+    >(BSDA_REVISION_REQUESTS, {
+      variables: { siret: company.siret, where: { status: "ACCEPTED" } }
+    });
+
+    expect(data.bsdaRevisionRequests.totalCount).toBe(1);
+    expect(data.bsdaRevisionRequests.edges.map(_ => _.node)[0].id).toEqual(
+      bsda1RevisionRequest.id
+    );
+  });
+
+  it("should filter based on bsdaId", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsda1 = await bsdaFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const bsda2 = await bsdaFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    // should be included
+    const bsda1RevisionRequest = await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda1.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    // should not be included
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda2.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<
+      Pick<Query, "bsdaRevisionRequests">,
+      QueryBsdaRevisionRequestsArgs
+    >(BSDA_REVISION_REQUESTS, {
+      variables: { siret: company.siret, where: { bsdaId: bsda1.id } }
+    });
+
+    expect(data.bsdaRevisionRequests.totalCount).toBe(1);
+    expect(data.bsdaRevisionRequests.edges.map(_ => _.node)[0].id).toEqual(
+      bsda1RevisionRequest.id
     );
   });
 });

--- a/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -201,7 +201,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
       Pick<Query, "bsdaRevisionRequests">,
       QueryBsdaRevisionRequestsArgs
     >(BSDA_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { bsdaId: bsda1.id } }
+      variables: { siret: company.siret, where: { bsdaId: { _eq: bsda1.id } } }
     });
 
     expect(data.bsdaRevisionRequests.totalCount).toBe(1);

--- a/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -153,7 +153,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
       Pick<Query, "bsdaRevisionRequests">,
       QueryBsdaRevisionRequestsArgs
     >(BSDA_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { status: "ACCEPTED" } }
+      variables: { siret: company.orgId, where: { status: "ACCEPTED" } }
     });
 
     expect(data.bsdaRevisionRequests.totalCount).toBe(1);
@@ -201,7 +201,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
       Pick<Query, "bsdaRevisionRequests">,
       QueryBsdaRevisionRequestsArgs
     >(BSDA_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { bsdaId: { _eq: bsda1.id } } }
+      variables: { siret: company.orgId, where: { bsdaId: { _eq: bsda1.id } } }
     });
 
     expect(data.bsdaRevisionRequests.totalCount).toBe(1);

--- a/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -114,7 +114,7 @@ describe("Mutation.bsdaRevisionRequests", () => {
     );
 
     expect(errors[0].message).toBe(
-      `Vous n'êtes pas membre de l'entreprise portant le siret "${company.siret}".`
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${company.siret}`
     );
   });
 

--- a/back/src/bsda/resolvers/queries/revisionRequests.ts
+++ b/back/src/bsda/resolvers/queries/revisionRequests.ts
@@ -1,60 +1,57 @@
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
-import { QueryBsdaRevisionRequestsArgs } from "../../../generated/graphql/types";
-import { GraphQLContext } from "../../../types";
+import { QueryResolvers } from "../../../generated/graphql/types";
 import { getReadonlyBsdaRepository } from "../../repository";
 import { getConnection } from "../../../common/pagination";
+import { Prisma } from "@prisma/client";
 import { Permission, checkUserPermissions } from "../../../permissions";
 
 const MIN_SIZE = 0;
 const MAX_SIZE = 50;
 
-export async function bsdaRevisionRequests(
-  _,
-  {
-    siret,
-    after,
-    first = MAX_SIZE,
-    where: inputWhere = {}
-  }: QueryBsdaRevisionRequestsArgs,
-  context: GraphQLContext
-) {
-  const user = checkIsAuthenticated(context);
+export const bsdaRevisionRequests: QueryResolvers["bsdaRevisionRequests"] =
+  async (_, args, context) => {
+    const { siret, after, first = MAX_SIZE, where: where = {} } = args;
+    const user = checkIsAuthenticated(context);
+    await checkUserPermissions(
+      user,
+      siret,
+      Permission.BsdCanList,
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${siret}`
+    );
+    const company = await getCompanyOrCompanyNotFound({ orgId: siret });
 
-  await checkUserPermissions(
-    user,
-    [siret].filter(Boolean),
-    Permission.BsdCanList,
-    `Vous n'êtes pas membre de l'entreprise portant le siret "${siret}".`
-  );
+    const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
 
-  const company = await getCompanyOrCompanyNotFound({ orgId: siret });
+    const prismaWhere: Prisma.BsdaRevisionRequestWhereInput = {
+      OR: [
+        { authoringCompanyId: company.id },
+        { approvals: { some: { approverSiret: company.orgId } } }
+      ],
+      ...(where.status ? { status: where.status } : {}),
+      ...(where.bsdaId ? { bsdaId: where.bsdaId } : {})
+    };
 
-  const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
+    const bsdaRepository = getReadonlyBsdaRepository();
+    const revisionRequestsTotalCount =
+      await bsdaRepository.countRevisionRequests(prismaWhere);
 
-  const { status } = inputWhere ?? {};
-  const where = {
-    OR: [
-      { authoringCompanyId: company.id },
-      { approvals: { some: { approverSiret: company.orgId } } }
-    ],
-    ...(status && { status })
-  };
+    return getConnection({
+      totalCount: revisionRequestsTotalCount,
+      findMany: prismaPaginationArgs =>
+        bsdaRepository.findManyBsdaRevisionRequest(prismaWhere, {
+          ...prismaPaginationArgs,
 
-  const bsdaRepository = getReadonlyBsdaRepository();
-  const revisionRequestsTotalCount = await bsdaRepository.countRevisionRequests(
-    where
-  );
-
-  return getConnection({
-    totalCount: revisionRequestsTotalCount,
-    findMany: prismaPaginationArgs =>
-      bsdaRepository.findManyBsdaRevisionRequest(where, {
-        ...prismaPaginationArgs,
-
-        orderBy: { createdAt: "desc" }
+          orderBy: { createdAt: "desc" }
+        }),
+      formatNode: node => ({
+        ...node,
+        // the following fields will be resolved in BsdaRevisionRequest resolver
+        approvals: [],
+        content: null,
+        authoringCompany: null,
+        bsda: null
       }),
-    formatNode: node => node,
-    ...{ after, first: pageSize }
-  });
-}
+      ...{ after, first: pageSize }
+    });
+  };

--- a/back/src/bsda/resolvers/queries/revisionRequests.ts
+++ b/back/src/bsda/resolvers/queries/revisionRequests.ts
@@ -1,6 +1,11 @@
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
-import { QueryResolvers } from "../../../generated/graphql/types";
+import {
+  Bsda,
+  BsdaRevisionRequestContent,
+  FormCompany,
+  QueryResolvers
+} from "../../../generated/graphql/types";
 import { getReadonlyBsdaRepository } from "../../repository";
 import { getConnection } from "../../../common/pagination";
 import { Prisma } from "@prisma/client";
@@ -12,7 +17,7 @@ const MAX_SIZE = 50;
 
 export const bsdaRevisionRequests: QueryResolvers["bsdaRevisionRequests"] =
   async (_, args, context) => {
-    const { siret, after, first = MAX_SIZE, where: where = {} } = args;
+    const { siret, after, first = MAX_SIZE, where: where } = args;
     const user = checkIsAuthenticated(context);
     await checkUserPermissions(
       user,
@@ -29,8 +34,8 @@ export const bsdaRevisionRequests: QueryResolvers["bsdaRevisionRequests"] =
         { authoringCompanyId: company.id },
         { approvals: { some: { approverSiret: company.orgId } } }
       ],
-      ...(where.status ? { status: where.status } : {}),
-      ...(where.bsdaId ? { bsdaId: toPrismaStringFilter(where.bsdaId) } : {})
+      ...(where?.status ? { status: where.status } : {}),
+      ...(where?.bsdaId ? { bsdaId: toPrismaStringFilter(where.bsdaId) } : {})
     };
 
     const bsdaRepository = getReadonlyBsdaRepository();
@@ -49,9 +54,9 @@ export const bsdaRevisionRequests: QueryResolvers["bsdaRevisionRequests"] =
         ...node,
         // the following fields will be resolved in BsdaRevisionRequest resolver
         approvals: [],
-        content: null,
-        authoringCompany: null,
-        bsda: null
+        content: {} as BsdaRevisionRequestContent,
+        authoringCompany: {} as FormCompany,
+        bsda: {} as Bsda
       }),
       ...{ after, first: pageSize }
     });

--- a/back/src/bsda/resolvers/queries/revisionRequests.ts
+++ b/back/src/bsda/resolvers/queries/revisionRequests.ts
@@ -5,6 +5,7 @@ import { getReadonlyBsdaRepository } from "../../repository";
 import { getConnection } from "../../../common/pagination";
 import { Prisma } from "@prisma/client";
 import { Permission, checkUserPermissions } from "../../../permissions";
+import { toPrismaStringFilter } from "../../../common/where";
 
 const MIN_SIZE = 0;
 const MAX_SIZE = 50;
@@ -29,7 +30,7 @@ export const bsdaRevisionRequests: QueryResolvers["bsdaRevisionRequests"] =
         { approvals: { some: { approverSiret: company.orgId } } }
       ],
       ...(where.status ? { status: where.status } : {}),
-      ...(where.bsdaId ? { bsdaId: where.bsdaId } : {})
+      ...(where.bsdaId ? { bsdaId: toPrismaStringFilter(where.bsdaId) } : {})
     };
 
     const bsdaRepository = getReadonlyBsdaRepository();

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -434,5 +434,8 @@ input BsdaRevisionRequestWasteInput {
 }
 
 input BsdaRevisionRequestWhere {
+  "Permet de filtrer sur un statut de demande de révision"
   status: RevisionRequestStatus
+  "Permet de filtrer sur un numéro de bordereau"
+  bsdaId: ID
 }

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -437,5 +437,5 @@ input BsdaRevisionRequestWhere {
   "Permet de filtrer sur un statut de demande de révision"
   status: RevisionRequestStatus
   "Permet de filtrer sur un numéro de bordereau"
-  bsdaId: ID
+  bsdaId: StringFilter
 }

--- a/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
@@ -208,7 +208,7 @@ describe("Mutation.formRevisionRequests", () => {
       Pick<Query, "formRevisionRequests">,
       QueryFormRevisionRequestsArgs
     >(FORM_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { bsddId: bsdd1.id } }
+      variables: { siret: company.siret, where: { bsddId: { _eq: bsdd1.id } } }
     });
 
     expect(data.formRevisionRequests.totalCount).toBe(1);

--- a/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
@@ -1,5 +1,8 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import { Query } from "../../../../generated/graphql/types";
+import {
+  Query,
+  QueryFormRevisionRequestsArgs
+} from "../../../../generated/graphql/types";
 import prisma from "../../../../prisma";
 import {
   formFactory,
@@ -8,8 +11,8 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 
 const FORM_REVISION_REQUESTS = `
-  query FormRevisionRequests($siret: String!) {
-    formRevisionRequests(siret: $siret) {
+  query FormRevisionRequests($siret: String!, $where:FormRevisionRequestWhere) {
+    formRevisionRequests(siret: $siret, where: $where) {
       totalCount
       pageInfo {
         hasNextPage
@@ -115,7 +118,57 @@ describe("Mutation.formRevisionRequests", () => {
     );
 
     expect(errors[0].message).toBe(
-      `Vous n'êtes pas membre de l'entreprise portant le siret "${company.siret}".`
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${company.siret}`
+    );
+  });
+
+  it("should filter based on bsddId", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdd1 = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const bsdd2 = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    // should be included
+    const bsdd1RevisionRequest = await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd1.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    // should not be included
+    await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd2.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<
+      Pick<Query, "formRevisionRequests">,
+      QueryFormRevisionRequestsArgs
+    >(FORM_REVISION_REQUESTS, {
+      variables: { siret: company.siret, where: { bsddId: bsdd1.id } }
+    });
+
+    expect(data.formRevisionRequests.totalCount).toBe(1);
+    expect(data.formRevisionRequests.edges.map(_ => _.node)[0].id).toEqual(
+      bsdd1RevisionRequest.id
     );
   });
 });

--- a/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
@@ -158,7 +158,7 @@ describe("Mutation.formRevisionRequests", () => {
       Pick<Query, "formRevisionRequests">,
       QueryFormRevisionRequestsArgs
     >(FORM_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { status: "ACCEPTED" } }
+      variables: { siret: company.orgId, where: { status: "ACCEPTED" } }
     });
 
     expect(data.formRevisionRequests.totalCount).toBe(1);
@@ -208,7 +208,7 @@ describe("Mutation.formRevisionRequests", () => {
       Pick<Query, "formRevisionRequests">,
       QueryFormRevisionRequestsArgs
     >(FORM_REVISION_REQUESTS, {
-      variables: { siret: company.siret, where: { bsddId: { _eq: bsdd1.id } } }
+      variables: { siret: company.orgId, where: { bsddId: { _eq: bsdd1.id } } }
     });
 
     expect(data.formRevisionRequests.totalCount).toBe(1);

--- a/back/src/forms/resolvers/queries/formRevisionRequests.ts
+++ b/back/src/forms/resolvers/queries/formRevisionRequests.ts
@@ -3,7 +3,12 @@ import { getCompanyOrCompanyNotFound } from "../../../companies/database";
 import prisma from "../../../prisma";
 import { getConnection } from "../../../common/pagination";
 import { Prisma } from "@prisma/client";
-import { QueryResolvers } from "../../../generated/graphql/types";
+import {
+  Form,
+  FormCompany,
+  FormRevisionRequestContent,
+  QueryResolvers
+} from "../../../generated/graphql/types";
 import { Permission, checkUserPermissions } from "../../../permissions";
 import { toPrismaStringFilter } from "../../../common/where";
 
@@ -12,7 +17,7 @@ const MAX_SIZE = 50;
 
 const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
   async (_, args, context) => {
-    const { siret, where = {}, first = MAX_SIZE, after } = args;
+    const { siret, where, first = MAX_SIZE, after } = args;
 
     const user = checkIsAuthenticated(context);
 
@@ -32,8 +37,8 @@ const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
         { authoringCompanyId: company.id },
         { approvals: { some: { approverSiret: company.orgId } } }
       ],
-      ...(where.status ? { status: where.status } : {}),
-      ...(where.bsddId ? { bsddId: toPrismaStringFilter(where.bsddId) } : {})
+      ...(where?.status ? { status: where.status } : {}),
+      ...(where?.bsddId ? { bsddId: toPrismaStringFilter(where.bsddId) } : {})
     };
 
     const revisionRequestsTotalCount = await prisma.bsddRevisionRequest.count({
@@ -52,9 +57,9 @@ const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
         ...node,
         // the following fields will be resolved in FormRevisionRequest resolver
         approvals: [],
-        content: null,
-        authoringCompany: null,
-        form: null
+        content: {} as FormRevisionRequestContent,
+        authoringCompany: {} as FormCompany,
+        form: {} as Form
       }),
       ...{ after, first: pageSize }
     });

--- a/back/src/forms/resolvers/queries/formRevisionRequests.ts
+++ b/back/src/forms/resolvers/queries/formRevisionRequests.ts
@@ -5,6 +5,7 @@ import { getConnection } from "../../../common/pagination";
 import { Prisma } from "@prisma/client";
 import { QueryResolvers } from "../../../generated/graphql/types";
 import { Permission, checkUserPermissions } from "../../../permissions";
+import { toPrismaStringFilter } from "../../../common/where";
 
 const MIN_SIZE = 0;
 const MAX_SIZE = 50;
@@ -32,7 +33,7 @@ const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
         { approvals: { some: { approverSiret: company.orgId } } }
       ],
       ...(where.status ? { status: where.status } : {}),
-      ...(where.bsddId ? { bsddId: where.bsddId } : {})
+      ...(where.bsddId ? { bsddId: toPrismaStringFilter(where.bsddId) } : {})
     };
 
     const revisionRequestsTotalCount = await prisma.bsddRevisionRequest.count({

--- a/back/src/forms/resolvers/queries/formRevisionRequests.ts
+++ b/back/src/forms/resolvers/queries/formRevisionRequests.ts
@@ -1,59 +1,62 @@
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
-import { QueryFormRevisionRequestsArgs } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
-import { GraphQLContext } from "../../../types";
 import { getConnection } from "../../../common/pagination";
-import { checkUserPermissions, Permission } from "../../../permissions";
+import { Prisma } from "@prisma/client";
+import { QueryResolvers } from "../../../generated/graphql/types";
+import { Permission, checkUserPermissions } from "../../../permissions";
 
 const MIN_SIZE = 0;
 const MAX_SIZE = 50;
 
-export default async function formRevisionRequests(
-  _,
-  {
-    siret,
-    after,
-    first = MAX_SIZE,
-    where: inputWhere = {}
-  }: QueryFormRevisionRequestsArgs,
-  context: GraphQLContext
-) {
-  const user = checkIsAuthenticated(context);
+const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
+  async (_, args, context) => {
+    const { siret, where = {}, first = MAX_SIZE, after } = args;
 
-  await checkUserPermissions(
-    user,
-    [siret].filter(Boolean),
-    Permission.BsdCanList,
-    `Vous n'êtes pas membre de l'entreprise portant le siret "${siret}".`
-  );
-  // TODO support orgId instead of siret for foreign companies
-  const company = await getCompanyOrCompanyNotFound({ siret });
+    const user = checkIsAuthenticated(context);
 
-  const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
+    await checkUserPermissions(
+      user,
+      siret,
+      Permission.BsdCanList,
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${siret}`
+    );
+    // TODO support orgId instead of siret for foreign companies
+    const company = await getCompanyOrCompanyNotFound({ siret });
 
-  const { status } = inputWhere ?? {};
-  const where = {
-    OR: [
-      { authoringCompanyId: company.id },
-      { approvals: { some: { approverSiret: company.orgId } } }
-    ],
-    ...(status && { status })
+    const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
+
+    const prismaWhere: Prisma.BsddRevisionRequestWhereInput = {
+      OR: [
+        { authoringCompanyId: company.id },
+        { approvals: { some: { approverSiret: company.orgId } } }
+      ],
+      ...(where.status ? { status: where.status } : {}),
+      ...(where.bsddId ? { bsddId: where.bsddId } : {})
+    };
+
+    const revisionRequestsTotalCount = await prisma.bsddRevisionRequest.count({
+      where: prismaWhere
+    });
+
+    return getConnection({
+      totalCount: revisionRequestsTotalCount,
+      findMany: prismaPaginationArgs =>
+        prisma.bsddRevisionRequest.findMany({
+          where: prismaWhere,
+          ...prismaPaginationArgs,
+          orderBy: { createdAt: "desc" }
+        }),
+      formatNode: node => ({
+        ...node,
+        // the following fields will be resolved in FormRevisionRequest resolver
+        approvals: [],
+        content: null,
+        authoringCompany: null,
+        form: null
+      }),
+      ...{ after, first: pageSize }
+    });
   };
 
-  const revisionRequestsTotalCount = await prisma.bsddRevisionRequest.count({
-    where
-  });
-
-  return getConnection({
-    totalCount: revisionRequestsTotalCount,
-    findMany: prismaPaginationArgs =>
-      prisma.bsddRevisionRequest.findMany({
-        where,
-        ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
-      }),
-    formatNode: node => node,
-    ...{ after, first: pageSize }
-  });
-}
+export default formRevisionRequestResolver;

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -924,7 +924,7 @@ input FormRevisionRequestTemporaryStorerInput {
 }
 
 input FormRevisionRequestWhere {
-  "Permet de filtrer sur un statut particulier de demande de révision"
+  "Permet de filtrer sur un statut de demande de révision"
   status: RevisionRequestStatus
   "Permet de filtrer sur un numéro de bordereau"
   bsddId: ID

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -927,5 +927,5 @@ input FormRevisionRequestWhere {
   "Permet de filtrer sur un statut de demande de révision"
   status: RevisionRequestStatus
   "Permet de filtrer sur un numéro de bordereau"
-  bsddId: ID
+  bsddId: StringFilter
 }

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -924,5 +924,8 @@ input FormRevisionRequestTemporaryStorerInput {
 }
 
 input FormRevisionRequestWhere {
+  "Permet de filtrer sur un statut particulier de demande de révision"
   status: RevisionRequestStatus
+  "Permet de filtrer sur un numéro de bordereau"
+  bsddId: ID
 }


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11644)
