### PR TITLE
[TRA-13028] Tests end-to-end avec Playwright

### DIFF
--- a/front/.github/workflows/playwright.yml
+++ b/front/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -28,3 +28,13 @@ yarn-error.log*
 # generated files
 /src/generated
 /public/dsfr/
+
+# Playwright files
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/front/e2e/registration.spec.ts
+++ b/front/e2e/registration.spec.ts
@@ -1,0 +1,16 @@
+import { test } from "@playwright/test";
+
+test("User ONE should be able to register", async ({ page }) => {
+  await page.goto("http://trackdechets.local/login");
+  await page.getByLabel("Email").click();
+  await page.getByRole("link", { name: "Créer un compte" }).click();
+  await page.getByLabel("Nom et prénom").click();
+  await page.getByLabel("Nom et prénom").fill("User ONE");
+  await page.getByLabel("Nom et prénom").press("Tab");
+  await page.getByLabel("Email").fill("user.one@beta.gouv.fr");
+  await page.getByLabel("Email").press("Tab");
+  await page.getByLabel("Mot de passe", { exact: true }).click();
+  await page.getByLabel("Mot de passe", { exact: true }).fill("Tr4ckDeChEt7!");
+  await page.getByText("Je certifie avoir lu les conditions générales").click();
+  await page.getByRole("button", { name: "Créer mon compte" }).click();
+});

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -69,6 +69,7 @@
         "@graphql-codegen/typescript": "^3.0.2",
         "@graphql-codegen/typescript-operations": "^3.0.2",
         "@graphql-codegen/typescript-resolvers": "^3.1.1",
+        "@playwright/test": "^1.39.0",
         "@storybook/addon-a11y": "^7.0.17",
         "@storybook/addon-actions": "^7.0.17",
         "@storybook/addon-essentials": "^7.0.17",
@@ -4641,6 +4642,21 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
       "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
       "dev": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.7",
@@ -16816,6 +16832,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -22552,6 +22582,36 @@
       "integrity": "sha512-lmOWYQ7s9KOUJ1R+YTOR3HrjdbxIS2Z4de0P/Jx2dQPteznJl2eX3tXxKClpvbfyGP59B5bbhW8ftN59HbbFSg==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/polished": {

--- a/front/package.json
+++ b/front/package.json
@@ -108,6 +108,7 @@
     "@graphql-codegen/typescript": "^3.0.2",
     "@graphql-codegen/typescript-operations": "^3.0.2",
     "@graphql-codegen/typescript-resolvers": "^3.1.1",
+    "@playwright/test": "^1.39.0",
     "@storybook/addon-a11y": "^7.0.17",
     "@storybook/addon-actions": "^7.0.17",
     "@storybook/addon-essentials": "^7.0.17",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,0 +1,67 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: false,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});


### PR DESCRIPTION
# Contexte

Afin de réduire le temps de recettage, notamment au niveau des checklists standards BSDs, et d'améliorer la couverture de test, cette PR vise à ajouter Playwright au repo.

Ticket Favro

[Etudier la faisabilité des tests end-to-end](https://favro.com/widget/ab14a4f0460a99a9d64d4945/44f82b6ab4cc0e7edb63c351?card=tra-13028)
