### PR TITLE
Recette / Max benne ou citerne

### DIFF
--- a/back/src/forms/repository/form/setAppendix1.ts
+++ b/back/src/forms/repository/form/setAppendix1.ts
@@ -1,9 +1,6 @@
 import { Form, Status } from "@prisma/client";
 import { RepositoryFnDeps } from "../../../common/repository/types";
-import { PackagingInfo } from "../../../generated/graphql/types";
 import { checkCanBeSealed } from "../../validation";
-import { sumPackagingInfos } from "../helper";
-import buildUpdateForm from "./update";
 import buildUpdateManyForms from "./updateMany";
 
 class FormFraction {
@@ -82,24 +79,6 @@ export function buildSetAppendix1({
         recipientCompanyMail: form.recipientCompanyMail,
         ecoOrganismeName: form.ecoOrganismeName,
         ecoOrganismeSiret: form.ecoOrganismeSiret
-      }
-    );
-
-    // Update container packagings
-    const updateForm = buildUpdateForm({ prisma, user });
-    await updateForm(
-      { id: form.id },
-      {
-        wasteDetailsPackagingInfos: sumPackagingInfos(
-          newAppendix1Fractions.map(
-            fraction =>
-              fraction.form.wasteDetailsPackagingInfos as PackagingInfo[]
-          )
-        ),
-        wasteDetailsQuantity: newAppendix1Fractions.reduce(
-          (sum, fraction) => sum + (fraction.form.wasteDetailsQuantity ?? 0),
-          0
-        )
       }
     );
 

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -103,10 +103,11 @@ const signTransportFn = async (
       }
 
       // During transporter signature, we recompute the total packaging infos
+      // But we only use the current form + forms picked up by the transporter to compute this quantity
       const appendix1Forms = await findGroupedFormsById(appendix1ContainerId);
-      const wasteDetailsPackagingInfos = appendix1Forms.map(
-        form => form.wasteDetailsPackagingInfos as PackagingInfo[]
-      );
+      const wasteDetailsPackagingInfos = appendix1Forms
+        .filter(form => existingForm.id === form.id || form.takenOverAt)
+        .map(form => form.wasteDetailsPackagingInfos as PackagingInfo[]);
 
       await update(
         { id: appendix1ContainerId },

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -98,7 +98,8 @@ const updateFormResolver = async (
   // So this is a 2 way constraint:
   // - casting remove keys in the input but unknown to the validator
   // - then we remove keys present in the casting result but not present in the input
-  const formUpdateInput: Prisma.FormUpdateInput = draftFormSchema.cast(form);
+  const formUpdateInput: Prisma.FormUpdateInput =
+    draftFormSchema.cast(form) ?? {};
   for (const key of Object.keys(formUpdateInput)) {
     if (!(key in form)) {
       delete formUpdateInput[key];

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -100,7 +100,7 @@ function SignTransportFormModalContent({
     },
   });
 
-  const [updateForm] = useMutation<
+  const [updateForm, { error: updateError }] = useMutation<
     Pick<Mutation, "updateForm">,
     MutationUpdateFormArgs
   >(UPDATE_FORM);
@@ -236,6 +236,7 @@ function SignTransportFormModalContent({
             )}
 
             {error && <NotificationError apolloError={error} />}
+            {updateError && <NotificationError apolloError={updateError} />}
 
             <div className="td-modal-actions">
               <button


### PR DESCRIPTION
Fix de recette.
On avait de nouveaux problèmes avec les conditionnements.
L'idée désormais est de bien valider les contenants sur les annexes 1 également, mais en laissant la donnée optionelle.
Sans ça, on enregistrait des données erronées qui ensuite bloquanient le bordereau.