### PR TITLE
Corrige le masquage du nom d'utilisateur

### DIFF
--- a/back/prisma/migrations/145_add_company_association_auto_acceptation.sql.sql
+++ b/back/prisma/migrations/145_add_company_association_auto_acceptation.sql.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    "default$default"."CompanyAssociation"
+ADD
+    COLUMN "automaticallyAccepted" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -247,13 +247,15 @@ model AnonymousCompany {
 }
 
 model CompanyAssociation {
-  id        String    @id @default(cuid())
-  role      UserRole
-  companyId String
-  company   Company   @relation(fields: [companyId], references: [id])
-  userId    String
-  user      User      @relation(fields: [userId], references: [id])
-  createdAt DateTime? @default(now()) @db.Timestamptz(6)
+  id                    String    @id @default(cuid())
+  role                  UserRole
+  companyId             String
+  company               Company   @relation(fields: [companyId], references: [id])
+  userId                String
+  user                  User      @relation(fields: [userId], references: [id])
+  createdAt             DateTime? @default(now()) @db.Timestamptz(6)
+  // Tell apart automatically accepted invitations from others
+  automaticallyAccepted Boolean   @default(false)
 
   @@index([userId], map: "_CompanyAssociationUserIdIdx")
   @@index([companyId], map: "_CompanyAssociationCompanyIdIdx")

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -16,7 +16,6 @@ import {
 import prisma from "../prisma";
 import { hashToken } from "../utils";
 import { createUser } from "../users/database";
-import { subMinutes } from "date-fns";
 
 /**
  * Create a user with name and email
@@ -128,11 +127,8 @@ export const userWithCompanyFactory = async (
   companyAssociationOpts: Partial<Prisma.CompanyAssociationCreateInput> = {}
 ): Promise<UserWithCompany> => {
   const company = await companyFactory(companyOpts);
-  // we fake a user created a few minutes ago to prevent their membership being considered as an auto-accepted invitation
-  const userCreatedAt = subMinutes(new Date(), 5);
 
   const user = await userFactory({
-    createdAt: userCreatedAt,
     ...userOpts,
     companyAssociations: {
       create: {

--- a/back/src/companies/resolvers/CompanyPrivate.ts
+++ b/back/src/companies/resolvers/CompanyPrivate.ts
@@ -23,7 +23,7 @@ const companyPrivateResolvers: CompanyPrivateResolvers = {
       ];
     }
 
-    return getCompanyUsers(parent.orgId, context.dataloaders);
+    return getCompanyUsers(parent.orgId, context.dataloaders, userId);
   },
   userRole: async (parent, _, context) => {
     const userId = context.user!.id;

--- a/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
@@ -152,7 +152,7 @@ describe("mutation acceptMembershipRequest", () => {
       expect(companyAssociations).toHaveLength(1);
       expect(companyAssociations[0].role).toEqual(role);
 
-      // when a new user is invited and accept invitaion, `automaticallyAccepted` is false
+      // when a new user is invited and accepts invitation, `automaticallyAccepted` is false
       expect(companyAssociations[0].automaticallyAccepted).toEqual(false);
 
       expect(sendMailSpy).toHaveBeenCalledWith(

--- a/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/acceptMembershipRequest.integration.ts
@@ -152,6 +152,9 @@ describe("mutation acceptMembershipRequest", () => {
       expect(companyAssociations).toHaveLength(1);
       expect(companyAssociations[0].role).toEqual(role);
 
+      // when a new user is invited and accept invitaion, `automaticallyAccepted` is false
+      expect(companyAssociations[0].automaticallyAccepted).toEqual(false);
+
       expect(sendMailSpy).toHaveBeenCalledWith(
         renderMail(membershipRequestAccepted, {
           to: [{ email: requester.email, name: requester.name }],

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
@@ -55,8 +55,6 @@ describe("mutation inviteUserToCompany", () => {
     expect(companyAssociations[0].automaticallyAccepted).toEqual(true);
     expect(companyAssociations[0].createdAt).toBeTruthy();
 
-    expect(companyAssociations[0].createdAt).toBeTruthy();
-
     const userCompany = await prisma.companyAssociation
       .findUniqueOrThrow({
         where: {

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
@@ -51,6 +51,10 @@ describe("mutation inviteUserToCompany", () => {
     expect(companyAssociations).toHaveLength(1);
     expect(companyAssociations[0].role).toEqual("MEMBER");
 
+    // when invited user was already on TD, `automaticallyAccepted` is true
+    expect(companyAssociations[0].automaticallyAccepted).toEqual(true);
+    expect(companyAssociations[0].createdAt).toBeTruthy();
+
     expect(companyAssociations[0].createdAt).toBeTruthy();
 
     const userCompany = await prisma.companyAssociation

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.test.ts
@@ -56,7 +56,9 @@ describe("inviteUserToCompany", () => {
       role: "MEMBER"
     });
 
-    expect(associateUserToCompanyMock).toBeCalledWith("id", siret, "MEMBER");
+    expect(associateUserToCompanyMock).toBeCalledWith("id", siret, "MEMBER", {
+      automaticallyAccepted: true
+    });
 
     expect(sendMailMock).toHaveBeenCalledWith(
       renderMail(notifyUserOfInvite, {

--- a/back/src/users/resolvers/mutations/inviteUserToCompanyService.ts
+++ b/back/src/users/resolvers/mutations/inviteUserToCompanyService.ts
@@ -34,7 +34,9 @@ export async function inviteUserToCompanyFn(
     // there is already an user with this email
     // associate the user with the company
 
-    await associateUserToCompany(existingUser.id, siret, role);
+    await associateUserToCompany(existingUser.id, siret, role, {
+      automaticallyAccepted: true
+    });
 
     const mail = renderMail(notifyUserOfInvite, {
       to: [{ email, name: existingUser.name }],


### PR DESCRIPTION
Corrige le masquage du nom d'utilisateur:

Lorsque etq utilisateur déjà inscrit sur TD, je suis invité sur un nouvel établissement:
   -  le mail que je reçois précise la conduite à tenir si cette invitation me paraît illégitime
    - mon nom et prénom ne sont visibles pour les tiers qu'après 7 jours

Retour à l'implémentation initiale:
- un boolean automaticallyAccepted est ajouté sur CompanyAssociation
- affichage d'une mention "Temporairement masqué" pendant 7 jours (laps de temps pour que l'utilisateur réagisse en cas d'invitation abusive)
- cette mention n'apparaît pas pour l'utilisateur concerné, ni sur les mail de refus DREAL

 
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10737)
