### PR TITLE
[TRA-11636] Lors de la duplication d'un BSD, les informations sur les entreprises sont mises à jour

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,22 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+# [2023.6.1] 06/06/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Les informations sur les entreprises (récépissés, raison sociale, certification) sont mises à jour lors de la duplication d'un bordereau [PR 2355](https://github.com/MTES-MCT/trackdechets/pull/2355)
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2023.5.4] 23/05/202
 
 #### :bug: Corrections de bugs

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -78,6 +78,7 @@ export const companyFactory = async (
       codeDepartement: "75",
       contactEmail: `contact_${companyIndex}@gmail.com`,
       contactPhone: `+${companyIndex} 606060606`,
+      contact: "Contact",
       verificationStatus: "VERIFIED",
       ...opts
     }
@@ -117,7 +118,7 @@ export interface UserWithCompany {
  * @param role: user role in the company
  */
 export const userWithCompanyFactory = async (
-  role: UserRole,
+  role: UserRole = "ADMIN",
   companyOpts: Partial<Prisma.CompanyCreateInput> = {},
   userOpts: Partial<Prisma.UserCreateInput> = {},
   companyAssociationOpts: Partial<Prisma.CompanyAssociationCreateInput> = {}

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -13,7 +13,7 @@ const sirenifyMock = jest
   .spyOn(sirenify, "default")
   .mockImplementation(input => Promise.resolve(input));
 
-export const CREATE_BSDA = `
+const CREATE_BSDA = `
 mutation CreateBsda($input: BsdaInput!) {
   createBsda(input: $input) {
     id

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -13,7 +13,7 @@ const sirenifyMock = jest
   .spyOn(sirenify, "default")
   .mockImplementation(input => Promise.resolve(input));
 
-const CREATE_BSDA = `
+export const CREATE_BSDA = `
 mutation CreateBsda($input: BsdaInput!) {
   createBsda(input: $input) {
     id

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -2,7 +2,6 @@ import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import makeClient from "../../../../__tests__/testClient";
 import { BsdaInput, Mutation } from "../../../../generated/graphql/types";
-import { CREATE_BSDA } from "./create.integration";
 import { gql } from "apollo-server-core";
 import { Company } from "@prisma/client";
 import { TestQuery } from "../../../../__tests__/apollo-integration-testing";
@@ -21,6 +20,32 @@ const CompanyFragment = gql`
     phone
     mail
   }
+`;
+
+const CREATE_BSDA = `
+mutation CreateBsda($input: BsdaInput!) {
+  createBsda(input: $input) {
+    id
+    destination {
+      company {
+          siret
+      }
+    }
+    emitter {
+      company {
+          siret
+      }
+    }
+    transporter {
+      transport {
+        plates
+      }
+    }
+    intermediaries {
+      siret
+    }
+  }
+}
 `;
 
 export const DUPLICATE_BSDA = gql`

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -1,0 +1,426 @@
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import makeClient from "../../../../__tests__/testClient";
+import { BsdaInput, Mutation } from "../../../../generated/graphql/types";
+import { CREATE_BSDA } from "./create.integration";
+import { gql } from "apollo-server-core";
+import { Company } from "@prisma/client";
+import { TestQuery } from "../../../../__tests__/apollo-integration-testing";
+import prisma from "../../../../prisma";
+import { xDaysAgo } from "../../../../commands/onboarding.helpers";
+
+const TODAY = new Date();
+const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
+
+const CompanyFragment = gql`
+  fragment CompanyFragment on FormCompany {
+    name
+    siret
+    address
+    contact
+    phone
+    mail
+  }
+`;
+
+export const DUPLICATE_BSDA = gql`
+  ${CompanyFragment}
+
+  mutation DuplicateBsda($id: ID!) {
+    duplicateBsda(id: $id) {
+      id
+      status
+      emitter {
+        company {
+          ...CompanyFragment
+        }
+      }
+      transporter {
+        company {
+          ...CompanyFragment
+        }
+        recepisse {
+          isExempted
+          number
+          validityLimit
+          department
+        }
+      }
+      broker {
+        company {
+          ...CompanyFragment
+        }
+        recepisse {
+          isExempted
+          number
+          validityLimit
+          department
+        }
+      }
+      worker {
+        company {
+          ...CompanyFragment
+        }
+      }
+      destination {
+        company {
+          ...CompanyFragment
+        }
+      }
+    }
+  }
+`;
+
+const buildBsdaInput = (
+  emitterCompany: Company,
+  transporterCompany: Company,
+  brokerCompany: Company,
+  workerCompany: Company,
+  destinationCompany: Company
+): BsdaInput => ({
+  emitter: {
+    isPrivateIndividual: false,
+    company: {
+      siret: emitterCompany.siret,
+      name: emitterCompany.siret,
+      address: emitterCompany.address,
+      contact: emitterCompany.contact,
+      phone: "emitterContactPhone",
+      mail: "emitter@mail.com"
+    }
+  },
+  worker: {
+    company: {
+      siret: workerCompany.siret,
+      name: workerCompany.siret,
+      address: workerCompany.address,
+      contact: workerCompany.contact,
+      phone: "workerContactPhone",
+      mail: "worker@mail.com"
+    }
+  },
+  transporter: {
+    company: {
+      siret: transporterCompany.siret,
+      name: transporterCompany.siret,
+      address: transporterCompany.address,
+      contact: transporterCompany.contact,
+      phone: "transporterContactPhone",
+      mail: "transporter@mail.com"
+    },
+    recepisse: {
+      isExempted: true,
+      number: "TRANSPORTER-RECEIPT-NUMBER",
+      validityLimit: TODAY.toISOString() as any,
+      department: "TRANSPORTER-RECEIPT-DEPARTMENT"
+    }
+  },
+  broker: {
+    company: {
+      siret: brokerCompany.siret,
+      name: brokerCompany.siret,
+      address: brokerCompany.address,
+      contact: brokerCompany.contact,
+      phone: "brokerContactPhone",
+      mail: "broker@mail.com"
+    },
+    recepisse: {
+      isExempted: true,
+      number: "BROKER-RECEIPT-NUMBER",
+      validityLimit: TODAY.toISOString() as any,
+      department: "BROKER-RECEIPT-DEPARTMENT"
+    }
+  },
+  waste: {
+    code: "06 07 01*",
+    adr: "ADR",
+    pop: true,
+    consistence: "SOLIDE",
+    familyCode: "Code famille",
+    materialName: "A material",
+    sealNumbers: ["1", "2"]
+  },
+  packagings: [{ quantity: 1, type: "PALETTE_FILME" }],
+  weight: { isEstimate: true, value: 1.2 },
+  destination: {
+    cap: "A cap",
+    plannedOperationCode: "D 9",
+    company: {
+      siret: destinationCompany.siret,
+      name: destinationCompany.siret,
+      address: destinationCompany.address,
+      contact: destinationCompany.contact,
+      phone: "destinationContactPhone",
+      mail: "destination@mail.com"
+    }
+  }
+});
+
+const createCompaniesAndBsda = async () => {
+  const { user: emitter, company: emitterCompany } =
+    await userWithCompanyFactory();
+  // TODO: toujours utile?
+  const { company: transporterCompany } = await userWithCompanyFactory(
+    "ADMIN",
+    {
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString() as any,
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    }
+  );
+  const { company: brokerCompany } = await userWithCompanyFactory("ADMIN", {
+    brokerReceipt: {
+      create: {
+        receiptNumber: "BROKER-RECEIPT-NUMBER",
+        validityLimit: TODAY.toISOString() as any,
+        department: "BROKER-RECEIPT-DEPARTMENT"
+      }
+    }
+  });
+  const { company: workerCompany } = await userWithCompanyFactory();
+  const { company: destinationCompany } = await userWithCompanyFactory();
+
+  const input = buildBsdaInput(
+    emitterCompany,
+    transporterCompany,
+    brokerCompany,
+    workerCompany,
+    destinationCompany
+  );
+
+  // Create the BSDA
+  const { mutate } = makeClient(emitter);
+  const { data: createBsdaData } = await mutate<Pick<Mutation, "createBsda">>(
+    CREATE_BSDA,
+    {
+      variables: {
+        input
+      }
+    }
+  );
+
+  return {
+    mutate,
+    emitterCompany,
+    transporterCompany,
+    brokerCompany,
+    workerCompany,
+    destinationCompany,
+    bsda: createBsdaData.createBsda
+  };
+};
+
+const duplicateBsda = (mutate: TestQuery, bsdaId: string) => {
+  return mutate<Pick<Mutation, "duplicateBsda">>(DUPLICATE_BSDA, {
+    variables: {
+      id: bsdaId
+    }
+  });
+};
+
+describe("Mutation.Bsda.duplicate", () => {
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  test("should duplicate a bsda", async () => {
+    // Given
+    const { mutate, bsda } = await createCompaniesAndBsda();
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+  });
+
+  test("transporter updates his company info > duplicated bsda should have the updated data", async () => {
+    // Given
+    const { mutate, transporterCompany, bsda } = await createCompaniesAndBsda();
+
+    await prisma.company.update({
+      where: {
+        id: transporterCompany.id
+      },
+      data: {
+        name: "UPDATED-TRANSPORTER-NAME",
+        address: "UPDATED-TRANSPORTER-ADRESS",
+        contact: "UPDATED-TRANSPORTER-CONTACT",
+        contactPhone: "UPDATED-TRANSPORTER-PHONE",
+        contactEmail: "UPDATED-TRANSPORTER-MAIL"
+      }
+    });
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+
+    // Check transporter info
+    const transporter = duplicateBsdaData.duplicateBsda.transporter?.company;
+    expect(transporter?.name).toEqual("UPDATED-TRANSPORTER-NAME");
+    expect(transporter?.address).toEqual("UPDATED-TRANSPORTER-ADRESS");
+    expect(transporter?.contact).toEqual("UPDATED-TRANSPORTER-CONTACT");
+    expect(transporter?.phone).toEqual("UPDATED-TRANSPORTER-PHONE");
+    expect(transporter?.mail).toEqual("UPDATED-TRANSPORTER-MAIL");
+  });
+
+  test("transporter updates his recepisse > duplicated bsda should have the updated data", async () => {
+    // Given
+    const { mutate, transporterCompany, bsda } = await createCompaniesAndBsda();
+
+    await prisma.company.update({
+      where: {
+        id: transporterCompany.id
+      },
+      data: {
+        transporterReceipt: {
+          update: {
+            receiptNumber: "UPDATED-TRANSPORTER-RECEIPT-NUMBER",
+            validityLimit: FOUR_DAYS_AGO.toISOString(),
+            department: "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+          }
+        }
+      }
+    });
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+
+    // Check receipt
+    const recepisse = duplicateBsdaData.duplicateBsda.transporter?.recepisse;
+    expect(recepisse?.department).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+    );
+    expect(recepisse?.validityLimit).toEqual(FOUR_DAYS_AGO.toISOString());
+    expect(recepisse?.number).toEqual("UPDATED-TRANSPORTER-RECEIPT-NUMBER");
+  });
+
+  test("broker updates his recepisse > duplicated bsda should have the updated data", async () => {
+    // Given
+    const { mutate, brokerCompany, bsda } = await createCompaniesAndBsda();
+
+    await prisma.company.update({
+      where: {
+        id: brokerCompany.id
+      },
+      data: {
+        brokerReceipt: {
+          update: {
+            receiptNumber: "UPDATED-BROKER-RECEIPT-NUMBER",
+            validityLimit: FOUR_DAYS_AGO.toISOString(),
+            department: "UPDATED-BROKER-RECEIPT-DEPARTMENT"
+          }
+        }
+      }
+    });
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+
+    // Check receipt
+    const recepisse = duplicateBsdaData.duplicateBsda.broker?.recepisse;
+    expect(recepisse?.department).toEqual("UPDATED-BROKER-RECEIPT-DEPARTMENT");
+    expect(recepisse?.validityLimit).toEqual(FOUR_DAYS_AGO.toISOString());
+    expect(recepisse?.number).toEqual("UPDATED-BROKER-RECEIPT-NUMBER");
+  });
+
+  test("broker updates his company info > duplicated bsda should have the updated data", async () => {
+    // Given
+    const { mutate, brokerCompany, bsda } = await createCompaniesAndBsda();
+
+    await prisma.company.update({
+      where: {
+        id: brokerCompany.id
+      },
+      data: {
+        name: "UPDATED-BROKER-NAME",
+        address: "UPDATED-BROKER-ADRESS",
+        contact: "UPDATED-BROKER-CONTACT",
+        contactPhone: "UPDATED-BROKER-PHONE",
+        contactEmail: "UPDATED-BROKER-MAIL"
+      }
+    });
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+
+    // Check transporter info
+    const broker = duplicateBsdaData.duplicateBsda.broker?.company;
+    expect(broker?.name).toEqual("UPDATED-BROKER-NAME");
+    expect(broker?.address).toEqual("UPDATED-BROKER-ADRESS");
+    expect(broker?.contact).toEqual("UPDATED-BROKER-CONTACT");
+    expect(broker?.phone).toEqual("UPDATED-BROKER-PHONE");
+    expect(broker?.mail).toEqual("UPDATED-BROKER-MAIL");
+  });
+
+  test("emitter updates his company info > duplicated bsda should have the updated data", async () => {
+    // Given
+    const { mutate, emitterCompany, bsda } = await createCompaniesAndBsda();
+
+    await prisma.company.update({
+      where: {
+        id: emitterCompany.id
+      },
+      data: {
+        name: "UPDATED-EMITTER-NAME",
+        address: "UPDATED-EMITTER-ADRESS",
+        contact: "UPDATED-EMITTER-CONTACT",
+        contactPhone: "UPDATED-EMITTER-PHONE",
+        contactEmail: "UPDATED-EMITTER-MAIL"
+      }
+    });
+
+    // When
+    const { errors, data: duplicateBsdaData } = await duplicateBsda(
+      mutate,
+      bsda.id
+    );
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(duplicateBsdaData.duplicateBsda.status).toBe("INITIAL");
+
+    // Check transporter info
+    const emitter = duplicateBsdaData.duplicateBsda.emitter?.company;
+    expect(emitter?.name).toEqual("UPDATED-EMITTER-NAME");
+    expect(emitter?.address).toEqual("UPDATED-EMITTER-ADRESS");
+    expect(emitter?.contact).toEqual("UPDATED-EMITTER-CONTACT");
+    expect(emitter?.phone).toEqual("UPDATED-EMITTER-PHONE");
+    expect(emitter?.mail).toEqual("UPDATED-EMITTER-MAIL");
+  });
+});

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -171,9 +171,9 @@ const buildBsdaInput = (
 });
 
 const createCompaniesAndBsda = async () => {
+  // Companies with their initial data
   const { user: emitter, company: emitterCompany } =
     await userWithCompanyFactory();
-  // TODO: toujours utile?
   const { company: transporterCompany } = await userWithCompanyFactory(
     "ADMIN",
     {

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -61,15 +61,19 @@ async function duplicateBsda({
   groupedInId,
   intermediaries,
   intermediariesOrgIds,
+  emitterCompanySiret,
+  transporterCompanySiret,
+  brokerCompanySiret,
+  workerCompanySiret,
   ...rest
 }: Bsda & {
   intermediaries: IntermediaryBsdaAssociation[];
 }): Promise<Prisma.BsdaCreateInput> {
   const companiesSirets: string[] = [
-    rest.emitterCompanySiret,
-    rest.transporterCompanySiret,
-    rest.brokerCompanySiret,
-    rest.workerCompanySiret
+    emitterCompanySiret,
+    transporterCompanySiret,
+    brokerCompanySiret,
+    workerCompanySiret
   ].filter((siret): siret is string => Boolean(siret));
 
   // Batch call all companies involved
@@ -87,16 +91,16 @@ async function duplicateBsda({
   });
 
   const emitter = companies.find(
-    company => company.siret === rest.emitterCompanySiret
+    company => company.siret === emitterCompanySiret
   );
   const broker = companies.find(
-    company => company.siret === rest.brokerCompanySiret
+    company => company.siret === brokerCompanySiret
   );
   const transporter = companies.find(
-    company => company.siret === rest.transporterCompanySiret
+    company => company.siret === transporterCompanySiret
   );
   const worker = companies.find(
-    company => company.siret === rest.workerCompanySiret
+    company => company.siret === workerCompanySiret
   );
 
   return {

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -105,6 +105,10 @@ async function duplicateBsda({
 
   return {
     ...rest,
+    emitterCompanySiret,
+    transporterCompanySiret,
+    brokerCompanySiret,
+    workerCompanySiret,
     id: getReadableId(ReadableIdPrefix.BSDA),
     status: BsdaStatus.INITIAL,
     isDraft: true,

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -68,7 +68,8 @@ async function duplicateBsda({
   const companiesSirets: string[] = [
     rest.emitterCompanySiret,
     rest.transporterCompanySiret,
-    rest.brokerCompanySiret
+    rest.brokerCompanySiret,
+    rest.workerCompanySiret
   ].filter((siret): siret is string => Boolean(siret));
 
   // Batch call all companies involved
@@ -80,7 +81,8 @@ async function duplicateBsda({
     },
     include: {
       transporterReceipt: true,
-      brokerReceipt: true
+      brokerReceipt: true,
+      workerCertification: true
     }
   });
 
@@ -92,6 +94,9 @@ async function duplicateBsda({
   );
   const transporter = companies.find(
     company => company.siret === rest.transporterCompanySiret
+  );
+  const worker = companies.find(
+    company => company.siret === rest.workerCompanySiret
   );
 
   return {
@@ -142,6 +147,22 @@ async function duplicateBsda({
     // Broker recepisse
     brokerRecepisseNumber: broker?.brokerReceipt?.receiptNumber,
     brokerRecepisseValidityLimit: broker?.brokerReceipt?.validityLimit,
-    brokerRecepisseDepartment: broker?.brokerReceipt?.department
+    brokerRecepisseDepartment: broker?.brokerReceipt?.department,
+    // Worker company info
+    workerCompanyAddress: worker?.address,
+    workerCompanyMail: worker?.contactEmail,
+    workerCompanyPhone: worker?.contactPhone,
+    workerCompanyName: worker?.name,
+    workerCompanyContact: worker?.contact,
+    // Worker certification
+    workerCertificationHasSubSectionFour:
+      worker?.workerCertification?.hasSubSectionFour,
+    workerCertificationHasSubSectionThree:
+      worker?.workerCertification?.hasSubSectionThree,
+    workerCertificationValidityLimit:
+      worker?.workerCertification?.validityLimit,
+    workerCertificationOrganisation: worker?.workerCertification?.organisation,
+    workerCertificationCertificationNumber:
+      worker?.workerCertification?.certificationNumber
   };
 }

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -65,7 +65,7 @@ async function duplicateBsda({
   transporterCompanySiret,
   brokerCompanySiret,
   workerCompanySiret,
-  ...rest
+  ...bsda
 }: Bsda & {
   intermediaries: IntermediaryBsdaAssociation[];
 }): Promise<Prisma.BsdaCreateInput> {
@@ -104,7 +104,7 @@ async function duplicateBsda({
   );
 
   return {
-    ...rest,
+    ...bsda,
     emitterCompanySiret,
     transporterCompanySiret,
     brokerCompanySiret,
@@ -112,7 +112,7 @@ async function duplicateBsda({
     id: getReadableId(ReadableIdPrefix.BSDA),
     status: BsdaStatus.INITIAL,
     isDraft: true,
-    packagings: rest.packagings ?? Prisma.JsonNull,
+    packagings: bsda.packagings ?? Prisma.JsonNull,
     ...(intermediaries && {
       intermediaries: {
         createMany: {
@@ -130,47 +130,65 @@ async function duplicateBsda({
       intermediariesOrgIds
     }),
     // Emitter company info
-    emitterCompanyAddress: emitter?.address,
-    emitterCompanyMail: emitter?.contactEmail,
-    emitterCompanyPhone: emitter?.contactPhone,
-    emitterCompanyName: emitter?.name,
-    emitterCompanyContact: emitter?.contact,
+    emitterCompanyAddress: emitter?.address ?? bsda.emitterCompanyAddress,
+    emitterCompanyMail: emitter?.contactEmail ?? bsda.emitterCompanyMail,
+    emitterCompanyPhone: emitter?.contactPhone ?? bsda.emitterCompanyPhone,
+    emitterCompanyName: emitter?.name ?? bsda.emitterCompanyName,
+    emitterCompanyContact: emitter?.contact ?? bsda.emitterCompanyContact,
     // Transporter company info
-    transporterCompanyAddress: transporter?.address,
-    transporterCompanyMail: transporter?.contactEmail,
-    transporterCompanyPhone: transporter?.contactPhone,
-    transporterCompanyName: transporter?.name,
-    transporterCompanyContact: transporter?.contact,
+    transporterCompanyAddress:
+      transporter?.address ?? bsda.transporterCompanyAddress,
+    transporterCompanyMail:
+      transporter?.contactEmail ?? bsda.transporterCompanyMail,
+    transporterCompanyPhone:
+      transporter?.contactPhone ?? bsda.transporterCompanyPhone,
+    transporterCompanyName: transporter?.name ?? bsda.transporterCompanyName,
+    transporterCompanyContact:
+      transporter?.contact ?? bsda.transporterCompanyContact,
     // Transporter recepisse
-    transporterRecepisseNumber: transporter?.transporterReceipt?.receiptNumber,
+    transporterRecepisseNumber:
+      transporter?.transporterReceipt?.receiptNumber ??
+      bsda.transporterRecepisseNumber,
     transporterRecepisseValidityLimit:
-      transporter?.transporterReceipt?.validityLimit,
-    transporterRecepisseDepartment: transporter?.transporterReceipt?.department,
+      transporter?.transporterReceipt?.validityLimit ??
+      bsda.transporterRecepisseValidityLimit,
+    transporterRecepisseDepartment:
+      transporter?.transporterReceipt?.department ??
+      bsda.transporterRecepisseDepartment,
     // Broker company info
-    brokerCompanyAddress: broker?.address,
-    brokerCompanyMail: broker?.contactEmail,
-    brokerCompanyPhone: broker?.contactPhone,
-    brokerCompanyName: broker?.name,
-    brokerCompanyContact: broker?.contact,
+    brokerCompanyAddress: broker?.address ?? bsda.brokerCompanyAddress,
+    brokerCompanyMail: broker?.contactEmail ?? bsda.brokerCompanyMail,
+    brokerCompanyPhone: broker?.contactPhone ?? bsda.brokerCompanyPhone,
+    brokerCompanyName: broker?.name ?? bsda.brokerCompanyName,
+    brokerCompanyContact: broker?.contact ?? bsda.brokerCompanyContact,
     // Broker recepisse
-    brokerRecepisseNumber: broker?.brokerReceipt?.receiptNumber,
-    brokerRecepisseValidityLimit: broker?.brokerReceipt?.validityLimit,
-    brokerRecepisseDepartment: broker?.brokerReceipt?.department,
+    brokerRecepisseNumber:
+      broker?.brokerReceipt?.receiptNumber ?? bsda.brokerRecepisseNumber,
+    brokerRecepisseValidityLimit:
+      broker?.brokerReceipt?.validityLimit ?? bsda.brokerRecepisseValidityLimit,
+    brokerRecepisseDepartment:
+      broker?.brokerReceipt?.department ?? bsda.brokerRecepisseDepartment,
     // Worker company info
-    workerCompanyAddress: worker?.address,
-    workerCompanyMail: worker?.contactEmail,
-    workerCompanyPhone: worker?.contactPhone,
-    workerCompanyName: worker?.name,
-    workerCompanyContact: worker?.contact,
+    workerCompanyAddress: worker?.address ?? bsda.workerCompanyAddress,
+    workerCompanyMail: worker?.contactEmail ?? bsda.workerCompanyMail,
+    workerCompanyPhone: worker?.contactPhone ?? bsda.workerCompanyPhone,
+    workerCompanyName: worker?.name ?? bsda.workerCompanyName,
+    workerCompanyContact: worker?.contact ?? bsda.workerCompanyContact,
     // Worker certification
     workerCertificationHasSubSectionFour:
-      worker?.workerCertification?.hasSubSectionFour,
+      worker?.workerCertification?.hasSubSectionFour ??
+      bsda.workerCertificationHasSubSectionFour,
     workerCertificationHasSubSectionThree:
-      worker?.workerCertification?.hasSubSectionThree,
+      worker?.workerCertification?.hasSubSectionThree ??
+      bsda.workerCertificationHasSubSectionThree,
     workerCertificationValidityLimit:
-      worker?.workerCertification?.validityLimit,
-    workerCertificationOrganisation: worker?.workerCertification?.organisation,
+      worker?.workerCertification?.validityLimit ??
+      bsda.workerCertificationValidityLimit,
+    workerCertificationOrganisation:
+      worker?.workerCertification?.organisation ??
+      bsda.workerCertificationOrganisation,
     workerCertificationCertificationNumber:
-      worker?.workerCertification?.certificationNumber
+      worker?.workerCertification?.certificationNumber ??
+      bsda.workerCertificationCertificationNumber
   };
 }

--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -1,10 +1,18 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdasriFactory, initialData } from "../../../__tests__/factories";
 import { Mutation } from "../../../../generated/graphql/types";
 import { BsdasriType } from "@prisma/client";
+import prisma from "../../../../prisma";
+import { xDaysAgo } from "../../../../commands/onboarding.helpers";
+
+const TODAY = new Date();
+const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
 
 const DUPLICATE_DASRI = `
 mutation DuplicateDasri($id: ID!){
@@ -133,5 +141,162 @@ describe("Mutation.duplicateBsdasri", () => {
 
     expect(data.duplicateBsdasri.status).toBe("INITIAL");
     expect(data.duplicateBsdasri.isDraft).toBe(true);
+  });
+
+  test("duplicated BSDASRI should have the updated data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+    const transporterReceipt =
+      await prisma.transporterReceipt.findUniqueOrThrow({
+        where: { id: transporterCompany.transporterReceiptId! }
+      });
+    const destinationCompany = await companyFactory();
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        emitterCompanyContact: emitter.company.contact,
+        emitterCompanyMail: emitter.company.contactEmail,
+        emitterCompanyPhone: emitter.company.contactPhone,
+        transporterCompanySiret: transporterCompany.siret,
+        transporterCompanyName: transporterCompany.name,
+        transporterCompanyAddress: transporterCompany.address,
+        transporterCompanyContact: transporterCompany.contact,
+        transporterCompanyMail: transporterCompany.contactEmail,
+        transporterCompanyPhone: transporterCompany.contactPhone,
+        transporterRecepisseNumber: transporterReceipt.receiptNumber,
+        transporterRecepisseDepartment: transporterReceipt.department,
+        transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
+        destinationCompanySiret: destinationCompany.siret,
+        destinationCompanyName: destinationCompany.name,
+        destinationCompanyAddress: destinationCompany.address,
+        destinationCompanyContact: destinationCompany.contact,
+        destinationCompanyMail: destinationCompany.contactEmail,
+        destinationCompanyPhone: destinationCompany.contactPhone
+      }
+    });
+    const { mutate } = makeClient(emitter.user);
+
+    await prisma.company.update({
+      where: { id: emitter.company.id },
+      data: {
+        name: "UPDATED-EMITTER-NAME",
+        address: "UPDATED-EMITTER-ADDRESS",
+        contact: "UPDATED-EMITTER-CONTACT",
+        contactPhone: "UPDATED-EMITTER-PHONE",
+        contactEmail: "UPDATED-EMITTER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: transporterCompany.id },
+      data: {
+        name: "UPDATED-TRANSPORTER-NAME",
+        address: "UPDATED-TRANSPORTER-ADDRESS",
+        contact: "UPDATED-TRANSPORTER-CONTACT",
+        contactPhone: "UPDATED-TRANSPORTER-PHONE",
+        contactEmail: "UPDATED-TRANSPORTER-MAIL"
+      }
+    });
+
+    await prisma.transporterReceipt.update({
+      where: { id: transporterCompany.transporterReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-TRANSPORTER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: destinationCompany.id },
+      data: {
+        name: "UPDATED-DESTINATION-NAME",
+        address: "UPDATED-DESTINATION-ADDRESS",
+        contact: "UPDATED-DESTINATION-CONTACT",
+        contactPhone: "UPDATED-DESTINATION-PHONE",
+        contactEmail: "UPDATED-DESTINATION-MAIL"
+      }
+    });
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: bsdasri.id
+        }
+      }
+    );
+
+    const duplicatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: data.duplicateBsdasri.id }
+    });
+
+    expect(duplicatedBsdasri.emitterCompanyName).toEqual(
+      "UPDATED-EMITTER-NAME"
+    );
+    expect(duplicatedBsdasri.emitterCompanyAddress).toEqual(
+      "UPDATED-EMITTER-ADDRESS"
+    );
+    expect(duplicatedBsdasri.emitterCompanyContact).toEqual(
+      "UPDATED-EMITTER-CONTACT"
+    );
+    expect(duplicatedBsdasri.emitterCompanyMail).toEqual(
+      "UPDATED-EMITTER-MAIL"
+    );
+    expect(duplicatedBsdasri.emitterCompanyPhone).toEqual(
+      "UPDATED-EMITTER-PHONE"
+    );
+
+    expect(duplicatedBsdasri.transporterCompanyName).toEqual(
+      "UPDATED-TRANSPORTER-NAME"
+    );
+    expect(duplicatedBsdasri.transporterCompanyAddress).toEqual(
+      "UPDATED-TRANSPORTER-ADDRESS"
+    );
+    expect(duplicatedBsdasri.transporterCompanyContact).toEqual(
+      "UPDATED-TRANSPORTER-CONTACT"
+    );
+    expect(duplicatedBsdasri.transporterCompanyMail).toEqual(
+      "UPDATED-TRANSPORTER-MAIL"
+    );
+    expect(duplicatedBsdasri.transporterCompanyPhone).toEqual(
+      "UPDATED-TRANSPORTER-PHONE"
+    );
+
+    expect(duplicatedBsdasri.transporterRecepisseNumber).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-NUMBER"
+    );
+    expect(duplicatedBsdasri.transporterRecepisseValidityLimit).toEqual(
+      FOUR_DAYS_AGO
+    );
+    expect(duplicatedBsdasri.transporterRecepisseDepartment).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+    );
+
+    expect(duplicatedBsdasri.destinationCompanyName).toEqual(
+      "UPDATED-DESTINATION-NAME"
+    );
+    expect(duplicatedBsdasri.destinationCompanyAddress).toEqual(
+      "UPDATED-DESTINATION-ADDRESS"
+    );
+    expect(duplicatedBsdasri.destinationCompanyContact).toEqual(
+      "UPDATED-DESTINATION-CONTACT"
+    );
+    expect(duplicatedBsdasri.destinationCompanyMail).toEqual(
+      "UPDATED-DESTINATION-MAIL"
+    );
+    expect(duplicatedBsdasri.destinationCompanyPhone).toEqual(
+      "UPDATED-DESTINATION-PHONE"
+    );
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -10,6 +10,7 @@ import { getBsdasriOrNotFound } from "../../database";
 import { ForbiddenError } from "apollo-server-express";
 import { getBsdasriRepository } from "../../repository";
 import { checkCanDuplicate } from "../../permissions";
+import prisma from "../../../prisma";
 
 /**
  *
@@ -43,9 +44,8 @@ const duplicateBsdasriResolver: MutationResolvers["duplicateBsdasri"] = async (
   return expandBsdasriFromDB(newBsdasri);
 };
 
-function duplicateBsdasri(
-  user: Express.User,
-  {
+async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
+  const {
     id,
     createdAt,
     updatedAt,
@@ -92,9 +92,13 @@ function duplicateBsdasri(
     identificationNumbers,
     synthesisEmitterSirets,
     ...fieldsToCopy
-  }: Bsdasri
-) {
+  } = bsdasri;
+
   const bsdasriRepository = getBsdasriRepository(user);
+
+  const { emitter, transporter, destination } = await getBsdasriCompanies(
+    bsdasri
+  );
 
   return bsdasriRepository.create({
     ...fieldsToCopy,
@@ -104,8 +108,79 @@ function duplicateBsdasri(
         : fieldsToCopy.emitterWastePackagings,
     id: getReadableId(ReadableIdPrefix.DASRI),
     status: BsdasriStatus.INITIAL,
-    isDraft: true
+    isDraft: true,
+    // Emitter company info
+    emitterCompanyAddress: emitter?.address ?? bsdasri.emitterCompanyAddress,
+    emitterCompanyMail: emitter?.contactEmail ?? bsdasri.emitterCompanyMail,
+    emitterCompanyPhone: emitter?.contactPhone ?? bsdasri.emitterCompanyPhone,
+    emitterCompanyName: emitter?.name ?? bsdasri.emitterCompanyName,
+    emitterCompanyContact: emitter?.contact ?? bsdasri.emitterCompanyContact,
+    // Destination company info
+    destinationCompanyAddress:
+      destination?.address ?? bsdasri.destinationCompanyAddress,
+    destinationCompanyMail:
+      destination?.contactEmail ?? bsdasri.destinationCompanyMail,
+    destinationCompanyPhone:
+      destination?.contactPhone ?? bsdasri.destinationCompanyPhone,
+    destinationCompanyName: destination?.name ?? bsdasri.destinationCompanyName,
+    destinationCompanyContact:
+      destination?.contact ?? bsdasri.destinationCompanyContact,
+    // Transporter company info
+    transporterCompanyAddress:
+      transporter?.address ?? bsdasri.transporterCompanyAddress,
+    transporterCompanyMail:
+      transporter?.contactEmail ?? bsdasri.transporterCompanyMail,
+    transporterCompanyPhone:
+      transporter?.contactPhone ?? bsdasri.transporterCompanyPhone,
+    transporterCompanyName: transporter?.name ?? bsdasri.transporterCompanyName,
+    transporterCompanyContact:
+      transporter?.contact ?? bsdasri.transporterCompanyContact,
+    // Transporter recepisse
+    transporterRecepisseNumber:
+      transporter?.transporterReceipt?.receiptNumber ??
+      bsdasri.transporterRecepisseNumber,
+    transporterRecepisseValidityLimit:
+      transporter?.transporterReceipt?.validityLimit ??
+      bsdasri.transporterRecepisseValidityLimit,
+    transporterRecepisseDepartment:
+      transporter?.transporterReceipt?.department ??
+      bsdasri.transporterRecepisseDepartment
   });
+}
+
+async function getBsdasriCompanies(bsdasri: Bsdasri) {
+  const companiesOrgIds: string[] = [
+    bsdasri.emitterCompanySiret,
+    bsdasri.transporterCompanySiret,
+    bsdasri.transporterCompanyVatNumber,
+    bsdasri.destinationCompanySiret
+  ].filter(Boolean);
+
+  // Batch call all companies involved
+  const companies = await prisma.company.findMany({
+    where: {
+      siret: {
+        in: companiesOrgIds
+      }
+    },
+    include: {
+      transporterReceipt: true
+    }
+  });
+
+  const emitter = companies.find(
+    company => company.orgId === bsdasri.emitterCompanySiret
+  );
+  const transporter = companies.find(
+    company =>
+      company.orgId === bsdasri.transporterCompanySiret ||
+      company.orgId === bsdasri.transporterCompanyVatNumber
+  );
+  const destination = companies.find(
+    company => company.orgId === bsdasri.destinationCompanySiret
+  );
+
+  return { emitter, transporter, destination };
 }
 
 export default duplicateBsdasriResolver;

--- a/back/src/bsffs/__tests__/factories.ts
+++ b/back/src/bsffs/__tests__/factories.ts
@@ -21,7 +21,7 @@ interface CreateBsffArgs {
   previousPackagings?: BsffPackaging[];
 }
 
-export function createBsff(
+export async function createBsff(
   {
     emitter,
     transporter,
@@ -61,6 +61,18 @@ export function createBsff(
       transporterCompanyPhone: transporter.company.contactPhone,
       transporterCompanyMail: transporter.company.contactEmail
     });
+    const transporterReceipt = await prisma.company
+      .findUnique({
+        where: { id: transporter.company.id }
+      })
+      .transporterReceipt();
+    if (transporterReceipt) {
+      Object.assign(data, {
+        transporterRecepisseNumber: transporterReceipt.receiptNumber,
+        transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
+        transporterRecepisseDepartment: transporterReceipt.department
+      });
+    }
   }
 
   if (destination) {

--- a/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
@@ -5,10 +5,7 @@ import {
   Mutation,
   MutationDuplicateBsffArgs
 } from "../../../../generated/graphql/types";
-import {
-  companyFactory,
-  userWithCompanyFactory
-} from "../../../../__tests__/factories";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { createBsff } from "../../../__tests__/factories";
 import { xDaysAgo } from "../../../../commands/onboarding.helpers";

--- a/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
@@ -5,9 +5,17 @@ import {
   Mutation,
   MutationDuplicateBsffArgs
 } from "../../../../generated/graphql/types";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { createBsff } from "../../../__tests__/factories";
+import { xDaysAgo } from "../../../../commands/onboarding.helpers";
+import prisma from "../../../../prisma";
+
+const TODAY = new Date();
+const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
 
 const DUPLICATE_BSFF = gql`
   mutation DuplicateBsff($id: ID!) {
@@ -119,5 +127,130 @@ describe("Mutation.duplicateBsff", () => {
         message: `Le BSFF n°${bsff.id} n'existe pas.`
       })
     ]);
+  });
+
+  test("duplicated BSFF should have the updated data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+
+    const transporter = await userWithCompanyFactory("MEMBER", {
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+
+    const destination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsff({ emitter, transporter, destination });
+    const { mutate } = makeClient(emitter.user);
+
+    await prisma.company.update({
+      where: { id: emitter.company.id },
+      data: {
+        name: "UPDATED-EMITTER-NAME",
+        address: "UPDATED-EMITTER-ADDRESS",
+        contact: "UPDATED-EMITTER-CONTACT",
+        contactPhone: "UPDATED-EMITTER-PHONE",
+        contactEmail: "UPDATED-EMITTER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: transporter.company.id },
+      data: {
+        name: "UPDATED-TRANSPORTER-NAME",
+        address: "UPDATED-TRANSPORTER-ADDRESS",
+        contact: "UPDATED-TRANSPORTER-CONTACT",
+        contactPhone: "UPDATED-TRANSPORTER-PHONE",
+        contactEmail: "UPDATED-TRANSPORTER-MAIL"
+      }
+    });
+
+    await prisma.transporterReceipt.update({
+      where: { id: transporter.company.transporterReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-TRANSPORTER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: destination.company.id },
+      data: {
+        name: "UPDATED-DESTINATION-NAME",
+        address: "UPDATED-DESTINATION-ADDRESS",
+        contact: "UPDATED-DESTINATION-CONTACT",
+        contactPhone: "UPDATED-DESTINATION-PHONE",
+        contactEmail: "UPDATED-DESTINATION-MAIL"
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "duplicateBsff">,
+      MutationDuplicateBsffArgs
+    >(DUPLICATE_BSFF, {
+      variables: {
+        id: bsff.id
+      }
+    });
+
+    const duplicatedBsff = await prisma.bsff.findUniqueOrThrow({
+      where: { id: data.duplicateBsff.id }
+    });
+
+    expect(duplicatedBsff.emitterCompanyName).toEqual("UPDATED-EMITTER-NAME");
+    expect(duplicatedBsff.emitterCompanyAddress).toEqual(
+      "UPDATED-EMITTER-ADDRESS"
+    );
+    expect(duplicatedBsff.emitterCompanyContact).toEqual(
+      "UPDATED-EMITTER-CONTACT"
+    );
+    expect(duplicatedBsff.emitterCompanyMail).toEqual("UPDATED-EMITTER-MAIL");
+    expect(duplicatedBsff.emitterCompanyPhone).toEqual("UPDATED-EMITTER-PHONE");
+
+    expect(duplicatedBsff.transporterCompanyName).toEqual(
+      "UPDATED-TRANSPORTER-NAME"
+    );
+    expect(duplicatedBsff.transporterCompanyAddress).toEqual(
+      "UPDATED-TRANSPORTER-ADDRESS"
+    );
+    expect(duplicatedBsff.transporterCompanyContact).toEqual(
+      "UPDATED-TRANSPORTER-CONTACT"
+    );
+    expect(duplicatedBsff.transporterCompanyMail).toEqual(
+      "UPDATED-TRANSPORTER-MAIL"
+    );
+    expect(duplicatedBsff.transporterCompanyPhone).toEqual(
+      "UPDATED-TRANSPORTER-PHONE"
+    );
+
+    expect(duplicatedBsff.transporterRecepisseNumber).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-NUMBER"
+    );
+    expect(duplicatedBsff.transporterRecepisseValidityLimit).toEqual(
+      FOUR_DAYS_AGO
+    );
+    expect(duplicatedBsff.transporterRecepisseDepartment).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+    );
+
+    expect(duplicatedBsff.destinationCompanyName).toEqual(
+      "UPDATED-DESTINATION-NAME"
+    );
+    expect(duplicatedBsff.destinationCompanyAddress).toEqual(
+      "UPDATED-DESTINATION-ADDRESS"
+    );
+    expect(duplicatedBsff.destinationCompanyContact).toEqual(
+      "UPDATED-DESTINATION-CONTACT"
+    );
+    expect(duplicatedBsff.destinationCompanyMail).toEqual(
+      "UPDATED-DESTINATION-MAIL"
+    );
+    expect(duplicatedBsff.destinationCompanyPhone).toEqual(
+      "UPDATED-DESTINATION-PHONE"
+    );
   });
 });

--- a/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
@@ -4,8 +4,9 @@ import { expandBsffFromDB } from "../../converter";
 import { checkCanDuplicate } from "../../permissions";
 import { getBsffOrNotFound } from "../../database";
 import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
-import { BsffStatus, Prisma } from "@prisma/client";
+import { Bsff, BsffStatus, Prisma } from "@prisma/client";
 import { getBsffRepository } from "../../repository";
+import prisma from "../../../prisma";
 
 const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
   _,
@@ -17,42 +18,65 @@ const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
 
   await checkCanDuplicate(user, existingBsff);
 
+  const { emitter, transporter, destination } = await getBsffCompanies(
+    existingBsff
+  );
+
   const createInput: Prisma.BsffCreateInput = {
     id: getReadableId(ReadableIdPrefix.FF),
     isDraft: true,
     type: existingBsff.type,
     status: BsffStatus.INITIAL,
-    emitterCompanyName: existingBsff.emitterCompanyName,
-    emitterCompanySiret: existingBsff.emitterCompanySiret,
-    emitterCompanyAddress: existingBsff.emitterCompanyAddress,
-    emitterCompanyContact: existingBsff.emitterCompanyContact,
-    emitterCompanyPhone: existingBsff.emitterCompanyPhone,
-    emitterCompanyMail: existingBsff.emitterCompanyMail,
+    emitterCompanyName: emitter?.name ?? existingBsff.emitterCompanyName,
+    emitterCompanySiret: emitter?.siret ?? existingBsff.emitterCompanySiret,
+    emitterCompanyAddress:
+      emitter?.address ?? existingBsff.emitterCompanyAddress,
+    emitterCompanyContact:
+      emitter?.contact ?? existingBsff.emitterCompanyContact,
+    emitterCompanyPhone:
+      emitter?.contactPhone ?? existingBsff.emitterCompanyPhone,
+    emitterCompanyMail:
+      emitter?.contactEmail ?? existingBsff.emitterCompanyMail,
     wasteCode: existingBsff.wasteCode,
     wasteDescription: existingBsff.wasteDescription,
     wasteAdr: existingBsff.wasteAdr,
     weightValue: existingBsff.weightValue,
     weightIsEstimate: existingBsff.weightIsEstimate,
-    transporterCompanyName: existingBsff.transporterCompanyName,
+    transporterCompanyName:
+      transporter?.name ?? existingBsff.transporterCompanyName,
     transporterCompanySiret: existingBsff.transporterCompanySiret,
     transporterCompanyVatNumber: existingBsff.transporterCompanyVatNumber,
-    transporterCompanyAddress: existingBsff.transporterCompanyAddress,
-    transporterCompanyContact: existingBsff.transporterCompanyContact,
-    transporterCompanyPhone: existingBsff.transporterCompanyPhone,
-    transporterCompanyMail: existingBsff.transporterCompanyMail,
-    transporterRecepisseNumber: existingBsff.transporterRecepisseNumber,
-    transporterRecepisseDepartment: existingBsff.transporterRecepisseDepartment,
+    transporterCompanyAddress:
+      transporter?.address ?? existingBsff.transporterCompanyAddress,
+    transporterCompanyContact:
+      transporter?.contact ?? existingBsff.transporterCompanyContact,
+    transporterCompanyPhone:
+      transporter?.contactPhone ?? existingBsff.transporterCompanyPhone,
+    transporterCompanyMail:
+      transporter?.contactEmail ?? existingBsff.transporterCompanyMail,
+    transporterRecepisseNumber:
+      transporter?.transporterReceipt?.receiptNumber ??
+      existingBsff.transporterRecepisseNumber,
+    transporterRecepisseDepartment:
+      transporter?.transporterReceipt?.department ??
+      existingBsff.transporterRecepisseDepartment,
     transporterRecepisseValidityLimit:
+      transporter?.transporterReceipt?.validityLimit ??
       existingBsff.transporterRecepisseValidityLimit,
     transporterTransportMode: existingBsff.transporterTransportMode,
     transporterTransportPlates: existingBsff.transporterTransportPlates,
     destinationCap: existingBsff.destinationCap,
-    destinationCompanyName: existingBsff.destinationCompanyName,
+    destinationCompanyName:
+      destination?.name ?? existingBsff.destinationCompanyName,
     destinationCompanySiret: existingBsff.destinationCompanySiret,
-    destinationCompanyAddress: existingBsff.destinationCompanyAddress,
-    destinationCompanyContact: existingBsff.destinationCompanyContact,
-    destinationCompanyPhone: existingBsff.destinationCompanyPhone,
-    destinationCompanyMail: existingBsff.destinationCompanyMail,
+    destinationCompanyAddress:
+      destination?.address ?? existingBsff.destinationCompanyAddress,
+    destinationCompanyContact:
+      destination?.contact ?? existingBsff.destinationCompanyContact,
+    destinationCompanyPhone:
+      destination?.contactPhone ?? existingBsff.destinationCompanyPhone,
+    destinationCompanyMail:
+      destination?.contactEmail ?? existingBsff.destinationCompanyMail,
     destinationPlannedOperationCode:
       existingBsff.destinationPlannedOperationCode
   };
@@ -68,5 +92,38 @@ const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
 
   return expandBsffFromDB(duplicatedBsff);
 };
+
+async function getBsffCompanies(bsff: Bsff) {
+  const companiesOrgIds = [
+    bsff.emitterCompanySiret,
+    bsff.transporterCompanySiret,
+    bsff.transporterCompanyVatNumber,
+    bsff.destinationCompanySiret
+  ].filter(Boolean);
+
+  // Batch fetch all companies involved in the BSFF
+  const companies = await prisma.company.findMany({
+    where: { orgId: { in: companiesOrgIds } },
+    include: {
+      transporterReceipt: true
+    }
+  });
+
+  const emitter = companies.find(
+    company => company.orgId === bsff.emitterCompanySiret
+  );
+
+  const destination = companies.find(
+    company => company.orgId === bsff.destinationCompanySiret
+  );
+
+  const transporter = companies.find(
+    company =>
+      company.orgId === bsff.transporterCompanySiret ||
+      company.orgId === bsff.transporterCompanyVatNumber
+  );
+
+  return { emitter, destination, transporter };
+}
 
 export default duplicateBsff;

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -1,0 +1,233 @@
+import { gql } from "apollo-server-core";
+import { xDaysAgo } from "../../../../commands/onboarding.helpers";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { bsvhuFactory } from "../../../__tests__/factories.vhu";
+import { Mutation } from "../../../../generated/graphql/types";
+import { ErrorCode } from "../../../../common/errors";
+import prisma from "../../../../prisma";
+
+const TODAY = new Date();
+const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
+
+const DUPLICATE_BVHU = gql`
+  mutation DuplicateBsvhu($id: ID!) {
+    duplicateBsvhu(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+describe("mutaion.duplicateBsvhu", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+    const { mutate } = makeClient(); // unauthenticated user
+    const { errors } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_BVHU,
+      {
+        variables: {
+          id: bsvhu.id
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+
+  it("should duplicate a BSVHU", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: { emitterCompanySiret: emitter.company.siret }
+    });
+    const { mutate } = makeClient(emitter.user);
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsvhu">>(
+      DUPLICATE_BVHU,
+      {
+        variables: { id: bsvhu.id }
+      }
+    );
+
+    expect(data.duplicateBsvhu.status).toEqual("INITIAL");
+  });
+
+  test("duplicated BSVHU should have the updated data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+    const transporterReceipt =
+      await prisma.transporterReceipt.findUniqueOrThrow({
+        where: { id: transporterCompany.transporterReceiptId! }
+      });
+    const destinationCompany = await companyFactory({
+      vhuAgrementDemolisseur: {
+        create: {
+          agrementNumber: "UPDATED-AGREEMENT-NUMBER",
+          department: "UPDATED-DEPARTMENT"
+        }
+      }
+    });
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        emitterCompanyContact: emitter.company.contact,
+        emitterCompanyMail: emitter.company.contactEmail,
+        emitterCompanyPhone: emitter.company.contactPhone,
+        transporterCompanySiret: transporterCompany.siret,
+        transporterCompanyName: transporterCompany.name,
+        transporterCompanyAddress: transporterCompany.address,
+        transporterCompanyContact: transporterCompany.contact,
+        transporterCompanyMail: transporterCompany.contactEmail,
+        transporterCompanyPhone: transporterCompany.contactPhone,
+        transporterRecepisseNumber: transporterReceipt.receiptNumber,
+        transporterRecepisseDepartment: transporterReceipt.department,
+        transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
+        destinationCompanySiret: destinationCompany.siret,
+        destinationCompanyName: destinationCompany.name,
+        destinationCompanyAddress: destinationCompany.address,
+        destinationCompanyContact: destinationCompany.contact,
+        destinationCompanyMail: destinationCompany.contactEmail,
+        destinationCompanyPhone: destinationCompany.contactPhone
+      }
+    });
+
+    const { mutate } = makeClient(emitter.user);
+
+    await prisma.company.update({
+      where: { id: emitter.company.id },
+      data: {
+        name: "UPDATED-EMITTER-NAME",
+        address: "UPDATED-EMITTER-ADDRESS",
+        contact: "UPDATED-EMITTER-CONTACT",
+        contactPhone: "UPDATED-EMITTER-PHONE",
+        contactEmail: "UPDATED-EMITTER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: transporterCompany.id },
+      data: {
+        name: "UPDATED-TRANSPORTER-NAME",
+        address: "UPDATED-TRANSPORTER-ADDRESS",
+        contact: "UPDATED-TRANSPORTER-CONTACT",
+        contactPhone: "UPDATED-TRANSPORTER-PHONE",
+        contactEmail: "UPDATED-TRANSPORTER-MAIL"
+      }
+    });
+
+    await prisma.transporterReceipt.update({
+      where: { id: transporterCompany.transporterReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-TRANSPORTER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: destinationCompany.id },
+      data: {
+        name: "UPDATED-DESTINATION-NAME",
+        address: "UPDATED-DESTINATION-ADDRESS",
+        contact: "UPDATED-DESTINATION-CONTACT",
+        contactPhone: "UPDATED-DESTINATION-PHONE",
+        contactEmail: "UPDATED-DESTINATION-MAIL"
+      }
+    });
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsvhu">>(
+      DUPLICATE_BVHU,
+      {
+        variables: {
+          id: bsvhu.id
+        }
+      }
+    );
+
+    const duplicatedBsvhu = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: data.duplicateBsvhu.id }
+    });
+
+    expect(duplicatedBsvhu.emitterCompanyName).toEqual("UPDATED-EMITTER-NAME");
+    expect(duplicatedBsvhu.emitterCompanyAddress).toEqual(
+      "UPDATED-EMITTER-ADDRESS"
+    );
+    expect(duplicatedBsvhu.emitterCompanyContact).toEqual(
+      "UPDATED-EMITTER-CONTACT"
+    );
+    expect(duplicatedBsvhu.emitterCompanyMail).toEqual("UPDATED-EMITTER-MAIL");
+    expect(duplicatedBsvhu.emitterCompanyPhone).toEqual(
+      "UPDATED-EMITTER-PHONE"
+    );
+
+    expect(duplicatedBsvhu.transporterCompanyName).toEqual(
+      "UPDATED-TRANSPORTER-NAME"
+    );
+    expect(duplicatedBsvhu.transporterCompanyAddress).toEqual(
+      "UPDATED-TRANSPORTER-ADDRESS"
+    );
+    expect(duplicatedBsvhu.transporterCompanyContact).toEqual(
+      "UPDATED-TRANSPORTER-CONTACT"
+    );
+    expect(duplicatedBsvhu.transporterCompanyMail).toEqual(
+      "UPDATED-TRANSPORTER-MAIL"
+    );
+    expect(duplicatedBsvhu.transporterCompanyPhone).toEqual(
+      "UPDATED-TRANSPORTER-PHONE"
+    );
+
+    expect(duplicatedBsvhu.transporterRecepisseNumber).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-NUMBER"
+    );
+    expect(duplicatedBsvhu.transporterRecepisseValidityLimit).toEqual(
+      FOUR_DAYS_AGO
+    );
+    expect(duplicatedBsvhu.transporterRecepisseDepartment).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+    );
+
+    expect(duplicatedBsvhu.destinationCompanyName).toEqual(
+      "UPDATED-DESTINATION-NAME"
+    );
+    expect(duplicatedBsvhu.destinationCompanyAddress).toEqual(
+      "UPDATED-DESTINATION-ADDRESS"
+    );
+    expect(duplicatedBsvhu.destinationCompanyContact).toEqual(
+      "UPDATED-DESTINATION-CONTACT"
+    );
+    expect(duplicatedBsvhu.destinationCompanyMail).toEqual(
+      "UPDATED-DESTINATION-MAIL"
+    );
+    expect(duplicatedBsvhu.destinationCompanyPhone).toEqual(
+      "UPDATED-DESTINATION-PHONE"
+    );
+  });
+});

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -1,4 +1,4 @@
-import { Prisma, BsvhuStatus } from "@prisma/client";
+import { Prisma, BsvhuStatus, Bsvhu } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
 import { MutationDuplicateBsvhuArgs } from "../../../generated/graphql/types";
@@ -6,6 +6,7 @@ import { expandVhuFormFromDb } from "../../converter";
 import { getBsvhuOrNotFound } from "../../database";
 import { getBsvhuRepository } from "../../repository";
 import { checkCanDuplicate } from "../../permissions";
+import prisma from "../../../prisma";
 
 export default async function duplicate(
   _,
@@ -18,36 +19,110 @@ export default async function duplicate(
 
   await checkCanDuplicate(user, prismaBsvhu);
   const bsvhuRepository = getBsvhuRepository(user);
-  const newBsvhu = await bsvhuRepository.create(getDuplicateData(prismaBsvhu));
+  const newBsvhu = await bsvhuRepository.create(
+    await getDuplicateData(prismaBsvhu)
+  );
 
   return expandVhuFormFromDb(newBsvhu);
 }
 
-function getDuplicateData({
-  id,
-  createdAt,
-  updatedAt,
-  emitterEmissionSignatureAuthor,
-  emitterEmissionSignatureDate,
-  transporterTransportSignatureAuthor,
-  transporterTransportSignatureDate,
-  destinationReceptionQuantity,
-  destinationReceptionWeight,
-  destinationReceptionAcceptationStatus,
-  destinationReceptionRefusalReason,
-  destinationReceptionIdentificationNumbers,
-  destinationReceptionIdentificationType,
-  destinationReceptionDate,
-  destinationOperationDate,
-  destinationOperationCode,
-  destinationOperationSignatureAuthor,
-  destinationOperationSignatureDate,
-  ...rest
-}): Prisma.BsvhuCreateInput {
+async function getDuplicateData(
+  bsvhu: Bsvhu
+): Promise<Prisma.BsvhuCreateInput> {
+  const {
+    id,
+    createdAt,
+    updatedAt,
+    emitterEmissionSignatureAuthor,
+    emitterEmissionSignatureDate,
+    transporterTransportSignatureAuthor,
+    transporterTransportSignatureDate,
+    destinationReceptionQuantity,
+    destinationReceptionWeight,
+    destinationReceptionAcceptationStatus,
+    destinationReceptionRefusalReason,
+    destinationReceptionIdentificationNumbers,
+    destinationReceptionIdentificationType,
+    destinationReceptionDate,
+    destinationOperationDate,
+    destinationOperationCode,
+    destinationOperationSignatureAuthor,
+    destinationOperationSignatureDate,
+    ...rest
+  } = bsvhu;
+
+  const { emitter, transporter, destination } = await getBsvhuCompanies(bsvhu);
+
   return {
     ...rest,
     id: getReadableId(ReadableIdPrefix.VHU),
     status: BsvhuStatus.INITIAL,
-    isDraft: true
+    isDraft: true,
+    emitterCompanyName: emitter?.name ?? bsvhu.emitterCompanyName,
+    emitterCompanyAddress: emitter?.address ?? bsvhu.emitterCompanyAddress,
+    emitterCompanyContact: emitter?.contact ?? bsvhu.emitterCompanyContact,
+    emitterCompanyPhone: emitter?.contactPhone ?? bsvhu.emitterCompanyPhone,
+    emitterCompanyMail: emitter?.contactEmail ?? bsvhu.emitterCompanyMail,
+    destinationCompanyName: destination?.name ?? bsvhu.destinationCompanyName,
+    destinationCompanyAddress:
+      destination?.address ?? bsvhu.destinationCompanyAddress,
+    destinationCompanyContact:
+      destination?.contact ?? bsvhu.destinationCompanyContact,
+    destinationCompanyPhone:
+      destination?.contactPhone ?? bsvhu.destinationCompanyPhone,
+    destinationCompanyMail:
+      destination?.contactEmail ?? bsvhu.destinationCompanyMail,
+    transporterCompanyName: transporter?.name ?? bsvhu.transporterCompanyName,
+    transporterCompanyAddress:
+      transporter?.address ?? bsvhu.transporterCompanyAddress,
+    transporterCompanyContact:
+      transporter?.contact ?? bsvhu.transporterCompanyContact,
+    transporterCompanyPhone:
+      transporter?.contactPhone ?? bsvhu.transporterCompanyPhone,
+    transporterCompanyMail:
+      transporter?.contactEmail ?? bsvhu.transporterCompanyMail,
+    transporterCompanyVatNumber: bsvhu.transporterCompanyVatNumber,
+    transporterRecepisseNumber:
+      transporter?.transporterReceipt?.receiptNumber ??
+      bsvhu.transporterRecepisseNumber,
+    transporterRecepisseDepartment:
+      transporter?.transporterReceipt?.department ??
+      bsvhu.transporterRecepisseDepartment,
+    transporterRecepisseValidityLimit:
+      transporter?.transporterReceipt?.validityLimit ??
+      bsvhu.transporterRecepisseValidityLimit
   };
+}
+
+async function getBsvhuCompanies(bsvhu: Bsvhu) {
+  const companiesOrgIds = [
+    bsvhu.emitterCompanySiret,
+    bsvhu.transporterCompanySiret,
+    bsvhu.transporterCompanyVatNumber,
+    bsvhu.destinationCompanySiret
+  ].filter(Boolean);
+
+  // Batch fetch all companies involved in the BSVHU
+  const companies = await prisma.company.findMany({
+    where: { orgId: { in: companiesOrgIds } },
+    include: {
+      transporterReceipt: true
+    }
+  });
+
+  const emitter = companies.find(
+    company => company.orgId === bsvhu.emitterCompanySiret
+  );
+
+  const destination = companies.find(
+    company => company.orgId === bsvhu.destinationCompanySiret
+  );
+
+  const transporter = companies.find(
+    company =>
+      company.orgId === bsvhu.transporterCompanySiret ||
+      company.orgId === bsvhu.transporterCompanyVatNumber
+  );
+
+  return { emitter, destination, transporter };
 }

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -1,4 +1,4 @@
-import { UserRole } from "@prisma/client";
+import { Prisma, UserRole } from "@prisma/client";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import { Mutation } from "../../../../generated/graphql/types";
 import prisma from "../../../../prisma";
@@ -8,6 +8,7 @@ import {
   formWithTempStorageFactory,
   siretify,
   toIntermediaryCompany,
+  userFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
@@ -23,6 +24,98 @@ const DUPLICATE_FORM = `
     }
   }
 `;
+
+const TODAY = new Date();
+
+async function createForm(opt: Partial<Prisma.FormCreateInput> = {}) {
+  const emitter = await userWithCompanyFactory("MEMBER");
+  const transporter = await userWithCompanyFactory("MEMBER", {
+    transporterReceipt: {
+      create: {
+        receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+        validityLimit: TODAY.toISOString() as any,
+        department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+      }
+    }
+  });
+  const transporterReceipt = await prisma.transporterReceipt.findUniqueOrThrow({
+    where: { id: transporter.company.transporterReceiptId! }
+  });
+  const recipient = await userWithCompanyFactory("MEMBER");
+  const broker = await userWithCompanyFactory("ADMIN", {
+    brokerReceipt: {
+      create: {
+        receiptNumber: "BROKER-RECEIPT-NUMBER",
+        validityLimit: TODAY.toISOString() as any,
+        department: "BROKER-RECEIPT-DEPARTMENT"
+      }
+    }
+  });
+  const brokerReceipt = await prisma.brokerReceipt.findUniqueOrThrow({
+    where: { id: broker.company.brokerReceiptId! }
+  });
+  const trader = await userWithCompanyFactory("ADMIN", {
+    traderReceipt: {
+      create: {
+        receiptNumber: "TRADER-RECEIPT-NUMBER",
+        validityLimit: TODAY.toISOString() as any,
+        department: "TRADER-RECEIPT-DEPARTMENT"
+      }
+    }
+  });
+
+  const traderReceipt = await prisma.traderReceipt.findUniqueOrThrow({
+    where: { id: trader.company.traderReceiptId! }
+  });
+
+  const form = await formFactory({
+    ownerId: emitter.user.id,
+    opt: {
+      emitterCompanySiret: emitter.company.siret,
+      emitterCompanyName: emitter.company.name,
+      emitterCompanyAddress: emitter.company.address,
+      emitterCompanyContact: emitter.company.contact,
+      emitterCompanyPhone: emitter.company.contactPhone,
+      emitterCompanyMail: emitter.company.contactEmail,
+      transporterCompanySiret: transporter.company.siret,
+      transporterCompanyName: transporter.company.name,
+      transporterCompanyAddress: transporter.company.address,
+      transporterCompanyContact: transporter.company.contact,
+      transporterCompanyPhone: transporter.company.contactPhone,
+      transporterCompanyMail: transporter.company.contactEmail,
+      transporterReceipt: transporterReceipt.receiptNumber,
+      transporterDepartment: transporterReceipt.department,
+      transporterValidityLimit: transporterReceipt.validityLimit,
+      recipientCompanySiret: recipient.company.siret,
+      recipientCompanyName: recipient.company.name,
+      recipientCompanyAddress: recipient.company.address,
+      recipientCompanyContact: recipient.company.contact,
+      recipientCompanyPhone: recipient.company.contactPhone,
+      recipientCompanyMail: recipient.company.contactEmail,
+      brokerCompanySiret: broker.company.siret,
+      brokerCompanyName: broker.company.name,
+      brokerCompanyAddress: broker.company.address,
+      brokerCompanyContact: broker.company.contact,
+      brokerCompanyPhone: broker.company.contactPhone,
+      brokerCompanyMail: broker.company.contactEmail,
+      brokerReceipt: brokerReceipt.receiptNumber,
+      brokerDepartment: brokerReceipt.department,
+      brokerValidityLimit: brokerReceipt.validityLimit,
+      traderCompanySiret: trader.company.siret,
+      traderCompanyName: trader.company.name,
+      traderCompanyAddress: trader.company.address,
+      traderCompanyContact: trader.company.contact,
+      traderCompanyPhone: trader.company.contactPhone,
+      traderCompanyMail: trader.company.contactEmail,
+      traderReceipt: traderReceipt.receiptNumber,
+      traderDepartment: traderReceipt.department,
+      traderValidityLimit: traderReceipt.validityLimit,
+      ...opt
+    }
+  });
+
+  return { form, emitter, transporter, recipient, broker, trader };
+}
 
 const validateIntermediariesInputMock = jest.fn();
 jest.mock("../../../validation", () => ({
@@ -53,7 +146,8 @@ describe("Mutation.duplicateForm", () => {
       }
     ]
   ])("should duplicate a form %s", async (_, opt) => {
-    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const { form, emitter } = await createForm(opt);
+
     const {
       id,
       emitterType,
@@ -127,13 +221,7 @@ describe("Mutation.duplicateForm", () => {
       ecoOrganismeName,
       ecoOrganismeSiret,
       ...rest
-    } = await formFactory({
-      ownerId: user.id,
-      opt: {
-        emitterCompanySiret: company.siret,
-        ...opt
-      }
-    });
+    } = form;
 
     const expectedSkipped = [
       "createdAt",
@@ -191,7 +279,7 @@ describe("Mutation.duplicateForm", () => {
     // it will ensure we think of adding necessary fields to the duplicate input
     expect(Object.keys(rest).sort()).toEqual(expectedSkipped.sort());
 
-    const { mutate } = makeClient(user);
+    const { mutate } = makeClient(emitter.user);
     const { data } = await mutate<Pick<Mutation, "duplicateForm">>(
       DUPLICATE_FORM,
       {
@@ -200,6 +288,7 @@ describe("Mutation.duplicateForm", () => {
         }
       }
     );
+
     const duplicatedForm = await prisma.form.findUnique({
       where: { id: data.duplicateForm.id }
     });
@@ -280,9 +369,25 @@ describe("Mutation.duplicateForm", () => {
 
   it("should duplicate the temporary storage detail", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const ttr = await companyFactory();
+    const destination = await companyFactory();
     const form = await formWithTempStorageFactory({
       ownerId: user.id,
-      opt: { emitterCompanySiret: company.siret }
+      opt: { emitterCompanySiret: company.siret },
+      forwardedInOpts: {
+        emitterCompanySiret: ttr.siret,
+        emitterCompanyName: ttr.name,
+        emitterCompanyAddress: ttr.address,
+        emitterCompanyContact: ttr.contact,
+        emitterCompanyPhone: ttr.contactPhone,
+        emitterCompanyMail: ttr.contactEmail,
+        recipientCompanySiret: destination.siret,
+        recipientCompanyName: destination.name,
+        recipientCompanyAddress: destination.address,
+        recipientCompanyContact: destination.contact,
+        recipientCompanyPhone: destination.contactPhone,
+        recipientCompanyMail: destination.contactEmail
+      }
     });
     const {
       emitterType,
@@ -576,4 +681,234 @@ describe("Mutation.duplicateForm", () => {
     expect(duplicatedForm.nextDestinationCompanyPhone).toBeNull();
     expect(duplicatedForm.nextDestinationCompanyVatNumber).toBeNull();
   });
+
+  test("duplicated BSDD should have the updated data when company info changes", async () => {
+    const { form, emitter, transporter, recipient, trader, broker } =
+      await createForm();
+
+    await prisma.company.update({
+      where: { id: emitter.company.id },
+      data: {
+        name: "UPDATED-EMITTER-NAME",
+        address: "UPDATED-EMITTER-ADDRESS",
+        contact: "UPDATED-EMITTER-CONTACT",
+        contactPhone: "UPDATED-EMITTER-PHONE",
+        contactEmail: "UPDATED-EMITTER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: transporter.company.id },
+      data: {
+        name: "UPDATED-TRANSPORTER-NAME",
+        address: "UPDATED-TRANSPORTER-ADDRESS",
+        contact: "UPDATED-TRANSPORTER-CONTACT",
+        contactPhone: "UPDATED-TRANSPORTER-PHONE",
+        contactEmail: "UPDATED-TRANSPORTER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: recipient.company.id },
+      data: {
+        name: "UPDATED-RECIPIENT-NAME",
+        address: "UPDATED-RECIPIENT-ADDRESS",
+        contact: "UPDATED-RECIPIENT-CONTACT",
+        contactPhone: "UPDATED-RECIPIENT-PHONE",
+        contactEmail: "UPDATED-RECIPIENT-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: trader.company.id },
+      data: {
+        name: "UPDATED-TRADER-NAME",
+        address: "UPDATED-TRADER-ADDRESS",
+        contact: "UPDATED-TRADER-CONTACT",
+        contactPhone: "UPDATED-TRADER-PHONE",
+        contactEmail: "UPDATED-TRADER-MAIL"
+      }
+    });
+
+    await prisma.company.update({
+      where: { id: broker.company.id },
+      data: {
+        name: "UPDATED-BROKER-NAME",
+        address: "UPDATED-BROKER-ADDRESS",
+        contact: "UPDATED-BROKER-CONTACT",
+        contactPhone: "UPDATED-BROKER-PHONE",
+        contactEmail: "UPDATED-BROKER-MAIL"
+      }
+    });
+
+    const { mutate } = makeClient(emitter.user);
+    const { data } = await mutate<Pick<Mutation, "duplicateForm">>(
+      DUPLICATE_FORM,
+      {
+        variables: {
+          id: form.id
+        }
+      }
+    );
+    const duplicatedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: data.duplicateForm.id }
+    });
+
+    expect(duplicatedForm.emitterCompanyName).toEqual("UPDATED-EMITTER-NAME");
+    expect(duplicatedForm.emitterCompanyAddress).toEqual(
+      "UPDATED-EMITTER-ADDRESS"
+    );
+    expect(duplicatedForm.emitterCompanyContact).toEqual(
+      "UPDATED-EMITTER-CONTACT"
+    );
+    expect(duplicatedForm.emitterCompanyMail).toEqual("UPDATED-EMITTER-MAIL");
+    expect(duplicatedForm.emitterCompanyPhone).toEqual("UPDATED-EMITTER-PHONE");
+    expect(duplicatedForm.transporterCompanyName).toEqual(
+      "UPDATED-TRANSPORTER-NAME"
+    );
+    expect(duplicatedForm.transporterCompanyAddress).toEqual(
+      "UPDATED-TRANSPORTER-ADDRESS"
+    );
+    expect(duplicatedForm.transporterCompanyContact).toEqual(
+      "UPDATED-TRANSPORTER-CONTACT"
+    );
+    expect(duplicatedForm.transporterCompanyMail).toEqual(
+      "UPDATED-TRANSPORTER-MAIL"
+    );
+    expect(duplicatedForm.transporterCompanyPhone).toEqual(
+      "UPDATED-TRANSPORTER-PHONE"
+    );
+    expect(duplicatedForm.recipientCompanyName).toEqual(
+      "UPDATED-RECIPIENT-NAME"
+    );
+    expect(duplicatedForm.recipientCompanyAddress).toEqual(
+      "UPDATED-RECIPIENT-ADDRESS"
+    );
+    expect(duplicatedForm.recipientCompanyContact).toEqual(
+      "UPDATED-RECIPIENT-CONTACT"
+    );
+    expect(duplicatedForm.recipientCompanyMail).toEqual(
+      "UPDATED-RECIPIENT-MAIL"
+    );
+    expect(duplicatedForm.recipientCompanyPhone).toEqual(
+      "UPDATED-RECIPIENT-PHONE"
+    );
+    expect(duplicatedForm.traderCompanyName).toEqual("UPDATED-TRADER-NAME");
+    expect(duplicatedForm.traderCompanyAddress).toEqual(
+      "UPDATED-TRADER-ADDRESS"
+    );
+    expect(duplicatedForm.traderCompanyContact).toEqual(
+      "UPDATED-TRADER-CONTACT"
+    );
+    expect(duplicatedForm.traderCompanyMail).toEqual("UPDATED-TRADER-MAIL");
+    expect(duplicatedForm.traderCompanyPhone).toEqual("UPDATED-TRADER-PHONE");
+    expect(duplicatedForm.recipientCompanyPhone).toEqual(
+      "UPDATED-RECIPIENT-PHONE"
+    );
+    expect(duplicatedForm.brokerCompanyName).toEqual("UPDATED-BROKER-NAME");
+    expect(duplicatedForm.brokerCompanyAddress).toEqual(
+      "UPDATED-BROKER-ADDRESS"
+    );
+    expect(duplicatedForm.brokerCompanyContact).toEqual(
+      "UPDATED-BROKER-CONTACT"
+    );
+    expect(duplicatedForm.brokerCompanyMail).toEqual("UPDATED-BROKER-MAIL");
+    expect(duplicatedForm.brokerCompanyPhone).toEqual("UPDATED-BROKER-PHONE");
+  });
+
+  test(
+    "duplicated BSDD with temp storage should have updated data" +
+      " in temp storage detail when company info changes",
+    async () => {
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+      const ttr = await companyFactory();
+      const destination = await companyFactory();
+      const form = await formWithTempStorageFactory({
+        ownerId: user.id,
+        opt: { emitterCompanySiret: company.siret },
+        forwardedInOpts: {
+          emitterCompanySiret: ttr.siret,
+          emitterCompanyName: ttr.name,
+          emitterCompanyAddress: ttr.address,
+          emitterCompanyContact: ttr.contact,
+          emitterCompanyPhone: ttr.contactPhone,
+          emitterCompanyMail: ttr.contactEmail,
+          recipientCompanySiret: destination.siret,
+          recipientCompanyName: destination.name,
+          recipientCompanyAddress: destination.address,
+          recipientCompanyContact: destination.contact,
+          recipientCompanyPhone: destination.contactPhone,
+          recipientCompanyMail: destination.contactEmail
+        }
+      });
+      const { mutate } = makeClient(user);
+
+      await prisma.company.update({
+        where: { id: ttr.id },
+        data: {
+          name: "UPDATED-TTR-NAME",
+          address: "UPDATED-TTR-ADDRESS",
+          contact: "UPDATED-TTR-CONTACT",
+          contactPhone: "UPDATED-TTR-PHONE",
+          contactEmail: "UPDATED-TTR-MAIL"
+        }
+      });
+
+      await prisma.company.update({
+        where: { id: destination.id },
+        data: {
+          name: "UPDATED-DESTINATION-NAME",
+          address: "UPDATED-DESTINATION-ADDRESS",
+          contact: "UPDATED-DESTINATION-CONTACT",
+          contactPhone: "UPDATED-DESTINATION-PHONE",
+          contactEmail: "UPDATED-DESTINATION-MAIL"
+        }
+      });
+
+      const { data } = await mutate<Pick<Mutation, "duplicateForm">>(
+        DUPLICATE_FORM,
+        {
+          variables: {
+            id: form.id
+          }
+        }
+      );
+      const duplicatedForwardedIn = await prisma.form
+        .findUniqueOrThrow({
+          where: { id: data.duplicateForm.id }
+        })
+        .forwardedIn();
+
+      expect(duplicatedForwardedIn.emitterCompanyName).toEqual(
+        "UPDATED-TTR-NAME"
+      );
+      expect(duplicatedForwardedIn.emitterCompanyAddress).toEqual(
+        "UPDATED-TTR-ADDRESS"
+      );
+      expect(duplicatedForwardedIn.emitterCompanyContact).toEqual(
+        "UPDATED-TTR-CONTACT"
+      );
+      expect(duplicatedForwardedIn.emitterCompanyPhone).toEqual(
+        "UPDATED-TTR-PHONE"
+      );
+      expect(duplicatedForwardedIn.emitterCompanyMail).toEqual(
+        "UPDATED-TTR-MAIL"
+      );
+      expect(duplicatedForwardedIn.recipientCompanyName).toEqual(
+        "UPDATED-DESTINATION-NAME"
+      );
+      expect(duplicatedForwardedIn.recipientCompanyAddress).toEqual(
+        "UPDATED-DESTINATION-ADDRESS"
+      );
+      expect(duplicatedForwardedIn.recipientCompanyContact).toEqual(
+        "UPDATED-DESTINATION-CONTACT"
+      );
+      expect(duplicatedForwardedIn.recipientCompanyPhone).toEqual(
+        "UPDATED-DESTINATION-PHONE"
+      );
+      expect(duplicatedForwardedIn.recipientCompanyMail).toEqual(
+        "UPDATED-DESTINATION-MAIL"
+      );
+    }
+  );
 });

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -8,10 +8,10 @@ import {
   formWithTempStorageFactory,
   siretify,
   toIntermediaryCompany,
-  userFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
+import { xDaysAgo } from "../../../../commands/onboarding.helpers";
 
 const DUPLICATE_FORM = `
   mutation DuplicateForm($id: ID!) {
@@ -26,6 +26,7 @@ const DUPLICATE_FORM = `
 `;
 
 const TODAY = new Date();
+const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
 
 async function createForm(opt: Partial<Prisma.FormCreateInput> = {}) {
   const emitter = await userWithCompanyFactory("MEMBER");
@@ -708,6 +709,15 @@ describe("Mutation.duplicateForm", () => {
       }
     });
 
+    await prisma.transporterReceipt.update({
+      where: { id: transporter.company.transporterReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-TRANSPORTER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+      }
+    });
+
     await prisma.company.update({
       where: { id: recipient.company.id },
       data: {
@@ -730,6 +740,15 @@ describe("Mutation.duplicateForm", () => {
       }
     });
 
+    await prisma.traderReceipt.update({
+      where: { id: trader.company.traderReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-TRADER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-TRADER-RECEIPT-DEPARTMENT"
+      }
+    });
+
     await prisma.company.update({
       where: { id: broker.company.id },
       data: {
@@ -738,6 +757,15 @@ describe("Mutation.duplicateForm", () => {
         contact: "UPDATED-BROKER-CONTACT",
         contactPhone: "UPDATED-BROKER-PHONE",
         contactEmail: "UPDATED-BROKER-MAIL"
+      }
+    });
+
+    await prisma.brokerReceipt.update({
+      where: { id: broker.company.brokerReceiptId! },
+      data: {
+        receiptNumber: "UPDATED-BROKER-RECEIPT-NUMBER",
+        validityLimit: FOUR_DAYS_AGO.toISOString(),
+        department: "UPDATED-BROKER-RECEIPT-DEPARTMENT"
       }
     });
 
@@ -763,6 +791,7 @@ describe("Mutation.duplicateForm", () => {
     );
     expect(duplicatedForm.emitterCompanyMail).toEqual("UPDATED-EMITTER-MAIL");
     expect(duplicatedForm.emitterCompanyPhone).toEqual("UPDATED-EMITTER-PHONE");
+
     expect(duplicatedForm.transporterCompanyName).toEqual(
       "UPDATED-TRANSPORTER-NAME"
     );
@@ -778,6 +807,15 @@ describe("Mutation.duplicateForm", () => {
     expect(duplicatedForm.transporterCompanyPhone).toEqual(
       "UPDATED-TRANSPORTER-PHONE"
     );
+
+    expect(duplicatedForm.transporterReceipt).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-NUMBER"
+    );
+    expect(duplicatedForm.transporterValidityLimit).toEqual(FOUR_DAYS_AGO);
+    expect(duplicatedForm.transporterDepartment).toEqual(
+      "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
+    );
+
     expect(duplicatedForm.recipientCompanyName).toEqual(
       "UPDATED-RECIPIENT-NAME"
     );
@@ -793,6 +831,10 @@ describe("Mutation.duplicateForm", () => {
     expect(duplicatedForm.recipientCompanyPhone).toEqual(
       "UPDATED-RECIPIENT-PHONE"
     );
+    expect(duplicatedForm.recipientCompanyPhone).toEqual(
+      "UPDATED-RECIPIENT-PHONE"
+    );
+
     expect(duplicatedForm.traderCompanyName).toEqual("UPDATED-TRADER-NAME");
     expect(duplicatedForm.traderCompanyAddress).toEqual(
       "UPDATED-TRADER-ADDRESS"
@@ -802,9 +844,15 @@ describe("Mutation.duplicateForm", () => {
     );
     expect(duplicatedForm.traderCompanyMail).toEqual("UPDATED-TRADER-MAIL");
     expect(duplicatedForm.traderCompanyPhone).toEqual("UPDATED-TRADER-PHONE");
-    expect(duplicatedForm.recipientCompanyPhone).toEqual(
-      "UPDATED-RECIPIENT-PHONE"
+
+    expect(duplicatedForm.traderReceipt).toEqual(
+      "UPDATED-TRADER-RECEIPT-NUMBER"
     );
+    expect(duplicatedForm.traderValidityLimit).toEqual(FOUR_DAYS_AGO);
+    expect(duplicatedForm.traderDepartment).toEqual(
+      "UPDATED-TRADER-RECEIPT-DEPARTMENT"
+    );
+
     expect(duplicatedForm.brokerCompanyName).toEqual("UPDATED-BROKER-NAME");
     expect(duplicatedForm.brokerCompanyAddress).toEqual(
       "UPDATED-BROKER-ADDRESS"
@@ -814,6 +862,14 @@ describe("Mutation.duplicateForm", () => {
     );
     expect(duplicatedForm.brokerCompanyMail).toEqual("UPDATED-BROKER-MAIL");
     expect(duplicatedForm.brokerCompanyPhone).toEqual("UPDATED-BROKER-PHONE");
+
+    expect(duplicatedForm.brokerReceipt).toEqual(
+      "UPDATED-BROKER-RECEIPT-NUMBER"
+    );
+    expect(duplicatedForm.brokerValidityLimit).toEqual(FOUR_DAYS_AGO);
+    expect(duplicatedForm.brokerDepartment).toEqual(
+      "UPDATED-BROKER-RECEIPT-DEPARTMENT"
+    );
   });
 
   test(

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -1,4 +1,13 @@
-import { Form, Prisma, Status, User } from "@prisma/client";
+import {
+  BrokerReceipt,
+  Company,
+  Form,
+  Prisma,
+  Status,
+  TraderReceipt,
+  TransporterReceipt,
+  User
+} from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { getFormOrFormNotFound } from "../../database";
@@ -8,6 +17,63 @@ import getReadableId from "../../readableId";
 import { getFormRepository } from "../../repository";
 import { FullForm } from "../../types";
 import { prismaJsonNoNull } from "../../../common/converter";
+import prisma from "../../../prisma";
+
+type FormCompanies = {
+  emitter: Company | undefined;
+  transporter:
+    | (Company & { transporterReceipt: TransporterReceipt | null })
+    | undefined;
+  recipient: Company | undefined;
+  trader: (Company & { traderReceipt: TraderReceipt | null }) | undefined;
+  broker: (Company & { brokerReceipt: BrokerReceipt | null }) | undefined;
+};
+
+/**
+ * Retrieves companies present on the form that a registered in TD
+ */
+async function getFormCompanies(form: Form): Promise<FormCompanies> {
+  const companiesOrgIds = [
+    form.emitterCompanySiret,
+    form.transporterCompanySiret,
+    form.transporterCompanyVatNumber,
+    form.recipientCompanySiret,
+    form.brokerCompanySiret,
+    form.traderCompanySiret
+  ].filter(Boolean);
+
+  // Batch fetch all companies involved in the form
+  const companies = await prisma.company.findMany({
+    where: { siret: { in: companiesOrgIds } },
+    include: {
+      transporterReceipt: true,
+      traderReceipt: true,
+      brokerReceipt: true
+    }
+  });
+
+  const emitter = companies.find(
+    company => company.orgId === form.emitterCompanySiret
+  );
+
+  const recipient = companies.find(
+    company => company.orgId === form.recipientCompanySiret
+  );
+
+  const broker = companies.find(
+    company => company.orgId === form.brokerCompanySiret
+  );
+  const transporter = companies.find(
+    company =>
+      company.orgId === form.transporterCompanySiret ||
+      company.orgId === form.transporterCompanyVatNumber
+  );
+  const trader = companies.find(
+    company => company.orgId === form.traderCompanySiret
+  );
+
+  return { emitter, recipient, transporter, broker, trader };
+}
 
 /**
  * Get duplicable form fields
@@ -15,7 +81,13 @@ import { prismaJsonNoNull } from "../../../common/converter";
  * @param {User} user user that should own the duplicated form
  * @param {Form} form the form to duplicate
  */
-function getDuplicateFormInput(user: User, form: Form): Prisma.FormCreateInput {
+async function getDuplicateFormInput(
+  user: User,
+  form: Form
+): Promise<Prisma.FormCreateInput> {
+  const { emitter, transporter, recipient, broker, trader } =
+    await getFormCompanies(form);
+
   return {
     readableId: getReadableId(),
     status: Status.DRAFT,
@@ -24,12 +96,12 @@ function getDuplicateFormInput(user: User, form: Form): Prisma.FormCreateInput {
     emitterPickupSite: form.emitterPickupSite,
     emitterIsPrivateIndividual: form.emitterIsPrivateIndividual,
     emitterIsForeignShip: form.emitterIsForeignShip,
-    emitterCompanyName: form.emitterCompanyName,
+    emitterCompanyName: emitter?.name ?? form.emitterCompanyName,
     emitterCompanySiret: form.emitterCompanySiret,
-    emitterCompanyAddress: form.emitterCompanyAddress,
-    emitterCompanyContact: form.emitterCompanyContact,
-    emitterCompanyPhone: form.emitterCompanyPhone,
-    emitterCompanyMail: form.emitterCompanyMail,
+    emitterCompanyAddress: emitter?.address ?? form.emitterCompanyAddress,
+    emitterCompanyContact: emitter?.contact ?? form.emitterCompanyContact,
+    emitterCompanyPhone: emitter?.contactPhone ?? form.emitterCompanyPhone,
+    emitterCompanyMail: emitter?.contactEmail ?? form.emitterCompanyMail,
     emitterCompanyOmiNumber: form.emitterCompanyOmiNumber,
     emitterWorkSiteName: form.emitterWorkSiteName,
     emitterWorkSiteAddress: form.emitterWorkSiteAddress,
@@ -38,23 +110,32 @@ function getDuplicateFormInput(user: User, form: Form): Prisma.FormCreateInput {
     emitterWorkSiteInfos: form.emitterWorkSiteInfos,
     recipientCap: form.recipientCap,
     recipientProcessingOperation: form.recipientProcessingOperation,
-    recipientCompanyName: form.recipientCompanyName,
+    recipientCompanyName: recipient?.name ?? form.recipientCompanyName,
     recipientCompanySiret: form.recipientCompanySiret,
-    recipientCompanyAddress: form.recipientCompanyAddress,
-    recipientCompanyContact: form.recipientCompanyContact,
-    recipientCompanyPhone: form.recipientCompanyPhone,
-    recipientCompanyMail: form.recipientCompanyMail,
+    recipientCompanyAddress: recipient?.address ?? form.recipientCompanyAddress,
+    recipientCompanyContact: recipient?.contact ?? form.recipientCompanyContact,
+    recipientCompanyPhone:
+      recipient?.contactPhone ?? form.recipientCompanyPhone,
+    recipientCompanyMail: recipient?.contactEmail ?? form.recipientCompanyMail,
     recipientIsTempStorage: form.recipientIsTempStorage,
-    transporterCompanyName: form.transporterCompanyName,
+    transporterCompanyName: transporter?.name ?? form.transporterCompanyName,
     transporterCompanySiret: form.transporterCompanySiret,
-    transporterCompanyAddress: form.transporterCompanyAddress,
-    transporterCompanyContact: form.transporterCompanyContact,
-    transporterCompanyPhone: form.transporterCompanyPhone,
-    transporterCompanyMail: form.transporterCompanyMail,
+    transporterCompanyAddress:
+      transporter?.address ?? form.transporterCompanyAddress,
+    transporterCompanyContact:
+      transporter?.contact ?? form.transporterCompanyContact,
+    transporterCompanyPhone:
+      transporter?.contactPhone ?? form.transporterCompanyPhone,
+    transporterCompanyMail:
+      transporter?.contactEmail ?? form.transporterCompanyMail,
     transporterCompanyVatNumber: form.transporterCompanyVatNumber,
-    transporterReceipt: form.transporterReceipt,
-    transporterDepartment: form.transporterDepartment,
-    transporterValidityLimit: form.transporterValidityLimit,
+    transporterReceipt:
+      transporter?.transporterReceipt?.receiptNumber ?? form.transporterReceipt,
+    transporterDepartment:
+      transporter?.transporterReceipt?.department ?? form.transporterDepartment,
+    transporterValidityLimit:
+      transporter?.transporterReceipt?.validityLimit ??
+      form.transporterValidityLimit,
     transporterTransportMode: form.transporterTransportMode,
     transporterIsExemptedOfReceipt: form.transporterIsExemptedOfReceipt,
     wasteDetailsCode: form.wasteDetailsCode,
@@ -72,24 +153,28 @@ function getDuplicateFormInput(user: User, form: Form): Prisma.FormCreateInput {
     wasteDetailsName: form.wasteDetailsName,
     wasteDetailsConsistence: form.wasteDetailsConsistence,
     wasteDetailsSampleNumber: form.wasteDetailsSampleNumber,
-    traderCompanyName: form.traderCompanyName,
+    traderCompanyName: trader?.name ?? form.traderCompanyName,
     traderCompanySiret: form.traderCompanySiret,
-    traderCompanyAddress: form.traderCompanyAddress,
-    traderCompanyContact: form.traderCompanyContact,
-    traderCompanyPhone: form.traderCompanyPhone,
-    traderCompanyMail: form.traderCompanyMail,
-    traderReceipt: form.traderReceipt,
-    traderDepartment: form.traderDepartment,
-    traderValidityLimit: form.traderValidityLimit,
-    brokerCompanyName: form.brokerCompanyName,
+    traderCompanyAddress: trader?.address ?? form.traderCompanyAddress,
+    traderCompanyContact: trader?.contact ?? form.traderCompanyContact,
+    traderCompanyPhone: trader?.contactPhone ?? form.traderCompanyPhone,
+    traderCompanyMail: trader?.contactEmail ?? form.traderCompanyMail,
+    traderReceipt: trader?.traderReceipt?.receiptNumber ?? form.traderReceipt,
+    traderDepartment:
+      trader?.traderReceipt?.department ?? form.traderDepartment,
+    traderValidityLimit:
+      trader?.traderReceipt?.validityLimit ?? form.traderValidityLimit,
+    brokerCompanyName: broker?.name ?? form.brokerCompanyName,
     brokerCompanySiret: form.brokerCompanySiret,
-    brokerCompanyAddress: form.brokerCompanyAddress,
-    brokerCompanyContact: form.brokerCompanyContact,
-    brokerCompanyPhone: form.brokerCompanyPhone,
-    brokerCompanyMail: form.brokerCompanyMail,
-    brokerReceipt: form.brokerReceipt,
-    brokerDepartment: form.brokerDepartment,
-    brokerValidityLimit: form.brokerValidityLimit,
+    brokerCompanyAddress: broker?.address ?? form.brokerCompanyAddress,
+    brokerCompanyContact: broker?.contact ?? form.brokerCompanyContact,
+    brokerCompanyPhone: broker?.contactPhone ?? form.brokerCompanyPhone,
+    brokerCompanyMail: broker?.contactEmail ?? form.brokerCompanyMail,
+    brokerReceipt: broker?.brokerReceipt?.receiptNumber ?? form.brokerReceipt,
+    brokerDepartment:
+      broker?.brokerReceipt?.department ?? form.brokerDepartment,
+    brokerValidityLimit:
+      broker?.brokerReceipt?.validityLimit ?? form.brokerValidityLimit,
     ecoOrganismeName: form.ecoOrganismeName,
     ecoOrganismeSiret: form.ecoOrganismeSiret
   };
@@ -98,10 +183,10 @@ function getDuplicateFormInput(user: User, form: Form): Prisma.FormCreateInput {
 /**
  * Get duplicable form fields on BSD suite
  */
-function getDuplicateFormForwardedInInput(
+async function getDuplicateFormForwardedInInput(
   user: User,
   form: FullForm
-): Omit<Prisma.FormCreateInput, "readableId"> {
+): Promise<Omit<Prisma.FormCreateInput, "readableId">> {
   const forwardedIn = form.forwardedIn;
 
   if (!forwardedIn) {
@@ -110,24 +195,33 @@ function getDuplicateFormForwardedInInput(
     );
   }
 
+  const { emitter, recipient } = await getFormCompanies(forwardedIn);
+
   return {
     status: Status.DRAFT,
     owner: { connect: { id: user.id } },
     emitterType: forwardedIn.emitterType,
-    emitterCompanyName: forwardedIn.emitterCompanyName,
+    emitterCompanyName: emitter?.name ?? forwardedIn.emitterCompanyName,
     emitterCompanySiret: forwardedIn.emitterCompanySiret,
-    emitterCompanyAddress: forwardedIn.emitterCompanyAddress,
-    emitterCompanyContact: forwardedIn.emitterCompanyContact,
-    emitterCompanyPhone: forwardedIn.emitterCompanyPhone,
-    emitterCompanyMail: forwardedIn.emitterCompanyMail,
+    emitterCompanyAddress:
+      emitter?.address ?? forwardedIn.emitterCompanyAddress,
+    emitterCompanyContact:
+      emitter?.contact ?? forwardedIn.emitterCompanyContact,
+    emitterCompanyPhone:
+      emitter?.contactPhone ?? forwardedIn.emitterCompanyPhone,
+    emitterCompanyMail: emitter?.contactEmail ?? forwardedIn.emitterCompanyMail,
     recipientCap: forwardedIn.recipientCap,
     recipientProcessingOperation: forwardedIn.recipientProcessingOperation,
-    recipientCompanyName: forwardedIn.recipientCompanyName,
+    recipientCompanyName: recipient?.name ?? forwardedIn.recipientCompanyName,
     recipientCompanySiret: forwardedIn.recipientCompanySiret,
-    recipientCompanyAddress: forwardedIn.recipientCompanyAddress,
-    recipientCompanyContact: forwardedIn.recipientCompanyContact,
-    recipientCompanyPhone: forwardedIn.recipientCompanyPhone,
-    recipientCompanyMail: forwardedIn.recipientCompanyMail,
+    recipientCompanyAddress:
+      recipient?.address ?? forwardedIn.recipientCompanyAddress,
+    recipientCompanyContact:
+      recipient?.contact ?? forwardedIn.recipientCompanyContact,
+    recipientCompanyPhone:
+      recipient?.contactPhone ?? forwardedIn.recipientCompanyPhone,
+    recipientCompanyMail:
+      recipient?.contactEmail ?? forwardedIn.recipientCompanyMail,
     wasteDetailsCode: forwardedIn.wasteDetailsCode,
     wasteDetailsPackagingInfos: prismaJsonNoNull(
       form.wasteDetailsPackagingInfos
@@ -158,13 +252,17 @@ const duplicateFormResolver: MutationResolvers["duplicateForm"] = async (
 
   const formRepository = getFormRepository(user);
 
-  const newFormInput = getDuplicateFormInput(user, existingForm);
+  const newFormInput = await getDuplicateFormInput(user, existingForm);
 
   const fullForm = await formRepository.findFullFormById(existingForm.id);
   if (fullForm?.forwardedIn) {
+    const forwardedFormInput = await getDuplicateFormForwardedInInput(
+      user,
+      fullForm
+    );
     newFormInput.forwardedIn = {
       create: {
-        ...getDuplicateFormForwardedInInput(user, fullForm),
+        ...forwardedFormInput,
         readableId: `${newFormInput.readableId}-suite`
       }
     };

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -1,13 +1,4 @@
-import {
-  BrokerReceipt,
-  Company,
-  Form,
-  Prisma,
-  Status,
-  TraderReceipt,
-  TransporterReceipt,
-  User
-} from "@prisma/client";
+import { Form, Prisma, Status, User } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { getFormOrFormNotFound } from "../../database";
@@ -19,20 +10,10 @@ import { FullForm } from "../../types";
 import { prismaJsonNoNull } from "../../../common/converter";
 import prisma from "../../../prisma";
 
-type FormCompanies = {
-  emitter: Company | undefined;
-  transporter:
-    | (Company & { transporterReceipt: TransporterReceipt | null })
-    | undefined;
-  recipient: Company | undefined;
-  trader: (Company & { traderReceipt: TraderReceipt | null }) | undefined;
-  broker: (Company & { brokerReceipt: BrokerReceipt | null }) | undefined;
-};
-
 /**
  * Retrieves companies present on the form that a registered in TD
  */
-async function getFormCompanies(form: Form): Promise<FormCompanies> {
+async function getFormCompanies(form: Form) {
   const companiesOrgIds = [
     form.emitterCompanySiret,
     form.transporterCompanySiret,
@@ -44,7 +25,7 @@ async function getFormCompanies(form: Form): Promise<FormCompanies> {
 
   // Batch fetch all companies involved in the form
   const companies = await prisma.company.findMany({
-    where: { siret: { in: companiesOrgIds } },
+    where: { orgId: { in: companiesOrgIds } },
     include: {
       transporterReceipt: true,
       traderReceipt: true,


### PR DESCRIPTION
# Contexte

Lorsqu'on duplique un bordereau, on reprend telles quelles les informations du bordereau d'origine. Or, certaines informations peuvent avoir changé entre temps, comme par exemple un numéro de récépissé transporteur.

Solution: lors de la duplication, on va chercher les informations susceptibles d'avoir évolué et on les injecte dans le nouveau bordereau. En fonction du rôle sur le bordereau (émetteur, transporteur, entreprise de travaux, courtier, négociant), on met à jour les infos suivantes : 
- raison sociale 
- adresse 
- nom, courriel et numéro de téléphone du contact 
- récépissé transporteur, négociant, courtier 
- certification d'entreprise de travaux 

L'implémentation initiale sur le BSDA a été faite par Gaël et j'ai (Benoît) généralisé à tous les bordereaux.

# Ticket

- [[Bug] Les champs automatiques devraient être MAJ lorsque l'on duplique  ou créé des BSD (raison sociale, récépissés de transport, négociants, courtiers, certifications, contacts de l'établissement...)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/acfab2d4cb9a160fc1f893e8?card=tra-11636)
