### PR TITLE
[TRA-13188/recette] `Bsda.groupedIn` et `Bsda.forwardedIn` ne se mettent pas à jour sur le tableau de bord en cas de dissociation

### DIFF
--- a/back/src/bsda/repository/bsda/create.ts
+++ b/back/src/bsda/repository/bsda/create.ts
@@ -15,7 +15,12 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
   return async (data, logMetadata?) => {
     const { prisma, user } = deps;
 
-    const bsda = await prisma.bsda.create({ data });
+    const bsda = await prisma.bsda.create({
+      data,
+      include: {
+        grouping: { select: { id: true } }
+      }
+    });
 
     await prisma.event.create({
       data: {
@@ -28,6 +33,25 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
     });
 
     prisma.addAfterCommitCallback(() => enqueueCreatedBsdToIndex(bsda.id));
+
+    // Une optimisation est en place sur le calcul des champs
+    // `Bsda.forwardedIn` et `Bsda.groupedIn` dans la query `bsds`
+    // permettant d'utiliser les valeurs de `forwardedIn` et `groupedIn`
+    // stockés dans ES. Afin que ES reste synchronisé en cas d'update sur le BSDA
+    // de regroupement ou de réexpedition, on est obligé de
+    // réindexer les bordereaux initiaux.
+
+    if (bsda.grouping.length > 0) {
+      for (const { id } of bsda.grouping) {
+        prisma.addAfterCommitCallback(() => enqueueCreatedBsdToIndex(id));
+      }
+    }
+
+    if (bsda.forwardingId) {
+      prisma.addAfterCommitCallback(() =>
+        enqueueCreatedBsdToIndex(bsda.forwardingId!)
+      );
+    }
 
     return bsda;
   };

--- a/back/src/bsda/repository/bsda/update.ts
+++ b/back/src/bsda/repository/bsda/update.ts
@@ -16,11 +16,31 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
 
-    const bsda = await prisma.bsda.update({ where, data });
+    // Une optimisation est en place sur le calcul des champs
+    // `Bsda.forwardedIn` et `Bsda.groupedIn` dans la query `bsds`
+    // permettant d'utiliser les valeurs de `forwardedIn` et `groupedIn`
+    // stockés dans ES. Afin que ES reste synchronisé en cas d'update sur le BSDA
+    // de regroupement ou de réexpedition, on est obligé de
+    // réindexer les bordereaux initiaux.
+    const previousBsdaInclude = {
+      grouping: { select: { id: true } },
+      forwarding: { select: { id: true } }
+    };
+
+    const { grouping, forwarding } = await prisma.bsda.findUniqueOrThrow({
+      where,
+      include: previousBsdaInclude
+    });
+
+    const updatedBsda = await prisma.bsda.update({
+      where,
+      data,
+      include: previousBsdaInclude
+    });
 
     await prisma.event.create({
       data: {
-        streamId: bsda.id,
+        streamId: updatedBsda.id,
         actor: user.id,
         type: bsdaEventTypes.updated,
         data: data as Prisma.InputJsonObject,
@@ -32,7 +52,7 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
     if (data.status) {
       await prisma.event.create({
         data: {
-          streamId: bsda.id,
+          streamId: updatedBsda.id,
           actor: user.id,
           type: bsdaEventTypes.signed,
           data: { status: data.status },
@@ -41,8 +61,45 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
       });
     }
 
-    prisma.addAfterCommitCallback(() => enqueueUpdatedBsdToIndex(bsda.id));
+    prisma.addAfterCommitCallback(() =>
+      enqueueUpdatedBsdToIndex(updatedBsda.id)
+    );
 
-    return bsda;
+    if (data.grouping !== undefined) {
+      // Identifiants des bordereaux regroupés avant l'update
+      const initialGroupedIds = grouping.map(({ id }) => id);
+      // Identifiants des bordereaux regroupés après l'update
+      const groupedIds = updatedBsda.grouping.map(({ id }) => id);
+      // Identifiants des bordereaux qui ont été enlevés du regroupement
+      const removedIds = grouping
+        .map(({ id }) => id)
+        .filter(id => !groupedIds.includes(id));
+      // Identifiants des bordereaux qui ont été ajoutés dans le regroupement
+      const addedIds = updatedBsda.grouping
+        .map(({ id }) => id)
+        .filter(id => !initialGroupedIds.includes(id));
+      // Identifiants des bordereaux qui doivent être réindexés pour que rawBsd.groupedIn
+      // ne soit pas dé-synchronisé
+      const dirtyIds = [...removedIds, ...addedIds];
+      for (const id of dirtyIds) {
+        prisma.addAfterCommitCallback(() => enqueueUpdatedBsdToIndex(id));
+      }
+    }
+
+    if (
+      data.forwarding !== undefined &&
+      forwarding?.id !== updatedBsda.forwardingId
+    ) {
+      // Identifiants des bordereaux qui doivent être réindexés pour que rawBsd.forwardedIn
+      // ne soit pas désynchronisé
+      const dirtyIds = [forwarding?.id, updatedBsda.forwardingId].filter(
+        Boolean
+      );
+      for (const id of dirtyIds) {
+        prisma.addAfterCommitCallback(() => enqueueUpdatedBsdToIndex(id));
+      }
+    }
+
+    return updatedBsda;
   };
 }

--- a/back/src/bsds/typeDefs/private/bsd.queries.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.queries.graphql
@@ -1,4 +1,23 @@
 type Query {
+  """
+  Requête interne multi-bordereaux pour l'affichage du tableau de bord.
+  Les champs suivants sont calculés directement depuis Elasticsearch sans
+  passer par la base de données pour des raisons de performance.
+
+  bsds {
+    ...on Bsda {
+      groupedIn  {...} // seul l'id est disponible
+      forwardedIn {...} // seul l'id est disponible
+    }
+    ...on Bsdasri {
+      grouping {...} // seul l'id est disponible
+      synthesizing {...} // seul l'id est disponible
+    }
+    ...on Bsff {
+      packagings {...} // tous les champs sont disponibles
+    }
+  }
+  """
   bsds(
     clue: String
     where: BsdWhere


### PR DESCRIPTION
Recette suite à #2845. Les bordereaux initiaux doivent être ré-indexés en cas de changement sur le bordereau suite pour que `Bsda.groupedIn` et `Bsda.forwardedIn` ne soit pas désynchronisés. 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13188)
