### PR TITLE
[tra-12942] - Fix transporter signature problem for appendix1

### DIFF
--- a/back/src/forms/resolvers/mutations/signedByTransporter.ts
+++ b/back/src/forms/resolvers/mutations/signedByTransporter.ts
@@ -32,6 +32,14 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
 
     const fullForm = await getFullForm(form);
 
+    // APPENDIX1_PRODUCER has been added long after this mutation was deprecated.
+    // Instead of adding complex logic in both cases, just prevent from using this mutation.
+    if (fullForm.emitterType === "APPENDIX1_PRODUCER") {
+      throw new UserInputError(
+        "Impossible de signer un bordereau d'annexe 1 avec cette mutation dépréciée. Merci d'utiliser la mutation `signTransportForm`."
+      );
+    }
+
     // La mutation `signedByTransporter` ne peut être appelée que par
     // le premier transporteur contrairement à `signTransportForm`
     const transporter = getFirstTransporterSync(fullForm);


### PR DESCRIPTION
Une vieille mutation de signature transporteur ne gère pas les BSDD APPENDIX1_PRODUCER.
Plutot que de gérer le cas, on l'interdit

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-12942)
