### PR TITLE
[TRA-12704] Améliorations des performances et bugfix des filtres rapides

### DIFF
--- a/back/prisma/scripts/index-bsdasris-indentificationNumbers.ts
+++ b/back/prisma/scripts/index-bsdasris-indentificationNumbers.ts
@@ -19,7 +19,7 @@ export class ReindexBsdasrisWithIdentificationNumbers implements Updater {
     for (const bsdasri of bsdasris) {
       // ~ 5000 bordereaux en prod
       // select count(*) from "default$default"."Bsdasri" where array_length("identificationNumbers", 1) > 0;
-      enqueueUpdatedBsdToIndex(bsdasri.id);
+      await enqueueUpdatedBsdToIndex(bsdasri.id);
     }
   }
 }

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -292,17 +292,17 @@ export const filterPredicates: {
   },
   {
     filterName: FilterName.transporterCustomInfo,
-    where: value => ({ transporter: { customInfo: { _match: value } } }),
+    where: value => ({ transporter: { customInfo: { _match: value } } })
   },
   {
     filterName: FilterName.pickupSiteName,
-    where: value => ({ emitter: { pickupSite: { name: { _match: value } } } }),
+    where: value => ({ emitter: { pickupSite: { name: { _match: value } } } })
   },
   {
     filterName: FilterName.pickupSiteAddress,
     where: value => ({
       emitter: { pickupSite: { address: { _match: value } } }
-    }),
+    })
   },
   {
     filterName: FilterName.tvaIntra,
@@ -329,7 +329,7 @@ export const filterPredicates: {
           ]
         }
       ]
-    }),
+    })
   },
   {
     filterName: FilterName.givenName,
@@ -355,7 +355,7 @@ export const filterPredicates: {
           ]
         }
       ]
-    }),
+    })
   },
   {
     filterName: FilterName.sealNumbers,
@@ -363,7 +363,7 @@ export const filterPredicates: {
       sealNumbers: {
         _itemContains: value
       }
-    }),
+    })
   },
   {
     filterName: FilterName.ficheInterventionNumbers,
@@ -371,7 +371,7 @@ export const filterPredicates: {
       ficheInterventionNumbers: {
         _itemContains: value
       }
-    }),
+    })
   },
   {
     filterName: FilterName.nextDestinationSiret,
@@ -381,7 +381,7 @@ export const filterPredicates: {
           nextDestination: { company: { siret: { _contains: value } } }
         }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.operationCode,
@@ -403,7 +403,7 @@ export const filterPredicates: {
       return {
         destination: { operation: { code: { _contains: value } } }
       };
-    },
+    }
   },
   {
     filterName: FilterName.emitterSignDate,
@@ -411,7 +411,7 @@ export const filterPredicates: {
       emitter: {
         emission: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.workerSignDate,
@@ -419,7 +419,7 @@ export const filterPredicates: {
       worker: {
         work: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.transporterTransportSignDate,
@@ -429,7 +429,7 @@ export const filterPredicates: {
           takenOverAt: { _lte: value.endDate, _gte: value.startDate }
         }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.destinationReceptionDate,
@@ -437,7 +437,7 @@ export const filterPredicates: {
       destination: {
         reception: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.destinationAcceptationDate,
@@ -445,7 +445,7 @@ export const filterPredicates: {
       destination: {
         acceptation: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.destinationOperationSignDate,
@@ -453,7 +453,7 @@ export const filterPredicates: {
       destination: {
         operation: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.siretProductorAddress,
@@ -461,11 +461,11 @@ export const filterPredicates: {
       emitter: {
         company: { address: { _match: value } }
       }
-    }),
+    })
   },
   {
     filterName: FilterName.cap,
-    where: value => ({ destination: { cap: { _match: value } } }),
+    where: value => ({ destination: { cap: { _match: value } } })
   }
 ];
 

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -44,7 +44,7 @@ import {
 } from "../common/Components/Icons/Icons";
 import { getOperationCodesFromSearchString } from "./dashboardServices";
 import { BsdCurrentTab } from "../common/types/commonTypes";
-import { BsdType, BsdWhere } from "codegen-ui";
+import { BsdType, BsdWhere, OrderBy } from "codegen-ui";
 
 export const MAX_FILTER = 5;
 
@@ -245,12 +245,12 @@ export const filterList = [...advancedFilterList.flat(), ...quickFilterList];
 export const filterPredicates: {
   filterName: string;
   where: (value: any) => BsdWhere;
-  order: string;
+  orderBy?: keyof OrderBy;
 }[] = [
   {
     filterName: FilterName.types,
     where: value => ({ type: { _in: value } }),
-    order: "type"
+    orderBy: "type"
   },
   {
     filterName: FilterName.waste,
@@ -264,7 +264,7 @@ export const filterPredicates: {
         }
       ]
     }),
-    order: "wasteCode"
+    orderBy: "wasteCode"
   },
   {
     filterName: FilterName.readableId,
@@ -282,11 +282,10 @@ export const filterPredicates: {
         }
       ]
     }),
-    order: "readableId"
+    orderBy: "readableId"
   },
   {
     filterName: FilterName.transporterNumberPlate,
-    order: "transporterNumberPlate",
     where: value => ({
       transporter: { transport: { plates: { _itemContains: value } } }
     })
@@ -294,19 +293,16 @@ export const filterPredicates: {
   {
     filterName: FilterName.transporterCustomInfo,
     where: value => ({ transporter: { customInfo: { _match: value } } }),
-    order: "transporterCustomInfo"
   },
   {
     filterName: FilterName.pickupSiteName,
     where: value => ({ emitter: { pickupSite: { name: { _match: value } } } }),
-    order: "name"
   },
   {
     filterName: FilterName.pickupSiteAddress,
     where: value => ({
       emitter: { pickupSite: { address: { _match: value } } }
     }),
-    order: "address"
   },
   {
     filterName: FilterName.tvaIntra,
@@ -334,7 +330,6 @@ export const filterPredicates: {
         }
       ]
     }),
-    order: "vatNumber"
   },
   {
     filterName: FilterName.givenName,
@@ -361,7 +356,6 @@ export const filterPredicates: {
         }
       ]
     }),
-    order: "name"
   },
   {
     filterName: FilterName.sealNumbers,
@@ -370,7 +364,6 @@ export const filterPredicates: {
         _itemContains: value
       }
     }),
-    order: "sealNumbers"
   },
   {
     filterName: FilterName.ficheInterventionNumbers,
@@ -379,7 +372,6 @@ export const filterPredicates: {
         _itemContains: value
       }
     }),
-    order: "sealNumbers"
   },
   {
     filterName: FilterName.nextDestinationSiret,
@@ -390,7 +382,6 @@ export const filterPredicates: {
         }
       }
     }),
-    order: "siret"
   },
   {
     filterName: FilterName.operationCode,
@@ -413,7 +404,6 @@ export const filterPredicates: {
         destination: { operation: { code: { _contains: value } } }
       };
     },
-    order: "code"
   },
   {
     filterName: FilterName.emitterSignDate,
@@ -422,7 +412,6 @@ export const filterPredicates: {
         emission: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
     }),
-    order: "date"
   },
   {
     filterName: FilterName.workerSignDate,
@@ -431,7 +420,6 @@ export const filterPredicates: {
         work: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
     }),
-    order: "date"
   },
   {
     filterName: FilterName.transporterTransportSignDate,
@@ -442,7 +430,6 @@ export const filterPredicates: {
         }
       }
     }),
-    order: "takenOverAt"
   },
   {
     filterName: FilterName.destinationReceptionDate,
@@ -451,7 +438,6 @@ export const filterPredicates: {
         reception: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
     }),
-    order: "date"
   },
   {
     filterName: FilterName.destinationAcceptationDate,
@@ -460,7 +446,6 @@ export const filterPredicates: {
         acceptation: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
     }),
-    order: "date"
   },
   {
     filterName: FilterName.destinationOperationSignDate,
@@ -469,7 +454,6 @@ export const filterPredicates: {
         operation: { date: { _lte: value.endDate, _gte: value.startDate } }
       }
     }),
-    order: "date"
   },
   {
     filterName: FilterName.siretProductorAddress,
@@ -478,12 +462,10 @@ export const filterPredicates: {
         company: { address: { _match: value } }
       }
     }),
-    order: "address"
   },
   {
     filterName: FilterName.cap,
     where: value => ({ destination: { cap: { _match: value } } }),
-    order: "cap"
   }
 ];
 

--- a/front/src/Apps/common/Components/Filters/Filters.tsx
+++ b/front/src/Apps/common/Components/Filters/Filters.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from "react";
 import { FiltersProps } from "./filtersTypes";
 import QuickFilters from "./QuickFilters";
 import AdvancedFilters from "./AdvancedFilters";
+import { isEqual } from "lodash";
 
 import "./filters.scss";
 import {
   advancedFilterList,
   quickFilterList
 } from "../../../Dashboard/dashboardUtils";
-import { deepEqual } from "../../../../dashboard/detail/common/utils";
 
 const purgeEmptyValues = (obj: { [key: string]: string | string[] }) => {
   return JSON.parse(
@@ -44,7 +44,7 @@ const Filters = ({
     });
 
     // If filters have actually changed, bubble up
-    if (!deepEqual(filters, newFilters)) {
+    if (!isEqual(filters, newFilters)) {
       onApplyFilters(newFilters);
       setFilters(newFilters);
     }

--- a/front/src/Apps/common/Components/Filters/Filters.tsx
+++ b/front/src/Apps/common/Components/Filters/Filters.tsx
@@ -8,6 +8,7 @@ import {
   advancedFilterList,
   quickFilterList
 } from "../../../Dashboard/dashboardUtils";
+import { deepEqual } from "../../../../dashboard/detail/common/utils";
 
 const purgeEmptyValues = (obj: { [key: string]: string | string[] }) => {
   return JSON.parse(
@@ -24,6 +25,9 @@ const Filters = ({
   const [advancedFilters, setAdvancedFilters] = useState({});
   const [quickFilters, setQuickFilters] = useState({});
 
+  // Combination & purge of advanced & quick filters
+  const [filters, setFilters] = useState({});
+
   const onApplyAdvancedFilters = filters => {
     setAdvancedFilters(filters);
   };
@@ -33,13 +37,18 @@ const Filters = ({
   };
 
   useEffect(() => {
-    const filters = purgeEmptyValues({
+    // Aggregate quick & advanced filters and remove empty values
+    const newFilters = purgeEmptyValues({
       ...advancedFilters,
       ...quickFilters
     });
 
-    onApplyFilters(filters);
-  }, [advancedFilters, onApplyFilters, quickFilters]);
+    // If filters have actually changed, bubble up
+    if (!deepEqual(filters, newFilters)) {
+      onApplyFilters(newFilters);
+      setFilters(newFilters);
+    }
+  }, [advancedFilters, onApplyFilters, quickFilters, filters]);
 
   return (
     <div className="filters">

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -42,8 +42,8 @@ import { COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS } from "../Apps/common/queries/c
 import "./dashboard.scss";
 import {
   filtersToQueryBsdsArgs,
-  getBlankstateDescription,
-  getBlankstateTitle,
+  getBlankslateDescription,
+  getBlankslateTitle,
   getRoutePredicate,
   Tabs
 } from "./Dashboard.utils";
@@ -425,11 +425,11 @@ const DashboardPage = () => {
       {!Boolean(bsdsTotalCount) && !isLoadingBsds && (
         <div className="dashboard-page__blankstate">
           <Blankslate>
-            {getBlankstateTitle(tabs) && (
-              <BlankslateTitle>{getBlankstateTitle(tabs)}</BlankslateTitle>
+            {getBlankslateTitle(tabs) && (
+              <BlankslateTitle>{getBlankslateTitle(tabs)}</BlankslateTitle>
             )}
             <BlankslateDescription>
-              {getBlankstateDescription(tabs)}
+              {getBlankslateDescription(tabs)}
             </BlankslateDescription>
           </Blankslate>
         </div>

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -286,20 +286,21 @@ const DashboardPage = () => {
             ...wheres
           };
 
-          if(predicate.orderBy) {
+          if (predicate.orderBy) {
             variables.orderBy![predicate.orderBy] = OrderType.Asc;
           }
         }
       });
 
       // Add all the compiled '_and', if any
-      if (_ands.length) variables.where!._and = _ands;
+      if (_ands.length) variables.where._and = _ands;
 
-      if(!Object.keys(variables.orderBy ?? {}).length) delete variables.orderBy;
+      if (!Object.keys(variables.orderBy ?? {}).length)
+        delete variables.orderBy;
 
       // If variables are different, re-fetch the data. Else, don't.
       // Probably a side-effect re-render, should not hammer the API
-      if(!deepEqual(variables, bsdsVariables)){
+      if (!deepEqual(variables, bsdsVariables)) {
         setBsdsVariables(variables);
       }
     },

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -82,7 +82,7 @@ const DashboardPage = () => {
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
   const [bsdsVariables, setBsdsVariables] = useState<QueryBsdsArgs>({
-    first: BSD_PER_PAGE,
+    first: BSD_PER_PAGE
   });
 
   const [bsdsReview, setBsdsReview] = useState<
@@ -97,34 +97,47 @@ const DashboardPage = () => {
     notifyOnNetworkStatusChange: true
   });
 
-  const tabs: Tabs = useMemo(() => ({
-    isActTab,
-    isDraftTab,
-    isFollowTab,
-    isArchivesTab,
-    isToCollectTab,
-    isCollectedTab,
-    isAllBsdsTab,
-    isReviewsTab
-  }), [isActTab, isAllBsdsTab, isArchivesTab, isCollectedTab, isDraftTab, isFollowTab, isReviewsTab, isToCollectTab]);
+  const tabs: Tabs = useMemo(
+    () => ({
+      isActTab,
+      isDraftTab,
+      isFollowTab,
+      isArchivesTab,
+      isToCollectTab,
+      isCollectedTab,
+      isAllBsdsTab,
+      isReviewsTab
+    }),
+    [
+      isActTab,
+      isAllBsdsTab,
+      isArchivesTab,
+      isCollectedTab,
+      isDraftTab,
+      isFollowTab,
+      isReviewsTab,
+      isToCollectTab
+    ]
+  );
 
   // Fetches the BSDs, building up the query. Query includes:
   // - Current company SIRET
   // - Current active tab
   // - Current filters
-  const fetchBsds = useCallback((newSiret, newVariables, newTabs) => {
-    const variables = {
-      ...newVariables
-    };
+  const fetchBsds = useCallback(
+    (newSiret, newVariables, newTabs) => {
+      const variables = { ...newVariables };
 
-    const routePredicate = getRoutePredicate({ ...newTabs, siret: newSiret });
+      const routePredicate = getRoutePredicate({ ...newTabs, siret: newSiret });
 
-    if (routePredicate) {
-      variables.where = { ...newVariables.where, ...routePredicate };
-    }
+      if (routePredicate) {
+        variables.where = { ...newVariables.where, ...routePredicate };
+      }
 
-    lazyFetchBsds({ variables });
-  }, [lazyFetchBsds]);
+      lazyFetchBsds({ variables });
+    },
+    [lazyFetchBsds]
+  );
 
   // Fetch the data again if any of the 3 changes:
   // - Current company SIRET
@@ -148,7 +161,7 @@ const DashboardPage = () => {
     if (tabs.isReviewsTab) {
       setAreAdvancedFiltersOpen(false);
       setBsdsVariables({
-        first: BSD_PER_PAGE,
+        first: BSD_PER_PAGE
       });
     }
   }, [tabs]);
@@ -197,8 +210,8 @@ const DashboardPage = () => {
 
   const siretsWithAutomaticSignature = companyData
     ? companyData.companyPrivateInfos.receivedSignatureAutomations.map(
-      automation => automation.from.siret
-    )
+        automation => automation.from.siret
+      )
     : [];
 
   const loadMoreBsds = React.useCallback(() => {
@@ -366,7 +379,7 @@ const DashboardPage = () => {
     : data?.bsds.totalCount;
   const hasNextPage = isReviewsTab
     ? dataBsdaReviews?.pageInfo?.hasNextPage! ||
-    dataBsddReviews?.pageInfo?.hasNextPage!
+      dataBsddReviews?.pageInfo?.hasNextPage!
     : data?.bsds.pageInfo.hasNextPage;
   const isLoadingBsds = isReviewsTab
     ? loadingBsdaReviews || loadingBsddReviews
@@ -413,9 +426,7 @@ const DashboardPage = () => {
         <div className="dashboard-page__blankstate">
           <Blankslate>
             {getBlankstateTitle(tabs) && (
-              <BlankslateTitle>
-                {getBlankstateTitle(tabs)}
-              </BlankslateTitle>
+              <BlankslateTitle>{getBlankstateTitle(tabs)}</BlankslateTitle>
             )}
             <BlankslateDescription>
               {getBlankstateDescription(tabs)}

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -293,7 +293,7 @@ const DashboardPage = () => {
       });
 
       // Add all the compiled '_and', if any
-      if (_ands.length) variables.where._and = _ands;
+      if (_ands.length) variables.where!._and = _ands;
 
       if (!Object.keys(variables.orderBy ?? {}).length)
         delete variables.orderBy;

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -145,7 +145,10 @@ const DashboardPage = () => {
   // - Current active tab
   // - Current filters
   useEffect(() => {
-    fetchBsds(siret, bsdsVariables, tabs);
+    // Only exception: the reviews tab. Fix incoming
+    if (!tabs.isReviewsTab) {
+      fetchBsds(siret, bsdsVariables, tabs);
+    }
   }, [bsdsVariables, siret, tabs, fetchBsds]);
 
   const handleFiltersSubmit = filterValues => {

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -47,6 +47,7 @@ import {
   getRoutePredicate,
   Tabs
 } from "./Dashboard.utils";
+import { useNotifier } from "../dashboard/components/BSDList/useNotifier";
 
 const DashboardPage = () => {
   const { permissions } = usePermissions();
@@ -165,6 +166,9 @@ const DashboardPage = () => {
       });
     }
   }, [tabs]);
+
+  // Be notified if someone else modifies bsds
+  useNotifier(siret, () => fetchBsds(siret, bsdsVariables, tabs));
 
   const [
     fetchBsdaRevisions,

--- a/front/src/Pages/Dashboard.utils.tsx
+++ b/front/src/Pages/Dashboard.utils.tsx
@@ -14,7 +14,7 @@ import {
   blankstate_reviews_desc,
   blankstate_reviews_title
 } from "../Apps/common/wordings/dashboard/wordingsDashboard";
-import { BsdWhere, OrderType, QueryBsdsArgs } from "../generated/graphql/types";
+import { BsdWhere, OrderType, QueryBsdsArgs } from "codegen-ui";
 import { filterList, filterPredicates } from "../Apps/Dashboard/dashboardUtils";
 
 export type Tabs = {

--- a/front/src/Pages/Dashboard.utils.tsx
+++ b/front/src/Pages/Dashboard.utils.tsx
@@ -96,7 +96,7 @@ export const getRoutePredicate = (props: Tabs & { siret }) => {
   // }
 };
 
-export const getBlankstateTitle = (tabs: Tabs): string | undefined => {
+export const getBlankslateTitle = (tabs: Tabs): string | undefined => {
   const { isActTab, isDraftTab, isFollowTab, isArchivesTab, isReviewsTab } =
     tabs;
 
@@ -118,7 +118,7 @@ export const getBlankstateTitle = (tabs: Tabs): string | undefined => {
   return blankstate_default_title;
 };
 
-export const getBlankstateDescription = ({
+export const getBlankslateDescription = ({
   isActTab,
   isDraftTab,
   isFollowTab,

--- a/front/src/Pages/Dashboard.utils.tsx
+++ b/front/src/Pages/Dashboard.utils.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { IconDuplicateFile } from "../Apps/common/Components/Icons/Icons";
+import {
+  blankstate_action_desc,
+  blankstate_action_title,
+  blankstate_default_desc,
+  blankstate_default_title,
+  blankstate_draft_desc,
+  blankstate_draft_title,
+  blankstate_follow_desc,
+  blankstate_follow_title,
+  blankstate_history_desc,
+  blankstate_history_title,
+  blankstate_reviews_desc,
+  blankstate_reviews_title
+} from "../Apps/common/wordings/dashboard/wordingsDashboard";
+import { BsdWhere, OrderType, QueryBsdsArgs } from "../generated/graphql/types";
+import { filterList, filterPredicates } from "../Apps/Dashboard/dashboardUtils";
+
+export type Tabs = {
+  isActTab;
+  isDraftTab;
+  isFollowTab;
+  isArchivesTab;
+  isToCollectTab;
+  isCollectedTab;
+  isAllBsdsTab;
+  isReviewsTab;
+};
+
+export const getRoutePredicate = (props: Tabs & { siret }) => {
+  const {
+    siret,
+    isActTab,
+    isDraftTab,
+    isFollowTab,
+    isArchivesTab,
+    isToCollectTab,
+    isCollectedTab,
+    isAllBsdsTab
+  } = props;
+
+  if (isActTab) {
+    return {
+      isForActionFor: [siret]
+    };
+  }
+  if (isDraftTab) {
+    return {
+      isDraftFor: [siret]
+    };
+  }
+  if (isFollowTab) {
+    return {
+      isFollowFor: [siret]
+    };
+  }
+  if (isArchivesTab) {
+    return {
+      isArchivedFor: [siret]
+    };
+  }
+  if (isToCollectTab) {
+    return {
+      isToCollectFor: [siret]
+    };
+  }
+  if (isCollectedTab) {
+    return {
+      isCollectedFor: [siret]
+    };
+  }
+  if (isAllBsdsTab) {
+    return {
+      isDraftFor: [siret],
+      isForActionFor: [siret],
+      isFollowFor: [siret],
+      isArchivedFor: [siret]
+    };
+  }
+  // if (isReviewsTab) {
+  //   return {
+  //     isRevisedFor: [siret],
+  //     isInRevisionFor: [siret],
+  //   };
+  // }
+  // if (isToReviewedTab) {
+  //   return {
+  //     isInRevisionFor: [siret],
+  //   };
+  // }
+  // if (isReviewedTab) {
+  //   return {
+  //     isRevisedFor: [siret],
+  //   };
+  // }
+};
+
+export const getBlankstateTitle = (tabs: Tabs): string | undefined => {
+  const { isActTab, isDraftTab, isFollowTab, isArchivesTab, isReviewsTab } =
+    tabs;
+
+  if (isActTab) {
+    return blankstate_action_title;
+  }
+  if (isDraftTab) {
+    return blankstate_draft_title;
+  }
+  if (isFollowTab) {
+    return blankstate_follow_title;
+  }
+  if (isArchivesTab) {
+    return blankstate_history_title;
+  }
+  if (isReviewsTab) {
+    return blankstate_reviews_title;
+  }
+  return blankstate_default_title;
+};
+
+export const getBlankstateDescription = ({
+  isActTab,
+  isDraftTab,
+  isFollowTab,
+  isArchivesTab,
+  isReviewsTab
+}) => {
+  if (isActTab) {
+    return blankstate_action_desc;
+  }
+  if (isDraftTab) {
+    return (
+      <>
+        <span>{blankstate_draft_desc}</span>{" "}
+        <span className="tw-inline-flex tw-ml-1">
+          <IconDuplicateFile color="blueLight" />
+        </span>
+      </>
+    );
+  }
+  if (isFollowTab) {
+    return blankstate_follow_desc;
+  }
+  if (isArchivesTab) {
+    return blankstate_history_desc;
+  }
+  if (isReviewsTab) {
+    return blankstate_reviews_desc;
+  }
+  return blankstate_default_desc;
+};
+
+export const filtersToQueryBsdsArgs = (
+  filterValues,
+  previousBsdsArgs
+) => {
+  const variables: QueryBsdsArgs = {
+    ...previousBsdsArgs,
+    where: {} as BsdWhere,
+    orderBy: {}
+  };
+
+  const filterKeys = Object.keys(filterValues);
+  const filters = filterList.filter(filter => filterKeys.includes(filter.name));
+
+  // Careful. Multiple filters might use '_and', let's not override
+  // it each iteration because of key uniqueness
+  let _ands: BsdWhere[] = [];
+
+  filters.forEach(f => {
+    const predicate = filterPredicates.find(
+      filterPredicate => filterPredicate.filterName === f.name
+    );
+    if (predicate) {
+      const filterValue = filterValues[f.name];
+      const { _and, ...wheres } = predicate.where(filterValue);
+
+      // Store the '_and' filters separately
+      if (_and) _ands = [..._ands, ..._and];
+
+      variables.where = {
+        ...variables.where,
+        ...wheres
+      };
+
+      if (predicate.orderBy) {
+        variables.orderBy![predicate.orderBy] = OrderType.Asc;
+      }
+    }
+  });
+
+  // Add all the compiled '_and', if any
+  if (_ands.length) variables.where!._and = _ands;
+
+  return variables;
+};

--- a/front/src/Pages/Dashboard.utils.tsx
+++ b/front/src/Pages/Dashboard.utils.tsx
@@ -150,10 +150,7 @@ export const getBlankstateDescription = ({
   return blankstate_default_desc;
 };
 
-export const filtersToQueryBsdsArgs = (
-  filterValues,
-  previousBsdsArgs
-) => {
+export const filtersToQueryBsdsArgs = (filterValues, previousBsdsArgs) => {
   const variables: QueryBsdsArgs = {
     ...previousBsdsArgs,
     where: {} as BsdWhere,

--- a/front/src/dashboard/detail/common/utils.tsx
+++ b/front/src/dashboard/detail/common/utils.tsx
@@ -76,12 +76,3 @@ export const deepValue = (obj, path) => {
   }
   return obj;
 };
-
-/**
- * Simple test of deep equality between two objects. Careful, quite fragile as
- * the order of the properties is important
- * https://stackoverflow.com/questions/1068834/object-comparison-in-javascript
- */
-export const deepEqual = (obj1, obj2) => {
-  return JSON.stringify(obj1) === JSON.stringify(obj2);
-};

--- a/front/src/dashboard/detail/common/utils.tsx
+++ b/front/src/dashboard/detail/common/utils.tsx
@@ -78,10 +78,10 @@ export const deepValue = (obj, path) => {
 };
 
 /**
- * Simple test of deep equality between two objects. Careful, quite fragile as 
+ * Simple test of deep equality between two objects. Careful, quite fragile as
  * the order of the properties is important
  * https://stackoverflow.com/questions/1068834/object-comparison-in-javascript
  */
 export const deepEqual = (obj1, obj2) => {
   return JSON.stringify(obj1) === JSON.stringify(obj2);
-}
+};

--- a/front/src/dashboard/detail/common/utils.tsx
+++ b/front/src/dashboard/detail/common/utils.tsx
@@ -76,3 +76,12 @@ export const deepValue = (obj, path) => {
   }
   return obj;
 };
+
+/**
+ * Simple test of deep equality between two objects. Careful, quite fragile as 
+ * the order of the properties is important
+ * https://stackoverflow.com/questions/1068834/object-comparison-in-javascript
+ */
+export const deepEqual = (obj1, obj2) => {
+  return JSON.stringify(obj1) === JSON.stringify(obj2);
+}


### PR DESCRIPTION
# Contexte

Correction de 2 choses:
- Le dashboard v2 faisait 5 calls `GetBsds` inutiles à chaque premier affichage. Fix pour que ça n'en fasse plus qu'un
- Le `orderBy` des filtres rapides ne fonctionnait pas
- ajoute d'un `await` manquant dans un script de migration

# Ticket Favro

[Ajouter les champs de recherche rapide](https://favro.com/widget/ab14a4f0460a99a9d64d4945/e044644940a534f63e06b04d?card=tra-12704)
