### PR TITLE
[tra-12085] BSDA - Correction sur la création re révision

### DIFF
--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
@@ -235,7 +235,7 @@ describe("Mutation.createBsdaRevisionRequest", () => {
     });
 
     expect(errors[0].message).toBe(
-      "Le code déchet n'est pas reconnu comme faisant partie de la liste officielle du code de l'environnement."
+      "Invalid enum value. Expected '06 07 01*' | '06 13 04*' | '10 13 09*' | '16 01 11*' | '16 02 12*' | '17 06 01*' | '17 06 05*' | '08 01 17*' | '08 04 09*' | '12 01 16*' | '15 01 11*' | '15 02 02*' | '16 02 13*' | '16 03 03*' | '17 01 06*' | '17 02 04*' | '17 03 01*' | '17 04 09*' | '17 04 10*' | '17 05 03*' | '17 05 05*' | '17 05 07*' | '17 06 03*' | '17 08 01*' | '17 09 03*', received 'Made up code'"
     );
   });
 

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../__tests__/factories";
 
 import { bsdaFactory } from "../../__tests__/factories";
-import { rawBsdaSchema } from "../schema";
+import { bsdaSchema } from "../schema";
 import { parseBsdaInContext } from "../index";
 import prisma from "../../../prisma";
 
@@ -22,7 +22,7 @@ describe("BSDA validation", () => {
   describe("BSDA should be valid - transitory empty strings", () => {
     test("when type is COLLECTION_2710 and unused company fields are nulls", async () => {
       // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
-      const { success } = await rawBsdaSchema.safeParseAsync({
+      const { success } = await bsdaSchema.safeParseAsync({
         ...bsda,
         type: BsdaType.COLLECTION_2710,
         transporterCompanySiret: null,
@@ -37,7 +37,7 @@ describe("BSDA validation", () => {
 
   describe("BSDA should be valid", () => {
     test("when all data is present", async () => {
-      const { success } = await rawBsdaSchema.safeParseAsync(bsda);
+      const { success } = await bsdaSchema.safeParseAsync(bsda);
       expect(success).toBe(true);
     });
 
@@ -46,7 +46,7 @@ describe("BSDA validation", () => {
         orgId: "BE0541696005",
         vatNumber: "BE0541696005"
       });
-      const { success } = await rawBsdaSchema.safeParseAsync({
+      const { success } = await bsdaSchema.safeParseAsync({
         ...bsda,
         transporterCompanyVatNumber: foreignTransporter.vatNumber,
         transporterCompanyName: "transporteur BE",
@@ -68,7 +68,7 @@ describe("BSDA validation", () => {
         transporterCompanyVatNumber: foreignTransporter.vatNumber
       };
 
-      const { success } = await rawBsdaSchema.safeParseAsync(data);
+      const { success } = await bsdaSchema.safeParseAsync(data);
       expect(success).toBe(true);
     });
 
@@ -108,7 +108,7 @@ describe("BSDA validation", () => {
 
     test("when type is COLLECTION_2710 and unused company fields are empty strings", async () => {
       // on COLLECTION_2710 Bsdas worker and trasporter fields are not used
-      const { success } = await rawBsdaSchema.safeParseAsync({
+      const { success } = await bsdaSchema.safeParseAsync({
         ...bsda,
         type: BsdaType.COLLECTION_2710,
         transporterCompanySiret: "",
@@ -125,7 +125,7 @@ describe("BSDA validation", () => {
         ...bsda,
         emitterCompanySiret: "1"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -141,7 +141,7 @@ describe("BSDA validation", () => {
         ...bsda,
         transporterCompanySiret: "1"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -157,7 +157,7 @@ describe("BSDA validation", () => {
         ...bsda,
         transporterCompanyVatNumber: "FR35552049447"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -215,7 +215,7 @@ describe("BSDA validation", () => {
         trasnporterCompanySiret: null,
         transporterCompanyVatNumber: "IT13029381004"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -236,7 +236,7 @@ describe("BSDA validation", () => {
         ...bsda,
         transporterCompanyVatNumber: company.vatNumber
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -254,7 +254,7 @@ describe("BSDA validation", () => {
         ...bsda,
         destinationCompanySiret: "1"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
 
       if (result.success) {
         throw new Error("Expected error.");
@@ -270,7 +270,7 @@ describe("BSDA validation", () => {
         ...bsda,
         destinationCompanySiret: "85001946400021"
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
       if (result.success) {
         throw new Error("Expected error.");
       }
@@ -286,7 +286,7 @@ describe("BSDA validation", () => {
         ...bsda,
         destinationCompanySiret: company.siret
       };
-      const result = await rawBsdaSchema.safeParseAsync(data);
+      const result = await bsdaSchema.safeParseAsync(data);
       if (result.success) {
         throw new Error("Expected error.");
       }

--- a/back/src/bsda/validation/index.ts
+++ b/back/src/bsda/validation/index.ts
@@ -8,7 +8,7 @@ import {
   getUserFunctions
 } from "./helpers";
 import { checkSealedAndRequiredFields, getSealedFields } from "./rules";
-import { rawBsdaSchema } from "./schema";
+import { bsdaSchema } from "./schema";
 import { runTransformers } from "./transformers";
 
 export type BsdaValidationContext = {
@@ -49,7 +49,7 @@ export async function parseBsdaInContext(
     unparsedBsda
   );
 
-  const contextualSchema = rawBsdaSchema
+  const contextualSchema = bsdaSchema
     .transform(async val => {
       const sealedFields = getSealedFields({
         bsda: val,

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -22,7 +22,7 @@ import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { OPERATIONS, WORKER_CERTIFICATION_ORGANISM } from "./constants";
 import { getOperationModesFromOperationCode } from "../../common/operationModes";
 
-const bsdaPackagingSchema = z
+export const bsdaPackagingSchema = z
   .object({
     type: z.enum([
       "BIG_BAG",
@@ -196,7 +196,8 @@ export const rawBsdaSchema = z
       .superRefine(intermediariesRefinement),
     intermediariesOrgIds: z.array(z.string()).optional()
   })
-  .superRefine((val, ctx) => {
+
+export const bsdaSchema = rawBsdaSchema.superRefine((val, ctx) => {
     if (
       val.destinationReceptionDate &&
       val.destinationOperationDate &&

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -40,164 +40,162 @@ export const bsdaPackagingSchema = z
       "Vous devez saisir la description du conditionnement quand le type de conditionnement est 'Autre'"
   });
 
-export const rawBsdaSchema = z
-  .object({
-    id: z.string().default(() => getReadableId(ReadableIdPrefix.BSDA)),
-    isDraft: z.boolean().default(false),
-    isDeleted: z.boolean().default(false),
-    type: z.nativeEnum(BsdaType).default(BsdaType.OTHER_COLLECTIONS),
-    emitterIsPrivateIndividual: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    emitterCompanyName: z.string().nullish(),
-    emitterCompanySiret: siretSchema.nullish(),
-    emitterCompanyAddress: z.string().nullish(),
-    emitterCompanyContact: z.string().nullish(),
-    emitterCompanyPhone: z.string().nullish(),
-    emitterCompanyMail: z.string().nullish(),
-    emitterCustomInfo: z.string().nullish(),
-    emitterPickupSiteName: z.string().nullish(),
-    emitterPickupSiteAddress: z.string().nullish(),
-    emitterPickupSiteCity: z.string().nullish(),
-    emitterPickupSitePostalCode: z.string().nullish(),
-    emitterPickupSiteInfos: z.string().nullish(),
-    emitterEmissionSignatureAuthor: z.string().nullish(),
-    emitterEmissionSignatureDate: z.coerce.date().nullish(),
-    ecoOrganismeName: z.string().nullish(),
-    ecoOrganismeSiret: siretSchema.nullish(),
-    wasteCode: z.enum(BSDA_WASTE_CODES).nullish(),
-    wasteFamilyCode: z.string().nullish(),
-    wasteMaterialName: z.string().nullish(),
-    wasteConsistence: z.nativeEnum(BsdaConsistence).nullish(),
-    wasteSealNumbers: z.array(z.string()).default([]),
-    wasteAdr: z.string().nullish(),
-    wastePop: z.coerce.boolean().transform(v => Boolean(v)),
-    packagings: z
-      .array(bsdaPackagingSchema)
-      .default([])
-      .transform(val => (val == null ? [] : val)),
-    weightIsEstimate: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    weightValue: z.number().nullish(),
-    brokerCompanyName: z.string().nullish(),
-    brokerCompanySiret: siretSchema.nullish(),
-    brokerCompanyAddress: z.string().nullish(),
-    brokerCompanyContact: z.string().nullish(),
-    brokerCompanyPhone: z.string().nullish(),
-    brokerCompanyMail: z.string().nullish(),
-    brokerRecepisseNumber: z.string().nullish(),
-    brokerRecepisseDepartment: z.string().nullish(),
-    brokerRecepisseValidityLimit: z.coerce.date().nullish(),
-    destinationCompanyName: z.string().nullish(),
-    destinationCompanySiret: siretSchema
-      .nullish()
-      .superRefine(isDestinationRefinement),
-    destinationCompanyAddress: z.string().nullish(),
-    destinationCompanyContact: z.string().nullish(),
-    destinationCompanyPhone: z.string().nullish(),
-    destinationCompanyMail: z.string().nullish(),
-    destinationCap: z.string().nullish(),
-    destinationPlannedOperationCode: z.enum(OPERATIONS).nullish(),
-    destinationCustomInfo: z.string().nullish(),
-    destinationReceptionDate: z.coerce.date().nullish(),
-    destinationReceptionWeight: z.number().nullish(),
-    destinationReceptionAcceptationStatus: z
-      .nativeEnum(WasteAcceptationStatus)
-      .nullish(),
-    destinationReceptionRefusalReason: z.string().nullish(),
-    destinationOperationCode: z.enum(OPERATIONS).nullish(),
-    destinationOperationMode: z.nativeEnum(OperationMode).nullish(),
-    destinationOperationDescription: z.string().nullish(),
-    destinationOperationDate: z.coerce
-      .date()
-      .nullish()
-      .refine(val => !val || val < new Date(), {
-        message: "La date d'opération ne peut pas être dans le futur."
-      }),
-    destinationOperationSignatureAuthor: z.string().nullish(),
-    destinationOperationSignatureDate: z.coerce.date().nullish(),
-    destinationOperationNextDestinationCompanySiret: siretSchema
-      .nullish()
-      .superRefine(isDestinationRefinement),
-    destinationOperationNextDestinationCompanyVatNumber:
-      foreignVatNumberSchema.nullish(),
-    destinationOperationNextDestinationCompanyName: z.string().nullish(),
-    destinationOperationNextDestinationCompanyAddress: z.string().nullish(),
-    destinationOperationNextDestinationCompanyContact: z.string().nullish(),
-    destinationOperationNextDestinationCompanyPhone: z.string().nullish(),
-    destinationOperationNextDestinationCompanyMail: z.string().nullish(),
-    destinationOperationNextDestinationCap: z.string().nullish(),
-    destinationOperationNextDestinationPlannedOperationCode: z
-      .string()
-      .nullish(),
-    transporterCompanyName: z.string().nullish(),
-    transporterCompanySiret: siretSchema.nullish(), // Further verifications done here under in superRefine
-    transporterCompanyAddress: z.string().nullish(),
-    transporterCompanyContact: z.string().nullish(),
-    transporterCompanyPhone: z.string().nullish(),
-    transporterCompanyMail: z.string().nullish(),
-    transporterCompanyVatNumber: foreignVatNumberSchema
-      .nullish()
-      .superRefine(isRegisteredVatNumberRefinement),
-    transporterCustomInfo: z.string().nullish(),
-    transporterRecepisseIsExempted: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    transporterRecepisseNumber: z.string().nullish(),
-    transporterRecepisseDepartment: z.string().nullish(),
-    transporterRecepisseValidityLimit: z.coerce.date().nullish(),
-    transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
-    transporterTransportPlates: z
-      .array(z.string())
-      .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
-      .default([]),
-    transporterTransportTakenOverAt: z.coerce.date().nullish(),
-    transporterTransportSignatureAuthor: z.string().nullish(),
-    transporterTransportSignatureDate: z.coerce.date().nullish(),
-    workerIsDisabled: z.coerce
-      .boolean()
-      .default(false)
-      .nullish()
-      .transform(v => Boolean(v)),
-    workerCompanyName: z.string().nullish(),
-    workerCompanySiret: siretSchema.nullish().superRefine(isWorkerRefinement),
-    workerCompanyAddress: z.string().nullish(),
-    workerCompanyContact: z.string().nullish(),
-    workerCompanyPhone: z.string().nullish(),
-    workerCompanyMail: z.string().nullish(),
-    workerCertificationHasSubSectionFour: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    workerCertificationHasSubSectionThree: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    workerCertificationCertificationNumber: z.string().nullish(),
-    workerCertificationValidityLimit: z.coerce.date().nullish(),
-    workerCertificationOrganisation: z
-      .enum(WORKER_CERTIFICATION_ORGANISM)
-      .nullish(),
-    workerWorkHasEmitterPaperSignature: z.coerce
-      .boolean()
-      .nullish()
-      .transform(v => Boolean(v)),
-    workerWorkSignatureAuthor: z.string().nullish(),
-    workerWorkSignatureDate: z.coerce.date().nullish(),
-    grouping: z.array(z.string()).optional(),
-    forwarding: z.string().nullish(),
-    intermediaries: z
-      .array(intermediarySchema)
-      .nullish()
-      .superRefine(intermediariesRefinement),
-    intermediariesOrgIds: z.array(z.string()).optional()
-  })
+export const rawBsdaSchema = z.object({
+  id: z.string().default(() => getReadableId(ReadableIdPrefix.BSDA)),
+  isDraft: z.boolean().default(false),
+  isDeleted: z.boolean().default(false),
+  type: z.nativeEnum(BsdaType).default(BsdaType.OTHER_COLLECTIONS),
+  emitterIsPrivateIndividual: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  emitterCompanyName: z.string().nullish(),
+  emitterCompanySiret: siretSchema.nullish(),
+  emitterCompanyAddress: z.string().nullish(),
+  emitterCompanyContact: z.string().nullish(),
+  emitterCompanyPhone: z.string().nullish(),
+  emitterCompanyMail: z.string().nullish(),
+  emitterCustomInfo: z.string().nullish(),
+  emitterPickupSiteName: z.string().nullish(),
+  emitterPickupSiteAddress: z.string().nullish(),
+  emitterPickupSiteCity: z.string().nullish(),
+  emitterPickupSitePostalCode: z.string().nullish(),
+  emitterPickupSiteInfos: z.string().nullish(),
+  emitterEmissionSignatureAuthor: z.string().nullish(),
+  emitterEmissionSignatureDate: z.coerce.date().nullish(),
+  ecoOrganismeName: z.string().nullish(),
+  ecoOrganismeSiret: siretSchema.nullish(),
+  wasteCode: z.enum(BSDA_WASTE_CODES).nullish(),
+  wasteFamilyCode: z.string().nullish(),
+  wasteMaterialName: z.string().nullish(),
+  wasteConsistence: z.nativeEnum(BsdaConsistence).nullish(),
+  wasteSealNumbers: z.array(z.string()).default([]),
+  wasteAdr: z.string().nullish(),
+  wastePop: z.coerce.boolean().transform(v => Boolean(v)),
+  packagings: z
+    .array(bsdaPackagingSchema)
+    .default([])
+    .transform(val => (val == null ? [] : val)),
+  weightIsEstimate: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  weightValue: z.number().nullish(),
+  brokerCompanyName: z.string().nullish(),
+  brokerCompanySiret: siretSchema.nullish(),
+  brokerCompanyAddress: z.string().nullish(),
+  brokerCompanyContact: z.string().nullish(),
+  brokerCompanyPhone: z.string().nullish(),
+  brokerCompanyMail: z.string().nullish(),
+  brokerRecepisseNumber: z.string().nullish(),
+  brokerRecepisseDepartment: z.string().nullish(),
+  brokerRecepisseValidityLimit: z.coerce.date().nullish(),
+  destinationCompanyName: z.string().nullish(),
+  destinationCompanySiret: siretSchema
+    .nullish()
+    .superRefine(isDestinationRefinement),
+  destinationCompanyAddress: z.string().nullish(),
+  destinationCompanyContact: z.string().nullish(),
+  destinationCompanyPhone: z.string().nullish(),
+  destinationCompanyMail: z.string().nullish(),
+  destinationCap: z.string().nullish(),
+  destinationPlannedOperationCode: z.enum(OPERATIONS).nullish(),
+  destinationCustomInfo: z.string().nullish(),
+  destinationReceptionDate: z.coerce.date().nullish(),
+  destinationReceptionWeight: z.number().nullish(),
+  destinationReceptionAcceptationStatus: z
+    .nativeEnum(WasteAcceptationStatus)
+    .nullish(),
+  destinationReceptionRefusalReason: z.string().nullish(),
+  destinationOperationCode: z.enum(OPERATIONS).nullish(),
+  destinationOperationMode: z.nativeEnum(OperationMode).nullish(),
+  destinationOperationDescription: z.string().nullish(),
+  destinationOperationDate: z.coerce
+    .date()
+    .nullish()
+    .refine(val => !val || val < new Date(), {
+      message: "La date d'opération ne peut pas être dans le futur."
+    }),
+  destinationOperationSignatureAuthor: z.string().nullish(),
+  destinationOperationSignatureDate: z.coerce.date().nullish(),
+  destinationOperationNextDestinationCompanySiret: siretSchema
+    .nullish()
+    .superRefine(isDestinationRefinement),
+  destinationOperationNextDestinationCompanyVatNumber:
+    foreignVatNumberSchema.nullish(),
+  destinationOperationNextDestinationCompanyName: z.string().nullish(),
+  destinationOperationNextDestinationCompanyAddress: z.string().nullish(),
+  destinationOperationNextDestinationCompanyContact: z.string().nullish(),
+  destinationOperationNextDestinationCompanyPhone: z.string().nullish(),
+  destinationOperationNextDestinationCompanyMail: z.string().nullish(),
+  destinationOperationNextDestinationCap: z.string().nullish(),
+  destinationOperationNextDestinationPlannedOperationCode: z.string().nullish(),
+  transporterCompanyName: z.string().nullish(),
+  transporterCompanySiret: siretSchema.nullish(), // Further verifications done here under in superRefine
+  transporterCompanyAddress: z.string().nullish(),
+  transporterCompanyContact: z.string().nullish(),
+  transporterCompanyPhone: z.string().nullish(),
+  transporterCompanyMail: z.string().nullish(),
+  transporterCompanyVatNumber: foreignVatNumberSchema
+    .nullish()
+    .superRefine(isRegisteredVatNumberRefinement),
+  transporterCustomInfo: z.string().nullish(),
+  transporterRecepisseIsExempted: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  transporterRecepisseNumber: z.string().nullish(),
+  transporterRecepisseDepartment: z.string().nullish(),
+  transporterRecepisseValidityLimit: z.coerce.date().nullish(),
+  transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
+  transporterTransportPlates: z
+    .array(z.string())
+    .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
+    .default([]),
+  transporterTransportTakenOverAt: z.coerce.date().nullish(),
+  transporterTransportSignatureAuthor: z.string().nullish(),
+  transporterTransportSignatureDate: z.coerce.date().nullish(),
+  workerIsDisabled: z.coerce
+    .boolean()
+    .default(false)
+    .nullish()
+    .transform(v => Boolean(v)),
+  workerCompanyName: z.string().nullish(),
+  workerCompanySiret: siretSchema.nullish().superRefine(isWorkerRefinement),
+  workerCompanyAddress: z.string().nullish(),
+  workerCompanyContact: z.string().nullish(),
+  workerCompanyPhone: z.string().nullish(),
+  workerCompanyMail: z.string().nullish(),
+  workerCertificationHasSubSectionFour: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  workerCertificationHasSubSectionThree: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  workerCertificationCertificationNumber: z.string().nullish(),
+  workerCertificationValidityLimit: z.coerce.date().nullish(),
+  workerCertificationOrganisation: z
+    .enum(WORKER_CERTIFICATION_ORGANISM)
+    .nullish(),
+  workerWorkHasEmitterPaperSignature: z.coerce
+    .boolean()
+    .nullish()
+    .transform(v => Boolean(v)),
+  workerWorkSignatureAuthor: z.string().nullish(),
+  workerWorkSignatureDate: z.coerce.date().nullish(),
+  grouping: z.array(z.string()).optional(),
+  forwarding: z.string().nullish(),
+  intermediaries: z
+    .array(intermediarySchema)
+    .nullish()
+    .superRefine(intermediariesRefinement),
+  intermediariesOrgIds: z.array(z.string()).optional()
+});
 
-export const bsdaSchema = rawBsdaSchema.superRefine((val, ctx) => {
+export const bsdaSchema = rawBsdaSchema
+  .superRefine((val, ctx) => {
     if (
       val.destinationReceptionDate &&
       val.destinationOperationDate &&


### PR DESCRIPTION
- Il ne devrait pas être possible de valider la révision d'un BSDA lorsqu'on ne saisit pas de nouvelles valeurs
- les controles de types devraient être effectués (cf packagings)

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12085)
