### PR TITLE
Remove legacy get activation handler

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -41,10 +41,7 @@ import { oauth2Router } from "./routers/oauth2-router";
 import { oidcRouter } from "./routers/oidc-router";
 import { roadControlPdfHandler } from "./routers/roadControlPdfRouter";
 import { resolvers, typeDefs } from "./schema";
-import {
-  legacyUserActivationHandler,
-  userActivationHandler
-} from "./users/activation";
+import { userActivationHandler } from "./users/activation";
 import { createUserDataLoaders } from "./users/dataloaders";
 import { getUIBaseURL } from "./utils";
 import { captchaGen, captchaSound } from "./captcha/captchaGen";
@@ -305,7 +302,7 @@ app.get("/captcha", (_, res) => captchaGen(res));
 app.get("/captcha-audio/:tokenId", (req, res) => {
   captchaSound(req.params.tokenId, res);
 });
-app.get("/userActivation", legacyUserActivationHandler); // todo: remove for 05/23 release
+
 app.post("/userActivation", userActivationHandler);
 
 app.get("/download", downloadRouter);

--- a/back/src/users/__tests__/activation.integration.ts
+++ b/back/src/users/__tests__/activation.integration.ts
@@ -9,31 +9,9 @@ import supertest from "supertest";
 
 import { app } from "../../server";
 const request = supertest(app);
-const { UI_HOST } = process.env;
+
 describe("user activation", () => {
   afterEach(resetDatabase);
-
-  it("should redirect to frontend activation page", async () => {
-    const user = await userFactory({
-      email: "bruce.wayne@trackdechets.fr",
-      isActive: false
-    });
-    const userActivationHash = await createActivationHash(user);
-    const res = await request.get(
-      `/userActivation?hash=${userActivationHash.hash}`
-    );
-
-    // this linked used to activate the user but now must redirect to a frontend page
-    const refreshedUser = await prisma.user.findUniqueOrThrow({
-      where: { id: user.id }
-    });
-    expect(refreshedUser.isActive).toEqual(false);
-
-    expect(res.status).toBe(302);
-    expect(res.header.location).toBe(
-      `http://${UI_HOST}/user-activation?hash=${userActivationHash.hash}`
-    );
-  });
 
   it("should activate an user", async () => {
     const user = await userFactory({

--- a/back/src/users/activation.ts
+++ b/back/src/users/activation.ts
@@ -3,21 +3,6 @@ import { getUIBaseURL } from "../utils";
 
 /**
  *
- * GET handler for user activations. Used to cause some problems with email clients eagerly fetching email links.
- * Replaced with a redirect to a confirm form poiting to `userActivationHandler`
- */
-export const legacyUserActivationHandler = async (req, res) => {
-  const { hash } = req.query;
-  if (hash == null) {
-    res.status(500).send("Hash manquant.");
-    return;
-  }
-  const UI_BASE_URL = getUIBaseURL();
-  return res.redirect(`${UI_BASE_URL}/user-activation?hash=${hash}`);
-};
-
-/**
- *
  * Activate a recently signed-up user
  *
  * - User receives an emailed link upon signup


### PR DESCRIPTION
L'activation d'un user se faisait historiquement via un GET sur api.ndd/user-activation grâce à un lien contenu dans l'email d'activation .
Suite aux pbs d'activations intempestives, le lien de l'email pointe vers ui.ndd/user-activation qui contient un formualire POST vers api.ndd/user-activation

Une redirection temporaire de  api.ndd/user-activation vers ui.ndd/user-activation permettait de ne pas casser les liens reçus par la version de l'email précédent.

Cette redirection n'est plus utile.

---

- [Ticket Favro]()
