### PR TITLE
HOTFIX - fallback vers l'API de l'INSEE an cas d'erreur SiretNotFoundError

### DIFF
--- a/back/src/companies/sirene/__tests__/redundancy.test.ts
+++ b/back/src/companies/sirene/__tests__/redundancy.test.ts
@@ -40,21 +40,19 @@ describe("redundant", () => {
     expect(fn2).not.toHaveBeenCalled();
   });
 
-  it("should not call fallback function when the first function throws SiretNotFoundError", async () => {
+  it("should call fallback function when the first function throws SiretNotFoundError", async () => {
     const fn = redundant(fn1, fn2);
 
     // test fn1 throws UserInputError
     fn1.mockRejectedValueOnce(new SiretNotFoundError());
+    fn2.mockResolvedValueOnce("bar");
 
-    try {
-      await fn("foo");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SiretNotFoundError);
-    }
+    const response = await fn("foo");
 
-    // fn2 should not be called
+    expect(response).toEqual("bar");
     expect(fn1).toHaveBeenCalled();
-    expect(fn2).not.toHaveBeenCalled();
+    // fn2 should have been called
+    expect(fn2).toHaveBeenCalled();
   });
 
   it("should call fallback function when the first function returns 5xx", async () => {

--- a/back/src/companies/sirene/redundancy.ts
+++ b/back/src/companies/sirene/redundancy.ts
@@ -1,5 +1,5 @@
 import type { AsyncReturnType } from "type-fest";
-import { AnonymousCompanyError, SiretNotFoundError } from "./errors";
+import { AnonymousCompanyError } from "./errors";
 
 /**
  * Loop over the functions until one of them returns a result
@@ -14,10 +14,7 @@ export function redundant<F extends (...args: any[]) => any>(...fns: F[]) {
         return response;
       } catch (error) {
         // fail fast for user-input errors
-        if (
-          error instanceof SiretNotFoundError ||
-          error instanceof AnonymousCompanyError
-        ) {
+        if (error instanceof AnonymousCompanyError) {
           throw error;
         }
 

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -1,11 +1,6 @@
 import { searchCompany as searchCompanyInsee } from "./insee/client";
-import { searchCompany as searchCompanySocialGouv } from "./social.gouv/client";
 import { searchCompany as searchCompanyTD } from "./trackdechets/client";
-import {
-  backoffIfTestEnvs,
-  backoffIfTooManyRequests,
-  throttle
-} from "./ratelimit";
+import { backoffIfTestEnvs, backoffIfTooManyRequests } from "./ratelimit";
 import { redundant } from "./redundancy";
 import { cache } from "./cache";
 import { SireneSearchResult } from "./types";
@@ -17,22 +12,10 @@ export const searchCompanyInseeThrottled =
     })
   );
 
-export const searchCompanySocialGouvThrottled =
-  backoffIfTestEnvs<SireneSearchResult>(
-    throttle(searchCompanySocialGouv, {
-      service: "social_gouv",
-      requestsPerSeconds: 50
-    })
-  );
-
 // list different implementations of searchCompany by order of priority.
 // please keep searchCompanyTD then searchCompanyInseeThrottled in this order
 // in order to preserve anonymous companies processing
-const searchCompanyProviders = [
-  searchCompanyTD,
-  searchCompanyInseeThrottled,
-  searchCompanySocialGouvThrottled
-];
+const searchCompanyProviders = [searchCompanyTD, searchCompanyInseeThrottled];
 
 /**
  * Apply throttle, redundant and cache decorators to searchCompany functions


### PR DESCRIPTION
On a beaucoup de demandes au support d'utilisateurs dont l'établissement a été crée depuis notre dernière mise à jour INSEE. Les utilisateurs ne retrouvent pas leurs établissements. C'est un effet de bord non anticipé de https://github.com/MTES-MCT/trackdechets/pull/2255. 
Cette PR vise à rollback les changements au niveau de la redondance des services SIRENE.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
