### PR TITLE
[TRA-13237] Mettre à jour les informations Sirene des établissements visés lors de la duplication d'un BSDASRI, FF et VHU

### DIFF
--- a/back/src/bsdasris/__tests__/sirenify.integration.ts
+++ b/back/src/bsdasris/__tests__/sirenify.integration.ts
@@ -189,10 +189,13 @@ describe("sirenifyBsdasriCreateInput", () => {
       // Transporter company info
       transporterCompanySiret: transporter.company.siret,
       transporterCompanyAddress: transporter.company.address,
-      transporterCompanyName: transporter.company.name,
+      transporterCompanyName: transporter.company.name
     } as Prisma.BsdasriCreateInput;
 
-    const sirenified = await sirenifyBsdasriCreateInput(bsdasriPrismaCreateInput, []);
+    const sirenified = await sirenifyBsdasriCreateInput(
+      bsdasriPrismaCreateInput,
+      []
+    );
 
     // Emitter
     expect(sirenified.emitterCompanyName).toEqual(
@@ -201,7 +204,7 @@ describe("sirenifyBsdasriCreateInput", () => {
     expect(sirenified.emitterCompanyAddress).toEqual(
       searchResults[emitter.company.siret!].address
     );
-    
+
     // Destination
     expect(sirenified.destinationCompanyName).toEqual(
       searchResults[destination.company.siret!].name

--- a/back/src/bsdasris/__tests__/sirenify.integration.ts
+++ b/back/src/bsdasris/__tests__/sirenify.integration.ts
@@ -7,6 +7,14 @@ import { AuthType } from "../../auth";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { Prisma } from "@prisma/client";
 
+const searchResult = (companyName: string) => {
+  return {
+    name: companyName,
+    address: `Adresse ${companyName}`,
+    statutDiffusionEtablissement: "O"
+  } as CompanySearchResult;
+};
+
 jest.mock("../../companies/search");
 
 describe("sirenify", () => {
@@ -16,14 +24,6 @@ describe("sirenify", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
@@ -89,14 +89,6 @@ describe("sirenify", () => {
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
 
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
-
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
       [transporter.company.siret!]: searchResult("transporteur"),
@@ -158,14 +150,6 @@ describe("sirenifyBsdasriCreateInput", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),

--- a/back/src/bsdasris/__tests__/sirenify.integration.ts
+++ b/back/src/bsdasris/__tests__/sirenify.integration.ts
@@ -2,9 +2,10 @@ import { CompanySearchResult } from "../../companies/types";
 import { userWithCompanyFactory } from "../../__tests__/factories";
 import { searchCompany } from "../../companies/search";
 import { BsdasriInput } from "../../generated/graphql/types";
-import { sirenify } from "../sirenify";
+import { sirenify, sirenifyBsdasriCreateInput } from "../sirenify";
 import { AuthType } from "../../auth";
 import { resetDatabase } from "../../../integration-tests/helper";
+import { Prisma } from "@prisma/client";
 
 jest.mock("../../companies/search");
 
@@ -146,6 +147,75 @@ describe("sirenify", () => {
     );
     expect(sirenified.destination!.company!.address).toEqual(
       searchResults[destination.company.siret!].address
+    );
+  });
+});
+
+describe("sirenifyBsdasriCreateInput", () => {
+  afterEach(resetDatabase);
+
+  it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are provided", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+
+    function searchResult(companyName: string) {
+      return {
+        name: companyName,
+        address: `Adresse ${companyName}`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire")
+    };
+
+    (searchCompany as jest.Mock).mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const bsdasriPrismaCreateInput = {
+      // Emitter company info
+      emitterCompanySiret: emitter.company.siret,
+      emitterCompanyAddress: emitter.company.address,
+      emitterCompanyName: emitter.company.name,
+      // Destination company info
+      destinationCompanySiret: destination.company.siret,
+      destinationCompanyAddress: destination.company.address,
+      destinationCompanyName: destination.company.name,
+      // Transporter company info
+      transporterCompanySiret: transporter.company.siret,
+      transporterCompanyAddress: transporter.company.address,
+      transporterCompanyName: transporter.company.name,
+    } as Prisma.BsdasriCreateInput;
+
+    const sirenified = await sirenifyBsdasriCreateInput(bsdasriPrismaCreateInput, []);
+
+    // Emitter
+    expect(sirenified.emitterCompanyName).toEqual(
+      searchResults[emitter.company.siret!].name
+    );
+    expect(sirenified.emitterCompanyAddress).toEqual(
+      searchResults[emitter.company.siret!].address
+    );
+    
+    // Destination
+    expect(sirenified.destinationCompanyName).toEqual(
+      searchResults[destination.company.siret!].name
+    );
+    expect(sirenified.destinationCompanyAddress).toEqual(
+      searchResults[destination.company.siret!].address
+    );
+
+    // Transporter
+    expect(sirenified.transporterCompanyName).toEqual(
+      searchResults[transporter.company.siret!].name
+    );
+    expect(sirenified.transporterCompanyAddress).toEqual(
+      searchResults[transporter.company.siret!].address
     );
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -6,10 +6,13 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdasriFactory, initialData } from "../../../__tests__/factories";
-import { Mutation } from "../../../../generated/graphql/types";
+import { CompanySearchResult, Mutation } from "../../../../generated/graphql/types";
 import { BsdasriType } from "@prisma/client";
 import prisma from "../../../../prisma";
 import { xDaysAgo } from "../../../../commands/onboarding.helpers";
+import { searchCompany } from "../../../../companies/search";
+
+jest.mock("../../../../companies/search");
 
 const TODAY = new Date();
 const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
@@ -318,5 +321,104 @@ describe("Mutation.duplicateBsdasri", () => {
     expect(duplicatedBsdasri2.transporterRecepisseNumber).toBeNull();
     expect(duplicatedBsdasri2.transporterRecepisseValidityLimit).toBeNull();
     expect(duplicatedBsdasri2.transporterRecepisseDepartment).toBeNull();
+  });
+
+  test("duplicated BSDASRI should have the updated SIRENE data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+    const transporterReceipt =
+      await prisma.transporterReceipt.findUniqueOrThrow({
+        where: { id: transporterCompany.transporterReceiptId! }
+      });
+    const destinationCompany = await companyFactory();
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        emitterCompanyContact: emitter.company.contact,
+        emitterCompanyMail: emitter.company.contactEmail,
+        emitterCompanyPhone: emitter.company.contactPhone,
+        transporterCompanySiret: transporterCompany.siret,
+        transporterCompanyName: transporterCompany.name,
+        transporterCompanyAddress: transporterCompany.address,
+        transporterCompanyContact: transporterCompany.contact,
+        transporterCompanyMail: transporterCompany.contactEmail,
+        transporterCompanyPhone: transporterCompany.contactPhone,
+        transporterRecepisseNumber: transporterReceipt.receiptNumber,
+        transporterRecepisseDepartment: transporterReceipt.department,
+        transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
+        destinationCompanySiret: destinationCompany.siret,
+        destinationCompanyName: destinationCompany.name,
+        destinationCompanyAddress: destinationCompany.address,
+        destinationCompanyContact: destinationCompany.contact,
+        destinationCompanyMail: destinationCompany.contactEmail,
+        destinationCompanyPhone: destinationCompany.contactPhone
+      }
+    });
+    const { mutate } = makeClient(emitter.user);
+
+    function searchResult(companyName: string) {
+      return {
+        name: `updated ${companyName} name`,
+        address: `updated ${companyName} address`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("emitter"),
+      [transporterCompany.siret!]: searchResult("transporter"),
+      [destinationCompany.siret!]: searchResult("destination"),
+    };
+
+    (searchCompany as jest.Mock).mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: bsdasri.id
+        }
+      }
+    );
+
+    const duplicatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: data.duplicateBsdasri.id }
+    });
+
+    // Emitter
+    expect(duplicatedBsdasri.emitterCompanyName).toEqual(
+      "updated emitter name"
+    );
+    expect(duplicatedBsdasri.emitterCompanyAddress).toEqual(
+      "updated emitter address"
+    );
+
+    // Transporter
+    expect(duplicatedBsdasri.transporterCompanyName).toEqual(
+      "updated transporter name"
+    );
+    expect(duplicatedBsdasri.transporterCompanyAddress).toEqual(
+      "updated transporter address"
+    );
+
+    // Destination
+    expect(duplicatedBsdasri.destinationCompanyName).toEqual(
+      "updated destination name"
+    );
+    expect(duplicatedBsdasri.destinationCompanyAddress).toEqual(
+      "updated destination address"
+    );
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -6,7 +6,10 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdasriFactory, initialData } from "../../../__tests__/factories";
-import { CompanySearchResult, Mutation } from "../../../../generated/graphql/types";
+import {
+  CompanySearchResult,
+  Mutation
+} from "../../../../generated/graphql/types";
 import { BsdasriType } from "@prisma/client";
 import prisma from "../../../../prisma";
 import { xDaysAgo } from "../../../../commands/onboarding.helpers";
@@ -377,7 +380,7 @@ describe("Mutation.duplicateBsdasri", () => {
     const searchResults = {
       [emitter.company.siret!]: searchResult("emitter"),
       [transporterCompany.siret!]: searchResult("transporter"),
-      [destinationCompany.siret!]: searchResult("destination"),
+      [destinationCompany.siret!]: searchResult("destination")
     };
 
     (searchCompany as jest.Mock).mockImplementation((clue: string) => {

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -11,6 +11,8 @@ import { getBsdasriRepository } from "../../repository";
 import { checkCanDuplicate } from "../../permissions";
 import prisma from "../../../prisma";
 import { ForbiddenError } from "../../../common/errors";
+import { sirenifyBsdasriCreateInput } from "../../sirenify";
+
 
 /**
  *
@@ -101,7 +103,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     bsdasri
   );
 
-  return bsdasriRepository.create({
+  const input: Prisma.BsdasriCreateInput = {
     ...fieldsToCopy,
     emitterWastePackagings:
       fieldsToCopy.emitterWastePackagings === null
@@ -143,7 +145,11 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
       transporter?.transporterReceipt?.validityLimit ?? null,
     transporterRecepisseDepartment:
       transporter?.transporterReceipt?.department ?? null
-  });
+  };
+
+  const sirenified = await sirenifyBsdasriCreateInput(input, []);
+
+  return bsdasriRepository.create(sirenified);
 }
 
 async function getBsdasriCompanies(bsdasri: Bsdasri) {

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -13,7 +13,6 @@ import prisma from "../../../prisma";
 import { ForbiddenError } from "../../../common/errors";
 import { sirenifyBsdasriCreateInput } from "../../sirenify";
 
-
 /**
  *
  * Duplicate a bsdasri

--- a/back/src/bsdasris/sirenify.ts
+++ b/back/src/bsdasris/sirenify.ts
@@ -28,9 +28,10 @@ const accessors = (input: BsdasriInput) => [
 
 export const sirenify = buildSirenify(accessors);
 
-const bsdasriCreateInputAccessors = (input: Prisma.BsdasriCreateInput, 
+const bsdasriCreateInputAccessors = (
+  input: Prisma.BsdasriCreateInput,
   sealedFields: string[] = [] // Tranformations should not be run on sealed fields
-  ) => [
+) => [
   {
     siret: input?.emitterCompanySiret,
     skip: sealedFields.includes("emitterCompanySiret"),
@@ -54,7 +55,9 @@ const bsdasriCreateInputAccessors = (input: Prisma.BsdasriCreateInput,
       input.destinationCompanyName = companyInput.name;
       input.destinationCompanyAddress = companyInput.address;
     }
-  },
+  }
 ];
 
-export const sirenifyBsdasriCreateInput = nextBuildSirenify(bsdasriCreateInputAccessors);
+export const sirenifyBsdasriCreateInput = nextBuildSirenify(
+  bsdasriCreateInputAccessors
+);

--- a/back/src/bsdasris/sirenify.ts
+++ b/back/src/bsdasris/sirenify.ts
@@ -1,4 +1,5 @@
-import buildSirenify from "../companies/sirenify";
+import { Prisma } from "@prisma/client";
+import buildSirenify, { nextBuildSirenify } from "../companies/sirenify";
 import { BsdasriInput, CompanyInput } from "../generated/graphql/types";
 
 const accessors = (input: BsdasriInput) => [
@@ -26,3 +27,34 @@ const accessors = (input: BsdasriInput) => [
 ];
 
 export const sirenify = buildSirenify(accessors);
+
+const bsdasriCreateInputAccessors = (input: Prisma.BsdasriCreateInput, 
+  sealedFields: string[] = [] // Tranformations should not be run on sealed fields
+  ) => [
+  {
+    siret: input?.emitterCompanySiret,
+    skip: sealedFields.includes("emitterCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.emitterCompanyName = companyInput.name;
+      input.emitterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.transporterCompanySiret,
+    skip: sealedFields.includes("transporterCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.transporterCompanyName = companyInput.name;
+      input.transporterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.destinationCompanySiret,
+    skip: sealedFields.includes("destinationCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.destinationCompanyName = companyInput.name;
+      input.destinationCompanyAddress = companyInput.address;
+    }
+  },
+];
+
+export const sirenifyBsdasriCreateInput = nextBuildSirenify(bsdasriCreateInputAccessors);

--- a/back/src/bsffs/__tests__/sirenify.integration.ts
+++ b/back/src/bsffs/__tests__/sirenify.integration.ts
@@ -16,6 +16,14 @@ import { AuthType } from "../../auth";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { Prisma } from "@prisma/client";
 
+const searchResult = (companyName: string) => {
+  return {
+    name: companyName,
+    address: `Adresse ${companyName}`,
+    statutDiffusionEtablissement: "O"
+  } as CompanySearchResult;
+};
+
 jest.mock("../../companies/search");
 
 describe("sirenifyBsffInput", () => {
@@ -25,14 +33,6 @@ describe("sirenifyBsffInput", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
@@ -98,14 +98,6 @@ describe("sirenifyBsffInput", () => {
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
 
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
-
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
       [transporter.company.siret!]: searchResult("transporteur"),
@@ -166,14 +158,6 @@ describe("sirenifyBsffPackagingInput", () => {
   it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are provided", async () => {
     const nextDestination = await userWithCompanyFactory("MEMBER");
 
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
-
     const searchResults = {
       [nextDestination.company.siret!]: searchResult("destination ultérieure")
     };
@@ -212,14 +196,6 @@ describe("sirenifyBsffPackagingInput", () => {
 
   it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are not provided", async () => {
     const nextDestination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [nextDestination.company.siret!]: searchResult("destination ultérieure")
@@ -262,14 +238,6 @@ describe("sirenifyBsffFicheInterventionInput", () => {
   it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are provided", async () => {
     const detenteur = await userWithCompanyFactory("MEMBER");
     const operateur = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [detenteur.company.siret!]: searchResult("détenteur"),
@@ -325,14 +293,6 @@ describe("sirenifyBsffFicheInterventionInput", () => {
   it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are not provided", async () => {
     const detenteur = await userWithCompanyFactory("MEMBER");
     const operateur = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [detenteur.company.siret!]: searchResult("détenteur"),

--- a/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
@@ -2,6 +2,7 @@ import { UserRole } from "@prisma/client";
 import { gql } from "graphql-tag";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import {
+  CompanySearchResult,
   Mutation,
   MutationDuplicateBsffArgs
 } from "../../../../generated/graphql/types";
@@ -10,6 +11,9 @@ import makeClient from "../../../../__tests__/testClient";
 import { createBsff } from "../../../__tests__/factories";
 import { xDaysAgo } from "../../../../commands/onboarding.helpers";
 import prisma from "../../../../prisma";
+import { searchCompany } from "../../../../companies/search";
+
+jest.mock("../../../../companies/search");
 
 const TODAY = new Date();
 const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
@@ -269,5 +273,76 @@ describe("Mutation.duplicateBsff", () => {
     expect(duplicatedBsff2.transporterRecepisseNumber).toBeNull();
     expect(duplicatedBsff2.transporterRecepisseValidityLimit).toBeNull();
     expect(duplicatedBsff2.transporterRecepisseDepartment).toBeNull();
+  });
+
+  test("duplicated BSFF should have the updated SIRENE data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+
+    const transporter = await userWithCompanyFactory("MEMBER", {
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+
+    const destination = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsff({ emitter, transporter, destination });
+    const { mutate } = makeClient(emitter.user);
+
+    function searchResult(companyName: string) {
+      return {
+        name: `updated ${companyName} name`,
+        address: `updated ${companyName} address`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("emitter"),
+      [transporter.company.siret!]: searchResult("transporter"),
+      [destination.company.siret!]: searchResult("destination")
+    };
+
+    (searchCompany as jest.Mock).mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "duplicateBsff">,
+      MutationDuplicateBsffArgs
+    >(DUPLICATE_BSFF, {
+      variables: {
+        id: bsff.id
+      }
+    });
+
+    const duplicatedBsff = await prisma.bsff.findUniqueOrThrow({
+      where: { id: data.duplicateBsff.id }
+    });
+
+    // Emitter
+    expect(duplicatedBsff.emitterCompanyName).toEqual("updated emitter name");
+    expect(duplicatedBsff.emitterCompanyAddress).toEqual(
+      "updated emitter address"
+    );
+
+    // Transporter
+    expect(duplicatedBsff.transporterCompanyName).toEqual(
+      "updated transporter name"
+    );
+    expect(duplicatedBsff.transporterCompanyAddress).toEqual(
+      "updated transporter address"
+    );
+
+    // Destination
+    expect(duplicatedBsff.destinationCompanyName).toEqual(
+      "updated destination name"
+    );
+    expect(duplicatedBsff.destinationCompanyAddress).toEqual(
+      "updated destination address"
+    );
   });
 });

--- a/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
@@ -7,6 +7,7 @@ import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
 import { Bsff, BsffStatus, Prisma } from "@prisma/client";
 import { getBsffRepository } from "../../repository";
 import prisma from "../../../prisma";
+import { sirenifyBsffCreateInput } from "../../sirenify";
 
 const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
   _,
@@ -81,8 +82,10 @@ const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
 
   const { create: createBsff } = getBsffRepository(user);
 
+  const sirenified = await sirenifyBsffCreateInput(createInput, []);
+
   const duplicatedBsff = await createBsff(
-    { data: createInput },
+    { data: sirenified },
     {
       duplicate: { id: existingBsff.id }
     }

--- a/back/src/bsffs/sirenify.ts
+++ b/back/src/bsffs/sirenify.ts
@@ -1,4 +1,5 @@
-import buildSirenify from "../companies/sirenify";
+import { Prisma } from "@prisma/client";
+import buildSirenify, { nextBuildSirenify } from "../companies/sirenify";
 import {
   BsffFicheInterventionInput,
   BsffInput,
@@ -77,4 +78,38 @@ const bsffFicheInterventionAccessors = (input: BsffFicheInterventionInput) => [
 
 export const sirenifyBsffFicheInterventionInput = buildSirenify(
   bsffFicheInterventionAccessors
+);
+
+const bsffCreateInputAccessors = (
+  input: Prisma.BsffCreateInput,
+  sealedFields: string[] = [] // Tranformations should not be run on sealed fields
+) => [
+  {
+    siret: input?.emitterCompanySiret,
+    skip: sealedFields.includes("emitterCompanySiret"),
+    setter: (input: Prisma.BsffCreateInput, companyInput: CompanyInput) => {
+      input.emitterCompanyName = companyInput.name;
+      input.emitterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.transporterCompanySiret,
+    skip: sealedFields.includes("transporterCompanySiret"),
+    setter: (input: Prisma.BsffCreateInput, companyInput: CompanyInput) => {
+      input.transporterCompanyName = companyInput.name;
+      input.transporterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.destinationCompanySiret,
+    skip: sealedFields.includes("destinationCompanySiret"),
+    setter: (input: Prisma.BsffCreateInput, companyInput: CompanyInput) => {
+      input.destinationCompanyName = companyInput.name;
+      input.destinationCompanyAddress = companyInput.address;
+    }
+  }
+];
+
+export const sirenifyBsffCreateInput = nextBuildSirenify(
+  bsffCreateInputAccessors
 );

--- a/back/src/bsvhu/__tests__/sirenify.integration.ts
+++ b/back/src/bsvhu/__tests__/sirenify.integration.ts
@@ -2,9 +2,10 @@ import { CompanySearchResult } from "../../companies/types";
 import { userWithCompanyFactory } from "../../__tests__/factories";
 import { searchCompany } from "../../companies/search";
 import { BsvhuInput } from "../../generated/graphql/types";
-import { sirenify } from "../sirenify";
+import { sirenify, sirenifyBsvhuCreateInput } from "../sirenify";
 import { AuthType } from "../../auth";
 import { resetDatabase } from "../../../integration-tests/helper";
+import { Prisma } from "@prisma/client";
 
 jest.mock("../../companies/search");
 
@@ -146,6 +147,78 @@ describe("sirenify", () => {
     );
     expect(sirenified.destination!.company!.address).toEqual(
       searchResults[destination.company.siret!].address
+    );
+  });
+});
+
+describe("sirenifyBsvhuCreateInput", () => {
+  afterEach(resetDatabase);
+
+  it("should overwrite `name` and `address` based on SIRENE data if `name` and `address` are provided", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+
+    function searchResult(companyName: string) {
+      return {
+        name: companyName,
+        address: `Adresse ${companyName}`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("émetteur"),
+      [transporter.company.siret!]: searchResult("transporteur"),
+      [destination.company.siret!]: searchResult("destinataire")
+    };
+
+    (searchCompany as jest.Mock).mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const bsvhuPrismaCreateInput = {
+      // Emitter company info
+      emitterCompanySiret: emitter.company.siret,
+      emitterCompanyAddress: emitter.company.address,
+      emitterCompanyName: emitter.company.name,
+      // Destination company info
+      destinationCompanySiret: destination.company.siret,
+      destinationCompanyAddress: destination.company.address,
+      destinationCompanyName: destination.company.name,
+      // Transporter company info
+      transporterCompanySiret: transporter.company.siret,
+      transporterCompanyAddress: transporter.company.address,
+      transporterCompanyName: transporter.company.name
+    } as Prisma.BsvhuCreateInput;
+
+    const sirenified = await sirenifyBsvhuCreateInput(
+      bsvhuPrismaCreateInput,
+      []
+    );
+
+    // Emitter
+    expect(sirenified.emitterCompanyName).toEqual(
+      searchResults[emitter.company.siret!].name
+    );
+    expect(sirenified.emitterCompanyAddress).toEqual(
+      searchResults[emitter.company.siret!].address
+    );
+
+    // Destination
+    expect(sirenified.destinationCompanyName).toEqual(
+      searchResults[destination.company.siret!].name
+    );
+    expect(sirenified.destinationCompanyAddress).toEqual(
+      searchResults[destination.company.siret!].address
+    );
+
+    // Transporter
+    expect(sirenified.transporterCompanyName).toEqual(
+      searchResults[transporter.company.siret!].name
+    );
+    expect(sirenified.transporterCompanyAddress).toEqual(
+      searchResults[transporter.company.siret!].address
     );
   });
 });

--- a/back/src/bsvhu/__tests__/sirenify.integration.ts
+++ b/back/src/bsvhu/__tests__/sirenify.integration.ts
@@ -7,6 +7,14 @@ import { AuthType } from "../../auth";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { Prisma } from "@prisma/client";
 
+const searchResult = (companyName: string) => {
+  return {
+    name: companyName,
+    address: `Adresse ${companyName}`,
+    statutDiffusionEtablissement: "O"
+  } as CompanySearchResult;
+};
+
 jest.mock("../../companies/search");
 
 describe("sirenify", () => {
@@ -16,14 +24,6 @@ describe("sirenify", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
@@ -89,14 +89,6 @@ describe("sirenify", () => {
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
 
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
-
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),
       [transporter.company.siret!]: searchResult("transporteur"),
@@ -158,14 +150,6 @@ describe("sirenifyBsvhuCreateInput", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const destination = await userWithCompanyFactory("MEMBER");
-
-    function searchResult(companyName: string) {
-      return {
-        name: companyName,
-        address: `Adresse ${companyName}`,
-        statutDiffusionEtablissement: "O"
-      } as CompanySearchResult;
-    }
 
     const searchResults = {
       [emitter.company.siret!]: searchResult("émetteur"),

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -8,9 +8,15 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsvhuFactory } from "../../../__tests__/factories.vhu";
-import { Mutation } from "../../../../generated/graphql/types";
+import {
+  CompanySearchResult,
+  Mutation
+} from "../../../../generated/graphql/types";
 import { ErrorCode } from "../../../../common/errors";
 import prisma from "../../../../prisma";
+import { searchCompany } from "../../../../companies/search";
+
+jest.mock("../../../../companies/search");
 
 const TODAY = new Date();
 const FOUR_DAYS_AGO = xDaysAgo(TODAY, 4);
@@ -283,6 +289,111 @@ describe("mutaion.duplicateBsvhu", () => {
     );
     expect(duplicatedBsvhu.destinationCompanyPhone).toEqual(
       "UPDATED-DESTINATION-PHONE"
+    );
+  });
+
+  test("duplicated BSVHU should have the updated SIRENE data when company info changes", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "TRANSPORTER- RECEIPT-DEPARTMENT"
+        }
+      }
+    });
+    const transporterReceipt =
+      await prisma.transporterReceipt.findUniqueOrThrow({
+        where: { id: transporterCompany.transporterReceiptId! }
+      });
+    const destinationCompany = await companyFactory({
+      vhuAgrementDemolisseur: {
+        create: {
+          agrementNumber: "UPDATED-AGREEMENT-NUMBER",
+          department: "UPDATED-DEPARTMENT"
+        }
+      }
+    });
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        emitterCompanyContact: emitter.company.contact,
+        emitterCompanyMail: emitter.company.contactEmail,
+        emitterCompanyPhone: emitter.company.contactPhone,
+        transporterCompanySiret: transporterCompany.siret,
+        transporterCompanyName: transporterCompany.name,
+        transporterCompanyAddress: transporterCompany.address,
+        transporterCompanyContact: transporterCompany.contact,
+        transporterCompanyMail: transporterCompany.contactEmail,
+        transporterCompanyPhone: transporterCompany.contactPhone,
+        transporterRecepisseNumber: transporterReceipt.receiptNumber,
+        transporterRecepisseDepartment: transporterReceipt.department,
+        transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
+        destinationCompanySiret: destinationCompany.siret,
+        destinationCompanyName: destinationCompany.name,
+        destinationCompanyAddress: destinationCompany.address,
+        destinationCompanyContact: destinationCompany.contact,
+        destinationCompanyMail: destinationCompany.contactEmail,
+        destinationCompanyPhone: destinationCompany.contactPhone
+      }
+    });
+
+    const { mutate } = makeClient(emitter.user);
+
+    function searchResult(companyName: string) {
+      return {
+        name: `updated ${companyName} name`,
+        address: `updated ${companyName} address`,
+        statutDiffusionEtablissement: "O"
+      } as CompanySearchResult;
+    }
+
+    const searchResults = {
+      [emitter.company.siret!]: searchResult("emitter"),
+      [transporterCompany.siret!]: searchResult("transporter"),
+      [destinationCompany.siret!]: searchResult("destination")
+    };
+
+    (searchCompany as jest.Mock).mockImplementation((clue: string) => {
+      return Promise.resolve(searchResults[clue]);
+    });
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBsvhu">>(
+      DUPLICATE_BVHU,
+      {
+        variables: {
+          id: bsvhu.id
+        }
+      }
+    );
+
+    const duplicatedBsvhu = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: data.duplicateBsvhu.id }
+    });
+
+    // Emitter
+    expect(duplicatedBsvhu.emitterCompanyName).toEqual("updated emitter name");
+    expect(duplicatedBsvhu.emitterCompanyAddress).toEqual(
+      "updated emitter address"
+    );
+
+    // Transporter
+    expect(duplicatedBsvhu.transporterCompanyName).toEqual(
+      "updated transporter name"
+    );
+    expect(duplicatedBsvhu.transporterCompanyAddress).toEqual(
+      "updated transporter address"
+    );
+
+    // Destination
+    expect(duplicatedBsvhu.destinationCompanyName).toEqual(
+      "updated destination name"
+    );
+    expect(duplicatedBsvhu.destinationCompanyAddress).toEqual(
+      "updated destination address"
     );
   });
 });

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -7,6 +7,7 @@ import { getBsvhuOrNotFound } from "../../database";
 import { getBsvhuRepository } from "../../repository";
 import { checkCanDuplicate } from "../../permissions";
 import prisma from "../../../prisma";
+import { sirenifyBsvhuCreateInput } from "../../sirenify";
 
 export default async function duplicate(
   _,
@@ -19,9 +20,12 @@ export default async function duplicate(
 
   await checkCanDuplicate(user, prismaBsvhu);
   const bsvhuRepository = getBsvhuRepository(user);
-  const newBsvhu = await bsvhuRepository.create(
-    await getDuplicateData(prismaBsvhu)
-  );
+
+  const duplicateData = await getDuplicateData(prismaBsvhu);
+
+  const sirenified = await sirenifyBsvhuCreateInput(duplicateData, []);
+
+  const newBsvhu = await bsvhuRepository.create(sirenified);
 
   return expandVhuFormFromDb(newBsvhu);
 }

--- a/back/src/bsvhu/sirenify.ts
+++ b/back/src/bsvhu/sirenify.ts
@@ -35,7 +35,7 @@ const bsvhuCreateInputAccessors = (
   {
     siret: input?.emitterCompanySiret,
     skip: sealedFields.includes("emitterCompanySiret"),
-    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+    setter: (input: Prisma.BsvhuCreateInput, companyInput: CompanyInput) => {
       input.emitterCompanyName = companyInput.name;
       input.emitterCompanyAddress = companyInput.address;
     }
@@ -43,7 +43,7 @@ const bsvhuCreateInputAccessors = (
   {
     siret: input?.transporterCompanySiret,
     skip: sealedFields.includes("transporterCompanySiret"),
-    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+    setter: (input: Prisma.BsvhuCreateInput, companyInput: CompanyInput) => {
       input.transporterCompanyName = companyInput.name;
       input.transporterCompanyAddress = companyInput.address;
     }
@@ -51,7 +51,7 @@ const bsvhuCreateInputAccessors = (
   {
     siret: input?.destinationCompanySiret,
     skip: sealedFields.includes("destinationCompanySiret"),
-    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+    setter: (input: Prisma.BsvhuCreateInput, companyInput: CompanyInput) => {
       input.destinationCompanyName = companyInput.name;
       input.destinationCompanyAddress = companyInput.address;
     }

--- a/back/src/bsvhu/sirenify.ts
+++ b/back/src/bsvhu/sirenify.ts
@@ -1,4 +1,5 @@
-import buildSirenify from "../companies/sirenify";
+import { Prisma } from "@prisma/client";
+import buildSirenify, { nextBuildSirenify } from "../companies/sirenify";
 import { BsvhuInput, CompanyInput } from "../generated/graphql/types";
 
 const accessors = (input: BsvhuInput) => [
@@ -26,3 +27,37 @@ const accessors = (input: BsvhuInput) => [
 ];
 
 export const sirenify = buildSirenify(accessors);
+
+const bsvhuCreateInputAccessors = (
+  input: Prisma.BsvhuCreateInput,
+  sealedFields: string[] = [] // Tranformations should not be run on sealed fields
+) => [
+  {
+    siret: input?.emitterCompanySiret,
+    skip: sealedFields.includes("emitterCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.emitterCompanyName = companyInput.name;
+      input.emitterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.transporterCompanySiret,
+    skip: sealedFields.includes("transporterCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.transporterCompanyName = companyInput.name;
+      input.transporterCompanyAddress = companyInput.address;
+    }
+  },
+  {
+    siret: input?.destinationCompanySiret,
+    skip: sealedFields.includes("destinationCompanySiret"),
+    setter: (input: Prisma.BsdasriCreateInput, companyInput: CompanyInput) => {
+      input.destinationCompanyName = companyInput.name;
+      input.destinationCompanyAddress = companyInput.address;
+    }
+  }
+];
+
+export const sirenifyBsvhuCreateInput = nextBuildSirenify(
+  bsvhuCreateInputAccessors
+);


### PR DESCRIPTION
# Contexte

Lorsqu'une entreprise duplique un BSDD, le nouveau BSDD reprend les informations entreprises dans la DB, qui peut être en retard par rapport aux infos SIRENE.

On modifie ce comportement pour aller chercher les infos les plus à jour via `sirenify`.

# Ticket Favro

[Mettre à jour les informations Sirene des établissements visés lors de la duplication d'un BSD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13237)
