### PR TITLE
Recette / Duplicate button

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/BSDDActions.tsx
@@ -90,8 +90,6 @@ export const BSDDActions = ({ form }: BSDDActionsProps) => {
                 styles.BSDDActionsMenu
               )}
             >
-              <TableRoadControlButton siret={siret} form={form} />
-
               <MenuLink
                 as={Link}
                 to={{


### PR DESCRIPTION
Le bouton de contrôle routier apparait 2 fois dans les actions du BSDD.