### PR TITLE
Nx : some integration test and dev improvements

### DIFF
--- a/back/integration-tests/start-queue-tests-if-not-started.sh
+++ b/back/integration-tests/start-queue-tests-if-not-started.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Get the PID of the PM2 process
+pid=$(npx pm2 pid start-queue-tests | tr -d '[:space:]')
+# Compare the PID with 0
+if [ "$pid" -eq 0 ]; then
+    # Start the process if it's not running
+    npx pm2 start npm --name start-queue-tests -- run start-queue-tests
+else
+    echo "Process is already running."
+fi

--- a/back/project.json
+++ b/back/project.json
@@ -51,6 +51,40 @@
           "codeCoverage": false
         }
       }
+    },
+    "start-test-background": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./back/integration-tests/start-queue-tests-if-not-started.sh"
+      }
+    },
+    "stop-test-background": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx pm2 stop npm --name start-queue-tests"
+      }
+    },
+    "fast-test": {
+      "executor": "@nx/jest:jest",
+      "dependsOn": [
+        {
+          "target": "start-test-background",
+          "projects": "self"
+        }
+      ],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "back/jest.config.js",
+        "passWithNoTests": false
+      },
+      "configurations": {
+        "integration": {
+          "jestConfig": "back/jest.config.integration.js",
+          "runInBand": true,
+          "forceExit": true,
+          "codeCoverage": false
+        }
+      }
     }
   },
   "tags": []

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  apps: [
+    {
+      name: "trackdechets",
+      script: ""
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "author": "",
   "scripts": {
     "scalingo-postbuild": "bash scripts/build/scalingo.sh",
-    "nx": "nx"
+    "nx": "nx",
+    "dev": "nx run-many -t serve --parallel=8",
+    "preintegration-tests": "npx nx run back:prisma --configuration=integration && npx nx run back:codegen --configuration=integration",
+    "start-queue-tests": "nx run-many -t serve --configuration=integration --projects=tag:backend:queues"
   },
   "engines": {
     "node": "^20"


### PR DESCRIPTION
- Launch all `npm run dev` => `nx run-many -t serve --parallel=8`
- Run once `npm run preintegration-tests` then launch fast one test `npx nx run back:fast-test:integration --testFile ...`. **`fast-test` depends on running automatically the api queues needed in background**