### PR TITLE
Fix Fronted Crash in BSDD action

### DIFF
--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -356,7 +356,7 @@ const ActBsddValidation = ({
     if (bsd.currentTransporterSiret === currentSiret) {
       if (
         // there are no segments yet, current transporter can create one
-        lastSegment === null ||
+        !lastSegment ||
         // the last segment was taken over and current user is the current transporter
         // which means there are no pending transfers so they can create a new segment
         lastSegment.takenOverAt

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -97,7 +97,7 @@ export function WorkflowAction(props: WorkflowActionProps) {
       if (form.currentTransporterSiret === siret) {
         if (
           // there are no segments yet, current transporter can create one
-          lastSegment == null ||
+          !lastSegment ||
           // the last segment was taken over and current user is the current transporter
           // which means there are no pending transfers so they can create a new segment
           lastSegment.takenOverAt


### PR DESCRIPTION
# Search for code `if(e.currentTransporterSiret===a){if(F===null||F.takenOverAt` and replace `lastSegment == null` with `!lastSegment`

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/71405/events/8d0b167bc35445f1bf237e1981a0f2fc/?project=20&referrer=issue-list&statsPeriod=14d)
