### PR TITLE
[YesWeHack] Ajout d'un rate limit sur la requête renewSecurityCode

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -142,6 +142,11 @@ export const server = new ApolloServer<GraphQLContext>({
       resendInvitation: {
         windowMs: RATE_LIMIT_WINDOW_SECONDS * 3 * 1000,
         maxRequestsPerWindow: 10 // 10 requests each 3 minutes
+      },
+      renewSecurityCode: {
+        // Hacker might massively generate new codes to spam 
+        windowMs: RATE_LIMIT_WINDOW_SECONDS * 3 * 1000,
+        maxRequestsPerWindow: 10 // 10 requests each 3 minutes
       }
     }),
     gqlRegenerateSessionPlugin(["changePassword"]),

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -144,7 +144,7 @@ export const server = new ApolloServer<GraphQLContext>({
         maxRequestsPerWindow: 10 // 10 requests each 3 minutes
       },
       renewSecurityCode: {
-        // Hacker might massively generate new codes to spam 
+        // Hacker might massively generate new codes to spam
         windowMs: RATE_LIMIT_WINDOW_SECONDS * 3 * 1000,
         maxRequestsPerWindow: 10 // 10 requests each 3 minutes
       }


### PR DESCRIPTION
# Contexte

Bug remonré sur YesWeHack. Ajout d'un rate limit sur la requête renewSecurityCode pour éviter le spam.

# Ticket Favro

[⚡️ YesWeHack - Ajout d'un rate limit sur la requête de renouvellement du code entreprise](https://favro.com/widget/ab14a4f0460a99a9d64d4945/40e9c96bd2208c492d992343?card=tra-13323)
