### PR TITLE
Fix BSDA update transporter receipt, clean frontend

### DIFF
--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -52,7 +52,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     { ...unparsedBsda, isDraft },
     {
       enableCompletionTransformers: true,
-      enablePreviousBsdasChecks: !canBypassSirenify(user),
+      enablePreviousBsdasChecks: true,
       currentSignatureType: !isDraft ? "EMISSION" : undefined
     }
   );

--- a/front/src/form/bsda/stepper/steps/Transporter.tsx
+++ b/front/src/form/bsda/stepper/steps/Transporter.tsx
@@ -35,24 +35,6 @@ export function Transporter({ disabled }) {
         allowForeignCompanies={true}
         isBsdaTransporter={true}
         registeredOnlyCompanies={true}
-        onCompanySelected={transporter => {
-          if (transporter?.transporterReceipt) {
-            setFieldValue(
-              "transporter.recepisse.number",
-              transporter.transporterReceipt.receiptNumber
-            );
-            setFieldValue(
-              "transporter.recepisse.validityLimit",
-              transporter.transporterReceipt.validityLimit
-            );
-            setFieldValue(
-              "transporter.recepisse.department",
-              transporter.transporterReceipt.department
-            );
-          } else {
-            setFieldValue("transporter.recepisse", null);
-          }
-        }}
       />
       <TransporterReceiptEditionSwitch
         transporter={values.transporter!}


### PR DESCRIPTION

- Revert partially #2581 
- Fix BSDA enable recipify completion bug
 
- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12376)
