### PR TITLE
Fix Recette sur généralisation récépissés transporteur pour BSDA, BSDASRIn, BSVHU

### DIFF
--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -112,7 +112,7 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
       }),
       customInfo: bsdasri.transporterCustomInfo,
       recepisse: nullIfNoValues({
-        ixExempted: bsdasri.transporterRecepisseIsExempted,
+        isExempted: bsdasri.transporterRecepisseIsExempted,
         department: bsdasri.transporterRecepisseDepartment,
         number: bsdasri.transporterRecepisseNumber,
         validityLimit: processDate(bsdasri.transporterRecepisseValidityLimit)
@@ -379,6 +379,9 @@ function flattenTransporterInput(input: {
     ),
     transporterCompanyVatNumber: chain(input.transporter, t =>
       chain(t.company, c => c.vatNumber)
+    ),
+    transporterRecepisseIsExempted: chain(input.transporter, t =>
+      chain(t.recepisse, recep => recep.isExempted)
     ),
     transporterRecepisseNumber: chain(input.transporter, t =>
       chain(t.recepisse, recep => recep.number)

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -23,7 +23,6 @@ import { PACKAGINGS_NAMES } from "form/bsda/components/packagings/Packagings";
 import {
   Bsda,
   BsdaNextDestination,
-  BsdaTransporter,
   BsdaType,
   FormCompany,
 } from "generated/graphql/types";

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -15,7 +15,7 @@ import styles from "dashboard/detail/common/BSDDetailContent.module.scss";
 import {
   DateRow,
   DetailRow,
-  TransporterRecepisseDetails,
+  TransporterReceiptDetails,
   YesNoRow,
 } from "dashboard/detail/common/Components";
 import { getVerboseAcceptationStatus } from "dashboard/detail/common/utils";
@@ -162,7 +162,7 @@ const Transporter = ({ form }: { form: Bsda }) => {
       <div className={styles.detailGrid}>
         <Company label="Transporteur" company={transporter?.company} />
       </div>
-      <TransporterRecepisseDetails transporter={transporter} />
+      <TransporterReceiptDetails transporter={transporter} />
       <div className={`${styles.detailGrid} `}>
         <DateRow
           value={transporter?.transport?.takenOverAt}

--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -31,8 +31,7 @@ import {
 import {
   DateRow,
   DetailRow,
-  TransporterRecepisseDetails,
-  YesNoRow,
+  TransporterReceiptDetails,
 } from "dashboard/detail/common/Components";
 
 import classNames from "classnames";
@@ -142,7 +141,7 @@ const Transporter = ({ form }: { form: Bsdasri }) => {
       <div className={styles.detailGrid}>
         <Company label="Transporteur" company={transporter?.company} />
       </div>
-      <TransporterRecepisseDetails transporter={transporter} />
+      <TransporterReceiptDetails transporter={transporter} />
       <div className={styles.detailGrid}>
         <DetailRow
           value={getTransportModeLabel(transporter?.transport?.mode)}

--- a/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
+++ b/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
@@ -4,7 +4,7 @@ import {
   IconWarehouseDelivery,
   IconWaterDam,
 } from "common/components/Icons";
-import { Bsvhu, BsvhuTransporter, FormCompany } from "generated/graphql/types";
+import { Bsvhu, FormCompany } from "generated/graphql/types";
 import React from "react";
 import QRCodeIcon from "react-qr-code";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
@@ -13,7 +13,7 @@ import { statusLabels } from "../../constants";
 import {
   DateRow,
   DetailRow,
-  TransporterRecepisseDetails,
+  TransporterReceiptDetails,
 } from "../common/Components";
 
 import styles from "../common/BSDDetailContent.module.scss";
@@ -173,7 +173,7 @@ function Transporter({ form }: { form: Bsvhu }) {
       <div className={styles.detailGrid}>
         <Company label="Transporteur" company={transporter?.company} />
       </div>
-      <TransporterRecepisseDetails transporter={transporter} />
+      <TransporterReceiptDetails transporter={transporter} />
       <div className={styles.detailGrid}>
         <DetailRow
           value={

--- a/front/src/dashboard/detail/common/Components.tsx
+++ b/front/src/dashboard/detail/common/Components.tsx
@@ -75,7 +75,10 @@ export const PackagingRow = ({
   );
 };
 
-export const TransporterRecepisseDetails = ({
+/**
+ * Transporter Recepisse details overview for BSDA, BSVHU and BSDASRI
+ */
+export const TransporterReceiptDetails = ({
   transporter,
 }: {
   transporter?: BsvhuTransporter | BsdaTransporter | BsdasriTransporter | null;
@@ -86,18 +89,22 @@ export const TransporterRecepisseDetails = ({
         value={transporter?.recepisse?.isExempted}
         label="Exemption de récépissé"
       />
-      <DetailRow
-        value={transporter?.recepisse?.number}
-        label="Numéro de récépissé"
-      />
-      <DetailRow
-        value={transporter?.recepisse?.department}
-        label="Département"
-      />
-      <DateRow
-        value={transporter?.recepisse?.validityLimit}
-        label="Date de validité de récépissé"
-      />
+      <>
+        <dt>{"Numéro de récépissé"}</dt>
+        <dd>{transporter?.recepisse?.number}</dd>
+      </>
+      {transporter?.recepisse?.number && (
+        <>
+          <DetailRow
+            value={transporter?.recepisse?.department}
+            label="Département"
+          />
+          <DateRow
+            value={transporter?.recepisse?.validityLimit}
+            label="Date de validité de récépissé"
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/front/src/form/bsda/stepper/steps/Transport.tsx
+++ b/front/src/form/bsda/stepper/steps/Transport.tsx
@@ -1,39 +1,16 @@
 import React, { lazy } from "react";
-import { Field, useFormikContext } from "formik";
+import { Field } from "formik";
 import { FieldTransportModeSelect } from "common/components";
-import TdSwitch from "common/components/Switch";
 import Tooltip from "common/components/Tooltip";
 import DateInput from "form/common/components/custom-inputs/DateInput";
-import { isForeignVat } from "generated/constants/companySearchHelpers";
-import { Bsda } from "generated/graphql/types";
 
 const TagsInput = lazy(() => import("common/components/tags-input/TagsInput"));
 
 type Props = { disabled: boolean };
 
 export function Transport({ disabled }: Props) {
-  const { setFieldValue, values } = useFormikContext<Bsda>();
-
   return (
     <>
-      {!isForeignVat(values.transporter?.company?.vatNumber!) && (
-        <>
-          <h4 className="form__section-heading">
-            Exemption de récépissé de déclaration de transport de déchets
-          </h4>
-          <div className="form__row">
-            <TdSwitch
-              checked={!!values.transporter?.recepisse?.isExempted}
-              onChange={checked =>
-                setFieldValue("transporter.recepisse.isExempted", checked)
-              }
-              disabled={disabled}
-              label="Le transporteur déclare être exempté de récépissé conformément aux
-            dispositions de l'article R.541-50 du code de l'environnement."
-            />
-          </div>
-        </>
-      )}
       <h4 className="form__section-heading">Détails</h4>
       <div className="form__row">
         <label>

--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { Transport } from "./Transport";
 import initialState from "../initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
+import { onCompanySelected } from "form/bsvhu/Transporter";
 
 export function Transporter({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
@@ -19,6 +20,8 @@ export function Transporter({ disabled }) {
       </div>
     );
   }
+
+  const { transporter: initialTransporter } = initialState;
 
   return (
     <>
@@ -36,29 +39,7 @@ export function Transporter({ disabled }) {
         allowForeignCompanies={true}
         isBsdaTransporter={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={transporter => {
-          if (transporter.transporterReceipt) {
-            setFieldValue(
-              "transporter.recepisse.number",
-              transporter.transporterReceipt.receiptNumber
-            );
-            setFieldValue(
-              "transporter.recepisse.validityLimit",
-              transporter.transporterReceipt.validityLimit
-            );
-            setFieldValue(
-              "transporter.recepisse.department",
-              transporter.transporterReceipt.department
-            );
-          } else {
-            setFieldValue("transporter.recepisse.number", "");
-            setFieldValue(
-              "transporter.recepisse.validityLimit",
-              initialState.transporter.recepisse.validityLimit
-            );
-            setFieldValue("transporter.recepisse.department", "");
-          }
-        }}
+        onCompanySelected={onCompanySelected(initialTransporter, setFieldValue)}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -4,6 +4,7 @@ import { Bsda, BsdaType } from "generated/graphql/types";
 import React from "react";
 import { Transport } from "./Transport";
 import initialState from "../initial-state";
+import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
 
 export function Transporter({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
@@ -59,7 +60,11 @@ export function Transporter({ disabled }) {
           }
         }}
       />
-
+      <TransporterReceiptEditionSwitch
+        transporter={values.transporter!}
+        disabled={disabled}
+        setFieldValue={setFieldValue}
+      />
       <Transport disabled={disabled} />
     </>
   );

--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Transport } from "./Transport";
 import initialState from "../initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
-import { onCompanySelected } from "form/bsvhu/Transporter";
+import { onTransporterSelected } from "form/bsvhu/Transporter";
 
 export function Transporter({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
@@ -39,7 +39,10 @@ export function Transporter({ disabled }) {
         allowForeignCompanies={true}
         isBsdaTransporter={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={onCompanySelected(initialTransporter, setFieldValue)}
+        onCompanySelected={onTransporterSelected(
+          initialTransporter,
+          setFieldValue
+        )}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -21,6 +21,7 @@ import companyStyles from "form/common/components/company/CompanyResult.module.s
 import RedErrorMessage from "common/components/RedErrorMessage";
 import TransporterReceipt from "form/common/components/company/TransporterReceipt";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
+import { onCompanySelected } from "form/bsvhu/Transporter";
 
 /**
  *
@@ -46,6 +47,7 @@ export default function Transporter({ status, stepName }) {
   );
 
   const transportEmphasis = stepName === "transport";
+  const { transporter: initialTransporter } = initialState();
   return (
     <>
       {transportEmphasis && <FillFieldsInfo />}
@@ -65,30 +67,10 @@ export default function Transporter({ status, stepName }) {
             optionalMail={true}
             allowForeignCompanies={true}
             registeredOnlyCompanies={true}
-            onCompanySelected={transporter => {
-              if (transporter.transporterReceipt) {
-                setFieldValue(
-                  "transporter.recepisse.number",
-                  transporter.transporterReceipt.receiptNumber
-                );
-                setFieldValue(
-                  "transporter.recepisse.validityLimit",
-                  transporter.transporterReceipt.validityLimit
-                );
-                setFieldValue(
-                  "transporter.recepisse.department",
-                  transporter.transporterReceipt.department
-                );
-              } else {
-                setFieldValue("transporter.recepisse.number", "");
-                setFieldValue(
-                  "transporter.recepisse.validityLimit",
-                  initialState().transporter.recepisse.validityLimit
-                );
-
-                setFieldValue("transporter.recepisse.department", "");
-              }
-            }}
+            onCompanySelected={onCompanySelected(
+              initialTransporter,
+              setFieldValue
+            )}
           />
         )}
       </div>

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -21,7 +21,7 @@ import companyStyles from "form/common/components/company/CompanyResult.module.s
 import RedErrorMessage from "common/components/RedErrorMessage";
 import TransporterReceipt from "form/common/components/company/TransporterReceipt";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
-import { onCompanySelected } from "form/bsvhu/Transporter";
+import { onTransporterSelected } from "form/bsvhu/Transporter";
 
 /**
  *
@@ -67,7 +67,7 @@ export default function Transporter({ status, stepName }) {
             optionalMail={true}
             allowForeignCompanies={true}
             registeredOnlyCompanies={true}
-            onCompanySelected={onCompanySelected(
+            onCompanySelected={onTransporterSelected(
               initialTransporter,
               setFieldValue
             )}

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -20,6 +20,7 @@ import { Loader } from "common/components";
 import companyStyles from "form/common/components/company/CompanyResult.module.scss";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import TransporterReceipt from "form/common/components/company/TransporterReceipt";
+import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
 
 /**
  *
@@ -91,7 +92,11 @@ export default function Transporter({ status, stepName }) {
           />
         )}
       </div>
-
+      <TransporterReceiptEditionSwitch
+        transporter={values.transporter!}
+        disabled={disabled}
+        setFieldValue={setFieldValue}
+      />
       {showHandedOverAtField ? (
         <div
           className={classNames("form__row", {

--- a/front/src/form/bsvhu/Transporter.tsx
+++ b/front/src/form/bsvhu/Transporter.tsx
@@ -5,7 +5,7 @@ import { Bsvhu } from "generated/graphql/types";
 import initialState from "./utils/initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
 
-export const onCompanySelected =
+export const onTransporterSelected =
   (initialTransporter, setFieldValue) => transporter => {
     if (transporter.transporterReceipt) {
       setFieldValue(
@@ -47,7 +47,10 @@ export default function Transporter({ disabled }) {
         heading="Entreprise de transport"
         allowForeignCompanies={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={onCompanySelected(initialTransporter, setFieldValue)}
+        onCompanySelected={onTransporterSelected(
+          initialTransporter,
+          setFieldValue
+        )}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/bsvhu/Transporter.tsx
+++ b/front/src/form/bsvhu/Transporter.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { useFormikContext } from "formik";
-import TdSwitch from "common/components/Switch";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Bsvhu } from "generated/graphql/types";
 import initialState from "./utils/initial-state";
-import { isForeignVat } from "generated/constants/companySearchHelpers";
+import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
 
 export default function Transporter({ disabled }) {
   const { setFieldValue, values } = useFormikContext<Bsvhu>();
@@ -46,24 +45,11 @@ export default function Transporter({ disabled }) {
           }
         }}
       />
-      {!isForeignVat(values.transporter?.company?.vatNumber!) && (
-        <>
-          <h4 className="form__section-heading">
-            Exemption de récépissé de déclaration de transport de déchets
-          </h4>
-          <div className="form__row">
-            <TdSwitch
-              checked={!!values.transporter?.recepisse?.isExempted}
-              onChange={checked =>
-                setFieldValue("transporter.recepisse.isExempted", checked)
-              }
-              disabled={disabled}
-              label="Le transporteur déclare être exempté de récépissé conformément aux
-            dispositions de l'article R.541-50 du code de l'environnement."
-            />
-          </div>
-        </>
-      )}
+      <TransporterReceiptEditionSwitch
+        transporter={values.transporter!}
+        disabled={disabled}
+        setFieldValue={setFieldValue}
+      />
     </>
   );
 }

--- a/front/src/form/bsvhu/Transporter.tsx
+++ b/front/src/form/bsvhu/Transporter.tsx
@@ -5,8 +5,34 @@ import { Bsvhu } from "generated/graphql/types";
 import initialState from "./utils/initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
 
+export const onCompanySelected =
+  (initialTransporter, setFieldValue) => transporter => {
+    if (transporter.transporterReceipt) {
+      setFieldValue(
+        "transporter.recepisse.number",
+        transporter.transporterReceipt.receiptNumber
+      );
+      setFieldValue(
+        "transporter.recepisse.validityLimit",
+        transporter.transporterReceipt.validityLimit
+      );
+      setFieldValue(
+        "transporter.recepisse.department",
+        transporter.transporterReceipt.department
+      );
+    } else {
+      setFieldValue("transporter.recepisse.number", "");
+      setFieldValue(
+        "transporter.recepisse.validityLimit",
+        initialTransporter.recepisse.validityLimit
+      );
+      setFieldValue("transporter.recepisse.department", "");
+    }
+  };
+
 export default function Transporter({ disabled }) {
   const { setFieldValue, values } = useFormikContext<Bsvhu>();
+  const { transporter: initialTransporter } = initialState;
   return (
     <>
       {disabled && (
@@ -21,29 +47,7 @@ export default function Transporter({ disabled }) {
         heading="Entreprise de transport"
         allowForeignCompanies={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={transporter => {
-          if (transporter.transporterReceipt) {
-            setFieldValue(
-              "transporter.recepisse.number",
-              transporter.transporterReceipt.receiptNumber
-            );
-            setFieldValue(
-              "transporter.recepisse.validityLimit",
-              transporter.transporterReceipt.validityLimit
-            );
-            setFieldValue(
-              "transporter.recepisse.department",
-              transporter.transporterReceipt.department
-            );
-          } else {
-            setFieldValue("transporter.recepisse.number", "");
-            setFieldValue(
-              "transporter.recepisse.validityLimit",
-              initialState.transporter.recepisse.validityLimit
-            );
-            setFieldValue("transporter.recepisse.department", "");
-          }
-        }}
+        onCompanySelected={onCompanySelected(initialTransporter, setFieldValue)}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/common/components/company/TransporterReceipt.tsx
+++ b/front/src/form/common/components/company/TransporterReceipt.tsx
@@ -9,7 +9,6 @@ import {
   BsvhuTransporterInput,
   TransporterInput,
   BsdaTransporter,
-  Bsff,
   BsffTransporter,
   BsdasriTransporter,
   BsvhuTransporter,

--- a/front/src/form/common/components/company/TransporterReceiptEditionSwitch.tsx
+++ b/front/src/form/common/components/company/TransporterReceiptEditionSwitch.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import TdSwitch from "common/components/Switch";
+import { isForeignVat } from "generated/constants/companySearchHelpers";
+import {
+  BsdaTransporterInput,
+  BsdasriTransporterInput,
+  BsvhuTransporterInput,
+} from "generated/graphql/types";
+
+/**
+ * Switch for BSDA, BSVHU and BSDASRI
+ */
+export default function TransporterReceiptEditionSwitch({
+  transporter,
+  disabled,
+  setFieldValue,
+}: {
+  transporter:
+    | BsdaTransporterInput
+    | BsdasriTransporterInput
+    | BsvhuTransporterInput;
+  disabled: boolean;
+  setFieldValue: (field: string, value: boolean) => void;
+}) {
+  return !isForeignVat(transporter?.company?.vatNumber!) ? (
+    <>
+      <h4 className="form__section-heading">
+        Exemption de récépissé de déclaration de transport de déchets
+      </h4>
+      <div className="form__row">
+        <TdSwitch
+          checked={!!transporter?.recepisse?.isExempted}
+          onChange={checked =>
+            setFieldValue("transporter.recepisse.isExempted", checked)
+          }
+          disabled={disabled}
+          label="Le transporteur déclare être exempté de récépissé conformément aux
+            dispositions de l'article R.541-50 du code de l'environnement."
+        />
+      </div>
+    </>
+  ) : (
+    <></>
+  );
+}


### PR DESCRIPTION
- Suppression toggle switch d'exemption de récépissé en modale signature transporter
- Refacto Transporter récépissé dans les vues modales de details, affichage du numéro vide ou non. Ne pas afficher date et département seulement si le numéro est renseigné.
- Renommage `TransporterReceiptDetails`, usage de Receipt dans les nommages du code
- Fix db-to-gql et gql-to-db converter pour `Bsdasri.transporterRecepisseIsExempted`
- Fix affichage signature transporter BSDA
- Refacto code dupliqué dans les params de CompanySelector pour les 3 types de bsd concernés

## BSDA Sans recepissé

![image](https://user-images.githubusercontent.com/76620/234902748-edcfd1bd-198e-4a44-9a55-77d6d44be1e2.png)

## BSDA avec exemption

![image](https://user-images.githubusercontent.com/76620/234902980-c90b63b7-abb2-43fa-8ace-e4359e419466.png)
