### PR TITLE
Affiche les toasts pour 6s contre 2s précédemment

### DIFF
--- a/front/src/common/config.ts
+++ b/front/src/common/config.ts
@@ -14,4 +14,4 @@ export const DEVELOPERS_DOCUMENTATION_URL =
   (import.meta.env.VITE_DEVELOPERS_DOCUMENTATION_URL as string) ||
   "https://developers.trackdechets.beta.gouv.fr";
 
-export const TOAST_DURATION = 2000; // ms
+export const TOAST_DURATION = 6000; // ms


### PR DESCRIPTION
La durée d'affichage des nouveaux toasts était un peu juste (2s), on passe à 6s (entre 5 et 7s sur l'ancienne version avec cogo-toast)


---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13210)
