### PR TITLE
ETQ utilisateur je peux m'inscrire avec toutes les adresses email valide

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,12 +4,15 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
+
 # [2023.8.2] 29/08/2023
 
 #### :rocket: Nouvelles fonctionnalités
 
 #### :bug: Corrections de bugs
- 
+
+- Une validation trop restrictive des emails à l'inscription empêchaient certains utilisateurs de s'inscrire. Il est désormais possible de s'inscrire avec toute adresse email valide. [PR 2650](https://github.com/MTES-MCT/trackdechets/pull/2650)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations
@@ -32,7 +35,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
-
 # [2023.8.1] 08/08/2023
 
 #### :rocket: Nouvelles fonctionnalités
@@ -41,6 +43,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Les brouillons des BSDD ne sont plus visibles par l'ensemble des acteurs du bordereau, mais uniquement par l'entreprise à l'origine de la création du bordereau. [PR 2600](https://github.com/MTES-MCT/trackdechets/pull/2600)
 
 #### :bug: Corrections de bugs
+
 - Correction d'un message d'erreur incompréhensible en l'absence des informations de contact entreprise sur le BSFF après avoir cliqué sur "Modifier" [PR 2601](https://github.com/MTES-MCT/trackdechets/pull/2601)
 - Correction de 'limpossibilité d'enlever la présence de POP sur les BSDDs via la révision [PR 2596](https://github.com/MTES-MCT/trackdechets/pull/2596)
 

--- a/front/src/login/Signup.tsx
+++ b/front/src/login/Signup.tsx
@@ -86,8 +86,9 @@ export default function Signup() {
 
   const handleEmailChange = e => {
     const { value } = e.target;
+    // Taken from HTML spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
     const mailRegex =
-      /^([A-Za-z0-9_\-.])+@([A-Za-z0-9_\-.])+\.([A-Za-z]{2,4})$/;
+      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
     if (value.match(mailRegex)) {
       setEmailValue(e.target.value);
       setErrorMessage("");
@@ -124,7 +125,7 @@ export default function Signup() {
               nativeInputProps={{
                 required: true,
                 type: "email",
-                onChange: handleEmailChange,
+                onBlur: handleEmailChange,
               }}
             />
             <PasswordInput


### PR DESCRIPTION
L'expression régulière utilisée était trop restrictive. On utilise désormais une regex tirée de la spec HTML.
Au passage j'ai remplacé le `onChange` par `onBlur` pour éviter que le message d'erreur s'affiche de façon intempestive lorsque l'on tape, à discuter.

https://github.com/MTES-MCT/trackdechets/assets/2269165/e9502b8c-efa5-46c6-a8a2-b80481696990


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2b2da82ba5246505946d1fe3?card=tra-12637)
