### PR TITLE
Fix Bsda worker certifications & CompanySelector company data query

### DIFF
--- a/back/src/companies/resolvers/CompanySearchPrivate.ts
+++ b/back/src/companies/resolvers/CompanySearchPrivate.ts
@@ -43,16 +43,19 @@ const companySearchPrivateResolvers: CompanySearchPrivateResolvers = {
   },
   receivedSignatureAutomations: parent => {
     return prisma.company
-      .findUnique({ where: { orgId: parent.orgId } })
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
       .receivedSignatureAutomations({
         include: { from: true, to: true }
       }) as any;
   },
-  workerCertification: parent => {
-    return prisma.company
-      .findUnique({ where: { id: parent.orgId } })
-      .workerCertification();
-  }
+  workerCertification: parent =>
+    prisma.company
+      .findUnique({
+        where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
+      })
+      .workerCertification()
 };
 
 export default companySearchPrivateResolvers;

--- a/back/src/companies/resolvers/queries/companyPrivateInfos.ts
+++ b/back/src/companies/resolvers/queries/companyPrivateInfos.ts
@@ -32,6 +32,7 @@ const companyInfosResolvers: QueryResolvers["companyPrivateInfos"] = async (
     prisma.company.findUnique({
       where,
       select: {
+        id: true,
         orgId: true,
         gerepId: true,
         securityCode: true,
@@ -43,7 +44,14 @@ const companyInfosResolvers: QueryResolvers["companyPrivateInfos"] = async (
   const companyInfosConvert: any = companyInfos;
   return {
     ...companyInfosConvert,
-    ...company,
+    ...{
+      trackdechetsId: company?.id,
+      orgId: company?.orgId,
+      gerepId: company?.gerepId,
+      securityCode: company?.securityCode,
+      verificationCode: company?.verificationCode,
+      givenName: company?.givenName
+    },
     // We don't need this infos in this query
     isAnonymousCompany: isAnonymousCompany > 0
   } as CompanySearchPrivate;

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -215,8 +215,99 @@ type CompanyPublic {
   workerCertification: WorkerCertification
 }
 
+interface CompanySearchPrivateCommon {
+  "SIRET ou TVA de l'établissement"
+  orgId: String!
+  "SIRET de l'établissement"
+  siret: String
+  "TVA de l'établissement"
+  vatNumber: String
+  "Code pays de l'établissement"
+  codePaysEtrangerEtablissement: String
+  "État administratif de l'établissement. A = Actif, F = Fermé"
+  etatAdministratif: String
+  "Adresse de l'établissement"
+  address: String
+  "Nom de l'établissement"
+  name: String
+  "Code NAF"
+  naf: String
+  "Libellé NAF"
+  libelleNaf: String
+  """
+  Installation classée pour la protection de l'environnement (ICPE)
+  associé à cet établissement
+  """
+  installation: Installation
+
+  "Email de contact"
+  contactEmail: String
+  "Numéro de téléphone de contact"
+  contactPhone: String
+  "Nom et prénom de contact"
+  contact: String
+  "Site web"
+  website: String
+  """
+  Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets
+  """
+  isRegistered: Boolean
+  """
+  Identifiant de l'entreprise sur la plateforme Trackdéchets. N'a une valeur que si l'entreprise est inscrite sur Trackdéchets (`isRegistered=true`)
+  """
+  trackdechetsId: ID
+  """
+  Profil de l'établissement sur Trackdéchets
+  ayant pour valeur un tableau vide quand l'établissement
+  n'est pas inscrit sur la plateforme `isRegistered=false`
+  """
+  companyTypes: [CompanyType!]
+
+  """
+  Liste des agréments de l'éco-organisme
+  """
+  ecoOrganismeAgreements: [URL!]
+
+  "L'entreprise autorise l'enlèvement d'un Dasri sans sa signature"
+  allowBsdasriTakeOverWithoutSignature: Boolean
+
+  """
+  Récépissé transporteur associé à cet établissement (le cas échéant)
+  """
+  transporterReceipt: TransporterReceipt
+
+  """
+  Récépissé négociant associé à cet établissement (le cas échant)
+  """
+  traderReceipt: TraderReceipt
+
+  """
+  Récépissé courtier associé à cet établissement (le cas échant)
+  """
+  brokerReceipt: BrokerReceipt
+
+  """
+  Agrément VHU démolisseur (le cas échéant, pour les profils VHU)
+  """
+  vhuAgrementDemolisseur: VhuAgrement
+
+  """
+  Agrément VHU broyeur (le cas échéant, pour les profils VHU)
+  """
+  vhuAgrementBroyeur: VhuAgrement
+  """
+  Statut de diffusion des informations de l'établisement selon l'INSEE
+  """
+  statutDiffusionEtablissement: StatutDiffusionEtablissement
+
+  """
+  Certification entreprise de travaux
+  """
+  workerCertification: WorkerCertification
+}
+
 "Information sur un établissement accessible publiquement en recherche floue"
-type CompanySearchResult {
+type CompanySearchResult implements CompanySearchPrivateCommon {
   "SIRET ou TVA de l'établissement"
   orgId: String!
   "SIRET de l'établissement"

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -110,12 +110,17 @@ type AnonymousCompany {
 }
 
 "Information sur un établissement recherché par le frontend"
-type CompanySearchPrivate {
+type CompanySearchPrivate implements CompanySearchPrivateCommon {
   "Profil de l'établissement"
   companyTypes: [CompanyType!]!
 
   "SIRET ou TVA de l'établissement"
   orgId: String!
+
+  """
+  Identifiant de l'entreprise sur la plateforme Trackdéchets. N'a une valeur que si l'entreprise est inscrite sur Trackdéchets (`isRegistered=true`)
+  """
+  trackdechetsId: ID
 
   "Identifiant GEREP"
   gerepId: String
@@ -209,8 +214,9 @@ type CompanySearchPrivate {
 
   "État administratif de l'établissement. A = Actif, F = Fermé"
   etatAdministratif: String
+
   "Statut de diffusion de l'établissement selon l'INSEE. O = Oui, N = Non"
-  statutDiffusionEtablissement: String
+  statutDiffusionEtablissement: StatutDiffusionEtablissement
 
   """
   Si oui on non cet établissement est inscrit sur la plateforme Trackdéchets

--- a/front/src/Apps/common/queries/company/query.ts
+++ b/front/src/Apps/common/queries/company/query.ts
@@ -213,17 +213,3 @@ export const TRANSPORTER_RECEIPT = gql`
     }
   }
 `;
-
-export const WORKER_CERTIFICATION = gql`
-  query SearchCompanies($clue: String!) {
-    searchCompanies(clue: $clue) {
-      workerCertification {
-        hasSubSectionFour
-        hasSubSectionThree
-        certificationNumber
-        validityLimit
-        organisation
-      }
-    }
-  }
-`;

--- a/front/src/Apps/common/queries/company/query.ts
+++ b/front/src/Apps/common/queries/company/query.ts
@@ -59,58 +59,74 @@ export const COMPANY_INFOS_REGISTERED_VALIDATION_SCHEMA = gql`
   }
 `;
 
+const commonCompanySearchString = `
+orgId
+siret
+vatNumber
+name
+address
+etatAdministratif
+codePaysEtrangerEtablissement
+isRegistered
+trackdechetsId
+contact
+contactPhone
+contactEmail
+companyTypes
+installation {
+  codeS3ic
+  urlFiche
+}
+transporterReceipt {
+  receiptNumber
+  validityLimit
+  department
+}
+traderReceipt {
+  receiptNumber
+  validityLimit
+  department
+}
+brokerReceipt {
+  receiptNumber
+  validityLimit
+  department
+}
+vhuAgrementDemolisseur {
+  agrementNumber
+  department
+}
+vhuAgrementBroyeur {
+  agrementNumber
+  department
+}
+workerCertification {
+  hasSubSectionFour
+  hasSubSectionThree
+  certificationNumber
+  validityLimit
+  organisation
+}`;
+
+const companySearchResultFragment = gql`
+  fragment CompanySearchResultFragment on CompanySearchResult {
+    ${commonCompanySearchString}
+  }
+`;
+
+const companySearchPrivateFragment = gql`
+  fragment CompanySearchPrivateFragment on CompanySearchPrivate {
+    ${commonCompanySearchString}
+  }
+`;
+
 export const SEARCH_COMPANIES = gql`
   query SearchCompanies($clue: String!, $department: String) {
     searchCompanies(clue: $clue, department: $department) {
-      orgId
-      siret
-      vatNumber
-      name
-      address
-      etatAdministratif
-      codePaysEtrangerEtablissement
-      isRegistered
-      trackdechetsId
-      contact
-      contactPhone
-      contactEmail
-      companyTypes
-      installation {
-        codeS3ic
-        urlFiche
-      }
-      transporterReceipt {
-        receiptNumber
-        validityLimit
-        department
-      }
-      traderReceipt {
-        receiptNumber
-        validityLimit
-        department
-      }
-      brokerReceipt {
-        receiptNumber
-        validityLimit
-        department
-      }
-      vhuAgrementDemolisseur {
-        agrementNumber
-        department
-      }
-      vhuAgrementBroyeur {
-        agrementNumber
-        department
-      }
-      workerCertification {
-        hasSubSectionFour
-        hasSubSectionThree
-        certificationNumber
-        validityLimit
-        organisation
-      }
+      ...CompanySearchResultFragment
     }
   }
+  ${companySearchResultFragment}
 `;
 
 /**
@@ -175,31 +191,10 @@ export const COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS = gql`
 export const COMPANY_SELECTOR_PRIVATE_INFOS = gql`
   query CompanyPrivateInfos($clue: String!) {
     companyPrivateInfos(clue: $clue) {
-      orgId
-      siret
-      name
-      address
-      vatNumber
-      etatAdministratif
-      statutDiffusionEtablissement
-      isRegistered
-      isAnonymousCompany
-      companyTypes
-      codePaysEtrangerEtablissement
-      transporterReceipt {
-        receiptNumber
-        validityLimit
-        department
-      }
-      workerCertification {
-        hasSubSectionFour
-        hasSubSectionThree
-        certificationNumber
-        validityLimit
-        organisation
-      }
+      ...CompanySearchPrivateFragment
     }
   }
+  ${companySearchPrivateFragment}
 `;
 
 export const TRANSPORTER_RECEIPT = gql`

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -30,32 +30,33 @@ export function Worker({ disabled }) {
     workerSelected => {
       if (workerSelected) {
         setWorker(workerSelected);
-        setFieldValue(
-          "worker.certification.hasSubSectionFour",
-          workerSelected?.workerCertification?.hasSubSectionFour
-        );
-        setFieldValue(
-          "worker.certification.hasSubSectionThree",
-          workerSelected?.workerCertification?.hasSubSectionThree
-        );
-        setFieldValue(
-          "worker.certification.certificationNumber",
-          workerSelected?.workerCertification?.certificationNumber
-        );
-        setFieldValue(
-          "worker.certification.validityLimit",
-          workerSelected?.workerCertification?.validityLimit
-        );
-        setFieldValue(
-          "worker.certification.organisation",
-          workerSelected?.workerCertification?.organisation
-        );
+        if (workerSelected?.workerCertification) {
+          setFieldValue(
+            "worker.certification.hasSubSectionFour",
+            workerSelected?.workerCertification?.hasSubSectionFour
+          );
+          setFieldValue(
+            "worker.certification.hasSubSectionThree",
+            workerSelected?.workerCertification?.hasSubSectionThree
+          );
+          setFieldValue(
+            "worker.certification.certificationNumber",
+            workerSelected?.workerCertification?.certificationNumber
+          );
+          setFieldValue(
+            "worker.certification.validityLimit",
+            workerSelected?.workerCertification?.validityLimit
+          );
+          setFieldValue(
+            "worker.certification.organisation",
+            workerSelected?.workerCertification?.organisation
+          );
+        } else {
+          setFieldValue("worker.certification", null);
+        }
       } else {
         setWorker(undefined);
-        setFieldValue(
-          "worker.certification",
-          initialState.worker.certification
-        );
+        setFieldValue("worker.certification", null);
       }
     },
     [setFieldValue, setWorker]
@@ -104,7 +105,7 @@ export function Worker({ disabled }) {
             onCompanyPrivateInfos={updateWorkerState}
             onCompanySelected={updateWorkerState}
           />
-          {(!!worker?.workerCertification || !isWorker()) && (
+          {worker && (
             <>
               <h4 className="form__section-heading">
                 Catégorie entreprise de travaux déclarée dans le profil

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -7,58 +7,27 @@ import {
   BsdaType,
   CompanyType,
   Maybe,
-  Query,
-  QuerySearchCompaniesArgs,
   WorkerCertification,
 } from "generated/graphql/types";
-import React, { useEffect, useState } from "react";
-import { WORKER_CERTIFICATION } from "Apps/common/queries/company/query";
-import { useQuery } from "@apollo/client";
-import { useParams } from "react-router-dom";
+import React, { useState } from "react";
+import initialState from "../initial-state";
 
 export function Worker({ disabled }) {
   const { setFieldValue, values, handleChange } = useFormikContext<Bsda>();
-  const [companyTypes, setCompanyTypes] = useState<CompanyType[] | undefined>();
 
   const isGroupement = values?.type === BsdaType.Gathering;
   const isEntreposageProvisoire = values?.type === BsdaType.Reshipment;
   const isDechetterie = values?.type === BsdaType.Collection_2710;
   const [workerCertification, setWorkerCertification] =
     useState<Maybe<WorkerCertification>>();
-  const { siret: currentSiret } = useParams<{ siret: string }>();
-  const [siret, setSelectedSiret] = useState<Maybe<string> | undefined>(
-    currentSiret
-  );
 
-  const { data } = useQuery<
-    Pick<Query, "searchCompanies">,
-    QuerySearchCompaniesArgs
-  >(WORKER_CERTIFICATION, {
-    variables: {
-      clue: siret as string,
-    },
-    fetchPolicy: "no-cache",
-  });
-  useEffect(() => {
-    if (!companyTypes?.includes(CompanyType.Worker)) {
-      setWorkerCertification(null);
-    }
-  }, [companyTypes]);
-
-  useEffect(() => {
-    setWorkerCertification(data?.searchCompanies[0]?.workerCertification);
-  }, [data?.searchCompanies]);
-
-  useEffect(() => {
-    setWorkerCertification(data?.searchCompanies[0]?.workerCertification);
-  }, [siret, data?.searchCompanies]);
+  const [isWorker, setIsWorker] = useState<boolean>(false);
+  const showWorkerCertification = !!workerCertification || !isWorker;
 
   const hasCertification =
     workerCertification &&
     (workerCertification.hasSubSectionThree ||
       workerCertification.hasSubSectionFour);
-  const isWorker =
-    hasCertification || companyTypes?.includes(CompanyType.Worker);
 
   if (isGroupement || isEntreposageProvisoire || isDechetterie) {
     return (
@@ -87,12 +56,7 @@ export function Worker({ disabled }) {
             className="td-checkbox"
             onChange={e => {
               handleChange(e);
-              setFieldValue("worker.company.name", null);
-              setFieldValue("worker.company.siret", null);
-              setFieldValue("worker.company.contact", null);
-              setFieldValue("worker.company.address", null);
-              setFieldValue("worker.company.mail", null);
-              setFieldValue("worker.company.phone", null);
+              setFieldValue("worker", initialState.worker);
             }}
           />
           Il n'y a pas d'entreprise de travaux
@@ -105,64 +69,100 @@ export function Worker({ disabled }) {
             disabled={disabled}
             name="worker.company"
             heading="Entreprise de travaux"
-            onCompanySelected={worker => {
-              setCompanyTypes(worker?.companyTypes ?? []);
-              setSelectedSiret(worker?.siret);
+            onCompanyPrivateInfos={worker => {
+              if (worker) {
+                setIsWorker(
+                  worker.companyTypes?.includes(CompanyType.Worker) ?? false
+                );
+                setWorkerCertification(worker?.workerCertification);
+                setFieldValue(
+                  "worker.certification.hasSubSectionFour",
+                  worker?.workerCertification?.hasSubSectionFour
+                );
+                setFieldValue(
+                  "worker.certification.hasSubSectionThree",
+                  worker?.workerCertification?.hasSubSectionThree
+                );
+                setFieldValue(
+                  "worker.certification.certificationNumber",
+                  worker?.workerCertification?.certificationNumber
+                );
+                setFieldValue(
+                  "worker.certification.validityLimit",
+                  worker?.workerCertification?.validityLimit
+                );
+                setFieldValue(
+                  "worker.certification.organisation",
+                  worker?.workerCertification?.organisation
+                );
+              } else {
+                setIsWorker(false);
+                setWorkerCertification(null);
+                setFieldValue(
+                  "worker.certification",
+                  initialState.worker.certification
+                );
+              }
             }}
           />
+          {showWorkerCertification && (
+            <>
+              <h4 className="form__section-heading">
+                Catégorie entreprise de travaux déclarée dans le profil
+                entreprise
+              </h4>
 
-          <h4 className="form__section-heading">
-            Catégorie entreprise de travaux déclarée dans le profil entreprise
-          </h4>
-
-          {!isWorker && (
-            <div>
-              <Alert
-                title={
-                  "L'entreprise n'est pas une entreprise de travaux amiante"
-                }
-                severity="error"
-                description="L'entreprise que vous renseignez ne s'est pas enregistrée avec un profil d'entreprise de travaux amiante ou n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations"
-              />
-            </div>
-          )}
-
-          {isWorker && !hasCertification && (
-            <div className="form__row">
-              {!workerCertification?.hasSubSectionFour &&
-                !workerCertification?.hasSubSectionThree && (
+              {!isWorker && (
+                <div>
                   <Alert
-                    title={"L'entreprise n'a pas complété son profil"}
-                    severity="warning"
-                    description="L'entreprise que vous renseignez s'est enregistrée avec un profil d'entreprise de travaux amiante mais n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations."
+                    title={
+                      "L'entreprise n'est pas une entreprise de travaux amiante"
+                    }
+                    severity="error"
+                    description="L'entreprise que vous renseignez ne s'est pas enregistrée avec un profil d'entreprise de travaux amiante ou n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations"
                   />
+                </div>
+              )}
+
+              {isWorker && !hasCertification && (
+                <div className="form__row">
+                  {!workerCertification?.hasSubSectionFour &&
+                    !workerCertification?.hasSubSectionThree && (
+                      <Alert
+                        title={"L'entreprise n'a pas complété son profil"}
+                        severity="warning"
+                        description="L'entreprise que vous renseignez s'est enregistrée avec un profil d'entreprise de travaux amiante mais n'a pas complété la catégorie de travaux dans son compte établissement de Trackdéchets. Il appartient à cette entreprise de compléter ses informations."
+                      />
+                    )}
+                </div>
+              )}
+
+              <div className="form__row">
+                {workerCertification?.hasSubSectionFour && (
+                  <>
+                    <p>
+                      SS4 <span aria-hidden> ✅</span>
+                    </p>
+                  </>
                 )}
-            </div>
+              </div>
+
+              <div className="form__row">
+                {workerCertification?.hasSubSectionThree && (
+                  <>
+                    <p>
+                      SS3 <span aria-hidden> ✅</span> numéro:{" "}
+                      {workerCertification?.certificationNumber} date de
+                      validité:{" "}
+                      {formatDate(workerCertification?.validityLimit!)}
+                      {" - "}
+                      organisme: {workerCertification?.organisation}
+                    </p>
+                  </>
+                )}
+              </div>
+            </>
           )}
-
-          <div className="form__row">
-            {workerCertification?.hasSubSectionFour && (
-              <>
-                <p>
-                  SS4 <span aria-hidden> ✅</span>
-                </p>
-              </>
-            )}
-          </div>
-
-          <div className="form__row">
-            {workerCertification?.hasSubSectionThree && (
-              <>
-                <p>
-                  SS3 <span aria-hidden> ✅</span> numéro:{" "}
-                  {workerCertification?.certificationNumber} date de validité:{" "}
-                  {formatDate(workerCertification?.validityLimit!)}
-                  {" - "}
-                  organisme: {workerCertification?.organisation}
-                </p>
-              </>
-            )}
-          </div>
         </>
       )}
     </>

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -12,7 +12,13 @@ import {
   isVat,
   isForeignVat,
 } from "generated/constants/companySearchHelpers";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { debounce } from "common/helper";
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
@@ -53,6 +59,7 @@ interface CompanySelectorProps {
   onCompanySelected?: (
     company?: CompanySearchResult | CompanySearchPrivate
   ) => void;
+  onCompanyPrivateInfos?: (company?: CompanySearchPrivate) => void;
   allowForeignCompanies?: boolean;
   registeredOnlyCompanies?: boolean;
   heading?: string;
@@ -77,6 +84,7 @@ export default function CompanySelector({
   isBsdaTransporter = false,
   optional = false,
   initialAutoSelectFirstCompany = true,
+  onCompanyPrivateInfos = undefined,
 }: CompanySelectorProps) {
   // siret is the current active company
   const { siret } = useParams<{ siret: string }>();
@@ -158,20 +166,20 @@ export default function CompanySelector({
    * CompanyPrivateInfos pour completer les informations
    * de la Company courante enregistrée dans le BSD à son ouverture
    */
-  const { data: companyPrivateData } = useQuery<
-    Pick<Query, "companyPrivateInfos">,
-    QueryCompanyPrivateInfosArgs
-  >(COMPANY_SELECTOR_PRIVATE_INFOS, {
-    variables: {
-      // Compatibility with intermediaries that don't have orgId
-      clue: orgId!,
-    },
-    skip: !orgId,
-  });
+  const { data: companyPrivateData, loading: isLoadingCompanyPrivateData } =
+    useQuery<Pick<Query, "companyPrivateInfos">, QueryCompanyPrivateInfosArgs>(
+      COMPANY_SELECTOR_PRIVATE_INFOS,
+      {
+        variables: {
+          // Compatibility with intermediaries that don't have orgId
+          clue: orgId!,
+        },
+        skip: !orgId,
+      }
+    );
 
   /**
-   * Update the current form value when companyPrivateInfos changes
-   * Hack to fix country data when needed.
+   * Hack pour écraser "country" dans le formulaire
    */
   useEffect(() => {
     if (
@@ -184,60 +192,87 @@ export default function CompanySelector({
     }
   }, [field.name, setFieldValue, companyPrivateData]);
 
-  function isUnknownCompanyName(companyName?: string): boolean {
-    return companyName === "---" || companyName === "";
-  }
+  /**
+   * Appel onCompanyPrivateInfos quand companyPrivateInfos répond
+   * Hack pour écraser "country" dans le formulaire
+   */
+  useMemo(() => {
+    if (companyPrivateData?.companyPrivateInfos) {
+      onCompanyPrivateInfos?.(companyPrivateData.companyPrivateInfos);
+    }
+  }, [onCompanyPrivateInfos, companyPrivateData]);
 
   /**
    * Selection d'un établissement dans le formulaire
    */
-  function selectCompany(company?: CompanySearchResult) {
-    if (disabled) return;
-    // empty the fields
-    if (!company) {
-      setFieldValue(field.name, getInitialCompany());
+
+  const selectCompany = useCallback(
+    (company?: CompanySearchResult) => {
+      function isUnknownCompanyName(companyName?: string): boolean {
+        return companyName === "---" || companyName === "";
+      }
+
+      if (disabled) return;
+      // empty the fields
+      if (!company) {
+        setFieldValue(field.name, getInitialCompany());
+        setFieldTouched(`${field.name}`, true, true);
+        onCompanySelected?.();
+        return;
+      }
+
+      // Side effects
+      const notVoidCompany = Object.keys(company).length !== 0; // unselect returns emtpy object {}
+      setMustBeRegistered(
+        notVoidCompany && !company.isRegistered && registeredOnlyCompanies
+      );
+
+      // Assure la mise à jour des variables d'etat d'affichage des sous-parties du Form
+      setDisplayForeignCompanyWithUnknownInfos(
+        isForeignVat(company.vatNumber!!) && isUnknownCompanyName(company.name!)
+      );
+
+      setIsForeignCompany(isForeignVat(company.vatNumber!!));
+      // Prépare la mise à jour du Form
+      const fields: FormCompany = {
+        orgId: company.orgId,
+        siret: company.siret,
+        vatNumber: company.vatNumber,
+        name:
+          company.name && !isUnknownCompanyName(company.name)
+            ? company.name
+            : "",
+        address: company.address ?? "",
+        contact: company.contact ?? "",
+        phone: company.contactPhone ?? "",
+        mail: company.contactEmail ?? "",
+        country: company.codePaysEtrangerEtablissement,
+      };
+
+      Object.keys(fields).forEach(key => {
+        setFieldValue(`${field.name}.${key}`, fields[key]);
+      });
       setFieldTouched(`${field.name}`, true, true);
-      onCompanySelected?.();
-      return;
-    }
+      onCompanySelected?.(company);
 
-    // Side effects
-    const notVoidCompany = Object.keys(company).length !== 0; // unselect returns emtpy object {}
-    setMustBeRegistered(
-      notVoidCompany && !company.isRegistered && registeredOnlyCompanies
-    );
-
-    // Assure la mise à jour des variables d'etat d'affichage des sous-parties du Form
-    setDisplayForeignCompanyWithUnknownInfos(
-      isForeignVat(company.vatNumber!!) && isUnknownCompanyName(company.name!)
-    );
-
-    setIsForeignCompany(isForeignVat(company.vatNumber!!));
-    // Prépare la mise à jour du Form
-    const fields: FormCompany = {
-      orgId: company.orgId,
-      siret: company.siret,
-      vatNumber: company.vatNumber,
-      name:
-        company.name && !isUnknownCompanyName(company.name) ? company.name : "",
-      address: company.address ?? "",
-      contact: company.contact ?? "",
-      phone: company.contactPhone ?? "",
-      mail: company.contactEmail ?? "",
-      country: company.codePaysEtrangerEtablissement,
-    };
-
-    Object.keys(fields).forEach(key => {
-      setFieldValue(`${field.name}.${key}`, fields[key]);
-    });
-    setFieldTouched(`${field.name}`, true, true);
-    onCompanySelected?.(company);
-
-    setSelectedCompanyDetails({
-      name: company.name,
-      address: company.address,
-    });
-  }
+      setSelectedCompanyDetails({
+        name: company.name,
+        address: company.address,
+      });
+    },
+    [
+      setSelectedCompanyDetails,
+      onCompanySelected,
+      setFieldTouched,
+      setFieldValue,
+      setIsForeignCompany,
+      setDisplayForeignCompanyWithUnknownInfos,
+      setMustBeRegistered,
+      disabled,
+      field.name,
+      registeredOnlyCompanies,
+    ]
+  );
 
   /**
    * Merge searchCompanies et favoritesData
@@ -469,29 +504,27 @@ export default function CompanySelector({
           <span>Aucun établissement ne correspond à cette recherche...</span>
         )}
         <RedErrorMessage name={`${field.name}.siret`} />
-        <CompanyResults<CompanySearchResult>
-          onSelect={company => selectCompany(company)}
-          onUnselect={() => selectCompany()}
-          results={searchResults}
-          selectedItem={
-            {
-              orgId,
-              siret: field.value?.siret,
-              vatNumber: field.value?.vatNumber,
-              name: field.value?.name,
-              address: field.value?.address,
-              codePaysEtrangerEtablissement: field.value?.country,
-              // complete with companyPrivateInfos data
-              ...(companyPrivateData?.companyPrivateInfos && {
-                isRegistered:
-                  companyPrivateData?.companyPrivateInfos.isRegistered,
-                codePaysEtrangerEtablissement:
-                  companyPrivateData?.companyPrivateInfos
-                    .codePaysEtrangerEtablissement,
-              }),
-            } as CompanySearchResult
-          }
-        />
+        {!isLoadingCompanyPrivateData && (
+          <CompanyResults<CompanySearchResult>
+            onSelect={company => selectCompany(company)}
+            onUnselect={() => selectCompany()}
+            results={searchResults}
+            selectedItem={
+              {
+                orgId,
+                siret: field.value?.siret,
+                vatNumber: field.value?.vatNumber,
+                name: field.value?.name,
+                address: field.value?.address,
+                codePaysEtrangerEtablissement: field.value?.country,
+                // complete with companyPrivateInfos data
+                ...(companyPrivateData?.companyPrivateInfos && {
+                  ...companyPrivateData.companyPrivateInfos,
+                }),
+              } as CompanySearchResult
+            }
+          />
+        )}
         <div className="form__row">
           {allowForeignCompanies && isForeignCompany && (
             <>

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -12,13 +12,7 @@ import {
   isVat,
   isForeignVat,
 } from "generated/constants/companySearchHelpers";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 
 import { debounce } from "common/helper";
 import { getInitialCompany } from "form/bsdd/utils/initial-state";
@@ -179,28 +173,22 @@ export default function CompanySelector({
     );
 
   /**
-   * Hack pour écraser "country" dans le formulaire
-   */
-  useEffect(() => {
-    if (
-      companyPrivateData?.companyPrivateInfos?.codePaysEtrangerEtablissement
-    ) {
-      setFieldValue(
-        `${field.name}.country`,
-        companyPrivateData.companyPrivateInfos.codePaysEtrangerEtablissement
-      );
-    }
-  }, [field.name, setFieldValue, companyPrivateData]);
-
-  /**
    * Appel onCompanyPrivateInfos quand companyPrivateInfos répond
    * Hack pour écraser "country" dans le formulaire
    */
   useMemo(() => {
     if (companyPrivateData?.companyPrivateInfos) {
       onCompanyPrivateInfos?.(companyPrivateData.companyPrivateInfos);
+      if (
+        companyPrivateData?.companyPrivateInfos?.codePaysEtrangerEtablissement
+      ) {
+        setFieldValue(
+          `${field.name}.country`,
+          companyPrivateData.companyPrivateInfos.codePaysEtrangerEtablissement
+        );
+      }
     }
-  }, [onCompanyPrivateInfos, companyPrivateData]);
+  }, [field.name, setFieldValue, onCompanyPrivateInfos, companyPrivateData]);
 
   /**
    * Selection d'un établissement dans le formulaire


### PR DESCRIPTION
Problème double :
- le back ne renvoyait pas les infos workerCertification dans la query companyPrivateInfos
- et dans le front, le passage d'infos de workerCertification ne remontait pas de CompanySelector à Worker.tsx

# Démo (ignorer le rendu pdf à la fin)

https://github.com/MTES-MCT/trackdechets/assets/76620/7916e8cc-1ba1-4ec1-9c26-b30fc178f90e


Solutions implémentées :
- fix CompanyPrivateInfos resolvers
- fix Worker.tsx
- fix CompanySelector.tsx

- Fix aussi #2586 sur l'absence des infos complémentaires quand on déselection-reselection une entreprise

![Peek 18-08-2023 14-56](https://github.com/MTES-MCT/trackdechets/assets/76620/c4e87c32-95e1-47f5-9994-ea3eaa77de86)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12486)
- [Ticket Favro BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12490)
- [Ticket Favro persistence infos contact CompanySelector](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11394)