### PR TITLE
TRA-12219 - Correctif - Impossible d'enlever la présence de POP via la révision

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,9 +7,17 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 # [2023.8.1] 08/08/2023
 
-#### :bug: Corrections de bugs
+#### :rocket: Nouvelles fonctionnalités
 
+#### :bug: Corrections de bugs
 - Correction d'un message d'erreur incompréhensible en l'absence des informations de contact entreprise sur le BSFF après avoir cliqué sur "Modifier" [PR 2601](https://github.com/MTES-MCT/trackdechets/pull/2601)
+- Correction de 'limpossibilité d'enlever la présence de POP sur les BSDDs via la révision [PR 2596](https://github.com/MTES-MCT/trackdechets/pull/2596)
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :house: Interne
 
 # [2023.7.2] 25/07/2023
 

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
@@ -203,6 +203,7 @@ export function BsddRequestRevision({ bsdd }: Props) {
                     value={Boolean(bsdd.wasteDetails?.pop) ? "Oui" : "Non"}
                     name="content.wasteDetails.pop"
                     defaultValue={initialReview.wasteDetails.pop}
+                    initialValue={false}
                   >
                     <Field
                       type="checkbox"

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
@@ -6,7 +6,9 @@ type Props = {
   title: string;
   children: React.ReactNode;
   name: string;
+  // Value coming from revised bsd, allowing reset when component is closed
   defaultValue: any;
+  // Optional value to initialize children field value, usefule for booleans
   initialValue?: any;
   value: string | number | React.ReactNode;
 };

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
@@ -30,7 +30,7 @@ export function ReviewableField({
       setValue(defaultValue);
     } else {
       // When toggling visibility to on, set children value to optional initialValue (to tell apart empty strings from boolean)
-      initialValue !== undefined && setValue(initialValue);
+      if (initialValue !== undefined) setValue(initialValue);
     }
     setIsEditing(!isEditing);
   }

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/request/ReviewableField.tsx
@@ -7,6 +7,7 @@ type Props = {
   children: React.ReactNode;
   name: string;
   defaultValue: any;
+  initialValue?: any;
   value: string | number | React.ReactNode;
 };
 
@@ -15,6 +16,7 @@ export function ReviewableField({
   title,
   name,
   defaultValue,
+  initialValue,
   children,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
@@ -22,10 +24,15 @@ export function ReviewableField({
 
   function handleIsEditingChange() {
     if (isEditing) {
+      // When toggling visibility to off, set children value to pre-existing value
       setValue(defaultValue);
+    } else {
+      // When toggling visibility to on, set children value to optional initialValue (to tell apart empty strings from boolean)
+      initialValue !== undefined && setValue(initialValue);
     }
     setIsEditing(!isEditing);
   }
+
   return (
     <div className="tw-pb-4">
       <div className="tw-flex">


### PR DESCRIPTION
La demande de révisions depuis l'UI ne prenait pas en compte les POP (oui->non).
C'est un pb de front, les champs sont initialisés avec une valeur chaîne vide, qui est ignorée lors de l'envoi de la mutation. 
Pour les booléens, le switch étant sur false, passer d'un POP true à false ne fonctionne pas, sauf à switcher sur true, puis false pour stocker la bonne valeur dans les values.

Cette PR ajoute un champ optionnel initlaValue au composant ReviewableField qui permet d’initialiser le champ avec un vrai false, la valeur originelle étant déjà restaurée en cas de fermeture du block de révision.

 
- [x] Mettre à jour le change log
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12219)
