### PR TITLE
Hotfix : Copy reshipment consistence from forwarded bsda

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -7,6 +7,9 @@ import {
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
+import { BsdaStatus } from "@prisma/client";
+import { bsdaFactory } from "../../../__tests__/factories";
+import prisma from "../../../../prisma";
 
 const CREATE_BSDA = `
 mutation CreateBsda($input: BsdaInput!) {
@@ -1267,5 +1270,181 @@ describe("Mutation.Bsda.create", () => {
     expect(errors[0].message).toContain(
       "est pas inscrite sur Trackdéchets en tant qu'installation de traitement"
     );
+  });
+
+  it("should create a RESHIPMENT bsda and copy consistence from forwarded bsda if field is not provided", async () => {
+    const { company: emitter } = await userWithCompanyFactory("MEMBER");
+    const { company: transporter } = await userWithCompanyFactory("MEMBER");
+    const { user, company: destination } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const { company: ttr } = await userWithCompanyFactory("MEMBER");
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.siret,
+        transporterCompanySiret: transporter.siret,
+        destinationCompanySiret: ttr.siret,
+        status: BsdaStatus.AWAITING_CHILD,
+        destinationOperationCode: "D 15",
+        wasteConsistence: "PULVERULENT"
+      }
+    });
+
+    const input: BsdaInput = {
+      type: "RESHIPMENT",
+      emitter: {
+        isPrivateIndividual: false,
+        company: {
+          siret: emitter.siret,
+          name: "The crusher",
+          address: "Rue de la carcasse",
+          contact: "Centre amiante",
+          phone: "0101010101",
+          mail: "emitter@mail.com"
+        }
+      },
+      worker: {
+        company: {
+          siret: siretify(2),
+          name: "worker",
+          address: "address",
+          contact: "contactEmail",
+          phone: "contactPhone",
+          mail: "contactEmail@mail.com"
+        }
+      },
+      waste: {
+        code: "06 07 01*",
+        adr: "ADR",
+        pop: true,
+        // consistence not provided
+        familyCode: "Code famille",
+        materialName: "A material",
+        sealNumbers: ["1", "2"]
+      },
+      packagings: [{ quantity: 1, type: "PALETTE_FILME" }],
+      weight: { isEstimate: true, value: 1.2 },
+      destination: {
+        cap: "A cap",
+        plannedOperationCode: "D 9",
+        company: {
+          siret: destination.siret,
+          name: "destination",
+          address: "address",
+          contact: "contactEmail",
+          phone: "contactPhone",
+          mail: "contactEmail@mail.com"
+        }
+      },
+      forwarding: bsda.id
+    };
+
+    const { mutate } = makeClient(user);
+    const { data, errors } = await mutate<Pick<Mutation, "createBsda">>(
+      CREATE_BSDA,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data.createBsda.id).toBeTruthy();
+    const reshipped = await prisma.bsda.findUnique({
+      where: { id: data.createBsda.id }
+    });
+    expect(reshipped?.type).toEqual("RESHIPMENT");
+    expect(reshipped?.forwardingId).toEqual(bsda.id);
+    expect(reshipped?.wasteConsistence).toEqual("PULVERULENT"); // consistence matches forwarde bsda consistence
+  });
+
+  it("should create a RESHIPMENT bsda and use provided cosnsitence field ", async () => {
+    const { company: emitter } = await userWithCompanyFactory("MEMBER");
+    const { company: transporter } = await userWithCompanyFactory("MEMBER");
+    const { user, company: destination } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const { company: ttr } = await userWithCompanyFactory("MEMBER");
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.siret,
+        transporterCompanySiret: transporter.siret,
+        destinationCompanySiret: ttr.siret,
+        status: BsdaStatus.AWAITING_CHILD,
+        destinationOperationCode: "D 15",
+        wasteConsistence: "SOLIDE"
+      }
+    });
+
+    const input: BsdaInput = {
+      type: "RESHIPMENT",
+      emitter: {
+        isPrivateIndividual: false,
+        company: {
+          siret: emitter.siret,
+          name: "The crusher",
+          address: "Rue de la carcasse",
+          contact: "Centre amiante",
+          phone: "0101010101",
+          mail: "emitter@mail.com"
+        }
+      },
+      worker: {
+        company: {
+          siret: siretify(2),
+          name: "worker",
+          address: "address",
+          contact: "contactEmail",
+          phone: "contactPhone",
+          mail: "contactEmail@mail.com"
+        }
+      },
+      waste: {
+        code: "06 07 01*",
+        adr: "ADR",
+        pop: true,
+        consistence: "PULVERULENT",
+        familyCode: "Code famille",
+        materialName: "A material",
+        sealNumbers: ["1", "2"]
+      },
+      packagings: [{ quantity: 1, type: "PALETTE_FILME" }],
+      weight: { isEstimate: true, value: 1.2 },
+      destination: {
+        cap: "A cap",
+        plannedOperationCode: "D 9",
+        company: {
+          siret: destination.siret,
+          name: "destination",
+          address: "address",
+          contact: "contactEmail",
+          phone: "contactPhone",
+          mail: "contactEmail@mail.com"
+        }
+      },
+      forwarding: bsda.id
+    };
+
+    const { mutate } = makeClient(user);
+    const { data, errors } = await mutate<Pick<Mutation, "createBsda">>(
+      CREATE_BSDA,
+      {
+        variables: {
+          input
+        }
+      }
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data.createBsda.id).toBeTruthy();
+    const reshipped = await prisma.bsda.findUnique({
+      where: { id: data.createBsda.id }
+    });
+    expect(reshipped?.type).toEqual("RESHIPMENT");
+    expect(reshipped?.forwardingId).toEqual(bsda.id);
+    expect(reshipped?.wasteConsistence).toEqual("PULVERULENT"); // consistence matches input
   });
 });

--- a/back/src/bsda/validation/transformers.ts
+++ b/back/src/bsda/validation/transformers.ts
@@ -1,0 +1,31 @@
+import prisma from "../../prisma";
+import { ZodBsda } from "./schema";
+
+/**
+ *
+ * @param val Runs a bunch (currently one) function to enrich bsda input with computed values
+ * @returns
+ */
+export const runTransformers = async (val: ZodBsda): Promise<ZodBsda> => {
+  const transformers = [reshipmentBsdaTransformer];
+  for (const transformer of transformers) {
+    val = await transformer(val);
+  }
+  return val;
+};
+
+const reshipmentBsdaTransformer = async (val: ZodBsda): Promise<ZodBsda> => {
+  if (
+    val.type === "RESHIPMENT" &&
+    !val?.wasteConsistence &&
+    !!val?.forwarding
+  ) {
+    const forwarding = await prisma.bsda.findUnique({
+      where: { id: val.forwarding }
+    });
+    if (!!forwarding) {
+      val = { ...val, wasteConsistence: forwarding.wasteConsistence };
+    }
+  }
+  return val;
+};

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -8,6 +8,7 @@ import { PARTIAL_OPERATIONS } from "./constants";
 import { editionRules } from "./rules";
 import { ZodBsda, rawBsdaSchema } from "./schema";
 import { capitalize } from "../../common/strings";
+import { runTransformers } from "./transformers";
 
 type BsdaValidationContext = {
   enablePreviousBsdasChecks?: boolean;
@@ -39,6 +40,8 @@ function getContextualBsdaSchema(validationContext: BsdaValidationContext) {
       if (validationContext.enableSirenification) {
         val = await sirenify(val);
       }
+
+      val = await runTransformers(val);
 
       return val;
     })


### PR DESCRIPTION
La consistance déchet d'un bsda de rééxpédition n'est copié que lorsque sa création est effectuée depuis l'UI.
Un bsda créé par api peut donc avoir une consistance vide.
Le formulaire d"édition ne permet pas de modifier la consitance du bsda de réexpédition.
Ainsi l'utilisateur se retrouve bloqué à la réception, le champ devenant nécessaire mais n'étant pas modifiable
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?onShow=mycards&card=tra-12079)
