### PR TITLE
Hotfix validation sur le mode de traitement BSDA, pas obligatoire avant la signature OPERATION

### DIFF
--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -451,7 +451,29 @@ describe("BSDA validation", () => {
         const res = await parseBsdaInContext(
           { persisted: data as any },
           {
-            currentSignatureType: "OPERATION"
+            currentSignatureType: "EMISSION"
+          }
+        );
+        expect(res).not.toBeUndefined();
+      }
+    );
+
+    test.each([
+      ["R 5", "REUTILISATION"],
+      ["R 13", undefined]
+    ])(
+      "should work if operation code & mode are compatible (code: %p, mode: %p)",
+      async (code, mode) => {
+        const data = {
+          ...bsda,
+          destinationOperationCode: code,
+          destinationOperationMode: mode
+        };
+
+        const res = await parseBsdaInContext(
+          { persisted: data as any },
+          {
+            currentSignatureType: "TRANSPORT"
           }
         );
         expect(res).not.toBeUndefined();
@@ -486,6 +508,22 @@ describe("BSDA validation", () => {
       }
     );
 
+    test("should not fail if operation code has associated operation modes but none is specified", async () => {
+      const data = {
+        ...bsda,
+        destinationOperationCode: "R 5",
+        destinationOperationMode: undefined
+      };
+
+      expect.assertions(1);
+
+      const res = await parseBsdaInContext(
+        { persisted: data as any },
+        { currentSignatureType: "EMISSION" }
+      );
+      expect(res).not.toBeUndefined();
+    });
+
     test("should fail if operation code has associated operation modes but none is specified", async () => {
       const data = {
         ...bsda,
@@ -503,7 +541,7 @@ describe("BSDA validation", () => {
       } catch (err) {
         expect(err.errors.length).toBeTruthy();
         expect(err.errors[0].message).toBe(
-          "Vous devez préciser un mode de traitement"
+          "Le mode de traitement est obligatoire."
         );
       }
     });

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -5,6 +5,7 @@ import { ZodBsda } from "./schema";
 import { isForeignVat } from "../../common/constants/companySearchHelpers";
 import { capitalize } from "../../common/strings";
 import { getUserFunctions } from "./helpers";
+import { getOperationModesFromOperationCode } from "../../common/operationModes";
 
 export type EditableBsdaFields = Required<
   Omit<
@@ -202,7 +203,22 @@ export const editionRules: EditionRules = {
     required: { from: "OPERATION", when: isNotRefused }
   },
   destinationOperationMode: {
-    sealed: { from: "OPERATION" }
+    readableFieldName: "le mode de traitement",
+    sealed: { from: "OPERATION" },
+    required: {
+      from: "OPERATION",
+      when: bsda => {
+        if (bsda.destinationOperationCode) {
+          const modes = getOperationModesFromOperationCode(
+            bsda.destinationOperationCode
+          );
+          if (modes.length && !bsda.destinationOperationMode) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
   },
   destinationOperationDescription: {
     sealed: { from: "OPERATION" }

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -214,12 +214,7 @@ export const rawBsdaSchema = z
         destinationOperationCode
       );
 
-      if (modes.length && !destinationOperationMode) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Vous devez préciser un mode de traitement"
-        });
-      } else if (
+      if (
         (modes.length &&
           destinationOperationMode &&
           !modes.includes(destinationOperationMode)) ||

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from "yup";
 import { getTransporterReceipt } from "../../bsdasris/recipify";
 import {
   BsvhuMetadata,
@@ -61,10 +62,10 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
         );
         return [];
       } catch (errors) {
-        return errors.inner?.map(e => {
+        return errors.inner?.map((e: ValidationError) => {
           return {
             message: e.message,
-            path: e.path,
+            path: e.path ?? "",
             requiredFor
           };
         });


### PR DESCRIPTION
# Message d'erreur : "Vous devez préciser un mode de traitement" au moment d'enregistrer les modifications d'un BSDA avant signature producteur

Ce champ devrait être requis **qu'à** la signature exutoire/"OPERATION"


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13127)
