### PR TITLE
Mod/monitor-event-loop

### DIFF
--- a/back/src/tracer.ts
+++ b/back/src/tracer.ts
@@ -1,6 +1,46 @@
 import { tracer } from "dd-trace";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { PrismaInstrumentation } from "@prisma/instrumentation";
+import { createHook } from "node:async_hooks";
+import { logger } from "@td/logger";
+
+const THRESHOLD_NS =
+  parseInt(process.env.EVENT_LOOP_THRESHOLD_MS ?? "200", 10) * 1e6;
+const cache = new Map<number, bigint>();
+
+function before(asyncId: number) {
+  cache.set(asyncId, process.hrtime.bigint());
+}
+
+function after(asyncId: number) {
+  const start = cache.get(asyncId);
+  if (start == null) {
+    return;
+  }
+  cache.delete(asyncId);
+
+  const end = process.hrtime.bigint();
+  const diff = end - start;
+  if (diff > THRESHOLD_NS) {
+    const time = Number(diff / BigInt(1e6));
+    logger.warn({
+      label: "EventLoopMonitor",
+      message: `Event loop was blocked for ${time}ms`,
+      metadata: {
+        time
+      }
+    });
+
+    const span = tracer.startSpan("EventLoopBlock", {
+      childOf: tracer.scope().active() ?? undefined,
+      startTime: new Date().getTime() - time,
+      tags: {
+        ["service.name"]: "event-loop-monitor"
+      }
+    });
+    span.finish();
+  }
+}
 
 if (process.env.NODE_ENV !== "test") {
   const { TracerProvider } = tracer.init({
@@ -17,6 +57,12 @@ if (process.env.NODE_ENV !== "test") {
 
     // Register the provider globally
     provider.register();
+
+    // Create an async hook to measure event loop delay.
+    // This is using async hooks and not AsyncLocalStorage because we want to report the information
+    // to Datadog, and dd-js uses async hooks. This enable us to attach new spans to the current async context.
+    const asyncHook = createHook({ before, after });
+    asyncHook.enable();
   }
 }
 


### PR DESCRIPTION
Ajout d'un tracer pour détecter lorsque l'event loop se bloque, et pouvoir identifier d'ou vient ce blocage en rattachant le blocage aux spans de l'APM dans Datadog.

Possibilité de configurer le threshold avec EVENT_LOOP_THRESHOLD_MS (défaut à 200ms)