### PR TITLE
[TRA-13111] Corrections diverses sur les operation modes

### DIFF
--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -522,6 +522,23 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
+    test.only("should work if operation mode is missing but step is not operation",
+      async () => {
+        const data = {
+          ...bsdasri,
+          destinationOperationCode: "D9",
+          destinationOperationMode: undefined, // Correct mode is ELIMINATION
+          destinationOperationDate: new Date(),
+          destinationReceptionWasteWeightValue: 10
+        };
+
+        const res = await validateBsdasri(data as any, {
+          transportSignature: true
+        });
+        expect(res).not.toBeUndefined();
+      }
+    );
+
     test.each([
       ["D9", "VALORISATION_ENERGETIQUE"], // Correct mode is ELIMINATION
       ["R12", "VALORISATION_ENERGETIQUE"] // R12 has no associated mode

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -522,7 +522,7 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
-    test.only("should work if operation mode is missing but step is not operation",
+    test("should work if operation mode is missing but step is not operation",
       async () => {
         const data = {
           ...bsdasri,

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -522,22 +522,20 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
-    test("should work if operation mode is missing but step is not operation",
-      async () => {
-        const data = {
-          ...bsdasri,
-          destinationOperationCode: "D9",
-          destinationOperationMode: undefined, // Correct mode is ELIMINATION
-          destinationOperationDate: new Date(),
-          destinationReceptionWasteWeightValue: 10
-        };
+    test("should work if operation mode is missing but step is not operation", async () => {
+      const data = {
+        ...bsdasri,
+        destinationOperationCode: "D9",
+        destinationOperationMode: undefined, // Correct mode is ELIMINATION
+        destinationOperationDate: new Date(),
+        destinationReceptionWasteWeightValue: 10
+      };
 
-        const res = await validateBsdasri(data as any, {
-          transportSignature: true
-        });
-        expect(res).not.toBeUndefined();
-      }
-    );
+      const res = await validateBsdasri(data as any, {
+        transportSignature: true
+      });
+      expect(res).not.toBeUndefined();
+    });
 
     test.each([
       ["D9", "VALORISATION_ENERGETIQUE"], // Correct mode is ELIMINATION

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -33,7 +33,7 @@ import {
   WeightUnits,
   transporterRecepisseSchema
 } from "../common/validation";
-import { getOperationModesFromOperationCode } from "../common/operationModes";
+import { destinationOperationModeValidation } from "../common/validation/operationMode";
 
 const wasteCodes = DASRI_WASTE_CODES.map(el => el.code);
 
@@ -650,43 +650,7 @@ export const operationSchema: FactorySchemaOf<
           return true;
         }
       ),
-    destinationOperationMode: yup
-      .mixed<OperationMode | null | undefined>()
-      .oneOf([...Object.values(OperationMode), null, undefined])
-      .nullable()
-      .test(
-        "processing-mode-matches-processing-operation",
-        "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
-        function (item) {
-          if (!context.operationSignature) return true;
-
-          const { destinationOperationCode } = this.parent;
-          const destinationOperationMode = item;
-
-          if (destinationOperationCode) {
-            const modes = getOperationModesFromOperationCode(
-              destinationOperationCode
-            );
-
-            if (modes.length && !destinationOperationMode) {
-              return new yup.ValidationError(
-                "Vous devez préciser un mode de traitement"
-              );
-            } else if (
-              (modes.length &&
-                destinationOperationMode &&
-                !modes.includes(destinationOperationMode)) ||
-              (!modes.length && destinationOperationMode)
-            ) {
-              return new yup.ValidationError(
-                "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
-              );
-            }
-          }
-
-          return true;
-        }
-      ),
+    destinationOperationMode: destinationOperationModeValidation(context),
     destinationOperationDate: yup
       .date()
       .label("Date de traitement")

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -34,7 +34,6 @@ import {
   transporterRecepisseSchema
 } from "../common/validation";
 import { getOperationModesFromOperationCode } from "../common/operationModes";
-import { ContextLines } from "@sentry/node/types/integrations";
 
 const wasteCodes = DASRI_WASTE_CODES.map(el => el.code);
 

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -659,7 +659,7 @@ export const operationSchema: FactorySchemaOf<
         "processing-mode-matches-processing-operation",
         "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
         function (item) {
-          if(!context.operationSignature) return true;
+          if (!context.operationSignature) return true;
 
           const { destinationOperationCode } = this.parent;
           const destinationOperationMode = item;

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -34,6 +34,7 @@ import {
   transporterRecepisseSchema
 } from "../common/validation";
 import { getOperationModesFromOperationCode } from "../common/operationModes";
+import { ContextLines } from "@sentry/node/types/integrations";
 
 const wasteCodes = DASRI_WASTE_CODES.map(el => el.code);
 
@@ -658,6 +659,8 @@ export const operationSchema: FactorySchemaOf<
         "processing-mode-matches-processing-operation",
         "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
         function (item) {
+          if(!context.operationSignature) return true;
+
           const { destinationOperationCode } = this.parent;
           const destinationOperationMode = item;
 

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -1,9 +1,4 @@
-import {
-  WasteAcceptationStatus,
-  Prisma,
-  BsdasriType,
-  OperationMode
-} from "@prisma/client";
+import { WasteAcceptationStatus, Prisma, BsdasriType } from "@prisma/client";
 import { isCollector } from "../companies/validation";
 import * as yup from "yup";
 import {

--- a/back/src/bsffs/__tests__/validation.integration.ts
+++ b/back/src/bsffs/__tests__/validation.integration.ts
@@ -351,6 +351,20 @@ describe("transporterSchema", () => {
       expect(isValid).toBe(false);
     });
   });
+
+  it("should succeed if operation mode is missing because step is not operation", async () => {
+    const bsff = {
+      ...transporterData,
+      operationCode: "R1",
+      operationMode: undefined
+    };
+
+    expect.assertions(1);
+
+    const isValid = await transporterSchema.isValid(bsff);
+
+    expect(isValid).toBe(true);
+  });
 });
 
 describe("destinationSchema", () => {

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -375,8 +375,23 @@ describe("BSVHU validation", () => {
       expect(res).not.toBeUndefined();
     });
 
+    test("should work if operation mode is missing but step is not operation", async () => {
+      const data = {
+        ...bsvhu,
+        destinationOperationCode: "D 9",
+        destinationOperationMode: undefined,  // Correct modes is ELIMINATION
+        destinationReceptionWeight: 10,
+        destinationReceptionAcceptationStatus: "ACCEPTED"
+      };
+
+      const res = await validateBsvhu(data as any, {
+        transportSignature: true
+      });
+      expect(res).not.toBeUndefined();
+    });
+
     test.each([
-      ["D 9", OperationMode.VALORISATION_ENERGETIQUE], // Correct modes are ELIMINATION
+      ["D 9", OperationMode.VALORISATION_ENERGETIQUE], // Correct modes is ELIMINATION
       ["R 12", OperationMode.VALORISATION_ENERGETIQUE] // R12 has no associated mode
     ])(
       "should not be valid if operation mode is not compatible with operation code (mode: %p, code: %p)",

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -379,7 +379,7 @@ describe("BSVHU validation", () => {
       const data = {
         ...bsvhu,
         destinationOperationCode: "D 9",
-        destinationOperationMode: undefined,  // Correct modes is ELIMINATION
+        destinationOperationMode: undefined, // Correct modes is ELIMINATION
         destinationReceptionWeight: 10,
         destinationReceptionAcceptationStatus: "ACCEPTED"
       };

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -2,8 +2,7 @@ import {
   Prisma,
   BsvhuIdentificationType,
   BsvhuPackaging,
-  WasteAcceptationStatus,
-  OperationMode
+  WasteAcceptationStatus
 } from "@prisma/client";
 import { PROCESSING_OPERATIONS_CODES } from "shared/constants";
 import {

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -198,7 +198,7 @@ const destinationSchema: FactorySchemaOf<
         "processing-mode-matches-processing-operation",
         "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
         function (item) {
-          if(!context.operationSignature) return true;
+          if (!context.operationSignature) return true;
 
           const { destinationOperationCode } = this.parent;
           const destinationOperationMode = item;

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -198,6 +198,8 @@ const destinationSchema: FactorySchemaOf<
         "processing-mode-matches-processing-operation",
         "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
         function (item) {
+          if(!context.operationSignature) return true;
+
           const { destinationOperationCode } = this.parent;
           const destinationOperationMode = item;
 

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -28,7 +28,7 @@ import {
   WeightUnits,
   transporterRecepisseSchema
 } from "../common/validation";
-import { getOperationModesFromOperationCode } from "../common/operationModes";
+import { destinationOperationModeValidation } from "../common/validation/operationMode";
 
 type Emitter = Pick<
   Prisma.BsvhuCreateInput,
@@ -190,43 +190,7 @@ const destinationSchema: FactorySchemaOf<
         context.operationSignature,
         `Destinataire: l'opération réalisée est obligatoire`
       ),
-    destinationOperationMode: yup
-      .mixed<OperationMode | null | undefined>()
-      .oneOf([...Object.values(OperationMode), null, undefined])
-      .nullable()
-      .test(
-        "processing-mode-matches-processing-operation",
-        "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
-        function (item) {
-          if (!context.operationSignature) return true;
-
-          const { destinationOperationCode } = this.parent;
-          const destinationOperationMode = item;
-
-          if (destinationOperationCode) {
-            const modes = getOperationModesFromOperationCode(
-              destinationOperationCode
-            );
-
-            if (modes.length && !destinationOperationMode) {
-              return new yup.ValidationError(
-                "Vous devez préciser un mode de traitement"
-              );
-            } else if (
-              (modes.length &&
-                destinationOperationMode &&
-                !modes.includes(destinationOperationMode)) ||
-              (!modes.length && destinationOperationMode)
-            ) {
-              return new yup.ValidationError(
-                "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
-              );
-            }
-          }
-
-          return true;
-        }
-      ),
+    destinationOperationMode: destinationOperationModeValidation(context),
     destinationPlannedOperationCode: yup
       .string()
       .oneOf([...PROCESSING_OPERATIONS_CODES, null, ""])

--- a/back/src/common/validation/operationMode.ts
+++ b/back/src/common/validation/operationMode.ts
@@ -1,0 +1,42 @@
+import * as yup from "yup";
+import { OperationMode } from "@prisma/client";
+import { getOperationModesFromOperationCode } from "../operationModes";
+
+export const destinationOperationModeValidation = context =>
+  yup
+    .mixed<OperationMode | null | undefined>()
+    .oneOf([...Object.values(OperationMode), null, undefined])
+    .nullable()
+    .test(
+      "processing-mode-matches-processing-operation",
+      "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
+      function (item) {
+        if (!context.operationSignature) return true;
+
+        const { destinationOperationCode } = this.parent;
+        const destinationOperationMode = item;
+
+        if (destinationOperationCode) {
+          const modes = getOperationModesFromOperationCode(
+            destinationOperationCode
+          );
+
+          if (modes.length && !destinationOperationMode) {
+            return new yup.ValidationError(
+              "Vous devez préciser un mode de traitement"
+            );
+          } else if (
+            (modes.length &&
+              destinationOperationMode &&
+              !modes.includes(destinationOperationMode)) ||
+            (!modes.length && destinationOperationMode)
+          ) {
+            return new yup.ValidationError(
+              "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
+            );
+          }
+        }
+
+        return true;
+      }
+    );

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1737,7 +1737,7 @@ describe("processedInfoSchema", () => {
         processedAt: new Date(),
         processedBy: "Test",
         processingOperationDescription: "test",
-        processingOperationDone: "R 2", 
+        processingOperationDone: "R 2",
         destinationOperationMode: undefined, // Should be REUTILISATION
         ...receivedInfo
       };

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1721,6 +1721,30 @@ describe("processedInfoSchema", () => {
       expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
     });
 
+    it.only("should be valid if operationMode is missing but step is not process", async () => {
+      const receivedInfo: ReceivedFormInput = {
+        wasteAcceptationStatus: "ACCEPTED",
+        quantityReceived: 12.5,
+        wasteRefusalReason: "",
+        receivedBy: "Jim",
+        receivedAt: new Date("2020-01-17T10:12:00+0100"),
+        signedAt: new Date("2020-01-17T10:12:00+0100")
+      };
+
+      const bsdd = {
+        nextDestination: null,
+        noTraceability: null,
+        processedAt: new Date(),
+        processedBy: "Test",
+        processingOperationDescription: "test",
+        processingOperationDone: "R 2", 
+        destinationOperationMode: undefined, // Should be REUTILISATION
+        ...receivedInfo
+      };
+
+      expect(await receivedInfoSchema.isValid(bsdd)).toEqual(true);
+    });
+
     test.each([
       ["D9", "VALORISATION_ENERGETIQUE"], // Correct modes are ELIMINATION
       ["R12", "VALORISATION_ENERGETIQUE"] // R12 has no associated mode

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -18,9 +18,9 @@ const OperationModeSelect = ({ operationCode, name }) => {
   useEffect(() => {
     // If the available modes change, and only ONE option is available,
     // select it by default. Else, reset the selection
-    if(modes.length > 1) {
+    if (modes.length > 1) {
       setFieldValue(name, undefined);
-    }else{
+    } else {
       setFieldValue(name, modes[0]);
     }
   }, [modes, name, setFieldValue]);

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -7,22 +7,23 @@ import {
   getOperationModesFromOperationCode
 } from "../operationModes";
 import Tooltip from "./Tooltip";
-import { deepValue } from "../../dashboard/detail/common/utils";
 
 const OperationModeSelect = ({ operationCode, name }) => {
-  const { setFieldValue, values } = useFormikContext();
+  const { setFieldValue } = useFormikContext();
   const modes = useMemo(
     () => getOperationModesFromOperationCode(operationCode),
     [operationCode]
   );
 
   useEffect(() => {
-    const value = deepValue(values, name);
-
-    if (!value || !modes.includes(value)) {
+    // If the available modes change, and only ONE option is available,
+    // select it by default. Else, reset the selection
+    if(modes.length > 1) {
+      setFieldValue(name, undefined);
+    }else{
       setFieldValue(name, modes[0]);
     }
-  }, [modes, name, setFieldValue, values]);
+  }, [modes, name, setFieldValue]);
 
   if (!modes.length) return null;
 


### PR DESCRIPTION
# Contexte

Corrections de quelques bugs sur la sélection des modes de traitement:
- l'operationMode n'est obligatoire qu'à la signature de traitement
- UI: par défaut les modes ne sont pas sélectionnés, sauf s'il n'y en a qu'un seul de disponible

# Démo

![demo_operation_modes_select](https://github.com/MTES-MCT/trackdechets/assets/45355989/83db8d5b-fbcc-498f-b9bf-fb5acb8f8700)

# Ticket Favro

[Message d'erreur lors publication d'un BSDASRI dupliqué "vous devez renseigner le mode de traitement" ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/44f82b6ab4cc0e7edb63c351?card=tra-13111)
