### PR TITLE
BSDA - Permettre de changer l'opération quand elle manque

### DIFF
--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -163,7 +163,7 @@ export function Destination({ disabled }) {
             <label>
               N° CAP:
               <Field
-                disabled={disabled}
+                disabled={hasNextDestination ? false : disabled}
                 type="text"
                 name={
                   hasNextDestination
@@ -187,7 +187,7 @@ export function Destination({ disabled }) {
               : "destination.plannedOperationCode"
           }
           className="td-select"
-          disabled={disabled}
+          disabled={hasNextDestination ? false : disabled}
         >
           <option />
           {isDechetterie && !hasNextDestination ? (


### PR DESCRIPTION
Opération finale & cap final sont des champs required qui parfois ne sont pas remplis.
Le formulaire ne permettait pas de les compléter. Ca corrige ça.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12638)
