### PR TITLE
[Bugfix][BSDA] S'il n'y a pas d'entreprise de travaux, toutes les données liées à l'entreprise de travaux doivent disparaître du BSD

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -904,7 +904,7 @@ describe("Mutation.updateBsda", () => {
     );
   });
 
-  it("if disabling the worker, all worker data (including certification) shoud be removed", async () => {
+  it("if disabling the worker, worker certification data shoud be removed", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const bsda = await bsdaFactory({
       opt: {
@@ -926,7 +926,11 @@ describe("Mutation.updateBsda", () => {
         id: bsda.id,
         input: {
           worker: {
-            isDisabled: true
+            isDisabled: true,
+            company: {
+              name: null,
+              siret: null
+            }
           }
         }
       }
@@ -942,10 +946,6 @@ describe("Mutation.updateBsda", () => {
 
     expect(updatedBsda?.workerCompanyName).toBeNull();
     expect(updatedBsda?.workerCompanySiret).toBeNull();
-    expect(updatedBsda?.workerCompanyAddress).toBeNull();
-    expect(updatedBsda?.workerCompanyContact).toBeNull();
-    expect(updatedBsda?.workerCompanyPhone).toBeNull();
-    expect(updatedBsda?.workerCompanyMail).toBeNull();
     expect(updatedBsda?.workerCertificationHasSubSectionFour).toBe(false);
     expect(updatedBsda?.workerCertificationHasSubSectionThree).toBe(false);
     expect(updatedBsda?.workerCertificationCertificationNumber).toBeNull();

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -13,6 +13,20 @@ import { getBsdaRepository } from "../../repository";
 import { parseBsda } from "../../validation/validate";
 import { canBypassSirenify } from "../../../companies/sirenify";
 
+const emptyWorkerData = {
+  workerCompanyName: null,
+  workerCompanySiret: null,
+  workerCompanyAddress: null,
+  workerCompanyContact: null,
+  workerCompanyPhone: null,
+  workerCompanyMail: null,
+  workerCertificationHasSubSectionFour: false,
+  workerCertificationHasSubSectionThree: false,
+  workerCertificationCertificationNumber: null,
+  workerCertificationValidityLimit: null,
+  workerCertificationOrganisation: null
+};
+
 export default async function edit(
   _,
   { id, input }: MutationUpdateBsdaArgs,
@@ -33,8 +47,10 @@ export default async function edit(
     ...flattenedInput,
     intermediaries: input.intermediaries ?? existingBsda.intermediaries,
     grouping: input.grouping || existingBsda.grouping.map(bsda => bsda.id),
-    forwarding: input.forwarding || existingBsda.forwarding?.id
+    forwarding: input.forwarding || existingBsda.forwarding?.id,
+    ...(flattenedInput.workerIsDisabled ? emptyWorkerData : {})
   };
+
   const bsda = await parseBsda(unparsedBsda, {
     enableCompletionTransformers: !canBypassSirenify(user),
     enablePreviousBsdasChecks: true,

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -11,21 +11,6 @@ import { checkEditionRules } from "../../validation/edition";
 import { checkCanUpdate } from "../../permissions";
 import { getBsdaRepository } from "../../repository";
 import { parseBsda } from "../../validation/validate";
-import { canBypassSirenify } from "../../../companies/sirenify";
-
-const emptyWorkerData = {
-  workerCompanyName: null,
-  workerCompanySiret: null,
-  workerCompanyAddress: null,
-  workerCompanyContact: null,
-  workerCompanyPhone: null,
-  workerCompanyMail: null,
-  workerCertificationHasSubSectionFour: false,
-  workerCertificationHasSubSectionThree: false,
-  workerCertificationCertificationNumber: null,
-  workerCertificationValidityLimit: null,
-  workerCertificationOrganisation: null
-};
 
 export default async function edit(
   _,
@@ -47,12 +32,11 @@ export default async function edit(
     ...flattenedInput,
     intermediaries: input.intermediaries ?? existingBsda.intermediaries,
     grouping: input.grouping || existingBsda.grouping.map(bsda => bsda.id),
-    forwarding: input.forwarding || existingBsda.forwarding?.id,
-    ...(flattenedInput.workerIsDisabled ? emptyWorkerData : {})
+    forwarding: input.forwarding || existingBsda.forwarding?.id
   };
 
   const bsda = await parseBsda(unparsedBsda, {
-    enableCompletionTransformers: !canBypassSirenify(user),
+    enableCompletionTransformers: true,
     enablePreviousBsdasChecks: true,
     currentSignatureType: getCurrentSignatureType(unparsedBsda)
   });

--- a/back/src/bsda/validation/transformers.ts
+++ b/back/src/bsda/validation/transformers.ts
@@ -15,7 +15,8 @@ export const runTransformers = async (
   const transformers = [
     reshipmentBsdaTransformer,
     sirenify,
-    recipisseTransporterTransformer
+    recipisseTransporterTransformer,
+    workerTransformer
   ];
   for (const transformer of transformers) {
     val = await transformer(val, sealedFields);
@@ -64,6 +65,18 @@ async function recipisseTransporterTransformer(
     val.transporterRecepisseValidityLimit =
       transporterReceipt?.validityLimit ?? null;
     val.transporterRecepisseDepartment = transporterReceipt?.department ?? null;
+  }
+
+  return val;
+}
+
+async function workerTransformer(val: ZodBsda, _: string[]): Promise<ZodBsda> {
+  if (val.workerIsDisabled) {
+    val.workerCertificationHasSubSectionFour = false;
+    val.workerCertificationHasSubSectionThree = false;
+    val.workerCertificationCertificationNumber = null;
+    val.workerCertificationValidityLimit = null;
+    val.workerCertificationOrganisation = null;
   }
 
   return val;

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -1,12 +1,14 @@
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { formatDate } from "common/datetime";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Field, useFormikContext } from "formik";
-import { Bsda, BsdaType } from "generated/graphql/types";
-import React from "react";
+import { Bsda, BsdaType, CompanyType } from "generated/graphql/types";
+import React, { useState } from "react";
 import initialState from "../initial-state";
 
 export function Worker({ disabled }) {
   const { setFieldValue, values, handleChange } = useFormikContext<Bsda>();
+  const [companyTypes, setCompanyTypes] = useState<CompanyType[]>([]);
 
   const isGroupement = values?.type === BsdaType.Gathering;
   const isEntreposageProvisoire = values?.type === BsdaType.Reshipment;
@@ -58,6 +60,8 @@ export function Worker({ disabled }) {
             name="worker.company"
             heading="Entreprise de travaux"
             onCompanySelected={worker => {
+              setCompanyTypes(worker?.companyTypes ?? []);
+
               if (worker?.workerCertification?.hasSubSectionFour) {
                 setFieldValue(
                   "worker.certification.hasSubSectionFour",
@@ -106,16 +110,28 @@ export function Worker({ disabled }) {
             Catégorie entreprise de travaux déclarée dans le profil entreprise
           </h4>
 
-          <div className="form__row">
-            {!values?.worker?.certification?.hasSubSectionFour &&
-              !values?.worker?.certification?.hasSubSectionThree && (
-                <p>
-                  L'entreprise de travaux amiante n'a pas complété ces
-                  informations dans son profil. Nous ne pouvons pas afficher la
-                  catégorie de travaux SS3 ou SS4 de l'entreprise.
-                </p>
-              )}
-          </div>
+          {companyTypes.includes(CompanyType.Worker) ? (
+            <div className="form__row">
+              {!values?.worker?.certification?.hasSubSectionFour &&
+                !values?.worker?.certification?.hasSubSectionThree && (
+                  <Alert
+                    title={"L'entreprise n'a pas complété son profil"}
+                    severity="warning"
+                    description="L'entreprise que vous renseignez s'est enregistrée avec un profil d'entreprise de travaux amiante mais n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations."
+                  />
+                )}
+            </div>
+          ) : (
+            <div>
+              <Alert
+                title={
+                  "L'entreprise n'est pas une entreprise de travaux amiante"
+                }
+                severity="error"
+                description="L'entreprise que vous renseignez ne s'est pas enregistrée avec un profil d'entreprise de travaux amiante ou n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations"
+              />
+            </div>
+          )}
 
           <div className="form__row">
             {values?.worker?.certification?.hasSubSectionFour && (

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -23,6 +23,20 @@ export function Worker({ disabled }) {
     );
   }
 
+  const resetWorkerData = () => {
+    setFieldValue("worker.company.name", null);
+    setFieldValue("worker.company.siret", null);
+    setFieldValue("worker.company.contact", null);
+    setFieldValue("worker.company.address", null);
+    setFieldValue("worker.company.mail", null);
+    setFieldValue("worker.company.phone", null);
+    setFieldValue("worker.certification.hasSubSectionFour", false);
+    setFieldValue("worker.certification.hasSubSectionThree", false);
+    setFieldValue("worker.certification.certificationNumber", null);
+    setFieldValue("worker.certification.validityLimit", null);
+    setFieldValue("worker.certification.organisation", null);
+  };
+
   return (
     <>
       {disabled && (
@@ -41,12 +55,7 @@ export function Worker({ disabled }) {
             className="td-checkbox"
             onChange={e => {
               handleChange(e);
-              setFieldValue("worker.company.name", null);
-              setFieldValue("worker.company.siret", null);
-              setFieldValue("worker.company.contact", null);
-              setFieldValue("worker.company.address", null);
-              setFieldValue("worker.company.mail", null);
-              setFieldValue("worker.company.phone", null);
+              resetWorkerData();
             }}
           />
           Il n'y a pas d'entreprise de travaux

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -1,14 +1,12 @@
-import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { formatDate } from "common/datetime";
 import CompanySelector from "form/common/components/company/CompanySelector";
 import { Field, useFormikContext } from "formik";
-import { Bsda, BsdaType, CompanyType } from "generated/graphql/types";
-import React, { useState } from "react";
+import { Bsda, BsdaType } from "generated/graphql/types";
+import React from "react";
 import initialState from "../initial-state";
 
 export function Worker({ disabled }) {
   const { setFieldValue, values, handleChange } = useFormikContext<Bsda>();
-  const [companyTypes, setCompanyTypes] = useState<CompanyType[]>([]);
 
   const isGroupement = values?.type === BsdaType.Gathering;
   const isEntreposageProvisoire = values?.type === BsdaType.Reshipment;
@@ -22,20 +20,6 @@ export function Worker({ disabled }) {
       </div>
     );
   }
-
-  const resetWorkerData = () => {
-    setFieldValue("worker.company.name", null);
-    setFieldValue("worker.company.siret", null);
-    setFieldValue("worker.company.contact", null);
-    setFieldValue("worker.company.address", null);
-    setFieldValue("worker.company.mail", null);
-    setFieldValue("worker.company.phone", null);
-    setFieldValue("worker.certification.hasSubSectionFour", false);
-    setFieldValue("worker.certification.hasSubSectionThree", false);
-    setFieldValue("worker.certification.certificationNumber", null);
-    setFieldValue("worker.certification.validityLimit", null);
-    setFieldValue("worker.certification.organisation", null);
-  };
 
   return (
     <>
@@ -55,7 +39,12 @@ export function Worker({ disabled }) {
             className="td-checkbox"
             onChange={e => {
               handleChange(e);
-              resetWorkerData();
+              setFieldValue("worker.company.name", null);
+              setFieldValue("worker.company.siret", null);
+              setFieldValue("worker.company.contact", null);
+              setFieldValue("worker.company.address", null);
+              setFieldValue("worker.company.mail", null);
+              setFieldValue("worker.company.phone", null);
             }}
           />
           Il n'y a pas d'entreprise de travaux
@@ -69,8 +58,6 @@ export function Worker({ disabled }) {
             name="worker.company"
             heading="Entreprise de travaux"
             onCompanySelected={worker => {
-              setCompanyTypes(worker?.companyTypes ?? []);
-
               if (worker?.workerCertification?.hasSubSectionFour) {
                 setFieldValue(
                   "worker.certification.hasSubSectionFour",
@@ -119,28 +106,16 @@ export function Worker({ disabled }) {
             Catégorie entreprise de travaux déclarée dans le profil entreprise
           </h4>
 
-          {companyTypes.includes(CompanyType.Worker) ? (
-            <div className="form__row">
-              {!values?.worker?.certification?.hasSubSectionFour &&
-                !values?.worker?.certification?.hasSubSectionThree && (
-                  <Alert
-                    title={"L'entreprise n'a pas complété son profil"}
-                    severity="warning"
-                    description="L'entreprise que vous renseignez s'est enregistrée avec un profil d'entreprise de travaux amiante mais n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations."
-                  />
-                )}
-            </div>
-          ) : (
-            <div>
-              <Alert
-                title={
-                  "L'entreprise n'est pas une entreprise de travaux amiante"
-                }
-                severity="error"
-                description="L'entreprise que vous renseignez ne s'est pas enregistrée avec un profil d'entreprise de travaux amiante ou n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations"
-              />
-            </div>
-          )}
+          <div className="form__row">
+            {!values?.worker?.certification?.hasSubSectionFour &&
+              !values?.worker?.certification?.hasSubSectionThree && (
+                <p>
+                  L'entreprise de travaux amiante n'a pas complété ces
+                  informations dans son profil. Nous ne pouvons pas afficher la
+                  catégorie de travaux SS3 ou SS4 de l'entreprise.
+                </p>
+              )}
+          </div>
 
           <div className="form__row">
             {values?.worker?.certification?.hasSubSectionFour && (


### PR DESCRIPTION
# Contexte

Si je duplique un BSDA, et que je coche la case "Il n'y a pas d'entreprise de travaux", certaines données concernant le worker du BSDA dupliqué persistent (comme la certification).

# Solution

Si `workerIsDisabled = true`, alors on ajoute quelques lignes pour vider complètement les données du worker.

# Ticket Favro

[BSDA lorsqu'on supprime une entreprise de travaux sur un BSDA dupliqué, la certification apparaît encore sur le PDF](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b34d77951d96c0ad27b28f5a?card=tra-12379)
