### PR TITLE
[tra-13172] Recepisse transporteur optionnel si le transport n'est pas par route

### DIFF
--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -122,13 +122,13 @@ describe("Mutation.signBsdasri emission", () => {
       expect(validated).toBeDefined();
     });
 
-    it("transporter recepisse is not required if transport mode is ROAD", async () => {
+    it("transporter recepisse is not required if transport mode is not ROAD", async () => {
       const data = {
         ...bsdasri,
-        transporterTransportMode: "ROAD",
-        transporterRecepisseDepartment: undefined,
-        transporterRecepisseNumber: undefined,
-        transporterRecepisseValidityLimit: undefined
+        transporterTransportMode: "AIR",
+        transporterRecepisseDepartment: "",
+        transporterRecepisseNumber: "",
+        transporterRecepisseValidityLimit: null
       };
       const validated = await validateBsdasri(data as any, {
         transportSignature: true

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -122,6 +122,20 @@ describe("Mutation.signBsdasri emission", () => {
       expect(validated).toBeDefined();
     });
 
+    it("transporter recepisse is not required if transport mode is ROAD", async () => {
+      const data = {
+        ...bsdasri,
+        transporterTransportMode: "ROAD",
+        transporterRecepisseDepartment: undefined,
+        transporterRecepisseNumber: undefined,
+        transporterRecepisseValidityLimit: undefined
+      };
+      const validated = await validateBsdasri(data as any, {
+        transportSignature: true
+      });
+      expect(validated).toBeDefined();
+    });
+
     it("should work if transport mode is ROAD & plates are defined", async () => {
       const data = {
         ...bsdasri,

--- a/back/src/bsffs/__tests__/validation.integration.ts
+++ b/back/src/bsffs/__tests__/validation.integration.ts
@@ -298,13 +298,13 @@ describe("transporterSchema", () => {
     expect(validated).toBeDefined();
   });
 
-  it("transporter recepisse is not required if transport mode is ROAD", async () => {
+  it("transporter recepisse is not required if transport mode is not ROAD", async () => {
     const bsff = {
       ...transporterData,
-      transporterTransportMode: "ROAD",
-      transporterRecepisseDepartment: undefined,
-      transporterRecepisseNumber: undefined,
-      transporterRecepisseValidityLimit: undefined
+      transporterTransportMode: "AIR",
+      transporterRecepisseDepartment: "",
+      transporterRecepisseNumber: "",
+      transporterRecepisseValidityLimit: null
     };
     const validated = await transporterSchema.isValid(bsff);
     expect(validated).toBeDefined();

--- a/back/src/bsffs/__tests__/validation.integration.ts
+++ b/back/src/bsffs/__tests__/validation.integration.ts
@@ -298,6 +298,18 @@ describe("transporterSchema", () => {
     expect(validated).toBeDefined();
   });
 
+  it("transporter recepisse is not required if transport mode is ROAD", async () => {
+    const bsff = {
+      ...transporterData,
+      transporterTransportMode: "ROAD",
+      transporterRecepisseDepartment: undefined,
+      transporterRecepisseNumber: undefined,
+      transporterRecepisseValidityLimit: undefined
+    };
+    const validated = await transporterSchema.isValid(bsff);
+    expect(validated).toBeDefined();
+  });
+
   it("should work if transport mode is ROAD & plates are defined", async () => {
     const bsff = {
       ...transporterData,

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -397,32 +397,62 @@ export const transporterRecepisseSchema = context => ({
   transporterRecepisseIsExempted: yup.boolean().nullable(),
   transporterRecepisseDepartment: yup
     .string()
-    .when(["transporterRecepisseIsExempted", "transporterCompanyVatNumber"], {
-      is: (isExempted, vat) => isExempted || isForeignVat(vat),
-      then: schema => schema.nullable().notRequired(),
-      otherwise: schema =>
-        schema.requiredIf(
-          context.transportSignature,
-          REQUIRED_RECEIPT_DEPARTMENT
-        )
-    }),
+    .when(
+      [
+        "transporterRecepisseIsExempted",
+        "transporterCompanyVatNumber",
+        "transporterTransportMode"
+      ],
+      {
+        is: (isExempted, vat, transportMode) =>
+          isExempted ||
+          isForeignVat(vat) ||
+          (transportMode && transportMode !== TransportMode.ROAD),
+        then: schema => schema.nullable().notRequired(),
+        otherwise: schema =>
+          schema.requiredIf(
+            context.transportSignature,
+            REQUIRED_RECEIPT_DEPARTMENT
+          )
+      }
+    ),
   transporterRecepisseNumber: yup
     .string()
-    .when(["transporterRecepisseIsExempted", "transporterCompanyVatNumber"], {
-      is: (isExempted, vat) => isExempted || isForeignVat(vat),
-      then: schema => schema.nullable().notRequired(),
-      otherwise: schema =>
-        schema.requiredIf(context.transportSignature, REQUIRED_RECEIPT_NUMBER)
-    }),
+    .when(
+      [
+        "transporterRecepisseIsExempted",
+        "transporterCompanyVatNumber",
+        "transporterTransportMode"
+      ],
+      {
+        is: (isExempted, vat, transportMode) =>
+          isExempted ||
+          isForeignVat(vat) ||
+          (transportMode && transportMode !== TransportMode.ROAD),
+        then: schema => schema.nullable().notRequired(),
+        otherwise: schema =>
+          schema.requiredIf(context.transportSignature, REQUIRED_RECEIPT_NUMBER)
+      }
+    ),
   transporterRecepisseValidityLimit: yup
     .date()
-    .when(["transporterRecepisseIsExempted", "transporterCompanyVatNumber"], {
-      is: (isExempted, vat) => isExempted || isForeignVat(vat),
-      then: schema => schema.nullable().notRequired(),
-      otherwise: schema =>
-        schema.requiredIf(
-          context.transportSignature,
-          REQUIRED_RECEIPT_VALIDITYLIMIT
-        )
-    })
+    .when(
+      [
+        "transporterRecepisseIsExempted",
+        "transporterCompanyVatNumber",
+        "transporterTransportMode"
+      ],
+      {
+        is: (isExempted, vat, transportMode) =>
+          isExempted ||
+          isForeignVat(vat) ||
+          (transportMode && transportMode !== TransportMode.ROAD),
+        then: schema => schema.nullable().notRequired(),
+        otherwise: schema =>
+          schema.requiredIf(
+            context.transportSignature,
+            REQUIRED_RECEIPT_VALIDITYLIMIT
+          )
+      }
+    )
 });

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -932,6 +932,28 @@ describe("beforeTransportSchema", () => {
     expect(isValid).toBeTruthy();
   });
 
+  it("transporter receipt is not required if transport mode is ROAD", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      transporters: [
+        {
+          ...transporterData,
+          transporterTransportMode: "ROAD",
+          transporterReceipt: undefined,
+          transporterDepartment: undefined,
+          transporterValidityLimit: undefined
+        }
+      ]
+    };
+    const isValid = beforeTransportSchemaFn({
+      signingTransporterOrgId: transporterData.transporterCompanySiret
+    }).isValid(testForm);
+
+    expect(isValid).toBeTruthy();
+  });
+
   it("should work if transport mode is ROAD & plates are defined", async () => {
     const testForm: Partial<Form> & {
       transporters: Partial<BsddTransporter>[];

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -932,7 +932,7 @@ describe("beforeTransportSchema", () => {
     expect(isValid).toBeTruthy();
   });
 
-  it("transporter receipt is not required if transport mode is ROAD", async () => {
+  it("transporter receipt is not required if transport mode is not ROAD", async () => {
     const testForm: Partial<Form> & {
       transporters: Partial<BsddTransporter>[];
     } = {
@@ -940,10 +940,10 @@ describe("beforeTransportSchema", () => {
       transporters: [
         {
           ...transporterData,
-          transporterTransportMode: "ROAD",
-          transporterReceipt: undefined,
-          transporterDepartment: undefined,
-          transporterValidityLimit: undefined
+          transporterTransportMode: "AIR",
+          transporterReceipt: "",
+          transporterDepartment: "",
+          transporterValidityLimit: null
         }
       ]
     };

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -972,37 +972,70 @@ export const transporterSchemaFn: FactorySchemaOf<
     transporterIsExemptedOfReceipt: yup.boolean().notRequired().nullable(),
     transporterReceipt: yup
       .string()
-      .when(["transporterIsExemptedOfReceipt", "transporterCompanyVatNumber"], {
-        is: (isExempted, vat) => isForeignVat(vat) || isExempted,
-        then: schema => schema.notRequired().nullable(),
-        otherwise: schema =>
-          schema.when(
-            ["transporterCompanySiret", "transporterCompanyVatNumber"],
-            requiredWhenTransporterSign(context, REQUIRED_RECEIPT_NUMBER)
-          )
-      }),
+      .when(
+        [
+          "transporterIsExemptedOfReceipt",
+          "transporterCompanyVatNumber",
+          "transporterTransportMode"
+        ],
+        {
+          is: (isExempted, vat, transportMode) =>
+            isForeignVat(vat) ||
+            isExempted ||
+            transportMode !== TransportMode.ROAD,
+          then: schema => schema.notRequired().nullable(),
+          otherwise: schema =>
+            schema.when(
+              ["transporterCompanySiret", "transporterCompanyVatNumber"],
+              requiredWhenTransporterSign(context, REQUIRED_RECEIPT_NUMBER)
+            )
+        }
+      ),
     transporterDepartment: yup
       .string()
-      .when(["transporterIsExemptedOfReceipt", "transporterCompanyVatNumber"], {
-        is: (isExempted, vat) => isForeignVat(vat) || isExempted,
-        then: schema => schema.notRequired().nullable(),
-        otherwise: schema =>
-          schema.when(
-            ["transporterCompanySiret", "transporterCompanyVatNumber"],
-            requiredWhenTransporterSign(context, REQUIRED_RECEIPT_DEPARTMENT)
-          )
-      }),
+      .when(
+        [
+          "transporterIsExemptedOfReceipt",
+          "transporterCompanyVatNumber",
+          "transporterTransportMode"
+        ],
+        {
+          is: (isExempted, vat, transportMode) =>
+            isForeignVat(vat) ||
+            isExempted ||
+            transportMode !== TransportMode.ROAD,
+          then: schema => schema.notRequired().nullable(),
+          otherwise: schema =>
+            schema.when(
+              ["transporterCompanySiret", "transporterCompanyVatNumber"],
+              requiredWhenTransporterSign(context, REQUIRED_RECEIPT_DEPARTMENT)
+            )
+        }
+      ),
     transporterValidityLimit: yup
       .string()
-      .when(["transporterIsExemptedOfReceipt", "transporterCompanyVatNumber"], {
-        is: (isExempted, vat) => isForeignVat(vat) || isExempted,
-        then: schema => schema.notRequired().nullable(),
-        otherwise: schema =>
-          schema.when(
-            ["transporterCompanySiret", "transporterCompanyVatNumber"],
-            requiredWhenTransporterSign(context, REQUIRED_RECEIPT_VALIDITYLIMIT)
-          )
-      }),
+      .when(
+        [
+          "transporterIsExemptedOfReceipt",
+          "transporterCompanyVatNumber",
+          "transporterTransportMode"
+        ],
+        {
+          is: (isExempted, vat, transportMode) =>
+            isForeignVat(vat) ||
+            isExempted ||
+            transportMode !== TransportMode.ROAD,
+          then: schema => schema.notRequired().nullable(),
+          otherwise: schema =>
+            schema.when(
+              ["transporterCompanySiret", "transporterCompanyVatNumber"],
+              requiredWhenTransporterSign(
+                context,
+                REQUIRED_RECEIPT_VALIDITYLIMIT
+              )
+            )
+        }
+      ),
     transporterTransportMode: yup.mixed<TransportMode>()
   });
 


### PR DESCRIPTION
Ne pas rendre obligatoire le récépissé transporteur si le transport est autre que Route

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13172)
