### PR TITLE
Recette / Affichage du num d'échantillon

### DIFF
--- a/front/src/common/fragments/bsdd.ts
+++ b/front/src/common/fragments/bsdd.ts
@@ -88,6 +88,7 @@ export const wasteDetailsFragment = gql`
     }
     analysisReferences
     landIdentifiers
+    sampleNumber
   }
 `;
 


### PR DESCRIPTION
Fix de recette.
Numéro d'échantillon pas chargé donc pas affiché.
cf https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-2323