### PR TITLE
[TRA-13088] Lors de la duplication d'un DASRI le packaging devrait être [], pas null

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -454,6 +454,6 @@ describe("Mutation.duplicateBsdasri", () => {
     expect(duplicatedDasri.emitterWasteWeightValue).toBeNull();
     expect(duplicatedDasri.emitterWasteWeightIsEstimate).toBeNull();
     expect(duplicatedDasri.emitterWasteVolume).toBeNull();
-    expect(duplicatedDasri.emitterWastePackagings).toBeNull();
+    expect(duplicatedDasri.emitterWastePackagings).toStrictEqual([]);
   });
 });

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -109,7 +109,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
 
   const input: Prisma.BsdasriCreateInput = {
     ...fieldsToCopy,
-    emitterWastePackagings: Prisma.JsonNull,
+    emitterWastePackagings: [],
     id: getReadableId(ReadableIdPrefix.DASRI),
     status: BsdasriStatus.INITIAL,
     isDraft: true,


### PR DESCRIPTION
# Contexte

Bugfix de recette.

Lorsqu'on duplique un DASRI, le `emitterWastePackagings` devrait être un array vide, pas null, sinon le front ne s'affiche plus correctement.

# Ticket Favro

[Ne pas dupliquer la quantité et le conditionnement lors de la duplication d'un BSDASRI ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/40e9c96bd2208c492d992343?card=tra-13088)