### PR TITLE
[TRA-13084] Rendre accessibles les champs `takenOverAt` et `takenOverAt` via l'objet `Transporter` (BSDD)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Rendre accessibles les champs `takenOverAt` et `takenOverAt` via l'objet Transporter (BSDD). [PR 2865](https://github.com/MTES-MCT/trackdechets/pull/2865)
+
 #### :house: Interne
 
 # [2023.11.1] 21/11/2023

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -1,4 +1,5 @@
 import {
+  bsddTransporterData,
   formFactory,
   formWithTempStorageFactory,
   userFactory
@@ -10,13 +11,25 @@ import { getFirstTransporter } from "../database";
 describe("expandFormFromDb", () => {
   it("should expand normal form from db", async () => {
     const user = await userFactory();
-    const form = await formFactory({ ownerId: user.id });
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        transporters: {
+          create: {
+            ...bsddTransporterData,
+            number: 1,
+            takenOverAt: new Date("2023-01-01"),
+            takenOverBy: "Roger"
+          }
+        }
+      }
+    });
+    const transporter = await getFirstTransporter(form);
     const fullForm = await prisma.form.findUniqueOrThrow({
       where: { id: form.id },
       include: expandableFormIncludes
     });
-    const transporter = await getFirstTransporter(form);
-    const expanded = await expandFormFromDb(fullForm);
+    const expanded = expandFormFromDb(fullForm);
     expect(expanded).toEqual({
       id: form.id,
       readableId: form.readableId,
@@ -71,7 +84,9 @@ describe("expandFormFromDb", () => {
         validityLimit: transporter!.transporterValidityLimit,
         numberPlate: transporter!.transporterNumberPlate,
         customInfo: transporter!.transporterCustomInfo,
-        mode: transporter!.transporterTransportMode
+        mode: transporter!.transporterTransportMode,
+        takenOverAt: new Date("2023-01-01T00:00:00.000Z"),
+        takenOverBy: "Roger"
       },
       transporters: [
         {
@@ -92,7 +107,9 @@ describe("expandFormFromDb", () => {
           validityLimit: transporter!.transporterValidityLimit,
           numberPlate: transporter!.transporterNumberPlate,
           customInfo: transporter!.transporterCustomInfo,
-          mode: transporter!.transporterTransportMode
+          mode: transporter!.transporterTransportMode,
+          takenOverAt: new Date("2023-01-01T00:00:00.000Z"),
+          takenOverBy: "Roger"
         }
       ],
       wasteDetails: {
@@ -213,7 +230,9 @@ describe("expandFormFromDb", () => {
         validityLimit: transporter!.transporterValidityLimit,
         numberPlate: transporter!.transporterNumberPlate,
         customInfo: null,
-        mode: transporter!.transporterTransportMode
+        mode: transporter!.transporterTransportMode,
+        takenOverAt: null,
+        takenOverBy: null
       },
       emittedAt: null,
       emittedBy: null,
@@ -262,7 +281,9 @@ describe("expandFormFromDb", () => {
       department: transporter!.transporterDepartment,
       validityLimit: transporter!.transporterValidityLimit,
       numberPlate: transporter!.transporterNumberPlate,
-      customInfo: transporter!.transporterCustomInfo
+      customInfo: transporter!.transporterCustomInfo,
+      takenOverAt: null,
+      takenOverBy: null
     });
   });
 
@@ -303,7 +324,9 @@ describe("expandFormFromDb", () => {
       department: transporter!.transporterDepartment,
       validityLimit: transporter!.transporterValidityLimit,
       numberPlate: transporter!.transporterNumberPlate,
-      customInfo: transporter!.transporterCustomInfo
+      customInfo: transporter!.transporterCustomInfo,
+      takenOverAt: null,
+      takenOverBy: null
     });
   });
 });

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -536,7 +536,9 @@ export function expandTransporterFromDb(
       !transporter.transporterCompanySiret &&
       transporter.transporterTransportMode === TransportMode.ROAD
         ? null
-        : transporter.transporterTransportMode
+        : transporter.transporterTransportMode,
+    takenOverAt: transporter.takenOverAt,
+    takenOverBy: transporter.takenOverBy
   });
 }
 

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -414,6 +414,12 @@ type Transporter {
 
   "Mode de transport"
   mode: TransportMode
+
+  "Date de prise en charge"
+  takenOverAt: DateTime
+
+  "Reponsable de la prise en charge"
+  takenOverBy: String
 }
 
 "Destination ultérieure prévue (case 12)"


### PR DESCRIPTION
Les champs `takenOverAt` et `takenOverBy` initialement présent sur `TransportSegment` n'était pas reporté sur `Transporter` ce qui pose problème car on a déprécié l'utilisation de `Form.transportSegments` au profit de `Form.transporters`.

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13084)
