### PR TITLE
[TRA-11095] Correction sur les quantités estimées dans les PDFs

### DIFF
--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -22,7 +22,7 @@ export function WasteDetails({ waste, weight }: Props) {
       <p>
         Consistance : {waste?.consistence ? CONSISTANCE[waste.consistence] : ""}
         <br />
-        Quantité en tonnes : {weight?.value}{" "}<br />
+        Quantité en tonnes : {weight?.value} <br />
         <input type="checkbox" checked={!weight?.isEstimate} readOnly /> Réelle
         <br />
         <input
@@ -30,7 +30,8 @@ export function WasteDetails({ waste, weight }: Props) {
           checked={Boolean(weight?.isEstimate)}
           readOnly
         />{" "}
-        Estimée<br/>
+        Estimée
+        <br />
         "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
       </p>
     </>

--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -22,7 +22,7 @@ export function WasteDetails({ waste, weight }: Props) {
       <p>
         Consistance : {waste?.consistence ? CONSISTANCE[waste.consistence] : ""}
         <br />
-        Quantité en tonnes : {weight?.value}{" "}
+        Quantité en tonnes : {weight?.value}{" "}<br />
         <input type="checkbox" checked={!weight?.isEstimate} readOnly /> Réelle
         <br />
         <input
@@ -30,7 +30,8 @@ export function WasteDetails({ waste, weight }: Props) {
           checked={Boolean(weight?.isEstimate)}
           readOnly
         />{" "}
-        Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
+        Estimée<br/>
+        "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
       </p>
     </>
   );

--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -226,13 +226,14 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               readOnly
             />{" "}
             réelle
-            <br/>
+            <br />
             <input
               type="checkbox"
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === true}
               readOnly
             />{" "}
-            Estimée<br/>
+            Estimée
+            <br />
             "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
           </div>
         </div>
@@ -368,7 +369,8 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            Estimée<br/>
+            Estimée
+            <br />
             "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
           </div>
         </div>

--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -225,14 +225,15 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === false}
               readOnly
             />{" "}
-            réelle <span> - </span>
+            réelle
+            <br/>
             <input
               type="checkbox"
               checked={bsdasri?.emitter?.emission?.weight?.isEstimate === true}
               readOnly
             />{" "}
-            Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
-            2023
+            Estimée<br/>
+            "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
           </div>
         </div>
         {/* End PRED */}
@@ -367,8 +368,8 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
               }
               readOnly
             />{" "}
-            Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
-            2023
+            Estimée<br/>
+            "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
           </div>
         </div>
         {/* End Transporter */}

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -302,13 +302,15 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
               />{" "}
               Réelle
             </span>{" "}
+            <br/>
             <span>
               <input
                 type="checkbox"
                 defaultChecked={bsff.weight?.isEstimate}
                 readOnly
               />{" "}
-              Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
+              Estimée<br/>
+              "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
               2023
             </span>
           </div>

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -302,16 +302,16 @@ function BsffQuantity({ bsff }: Pick<Props, "bsff">) {
               />{" "}
               Réelle
             </span>{" "}
-            <br/>
+            <br />
             <span>
               <input
                 type="checkbox"
                 defaultChecked={bsff.weight?.isEstimate}
                 readOnly
               />{" "}
-              Estimée<br/>
-              "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR
-              2023
+              Estimée
+              <br />
+              "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
             </span>
           </div>
           <div>Kilogramme(s) : {bsff.weight.value}</div>

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -84,7 +84,8 @@ function QuantityFields({ quantity, quantityType }: QuantityFieldsProps) {
         checked={quantityType === QuantityType.ESTIMATED}
         readOnly
       />{" "}
-      Estimée<br/>
+      Estimée
+      <br />
       "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
     </p>
   );

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -84,7 +84,8 @@ function QuantityFields({ quantity, quantityType }: QuantityFieldsProps) {
         checked={quantityType === QuantityType.ESTIMATED}
         readOnly
       />{" "}
-      Estimée "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
+      Estimée<br/>
+      "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
     </p>
   );
 }


### PR DESCRIPTION
# Contexte

Suite à la demande d'Emmanuel, quelques corrections de layout pour les quantités estimées dans les PDFs

# Démo

### BSDD

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/bb6e5625-86de-4801-9a81-e0c6d79ea6c8)

### BSDA

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/0fde048a-393c-4f8c-b509-21af579014ff)

### BSDASRI

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/cb983440-6f89-4a75-9654-b41140f2ae8f)

### BSFF

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/8dc2a9a9-a2a0-44ef-b74d-d6d0809f4cab)

# Ticket Favro 

[Wording: mise en conformité ADR2023 sur les quantités estimées](https://favro.com/widget/ab14a4f0460a99a9d64d4945/44f82b6ab4cc0e7edb63c351?card=tra-11095)