### PR TITLE
[tra-12687] BSDA - Fix intermediaries update

### DIFF
--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -50,15 +50,16 @@ export default async function edit(
     bsda.grouping && bsda.grouping.length > 0
       ? { set: bsda.grouping.map(id => ({ id })) }
       : undefined;
-  const intermediaries =
-    bsda.intermediaries && bsda.intermediaries.length > 0
-      ? {
-          deleteMany: {},
+  const intermediaries = bsda.intermediaries
+    ? {
+        deleteMany: {},
+        ...(bsda.intermediaries.length > 0 && {
           createMany: {
             data: companyToIntermediaryInput(bsda.intermediaries)
           }
-        }
-      : undefined;
+        })
+      }
+    : undefined;
 
   const bsdaRepository = getBsdaRepository(user);
   const updatedBsda = await bsdaRepository.update(


### PR DESCRIPTION
Lorsqu'on supprimait tous les intermédiaires sur le BSDA la modification n'était pas prise en compte.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12687)
