### PR TITLE
Fix UI freeze in BSFF form

### DIFF
--- a/front/src/form/bsff/WasteInfo.tsx
+++ b/front/src/form/bsff/WasteInfo.tsx
@@ -35,12 +35,18 @@ export default function WasteInfo({ disabled }) {
     setFieldValue,
   ]);
 
+  // Compute the sum of packagings weight to prefill `weight.value`
+  const totalWeight = useMemo(
+    () =>
+      values.packagings.reduce((acc, p) => {
+        return acc + p.weight ?? 0;
+      }, 0),
+    [values.packagings]
+  );
+
   useEffect(() => {
-    const totalWeight = values.packagings.reduce((acc, p) => {
-      return acc + p.weight ?? 0;
-    }, 0);
     setFieldValue("weight.value", totalWeight);
-  }, [values.packagings, setFieldValue]);
+  }, [totalWeight, setFieldValue]);
 
   const ficheInterventionsWeight = useMemo(
     () => values.ficheInterventions?.reduce((w, FI) => w + FI.weight, 0),


### PR DESCRIPTION
`setFieldValue("weight.value", totalWeight)` était appelé dès qu'on avait une modification sur un des contenants, même si cette modification ne concerne pas le poids. Il était donc appelé très souvent lorsque l'on tape un numéro de contenant ce qui provoquait un emballement (pourquoi exactement ??). 
Du coup là je calcule le poids total, puis j'ajoute un effet qui appelle `setFieldValue("weight.value", totalWeight)` mais uniquement si le poids total a changé.

- [Ticket Favro](https://favro.com/widget/ab14a4f0460a99a9d64d4945/5c8180d63be0e14ca2febc2d?card=tra-12325)
