### PR TITLE
Downgrade prisma/telemetry to 5.0

### DIFF
--- a/back/package-lock.json
+++ b/back/package-lock.json
@@ -21,7 +21,7 @@
         "@graphql-tools/schema": "^9.0.17",
         "@opentelemetry/instrumentation": "^0.41.0",
         "@prisma/client": "^5.3.0",
-        "@prisma/instrumentation": "^5.3.0",
+        "@prisma/instrumentation": "5.0.0",
         "@sentry/integrations": "^6.19.7",
         "@sentry/node": "^6.19.6",
         "@total-typescript/ts-reset": "^0.4.2",
@@ -7247,12 +7247,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
-      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -7261,20 +7261,64 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
-      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -7431,13 +7475,53 @@
       "integrity": "sha512-uftIog5FQ/OUR8Vb9TzpNBJ6L+zJnBgmd1A0uPJUzuvGMU32UmeyobpdXVzST5UprKryTdWOYXQFVyiQ2OU4Nw=="
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.3.0.tgz",
-      "integrity": "sha512-VcAS6AQlLmqpaRgA2Nlm08hgbcS6fXWaTaej70ShoTJsePPEP2jf47wczUnQrygRfhhfu5aqkff/jwZrkkumBA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.0.0.tgz",
+      "integrity": "sha512-GUt9ztQXriBmxPIDBd20eBHOX+LaF3zj4ot6mpMB/2YkceU4MvicdEoaX2VkF3r/xM7TatCF9IR2d35wOIv2GA==",
       "dependencies": {
         "@opentelemetry/api": "1.4.1",
-        "@opentelemetry/instrumentation": "0.41.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2"
+        "@opentelemetry/instrumentation": "0.40.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
+      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.3.5",
+        "require-in-the-middle": "^7.1.0",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
+      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "dependencies": {
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -26584,22 +26668,52 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
-      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "requires": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
-      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
       "requires": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+          "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.14.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+          "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+        }
       }
     },
     "@opentelemetry/semantic-conventions": {
@@ -26725,13 +26839,43 @@
       "integrity": "sha512-uftIog5FQ/OUR8Vb9TzpNBJ6L+zJnBgmd1A0uPJUzuvGMU32UmeyobpdXVzST5UprKryTdWOYXQFVyiQ2OU4Nw=="
     },
     "@prisma/instrumentation": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.3.0.tgz",
-      "integrity": "sha512-VcAS6AQlLmqpaRgA2Nlm08hgbcS6fXWaTaej70ShoTJsePPEP2jf47wczUnQrygRfhhfu5aqkff/jwZrkkumBA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.0.0.tgz",
+      "integrity": "sha512-GUt9ztQXriBmxPIDBd20eBHOX+LaF3zj4ot6mpMB/2YkceU4MvicdEoaX2VkF3r/xM7TatCF9IR2d35wOIv2GA==",
       "requires": {
         "@opentelemetry/api": "1.4.1",
-        "@opentelemetry/instrumentation": "0.41.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2"
+        "@opentelemetry/instrumentation": "0.40.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
+      },
+      "dependencies": {
+        "@opentelemetry/instrumentation": {
+          "version": "0.40.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
+          "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+          "requires": {
+            "@types/shimmer": "^1.0.2",
+            "import-in-the-middle": "1.3.5",
+            "require-in-the-middle": "^7.1.0",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "import-in-the-middle": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
+          "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+          "requires": {
+            "module-details-from-path": "^1.0.3"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@protobufjs/aspromise": {

--- a/back/package.json
+++ b/back/package.json
@@ -69,7 +69,7 @@
     "@graphql-tools/schema": "^9.0.17",
     "@opentelemetry/instrumentation": "^0.41.0",
     "@prisma/client": "^5.3.0",
-    "@prisma/instrumentation": "^5.3.0",
+    "@prisma/instrumentation": "5.0.0",
     "@sentry/integrations": "^6.19.7",
     "@sentry/node": "^6.19.6",
     "@total-typescript/ts-reset": "^0.4.2",


### PR DESCRIPTION
Suite à une erreur sur dev

```
2023-09-13 15:22:39.830156939 +0200 CEST[web-1] TypeError: parentTracer.getSpanLimits is not a function
2023-09-13 15:22:39.830163162 +0200 CEST[web-1] at new Span (/app/node_modules/@opentelemetry/sdk-trace-base/build/src/Span.js:59:41)
2023-09-13 15:22:39.830165274 +0200 CEST[web-1] at Ki.createEngineSpan (/app/node_modules/@prisma/client/runtime/library.js:123:1600)
2023-09-13 15:22:39.830166210 +0200 CEST[web-1] at pr.logger (/app/node_modules/@prisma/client/runtime/library.js:114:1093)
2023-09-13 15:22:39.830163917 +0200 CEST[web-1] at /app/node_modules/@prisma/instrumentation/dist/ActiveTracingHelper.js:59:20
2023-09-13 15:22:39.830164875 +0200 CEST[web-1] at ActiveTracingHelper.createEngineSpan (/app/node_modules/@prisma/instrumentation/dist/ActiveTracingHelper.js:44:27)
2023-09-13 15:22:39.830164441 +0200 CEST[web-1] at Array.forEach (<anonymous>)
2023-09-13 15:22:39.830166593 +0200 CEST[web-1] at /app/node_modules/@prisma/client/runtime/library.js:114:850
```