### PR TITLE
Ajout de filtres à la query `bsds` pour filtrer sur les bordereaux ayant une demande de révision en cours ou passée

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+- Ajout de filtres à la query bsds pour filtrer sur les bordereaux ayant une demande de révision en cours ou passée [PR 2598](Ajout de filtres à la query bsds pour filtrer sur les bordereaux ayant une demande de révision en cours ou passée)
+
 # [2023.8.3] 29/08/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/prisma/scripts/reindexTransporterInfo.ts
+++ b/back/prisma/scripts/reindexTransporterInfo.ts
@@ -1,7 +1,10 @@
 import { Updater, registerUpdater } from "./helper/helper";
 import prisma from "../../src/prisma";
 import { indexBsds, index } from "../../src/common/elastic";
-import { toBsdElastic as bsdaToBsdElastic } from "../../src/bsda/elastic";
+import {
+  BsdaForElasticInclude,
+  toBsdElastic as bsdaToBsdElastic
+} from "../../src/bsda/elastic";
 import { toBsdElastic as bsdasriToBsdElastic } from "../../src/bsdasris/elastic";
 import { toBsdElastic as bsffToBsdElastic } from "../../src/bsffs/elastic";
 
@@ -19,7 +22,7 @@ export class ReindexTransporterInfo implements Updater {
           { transporterTransportPlates: { isEmpty: false } }
         ]
       },
-      include: { intermediaries: true }
+      include: BsdaForElasticInclude
     });
 
     const bsdasris = await prisma.bsdasri.findMany({

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -46,7 +46,7 @@ import {
 } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { Decimal } from "decimal.js-light";
-import { RawBsda } from "./elastic";
+import { BsdaForElastic } from "./elastic";
 
 export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
   return {
@@ -221,7 +221,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
   };
 }
 export function expandBsdaFromElastic(
-  bsda: RawBsda
+  bsda: BsdaForElastic
 ): GraphqlBsda & { groupedIn?: string; forwardedIn?: string } {
   const expanded = expandBsdaFromDb(bsda);
 

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -1,18 +1,43 @@
-import {
-  Bsda,
-  BsdaStatus,
-  BsdType,
-  IntermediaryBsdaAssociation
-} from "@prisma/client";
+import { Bsda, BsdaStatus, BsdType } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import { buildAddress } from "../companies/sirene/utils";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
+import {
+  BsdaWithForwardedIn,
+  BsdaWithForwardedInInclude,
+  BsdaWithGroupedIn,
+  BsdaWithGroupedInInclude,
+  BsdaWithIntermediaries,
+  BsdaWithIntermediariesInclude,
+  BsdaWithRevisionRequests,
+  BsdaWithRevisionRequestsInclude
+} from "./types";
+import prisma from "../prisma";
+import { getRevisionOrgIds } from "../common/elasticHelpers";
 
-export type RawBsda = Bsda & {
-  intermediaries: IntermediaryBsdaAssociation[];
+export type BsdaForElastic = Bsda &
+  BsdaWithIntermediaries &
+  BsdaWithForwardedIn &
+  BsdaWithGroupedIn &
+  BsdaWithRevisionRequests;
+
+export const BsdaForElasticInclude = {
+  ...BsdaWithIntermediariesInclude,
+  ...BsdaWithForwardedInInclude,
+  ...BsdaWithGroupedInInclude,
+  ...BsdaWithRevisionRequestsInclude
 };
+
+export async function getBsdaForElastic(
+  bsda: Pick<Bsda, "id">
+): Promise<BsdaForElastic> {
+  return prisma.bsda.findUniqueOrThrow({
+    where: { id: bsda.id },
+    include: BsdaForElasticInclude
+  });
+}
 
 type WhereKeys =
   | "isDraftFor"
@@ -31,7 +56,7 @@ type WhereKeys =
 // | PROCESSED          | archive         | archive         | archive     | archive         | follow          | archive      |
 // | REFUSED            | archive         | archive         | archive     | archive         | follow          | archive      |
 // | AWAITING_CHILD     | follow          | follow          | follow      | follow          | follow          | follow       |
-function getWhere(bsda: RawBsda): Pick<BsdElastic, WhereKeys> {
+function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
   const where: Record<WhereKeys, string[]> = {
     isDraftFor: [],
     isForActionFor: [],
@@ -149,7 +174,7 @@ function getWhere(bsda: RawBsda): Pick<BsdElastic, WhereKeys> {
   return where;
 }
 
-export function toBsdElastic(bsda: RawBsda): BsdElastic {
+export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
   const where = getWhere(bsda);
 
   return {
@@ -229,8 +254,8 @@ export function toBsdElastic(bsda: RawBsda): BsdElastic {
     destinationAcceptationDate: bsda.destinationReceptionDate?.getTime(),
     destinationAcceptationWeight: bsda.destinationReceptionWeight,
     destinationOperationDate: bsda.destinationOperationDate?.getTime(),
-
     ...where,
+    ...getBsdaRevisionOrgIds(bsda),
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsda),
     intermediaries: bsda.intermediaries,
@@ -238,6 +263,16 @@ export function toBsdElastic(bsda: RawBsda): BsdElastic {
   };
 }
 
-export function indexBsda(bsda: RawBsda, ctx?: GraphQLContext) {
+export function indexBsda(bsda: BsdaForElastic, ctx?: GraphQLContext) {
   return indexBsd(toBsdElastic(bsda), ctx);
+}
+
+/**
+ * Pour un BSDD donné, retourne l'ensemble des identifiants d'établissements
+ * pour lesquels il y a une demande de révision en cours ou passée.
+ */
+export function getBsdaRevisionOrgIds(
+  bsda: BsdaForElastic
+): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
+  return getRevisionOrgIds(bsda.BsdaRevisionRequest);
 }

--- a/back/src/bsda/repository/revisionRequest/accept.ts
+++ b/back/src/bsda/repository/revisionRequest/accept.ts
@@ -11,10 +11,10 @@ import {
   RepositoryFnDeps,
   RepositoryTransaction
 } from "../../../common/repository/types";
-import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { PARTIAL_OPERATIONS } from "../../validation/constants";
 import { NON_CANCELLABLE_BSDA_STATUSES } from "../../resolvers/mutations/revisionRequest/createRevisionRequest";
 import { ForbiddenError } from "../../../common/errors";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,

--- a/back/src/bsda/repository/revisionRequest/create.ts
+++ b/back/src/bsda/repository/revisionRequest/create.ts
@@ -4,6 +4,7 @@ import {
   RepositoryFnDeps
 } from "../../../common/repository/types";
 import { approveAndApplyRevisionRequest } from "./accept";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 
 export type CreateRevisionRequestFn = (
   data: Prisma.BsdaRevisionRequestCreateInput,
@@ -30,6 +31,10 @@ export function buildCreateRevisionRequest(
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
+
+    prisma.addAfterCommitCallback(() =>
+      enqueueUpdatedBsdToIndex(revisionRequest.bsdaId)
+    );
 
     if (revisionRequest.approvals.length > 0) {
       return revisionRequest;

--- a/back/src/bsda/types.ts
+++ b/back/src/bsda/types.ts
@@ -1,0 +1,61 @@
+import { Prisma } from "@prisma/client";
+
+export const BsdaWithIntermediariesInclude =
+  Prisma.validator<Prisma.BsdaInclude>()({
+    intermediaries: true
+  });
+
+export type BsdaWithIntermediaries = Prisma.BsdaGetPayload<{
+  include: typeof BsdaWithIntermediariesInclude;
+}>;
+
+export const BsdaWithForwardedInInclude =
+  Prisma.validator<Prisma.BsdaInclude>()({
+    forwardedIn: { select: { id: true } }
+  });
+
+export type BsdaWithForwardedIn = Prisma.BsdaGetPayload<{
+  include: typeof BsdaWithForwardedInInclude;
+}>;
+
+export const BsdaWithGroupedInInclude = Prisma.validator<Prisma.BsdaInclude>()({
+  forwardedIn: { select: { id: true } }
+});
+
+export type BsdaWithGroupedIn = Prisma.BsdaGetPayload<{
+  include: typeof BsdaWithGroupedInInclude;
+}>;
+
+export const BsdaRevisionRequestWithAuthoringCompanyInclude =
+  Prisma.validator<Prisma.BsdaRevisionRequestInclude>()({
+    authoringCompany: { select: { orgId: true } }
+  });
+
+export type BsdaRevisionRequestWithAuthoringCompany =
+  Prisma.BsdaRevisionRequestGetPayload<{
+    include: typeof BsdaRevisionRequestWithAuthoringCompanyInclude;
+  }>;
+
+export const BsdaRevisionRequestWithApprovalsInclude =
+  Prisma.validator<Prisma.BsdaRevisionRequestInclude>()({
+    approvals: { select: { approverSiret: true } }
+  });
+
+export type BsdaRevisionRequestWithApprovals =
+  Prisma.BsdaRevisionRequestGetPayload<{
+    include: typeof BsdaRevisionRequestWithApprovalsInclude;
+  }>;
+
+export const BsdaWithRevisionRequestsInclude =
+  Prisma.validator<Prisma.BsdaInclude>()({
+    BsdaRevisionRequest: {
+      include: {
+        ...BsdaRevisionRequestWithAuthoringCompanyInclude,
+        ...BsdaRevisionRequestWithApprovalsInclude
+      }
+    }
+  });
+
+export type BsdaWithRevisionRequests = Prisma.BsdaGetPayload<{
+  include: typeof BsdaWithRevisionRequestsInclude;
+}>;

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -41,7 +41,7 @@ import {
 import { Prisma, Bsdasri, BsdasriStatus } from "@prisma/client";
 import { Decimal } from "decimal.js-light";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
-import { RawBsdasri } from "./elastic";
+import { BsdasriForElastic } from "./elastic";
 
 export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
   return {
@@ -195,7 +195,9 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
   };
 }
 
-export function expandBsdasriFromElastic(bsdasri: RawBsdasri): GqlBsdasri {
+export function expandBsdasriFromElastic(
+  bsdasri: BsdasriForElastic
+): GqlBsdasri {
   const expanded = expandBsdasriFromDB(bsdasri);
 
   // pass down related field to sub-resolvers

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -111,12 +111,12 @@ function getWhere(bsdasri: Bsdasri): Pick<BsdElastic, WhereKeys> {
   return where;
 }
 
-export type RawBsdasri = Bsdasri;
+export type BsdasriForElastic = Bsdasri;
 
 /**
  * Convert a dasri from the bsdasri table to Elastic Search's BSD model.
  */
-export function toBsdElastic(bsdasri: RawBsdasri): BsdElastic {
+export function toBsdElastic(bsdasri: BsdasriForElastic): BsdElastic {
   const where = getWhere(bsdasri);
 
   return {
@@ -189,6 +189,8 @@ export function toBsdElastic(bsdasri: RawBsdasri): BsdElastic {
     destinationAcceptationWeight: bsdasri.destinationReceptionWasteWeightValue,
     destinationOperationDate: bsdasri.destinationOperationDate?.getTime(),
     ...where,
+    isInRevisionFor: [],
+    isRevisedFor: [],
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsdasri),
     rawBsd: bsdasri

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -9,10 +9,16 @@ import {
   BsdElastic
 } from "../../common/elastic";
 import { BsdType } from "../../generated/graphql/types";
-import { toBsdElastic as bsdaToBsdElastic } from "../../bsda/elastic";
+import {
+  BsdaForElasticInclude,
+  toBsdElastic as bsdaToBsdElastic
+} from "../../bsda/elastic";
 import { toBsdElastic as bsdasriToBsdElastic } from "../../bsdasris/elastic";
 import { toBsdElastic as bsffToBsdElastic } from "../../bsffs/elastic";
-import { toBsdElastic as formToBsdElastic } from "../../forms/elastic";
+import {
+  FormForElasticInclude,
+  toBsdElastic as formToBsdElastic
+} from "../../forms/elastic";
 import { toBsdElastic as bsvhuToBsdElastic } from "../../bsvhu/elastic";
 import { indexQueue } from "../../queue/producers/elastic";
 import { IndexAllFnSignature, FindManyAndIndexBsdsFnSignature } from "./types";
@@ -51,11 +57,7 @@ const prismaFindManyOptions = {
   },
   bsvhu: {},
   bsda: {
-    include: {
-      forwardedIn: { select: { id: true } },
-      groupedIn: { select: { id: true } },
-      intermediaries: true
-    }
+    include: BsdaForElasticInclude
   },
   bsdasri: {
     include: {
@@ -64,12 +66,7 @@ const prismaFindManyOptions = {
     }
   },
   bsdd: {
-    include: {
-      forwarding: true,
-      forwardedIn: { include: { transporters: true } },
-      transporters: true,
-      intermediaries: true
-    }
+    include: FormForElasticInclude
   }
 };
 

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
@@ -8,7 +8,9 @@ import {
   MutationSignedByTransporterArgs,
   MutationMarkAsReceivedArgs,
   MutationMarkAsProcessedArgs,
-  CreateFormInput
+  CreateFormInput,
+  MutationCreateFormRevisionRequestArgs,
+  MutationSubmitFormRevisionRequestApprovalArgs
 } from "../../../../generated/graphql/types";
 import {
   resetDatabase,
@@ -22,8 +24,8 @@ import {
   transporterReceiptFactory
 } from "../../../../__tests__/factories";
 
-import { indexForm } from "../../../../forms/elastic";
-import { getFullForm } from "../../../../forms/database";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
+import { gql } from "graphql-tag";
 
 const searchCompanyMock = jest.spyOn(
   require("../../../../companies/search"),
@@ -74,6 +76,7 @@ describe("Query.bsds workflow", () => {
   let recipient: { user: User; company: Company };
   let intermediary: { user: User; company: Company };
   let formId: string;
+  let revisionRequestId: string;
 
   beforeAll(async () => {
     emitter = await userWithCompanyFactory(UserRole.ADMIN, {
@@ -506,6 +509,237 @@ describe("Query.bsds workflow", () => {
       ]);
     });
   });
+
+  describe("when the bsd is under revision", () => {
+    beforeAll(async () => {
+      expect(formId).toBeDefined();
+      const { mutate } = makeClient(recipient.user);
+      const CREATE_FORM_REVISION_REQUEST = gql`
+        mutation CreateFormRevisionRequest(
+          $input: CreateFormRevisionRequestInput!
+        ) {
+          createFormRevisionRequest(input: $input) {
+            id
+          }
+        }
+      `;
+
+      const { errors, data } = await mutate<
+        Pick<Mutation, "createFormRevisionRequest">,
+        MutationCreateFormRevisionRequestArgs
+      >(CREATE_FORM_REVISION_REQUEST, {
+        variables: {
+          input: {
+            formId: formId,
+            authoringCompanySiret: recipient.company.siret!,
+            comment: "oups",
+            content: { wasteDetails: { code: "04 01 03*" } }
+          }
+        }
+      });
+      expect(errors).toBeUndefined();
+      revisionRequestId = data.createFormRevisionRequest.id;
+      await refreshElasticSearch();
+    });
+
+    it("should list bsd in destination `isIsRevisionFor` forms", async () => {
+      const { query } = makeClient(recipient.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [recipient.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    });
+
+    it("should list bsd in emitter `isIsRevisionFor` forms", async () => {
+      const { query } = makeClient(emitter.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [emitter.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    });
+
+    it(
+      "should list bsds in emitter's top category `Révisions` made up" +
+        " of `isInRevisionFor` and `isRevisedFor`",
+      async () => {
+        const { query } = makeClient(emitter.user);
+        const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+          GET_BSDS,
+          {
+            variables: {
+              where: {
+                isInRevisionFor: [emitter.company.siret!],
+                isRevisedFor: [emitter.company.siret!]
+              }
+            }
+          }
+        );
+
+        expect(data.bsds.edges).toEqual([
+          expect.objectContaining({ node: { id: formId } })
+        ]);
+      }
+    );
+
+    it(
+      "should list bsds in destination's top category `Révisions` made up" +
+        " of `isInRevisionFor` and `isRevisedFor`",
+      async () => {
+        const { query } = makeClient(recipient.user);
+        const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+          GET_BSDS,
+          {
+            variables: {
+              where: {
+                isInRevisionFor: [recipient.company.siret!],
+                isRevisedFor: [recipient.company.siret!]
+              }
+            }
+          }
+        );
+
+        expect(data.bsds.edges).toEqual([
+          expect.objectContaining({ node: { id: formId } })
+        ]);
+      }
+    );
+  });
+
+  describe("when the bsd revision has been accepted", () => {
+    beforeAll(async () => {
+      expect(formId).toBeDefined();
+      const { mutate } = makeClient(emitter.user);
+      const SUBMIT_FORM_REVISION_REQUEST_APPROVAL = gql`
+        mutation SubmitFormRevisionRequestApproval(
+          $id: ID!
+          $isApproved: Boolean!
+          $comment: String
+        ) {
+          submitFormRevisionRequestApproval(
+            id: $id
+            isApproved: $isApproved
+            comment: $comment
+          ) {
+            id
+          }
+        }
+      `;
+
+      const { errors } = await mutate<
+        Pick<Mutation, "submitFormRevisionRequestApproval">,
+        MutationSubmitFormRevisionRequestApprovalArgs
+      >(SUBMIT_FORM_REVISION_REQUEST_APPROVAL, {
+        variables: {
+          id: revisionRequestId,
+          isApproved: true
+        }
+      });
+      expect(errors).toBeUndefined();
+      await refreshElasticSearch();
+    });
+
+    it("should list bsd in destination `isRevisedFor` forms", async () => {
+      const { query } = makeClient(recipient.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isRevisedFor: [recipient.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    });
+
+    it("should list bsd in emitter `isRevisedFor` forms", async () => {
+      const { query } = makeClient(emitter.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isRevisedFor: [emitter.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    });
+  });
+
+  it(
+    "should list bsds in emitter's top category `Révisions` made up" +
+      " of `isInRevisionFor` and `isRevisedFor`",
+    async () => {
+      const { query } = makeClient(emitter.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [emitter.company.siret!],
+              isRevisedFor: [emitter.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    }
+  );
+
+  it(
+    "should list bsds in destination's top category `Révisions` made up" +
+      " of `isInRevisionFor` and `isRevisedFor`",
+    async () => {
+      const { query } = makeClient(recipient.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [recipient.company.siret!],
+              isRevisedFor: [recipient.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: formId } })
+      ]);
+    }
+  );
 });
 
 describe("Query.bsds edge cases", () => {
@@ -544,9 +778,9 @@ describe("Query.bsds edge cases", () => {
       }
     });
 
-    const fullForm = await getFullForm(form);
+    const rawForm = await getFormForElastic(form);
 
-    await indexForm(fullForm);
+    await indexForm(rawForm);
     await refreshElasticSearch();
 
     const { query: transporterQuery } = makeClient(
@@ -581,5 +815,38 @@ describe("Query.bsds edge cases", () => {
     expect(res.data.bsds.edges).toEqual([
       expect.objectContaining({ node: { id: form.id } })
     ]);
+  });
+
+  it("should not return other user's bsds when no filter is passed", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+
+    const anotherEmitter = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+
+    const form = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "PROCESSED",
+        emitterCompanySiret: anotherEmitter.company.siret
+      }
+    });
+
+    const formForElastic = await getFormForElastic(form);
+
+    await indexForm(formForElastic);
+    await refreshElasticSearch();
+
+    const { query } = makeClient(emitter.user);
+
+    const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(GET_BSDS);
+
+    expect(data.bsds.edges).toHaveLength(0);
   });
 });

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -26,11 +26,12 @@ import { bsdSearchSchema } from "../../validation";
 import { toElasticQuery } from "../../where";
 import { Permission, can, getUserRoles } from "../../../permissions";
 import { distinct } from "../../../common/arrays";
-import { RawForm } from "../../../forms/elastic";
-import { RawBsdasri } from "../../../bsdasris/elastic";
-import { RawBsvhu } from "../../../bsvhu/elastic";
-import { RawBsda } from "../../../bsda/elastic";
-import { RawBsff } from "../../../bsffs/elastic";
+import { FormForElastic } from "../../../forms/elastic";
+import { BsdasriForElastic } from "../../../bsdasris/elastic";
+import { BsvhuForElastic } from "../../../bsvhu/elastic";
+import { BsdaForElastic } from "../../../bsda/elastic";
+import { BsffForElastic } from "../../../bsffs/elastic";
+import { QueryContainer } from "@elastic/elasticsearch/api/types";
 
 // complete Typescript example:
 // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/_a_complete_example.html
@@ -50,11 +51,11 @@ export interface GetResponse<T> {
 }
 
 type PrismaBsdMap = {
-  bsdds: RawForm[];
-  bsdasris: RawBsdasri[];
-  bsvhus: RawBsvhu[];
-  bsdas: RawBsda[];
-  bsffs: RawBsff[];
+  bsdds: FormForElastic[];
+  bsdasris: BsdasriForElastic[];
+  bsvhus: BsvhuForElastic[];
+  bsdas: BsdaForElastic[];
+  bsffs: BsffForElastic[];
 };
 
 /**
@@ -64,11 +65,13 @@ async function toRawBsds(bsdsElastic: BsdElastic[]): Promise<PrismaBsdMap> {
   const { BSDD, BSDA, BSDASRI, BSFF, BSVHU } = groupByBsdType(bsdsElastic);
 
   return {
-    bsdds: BSDD.map(bsdElastic => bsdElastic.rawBsd as RawForm),
-    bsdasris: BSDASRI.map(bsdsElastic => bsdsElastic.rawBsd as RawBsdasri),
-    bsvhus: BSVHU.map(bsdElastic => bsdElastic.rawBsd as RawBsvhu),
-    bsdas: BSDA.map(bsdElastic => bsdElastic.rawBsd as RawBsda),
-    bsffs: BSFF.map(bsdsElastic => bsdsElastic.rawBsd as RawBsff)
+    bsdds: BSDD.map(bsdElastic => bsdElastic.rawBsd as FormForElastic),
+    bsdasris: BSDASRI.map(
+      bsdsElastic => bsdsElastic.rawBsd as BsdasriForElastic
+    ),
+    bsvhus: BSVHU.map(bsdElastic => bsdElastic.rawBsd as BsvhuForElastic),
+    bsdas: BSDA.map(bsdElastic => bsdElastic.rawBsd as BsdaForElastic),
+    bsffs: BSFF.map(bsdsElastic => bsdsElastic.rawBsd as BsffForElastic)
   };
 }
 
@@ -87,24 +90,45 @@ async function buildQuery(
     }
   };
 
+  const tabsQuery: Array<QueryContainer> = [];
+
   Object.entries({
     isDraftFor: where?.isDraftFor,
     isForActionFor: where?.isForActionFor,
     isFollowFor: where?.isFollowFor,
     isArchivedFor: where?.isArchivedFor,
     isToCollectFor: where?.isToCollectFor,
-    isCollectedFor: where?.isCollectedFor
+    isCollectedFor: where?.isCollectedFor,
+    isInRevisionFor: where?.isInRevisionFor,
+    isRevisedFor: where?.isRevisedFor
   })
     .filter(([_, value]) => value != null)
     .forEach(([key, value]) => {
       if (Array.isArray(query.bool.filter)) {
-        query.bool.filter.push({
+        tabsQuery.push({
           terms: {
             [key]: value!
           }
         });
       }
     });
+
+  // Permet de filtrer sur un ensemble de catégories en même temps
+  // pour l'affichage des catégories parentes dans la v2 du dashboard
+  // On veut par exemple pouvoir afficher une catégorie "Transport" qui
+  // regroupe les bordereaux "En attente de collecte" et les bordereaux
+  // "Collecté".
+
+  // query { bsds(
+  //  where: {
+  //    isToCollectFor: [<SIRET>],
+  //    isCollectedFor: [<SIRET>]}
+  // )
+  // { id } }
+
+  if (tabsQuery.length > 0) {
+    query.bool.filter.push({ bool: { should: tabsQuery } });
+  }
 
   if (clue) {
     (query.bool.must as estypes.QueryContainer[]).push({

--- a/back/src/bsds/typeDefs/private/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.inputs.graphql
@@ -29,6 +29,10 @@ input BsdWhere {
   isArchivedFor: [String!]
   isToCollectFor: [String!]
   isCollectedFor: [String!]
+  # Révisions en cours
+  isInRevisionFor: [String!]
+  # Révisions passées
+  isRevisedFor: [String!]
 
   sirets: StringNullableListFilter
 

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -9,7 +9,7 @@ import {
 import * as GraphQL from "../generated/graphql/types";
 import { BsffPackaging, BsffPackagingType } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
-import { RawBsff } from "./elastic";
+import { BsffForElastic } from "./elastic";
 
 function flattenEmitterInput(input: { emitter?: GraphQL.BsffEmitter | null }) {
   return {
@@ -373,7 +373,7 @@ export function expandBsffPackagingFromDB(
   };
 }
 
-export function expandBsffFromElastic(bsff: RawBsff): GraphQL.Bsff {
+export function expandBsffFromElastic(bsff: BsffForElastic): GraphQL.Bsff {
   const expanded = expandBsffFromDB(bsff);
 
   // pass down related field to sub-resolvers

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -12,13 +12,13 @@ import { toBsffDestination } from "./compat";
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { getReadonlyBsffRepository } from "./repository";
 
-export type RawBsff = Bsff & {
+export type BsffForElastic = Bsff & {
   packagings: BsffPackaging[];
 } & {
   ficheInterventions: BsffFicheIntervention[];
 };
 
-export function toBsdElastic(bsff: RawBsff): BsdElastic {
+export function toBsdElastic(bsff: BsffForElastic): BsdElastic {
   const bsffDestination = toBsffDestination(bsff.packagings);
 
   const bsd = {
@@ -95,6 +95,8 @@ export function toBsdElastic(bsff: RawBsff): BsdElastic {
     isArchivedFor: [] as string[],
     isToCollectFor: [] as string[],
     isCollectedFor: [] as string[],
+    isInRevisionFor: [] as string[],
+    isRevisedFor: [] as string[],
     sirets: [
       bsff.emitterCompanySiret,
       bsff.transporterCompanySiret,

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -95,12 +95,12 @@ function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
   return where;
 }
 
-export type RawBsvhu = Bsvhu;
+export type BsvhuForElastic = Bsvhu;
 
 /**
  * Convert a bsvhu from the bsvhu table to Elastic Search's BSD model.
  */
-export function toBsdElastic(bsvhu: RawBsvhu): BsdElastic {
+export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
   const where = getWhere(bsvhu);
 
   return {
@@ -174,6 +174,8 @@ export function toBsdElastic(bsvhu: RawBsvhu): BsdElastic {
     destinationAcceptationWeight: bsvhu.destinationReceptionWeight,
     destinationOperationDate: bsvhu.destinationOperationDate?.getTime(),
     ...where,
+    isInRevisionFor: [],
+    isRevisedFor: [],
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsvhu),
     rawBsd: bsvhu

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -5,12 +5,12 @@ import { GraphQLContext } from "../types";
 import { AuthType } from "../auth";
 import logger from "../logging/logger";
 import { BsdType, FormCompany } from "../generated/graphql/types";
-import { RawForm } from "../forms/elastic";
-import { RawBsda } from "../bsda/elastic";
-import { RawBsdasri } from "../bsdasris/elastic";
-import { RawBsvhu } from "../bsvhu/elastic";
-import { RawBsff } from "../bsffs/elastic";
 import { OperationMode } from "@prisma/client";
+import { FormForElastic } from "../forms/elastic";
+import { BsdaForElastic } from "../bsda/elastic";
+import { BsdasriForElastic } from "../bsdasris/elastic";
+import { BsvhuForElastic } from "../bsvhu/elastic";
+import { BsffForElastic } from "../bsffs/elastic";
 
 export interface BsdElastic {
   type: BsdType;
@@ -96,10 +96,19 @@ export interface BsdElastic {
   isOutgoingWasteFor: string[];
   isTransportedWasteFor: string[];
   isManagedWasteFor: string[];
+  // Liste des établissements concernés par une demande de révision en cours sur ce bordereau
+  isInRevisionFor: string[];
+  // Liste des établissements concernés par une demande de révision passée sur ce bordereau
+  isRevisedFor: string[];
 
   intermediaries?: FormCompany[] | null;
 
-  rawBsd: RawForm | RawBsda | RawBsdasri | RawBsvhu | RawBsff;
+  rawBsd:
+    | FormForElastic
+    | BsdaForElastic
+    | BsdasriForElastic
+    | BsvhuForElastic
+    | BsffForElastic;
 }
 
 const textField = {
@@ -263,6 +272,8 @@ const properties: Record<keyof BsdElastic, Record<string, unknown>> = {
   isOutgoingWasteFor: stringField,
   isTransportedWasteFor: stringField,
   isManagedWasteFor: stringField,
+  isInRevisionFor: stringField,
+  isRevisedFor: stringField,
 
   intermediaries: {
     properties: {

--- a/back/src/common/elasticHelpers.ts
+++ b/back/src/common/elasticHelpers.ts
@@ -1,0 +1,63 @@
+import { BsdElastic } from "./elastic";
+import { RevisionRequestStatus } from "@prisma/client";
+
+type RevisionRequest = {
+  status: RevisionRequestStatus;
+  approvals: {
+    approverSiret: string;
+  }[];
+  authoringCompany: {
+    orgId: string;
+  };
+};
+
+/**
+ * Pour une liste de demandes de révisions BSDD ou BSDA, retourne l'ensemble
+ * des identifiants d'établissements pour lesquels il y a une demande de révision
+ * en cours ou passée.
+ */
+export function getRevisionOrgIds(
+  revisionRequests: RevisionRequest[]
+): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
+  const { isInRevisionFor, isRevisedFor } = revisionRequests.reduce<
+    ReturnType<typeof getRevisionOrgIds>
+  >(
+    // Pour chaque demande de révision en cours ou passés sur le bordereau
+    ({ isInRevisionFor, isRevisedFor }, revisionRequest) => {
+      // On commence par calculer la liste des identifiants d'établissements
+      // concernés par la demande de révision. En théorie cette liste est plus ou
+      // moins la même d'une demande de révision à l'autre
+      const revisionRequestOrgIds = [
+        revisionRequest.authoringCompany.orgId,
+        ...revisionRequest.approvals.map(a => a.approverSiret)
+      ];
+      // En fonction du statut de la demande de révision, on affecte les identifiants
+      // d'établissements soit à `isInRevisionFor`, soit à `isRevisedFor`. L'utilisation
+      // de `new Set(...)` permet de s'assurer que les identifiants sont uniques dans la liste.
+
+      return revisionRequest.status === "PENDING"
+        ? {
+            isInRevisionFor: [
+              ...new Set([...isInRevisionFor, ...revisionRequestOrgIds])
+            ],
+            isRevisedFor
+          }
+        : {
+            isInRevisionFor,
+            isRevisedFor: [
+              ...new Set([...isRevisedFor, ...revisionRequestOrgIds])
+            ]
+          };
+    },
+    { isInRevisionFor: [], isRevisedFor: [] }
+  );
+
+  // Si on a à la fois une demande de révision en cours et des demandes de révision passées
+  // on veut que le bordereau apparaisse uniquement dans l'onglet `En révision`. On ajoute donc
+  // un filtre sur `isRevisedFor` pour s'assurer qu'un identifiant d'établissement apparaisse
+  // soit dans `isInRevisionFor`, soit dans `isRevisedFor` mais pas dans les deux.
+  return {
+    isInRevisionFor: isInRevisionFor,
+    isRevisedFor: isRevisedFor.filter(orgId => !isInRevisionFor.includes(orgId))
+  };
+}

--- a/back/src/forms/__tests__/elasticHelpers.integration.ts
+++ b/back/src/forms/__tests__/elasticHelpers.integration.ts
@@ -1,0 +1,119 @@
+import { gql } from "graphql-tag";
+import { formFactory, userWithCompanyFactory } from "../../__tests__/factories";
+import makeClient from "../../__tests__/testClient";
+import {
+  Mutation,
+  MutationCreateFormRevisionRequestArgs
+} from "../../generated/graphql/types";
+import { getFormRevisionOrgIds } from "../elasticHelpers";
+import { getFormForElastic } from "../elastic";
+import prisma from "../../prisma";
+import { resetDatabase } from "../../../integration-tests/helper";
+
+const CREATE_FORM_REVISION_REQUEST = gql`
+  mutation CreateFormRevisionRequest($input: CreateFormRevisionRequestInput!) {
+    createFormRevisionRequest(input: $input) {
+      id
+    }
+  }
+`;
+
+describe("getFormRevisionOrgIds", () => {
+  afterEach(resetDatabase);
+
+  it("should list organisation identifiers in `isInRevisionFor` and `isRevisedFor`", async () => {
+    const emitter = await userWithCompanyFactory("ADMIN");
+    const transporter = await userWithCompanyFactory("ADMIN");
+    const recipient = await userWithCompanyFactory("ADMIN");
+
+    const form = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "PROCESSED",
+        emitterCompanySiret: emitter.company.siret,
+        recipientCompanySiret: recipient.company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: transporter.company.siret,
+            number: 1
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(emitter.user);
+
+    const formForElastic = await getFormForElastic(form);
+    const revisionOrgIds = getFormRevisionOrgIds(formForElastic);
+
+    expect(revisionOrgIds.isInRevisionFor).toHaveLength(0);
+    expect(revisionOrgIds.isRevisedFor).toHaveLength(0);
+
+    const { errors, data } = await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: form.id,
+          authoringCompanySiret: emitter.company.siret!,
+          comment: "oups",
+          content: { wasteDetails: { code: "04 01 03*" } }
+        }
+      }
+    });
+
+    const revisionRequest = data.createFormRevisionRequest;
+
+    expect(errors).toBeUndefined();
+
+    const formForElastic2 = await getFormForElastic(form);
+    const revisionOrgIds2 = getFormRevisionOrgIds(formForElastic2);
+
+    // Une demande de révision est en cours, les bordereaux doivent apparaitre dans
+    // l'onglet "Révision en cours"
+    expect(revisionOrgIds2.isInRevisionFor).toHaveLength(2);
+    expect(revisionOrgIds2.isInRevisionFor).toContain(emitter.company.siret);
+    expect(revisionOrgIds2.isInRevisionFor).toContain(recipient.company.siret);
+    expect(revisionOrgIds2.isRevisedFor).toHaveLength(0);
+
+    await prisma.bsddRevisionRequest.update({
+      where: { id: revisionRequest.id },
+      data: { status: "ACCEPTED" }
+    });
+
+    const formForElastic3 = await getFormForElastic(form);
+    const revisionOrgIds3 = getFormRevisionOrgIds(formForElastic3);
+
+    // La demande de révision a été accepté, les bordereaux doivent apparaitre
+    // dans l'onglet "Révisions passés"
+    expect(revisionOrgIds3.isInRevisionFor).toHaveLength(0);
+    expect(revisionOrgIds3.isRevisedFor).toHaveLength(2);
+    expect(revisionOrgIds3.isRevisedFor).toContain(emitter.company.siret);
+    expect(revisionOrgIds3.isRevisedFor).toContain(recipient.company.siret);
+
+    await mutate<
+      Pick<Mutation, "createFormRevisionRequest">,
+      MutationCreateFormRevisionRequestArgs
+    >(CREATE_FORM_REVISION_REQUEST, {
+      variables: {
+        input: {
+          formId: form.id,
+          authoringCompanySiret: emitter.company.siret!,
+          comment: "oups",
+          content: { wasteDetails: { code: "04 01 03*" } }
+        }
+      }
+    });
+
+    const formForElastic4 = await getFormForElastic(form);
+    const revisionOrgIds4 = getFormRevisionOrgIds(formForElastic4);
+
+    // Une nouvelle demande de révision a été effectuée, le bordereau doit
+    // rebasculer dans l'onglet "Révision en cours"
+    expect(revisionOrgIds4.isInRevisionFor).toHaveLength(2);
+    expect(revisionOrgIds4.isInRevisionFor).toContain(emitter.company.siret);
+    expect(revisionOrgIds4.isInRevisionFor).toContain(recipient.company.siret);
+    expect(revisionOrgIds4.isRevisedFor).toHaveLength(0);
+  });
+});

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -61,7 +61,7 @@ import {
 import prisma from "../prisma";
 import { extractPostalCode } from "../utils";
 import { getFirstTransporterSync } from "./database";
-import { RawForm } from "./elastic";
+import { FormForElastic } from "./elastic";
 import DataLoader from "dataloader";
 
 function flattenDestinationInput(input: {
@@ -814,7 +814,7 @@ export function expandFormFromDb(
 }
 
 export async function expandFormFromElastic(
-  form: RawForm,
+  form: FormForElastic,
   formLoader?: DataLoader<
     string,
     PrismaFormWithForwardedInAndTransporters | undefined,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -1,19 +1,57 @@
 import { Form, OperationMode } from "@prisma/client";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
-import { FullForm } from "./types";
+import {
+  FormWithForwardedIn,
+  FormWithForwardedInInclude,
+  FormWithIntermediaries,
+  FormWithIntermediariesInclude,
+  FormWithRevisionRequests,
+  FormWithTransporters,
+  FormWithTransportersInclude,
+  FormWithRevisionRequestsInclude,
+  FormWithForwarding,
+  FormWithForwardingInclude
+} from "./types";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
-import { getSiretsByTab, getRecipient } from "./elasticHelpers";
+import {
+  getSiretsByTab,
+  getRecipient,
+  getFormRevisionOrgIds
+} from "./elasticHelpers";
 
 import { buildAddress } from "../companies/sirene/utils";
 import { getFirstTransporterSync } from "./database";
+import prisma from "../prisma";
 
-export type RawForm = FullForm & { forwarding?: Form };
+export type FormForElastic = Form &
+  FormWithTransporters &
+  FormWithForwardedIn &
+  FormWithIntermediaries &
+  FormWithForwarding &
+  FormWithRevisionRequests;
+
+export const FormForElasticInclude = {
+  ...FormWithForwardedInInclude,
+  ...FormWithForwardingInclude,
+  ...FormWithTransportersInclude,
+  ...FormWithIntermediariesInclude,
+  ...FormWithRevisionRequestsInclude
+};
+
+export async function getFormForElastic(
+  form: Pick<Form, "readableId">
+): Promise<FormForElastic> {
+  return prisma.form.findUniqueOrThrow({
+    where: { readableId: form.readableId },
+    include: FormForElasticInclude
+  });
+}
 
 /**
  * Convert a BSD from the forms table to Elastic Search's BSD model.
  */
-export function toBsdElastic(form: RawForm): BsdElastic {
+export function toBsdElastic(form: FormForElastic): BsdElastic {
   const siretsByTab = getSiretsByTab(form);
 
   const recipient = getRecipient(form);
@@ -101,9 +139,11 @@ export function toBsdElastic(form: RawForm): BsdElastic {
           isFollowFor: [],
           isArchivedFor: [],
           isToCollectFor: [],
-          isCollectedFor: []
+          isCollectedFor: [],
+          isInRevisionFor: []
         }
       : siretsByTab),
+    ...getFormRevisionOrgIds(form),
     sirets: Object.values(siretsByTab).flat(),
     ...getRegistryFields(form),
     intermediaries: form.intermediaries,
@@ -112,7 +152,7 @@ export function toBsdElastic(form: RawForm): BsdElastic {
 }
 
 export async function indexForm(
-  form: FullForm,
+  form: FormForElastic,
   ctx?: GraphQLContext
 ): Promise<BsdElastic> {
   // prevent unwanted cascaded reindexation
@@ -126,7 +166,8 @@ export async function indexForm(
         ...form.forwardedIn,
         intermediaries: [],
         forwardedIn: null,
-        forwarding: form
+        forwarding: form,
+        bsddRevisionRequests: []
       })
     );
   }

--- a/back/src/forms/elasticHelpers.ts
+++ b/back/src/forms/elasticHelpers.ts
@@ -4,6 +4,8 @@ import { FullForm } from "./types";
 
 import { getTransporterCompanyOrgId } from "../common/constants/companySearchHelpers";
 import { getFirstTransporterSync } from "./database";
+import { FormForElastic } from "./elastic";
+import { getRevisionOrgIds } from "../common/elasticHelpers";
 
 /**
  * Computes which SIRET or VAT number should appear on which tab in the frontend
@@ -228,4 +230,14 @@ function getFormSirets(form: FullForm) {
   }
 
   return allFormSirets;
+}
+
+/**
+ * Pour un BSDD donné, retourne l'ensemble identifiants d'établissements
+ * pour lesquels il y a une demande de révision en cours ou passé.
+ */
+export function getFormRevisionOrgIds(
+  form: FormForElastic
+): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
+  return getRevisionOrgIds(form.bsddRevisionRequests);
 }

--- a/back/src/forms/repository/form/__tests__/delete.integration.ts
+++ b/back/src/forms/repository/form/__tests__/delete.integration.ts
@@ -16,10 +16,9 @@ import {
   index,
   indexBsd
 } from "../../../../common/elastic";
-import { indexForm, toBsdElastic } from "../../../elastic";
+import { getFormForElastic, indexForm, toBsdElastic } from "../../../elastic";
 import { getStream } from "../../../../activity-events";
 import { getFormRepository } from "../..";
-import { getFullForm } from "../../../database";
 
 describe("formRepository.delete", () => {
   afterEach(resetDatabase);
@@ -40,7 +39,7 @@ describe("formRepository.delete", () => {
 
     const form = await formFactory({ ownerId: user.id });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
 
     const hits = await searchBsds();
@@ -88,10 +87,12 @@ describe("formRepository.delete", () => {
     const user = await userFactory();
 
     const form = await formWithTempStorageFactory({ ownerId: user.id });
-    const fullForm = await getFullForm(form);
+    const fullForm = await getFormForElastic(form);
 
     await indexBsd(toBsdElastic(fullForm));
-    await indexBsd(toBsdElastic(await getFullForm(fullForm.forwardedIn!)));
+    await indexBsd(
+      toBsdElastic(await getFormForElastic(fullForm.forwardedIn!))
+    );
 
     await refreshElasticSearch();
 

--- a/back/src/forms/resolvers/queries/__tests__/formsRegister.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formsRegister.integration.ts
@@ -14,15 +14,14 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { Query } from "../../../../generated/graphql/types";
-import { indexForm } from "../../../elastic";
-import { getFullForm } from "../../../database";
+import { getFormForElastic, indexForm } from "../../../elastic";
 
 async function emitterFormFactory(ownerId: string, siret: string) {
   const form = await formFactory({
     ownerId,
     opt: { emitterCompanySiret: siret, sentAt: new Date() }
   });
-  await indexForm(await getFullForm(form));
+  await indexForm(await getFormForElastic(form));
   return form;
 }
 
@@ -34,7 +33,7 @@ async function recipientFormFactory(ownerId: string, siret: string) {
       receivedAt: new Date()
     }
   });
-  await indexForm(await getFullForm(form));
+  await indexForm(await getFormForElastic(form));
   return form;
 }
 
@@ -51,7 +50,7 @@ async function transporterFormFactory(ownerId: string, siret: string) {
       }
     }
   });
-  await indexForm(await getFullForm(form));
+  await indexForm(await getFormForElastic(form));
   return form;
 }
 
@@ -60,7 +59,7 @@ async function traderFormFactory(ownerId: string, siret: string) {
     ownerId,
     opt: { traderCompanySiret: siret, sentAt: new Date() }
   });
-  await indexForm(await getFullForm(form));
+  await indexForm(await getFormForElastic(form));
   return form;
 }
 

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -9,8 +9,113 @@ import {
 } from "@prisma/client";
 import { FormStatus } from "../generated/graphql/types";
 
+export const FormWithTransportersInclude =
+  Prisma.validator<Prisma.FormInclude>()({
+    transporters: true
+  });
+
+export type FormWithTransporters = Prisma.FormGetPayload<{
+  include: typeof FormWithTransportersInclude;
+}>;
+
+export const FormWithForwardedInInclude =
+  Prisma.validator<Prisma.FormInclude>()({
+    forwardedIn: { include: FormWithTransportersInclude }
+  });
+
+export type FormWithForwardedIn = Prisma.FormGetPayload<{
+  include: typeof FormWithForwardedInInclude;
+}>;
+
+export const FormWithIntermediariesInclude =
+  Prisma.validator<Prisma.FormInclude>()({
+    intermediaries: true
+  });
+
+export type FormWithIntermediaries = Prisma.FormGetPayload<{
+  include: typeof FormWithIntermediariesInclude;
+}>;
+
+export const FormWithForwardingInclude = Prisma.validator<Prisma.FormInclude>()(
+  {
+    forwarding: true
+  }
+);
+
+export type FormWithForwarding = Prisma.FormGetPayload<{
+  include: typeof FormWithForwardingInclude;
+}>;
+
+export const BsddRevisionRequestWithAuthoringCompanyInclude =
+  Prisma.validator<Prisma.BsddRevisionRequestInclude>()({
+    authoringCompany: { select: { orgId: true } }
+  });
+
+export type BsddRevisionRequestWithAuthoringCompany =
+  Prisma.BsddRevisionRequestGetPayload<{
+    include: typeof BsddRevisionRequestWithAuthoringCompanyInclude;
+  }>;
+
+export const BsddRevisionRequestWithApprovalsInclude =
+  Prisma.validator<Prisma.BsddRevisionRequestInclude>()({
+    approvals: { select: { approverSiret: true } }
+  });
+
+export type BsddRevisionRequestWithApprovals =
+  Prisma.BsddRevisionRequestGetPayload<{
+    include: typeof BsddRevisionRequestWithApprovalsInclude;
+  }>;
+
+export const FormWithRevisionRequestsInclude =
+  Prisma.validator<Prisma.FormInclude>()({
+    bsddRevisionRequests: {
+      include: {
+        ...BsddRevisionRequestWithAuthoringCompanyInclude,
+        ...BsddRevisionRequestWithApprovalsInclude
+      }
+    }
+  });
+
+export type FormWithRevisionRequests = Prisma.FormGetPayload<{
+  include: typeof FormWithRevisionRequestsInclude;
+}>;
+
 /**
  * A Prisma Form with linked objects
+ * ***********************************
+ *
+ * NE PLUS UTILISER SI POSSIBLE
+ *
+ * Nouvelles conventions :
+ *
+ * Pour chaque fonction, on définit la forme attendue de l'objet Form
+ * par un type spécifique que l'on définit juste au dessus de la fonction
+ * à partir des petites "briques" définies au dessus et que l'on
+ * nomme FormFor[NomDeLaFonction] ou autre chose du genre.
+ * Dans le contexte appelant, on crée un include prisma en composant
+ * les includes définit au dessus/
+ *
+ * Exemple :
+ *
+ * type FormForFoo = FormWithTransporters & FormWithIntermediaries
+ *
+ * function getFormForFoo(form: Form): Promise<FormForFoo> {
+ *  return prisma.form.findUniqueOrThrow({
+ *    where: {id: form.id },
+ *    include: { ...FormWithTransportersInclude, ...FormWithIntermediariesInclude }
+ *  })
+ * }
+ *
+ * function foo(form: FormForFoo){
+ *  /// function definition
+ *  return form
+ * }
+ *
+ * // Dans le contexte appelant
+ *
+ * const form = await getFormForFoo()
+ *
+ * foo(form)
  */
 export interface FullForm extends Form {
   forwardedIn: (Form & { transporters: BsddTransporter[] }) | null;

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -1,5 +1,8 @@
 import { Job } from "bull";
-import { toBsdElastic as toBsdaElastic } from "../../bsda/elastic";
+import {
+  BsdaForElasticInclude,
+  toBsdElastic as toBsdaElastic
+} from "../../bsda/elastic";
 import { toBsdElastic as toBsdasriElastic } from "../../bsdasris/elastic";
 import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
 import { toBsdElastic as toBsffElastic } from "../../bsffs/elastic";
@@ -15,7 +18,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   if (bsdId.startsWith("BSDA-")) {
     const bsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: bsdId },
-      include: { intermediaries: true }
+      include: BsdaForElasticInclude
     });
 
     return toBsdaElastic(bsda);

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -3,7 +3,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../integration-tests/helper";
-import { indexBsda } from "../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../bsda/elastic";
 import { bsdaFactory } from "../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
@@ -19,8 +19,7 @@ import {
 import { indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
-import { getFullForm } from "../../forms/database";
-import { indexForm } from "../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { WasteRegistryType } from "../../generated/graphql/types";
 import {
   formFactory,
@@ -114,7 +113,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -141,7 +140,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [ttr.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -169,7 +168,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
@@ -193,7 +192,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
@@ -207,7 +206,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         receivedAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -220,7 +219,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         receivedAt: null
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
@@ -233,7 +232,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         destinationOperationSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -246,7 +246,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         destinationOperationSignatureDate: null
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
     expect(bsds).toEqual([]);
@@ -334,7 +335,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -347,7 +348,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: null
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
@@ -376,7 +377,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [ttr.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
@@ -389,7 +390,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -402,7 +404,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: null
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
     expect(bsds).toEqual([]);
@@ -415,7 +418,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -428,7 +432,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: null
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
     expect(bsds).toEqual([]);
@@ -548,7 +553,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         }
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -566,7 +571,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         }
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
@@ -598,7 +603,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
@@ -611,7 +616,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -624,7 +630,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: null
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
     expect(bsds).toEqual([]);
@@ -713,7 +720,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -726,7 +733,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -739,7 +746,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: null
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
@@ -752,7 +759,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: null
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
@@ -765,7 +772,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -778,7 +786,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: null
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([]);
@@ -792,7 +801,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -810,7 +819,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         }
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -824,7 +833,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         receivedAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -837,7 +846,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         sentAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [trader.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -849,7 +858,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         brokerCompanySiret: broker.company.siret
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -864,7 +873,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [ttr.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
@@ -883,7 +892,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
@@ -899,7 +908,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
       }
     });
 
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [destination.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
@@ -914,7 +923,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [emitter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -927,7 +937,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -941,7 +952,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         destinationOperationSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [destination.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
@@ -954,7 +966,8 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         transporterTransportSignatureDate: new Date()
       }
     });
-    await indexBsda({ ...bsda, intermediaries: [] });
+    const bsdaForElastic = await getBsdaForElastic(bsda);
+    await indexBsda(bsdaForElastic);
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [broker.company.siret!]);
     expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -9,9 +9,8 @@ import { bsdaFactory } from "../../bsda/__tests__/factories";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { createBsffAfterReception } from "../../bsffs/__tests__/factories";
-import { getFullForm } from "../../forms/database";
-import { indexForm } from "../../forms/elastic";
-import { indexBsda } from "../../bsda/elastic";
+import { getFormForElastic, indexForm } from "../../forms/elastic";
+import { getBsdaForElastic, indexBsda } from "../../bsda/elastic";
 import { indexBsdasri } from "../../bsdasris/elastic";
 import { indexBsvhu } from "../../bsvhu/elastic";
 import { indexBsff } from "../../bsffs/elastic";
@@ -59,7 +58,9 @@ describe("wastesReader", () => {
         )
     );
 
-    await Promise.all(bsds.map(async bsd => indexForm(await getFullForm(bsd))));
+    await Promise.all(
+      bsds.map(async bsd => indexForm(await getFormForElastic(bsd)))
+    );
 
     // create 5 incoming BSDAs
     const bsdas = await Promise.all(
@@ -77,7 +78,10 @@ describe("wastesReader", () => {
     );
 
     await Promise.all(
-      bsdas.map(bsda => indexBsda({ ...bsda, intermediaries: [] }))
+      bsdas.map(async bsda => {
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
+      })
     );
 
     // create 5 incoming BSDASRIs

--- a/back/src/registry/__tests__/where.integration.ts
+++ b/back/src/registry/__tests__/where.integration.ts
@@ -3,7 +3,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../integration-tests/helper";
-import { indexBsda } from "../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../bsda/elastic";
 import { bsdaFactory } from "../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
@@ -12,8 +12,7 @@ import { createBsff } from "../../bsffs/__tests__/factories";
 import { indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
-import { getFullForm } from "../../forms/database";
-import { indexForm } from "../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { BsdType, WasteRegistryWhere } from "../../generated/graphql/types";
 import { formFactory, siretify, userFactory } from "../../__tests__/factories";
 import { toElasticFilter } from "../where";
@@ -35,15 +34,15 @@ describe("toElasticFilter", () => {
   it("should filter bsds by id (equality)", async () => {
     const user = await userFactory();
     const BSDS = {
-      BSDD: await getFullForm(await formFactory({ ownerId: user.id })),
-      BSDA: await bsdaFactory({}),
+      BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
+      BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await bsdasriFactory({}),
       BSVHU: await bsvhuFactory({}),
       BSFF: await createBsff()
     };
     await Promise.all([
       indexForm(BSDS["BSDD"]),
-      indexBsda({ ...BSDS["BSDA"], intermediaries: [] }),
+      indexBsda({ ...BSDS["BSDA"] }),
       indexBsdasri(BSDS["BSDASRI"]),
       indexBsvhu(BSDS["BSVHU"]),
       indexBsff(BSDS["BSFF"])
@@ -76,8 +75,8 @@ describe("toElasticFilter", () => {
     async bsdType => {
       const user = await userFactory();
       const BSDS = {
-        BSDD: await getFullForm(await formFactory({ ownerId: user.id })),
-        BSDA: await bsdaFactory({}),
+        BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
+        BSDA: await getBsdaForElastic(await bsdaFactory({})),
         BSDASRI: await bsdasriFactory({}),
         BSVHU: await bsvhuFactory({}),
         BSFF: await createBsff()
@@ -89,7 +88,7 @@ describe("toElasticFilter", () => {
 
       await Promise.all([
         indexForm(BSDS["BSDD"]),
-        indexBsda({ ...BSDS["BSDA"], intermediaries: [] }),
+        indexBsda({ ...BSDS["BSDA"] }),
         indexBsdasri(BSDS["BSDASRI"]),
         indexBsvhu(BSDS["BSVHU"]),
         indexBsff(BSDS["BSFF"])
@@ -105,8 +104,8 @@ describe("toElasticFilter", () => {
   it("should filter on bsdType (present in list)", async () => {
     const user = await userFactory();
     const BSDS = {
-      BSDD: await getFullForm(await formFactory({ ownerId: user.id })),
-      BSDA: await bsdaFactory({}),
+      BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
+      BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await bsdasriFactory({}),
       BSVHU: await bsvhuFactory({}),
       BSFF: await createBsff()
@@ -118,7 +117,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all([
       indexForm(BSDS["BSDD"]),
-      indexBsda({ ...BSDS["BSDA"], intermediaries: [] }),
+      indexBsda({ ...BSDS["BSDA"] }),
       indexBsdasri(BSDS["BSDASRI"]),
       indexBsvhu(BSDS["BSVHU"]),
       indexBsff(BSDS["BSFF"])
@@ -172,7 +171,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -223,7 +222,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -500,7 +500,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -551,7 +551,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -832,7 +833,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -882,7 +883,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -1139,7 +1141,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -1175,7 +1177,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -1333,7 +1336,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -1369,7 +1372,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -1527,7 +1531,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3, form4].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -1562,7 +1566,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -1714,7 +1719,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -1746,7 +1751,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -1866,7 +1872,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -1896,7 +1902,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2015,7 +2022,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2044,7 +2051,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2170,7 +2178,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2200,7 +2208,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2326,7 +2335,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2359,7 +2368,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2500,7 +2510,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2529,7 +2539,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2649,7 +2660,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2679,7 +2690,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2801,7 +2813,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2834,7 +2846,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();
@@ -2967,7 +2980,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [form1, form2, form3].map(async f => {
-        return indexForm(await getFullForm(f));
+        return indexForm(await getFormForElastic(f));
       })
     );
     await refreshElasticSearch();
@@ -2996,7 +3009,8 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsda1, bsda2, bsda3].map(async bsda => {
-        return indexBsda({ ...bsda, intermediaries: [] });
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -17,7 +17,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../../../integration-tests/helper";
-import { indexBsda } from "../../../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../../../bsda/elastic";
 import { bsdaFactory } from "../../../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../../../bsdasris/elastic";
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
@@ -25,8 +25,7 @@ import { indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
 import { indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
-import { getFullForm } from "../../../../forms/database";
-import { indexForm } from "../../../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   formFactory,
@@ -162,8 +161,8 @@ describe("All wastes registry", () => {
       }
     );
     await Promise.all([
-      indexForm(await getFullForm(bsd1)),
-      indexBsda({ ...bsd2, intermediaries: [] }),
+      indexForm(await getFormForElastic(bsd1)),
+      indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(bsd3),
       indexBsvhu(bsd4),
       indexBsff(bsd5)

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -17,7 +17,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../../../integration-tests/helper";
-import { indexBsda } from "../../../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../../../bsda/elastic";
 import { bsdaFactory } from "../../../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../../../bsdasris/elastic";
 
@@ -26,8 +26,7 @@ import { indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
 import { indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
-import { getFullForm } from "../../../../forms/database";
-import { indexForm } from "../../../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   companyFactory,
@@ -180,8 +179,8 @@ describe("Incoming wastes registry", () => {
       }
     );
     await Promise.all([
-      indexForm(await getFullForm(bsd1)),
-      indexBsda({ ...bsd2, intermediaries: [] }),
+      indexForm(await getFormForElastic(bsd1)),
+      indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(bsd3),
       indexBsvhu(bsd4),
       indexBsff(bsd5)
@@ -351,7 +350,7 @@ describe("Incoming wastes registry", () => {
         receivedAt: new Date()
       }
     });
-    await indexForm(await getFullForm(form));
+    await indexForm(await getFormForElastic(form));
     await refreshElasticSearch();
     const { query } = makeClient(userDestination);
     const { data } = await query<Pick<Query, "incomingWastes">>(

--- a/back/src/registry/resolvers/queries/__tests__/managedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/managedWastes.integration.ts
@@ -12,10 +12,9 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../../../integration-tests/helper";
-import { indexBsda } from "../../../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../../../bsda/elastic";
 import { bsdaFactory } from "../../../../bsda/__tests__/factories";
-import { getFullForm } from "../../../../forms/database";
-import { indexForm } from "../../../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   formFactory,
@@ -113,8 +112,8 @@ describe("Managed wastes registry", () => {
     });
 
     await Promise.all([
-      indexForm(await getFullForm(bsd1)),
-      indexBsda({ ...bsd2, intermediaries: [] })
+      indexForm(await getFormForElastic(bsd1)),
+      indexBsda(await getBsdaForElastic(bsd2))
     ]);
     await refreshElasticSearch();
   });

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -17,7 +17,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../../../integration-tests/helper";
-import { indexBsda } from "../../../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../../../bsda/elastic";
 import { bsdaFactory } from "../../../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../../../bsdasris/elastic";
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
@@ -25,8 +25,7 @@ import { indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
 import { indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
-import { getFullForm } from "../../../../forms/database";
-import { indexForm } from "../../../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   formFactory,
@@ -171,8 +170,8 @@ describe("Outgoing wastes registry", () => {
     );
 
     await Promise.all([
-      indexForm(await getFullForm(bsd1)),
-      indexBsda({ ...bsd2, intermediaries: [] }),
+      indexForm(await getFormForElastic(bsd1)),
+      indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(bsd3),
       indexBsvhu(bsd4),
       indexBsff(bsd5)

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -17,7 +17,7 @@ import {
   refreshElasticSearch,
   resetDatabase
 } from "../../../../../integration-tests/helper";
-import { indexBsda } from "../../../../bsda/elastic";
+import { getBsdaForElastic, indexBsda } from "../../../../bsda/elastic";
 import { bsdaFactory } from "../../../../bsda/__tests__/factories";
 import { indexBsdasri } from "../../../../bsdasris/elastic";
 
@@ -26,8 +26,7 @@ import { indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
 import { indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
-import { getFullForm } from "../../../../forms/database";
-import { indexForm } from "../../../../forms/elastic";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   formFactory,
@@ -170,8 +169,8 @@ describe("Transported wastes registry", () => {
     );
 
     await Promise.all([
-      indexForm(await getFullForm(bsd1)),
-      indexBsda({ ...bsd2, intermediaries: [] }),
+      indexForm(await getFormForElastic(bsd1)),
+      indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(bsd3),
       indexBsvhu(bsd4),
       indexBsff(bsd5)

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
@@ -14,8 +14,7 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 import { Query } from "../../../../generated/graphql/types";
 import { WASTES_REGISTRY_CSV } from "./queries";
-import { indexForm } from "../../../../forms/elastic";
-import { getFullForm } from "../../../../forms/database";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 
 function emitterFormFactory(ownerId: string, siret: string) {
   return formFactory({
@@ -124,7 +123,7 @@ describe("query { wastesRegistryCsv }", () => {
           ? traderFormFactory
           : emitterFormFactory;
       const form = await customFormFactory(user.id, company.siret!);
-      await indexForm(await getFullForm(form));
+      await indexForm(await getFormForElastic(form));
       await refreshElasticSearch();
       const { query } = makeClient(user);
       const { data } = await query<Pick<Query, "wastesRegistryCsv">>(

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
@@ -15,8 +15,7 @@ import {
 import makeClient from "../../../../__tests__/testClient";
 import { Query } from "../../../../generated/graphql/types";
 import { WASTES_REGISTRY_XLS } from "./queries";
-import { indexForm } from "../../../../forms/elastic";
-import { getFullForm } from "../../../../forms/database";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 
 function emitterFormFactory(ownerId: string, siret: string) {
   return formFactory({
@@ -125,7 +124,7 @@ describe("query { wastesRegistryXls }", () => {
           ? traderFormFactory
           : emitterFormFactory;
       const form = await customFormFactory(user.id, company.siret!);
-      await indexForm(await getFullForm(form));
+      await indexForm(await getFormForElastic(form));
       await refreshElasticSearch();
       const { query } = makeClient(user);
       const { data } = await query<Pick<Query, "wastesRegistryXls">>(


### PR DESCRIPTION
https://github.com/MTES-MCT/trackdechets/assets/2269165/5ee7d6ec-16f7-4ff3-bdb5-dd5ba4b3d0ce




- Ajout de deux champs au mapping ES : `isInRevisionFor` et `isRevisedFor`
- J'ai refacto un peu le code au passage pour être sûr qu'on calcule bien le même objet Form (`FormForElastic`, `BsdaForElastic`) dans les différents bouts de code qui gère l'indexation (queue, bulk, panneau d'admin). Ça permettra à l'avenir d'éviter que ce genre de bug se reproduise : [BUG - Le transporteur ne visualise pas le bordereau sur son Tableau de bord alors qu'il est bien visé](https://github.com/MTES-MCT/trackdechets/pull/2661).
- J'ai par ailleurs modifié légèrement la gestion des filtres sur la query `bsds` pour permettre l'affichage des "dossiers parents" (Cf les dossiers "Révisions" et "Transport" sur la maquette de Raphaël ci-dessous). On peut désormais composer les filtres `isDraftFor`, `isArchivedFor`, etc, en les mettant côte à côte dans le `where`. Ex: `{ isInRevisionFor: [<SIRET>], isRevisedFor: [<SIRET>]}`. Ce n'est pas idéal car ça fait un "OU logique" alors qu'en général ce genre de syntaxe sert à faire un "ET logique". Je n'ai cependant pas trouvé de moyen plus élégant de le faire car les filtres standards (sur le code déchet, etc) ne sont pas gérés de la même façon que les filtres sur les dossiers. À mon sens il faudrait peut-être séparer le `where` en deux. Une partie qui gère les filtres standards (sur le code déchet, etc) et une autre partie qui gère l'affichage des dossiers mais c'est un peu en dehors du scope de cette PR et ça ferait réécrire tous les appels front. 


![menu révision](https://github.com/MTES-MCT/trackdechets/assets/2269165/3ca58c08-ed92-4012-bfd5-85ece3233af0)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [[Dashboard] BACK Voir tous mes bordereaux de révision sous l'onglet principal "Mes Bordereaux - révision"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12238)
