### PR TITLE
Fix TransporterReceipt & appendix 1

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -4,6 +4,7 @@ import { gql, useMutation, useQuery } from "@apollo/client";
 import { Field, Form as FormikForm, Formik } from "formik";
 import * as yup from "yup";
 import {
+  EmitterType,
   Mutation,
   MutationSignTransportFormArgs,
   Query,
@@ -145,7 +146,9 @@ function SignTransportFormModalContent({
           <FormikForm>
             <FormWasteTransportSummary form={form} />
             <FormJourneySummary form={form} />
-            <TransporterReceipt transporter={form.transporter!} />
+            {form.emitter?.type !== EmitterType.Appendix1Producer && (
+              <TransporterReceipt transporter={form.transporter!} />
+            )}
             <p>
               En qualité de <strong>transporteur du déchet</strong>, j'atteste
               que les informations ci-dessus sont correctes. En signant ce


### PR DESCRIPTION
Le form n'a pas toutes les données transporter. uniquement le siret & contact. Donc il ne faut pas tester si le récepissé est bien présent ou pas dans ce cas. L'info est portée par l'appendix1, pas l'appendix1_producer