### PR TITLE
Fix import for notifier

### DIFF
--- a/back/src/notifier/consumer.ts
+++ b/back/src/notifier/consumer.ts
@@ -1,5 +1,5 @@
 import { Job } from "bull";
-import { BsdUpdateQueueItem, updatesQueue } from "../queue/producers/elastic";
+import { BsdUpdateQueueItem, updatesQueue } from "../queue/producers/bsdUpdate";
 
 import { pushSseUpdate } from "./handlers/sse";
 

--- a/back/src/queue/bull-board.ts
+++ b/back/src/queue/bull-board.ts
@@ -5,7 +5,8 @@ import {
   geocodeCompanyQueue,
   setCompanyDepartementQueue
 } from "./producers/company";
-import { indexQueue, updatesQueue } from "./producers/elastic";
+import { indexQueue } from "./producers/elastic";
+import { updatesQueue } from "./producers/bsdUpdate";
 import { webhooksQueue } from "./producers/webhooks";
 import { syncEventsQueue } from "./producers/events";
 import { mailQueue } from "./producers/mail";

--- a/back/src/queue/producers/bsdUpdate.ts
+++ b/back/src/queue/producers/bsdUpdate.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line import/no-named-as-default
+import Queue from "bull";
+
+const { REDIS_URL, NODE_ENV } = process.env;
+
+export type BsdUpdateQueueItem = {
+  sirets: string[];
+  id: string;
+  jobName?: string;
+};
+
+const INDEX_REFRESH_INTERVAL = 1000;
+
+// Updates queue, used by the notifier. Items are enqueued once indexation is done
+export const updatesQueue = new Queue<BsdUpdateQueueItem>(
+  `queue_updates_elastic_${NODE_ENV}`,
+  REDIS_URL!,
+  {
+    defaultJobOptions: {
+      delay: INDEX_REFRESH_INTERVAL, // We delay processing to make sure updates have been refreshed in ES
+      removeOnComplete: 100
+    }
+  }
+);


### PR DESCRIPTION
Correction d'imports qui faisaient que prisma était importé par le notifier. Demandant alors l'ajour d'ENV.