### PR TITLE
Sirenify devrait fonctionner pour les établissements non diffusibles inscrits sur Trackdéchets

### DIFF
--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -82,7 +82,12 @@ export default function buildSirenify<T>(
           );
         }
 
-        if (companySearchResult.statutDiffusionEtablissement === "O") {
+        if (
+          companySearchResult.statutDiffusionEtablissement === "O" ||
+          // on auto-complète également nom et adresse si l'établissement est non diffusible
+          // mais inscrit sur Trackdéchets
+          companySearchResult.isRegistered
+        ) {
           const { setter, getter } = accessors[idx];
 
           sirenifiedInput = setter(sirenifiedInput, {


### PR DESCRIPTION
Le workflow recommandé dans la doc est le suivant : 

![Capture d’écran 2023-08-31 à 11 30 03](https://github.com/MTES-MCT/trackdechets/assets/2269165/3e05c14b-4bb9-4a8a-b47d-d51c37a195d8)


Or si on fait cela avec un établissement non diffusible, `companyInfos` renvoie `null` pour l'adresse et le nom et l'info n'est pas auto-complétée par l'API. Le bordereau est donc bloqué en signature car il manque des informations.

Cette PR vise à autoriser l'auto-complétion pour les établissements non diffusible inscrit sur Trackdéchets.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12671)
