### PR TITLE
Corrige l'écran figé sur smartphone lors de l'ouverture de l'aperçu

### DIFF
--- a/front/src/Apps/Common/Components/DropdownMenu/DropdownMenu.tsx
+++ b/front/src/Apps/Common/Components/DropdownMenu/DropdownMenu.tsx
@@ -34,7 +34,10 @@ const DropdownMenu = ({
             "menu-btn__iconAlone": iconAlone,
           })}
           disabled={isDisabled}
-          onClick={onClick}
+          onClick={e => {
+            setIsOpen(false);
+            onClick();
+          }}
         >
           {menuTitle}
         </button>


### PR DESCRIPTION
Sur mobile, l'écran ne réagit plus au touch lors de l'ouverture de l'aperçu d'un bsd


---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11234)
