### PR TITLE
Annexe 1 - Améliorations

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -819,6 +819,7 @@ export async function expandInitialFormFromDb(
     emitter,
     recipient,
     transporter,
+    takenOverAt,
     signedAt,
     quantityReceived,
     processingOperationDone,
@@ -837,6 +838,7 @@ export async function expandInitialFormFromDb(
     emitterPostalCode: hasPickupSite
       ? emitter?.workSite?.postalCode
       : extractPostalCode(emitter?.company?.address),
+    takenOverAt: processDate(takenOverAt),
     signedAt: processDate(signedAt),
     recipient,
     transporter,

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -545,6 +545,12 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                 </React.Fragment>
               ))}
             </p>
+            {form.wasteDetails?.sampleNumber && (
+              <p>
+                Numéro d'échantillon :<br />
+                {form.wasteDetails.sampleNumber}
+              </p>
+            )}
           </div>
 
           <div className="BoxCol">
@@ -1002,6 +1008,9 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                     )}
                     <th>Date de prise en charge initiale</th>
                     <th>Code postal lieu de collecte</th>
+                    {form?.emitter?.type === EmitterType.APPENDIX1 && (
+                      <th>N° d'échantillon</th>
+                    )}
                   </tr>
                 </thead>
                 <tbody>
@@ -1036,6 +1045,9 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                           : formatDate(groupedForm?.signedAt)}
                       </td>
                       <td>{groupedForm?.emitterPostalCode}</td>
+                      {form?.emitter?.type === EmitterType.APPENDIX1 && (
+                        <td>{groupedForm?.wasteDetails?.sampleNumber}</td>
+                      )}
                     </tr>
                   ))}
                 </tbody>

--- a/back/src/forms/repository/helper.ts
+++ b/back/src/forms/repository/helper.ts
@@ -4,10 +4,19 @@ export function sumPackagingInfos(groupOfPackagingInfos: PackagingInfo[][]) {
   return groupOfPackagingInfos.reduce((sumOfPackagings, packagings) => {
     for (const packaging of packagings) {
       const alreadyExistingPackagingType = sumOfPackagings.find(
-        p => p.type === packaging.type
+        p => p.type === packaging.type && packaging.type !== "AUTRE"
       );
-      if (alreadyExistingPackagingType && packaging.type !== "AUTRE") {
-        alreadyExistingPackagingType.quantity += packaging.quantity;
+      if (alreadyExistingPackagingType) {
+        const isCiterneOrBenne = ["CITERNE", "BENNE"].includes(packaging.type);
+        if (isCiterneOrBenne) {
+          // If one of the appendix has 2 bennes and the other have 1, we keep the 2.
+          alreadyExistingPackagingType.quantity = Math.max(
+            alreadyExistingPackagingType.quantity,
+            packaging.quantity
+          );
+        } else {
+          alreadyExistingPackagingType.quantity += packaging.quantity;
+        }
       } else {
         sumOfPackagings.push(packaging);
       }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -127,9 +127,9 @@ function SignTransportFormModalContent({
           transporterNumberPlate:
             form.stateSummary?.transporterNumberPlate ?? "",
           update: {
-            quantity: 0,
-            sampleNumber: "",
-            packagingInfos: [],
+            quantity: form.wasteDetails?.quantity ?? 0,
+            sampleNumber: form.wasteDetails?.sampleNumber ?? "",
+            packagingInfos: form.wasteDetails?.packagingInfos ?? [],
           },
         }}
         validationSchema={validationSchema}

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -668,6 +668,12 @@ export default function BSDDetailContent({
               <dt>Code onu</dt>
               <dd>{form?.stateSummary?.onuCode}</dd>
               <dt>POP</dt> <dd>{form.wasteDetails?.pop ? "Oui" : "Non"}</dd>
+              {form?.emitter?.type === EmitterType.Appendix1Producer && (
+                <>
+                  <dt>Numéro d'échantillon</dt>
+                  <dd>{form?.wasteDetails?.sampleNumber}</dd>
+                </>
+              )}
             </div>
 
             {form.ecoOrganisme && (

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -1,7 +1,7 @@
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { RadioButton } from "form/common/components/custom-inputs/RadioButton";
 import { Field, useField, useFormikContext } from "formik";
-import { EmitterType, Form } from "generated/graphql/types";
+import { CompanyType, EmitterType, Form } from "generated/graphql/types";
 import React, { useEffect } from "react";
 import EcoOrganismes from "./components/eco-organismes/EcoOrganismes";
 import WorkSite from "form/common/components/work-site/WorkSite";
@@ -293,6 +293,22 @@ export default function Emitter({ disabled }) {
               if (values.emitter?.type === EmitterType.Appendix1) {
                 setFieldValue("transporter.company", company);
               }
+            }}
+            filter={companies => {
+              if (values.emitter?.type === EmitterType.Appendix1) {
+                const authorizedTypes = [
+                  CompanyType.Collector,
+                  CompanyType.Transporter,
+                  CompanyType.Wasteprocessor,
+                  CompanyType.WasteCenter,
+                ];
+                return companies.filter(company =>
+                  company.companyTypes.some(type =>
+                    authorizedTypes.includes(type)
+                  )
+                );
+              }
+              return companies;
             }}
           />
         </div>

--- a/front/src/form/bsdd/appendix1Producer/form.tsx
+++ b/front/src/form/bsdd/appendix1Producer/form.tsx
@@ -10,8 +10,12 @@ import {
   MutationUpdateFormArgs,
 } from "generated/graphql/types";
 import React from "react";
-import { getInitialCompany } from "../utils/initial-state";
+import {
+  getInitialCompany,
+  getInitialEmitterWorkSite,
+} from "../utils/initial-state";
 import { CREATE_FORM, UPDATE_FORM } from "../utils/queries";
+import WorkSite from "form/common/components/work-site/WorkSite";
 
 export function Appendix1ProducerForm({
   container,
@@ -97,14 +101,16 @@ export function Appendix1ProducerForm({
                     setFieldValue("emitter.isForeignShip", false);
                   }}
                 />
-                L'émetteur est un particulier
+                L'émetteur est un particulier ou une association / copropriété
+                sans SIRET
               </label>
             </div>
             {values.emitter?.isPrivateIndividual ? (
               <div className="form__row">
                 <div className="form__row">
                   <label>
-                    Nom et prénom
+                    Nom et prénom ou Nom de l'association ou Nom de la
+                    copropriété
                     <Field
                       type="text"
                       name="emitter.company.name"
@@ -146,6 +152,13 @@ export function Appendix1ProducerForm({
             ) : (
               <CompanySelector name="emitter.company" />
             )}
+
+            <WorkSite
+              switchLabel="Je souhaite ajouter une adresse de chantier ou de collecte"
+              headingTitle="Adresse chantier"
+              designation="du chantier ou lieu de collecte"
+              getInitialEmitterWorkSiteFn={getInitialEmitterWorkSite}
+            />
 
             <div className="tw-pb-2 tw-flex tw-justify-end">
               <button

--- a/front/src/form/common/components/company/MyCompanySelector.tsx
+++ b/front/src/form/common/components/company/MyCompanySelector.tsx
@@ -28,6 +28,7 @@ export const GET_ME = gql`
         contactEmail
         contactPhone
         address
+        companyTypes
       }
     }
   }
@@ -37,10 +38,12 @@ export default function MyCompanySelector({
   fieldName,
   onSelect,
   siretEditable = true,
+  filter,
 }: {
   fieldName: string;
   onSelect: (company) => void;
   siretEditable: boolean;
+  filter?: (companies: CompanyPrivate[]) => CompanyPrivate[];
 }) {
   const { setFieldValue } = useFormikContext<CreateFormInput>();
   const [field] = useField({ name: fieldName });
@@ -97,7 +100,9 @@ export default function MyCompanySelector({
   });
 
   const companies = useMemo(() => {
-    return sortCompaniesByName(data?.me.companies ?? []);
+    const allCompanies = data?.me.companies ?? [];
+    const filteredCompanies = filter ? filter(allCompanies) : allCompanies;
+    return sortCompaniesByName(filteredCompanies);
   }, [data]);
 
   if (loading) {
@@ -108,7 +113,7 @@ export default function MyCompanySelector({
     return <InlineError apolloError={error} />;
   }
 
-  if (data) {
+  if (companies) {
     return (
       <>
         {siretEditable ? (


### PR DESCRIPTION
Nouveau lot d'améliorations annexe 1

- amélioration de la gestion des conditionnements: pour les bennes et les citernes, il est impossible d'avoir un total de plus de 2 sur le chapeau
- on restreint les établissements affichés lors de la selection d'un émetteur de bordereau chapeau sur l'interface aux entreprises TTR / Traitement / Transporter
- on peut renseigner une adresse de colelcte sur les annexes 1
- amélioration du wording pour les particuliers sur les annexes 1 en incluant les associations
- affichage du numéro d'échantillon sur l'aperçu de l'annexe et le pdf

----

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
