### PR TITLE
add index on BsddRevisionRequest.status

### DIFF
--- a/back/prisma/migrations/154_bsddrevisionrequest_indices.sql
+++ b/back/prisma/migrations/154_bsddrevisionrequest_indices.sql
@@ -1,0 +1,2 @@
+-- BsdaRevisionRequest
+CREATE INDEX IF NOT EXISTS "_BsdaRevisionRequestStatusIdx" ON "default$default"."BsdaRevisionRequest"("status");

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -756,14 +756,14 @@ model GovernmentAccount {
   name             String // Exemple RNDTS, GEREP, etc
   permissions      GovernmentPermission[]
   // Liste blanche d'IP pour les connexions depuis ce compte de service
-  // Seules les connexions depuis ces adresses IP auront les permissions 
-  // étendues définies par le champ `permissions`. 
+  // Seules les connexions depuis ces adresses IP auront les permissions
+  // étendues définies par le champ `permissions`.
   authorizedIPs    String[]
   // Permet de restreindre les permissions étendues définies par le
   // le champ `GovernmentAccount.permissions` à une liste d'établissements.
-  // Cela permet à des applications gouvernementales tierces d'effectuer 
+  // Cela permet à des applications gouvernementales tierces d'effectuer
   // des tests sur des données réelles sur un nombre restreint d'entreprises.
-  // Pour que les permissions étendues s'appliquent à tous les établissements, 
+  // Pour que les permissions étendues s'appliquent à tous les établissements,
   // passer la valeur 'ALL'
   authorizedOrgIds String[]
   User             User[]
@@ -1497,6 +1497,7 @@ model BsdaRevisionRequest {
   isCanceled Boolean @default(false)
 
   @@index([authoringCompanyId], map: "_BsdaRevisionRequestAuthoringCompanyIdIdx")
+  @@index([status], map: "_BsdaRevisionRequestStatusIdx")
   @@index([bsdaId], map: "_BsdaRevisionRequestBsdaIdIdx")
 }
 


### PR DESCRIPTION
# Accéleration SQL de `formRevisionRequestResolver`

Pour le SQL généré suivant, on ajoute un index manquant :

```
SELECT COUNT ( * ) 
FROM ( 
    SELECT default$default . BsddRevisionRequest . id 
    FROM default$default . BsddRevisionRequest 
    WHERE ( ( default$default . BsddRevisionRequest . authoringCompanyId = ? OR ( default$default . BsddRevisionRequest . id ) IN ( 
        SELECT t0 . id 
        FROM default$default . BsddRevisionRequest AS t0 
            INNER JOIN default$default . BsddRevisionRequestApproval AS j0 ON ( j0 . revisionRequestId ) = ( t0 . id ) 
        WHERE ( j0 . approverSiret = ? AND t0 . id IS NOT ? ) 
    ) ) AND default$default . BsddRevisionRequest . status = ? ) OFFSET ? 
) AS sub```

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
