### PR TITLE
BSDA - Champ date d'opération contraint

### DIFF
--- a/front/src/form/bsda/stepper/steps/Operation.tsx
+++ b/front/src/form/bsda/stepper/steps/Operation.tsx
@@ -113,6 +113,8 @@ export default function Operation({ bsda }: Props) {
               Date de l'opération
               <Field
                 component={DateInput}
+                minDate={subMonths(TODAY, 2)}
+                maxDate={TODAY}
                 name="destination.operation.date"
                 className={`td-input td-input--small`}
               />


### PR DESCRIPTION
Le date picker pour la date d'opération ne doit pas proposer des dates antérieures à il y a 2 mois ou postérieures à aujourd'hui

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12723)
