### PR TITLE
TRA-7473 Amélioration UI de groupement dasris

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,19 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+# [2023.8.2] 29/08/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+ 
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Amélioration de l'interface de groupement des dasris [PR 2638](https://github.com/MTES-MCT/trackdechets/pull/2638)
+
+#### :house: Interne
 
 # [2023.8.1] 08/08/2023
 

--- a/front/src/form/bsdasri/components/grouping/BsdasriGroupingSelector.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriGroupingSelector.tsx
@@ -17,6 +17,7 @@ function reducer(state: State, action: Action) {
       const sp = action.payload;
       return {
         selected: [sp.id, ...state.selected],
+        weights: [],
       };
     case "unselect":
       const usp = action.payload;
@@ -44,10 +45,7 @@ export default function BsdasriGroupingSelector({ name }) {
   const regroupedInDB = getIn(values, name) || [];
 
   useEffect(() => {
-    setFieldValue(
-      name,
-      state.selected.map(s => s)
-    );
+    setFieldValue(name, state.selected);
   }, [state, name, setFieldValue]);
 
   function onToggle(payload: Bsdasri | Bsdasri[]) {

--- a/front/src/form/bsdasri/components/packagings/Packagings.tsx
+++ b/front/src/form/bsdasri/components/packagings/Packagings.tsx
@@ -18,9 +18,11 @@ export default function DasriPackagings({
   form,
   id,
   disabled,
+  summaryHint,
   ...props
-}: FieldProps<BsdasriPackaging[] | null> &
-  InputHTMLAttributes<HTMLInputElement>) {
+}: FieldProps<BsdasriPackaging[] | null> & {
+  summaryHint?: string;
+} & InputHTMLAttributes<HTMLInputElement>) {
   const { setFieldValue } = useFormikContext();
 
   if (!value) {
@@ -172,7 +174,12 @@ export default function DasriPackagings({
         )}
       />
       {value?.length > 0 && (
-        <div className="tw-mt-4">{getDasriPackagingInfosSummary(value)}</div>
+        <div className="tw-mt-4">
+          <>
+            {getDasriPackagingInfosSummary(value)}{" "}
+            {!!summaryHint && <span>{summaryHint}</span>}
+          </>
+        </div>
       )}
     </div>
   );

--- a/front/src/form/bsdasri/steps/Emitter.tsx
+++ b/front/src/form/bsdasri/steps/Emitter.tsx
@@ -102,7 +102,11 @@ export function Emitter({ status, stepName, disabled = false }) {
   const isRegrouping = values.type === BsdasriType.Grouping;
 
   const emissionEmphasis = stepName === "emission";
-
+  const weightLabel = `Je souhaite préciser le poids ${
+    isRegrouping
+      ? "- report des poids des bsds sélectionnés, le cas échéant"
+      : ""
+  }`;
   const { siret } = useParams<{ siret: string }>();
   const isUserCurrentEmitter = values?.emitter?.company?.siret === siret;
 
@@ -196,9 +200,15 @@ export function Emitter({ status, stepName, disabled = false }) {
           "field-emphasis": emissionEmphasis,
         })}
       >
+        {isRegrouping && (
+          <p className="tw-text-center tw-mb-2">
+            Report des conditionnements sélectionnés / peut être modifié
+          </p>
+        )}
         <Field
           name="emitter.emission.packagings"
           component={Packagings}
+          summaryHint="- Report des volumes sélectionnés"
           disabled={editionDisabled}
         />
       </div>
@@ -210,7 +220,7 @@ export function Emitter({ status, stepName, disabled = false }) {
       >
         <WeightWidget
           disabled={editionDisabled}
-          switchLabel="Je souhaite préciser le poids"
+          switchLabel={weightLabel}
           dasriPath="emitter.emission"
           getInitialWeightFn={getInitialWeightFn}
         />


### PR DESCRIPTION
Améliore le formulaire de gestion des dasris de groupement:
- pré-remplissage des packagings
- pré-remplissage du poids total
- ajout de colonne sur le tableau
- mentions additionnelles
 
<img width="1081" alt="Capture d’écran 2023-08-14 à 11 31 49" src="https://github.com/MTES-MCT/trackdechets/assets/878396/708b3b7b-d9d7-4983-beea-b8d3232c6618">



- [x ] Mettre à jour le change log

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7473)
