### PR TITLE
Ajout de routes de profiling

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -55,6 +55,7 @@
         "graphql-scalars": "^1.20.4",
         "graylog2": "^0.2.1",
         "helmet": "^6.2.0",
+        "inspector-api": "^1.4.7",
         "ioredis": "^4.28.0",
         "jose": "^4.11.2",
         "jsvat": "^2.5.3",
@@ -11148,9 +11149,9 @@
       "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "node_modules/dd-trace": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.29.1.tgz",
-      "integrity": "sha512-EKpamMiBbuL65Dq+TuyCf5Bc7NEhD0uwpgmbKN7tXK5O5fswdGDvyO1013B8SWnQQNcfoFvnlgtw/TmBYs9mXg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.30.0.tgz",
+      "integrity": "sha512-LgcBzOOI7X8TQvG0yuihKAZ6kc/BqAMsSrb7qcMW5jimavSBTqZHQOMnc7Ej/q2qSdvzo8WsnpoKtVblWkxRyw==",
       "hasInstallScript": true,
       "dependencies": {
         "@datadog/native-appsec": "^3.2.0",
@@ -11163,10 +11164,10 @@
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
-        "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.5",
+        "ignore": "^5.2.4",
+        "import-in-the-middle": "^1.4.1",
         "int64-buffer": "^0.1.9",
-        "ipaddr.js": "^2.0.1",
+        "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
         "koalas": "^1.0.2",
         "limiter": "^1.1.4",
@@ -11178,21 +11179,21 @@
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
         "msgpack-lite": "^0.1.26",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
         "protobufjs": "^7.2.4",
-        "retry": "^0.10.1",
-        "semver": "^7.3.8"
+        "retry": "^0.13.1",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/dd-trace/node_modules/ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "engines": {
         "node": ">= 10"
       }
@@ -11206,17 +11207,17 @@
       }
     },
     "node_modules/dd-trace/node_modules/retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
-        "node": "*"
+        "node": ">= 4"
       }
     },
     "node_modules/dd-trace/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13879,9 +13880,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -14112,6 +14113,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/inspector-api": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/inspector-api/-/inspector-api-1.4.7.tgz",
+      "integrity": "sha512-Bohof/IbQB9Ov5w5QSDPMtfrDzTjJLQq/dd8l0PCPlPxfz9k/9ohDNjrhDuJBUqlNQEbz1sPVu9i7jJPYyRoww==",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.359.0"
+      },
+      "bin": {
+        "inspector-api": "index.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
     },
     "node_modules/int64-buffer": {
@@ -29918,9 +29934,9 @@
       "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA=="
     },
     "dd-trace": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.29.1.tgz",
-      "integrity": "sha512-EKpamMiBbuL65Dq+TuyCf5Bc7NEhD0uwpgmbKN7tXK5O5fswdGDvyO1013B8SWnQQNcfoFvnlgtw/TmBYs9mXg==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-3.30.0.tgz",
+      "integrity": "sha512-LgcBzOOI7X8TQvG0yuihKAZ6kc/BqAMsSrb7qcMW5jimavSBTqZHQOMnc7Ej/q2qSdvzo8WsnpoKtVblWkxRyw==",
       "requires": {
         "@datadog/native-appsec": "^3.2.0",
         "@datadog/native-iast-rewriter": "2.0.1",
@@ -29932,10 +29948,10 @@
         "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
-        "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.5",
+        "ignore": "^5.2.4",
+        "import-in-the-middle": "^1.4.1",
         "int64-buffer": "^0.1.9",
-        "ipaddr.js": "^2.0.1",
+        "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
         "koalas": "^1.0.2",
         "limiter": "^1.1.4",
@@ -29947,18 +29963,18 @@
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
         "msgpack-lite": "^0.1.26",
-        "node-abort-controller": "^3.0.1",
+        "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
         "protobufjs": "^7.2.4",
-        "retry": "^0.10.1",
-        "semver": "^7.3.8"
+        "retry": "^0.13.1",
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "ipaddr.js": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-          "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+          "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ=="
         },
         "lru-cache": {
           "version": "7.14.1",
@@ -29966,14 +29982,14 @@
           "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         },
         "retry": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
         },
         "semver": {
-          "version": "7.5.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           },
@@ -31979,9 +31995,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
     },
     "ignore-walk": {
       "version": "3.0.3",
@@ -32159,6 +32175,14 @@
             "strip-ansi": "^6.0.0"
           }
         }
+      }
+    },
+    "inspector-api": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/inspector-api/-/inspector-api-1.4.7.tgz",
+      "integrity": "sha512-Bohof/IbQB9Ov5w5QSDPMtfrDzTjJLQq/dd8l0PCPlPxfz9k/9ohDNjrhDuJBUqlNQEbz1sPVu9i7jJPYyRoww==",
+      "requires": {
+        "@aws-sdk/client-s3": "^3.359.0"
       }
     },
     "int64-buffer": {

--- a/back/package.json
+++ b/back/package.json
@@ -103,6 +103,7 @@
     "graphql-scalars": "^1.20.4",
     "graylog2": "^0.2.1",
     "helmet": "^6.2.0",
+    "inspector-api": "^1.4.7",
     "ioredis": "^4.28.0",
     "jose": "^4.11.2",
     "jsvat": "^2.5.3",

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -1,7 +1,7 @@
 import { app, startApolloServer } from "./server";
 import { closeQueues } from "./queue/producers";
 import { cleanGqlCaches } from "./temp-memory";
-import { heapSnapshotToS3Router } from "./logging/heapSnapshot";
+import { cpuProfiling, memorySampling } from "./logging/heapSnapshot";
 import { envVariables } from "./env";
 
 envVariables.parse(process.env);
@@ -22,7 +22,8 @@ async function start() {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
-  process.on("SIGUSR1", heapSnapshotToS3Router);
+  process.on("SIGUSR1", memorySampling);
+  process.on("SIGUSR2", cpuProfiling);
 }
 
 if (process.env.TZ !== "Europe/Paris") {

--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -22,7 +22,7 @@ const inspector = new Inspector({
 
 const DURATION = process.env.INSPECTOR_DURATION
   ? parseInt(process.env.INSPECTOR_DURATION, 10)
-  : 10000;
+  : 30000;
 
 export async function cpuProfiling() {
   await inspector.profiler.enable();

--- a/back/src/logging/heapSnapshot.ts
+++ b/back/src/logging/heapSnapshot.ts
@@ -2,6 +2,45 @@ import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createWriteStream } from "fs";
 import v8 from "v8";
+import Inspector from "inspector-api";
+
+const inspector = new Inspector({
+  storage: {
+    type: "s3",
+    bucket: process.env.S3_BUCKET,
+    dir: "inspector"
+  },
+  aws: {
+    endpoint: process.env.S3_ENDPOINT,
+    region: process.env.S3_REGION,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!
+    }
+  }
+});
+
+const DURATION = process.env.INSPECTOR_DURATION
+  ? parseInt(process.env.INSPECTOR_DURATION, 10)
+  : 10000;
+
+export async function cpuProfiling() {
+  await inspector.profiler.enable();
+  await inspector.profiler.start();
+
+  setTimeout(async () => {
+    await inspector.profiler.stop();
+  }, DURATION);
+}
+
+export async function memorySampling() {
+  await inspector.heap.enable();
+  await inspector.heap.startSampling();
+
+  setTimeout(async () => {
+    await inspector.heap.stopSampling();
+  }, DURATION);
+}
 
 export async function heapSnapshotToS3Router() {
   // It's important that the filename end with `.heapsnapshot`,


### PR DESCRIPTION
Au lieu de faire des heap snapshot, on donne la possibilité de faire du sampling sur la heap + des profiling CPU.
Par défaut de 10 secondes. On peut configurer la durée avec `process.env.INSPECTOR_DURATION`.
C'est déclenché par des signals Unix, donc on peut choisr le container sur lesquels on les run avec `scalingo --app my-app send-signal --signal SIGUSR1 web-1`

C'est uploadé vers S3 comme pour les heap dump.