### PR TITLE
Fix bsdd update max weight validation

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -2350,6 +2350,49 @@ describe("Mutation.updateForm", () => {
     ]);
   });
 
+  it("should be possible to update a weight > 40 T when transport mode is not ROAD", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const { mutate } = makeClient(user);
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "SEALED",
+        emitterCompanySiret: company.siret,
+        emitterType: EmitterType.APPENDIX2,
+        wasteDetailsCode: "01 03 04*",
+        wasteDetailsQuantity: 10,
+        transporters: {
+          create: {
+            transporterTransportMode: "ROAD",
+            number: 1
+          }
+        }
+      }
+    });
+    const { data } = await mutate<
+      Pick<Mutation, "updateForm">,
+      MutationUpdateFormArgs
+    >(UPDATE_FORM, {
+      variables: {
+        updateFormInput: {
+          id: form.id,
+          wasteDetails: { quantity: 50 },
+          transporter: { mode: "RIVER" }
+        }
+      }
+    });
+    const updatedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: data.updateForm.id },
+      include: { transporters: true }
+    });
+    expect(updatedForm.wasteDetailsQuantity).toEqual(50);
+
+    expect(updatedForm.transporters).toHaveLength(1);
+    expect(updatedForm.transporters[0]?.transporterTransportMode).toEqual(
+      "RIVER"
+    );
+  });
+
   it("should clean appendix1 items on update", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const { company: producerCompany } = await userWithCompanyFactory("MEMBER");

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -120,7 +120,7 @@ const updateFormResolver = async (
         }
       };
       // on remplace le premier transporteur par la fusion du trs en db et du payload
-      // on conserve la chaîne eventuelle de transporteurs caraceratins validations portent sur l'ensemble des transporteurs
+      // on conserve la chaîne eventuelle de transporteurs car certaines validations portent sur l'ensemble des transporteurs
       // (eg. poids max et mode de transport)
       transportersForValidation[0] = {
         ...existingFirstTransporter,

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -118,10 +118,13 @@ const updateFormResolver = async (
           data: transporterData
         }
       };
-      transportersForValidation.push({
+      // on remplace le premier transporteur par la fusion du trs en db et du payload
+      // on conserve la chaîne eventuelle de transporteurs caraceratins validations portent sur l'ensemble des transporteurs
+      // (eg. poids max et mode de transport)
+      transportersForValidation[0] = {
         ...existingFirstTransporter,
         ...transporterData
-      });
+      };
     } else {
       // Aucun transporteur n'a encore été associé, let's create one
       transporters.create = {


### PR DESCRIPTION
Suite recette:

Lors de la modification d'un bsdd, mettre à jour le poids à plus de 40 tonnes et le mode de transport à autre chose que route n'est pas accepté bien que ça soit valide.

Le toast n'apparaît pas: le correctif fera l'objet d'un pr distincte.
 
---

- [Ticket Favro]()
