### PR TITLE
Refacto bsff exemption (recette auto-completion recepissés, suite)

### DIFF
--- a/back/prisma/migrations/147_create_bsff_recepisse_exemption.sql
+++ b/back/prisma/migrations/147_create_bsff_recepisse_exemption.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    "default$default"."Bsff"
+ADD COLUMN
+    "transporterRecepisseIsExempted" BOOLEAN DEFAULT FALSE;
+
+UPDATE "default$default"."Bsff" SET "transporterRecepisseIsExempted" = true WHERE "transporterRecepisseNumber" IS NULL;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1026,9 +1026,9 @@ model Bsdasri {
   synthesizedInId                             String?
 
   // Denormalized fields, storing associated dasri sirets to speed up some queries
-  // Emitter sirets list in case of synthesis bsd 
+  // Emitter sirets list in case of synthesis bsd
   synthesisEmitterSirets String[] @default([])
-  // Emitter sirets list in case of grouping bsd 
+  // Emitter sirets list in case of grouping bsd
   groupingEmitterSirets  String[] @default([])
 
   // partial indices _BsdasriTypeIdx, _BsdasriIsDraftIdx, _BsdasriIsDeletedIdx see migration82_missing_indices.sql
@@ -1092,6 +1092,7 @@ model Bsff {
   transporterRecepisseNumber        String?
   transporterRecepisseDepartment    String?
   transporterRecepisseValidityLimit DateTime? @db.Timestamptz(6)
+  transporterRecepisseIsExempted      Boolean?
 
   transporterTransportMode            TransportMode? @default(ROAD)
   transporterTransportPlates          String[]

--- a/back/src/bsdasris/recipify.ts
+++ b/back/src/bsdasris/recipify.ts
@@ -7,7 +7,7 @@ import {
   autocompletedRecepisse,
   genericGetter
 } from "../common/validation/recipify";
-import { Bsda, Bsdasri, Bsvhu } from "@prisma/client";
+import { Bsda, Bsdasri, Bsff, Bsvhu } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import prisma from "../prisma";
 
@@ -35,7 +35,7 @@ export interface BsdTransporterReceiptPart {
 }
 
 export async function getTransporterReceipt(
-  existingBsd: Bsdasri | Bsvhu | Bsda
+  existingBsd: Bsdasri | Bsvhu | Bsda | Bsff
 ): Promise<BsdTransporterReceiptPart> {
   // fetch TransporterReceipt
   const orgId = getTransporterCompanyOrgId(existingBsd);

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -4,8 +4,7 @@ import {
   safeInput,
   processDate,
   chain,
-  undefinedOrDefault,
-  nullIfAllNull
+  undefinedOrDefault
 } from "../common/converter";
 import * as GraphQL from "../generated/graphql/types";
 import { BsffPackaging, BsffPackagingType } from "@prisma/client";
@@ -74,6 +73,9 @@ function flattenTransporterInput(input: {
     ),
     transporterRecepisseValidityLimit: chain(input.transporter, t =>
       chain(t.recepisse, r => r.validityLimit)
+    ),
+    transporterRecepisseIsExempted: chain(input.transporter, t =>
+      chain(t.recepisse, r => r.isExempted)
     ),
     transporterTransportMode: chain(input.transporter, t =>
       chain(t.transport, tr => tr.mode)
@@ -211,10 +213,13 @@ export function expandBsffFromDB(prismaBsff: Prisma.Bsff): GraphQL.Bsff {
         phone: prismaBsff.transporterCompanyPhone,
         mail: prismaBsff.transporterCompanyMail
       }),
-      recepisse: nullIfAllNull<GraphQL.BsffTransporterRecepisse>({
+      recepisse: nullIfNoValues<GraphQL.BsffTransporterRecepisse>({
         number: prismaBsff.transporterRecepisseNumber,
         department: prismaBsff.transporterRecepisseDepartment,
-        validityLimit: processDate(prismaBsff.transporterRecepisseValidityLimit)
+        validityLimit: processDate(
+          prismaBsff.transporterRecepisseValidityLimit
+        ),
+        isExempted: prismaBsff.transporterRecepisseIsExempted
       }),
       customInfo: prismaBsff.transporterCustomInfo,
       transport: nullIfNoValues<GraphQL.BsffTransport>({

--- a/back/src/bsffs/edition/bsffEdition.ts
+++ b/back/src/bsffs/edition/bsffEdition.ts
@@ -68,6 +68,7 @@ export const editionRules: {
   transporterRecepisseNumber: "TRANSPORT",
   transporterRecepisseDepartment: "TRANSPORT",
   transporterRecepisseValidityLimit: "TRANSPORT",
+  transporterRecepisseIsExempted: "TRANSPORT",
   transporterTransportMode: "TRANSPORT",
   transporterTransportPlates: "TRANSPORT",
   transporterTransportTakenOverAt: "TRANSPORT",

--- a/back/src/bsffs/fragments.ts
+++ b/back/src/bsffs/fragments.ts
@@ -119,6 +119,7 @@ export const fullBsff = gql`
         number
         department
         validityLimit
+        isExempted
       }
       transport {
         mode

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -20,6 +20,7 @@ import {
 import { BSFF_WASTES } from "../../common/constants";
 import { extractPostalCode } from "../../utils";
 import { Decimal } from "decimal.js-light";
+import { Recepisse } from "./Recepisse";
 
 type Props = {
   bsff: Bsff & { packagings: BsffPackaging[] } & {
@@ -350,22 +351,14 @@ function BsffTransporter({ bsff }: Pick<Props, "bsff">) {
             <FormCompanyFields company={bsff.transporter?.company} />
           </div>
           <div className="Col">
-            {bsff.transporter?.company?.siret &&
-            !bsff.transporter?.recepisse ? (
+            {bsff?.transporter?.recepisse?.isExempted ? (
               <p>
-                <input type="checkbox" defaultChecked readOnly /> Je déclare
-                être exempté de récépissé au titre de l'article R.541-50 du code
-                de l'environnement
+                Le transporteur déclare être exempté de récépissé conformément
+                aux dispositions de l'article R.541-50 du code de
+                l'environnement.
               </p>
             ) : (
-              <p>
-                Récépissé n° : {bsff.transporter?.recepisse?.number}
-                <br />
-                Département : {bsff.transporter?.recepisse?.department}
-                <br />
-                Limite de validité :{" "}
-                {formatDate(bsff.transporter?.recepisse?.validityLimit)}
-              </p>
+              <Recepisse recepisse={bsff?.transporter?.recepisse} />
             )}
             <p>
               Mode de transport :{" "}

--- a/back/src/bsffs/pdf/Recepisse.tsx
+++ b/back/src/bsffs/pdf/Recepisse.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { formatDate } from "../../common/pdf";
+import { BsffTransporterRecepisse } from "../../generated/graphql/types";
+
+type Props = { recepisse: BsffTransporterRecepisse | null | undefined };
+
+export function Recepisse({ recepisse }: Props) {
+  return (
+    <p>
+      Récépissé n° : {recepisse?.number}
+      <br />
+      Département : {recepisse?.department}
+      <br />
+      Limite de validité : {formatDate(recepisse?.validityLimit)}
+    </p>
+  );
+}

--- a/back/src/bsffs/recipify.ts
+++ b/back/src/bsffs/recipify.ts
@@ -8,9 +8,6 @@ import { recipifyGeneric } from "../companies/recipify";
 const bsffAccessors = (input: BsffInput) => [
   {
     getter: () =>
-      // Old way of exempting is null
-      input?.transporter?.recepisse !== null &&
-      // New way added to the old
       input?.transporter?.recepisse?.isExempted !== true
         ? input?.transporter?.company
         : null,

--- a/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
@@ -29,6 +29,7 @@ import {
   createBsffAfterOperation,
   createBsffBeforeAcceptation
 } from "../../../__tests__/factories";
+import { REQUIRED_RECEIPT_NUMBER } from "../../../../common/validation";
 
 const SIGN = gql`
   mutation Sign($id: ID!, $input: BsffSignatureInput!) {
@@ -295,13 +296,11 @@ describe("Mutation.signBsff", () => {
     });
 
     it("should throw an error if the transporter tries to sign without receipt", async () => {
-      const bsff = await createBsffBeforeTransport(
-        { emitter, transporter, destination },
-        {
-          emitterEmissionSignatureDate: null,
-          emitterEmissionSignatureAuthor: null
-        }
-      );
+      const bsff = await createBsffBeforeTransport({
+        emitter,
+        transporter,
+        destination
+      });
       // remove the receipt
       await prisma.transporterReceipt.delete({ where: { id: receipt.id } });
       const { mutate } = makeClient(transporter.user);
@@ -321,8 +320,7 @@ describe("Mutation.signBsff", () => {
 
       expect(errors).toEqual([
         expect.objectContaining({
-          message:
-            "Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+          message: expect.stringContaining(REQUIRED_RECEIPT_NUMBER)
         })
       ]);
       // restore it

--- a/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
@@ -60,6 +60,7 @@ const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
       transporter?.transporterReceipt?.department ?? null,
     transporterRecepisseValidityLimit:
       transporter?.transporterReceipt?.validityLimit ?? null,
+    transporterRecepisseIsExempted: existingBsff.transporterRecepisseIsExempted,
     transporterTransportMode: existingBsff.transporterTransportMode,
     transporterTransportPlates: existingBsff.transporterTransportPlates,
     destinationCap: existingBsff.destinationCap,

--- a/back/src/bsffs/typeDefs/bsff.objects.graphql
+++ b/back/src/bsffs/typeDefs/bsff.objects.graphql
@@ -214,6 +214,8 @@ type BsffTransporterRecepisse {
   department: String
   "Date limite de validité du récépissé."
   validityLimit: DateTime
+  "Exemption de récépissé (conformément aux dispositions de l'article R.541-50 du code de l'environnement)"
+  isExempted: Boolean
 }
 type BsffTransport {
   "Date de prise en charge"

--- a/back/src/bsffs/validation.ts
+++ b/back/src/bsffs/validation.ts
@@ -20,6 +20,7 @@ import {
   siret,
   siretConditions,
   siretTests,
+  transporterRecepisseSchema,
   vatNumberTests,
   weight,
   weightConditions,
@@ -61,6 +62,7 @@ type Transporter = Pick<
   | "transporterRecepisseNumber"
   | "transporterRecepisseDepartment"
   | "transporterRecepisseValidityLimit"
+  | "transporterRecepisseIsExempted"
 >;
 
 type WasteDetails = Pick<
@@ -214,9 +216,7 @@ export const transporterSchemaFn: FactorySchemaOf<
         transporterSignature,
         "Transporteur : l'adresse email est requise"
       ),
-    transporterRecepisseNumber: yup.string().nullable(),
-    transporterRecepisseDepartment: yup.string().nullable(),
-    transporterRecepisseValidityLimit: yup.date().nullable()
+    ...transporterRecepisseSchema({ transportSignature: transporterSignature })
   });
 };
 

--- a/back/src/common/converter.ts
+++ b/back/src/common/converter.ts
@@ -1,16 +1,6 @@
 import { Prisma } from "@prisma/client";
 
 /**
- * Return null if all object values are null
- * obj otherwise
- */
-export function nullIfAllNull<T extends Record<string, unknown>>(obj: {
-  [P in keyof T]?: T[P] | null; // Allow null values on the input, even if forbidden by gql
-}): T | null {
-  return Object.values(obj).every(v => v === null) ? null : (obj as T);
-}
-
-/**
  * Return null if all object values are null or an empty string
  * obj otherwise
  */

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -353,12 +353,15 @@ export async function validateIntermediariesInput(
   return intermediaries;
 }
 
+/**
+ * Common transporter receipt error message
+ */
 export const REQUIRED_RECEIPT_VALIDITYLIMIT = `Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
 export const REQUIRED_RECEIPT_NUMBER = `Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
 export const REQUIRED_RECEIPT_DEPARTMENT = `Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets`;
 
 /**
- * Common transporter receipt schema for BSVHU, BSDASRI
+ * Common transporter receipt schema for BSVHU, BSDASRI, BSDA and BSFF
  */
 export const transporterRecepisseSchema = context => ({
   transporterRecepisseIsExempted: yup.boolean().nullable(),
@@ -370,7 +373,7 @@ export const transporterRecepisseSchema = context => ({
       otherwise: schema =>
         schema.requiredIf(
           context.transportSignature,
-          REQUIRED_RECEIPT_VALIDITYLIMIT
+          REQUIRED_RECEIPT_DEPARTMENT
         )
     }),
   transporterRecepisseNumber: yup
@@ -389,7 +392,7 @@ export const transporterRecepisseSchema = context => ({
       otherwise: schema =>
         schema.requiredIf(
           context.transportSignature,
-          REQUIRED_RECEIPT_DEPARTMENT
+          REQUIRED_RECEIPT_VALIDITYLIMIT
         )
     })
 });

--- a/front/src/Apps/common/queries/fragments/bsff.ts
+++ b/front/src/Apps/common/queries/fragments/bsff.ts
@@ -145,6 +145,7 @@ export const FullBsffFragment = gql`
         number
         department
         validityLimit
+        isExempted
       }
       transport {
         mode

--- a/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
+++ b/front/src/dashboard/detail/bsff/BsffDetailContent.tsx
@@ -320,10 +320,10 @@ function Transporter({ form }: { form: Bsff }) {
         {!isForeignVat(form?.transporter?.company?.vatNumber!!) && (
           <>
             <YesNoRow
-              value={!form?.transporter?.recepisse}
+              value={form?.transporter?.recepisse?.isExempted}
               label="Exemption de récépissé"
             />
-            {form?.transporter?.recepisse !== null && (
+            {form?.transporter?.recepisse?.isExempted !== true && (
               <>
                 <DetailRow
                   value={form.transporter?.recepisse?.number}

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -52,12 +52,7 @@ export default function BsffStepsList(props: Props) {
       return {
         ...formQuery.data?.bsff,
         previousPackagings,
-        transporter: {
-          ...transporter,
-          isExemptedOfRecepisse:
-            !!bsff?.transporter?.company?.orgId &&
-            bsff?.transporter?.recepisse === null,
-        },
+        transporter,
       };
     }
     const bsff = formQuery.data?.bsff;
@@ -90,21 +85,14 @@ export default function BsffStepsList(props: Props) {
       previousPackagings,
       packagings,
       type,
-      transporter: { isExemptedOfRecepisse, ...transporter },
+      transporter,
       destination: { plannedOperationCode, ...destination },
       ...input
     } = values;
-    // clean the temp value because it's absent from the Input gql type
-    delete transporter.isExemptedOfRecepisse;
     saveForm({
       type,
       ...input,
-      transporter: {
-        ...transporter,
-        recepisse: {
-          isExempted: isExemptedOfRecepisse,
-        },
-      },
+      transporter,
       destination: {
         ...destination,
         plannedOperationCode:

--- a/front/src/form/bsff/Transporter.tsx
+++ b/front/src/form/bsff/Transporter.tsx
@@ -2,17 +2,13 @@ import React, { lazy } from "react";
 import { FieldTransportModeSelect, Switch } from "common/components";
 import TdTooltip from "common/components/Tooltip";
 import CompanySelector from "form/common/components/company/CompanySelector";
-import { Field, useField, useFormikContext } from "formik";
+import { Field, useFormikContext } from "formik";
 import { Bsff } from "generated/graphql/types";
 import { isForeignVat } from "generated/constants/companySearchHelpers";
 const TagsInput = lazy(() => import("common/components/tags-input/TagsInput"));
 
 export default function Transporter({ disabled }) {
   const { setFieldValue, values } = useFormikContext<Bsff>();
-  // temp field
-  const [{ value: isExemptedOfRecepisse }, ,] = useField<boolean>(
-    "transporter.isExemptedOfRecepisse"
-  );
 
   return (
     <>
@@ -38,9 +34,9 @@ export default function Transporter({ disabled }) {
           </h4>
           <div className="form__row">
             <Switch
-              checked={isExemptedOfRecepisse}
+              checked={values.transporter?.recepisse?.isExempted === true}
               onChange={checked => {
-                setFieldValue("transporter.isExemptedOfRecepisse", checked);
+                setFieldValue("transporter.recepisse.isExempted", checked);
               }}
               label="Le transporteur déclare être exempté de récépissé conformément
                       aux dispositions de l'article R.541-50 du code de

--- a/front/src/form/bsff/utils/initial-state.ts
+++ b/front/src/form/bsff/utils/initial-state.ts
@@ -8,12 +8,8 @@ import {
   TransportMode,
 } from "generated/graphql/types";
 
-export interface BsffFormTransporterInput extends BsffTransporterInput {
-  isExemptedOfRecepisse: boolean;
-}
-
 export interface BsffFormInput extends BsffInput {
-  transporter: BsffFormTransporterInput;
+  transporter: BsffTransporterInput;
   previousPackagings: BsffPackagingInput[];
 }
 
@@ -27,8 +23,9 @@ const initialState: BsffFormInput = {
     company: {
       ...getInitialCompany(),
     },
-    // TEMP FIELD for the frontend to handle this special case
-    isExemptedOfRecepisse: false,
+    recepisse: {
+      isExempted: false,
+    },
     transport: {
       mode: TransportMode.Road,
       plates: [],

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -31,6 +31,7 @@ import {
   QueryFavoritesArgs,
   QuerySearchCompaniesArgs,
   TransporterInput,
+  BsffTransporterInput,
 } from "generated/graphql/types";
 import { useParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
@@ -42,7 +43,6 @@ import {
   SEARCH_COMPANIES,
 } from "./query";
 import TransporterReceipt from "./TransporterReceipt";
-import { BsffFormTransporterInput } from "form/bsff/utils/initial-state";
 
 const DEBOUNCE_DELAY = 500;
 
@@ -93,7 +93,7 @@ export default function CompanySelector({
         | Maybe<BsdaTransporterInput>
         | Maybe<BsdasriTransporterInput>
         | Maybe<BsvhuTransporterInput>
-        | Maybe<BsffFormTransporterInput>;
+        | Maybe<BsffTransporterInput>;
     }>();
 
   // determine if the current Form company is foreign

--- a/front/src/form/common/components/company/TransporterReceipt.tsx
+++ b/front/src/form/common/components/company/TransporterReceipt.tsx
@@ -17,7 +17,6 @@ import {
 } from "generated/graphql/types";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { isForeignVat } from "generated/constants/companySearchHelpers";
-import { BsffFormTransporterInput } from "form/bsff/utils/initial-state";
 import { TRANSPORTER_RECEIPT } from "./query";
 import { useQuery } from "@apollo/client";
 
@@ -49,13 +48,10 @@ export default function TransporterReceiptComponent({
       return !!(transporter as BsvhuTransporter)?.recepisse?.isExempted;
     } else if (!!(transporter as BsdasriTransporter)?.recepisse?.isExempted) {
       return !!(transporter as BsdasriTransporter)?.recepisse?.isExempted;
+    } else if (!!(transporter as BsffTransporterInput)?.recepisse?.isExempted) {
+      return !!(transporter as BsffTransporterInput).recepisse?.isExempted;
     } else if (
-      !!(transporter as BsffFormTransporterInput)?.isExemptedOfRecepisse
-    ) {
-      return !!(transporter as BsffFormTransporterInput).isExemptedOfRecepisse;
-    } else if (
-      !!(transporter as BsffTransporter)?.company?.orgId &&
-      (transporter as BsffTransporter)?.recepisse === null
+      (transporter as BsffTransporter)?.recepisse?.isExempted === true
     ) {
       // specific for the Bsff transporter signature dialog where recepisse === null means exempted
       return true;


### PR DESCRIPTION
Suite #2526 
- Correction : bloquer la signature transporteur (seulement) si le récépissé est absent et l'exemption n'est pas cochée
- Harmonisation gestion de l'exemption des récépissés transporteurs pour le BSFF, ajout d'un champ DB Bsff.transporterRecepisseIsExempted, ajout du champs dans l'object GQL et l'input
  - précédemment, BSFF était une exception, `bsff.transporter.recepisse === null` signifiait l'exemption de récépissé, là on revient sur le boolean `transporterRecepisseIsExempted` explicite et plus simple à gérer

[Peek 12-07-2023 17-01.webm](https://github.com/MTES-MCT/trackdechets/assets/76620/32181db4-0c2d-4458-89fb-2cda2c4393de)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11257)
