### PR TITLE
Correction de la documentation: operationMode est obligatoire pour signer l'étape de traitement

### DIFF
--- a/back/src/bsda/typeDefs/bsda.mutations.graphql
+++ b/back/src/bsda/typeDefs/bsda.mutations.graphql
@@ -107,6 +107,7 @@ type Mutation {
     }
     operation {
       code
+      mode
       date
     }
   }

--- a/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
@@ -124,6 +124,7 @@ type Mutation {
         value
       }
       code
+      mode
       date
     }
   }

--- a/back/src/bsffs/typeDefs/bsff.mutations.graphql
+++ b/back/src/bsffs/typeDefs/bsff.mutations.graphql
@@ -195,6 +195,7 @@ type Mutation {
     operation {
       date
       code
+      mode
       description
     }
   }

--- a/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
@@ -89,6 +89,7 @@ type Mutation {
     }
     operation {
       code
+      mode
     }
     agrementNumber
   }


### PR DESCRIPTION
# Contexte

La doc ne mentionne pas l'operationMode comme obligatoire pour signer l'étape de traitement. Correction de cet oubli.

# PR d'origine

[[TRA-12778] Le mode de traitement devient obligatoire pour l'étape de traitement de l'exutoire #2765](https://github.com/MTES-MCT/trackdechets/pull/2765)


