### PR TITLE
Fix/recette-nov-2

### DIFF
--- a/back/src/bsda/validation/dynamicRefinements.ts
+++ b/back/src/bsda/validation/dynamicRefinements.ts
@@ -103,6 +103,8 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
   }
 
   if (
+    // This rule only applies to BSDA that have not been signed before 2023-11-23
+    (!bsda.emitterEmissionSignatureDate || bsda.emitterEmissionSignatureDate >= new Date("2023-11-23")) &&
     bsda.type === "GATHERING" &&
     previousBsdasWithDestination.some(
       previousBsda => previousBsda.wasteCode !== bsda.wasteCode

--- a/back/src/bsda/validation/dynamicRefinements.ts
+++ b/back/src/bsda/validation/dynamicRefinements.ts
@@ -104,7 +104,8 @@ async function validatePreviousBsdas(bsda: ZodBsda, ctx: RefinementCtx) {
 
   if (
     // This rule only applies to BSDA that have not been signed before 2023-11-23
-    (!bsda.emitterEmissionSignatureDate || bsda.emitterEmissionSignatureDate >= new Date("2023-11-23")) &&
+    (!bsda.emitterEmissionSignatureDate ||
+      bsda.emitterEmissionSignatureDate >= new Date("2023-11-23")) &&
     bsda.type === "GATHERING" &&
     previousBsdasWithDestination.some(
       previousBsda => previousBsda.wasteCode !== bsda.wasteCode

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -133,10 +133,9 @@ export default function SignTransportFormModalContent({
         try {
           const { update } = values;
           if (
-            form.emitter?.type === EmitterType.Appendix1Producer &&
-            (update.quantity ||
-              update.sampleNumber ||
-              update.packagingInfos.length > 0)
+            update.sampleNumber ||
+            (form.emitter?.type === EmitterType.Appendix1Producer &&
+              (update.quantity || update.packagingInfos.length > 0))
           ) {
             await updateForm({
               variables: {


### PR DESCRIPTION
https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12030 - On n'applique pas les nouveaux checks pour les viex bsdas
https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12959 - fix pour les huiles noires, la valeur ne s'enregistrait pas