### PR TITLE
[TRA-12400] Ajout d'un bouton de déconnexion pour le protocole Oauth2

### DIFF
--- a/doc/docs/guides/oauth2.md
+++ b/doc/docs/guides/oauth2.md
@@ -71,7 +71,7 @@ Les arguments suivants doivent être passés en "query string" de la requête (C
 
 - `client_id={client_id}`: L'identifiant de l'application cliente
 - `response_type=code`
-- `redirect_url={redirect_uri}`: URL de redirection
+- `redirect_uri={redirect_uri}`: URL de redirection
 
 Exemple: `https://app.trackdechets.beta.gouv.fr/oauth2/authorize/dialog?response_type=code&redirect_uri=https://client.example.com/cb&client_id=ck7d66y9s00x20784u4u7fp8l`
 

--- a/front/src/oauth/Oauth2Dialog.tsx
+++ b/front/src/oauth/Oauth2Dialog.tsx
@@ -3,6 +3,7 @@ import { IconCheckCircle1 } from "../Apps/common/Components/Icons/Icons";
 import Loader from "../Apps/common/Components/Loader/Loaders";
 import styles from "./Dialog.module.scss";
 import { useOAuth2, AuthorizePayload } from "./use-oauth2";
+import { localAuthService } from "../login/auth.service";
 
 export default function Oauth2Dialog() {
   const { VITE_API_ENDPOINT } = import.meta.env;
@@ -33,7 +34,26 @@ export default function Oauth2Dialog() {
         <IconCheckCircle1 size="40px" />
         <img src="/trackdechets.png" alt="trackdechets" width="100px" />
       </div>
-      <h4 className="text-center">Autoriser {client.name}</h4>
+      <div className="tw-flex tw-justify-between tw-mt-4">
+        <h4 className="text-center">Autoriser {client.name}</h4>
+        <form
+            className={styles.headerConnexion}
+            name="logout"
+            action={`${VITE_API_ENDPOINT}/logout`}
+            method="post"
+          >
+            <button
+              className={`${styles.headerConnexion} btn btn--sqr`}
+              onClick={() => {
+                localAuthService.locallySignOut();
+                document.forms["logout"].submit();
+                return false;
+              }}
+            >
+              <span>Se déconnecter</span>
+            </button>
+          </form>
+      </div>
       <div className="panel tw-mt-2">
         <p className="text-center">
           {user.name}, l'application {client.name} souhaite accéder à votre

--- a/front/src/oauth/Oauth2Dialog.tsx
+++ b/front/src/oauth/Oauth2Dialog.tsx
@@ -37,22 +37,22 @@ export default function Oauth2Dialog() {
       <div className="tw-flex tw-justify-between tw-mt-4">
         <h4 className="text-center">Autoriser {client.name}</h4>
         <form
-            className={styles.headerConnexion}
-            name="logout"
-            action={`${VITE_API_ENDPOINT}/logout`}
-            method="post"
+          className={styles.headerConnexion}
+          name="logout"
+          action={`${VITE_API_ENDPOINT}/logout`}
+          method="post"
+        >
+          <button
+            className={`${styles.headerConnexion} btn btn--sqr`}
+            onClick={() => {
+              localAuthService.locallySignOut();
+              document.forms["logout"].submit();
+              return false;
+            }}
           >
-            <button
-              className={`${styles.headerConnexion} btn btn--sqr`}
-              onClick={() => {
-                localAuthService.locallySignOut();
-                document.forms["logout"].submit();
-                return false;
-              }}
-            >
-              <span>Se déconnecter</span>
-            </button>
-          </form>
+            <span>Se déconnecter</span>
+          </button>
+        </form>
       </div>
       <div className="panel tw-mt-2">
         <p className="text-center">


### PR DESCRIPTION
# Contexte

Certains utilisateurs du login Oauth2 réclament la possibilité de pouvoir se déconnecter. 

On ajoute le bouton de déconnexion (comme sur Open ID)

# Démo

![demo_oauth2_deco](https://github.com/MTES-MCT/trackdechets/assets/45355989/4e29f875-9fbc-4480-99de-0b069d4898a5)

# Ticket Favro

[Oauth2: autoriser la déconnexion](https://favro.com/widget/ab14a4f0460a99a9d64d4945/44f82b6ab4cc0e7edb63c351?card=tra-12400)
