### PR TITLE
[tra-12963] Révisions - Fix d'affichage

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsda/approve/BsdaApproveRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsda/approve/BsdaApproveRevision.tsx
@@ -246,12 +246,15 @@ export function DisplayRevision({ review }: Props) {
         label="Code d'opération réalisée"
         bsddValue={review.bsda.destination?.operation?.code}
         reviewValue={
-          review.content.destination?.operation?.code +
-          (review.content.destination?.operation?.mode
-            ? ` (${getOperationModeLabel(
+          [
+            review.content.destination?.operation?.code,
+            review.content.destination?.operation?.mode &&
+              `(${getOperationModeLabel(
                 review.content.destination?.operation?.mode ?? ""
               )})`
-            : "")
+          ]
+            .filter(Boolean)
+            .join(" ") || null
         }
       />
 

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddApproveRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/approve/BsddApproveRevision.tsx
@@ -257,12 +257,15 @@ export function DisplayRevision({ review }: Props) {
         label="Opération réalisée"
         bsddValue={review.form.processingOperationDone}
         reviewValue={
-          review.content.processingOperationDone +
-          (review.content.destinationOperationMode
-            ? ` (${getOperationModeLabel(
+          [
+            review.content.processingOperationDone,
+            review.content.destinationOperationMode &&
+              `(${getOperationModeLabel(
                 review.content.destinationOperationMode ?? ""
               )})`
-            : "")
+          ]
+            .filter(Boolean)
+            .join(" ") || null
         }
       />
 


### PR DESCRIPTION
Le champ opération réalisée s'affichait à tort sur les révisions même lorsqu'il était vide.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12963)
