### PR TITLE
HOTFIX Refus de réception BSDA

### DIFF
--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -323,9 +323,8 @@ function flattenBsdaDestinationInput({
     ),
     destinationCustomInfo: chain(destination, d => d.customInfo),
     destinationCap: chain(destination, d => d.cap),
-    destinationPlannedOperationCode: chain(
-      destination,
-      d => d.plannedOperationCode
+    destinationPlannedOperationCode: chain(destination, d =>
+      noEmptyString(d.plannedOperationCode)
     ),
 
     destinationReceptionDate: chain(destination, d =>
@@ -343,7 +342,7 @@ function flattenBsdaDestinationInput({
       chain(d.reception, r => r.refusalReason)
     ),
     destinationOperationCode: chain(destination, d =>
-      chain(d.operation, o => o.code)
+      chain(d.operation, o => noEmptyString(o.code))
     ),
     destinationOperationDescription: chain(destination, d =>
       chain(d.operation, o => o.description)


### PR DESCRIPTION
Le refus de bsda plante avec un message Invalid enum value. Expected 'R 5' | 'D 5' | 'D 9' | 'R 13' | 'D 15', received ''

Souci avec Zod qui attend enum + null et reçoit une "". Fix en utilisant noEmptyString
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12068)
