### PR TITLE
Hotfix/Dataloaders & perfs

### DIFF
--- a/back/src/auth.ts
+++ b/back/src/auth.ts
@@ -170,7 +170,9 @@ passport.deserializeUser((id: string, done) => {
  * or if it was set more than one day ago
  * @param accessToken
  */
-export function updateAccessTokenLastUsed(accessToken: AccessToken) {
+export function updateAccessTokenLastUsed(
+  accessToken: Pick<AccessToken, "lastUsed" | "token">
+) {
   // use new Date(Date.now()) instead of new Date()
   // in order to mock Date.now in unit test auth.test.ts
   const now = new Date(Date.now());
@@ -194,7 +196,12 @@ passport.use(
         where: {
           token: hashToken(token)
         },
-        include: { user: true }
+        select: {
+          isRevoked: true,
+          lastUsed: true,
+          token: true,
+          user: true
+        }
       });
       if (accessToken && !accessToken.isRevoked) {
         const user = accessToken.user;

--- a/back/src/bsda/resolvers/BsdaRevisionRequest.ts
+++ b/back/src/bsda/resolvers/BsdaRevisionRequest.ts
@@ -11,17 +11,25 @@ import {
 
 const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   approvals: async parent => {
-    return prisma.bsdaRevisionRequest
-      .findUniqueOrThrow({ where: { id: parent.id } })
+    const approvals = await prisma.bsdaRevisionRequest
+      .findUnique({ where: { id: parent.id } })
       .approvals();
+    return approvals ?? [];
   },
   content: parent => {
     return expandBsdaRevisionRequestContent(parent as any);
   },
-  authoringCompany: parent => {
-    return prisma.bsdaRevisionRequest
-      .findUniqueOrThrow({ where: { id: parent.id } })
+  authoringCompany: async parent => {
+    const authoringCompany = await prisma.bsdaRevisionRequest
+      .findUnique({ where: { id: parent.id } })
       .authoringCompany();
+
+    if (!authoringCompany) {
+      throw new Error(
+        `BsdaRevisionRequest ${parent.id} has no authoring company.`
+      );
+    }
+    return authoringCompany;
   },
   bsda: async (parent: BsdaRevisionRequest & { bsdaId: string }) => {
     const actualBsda = await prisma.bsdaRevisionRequest


### PR DESCRIPTION
Pour charger les révisions, les dataloaders n'étaient plus utilisées à cause de l'utilisation de `findUniqueOrThrow`. Seules les révisions étaient touchées par ce problème semble t il