### PR TITLE
Permettre aux transporteurs de Monaco de s'inscrire avec leur numéro de TVA intracomm (FR....)

### DIFF
--- a/back/src/common/constants/__tests__/companySearchHelpers.test.ts
+++ b/back/src/common/constants/__tests__/companySearchHelpers.test.ts
@@ -10,6 +10,8 @@ import {
 test("isVat", () => {
   expect(isVat("FR87850019464")).toEqual(true);
   expect(isVat("BE0541696005")).toEqual(true);
+  expect(isVat("FR52000063031")).toEqual(true);
+  expect(isVat("FR 52000063031")).toEqual(false);
 });
 
 test("isFRVat", () => {
@@ -18,6 +20,7 @@ test("isFRVat", () => {
   expect(isFRVat("FR87-85-0019464")).toEqual(false);
   expect(isFRVat("FR87850019464")).toEqual(true);
   expect(isFRVat("BE0541696005")).toEqual(false);
+  expect(isFRVat("FR52000063031")).toEqual(false);
 });
 
 test("not isVat", () => {
@@ -49,12 +52,16 @@ test("isForeignVat", () => {
   expect(isForeignVat("FR87-85-0019464")).toEqual(false);
   expect(isForeignVat("FR87850019464")).toEqual(false);
   expect(isForeignVat("BE0541696005")).toEqual(true);
+  expect(isForeignVat("BE 054 1696005")).toEqual(false);
+  expect(isForeignVat("FR52000063031")).toEqual(true);
+  expect(isForeignVat("FR 52000063031")).toEqual(false);
 });
 
 test("luhnCheck", () => {
   expect(luhnCheck("4485275742308327")).toBeTruthy();
   expect(luhnCheck(6011329933655299)).toBeTruthy();
   expect(luhnCheck(123456789)).toBeFalsy();
+  expect(luhnCheck("000063031")).toBeFalsy();
 });
 
 test("isSiret", () => {

--- a/back/src/common/constants/companySearchHelpers.ts
+++ b/back/src/common/constants/companySearchHelpers.ts
@@ -139,11 +139,26 @@ export const isVat = (clue: string | null | undefined): boolean => {
 };
 
 /**
+ * Return the french VAT key for a SIREN (first 2 numbers of the VAT)
+ */
+const sirenToVatKey = (siren: string): number =>
+  (12 + 3 * (parseInt(siren, 10) % 97)) % 97;
+
+/**
  * TVA Français
  */
 export const isFRVat = (clue: string | null | undefined): boolean => {
-  if (!clue || !isVat(clue)) return false;
-  return clue.slice(0, 2).toUpperCase().startsWith("FR");
+  if (
+    !isVat(clue) ||
+    clue?.length !== 13 ||
+    !clue.slice(0, 2).toUpperCase().startsWith("FR")
+  ) {
+    return false;
+  }
+  const siren = clue.slice(4);
+  return (
+    sirenToVatKey(siren) === parseInt(clue.slice(2, 4), 10) && luhnCheck(siren)
+  );
 };
 
 /**

--- a/front/src/account/AccountCompanyAddForeign.tsx
+++ b/front/src/account/AccountCompanyAddForeign.tsx
@@ -198,6 +198,8 @@ export default function AccountCompanyAddForeign() {
             {...{
               onCompanyInfos: companyInfos => setCompanyInfos(companyInfos),
             }}
+            label={memoizedStrings.vatNumber.label}
+            hintText=""
           />
         </div>
       </div>

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -292,7 +292,8 @@ export default function AccountCompanyAddSiret({
                         stateRelatedMessage={errors.siret || ""}
                         disabled={isDisabled}
                         nativeInputProps={{
-                          onChange: e => {
+                          // force remove whitespace
+                          onKeyUp: (e: React.ChangeEvent<HTMLInputElement>) => {
                             const siret = e.target.value
                               .split(" ")
                               .join("")


### PR DESCRIPTION
- Un numéro de TVA français contient FR[clé 2 chiffres][SIREN] et fait 13 caractères exactement
- Par exclusion on peut autoriser les numéro de TVA commençant par FR, ne respectant pas la règle des numéros français, car ils correspondront alors à des numéros comme les monégasques.
- donc si pour un numéro de TVA commençant par FR, les 9 derniers chiffres ne sont pas un format de siren "valide" (une formule "luhn") et que la clé de 2 chiffres n'est pas codée d'après la bonne formule (une formule connue aussi) à partir des 9 suivants, alors c'est une entreprise "étrangère" qu'on pourrait laisser s'inscrire avec nu TVA en FR.
- on vérifie quand même la validité des formats de numéro de TVA intra-communautaire et on recherche leurs coordonnées dans l'api VIES de l'UE. Ce qui permet de filtrer les numéro vraiment farfelus (comme actuellement en fait)

![image](https://github.com/MTES-MCT/trackdechets/assets/76620/af5b2a90-b07a-448d-88a6-584a589e72c2)

# Amélioration des labels du formulaire de création d'un transporteur étranger

![image](https://github.com/MTES-MCT/trackdechets/assets/76620/a916f59d-fa6d-4a20-8369-3500e1ebef83)

# Fix regression dans l'input SIRET/VAT : suppression auto des espaces
# Amélioration des messages d'erreur de l'input SIRET/VAT

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-8112)
