### PR TITLE
Corrige le composant des numéros de scellés du bsda

### DIFF
--- a/front/src/common/components/tags-input/TagsInput.tsx
+++ b/front/src/common/components/tags-input/TagsInput.tsx
@@ -56,13 +56,16 @@ export default function TagsInput(props) {
                 {tag}
                 <button
                   type="button"
-                  onClick={() => !props.disabled && arrayHelpers.remove(index)}
+                  onClick={e => {
+                    e.preventDefault();
+                    !props.disabled && arrayHelpers.remove(index);
+                  }}
                 >
                   +
                 </button>
               </li>
             ))}
-            <li className="input-tag__tags__input">
+            <li className="input-tag__tags__input" id={field.name}>
               <input
                 type="text"
                 onKeyDown={e => onInputKeyDown(e, arrayHelpers)}

--- a/front/src/form/bsda/stepper/steps/WasteInfo.tsx
+++ b/front/src/form/bsda/stepper/steps/WasteInfo.tsx
@@ -212,11 +212,11 @@ export function WasteInfoWorker({ disabled }) {
             <Tooltip msg="Ils peuvent être remplis au moment de la signature. Vous n'êtes pas obligé de les compléter à la création du bordereau." />
           </h4>
           <div className="form__row">
-            <label>
+            <label htmlFor="waste.sealNumbers">
               Numéros de scellés
               <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-              <TagsInput name="waste.sealNumbers" disabled={disabled} />
             </label>
+            <TagsInput name="waste.sealNumbers" disabled={disabled} />
           </div>
           <p>
             Vous avez saisi {values.waste?.sealNumbers?.length ?? 0} scellé(s)


### PR DESCRIPTION
Lorsqu'on clique sur la croix pour supprimer un numéro de scellé, le 1er numéro de la liste est toujours supprimé en même temps que celui sur lequel on a cliqué sur la croix. Se produit sur chrome, pas ff.

Si on clique sur le label du champ, même comportement.
Le pb existe partout où TagsInput est utilisé, si concluant faudra généraliser.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12300)
