### PR TITLE
[TRA-12285] Annexe 1: une seule entrée d'immatriculation pour les bordereaux enfants + chapeau

### DIFF
--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -203,15 +203,13 @@ const signTransportFn = async (
         }
       );
 
-      // For user convenience, we update the bsds with the
-      // immatriculation (if not filled already)
+      // At any given time, all bsds from an Annexe1 must have the same plates
       const ids = appendix1Forms.map(form => form.id);
 
       // Update their plates
       await transaction.bsddTransporter.updateMany({
         where: {
-          formId: { in: ids },
-          OR: [{ transporterNumberPlate: null }, { transporterNumberPlate: "" }]
+          formId: { in: ids }
         },
         data: {
           transporterNumberPlate: transporterUpdate.transporterNumberPlate


### PR DESCRIPTION
# Bordereaux concernés

- BSDD (Annexe 1)

# Etat actuel

Depuis que les plaques d'immatriculation sont obligatoires, pour les annexes 1, la plaque déclarée sur le premier bordereau est reportée sur les suivants.

Cependant, elle n'est pas répercutée sur le bordereau chapeau. Aussi, il est possible de déclarer des plaques différentes pour les différents bordereaux enfants.

# Etat désiré

Pour les annexes 1, on ne veut qu'une seule entrée pour le champ d'immatriculation, qui soit le même pour le bordereau chapeau et tous les bordereaux enfants.

On parle "d'entrée" parce que c'est un champ de texte libre, donc le transporteur peut renseigner plusieurs plaques, comme par exemple: "XX-000-XX, YY-000-YY".

# Démo

![annexe1_plates_override_demo](https://github.com/MTES-MCT/trackdechets/assets/45355989/e320b92f-ddb6-4df3-aed2-8a494981926a)

# Ticket Favro

[Annexe 1: une seule entrée d'immatriculation pour les bordereaux enfants + chapeau](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b34d77951d96c0ad27b28f5a?card=tra-12285)