### PR TITLE
Fix searchCompanies data return

### DIFF
--- a/back/src/companies/resolvers/queries/__tests__/companyInfos.test.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyInfos.test.ts
@@ -164,6 +164,7 @@ describe("companyInfos search with a VAT number", () => {
       name: "Code en stock",
       address: "une adresse",
       orgId: "IT09301420155",
+      vatNumber: "IT09301420155",
       contactEmail: "benoit.guigal@protonmail.com",
       contactPhone: "06 67 78 xx xx",
       website: "http://benoitguigal.fr"

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -71,6 +71,7 @@ async function findCompanyAndMergeInfos(
   const where = {
     where: { orgId: cleanClue }
   };
+
   const trackdechetsCompanyInfo = await prisma.company.findUnique({
     ...where,
     select: {
@@ -162,7 +163,6 @@ export async function searchCompany(
           codePaysEtrangerEtablissement: country.isoCode.short,
           statutDiffusionEtablissement: "O",
           etatAdministratif: "A",
-          vatNumber: cleanedClue,
           ...company
         };
       }

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -42,10 +42,19 @@ export const mergeCompanyToCompanySearchResult = (
 ): CompanySearchResult => ({
   orgId,
   // ensure compatibility with CompanyPublic
+  siret: trackdechetsCompanyInfo?.siret,
+  name: trackdechetsCompanyInfo?.name,
+  address: trackdechetsCompanyInfo?.address,
+  vatNumber: trackdechetsCompanyInfo?.vatNumber,
+  companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
+  contact: trackdechetsCompanyInfo?.contact,
+  contactEmail: trackdechetsCompanyInfo?.contactEmail,
+  contactPhone: trackdechetsCompanyInfo?.contactPhone,
+  allowBsdasriTakeOverWithoutSignature:
+    trackdechetsCompanyInfo?.allowBsdasriTakeOverWithoutSignature,
   ecoOrganismeAgreements: [],
   isRegistered: trackdechetsCompanyInfo != null,
   trackdechetsId: trackdechetsCompanyInfo?.id,
-  companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
   ...(trackdechetsCompanyInfo != null && {
     ...convertUrls(trackdechetsCompanyInfo)
   }),


### PR DESCRIPTION
# La query SearchCompanies ne renvoie pas les infos contact établissement TD.

- TODO tests

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12709)
