### PR TITLE
Corrige le fonctionnement des modales sur mobiles 

### DIFF
--- a/front/src/Apps/Common/Components/DropdownMenu/DropdownMenu.tsx
+++ b/front/src/Apps/Common/Components/DropdownMenu/DropdownMenu.tsx
@@ -51,7 +51,10 @@ const DropdownMenu = ({
                     <button
                       type="button"
                       className="fr-btn fr-btn--tertiary-no-outline"
-                      onClick={link.handleClick}
+                      onClick={e => {
+                        setIsOpen(false);
+                        !!link.handleClick && link.handleClick(e);
+                      }}
                     >
                       {link.icon && (
                         <span className="dropdown-menu__content__icon">


### PR DESCRIPTION
Sur appareil mobile, les boutons de certaines modales sont complètement inactifs.

Technique:
Un composant FocusTrap capte le focus du dropdown pour faciliter la navigation clavier, mais les éléments enfants voient les éléments touch désactivés.
On ferme désormais le dropdown au clic sur ses enfants, désactivant par là le FocusTrap.

 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11234s)
