### PR TITLE
Rend le lien vers les dasris associés plus visible

### DIFF
--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -18,6 +18,7 @@ import {
   IconRenewableEnergyEarth,
   IconBSDasri,
   IconDuplicateFile,
+  IconPdf,
 } from "common/components/Icons";
 import { InitialDasris } from "./InitialDasris";
 import QRCodeIcon from "react-qr-code";
@@ -530,11 +531,13 @@ const AssociatedTo = ({ formId, label }: { formId: string; label: string }) => {
     <DetailRow
       value={
         <span>
-          {formId} (
-          <button className="link" onClick={() => downloadPdf()}>
-            PDF
+          {formId}
+          <button className="link tw-flex" onClick={() => downloadPdf()}>
+            <IconPdf size="18px" color="blueLight" />
+            <span className={classNames(styles.downloadLink, "tw-ml-1")}>
+              Pdf
+            </span>
           </button>
-          )
         </span>
       }
       label={`${label} bordereau n°`}


### PR DESCRIPTION
 Retour de recette: lien pas assez visible dans l'aperçu des dasris de synthèse/grouepement

<img width="615" alt="Capture d’écran 2023-06-05 à 19 00 50" src="https://github.com/MTES-MCT/trackdechets/assets/878396/cbfca135-374a-4eeb-b289-c07a7509f0f2">

 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?onShow=mycards&card=tra-11111)
