### PR TITLE
Fix BsdasriMetadata error crash with null ValidationError.path

### DIFF
--- a/back/src/bsdasris/resolvers/Metadata.ts
+++ b/back/src/bsdasris/resolvers/Metadata.ts
@@ -5,6 +5,7 @@ import {
 } from "../../generated/graphql/types";
 import { getBsdasriOrNotFound } from "../database";
 import { validateBsdasri, getRequiredFor } from "../validation";
+import { ValidationError } from "yup";
 
 const bsdasriMetadataResolvers: BsdasriMetadataResolvers = {
   errors: async (metadata: BsdasriMetadata & { id: string }) => {
@@ -19,9 +20,9 @@ const bsdasriMetadataResolvers: BsdasriMetadataResolvers = {
       });
       return [];
     } catch (errors) {
-      return errors.inner?.map(e => ({
+      return errors.inner?.map((e: ValidationError) => ({
         message: e.message,
-        path: e.path,
+        path: e.path ?? "",
         requiredFor: getRequiredFor(e.path)
       }));
     }

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -731,7 +731,7 @@ export const select = (arr: string[], truthTable: boolean[]): string[] =>
 /**
  * Return wich operation requires the given path to be filled
  */
-export const getRequiredFor = (path: string) => {
+export const getRequiredFor = (path: string | undefined) => {
   const emission = Object.keys(
     emitterSchema({}).concat(emissionSchema({})).describe().fields
   );
@@ -744,7 +744,7 @@ export const getRequiredFor = (path: string) => {
 
   const operation = Object.keys(operationSchema({}).describe().fields);
   const truthTable = [emission, transport, reception, operation].map(el =>
-    el.includes(path)
+    path ? el.includes(path) : false
   );
   const steps = [
     "EMISSION",


### PR DESCRIPTION
```
Error: Cannot return null for non-nullable field BsdasriError.path.
    at completeValue (/app/node_modules/graphql/execution/execute.js:594:13)
    at executeField (/app/node_modules/graphql/execution/execute.js:489:19)
    at executeFields (/app/node_modules/graphql/execution/execute.js:413:20)
    at completeObjectValue (/app/node_modules/graphql/execution/execute.js:914:10)
    at completeValue (/app/node_modules/graphql/execution/execute.js:635:12)
    at /app/node_modules/graphql/execution/execute.js:696:25
    at Function.from (<anonymous>)
```