### PR TITLE
[TRA-8959] Permettre aux écoorganismes de gérer les révisions du bsdd

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -41,6 +41,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Améliorations performances back-end, sur les révisions Bsda, Bsdd et l'authentification (dataloaders et requêtes SQL) [PR 2350](https://github.com/MTES-MCT/trackdechets/pull/2350)
+- Les éco-organismes peuvent gérer les révisions du BSDD [PR 2356](https://github.com/MTES-MCT/trackdechets/pull/2356)
 
 #### :memo: Documentation
 

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -25,7 +25,7 @@ import { expandBsffFromElastic } from "../../../bsffs/converter";
 import { bsdSearchSchema } from "../../validation";
 import { toElasticQuery } from "../../where";
 import { Permission, can, getUserRoles } from "../../../permissions";
-import { deduplicate } from "../../../common/arrays";
+import { distinct } from "../../../common/arrays";
 
 // complete Typescript example:
 // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/_a_complete_example.html
@@ -258,7 +258,7 @@ async function buildDasris(dasris: Bsdasri[]) {
     .map(bsd => bsd.emitterCompanySiret)
     .filter(Boolean);
 
-  const uniqueSirets = deduplicate(emitterSirets);
+  const uniqueSirets = distinct(emitterSirets);
 
   // build an array of sirets allowing direct takeover
   const allows = (

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -25,6 +25,7 @@ import { expandBsffFromElastic } from "../../../bsffs/converter";
 import { bsdSearchSchema } from "../../validation";
 import { toElasticQuery } from "../../where";
 import { Permission, can, getUserRoles } from "../../../permissions";
+import { deduplicate } from "../../../common/arrays";
 
 // complete Typescript example:
 // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/_a_complete_example.html
@@ -257,8 +258,7 @@ async function buildDasris(dasris: Bsdasri[]) {
     .map(bsd => bsd.emitterCompanySiret)
     .filter(Boolean);
 
-  // deduplicate sirets
-  const uniqueSirets = Array.from(new Set(emitterSirets));
+  const uniqueSirets = deduplicate(emitterSirets);
 
   // build an array of sirets allowing direct takeover
   const allows = (

--- a/back/src/captcha/captchaGen.ts
+++ b/back/src/captcha/captchaGen.ts
@@ -7,7 +7,7 @@ import {
   clearCaptchaToken
 } from "../common/redis/captcha";
 import path from "path";
-import { deduplicate } from "../common/arrays";
+import { distinct } from "../common/arrays";
 
 const CAPTCHA_LENGTH = 5;
 
@@ -180,7 +180,7 @@ export async function captchaSound(captchaToken, res) {
   }
 
   const captchaArray = captchaString.toLowerCase().split("");
-  const letters = deduplicate(captchaArray);
+  const letters = distinct(captchaArray);
 
   const audio: string[] = [];
   const playList: number[] = [];

--- a/back/src/captcha/captchaGen.ts
+++ b/back/src/captcha/captchaGen.ts
@@ -7,6 +7,8 @@ import {
   clearCaptchaToken
 } from "../common/redis/captcha";
 import path from "path";
+import { deduplicate } from "../common/arrays";
+
 const CAPTCHA_LENGTH = 5;
 
 function randomInt(max) {
@@ -178,7 +180,7 @@ export async function captchaSound(captchaToken, res) {
   }
 
   const captchaArray = captchaString.toLowerCase().split("");
-  const letters = Array.from(new Set(captchaArray)); // remove duplicates
+  const letters = deduplicate(captchaArray);
 
   const audio: string[] = [];
   const playList: number[] = [];

--- a/back/src/common/arrays.ts
+++ b/back/src/common/arrays.ts
@@ -1,0 +1,1 @@
+export const deduplicate = <T>(arr: T[]): T[] => Array.from(new Set(arr));

--- a/back/src/common/arrays.ts
+++ b/back/src/common/arrays.ts
@@ -1,1 +1,1 @@
-export const deduplicate = <T>(arr: T[]): T[] => Array.from(new Set(arr));
+export const distinct = <T>(arr: T[]): T[] => Array.from(new Set(arr));

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -472,6 +472,7 @@ export async function checkCanRequestRevision(user: User, form: Form) {
   const authorizedOrgIds = [
     fullForm.emitterCompanySiret,
     fullForm.recipientCompanySiret,
+    fullForm.ecoOrganismeSiret,
     fullForm.forwardedIn?.recipientCompanySiret
   ].filter(Boolean);
 

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -19,7 +19,7 @@ import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { NON_CANCELLABLE_BSDD_STATUSES } from "../../resolvers/mutations/createFormRevisionRequest";
 import { ForbiddenError } from "apollo-server-core";
 import buildRemoveAppendix2 from "../form/removeAppendix2";
-import { deduplicate } from "../../../common/arrays";
+import { distinct } from "../../../common/arrays";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
@@ -32,7 +32,7 @@ export type AcceptRevisionRequestApprovalFn = (
  * We have to handle eco organismes which might be present on bsdd:
  * Retrieve form
  * Get producer sirets: emitter + eco-organisme if present
- * If we have both, 2 pending approvals were egerated, one is already accepted
+ * If we have both, 2 pending approvals were generated, one is already accepted
  * Update the remaining approval to automatically accept it
  */
 const handleEcoOrganismeApprovals = async (
@@ -46,7 +46,7 @@ const handleEcoOrganismeApprovals = async (
   });
   const approverSiret = updatedApproval.approverSiret;
 
-  const producerSirets = deduplicate(
+  const producerSirets = distinct(
     [bsd?.emitterCompanySiret, bsd?.ecoOrganismeSiret].filter(Boolean)
   );
   if (producerSirets.length > 1 && producerSirets.includes(approverSiret)) {

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -3,6 +3,7 @@ import {
   Form,
   Prisma,
   RevisionRequestApprovalStatus,
+  BsddRevisionRequestApproval,
   RevisionRequestStatus,
   Status
 } from "@prisma/client";
@@ -18,12 +19,74 @@ import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { NON_CANCELLABLE_BSDD_STATUSES } from "../../resolvers/mutations/createFormRevisionRequest";
 import { ForbiddenError } from "apollo-server-core";
 import buildRemoveAppendix2 from "../form/removeAppendix2";
+import { deduplicate } from "../../../common/arrays";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
   { comment }: { comment?: string | null },
   logMetadata?: LogMetadata
 ) => Promise<void>;
+
+/**
+ *
+ * We have to handle eco organismes which might be present on bsdd:
+ * Retrieve form
+ * Get producer sirets: emitter + eco-organisme if present
+ * If we have both, 2 pending approvals were egerated, one is already accepted
+ * Update the remaining approval to automatically accept it
+ */
+const handleEcoOrganismeApprovals = async (
+  prisma: RepositoryTransaction,
+  updatedApproval: BsddRevisionRequestApproval & {
+    revisionRequest: BsddRevisionRequest;
+  }
+) => {
+  const bsd = await prisma.form.findUnique({
+    where: { id: updatedApproval.revisionRequest.bsddId }
+  });
+  const approverSiret = updatedApproval.approverSiret;
+
+  const producerSirets = deduplicate(
+    [bsd?.emitterCompanySiret, bsd?.ecoOrganismeSiret].filter(Boolean)
+  );
+  if (producerSirets.length > 1 && producerSirets.includes(approverSiret)) {
+    const otherSiret = producerSirets.filter(
+      siret => siret !== approverSiret
+    )[0];
+
+    const otherApproval = await prisma.bsddRevisionRequestApproval.findFirst({
+      where: {
+        revisionRequestId: updatedApproval.revisionRequest.id,
+        approverSiret: otherSiret
+      }
+    });
+    if (otherApproval) {
+      await prisma.bsddRevisionRequestApproval.update({
+        where: {
+          id: otherApproval.id
+        },
+        data: {
+          status: RevisionRequestApprovalStatus.ACCEPTED,
+          comment: "Auto approval"
+        }
+      });
+
+      await prisma.event.create({
+        data: {
+          streamId: otherApproval.revisionRequestId,
+          actor: "system",
+          type: "BsddRevisionRequestAccepted",
+          data: {
+            content: {
+              status: RevisionRequestApprovalStatus.ACCEPTED,
+              comment: "Auto"
+            }
+          }
+        }
+      });
+    }
+  }
+};
 
 const buildAcceptRevisionRequestApproval: (
   deps: RepositoryFnDeps
@@ -37,9 +100,9 @@ const buildAcceptRevisionRequestApproval: (
       data: {
         status: RevisionRequestApprovalStatus.ACCEPTED,
         comment
-      }
+      },
+      include: { revisionRequest: true }
     });
-
     await prisma.event.create({
       data: {
         streamId: updatedApproval.revisionRequestId,
@@ -54,6 +117,9 @@ const buildAcceptRevisionRequestApproval: (
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
+
+    // when eco organisme is present onf bsdd
+    await handleEcoOrganismeApprovals(prisma, updatedApproval);
 
     // If it was the last approval:
     // - mark the revision as approved

--- a/back/src/forms/resolvers/FormRevisionRequest.ts
+++ b/back/src/forms/resolvers/FormRevisionRequest.ts
@@ -44,7 +44,6 @@ const formRevisionRequestResolvers: FormRevisionRequestResolvers = {
     if (!fullBsdd) {
       throw new Error(`FormRevisionRequest ${parent.id} has no form.`);
     }
-
     const bsdd = await getBsddFromActivityEvents(
       {
         bsddId: parent.bsddId,

--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -65,7 +65,7 @@ describe("Mutation.createFormRevisionRequest", () => {
     );
   });
 
-  it("should fail if current user is neither emitter or recipient of the bsdd", async () => {
+  it("should fail if current user is neither emitter, eco-organisme or  recipient of the bsdd", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("ADMIN");
     const { user, company } = await userWithCompanyFactory("ADMIN");
 
@@ -191,7 +191,7 @@ describe("Mutation.createFormRevisionRequest", () => {
     );
   });
 
-  it("should create a revisionRequest and identifying current user as the requester", async () => {
+  it("should create a revisionRequest and identifying current user as the requester (emitter)", async () => {
     const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const bsdd = await formFactory({
@@ -221,8 +221,105 @@ describe("Mutation.createFormRevisionRequest", () => {
     expect(data.createFormRevisionRequest.authoringCompany.siret).toBe(
       company.siret
     );
+    // one approval is created
+    expect(data.createFormRevisionRequest.approvals).toStrictEqual([
+      { approverSiret: recipientCompany.siret, status: "PENDING" }
+    ]);
   });
+  it("should create a revisionRequest and identifying current user as the requester (eco-organisme)", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("ADMIN");
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
 
+    const { user, company: ecoOrganismeCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        ecoOrganismeSiret: ecoOrganismeCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: bsdd.id,
+          content: { wasteDetails: { code: "01 03 08" } },
+          comment: "A comment",
+          authoringCompanySiret: ecoOrganismeCompany.siret!
+        }
+      }
+    });
+
+    expect(data.createFormRevisionRequest.form.id).toBe(bsdd.id);
+    expect(data.createFormRevisionRequest.authoringCompany.siret).toBe(
+      ecoOrganismeCompany.siret
+    );
+
+    expect(data.createFormRevisionRequest.approvals.length).toBe(1);
+    expect(data.createFormRevisionRequest.approvals[0].approverSiret).toBe(
+      recipientCompany.siret
+    );
+    expect(data.createFormRevisionRequest.approvals[0].status).toBe("PENDING");
+    // one approval is created
+    expect(data.createFormRevisionRequest.approvals).toStrictEqual([
+      { approverSiret: recipientCompany.siret, status: "PENDING" }
+    ]);
+  });
+  it("should create a revisionRequest and identifying current user as the requester (recipient) when an eco-organisme is on the bsdd", async () => {
+    // when an eco-org is on the bsdd, revision requested by the recipient should trigger approvals creation for emitter and ecoorg
+    const { company: emitterCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company: recipientCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+
+    const { company: ecoOrganismeCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        ecoOrganismeSiret: ecoOrganismeCompany.siret,
+        recipientCompanySiret: recipientCompany.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: bsdd.id,
+          content: { wasteDetails: { code: "01 03 08" } },
+          comment: "A comment",
+          authoringCompanySiret: recipientCompany.siret!
+        }
+      }
+    });
+
+    expect(data.createFormRevisionRequest.form.id).toBe(bsdd.id);
+    expect(data.createFormRevisionRequest.authoringCompany.siret).toBe(
+      recipientCompany.siret
+    );
+
+    expect(data.createFormRevisionRequest.approvals.length).toBe(2);
+    const approvalsSirets = data.createFormRevisionRequest.approvals.map(
+      approval => approval.approverSiret
+    );
+    expect(approvalsSirets.includes(emitterCompany.siret!)).toBe(true);
+    expect(approvalsSirets.includes(ecoOrganismeCompany.siret!)).toBe(true);
+    expect(data.createFormRevisionRequest.approvals[0].status).toBe("PENDING");
+    expect(data.createFormRevisionRequest.approvals[1].status).toBe("PENDING");
+  });
   it("should create a revisionRequest and identifying current user as the requester (temporary storage) ", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const bsdd = await formFactory({

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -140,6 +140,7 @@ async function getAuthoringCompany(
     ![
       bsdd.emitterCompanySiret,
       bsdd.recipientCompanySiret,
+      bsdd.ecoOrganismeSiret,
       forwardedIn?.recipientCompanySiret
     ].includes(authoringCompanySiret)
   ) {
@@ -265,8 +266,16 @@ async function getApproversSirets(
   authoringCompanySiret: string,
   user: Express.User
 ) {
-  const approvers = [
+  // do not include emitter and ecoOrg sirets if authoring company is one of them
+  const authoringCompanyIsEmitterOrEcoOrg = [
     bsdd.emitterCompanySiret,
+    bsdd.ecoOrganismeSiret
+  ].includes(authoringCompanySiret);
+
+  const approvers = [
+    ...(authoringCompanyIsEmitterOrEcoOrg
+      ? []
+      : [bsdd.emitterCompanySiret, bsdd.ecoOrganismeSiret]),
     bsdd.traderCompanySiret,
     bsdd.recipientCompanySiret
   ].filter(Boolean);

--- a/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formRevisionRequests.integration.ts
@@ -105,6 +105,77 @@ describe("Mutation.formRevisionRequests", () => {
     expect(data.formRevisionRequests.pageInfo.hasNextPage).toBe(false);
   });
 
+  it("should list every revisionRequest related to eco-organismes", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { company: otherCompany } = await userWithCompanyFactory("ADMIN");
+    const { query } = makeClient(user);
+
+    const bsdd1 = await formFactory({
+      ownerId: user.id,
+      opt: { ecoOrganismeSiret: company.siret }
+    });
+    const bsdd2 = await formFactory({
+      ownerId: user.id,
+      opt: { ecoOrganismeSiret: company.siret }
+    });
+
+    // 2 unsettled
+    await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd1.id,
+        authoringCompanyId: otherCompany.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: ""
+      }
+    });
+    await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd2.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: otherCompany.siret! } },
+        comment: ""
+      }
+    });
+
+    // 2 settled revisionRequests
+    await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd2.id,
+        authoringCompanyId: company.id,
+        approvals: {
+          create: {
+            approverSiret: otherCompany.siret!,
+            status: "ACCEPTED"
+          }
+        },
+        comment: ""
+      }
+    });
+    await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd2.id,
+        authoringCompanyId: company.id,
+        approvals: {
+          create: {
+            approverSiret: otherCompany.siret!,
+            status: "REFUSED"
+          }
+        },
+        comment: ""
+      }
+    });
+
+    const { data } = await query<Pick<Query, "formRevisionRequests">>(
+      FORM_REVISION_REQUESTS,
+      {
+        variables: { siret: company.siret }
+      }
+    );
+
+    expect(data.formRevisionRequests.totalCount).toBe(4);
+    expect(data.formRevisionRequests.pageInfo.hasNextPage).toBe(false);
+  });
+
   it("should fail if requesting a siret current user is not part of", async () => {
     const { user } = await userWithCompanyFactory("ADMIN");
     const { company } = await userWithCompanyFactory("ADMIN");


### PR DESCRIPTION
On inclut les éco-orgs sur le process des révisions/
Un éco-organisme peut:
- demander une révision
- voir ses révisions en cours
- accepter ou refuser une révision. 

Quand il demande une révision, l'émetteur n'a pas besoin d'approuver (et réciproquement)
Quand le destinataire demande une révision, l’émetteur ou l'éco-org doit approuver (l'autre approval est validée automatiquement)

 
- [x] Mettre à jour le change log
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8959)
