### PR TITLE
[tra-13000] Hotfix searchCompanies isRegistered and missing data

### DIFF
--- a/back/src/companies/__tests__/search.integration.ts
+++ b/back/src/companies/__tests__/search.integration.ts
@@ -1,0 +1,114 @@
+import { resetDatabase } from "../../../integration-tests/helper";
+import { companyFactory, siretify } from "../../__tests__/factories";
+import { makeSearchCompanies, searchCompany } from "../search";
+import { SireneSearchResult } from "../sirene/types";
+import { CompanySearchResult } from "../types";
+
+const mockSearchCompanyBackend = jest.fn();
+jest.mock("../sirene/searchCompany", () => ({
+  __esModule: true,
+  default: (...args) => mockSearchCompanyBackend(...args)
+}));
+
+describe("searchCompanies(clue, department, allowForeignCompanies) }", () => {
+  const searchCompaniesMockFn = jest.fn();
+  const searchCompanies = makeSearchCompanies({
+    injectedSearchCompany: searchCompany,
+    injectedSearchCompanies: searchCompaniesMockFn
+  });
+
+  beforeEach(() => {
+    searchCompaniesMockFn.mockReset();
+  });
+
+  afterEach(async () => {
+    await resetDatabase();
+  });
+
+  it("should search by string clue, merging info from SIRENE and Trackdechets DB, including isRegistered and trackdechetsId", async () => {
+    const company = await companyFactory();
+    searchCompaniesMockFn.mockResolvedValueOnce([
+      {
+        siret: company.siret,
+        name: company.name,
+        address: "4 BD LONGCHAMP 13001 MARSEILLE",
+        addressCity: "MARSEILLE",
+        addressPostalCode: "13000",
+        addressVoie: "4 BD LONGCHAMP",
+        codeCommune: undefined,
+        libelleNaf: "Programmation informatique",
+        naf: "6201Z",
+        etatAdministratif: "A",
+        statutDiffusionEtablissement: "O",
+        codePaysEtrangerEtablissement: undefined
+      }
+    ] as SireneSearchResult[]);
+
+    const companies = await searchCompanies("Code en Stock");
+    expect(companies).toHaveLength(1);
+    expect(companies[0].isRegistered).toBeTruthy();
+    expect(companies[0].trackdechetsId).toBe(company.id);
+  });
+
+  it("should search by SIRET, merging SIRENE and Trackdechets DB infos, including isRegistered and trackdechetsId", async () => {
+    const company = await companyFactory();
+    mockSearchCompanyBackend.mockResolvedValueOnce({
+      orgId: company.siret,
+      siret: company.siret,
+      denominationUniteLegale: company.name,
+      name: company.name,
+      numeroVoieEtablissement: "4",
+      typeVoieEtablissement: "BD",
+      libelleVoieEtablissement: "LONGCHAMP",
+      codePostalEtablissement: "13001",
+      libelleCommuneEtablissement: "MARSEILLE",
+      activitePrincipaleEtablissement: "6201Z",
+      address: "4 BD LONGCHAMP 13001 MARSEILLE",
+      addressCity: "MARSEILLE",
+      addressPostalCode: "13000",
+      addressVoie: "4 BD LONGCHAMP",
+      codeCommune: undefined,
+      libelleNaf: "Programmation informatique",
+      naf: "6201Z",
+      etatAdministratif: "A",
+      statutDiffusionEtablissement: "O",
+      codePaysEtrangerEtablissement: undefined
+    } as CompanySearchResult);
+
+    const companies = await searchCompanies(company.orgId!);
+    expect(companies).toHaveLength(1);
+    expect(companies[0].isRegistered).toBeTruthy();
+    expect(companies[0].trackdechetsId).toBe(company.id);
+  });
+
+  it("should search by SIRET, event without Trackdechets DB infos, including isRegistered and trackdechetsId", async () => {
+    const siret = siretify();
+    mockSearchCompanyBackend.mockResolvedValueOnce({
+      orgId: siret,
+      siret: siret,
+      denominationUniteLegale: "company.name",
+      name: "company.name",
+      numeroVoieEtablissement: "4",
+      typeVoieEtablissement: "BD",
+      libelleVoieEtablissement: "LONGCHAMP",
+      codePostalEtablissement: "13001",
+      libelleCommuneEtablissement: "MARSEILLE",
+      activitePrincipaleEtablissement: "6201Z",
+      address: "4 BD LONGCHAMP 13001 MARSEILLE",
+      addressCity: "MARSEILLE",
+      addressPostalCode: "13000",
+      addressVoie: "4 BD LONGCHAMP",
+      codeCommune: undefined,
+      libelleNaf: "Programmation informatique",
+      naf: "6201Z",
+      etatAdministratif: "A",
+      statutDiffusionEtablissement: "O",
+      codePaysEtrangerEtablissement: undefined
+    } as CompanySearchResult);
+
+    const companies = await searchCompanies(siret);
+    expect(companies).toHaveLength(1);
+    expect(companies[0].isRegistered).toBeFalsy();
+    expect(companies[0].trackdechetsId).toBeUndefined();
+  });
+});

--- a/back/src/companies/__tests__/sirenify.test.ts
+++ b/back/src/companies/__tests__/sirenify.test.ts
@@ -3,10 +3,7 @@ import { AuthType } from "@prisma/client";
 import { CompanyInput } from "../../generated/graphql/types";
 import buildSirenify, { searchCompanyFailFast } from "../sirenify";
 
-const searchCompanySpy = jest.spyOn(
-  require("../../companies/search"),
-  "searchCompany"
-);
+const searchCompanySpy = jest.spyOn(require("../search"), "searchCompany");
 
 type Input = { company: CompanyInput };
 

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -4,7 +4,6 @@ import redundantCachedSearchSirene from "./sirene/searchCompany";
 import decoratedSearchCompanies from "./sirene/searchCompanies";
 import { CompanySearchResult } from "./types";
 import { searchVat } from "./vat";
-import { convertUrls } from "./database";
 import {
   isSiret,
   isVat,
@@ -41,7 +40,7 @@ export const mergeCompanyToCompanySearchResult = (
   companyInfo: SireneSearchResult | CompanyVatSearchResult | null
 ): CompanySearchResult => ({
   orgId,
-  // ensure compatibility with CompanyPublic
+  // expose only some of db Company
   siret: trackdechetsCompanyInfo?.siret,
   name: trackdechetsCompanyInfo?.name,
   address: trackdechetsCompanyInfo?.address,
@@ -50,48 +49,51 @@ export const mergeCompanyToCompanySearchResult = (
   contact: trackdechetsCompanyInfo?.contact,
   contactEmail: trackdechetsCompanyInfo?.contactEmail,
   contactPhone: trackdechetsCompanyInfo?.contactPhone,
+  website: trackdechetsCompanyInfo?.website,
+  ecoOrganismeAgreements:
+    trackdechetsCompanyInfo?.ecoOrganismeAgreements?.map(a => new URL(a)) ?? [],
   allowBsdasriTakeOverWithoutSignature:
     trackdechetsCompanyInfo?.allowBsdasriTakeOverWithoutSignature,
-  ecoOrganismeAgreements: [],
+  // specific data for CompanySearchResult
   isRegistered: trackdechetsCompanyInfo != null,
   trackdechetsId: trackdechetsCompanyInfo?.id,
-  ...(trackdechetsCompanyInfo != null && {
-    ...convertUrls(trackdechetsCompanyInfo)
-  }),
   // override database infos with Sirene or VAT search
   ...companyInfo
 });
+
+const companySelectedFields = {
+  id: true,
+  orgId: true,
+  siret: true,
+  name: true,
+  address: true,
+  vatNumber: true,
+  companyTypes: true,
+  contact: true,
+  contactEmail: true,
+  contactPhone: true,
+  website: true,
+  ecoOrganismeAgreements: true,
+  allowBsdasriTakeOverWithoutSignature: true
+};
+
 /**
  * Search database and merge with company info from search engines
  */
 async function findCompanyAndMergeInfos(
-  cleanClue: string,
+  orgId: string,
   companyInfo: SireneSearchResult | CompanyVatSearchResult | null
 ): Promise<CompanySearchResult> {
   const where = {
-    where: { orgId: cleanClue }
+    where: { orgId }
   };
 
   const trackdechetsCompanyInfo = await prisma.company.findUnique({
     ...where,
-    select: {
-      id: true,
-      orgId: true,
-      siret: true,
-      name: true,
-      address: true,
-      vatNumber: true,
-      companyTypes: true,
-      contact: true,
-      contactEmail: true,
-      contactPhone: true,
-      website: true,
-      ecoOrganismeAgreements: true,
-      allowBsdasriTakeOverWithoutSignature: true
-    }
+    select: companySelectedFields
   });
   return mergeCompanyToCompanySearchResult(
-    cleanClue,
+    orgId,
     trackdechetsCompanyInfo,
     companyInfo
   );
@@ -199,25 +201,49 @@ export const makeSearchCompanies =
             [c]
               // Exclude closed companies
               .filter(c => c.etatAdministratif && c.etatAdministratif === "A")
-              // Exclude anonymous company not registered in TD
-              .filter(
-                c => c.statutDiffusionEtablissement !== "N" || c.isRegistered
-              )
           );
         })
         .catch(_ => []);
     }
     // fuzzy searching only for French companies
-    return injectedSearchCompanies(clue, department).then(async results => {
-      if (!results) {
-        return [];
-      }
+    return injectedSearchCompanies(clue, department).then(
+      async resultsInsee => {
+        if (!resultsInsee) {
+          return [];
+        }
+        const orgIds = resultsInsee.map(r => r.siret as string);
+        // Initialize an object with all orgIds set to null
+        const companies = orgIds.reduce((acc, id) => {
+          acc[id] = null;
+          return acc;
+        }, {} as { [key: number]: any | null });
+        // Find all existing Companies in DB
+        const companiesInDb = await prisma.company.findMany({
+          where: {
+            orgId: { in: orgIds }
+          },
+          select: companySelectedFields
+        });
+        // Populate the object with the fetched organizations
+        companiesInDb.forEach(org => {
+          companies[org.orgId] = org;
+        });
 
-      return results.map(company => ({
-        ...company,
-        orgId: company.siret!
-      }));
-    });
+        return resultsInsee.map(companyInsee => ({
+          ...(companies[companyInsee.siret!]
+            ? mergeCompanyToCompanySearchResult(
+                companyInsee.siret!,
+                companies[companyInsee.siret!],
+                companyInsee
+              )
+            : {
+                ...companyInsee,
+                orgId: companyInsee.siret!,
+                isRegistered: false
+              })
+        }));
+      }
+    );
   };
 
 /**

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -9,6 +9,7 @@ import { AnonymousCompanyError, SiretNotFoundError } from "../errors";
 import { format } from "date-fns";
 
 const SIRENE_API_BASE_URL = "https://api.insee.fr/entreprises/sirene/V3";
+export const SEARCH_COMPANIES_MAX_SIZE = 20;
 
 /**
  * Build a company object from a search response
@@ -149,7 +150,7 @@ export function searchCompanies(
   // the date parameter allows to apply the filter on current period
   const q = `${filters.join(" AND ")} &date=${today}`;
 
-  const searchUrl = `${SIRENE_API_BASE_URL}/siret?q=${q}`;
+  const searchUrl = `${SIRENE_API_BASE_URL}/siret?q=${q}&nombre=${SEARCH_COMPANIES_MAX_SIZE}`;
 
   // API docs https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=Sirene&version=V3&provider=insee#!/Etablissement/findSiretByQ
   // Nombre d'éléments demandés dans la réponse, défaut 20

--- a/back/src/companies/sirene/searchCompany.ts
+++ b/back/src/companies/sirene/searchCompany.ts
@@ -24,6 +24,8 @@ const decoratedSearchCompany = cache<SireneSearchResult | null>(
   redundant(...searchCompanyProviders)
 );
 
-export default function searchCompany(siret: string) {
+export default function searchCompany(
+  siret: string
+): Promise<SireneSearchResult | null> {
   return decoratedSearchCompany(siret);
 }

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -10,6 +10,7 @@ import {
   SearchStockEtablissement
 } from "./types";
 import client from "./esClient";
+import { SEARCH_COMPANIES_MAX_SIZE } from "../insee/client";
 
 const { ResponseError } = errors;
 /**
@@ -208,7 +209,7 @@ export const searchCompanies = (
   const searchRequest: SearchOptions = {
     ...options,
     _source_excludes: "td_search_companies",
-    size: 20,
+    size: SEARCH_COMPANIES_MAX_SIZE,
     index,
     body: {
       // QueryDSL docs https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html


### PR DESCRIPTION
# Modifier la valeur null de isRegistered et trackdechetsId de la query searchCompanies (API)

- Ajouts des informations de la DB trackdechets dans la recherche floue de la query searchCompanies(), désormais authentifiée, et toujours limitée à 20 résultats.

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/76620/fda758b6-998d-44e6-88a6-5ff8dafaba62)
![image](https://github.com/MTES-MCT/trackdechets/assets/76620/2a4715bf-5467-4aea-a621-aaf5a38dbbd0)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13000)
