### PR TITLE
POC "traçabilité complète"

### DIFF
--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -319,6 +319,19 @@ model EcoOrganisme {
   handleBsdasri Boolean @default(false)
 }
 
+// Modèle qui peut être partagé entre tous les
+// bordereaux
+model FinalOperation {
+  id                      String  @id @default(cuid())
+  finalFormReadableId     String
+  operationCode           String
+  quantity                Float
+  destinationCompanySiret String
+  destinationCompanyName  String
+  Form                    Form?   @relation(fields: [formId], references: [id])
+  formId                  String?
+}
+
 model Form {
   id                                 String                  @id @default(cuid())
   createdAt                          DateTime                @default(now()) @db.Timestamptz(6)
@@ -441,6 +454,8 @@ model Form {
   transportersSirets   String[] @default([])
   intermediariesSirets String[] @default([])
   canAccessDraftSirets String[] @default([])
+
+  finalOperations FinalOperation[]
 
   // partial index _FormIsDeletedIdx see migration82_missing_indices.sql
   // partial index _FormRecipientIsTempStorageIdx see 99_add_form_indices.sql
@@ -929,7 +944,7 @@ model Bsvhu {
   destinationReceptionIdentificationType    BsvhuIdentificationType?
   destinationReceptionDate                  DateTime?                @db.Timestamptz(6)
 
-  destinationOperationDate                            DateTime? @db.Timestamptz(6)
+  destinationOperationDate                            DateTime?      @db.Timestamptz(6)
   destinationOperationCode                            String?
   destinationOperationMode                            OperationMode?
   destinationOperationNextDestinationCompanyName      String?
@@ -940,7 +955,7 @@ model Bsvhu {
   destinationOperationNextDestinationCompanyMail      String?
   destinationOperationNextDestinationCompanyVatNumber String?
   destinationOperationSignatureAuthor                 String?
-  destinationOperationSignatureDate                   DateTime? @db.Timestamptz(6)
+  destinationOperationSignatureDate                   DateTime?      @db.Timestamptz(6)
 
   // partial indices _BsvhuIsDeletedIdx,_BsvhuIsDraftIdx  see migration82_missing_indices.sql
 
@@ -1259,13 +1274,13 @@ model BsffPackaging {
   acceptationSignatureAuthor String?
   acceptationSignatureDate   DateTime? @db.Timestamptz(6)
 
-  operationDate            DateTime? @db.Timestamptz(6)
-  operationNoTraceability  Boolean   @default(false)
+  operationDate            DateTime?      @db.Timestamptz(6)
+  operationNoTraceability  Boolean        @default(false)
   operationCode            String?
   operationMode            OperationMode?
   operationDescription     String?
   operationSignatureAuthor String?
-  operationSignatureDate   DateTime? @db.Timestamptz(6)
+  operationSignatureDate   DateTime?      @db.Timestamptz(6)
 
   operationNextDestinationPlannedOperationCode String?
   operationNextDestinationCap                  String?
@@ -1398,9 +1413,9 @@ model Bsda {
   destinationOperationCode            String?
   destinationOperationMode            OperationMode?
   destinationOperationDescription     String?
-  destinationOperationDate            DateTime? @db.Timestamptz(6)
+  destinationOperationDate            DateTime?      @db.Timestamptz(6)
   destinationOperationSignatureAuthor String?
-  destinationOperationSignatureDate   DateTime? @db.Timestamptz(6)
+  destinationOperationSignatureDate   DateTime?      @db.Timestamptz(6)
 
   destinationOperationNextDestinationCompanySiret         String?
   destinationOperationNextDestinationCompanyVatNumber     String?

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -1,5 +1,8 @@
-import { EmitterType, Prisma, Status } from "@prisma/client";
-import { PROCESSING_OPERATIONS } from "../../../common/constants";
+import { EmitterType, Form, Prisma, Status } from "@prisma/client";
+import {
+  PROCESSING_OPERATIONS,
+  ProcessingOperationType
+} from "../../../common/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { getFormOrFormNotFound } from "../../database";
@@ -21,6 +24,7 @@ import {
   isSiret,
   isVat
 } from "../../../common/constants/companySearchHelpers";
+import prisma from "../../../prisma";
 
 const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   parent,
@@ -124,7 +128,79 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     return processedForm;
   });
 
+  await operationHook(processedForm, processedForm.id);
+
   return getAndExpandFormFromDb(processedForm.id);
 };
 
 export default markAsProcessedResolver;
+
+type OperationHookArgs = Pick<
+  Form,
+  | "readableId"
+  | "quantityReceived"
+  | "processingOperationDone"
+  | "recipientCompanySiret"
+  | "recipientCompanyName"
+  | "noTraceability"
+>;
+
+// Hook qui est appelé à chaque fois qu'un applique une opération
+// de traitement sur un bordereau
+// À ajouter dans une queue plutôt que de faire ça en synchrone
+export async function operationHook(
+  // Informations sur le traitement final
+  operation: OperationHookArgs,
+  // Identifiant du bordereau
+  formId: string
+) {
+  // Codes de traitement finaux
+  const finalOperationCodes = PROCESSING_OPERATIONS.filter(
+    p =>
+      p.type === ProcessingOperationType.Eliminiation ||
+      p.type === ProcessingOperationType.Valorisation
+  ).map(p => p.code);
+  if (
+    finalOperationCodes.includes(operation.processingOperationDone!) ||
+    operation.noTraceability
+  ) {
+    // On va chercher tous les bordereaux initiaux
+
+    const formWithInitialForms = await prisma.form.findUniqueOrThrow({
+      where: { id: formId },
+      include: {
+        forwarding: true,
+        grouping: { include: { initialForm: true } }
+      }
+    });
+
+    const initialForms = [
+      formWithInitialForms.forwarding,
+      ...(formWithInitialForms.grouping ?? []).map(g => g.initialForm)
+    ].filter(Boolean);
+
+    for (const initialForm of initialForms) {
+      await prisma.form.update({
+        where: { id: initialForm.id },
+        data: {
+          finalOperations: {
+            create: {
+              finalFormReadableId: operation.readableId,
+              quantity: operation.quantityReceived!,
+              operationCode: operation.processingOperationDone!,
+              destinationCompanySiret: operation.recipientCompanySiret!,
+              destinationCompanyName: operation.recipientCompanyName!
+            }
+          }
+        }
+      });
+
+      // Applique le hook de façon récursive sur les bordereaux initiaux
+      // TODO gérer ça avec une queue
+      // Potentiel point particulier : s'il y a eu scission puis regroupement
+      // le hook pourrait être appelé plusieurs fois, il faudrait donc ajouter
+      // un check sur l'unicité de finalFormReadableId
+      await operationHook(operation, initialForm.id);
+    }
+  }
+}


### PR DESCRIPTION
Petit POC illustrant un moyen générique de mettre à jour les infos de traitement final sur les bordereaux initiaux en cas d'entreposage provisoire, regroupement, reconditionnement. L'idée est de se baser sur une fonction qui s'applique récursivement en remontant la chaîne de traçabilité. Il faudrait gérer ça via des tâches asynchrones en passant par la job queue.


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12745)
