### PR TITLE
[Bug] Les BSDD regroupés devraient basculer dans l'onglet Archives et avoir le statut "Traité" lorsque le BSDD suite à été traité. 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - BSDD: un éco-organisme ne peut plus être sélectionné en tant qu'émetteur des déchets [PR 2665](https://github.com/MTES-MCT/trackdechets/pull/2665)
 - BSFF : ETQ émetteur je veux modifier mon BSD après l'avoir signé mais les modifications de contenant ne sont pas prises en compte [PR 2686](https://github.com/MTES-MCT/trackdechets/pull/2686)
+- Les BSDD regroupés devraient basculer dans l'onglet Archives et avoir le statut "Traité" lorsque le BSDD suite à été traité [PR 2712](https://github.com/MTES-MCT/trackdechets/pull/2712)
 
 #### :boom: Breaking changes
 

--- a/back/prisma/scripts/fixGroupedFormsStatus.ts
+++ b/back/prisma/scripts/fixGroupedFormsStatus.ts
@@ -1,0 +1,13 @@
+import { fixedGroupedFormsStatus } from "../../src/scripts/prisma/fixGroupedFormsStatus";
+import { Updater, registerUpdater } from "./helper/helper";
+
+@registerUpdater(
+  "Fix status of grouped BSDs with temp storage",
+  "Fix status of grouped BSDs with temp storage",
+  true
+)
+export class FixGroupedFormsStatusUpdater implements Updater {
+  async run() {
+    await fixedGroupedFormsStatus();
+  }
+}

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -1,7 +1,6 @@
 import { Form, OperationMode } from "@prisma/client";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import {
-  FormWithForwardedIn,
   FormWithForwardedInWithTransportersInclude,
   FormWithIntermediaries,
   FormWithIntermediariesInclude,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -2,7 +2,7 @@ import { Form, OperationMode } from "@prisma/client";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import {
   FormWithForwardedIn,
-  FormWithForwardedInInclude,
+  FormWithForwardedInWithTransportersInclude,
   FormWithIntermediaries,
   FormWithIntermediariesInclude,
   FormWithRevisionRequests,
@@ -10,7 +10,8 @@ import {
   FormWithTransportersInclude,
   FormWithRevisionRequestsInclude,
   FormWithForwarding,
-  FormWithForwardingInclude
+  FormWithForwardingInclude,
+  FormWithForwardedInWithTransporters
 } from "./types";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
@@ -26,13 +27,13 @@ import prisma from "../prisma";
 
 export type FormForElastic = Form &
   FormWithTransporters &
-  FormWithForwardedIn &
+  FormWithForwardedInWithTransporters &
   FormWithIntermediaries &
   FormWithForwarding &
   FormWithRevisionRequests;
 
 export const FormForElasticInclude = {
-  ...FormWithForwardedInInclude,
+  ...FormWithForwardedInWithTransportersInclude,
   ...FormWithForwardingInclude,
   ...FormWithTransportersInclude,
   ...FormWithIntermediariesInclude,

--- a/back/src/forms/repository/form/findGroupedFormsById.ts
+++ b/back/src/forms/repository/form/findGroupedFormsById.ts
@@ -1,16 +1,19 @@
 import { Form } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+import { FormWithForwardedIn } from "../../types";
 
-export type FindGroupedFormsByIdFn = (id: string) => Promise<Form[]>;
+export type FindGroupedFormsByIdFn = (
+  id: string
+) => Promise<Array<Form & FormWithForwardedIn>>;
 
 const buildFindGroupedFormsById: (
   deps: ReadRepositoryFnDeps
 ) => FindGroupedFormsByIdFn =
   ({ prisma }) =>
   async id => {
-    const grouping = await prisma.form
-      .findUnique({ where: { id } })
-      .grouping({ include: { initialForm: true } });
+    const grouping = await prisma.form.findUnique({ where: { id } }).grouping({
+      include: { initialForm: { include: { forwardedIn: true } } }
+    });
 
     if (!grouping) {
       return [];

--- a/back/src/forms/repository/form/setAppendix2.ts
+++ b/back/src/forms/repository/form/setAppendix2.ts
@@ -1,6 +1,8 @@
 import { Form } from "@prisma/client";
 import { RepositoryFnDeps } from "../../../common/repository/types";
-import buildUpdateAppendix2Forms from "./updateAppendix2Forms";
+import buildUpdateAppendix2Forms, {
+  FormForUpdateAppendix2FormsInclude
+} from "./updateAppendix2Forms";
 
 class FormFraction {
   form: Form;
@@ -113,7 +115,8 @@ const buildSetAppendix2: (deps: RepositoryFnDeps) => SetAppendix2Fn =
     ];
 
     const dirtyForms = await prisma.form.findMany({
-      where: { id: { in: dirtyFormIds } }
+      where: { id: { in: dirtyFormIds } },
+      include: FormForUpdateAppendix2FormsInclude
     });
 
     const updateAppendix2Forms = buildUpdateAppendix2Forms({ prisma, user });

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -4,8 +4,15 @@ import { RepositoryFnDeps } from "../../../common/repository/types";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import buildUpdateManyForms from "./updateMany";
+import { FormWithForwardedIn, FormWithForwardedInInclude } from "../../types";
 
-export type UpdateAppendix2Forms = (forms: Form[]) => Promise<void>;
+type FormForUpdateAppendix2Forms = Form & FormWithForwardedIn;
+
+export const FormForUpdateAppendix2FormsInclude = FormWithForwardedInInclude;
+
+export type UpdateAppendix2Forms = (
+  forms: FormForUpdateAppendix2Forms[]
+) => Promise<void>;
 
 const buildUpdateAppendix2Forms: (
   deps: RepositoryFnDeps
@@ -24,17 +31,20 @@ const buildUpdateAppendix2Forms: (
     if (![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)) {
       continue;
     }
-    const { id, quantityReceived } = form;
+
+    const quantityReceived = form.forwardedIn
+      ? form.forwardedIn.quantityReceived
+      : form.quantityReceived;
 
     const quantityGrouped = new Decimal(
       formGroupements
-        .filter(grp => grp.initialFormId === id)
+        .filter(grp => grp.initialFormId === form.id)
         .map(grp => grp.quantity)
         .reduce((prev, cur) => prev + cur, 0) ?? 0
     ).toDecimalPlaces(6); // set precision to gramme
 
     const groupementForms = formGroupements
-      .filter(grp => grp.initialFormId === id)
+      .filter(grp => grp.initialFormId === form.id)
       .map(g => g.nextForm);
 
     const groupedInTotality =
@@ -76,7 +86,7 @@ const buildUpdateAppendix2Forms: (
 
       formUpdatesByStatus.set(status, [
         ...(formUpdatesByStatus.get(status) ?? []),
-        id
+        form.id
       ]);
     } else if (
       form.status === Status.AWAITING_GROUP &&
@@ -87,12 +97,12 @@ const buildUpdateAppendix2Forms: (
       });
       formUpdatesByStatus.set(status, [
         ...(formUpdatesByStatus.get(status) ?? []),
-        id
+        form.id
       ]);
     } else {
       formUpdatesByStatus.set(nextStatus, [
         ...(formUpdatesByStatus.get(nextStatus) ?? []),
-        id
+        form.id
       ]);
     }
   }

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -20,11 +20,20 @@ export type FormWithTransporters = Prisma.FormGetPayload<{
 
 export const FormWithForwardedInInclude =
   Prisma.validator<Prisma.FormInclude>()({
-    forwardedIn: { include: FormWithTransportersInclude }
+    forwardedIn: true
   });
 
 export type FormWithForwardedIn = Prisma.FormGetPayload<{
   include: typeof FormWithForwardedInInclude;
+}>;
+
+export const FormWithForwardedInWithTransportersInclude =
+  Prisma.validator<Prisma.FormInclude>()({
+    forwardedIn: { include: { transporters: true } }
+  });
+
+export type FormWithForwardedInWithTransporters = Prisma.FormGetPayload<{
+  include: typeof FormWithForwardedInWithTransportersInclude;
 }>;
 
 export const FormWithIntermediariesInclude =

--- a/back/src/scripts/prisma/__tests__/fixGroupedFormsStatus.integration.ts
+++ b/back/src/scripts/prisma/__tests__/fixGroupedFormsStatus.integration.ts
@@ -1,0 +1,166 @@
+import { resetDatabase } from "../../../../integration-tests/helper";
+import {
+  formFactory,
+  formWithTempStorageFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import prisma from "../../../prisma";
+import { fixedGroupedFormsStatus } from "../fixGroupedFormsStatus";
+
+describe("fixGroupedFormStatus", () => {
+  afterEach(resetDatabase);
+
+  it("should set status to GROUPED if necessary", async () => {
+    const emitter = await userWithCompanyFactory("ADMIN");
+    const tempStorage = await userWithCompanyFactory("ADMIN");
+    const ttr = await userWithCompanyFactory("ADMIN");
+
+    const groupedForm1 = await formWithTempStorageFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "AWAITING_GROUP",
+        emitterCompanySiret: emitter.company.siret,
+        recipientCompanySiret: tempStorage.company.siret,
+        quantityReceived: 1
+      },
+      forwardedInOpts: {
+        recipientCompanySiret: ttr.company.siret,
+        quantityReceived: 0.5
+      }
+    });
+
+    const groupedForm2 = await formWithTempStorageFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "AWAITING_GROUP",
+        emitterCompanySiret: emitter.company.siret,
+        recipientCompanySiret: tempStorage.company.siret,
+        quantityReceived: 1
+      },
+      forwardedInOpts: {
+        recipientCompanySiret: ttr.company.siret,
+        quantityReceived: 0.5
+      }
+    });
+
+    const groupedForm3 = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        status: "AWAITING_GROUP",
+        quantityReceived: 1
+      }
+    });
+
+    // create groupement
+    await formFactory({
+      ownerId: ttr.user.id,
+      opt: {
+        status: "SEALED",
+        grouping: {
+          create: [
+            { initialFormId: groupedForm1.id, quantity: 0.5 }, // regroupé en totalité
+            { initialFormId: groupedForm2.id, quantity: 0.4 }, // regroupé partiellement
+            { initialFormId: groupedForm3.id, quantity: 1 } // regroupé en totalité
+          ]
+        }
+      }
+    });
+
+    await fixedGroupedFormsStatus();
+
+    const updatedGroupedForm1 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm1.id }
+    });
+    expect(updatedGroupedForm1.status).toEqual("GROUPED");
+
+    const updatedGroupedForm2 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm2.id }
+    });
+    // Le bordereau 2 n'est pas regroupé en totalité il reste au statut AWAITING_GROUP
+    expect(updatedGroupedForm2.status).toEqual("AWAITING_GROUP");
+
+    const updatedGroupedForm3 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm3.id }
+    });
+    // Le script ne doit pas s'appliquer pas aux bordereaux sans entreposage provisoire
+    expect(updatedGroupedForm3.status).toEqual("AWAITING_GROUP");
+  });
+
+  it("should set status to PROCESSED if necessary", async () => {
+    const emitter = await userWithCompanyFactory("ADMIN");
+    const tempStorage = await userWithCompanyFactory("ADMIN");
+    const ttr = await userWithCompanyFactory("ADMIN");
+
+    const groupedForm1 = await formWithTempStorageFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "AWAITING_GROUP",
+        emitterCompanySiret: emitter.company.siret,
+        recipientCompanySiret: tempStorage.company.siret,
+        quantityReceived: 1
+      },
+      forwardedInOpts: {
+        recipientCompanySiret: ttr.company.siret,
+        quantityReceived: 0.5
+      }
+    });
+
+    const groupedForm2 = await formWithTempStorageFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "AWAITING_GROUP",
+        emitterCompanySiret: emitter.company.siret,
+        recipientCompanySiret: tempStorage.company.siret,
+        quantityReceived: 1
+      },
+      forwardedInOpts: {
+        recipientCompanySiret: ttr.company.siret,
+        quantityReceived: 0.5
+      }
+    });
+
+    const groupedForm3 = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        status: "AWAITING_GROUP",
+        quantityReceived: 1
+      }
+    });
+
+    // create groupement
+    await formFactory({
+      ownerId: ttr.user.id,
+      opt: {
+        status: "PROCESSED",
+        grouping: {
+          create: [
+            { initialFormId: groupedForm1.id, quantity: 0.5 }, // regroupé en totalité
+            { initialFormId: groupedForm2.id, quantity: 0.4 }, // regroupé partiellement
+            { initialFormId: groupedForm3.id, quantity: 1 } // regroupé en totalité
+          ]
+        }
+      }
+    });
+
+    await fixedGroupedFormsStatus();
+
+    const updatedGroupedForm1 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm1.id }
+    });
+    expect(updatedGroupedForm1.status).toEqual("PROCESSED");
+
+    const updatedGroupedForm2 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm2.id }
+    });
+    // Le bordereau 2 n'est pas regroupé en totalité il reste au statut AWAITING_GROUP
+    expect(updatedGroupedForm2.status).toEqual("AWAITING_GROUP");
+
+    const updatedGroupedForm3 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm3.id }
+    });
+    // Le script ne doit pas s'appliquer pas aux bordereaux sans entreposage provisoire
+    expect(updatedGroupedForm3.status).toEqual("AWAITING_GROUP");
+  });
+});

--- a/back/src/scripts/prisma/fixGroupedFormsStatus.ts
+++ b/back/src/scripts/prisma/fixGroupedFormsStatus.ts
@@ -1,0 +1,38 @@
+import { processBsdIdentifiersByChunk } from "../../bsds/indexation/bulkIndexBsds";
+import { getFormRepository } from "../../forms/repository";
+import { FormForUpdateAppendix2FormsInclude } from "../../forms/repository/form/updateAppendix2Forms";
+import prisma from "../../prisma";
+
+export async function fixedGroupedFormsStatus() {
+  const formIds = await prisma.form.findMany({
+    where: {
+      groupedIn: { some: {} },
+      forwardedInId: { not: null },
+      status: { in: ["AWAITING_GROUP", "GROUPED"] }
+    },
+    select: { id: true }
+  });
+
+  // ~ 6000 bordereaux
+  console.log(
+    `Mise à jour du statut de ${formIds.length} bordereaux avec` +
+      ` entreposage provisoire annexés à des bordereaux de regroupement`
+  );
+
+  await processBsdIdentifiersByChunk(
+    formIds.map(f => f.id),
+    async ids => {
+      const forms = await prisma.form.findMany({
+        where: { id: { in: ids } },
+        include: FormForUpdateAppendix2FormsInclude
+      });
+
+      const { updateAppendix2Forms } = getFormRepository({
+        id: "support_tech"
+      } as Express.User);
+
+      await updateAppendix2Forms(forms);
+    },
+    100 // process les bordereaux 100 par 100
+  );
+}


### PR DESCRIPTION
Cas particulier en cas d'entreposage provisoire qui était mal géré 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-11764)
