### PR TITLE
Rendre impossible la suppression d'un transporteur via la mutation `deleteFormTransporter` si celui-ci a déjà signé le BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,20 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2023.11.1]
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+- Rendre impossible la suppression d'un transporteur BSDD via la mutation `deleteFormTransporter` si celui-ci a déjà signé le BSDD [PR 2836](https://github.com/MTES-MCT/trackdechets/pull/2836)
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :house: Interne
+
 # [2023.10.2] 31/10/2023
 
 #### :rocket: Nouvelles fonctionnalités
@@ -57,7 +71,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
-- Optimisation appendixForms : pré-calcul de quantityGrouped [PR 2701](https://github.com/MTES-MCT/trackdechets/pull/2701) 
+- Optimisation appendixForms : pré-calcul de quantityGrouped [PR 2701](https://github.com/MTES-MCT/trackdechets/pull/2701)
 - Suppression du script `npm run queue:obliterate` [PR 2475](https://github.com/MTES-MCT/trackdechets/pull/2475)
 
 # [2023.9.1] 19/09/2023

--- a/back/src/forms/resolvers/mutations/deleteFormTransporter.ts
+++ b/back/src/forms/resolvers/mutations/deleteFormTransporter.ts
@@ -1,4 +1,6 @@
+import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
+// import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
 import {
@@ -16,6 +18,11 @@ const deleteFormTransporterResolver: MutationResolvers["deleteFormTransporter"] 
 
     // TODO this should be done in a transaction
     if (transporter.formId) {
+      if (transporter.takenOverAt) {
+        throw new UserInputError(
+          `Ce transporteur BSDD ne peut-être supprimé car il a déjà signé l'enlèvement du déchet`
+        );
+      }
       const form = await getFormOrFormNotFound({ id: transporter.formId });
       const transporters = await getTransporters({ id: form.id });
       await checkCanUpdate(user, form, {

--- a/back/src/forms/resolvers/mutations/deleteFormTransporter.ts
+++ b/back/src/forms/resolvers/mutations/deleteFormTransporter.ts
@@ -1,6 +1,5 @@
 import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
-// import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
 import {


### PR DESCRIPTION


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Rendre impossible la suppression d'un transporteur via la mutation deleteFormTransporter, si celui-ci a déjà signé le BSDD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13085)
