### PR TITLE
[Bug][TRA-12015] Lorsque je clique en dehors de la modal transporteur DASRI, la section du menu ne devrait pas changer

### DIFF
--- a/front/src/dashboard/Dashboard.tsx
+++ b/front/src/dashboard/Dashboard.tsx
@@ -263,7 +263,7 @@ export default function Dashboard() {
               </Route>
               <Route path={routes.dashboard.bsdasris.sign.transporter}>
                 <Modal
-                  onClose={() => history.push(actionDashboard)}
+                  onClose={() => history.push(toCollectDashboard)}
                   ariaLabel="Signature transporteur"
                   isOpen
                 >


### PR DESCRIPTION
# URL où le bug s'est produit/se reproduit 

Section "A collecter"

[http://trackdechets.local/dashboard/53230142100022/transport/to-collect](https://github.com/MTES-MCT/trackdechets/compare/fix/tra-12015?expand=1)

# Comportement attendu

Dans la section "A collecter", si j'ouvre le détail d'un BSDASRI (à confirmer pour les autres types de bordereaux), et que je clique à côté de la modal, je devrais rester dans la section "A collecter"

# Comportement constaté par l'utilisateur

Je suis renvoyé dans la section "Pour action"

# Etapes à effectuer pour reproduire le pb (si faisable) 

- Aller dans "Mon espace" > "A collecter"
- Ouvrir la modal de détail d'un BSDASRI (à confirmer pour les autres types de bordereaux)
- Cliquer à côté de la modal
- Constater que la section a changé pour "Pour action"

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/c3671358-e415-47a4-84b8-b31f27639069)

# Ticket

[[Bug FRONT] Lorsque je clique en dehors d'une modal, la section du menu ne devrait pas changer](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12015)
