### PR TITLE
Hotfix restauration Form.nextTransporterSiret and Form.currentTransporterSiret

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.5.2] 17/05/2023
+#### :bug: Corrections de bugs
+
+- Lancer un erreur pour une migration ratée pour stopper le déploiement [PR 2398](https://github.com/MTES-MCT/trackdechets/pull/2398)
+- Restaurer les champs GQL Form.nextTransporterSiret and Form.currentTransporterSiret [PR 2399](https://github.com/MTES-MCT/trackdechets/pull/2399)
+
 # [2023.5.1] 16/05/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -109,8 +109,8 @@ describe("expandFormFromDb", () => {
       processedAt: null,
       noTraceability: null,
       nextDestination: null,
-      currentTransporterOrgId: null,
-      nextTransporterOrgId: null,
+      currentTransporterSiret: null,
+      nextTransporterSiret: null,
       temporaryStorageDetail: null
     });
   });

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -716,8 +716,8 @@ export async function expandFormFromDb(
             mail: form.nextDestinationCompanyMail
           })
         }),
-    currentTransporterOrgId: form.currentTransporterOrgId,
-    nextTransporterOrgId: form.nextTransporterOrgId,
+    currentTransporterSiret: form.currentTransporterOrgId,
+    nextTransporterSiret: form.nextTransporterOrgId,
     intermediaries: [],
     temporaryStorageDetail: forwardedIn
       ? {

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -137,8 +137,8 @@ type Form {
 
   transportSegments: [TransportSegment!]
 
-  currentTransporterOrgId: String
-  nextTransporterOrgId: String
+  currentTransporterSiret: String
+  nextTransporterSiret: String
 
   """
   Entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,

--- a/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
@@ -663,8 +663,8 @@ describe("Bsd card primary action label", () => {
         },
         temporaryStorageDetail: null,
         transportSegments: [],
-        currentTransporterOrgId: null,
-        nextTransporterOrgId: null,
+        currentTransporterSiret: null,
+        nextTransporterSiret: null,
         __typename: "Form",
       } as unknown as Form;
       const { queryByTestId } = render(
@@ -787,8 +787,8 @@ describe("Bsd card primary action label", () => {
             __typename: "TransportSegment",
           },
         ],
-        currentTransporterOrgId: "13001045700013",
-        nextTransporterOrgId: "13001045700013",
+        currentTransporterSiret: "13001045700013",
+        nextTransporterSiret: "13001045700013",
         __typename: "Form",
       } as unknown as Form;
       render(
@@ -980,8 +980,8 @@ describe("Bsd card primary action label", () => {
         },
         temporaryStorageDetail: null,
         transportSegments: [],
-        currentTransporterOrgId: "",
-        nextTransporterOrgId: null,
+        currentTransporterSiret: "",
+        nextTransporterSiret: null,
         __typename: "Form",
       } as unknown as Form;
 

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.test.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.test.tsx
@@ -309,7 +309,7 @@ describe("ActBsddValidation", () => {
     const sentBsdSegmentDraft = {
       id: "1",
       status: "SENT",
-      currentTransporterOrgId: "12345678901234",
+      currentTransporterSiret: "12345678901234",
       transportSegments: [
         {
           id: "ckyef9g3a2924349syhsqc1wa",
@@ -343,7 +343,7 @@ describe("ActBsddValidation", () => {
     const sentBsdSegmetnTakenOverAt = {
       id: "1",
       status: "SENT",
-      currentTransporterOrgId: "12345678901234",
+      currentTransporterSiret: "12345678901234",
       transportSegments: [
         {
           id: "ckyef9g3a2924349syhsqc1wa",
@@ -378,8 +378,8 @@ describe("ActBsddValidation", () => {
     const sentBsdSegmentReadyToTakenOver = {
       id: "1",
       status: "SENT",
-      currentTransporterOrgId: "12345678901234",
-      nextTransporterOrgId: "12345678901234",
+      currentTransporterSiret: "12345678901234",
+      nextTransporterSiret: "12345678901234",
       transportSegments: [
         {
           id: "ckyef9g3a2924349syhsqc1wa",

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -326,7 +326,7 @@ const ActBsddValidation = ({
     const transportSegments = bsd.transportSegments ?? [];
     const lastSegment = transportSegments[transportSegments.length - 1];
 
-    if (bsd.currentTransporterOrgId === currentSiret) {
+    if (bsd.currentTransporterSiret === currentSiret) {
       if (
         // there are no segments yet, current transporter can create one
         lastSegment === null ||
@@ -347,7 +347,7 @@ const ActBsddValidation = ({
     }
 
     if (
-      bsd.nextTransporterOrgId === currentSiret &&
+      bsd.nextTransporterSiret === currentSiret &&
       lastSegment.readyToTakeOver
     ) {
       return <TakeOverSegment form={bsd} siret={currentSiret} />;

--- a/front/src/Apps/Dashboard/__mocks__/bsdListAct.json
+++ b/front/src/Apps/Dashboard/__mocks__/bsdListAct.json
@@ -562,8 +562,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": null,
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": null,
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -904,8 +904,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"

--- a/front/src/Apps/Dashboard/__mocks__/bsdListArchive.json
+++ b/front/src/Apps/Dashboard/__mocks__/bsdListArchive.json
@@ -78,8 +78,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -163,8 +163,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -248,8 +248,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -333,8 +333,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -711,8 +711,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"

--- a/front/src/Apps/Dashboard/__mocks__/bsdListDraft.json
+++ b/front/src/Apps/Dashboard/__mocks__/bsdListDraft.json
@@ -79,8 +79,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": null,
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": null,
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"
@@ -286,8 +286,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": null,
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": null,
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"

--- a/front/src/Apps/Dashboard/__mocks__/bsdListFollow.json
+++ b/front/src/Apps/Dashboard/__mocks__/bsdListFollow.json
@@ -78,8 +78,8 @@
       },
       "temporaryStorageDetail": null,
       "transportSegments": [],
-      "currentTransporterOrgId": "",
-      "nextTransporterOrgId": null,
+      "currentTransporterSiret": "",
+      "nextTransporterSiret": null,
       "__typename": "Form"
     },
     "__typename": "BsdEdge"

--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -292,8 +292,8 @@ const mutableFieldsFragment = gql`
     temporaryStorageDetail {
       ...TemporaryStorageDetailFragment
     }
-    currentTransporterOrgId
-    nextTransporterOrgId
+    currentTransporterSiret
+    nextTransporterSiret
     transportSegments {
       ...Segment
     }
@@ -324,8 +324,8 @@ export const transporterFormFragment = gql`
   fragment TransporterFormFragment on Form {
     ...MutableFieldsFragment
     ...StaticFieldsFragment
-    currentTransporterOrgId
-    nextTransporterOrgId
+    currentTransporterSiret
+    nextTransporterSiret
     transportSegments {
       ...Segment
     }
@@ -513,7 +513,7 @@ export const dashboardFormFragment = gql`
       previousTransporterCompanySiret
       takenOverAt
     }
-    currentTransporterOrgId
-    nextTransporterOrgId
+    currentTransporterSiret
+    nextTransporterSiret
   }
 `;

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -94,7 +94,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       const transportSegments = form.transportSegments ?? [];
       const lastSegment = transportSegments[transportSegments.length - 1];
 
-      if (form.currentTransporterOrgId === siret) {
+      if (form.currentTransporterSiret === siret) {
         if (
           // there are no segments yet, current transporter can create one
           lastSegment == null ||
@@ -114,7 +114,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
         }
       }
 
-      if (form.nextTransporterOrgId === siret && lastSegment.readyToTakeOver) {
+      if (form.nextTransporterSiret === siret && lastSegment.readyToTakeOver) {
         return <TakeOverSegment {...props} />;
       }
 


### PR DESCRIPTION
## Il y a eu une confusion sur les annonces de Breaking change sur l'api


```400 Contenu : {« errors »:[{« message »:« Cannot query field « currentTransporterSiret » on type « Form ». Did you mean « currentTransporterOrgId » or « nextTransporterOrgId »? »,« locations »:[{« line »:1,« column »:317}],« extensions »:{« code »:« GRAPHQL_VALIDATION_FAILED »}},{« message »:« Cannot query field « nextTransporterSiret » on type « Form ». Did you mean « nextTransporterOrgId » or « transporter »? »,« locations »:[{« line »:1,« column »:341}],« extensions »:{« code »:« GRAPHQL_VALIDATION_FAILED »}}]}```

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Forum Tech](https://forum.trackdechets.beta.gouv.fr/t/erreur-bsd-currenttransportersiret/1421/5)
