### PR TITLE
Recette/ Fix pour tra-7031

### DIFF
--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -89,7 +89,11 @@ export function Worker({ disabled }) {
             className="td-checkbox"
             onChange={e => {
               handleChange(e);
-              setFieldValue("worker", initialState.worker);
+              setFieldValue("worker.company", initialState.worker.company);
+              setFieldValue(
+                "worker.certification",
+                initialState.worker.certification
+              );
             }}
           />
           Il n'y a pas d'entreprise de travaux


### PR DESCRIPTION
La coche "pas d'entreprise de travaux" ne
fonctionnait plus.

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7031)
