### PR TITLE
Limit forms query to maximum 500 elements

### DIFF
--- a/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/forms.integration.ts
@@ -561,7 +561,7 @@ describe("Query.forms", () => {
     expect(data.forms.length).toBe(50);
   });
 
-  it("should not accepted a first argument lower than 1 or greater than 500", async () => {
+  it("should not accepted a first argument lower than 1 or greater than 100", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     // The user has many forms, and a different role in each
     await createForms(user.id, [
@@ -605,7 +605,7 @@ describe("Query.forms", () => {
           }
         }
       `,
-      { variables: { first: 501 } }
+      { variables: { first: 101 } }
     );
     expect(tooBigErrors.length).toBe(1);
   });

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -10,6 +10,8 @@ import { expandFormFromDb, expandableFormIncludes } from "../../converter";
 import { getPrismaPaginationArgs } from "../../../common/pagination";
 import { checkCanList } from "../../permissions";
 
+const MAX_FORMS_LIMIT = 100;
+
 const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
   const user = checkIsAuthenticated(context);
 
@@ -43,7 +45,8 @@ const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
     after: rest.cursorAfter,
     last: rest.last,
     before: rest.cursorBefore,
-    skip: rest.skip
+    skip: rest.skip,
+    maxPaginateBy: MAX_FORMS_LIMIT
   };
 
   const paginationArgs = getPrismaPaginationArgs(gqlPaginationArgs);

--- a/back/src/forms/typeDefs/bsdd.queries.graphql
+++ b/back/src/forms/typeDefs/bsdd.queries.graphql
@@ -59,7 +59,7 @@ type Query {
     Permet en conjonction avec `cursorAfter` de paginer "en avant"
     (des bordereaux les plus récents aux bordereaux les plus anciens)
     Nombre de bordereaux retournés après le `cursorAfter`
-    Défaut à 50, maximum à 500
+    Défaut à 50, maximum à 100
     """
     first: Int
 
@@ -77,7 +77,7 @@ type Query {
     """
     (Optionnel) PAGINATION
     Nombre de bordereaux retournés avant le `cursorBefore`
-    Défaut à 50, maximum à 500
+    Défaut à 50, maximum à 100
     """
     last: Int
 


### PR DESCRIPTION
# Éviter [les timeout](https://app.datadoghq.eu/apm/traces?query=%40_top_level%3A1%20env%3Aproduction%20service%3Aback%20&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=5701174966572957963&spanType=service-entry&spanViewType=logs&timeHint=1693565759307&trace=AgAAAYpQYq9LGTPMewAAAAAAAAAYAAAAAEFZcFFZcmpGQUFBVEhfNDVFWlhoTW1NSwAAACQAAAAAMDE4YTUwOTgtZDk3Ni00NGM2LWI1MTgtNWE2MDU5YzA2N2Zk&traceID=748553095426521873&traceSearchQuery=%7B%22traceQuery%22%3A%22%22%2C%22spanQueries%22%3A%7B%22a%22%3A%22%22%7D%7D&view=spans&start=1694866682086&end=1697458682086&paused=false) pour les query forms

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?onShow=mycards&card=tra-12690)
