### PR TITLE
Recette aout

### DIFF
--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -15,7 +15,8 @@ import {
   siretSchema,
   foreignVatNumberSchema,
   isDestinationRefinement,
-  isTransporterRefinement
+  isTransporterRefinement,
+  isWorkerRefinement
 } from "../../common/validation/siret";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { OPERATIONS, WORKER_CERTIFICATION_ORGANISM } from "./constants";
@@ -161,7 +162,7 @@ export const rawBsdaSchema = z
       .nullish()
       .transform(v => Boolean(v)),
     workerCompanyName: z.string().nullish(),
-    workerCompanySiret: siretSchema.nullish(),
+    workerCompanySiret: siretSchema.nullish().superRefine(isWorkerRefinement),
     workerCompanyAddress: z.string().nullish(),
     workerCompanyContact: z.string().nullish(),
     workerCompanyPhone: z.string().nullish(),

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -583,6 +583,32 @@ describe("sealedFormSchema", () => {
         "Transporteur : Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement"
       );
     });
+
+    it("when parcel number coordinate is out of range", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        wasteDetailsParcelNumbers: [
+          { city: "Paris", postalCode: "75018", x: 100, y: 0 }
+        ]
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "Parcelle: la coordonnée X doit être inférieure ou égale à 90"
+      );
+    });
+
+    it("when parcel number coordinate has too many decimals", async () => {
+      const partialForm: Partial<Form> = {
+        ...sealedForm,
+        wasteDetailsParcelNumbers: [
+          { city: "Paris", postalCode: "75018", x: 5.1234567, y: 5 }
+        ]
+      };
+      const validateFn = () => sealedFormSchema.validate(partialForm);
+      await expect(validateFn()).rejects.toThrow(
+        "La coordonnée ne peut pas avoir plus de 6 décimales"
+      );
+    });
   });
 
   describe("Emitter transports own waste", () => {

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -452,7 +452,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
               Coordonnée(s) GPS :{" "}
               {form.wasteDetails?.parcelNumbers
                 ?.filter(pn => pn.x && pn.y)
-                .map(pn => [`lon ${pn.x}`, `lat ${pn.y}`].join(" / "))
+                .map(pn => [`lon ${pn.x}°`, `lat ${pn.y}°`].join(" / "))
                 .join(", ")}
               <br />
               Référence(s) laboratoire(s) :{" "}

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -599,9 +599,38 @@ const parcelNumber = yup.object({
     .max(5)
     .required("Parcelle: le numéro de parcelle est obligatoire")
 });
+const patternSixDigisAfterComma = /^\d+(\.\d{0,6})?$/;
 const parcelCoordinates = yup.object({
-  x: yup.number().required("Parcelle: la coordonnée X est obligatoire"),
-  y: yup.number().required("Parcelle: la coordonnée Y est obligatoire")
+  x: yup
+    .number()
+    .test(
+      "is-decimal",
+      "La coordonnée ne peut pas avoir plus de 6 décimales",
+      (val: any) => {
+        if (val != undefined) {
+          return patternSixDigisAfterComma.test(val);
+        }
+        return true;
+      }
+    )
+    .min(-90, "Parcelle: la coordonnée X doit être supérieure ou égale à -90")
+    .max(90, "Parcelle: la coordonnée X doit être inférieure ou égale à 90")
+    .required("Parcelle: la coordonnée X est obligatoire"),
+  y: yup
+    .number()
+    .test(
+      "is-decimal",
+      "La coordonnée ne peut pas avoir plus de 6 décimales",
+      (val: any) => {
+        if (val != undefined) {
+          return patternSixDigisAfterComma.test(val);
+        }
+        return true;
+      }
+    )
+    .min(-180, "Parcelle: la coordonnée Y doit être supérieure ou égale à -180")
+    .max(180, "Parcelle: la coordonnée Y doit être inférieure ou égale à 180")
+    .required("Parcelle: la coordonnée Y est obligatoire")
 });
 const parcelInfos = yup.lazy(value => {
   if (value.prefix || value.section || value.number) {

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -650,8 +650,8 @@ export default function BSDDetailContent({
                         pn.prefix,
                         pn.section,
                         pn.number,
-                        pn.x,
-                        pn.y,
+                        pn.x ? `${pn.x}°` : null,
+                        pn.y ? `${pn.y}°` : null,
                       ]
                         .filter(Boolean)
                         .join("/")}`

--- a/front/src/form/bsda/stepper/steps/WasteInfo.tsx
+++ b/front/src/form/bsda/stepper/steps/WasteInfo.tsx
@@ -119,7 +119,8 @@ export function WasteInfoWorker({ disabled }) {
 
       <div className="form__row">
         <label>
-          Mention au titre des règlements ADR/RID/ADN/IMDG (Optionnel)
+          Mention au titre des règlements ADR/RID/ADN/IMDG - ou "non soumis" le
+          cas échéant
           <Field
             disabled={disabled}
             type="text"

--- a/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
+++ b/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
@@ -238,7 +238,7 @@ function ParcelGps({ index }) {
     <div>
       <div className="form__row">
         <label>
-          Coordonnée X (WGS 84)
+          Coordonnée X (WGS 84) en °
           <Field
             type="number"
             name={`wasteDetails.parcelNumbers.${index}.x`}
@@ -248,7 +248,7 @@ function ParcelGps({ index }) {
       </div>
       <div className="form__row">
         <label>
-          Coordonnée Y (WGS 84)
+          Coordonnée Y (WGS 84) en °
           <Field
             type="number"
             name={`wasteDetails.parcelNumbers.${index}.y`}


### PR DESCRIPTION
Plusieurs éléments de recette:
- règles de validation sur les coordonnées géo
- affichage d'un `°` à côté des coordonnées
- correction sur la visibilité des brouillons quand on change de siret pendant qu'il reste brouillon
- correction pour interdire les entreprise de travaux non inscrites en tant que tel sur la plateforme