### PR TITLE
[TRA-11795] Ajout d'un colonne dans le registre avec une version lisible du statut des BSDs

### DIFF
--- a/back/src/common/statuses.ts
+++ b/back/src/common/statuses.ts
@@ -1,0 +1,86 @@
+import {
+  BsffStatus,
+  BsdaStatus,
+  BsdasriStatus,
+  BsvhuStatus
+} from "@prisma/client";
+
+export const statusLabels: { [key: string]: string } = {
+  DRAFT: "Brouillon",
+  SEALED: "En attente de signature par l'émetteur",
+  SENT: "En attente de réception",
+  RECEIVED: "Reçu, en attente d'acceptation ou de refus",
+  ACCEPTED: "Accepté, en attente de traitement",
+  PROCESSED: "Traité",
+  AWAITING_GROUP: "En attente de regroupement",
+  FOLLOWED_WITH_PNTTD: "Suivi via PNTTD",
+  GROUPED: "Annexé à un bordereau de regroupement",
+  NO_TRACEABILITY: "Regroupé, avec autorisation de rupture de traçabilité",
+  REFUSED: "Refusé",
+  TEMP_STORED: "Arrivé à l'entreposage provisoire, en attente d'acceptation",
+  TEMP_STORER_ACCEPTED: "Entreposé temporairement ou en reconditionnement",
+  RESENT: "En attente de réception pour traitement",
+  RESEALED:
+    "En attente de signature par l'installation d'entreposage provisoire",
+  INITIAL: "Initial",
+  SIGNED_BY_PRODUCER: "Signé par l'émetteur",
+  SIGNED_BY_EMITTER: "Signé par l'émetteur",
+  SIGNED_BY_TEMP_STORER: "Signé par l'installation d'entreposage provisoire",
+  SIGNED_BY_WORKER: "Signé par l'entreprise de travaux",
+  AWAITING_CHILD: "En attente ou associé à un BSD suite",
+  CANCELED: "Annulé"
+};
+
+export const vhuVerboseStatuses: Record<BsvhuStatus, string> = {
+  ...statusLabels,
+  INITIAL: "Initial",
+  SIGNED_BY_PRODUCER: "Signé par le producteur",
+  SENT: "En cours d'acheminement",
+  PROCESSED: "Traité",
+  REFUSED: "Refusé"
+};
+
+export const dasriVerboseStatuses: Record<BsdasriStatus, string> = {
+  ...statusLabels,
+  INITIAL: "Initial",
+  SIGNED_BY_PRODUCER: "Signé par l'émetteur",
+  SENT: "Envoyé",
+  RECEIVED: "Reçu",
+  PROCESSED: "Traité",
+  REFUSED: "Refusé",
+  AWAITING_GROUP: "En attente de regroupement"
+};
+
+export const bsdaVerboseStatuses: Record<BsdaStatus, string> = {
+  ...statusLabels,
+  INITIAL: "Initial",
+  SIGNED_BY_PRODUCER: "Signé par le producteur",
+  SIGNED_BY_WORKER: "Signé par l'entreprise de travaux",
+  SENT: "Envoyé",
+  PROCESSED: "Traité",
+  REFUSED: "Refusé",
+  AWAITING_CHILD: "En attente d'un BSDA suite",
+  CANCELED: "Annulé"
+};
+
+export const bsffVerboseStatuses: Record<BsffStatus, string> = {
+  ...statusLabels,
+  INITIAL: "En attente de signature par l'émetteur",
+  SIGNED_BY_EMITTER: "Signé par l'émetteur",
+  SENT: "Signé par le transporteur",
+  RECEIVED: "Reçu par le destinataire",
+  INTERMEDIATELY_PROCESSED: "Traité, en attente de suivi",
+  PROCESSED: "Traité",
+  REFUSED: "Refusé par le destinataire",
+  ACCEPTED: "En attente de traitement",
+  PARTIALLY_REFUSED: "Refusé partiellement, en attente de traitement"
+};
+
+export const formatStatusLabel = (_, bsd) => {
+  if (bsd.bsdType === "BSDD") return statusLabels[bsd.status];
+  if (bsd.bsdType === "BSVHU") return vhuVerboseStatuses[bsd.status];
+  if (bsd.bsdType === "BSFF") return bsffVerboseStatuses[bsd.status];
+  if (bsd.bsdType === "BSDASRI") return dasriVerboseStatuses[bsd.status];
+  if (bsd.bsdType === "BSDA") return bsdaVerboseStatuses[bsd.status];
+  return "";
+};

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -7,15 +7,23 @@ import {
   TransportedWaste
 } from "../generated/graphql/types";
 import { GenericWaste } from "./types";
+import { formatStatusLabel } from "../common/statuses";
+
+// Type for custom fields that might not be in the DB
+// But that we still want to display (ie for user convenience)
+type CustomWaste = {
+  statusLabel: string;
+};
 
 type Column = {
   field: keyof (IncomingWaste &
     OutgoingWaste &
     TransportedWaste &
     ManagedWaste &
-    AllWaste);
+    AllWaste &
+    CustomWaste);
   label: string;
-  format?: (v: unknown) => string | number | null;
+  format?: (v: unknown, full: unknown) => string | number | null;
 };
 
 const formatDate = (d: Date | null) => d?.toISOString().slice(0, 10) ?? "";
@@ -58,7 +66,12 @@ const columns: Column[] = [
   },
   { field: "bsdType", label: "Type de bordereau" },
   { field: "customId", label: "Identifiant secondaire" },
-  { field: "status", label: "Statut du bordereau" },
+  { field: "status", label: "Statut du bordereau (code)" },
+  {
+    field: "status",
+    label: "Statut du bordereau",
+    format: formatStatusLabel
+  },
   { field: "wasteDescription", label: "Dénomination usuelle" },
   { field: "wasteCode", label: "Code du déchet" },
   {
@@ -211,7 +224,7 @@ export function formatRow(waste: GenericWaste, useLabelAsKey = false) {
       return {
         ...acc,
         [key]: column.format
-          ? column.format(waste[column.field])
+          ? column.format(waste[column.field], waste)
           : waste[column.field] ?? ""
       };
     }


### PR DESCRIPTION
# Contexte

Dans le fichier Excel du registre, la colonne "Statut du bordereau" affiche la valeur en base, à savoir l'enum, ce qui est peu lisible. On ajoute une colonne avec la version "en français".

Pour les phrases correpondant aux status, j'ai repris les textes côtés front.

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/0f6c2c33-b046-4fc2-8a1d-f067b17d3417)

# Ticket Favro

- [Ajout d'un colonne dans le registre avec une version lisible du statut des BSDs](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b97366202b804d314de8c684?card=tra-11795)
