### PR TITLE
Hotfix/Validation BSDA

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -1190,8 +1190,8 @@ describe("Mutation.updateBsda", () => {
         transporterCompanySiret: transporter.company.siret,
         destinationOperationNextDestinationCompanySiret:
           destination.company.siret,
-        emitterEmissionSignatureAuthor: "Emit",
-        workerWorkSignatureAuthor: "Work"
+        emitterEmissionSignatureDate: new Date(),
+        workerWorkSignatureDate: new Date()
       }
     });
 

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -72,6 +72,23 @@ describe("BSDA validation", () => {
       expect(success).toBe(true);
     });
 
+    it("transporter recepisse is not required if transport mode is not ROAD", async () => {
+      const data = {
+        ...bsda,
+        transporterRecepisseNumber: null,
+        transporterRecepisseDepartment: null,
+        transporterRecepisseValidityLimit: null,
+        transporterTransportMode: "AIR"
+      };
+
+      await parseBsdaInContext(
+        { persisted: data as any },
+        {
+          currentSignatureType: "TRANSPORT"
+        }
+      );
+    });
+
     it("transporter plate is not required if transport mode is not ROAD", async () => {
       const data = {
         ...bsda,

--- a/back/src/bsda/validation/dynamicRefinements.ts
+++ b/back/src/bsda/validation/dynamicRefinements.ts
@@ -163,7 +163,7 @@ async function validateDestination(
   currentSignatureType: BsdaSignatureType | undefined,
   ctx: RefinementCtx
 ) {
-  // Destination is freeely editable until EMISSION signature.
+  // Destination is freely editable until EMISSION signature.
   // Once transported, destination is not editable for anyone.
   // This is enforced by the sealing rules
   if (

--- a/back/src/bsda/validation/dynamicRefinements.ts
+++ b/back/src/bsda/validation/dynamicRefinements.ts
@@ -1,11 +1,11 @@
 import { Bsda, BsdaStatus } from "@prisma/client";
 import { RefinementCtx, z } from "zod";
 import { isTransporterRefinement } from "../../common/validation/siret";
-import { BsdaSignatureType } from "../../generated/graphql/types";
 import { getReadonlyBsdaRepository } from "../repository";
 import { PARTIAL_OPERATIONS } from "./constants";
 import { BsdaValidationContext } from "./index";
 import { ZodBsda } from "./schema";
+import { BsdaSignatureType } from "../../generated/graphql/types";
 
 export async function applyDynamicRefinement(
   bsda: ZodBsda,
@@ -163,8 +163,9 @@ async function validateDestination(
   currentSignatureType: BsdaSignatureType | undefined,
   ctx: RefinementCtx
 ) {
-  // If the bsda has no signature, fields are freeely editable.
-  // If the bsda is already transported, fields are not editable.
+  // Destination is freeely editable until EMISSION signature.
+  // Once transported, destination is not editable for anyone.
+  // This is enforced by the sealing rules
   if (
     currentSignatureType === undefined ||
     currentSignatureType === "OPERATION"
@@ -189,6 +190,20 @@ async function validateDestination(
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message: `Impossible d'ajouter un intermédiaire d'entreposage provisoire sans indiquer la destination prévue initialement comme destination finale.`,
+      fatal: true
+    });
+  }
+
+  // If we remove a temporary destination, the final destination must remain the same
+  if (
+    currentBsda.destinationOperationNextDestinationCompanySiret &&
+    !bsda.destinationOperationNextDestinationCompanySiret &&
+    bsda.destinationCompanySiret !==
+      currentBsda.destinationOperationNextDestinationCompanySiret
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Impossible de retirer un intermédiaire d'entreposage provisoire sans indiquer la destination finale prévue initialement comme destination.`,
       fatal: true
     });
   }

--- a/back/src/bsda/validation/index.ts
+++ b/back/src/bsda/validation/index.ts
@@ -53,6 +53,7 @@ export async function parseBsdaInContext(
     .transform(async val => {
       const sealedFields = getSealedFields({
         bsda: val,
+        persistedBsda: unparsedInputs.persisted,
         userFunctions,
         signaturesToCheck
       });
@@ -64,7 +65,13 @@ export async function parseBsdaInContext(
     })
     .superRefine(async (val, ctx) => {
       checkSealedAndRequiredFields(
-        { bsda: val, updatedFields, userFunctions, signaturesToCheck },
+        {
+          bsda: val,
+          persistedBsda: unparsedInputs.persisted,
+          updatedFields,
+          userFunctions,
+          signaturesToCheck
+        },
         ctx
       );
 

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -1,4 +1,4 @@
-import { BsdaType, Prisma, WasteAcceptationStatus } from "@prisma/client";
+import { BsdaType, TransportMode, Prisma, WasteAcceptationStatus } from "@prisma/client";
 import { RefinementCtx, z } from "zod";
 import { BsdaSignatureType } from "../../generated/graphql/types";
 import { ZodBsda } from "./schema";
@@ -392,10 +392,7 @@ export const editionRules: EditionRules = {
     sealed: { from: "TRANSPORT" },
     required: {
       from: "TRANSPORT",
-      when: bsda =>
-        hasTransporter(bsda) &&
-        !bsda.transporterRecepisseIsExempted &&
-        !isForeignVat(bsda.transporterCompanyVatNumber),
+      when: requireTransporterRecepisse,
       suffix: "L'établissement doit renseigner son récépissé dans Trackdéchets"
     },
     readableFieldName: "Transporteur: le numéro de récépissé"
@@ -404,10 +401,7 @@ export const editionRules: EditionRules = {
     sealed: { from: "TRANSPORT" },
     required: {
       from: "TRANSPORT",
-      when: bsda =>
-        hasTransporter(bsda) &&
-        !bsda.transporterRecepisseIsExempted &&
-        !isForeignVat(bsda.transporterCompanyVatNumber),
+      when: requireTransporterRecepisse,
       suffix: "L'établissement doit renseigner son récépissé dans Trackdéchets"
     },
     readableFieldName: "Transporteur: le département de récépissé"
@@ -416,10 +410,7 @@ export const editionRules: EditionRules = {
     sealed: { from: "TRANSPORT" },
     required: {
       from: "TRANSPORT",
-      when: bsda =>
-        hasTransporter(bsda) &&
-        !bsda.transporterRecepisseIsExempted &&
-        !isForeignVat(bsda.transporterCompanyVatNumber),
+      when: requireTransporterRecepisse,
       suffix: "L'établissement doit renseigner son récépissé dans Trackdéchets"
     },
     readableFieldName: "Transporteur: la date de validité du récépissé"
@@ -601,6 +592,13 @@ function hasWorker(bsda: ZodBsda) {
 
 function hasTransporter(bsda: ZodBsda) {
   return bsda.type !== BsdaType.COLLECTION_2710;
+}
+
+function requireTransporterRecepisse(bsda: ZodBsda) {
+  return hasTransporter(bsda) &&
+    !bsda.transporterRecepisseIsExempted &&
+    bsda.transporterTransportMode === TransportMode.ROAD &&
+    !isForeignVat(bsda.transporterCompanyVatNumber)
 }
 
 function isRefusedOrPartiallyRefused(bsda: ZodBsda) {

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -1,4 +1,9 @@
-import { BsdaType, TransportMode, Prisma, WasteAcceptationStatus } from "@prisma/client";
+import {
+  BsdaType,
+  TransportMode,
+  Prisma,
+  WasteAcceptationStatus
+} from "@prisma/client";
 import { RefinementCtx, z } from "zod";
 import { BsdaSignatureType } from "../../generated/graphql/types";
 import { ZodBsda } from "./schema";
@@ -595,10 +600,12 @@ function hasTransporter(bsda: ZodBsda) {
 }
 
 function requireTransporterRecepisse(bsda: ZodBsda) {
-  return hasTransporter(bsda) &&
+  return (
+    hasTransporter(bsda) &&
     !bsda.transporterRecepisseIsExempted &&
     bsda.transporterTransportMode === TransportMode.ROAD &&
     !isForeignVat(bsda.transporterCompanyVatNumber)
+  );
 }
 
 function isRefusedOrPartiallyRefused(bsda: ZodBsda) {


### PR DESCRIPTION
2 corrections sur la validation du BSDA:
- ne pas require le recepisse transporteur si le mode de transport n'est pas "ROAD"
- permettre de supprimer un entreposage provisoire après signature producteur. Et améilorer les controles sur qui peut modifier la destination et quand (a été checké en recette par AS) 