### PR TITLE
Recette - Fix dates de signature

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -91,7 +91,7 @@ export function SignOperation({
           <Formik
             initialValues={{
               author: "",
-              date: TODAY,
+              date: TODAY.toISOString(),
               ...getComputedState(
                 {
                   destination: {

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -98,7 +98,7 @@ export function SignTransport({
           <Formik
             initialValues={{
               author: "",
-              date: TODAY,
+              date: TODAY.toISOString(),
               ...getComputedState(
                 {
                   transporter: {

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
@@ -87,7 +87,7 @@ export function SignWork({
         ) : (
           <Formik
             initialValues={{
-              date: TODAY,
+              date: TODAY.toISOString(),
               author: "",
               ...getComputedState(
                 {

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -182,7 +182,7 @@ export function RouteSignBsdasri({
       <Formik
         initialValues={{
           ...formState,
-          signature: { author: "", date: TODAY },
+          signature: { author: "", date: TODAY.toISOString() },
         }}
         validationSchema={() => signatureValidationSchema}
         onSubmit={async values => {


### PR DESCRIPTION
Correction de recette. On le bug suivant à plusieurs signatures.
Je ne comprends pas pourquoi ca marchait avant

> Variable "$input" got invalid value {} at "input.date"; Seul les chaînes de caractères au format ISO 8601 sont acceptées en tant que date. Reçu [object Object].