### PR TITLE
[TRA-11257] Auto-completion des récépissés Transporteurs Tous BSD

### DIFF
--- a/back/src/__tests__/factories.integration.ts
+++ b/back/src/__tests__/factories.integration.ts
@@ -6,6 +6,7 @@ import {
   siretify,
   statusLogFactory,
   transportSegmentFactory,
+  transporterReceiptFactory,
   userFactory,
   userWithCompanyFactory
 } from "./factories";
@@ -160,4 +161,16 @@ test("should create a transport segment", async () => {
     .findUnique({ where: { id: frm.id } })
     .transporters({ where: { number: { gte: 2 } } });
   expect(transporters!.length).toEqual(1);
+});
+
+test("should create a transporter receipt and associate it to a company", async () => {
+  const company = await companyFactory();
+
+  const receipt = await transporterReceiptFactory({ company });
+
+  const retrievedCompany = await prisma.company.findUnique({
+    where: { id: company.id }
+  });
+
+  expect(retrievedCompany?.transporterReceiptId).toEqual(receipt.id);
 });

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -527,3 +527,29 @@ export const toIntermediaryCompany = (company: Company, contact = "toto") => ({
   address: company.address,
   contact
 });
+
+export const transporterReceiptFactory = async ({
+  number = "the number",
+  department = "83",
+  company
+}: {
+  number?: string;
+  department?: string;
+  company?: Company;
+}) => {
+  const receipt = await prisma.transporterReceipt.create({
+    data: {
+      receiptNumber: number,
+      validityLimit: "2055-01-01T00:00:00.000Z",
+      department: department
+    }
+  });
+  if (!!company) {
+    await prisma.company.update({
+      where: { id: company.id },
+      data: { transporterReceipt: { connect: { id: receipt.id } } }
+    });
+  }
+
+  return receipt;
+};

--- a/back/src/__tests__/testWorkflow.ts
+++ b/back/src/__tests__/testWorkflow.ts
@@ -1,5 +1,10 @@
+import { isForeignVat } from "../common/constants/companySearchHelpers";
 import { Workflow } from "../common/workflow";
-import { userWithCompanyFactory, ecoOrganismeFactory } from "./factories";
+import {
+  userWithCompanyFactory,
+  ecoOrganismeFactory,
+  transporterReceiptFactory
+} from "./factories";
 import makeClient from "./testClient";
 
 async function testWorkflow(workflow: Workflow) {
@@ -16,7 +21,13 @@ async function testWorkflow(workflow: Workflow) {
       // create ecoOrganisme to allow its user to perform api calls
       await ecoOrganismeFactory({ siret: company.siret!, handleBsdasri: true });
     }
-
+    if (
+      workflowCompany.companyTypes.includes("TRANSPORTER") &&
+      !isForeignVat(company.vatNumber)
+    ) {
+      // create transporter receipt
+      await transporterReceiptFactory({ company });
+    }
     context = { ...context, [workflowCompany.name]: { ...company, user } };
   }
 

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -9,7 +9,10 @@ import {
   MutationUpdateBsdaArgs
 } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
-import { userWithCompanyFactory } from "../../../__tests__/factories";
+import {
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
 import makeClient from "../../../__tests__/testClient";
 import { getStream } from "../../data";
 
@@ -55,6 +58,7 @@ describe("ActivityEvent.Bsda", () => {
         companyTypes: { set: ["WASTEPROCESSOR", "TRANSPORTER"] }
       }
     );
+    await transporterReceiptFactory({ company: destinationCompany });
     const { mutate } = makeClient(user);
 
     // Create Bsda
@@ -105,11 +109,6 @@ describe("ActivityEvent.Bsda", () => {
             }
           },
           transporter: {
-            recepisse: {
-              number: "AA84",
-              department: "82",
-              validityLimit: "2018-12-11T00:00:00.000Z" as any
-            },
             transport: {
               plates: ["12345"]
             },
@@ -283,11 +282,6 @@ describe("ActivityEvent.Bsda", () => {
             }
           },
           transporter: {
-            recepisse: {
-              number: "AA84",
-              department: "82",
-              validityLimit: "2018-12-11T00:00:00.000Z" as any
-            },
             transport: {
               plates: ["12345"]
             },

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -7,7 +7,9 @@ import {
 import prisma from "../../../prisma";
 import {
   formFactory,
-  userWithCompanyFactory
+  userWithCompanyFactory,
+  transporterReceiptFactory,
+  companyFactory
 } from "../../../__tests__/factories";
 import makeClient from "../../../__tests__/testClient";
 import { getStream } from "../../data";
@@ -56,6 +58,12 @@ describe("ActivityEvent.Bsdd", () => {
         companyTypes: { set: ["WASTEPROCESSOR", "TRANSPORTER"] }
       }
     );
+    const transporterCompany = await companyFactory({
+      companyTypes: { set: ["TRANSPORTER"] }
+    });
+    await transporterReceiptFactory({
+      company: transporterCompany
+    });
     const { mutate } = makeClient(user);
 
     // Create form
@@ -94,13 +102,10 @@ describe("ActivityEvent.Bsdd", () => {
             isTempStorage: false
           },
           transporter: {
-            receipt: "sdfg",
-            department: "82",
-            validityLimit: "2018-12-11T00:00:00.000Z",
             numberPlate: "12345",
             company: {
-              name: destinationCompany.name,
-              siret: destinationCompany.siret,
+              name: transporterCompany.name,
+              siret: transporterCompany.siret,
               address: "8 rue du Général de Gaulle",
               contact: "Transporteur",
               phone: "03",

--- a/back/src/bsda/__tests__/workflow.integration.ts
+++ b/back/src/bsda/__tests__/workflow.integration.ts
@@ -3,7 +3,10 @@ import { User } from "@prisma/client";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { app } from "../../server";
 import { createAccessToken } from "../../users/database";
-import { userWithCompanyFactory } from "../../__tests__/factories";
+import {
+  userWithCompanyFactory,
+  transporterReceiptFactory
+} from "../../__tests__/factories";
 
 const request = supertest(app);
 
@@ -202,17 +205,13 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
     expect(exutoireSignatureResponse.body.data.signBsda.status).toBe(
       "SIGNED_BY_WORKER"
     );
-
+    // le transporteur renseigne son récépissé juste avant signature.
+    await transporterReceiptFactory({ company: transporterCompany });
     // Ensuite le transporteur édite ses données, puis signe
     const transporterBsdaQuery = `
         mutation {
             updateBsda(id: "${id}", input: {
               transporter: {
-                recepisse: {
-                  number: "recepisse number"
-                  department: "75"
-                  validityLimit: "2020-06-30"
-                }
                 transport: {
                   mode: ROAD,
                   plates: ["AA-XX-00"]
@@ -395,17 +394,13 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
     expect(workerSignatureResponse.body.data.signBsda.status).toBe(
       "SIGNED_BY_WORKER"
     );
-
+    // le transporteur renseigne son récépissé juste avant signature.
+    await transporterReceiptFactory({ company: transporterCompany });
     // Ensuite le transporteur édite ses données, puis signe
     const transporterBsdaQuery = `
         mutation {
             updateBsda(id: "${id}", input: {
               transporter: {
-                recepisse: {
-                  number: "recepisse number"
-                  department: "75"
-                  validityLimit: "2020-06-30"
-                }
                 transport: {
                   mode: ROAD,
                   plates: ["AA-XX-00"]

--- a/back/src/bsda/examples/fixtures.ts
+++ b/back/src/bsda/examples/fixtures.ts
@@ -79,16 +79,9 @@ function transporterCompanyInput(siret: string) {
   };
 }
 
-const recepisseInput = {
-  number: "12379",
-  department: "07",
-  validityLimit: "2020-06-30"
-};
-
 function transporterInput(siret: string) {
   return {
-    company: transporterCompanyInput(siret),
-    recepisse: recepisseInput
+    company: transporterCompanyInput(siret)
   };
 }
 
@@ -167,7 +160,6 @@ function destinationSignatureUpdateInput() {
 function transporterToGroupInput(siret: string) {
   return {
     company: transporterCompanyInput(siret),
-    recepisse: recepisseInput,
     transport: {
       mode: "ROAD",
       plates: ["abc21cde"],

--- a/back/src/bsda/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsda/examples/fixturesForeignTransporter.ts
@@ -32,8 +32,7 @@ function transporterCompanyInput(vatNumber: string) {
 
 function transporterInput(vatNumber: string) {
   return {
-    company: transporterCompanyInput(vatNumber),
-    recepisse: null
+    company: transporterCompanyInput(vatNumber)
   };
 }
 

--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -11,7 +11,7 @@ export const Metadata: BsdaMetadataResolvers = {
   errors: async (
     metadata: BsdaMetadata & { id: string; status: BsdaStatus }
   ) => {
-    const prismaForm = await getBsdaOrNotFound(metadata.id);
+    const prismaBsda = await getBsdaOrNotFound(metadata.id);
 
     const validationMatrix = [
       {
@@ -46,7 +46,9 @@ export const Metadata: BsdaMetadataResolvers = {
     );
     for (const { currentSignatureType } of filteredValidationMatrix) {
       try {
-        await parseBsda(prismaForm, { currentSignatureType });
+        await parseBsda(prismaBsda, {
+          currentSignatureType
+        });
         return [];
       } catch (errors) {
         return errors.inner?.map(e => {

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -34,7 +34,6 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
   const user = checkIsAuthenticated(context);
 
   await checkCanCreate(user, input);
-
   const companies = await getUserCompanies(user.id);
   const destinationCompany = companies.find(
     company => company.siret === input.destination?.company?.siret
@@ -52,7 +51,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
   const bsda = await parseBsda(
     { ...unparsedBsda, isDraft },
     {
-      enableSirenification: true,
+      enableCompletionTransformers: true,
       enablePreviousBsdasChecks: !canBypassSirenify(user),
       currentSignatureType: !isDraft ? "EMISSION" : undefined
     }

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -36,7 +36,7 @@ export default async function edit(
     forwarding: input.forwarding || existingBsda.forwarding?.id
   };
   const bsda = await parseBsda(unparsedBsda, {
-    enableSirenification: !canBypassSirenify(user),
+    enableCompletionTransformers: !canBypassSirenify(user),
     enablePreviousBsdasChecks: true,
     currentSignatureType: getCurrentSignatureType(unparsedBsda)
   });

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -323,6 +323,17 @@ input BsdaRecepisseInput {
   "Exemption de récépissé (conformément aux dispositions de l'article R.541-50 du code de l'environnement)"
   isExempted: Boolean
   "Numéro de récépissé"
+  number: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
+  "Département"
+  department: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
+  "Date limite de validité"
+  validityLimit: DateTime @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
+}
+
+input BsdaBrokerRecepisseInput {
+  "Exemption de récépissé (conformément aux dispositions de l'article R.541-50 du code de l'environnement)"
+  isExempted: Boolean
+  "Numéro de récépissé"
   number: String
   "Département"
   department: String
@@ -343,7 +354,7 @@ input BsdaBrokerInput {
   "Coordonnées de l'entreprise courtier"
   company: CompanyInput
   "Récépissé courtier"
-  recepisse: BsdaRecepisseInput
+  recepisse: BsdaBrokerRecepisseInput
 }
 
 input BsdaSignatureInput {

--- a/back/src/bsda/validation/__tests__/edition.test.ts
+++ b/back/src/bsda/validation/__tests__/edition.test.ts
@@ -42,11 +42,10 @@ describe("edition", () => {
       omiNumber: ""
     };
 
-    const recepisse: Required<BsdaRecepisseInput> = {
-      isExempted: true,
-      number: "",
-      department: "",
-      validityLimit: new Date()
+    const recepisse: Required<
+      Omit<BsdaRecepisseInput, "number" | "department" | "validityLimit">
+    > = {
+      isExempted: true
     };
 
     const pickupSite: Required<PickupSiteInput> = {

--- a/back/src/bsda/validation/__tests__/transformers.integration.ts
+++ b/back/src/bsda/validation/__tests__/transformers.integration.ts
@@ -1,0 +1,76 @@
+import { runTransformers } from "../transformers";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../../__tests__/factories";
+import { bsdaFactory } from "../../__tests__/factories";
+
+describe("BSDA Zod transformers", () => {
+  describe("recipisseTransporterTransformer", () => {
+    it("runTransformers should correctly process input and return completedInput with transporter receipt", async () => {
+      const company = await companyFactory();
+      const receipt = await transporterReceiptFactory({ company });
+      const bsda = await bsdaFactory({
+        opt: {
+          transporterCompanySiret: company.siret,
+          transporterCompanyVatNumber: company.vatNumber,
+          transporterRecepisseIsExempted: false,
+          transporterRecepisseNumber: null,
+          transporterRecepisseDepartment: null,
+          transporterRecepisseValidityLimit: null
+        }
+      });
+
+      const completedInput = await runTransformers(bsda as any, []);
+      expect(completedInput).toMatchObject({
+        transporterRecepisseIsExempted: false,
+        transporterRecepisseNumber: receipt.receiptNumber,
+        transporterRecepisseDepartment: receipt.department,
+        transporterRecepisseValidityLimit: receipt.validityLimit
+      });
+    });
+
+    it("runTransformers should remove receipt from BSDA when TransporterReceipt does not exist", async () => {
+      const company = await companyFactory();
+      const bsda = await bsdaFactory({
+        opt: {
+          transporterCompanySiret: company.siret,
+          transporterCompanyVatNumber: company.vatNumber,
+          transporterRecepisseIsExempted: false,
+          transporterRecepisseNumber: "null",
+          transporterRecepisseDepartment: "42",
+          transporterRecepisseValidityLimit: new Date()
+        }
+      });
+
+      const completedInput = await runTransformers(bsda as any, []);
+      expect(completedInput).toMatchObject({
+        transporterRecepisseIsExempted: false,
+        transporterRecepisseNumber: null,
+        transporterRecepisseDepartment: null,
+        transporterRecepisseValidityLimit: null
+      });
+    });
+    it("runTransformers should correctly process Input with isExempted true and return completedInput without transporter recepisse", async () => {
+      const company = await companyFactory();
+      const bsda = await bsdaFactory({
+        opt: {
+          transporterCompanySiret: company.siret,
+          transporterCompanyVatNumber: company.vatNumber,
+          transporterRecepisseIsExempted: true,
+          transporterRecepisseNumber: null,
+          transporterRecepisseDepartment: null,
+          transporterRecepisseValidityLimit: null
+        }
+      });
+
+      const completedInput = await runTransformers(bsda as any, []);
+      expect(completedInput).toMatchObject({
+        transporterRecepisseIsExempted: true,
+        transporterRecepisseNumber: null,
+        transporterRecepisseDepartment: null,
+        transporterRecepisseValidityLimit: null
+      });
+    });
+  });
+});

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -300,10 +300,12 @@ describe("BSDA validation", () => {
       };
 
       try {
-        await parseBsda(data, { currentSignatureType: "TRANSPORT" });
+        await parseBsda(data, {
+          currentSignatureType: "TRANSPORT"
+        });
       } catch (error) {
         expect(error.issues[0].message).toBe(
-          "Le numéro de récépissé transporteur est obligatoire."
+          "Transporteur: le numéro de récépissé est obligatoire. L'établissement doit renseigner son récépissé dans Trackdéchets"
         );
       }
     });
@@ -381,7 +383,9 @@ describe("BSDA validation", () => {
       expect.assertions(1);
 
       try {
-        await parseBsda(data);
+        await parseBsda(data, {
+          currentSignatureType: "TRANSPORT"
+        });
       } catch (error) {
         expect(error.issues[0].message).toBe(
           `Le transporteur saisi sur le bordereau (SIRET: ${emitterAndTransporter.siret}) n'est pas inscrit sur Trackdéchets en tant qu'entreprise de transport.` +

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -37,6 +37,7 @@ export const editionRules: {
     isRequired: boolean | ((val: ZodBsda) => boolean); // Whether or not the field is required when sealed. The rule can depend on other fields
     superRefineWhenSealed?: (val: ZodBsda[Key], ctx: RefinementCtx) => void; // For custom rules to apply when the field is sealed
     name?: string; // A custom field name for errors
+    suffix?: string; // A custom message at the end of the error
   };
 } = {
   type: { sealedBy: "EMISSION", isRequired: true },
@@ -203,7 +204,8 @@ export const editionRules: {
       hasTransporter(bsda) &&
       !bsda.transporterRecepisseIsExempted &&
       !isForeignVat(bsda.transporterCompanyVatNumber),
-    name: "le numéro de récépissé transporteur"
+    name: "Transporteur: le numéro de récépissé",
+    suffix: " L'établissement doit renseigner son récépissé dans Trackdéchets"
   },
   transporterRecepisseDepartment: {
     sealedBy: "TRANSPORT",
@@ -211,7 +213,8 @@ export const editionRules: {
       hasTransporter(bsda) &&
       !bsda.transporterRecepisseIsExempted &&
       !isForeignVat(bsda.transporterCompanyVatNumber),
-    name: "le département de récépissé transporteur"
+    name: "Transporteur: le département de récépissé",
+    suffix: " L'établissement doit renseigner son récépissé dans Trackdéchets"
   },
   transporterRecepisseValidityLimit: {
     sealedBy: "TRANSPORT",
@@ -219,7 +222,8 @@ export const editionRules: {
       hasTransporter(bsda) &&
       !bsda.transporterRecepisseIsExempted &&
       !isForeignVat(bsda.transporterCompanyVatNumber),
-    name: "la date de validité du récépissé transporteur"
+    name: "Transporteur: la date de validité du récépissé",
+    suffix: " L'établissement doit renseigner son récépissé dans Trackdéchets"
   },
   transporterTransportMode: {
     sealedBy: "TRANSPORT",

--- a/back/src/bsda/validation/transformers.ts
+++ b/back/src/bsda/validation/transformers.ts
@@ -1,20 +1,32 @@
+import { getTransporterCompanyOrgId } from "../../common/constants/companySearchHelpers";
 import prisma from "../../prisma";
 import { ZodBsda } from "./schema";
+import { sirenify } from "./sirenify";
 
 /**
  *
- * @param val Runs a bunch (currently one) function to enrich bsda input with computed values
+ * @param val Runs a bunch function to enrich bsda input with computed values
  * @returns
  */
-export const runTransformers = async (val: ZodBsda): Promise<ZodBsda> => {
-  const transformers = [reshipmentBsdaTransformer];
+export const runTransformers = async (
+  val: ZodBsda,
+  sealedFields: string[] // Tranformations should not be run on sealed fields
+): Promise<ZodBsda> => {
+  const transformers = [
+    reshipmentBsdaTransformer,
+    sirenify,
+    recipisseTransporterTransformer
+  ];
   for (const transformer of transformers) {
-    val = await transformer(val);
+    val = await transformer(val, sealedFields);
   }
   return val;
 };
 
-const reshipmentBsdaTransformer = async (val: ZodBsda): Promise<ZodBsda> => {
+async function reshipmentBsdaTransformer(
+  val: ZodBsda,
+  _: string[]
+): Promise<ZodBsda> {
   if (
     val.type === "RESHIPMENT" &&
     !val?.wasteConsistence &&
@@ -28,4 +40,31 @@ const reshipmentBsdaTransformer = async (val: ZodBsda): Promise<ZodBsda> => {
     }
   }
   return val;
-};
+}
+
+async function recipisseTransporterTransformer(
+  val: ZodBsda,
+  _: string[]
+): Promise<ZodBsda> {
+  const orgId = getTransporterCompanyOrgId({
+    transporterCompanySiret: val.transporterCompanySiret ?? null,
+    transporterCompanyVatNumber: val.transporterCompanyVatNumber ?? null
+  });
+
+  if (!val.transporterRecepisseIsExempted && orgId) {
+    const transporterReceipt = await prisma.company
+      .findUnique({
+        where: {
+          orgId
+        }
+      })
+      .transporterReceipt();
+
+    val.transporterRecepisseNumber = transporterReceipt?.receiptNumber ?? null;
+    val.transporterRecepisseValidityLimit =
+      transporterReceipt?.validityLimit ?? null;
+    val.transporterRecepisseDepartment = transporterReceipt?.department ?? null;
+  }
+
+  return val;
+}

--- a/back/src/bsdasris/__tests__/edition.test.ts
+++ b/back/src/bsdasris/__tests__/edition.test.ts
@@ -37,11 +37,10 @@ describe("edition", () => {
       vatNumber: ""
     };
 
-    const recepisse: Required<BsdasriRecepisseInput> = {
-      isExempted: false,
-      number: "",
-      department: "",
-      validityLimit: new Date("2022-01-01")
+    const recepisse: Required<
+      Omit<BsdasriRecepisseInput, "number" | "department" | "validityLimit">
+    > = {
+      isExempted: false
     };
 
     const packaging: Required<BsdasriPackagingsInput> = {

--- a/back/src/bsdasris/__tests__/factories.ts
+++ b/back/src/bsdasris/__tests__/factories.ts
@@ -83,6 +83,7 @@ export const readyToTakeOverData = company => ({
   transporterCompanyPhone: "987654534",
   transporterCompanyContact: "Contact",
   transporterCompanyMail: "transporter@test.fr",
+  // ignored and deprecated fields
   transporterRecepisseNumber: "xyz",
   transporterRecepisseDepartment: "83",
   transporterRecepisseValidityLimit: new Date(),

--- a/back/src/bsdasris/__tests__/recipify.integration.ts
+++ b/back/src/bsdasris/__tests__/recipify.integration.ts
@@ -1,0 +1,47 @@
+import { recipify } from "../recipify";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../__tests__/factories";
+
+describe("Bsdasri Recipify Module", () => {
+  it("recipify should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        recepisse: {
+          isExempted: false
+        }
+      }
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipify(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: mockInput.transporter.company,
+        recepisse: {
+          isExempted: false,
+          department: receipt.department,
+          number: receipt.receiptNumber,
+          validityLimit: receipt.validityLimit
+        }
+      }
+    });
+  });
+
+  it("recipify should correctly process Input with isExempted true and return completedInput without transporter recepisse", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company: company,
+        recepisse: {
+          isExempted: true
+        }
+      }
+    };
+
+    const completedInput = await recipify(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -152,11 +152,13 @@ describe("Mutation.signBsdasri emission", () => {
           transportSignature: true
         });
       } catch (err) {
-        expect(err.errors).toEqual([
-          "Transporteur: le département associé au récépissé est obligatoire",
-          "Transporteur: le numéro de récépissé est obligatoire",
-          "Transporteur: la date limite de validité du récépissé est obligatoire"
-        ]);
+        expect(err.errors).toEqual(
+          expect.arrayContaining([
+            "Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+            "Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+            "Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+          ])
+        );
       }
     });
 

--- a/back/src/bsdasris/examples/fixtures.ts
+++ b/back/src/bsdasris/examples/fixtures.ts
@@ -46,16 +46,9 @@ function transporteurCompanyInput(siret: string) {
   };
 }
 
-const recepisseInput = {
-  number: "KIH-458-87",
-  department: "07",
-  validityLimit: "2022-01-01"
-};
-
 function transporterInput(siret: string) {
   return {
-    company: transporteurCompanyInput(siret),
-    recepisse: recepisseInput
+    company: transporteurCompanyInput(siret)
   };
 }
 

--- a/back/src/bsdasris/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsdasris/examples/fixturesForeignTransporter.ts
@@ -29,8 +29,7 @@ function transporteurCompanyInput(vatNumber: string) {
 
 function transporterInput(vatNumber: string) {
   return {
-    company: transporteurCompanyInput(vatNumber),
-    recepisse: null
+    company: transporteurCompanyInput(vatNumber)
   };
 }
 

--- a/back/src/bsdasris/fragments.ts
+++ b/back/src/bsdasris/fragments.ts
@@ -80,6 +80,7 @@ export const fullBsdasriFragment = gql`
         number
         department
         validityLimit
+        isExempted
       }
       transport {
         handedOverAt

--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   Document,
   formatDate,
@@ -9,12 +9,14 @@ import {
   Bsdasri,
   InitialBsdasri,
   BsdasriSignature,
-  Maybe
+  Maybe,
+  BsdaRecepisse
 } from "../../../generated/graphql/types";
 import { TraceabilityTable } from "./TraceabilityTable";
 import { PackagingInfosTable } from "./PackagingInfosTable";
 import { FormCompanyFields } from "./FormCompanyFields";
 import { BsdasriType } from "@prisma/client";
+import { Recepisse } from "../../../bsda/pdf/components/Recepisse";
 
 /**
  *
@@ -240,17 +242,17 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
             </p>
             <FormCompanyFields company={bsdasri.transporter?.company} />
             <p>
-              <strong>Récépissé</strong> <br />
-              <span>Numéro : {bsdasri?.transporter?.recepisse?.number}</span>
-              <br />
-              <span>
-                Département: {bsdasri?.transporter?.recepisse?.department}
-              </span>
-              <span> - </span>
-              <span>
-                Validité:{" "}
-                {formatDate(bsdasri?.transporter?.recepisse?.validityLimit)}
-              </span>
+              {bsdasri?.transporter?.recepisse?.isExempted ? (
+                <p>
+                  Le transporteur déclare être exempté de récépissé conformément
+                  aux dispositions de l'article R.541-50 du code de
+                  l'environnement.
+                </p>
+              ) : (
+                <Recepisse
+                  recepisse={bsdasri?.transporter?.recepisse as BsdaRecepisse}
+                />
+              )}
             </p>
             <p>
               Mode de transport:{" "}

--- a/back/src/bsdasris/recipify.ts
+++ b/back/src/bsdasris/recipify.ts
@@ -1,0 +1,55 @@
+import {
+  BsdasriInput,
+  BsdasriRecepisseInput
+} from "../generated/graphql/types";
+import { recipifyGeneric } from "../companies/recipify";
+import {
+  autocompletedRecepisse,
+  genericGetter
+} from "../common/validation/recipify";
+import { Bsda, Bsdasri, Bsvhu } from "@prisma/client";
+import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
+import prisma from "../prisma";
+
+const dasriAccessors = (input: BsdasriInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (input: BsdasriInput, recepisseInput: BsdasriRecepisseInput) => ({
+      ...input,
+      transporter: {
+        company: input.transporter?.company,
+        transport: input.transporter?.transport,
+        customInfo: input.transporter?.customInfo,
+        recepisse: autocompletedRecepisse(input, recepisseInput)
+      }
+    })
+  }
+];
+
+export const recipify = recipifyGeneric(dasriAccessors);
+
+export interface BsdTransporterReceiptPart {
+  transporterRecepisseNumber: string | null;
+  transporterRecepisseDepartment: string | null;
+  transporterRecepisseValidityLimit: Date | null;
+}
+
+export async function getTransporterReceipt(
+  existingBsd: Bsdasri | Bsvhu | Bsda
+): Promise<BsdTransporterReceiptPart> {
+  // fetch TransporterReceipt
+  const orgId = getTransporterCompanyOrgId(existingBsd);
+  let transporterReceipt;
+  if (orgId) {
+    transporterReceipt = await prisma.company
+      .findUnique({
+        where: { orgId }
+      })
+      .transporterReceipt();
+  }
+  return {
+    transporterRecepisseNumber: transporterReceipt?.receiptNumber ?? null,
+    transporterRecepisseDepartment: transporterReceipt?.department ?? null,
+    transporterRecepisseValidityLimit: transporterReceipt?.validityLimit ?? null
+  };
+}

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriSynthesis.integration.ts
@@ -78,11 +78,6 @@ describe("Mutation.createDasri", () => {
           phone: "06 18 76 02 00",
           mail: "transporteur@test.fr",
           address: "avenue de la mer"
-        },
-        recepisse: {
-          number: "abcd",
-          department: "21",
-          validityLimit: new Date().toISOString()
         }
       },
       ...(await getDestinationCompanyInfo()),

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
@@ -1,5 +1,8 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { BsdasriStatus, WasteAcceptationStatus } from "@prisma/client";
 import {
@@ -23,7 +26,7 @@ describe("Mutation.signBsdasri transport", () => {
     const { company: destinationCompany } = await userWithCompanyFactory(
       "MEMBER"
     );
-
+    await transporterReceiptFactory({ company: transporterCompany });
     const dasri = await bsdasriFactory({
       opt: {
         ...initialData(emitterCompany),
@@ -54,6 +57,82 @@ describe("Mutation.signBsdasri transport", () => {
     expect(readyTotakeOverDasri.transportSignatoryId).toEqual(transporter.id);
   });
 
+  it("should put transport signature on a SIGNED_BY_PRODUCER dasri", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { user: transporter, company: transporterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        emitterEmissionSignatureDate: new Date(),
+        transporterRecepisseIsExempted: true,
+        emitterEmissionSignatureAuthor: "Producteur",
+        status: BsdasriStatus.SIGNED_BY_PRODUCER
+      }
+    });
+    const { mutate } = makeClient(transporter); // transporter
+
+    await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "TRANSPORT", author: "Jimmy" }
+      }
+    });
+
+    const readyTotakeOverDasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: dasri.id }
+    });
+    expect(readyTotakeOverDasri.status).toEqual("SENT");
+    expect(readyTotakeOverDasri.transporterTransportSignatureAuthor).toEqual(
+      "Jimmy"
+    );
+    expect(readyTotakeOverDasri.transporterTransportSignatureDate).toBeTruthy();
+    expect(readyTotakeOverDasri.transportSignatoryId).toEqual(transporter.id);
+  });
+
+  it("should not allow the transport signature when recepisse is absent", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { user: transporter, company: transporterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        emitterEmissionSignatureDate: new Date(),
+        emitterEmissionSignatureAuthor: "Producteur",
+        status: BsdasriStatus.SIGNED_BY_PRODUCER
+      }
+    });
+    const { mutate } = makeClient(transporter); // transporter
+
+    const { errors } = await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "TRANSPORT", author: "Jimmy" }
+      }
+    });
+    expect(errors[0].message).toMatch(
+      "Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+    );
+    expect(errors[0].message).toMatch(
+      "Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+    );
+    expect(errors[0].message).toMatch(
+      "Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+    );
+  });
+
   it("should mark a dasri as refused when transporter acceptation is refused", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
     const { user: transporter, company: transporterCompany } =
@@ -70,6 +149,7 @@ describe("Mutation.signBsdasri transport", () => {
         transporterAcceptationStatus: WasteAcceptationStatus.REFUSED,
         transporterWasteRefusalReason: "J'en veux pas",
         transporterWasteRefusedWeightValue: 66,
+        transporterRecepisseIsExempted: true,
         status: BsdasriStatus.SIGNED_BY_PRODUCER,
         emitterEmissionSignatureDate: new Date(),
         emitterEmissionSignatureAuthor: "Producteur"

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransportDirectTakeover.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransportDirectTakeover.integration.ts
@@ -2,6 +2,7 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import {
   companyFactory,
+  transporterReceiptFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
@@ -27,6 +28,7 @@ describe("Mutation.signBsdasri transport", () => {
 
     const { user: transporter, company: transporterCompany } =
       await userWithCompanyFactory("MEMBER");
+    await transporterReceiptFactory({ company: transporterCompany });
     const destinationCompany = await companyFactory();
 
     const dasri = await bsdasriFactory({
@@ -97,6 +99,7 @@ describe("Mutation.signBsdasri transport", () => {
 
     const { user: transporter, company: transporterCompany } =
       await userWithCompanyFactory("MEMBER");
+    await transporterReceiptFactory({ company: transporterCompany });
     const destination = await companyFactory();
 
     // missing onu code

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
@@ -1,5 +1,8 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import {
   BsdasriStatus,
@@ -75,6 +78,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
     const { user: transporter, company: transporterCompany } =
       await userWithCompanyFactory("MEMBER");
+    await transporterReceiptFactory({ company: transporterCompany });
     const { company: destinationCompany } = await userWithCompanyFactory(
       "MEMBER"
     );
@@ -147,6 +151,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
       );
       const { user: transporter, company: transporterCompany } =
         await userWithCompanyFactory("MEMBER");
+      await transporterReceiptFactory({ company: transporterCompany });
       const { company: destinationCompany } = await userWithCompanyFactory(
         "MEMBER"
       );

--- a/back/src/bsdasris/resolvers/mutations/createBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createBsdasri.ts
@@ -8,6 +8,7 @@ import { emitterIsAllowedToGroup, checkDasrisAreGroupable } from "./utils";
 import { BsdasriType } from "@prisma/client";
 import { getBsdasriRepository } from "../../repository";
 import sirenify from "../../sirenify";
+import { recipify } from "../../recipify";
 import { checkCanCreate } from "../../permissions";
 
 const getValidationContext = ({
@@ -44,7 +45,10 @@ const createBsdasri = async (
   await checkCanCreate(user, input);
 
   const sirenifiedInput = await sirenify(rest, user);
-  const flattenedInput = flattenBsdasriInput(sirenifiedInput);
+
+  const autocompletedInput = await recipify(sirenifiedInput);
+
+  const flattenedInput = flattenBsdasriInput(autocompletedInput);
 
   const isGrouping = !!grouping && !!grouping.length;
 

--- a/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
@@ -8,6 +8,7 @@ import { emitterIsAllowedToGroup, checkDasrisAreGroupable } from "./utils";
 import { getBsdasriRepository } from "../../repository";
 import { checkEditionRules } from "../../edition";
 import sirenify from "../../sirenify";
+import { recipify } from "../../recipify";
 
 const getGroupedBsdasriArgs = (
   inputRegroupedBsdasris: string[] | null | undefined
@@ -48,7 +49,8 @@ const updateBsdasri = async ({
   const { grouping: inputGrouping, synthesizing: inputSynthesizing } = input;
   const isGroupingType = dbBsdasri.type === BsdasriType.GROUPING;
   const sirenifiedInput = await sirenify(input, user);
-  const flattenedInput = flattenBsdasriInput(sirenifiedInput);
+  const autocompletedInput = await recipify(sirenifiedInput);
+  const flattenedInput = flattenBsdasriInput(autocompletedInput);
 
   if (inputGrouping && inputGrouping.length > 0 && !isGroupingType) {
     throw new UserInputError(

--- a/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
@@ -12,6 +12,7 @@ import {
 } from "../../repository";
 import { checkEditionRules } from "../../edition";
 import sirenify from "../../sirenify";
+import { recipify } from "../../recipify";
 
 const buildSynthesizedBsdasriArgs = async (
   dasrisToAssociate: Bsdasri[] | null | undefined,
@@ -105,7 +106,8 @@ const updateSynthesisBsdasri = async ({
     dbBsdasri.status
   );
   const sirenifiedInput = await sirenify(rest, user);
-  const flattenedInput = flattenBsdasriInput(sirenifiedInput);
+  const autocompletedInput = await recipify(sirenifiedInput);
+  const flattenedInput = flattenBsdasriInput(autocompletedInput);
 
   await checkEditionRules(dbBsdasri, input, user);
 

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -199,11 +199,11 @@ input BsdasriRecepisseInput {
   "Exemption de récépissé"
   isExempted: Boolean
   "Numéro de récépissé"
-  number: String
+  number: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
   "Département"
-  department: String
+  department: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
   "Date limite de validité"
-  validityLimit: DateTime
+  validityLimit: DateTime @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 }
 
 input BsdasriTransporterInput {

--- a/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
@@ -85,9 +85,6 @@ type Mutation {
       takenOverAt
     }
     recepisse {
-      number
-      department
-      validityLimit
       isExempted
     }
   }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -17,7 +17,11 @@ import {
   QueryBsdsArgs
 } from "../../../../generated/graphql/types";
 import prisma from "../../../../prisma";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  userWithCompanyFactory,
+  transporterReceiptFactory
+} from "../../../../__tests__/factories";
+
 import makeClient from "../../../../__tests__/testClient";
 
 const CREATE_DRAFT_BSDA = `
@@ -82,6 +86,7 @@ describe("Query.bsds.bsda base workflow", () => {
         set: ["TRANSPORTER"]
       }
     });
+    await transporterReceiptFactory({ company: transporter.company });
     destination = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["WASTEPROCESSOR"]
@@ -132,11 +137,6 @@ describe("Query.bsds.bsda base workflow", () => {
                 contact: "contactEmail",
                 phone: "contactPhone",
                 mail: "contactEmail@mail.com"
-              },
-              recepisse: {
-                department: "83",
-                number: "1234",
-                validityLimit: new Date().toISOString() as any
               },
               transport: {
                 mode: "ROAD",

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -1,4 +1,3 @@
-import { addYears } from "date-fns";
 import {
   Company,
   User,
@@ -23,7 +22,10 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
 import { indexBsdasri } from "../../../../bsdasris/elastic";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  userWithCompanyFactory,
+  transporterReceiptFactory
+} from "../../../../__tests__/factories";
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 
 const CREATE_DRAFT_DASRI = `
@@ -82,6 +84,7 @@ describe("Query.bsds.dasris base workflow", () => {
         set: ["TRANSPORTER"]
       }
     });
+    await transporterReceiptFactory({ company: transporter.company });
     destination = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["WASTEPROCESSOR"]
@@ -137,11 +140,6 @@ describe("Query.bsds.dasris base workflow", () => {
                 contact: "Jean-Michel",
                 mail: "jean.michel@gmaiL.com",
                 phone: "06"
-              },
-              recepisse: {
-                number: "123456789",
-                department: "69",
-                validityLimit: addYears(new Date(), 1).toISOString() as any
               },
               transport: {
                 takenOverAt: new Date().toISOString() as any,

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
@@ -1,4 +1,3 @@
-import { addYears } from "date-fns";
 import { Company, User, UserRole } from "@prisma/client";
 import {
   Query,
@@ -19,7 +18,8 @@ import makeClient from "../../../../__tests__/testClient";
 import {
   userWithCompanyFactory,
   formFactory,
-  toIntermediaryCompany
+  toIntermediaryCompany,
+  transporterReceiptFactory
 } from "../../../../__tests__/factories";
 
 import { indexForm } from "../../../../forms/elastic";
@@ -91,6 +91,10 @@ describe("Query.bsds workflow", () => {
         set: ["TRANSPORTER"]
       }
     });
+    await transporterReceiptFactory({
+      company: transporter.company
+    });
+
     recipient = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["WASTEPROCESSOR"]
@@ -131,10 +135,7 @@ describe("Query.bsds workflow", () => {
             contact: "Jean-Michel",
             mail: "jean.michel@gmaiL.com",
             phone: "06"
-          },
-          receipt: "123456789",
-          department: "69",
-          validityLimit: addYears(new Date(), 1).toISOString() as any
+          }
         },
         recipient: {
           company: {

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -1,4 +1,3 @@
-import { addYears } from "date-fns";
 import {
   Company,
   User,
@@ -23,7 +22,10 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
 import { indexBsvhu } from "../../../../bsvhu/elastic";
-import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import {
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 
 const GET_BSDS = `
@@ -43,7 +45,7 @@ const CREATE_DRAFT_VHU = `
 mutation CreateDraftVhu($input: BsvhuInput!) {
   createDraftBsvhu(input: $input) {
     id
-     
+
   }
 }
 `;
@@ -82,6 +84,7 @@ describe("Query.bsds.vhus base workflow", () => {
         set: ["TRANSPORTER"]
       }
     });
+    await transporterReceiptFactory({ company: transporter.company });
     destination = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["WASTEPROCESSOR"]
@@ -148,11 +151,6 @@ describe("Query.bsds.vhus base workflow", () => {
                 contact: "Un transporteur de voiture cassée",
                 phone: "0101010101",
                 mail: "transporter@mail.com"
-              },
-              recepisse: {
-                number: "122",
-                department: "83",
-                validityLimit: addYears(new Date(), 1).toISOString() as any
               }
             }
           }

--- a/back/src/bsffs/__tests__/recipify.integration.ts
+++ b/back/src/bsffs/__tests__/recipify.integration.ts
@@ -1,0 +1,60 @@
+import { recipify as recipifyFn } from "../recipify";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../__tests__/factories";
+
+describe("Bsff Recipify Module", () => {
+  it("recipifyGeneric should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        recepisse: {
+          isExempted: false
+        }
+      }
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: mockInput.transporter.company,
+        recepisse: {
+          isExempted: false,
+          department: receipt.department,
+          number: receipt.receiptNumber,
+          validityLimit: receipt.validityLimit
+        }
+      }
+    });
+  });
+
+  it("recipifyGeneric should correctly process BsffInput with null recepisse and return completedInput", async () => {
+    const mockInput = {
+      transporter: {
+        company: {
+          siret: "12345678912345",
+          recepisse: null
+        }
+      }
+    };
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+
+  it("recipifyGeneric should correctly process input with null recepisse and return completedInput", async () => {
+    const mockInput = {
+      transporter: {
+        company: {
+          siret: "12345678912345",
+          recepisse: {
+            isExempted: true
+          }
+        }
+      }
+    };
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});

--- a/back/src/bsffs/database.ts
+++ b/back/src/bsffs/database.ts
@@ -34,6 +34,7 @@ import {
 } from "./repository";
 import { sirenifyBsffInput } from "./sirenify";
 import { Permission, can, getUserRoles } from "../permissions";
+import { recipify } from "./recipify";
 
 export async function getBsffOrNotFound(where: Prisma.BsffWhereUniqueInput) {
   const { findUnique } = getReadonlyBsffRepository();
@@ -152,11 +153,12 @@ export async function createBsff(
   await checkCanCreate(user, input);
 
   const sirenifiedInput = await sirenifyBsffInput(input, user);
+  const autocompletedInput = await recipify(sirenifiedInput);
 
   const flatInput: Prisma.BsffCreateInput = {
     id: getReadableId(ReadableIdPrefix.FF),
     isDraft,
-    ...flattenBsffInput(sirenifiedInput)
+    ...flattenBsffInput(autocompletedInput)
   };
 
   if (!input.type) {

--- a/back/src/bsffs/edition/__tests__/bsffEdition.test.ts
+++ b/back/src/bsffs/edition/__tests__/bsffEdition.test.ts
@@ -39,10 +39,13 @@ describe("edition", () => {
       adr: ""
     };
 
-    const recepisse: Required<BsffTransporterRecepisseInput> = {
-      number: "XXXX",
-      department: "",
-      validityLimit: new Date()
+    const recepisse: Required<
+      Omit<
+        BsffTransporterRecepisseInput,
+        "number" | "department" | "validityLimit"
+      >
+    > = {
+      isExempted: false
     };
 
     const transport: Required<BsffTransporterTransportInput> = {

--- a/back/src/bsffs/examples/fixtures.ts
+++ b/back/src/bsffs/examples/fixtures.ts
@@ -35,11 +35,6 @@ function transporterInput(siret: string) {
       contact: "Claire Dupuis",
       mail: "claire.dupuis@transportco.fr",
       phone: "04 00 00 00 00"
-    },
-    recepisse: {
-      number: "XXXXX",
-      department: "07",
-      validityLimit: "2023-01-01"
     }
   };
 }

--- a/back/src/bsffs/examples/fixturesForeignTransporter.ts
+++ b/back/src/bsffs/examples/fixturesForeignTransporter.ts
@@ -18,8 +18,7 @@ function transporterInput(vatNumber: string) {
       contact: "Claire Dupuis",
       mail: "claire.dupuis@transportco.fr",
       phone: "04 00 00 00 00"
-    },
-    recepisse: null
+    }
   };
 }
 

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import {
   BsffPackagingType,
   BsffType,

--- a/back/src/bsffs/recipify.ts
+++ b/back/src/bsffs/recipify.ts
@@ -1,0 +1,33 @@
+import {
+  BsffInput,
+  BsffTransporterRecepisseInput
+} from "../generated/graphql/types";
+
+import { recipifyGeneric } from "../companies/recipify";
+
+const bsffAccessors = (input: BsffInput) => [
+  {
+    getter: () =>
+      // Old way of exempting is null
+      input?.transporter?.recepisse !== null &&
+      // New way added to the old
+      input?.transporter?.recepisse?.isExempted !== true
+        ? input?.transporter?.company
+        : null,
+    setter: (
+      input: BsffInput,
+      recepisseInput: BsffTransporterRecepisseInput
+    ) => ({
+      ...input,
+      transporter: {
+        ...input.transporter,
+        recepisse: {
+          ...input.transporter?.recepisse,
+          ...recepisseInput
+        }
+      }
+    })
+  }
+];
+
+export const recipify = recipifyGeneric(bsffAccessors);

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -17,7 +17,8 @@ import { associateUserToCompany } from "../../../../users/database";
 import {
   companyFactory,
   siretify,
-  userWithCompanyFactory
+  userWithCompanyFactory,
+  transporterReceiptFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { OPERATION } from "../../../constants";
@@ -78,6 +79,126 @@ describe("Mutation.updateBsff", () => {
     expect(data.updateBsff.id).toBeTruthy();
     // check input is sirenified
     expect(sirenifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should update a bsff transporter recepisse with data pulled from db", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsff(
+      { emitter, transporter: emitter },
+      { isDraft: true }
+    );
+
+    const transporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const receipt = await transporterReceiptFactory({
+      company: transporter
+    });
+    const { mutate } = makeClient(emitter.user);
+    const { data } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          transporter: {
+            company: {
+              siret: transporter.siret
+            }
+          }
+        }
+      }
+    });
+
+    // recepisse is pulled from db
+    expect(data.updateBsff.transporter!.recepisse!.number).toEqual(
+      receipt.receiptNumber
+    );
+    expect(data.updateBsff.transporter!.recepisse!.department).toEqual(
+      receipt.department
+    );
+    expect(data.updateBsff.transporter!.recepisse!.validityLimit).toEqual(
+      receipt.validityLimit.toISOString()
+    );
+  });
+
+  it("should empty a bsff transporter recepisse if transporter has no receipt data", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsff(
+      { emitter, transporter: emitter },
+      { isDraft: true }
+    );
+    await prisma.bsff.update({
+      where: { id: bsff.id },
+      data: {
+        transporterRecepisseNumber: "abc",
+        transporterRecepisseDepartment: "13",
+        transporterRecepisseValidityLimit: new Date()
+      }
+    });
+
+    const transporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const { mutate } = makeClient(emitter.user);
+    const { data } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          transporter: {
+            company: {
+              siret: transporter.siret
+            }
+          }
+        }
+      }
+    });
+
+    // recepisse is pulled from db
+    expect(data.updateBsff.transporter!.recepisse).toEqual(null);
+  });
+
+  it("should empty a bsff transporter recepisse if transporter has isExempted", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsff(
+      { emitter, transporter: emitter },
+      { isDraft: true }
+    );
+    await prisma.bsff.update({
+      where: { id: bsff.id },
+      data: {
+        transporterRecepisseNumber: "abc",
+        transporterRecepisseDepartment: "13",
+        transporterRecepisseValidityLimit: new Date()
+      }
+    });
+
+    const transporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const { mutate } = makeClient(emitter.user);
+    const { data } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          transporter: {
+            company: {
+              siret: transporter.siret
+            }
+          }
+        }
+      }
+    });
+
+    // recepisse is pulled from db
+    expect(data.updateBsff.transporter!.recepisse).toEqual(null);
   });
 
   it("should allow user to update a bsff packagings", async () => {

--- a/back/src/bsffs/resolvers/mutations/updateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsff.ts
@@ -18,6 +18,7 @@ import {
 } from "../../repository";
 import { checkEditionRules } from "../../edition/bsffEdition";
 import { sirenifyBsffInput } from "../../sirenify";
+import { recipify } from "../../recipify";
 
 const updateBsff: MutationResolvers["updateBsff"] = async (
   _,
@@ -63,7 +64,8 @@ const updateBsff: MutationResolvers["updateBsff"] = async (
     delete input.ficheInterventions;
   }
   const sirenifiedInput = await sirenifyBsffInput(input, user);
-  const flatInput = flattenBsffInput(sirenifiedInput);
+  const autocompletedInput = await recipify(sirenifiedInput);
+  const flatInput = flattenBsffInput(autocompletedInput);
 
   const futureBsff = {
     ...existingBsff,

--- a/back/src/bsffs/typeDefs/bsff.inputs.graphql
+++ b/back/src/bsffs/typeDefs/bsff.inputs.graphql
@@ -272,19 +272,21 @@ input BsffWeightInput {
 
 input BsffTransporterInput {
   company: CompanyInput
-  "Informations sur le récepissé transporteur."
+  "Informations sur le récepissé transporteur. Si 'null', l'exemption de récépissé est assumée (conformément aux dispositions de l'article R.541-50 du code de l'environnement)"
   recepisse: BsffTransporterRecepisseInput
   transport: BsffTransporterTransportInput
   "Champ libre"
   customInfo: String
 }
 input BsffTransporterRecepisseInput {
+  "Exemption de récépissé (conformément aux dispositions de l'article R.541-50 du code de l'environnement)"
+  isExempted: Boolean
   "Le cas échéant, numéro de récépissé mentionné à l'article R. 541-51 du code de l'environnement."
-  number: String
+  number: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
   "Le cas échéant, département de la déclaration mentionnée à l'article R. 541-50 du code de l'environnement."
-  department: String
+  department: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
   "Le cas échéant, limite de validité du récépissé."
-  validityLimit: DateTime
+  validityLimit: DateTime @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 }
 input BsffTransporterTransportInput {
   "Date de prise en charge"

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -102,7 +102,7 @@ type Operation = Pick<
 
 // Validation function can be called either on an existing Bsff
 // or on a create payload
-type BsffLike = (Bsff | Prisma.BsffCreateInput) & {
+export type BsffLike = (Bsff | Prisma.BsffCreateInput) & {
   packagings?: Pick<
     BsffPackaging,
     "type" | "name" | "other" | "numero" | "volume" | "weight"

--- a/back/src/bsvhu/__tests__/edition.test.ts
+++ b/back/src/bsvhu/__tests__/edition.test.ts
@@ -35,11 +35,10 @@ describe("edition", () => {
       omiNumber: ""
     };
 
-    const recepisse: Required<BsvhuRecepisseInput> = {
-      isExempted: true,
-      number: "",
-      department: "",
-      validityLimit: new Date()
+    const recepisse: Required<
+      Omit<BsvhuRecepisseInput, "number" | "department" | "validityLimit">
+    > = {
+      isExempted: true
     };
 
     const emitter: Required<BsvhuEmitterInput> = {

--- a/back/src/bsvhu/__tests__/recipify.integration.ts
+++ b/back/src/bsvhu/__tests__/recipify.integration.ts
@@ -1,0 +1,47 @@
+import { recipify } from "../recipify";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../__tests__/factories";
+
+describe("BSVHU Recipify Module", () => {
+  it("recipify should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        recepisse: {
+          isExempted: false
+        }
+      }
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipify(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: mockInput.transporter.company,
+        recepisse: {
+          isExempted: false,
+          department: receipt.department,
+          number: receipt.receiptNumber,
+          validityLimit: receipt.validityLimit
+        }
+      }
+    });
+  });
+
+  it("recipify should correctly process input with isExempted true and return completedInput without transporter recepisse", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company: company,
+        recepisse: {
+          isExempted: true
+        }
+      }
+    };
+
+    const completedInput = await recipify(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -291,11 +291,13 @@ describe("BSVHU validation", () => {
           transportSignature: true
         });
       } catch (err) {
-        expect(err.errors).toEqual([
-          "Transporteur: le département associé au récépissé est obligatoire",
-          "Transporteur: le numéro de récépissé est obligatoire",
-          "Transporteur: la date limite de validité du récépissé est obligatoire"
-        ]);
+        expect(err.errors).toEqual(
+          expect.arrayContaining([
+            "Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+            "Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+            "Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+          ])
+        );
       }
     });
   });

--- a/back/src/bsvhu/__tests__/workflow.integration.ts
+++ b/back/src/bsvhu/__tests__/workflow.integration.ts
@@ -118,9 +118,7 @@ describe("Exemples de circuit du bordereau de suivi de véhicule hors d'usage", 
             updateBsvhu(id: "${id}", input: {
               transporter: {
                 recepisse: {
-                  number: "recepisse number"
-                  department: "75"
-                  validityLimit: "2020-06-30"
+                  isExempted: true
                 }
               }
             }) { id }

--- a/back/src/bsvhu/recipify.ts
+++ b/back/src/bsvhu/recipify.ts
@@ -1,0 +1,23 @@
+import { BsvhuInput, BsvhuRecepisseInput } from "../generated/graphql/types";
+
+import { recipifyGeneric } from "../companies/recipify";
+import {
+  autocompletedRecepisse,
+  genericGetter
+} from "../common/validation/recipify";
+
+const bsvhuAccessors = (input: BsvhuInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (input: BsvhuInput, recepisseInput: BsvhuRecepisseInput) => ({
+      ...input,
+      transporter: {
+        company: input.transporter?.company,
+        transport: input.transporter?.transport,
+        recepisse: autocompletedRecepisse(input, recepisseInput)
+      }
+    })
+  }
+];
+
+export const recipify = recipifyGeneric(bsvhuAccessors);

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -10,6 +10,8 @@ import { expandVhuFormFromDb, flattenVhuInput } from "../../converter";
 import { validateBsvhu } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
 import sirenify from "../../sirenify";
+import { recipify } from "../../recipify";
+
 import { checkCanCreate } from "../../permissions";
 
 type CreateBsvhu = {
@@ -30,8 +32,10 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
   const user = checkIsAuthenticated(context);
 
   const sirenifiedInput = await sirenify(input, user);
+  const autocompletedInput = await recipify(sirenifiedInput);
+
   await checkCanCreate(user, input);
-  const form = flattenVhuInput(sirenifiedInput);
+  const form = flattenVhuInput(autocompletedInput);
 
   await validateBsvhu(form, { emissionSignature: !isDraft });
   const bsvhuRepository = getBsvhuRepository(user);

--- a/back/src/bsvhu/resolvers/mutations/update.ts
+++ b/back/src/bsvhu/resolvers/mutations/update.ts
@@ -8,6 +8,7 @@ import { validateBsvhu } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
 import { checkEditionRules } from "../../edition";
 import sirenify from "../../sirenify";
+import { recipify } from "../../recipify";
 import { checkCanUpdate } from "../../permissions";
 
 export default async function edit(
@@ -22,7 +23,9 @@ export default async function edit(
   await checkCanUpdate(user, existingBsvhu, input);
 
   const sirenifiedInput = await sirenify(input, user);
-  const formUpdate = flattenVhuInput(sirenifiedInput);
+  const autocompletedInput = await recipify(sirenifiedInput);
+
+  const formUpdate = flattenVhuInput(autocompletedInput);
 
   const resultingForm = { ...existingBsvhu, ...formUpdate };
 

--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -174,9 +174,9 @@ input BsvhuTransportInput {
 input BsvhuRecepisseInput {
   "Exemption de récépissé"
   isExempted: Boolean
-  number: String
-  department: String
-  validityLimit: DateTime
+  number: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
+  department: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
+  validityLimit: DateTime @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 }
 
 input BsvhuSignatureInput {

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -352,6 +352,14 @@ export async function validateIntermediariesInput(
 
   return intermediaries;
 }
+
+export const REQUIRED_RECEIPT_VALIDITYLIMIT = `Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
+export const REQUIRED_RECEIPT_NUMBER = `Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
+export const REQUIRED_RECEIPT_DEPARTMENT = `Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
+
+/**
+ * Common transporter receipt schema for BSVHU, BSDASRI
+ */
 export const transporterRecepisseSchema = context => ({
   transporterRecepisseIsExempted: yup.boolean().nullable(),
   transporterRecepisseDepartment: yup
@@ -362,7 +370,7 @@ export const transporterRecepisseSchema = context => ({
       otherwise: schema =>
         schema.requiredIf(
           context.transportSignature,
-          `Transporteur: le département associé au récépissé est obligatoire`
+          REQUIRED_RECEIPT_VALIDITYLIMIT
         )
     }),
   transporterRecepisseNumber: yup
@@ -371,10 +379,7 @@ export const transporterRecepisseSchema = context => ({
       is: (isExempted, vat) => isExempted || isForeignVat(vat),
       then: schema => schema.nullable().notRequired(),
       otherwise: schema =>
-        schema.requiredIf(
-          context.transportSignature,
-          `Transporteur: le numéro de récépissé est obligatoire`
-        )
+        schema.requiredIf(context.transportSignature, REQUIRED_RECEIPT_NUMBER)
     }),
   transporterRecepisseValidityLimit: yup
     .date()
@@ -384,7 +389,7 @@ export const transporterRecepisseSchema = context => ({
       otherwise: schema =>
         schema.requiredIf(
           context.transportSignature,
-          `Transporteur: la date limite de validité du récépissé est obligatoire`
+          REQUIRED_RECEIPT_DEPARTMENT
         )
     })
 });

--- a/back/src/common/validation/recipify.ts
+++ b/back/src/common/validation/recipify.ts
@@ -1,0 +1,53 @@
+import {
+  BsdaInput,
+  BsdasriInput,
+  BsdasriRecepisseInput,
+  BsvhuInput,
+  BsvhuRecepisseInput
+} from "../../generated/graphql/types";
+
+import { recipifyGeneric } from "../../companies/recipify";
+
+/**
+ * Generic setter for Bsvhu and Bsdasri
+ * @param input auto-completed Input
+ * @param recepisseInput Original input
+ * @returns
+ */
+export const autocompletedRecepisse = (
+  input: BsvhuInput | BsdasriInput,
+  recepisseInput: BsvhuRecepisseInput | BsdasriRecepisseInput
+) => ({
+  ...input.transporter?.recepisse,
+  ...recepisseInput
+});
+
+/**
+ * Generic getter for Bsda, Bsvhu and Bsdasri
+ * Null when exempted or if transporter company has not changed
+ * @param input auto-completed Input
+ * @returns
+ */
+export const genericGetter = (input: BsvhuInput | BsdasriInput) => () =>
+  input?.transporter?.recepisse?.isExempted !== true
+    ? input?.transporter?.company
+    : null;
+
+const accessors = (input: BsdaInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (
+      input: BsvhuInput | BsdasriInput,
+      recepisseInput: BsvhuRecepisseInput | BsdasriRecepisseInput
+    ) => ({
+      ...input,
+      transporter: {
+        company: input.transporter?.company,
+        transport: input.transporter?.transport,
+        recepisse: autocompletedRecepisse(input, recepisseInput)
+      }
+    })
+  }
+];
+
+export const recipify = recipifyGeneric(accessors);

--- a/back/src/common/validation/siret.ts
+++ b/back/src/common/validation/siret.ts
@@ -43,6 +43,9 @@ export const foreignVatNumberSchema = vatNumberSchema.refine(value => {
   return isForeignVat(value);
 }, "Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement");
 
+export const missingCompanyError = siret =>
+  `L'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`;
+
 export const isRegisteredSiretRefinement =
   (role, transporterRecepisseIsExempted = false) =>
   async (siret: string, ctx) => {
@@ -54,7 +57,7 @@ export const isRegisteredSiretRefinement =
     if (company === null) {
       return ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: `L'établissement avec le SIRET ${siret} n'est pas inscrit sur Trackdéchets`
+        message: missingCompanyError(siret)
       });
     }
     if (role === "DESTINATION") {

--- a/back/src/companies/__tests__/recipify.integration.ts
+++ b/back/src/companies/__tests__/recipify.integration.ts
@@ -1,0 +1,113 @@
+import { recipifyGeneric, findCompanyFailFast } from "../recipify";
+import logger from "../../logging/logger";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../__tests__/factories";
+
+jest.spyOn(logger, "info");
+
+describe("Company Recipify Module", () => {
+  it("findCompanyFailFast should return company transportReceiptId = null", async () => {
+    const company = await companyFactory();
+
+    const companySearchResult = await findCompanyFailFast(company.orgId);
+    expect(companySearchResult).toEqual({ transporterReceiptId: null });
+  });
+
+  it("findCompanyFailFast should return company transportReceiptId", async () => {
+    const company = await companyFactory();
+    const receipt = await transporterReceiptFactory({ company });
+
+    const companySearchResult = await findCompanyFailFast(company.orgId);
+    expect(companySearchResult).toEqual({ transporterReceiptId: receipt.id });
+  });
+
+  it("findCompanyFailFast should log an error message when company is not found", async () => {
+    expect(findCompanyFailFast("1234")).resolves.toBe(null);
+  });
+
+  it("recipifyGeneric should complete data as configured in the accessors", async () => {
+    const company = await companyFactory();
+    const receipt = await transporterReceiptFactory({ company });
+    const mockInput = {
+      transporter: {
+        company
+      }
+    };
+
+    const mockAccessor = () => [
+      {
+        getter: () => company,
+        setter: (input: any, receipt: any) => ({
+          ...input,
+          anyReceiptFormat: receipt
+        })
+      }
+    ];
+
+    const recipifyFn = recipifyGeneric(mockAccessor);
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual({
+      ...mockInput,
+      anyReceiptFormat: {
+        number: receipt.receiptNumber,
+        validityLimit: receipt.validityLimit,
+        department: receipt.department
+      }
+    });
+  });
+
+  it("recipifyGeneric should complete with null receipt values if not TransporterReceipt is not found", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company
+      }
+    };
+
+    const mockAccessor = () => [
+      {
+        getter: () => company,
+        setter: (input: any, receipt: any) => ({
+          ...input,
+          anyReceiptFormat: receipt
+        })
+      }
+    ];
+
+    const recipifyFn = recipifyGeneric(mockAccessor);
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual({
+      ...mockInput,
+      anyReceiptFormat: {
+        number: null,
+        validityLimit: null,
+        department: null
+      }
+    });
+  });
+
+  it("recipifyGeneric should not modify the input if the getter return null", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company
+      }
+    };
+
+    const mockAccessor = () => [
+      {
+        getter: () => null,
+        setter: (input: any, receipt: any) => ({
+          ...input,
+          anyReceiptFormat: receipt
+        })
+      }
+    ];
+
+    const recipifyFn = recipifyGeneric(mockAccessor);
+    const completedInput = await recipifyFn(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});

--- a/back/src/companies/recipify.ts
+++ b/back/src/companies/recipify.ts
@@ -1,0 +1,97 @@
+import {
+  CompanyInput,
+  BsdasriRecepisseInput
+} from "../generated/graphql/types";
+import prisma from "../prisma";
+
+type RecipifyOutput = {
+  number: string | null;
+  validityLimit: Date | null;
+  department: string | null;
+};
+
+type RecipifyFn<T> = (input: T) => Promise<T>;
+
+type RecepisseInputAccessor<T> = {
+  getter: () => CompanyInput | null | undefined;
+  setter: (input: T, recepisseInput: BsdasriRecepisseInput) => T;
+};
+
+/**
+ * Search a Company.transporterReceiptId within 1 sec or throw an error
+ */
+export async function findCompanyFailFast(orgId: string) {
+  const where = {
+    where: { orgId }
+  };
+  // make sure we do not wait more thant 1s here to avoid bottlenecks
+  const raceWith = new Promise<null>(resolve =>
+    setTimeout(resolve, 1000, null)
+  );
+
+  try {
+    return Promise.race([findCompany(where), raceWith]);
+  } catch (e) {
+    return null;
+  }
+}
+
+function findCompany(where: { where: { orgId: string } }) {
+  return prisma.company.findUnique({
+    ...where,
+    select: {
+      transporterReceiptId: true
+    }
+  });
+}
+
+export function recipifyGeneric<T>(
+  recepisseInputAccessors: (input: T) => RecepisseInputAccessor<T>[]
+): RecipifyFn<T> {
+  return async input => {
+    const accessors = recepisseInputAccessors(input);
+    const companyInputs = accessors.map(({ getter }) => getter());
+
+    const companies = await Promise.all(
+      companyInputs.map(companyInput =>
+        companyInput && (companyInput.siret || companyInput.vatNumber)
+          ? findCompanyFailFast(companyInput.siret ?? companyInput.vatNumber!)
+          : null
+      )
+    );
+
+    let completedInput = { ...input };
+    for (const [idx, company] of companies.entries()) {
+      const { setter } = accessors[idx];
+      // if company exists, we auto-complete
+      if (company) {
+        let receipt: RecipifyOutput;
+        if (!!company?.transporterReceiptId) {
+          const dbReceipt = await prisma.transporterReceipt.findFirst({
+            where: { id: company.transporterReceiptId },
+            select: {
+              receiptNumber: true,
+              validityLimit: true,
+              department: true
+            }
+          });
+          receipt = {
+            number: dbReceipt?.receiptNumber ?? null,
+            validityLimit: dbReceipt?.validityLimit ?? null,
+            department: dbReceipt?.department ?? null
+          };
+        } else {
+          receipt = {
+            number: null,
+            validityLimit: null,
+            department: null
+          };
+        }
+
+        completedInput = setter(completedInput, receipt);
+      }
+    }
+
+    return completedInput;
+  };
+}

--- a/back/src/forms/__tests__/edition.test.ts
+++ b/back/src/forms/__tests__/edition.test.ts
@@ -57,12 +57,11 @@ describe("edition", () => {
       isTempStorage: false
     };
 
-    const transporter: Required<TransporterInput> = {
+    const transporter: Required<
+      Omit<TransporterInput, "department" | "validityLimit" | "receipt">
+    > = {
       company,
       isExemptedOfReceipt: false,
-      receipt: "",
-      department: "",
-      validityLimit: new Date(),
       numberPlate: "",
       customInfo: "",
       mode: "ROAD"

--- a/back/src/forms/__tests__/form-converter.test.ts
+++ b/back/src/forms/__tests__/form-converter.test.ts
@@ -102,8 +102,11 @@ describe("flattenFormInput", () => {
         }
       },
       transporter: {
+        // ignored field
         receipt: "12379",
+        // ignored field
         department: "07",
+        // ignored field
         validityLimit: new Date("2020-06-30"),
         numberPlate: "AD-007-TS",
         company: null

--- a/back/src/forms/__tests__/recipify.integration.ts
+++ b/back/src/forms/__tests__/recipify.integration.ts
@@ -1,0 +1,170 @@
+import {
+  recipifyFormInput,
+  recipifyResealedFormInput,
+  recipifyTransportSegmentInput,
+  recipifyTransporterInDb
+} from "../recipify";
+import {
+  companyFactory,
+  formFactory,
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../__tests__/factories";
+import { TransportMode } from "../../generated/graphql/types";
+import { getFirstTransporter } from "../database";
+
+describe("Test Bsdd Transporter Recipify Module for FormInput", () => {
+  it("recipify should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: false
+      }
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipifyFormInput(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: company,
+        isExemptedOfReceipt: false,
+        receipt: receipt.receiptNumber,
+        department: receipt.department,
+        validityLimit: receipt.validityLimit
+      }
+    });
+  });
+
+  it("recipify should correctly process input with isExempted true and return completedInput with receipt exemption", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: true
+      }
+    };
+
+    const completedInput = await recipifyFormInput(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});
+
+describe("Bsdd Resealed Recipify Module", () => {
+  it("recipify should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: false
+      }
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipifyResealedFormInput(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: mockInput.transporter.company,
+        isExemptedOfReceipt: false,
+        receipt: receipt.receiptNumber,
+        department: receipt.department,
+        validityLimit: receipt.validityLimit
+      }
+    });
+  });
+
+  it("recipify should correctly process input with isExempted true and return completedInput with receipt exemption", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: true
+      }
+    };
+
+    const completedInput = await recipifyResealedFormInput(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});
+
+describe("Bsdd Transporter segment Recipify Module", () => {
+  it("recipify should correctly process input and return completedInput with transporter receipt", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: false
+      },
+      mode: "ROAD" as TransportMode
+    };
+    const receipt = await transporterReceiptFactory({ company });
+    const completedInput = await recipifyTransportSegmentInput(mockInput);
+    expect(completedInput).toEqual({
+      transporter: {
+        company: mockInput.transporter.company,
+        isExemptedOfReceipt: false,
+        receipt: receipt.receiptNumber,
+        department: receipt.department,
+        validityLimit: receipt.validityLimit
+      },
+      mode: "ROAD" as TransportMode
+    });
+  });
+
+  it("recipify should correctly process input with isExempted true and return completedInput with receipt exemption", async () => {
+    const company = await companyFactory();
+    const mockInput = {
+      transporter: {
+        company,
+        isExemptedOfReceipt: true
+      },
+      mode: "ROAD" as TransportMode
+    };
+
+    const completedInput = await recipifyTransportSegmentInput(mockInput);
+    expect(completedInput).toEqual(mockInput);
+  });
+});
+
+describe("Test Bsdd Transporter recipify module for db update, recipifyTransporterInDb", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should return undefined when the transporter is null", async () => {
+    const result = await recipifyTransporterInDb(null);
+    expect(result).toBeUndefined();
+  });
+
+  it("should correctly recipify and update a transporter", async () => {
+    const { company, user } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            transporterCompanySiret: company.siret,
+            number: 1
+          }
+        }
+      }
+    });
+    const transporter = await getFirstTransporter(form);
+    expect(transporter).toBeDefined();
+    const receipt = await transporterReceiptFactory({ company });
+
+    const result = await recipifyTransporterInDb(transporter);
+    expect(result).toEqual({
+      transporters: {
+        update: {
+          data: {
+            transporterReceipt: receipt.receiptNumber,
+            transporterDepartment: receipt.department,
+            transporterValidityLimit: receipt.validityLimit,
+            transporterIsExemptedOfReceipt: false
+          },
+          where: { id: transporter?.id }
+        }
+      }
+    });
+  });
+});

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -11,6 +11,7 @@ import {
 import { ReceivedFormInput } from "../../generated/graphql/types";
 import { companyFactory, siretify } from "../../__tests__/factories";
 import { resetDatabase } from "../../../integration-tests/helper";
+import { REQUIRED_RECEIPT_NUMBER } from "../../common/validation";
 
 const siret1 = siretify(1);
 const siret2 = siretify(2);
@@ -646,9 +647,7 @@ describe("beforeTransportSchema", () => {
 
     const validateFn = () => beforeTransportSchema.validate(testForm);
 
-    await expect(validateFn()).rejects.toThrow(
-      "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, il est donc est obligatoire"
-    );
+    await expect(validateFn()).rejects.toThrow(REQUIRED_RECEIPT_NUMBER);
   });
 
   it("should not be valid when there is nor transporterCompanySiret nor transporterCompanyVatNumber", async () => {

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -159,6 +159,7 @@ export function flattenTransporterInput(input: {
       input.transporter,
       t => t.isExemptedOfReceipt
     ),
+    // deprecated receipt fields, ignored
     transporterReceipt: chain(input.transporter, t => t.receipt),
     transporterDepartment: chain(input.transporter, t => t.department),
     transporterValidityLimit: chain(input.transporter, t => t.validityLimit),

--- a/back/src/forms/examples/fixtures.ts
+++ b/back/src/forms/examples/fixtures.ts
@@ -50,17 +50,9 @@ function transporter2CompanyInput(siret: string) {
   };
 }
 
-const receiptInput = {
-  receipt: "12379",
-  department: "07",
-  validityLimit: "2020-06-30T00:00:00.000",
-  numberPlate: "AD-007-TS"
-};
-
 function transporterInput(siret: string) {
   return {
-    company: transporterCompanyInput(siret),
-    ...receiptInput
+    company: transporterCompanyInput(siret)
   };
 }
 
@@ -185,8 +177,7 @@ function resealedInfosInput(siret: string) {
 function nextSegmentInfoInput(siret: string) {
   return {
     transporter: {
-      company: transporter2CompanyInput(siret),
-      ...receiptInput
+      company: transporter2CompanyInput(siret)
     },
     mode: "RAIL"
   };
@@ -209,7 +200,6 @@ export default {
   ttrInput,
   wasteDetailsInput,
   workSiteInput,
-  receiptInput,
   signEmissionFormInput,
   signTransportFormInput,
   receivedInfoInput,

--- a/back/src/forms/examples/fixturesForeignTransporter.ts
+++ b/back/src/forms/examples/fixturesForeignTransporter.ts
@@ -3,7 +3,6 @@ import fixtures from "./fixtures";
 const {
   emitterCompanyInput,
   emitterInput,
-  receiptInput,
   traiteurCompanyInput,
   recipientInput,
   ttrCompanyInput,
@@ -47,8 +46,7 @@ function transporter2CompanyInput(vatNumber: string) {
 function nextSegmentInfoInput(vatNumber: string) {
   return {
     transporter: {
-      company: transporter2CompanyInput(vatNumber),
-      ...receiptInput
+      company: transporter2CompanyInput(vatNumber)
     },
     mode: "RAIL"
   };
@@ -57,9 +55,6 @@ function nextSegmentInfoInput(vatNumber: string) {
 function transporterInput(vatNumber: string) {
   return {
     company: transporterCompanyInput(vatNumber),
-    receipt: null,
-    department: null,
-    validityLimit: null,
     numberPlate: null
   };
 }
@@ -82,7 +77,6 @@ export default {
   ttrInput,
   wasteDetailsInput,
   workSiteInput,
-  receiptInput,
   signEmissionFormInput,
   signTransportFormInput,
   receivedInfoInput,

--- a/back/src/forms/recipify.ts
+++ b/back/src/forms/recipify.ts
@@ -1,0 +1,139 @@
+import {
+  FormInput,
+  ResealedFormInput,
+  NextSegmentInfoInput
+} from "../generated/graphql/types";
+
+import { recipifyGeneric } from "../companies/recipify";
+import { BsddTransporter, Prisma } from "@prisma/client";
+
+type Receipt = {
+  number?: string | null;
+  department?: string | null;
+  validityLimit?: Date | null;
+};
+
+/**
+ * Null if exemption is true OR if transporter company has not changed
+ */
+const genericGetter = (input: FormInput) => () =>
+  input?.transporter?.isExemptedOfReceipt !== true
+    ? input?.transporter?.company
+    : null;
+
+const formInputAccessors = (input: FormInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (
+      input: FormInput,
+      transporterAutocompleted: Receipt
+    ): FormInput => {
+      const { number, department, validityLimit } = transporterAutocompleted;
+      return {
+        ...input,
+        transporter: {
+          ...input.transporter,
+          ...{ receipt: number, department, validityLimit }
+        }
+      };
+    }
+  }
+];
+export const recipifyFormInput = recipifyGeneric(formInputAccessors);
+
+const resealedFormInputAccessors = (input: ResealedFormInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (
+      input: ResealedFormInput,
+      transporterAutocompleted: Receipt
+    ): ResealedFormInput => {
+      const { number, department, validityLimit } = transporterAutocompleted;
+      return {
+        ...input,
+        transporter: {
+          ...input.transporter,
+          ...{ receipt: number, department, validityLimit }
+        }
+      };
+    }
+  }
+];
+
+export const recipifyResealedFormInput = recipifyGeneric(
+  resealedFormInputAccessors
+);
+
+const transportSegmentInputAccessors = (input: NextSegmentInfoInput) => [
+  {
+    getter: genericGetter(input),
+    setter: (
+      input: NextSegmentInfoInput,
+      transporterAutocompleted: Receipt
+    ): NextSegmentInfoInput => {
+      const { number, department, validityLimit } = transporterAutocompleted;
+      return {
+        ...input,
+        transporter: {
+          ...input.transporter,
+          ...{ receipt: number, department, validityLimit }
+        }
+      };
+    }
+  }
+];
+
+export const recipifyTransportSegmentInput = recipifyGeneric(
+  transportSegmentInputAccessors
+);
+
+/**
+ * Used to update the transporteur receipt
+ * when no FormInput and recipify function above are unusable
+ * @param transporter BsddTransporter
+ * @returns Prisma Update payload
+ */
+export async function recipifyTransporterInDb(
+  transporter: BsddTransporter | null
+): Promise<{
+  transporters: {
+    update: Prisma.BsddTransporterUpdateWithWhereUniqueWithoutFormInput;
+  };
+}> {
+  let formUpdateInput;
+
+  if (transporter) {
+    const recipifiedTransporter = await recipifyFormInput({
+      transporter: {
+        isExemptedOfReceipt: transporter.transporterIsExemptedOfReceipt,
+        receipt: transporter.transporterReceipt,
+        validityLimit: transporter.transporterValidityLimit,
+        department: transporter.transporterDepartment,
+        company: {
+          siret: transporter.transporterCompanySiret,
+          vatNumber: transporter.transporterCompanyVatNumber
+        }
+      }
+    });
+    const update: Prisma.BsddTransporterUpdateWithWhereUniqueWithoutFormInput =
+      {
+        data: {
+          transporterReceipt:
+            recipifiedTransporter.transporter?.receipt ?? null,
+          transporterDepartment:
+            recipifiedTransporter.transporter?.department ?? null,
+          transporterValidityLimit:
+            recipifiedTransporter.transporter?.validityLimit ?? null,
+          transporterIsExemptedOfReceipt:
+            recipifiedTransporter.transporter?.isExemptedOfReceipt ?? null
+        },
+        where: { id: transporter.id }
+      };
+    formUpdateInput = {
+      transporters: {
+        update
+      }
+    };
+  }
+  return formUpdateInput;
+}

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -91,7 +91,7 @@ describe("Mutation.markAsSealed", () => {
         companyTypes: { set: [companyType(role) as CompanyType] }
       });
 
-      let form = await formFactory({
+      const form = await formFactory({
         ownerId: user.id,
         opt: {
           status: "DRAFT",
@@ -127,12 +127,12 @@ describe("Mutation.markAsSealed", () => {
         }
       });
 
-      form = await prisma.form.findUniqueOrThrow({
+      const formDb = await prisma.form.findUniqueOrThrow({
         where: { id: form.id },
-        include: { forwardedIn: true }
+        include: { transporters: true }
       });
 
-      expect(form.status).toEqual("SEALED");
+      expect(formDb.status).toEqual("SEALED");
 
       // check relevant statusLog is created
       const statusLogs = await prisma.statusLog.findMany({

--- a/back/src/forms/resolvers/mutations/__tests__/mutations.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/mutations.ts
@@ -3,6 +3,15 @@ export const MARK_AS_SEALED = `
     markAsSealed(id: $id) {
       id
       status
+      transporter {
+        company {
+          siret
+        }
+        isExemptedOfReceipt
+        receipt
+        validityLimit
+        department
+      }
     }
   }
 `;

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -9,7 +9,8 @@ import {
   siretify,
   toIntermediaryCompany,
   userFactory,
-  userWithCompanyFactory
+  userWithCompanyFactory,
+  transporterReceiptFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import {
@@ -239,6 +240,126 @@ describe("Mutation.updateForm", () => {
       expect(sirenifyMock).toHaveBeenCalledTimes(1);
     }
   );
+
+  it("should autocomplete transporter receipt with receipt pulled from db", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    await transporterReceiptFactory({
+      company: transporterCompany
+    });
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: company.siret,
+            number: 1
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const updateFormInput = {
+      id: form.id,
+      transporter: {
+        company: { siret: transporterCompany.siret }
+      }
+    };
+    const { data } = await mutate<Pick<Mutation, "updateForm">>(UPDATE_FORM, {
+      variables: { updateFormInput }
+    });
+    // receipt data is pulled from db
+    expect(data.updateForm.transporter!.receipt).toEqual("the number");
+    expect(data.updateForm.transporter!.department).toEqual("83");
+    expect(data.updateForm.transporter!.validityLimit).toEqual(
+      "2055-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("should null transporter receipt is they do not have receipt in db", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    // transporter has not receipt stored in db
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: company.siret,
+            number: 1,
+            transporterReceipt: "plop",
+            transporterDepartment: "65",
+            transporterValidityLimit: new Date()
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const updateFormInput = {
+      id: form.id,
+      transporter: {
+        company: { siret: transporterCompany.siret }
+      }
+    };
+    const { data } = await mutate<Pick<Mutation, "updateForm">>(UPDATE_FORM, {
+      variables: { updateFormInput }
+    });
+    // receipt data is pulled from db
+    expect(data.updateForm.transporter!.receipt).toEqual(null);
+    expect(data.updateForm.transporter!.department).toEqual(null);
+    expect(data.updateForm.transporter!.validityLimit).toEqual(null);
+  });
+
+  it("should let the transporter receipt unchanged if transporter is unchanged", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const receipt = await transporterReceiptFactory({ company });
+    // form receipt is fileld
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "DRAFT",
+        emitterCompanySiret: company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: company.siret,
+            number: 1,
+            transporterReceipt: receipt.receiptNumber,
+            transporterDepartment: receipt.department,
+            transporterValidityLimit: receipt.validityLimit
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    // transporter is unchanged
+    const updateFormInput = {
+      id: form.id,
+      wasteDetails: {
+        code: "01 01 01"
+      }
+    };
+    const { data } = await mutate<Pick<Mutation, "updateForm">>(UPDATE_FORM, {
+      variables: { updateFormInput }
+    });
+    // receipt data is unchanged
+    expect(data.updateForm.transporter!.receipt).toEqual(receipt.receiptNumber);
+    expect(data.updateForm.transporter!.department).toEqual(receipt.department);
+    expect(data.updateForm.transporter!.validityLimit).toEqual(
+      receipt.validityLimit.toISOString()
+    );
+  });
 
   it.each(["emitter", "trader", "broker", "recipient", "transporter"])(
     "should allow %p to update a sealed form",
@@ -1966,6 +2087,12 @@ describe("Mutation.updateForm", () => {
 
   it("should update denormalized fields", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    await transporterReceiptFactory({ company: transporterCompany });
+
+    const intermediaryCompany = await companyFactory();
     const { mutate } = makeClient(user);
 
     const form = await formFactory({
@@ -1985,9 +2112,9 @@ describe("Mutation.updateForm", () => {
       variables: {
         updateFormInput: {
           id: form.id,
-          transporter: { company: { siret: company.siret } },
+          transporter: { company: { siret: transporterCompany.siret } },
           recipient: { company: { siret: company.siret } },
-          intermediaries: [toIntermediaryCompany(company)]
+          intermediaries: [toIntermediaryCompany(intermediaryCompany)]
         }
       }
     });
@@ -1997,8 +2124,10 @@ describe("Mutation.updateForm", () => {
     });
 
     expect(updatedForm.recipientsSirets).toContain(company.siret);
-    expect(updatedForm.transportersSirets).toContain(company.siret);
-    expect(updatedForm.intermediariesSirets).toContain(company.siret);
+    expect(updatedForm.transportersSirets).toContain(transporterCompany.siret);
+    expect(updatedForm.intermediariesSirets).toContain(
+      intermediaryCompany.siret
+    );
   });
 
   it("should not be possible to update a weight > 40 T when transport mode is ROAD", async () => {

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -25,6 +25,7 @@ import { appendix2toFormFractions } from "../../compat";
 import { runInTransaction } from "../../../common/repository/helper";
 import { validateIntermediariesInput } from "../../../common/validation";
 import { sirenifyFormInput } from "../../sirenify";
+import { recipifyFormInput } from "../../recipify";
 import { checkCanCreate } from "../../permissions";
 
 const createFormResolver = async (
@@ -34,13 +35,15 @@ const createFormResolver = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
+  const sirenifiedFormInput = await sirenifyFormInput(createFormInput, user);
+
   const {
     appendix2Forms,
     grouping,
     temporaryStorageDetail,
     intermediaries,
     ...formContent
-  } = await sirenifyFormInput(createFormInput, user);
+  } = await recipifyFormInput(sirenifiedFormInput);
 
   if (appendix2Forms && grouping) {
     throw new UserInputError(

--- a/back/src/forms/resolvers/mutations/signedByTransporter.ts
+++ b/back/src/forms/resolvers/mutations/signedByTransporter.ts
@@ -20,6 +20,7 @@ import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import { Prisma } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "../../../common/constants/companySearchHelpers";
+import { getFormReceiptField } from "./signTransportForm";
 
 const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
   async (parent, args, context) => {
@@ -67,10 +68,12 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
       wasteDetailsOnuCode: infos.onuCode ?? form.wasteDetailsOnuCode
     };
 
+    const receiptFields = await getFormReceiptField(transporter);
     const futureForm = {
       ...transporter,
       ...form,
-      ...wasteDetails
+      ...wasteDetails,
+      ...receiptFields
     };
 
     // check waste details override is valid and transporter info is filled
@@ -80,7 +83,8 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
 
     const transporterUpdate: Prisma.BsddTransporterUpdateWithoutFormInput = {
       takenOverAt: infos.sentAt, // takenOverAt is duplicated between Form and BsddTransporter
-      takenOverBy: user.name // takenOverBy is duplicated between Form and BsddTransporter
+      takenOverBy: user.name, // takenOverBy is duplicated between Form and BsddTransporter
+      ...receiptFields
     };
 
     if (form.takenOverAt && fullForm.forwardedIn) {

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -27,6 +27,7 @@ import { UserInputError } from "apollo-server-core";
 import { appendix2toFormFractions } from "../../compat";
 import { runInTransaction } from "../../../common/repository/helper";
 import { sirenifyFormInput } from "../../sirenify";
+import { recipifyFormInput } from "../../recipify";
 import { validateIntermediariesInput } from "../../../common/validation";
 
 function validateArgs(args: MutationUpdateFormArgs) {
@@ -48,13 +49,15 @@ const updateFormResolver = async (
 
   const id = updateFormInput.id;
 
+  const sirenifiedFormInput = await sirenifyFormInput(updateFormInput, user);
+
   const {
     appendix2Forms,
     grouping,
     temporaryStorageDetail,
     intermediaries,
     ...formContent
-  } = await sirenifyFormInput(updateFormInput, user);
+  } = await recipifyFormInput(sirenifiedFormInput);
 
   if (appendix2Forms && grouping) {
     throw new UserInputError(

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -490,13 +490,13 @@ input TransporterInput {
   isExemptedOfReceipt: Boolean
 
   "N° de récipissé. Obligatoire lorsque l'exemption de récépissé n'est pas précisée"
-  receipt: String
+  receipt: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 
   "Département du récépissé. Obligatoire lorsque l'exemption de récépissé n'est pas précisée"
-  department: String
+  department: String @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 
   "Limite de validité du récépissé. Obligatoire lorsque l'exemption de récépissé n'est pas précisée"
-  validityLimit: DateTime
+  validityLimit: DateTime @deprecated(reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport ")
 
   "Numéro de plaque d'immatriculation"
   numberPlate: String

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -30,6 +30,9 @@ import {
 } from "../common/constants/companySearchHelpers";
 import {
   foreignVatNumber,
+  REQUIRED_RECEIPT_DEPARTMENT,
+  REQUIRED_RECEIPT_NUMBER,
+  REQUIRED_RECEIPT_VALIDITYLIMIT,
   siret,
   siretConditions,
   siretTests,
@@ -863,10 +866,7 @@ export const transporterSchemaFn: FactorySchemaOf<
         is: (isExempted, vat) => isForeignVat(vat) || isExempted,
         then: schema => schema.notRequired().nullable(),
         otherwise: schema =>
-          schema.requiredIf(
-            transporterSignature,
-            "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, il est donc est obligatoire"
-          )
+          schema.requiredIf(transporterSignature, REQUIRED_RECEIPT_NUMBER)
       }),
     transporterDepartment: yup
       .string()
@@ -874,12 +874,19 @@ export const transporterSchemaFn: FactorySchemaOf<
         is: (isExempted, vat) => isForeignVat(vat) || isExempted,
         then: schema => schema.notRequired().nullable(),
         otherwise: schema =>
+          schema.requiredIf(transporterSignature, REQUIRED_RECEIPT_DEPARTMENT)
+      }),
+    transporterValidityLimit: yup
+      .date()
+      .when(["transporterIsExemptedOfReceipt", "transporterCompanyVatNumber"], {
+        is: (isExempted, vat) => isForeignVat(vat) || isExempted,
+        then: schema => schema.notRequired().nullable(),
+        otherwise: schema =>
           schema.requiredIf(
             transporterSignature,
-            "Le département du transporteur est obligatoire"
+            REQUIRED_RECEIPT_VALIDITYLIMIT
           )
-      }),
-    transporterValidityLimit: yup.date().nullable()
+      })
   });
 
 // 8 - Collecteur-transporteur vide dans le cas du pipeline

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
@@ -45,9 +45,6 @@ const emptyState = {
   },
   transporter: {
     isExemptedOfReceipt: false,
-    receipt: "",
-    department: "",
-    validityLimit: null,
     numberPlate: "",
     company: {
       siret: "",

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/segments/PrepareSegment.tsx
@@ -69,9 +69,6 @@ export function PrepareSegment({ form, siret }: WorkflowActionProps) {
         vatNumber: "",
       },
       isExemptedOfReceipt: false,
-      receipt: null,
-      department: null,
-      validityLimit: null,
       numberPlate: null,
     },
 

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -100,9 +100,6 @@ export function SignTransport({
                   transporter: {
                     recepisse: {
                       isExempted: false,
-                      number: "",
-                      department: "",
-                      validityLimit: null,
                     },
                     transport: {
                       mode: TransportMode.Road,

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -75,7 +75,11 @@ export function SignTransport({
               Vous devez mettre à jour le bordereau et renseigner les champs
               obligatoires avant de le signer.
             </p>
-
+            <ul className="tw-mb-2 tw-text-red-700 tw-list-disc">
+              {bsvhu.metadata?.errors.map((error, idx) => (
+                <li key={idx}>{error.message}</li>
+              ))}
+            </ul>
             <Link
               to={generatePath(routes[dashboardRoutePrefix].bsvhus.edit, {
                 siret,

--- a/front/src/dashboard/detail/bsdd/EditSegment.tsx
+++ b/front/src/dashboard/detail/bsdd/EditSegment.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from "react";
 import { useMutation, gql } from "@apollo/client";
 import { Field, Form as FormikForm, Formik } from "formik";
-import { string, object, date, boolean } from "yup";
+import { string, object, boolean } from "yup";
 import cogoToast from "cogo-toast";
 import {
-  CompanySearchPrivate,
-  CompanySearchResult,
   Mutation,
   MutationEditSegmentArgs,
   NextSegmentInfoInput,
@@ -43,27 +41,6 @@ type Props = {
 export const validationSchema = object().shape({
   transporter: object().shape({
     isExemptedOfReceipt: boolean().nullable(),
-    receipt: string().when(["isExemptedOfReceipt", "company.vatNumber"], {
-      is: (isExemptedOfReceipt: boolean, transporterCompanyVatNumber: string) =>
-        isForeignVat(transporterCompanyVatNumber) || isExemptedOfReceipt,
-      then: schema => schema.nullable(true),
-      otherwise: schema =>
-        schema
-          .ensure()
-          .required(
-            "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, il est donc est obligatoire"
-          ),
-    }),
-    department: string().when(["isExemptedOfReceipt", "company.vatNumber"], {
-      is: (isExemptedOfReceipt: boolean, transporterCompanyVatNumber: string) =>
-        isForeignVat(transporterCompanyVatNumber) || isExemptedOfReceipt,
-      then: schema => schema.nullable(true),
-      otherwise: schema =>
-        schema
-          .ensure()
-          .required("Le département du transporteur est obligatoire"),
-    }),
-    validityLimit: date().nullable(true),
     numberPlate: string().nullable(true),
     company: transporterCompanySchema,
   }),
@@ -74,32 +51,12 @@ export const validationSchema = object().shape({
  * @param setFieldValue Formik function
  * @returns
  */
-export const onCompanySelected =
-  setFieldValue =>
-  (transporter?: CompanySearchResult | CompanySearchPrivate) => {
-    if (transporter?.transporterReceipt) {
-      setFieldValue(
-        "transporter.receipt",
-        transporter?.transporterReceipt.receiptNumber
-      );
-      setFieldValue(
-        "transporter.validityLimit",
-        transporter?.transporterReceipt.validityLimit
-      );
-      setFieldValue(
-        "transporter.department",
-        transporter?.transporterReceipt.department
-      );
-    } else {
-      setFieldValue("transporter.receipt", null);
-      setFieldValue("transporter.validityLimit", null);
-      setFieldValue("transporter.department", null);
-    }
-    // automatically check the receipt exemption
-    if (isForeignVat(transporter?.vatNumber!)) {
-      setFieldValue("transporter.isExemptedOfReceipt", true);
-    }
-  };
+export const onCompanySelected = setFieldValue => transporter => {
+  // automatically check the receipt exemption
+  if (isForeignVat(transporter?.vatNumber!)) {
+    setFieldValue("transporter.isExemptedOfReceipt", true);
+  }
+};
 
 export default function EditSegment({ siret, segment }: Props) {
   const [isOpen, setIsOpen] = useState(false);

--- a/front/src/form/bsda/stepper/initial-state.ts
+++ b/front/src/form/bsda/stepper/initial-state.ts
@@ -47,9 +47,6 @@ const initialState = {
       ...getInitialCompany(),
     },
     recepisse: {
-      number: "",
-      department: "",
-      validityLimit: null,
       isExempted: false,
     },
     transport: {

--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -3,9 +3,7 @@ import { useFormikContext } from "formik";
 import { Bsda, BsdaType } from "generated/graphql/types";
 import React from "react";
 import { Transport } from "./Transport";
-import initialState from "../initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
-import { onTransporterSelected } from "form/bsvhu/Transporter";
 
 export function Transporter({ disabled }) {
   const { values, setFieldValue } = useFormikContext<Bsda>();
@@ -20,8 +18,6 @@ export function Transporter({ disabled }) {
       </div>
     );
   }
-
-  const { transporter: initialTransporter } = initialState;
 
   return (
     <>
@@ -39,10 +35,6 @@ export function Transporter({ disabled }) {
         allowForeignCompanies={true}
         isBsdaTransporter={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={onTransporterSelected(
-          initialTransporter,
-          setFieldValue
-        )}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -10,7 +10,6 @@ import {
   QueryCompanyInfosArgs,
 } from "generated/graphql/types";
 import React from "react";
-import initialState from "../utils/initial-state";
 import { gql, useQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { FillFieldsInfo, DisabledFieldsInfo } from "../utils/commons";
@@ -21,7 +20,6 @@ import companyStyles from "form/common/components/company/CompanyResult.module.s
 import RedErrorMessage from "common/components/RedErrorMessage";
 import TransporterReceipt from "form/common/components/company/TransporterReceipt";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
-import { onTransporterSelected } from "form/bsvhu/Transporter";
 
 /**
  *
@@ -47,7 +45,6 @@ export default function Transporter({ status, stepName }) {
   );
 
   const transportEmphasis = stepName === "transport";
-  const { transporter: initialTransporter } = initialState();
   return (
     <>
       {transportEmphasis && <FillFieldsInfo />}
@@ -67,10 +64,6 @@ export default function Transporter({ status, stepName }) {
             optionalMail={true}
             allowForeignCompanies={true}
             registeredOnlyCompanies={true}
-            onCompanySelected={onTransporterSelected(
-              initialTransporter,
-              setFieldValue
-            )}
           />
         )}
       </div>
@@ -160,28 +153,6 @@ function CurrentCompanyWidget({ disabled = false }) {
           `transporter.company.phone`,
           completed?.companyInfos?.contactPhone
         );
-      }
-      if (completed?.companyInfos?.transporterReceipt) {
-        setFieldValue(
-          "transporter.recepisse.number",
-          completed?.companyInfos?.transporterReceipt.receiptNumber
-        );
-        setFieldValue(
-          "transporter.recepisse.validityLimit",
-          completed?.companyInfos?.transporterReceipt.validityLimit
-        );
-        setFieldValue(
-          "transporter.recepisse.department",
-          completed?.companyInfos?.transporterReceipt.department
-        );
-      } else {
-        setFieldValue("transporter.recepisse.number", "");
-        setFieldValue(
-          "transporter.recepisse.validityLimit",
-          initialState().transporter.recepisse.validityLimit
-        );
-
-        setFieldValue("transporter.recepisse.department", "");
       }
     },
   });

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -12,7 +12,6 @@ import {
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import Tooltip from "common/components/Tooltip";
-import initialState from "../utils/initial-state";
 
 type Props = { disabled: boolean };
 
@@ -109,28 +108,6 @@ export function Type({ disabled }: Props) {
       );
       setFieldValue("transporter.company.address", data?.companyInfos.address);
       setFieldValue("transporter.company.name", data?.companyInfos.name);
-      if (data?.companyInfos?.transporterReceipt) {
-        setFieldValue(
-          "transporter.recepisse.number",
-          data?.companyInfos?.transporterReceipt.receiptNumber
-        );
-        setFieldValue(
-          "transporter.recepisse.validityLimit",
-          data?.companyInfos?.transporterReceipt.validityLimit
-        );
-        setFieldValue(
-          "transporter.recepisse.department",
-          data?.companyInfos?.transporterReceipt.department
-        );
-      } else {
-        setFieldValue("transporter.recepisse.number", "");
-        setFieldValue(
-          "transporter.recepisse.validityLimit",
-          initialState().transporter.recepisse.validityLimit
-        );
-
-        setFieldValue("transporter.recepisse.department", "");
-      }
       setFieldValue("grouping", []);
     }
   }, [type, setFieldValue, data]);

--- a/front/src/form/bsdasri/utils/initial-state.ts
+++ b/front/src/form/bsdasri/utils/initial-state.ts
@@ -1,5 +1,4 @@
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
-import { addYears, startOfYear } from "date-fns";
 
 import {
   BsdasriWeight,
@@ -49,9 +48,6 @@ const getInitialState = (f?: Bsdasri | null) => ({
     customInfo: "",
     recepisse: {
       isExempted: false,
-      number: "",
-      department: "",
-      validityLimit: startOfYear(addYears(new Date(), 1)).toISOString(),
     },
     transport: {
       mode: "ROAD",

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -146,9 +146,6 @@ export function getInitialState(f?: Form | null): FormInput {
     },
     transporter: {
       isExemptedOfReceipt: f?.transporter?.isExemptedOfReceipt ?? false,
-      receipt: f?.transporter?.receipt ?? "",
-      department: f?.transporter?.department ?? "",
-      validityLimit: f?.transporter?.validityLimit ?? null,
       numberPlate: f?.transporter?.numberPlate ?? "",
       customInfo: f?.transporter?.customInfo ?? null,
       company: getInitialCompany(f?.transporter?.company),

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -6,7 +6,6 @@ import {
   array,
   boolean,
   setLocale,
-  StringSchema,
   mixed,
   SchemaOf,
 } from "yup";
@@ -26,7 +25,6 @@ import {
   isVat,
   isFRVat,
   isSiret,
-  isForeignVat,
 } from "generated/constants/companySearchHelpers";
 import {
   companySchema,
@@ -75,51 +73,6 @@ const companyRegistrationAndTypeSchema = companySchema.concat(
 
 export const transporterSchema = object().shape({
   isExemptedOfReceipt: boolean().nullable(true),
-  receipt: string()
-    .when(
-      "isExemptedOfReceipt",
-      (isExemptedOfReceipt: boolean, schema: StringSchema) =>
-        isExemptedOfReceipt
-          ? schema.nullable(true)
-          : schema
-              .ensure()
-              .required(
-                "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, le numéro est donc est obligatoire"
-              )
-    )
-    .when(
-      "transporter.company.vatNumber",
-      (transporterCompanyVatNumber, schema) =>
-        isForeignVat(transporterCompanyVatNumber)
-          ? schema.nullable(true)
-          : schema
-              .ensure()
-              .required(
-                "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, le numéro est donc est obligatoire"
-              )
-    ),
-  department: string()
-    .when(
-      "isExemptedOfReceipt",
-      (isExemptedOfReceipt: boolean, schema: StringSchema) =>
-        isExemptedOfReceipt
-          ? schema.nullable(true)
-          : schema.required(
-              "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, le département est donc est obligatoire"
-            )
-    )
-    .when(
-      "transporter.company.vatNumber",
-      (transporterCompanyVatNumber, schema) =>
-        isForeignVat(transporterCompanyVatNumber)
-          ? schema.nullable(true)
-          : schema
-              .ensure()
-              .required(
-                "Vous n'avez pas précisé bénéficier de l'exemption de récépissé, le département du transporteur est obligatoire"
-              )
-    ),
-  validityLimit: date().nullable(true),
   numberPlate: string().nullable(true),
   company: transporterCompanySchema,
 });

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -90,23 +90,20 @@ export default function BsffStepsList(props: Props) {
       previousPackagings,
       packagings,
       type,
-      transporter: { recepisse, isExemptedOfRecepisse, ...transporter },
+      transporter: { isExemptedOfRecepisse, ...transporter },
       destination: { plannedOperationCode, ...destination },
       ...input
     } = values;
-
+    // clean the temp value because it's absent from the Input gql type
+    delete transporter.isExemptedOfRecepisse;
     saveForm({
       type,
       ...input,
       transporter: {
-        recepisse: isExemptedOfRecepisse
-          ? null
-          : {
-              ...recepisse,
-              validityLimit:
-                recepisse.validityLimit === "" ? null : recepisse.validityLimit,
-            },
         ...transporter,
+        recepisse: {
+          isExempted: isExemptedOfRecepisse,
+        },
       },
       destination: {
         ...destination,

--- a/front/src/form/bsff/Transporter.tsx
+++ b/front/src/form/bsff/Transporter.tsx
@@ -4,12 +4,12 @@ import TdTooltip from "common/components/Tooltip";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Field, useField, useFormikContext } from "formik";
 import { Bsff } from "generated/graphql/types";
-import initialState from "./utils/initial-state";
 import { isForeignVat } from "generated/constants/companySearchHelpers";
 const TagsInput = lazy(() => import("common/components/tags-input/TagsInput"));
 
 export default function Transporter({ disabled }) {
   const { setFieldValue, values } = useFormikContext<Bsff>();
+  // temp field
   const [{ value: isExemptedOfRecepisse }, ,] = useField<boolean>(
     "transporter.isExemptedOfRecepisse"
   );
@@ -29,20 +29,6 @@ export default function Transporter({ disabled }) {
         heading="Entreprise de transport"
         allowForeignCompanies={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={transporter => {
-          if (transporter?.transporterReceipt) {
-            setFieldValue("transporter.recepisse", {
-              number: transporter.transporterReceipt.receiptNumber,
-              validityLimit: transporter.transporterReceipt.validityLimit,
-              department: transporter.transporterReceipt.department,
-            });
-          } else {
-            setFieldValue(
-              "transporter.recepisse",
-              initialState.transporter.recepisse
-            );
-          }
-        }}
       />
 
       {!isForeignVat(values?.transporter?.company?.vatNumber!!) && (

--- a/front/src/form/bsff/utils/initial-state.ts
+++ b/front/src/form/bsff/utils/initial-state.ts
@@ -27,12 +27,8 @@ const initialState: BsffFormInput = {
     company: {
       ...getInitialCompany(),
     },
+    // TEMP FIELD for the frontend to handle this special case
     isExemptedOfRecepisse: false,
-    recepisse: {
-      number: "",
-      department: "",
-      validityLimit: "",
-    },
     transport: {
       mode: TransportMode.Road,
       plates: [],

--- a/front/src/form/bsff/utils/schema.ts
+++ b/front/src/form/bsff/utils/schema.ts
@@ -10,23 +10,6 @@ export const transporterSchema = yup.object().shape({
   isExemptedOfReceipt: yup.boolean().nullable(true),
   numberPlate: yup.string().nullable(true),
   company: transporterCompanySchema,
-  recepisse: yup.object({
-    number: yup.string().nullable(true),
-    department: yup
-      .string()
-      .when("number", (number: string, schema: yup.StringSchema) =>
-        number?.length
-          ? schema.required("Le département est un champ requis")
-          : schema.nullable(true)
-      ),
-    validityLimit: yup
-      .date()
-      .when("number", (number: string, schema: yup.DateSchema) =>
-        number?.length
-          ? schema.required("La limite de validité est un champ requis")
-          : schema.nullable(true)
-      ),
-  }),
 });
 
 const destinationSchema = yup.object().shape({

--- a/front/src/form/bsvhu/Transporter.tsx
+++ b/front/src/form/bsvhu/Transporter.tsx
@@ -2,37 +2,10 @@ import React from "react";
 import { useFormikContext } from "formik";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Bsvhu } from "generated/graphql/types";
-import initialState from "./utils/initial-state";
 import TransporterReceiptEditionSwitch from "form/common/components/company/TransporterReceiptEditionSwitch";
-
-export const onTransporterSelected =
-  (initialTransporter, setFieldValue) => transporter => {
-    if (transporter?.transporterReceipt) {
-      setFieldValue(
-        "transporter.recepisse.number",
-        transporter.transporterReceipt.receiptNumber
-      );
-      setFieldValue(
-        "transporter.recepisse.validityLimit",
-        transporter.transporterReceipt.validityLimit
-      );
-      setFieldValue(
-        "transporter.recepisse.department",
-        transporter.transporterReceipt.department
-      );
-    } else {
-      setFieldValue("transporter.recepisse.number", "");
-      setFieldValue(
-        "transporter.recepisse.validityLimit",
-        initialTransporter.recepisse.validityLimit
-      );
-      setFieldValue("transporter.recepisse.department", "");
-    }
-  };
 
 export default function Transporter({ disabled }) {
   const { setFieldValue, values } = useFormikContext<Bsvhu>();
-  const { transporter: initialTransporter } = initialState;
   return (
     <>
       {disabled && (
@@ -47,10 +20,6 @@ export default function Transporter({ disabled }) {
         heading="Entreprise de transport"
         allowForeignCompanies={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={onTransporterSelected(
-          initialTransporter,
-          setFieldValue
-        )}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}

--- a/front/src/form/bsvhu/utils/initial-state.ts
+++ b/front/src/form/bsvhu/utils/initial-state.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-anonymous-default-export */
-import { startOfYear, addYears } from "date-fns";
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
 
 export default {
@@ -44,9 +43,6 @@ export default {
     },
     recepisse: {
       isExempted: false,
-      number: "",
-      department: "",
-      validityLimit: startOfYear(addYears(new Date(), 1)).toISOString(),
     },
   },
 };

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -574,7 +574,7 @@ export default function CompanySelector({
         </div>
 
         {values.transporter && !!orgId && name === "transporter.company" && (
-          <TransporterReceipt transporter={values.transporter} />
+          <TransporterReceipt transporter={values.transporter!} />
         )}
       </div>
     </>

--- a/front/src/form/common/components/company/query.ts
+++ b/front/src/form/common/components/company/query.ts
@@ -192,3 +192,15 @@ export const COMPANY_SELECTOR_PRIVATE_INFOS = gql`
     }
   }
 `;
+
+export const TRANSPORTER_RECEIPT = gql`
+  query CompanyPrivateInfos($clue: String!) {
+    companyPrivateInfos(clue: $clue) {
+      transporterReceipt {
+        receiptNumber
+        validityLimit
+        department
+      }
+    }
+  }
+`;


### PR DESCRIPTION
Reprise de #2402 

- Permettre d'aller jusqu'à l'étape transporteur sans récépissé ni précision d'exemption. (sauf BSFF)
- Permettre de mettre à jour automatiquement les récépissés transporteur (tous BSD)
- ETQ Utilisateur web, aucun changement de cette PR, le récépissé est toujours affiché automatiquement dans les étapes d'édition. C'est juste la logique client/serveur qui change

## TODO

- Démo à venir semaine 28

# Breaking change annoncé pour le 18/7/2023

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11257)
