### PR TITLE
Ajout des infos d'entreposage provisoire dans le registre BSDD

### DIFF
--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -12,7 +12,7 @@ import { RegistryForm } from "../registry/elastic";
  * @returns
  */
 export function simpleFormToBsdd(
-  form: Omit<RegistryForm, "grouping" | "forwarding">
+  form: Omit<RegistryForm, "grouping" | "forwarding" | "forwardedIn">
 ): Bsdd {
   const transporters = (form.transporters ?? []).sort(
     (t1, t2) => t1.number - t2.number
@@ -137,7 +137,7 @@ export function simpleFormToBsdd(
     destinationCompanyMail: form.recipientCompanyMail,
     destinationCustomInfo: null,
     destinationReceptionDate: form.receivedAt,
-    // NOTE : quantityReceived DB to generic object translation
+    destinationIsTempStorage: form.recipientIsTempStorage,
     destinationReceptionWeight: form.quantityReceived,
     destinationReceptionAcceptationStatus: form.wasteAcceptationStatus,
     destinationReceptionRefusalReason: form.wasteRefusalReason,
@@ -166,10 +166,16 @@ export function simpleFormToBsdd(
   };
 }
 
+/**
+ * Registry waste converter
+ * @param form
+ */
 export function formToBsdd(form: RegistryForm): Bsdd & {
   grouping: Bsdd[];
 } & {
   forwarding: (Bsdd & { grouping: Bsdd[] }) | null;
+} & {
+  forwardedIn: (Bsdd & { grouping: Bsdd[] }) | null;
 } {
   let grouping: Bsdd[] = [];
 
@@ -189,6 +195,14 @@ export function formToBsdd(form: RegistryForm): Bsdd & {
           }
         }
       : { forwarding: null }),
+    ...(form.forwardedIn
+      ? {
+          forwardedIn: {
+            ...simpleFormToBsdd(form.forwardedIn),
+            grouping: []
+          }
+        }
+      : { forwardedIn: null }),
     grouping
   };
 }

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -137,6 +137,7 @@ export function simpleFormToBsdd(
     destinationCompanyMail: form.recipientCompanyMail,
     destinationCustomInfo: null,
     destinationReceptionDate: form.receivedAt,
+    // NOTE : quantityReceived DB to generic object translation
     destinationReceptionWeight: form.quantityReceived,
     destinationReceptionAcceptationStatus: form.wasteAcceptationStatus,
     destinationReceptionRefusalReason: form.wasteRefusalReason,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -89,6 +89,7 @@ export function toBsdElastic(form: RawForm): BsdElastic {
       form.takenOverAt?.getTime() ?? form.sentAt?.getTime(),
     destinationReceptionDate: form.receivedAt?.getTime(),
     destinationAcceptationDate: form.signedAt?.getTime(),
+    // NOTE : quantityReceived to BsdElastic object
     destinationAcceptationWeight: form.quantityReceived,
     destinationOperationDate: form.processedAt?.getTime(),
     ...(form.forwarding

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -154,14 +154,14 @@ export function toIncomingWaste(
     transporter3CompanySiret: bsdd.transporter3CompanySiret,
     transporter3RecepisseNumber: bsdd.transporter3RecepisseNumber,
     transporter3CompanyMail: bsdd.transporter3CompanyMail,
-    temporaryStorageDetailCompanySiret: bsdd.forwarding.emitterCompanySiret,
-    temporaryStorageDetailCompanyName: bsdd.forwarding.emitterCompanyName,
+    temporaryStorageDetailCompanySiret: bsdd.forwarding?.emitterCompanySiret,
+    temporaryStorageDetailCompanyName: bsdd.forwarding?.emitterCompanyName,
     temporaryStorageDetailQuantityReceived:
-      bsdd.forwarding.destinationReceptionWeight,
+      bsdd.forwarding?.destinationReceptionWeight,
     temporaryStorageDetailPlannedOperationCode:
-      bsdd.forwarding.destinationPlannedOperationCode,
+      bsdd.forwarding?.destinationPlannedOperationCode,
     temporaryStorageDetailOperationCode:
-      bsdd.forwarding.destinationOperationCode
+      bsdd.forwarding?.destinationOperationCode
   };
 }
 

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -90,7 +90,9 @@ function toGenericWaste(bsdd: Bsdd): GenericWaste {
 }
 
 export function toIncomingWaste(
-  bsdd: Bsdd & { forwarding: Bsdd } & { grouping: Bsdd[] }
+  bsdd: Bsdd & { forwarding: Bsdd } & { grouping: Bsdd[] } & {
+    forwardedIn: Bsdd;
+  }
 ): IncomingWaste {
   const initialEmitter: Record<string, string[] | null> = {
     initialEmitterCompanyAddress: null,
@@ -154,14 +156,15 @@ export function toIncomingWaste(
     transporter3CompanySiret: bsdd.transporter3CompanySiret,
     transporter3RecepisseNumber: bsdd.transporter3RecepisseNumber,
     transporter3CompanyMail: bsdd.transporter3CompanyMail,
-    temporaryStorageDetailCompanySiret: bsdd.forwarding?.emitterCompanySiret,
-    temporaryStorageDetailCompanyName: bsdd.forwarding?.emitterCompanyName,
-    temporaryStorageDetailQuantityReceived:
-      bsdd.forwarding?.destinationReceptionWeight,
-    temporaryStorageDetailPlannedOperationCode:
-      bsdd.forwarding?.destinationPlannedOperationCode,
-    temporaryStorageDetailOperationCode:
-      bsdd.forwarding?.destinationOperationCode
+    ...(bsdd.destinationIsTempStorage === true && {
+      temporaryStorageDetailCompanySiret: bsdd.destinationCompanySiret,
+      temporaryStorageDetailCompanyName: bsdd.destinationCompanyName,
+      temporaryStorageDetailQuantityReceived:
+        bsdd.forwardedIn?.destinationReceptionWeight,
+      temporaryStorageDetailPlannedOperationCode:
+        bsdd.forwardedIn?.destinationPlannedOperationCode,
+      temporaryStorageDetailOperationdCode: bsdd.destinationOperationCode
+    })
   };
 }
 

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -153,7 +153,15 @@ export function toIncomingWaste(
     transporter3CompanyName: bsdd.transporter3CompanyName,
     transporter3CompanySiret: bsdd.transporter3CompanySiret,
     transporter3RecepisseNumber: bsdd.transporter3RecepisseNumber,
-    transporter3CompanyMail: bsdd.transporter3CompanyMail
+    transporter3CompanyMail: bsdd.transporter3CompanyMail,
+    temporaryStorageDetailCompanySiret: bsdd.forwarding.emitterCompanySiret,
+    temporaryStorageDetailCompanyName: bsdd.forwarding.emitterCompanyName,
+    temporaryStorageDetailQuantityReceived:
+      bsdd.forwarding.destinationReceptionWeight,
+    temporaryStorageDetailPlannedOperationCode:
+      bsdd.forwarding.destinationPlannedOperationCode,
+    temporaryStorageDetailOperationCode:
+      bsdd.forwarding.destinationOperationCode
   };
 }
 

--- a/back/src/forms/resolvers/forms/appendix2Forms.ts
+++ b/back/src/forms/resolvers/forms/appendix2Forms.ts
@@ -12,7 +12,7 @@ const appendix2FormsResolver: FormResolvers["appendix2Forms"] = async (
   if (form.emitter?.type !== "APPENDIX2") {
     return null;
   }
-
+  // TODO pick this method to complete the registry
   const grouping = await prisma.form
     .findUnique({ where: { id: form.id } })
     .grouping({

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -146,4 +146,5 @@ export type Bsdd = {
   destinationOperationDate: Date | null;
   destinationOperationSignatureDate: Date | null;
   destinationCap: string | null;
+  destinationIsTempStorage: boolean | null;
 };

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -201,7 +201,27 @@ const columns: Column[] = [
     label: "Transporteur n°3 immatriculation",
     format: formatArray
   },
-  { field: "transporter3CompanyMail", label: "Transporteur n°3 contact" }
+  { field: "transporter3CompanyMail", label: "Transporteur n°3 contact" },
+  {
+    field: "temporaryStorageDetailCompanySiret",
+    label: "Extra - Numéro de SIRET de l'établissement d'entreposage provisoire"
+  },
+  {
+    field: "temporaryStorageDetailCompanyName",
+    label: "Extra - Raison sociale de l'établissement d'entreposage provisoire"
+  },
+  {
+    field: "temporaryStorageDetailQuantityReceived",
+    label: "Extra - Quantité reçue en tonnes de l'entreposage provisoire"
+  },
+  {
+    field: "temporaryStorageDetailPlannedOperationCode",
+    label: "Extra - Le code du traitement prévu dans l'entreposage provisoire"
+  },
+  {
+    field: "temporaryStorageDetailOperationCode",
+    label: "Extra - Le code du traitement réalisé dans l'entreposage provisoire"
+  }
 ];
 
 export function formatRow(waste: GenericWaste, useLabelAsKey = false) {

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -8,6 +8,7 @@ import {
 import { toElasticFilter } from "./where";
 import { Bsvhu, Prisma } from "@prisma/client";
 import prisma from "../prisma";
+import { getFullForm } from "../forms/database";
 
 export function buildQuery(
   registryType: WasteRegistryType,
@@ -78,6 +79,7 @@ export async function searchBsds(
 
 export const RegistryFormInclude = {
   forwarding: { include: { transporters: true } },
+  forwardedIn: { include: { transporters: true } },
   grouping: { include: { initialForm: { include: { transporters: true } } } },
   transporters: true
 };

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -198,6 +198,18 @@ type IncomingWaste {
   workerCompanySiret: String
   "Extra - L'adresse de l'entreprise de travaux (amiante uniquement)"
   workerCompanyAddress: String
+
+  "Extra - Numéro de SIRET de l'établissement d'entreposage provisoire"
+  temporaryStorageDetailCompanySiret: String
+  "Extra - Raison sociale de l'établissement d'entreposage provisoire"
+  temporaryStorageDetailCompanyName: String
+  "Extra - Quantité reçue en tonnes de l'entreposage provisoire"
+  temporaryStorageDetailQuantityReceived: Float
+  "Extra - Le code du traitement prévu dans l'entreposage provisoire"
+  temporaryStorageDetailPlannedOperationCode: String
+  "Extra - Le code du traitement réalisé dans l'entreposage provisoire"
+  temporaryStorageDetailOperationCode: String
+
 }
 
 type IncomingWasteEdge {


### PR DESCRIPTION
# Registre BSDD (entrant seul ?)

- ajouter : entreposage provisoire / destinataire du bordereau / installation finale (le cas échéant) / installation ultérieure prévue
- avec à chaque fois:
	- siret
	- nom établissement
	- poids réel (sauf destination prévue)
	- code opération réalisée (sauf destination prévue)
	- code opération prévue (pour destination prévue)

---
- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9971)
