### PR TITLE
Corrige l'application des revisions du bsdd pour les pop

### DIFF
--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -165,7 +165,7 @@ async function getUpdateFromFormRevisionRequest(
     recipientCap: revisionRequest.recipientCap,
     wasteDetailsCode: revisionRequest.wasteDetailsCode,
     wasteDetailsName: revisionRequest.wasteDetailsName,
-    ...(revisionRequest.wasteDetailsPop && {
+    ...(revisionRequest.wasteDetailsPop !== null && {
       wasteDetailsPop: revisionRequest.wasteDetailsPop
     }),
     ...(revisionRequest.wasteDetailsPackagingInfos && {


### PR DESCRIPTION
L'application d'une révision de true -> false des pop du bsdd n'était pas appliquée.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12219)
