### PR TITLE
Corrige l'ajout d'entreposage provisoire sur un bsdd avec pipeline

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -161,6 +161,98 @@ describe("Mutation markAsResealed", () => {
     expect(resealedForm.forwardedIn!.status).toEqual("SEALED");
   });
 
+  test("a form with pipeline packaging infos can not be converted to temp storage", async () => {
+    const owner = await userFactory();
+    const { user, company: collector } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: { set: [CompanyType.COLLECTOR] }
+      }
+    );
+    const destination = await destinationFactory();
+    const transporter = await companyFactory({
+      companyTypes: { set: [CompanyType.TRANSPORTER] }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "ACCEPTED",
+        recipientCompanySiret: collector.siret,
+        quantityReceived: 1,
+        transporterCompanyAddress: null,
+        transporterCompanyContact: null,
+        transporterCompanyMail: null,
+        transporterCompanyName: null,
+        transporterCompanyPhone: null,
+        transporterCompanySiret: null,
+        transporterDepartment: null,
+        wasteDetailsPackagingInfos: [
+          {
+            type: "PIPELINE",
+            other: "",
+            quantity: 1
+          }
+        ]
+      }
+    });
+
+    await mutate<Pick<Mutation, "markAsResealed">, MutationMarkAsResealedArgs>(
+      MARK_AS_RESEALED,
+      {
+        variables: {
+          id: form.id,
+          resealedInfos: {
+            destination: {
+              company: {
+                siret: destination.siret,
+                name: destination.name,
+                address: destination.address,
+                contact: "Mr Destination",
+                mail: destination.contactEmail,
+                phone: destination.contactPhone
+              },
+              cap: "CAP 2",
+              processingOperation: "R 1"
+            },
+            transporter: {
+              company: {
+                siret: transporter.siret,
+                name: transporter.name,
+                address: transporter.address,
+                contact: "Mr transporter",
+                mail: transporter.contactEmail,
+                phone: transporter.contactPhone
+              },
+              isExemptedOfReceipt: true
+            }
+          }
+        }
+      }
+    );
+
+    const resealedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id },
+      include: { forwardedIn: true }
+    });
+    expect(resealedForm.status).toEqual("RESEALED");
+    expect(resealedForm.forwardedIn!.emitterCompanySiret).toEqual(
+      collector.siret
+    );
+    expect(resealedForm.forwardedIn!.recipientCompanySiret).toEqual(
+      destination.siret
+    );
+    expect(resealedForm.forwardedIn!.transporterCompanySiret).toEqual(
+      transporter.siret
+    );
+    expect(resealedForm.forwardedIn!.readableId).toEqual(
+      `${form.readableId}-suite`
+    );
+    expect(resealedForm.forwardedIn!.status).toEqual("SEALED");
+  });
+
   test("it should fail if temporary storage detail is incomplete", async () => {
     const owner = await userFactory();
     const { user, company: collector } = await userWithCompanyFactory(


### PR DESCRIPTION

# STAND BY 

Corrige un problème bloquant sur le BSDD lorsqu'un packaging de type PIPELINE figure sur le bordereau initial:

Explications tech
- on utilise le sealedFormSchema avec les inputs du bsd suite mergés avec les données du bsd initial
- si l'input ne contient pas de packaging infos copie celui du bsd initial
- le sealedFormSchema regarde si on a un packaging de type PIPELINE, le cas écheant attend des champs transporteur vides
- comme on a copié les infos du bsd inital -> fail de la validation et blocage

Correctif: pour la validation, si pas de packaging infos dans l'input, on passe un packaging infos "dummy"  pour faire passer la validation

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11945)
