### PR TITLE
Ne pas permettre de mettre un traitement intermédiaire à un bsdasri de synthese (pas R12 ou D12)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,21 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.8.2] 29/08/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+- Interdiction des codes de groupement sur les dasris de synthèse[PR 2639](https://github.com/MTES-MCT/trackdechets/pull/2639)
+
+#### :house: Interne
+
+
 # [2023.8.1] 08/08/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -155,7 +155,7 @@ type BsdasriReception {
 type BsdasriOperation {
   "Quantité traitée"
   weight: BsdasriOperationWeight
-  "Code de l'opération de traitement"
+  "Code de l'opération de traitement - Les codes R12 et D12 sont interdits pour les bsds de synthèse."
   code: String
   "Date de l'opération de traitement"
   date: DateTime

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -626,6 +626,22 @@ export const operationSchema: FactorySchemaOf<
           }
           return true;
         }
+      )
+      .test(
+        "groupingCodesFordbiddenForSynthesis",
+        "Les codes R12 et D12 sont interdits sur un bordereau de synthèse",
+        async (value, ctx) => {
+          const type = ctx.parent.type;
+
+          if (
+            value &&
+            DASRI_GROUPING_OPERATIONS_CODES.includes(value) &&
+            type === BsdasriType.SYNTHESIS
+          ) {
+            return false;
+          }
+          return true;
+        }
       ),
 
     destinationOperationDate: yup

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -6,7 +6,6 @@ import WeightWidget from "form/bsdasri/components/Weight";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import Acceptation from "form/bsdasri/components/acceptation/Acceptation";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
-
 import {
   ExtraSignatureType,
   SignatureType,
@@ -218,7 +217,7 @@ export function ReceptionSignatureForm() {
 }
 export function OperationSignatureForm() {
   const TODAY = new Date();
-
+  const { values } = useFormikContext<Bsdasri>();
   return (
     <>
       <div className="form__row">
@@ -237,14 +236,18 @@ export function OperationSignatureForm() {
           <option value="R1">
             R1 - Incinération + valorisation énergétique
           </option>
-          <option value="D12">
-            D12 - Groupement avant désinfection en D9 ou incinération en D10 sur
-            un site relevant de la rubrique 2718
-          </option>
-          <option value="R12">
-            R12 - Groupement avant incinération en R1, sur un site relevant de
-            la rubrique 2718
-          </option>
+          {values.type !== BsdasriType.Synthesis ? (
+            <>
+              <option value="D12">
+                D12 - Groupement avant désinfection en D9 ou incinération en D10
+                sur un site relevant de la rubrique 2718
+              </option>
+              <option value="R12">
+                R12 - Groupement avant incinération en R1, sur un site relevant
+                de la rubrique 2718
+              </option>
+            </>
+          ) : null}
         </Field>
       </div>
       <div className="form__row">

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -106,6 +106,7 @@ const removeSections = (
       ...commonKeys,
     ],
   };
+
   return omitDeep(input, mapping[status]);
 };
 export default function BsdasriStepsList(props: Props) {
@@ -164,6 +165,8 @@ export default function BsdasriStepsList(props: Props) {
       if (type === BsdasriType.Synthesis) {
         // synthesis bsdasri are  never created in draft state
         const { grouping, emitter, ecoOrganisme, ...cleanedInput } = input;
+
+        console.log(input);
         return updateBsdasri({
           variables: {
             id: formState.id,

--- a/front/src/form/bsdasri/steps/Destination.tsx
+++ b/front/src/form/bsdasri/steps/Destination.tsx
@@ -1,4 +1,3 @@
-import { RedErrorMessage } from "common/components";
 import CompanySelector from "form/common/components/company/CompanySelector";
 
 import { Field } from "formik";
@@ -8,8 +7,7 @@ import { BsdasriStatus } from "generated/graphql/types";
 import Reception from "./Reception";
 import Operation from "./Operation";
 import { FillFieldsInfo, DisabledFieldsInfo } from "../utils/commons";
-import DateInput from "form/common/components/custom-inputs/DateInput";
-import NumberInput from "form/common/components/custom-inputs/NumberInput";
+
 import classNames from "classnames";
 import Tooltip from "common/components/Tooltip";
 import { customInfoToolTip } from "./Emitter";
@@ -17,7 +15,6 @@ import { customInfoToolTip } from "./Emitter";
 export default function Destination({ status, stepName, disabled = false }) {
   const receptionDisabled = disabled || BsdasriStatus.Received === status;
 
-  const showOperationFields = status === BsdasriStatus.Received;
   const operationEmphasis = stepName === "operation";
   const receptionEmphasis = stepName === "reception";
 
@@ -56,82 +53,6 @@ export default function Destination({ status, stepName, disabled = false }) {
       <Operation status={status} disabled={disabled} />
 
       <h4 className="form__section-heading">Traitement du déchet</h4>
-      {/*No need to disable operation fields, processed forms are not editable */}
-      {showOperationFields ? (
-        <>
-          <div
-            className={classNames("form__row", {
-              "field-emphasis": operationEmphasis,
-            })}
-          >
-            <label>Opération réalisée</label>
-            <Field
-              as="select"
-              name="destination.operation.code"
-              className="td-select"
-            >
-              <option value="">-----</option>
-
-              <option value="D9">
-                D9 - Prétraitement par désinfection - Banaliseur
-              </option>
-              <option value="D10">D10 - Incinération</option>
-              <option value="R1">
-                R1 - Incinération + valorisation énergétique
-              </option>
-              <option value="D12">
-                D12 - Groupement avant désinfection en D9 ou incinération en D10
-                sur un site relevant de la rubrique 2718
-              </option>
-              <option value="R12">
-                R12 - Groupement avant incinération en R1, sur un site relevant
-                de la rubrique 2718
-              </option>
-            </Field>
-          </div>
-          <div
-            className={classNames("form__row", {
-              "field-emphasis": operationEmphasis,
-            })}
-          >
-            <label>
-              Date de l'opération :
-              <div className="td-date-wrapper">
-                <Field
-                  name="destination.operation.date"
-                  component={DateInput}
-                  className="td-input"
-                />
-              </div>
-            </label>
-          </div>
-
-          <h4 className="form__section-heading">Quantité traitée</h4>
-
-          <div
-            className={classNames("form__row", {
-              "field-emphasis": operationEmphasis,
-            })}
-          >
-            <label>
-              Poids en kg :
-              <Field
-                component={NumberInput}
-                name="destination.operation.weight.value"
-                className="td-input dasri__waste-details__weight"
-                placeholder="En kg"
-                min="0"
-                step="0.1"
-              />
-              <span className="tw-ml-2">kg</span>
-            </label>
-
-            <RedErrorMessage name="destination.operation.weight.value" />
-          </div>
-        </>
-      ) : (
-        <p>Cette section sera disponible quand le déchet aura été reçu</p>
-      )}
     </>
   );
 }

--- a/front/src/form/bsdasri/steps/Operation.tsx
+++ b/front/src/form/bsdasri/steps/Operation.tsx
@@ -1,16 +1,15 @@
 import { RedErrorMessage } from "common/components";
 
-import { Field } from "formik";
+import { Field, useFormikContext } from "formik";
 import React from "react";
-import { BsdasriStatus } from "generated/graphql/types";
-
+import { BsdasriStatus, Bsdasri, BsdasriType } from "generated/graphql/types";
 import DateInput from "form/common/components/custom-inputs/DateInput";
 import NumberInput from "form/common/components/custom-inputs/NumberInput";
 import classNames from "classnames";
 
 export default function Operation({ status, disabled = false }) {
   const operationEmphasis = false;
-
+  const { values } = useFormikContext<Bsdasri>();
   const showOperationFields = status === BsdasriStatus.Received;
   return (
     <>
@@ -37,14 +36,19 @@ export default function Operation({ status, disabled = false }) {
               <option value="R1">
                 R1 - Incinération + valorisation énergétique
               </option>
-              <option value="D12">
-                D12 - Groupement avant désinfection en D9 ou incinération en D10
-                sur un site relevant de la rubrique 2718
-              </option>
-              <option value="R12">
-                R12 - Groupement avant incinération en R1, sur un site relevant
-                de la rubrique 2718
-              </option>
+
+              {values.type !== BsdasriType.Synthesis ? (
+                <>
+                  <option value="D12">
+                    D12 - Groupement avant désinfection en D9 ou incinération en
+                    D10 sur un site relevant de la rubrique 2718
+                  </option>
+                  <option value="R12">
+                    R12 - Groupement avant incinération en R1, sur un site
+                    relevant de la rubrique 2718
+                  </option>
+                </>
+              ) : null}
             </Field>
           </div>
           <div


### PR DESCRIPTION
Interdiction des codes R12 et D12 sur le dasri de synthèse
- validation supplémentaire sur le back
- restriction des options proposées par le select de signature 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10451)
