### PR TITLE
HOTFIX / Transform & entreprise fermée

### DIFF
--- a/back/src/bsda/validation/__tests__/sirenify.integration.ts
+++ b/back/src/bsda/validation/__tests__/sirenify.integration.ts
@@ -190,4 +190,104 @@ describe("sirenify", () => {
       searchResults[intermediary2.company.siret!].address
     );
   });
+
+  it("should not overwrite `name` and `address` based on SIRENE data for sealed fields", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+    const worker = await userWithCompanyFactory("MEMBER");
+    const intermediary1 = await userWithCompanyFactory("MEMBER");
+    const intermediary2 = await userWithCompanyFactory("MEMBER");
+
+    function searchResult(companyName: string) {
+      return {
+        name: companyName,
+        address: `Adresse ${companyName}`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire"),
+      [worker.company.siret!]: searchResult("courtier"),
+      [intermediary1.company.siret!]: searchResult("intermédiaire 1"),
+      [intermediary2.company.siret!]: searchResult("intermédiaire 2")
+    };
+
+    searchCompanySpy.mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const bsdaInput = {
+      emitterCompanySiret: emitter.company.siret,
+      emitterCompanyName: "N'importe",
+      emitterCompanyAddress: "Nawak",
+      transporterCompanySiret: transporter.company.siret,
+      transporterCompanyName: "N'importe",
+      transporterCompanyAddress: "Nawak",
+      destinationCompanySiret: destination.company.siret,
+      destinationCompanyName: "N'importe",
+      destinationCompanyAddress: "Nawak",
+      workerCompanySiret: worker.company.siret,
+      workerCompanyName: "N'importe",
+      workerCompanyAddress: "Nawak",
+      intermediaries: [
+        {
+          siret: intermediary1.company.siret,
+          contact: "Mr intermédiaire 1",
+          name: "N'importe",
+          address: "Nawak"
+        },
+        {
+          siret: intermediary2.company.siret,
+          contact: "Mr intermédiaire 2",
+          name: "N'importe",
+          address: "Nawak"
+        }
+      ]
+    };
+
+    const sealedFields = ["emitterCompanySiret", "transporterCompanySiret"];
+    const sirenified = await sirenify(bsdaInput, sealedFields);
+
+    // Unchanged
+    expect(sirenified.emitterCompanyName).toEqual(bsdaInput.emitterCompanyName);
+    expect(sirenified.emitterCompanyAddress).toEqual(
+      bsdaInput.emitterCompanyAddress
+    );
+    expect(sirenified.transporterCompanyName).toEqual(
+      bsdaInput.transporterCompanyName
+    );
+    expect(sirenified.transporterCompanyAddress).toEqual(
+      bsdaInput.transporterCompanyAddress
+    );
+
+    // Changed
+    expect(sirenified.destinationCompanyName).toEqual(
+      searchResults[destination.company.siret!].name
+    );
+    expect(sirenified.destinationCompanyAddress).toEqual(
+      searchResults[destination.company.siret!].address
+    );
+    expect(sirenified.workerCompanyName).toEqual(
+      searchResults[worker.company.siret!].name
+    );
+    expect(sirenified.workerCompanyAddress).toEqual(
+      searchResults[worker.company.siret!].address
+    );
+    expect(sirenified.intermediaries![0].name).toEqual(
+      searchResults[intermediary1.company.siret!].name
+    );
+    expect(sirenified.intermediaries![0].address).toEqual(
+      searchResults[intermediary1.company.siret!].address
+    );
+    expect(sirenified.intermediaries![1].name).toEqual(
+      searchResults[intermediary2.company.siret!].name
+    );
+    expect(sirenified.intermediaries![1].address).toEqual(
+      searchResults[intermediary2.company.siret!].address
+    );
+  });
 });

--- a/back/src/bsda/validation/__tests__/sirenify.integration.ts
+++ b/back/src/bsda/validation/__tests__/sirenify.integration.ts
@@ -67,7 +67,7 @@ describe("sirenify", () => {
       ]
     };
 
-    const sirenified = await sirenify(bsdaInput);
+    const sirenified = await sirenify(bsdaInput, []);
 
     expect(sirenified.emitterCompanyName).toEqual(
       searchResults[emitter.company.siret!].name
@@ -151,7 +151,7 @@ describe("sirenify", () => {
       ]
     };
 
-    const sirenified = await sirenify(bsdaInput);
+    const sirenified = await sirenify(bsdaInput, []);
 
     expect(sirenified.emitterCompanyName).toEqual(
       searchResults[emitter.company.siret!].name

--- a/back/src/bsda/validation/sirenify.ts
+++ b/back/src/bsda/validation/sirenify.ts
@@ -7,9 +7,13 @@ type SiretInfos = {
   address: string | null | undefined;
 };
 
-const accessors = (input: ReturnType<typeof flattenBsdaInput>) => [
+const accessors = (
+  input: ReturnType<typeof flattenBsdaInput>,
+  sealedFields: string[]
+) => [
   {
     siret: input?.emitterCompanySiret,
+    skip: sealedFields.includes("emitterCompanySiret"),
     setter: (input, companyInput: SiretInfos) => {
       input.emitterCompanyName = companyInput.name;
       input.emitterCompanyAddress = companyInput.address;
@@ -17,6 +21,7 @@ const accessors = (input: ReturnType<typeof flattenBsdaInput>) => [
   },
   {
     siret: input?.transporterCompanySiret,
+    skip: sealedFields.includes("transporterCompanySiret"),
     setter: (input, companyInput: CompanyInput) => {
       input.transporterCompanyName = companyInput.name;
       input.transporterCompanyAddress = companyInput.address;
@@ -24,6 +29,7 @@ const accessors = (input: ReturnType<typeof flattenBsdaInput>) => [
   },
   {
     siret: input?.destinationCompanySiret,
+    skip: sealedFields.includes("destinationCompanySiret"),
     setter: (input, companyInput: CompanyInput) => {
       input.destinationCompanyName = companyInput.name;
       input.destinationCompanyAddress = companyInput.address;
@@ -31,6 +37,7 @@ const accessors = (input: ReturnType<typeof flattenBsdaInput>) => [
   },
   {
     siret: input?.workerCompanySiret,
+    skip: sealedFields.includes("workerCompanySiret"),
     setter: (input, companyInput: CompanyInput) => {
       input.workerCompanyName = companyInput.name;
       input.workerCompanyAddress = companyInput.address;
@@ -38,6 +45,7 @@ const accessors = (input: ReturnType<typeof flattenBsdaInput>) => [
   },
   ...(input.intermediaries ?? []).map((_, idx) => ({
     siret: input.intermediaries![idx].siret,
+    skip: sealedFields.includes("intermediaries"),
     setter: (input, companyInput: CompanyInput) => {
       const intermediary = input.intermediaries[idx];
 

--- a/back/src/bsda/validation/sirenify.ts
+++ b/back/src/bsda/validation/sirenify.ts
@@ -9,7 +9,7 @@ type SiretInfos = {
 
 const accessors = (
   input: ReturnType<typeof flattenBsdaInput>,
-  sealedFields: string[]
+  sealedFields: string[] // Tranformations should not be run on sealed fields
 ) => [
   {
     siret: input?.emitterCompanySiret,


### PR DESCRIPTION
On a le cas d'une entreprise fermée, sur laquelle on joue le sirenify, mais donc qui fait planter la validation.

Or c'est un bsda SENT avec un émetteur fermé. Le BSDA doit pouvoir aller au bout de son cycle de vie. L'idée ici est donc de ne pas runner les transformer sirenify sur les champs déjà vérouillés

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
