### PR TITLE
Fix de recette pour les BSDD (entreposage provisoire) & BSDASRI

### DIFF
--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -261,6 +261,10 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
                 : ""}
             </p>
             <p>
+              Immatriculation(s) :{" "}
+              {bsdasri?.transporter?.transport?.plates?.join(", ")}
+            </p>
+            <p>
               <strong>Date de remise à l'installation de destination :</strong>
               {formatDate(
                 bsdasri?.transporter?.transport?.handedOverAt ??

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -165,8 +165,8 @@ export function getOtherPackagingLabel(packagingInfos: PackagingInfo[]) {
     otherPackagings.length === 0
       ? "à préciser"
       : otherPackagings
-        .map(({ quantity, other }) => `${quantity} ${other ?? "?"}`)
-        .join(", ");
+          .map(({ quantity, other }) => `${quantity} ${other ?? "?"}`)
+          .join(", ");
   return `Autre (${otherPackagingsSummary})`;
 }
 
@@ -234,6 +234,7 @@ function TransporterFormCompanyFields({
   takenOverAt,
   takenOverBy
 }: TransporterFormCompanyFieldsProps) {
+  console.log("transporter", transporter);
   return (
     <div className="Row">
       <div className="Col">
@@ -284,9 +285,9 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
 
   const form: GraphQLForm = {
     ...(await expandFormFromDb(fullPrismaForm)),
-    transportSegments: fullPrismaForm.transporters?.filter(transporter => transporter.number >= 2).map(
-      expandTransportSegmentFromDb
-    ),
+    transportSegments: fullPrismaForm.transporters
+      ?.filter(transporter => transporter.number >= 2)
+      .map(expandTransportSegmentFromDb),
     grouping: await Promise.all(
       grouping.map(async ({ form, quantity }) => ({
         form: await expandInitialFormFromDb(form),
@@ -372,7 +373,12 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
               {!!form.customId && <>({form.customId})</>}
               {!!groupedIn?.length && (
                 <>
-                  <strong>Annexé au bordereau {form.emitter?.type === EmitterType.APPENDIX1_PRODUCER && "de tournée dédiée"} n° :</strong>{" "}
+                  <strong>
+                    Annexé au bordereau{" "}
+                    {form.emitter?.type === EmitterType.APPENDIX1_PRODUCER &&
+                      "de tournée dédiée"}{" "}
+                    n° :
+                  </strong>{" "}
                   {groupedIn.map(bsd => bsd.readableId)}
                 </>
               )}
@@ -809,6 +815,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                 </p>
                 <AcceptationFields
                   {...form.temporaryStorageDetail?.temporaryStorer}
+                  signedAt={form.signedAt}
                 />
                 <p>
                   Nom :{" "}
@@ -842,7 +849,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                   packagingInfos={
                     isRepackging
                       ? form.temporaryStorageDetail?.wasteDetails
-                        ?.packagingInfos ?? []
+                          ?.packagingInfos ?? []
                       : []
                   }
                 />

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -814,7 +814,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
                 </p>
                 <AcceptationFields
                   {...form.temporaryStorageDetail?.temporaryStorer}
-                  signedAt={form.signedAt}
+                  signedAt={fullPrismaForm.signedAt}
                 />
                 <p>
                   Nom :{" "}

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -234,7 +234,6 @@ function TransporterFormCompanyFields({
   takenOverAt,
   takenOverBy
 }: TransporterFormCompanyFieldsProps) {
-  console.log("transporter", transporter);
   return (
     <div className="Row">
       <div className="Col">

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
@@ -18,6 +18,7 @@ import {
   Mutation,
   QuantityType,
   ResealedFormInput,
+  TransportMode,
 } from "generated/graphql/types";
 import React, { useState } from "react";
 
@@ -46,6 +47,7 @@ const emptyState = {
   transporter: {
     isExemptedOfReceipt: false,
     numberPlate: "",
+    mode: TransportMode.Road,
     company: {
       siret: "",
       vatNumber: "",


### PR DESCRIPTION
# Contexte

Corrections pour la recette:
- PDF de BSDD / Entreposage provisoire: date de signature absente
- BSDD / Entreposage provisoire: le formulaire front n'envoie pas le transportMode si le user laisse la valeur par défaut
- BSDASRIs: le PDF ne contient pas l'immatriculation