### PR TITLE
Fix 2710 bsda reception

### DIFF
--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -15,6 +15,35 @@ describe("BSDA validation", () => {
 
   afterEach(resetDatabase);
 
+  describe("BSDA should be valid - transitory empty strings", () => {
+    test("when type is COLLECTION_2710 and unused company fields are empty strings", async () => {
+      // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
+      const { success } = await rawBsdaSchema.safeParseAsync({
+        ...bsda,
+        type: BsdaType.COLLECTION_2710,
+        transporterCompanySiret: "",
+        transporterCompanyName: "",
+        workerCompanyName: "",
+        workerCompanySiret: ""
+      });
+
+      expect(success).toEqual(true);
+    });
+    test("when type is COLLECTION_2710 and unused company fields are  empty nulls", async () => {
+      // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
+      const { success } = await rawBsdaSchema.safeParseAsync({
+        ...bsda,
+        type: BsdaType.COLLECTION_2710,
+        transporterCompanySiret: null,
+        transporterCompanyName: null,
+        workerCompanyName: null,
+        workerCompanySiret: null
+      });
+
+      expect(success).toEqual(true);
+    });
+  });
+
   describe("BSDA should be valid", () => {
     test("when all data is present", async () => {
       const { success } = await rawBsdaSchema.safeParseAsync(bsda);

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -18,6 +18,7 @@ import {
 } from "../../common/validation/siret";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { OPERATIONS, WORKER_CERTIFICATION_ORGANISM } from "./constants";
+import { noEmptyString } from "../../common/converter";
 
 const bsdaPackagingSchema = z
   .object({
@@ -237,8 +238,8 @@ export const rawBsdaSchema = z
 
     if (
       val.type === BsdaType.COLLECTION_2710 &&
-      (val.transporterCompanyName != null ||
-        val.transporterCompanySiret != null)
+      (noEmptyString(val.transporterCompanyName) != null ||
+        noEmptyString(val.transporterCompanySiret) != null)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -248,7 +249,8 @@ export const rawBsdaSchema = z
 
     if (
       val.type === BsdaType.COLLECTION_2710 &&
-      (val.workerCompanyName != null || val.workerCompanySiret != null)
+      (noEmptyString(val.workerCompanyName) != null ||
+        noEmptyString(val.workerCompanySiret) != null)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
En collecte 2710, la validation bsda attend les champs transporter et worker à null, mais en db on a des chaînes vides. Cette pr permet de tolérer les 2 pour les champs concernés.

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12103)
