### PR TITLE
[BUGFIX] Un utilisateur doit pouvoir éditer son nom ou son numéro de téléphone indépendamment (page de profil)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
-- Il est désormais possible d'éditer le nom ou le numéro de téléphone indépendamment sur la page de profil
+- Il est à nouveau possible d'éditer le nom ou le numéro de téléphone indépendamment sur la page de profil [PR 2367](https://github.com/MTES-MCT/trackdechets/pull/2367)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.5.1] 16/05/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+- Il est désormais possible d'éditer le nom ou le numéro de téléphone indépendamment sur la page de profil
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :memo: Documentation
+
+#### :house: Interne
+
 # [2023.4.2] 24/04/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
@@ -6,10 +6,9 @@ import prisma from "../../../../prisma";
 import { ErrorCode } from "../../../../common/errors";
 
 const EDIT_PROFILE = `
-  mutation EditProfile($name: String!, $phone: String){
+  mutation EditProfile($name: String, $phone: String){
     editProfile(name: $name, phone: $phone){
       name
-      email
       phone
     }
   }
@@ -28,6 +27,74 @@ describe("mutation editProfile", () => {
     });
     expect(updatedUser.name).toEqual(name);
     expect(updatedUser.phone).toEqual(phone);
+  });
+
+  it("should be able to edit only the phone number", async () => {
+    // Given
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const newPhone = "01234567891";
+
+    // When
+    await mutate(EDIT_PROFILE, { variables: { phone: newPhone } });
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    // Then
+    expect(updatedUser.name).toEqual(user.name);
+    expect(updatedUser.phone).toEqual(newPhone);
+  });
+
+  it("should be able to edit only the name", async () => {
+    // Given
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const newName = "New Name";
+
+    // When
+    await mutate(EDIT_PROFILE, { variables: { name: newName } });
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    // Then
+    expect(updatedUser.name).toEqual(newName);
+    expect(updatedUser.phone).toEqual(user.phone);
+  });
+
+  it("should be able to empty the name", async () => {
+    // Given
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const newName = "";
+
+    // When
+    await mutate(EDIT_PROFILE, { variables: { name: newName } });
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    // Then
+    expect(updatedUser.name).toEqual(newName);
+    expect(updatedUser.phone).toEqual(user.phone);
+  });
+
+  it("should be able to empty the phone number", async () => {
+    // Given
+    const user = await userFactory();
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const newPhone = "";
+
+    // When
+    await mutate(EDIT_PROFILE, { variables: { phone: newPhone } });
+    const updatedUser = await prisma.user.findUniqueOrThrow({
+      where: { id: user.id }
+    });
+
+    // Then
+    expect(updatedUser.name).toEqual(user.name);
+    expect(updatedUser.phone).toEqual(newPhone);
   });
 
   it("should fail to edit profile when name payload contains unsafe chars", async () => {

--- a/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/editProfile.integration.ts
@@ -63,20 +63,30 @@ describe("mutation editProfile", () => {
     expect(updatedUser.phone).toEqual(user.phone);
   });
 
-  it("should be able to empty the name", async () => {
+  it("should not be able to empty the name", async () => {
     // Given
     const user = await userFactory();
     const { mutate } = makeClient({ ...user, auth: AuthType.Session });
     const newName = "";
 
     // When
-    await mutate(EDIT_PROFILE, { variables: { name: newName } });
+    const { errors } = await mutate(EDIT_PROFILE, {
+      variables: { name: newName }
+    });
     const updatedUser = await prisma.user.findUniqueOrThrow({
       where: { id: user.id }
     });
 
     // Then
-    expect(updatedUser.name).toEqual(newName);
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: `The name cannot be an empty string`,
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+    expect(updatedUser.name).toEqual(user.name);
     expect(updatedUser.phone).toEqual(user.phone);
   });
 

--- a/back/src/users/resolvers/mutations/editProfile.ts
+++ b/back/src/users/resolvers/mutations/editProfile.ts
@@ -19,16 +19,16 @@ export async function editProfileFn(
   payload: MutationEditProfileArgs
 ) {
   const editProfileSchema = yup.object({
-    name: yup.string().required().isSafeSSTI(),
+    name: yup.string().isSafeSSTI(),
     phone: yup.string()
   });
   editProfileSchema.validateSync(payload);
 
   const { name, phone } = payload;
 
-  const data = {
-    ...(name !== undefined ? { name } : {}),
-    ...(phone !== undefined ? { phone } : {})
+  const data: { name?: string; phone?: string } = {
+    ...(name !== undefined ? { name: name as string } : {}),
+    ...(phone !== undefined ? { phone: phone as string } : {})
   };
 
   const updatedUser = await prisma.user.update({

--- a/back/src/users/resolvers/mutations/editProfile.ts
+++ b/back/src/users/resolvers/mutations/editProfile.ts
@@ -19,16 +19,23 @@ export async function editProfileFn(
   payload: MutationEditProfileArgs
 ) {
   const editProfileSchema = yup.object({
-    name: yup.string().isSafeSSTI(),
+    name: yup
+      .string()
+      .test(
+        "empty",
+        "The name cannot be an empty string",
+        name => name?.length !== 0
+      )
+      .isSafeSSTI(),
     phone: yup.string()
   });
   editProfileSchema.validateSync(payload);
 
   const { name, phone } = payload;
 
-  const data: { name?: string; phone?: string } = {
-    ...(name !== undefined ? { name: name as string } : {}),
-    ...(phone !== undefined ? { phone: phone as string } : {})
+  const data: { name?: string; phone?: string | null } = {
+    ...(name != null ? { name } : {}),
+    ...(phone !== undefined ? { phone } : {})
   };
 
   const updatedUser = await prisma.user.update({

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -33,7 +33,7 @@ type Mutation {
   USAGE INTERNE
   Met à jour les informations de l'utilisateur
   """
-  editProfile(name: String!, phone: String): User!
+  editProfile(name: String, phone: String): User!
 
   """
   USAGE INTERNE


### PR DESCRIPTION
# Contexte

A cause d'une MAJ il n'est plus possible d'éditer le numéro de téléphone indépendamment du nom sur la page de profil, parce que le nom est requis dans la mutation:

![image](https://user-images.githubusercontent.com/45355989/236205979-3d9fd782-e697-4ee0-bf26-6c5cb3d4ab9f.png)

### Solution

Rendre le nom facultatif


