### PR TITLE
ETQ utilisateur je peux charger plus de 50 contenants à regrouper lors de la création d'un BSFF de regroupement 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- ETQ utilisateur je peux charger plus de 50 contenants à regrouper lors de la création d'un BSFF de regroupement [PR 2654](https://github.com/MTES-MCT/trackdechets/pull/2654)
+
 #### :boom: Breaking changes
 
 #### :nail_care: Améliorations

--- a/front/src/form/bsff/components/PreviousPackagingsPicker.tsx
+++ b/front/src/form/bsff/components/PreviousPackagingsPicker.tsx
@@ -136,7 +136,7 @@ export function PreviousPackagingsPicker({
   >(GET_PREVIOUS_PACKAGINGS, {
     variables: {
       // pagination does not play well with bsff picking
-      first: 5000,
+      first: 500,
       where,
     },
     // make sure we have fresh data here

--- a/front/src/form/bsff/utils/queries.ts
+++ b/front/src/form/bsff/utils/queries.ts
@@ -14,8 +14,8 @@ export const GET_BSFF_FORM = gql`
 `;
 
 export const GET_PREVIOUS_PACKAGINGS = gql`
-  query BsffPackagings($where: BsffPackagingWhere) {
-    bsffPackagings(where: $where) {
+  query BsffPackagings($where: BsffPackagingWhere, $first: Int) {
+    bsffPackagings(where: $where, first: $first) {
       totalCount
       pageInfo {
         hasNextPage


### PR DESCRIPTION
Le paramètre `first` n'était pas passé dans la query GraphQL

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12485)
