### PR TITLE
Display multimodal tranporter infos

### DIFF
--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -104,9 +104,39 @@ const TransportSegmentDetail = ({ segment, siret }: SegmentProps) => {
     <>
       <div className={styles.detailGrid}>
         <Company label={label} company={segment?.transporter?.company} />
+      </div>
+
+      <div className={styles.detailGrid}>
+        <YesNoRow
+          value={segment?.transporter?.isExemptedOfReceipt}
+          label="Exemption de récépissé"
+        />
+        {!segment?.transporter?.isExemptedOfReceipt && (
+          <>
+            <DetailRow
+              value={segment?.transporter?.receipt}
+              label="Numéro de récépissé"
+              showEmpty={true}
+            />
+            <DetailRow
+              value={segment?.transporter?.department}
+              label="Département"
+              showEmpty={true}
+            />
+            <DateRow
+              value={segment?.transporter?.validityLimit}
+              label="Date de validité"
+            />
+          </>
+        )}
+        <DetailRow
+          value={segment?.transporter?.numberPlate}
+          label="Immatriculation"
+        />
 
         <DateRow value={segment?.takenOverAt} label="Pris en charge le" />
         <DetailRow value={segment?.takenOverBy} label="Pris en charge par" />
+
         <DetailRow
           value={getTransportModeLabel(segment?.mode)}
           label="Mode de transport"


### PR DESCRIPTION
Cahier de recette: lors du multimodal, la plaque d'immat des transporters > 1 n'est visible ni sur le dashboard ni sur l'aperçu. Vues les refontes en cours du multimodal et du dashboard cette PR ne touche pas au dashboard mais affiche plus d'infos dans l'aperçu.


## Avant 
<img width="637" alt="Capture d’écran 2023-08-07 à 16 53 06" src="https://github.com/MTES-MCT/trackdechets/assets/878396/6956b550-53a0-4296-923e-3985d3e96cc1">


## Après
<img width="934" alt="Capture d’écran 2023-08-07 à 16 19 08" src="https://github.com/MTES-MCT/trackdechets/assets/878396/8c8b6375-006e-4142-8d77-18dafed34a76">


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12445)
