### PR TITLE
[tra-12959] BSDD - Numéro d'échantillon éditable

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteTransportSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteTransportSummary.tsx
@@ -183,8 +183,7 @@ export function FormWasteTransportSummary({
             </DataListDescription>
           )}
         </DataListItem>
-        {form.emitter?.type === EmitterType.Appendix1Producer &&
-          form.wasteDetails?.code &&
+        {form.wasteDetails?.code &&
           SAMPLE_NUMBER_WASTE_CODES.includes(form.wasteDetails.code) && (
             <DataListItem>
               <DataListTerm>Numéro d'échantillon</DataListTerm>

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -695,10 +695,10 @@ export default function BSDDetailContent({
               <dt>Code onu</dt>
               <dd>{form?.stateSummary?.onuCode}</dd>
               <dt>POP</dt> <dd>{form.wasteDetails?.pop ? "Oui" : "Non"}</dd>
-              {form?.emitter?.type === EmitterType.Appendix1Producer && (
+              {form?.wasteDetails?.sampleNumber && (
                 <>
                   <dt>Numéro d'échantillon</dt>
-                  <dd>{form?.wasteDetails?.sampleNumber}</dd>
+                  <dd>{form.wasteDetails.sampleNumber}</dd>
                 </>
               )}
             </div>


### PR DESCRIPTION
Le numéro d'échantillon devient disponible en dehors des annexes 1 si le code déchet fait partie de la liste de codes éligibles

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12959)
