### PR TITLE
Fix Recette restaurer le graphql previousTransporterCompanySiret

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -851,7 +851,9 @@ export function expandTransportSegmentFromDb(
 ): GraphQLTransportSegment {
   return {
     id: segment.id,
-    previousTransporterCompanyOrgId: segment.previousTransporterCompanyOrgId,
+    // GraphQLTransportSegment specifications was not changed to previousTransporterCompanyOrgId
+    // in order to keep the public API intact
+    previousTransporterCompanySiret: segment.previousTransporterCompanyOrgId,
     transporter: nullIfNoValues({
       company: nullIfNoValues({
         name: segment.transporterCompanyName,

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -615,8 +615,8 @@ type formsLifeCycleData {
 type TransportSegment {
   id: ID!
 
-  "Siret du transporteur précédent"
-  previousTransporterCompanyOrgId: String
+  "Siret ou numéro de TVA intra-communautaire du transporteur précédent"
+  previousTransporterCompanySiret: String
 
   "Transporteur du segment"
   transporter: Transporter

--- a/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
@@ -782,7 +782,7 @@ describe("Bsd card primary action label", () => {
           {
             id: "ckyef9g3a2924349syhsqc1wa",
             readyToTakeOver: false,
-            previousTransporterCompanyOrgId: "13001045700013",
+            previousTransporterCompanySiret: "13001045700013",
             takenOverAt: null,
             __typename: "TransportSegment",
           },

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.test.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.test.tsx
@@ -314,7 +314,7 @@ describe("ActBsddValidation", () => {
         {
           id: "ckyef9g3a2924349syhsqc1wa",
           readyToTakeOver: false,
-          previousTransporterCompanyOrgId: "12345678901234",
+          previousTransporterCompanySiret: "12345678901234",
           takenOverAt: null,
           __typename: "TransportSegment",
         },
@@ -347,7 +347,7 @@ describe("ActBsddValidation", () => {
       transportSegments: [
         {
           id: "ckyef9g3a2924349syhsqc1wa",
-          previousTransporterCompanyOrgId: "12345678901234",
+          previousTransporterCompanySiret: "12345678901234",
           takenOverAt: "2023-03-17",
           __typename: "TransportSegment",
         },
@@ -383,7 +383,7 @@ describe("ActBsddValidation", () => {
       transportSegments: [
         {
           id: "ckyef9g3a2924349syhsqc1wa",
-          previousTransporterCompanyOrgId: "12345678901234",
+          previousTransporterCompanySiret: "12345678901234",
           takenOverAt: null,
           readyToTakeOver: true,
           __typename: "TransportSegment",

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -340,7 +340,7 @@ const ActBsddValidation = ({
         // the last segment is still a draft
         !lastSegment.readyToTakeOver &&
         // that was created by the current user
-        lastSegment.previousTransporterCompanyOrgId === currentSiret
+        lastSegment.previousTransporterCompanySiret === currentSiret
       ) {
         return <MarkSegmentAsReadyToTakeOver form={bsd} siret={currentSiret} />;
       }

--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -171,7 +171,7 @@ export const segmentFragment = gql`
     mode
     takenOverAt
     takenOverBy
-    previousTransporterCompanyOrgId
+    previousTransporterCompanySiret
     segmentNumber
   }
 `;
@@ -510,7 +510,7 @@ export const dashboardFormFragment = gql`
     transportSegments {
       id
       readyToTakeOver
-      previousTransporterCompanyOrgId
+      previousTransporterCompanySiret
       takenOverAt
     }
     currentTransporterOrgId

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -108,7 +108,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
           // the last segment is still a draft
           !lastSegment.readyToTakeOver &&
           // that was created by the current user
-          lastSegment.previousTransporterCompanyOrgId === siret
+          lastSegment.previousTransporterCompanySiret === siret
         ) {
           return <MarkSegmentAsReadyToTakeOver {...props} />;
         }

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -114,7 +114,7 @@ const TransportSegmentDetail = ({ segment, siret }: SegmentProps) => {
       {!segment.readyToTakeOver &&
         [
           segment.transporter?.company?.orgId,
-          segment.previousTransporterCompanyOrgId,
+          segment.previousTransporterCompanySiret,
         ].includes(siret) && <EditSegment segment={segment} siret={siret} />}
     </>
   );


### PR DESCRIPTION
- Supprime le changement d'api GQL publique non-annoncé de previousTransporterCompanySiret vers previousTransporterCompanyOrgId

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
