### PR TITLE
Recette / Bouton d'action annexe 1 particulier

### DIFF
--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -255,6 +255,7 @@ const mutableFieldsFragment = gql`
             name
             siret
           }
+          isPrivateIndividual
         }
         transporter {
           company {


### PR DESCRIPTION
Correction de recette.
Le champ isPrivateIndividual doit être chargé pour afficher les bons boutons d'action sur l'annexe 1