### PR TITLE
[TRA-12869] Le filtre de recherche rapide sur les SIRET retourne des résultats erronés

### DIFF
--- a/back/src/bsds/where.ts
+++ b/back/src/bsds/where.ts
@@ -6,6 +6,7 @@ import {
 } from "../common/constants/GET_BSDS_CONSTANTS";
 import {
   toElasticDateQuery,
+  toElasticSiretQuery,
   toElasticStringListQuery,
   toElasticStringQuery,
   toElasticTextQuery
@@ -106,7 +107,7 @@ export function toElasticSimpleQuery(where: BsdWhere) {
           "destinationCompanyName",
           where.destination?.company?.name
         ),
-        toElasticStringQuery(
+        toElasticSiretQuery(
           "destinationCompanySiret",
           where.destination?.company?.siret
         ),

--- a/back/src/common/where.ts
+++ b/back/src/common/where.ts
@@ -270,6 +270,22 @@ export function toElasticTextQuery(
   };
 }
 
+export function toElasticSiretQuery(
+  fieldName: string,
+  stringFilter: StringFilter | null | undefined,
+  maxLength = 50
+): estypes.QueryContainer | undefined {
+  if (stringFilter?._contains?.length === 14) {
+    return toElasticStringQuery(
+      fieldName,
+      { _eq: stringFilter?._contains },
+      maxLength
+    );
+  }
+
+  return toElasticStringQuery(fieldName, stringFilter, maxLength);
+}
+
 export function toElasticStringQuery(
   fieldName: string,
   stringFilter: StringFilter | null | undefined,


### PR DESCRIPTION
# Contexte

Sur le filtre de recherche rapide, la recherche par SIRET renvoie de mauvais résultats, notamment dans le cas suivant:
![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/fbf3feff-2b6e-4de8-8c44-05ed0470dde7)

On peut constater que si je tape "48011152500014", alors les deux entreprises avec des SIRET différents, 48011152500014 et 48011152500147, sont renvoyées.

# Explication

Le bug est dû au fait que l'on traduit la requête front suivante:
`{"destination":{"company":{"siret":{"_contains":"48011152500014"}}}}]}]}`
En la query ES suivante:
`{"match":{"destinationCompanySiret.ngram":{"query":"48011 15250 0014","operator":"and"}}}`

Cette query match autant 48011152500014 que 48011152500147.

# Solution

La solution naïve proposée ici est de changer la query ES si le SIRET est entier:
```
  if (stringFilter?._contains?.length === 14) {
    return toElasticStringQuery(
      fieldName,
      { _eq: stringFilter?._contains },
      maxLength
    );
  }

  return toElasticStringQuery(fieldName, stringFilter, maxLength);
```

Cependant, cette solution scale mal. Si le SIRET peut varier en longueur (SIRET étrangers ou autres), ou si le bug arrive sur d'autres champs, on est limités.

# Ticket Favro

[Correspondance Filtres SIRET - Recherche exacte](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e044644940a534f63e06b04d?card=tra-12869)
