### PR TITLE
Annexe 1 - Manque des infos sur le PDF

### DIFF
--- a/back/src/forms/repository/form/setAppendix1.ts
+++ b/back/src/forms/repository/form/setAppendix1.ts
@@ -64,6 +64,7 @@ export function buildSetAppendix1({
             wasteDetailsCode: form.wasteDetailsCode,
             wasteDetailsIsDangerous: form.wasteDetailsIsDangerous,
             wasteDetailsName: form.wasteDetailsName,
+            wasteDetailsQuantityType: "ESTIMATED",
 
             recipientCompanySiret: form.recipientCompanySiret,
             recipientCompanyName: form.recipientCompanyName,

--- a/back/src/forms/repository/form/updateAppendix1Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix1Forms.ts
@@ -108,9 +108,15 @@ export function buildUpdateAppendix1Forms(
     const updateManyForms = buildUpdateManyForms({ prisma, user });
     const promises: Promise<Prisma.BatchPayload | Form>[] = [];
 
-    // Status updates
+    // Status updates, plus push back infos onto the appendix 1 for the PDF
     for (const [status, ids] of formUpdatesByStatus.entries()) {
-      promises.push(updateManyForms(ids, { status }));
+      promises.push(
+        updateManyForms(ids, {
+          status,
+          receivedAt: container.receivedAt,
+          receivedBy: container.receivedBy
+        })
+      );
     }
 
     // Unlink & deletions


### PR DESCRIPTION
3 champs manquants sur le PDF annexe 1
- infos sur date & personne qui réceptionne. On les reprend depuis le chapeau
- type de quantité: c'est toujours estimé

On corrige donc le PDF pour qu'il contienne ces valeurs

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12248)
