### PR TITLE
HOTFIX - je ne vois pas le BSDA dupliqué quand je suis installation de destination

### DIFF
--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -119,6 +119,7 @@ async function duplicateBsda({
     transporterCompanyVatNumber,
     brokerCompanySiret,
     workerCompanySiret,
+    destinationCompanySiret,
     id: getReadableId(ReadableIdPrefix.BSDA),
     status: BsdaStatus.INITIAL,
     isDraft: true,


### PR DESCRIPTION
https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12040

Je prendrai le temps ensuite d'ajouter des tests pour vérifier que tous les champs sont bien présents. Il faudrait généraliser le genre de test que l'on a sur le BSDD

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
