### PR TITLE
Obfuscate invited user names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,22 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+# [2023.6.2] 27/06/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Masque les noms et prénoms d'une utilisateur ajouté à un établissement peandant sept jours [PR 2471](https://github.com/MTES-MCT/trackdechets/pull/2471).
+
+#### :memo: Documentation
+
+#### :house: Interne
 
 # [2023.6.1] 06/06/2023
 

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -16,6 +16,8 @@ import {
 import prisma from "../prisma";
 import { hashToken } from "../utils";
 import { createUser } from "../users/database";
+import { subMinutes } from "date-fns";
+
 /**
  * Create a user with name and email
  * @param opt: extra parameters
@@ -126,8 +128,11 @@ export const userWithCompanyFactory = async (
   companyAssociationOpts: Partial<Prisma.CompanyAssociationCreateInput> = {}
 ): Promise<UserWithCompany> => {
   const company = await companyFactory(companyOpts);
+  // we fake a user created a few minutes ago to prevent their membership being considered as an auto-accepted invitation
+  const userCreatedAt = subMinutes(new Date(), 5);
 
   const user = await userFactory({
+    createdAt: userCreatedAt,
     ...userOpts,
     companyAssociations: {
       create: {

--- a/back/src/companies/resolvers/CompanyPrivate.ts
+++ b/back/src/companies/resolvers/CompanyPrivate.ts
@@ -9,6 +9,7 @@ const companyPrivateResolvers: CompanyPrivateResolvers = {
   users: async (parent, _, context) => {
     const userId = context.user!.id;
     const userRole = await getUserRole(userId, parent.orgId);
+
     if (userRole !== "ADMIN") {
       return [
         {

--- a/back/src/mailer/templates/mustache/notification-invitation.html
+++ b/back/src/mailer/templates/mustache/notification-invitation.html
@@ -7,3 +7,7 @@
     Trackdéchets</a>.</p>
 <br />
 <p>Vous aurez accès à l'ensemble des données concernant l'entreprise <strong>{{companyName}}</strong>.</p>
+<br />
+<p>Si cette invitation vous semble être suspecte ou une erreur, merci de contacter.
+  le support Trackdéchets via le <a href="https://assistance.trackdechets.beta.gouv.fr/">formulaire d'assistance</a>
+</p>

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
@@ -50,6 +50,9 @@ describe("mutation inviteUserToCompany", () => {
       .companyAssociations();
     expect(companyAssociations).toHaveLength(1);
     expect(companyAssociations[0].role).toEqual("MEMBER");
+
+    expect(companyAssociations[0].createdAt).toBeTruthy();
+
     const userCompany = await prisma.companyAssociation
       .findUniqueOrThrow({
         where: {
@@ -57,6 +60,7 @@ describe("mutation inviteUserToCompany", () => {
         }
       })
       .company();
+    expect(userCompany.siret).toEqual(company.siret);
     expect(userCompany.siret).toEqual(company.siret);
   });
 

--- a/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/sendMembershipRequest.integration.ts
@@ -15,6 +15,7 @@ import {
   membershipRequest as membershipRequestMail
 } from "../../../../mailer/templates";
 import { Mutation } from "../../../../generated/graphql/types";
+import { subMinutes } from "date-fns";
 
 // No mails
 const sendMailSpy = jest.spyOn(mailsHelper, "sendMail");
@@ -49,7 +50,10 @@ describe("mutation sendMembershipRequest", () => {
 
   it("should send a request to all admins of the company and create a MembershipRequest record. Admins emails partially hidden.", async () => {
     const requester = await userFactory();
-    const admin = await userFactory({ email: "john.snow@trackdechets.fr" });
+    const admin = await userFactory({
+      email: "john.snow@trackdechets.fr",
+      createdAt: subMinutes(new Date(), 5)
+    });
     const company = await companyFactory();
     await associateUserToCompany(admin.id, company.siret, "ADMIN");
     const { mutate } = makeClient(requester);
@@ -118,7 +122,8 @@ describe("mutation sendMembershipRequest", () => {
       email: `requester${userIndex}@trackdechets.fr`
     });
     const admin = await userFactory({
-      email: `admin${userIndex}@trackdechets.fr`
+      email: `admin${userIndex}@trackdechets.fr`,
+      createdAt: subMinutes(new Date(), 5)
     });
     const company = await companyFactory();
     await associateUserToCompany(admin.id, company.siret, "ADMIN");


### PR DESCRIPTION
Pb RGPD: si j'invite dans mon établissement un utilisateur déjà inscrit sur TD grâce à son email,  j'ai accès immédiatement à son nom/prénom, l'invitation étant automatiquement acceptée. C'est un pb d'un pont de vue privacy.
Pour limiter le pb sans perturber l'experience utilisateur:

Lorsque  etq utilisateur déjà inscrit sur TD, je suis invité sur un nouvel établissement:
- le mail que je reçois précise la conduite à tenir si cette invitation me paraît illégitime
- mon nom et prénom ne sont visibles pour la personne qui m'invite qu'après 7 jours

https://github.com/MTES-MCT/trackdechets/assets/878396/9d2b17ab-3663-4983-a97f-af8a709aaba8


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10737)
