### PR TITLE
Tra-10736 - Ajout d'un entreposage provisoire

### DIFF
--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -81,13 +81,13 @@ export const editionRules: {
   ecoOrganismeSiret: { sealedBy: "TRANSPORT", isRequired: false },
   destinationCompanyName: { sealedBy: "EMISSION", isRequired: true },
   destinationCompanySiret: {
-    sealedBy: "EMISSION",
+    sealedBy: "TRANSPORT",
     isRequired: true
   },
-  destinationCompanyAddress: { sealedBy: "EMISSION", isRequired: true },
-  destinationCompanyContact: { sealedBy: "EMISSION", isRequired: true },
-  destinationCompanyPhone: { sealedBy: "EMISSION", isRequired: true },
-  destinationCompanyMail: { sealedBy: "EMISSION", isRequired: true },
+  destinationCompanyAddress: { sealedBy: "TRANSPORT", isRequired: true },
+  destinationCompanyContact: { sealedBy: "TRANSPORT", isRequired: true },
+  destinationCompanyPhone: { sealedBy: "TRANSPORT", isRequired: true },
+  destinationCompanyMail: { sealedBy: "TRANSPORT", isRequired: true },
   destinationCustomInfo: { sealedBy: "OPERATION", isRequired: false },
   destinationCap: {
     sealedBy: "EMISSION",

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -231,9 +231,9 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
 }
 
 /**
- * Destination is editable until TRANSPORT. But afer EMISSION:
- * - if you change the destination, the current destination must become the nextDestination
-   - if you change the nextDestination
+ * Destination is editable until TRANSPORT.
+ * But afer EMISSION, if you change the destination, the current destination must become the nextDestination.
+ * 
  * @param bsda 
  * @param currentSignatureType 
  * @param ctx 
@@ -243,7 +243,8 @@ async function validateDestination(
   currentSignatureType: BsdaSignatureType | undefined,
   ctx: RefinementCtx
 ) {
-  // If the bsda has no signature or is already transported, abort as the fields are not editable.
+  // If the bsda has no signature, fields are freeely editable.
+  // If the bsda is already transported, fields are not editable.
   if (
     currentSignatureType === undefined ||
     currentSignatureType === "OPERATION"

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -233,10 +233,10 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
 /**
  * Destination is editable until TRANSPORT.
  * But afer EMISSION, if you change the destination, the current destination must become the nextDestination.
- * 
- * @param bsda 
- * @param currentSignatureType 
- * @param ctx 
+ *
+ * @param bsda
+ * @param currentSignatureType
+ * @param ctx
  */
 async function validateDestination(
   bsda: ZodBsda,

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -83,6 +83,12 @@ function getContextualBsdaSchema(validationContext: BsdaValidationContext) {
       if (validationContext.enablePreviousBsdasChecks) {
         await validatePreviousBsdas(val, ctx);
       }
+
+      await validateDestination(
+        val,
+        validationContext.currentSignatureType,
+        ctx
+      );
     });
 }
 
@@ -221,5 +227,42 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
         fatal: true
       });
     }
+  }
+}
+
+/**
+ * Destination is editable until TRANSPORT. But afer EMISSION:
+ * - if you change the destination, the current destination must become the nextDestination
+   - if you change the nextDestination
+ * @param bsda 
+ * @param currentSignatureType 
+ * @param ctx 
+ */
+async function validateDestination(
+  bsda: ZodBsda,
+  currentSignatureType: BsdaSignatureType | undefined,
+  ctx: RefinementCtx
+) {
+  // If the bsda has no signature or is already transported, abort as the fields are not editable.
+  if (
+    currentSignatureType === undefined ||
+    currentSignatureType === "OPERATION"
+  ) {
+    return;
+  }
+
+  const { findUnique } = getReadonlyBsdaRepository();
+  const currentBsda = await findUnique({ id: bsda.id });
+
+  if (
+    currentBsda.destinationCompanySiret !== bsda.destinationCompanySiret &&
+    bsda.destinationOperationNextDestinationCompanySiret !==
+      currentBsda.destinationCompanySiret
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Impossible d'ajouter un intermédiaire d'entreposage provisoire sans indiquer la destination prévue initialement comment destination finale.`,
+      fatal: true
+    });
   }
 }

--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -255,6 +255,7 @@ async function validateDestination(
   const currentBsda = await findUnique({ id: bsda.id });
 
   if (
+    currentBsda &&
     currentBsda.destinationCompanySiret !== bsda.destinationCompanySiret &&
     bsda.destinationOperationNextDestinationCompanySiret !==
       currentBsda.destinationCompanySiret

--- a/front/src/form/bsda/FormContainer.tsx
+++ b/front/src/form/bsda/FormContainer.tsx
@@ -64,7 +64,7 @@ export default function FormContainer() {
                   <StepContainer
                     component={Destination}
                     title="Destination"
-                    disabled={disabledAfterEmission}
+                    disabled={transporterSigned}
                   />
                 </>
               );


### PR DESCRIPTION
On autorise à modifier la destination jusqu'à la signature transporteur, à condition que la destination devienne nextDestination

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10736)
