### PR TITLE
[tra-12030] BSDA - améliorations sur le groupement

### DIFF
--- a/back/src/bsda/pdf/components/BsdaPdf.tsx
+++ b/back/src/bsda/pdf/components/BsdaPdf.tsx
@@ -406,6 +406,7 @@ export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
           </p>
           <p>
             <strong>Code déchet : {bsda?.waste?.code}</strong>
+            <strong>Nom du matériau : {bsda?.waste?.materialName}</strong>
           </p>
           <p className="TextAlignCenter">
             <strong>

--- a/back/src/bsda/pdf/components/TraceabilityTable.tsx
+++ b/back/src/bsda/pdf/components/TraceabilityTable.tsx
@@ -10,10 +10,10 @@ export function TraceabilityTable({ previousBsdas }: Props) {
         <tr>
           <th>Identifiant</th>
           <th>Niveau</th>
-          <th>Code déchet</th>
-          <th>Dénomination</th>
+          <th>Code famille</th>
+          <th>Nom du matériau</th>
           <th>CAP (exutoire)</th>
-          <th>Quantité (en T)</th>
+          <th>Quantité (en t)</th>
           <th>Date de collecte</th>
           <th>Exutoire prévu</th>
         </tr>
@@ -23,7 +23,7 @@ export function TraceabilityTable({ previousBsdas }: Props) {
           <tr key={bsda.id}>
             <td>{bsda?.id}</td>
             <td>{bsda?.type === "OTHER_COLLECTIONS" ? 1 : 2}</td>
-            <td>{bsda?.waste?.code}</td>
+            <td>{bsda?.waste?.familyCode}</td>
             <td>{bsda?.waste?.materialName}</td>
             <td>
               {bsda?.destination?.operation?.nextDestination?.cap ??

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -377,6 +377,45 @@ describe("BSDA validation", () => {
         }
       }
     );
+
+    it("cannot group BSDA if the grouped waste code are not equal to the grouping BSDA waste code", async () => {
+      const grouping = [
+        await bsdaFactory({
+          opt: {
+            wasteCode: "10 13 09*",
+            status: "AWAITING_CHILD",
+            destinationOperationCode: "D 15",
+            destinationCompanySiret: bsda.emitterCompanySiret
+          }
+        })
+      ];
+      expect.assertions(1);
+
+      const data = {
+        ...bsda,
+        type: "GATHERING"
+      };
+
+      try {
+        await parseBsdaInContext(
+          {
+            input: {
+              waste: { code: "17 05 03*" },
+              grouping: grouping.map(bsda => bsda.id)
+            },
+            persisted: data as any
+          },
+          { enablePreviousBsdasChecks: true }
+        );
+      } catch (error) {
+        expect(error.issues).toEqual([
+          expect.objectContaining({
+            message:
+              "Tous les bordereaux groupés doivent avoir le même code déchet que le bordereau de groupement."
+          })
+        ]);
+      }
+    });
   });
 
   describe("Emitter transports own waste", () => {

--- a/back/src/bsda/validation/dynamicRefinements.ts
+++ b/back/src/bsda/validation/dynamicRefinements.ts
@@ -102,6 +102,20 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
     return z.NEVER;
   }
 
+  if (
+    bsda.type === "GATHERING" &&
+    previousBsdasWithDestination.some(
+      previousBsda => previousBsda.wasteCode !== bsda.wasteCode
+    )
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Tous les bordereaux groupés doivent avoir le même code déchet que le bordereau de groupement.`,
+      fatal: true
+    });
+    return z.NEVER;
+  }
+
   for (const previousBsda of previousBsdas) {
     if (previousBsda.status === BsdaStatus.PROCESSED) {
       ctx.addIssue({

--- a/front/src/dashboard/detail/bsda/InitialBsdas.tsx
+++ b/front/src/dashboard/detail/bsda/InitialBsdas.tsx
@@ -19,8 +19,10 @@ export function InitialBsdas({ bsdas }: { bsdas: InitialBsda[] }) {
         <TableRow>
           <TableHeaderCell>Identifiant</TableHeaderCell>
           <TableHeaderCell>Code déchet</TableHeaderCell>
+          <TableHeaderCell>Nom du matériau</TableHeaderCell>
+          <TableHeaderCell>Code famille</TableHeaderCell>
           <TableHeaderCell>CAP (exutoire)</TableHeaderCell>
-          <TableHeaderCell>Quantité (en T)</TableHeaderCell>
+          <TableHeaderCell>Quantité (en t)</TableHeaderCell>
           <TableHeaderCell>Exutoire prévu</TableHeaderCell>
           <TableHeaderCell>Télécharger</TableHeaderCell>
         </TableRow>
@@ -29,9 +31,9 @@ export function InitialBsdas({ bsdas }: { bsdas: InitialBsda[] }) {
         {bsdas.map(bsda => (
           <TableRow key={bsda.id}>
             <TableCell>{bsda.id}</TableCell>
-            <TableCell>
-              {bsda.waste?.code} {bsda.waste?.materialName}
-            </TableCell>
+            <TableCell>{bsda.waste?.code}</TableCell>
+            <TableCell>{bsda.waste?.materialName}</TableCell>
+            <TableCell>{bsda.waste?.familyCode}</TableCell>
             <TableCell>
               {bsda.destination?.operation?.nextDestination?.cap ??
                 bsda.destination?.cap}

--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -56,6 +56,7 @@ export function BsdaPicker({ name, bsdaId }: Props) {
   const isForwardingPicker = name === "forwarding";
 
   function onGroupingChange(groupedBsdas: Bsda[]) {
+    setFieldValue("waste.code", groupedBsdas?.[0]?.waste?.code ?? "");
     setFieldValue(
       "weight.value",
       groupedBsdas?.reduce(
@@ -211,7 +212,8 @@ function PickerTable({
           <TableRow>
             <TableHeaderCell />
             <TableHeaderCell>Numéro</TableHeaderCell>
-            <TableHeaderCell>Déchet</TableHeaderCell>
+            <TableHeaderCell>Code déchet</TableHeaderCell>
+            <TableHeaderCell>Nom du matériau</TableHeaderCell>
             <TableHeaderCell>Poids reçu (tonnes)</TableHeaderCell>
             <TableHeaderCell>Émetteur</TableHeaderCell>
             <TableHeaderCell>CAP final</TableHeaderCell>
@@ -220,13 +222,18 @@ function PickerTable({
         </TableHead>
         <TableBody>
           {bsdas.map(bsda => {
-            const getNextDestinationSiret = b =>
-              b?.destination?.operation?.nextDestination?.company?.siret;
-            const isDisabled =
+            const firstSelectedBsda =
               Array.isArray(selected) &&
               selected.length > 0 &&
-              getNextDestinationSiret(bsdas.find(b => b.id === selected[0])) !==
-                getNextDestinationSiret(bsda);
+              bsdas.find(b => b.id === selected[0]);
+            const getNextDestinationSiret = b =>
+              b?.destination?.operation?.nextDestination?.company?.siret;
+
+            const isDisabled =
+              firstSelectedBsda &&
+              (getNextDestinationSiret(firstSelectedBsda) !==
+                getNextDestinationSiret(bsda) ||
+                bsda.waste?.code !== firstSelectedBsda?.waste?.code);
 
             return (
               <TableRow
@@ -243,9 +250,8 @@ function PickerTable({
                   />
                 </TableCell>
                 <TableCell>{bsda.id}</TableCell>
-                <TableCell>
-                  {bsda.waste?.code} - {bsda.waste?.materialName ?? "inconnue"}
-                </TableCell>
+                <TableCell>{bsda.waste?.code}</TableCell>
+                <TableCell>{bsda.waste?.materialName ?? "inconnu"}</TableCell>
                 <TableCell>{bsda.destination?.reception?.weight}</TableCell>
                 <TableCell>{bsda.emitter?.company?.name}</TableCell>
                 <TableCell>

--- a/front/src/form/bsda/stepper/steps/WasteInfo.tsx
+++ b/front/src/form/bsda/stepper/steps/WasteInfo.tsx
@@ -23,6 +23,7 @@ export function WasteInfo({ disabled }) {
     siret
   );
   const isEntreposageProvisoire = values?.type === BsdaType.Reshipment;
+  const isGrouping = values?.type === BsdaType.Gathering;
 
   if (isEntreposageProvisoire) {
     return (
@@ -49,7 +50,7 @@ export function WasteInfo({ disabled }) {
           as="select"
           name="waste.code"
           className="td-select"
-          disabled={disabledAfterEmission}
+          disabled={disabledAfterEmission || isGrouping}
         >
           <option />
           {BSDA_WASTES.map(item => (


### PR DESCRIPTION
Groupement BSDA, ne permettre de sélectionner que des BSDA ayant le même code déchet et la même destination

https://github.com/MTES-MCT/trackdechets/assets/5145523/35afe128-8441-4607-9293-469b495f52b7


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12030)
