### PR TITLE
Hotfix/ Date prise en charge BSDA

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -139,7 +139,7 @@ export function SignTransport({
             {({ isSubmitting, handleReset }) => (
               <Form>
                 <div className="tw-mb-6">
-                  <Transport disabled={false} />
+                  <Transport disabled={false} required={true} />
                 </div>
                 <div className="form__row">
                   <label>

--- a/front/src/form/bsda/stepper/steps/Transport.tsx
+++ b/front/src/form/bsda/stepper/steps/Transport.tsx
@@ -7,9 +7,9 @@ import { subMonths } from "date-fns";
 
 const TagsInput = lazy(() => import("common/components/tags-input/TagsInput"));
 
-type Props = { disabled: boolean };
+type Props = { disabled: boolean; required?: boolean };
 
-export function Transport({ disabled }: Props) {
+export function Transport({ disabled, required = false }: Props) {
   const TODAY = new Date();
 
   return (
@@ -49,7 +49,7 @@ export function Transport({ disabled }: Props) {
             disabled={disabled}
             minDate={subMonths(TODAY, 2)}
             maxDate={TODAY}
-            required
+            required={required}
           />
         </label>
       </div>


### PR DESCRIPTION
La date de prise en charge est obligatoire même en brouillon, bloquant l'avancée sur le formulaire.

cf https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12200