### PR TITLE
Do not catch migration error

### DIFF
--- a/back/prisma/migrate.ts
+++ b/back/prisma/migrate.ts
@@ -8,5 +8,4 @@ const pool = new Pool({
 
 migrate({ client: pool }, path.join(__dirname, "migrations"))
   .then(() => console.log("Migration successful"))
-  .catch(err => console.error(err))
   .finally(() => pool.end());


### PR DESCRIPTION
Cette PR vise à éviter qu'un build Scalingo puisse se faire alors que les migrations sont échec. 
À tester en recette avant de corriger l'erreur de hash pour reproduire une erreur.
