### PR TITLE
disable entering manual date from DateInput

### DIFF
--- a/front/src/form/common/components/custom-inputs/DateInput.tsx
+++ b/front/src/form/common/components/custom-inputs/DateInput.tsx
@@ -39,6 +39,10 @@ export default function DateInput({
       onChange={(value: Date | null) => {
         setFieldValue(field.name, value ? format(value, "yyyy-MM-dd") : null);
       }}
+      onChangeRaw={e => {
+        // disable entering manual date
+        e.preventDefault();
+      }}
     />
   );
 }


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

on a une série d'erreurs [sentry](https://sentry.incubateur.net/organizations/betagouv/issues/34438/events/20b3073c6cf14d90b281920652954f6a/events/?end=2023-05-09T23%3A59%3A59&environment=production&project=19&start=2023-05-09T00%3A00%3A00&utc=true) qui sont dues au fait que la date envoyée à l'API est mal formatée

`Invalid value for argumenttransporterTransportTakenOverAt: input contains invalid characters. Expected ISO-8601 DateTime.
`

## Fix proposé
- Désactivation de la saisie manuelle de date dans le date picker
- Ecran impactés : tous ceux qui uilisent DateInput (Modale pour valider la réception, export registre, mon compte, ...)
https://reactdatepicker.com/#example-get-raw-input-value-on-change

https://github.com/MTES-MCT/trackdechets/assets/37509748/8546a5c5-5ff4-4179-8a50-237eacd4153f


