### PR TITLE
Debug ajout d'une fiche d'intervention

### DIFF
--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -385,11 +385,12 @@ export function FicheInterventionList({
 
                 setIsModalOpen(true);
               })
-              .catch(() => {
-                window.alert(
-                  `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
-                );
-                return;
+              .catch(err => {
+                console.log(err);
+                // window.alert(
+                //   `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
+                // );
+                setIsModalOpen(true);
               });
           }}
         >


### PR DESCRIPTION
https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12054

Trsè étrange, impossible de reproduire en local avec un dump. Je ne vois pas d'autres solutions que de faire un console.log et de skip la validation pour l'instant afin de débloquer les utilisateurs...