### PR TITLE
BSDA/ Email de refus automatique en cas de refus par le destinataire

### DIFF
--- a/back/src/bsda/mails/__tests__/refused.integration.ts
+++ b/back/src/bsda/mails/__tests__/refused.integration.ts
@@ -1,0 +1,133 @@
+import { Status, UserRole, WasteAcceptationStatus } from "@prisma/client";
+import {
+  formFactory,
+  formWithTempStorageFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import { renderBsdaRefusedEmail } from "../refused";
+import * as generatePdf from "../../pdf/generator";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { bsdaFactory } from "../../__tests__/factories";
+
+jest.spyOn(generatePdf, "buildPdfAsBase64").mockResolvedValue("");
+
+describe("renderBsdaRefusedEmail", () => {
+  afterAll(resetDatabase);
+
+  test("when the bsda is refused by the destination", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        destinationCompanySiret: destination.company.siret,
+        destinationCompanyName: destination.company.name,
+        destinationCompanyAddress: destination.company.address,
+        emitterEmissionSignatureDate: new Date("2022-01-01"),
+        destinationReceptionDate: new Date("2022-01-02"),
+        status: Status.REFUSED,
+        destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
+        destinationReceptionRefusalReason: "Parce que !!"
+      }
+    });
+    const email = await renderBsdaRefusedEmail(bsda);
+    expect(email!.to).toEqual([
+      { email: emitter.user.email, name: emitter.user.name }
+    ]);
+    expect(email!.cc).toEqual([
+      { email: destination.user.email, name: destination.user.name }
+    ]);
+    expect(email!.body).toContain(`<p>
+  Nous vous informons que la société ${destination.company.name} (${destination.company.siret}) a refusé le
+  2 janvier 2022, le déchet de la
+  société suivante :
+</p>
+<br />
+<ul>
+  <li>${emitter.company.name} (${emitter.company.siret}) - ${emitter.company.address}</li>
+  <li>Informations relatives aux déchets refusés :</li>
+  <ul>
+    <li>Numéro du BSD: ${bsda.id}</li>
+    <li>Appellation du déchet : ${bsda.wasteMaterialName}</li>
+    <li>Code déchet : ${bsda.wasteCode}</li>
+    <li>Motif de refus :
+      <span>${bsda.destinationReceptionRefusalReason}</span>`);
+  });
+
+  test("when the bsda is refused by the destination and dreal notification is activated", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        destinationCompanySiret: destination.company.siret,
+        destinationCompanyName: destination.company.name,
+        destinationCompanyAddress: destination.company.address,
+        emitterEmissionSignatureDate: new Date("2022-01-01"),
+        destinationReceptionDate: new Date("2022-01-02"),
+        status: Status.REFUSED,
+        destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
+        destinationReceptionRefusalReason: "Parce que !!"
+      }
+    });
+    const email = await renderBsdaRefusedEmail(bsda, true);
+    expect(email!.cc).toEqual([
+      { email: destination.user.email, name: destination.user.name },
+      {
+        email: "sric.ud92.drieat-if@developpement-durable.gouv.fr",
+        name: "UD75 (Unité Départementale de Paris)"
+      }
+    ]);
+  });
+
+  test("when the bsda is partially refused by the destination", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        destinationCompanySiret: destination.company.siret,
+        destinationCompanyName: destination.company.name,
+        destinationCompanyAddress: destination.company.address,
+        emitterEmissionSignatureDate: new Date("2022-01-01"),
+        destinationReceptionDate: new Date("2022-01-02"),
+        status: Status.PROCESSED,
+        destinationReceptionAcceptationStatus:
+          WasteAcceptationStatus.PARTIALLY_REFUSED,
+        destinationReceptionRefusalReason: "Parce que !!"
+      }
+    });
+    const email = await renderBsdaRefusedEmail(bsda);
+    expect(email!.to).toEqual([
+      { email: emitter.user.email, name: emitter.user.name }
+    ]);
+    expect(email!.cc).toEqual([
+      { email: destination.user.email, name: destination.user.name }
+    ]);
+    expect(email!.body).toContain(`<p>
+  Nous vous informons que la société ${bsda.destinationCompanyName} (${bsda.destinationCompanySiret}) a refusé
+  partiellement le 2 janvier 2022, le
+  déchet de la société suivante :
+</p>
+<br />
+<ul>
+  <li>${bsda.emitterCompanyName} (${bsda.emitterCompanySiret}) - ${bsda.emitterCompanyAddress}</li>
+  <li>Informations relatives aux déchets refusés :</li>
+  <ul>
+    <li>Numéro du BSD : ${bsda.id}</li>
+    <li>Appellation du déchet : ${bsda.wasteMaterialName}</li>
+    <li>Code déchet : ${bsda.wasteCode}</li>
+    <li>Quantité acceptée: ${bsda.destinationReceptionWeight} tonnes</li>
+    <li>Motif de refus :
+      <span>${bsda.destinationReceptionRefusalReason}</span>`);
+  });
+});

--- a/back/src/bsda/mails/__tests__/refused.integration.ts
+++ b/back/src/bsda/mails/__tests__/refused.integration.ts
@@ -1,9 +1,5 @@
 import { Status, UserRole, WasteAcceptationStatus } from "@prisma/client";
-import {
-  formFactory,
-  formWithTempStorageFactory,
-  userWithCompanyFactory
-} from "../../../__tests__/factories";
+import { userWithCompanyFactory } from "../../../__tests__/factories";
 import { renderBsdaRefusedEmail } from "../refused";
 import * as generatePdf from "../../pdf/generator";
 import { resetDatabase } from "../../../../integration-tests/helper";

--- a/back/src/bsda/mails/refused.ts
+++ b/back/src/bsda/mails/refused.ts
@@ -1,0 +1,60 @@
+import { Mail } from "../../mailer/types";
+import { Bsda } from "@prisma/client";
+import { getCompanyAdminUsers } from "../../companies/database";
+import prisma from "../../prisma";
+import { buildPdfAsBase64 } from "../pdf/generator";
+import DREALS from "../../common/constants/DREALS";
+
+const { NOTIFY_DREAL_WHEN_FORM_DECLINED } = process.env;
+
+export async function renderBsdaRefusedEmail(
+  bsda: Bsda,
+  notifyDreal = NOTIFY_DREAL_WHEN_FORM_DECLINED === "true"
+): Promise<Mail | undefined> {
+  const attachmentData = {
+    file: await buildPdfAsBase64(bsda),
+    name: `${bsda.id}.pdf`
+  };
+
+  const emitterCompanyAdmins = await getCompanyAdminUsers(
+    bsda.emitterCompanySiret!
+  );
+  const destinationCompanyAdmins = await getCompanyAdminUsers(
+    bsda.destinationCompanySiret!
+  );
+
+  let drealsRecipients: typeof DREALS = [];
+
+  if (notifyDreal) {
+    const companies = await prisma.company.findMany({
+      where: {
+        siret: {
+          in: [bsda.emitterCompanySiret!, bsda.emitterCompanySiret!]
+        }
+      },
+      select: { codeDepartement: true }
+    });
+    const formDepartments = companies.map(c => c.codeDepartement);
+    // get recipients from dreals list
+    drealsRecipients = DREALS.filter(d => formDepartments.includes(d.Dept));
+  }
+
+  const to = emitterCompanyAdmins.map(admin => ({
+    email: admin.email,
+    name: admin.name ?? ""
+  }));
+
+  // include drealsRecipients if settings says so
+  const cc = [
+    ...destinationCompanyAdmins,
+    ...(notifyDreal ? drealsRecipients : [])
+  ].map(admin => ({ email: admin.email, name: admin.name ?? "" }));
+
+  // Get formNotAccepted or formPartiallyRefused mail function according to wasteAcceptationStatus value
+  // const mailTemplate = {
+  //   REFUSED: formNotAccepted,
+  //   PARTIALLY_REFUSED: formPartiallyRefused
+  // }[bsda.destinationReceptionAcceptationStatus!];
+
+  return;
+}

--- a/back/src/bsda/pdf/components/TraceabilityTable.tsx
+++ b/back/src/bsda/pdf/components/TraceabilityTable.tsx
@@ -20,7 +20,7 @@ export function TraceabilityTable({ previousBsdas }: Props) {
       </thead>
       <tbody>
         {previousBsdas.map(bsda => (
-          <tr>
+          <tr key={bsda.id}>
             <td>{bsda?.id}</td>
             <td>{bsda?.type === "OTHER_COLLECTIONS" ? 1 : 2}</td>
             <td>{bsda?.waste?.code}</td>

--- a/back/src/bsda/pdf/generator.tsx
+++ b/back/src/bsda/pdf/generator.tsx
@@ -25,12 +25,13 @@ export async function buildPdf(bsda: Bsda) {
   return generatePdf(html);
 }
 
-export function buildPdfAsBase64(bsda: Bsda): Promise<string> {
-  return new Promise(async (resolve, reject) => {
+export async function buildPdfAsBase64(bsda: Bsda): Promise<string> {
+  const readableStream = await buildPdf(bsda);
+
+  return new Promise((resolve, reject) => {
     const convertToBase64 = concatStream(buffer =>
       resolve(buffer.toString("base64"))
     );
-    const readableStream = await buildPdf(bsda);
 
     readableStream.on("error", reject);
     readableStream.pipe(convertToBase64);

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -12,6 +12,10 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdaFactory } from "../../../__tests__/factories";
+import * as generatePdf from "../../../pdf/generator";
+
+const buildPdfAsBase64Spy = jest.spyOn(generatePdf, "buildPdfAsBase64");
+buildPdfAsBase64Spy.mockResolvedValue("");
 
 const SIGN_BSDA = `
 mutation SignBsda($id: ID!, $input: BsdaSignatureInput!) {

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -6,10 +6,17 @@ import {
   WasteAcceptationStatus
 } from "@prisma/client";
 import {
+  BsdTransporterReceiptPart,
+  getTransporterReceipt
+} from "../../../bsdasris/recipify";
+import {
   AlreadySignedError,
   InvalidSignatureError
 } from "../../../bsvhu/errors";
+import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { runInTransaction } from "../../../common/repository/helper";
+import { InvalidTransition } from "../../../forms/errors";
 import {
   BsdaSignatureInput,
   BsdaSignatureType,
@@ -19,20 +26,14 @@ import {
 import { sendMail } from "../../../mailer/mailing";
 import { finalDestinationModified } from "../../../mailer/templates";
 import { renderMail } from "../../../mailer/templates/renderers";
+import { checkCanSignFor } from "../../../permissions";
 import { GraphQLContext } from "../../../types";
 import { expandBsdaFromDb } from "../../converter";
 import { getBsdaHistory, getBsdaOrNotFound } from "../../database";
 import { machine } from "../../machine";
+import { renderBsdaRefusedEmail } from "../../mails/refused";
 import { BsdaRepository, getBsdaRepository } from "../../repository";
-import { runInTransaction } from "../../../common/repository/helper";
 import { parseBsda } from "../../validation/validate";
-import { checkCanSignFor } from "../../../permissions";
-import { InvalidTransition } from "../../../forms/errors";
-import {
-  BsdTransporterReceiptPart,
-  getTransporterReceipt
-} from "../../../bsdasris/recipify";
-import { UserInputError } from "../../../common/errors";
 
 const signBsda: MutationResolvers["signBsda"] = async (
   _,

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -21,8 +21,11 @@ import {
   userWithCompanyFactory,
   transporterReceiptFactory
 } from "../../../../__tests__/factories";
-
+import * as generatePdf from "../../../../bsda/pdf/generator";
 import makeClient from "../../../../__tests__/testClient";
+
+const buildPdfAsBase64Spy = jest.spyOn(generatePdf, "buildPdfAsBase64");
+buildPdfAsBase64Spy.mockResolvedValue("");
 
 const CREATE_DRAFT_BSDA = `
 mutation CreateDraftBsda($input: BsdaInput!) {

--- a/front/src/form/bsdd/appendix1Producer/form.tsx
+++ b/front/src/form/bsdd/appendix1Producer/form.tsx
@@ -99,6 +99,8 @@ export function Appendix1ProducerForm({
                     setFieldValue("emitter.company.address", null);
                     setFieldValue("emitter.company.country", null);
                     setFieldValue("emitter.company.orgId", null);
+                    setFieldValue("emitter.company.mail", "");
+                    setFieldValue("emitter.company.phone", "");
                     setFieldValue("emitter.isForeignShip", false);
                   }}
                 />


### PR DESCRIPTION
Fonctionnalité similaire à ce qui existe déjà sur le BSDD.
On reprend d'ailleurs les templates de mail

A noter qu'un mini fix annexe 1 s'est glissé dans la PR: https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12008
=> vider les champs quand on sélectionne "particulier" à la création de l'annexe 1

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10175)
