### PR TITLE
remove $ escaping in deploy-db, and add npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "",
   "scripts": {
     "scalingo-postbuild": "bash scripts/build/scalingo.sh",
-    "nx": "nx"
+    "nx": "nx",
+    "dev": "npx nx run-many -t serve --parallel=6 --projects=front,api,tag:backend:background"
   },
   "engines": {
     "node": "^20"

--- a/scripts/deploy-db.sh
+++ b/scripts/deploy-db.sh
@@ -8,7 +8,7 @@ red=$(tput setaf 9)
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-USING_ENV_FILE=false
+USING_ENV_FILE=true
 
 if [ -z "$DATABASE_URL" ]
 then
@@ -31,7 +31,7 @@ then
           break
       else
           echo -"${red}$pathToEnv is not a valid path.${reset}"
-      fi 
+      fi
     done
   else
     echo "${bold}! You need to set the ${green}\$DATABASE_URL${reset}${bold} env variable.${reset}"
@@ -75,12 +75,5 @@ until curl -XGET "$ELASTIC_SEARCH_URL" 2> /dev/null; do
   sleep 1
 done
 
-# Escape $ sign in DATABASE_URL if the env has been loaded from a .env file
-# This is because NX expands env variables in .env files
-if [ "$USING_ENV_FILE" = true ] ; then
-  echo "Using env file, escaping \$ sign in DATABASE_URL"
-  DATABASE_URL="${DATABASE_URL//$/\\$}"
-fi
-
 echo "3/3 - Create tables & index";
-npx nx run back:"preintegration-tests"
+npm --prefix back run preintegration-tests


### PR DESCRIPTION
- Ajout raccourci pour lancer l'en local complet  `npm run dev`
- Fixer Deploy-db.sh pour supporter `DATABASE_URL='postgresql://trackdechets:password@postgres:5432/prisma_test?schema=default$default'` dans le fichier .env.integration (il faut garder `DATABASE_URL="postgresql://trackdechets:password@postgres:5432/prisma"` dans le fichier .env)
