### PR TITLE
[TRA-12968] Amélioration de l'affichage des BSDA de groupement dans l'aperçu

### DIFF
--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -35,6 +35,7 @@ import { InitialBsdas } from "./InitialBsdas";
 import { getOperationModeLabel } from "../../../common/operationModes";
 import EstimatedQuantityTooltip from "../../../common/components/EstimatedQuantityTooltip";
 import { BSDA_VERBOSE_STATUSES } from "shared/constants";
+import ExpandableList from "./ExpandableList";
 
 type CompanyProps = {
   company?: FormCompany | null;
@@ -415,6 +416,12 @@ const Intermediaries = ({ intermediaries }) => (
   </>
 );
 
+const displayArrayElementsCount = elements => {
+  if (!elements || !elements.length || elements.length < 10) return null;
+
+  return `(${elements.length})`;
+};
+
 export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
   const { siret } = useParams<{ siret: string }>();
   const history = useHistory();
@@ -504,7 +511,9 @@ export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
             </dd>
 
             <dt>Scellés</dt>
-            <dd>{form?.waste?.sealNumbers?.join(", ")}</dd>
+            <dd>
+              <ExpandableList elements={form?.waste?.sealNumbers} />
+            </dd>
 
             <dt>Présence de POP</dt>
             <dd>{form?.waste?.pop ? "Oui" : "Non"}</dd>
@@ -513,8 +522,10 @@ export default function BsdaDetailContent({ form }: SlipDetailContentProps) {
           <div className={styles.detailGrid}>
             {Boolean(form?.grouping?.length) && (
               <>
-                <dt>Bordereaux groupés:</dt>
-                <dd> {form?.grouping?.map(g => g.id).join(", ")}</dd>
+                <dt>Bordereaux groupés</dt>
+                <dd>
+                  <ExpandableList elements={form?.grouping?.map(g => g.id)} />
+                </dd>
               </>
             )}
           </div>

--- a/front/src/dashboard/detail/bsda/ExpandableList.tsx
+++ b/front/src/dashboard/detail/bsda/ExpandableList.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useState } from "react";
+
+const DEFAULT_DISPLAY_NBR = 10;
+
+interface Props {
+  elements: any[];
+}
+
+const ExpandableList = ({ elements }: Props) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+  if (!elements || !elements.length){
+    return null;
+  } 
+  
+  if(elements.length <= DEFAULT_DISPLAY_NBR) {
+    return elements.join(", ");
+  }
+
+  if (isExpanded) {
+    return (
+      <>
+        {elements.join(", ")}
+        <br />
+        <a
+          href="#"
+          onClick={e => {
+            setIsExpanded(false);
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          Voir moins...
+        </a>
+      </>
+    );
+  }
+
+  return (
+    <>
+      {elements.slice(0, DEFAULT_DISPLAY_NBR).join(", ")}{" "}
+      <i>et {elements.length - DEFAULT_DISPLAY_NBR} autre(s)</i>
+      <br />
+      <a
+        href="#"
+        onClick={e => {
+          setIsExpanded(true);
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+      >
+        Voir plus...
+      </a>
+    </>
+  );
+};
+
+export default ExpandableList;


### PR DESCRIPTION
# Contexte

Lorsque le nombre de BSDA groupés (ou le nombre de scellés associés) devient trop grand, l'affichage dans l'Aperçu est infâme.

Tentative de rendre ça un peu plus digeste.

# Démo

![demo_lists_bsda](https://github.com/MTES-MCT/trackdechets/assets/45355989/05647884-8b83-4be7-a2e3-956bb6737022)

# Ticket Favro

[Afficher le nombre de scellés sur l'Aperçu et revoir la limite du nombre de scellés affichés sur le PDF d'un  BSDA](https://favro.com/widget/ab14a4f0460a99a9d64d4945/40e9c96bd2208c492d992343?card=tra-12968)
