### PR TITLE
Hotfix / Dataloaders pour les groupements

### DIFF
--- a/back/src/forms/resolvers/forms/groupedIn.ts
+++ b/back/src/forms/resolvers/forms/groupedIn.ts
@@ -1,18 +1,25 @@
 import { FormResolvers } from "../../../generated/graphql/types";
-import prisma from "../../../prisma";
 import { expandFormFromDb } from "../../converter";
 
-const groupedInResolver: FormResolvers["groupedIn"] = async form => {
-  const groupement = await prisma.formGroupement.findMany({
-    where: { initialFormId: form.id },
-    include: { nextForm: true }
-  });
+const groupedInResolver: FormResolvers["groupedIn"] = async (
+  form,
+  _,
+  { dataloaders }
+) => {
+  const groupements = await dataloaders.initialFormGoupements.load(form.id);
+  const nextFormIds = groupements.map(g => g.nextFormId);
+  const nextForms = await Promise.all(
+    nextFormIds.map(id => dataloaders.forms.load(id))
+  );
 
   return Promise.all(
-    groupement.map(async ({ nextForm, quantity }) => ({
-      form: await expandFormFromDb(nextForm),
-      quantity
-    }))
+    groupements.map(async ({ quantity, nextFormId }) => {
+      const nextForm = nextForms.find(f => f && f.id === nextFormId);
+      return {
+        form: await expandFormFromDb(nextForm),
+        quantity
+      };
+    })
   );
 };
 

--- a/back/src/forms/resolvers/forms/grouping.ts
+++ b/back/src/forms/resolvers/forms/grouping.ts
@@ -1,24 +1,32 @@
 import { FormResolvers } from "../../../generated/graphql/types";
-import prisma from "../../../prisma";
 import { expandInitialFormFromDb } from "../../converter";
 
 const groupingResolver: FormResolvers["grouping"] = async (
   form,
   _,
-  context
+  { dataloaders }
 ) => {
-  const formGroupements = await prisma.formGroupement.findMany({
-    where: { nextFormId: form.id },
-    include: { initialForm: true }
-  });
+  const groupements = await dataloaders.nextFormGoupements.load(form.id);
+  const initialFormIds = groupements.map(g => g.initialFormId);
+  const initialForms = await Promise.all(
+    initialFormIds.map(id => dataloaders.forms.load(id))
+  );
+
   return Promise.all(
-    formGroupements.map(async ({ quantity, initialForm }) => ({
-      quantity,
-      form: await expandInitialFormFromDb(
-        initialForm,
-        context.dataloaders.forwardedIns
-      )
-    }))
+    groupements.map(async ({ quantity, initialFormId }) => {
+      const initialForm = initialForms.find(f => f && f.id === initialFormId);
+      if (!initialForm) {
+        throw new Error(`Invalid initial form with id ${initialFormId}`);
+      }
+
+      return {
+        form: await expandInitialFormFromDb(
+          initialForm,
+          dataloaders.forwardedIns
+        ),
+        quantity
+      };
+    })
   );
 };
 

--- a/back/src/forms/resolvers/forms/quantityGrouped.ts
+++ b/back/src/forms/resolvers/forms/quantityGrouped.ts
@@ -6,7 +6,7 @@ export default async function quantityGrouped(
   _,
   context: GraphQLContext
 ) {
-  const formGroupements = await context.dataloaders.formGoupements.load(
+  const formGroupements = await context.dataloaders.initialFormGoupements.load(
     form.id
   );
 


### PR DESCRIPTION
Utilisation de dataloaders pour les groupements. On est spammé de requêtes FormGroupement qui nous causent des problèmes en DB