### PR TITLE
Update de la documentation sur la pagination `bsffs`

### DIFF
--- a/back/src/bsffs/typeDefs/bsff.queries.graphql
+++ b/back/src/bsffs/typeDefs/bsff.queries.graphql
@@ -7,13 +7,41 @@ type Query {
 
   "Retourne tous les bordereaux de l'utilisateur connecté, en respectant les différents filtres."
   bsffs(
-    "Retourne les bordereaux après celui qui correspond à l'identifiant donné."
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `first` de paginer "en avant"
+    (des bordereaux les plus récents aux bordereaux les plus anciens).
+    Curseur après lequel les bordereaux doivent être retournés.
+    Attend un identifiant (propriété `id`) du BSFF.
+    Défaut à vide, pour retourner les bordereaux les plus récents.
+    Le BSFF précisé dans le curseur ne fait pas partie du résultat
+    """
     after: ID
-    "Retourne les bordereaux avant celui qui correspond à l'identifiant donné."
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `last` de paginer "en arrière"
+    (des bordereaux les plus anciens aux bordereaux les plus récents).
+    Curseur avant lequel les bordereaux doivent être retournés.
+    Attend un identifiant (propriété `id`) du BSFF.
+    Défaut à vide, pour retourner les bordereaux les plus anciens.
+    Le BSFF précisé dans le curseur ne fait pas partie du résultat
+    """
     before: ID
-    "Retourne les x premiers bordereaux."
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `after` de paginer "en avant"
+    (des bordereaux les plus récents aux bordereaux les plus anciens).
+    Nombre de bordereaux retournés après le `after`.
+    Défaut à 50, maximum à 500.
+    """
     first: Int
-    "Retourne les x derniers bordereaux."
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `before` de paginer "en arrière"
+    (des bordereaux les plus anciens aux bordereaux les plus récents).
+    Nombre de bordereaux retournés avant le `before`.
+    Défaut à 50, maximum à 500.
+    """
     last: Int
     "Filtre les résultats d'après certains critères."
     where: BsffWhere


### PR DESCRIPTION
https://forum.trackdechets.beta.gouv.fr/t/le-nombre-max-de-resultats-renvoyes-par-la-query-forms-sera-limite-a-100/1533/2


