### PR TITLE
HOTFIX Impossible de télécharger le registre pour certains codes déchets

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
@@ -4,7 +4,7 @@ import { FieldSwitch, RedErrorMessage } from "common/components";
 import Packagings from "form/bsdd/components/packagings/Packagings";
 import {
   WasteCodeSelect,
-  wasteCodeValidator,
+  bsddWasteCodeValidator,
 } from "form/bsdd/components/waste-code";
 import {
   getInitialBroker,
@@ -182,7 +182,7 @@ export function BsddRequestRevision({ bsdd }: Props) {
                     <Field
                       name="content.wasteDetails.code"
                       component={WasteCodeSelect}
-                      validate={wasteCodeValidator}
+                      validate={bsddWasteCodeValidator}
                     />
                   </ReviewableField>
 

--- a/front/src/dashboard/exports/ExportsForm.tsx
+++ b/front/src/dashboard/exports/ExportsForm.tsx
@@ -9,12 +9,13 @@ import {
   WasteRegistryType,
 } from "generated/graphql/types";
 import WasteTreeModal from "search/WasteTreeModal";
-import { wasteCodeValidator } from "form/bsdd/components/waste-code/waste-code.validator";
+
 import { ALL_WASTES, ALL_WASTES_TREE } from "generated/constants";
 import { useLazyQuery, gql } from "@apollo/client";
 import { NotificationError } from "Apps/common/Components/Error/Error";
 import RedErrorMessage from "common/components/RedErrorMessage";
 import { sortCompaniesByName } from "common/helper";
+import { wasteCodeValidator } from "form/common/wasteCode";
 
 interface IProps {
   companies: CompanyPrivate[];

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -12,7 +12,10 @@ import React, { useEffect } from "react";
 import Appendix2MultiSelect from "./components/appendix/Appendix2MultiSelect";
 import Packagings from "./components/packagings/Packagings";
 import { ParcelNumbersSelector } from "./components/parcel-number/ParcelNumber";
-import { WasteCodeSelect, wasteCodeValidator } from "./components/waste-code";
+import {
+  WasteCodeSelect,
+  bsddWasteCodeValidator,
+} from "./components/waste-code";
 import "./WasteInfo.scss";
 
 type Values = {
@@ -71,7 +74,7 @@ export default connect<{ disabled }, Values>(function WasteInfo({
         <Field
           name="wasteDetails.code"
           component={WasteCodeSelect}
-          validate={wasteCodeValidator}
+          validate={bsddWasteCodeValidator}
           disabled={disabled}
         />
       </div>

--- a/front/src/form/bsdd/components/waste-code/index.ts
+++ b/front/src/form/bsdd/components/waste-code/index.ts
@@ -1,2 +1,2 @@
 export { WasteCodeSelect } from "./WasteCode";
-export { wasteCodeValidator } from "./waste-code.validator";
+export { bsddWasteCodeValidator } from "./waste-code.validator";

--- a/front/src/form/bsdd/components/waste-code/waste-code.validator.ts
+++ b/front/src/form/bsdd/components/waste-code/waste-code.validator.ts
@@ -1,21 +1,20 @@
-import { BSDD_WASTES, ALL_WASTES } from "generated/constants";
+import { wasteCodeValidator } from "form/common/wasteCode";
+import { BSDD_WASTES } from "generated/constants";
 
-export function wasteCodeValidator(wasteCode: string) {
-  const wasteCodeWithoutSpaces = wasteCode.replace(/\s+/g, "");
-  if (wasteCodeWithoutSpaces.length < 6) {
-    return "Le code déchet saisi n'existe pas. Il doit être composé d'au moins 6 caractères.";
-  }
-  if (wasteCodeWithoutSpaces.length > 7) {
-    return "Le code déchet saisi n'existe pas. Il doit être composé de moins de 7 caractères.";
-  }
+export function bsddWasteCodeValidator(wasteCode: string) {
+  const error = wasteCodeValidator(wasteCode);
 
-  if (BSDD_WASTES.find(waste => waste.code === wasteCode)) {
-    return undefined;
+  if (error) {
+    return error;
   }
 
-  if (ALL_WASTES.find(waste => waste.code === wasteCode)) {
-    return "Le code déchet saisi correspond à une typologie de déchets nécessitant d'utiliser un Bordereau de suivi spécifique. Veuillez créer le bordereau adéquat (BSDA, BSFF, BSDASRI ou BSVHU).";
+  if (!BSDD_WASTES.find(waste => waste.code === wasteCode)) {
+    return (
+      "Le code déchet saisi correspond à une typologie de déchets nécessitant" +
+      " d'utiliser un Bordereau de suivi spécifique. Veuillez créer le bordereau" +
+      " adéquat (BSDA, BSFF, BSDASRI ou BSVHU)."
+    );
   }
 
-  return "Le code déchet saisi n'existe pas.";
+  return undefined;
 }

--- a/front/src/form/bsdd/components/waste-code/waste-code.validator.ts
+++ b/front/src/form/bsdd/components/waste-code/waste-code.validator.ts
@@ -2,13 +2,15 @@ import { wasteCodeValidator } from "form/common/wasteCode";
 import { BSDD_WASTES } from "generated/constants";
 
 export function bsddWasteCodeValidator(wasteCode: string) {
-  const error = wasteCodeValidator(wasteCode);
+  const wasteCodeWithoutSpaces = wasteCode.replace(/\s+/g, "");
+
+  const error = wasteCodeValidator(wasteCodeWithoutSpaces);
 
   if (error) {
     return error;
   }
 
-  if (!BSDD_WASTES.find(waste => waste.code === wasteCode)) {
+  if (!BSDD_WASTES.find(waste => waste.code === wasteCodeWithoutSpaces)) {
     return (
       "Le code déchet saisi correspond à une typologie de déchets nécessitant" +
       " d'utiliser un Bordereau de suivi spécifique. Veuillez créer le bordereau" +

--- a/front/src/form/common/wasteCode.ts
+++ b/front/src/form/common/wasteCode.ts
@@ -1,0 +1,17 @@
+import { ALL_WASTES } from "generated/constants";
+
+export function wasteCodeValidator(wasteCode: string) {
+  const wasteCodeWithoutSpaces = wasteCode.replace(/\s+/g, "");
+  if (wasteCodeWithoutSpaces.length < 6) {
+    return "Le code déchet saisi n'existe pas. Il doit être composé d'au moins 6 caractères.";
+  }
+  if (wasteCodeWithoutSpaces.length > 7) {
+    return "Le code déchet saisi n'existe pas. Il doit être composé de moins de 7 caractères.";
+  }
+
+  if (!ALL_WASTES.find(waste => waste.code === wasteCode)) {
+    return "Le code déchet saisi n'existe pas.";
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Registre : Impossible de télécharger le registre pour certains codes déchets : "Le code déchet saisi correspond à une typologie de déchets nécessitant d'utiliser un Bordereau de suivi spécifique. Veuillez créer le bordereau adéquat (BSDA, BSFF, BSDASRI ou BSVHU)."](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12259)
