### PR TITLE
Auto Empty string

### DIFF
--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -3,8 +3,7 @@ import {
   safeInput,
   processDate,
   chain,
-  undefinedOrDefault,
-  noEmptyString
+  undefinedOrDefault
 } from "../common/converter";
 
 import {
@@ -257,12 +256,8 @@ export function flattenBsdaInput(formInput: BsdaInput) {
 function flattenBsdaEmitterInput({ emitter }: Pick<BsdaInput, "emitter">) {
   return {
     emitterIsPrivateIndividual: chain(emitter, e => e.isPrivateIndividual),
-    emitterCompanyName: chain(emitter, e =>
-      chain(e.company, c => noEmptyString(c.name))
-    ),
-    emitterCompanySiret: chain(emitter, e =>
-      chain(e.company, c => noEmptyString(c.siret))
-    ),
+    emitterCompanyName: chain(emitter, e => chain(e.company, c => c.name)),
+    emitterCompanySiret: chain(emitter, e => chain(e.company, c => c.siret)),
     emitterCompanyAddress: chain(emitter, e =>
       chain(e.company, c => c.address)
     ),
@@ -304,10 +299,10 @@ function flattenBsdaDestinationInput({
 }: Pick<BsdaInput, "destination">) {
   return {
     destinationCompanyName: chain(destination, d =>
-      chain(d.company, c => noEmptyString(c.name))
+      chain(d.company, c => c.name)
     ),
     destinationCompanySiret: chain(destination, d =>
-      chain(d.company, c => noEmptyString(c.siret))
+      chain(d.company, c => c.siret)
     ),
     destinationCompanyAddress: chain(destination, d =>
       chain(d.company, c => c.address)
@@ -323,8 +318,9 @@ function flattenBsdaDestinationInput({
     ),
     destinationCustomInfo: chain(destination, d => d.customInfo),
     destinationCap: chain(destination, d => d.cap),
-    destinationPlannedOperationCode: chain(destination, d =>
-      noEmptyString(d.plannedOperationCode)
+    destinationPlannedOperationCode: chain(
+      destination,
+      d => d.plannedOperationCode
     ),
     destinationReceptionDate: chain(destination, d =>
       chain(d.reception, r => r.date)
@@ -341,7 +337,7 @@ function flattenBsdaDestinationInput({
       chain(d.reception, r => r.refusalReason)
     ),
     destinationOperationCode: chain(destination, d =>
-      chain(d.operation, o => noEmptyString(o.code))
+      chain(d.operation, o => o.code)
     ),
     destinationOperationDescription: chain(destination, d =>
       chain(d.operation, o => o.description)
@@ -351,16 +347,12 @@ function flattenBsdaDestinationInput({
     ),
     destinationOperationNextDestinationCompanyName: chain(destination, d =>
       chain(d.operation, o =>
-        chain(o.nextDestination, nd =>
-          chain(nd.company, c => noEmptyString(c.name))
-        )
+        chain(o.nextDestination, nd => chain(nd.company, c => c.name))
       )
     ),
     destinationOperationNextDestinationCompanySiret: chain(destination, d =>
       chain(d.operation, o =>
-        chain(o.nextDestination, nd =>
-          chain(nd.company, c => noEmptyString(c.siret))
-        )
+        chain(o.nextDestination, nd => chain(nd.company, c => c.siret))
       )
     ),
     destinationOperationNextDestinationCompanyVatNumber: chain(destination, d =>
@@ -406,10 +398,10 @@ function flattenBsdaTransporterInput({
 }: Pick<BsdaInput, "transporter">) {
   return {
     transporterCompanyName: chain(transporter, t =>
-      chain(t.company, c => noEmptyString(c.name))
+      chain(t.company, c => c.name)
     ),
     transporterCompanySiret: chain(transporter, t =>
-      chain(t.company, c => noEmptyString(c.siret))
+      chain(t.company, c => c.siret)
     ),
     transporterCompanyAddress: chain(transporter, t =>
       chain(t.company, c => c.address)
@@ -455,12 +447,8 @@ function flattenBsdaTransporterInput({
 function flattenBsdaWorkerInput({ worker }: Pick<BsdaInput, "worker">) {
   return {
     workerIsDisabled: chain(worker, w => Boolean(w.isDisabled)),
-    workerCompanyName: chain(worker, w =>
-      chain(w.company, c => noEmptyString(c.name))
-    ),
-    workerCompanySiret: chain(worker, w =>
-      chain(w.company, c => noEmptyString(c.siret))
-    ),
+    workerCompanyName: chain(worker, w => chain(w.company, c => c.name)),
+    workerCompanySiret: chain(worker, w => chain(w.company, c => c.siret)),
     workerCompanyAddress: chain(worker, w => chain(w.company, c => c.address)),
     workerCompanyContact: chain(worker, w => chain(w.company, c => c.contact)),
     workerCompanyPhone: chain(worker, w => chain(w.company, c => c.phone)),
@@ -481,19 +469,15 @@ function flattenBsdaWorkerInput({ worker }: Pick<BsdaInput, "worker">) {
       chain(w.certification, c => c.validityLimit)
     ),
     workerCertificationOrganisation: chain(worker, w =>
-      chain(w.certification, c => noEmptyString(c.organisation))
+      chain(w.certification, c => c.organisation)
     )
   };
 }
 
 function flattenBsdaBrokerInput({ broker }: Pick<BsdaInput, "broker">) {
   return {
-    brokerCompanyName: chain(broker, b =>
-      chain(b.company, c => noEmptyString(c.name))
-    ),
-    brokerCompanySiret: chain(broker, b =>
-      chain(b.company, c => noEmptyString(c.siret))
-    ),
+    brokerCompanyName: chain(broker, b => chain(b.company, c => c.name)),
+    brokerCompanySiret: chain(broker, b => chain(b.company, c => c.siret)),
     brokerCompanyAddress: chain(broker, b => chain(b.company, c => c.address)),
     brokerCompanyContact: chain(broker, b => chain(b.company, c => c.contact)),
     brokerCompanyPhone: chain(broker, b => chain(b.company, c => c.phone)),
@@ -521,7 +505,7 @@ function flattenBsdaWeightInput({ weight }: Pick<BsdaInput, "weight">) {
 
 function flattenBsdaWasteInput({ waste }: Pick<BsdaInput, "waste">) {
   return {
-    wasteCode: chain(waste, w => noEmptyString(w.code)),
+    wasteCode: chain(waste, w => w.code),
     wasteAdr: chain(waste, w => w.adr),
     wasteFamilyCode: chain(waste, w => w.familyCode),
     // TODO: name is deprecated, but still supported as an input for now.
@@ -572,13 +556,13 @@ export function flattenBsdaRevisionRequestInput(
       chain(r.broker, b => chain(b.company, c => c.mail))
     ),
     brokerCompanyName: chain(reviewContent, r =>
-      chain(r.broker, b => chain(b.company, c => noEmptyString(c.name)))
+      chain(r.broker, b => chain(b.company, c => c.name))
     ),
     brokerCompanyPhone: chain(reviewContent, r =>
       chain(r.broker, b => chain(b.company, c => c.phone))
     ),
     brokerCompanySiret: chain(reviewContent, r =>
-      chain(r.broker, b => chain(b.company, c => noEmptyString(c.siret)))
+      chain(r.broker, b => chain(b.company, c => c.siret))
     ),
     brokerRecepisseNumber: chain(reviewContent, r =>
       chain(r.broker, b => chain(b.recepisse, re => re.number))
@@ -618,7 +602,7 @@ export function flattenBsdaRevisionRequestInput(
       []
     ),
     destinationOperationCode: chain(reviewContent, r =>
-      chain(r.destination, d => chain(d.operation, o => noEmptyString(o.code)))
+      chain(r.destination, d => chain(d.operation, o => o.code))
     ),
     destinationOperationDescription: chain(reviewContent, r =>
       chain(r.destination, d => chain(d.operation, o => o.description))

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -675,7 +675,7 @@ describe("Mutation.Bsda.create", () => {
     expect(data.createBsda.id).toBeDefined();
   });
 
-  it("should allow creating the bsda with type COLLECTION_2710 even if transporter and worker have empty strings as siret", async () => {
+  it("should not allow creating the bsda with type COLLECTION_2710 even if transporter and worker have empty strings as siret", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER", {
       companyTypes: { set: ["WASTE_CENTER"] }
     });
@@ -744,13 +744,13 @@ describe("Mutation.Bsda.create", () => {
     };
 
     const { mutate } = makeClient(user);
-    const { data } = await mutate<Pick<Mutation, "createBsda">>(CREATE_BSDA, {
+    const { errors } = await mutate<Pick<Mutation, "createBsda">>(CREATE_BSDA, {
       variables: {
         input
       }
     });
 
-    expect(data.createBsda.id).toBeDefined();
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it("should disallow creating a bsda with packaging OTHER and no description", async () => {

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -16,20 +16,7 @@ describe("BSDA validation", () => {
   afterEach(resetDatabase);
 
   describe("BSDA should be valid - transitory empty strings", () => {
-    test("when type is COLLECTION_2710 and unused company fields are empty strings", async () => {
-      // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
-      const { success } = await rawBsdaSchema.safeParseAsync({
-        ...bsda,
-        type: BsdaType.COLLECTION_2710,
-        transporterCompanySiret: "",
-        transporterCompanyName: "",
-        workerCompanyName: "",
-        workerCompanySiret: ""
-      });
-
-      expect(success).toEqual(true);
-    });
-    test("when type is COLLECTION_2710 and unused company fields are  empty nulls", async () => {
+    test("when type is COLLECTION_2710 and unused company fields are nulls", async () => {
       // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
       const { success } = await rawBsdaSchema.safeParseAsync({
         ...bsda,
@@ -84,6 +71,21 @@ describe("BSDA validation", () => {
 
   describe("BSDA should not be valid", () => {
     afterEach(resetDatabase);
+
+    test("when type is COLLECTION_2710 and unused company fields are empty strings", async () => {
+      // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
+      const { success } = await rawBsdaSchema.safeParseAsync({
+        ...bsda,
+        type: BsdaType.COLLECTION_2710,
+        transporterCompanySiret: "",
+        transporterCompanyName: "",
+        workerCompanyName: "",
+        workerCompanySiret: ""
+      });
+
+      expect(success).toEqual(false);
+    });
+
     test("when emitter siret is not valid", async () => {
       const data = {
         ...bsda,

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -18,7 +18,6 @@ import {
 } from "../../common/validation/siret";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { OPERATIONS, WORKER_CERTIFICATION_ORGANISM } from "./constants";
-import { noEmptyString } from "../../common/converter";
 
 const bsdaPackagingSchema = z
   .object({
@@ -238,8 +237,8 @@ export const rawBsdaSchema = z
 
     if (
       val.type === BsdaType.COLLECTION_2710 &&
-      (noEmptyString(val.transporterCompanyName) != null ||
-        noEmptyString(val.transporterCompanySiret) != null)
+      (val.transporterCompanyName != null ||
+        val.transporterCompanySiret != null)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -249,8 +248,7 @@ export const rawBsdaSchema = z
 
     if (
       val.type === BsdaType.COLLECTION_2710 &&
-      (noEmptyString(val.workerCompanyName) != null ||
-        noEmptyString(val.workerCompanySiret) != null)
+      (val.workerCompanyName != null || val.workerCompanySiret != null)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/back/src/common/converter.ts
+++ b/back/src/common/converter.ts
@@ -69,15 +69,17 @@ export function removeEmpty<T extends Record<string, unknown>>(
 
 /**
  * Equivalent to a typescript optional chaining operator foo?.bar
- * except that it returns "null" instead of "undefined" if "null" is encountered in the chain
+ * except that :
+ * - it returns "null" instead of "undefined" if "null" is encountered in the chain
+ * - it returns "null" instead of an empty string
  * It allows to differentiate between voluntary null update and field omission that should
- * not update any data
+ * not update any data, and treats empty string as null updates
  */
 export function chain<T, K>(
   o: T,
   getter: (o: NonNullable<T>) => K
 ): K | null | undefined {
-  if (o === null) {
+  if (o === null || o === "") {
     return null;
   }
   if (o === undefined) {
@@ -108,17 +110,6 @@ export function prismaJsonNoNull<I>(value: I) {
     return Prisma.JsonNull;
   }
 
-  return value;
-}
-
-/**
- * Returns null if the value is an empty string.
- * Otherwise returns the value.
- */
-export function noEmptyString(
-  value: string | null | undefined
-): string | null | undefined {
-  if (value === "") return null;
   return value;
 }
 


### PR DESCRIPTION
On applique un équivalent à emptyString au niveau de chain.
L'objectif est d'avoir des données propres en base, et de ne pas mélanger empty strings & null.

Les vérifications suivantes ont été faites sur le bsda pour s'assurer qu'on n'avait pas de donnée problématique:

```
SELECT count(*) from "default$default"."Bsda" b where "transporterCompanyName" = ''
SELECT count(*) from "default$default"."Bsda" b where "transporterCompanySiret" = ''
SELECT count(*) from "default$default"."Bsda" b where "workerCompanyName" = ''
SELECT count(*) from "default$default"."Bsda" b where "workerCompanySiret" = ''
```