### PR TITLE
[Bugfix] ETQ transporter de BSDA je devrais voir le formulaire de signature avec l'immatriculation

### DIFF
--- a/back/src/bsda/validation/validate.ts
+++ b/back/src/bsda/validation/validate.ts
@@ -98,7 +98,8 @@ function getContextualBsdaSchema(validationContext: BsdaValidationContext) {
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: "La plaque d'immatriculation est requise"
+            message: "La plaque d'immatriculation est requise",
+            path: ["transporterTransportPlates"]
           });
         }
       }

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -70,7 +70,8 @@ export function SignTransport({
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter
-            !error.path.startsWith("transporterRecepisse")
+            !error.path.startsWith("transporterRecepisse") &&
+            error.path !== "transporterTransportPlates"
         ) ? (
           <>
             <p className="tw-m-2 tw-text-red-700">


### PR DESCRIPTION
# Contexte

Lors de la signature du transporteur, si l'immatriculation n'est pas remplie (BSDA), une modal s'affiche qui renvoie vers l'édition du BSDA: 

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/09cf14e1-1a26-4e28-ae7d-ee152da31f5d)

On veut à la place avoir la modal de signature qui propose directement de modfiier l'immatriculation:

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/cf6a4b91-4cbb-4033-9b98-07252714b946)

# Ticket Favro

[[Breaking Change] L'immatriculation est obligatoire à la signature du transporteur (BSDD, BSFF, BSDASRI, BSDA)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/5c8180d63be0e14ca2febc2d?card=tra-11188)