### PR TITLE
[TRA-10538] Harmonisation des dates - Fix de recette

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
@@ -72,7 +72,6 @@ const validationSchema = (form: TdForm, today: Date) => {
         startOfDay(parseDate(form.takenOverAt!)),
         "La date de réception du déchet ne peut pas être antérieure à sa date d'enlèvement."
       )
-      .max(today, "La date de réception du déchet ne peut être dans le futur")
       // we only care about the day, not the exact time
       .transform(value => startOfDay(parseDate(value))),
     receivedBy: yup

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionFormModalContent.tsx
@@ -31,25 +31,17 @@ interface SignEmissionFormModalProps {
   onClose: () => void;
 }
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    emittedAt: yup
-      .date()
-      .required("La date d'émission est requise")
-      .max(today, "La date d'émission ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date d'émission ne peut être antérieure à 2 mois"
-      ),
-    emittedBy: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-    securityCode: yup
-      .string()
-      .nullable()
-      .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
-  });
+const validationSchema = yup.object({
+  emittedAt: yup.date().required("La date d'émission est requise"),
+  emittedBy: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+  securityCode: yup
+    .string()
+    .nullable()
+    .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
+});
 
 enum EmitterType {
   Emitter = "Emitter",
@@ -166,7 +158,7 @@ function SignEmissionFormModalContent({
     <>
       <Formik
         initialValues={initialValues}
-        validationSchema={getValidationSchema(TODAY)}
+        validationSchema={validationSchema}
         onSubmit={handlesubmit}
       >
         {({ values }) => {

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -26,25 +26,17 @@ import TransporterReceipt from "form/common/components/company/TransporterReceip
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    takenOverAt: yup
-      .date()
-      .required("La date de prise en charge est requise")
-      .max(today, "La date de prise en charge ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date de prise en charge ne peut être antérieure à 2 mois"
-      ),
-    takenOverBy: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-    securityCode: yup
-      .string()
-      .nullable()
-      .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
-  });
+const validationSchema = yup.object({
+  takenOverAt: yup.date().required("La date de prise en charge est requise"),
+  takenOverBy: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+  securityCode: yup
+    .string()
+    .nullable()
+    .matches(/[0-9]{4}/, "Le code de signature est composé de 4 chiffres"),
+});
 interface SignTransportFormModalProps {
   title: string;
   siret: string;
@@ -121,7 +113,6 @@ export default function SignTransportFormModalContent({
   const form = data?.form;
 
   const TODAY = new Date();
-  const validationSchema = getValidationSchema(TODAY);
 
   return (
     <>

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
@@ -16,21 +16,13 @@ import { SignBsda, SIGN_BSDA } from "./SignBsda";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date d'émission est requise")
-      .max(today, "La date d'émission ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date d'émission ne peut être antérieure à 2 mois"
-      ),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date d'émission est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -97,7 +89,7 @@ export function SignEmission({
               date: TODAY.toISOString(),
               author: "",
             }}
-            validationSchema={getValidationSchema(TODAY)}
+            validationSchema={validationSchema}
             onSubmit={async values => {
               await signBsda({
                 variables: {

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -21,18 +21,13 @@ import * as yup from "yup";
 import { SignBsda, SIGN_BSDA } from "./SignBsda";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date est requise")
-      .max(today, "La date ne peut être dans le futur")
-      .min(subMonths(today, 2), "La date ne peut être antérieure à 2 mois"),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -117,7 +112,7 @@ export function SignOperation({
                 bsda
               ),
             }}
-            validationSchema={getValidationSchema(TODAY)}
+            validationSchema={validationSchema}
             onSubmit={async values => {
               const { id, author, date, ...update } = values;
               await updateBsda({

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -22,18 +22,13 @@ import { SignBsda, SIGN_BSDA } from "./SignBsda";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date est requise")
-      .max(today, "La date ne peut être dans le futur")
-      .min(subMonths(today, 2), "La date ne peut être antérieure à 2 mois"),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -119,7 +114,7 @@ export function SignTransport({
                 bsda
               ),
             }}
-            validationSchema={getValidationSchema(TODAY)}
+            validationSchema={validationSchema}
             onSubmit={async values => {
               const { id, author, date, ...update } = values;
               await updateBsda({

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
@@ -21,18 +21,13 @@ import { SignBsda, SIGN_BSDA } from "./SignBsda";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date est requise")
-      .max(today, "La date ne peut être dans le futur")
-      .min(subMonths(today, 2), "La date ne peut être antérieure à 2 mois"),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -112,7 +107,7 @@ export function SignWork({
                 bsda
               ),
             }}
-            validationSchema={getValidationSchema(TODAY)}
+            validationSchema={validationSchema}
             onSubmit={async values => {
               const { id, author, date, ...update } = values;
               await updateBsda({

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -184,7 +184,7 @@ export function RouteSignBsdasri({
           ...formState,
           signature: { author: "", date: TODAY },
         }}
-        validationSchema={() => signatureValidationSchema(bsdasri, TODAY)}
+        validationSchema={() => signatureValidationSchema}
         onSubmit={async values => {
           const { id, signature, ...rest } = values;
 

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/utils.ts
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/utils.ts
@@ -1,24 +1,11 @@
 import * as yup from "yup";
-import { Bsdasri } from "generated/graphql/types";
-import { subMonths } from "date-fns";
 
-export const signatureValidationSchema = (form: Bsdasri, today: Date) =>
-  yup.object({
-    signature: yup.object({
-      date: yup
-        .date()
-        .required("La date d'émission est requise")
-        .max(today, "La date d'émission ne peut être dans le futur")
-        .min(
-          subMonths(today, 2),
-          "La date d'émission ne peut être antérieure à 2 mois"
-        ),
-      author: yup
-        .string()
-        .nullable()
-        .required("Le nom du signataire est requis"),
-    }),
-  });
+export const signatureValidationSchema = yup.object({
+  signature: yup.object({
+    date: yup.date().required("La date d'émission est requise"),
+    author: yup.string().nullable().required("Le nom du signataire est requis"),
+  }),
+});
 
 export const emissionSignatureSecretCodeValidationSchema = yup.object({
   signature: yup.object({

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
@@ -16,21 +16,13 @@ import { GET_BSDS } from "Apps/common/queries";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date d'émission est requise")
-      .max(today, "La date d'émission ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date d'émission ne peut être antérieure à 2 mois"
-      ),
-    signatureAuthor: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date d'émission est requise"),
+  signatureAuthor: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 interface SignEmissionFormProps {
   bsff: Bsff;
@@ -51,7 +43,7 @@ function SignEmissionForm({ bsff, onCancel }: SignEmissionFormProps) {
         signatureAuthor: "",
         date: TODAY,
       }}
-      validationSchema={getValidationSchema(TODAY)}
+      validationSchema={validationSchema}
       onSubmit={async values => {
         await signBsff({
           variables: {

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
@@ -32,6 +32,7 @@ import { BsffPackagingSummary } from "./BsffPackagingSummary";
 import { OPERATION } from "form/bsff/utils/constants";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { companySchema } from "common/validation/schema";
+import { subMonths } from "date-fns";
 
 const operationCode = yup
   .string()
@@ -299,7 +300,7 @@ export function SignBsffOperationOnePackagingModalContent({
         {({ values, setValues }) => (
           <Form>
             <div className="form__row">
-              <label className="tw-font-semibold">
+              <label>
                 Date du traitement
                 <div className="td-date-wrapper">
                   <Field
@@ -307,6 +308,8 @@ export function SignBsffOperationOnePackagingModalContent({
                     name="date"
                     component={DateInput}
                     maxDate={TODAY}
+                    minDate={subMonths(TODAY, 2)}
+                    required
                   />
                 </div>
               </label>

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
@@ -41,34 +41,33 @@ const operationCode = yup
     "Le code de l'opération de traitement ne fait pas partie de la liste reconnue"
   );
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    code: operationCode,
-    description: yup
-      .string()
-      .ensure()
-      .required("La description de l'opération réalisée est obligatoire"),
-    date: yup.date().required("La date de l'opération est requise"),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-    nextDestination: yup.object().when("code", {
-      is: (code: string) => OPERATION[code]?.successors?.length > 0,
-      then: schema =>
-        schema.when("noTraceability", {
-          is: true,
-          then: schema => schema.nullable(),
-          otherwise: schema =>
-            schema.shape({
-              plannedOperationCode: operationCode,
-              company: companySchema,
-              cap: yup.string().nullable().notRequired(),
-            }),
-        }),
-      otherwise: schema => schema.nullable(),
-    }),
-  });
+const validationSchema = yup.object({
+  code: operationCode,
+  description: yup
+    .string()
+    .ensure()
+    .required("La description de l'opération réalisée est obligatoire"),
+  date: yup.date().required("La date de l'opération est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+  nextDestination: yup.object().when("code", {
+    is: (code: string) => OPERATION[code]?.successors?.length > 0,
+    then: schema =>
+      schema.when("noTraceability", {
+        is: true,
+        then: schema => schema.nullable(),
+        otherwise: schema =>
+          schema.shape({
+            plannedOperationCode: operationCode,
+            company: companySchema,
+            cap: yup.string().nullable().notRequired(),
+          }),
+      }),
+    otherwise: schema => schema.nullable(),
+  }),
+});
 
 interface SignBsffOperationProps {
   bsffId: string;
@@ -247,7 +246,6 @@ export function SignBsffOperationOnePackagingModalContent({
   >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   const TODAY = new Date();
-  const validationSchema = getValidationSchema(TODAY);
 
   const loading = updateBsffPackagingResult.loading || signBsffResult.loading;
   const error = updateBsffPackagingResult.error ?? signBsffResult.error;

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
@@ -17,21 +17,13 @@ import { SignBsff } from "./SignBsff";
 import { GET_BSDS } from "Apps/common/queries";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    receptionDate: yup
-      .date()
-      .required("La date de réception est requise")
-      .max(today, "La date de réception ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date de réception ne peut être antérieure à 2 mois"
-      ),
-    signatureAuthor: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  receptionDate: yup.date().required("La date de réception est requise"),
+  signatureAuthor: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 interface SignReceptionModalProps {
   bsff: Bsff;
@@ -49,7 +41,6 @@ function SignReceptionModal({ bsff, onCancel }: SignReceptionModalProps) {
   >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   const TODAY = new Date();
-  const validationSchema = getValidationSchema(TODAY);
 
   const loading = updateBsffResult.loading || signBsffResult.loading;
   const error = updateBsffResult.error ?? signBsffResult.error;

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -19,21 +19,13 @@ import DateInput from "form/common/components/custom-inputs/DateInput";
 import TransporterReceipt from "form/common/components/company/TransporterReceipt";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    takenOverAt: yup
-      .date()
-      .required("La date de prise en charge est requise")
-      .max(today, "La date de prise en charge ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date de prise en charge ne peut être antérieure à 2 mois"
-      ),
-    signatureAuthor: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  takenOverAt: yup.date().required("La date de prise en charge est requise"),
+  signatureAuthor: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 interface SignTransportFormProps {
   bsff: Bsff;
@@ -52,7 +44,6 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
   >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
 
   const TODAY = new Date();
-  const validationSchema = getValidationSchema(TODAY);
 
   return (
     <Formik

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
@@ -15,21 +15,13 @@ import { SignBsvhu, SIGN_BSVHU } from "./SignBsvhu";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date d'émission est requise")
-      .max(today, "La date d'émission ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date d'émission ne peut être antérieure à 2 mois"
-      ),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date d'émission est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -88,7 +80,7 @@ export function SignEmission({
               author: "",
               date: TODAY.toISOString(),
             }}
-            validationSchema={getValidationSchema(TODAY)}
+            validationSchema={validationSchema}
             onSubmit={async values => {
               await signBsvhu({
                 variables: {

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -18,18 +18,13 @@ import { SignBsvhu, SIGN_BSVHU } from "./SignBsvhu";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    date: yup
-      .date()
-      .required("La date est requise")
-      .max(today, "La date ne peut être dans le futur")
-      .min(subMonths(today, 2), "La date ne peut être antérieure à 2 mois"),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  date: yup.date().required("La date est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -93,7 +88,7 @@ export function SignOperation({
               bsvhu
             ),
           }}
-          validationSchema={getValidationSchema(TODAY)}
+          validationSchema={validationSchema}
           onSubmit={async values => {
             const { id, author, date, ...update } = values;
             await updateBsvhu({

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -18,21 +18,13 @@ import * as yup from "yup";
 import { SignBsvhu, SIGN_BSVHU } from "./SignBsvhu";
 import { subMonths } from "date-fns";
 
-const getValidationSchema = (today: Date) =>
-  yup.object({
-    takenOverAt: yup
-      .date()
-      .required("La date de prise en charge est requise")
-      .max(today, "La date de prise en charge ne peut être dans le futur")
-      .min(
-        subMonths(today, 2),
-        "La date de prise en charge ne peut être antérieure à 2 mois"
-      ),
-    author: yup
-      .string()
-      .ensure()
-      .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
-  });
+const validationSchema = yup.object({
+  takenOverAt: yup.date().required("La date de prise en charge est requise"),
+  author: yup
+    .string()
+    .ensure()
+    .min(1, "Le nom et prénom de l'auteur de la signature est requis"),
+});
 
 type Props = {
   siret: string;
@@ -74,7 +66,6 @@ export function SignTransport({
     >
       {({ bsvhu, onClose }) => {
         const TODAY = new Date();
-        const validationSchema = getValidationSchema(TODAY);
 
         return bsvhu.metadata?.errors.some(
           error => error.requiredFor === SignatureTypeInput.Transport


### PR DESCRIPTION
# Contexte

Correction des problèmes rencontrés lors de la recette pour la PR [[TRA-10538] Harmonisation des inputs & validations de dates sur les étapes de signature des bordereaux #2431](https://github.com/MTES-MCT/trackdechets/pull/2431)

# Fix

- Conflit d'1 journée entre la validation `yup` et les contraintes du champ `Date`. Comme discuté avec Benoît, de toute façon la validation `yup` sert à rien, donc je l'ai arrachée
- Opération de traitement pour les BSFFs: le champ `Date` n'était pas corrigé

# Ticket Favro

[Tous BSD - dates - Cohérence des dates à vérifier par type de bordereaux](https://favro.com/widget/ab14a4f0460a99a9d64d4945/1c2bdfe724d121874de31113?card=tra-10538)