### PR TITLE
Deny access to unauthenticated searchCompanies queries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,27 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.10.2] 31/10/2023
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+#### :bug: Corrections de bugs
+
+
+#### :boom: Breaking changes
+
+- Rendre authentifiée la requête api `searchCompanies` [PR 2781](https://github.com/MTES-MCT/trackdechets/pull/2781)
+
+#### :nail_care: Améliorations
+
+#### :house: Interne
+
+#### :house: Interne
+
+
+
 # [2023.10.1] 10/10/2023
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/companies/resolvers/queries/searchCompanies.ts
+++ b/back/src/companies/resolvers/queries/searchCompanies.ts
@@ -8,11 +8,6 @@ const searchCompaniesResolver: QueryResolvers["searchCompanies"] = async (
   { clue, department, allowForeignCompanies },
   context
 ) => {
-  applyAuthStrategies(context, [
-    AuthType.Session,
-    // On autorise la recherche par API
-    AuthType.Bearer
-  ]);
   checkIsAuthenticated(context);
   return searchCompanies(clue, department, allowForeignCompanies);
 };

--- a/back/src/companies/resolvers/queries/searchCompanies.ts
+++ b/back/src/companies/resolvers/queries/searchCompanies.ts
@@ -1,4 +1,3 @@
-import { applyAuthStrategies, AuthType } from "../../../auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { QueryResolvers } from "../../../generated/graphql/types";
 import { searchCompanies } from "../../search";

--- a/back/src/companies/resolvers/queries/searchCompanies.ts
+++ b/back/src/companies/resolvers/queries/searchCompanies.ts
@@ -1,10 +1,20 @@
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { checkIsAuthenticated } from "../../../common/permissions";
 import { QueryResolvers } from "../../../generated/graphql/types";
 import { searchCompanies } from "../../search";
 
 const searchCompaniesResolver: QueryResolvers["searchCompanies"] = async (
   _,
   { clue, department, allowForeignCompanies },
-  _context
-) => searchCompanies(clue, department, allowForeignCompanies);
+  context
+) => {
+  applyAuthStrategies(context, [
+    AuthType.Session,
+    // On autorise la recherche par API
+    AuthType.Bearer
+  ]);
+  checkIsAuthenticated(context);
+  return searchCompanies(clue, department, allowForeignCompanies);
+};
 
 export default searchCompaniesResolver;


### PR DESCRIPTION
# searchCompanies était restée publique par omission

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?onShow=mycards&card=tra-12713)
