### PR TITLE
[TRA-12886]  PDF, DASRI Regroupement : le nombre de contenants modifié d'un DASRI initial n'apparait pas correctement sur le PDF du DASRI de regroupement

### DIFF
--- a/back/src/bsdasris/pdf/generator.tsx
+++ b/back/src/bsdasris/pdf/generator.tsx
@@ -3,7 +3,11 @@ import * as QRCode from "qrcode";
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 import { generatePdf } from "../../common/pdf";
-import { expandBsdasriFromDB, expandGroupingDasri, expandSynthesizingDasri } from "../converter";
+import {
+  expandBsdasriFromDB,
+  expandGroupingDasri,
+  expandSynthesizingDasri
+} from "../converter";
 import prisma from "../../prisma";
 import { BsdasriPdf } from "./components/BsdasriPdf";
 

--- a/back/src/bsdasris/pdf/generator.tsx
+++ b/back/src/bsdasris/pdf/generator.tsx
@@ -3,7 +3,7 @@ import * as QRCode from "qrcode";
 import * as React from "react";
 import * as ReactDOMServer from "react-dom/server";
 import { generatePdf } from "../../common/pdf";
-import { expandBsdasriFromDB, expandSynthesizingDasri } from "../converter";
+import { expandBsdasriFromDB, expandGroupingDasri, expandSynthesizingDasri } from "../converter";
 import prisma from "../../prisma";
 import { BsdasriPdf } from "./components/BsdasriPdf";
 
@@ -22,7 +22,7 @@ const getAssociatedBsdasris = async (bsdasri: Bsdasri) => {
         groupedInId: bsdasri.id
       }
     });
-    return associated.map(bsd => expandSynthesizingDasri(bsd));
+    return associated.map(bsd => expandGroupingDasri(bsd));
   }
   return null;
 };


### PR DESCRIPTION
# Contexte

Sur le PDF d'un DASRI de regroupement, les nbr de contenants & volumes associés sont ceux renseignés par l'émetter, pas ceux renseignés par le destinataire. On veut ceux du destinataire.

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/75e8127b-4c46-41e4-8e0e-6ec1c74bd3ce)

# Ticket Favro

[PDF, DASRI Regroupement : le nombre de contenants modifié d'un DASRI initial n'apparait pas correctement sur le PDF du DASRI de regroupement](https://favro.com/widget/ab14a4f0460a99a9d64d4945/40e9c96bd2208c492d992343?card=tra-12886)
