### PR TITLE
Hotfix field.value.country

### DIFF
--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -98,8 +98,8 @@ export default function CompanySelector({
 
   // determine if the current Form company is foreign
   const [isForeignCompany, setIsForeignCompany] = useState(
-    (field.value.country && field.value.country !== "FR") ||
-      isForeignVat(field.value.vatNumber!)
+    (field.value?.country && field.value?.country !== "FR") ||
+      isForeignVat(field.value?.vatNumber!)
   );
   // this 2 input ref are to cross-link the value of the input in both search input and department input
   const departmentInputRef = useRef<HTMLInputElement>(null);
@@ -112,7 +112,7 @@ export default function CompanySelector({
   ] = useState<boolean>(false);
 
   // Memoize for changes in field.value.siret and field.value.orgId
-  // To support both FormCompany and Intermediary (that don't have orgId)
+  // To support both FormCompany and Intermediary (which doesn't have orgId)
   const orgId = useMemo(
     () => field.value?.orgId ?? field.value?.siret ?? null,
     [field.value?.siret, field.value?.orgId]


### PR DESCRIPTION
# CompanySelector bug

- `value.country` crashes when value is null

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
