### PR TITLE
Allègement réponse indexation ES bulkIndex

### DIFF
--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -375,7 +375,9 @@ export function indexBsds(indexName: string, bsds: BsdElastic[]) {
         }
       },
       bsd
-    ])
+    ]),
+    // lighten the response
+    _source_excludes: ["items.index._*", "took"]
   });
 }
 


### PR DESCRIPTION
- Déjà présent sur l'indexation Sirene : https://github.com/MTES-MCT/trackdechets-sirene-search/blob/main/src/indexation/elasticSearch.helpers.ts#L199
- Evite les réponses très volumineuses entre ES et node