### PR TITLE
[TRA-11095] Wording: mise en conformité ADR2023 sur les quantités estimées

### DIFF
--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -30,7 +30,8 @@ export function WasteDetails({ waste, weight }: Props) {
           checked={Boolean(weight?.isEstimate)}
           readOnly
         />{" "}
-        Estimée conformément à l'article 5.4.1.1.3.2 de l'ADR 2023
+        Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de l'ADR
+        2023
       </p>
     </>
   );

--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -30,8 +30,7 @@ export function WasteDetails({ waste, weight }: Props) {
           checked={Boolean(weight?.isEstimate)}
           readOnly
         />{" "}
-        Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de l'ADR
-        2023
+        Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
       </p>
     </>
   );

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -308,7 +308,8 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
                 defaultChecked={bsff.weight?.isEstimate}
                 readOnly
               />{" "}
-              Estimée conformément à l'article 5.4.1.1.3.2 de l'ADR 2023
+              Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de
+              l'ADR 2023
             </span>
           </div>
           <div>Kilogramme(s) : {bsff.weight.value}</div>

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -308,8 +308,8 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
                 defaultChecked={bsff.weight?.isEstimate}
                 readOnly
               />{" "}
-              Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de
-              l'ADR 2023
+              Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+              2023
             </span>
           </div>
           <div>Kilogramme(s) : {bsff.weight.value}</div>

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -84,7 +84,8 @@ function QuantityFields({ quantity, quantityType }: QuantityFieldsProps) {
         checked={quantityType === QuantityType.ESTIMATED}
         readOnly
       />{" "}
-      Estimée conformément à l'article 5.4.1.1.3.2 de l'ADR 2023
+      Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de l'ADR
+      2023
     </p>
   );
 }

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -84,8 +84,7 @@ function QuantityFields({ quantity, quantityType }: QuantityFieldsProps) {
         checked={quantityType === QuantityType.ESTIMATED}
         readOnly
       />{" "}
-      Estimée "Quantité estimée conformément à l'article 5.4.1.1.3.2" de l'ADR
-      2023
+      Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
     </p>
   );
 }

--- a/front/src/common/components/EstimatedQuantityTooltip.tsx
+++ b/front/src/common/components/EstimatedQuantityTooltip.tsx
@@ -3,7 +3,9 @@ import Tooltip from "./Tooltip";
 
 const EstimatedQuantityTooltip = () => {
   return (
-    <Tooltip msg="Quantité estimée conformément à l'article 5.4.1.1.3.2 de l'ADR 2023 " />
+    <Tooltip
+      msg={`"Quantité estimée conformément à l'article 5.4.1.1.3.2" de l'ADR 2023 `}
+    />
   );
 };
 


### PR DESCRIPTION
# Contexte

On a des remontées d'utilisateurs qui veulent qu'on soit plus rigoureux sur le texte affiché pour les quantités estimées.

# Démo

Tooltips:
![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/952775a6-7334-4938-8f9e-5afd42ca2ff1)

PDF:
![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/666fc5ce-9bd2-48da-9e6f-00c076c06dc8)

# Ticket Favro

[Wording: mise en conformité ADR2023 sur les quantités estimées](https://favro.com/widget/ab14a4f0460a99a9d64d4945/44f82b6ab4cc0e7edb63c351?card=tra-11095)