### PR TITLE
[TRA-13409] Impossible de réviser les numéros de scellés

### DIFF
--- a/front/src/dashboard/components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@apollo/client";
 import { Field, Form, Formik } from "formik";
-import React, { lazy } from "react";
+import React from "react";
 import { useNavigate } from "react-router";
 import { useParams } from "react-router-dom";
 import * as yup from "yup";

--- a/front/src/dashboard/components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -26,9 +26,7 @@ import styles from "./BsdaRequestRevision.module.scss";
 import { BSDA_WASTES } from "shared/constants";
 import { BsdaRequestRevisionCancelationInput } from "../BsdaRequestRevisionCancelationInput";
 import OperationModeSelect from "../../../../../common/components/OperationModeSelect";
-const TagsInput = lazy(
-  () => import("../../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../../common/components/tags-input/TagsInput";
 
 type Props = {
   bsda: Bsda;


### PR DESCRIPTION
# Contexte

Quand on fait une révision sur un BSDA, et qu'on clique sur le toggle pour les scellés, ça provoque une récursion infinie.

# Ticket Favro

[Impossible de réviser les numéros de scellés](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13409)
