### PR TITLE
[tra-12420] Message d'erreur incompréhensible dans le formulaire BSFF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.8.1] 08/08/2023
+
+#### :bug: Corrections de bugs
+
+- Correction d'un message d'erreur incompréhensible en l'absence des informations de contact entreprise sur le BSFF après avoir cliqué sur "Modifier" [PR 2601](https://github.com/MTES-MCT/trackdechets/pull/2601)
+
 # [2023.7.2] 25/07/2023
 
 #### :house: Interne

--- a/front/src/common/validation/schema.ts
+++ b/front/src/common/validation/schema.ts
@@ -36,11 +36,16 @@ export const companySchema = yup.object().shape({
     .nullable(),
   contact: yup
     .string()
+    .nullable()
     .required("Le contact dans l'entreprise est obligatoire"),
-  phone: yup.string().required("Le téléphone de l'entreprise est obligatoire"),
+  phone: yup
+    .string()
+    .nullable()
+    .required("Le téléphone de l'entreprise est obligatoire"),
   mail: yup
     .string()
     .email("Le format d'adresse email est incorrect")
+    .nullable()
     .required("L'email est obligatoire"),
   omiNumber: yup
     .string()


### PR DESCRIPTION
## Vidéo montrant le bug


https://github.com/MTES-MCT/trackdechets/assets/2269165/e7c2a33f-f894-47cc-b9ae-20f3bda5a1f2

## Vidéo après correctif 


https://github.com/MTES-MCT/trackdechets/assets/2269165/57d686d4-d16f-411d-bbcc-c6e76e0206b0


Je ne suis pas certain de comprendre pourquoi ce comportement n'est pas observé sur les autres bordereaux. Il me semble toutefois que ça fait sens de passer le schéma à `nullabel().required()` pour que l'absence de valeur ne soit pas considéré comme une erreur de type.


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Message d'erreur non compréhensible en l'absence des informations de contact sur le BSFF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12420)
