### PR TITLE
[TRA-12375] Introduction des comptes gouvernementaux pour remplacer le champ `isRegistreNational`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.7.2] 25/07/2023
+
+#### :house: Interne
+
+- Introduction des comptes gouvernementaux pour remplacer le champ `isRegistreNational` [PR 2585](https://github.com/MTES-MCT/trackdechets/pull/2585)
+
 # [2023.7.1] 18/07/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/prisma/migrations/148_add_government_account.sql
+++ b/back/prisma/migrations/148_add_government_account.sql
@@ -1,0 +1,35 @@
+/*
+ Warnings:
+ 
+ - A unique constraint covering the columns `[governmentAccountId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+ 
+ */
+-- CreateEnum
+CREATE TYPE "default$default"."GovernmentPermission" AS ENUM ('REGISTRY_CAN_READ_ALL');
+
+-- AlterTable
+ALTER TABLE
+  "default$default"."User"
+ADD
+  COLUMN "governmentAccountId" TEXT;
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "default$default"."GovernmentAccount" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "permissions" "default$default"."GovernmentPermission" [],
+  "authorizedIPs" TEXT [],
+  "authorizedOrgIds" TEXT [],
+  CONSTRAINT "GovernmentAccount_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_governmentAccountId_key" ON "default$default"."User"("governmentAccountId");
+
+-- AddForeignKey
+ALTER TABLE
+  "default$default"."User"
+ADD
+  CONSTRAINT "User_governmentAccountId_fkey" FOREIGN KEY ("governmentAccountId") REFERENCES "default$default"."GovernmentAccount"("id") ON DELETE
+SET
+  NULL ON UPDATE CASCADE;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -716,8 +716,10 @@ model User {
   firstAssociationDate  DateTime?               @db.Timestamptz(6) // when was this user first associated to any company ? - emailing purpose @db.Timestamptz(6)
   isActive              Boolean?                @default(false)
   isAdmin               Boolean?                @default(false)
-  // compte de service avec des droits étendus
+  // TODO champ à supprimer suite à la création des comptes gouvernementaux
   isRegistreNational    Boolean?                @default(false)
+  // compte gouvernemental avec des droits étendus
+  governmentAccount     GovernmentAccount?      @relation(fields: [governmentAccountId], references: [id], onDelete: SetNull)
   applications          Application[]
   companyAssociations   CompanyAssociation[]
   AccessToken           AccessToken[]
@@ -734,6 +736,30 @@ model User {
   bsdasriTransportSignatures Bsdasri[] @relation("BsdasriTransportSignature")
   bsdasriReceptionSignatures Bsdasri[] @relation("BsdasriReceptionSignature")
   bsdasriOperationignatures  Bsdasri[] @relation("BsdasriOperationSignature")
+  governmentAccountId        String?   @unique
+}
+
+enum GovernmentPermission {
+  // Accès en lecture au registre de tous les établissements
+  REGISTRY_CAN_READ_ALL
+}
+
+model GovernmentAccount {
+  id               String                 @id @default(cuid())
+  name             String // Exemple RNDTS, GEREP, etc
+  permissions      GovernmentPermission[]
+  // Liste blanche d'IP pour les connexions depuis ce compte de service
+  // Seules les connexions depuis ces adresses IP auront les permissions 
+  // étendues définies par le champ `permissions`. 
+  authorizedIPs    String[]
+  // Permet de restreindre les permissions étendues définies par le
+  // le champ `GovernmentAccount.permissions` à une liste d'établissements.
+  // Cela permet à des applications gouvernementales tierces d'effectuer 
+  // des tests sur des données réelles sur un nombre restreint d'entreprises.
+  // Pour que les permissions étendues s'appliquent à tous les établissements, 
+  // passer la valeur 'ALL'
+  authorizedOrgIds String[]
+  User             User[]
 }
 
 model UserAccountHash {
@@ -1092,7 +1118,7 @@ model Bsff {
   transporterRecepisseNumber        String?
   transporterRecepisseDepartment    String?
   transporterRecepisseValidityLimit DateTime? @db.Timestamptz(6)
-  transporterRecepisseIsExempted      Boolean?
+  transporterRecepisseIsExempted    Boolean?
 
   transporterTransportMode            TransportMode? @default(ROAD)
   transporterTransportPlates          String[]

--- a/back/prisma/scripts/createGovernementAccounts.ts
+++ b/back/prisma/scripts/createGovernementAccounts.ts
@@ -1,0 +1,32 @@
+import prisma from "../../src/prisma";
+import { registerUpdater, Updater } from "./helper/helper";
+
+@registerUpdater(
+  "Create government accounts",
+  "Create government accounts",
+  false
+)
+export class CreateGovernementAccounts implements Updater {
+  async run() {
+    const registreNationalUsers = await prisma.user.findMany({
+      where: { isRegistreNational: true }
+    });
+    for (const user of registreNationalUsers) {
+      if (!user.governmentAccountId) {
+        const accountName = user.email.includes("gerep") ? "GEREP" : "RNDTS";
+        await prisma.user.update({
+          where: { id: user.id },
+          data: {
+            governmentAccount: {
+              create: {
+                name: accountName,
+                authorizedOrgIds: ["ALL"],
+                authorizedIPs: [] // à compléter à la mano
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+}

--- a/back/prisma/scripts/createGovernementAccounts.ts
+++ b/back/prisma/scripts/createGovernementAccounts.ts
@@ -4,7 +4,7 @@ import { registerUpdater, Updater } from "./helper/helper";
 @registerUpdater(
   "Create government accounts",
   "Create government accounts",
-  false
+  true
 )
 export class CreateGovernementAccounts implements Updater {
   async run() {
@@ -19,6 +19,7 @@ export class CreateGovernementAccounts implements Updater {
           data: {
             governmentAccount: {
               create: {
+                permissions: ["REGISTRY_CAN_READ_ALL"],
                 name: accountName,
                 authorizedOrgIds: ["ALL"],
                 authorizedIPs: [] // à compléter à la mano

--- a/back/prisma/scripts/denormalize-dasris-grouping.ts
+++ b/back/prisma/scripts/denormalize-dasris-grouping.ts
@@ -4,7 +4,7 @@ import { registerUpdater, Updater } from "./helper/helper";
 @registerUpdater(
   "Denormalize dasris",
   "Denormalize grouping dasris by caching grouped bsd emitters sirets",
-  true
+  false
 )
 export class UpdateBsdasrisGroupedEmitters implements Updater {
   async run() {

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -42,7 +42,7 @@ export const userFactory = async (
  * a random number will not pass the luhnCheck
  * @param index numerical index
  */
-export function siretify(index: number | undefined) {
+export function siretify(index?: number) {
   if (index && index <= 9) {
     // Compatibility with an old version of siretify using
     // a company index. This should be refactored to remove
@@ -160,7 +160,9 @@ export const destinationFactory = async (
  * Create a user and an accessToken
  * @param opt : extra parameters for user
  */
-export const userWithAccessTokenFactory = async (opt = {}) => {
+export const userWithAccessTokenFactory = async (
+  opt: Partial<Prisma.UserCreateInput> = {}
+) => {
   const user = await userFactory(opt);
 
   const accessTokenIndex = (await prisma.accessToken.count()) + 1;

--- a/back/src/env.ts
+++ b/back/src/env.ts
@@ -34,7 +34,6 @@ export const envVariables = z
     OIDC_PRIVATE_KEY: z.string(),
     // -------
     // Various
-    REGISTRY_WHITE_LIST_IP: z.string().optional(),
     USERS_BLACKLIST: z.string().optional(),
     MAX_REQUESTS_PER_WINDOW: z.string().optional().default("1000"),
     STARTUP_FILE: z.string().optional(),

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -10,7 +10,8 @@ import {
   Status,
   User,
   UserRole,
-  BsdasriStatus
+  BsdasriStatus,
+  GovernmentPermission
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -28,14 +29,17 @@ import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFullForm } from "../../../../forms/database";
 import { indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
-import { TestQuery } from "../../../../__tests__/apollo-integration-testing";
 import {
   formFactory,
-  userFactory,
+  siretify,
+  userWithAccessTokenFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { TRANSPORTED_WASTES } from "./queries";
+import supertest from "supertest";
+import { faker } from "@faker-js/faker";
+import { app } from "../../../../server";
 
 describe("Transported wastes registry", () => {
   let emitter: { user: User; company: Company };
@@ -313,50 +317,129 @@ describe("Transported wastes registry", () => {
   });
 
   it("should allow user to request any siret if authenticated from a service account", async () => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV, REGISTRY_WHITE_LIST_IP: "127.0.0.1" };
-    const server = require("../../../../server").server;
-    await server.start();
-    const makeClientLocal: (user?: User) => {
-      query: TestQuery;
-    } = require("../../../../__tests__/testClient").default;
-    const user = await userFactory({ isRegistreNational: true });
-    const { query } = makeClientLocal(user);
-    const { data } = await query<Pick<Query, "transportedWastes">>(
-      TRANSPORTED_WASTES,
-      {
-        variables: {
-          sirets: [transporter.company.siret],
-          first: 2
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "RDNTS",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
         }
       }
-    );
-    expect(data.transportedWastes.edges).toHaveLength(2);
+    });
+
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ transportedWastes(sirets: ["${transporter.company.siret}"]) { totalCount } }`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+
+    expect(res.body).toEqual({
+      data: { transportedWastes: { totalCount: 5 } }
+    });
+  });
+
+  it("should allow user to request any siret if authenticated from a service account and orgId is in the white list", async () => {
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "RDNTS",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL],
+          authorizedOrgIds: [transporter.company!.siret!],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ transportedWastes(sirets: ["${transporter.company.siret}"]) { totalCount } }`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+
+    expect(res.body).toEqual({
+      data: { transportedWastes: { totalCount: 5 } }
+    });
   });
 
   it("should not accept service account connection from IP address not in the white list", async () => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV, REGISTRY_WHITE_LIST_IP: undefined };
-    const server = require("../../../../server").server;
-    await server.start();
-    const makeClientLocal: (user?: User) => {
-      query: TestQuery;
-    } = require("../../../../__tests__/testClient").default;
-    const user = await userFactory({ isRegistreNational: true });
-    const { query } = makeClientLocal(user);
-    const { errors } = await query<Pick<Query, "transportedWastes">>(
-      TRANSPORTED_WASTES,
-      {
-        variables: {
-          sirets: [destination.company.siret],
-          first: 2
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    const forbiddenIP = faker.internet.ipv4();
+
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "RDNTS",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
         }
       }
-    );
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message: `Vous n'êtes pas autorisé à accéder au registre de l'établissement portant le n°SIRET ${destination.company.siret}`
+    });
+
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ transportedWastes(sirets: ["${transporter.company.siret}"]) { totalCount } }`
       })
-    ]);
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", forbiddenIP);
+
+    expect(res.body).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: `Vous n'êtes pas autorisé à accéder au registre de l'établissement portant le n°SIRET ${transporter.company.siret}`
+        })
+      ]
+    });
+  });
+
+  it("should not accept service account connection from authorized IP address if orgId does not match", async () => {
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "RDNTS",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL],
+          authorizedOrgIds: [siretify()],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ transportedWastes(sirets: ["${transporter.company.siret}"]) { totalCount } }`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+
+    expect(res.body).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: `Vous n'êtes pas autorisé à accéder au registre de l'établissement portant le n°SIRET ${transporter.company.siret}`
+        })
+      ]
+    });
   });
 });

--- a/back/src/registry/resolvers/queries/incomingWastes.ts
+++ b/back/src/registry/resolvers/queries/incomingWastes.ts
@@ -1,7 +1,7 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkIsRegistreNational } from "../../permissions";
+import { hasGovernmentRegistryPerm } from "../../permissions";
 import { Permission, checkUserPermissions } from "../../../permissions";
 
 const incomingWastesResolver: QueryResolvers["incomingWastes"] = async (
@@ -11,10 +11,13 @@ const incomingWastesResolver: QueryResolvers["incomingWastes"] = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
-  const isRegistreNational = checkIsRegistreNational(user);
+  const hasGovernmentPermission = await hasGovernmentRegistryPerm(
+    user,
+    args.sirets
+  );
 
   // bypass authorization if the user is authenticated from a service account
-  if (!isRegistreNational) {
+  if (!hasGovernmentPermission) {
     for (const siret of args.sirets) {
       await checkUserPermissions(
         user,

--- a/back/src/registry/resolvers/queries/managedWastes.ts
+++ b/back/src/registry/resolvers/queries/managedWastes.ts
@@ -1,7 +1,7 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkIsRegistreNational } from "../../permissions";
+import { hasGovernmentRegistryPerm } from "../../permissions";
 import { Permission, checkUserPermissions } from "../../../permissions";
 
 const managedWastesResolver: QueryResolvers["managedWastes"] = async (
@@ -11,10 +11,13 @@ const managedWastesResolver: QueryResolvers["managedWastes"] = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
-  const isRegistreNational = checkIsRegistreNational(user);
+  const hasGovernmentPermission = await hasGovernmentRegistryPerm(
+    user,
+    args.sirets
+  );
 
   // bypass authorization if the user is authenticated from a service account
-  if (!isRegistreNational) {
+  if (!hasGovernmentPermission) {
     for (const siret of args.sirets) {
       await checkUserPermissions(
         user,

--- a/back/src/registry/resolvers/queries/outgoingWastes.ts
+++ b/back/src/registry/resolvers/queries/outgoingWastes.ts
@@ -1,7 +1,7 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkIsRegistreNational } from "../../permissions";
+import { hasGovernmentRegistryPerm } from "../../permissions";
 import { Permission, checkUserPermissions } from "../../../permissions";
 
 const outgoingWastesResolver: QueryResolvers["outgoingWastes"] = async (
@@ -11,10 +11,13 @@ const outgoingWastesResolver: QueryResolvers["outgoingWastes"] = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
-  const isRegistreNational = checkIsRegistreNational(user);
+  const hasGovernmentPermission = await hasGovernmentRegistryPerm(
+    user,
+    args.sirets
+  );
 
   // bypass authorization if the user is authenticated from a service account
-  if (!isRegistreNational) {
+  if (!hasGovernmentPermission) {
     for (const siret of args.sirets) {
       await checkUserPermissions(
         user,

--- a/back/src/registry/resolvers/queries/transportedWastes.ts
+++ b/back/src/registry/resolvers/queries/transportedWastes.ts
@@ -1,7 +1,7 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { checkIsRegistreNational } from "../../permissions";
+import { hasGovernmentRegistryPerm } from "../../permissions";
 import { Permission, checkUserPermissions } from "../../../permissions";
 
 const transportedWastesResolver: QueryResolvers["transportedWastes"] = async (
@@ -11,10 +11,13 @@ const transportedWastesResolver: QueryResolvers["transportedWastes"] = async (
 ) => {
   const user = checkIsAuthenticated(context);
 
-  const isRegistreNational = checkIsRegistreNational(user);
+  const hasGovernmentPermission = await hasGovernmentRegistryPerm(
+    user,
+    args.sirets
+  );
 
   // bypass authorization if the user authenticated from a service account
-  if (!isRegistreNational) {
+  if (!hasGovernmentPermission) {
     for (const siret of args.sirets) {
       await checkUserPermissions(
         user,


### PR DESCRIPTION
## Release intermédiaire 2023.7.2

- Le champ `isRegistreNational` ne convient plus car il est possible de donner des accès à d'autres applicatifs de l'état (ex : GEREP).
- On veut que les adresses IP autorisées soient liées à un applicatif en particulier et non plus passées en variable d'environnement. 
- Par ailleurs on veut pouvoir donner un accès limité à un certain nombres d'établissements pour réaliser des tests. 


Passage en MEP intermédiaire pour permettre à l'équipe de GEREP d'avancer.

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12375)
