### PR TITLE
Recette : Fix tags input everywhere

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/TransporterInfoEdit.tsx
@@ -98,11 +98,11 @@ export function TransporterInfoEdit({
             </div>
 
             <div className="form__row">
-              <label>
+              <label htmlFor="transporter.transport.plates">
                 Immatriculations
                 <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-                <TagsInput name="transporter.transport.plates" limit={2} />
               </label>
+              <TagsInput name="transporter.transport.plates" limit={2} />
             </div>
 
             <div className="form__actions">

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/UpdateTransporterPlates.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/UpdateTransporterPlates.tsx
@@ -87,11 +87,11 @@ function UpdateTransporterPlatesModal({
         }}
       >
         <Form>
-          <label>
+          <label htmlFor="plates">
             Immatriculations
             <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-            <TagsInput name="plates" limit={2} />
           </label>
+          <TagsInput name="plates" limit={2} />
 
           {!!error && <NotificationError apolloError={error} />}
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -94,10 +94,10 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
           {!bsff.transporter?.transport?.mode ||
             (bsff.transporter?.transport?.mode === TransportMode.Road && (
               <div className="form__row">
-                <label>
+                <label htmlFor="transporterTransportPlates">
                   Immatriculations
-                  <TagsInput name="transporterTransportPlates" />
                 </label>
+                <TagsInput name="transporterTransportPlates" />
               </div>
             ))}
 

--- a/front/src/form/bsda/stepper/steps/Transport.tsx
+++ b/front/src/form/bsda/stepper/steps/Transport.tsx
@@ -28,15 +28,15 @@ export function Transport({ disabled, required = false }: Props) {
       </div>
 
       <div className="form__row">
-        <label>
+        <label htmlFor="transporter.transport.plates">
           Immatriculations
           <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-          <TagsInput
-            name="transporter.transport.plates"
-            disabled={disabled}
-            limit={2}
-          />
         </label>
+        <TagsInput
+          name="transporter.transport.plates"
+          disabled={disabled}
+          limit={2}
+        />
       </div>
 
       <div className="form__row">

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -66,14 +66,11 @@ export default function Transport({ status, editionDisabled = false }) {
       </div>{" "}
       {showTransportePlates && (
         <div className="form__row">
-          <label>
+          <label htmlFor="transporter.transport.plates">
             Immatriculations
             <Tooltip msg={customInfoToolTip} />
-            <TagsInput
-              name="transporter.transport.plates"
-              disabled={disabled}
-            />
           </label>
+          <TagsInput name="transporter.transport.plates" disabled={disabled} />
         </div>
       )}
       {showTransportFields && (
@@ -133,11 +130,11 @@ export default function Transport({ status, editionDisabled = false }) {
         </>
       )}
       <div className="form__row">
-        <label>
+        <label htmlFor="identification.numbers">
           Numéros de containers
           <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-          <TagsInput name="identification.numbers" disabled={disabled} />
         </label>
+        <TagsInput name="identification.numbers" disabled={disabled} />
       </div>
     </>
   );

--- a/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
+++ b/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
@@ -98,21 +98,21 @@ export function ParcelNumbersSelector({ field }: FieldProps) {
       )}
 
       <div className="form__row">
-        <label>
+        <label htmlFor="wasteDetails.landIdentifiers">
           Identifiant(s) du terrain lorsque les terres ont été extraites d'un
           terrain placé en secteur d'information sur les sols au titre de
           l'article L. 125-6 (optionnel)
           <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-          <TagsInput name="wasteDetails.landIdentifiers" />
         </label>
+        <TagsInput name="wasteDetails.landIdentifiers" />
       </div>
 
       <div className="form__row">
-        <label>
+        <label htmlFor="wasteDetails.analysisReferences">
           Références d'analyses (optionnel)
           <Tooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-          <TagsInput name="wasteDetails.analysisReferences" />
         </label>
+        <TagsInput name="wasteDetails.analysisReferences" />
       </div>
     </div>
   );

--- a/front/src/form/bsff/Transporter.tsx
+++ b/front/src/form/bsff/Transporter.tsx
@@ -59,15 +59,15 @@ export default function Transporter({ disabled }) {
       </div>
 
       <div className="form__row">
-        <label>
+        <label htmlFor="transporter.transport.plates">
           Immatriculations
           <TdTooltip msg="Saisissez les numéros un par un. Appuyez sur la touche <Entrée> ou <Tab> pour valider chacun" />
-          <TagsInput
-            name="transporter.transport.plates"
-            disabled={disabled}
-            limit={2}
-          />
         </label>
+        <TagsInput
+          name="transporter.transport.plates"
+          disabled={disabled}
+          limit={2}
+        />
       </div>
     </>
   );

--- a/front/src/form/bsvhu/Operation.tsx
+++ b/front/src/form/bsvhu/Operation.tsx
@@ -94,12 +94,12 @@ export default function Operation() {
         <>
           <h4 className="form__section-heading">Identification</h4>
           <div className="form__row">
-            <label>
+            <label htmlFor="destination.reception.identification.numbers">
               Identification des numeros entrant des lots ou des VHU (livre de
               police)
               <Tooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
-              <TagsInput name="destination.reception.identification.numbers" />
             </label>
+            <TagsInput name="destination.reception.identification.numbers" />
           </div>
         </>
       )}

--- a/front/src/form/bsvhu/WasteInfo.tsx
+++ b/front/src/form/bsvhu/WasteInfo.tsx
@@ -94,11 +94,11 @@ export default function WasteInfo({ disabled }) {
       </div>
 
       <div className="form__row">
-        <label>
+        <label htmlFor="identification.numbers">
           Détail des identifications
           <Tooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
-          <TagsInput name="identification.numbers" disabled={disabled} />
         </label>
+        <TagsInput name="identification.numbers" disabled={disabled} />
       </div>
 
       <h4 className="form__section-heading">Quantité</h4>


### PR DESCRIPTION
Comme pour les numéros de scellés, on a des comportements inattendus sur tous les tags inputs sous chrome (clic sur le label ou sur le dernier élément supprime le premier).
On applique la même recette que sur https://github.com/MTES-MCT/trackdechets/pull/2621

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12300)
