### PR TITLE
Hotfix ajout de FI

### DIFF
--- a/front/src/form/bsff/FicheInterventionList.tsx
+++ b/front/src/form/bsff/FicheInterventionList.tsx
@@ -15,7 +15,6 @@ import {
   MutationCreateFicheInterventionBsffArgs,
 } from "generated/graphql/types";
 import * as React from "react";
-import countries from "world-countries";
 import * as yup from "yup";
 import { FicheInterventionFragment } from "common/fragments";
 
@@ -38,10 +37,7 @@ const companySchema: yup.SchemaOf<CompanyInput> = yup.object({
     .required("Le numéro de téléphone de l'établissement est requis"),
   siret: yup.string().required("Le numéro SIRET de l'établissement est requis"),
   vatNumber: yup.string().nullable(),
-  country: yup
-    .string()
-    .oneOf([...countries.map(country => country.cca2), null])
-    .nullable(),
+  country: yup.string().notRequired().nullable(),
   omiNumber: yup.string().nullable(),
   orgId: yup.string().nullable(),
 });
@@ -385,12 +381,11 @@ export function FicheInterventionList({
 
                 setIsModalOpen(true);
               })
-              .catch(err => {
-                console.log(err);
-                // window.alert(
-                //   `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
-                // );
-                setIsModalOpen(true);
+              .catch(e => {
+                window.alert(
+                  `Veuillez compléter les champs de l'opérateur avant l'ajout d'une fiche d'intervention.`
+                );
+                return;
               });
           }}
         >


### PR DESCRIPTION
Une maj récente du companyselector renvoie un champ country: "" dans certains cas, bloquant la validation front et l'apparition de la modale de la fi.
<img width="1280" alt="Capture d’écran 2023-06-07 à 19 01 38" src="https://github.com/MTES-MCT/trackdechets/assets/878396/2892f0ba-b73d-4d7e-9bd3-783f588cf697">


https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12054



 
