### PR TITLE
Fix Wording pipeline

### DIFF
--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -180,7 +180,7 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
           { label: "Citerne", value: "CITERNE" },
           { label: "GRV", value: "GRV" },
           { label: "Fûts", value: "FUT" },
-          { label: "Pipeline", value: "PIPELINE" },
+          { label: "Conditionnné pour Pipeline", value: "PIPELINE" },
           { label: getOtherPackagingLabel(packagingInfos), value: "AUTRE" }
         ].map((packagingType, index) => (
           <tr key={index}>

--- a/back/src/forms/typeDefs/bsdd.enums.graphql
+++ b/back/src/forms/typeDefs/bsdd.enums.graphql
@@ -110,7 +110,7 @@ enum Packagings {
   "Benne"
   BENNE
 
-  "Pipeline"
+  "Conditionné pour pipeline"
   PIPELINE
 
   "Autre"

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
@@ -63,7 +63,9 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
           </JourneyStopDescription>
         )}
         {formTransportIsPipeline(form) && (
-          <JourneyStopDescription>Par pipeline</JourneyStopDescription>
+          <JourneyStopDescription>
+            Conditionné pour Pipeline
+          </JourneyStopDescription>
         )}
       </JourneyStop>
       {form.temporaryStorageDetail && (

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -879,7 +879,10 @@ export default function BSDDetailContent({
                 </>
               ) : (
                 <div className={`${styles.detailGrid} `}>
-                  <DetailRow value="par pipeline" label="Transport" />
+                  <DetailRow
+                    value="Conditionné pour Pipeline"
+                    label="Transport"
+                  />
                 </div>
               )}
             </TabPanel>

--- a/front/src/form/bsdd/utils/packagings.ts
+++ b/front/src/form/bsdd/utils/packagings.ts
@@ -5,7 +5,7 @@ export const PACKAGINGS_NAMES = {
   [Packagings.Citerne]: "Citerne(s)",
   [Packagings.Fut]: "Fût(s)",
   [Packagings.Grv]: "GRV(s)",
-  [Packagings.Pipeline]: "Pipeline",
+  [Packagings.Pipeline]: "Conditionné pour Pipeline",
   [Packagings.Autre]: "Autre(s)",
 };
 


### PR DESCRIPTION
Demande product de remplacer le label "Pipeline" partout sauf sur la page transport de l'edition.
