### PR TITLE
[tra-12879] Pas d'annulation d'un BSDD de tournée

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -662,7 +662,9 @@ describe("Mutation.createFormRevisionRequest", () => {
     // Because the error messages vary depending on the status,
     // let's just check that there is an error and not focus on the msg
     expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0].message).toBe("Impossible d'annuler un bordereau de tournée dédiée.");
+    expect(errors[0].message).toBe(
+      "Impossible d'annuler un bordereau de tournée dédiée."
+    );
   });
 
   it("should fail if trying to use a forbidden waste code on EmitterType.APPENDIX1 bsdd", async () => {

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -241,6 +241,13 @@ async function getFlatContent(
     );
   }
 
+  // One cannot request a CANCELATION on an appendix1
+  if (flatContent.isCanceled && bsdd.emitterType === EmitterType.APPENDIX1) {
+    throw new ForbiddenError(
+      "Impossible d'annuler un bordereau de tournée dédiée."
+    );
+  }
+
   // One cannot request a CANCELATION if the BSDD has advanced too far in the workflow
   if (
     flatContent.isCanceled &&

--- a/front/src/dashboard/components/RevisionRequestList/bsdd/BsddRequestRevisionCancelationInput.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdd/BsddRequestRevisionCancelationInput.tsx
@@ -40,7 +40,9 @@ export function BsddRequestRevisionCancelationInput({
   bsdd,
   onChange
 }: Props) {
-  const canBeCancelled = CANCELLABLE_BSDD_STATUSES.includes(bsdd.status);
+  const canBeCancelled =
+    CANCELLABLE_BSDD_STATUSES.includes(bsdd.status) &&
+    bsdd.emitter?.type !== "APPENDIX1";
 
   return (
     <Switch


### PR DESCRIPTION
Retirer la possibilité d'Annuler un bordereau de tournée dédiée via la Révision

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12879)
