### PR TITLE
HOTFIX/ GQL variables parsing

### DIFF
--- a/back/src/common/middlewares/__tests__/graphqlBodyParser.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlBodyParser.test.ts
@@ -1,8 +1,5 @@
 import express, { json } from "express";
 import supertest from "supertest";
-import logger from "../../../logging/logger";
-import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
-import loggingMiddleware from "../loggingMiddleware";
 import { graphqlBodyParser } from "../graphqlBodyParser";
 
 describe("graphqlBodyParser", () => {

--- a/back/src/common/middlewares/__tests__/graphqlBodyParser.test.ts
+++ b/back/src/common/middlewares/__tests__/graphqlBodyParser.test.ts
@@ -1,0 +1,40 @@
+import express, { json } from "express";
+import supertest from "supertest";
+import logger from "../../../logging/logger";
+import { graphqlQueryParserMiddleware } from "../graphqlQueryParser";
+import loggingMiddleware from "../loggingMiddleware";
+import { graphqlBodyParser } from "../graphqlBodyParser";
+
+describe("graphqlBodyParser", () => {
+  const app = express();
+  const graphQLPath = "/";
+  app.use(json());
+  app.use(graphQLPath, graphqlBodyParser);
+
+  app.get("/hello", (req, res) => {
+    res.status(200).send("world");
+  });
+  app.post(graphQLPath, (req, res) => {
+    // Return body
+    res.status(200).send({ reqBody: req.body });
+  });
+
+  const request = supertest(app);
+
+  it("should convert JSON encoded variables to JSON", async () => {
+    const response = await request
+      .post(graphQLPath)
+      .send({ query: "{ __typename }", variables: '{ "foo": 1 }' });
+
+    expect(response.body.reqBody.variables.foo).toBe(1);
+  });
+
+  it("should convert application/graphql requests", async () => {
+    const response = await request
+      .post(graphQLPath)
+      .set("Content-Type", "application/graphql")
+      .send("{ __typename }");
+
+    expect(response.body.reqBody.query).toBe("{ __typename }");
+  });
+});

--- a/back/src/common/middlewares/graphqlBodyParser.ts
+++ b/back/src/common/middlewares/graphqlBodyParser.ts
@@ -1,14 +1,24 @@
 import { Request, Response, NextFunction, text } from "express";
 
 /**
- * GraphQL server middleware to support application/graphql requests
- * Taken from https://github.com/graphql-middleware/body-parser-graphql
+ * GraphQL server middleware to:
+ * - accept JSON-encoded strings for gql variables
+ * - support application/graphql requests (taken from https://github.com/graphql-middleware/body-parser-graphql)
  */
 export function graphqlBodyParser(
   req: Request,
   res: Response,
   next: NextFunction
 ) {
+  if (typeof req.body?.variables === "string") {
+    try {
+      req.body.variables = JSON.parse(req.body.variables);
+    } catch (e) {
+      // https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#json-parsing-failure
+      res.status(400).send(e instanceof Error ? e.message : e);
+    }
+  }
+
   if (req.is("application/graphql")) {
     text({ type: "application/graphql" })(req, res, () => {
       req.headers["content-type"] = "application/json";


### PR DESCRIPTION
Plusieurs intégateurs envoient des JSON-encoded strings dans la prop variables.

La spec Gql dit object uniquement: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#json-encoding
Mais Apollo 3 acceptait des string json encoded. Ce n'est plus le cas d'apollo 4: https://www.apollographql.com/docs/apollo-server/migration#doubly-escaped-variables-and-extensions-in-requests

D'ou le bug. Pour ne pas casser les intégrations existantes, on l'autorise.
