### PR TITLE
[tra-12933]Afficher le bouton 'Valider l'acceptation' au lieu de 'Gérer les contenants' lorsqu'il n'y a qu'un seul contenant pour un BSFF

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -556,7 +556,10 @@ export const getReceivedBtnLabel = (
     isSameSiretDestination(currentSiret, bsd) &&
     permissions.includes(UserPermission.BsdCanSignOperation)
   ) {
-    // ajouter bsff status received with packagings see dashboard/components/BSDList/BSFF/WorkflowAction/WorkflowAction.tsx
+    if (bsd.packagings?.length === 1) {
+      return VALIDER_ACCEPTATION;
+    }
+
     return SIGNATURE_ACCEPTATION_CONTENANT;
   }
 


### PR DESCRIPTION


<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12933)

<img width="2337" alt="Screenshot 2023-10-26 at 16 35 47" src="https://github.com/MTES-MCT/trackdechets/assets/37509748/83d251f1-4558-4b8c-8214-1a7a71ac0065">

