### PR TITLE
[tra-10736] - Glitch d'auto remplissage

### DIFF
--- a/front/src/form/bsda/stepper/steps/Emitter.tsx
+++ b/front/src/form/bsda/stepper/steps/Emitter.tsx
@@ -3,6 +3,7 @@ import { Field, useFormikContext } from "formik";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Bsda, BsdaType, BsdaPickupSite } from "generated/graphql/types";
 import WorkSite from "form/common/components/work-site/WorkSite";
+import { getInitialCompany } from "form/bsdd/utils/initial-state";
 
 export function Emitter({ disabled }) {
   const { values, handleChange, setFieldValue } = useFormikContext<Bsda>();
@@ -45,7 +46,7 @@ export function Emitter({ disabled }) {
               className="td-checkbox"
               onChange={e => {
                 handleChange(e);
-                setFieldValue("emitter.company.siret", null);
+                setFieldValue("emitter.company", getInitialCompany());
               }}
             />
             Le MOA ou le détenteur est un particulier


### PR DESCRIPTION
BSDA : Les Champs de contact du particulier ne devraient pas s'auto-remplir avec les infos de mes établissements favoris

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10473)
