### PR TITLE
[BUGFIX] L'envoi de mails de rappels ne devrait pas crasher si une entreprise a été supprimée

### DIFF
--- a/back/src/commands/__tests__/onboarding.helpers.integration.ts
+++ b/back/src/commands/__tests__/onboarding.helpers.integration.ts
@@ -31,7 +31,6 @@ import {
   Mutation,
   MutationDeleteCompanyArgs
 } from "../../generated/graphql/types";
-import { DELETE_COMPANY } from "../../companies/resolvers/mutations/__tests__/deleteCompany.integration";
 import makeClient from "../../__tests__/testClient";
 
 const TODAY = new Date();
@@ -39,6 +38,14 @@ const ONE_DAY_AGO = xDaysAgo(TODAY, 1);
 const TWO_DAYS_AGO = xDaysAgo(TODAY, 2);
 const THREE_DAYS_AGO = xDaysAgo(TODAY, 3);
 const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
+
+export const DELETE_COMPANY = `
+  mutation DeleteCompany($id: ID!) {
+    deleteCompany(id: $id) {
+      id
+    }
+  }
+`;
 
 describe("getRecentlyRegisteredUsersWithNoCompanyNorMembershipRequest", () => {
   afterEach(resetDatabase);

--- a/back/src/commands/onboarding.helpers.ts
+++ b/back/src/commands/onboarding.helpers.ts
@@ -399,7 +399,10 @@ export const addPendingApprovalsCompanyAdmins = async (
       ...request,
       approvals: request.approvals
         .filter(
-          approval => approval.status === RevisionRequestApprovalStatus.PENDING
+          approval =>
+            approval.status === RevisionRequestApprovalStatus.PENDING &&
+            // Make sure company exists. May have been deleted.
+            Boolean(companiesAndAdminsByOrgIds[approval.approverSiret])
         )
         .map(approval => ({
           ...approval,
@@ -471,6 +474,7 @@ export const sendPendingRevisionRequestToAdminDetailsEmail = async (
   if (requests.length) {
     // Build a message template for each request, for each approval
     const messageVersions: MessageVersion[] = requests
+      .filter(request => request.approvals.length !== 0)
       .map(request => {
         return request.approvals.map(approval => {
           const variables = {

--- a/back/src/companies/resolvers/mutations/__tests__/deleteCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/deleteCompany.integration.ts
@@ -8,7 +8,7 @@ import prisma from "../../../../prisma";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 
-export const DELETE_COMPANY = `
+const DELETE_COMPANY = `
   mutation DeleteCompany($id: ID!) {
     deleteCompany(id: $id) {
       id

--- a/back/src/companies/resolvers/mutations/__tests__/deleteCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/deleteCompany.integration.ts
@@ -8,7 +8,7 @@ import prisma from "../../../../prisma";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 
-const DELETE_COMPANY = `
+export const DELETE_COMPANY = `
   mutation DeleteCompany($id: ID!) {
     deleteCompany(id: $id) {
       id


### PR DESCRIPTION
# Contexte

Bug remonté par Benoît, cf [détails dans Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/38873/?environment=production&project=19&query=is%3Aunresolved&referrer=issue-stream).

A priori il est possible que pour une `RequestApproval` donnée, le `approverSiret` ne corresponde à aucune entreprise. J'ai vérifié le code de suppression d'une entreprise et on ne supprime pas les `RevisionRequests`.

![Capture d’écran 2023-06-28 à 08 57 35](https://github.com/MTES-MCT/trackdechets/assets/45355989/ab53cfc7-fb82-442f-9a15-b67f89a59a09)

# Solution

Filtrer les `requestApprovals` dont le siret ne correspond à aucune entreprise.

