### PR TITLE
Add logout button to oidc connexion page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,20 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+# [2023.6.1] 06/06/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+- Ajout d'un bouton de déconnexion sur la page d'autorisation OpenId Connect [PR 2386](https://github.com/MTES-MCT/trackdechets/pull/2386)
+
+#### :memo: Documentation
+
+#### :house: Interne
 
 # [2023.5.3] 22/05/2023
 

--- a/front/src/oauth/OidcDialog.tsx
+++ b/front/src/oauth/OidcDialog.tsx
@@ -4,6 +4,7 @@ import Loader from "../common/components/Loaders";
 import styles from "./Dialog.module.scss";
 import { useOIDC, AuthorizePayload } from "./use-oidc";
 import * as queryString from "query-string";
+import { localAuthService } from "login/auth.service";
 
 import { useLocation } from "react-router-dom";
 export default function OidcDialog() {
@@ -34,7 +35,26 @@ export default function OidcDialog() {
         <IconCheckCircle1 size="40px" />
         <img src="/trackdechets.png" alt="trackdechets" width="100px" />
       </div>
-      <h4 className="text-center">S'identifier sur {client.name}</h4>
+      <div className="tw-flex tw-justify-between tw-mt-4">
+        <h4 className="text-center">S'identifier sur {client.name}</h4>
+        <form
+          className={styles.headerConnexion}
+          name="logout"
+          action={`${VITE_API_ENDPOINT}/logout`}
+          method="post"
+        >
+          <button
+            className={`${styles.headerConnexion} btn btn--sqr`}
+            onClick={() => {
+              localAuthService.locallySignOut();
+              document.forms["logout"].submit();
+              return false;
+            }}
+          >
+            <span>Se déconnecter</span>
+          </button>
+        </form>
+      </div>
       <div className="panel tw-mt-2">
         <p className="text-center">
           {user.name}, l'application {client.name} souhaite accéder à votre


### PR DESCRIPTION
Quand un user d'openid connect est dans le workflow de connexion, il est redirigé depuis le client vers la page de connexion OIDC de Trackdéchets. S'il est déjà connecté sur TD, mais souhaite utiliser un autre compte, il n'y avait pas de lien évident pour se connecter.
Cette PR ajoute un simple lien de déconnexion.
<img width="727" alt="Capture d’écran 2023-05-24 à 15 51 12" src="https://github.com/MTES-MCT/trackdechets/assets/878396/91e9cb7d-64e6-4640-915d-8226319b0b42">

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11744)
