### PR TITLE
HOTFIX / BSDD pdf

### DIFF
--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -279,7 +279,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
 
   const form: GraphQLForm = {
     ...(await expandFormFromDb(fullPrismaForm)),
-    transportSegments: fullPrismaForm.transporters?.map(
+    transportSegments: fullPrismaForm.transporters?.filter(transporter => transporter.number >= 2).map(
       expandTransportSegmentFromDb
     ),
     grouping: await Promise.all(


### PR DESCRIPTION
Hotfix BSDD PDF. La page de transport multimodal apparaissait meme quand on avait un seul transproteur