### PR TITLE
[tra-13215] Implémentation Back pour l'affichage des Révisions

### DIFF
--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1465,8 +1465,8 @@ model Bsda {
   forwardingId String? @unique
   forwardedIn  Bsda?   @relation("BsdaForwarding")
 
-  BsdaRevisionRequest BsdaRevisionRequest[]
-  intermediaries      IntermediaryBsdaAssociation[]
+  bsdaRevisionRequests BsdaRevisionRequest[]
+  intermediaries       IntermediaryBsdaAssociation[]
 
   // denormalization - sirets and vats from intermediaries
   intermediariesOrgIds String[] @default([])

--- a/back/project.json
+++ b/back/project.json
@@ -16,7 +16,7 @@
       "command": "tsc -p back/tsconfig.lib.json --noEmit"
     },
     "codegen": {
-      "inputs": ["{projectRoot}/**/*.gql"],
+      "inputs": ["{projectRoot}/**/*.graphql"],
       "cache": true,
       "executor": "nx:run-commands",
       "options": {

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -47,7 +47,7 @@ import {
 } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "shared/constants";
 import { Decimal } from "decimal.js-light";
-import { BsdaForElastic } from "./elastic";
+import { BsdaInElastic } from "./elastic";
 
 export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
   return {
@@ -221,7 +221,7 @@ export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
     metadata: undefined as any
   };
 }
-export function expandBsdaFromElastic(bsda: BsdaForElastic): GraphqlBsda {
+export function expandBsdaFromElastic(bsda: BsdaInElastic): GraphqlBsda {
   const expanded = expandBsdaFromDb(bsda);
 
   const groupedIn = bsda.groupedIn
@@ -243,7 +243,13 @@ export function expandBsdaFromElastic(bsda: BsdaForElastic): GraphqlBsda {
   return {
     ...expanded,
     groupedIn,
-    forwardedIn
+    forwardedIn,
+    metadata: {
+      revisionsInfos: {
+        hasBeenRevised: bsda.isRevisedFor.length > 0,
+        activeRevision: bsda.activeRevisionInfos
+      }
+    }
   };
 }
 

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -246,7 +246,7 @@ export function expandBsdaFromElastic(bsda: BsdaInElastic): GraphqlBsda {
     forwardedIn,
     metadata: {
       revisionsInfos: {
-        hasBeenRevised: bsda.isRevisedFor.length > 0,
+        hasBeenRevised: bsda.hasBeenRevised,
         activeRevision: bsda.activeRevisionInfos
       }
     }

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -28,6 +28,7 @@ export type BsdaForElastic = Bsda &
 
 export type BsdaInElastic = BsdaForElastic &
   Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> & {
+    hasBeenRevised: boolean;
     activeRevisionInfos: ActiveRevisionInfos | undefined;
   };
 
@@ -185,7 +186,7 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
 export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
   const where = getWhere(bsda);
 
-  const { isInRevisionFor, isRevisedFor, activeRevisionInfos } =
+  const { isInRevisionFor, isRevisedFor, hasBeenRevised, activeRevisionInfos } =
     getBsdaRevisionsInfos(bsda);
 
   return {
@@ -275,6 +276,7 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
       ...bsda,
       isInRevisionFor,
       isRevisedFor,
+      hasBeenRevised,
       activeRevisionInfos
     }
   };

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -291,5 +291,5 @@ export function indexBsda(bsda: BsdaForElastic, ctx?: GraphQLContext) {
 export function getBsdaRevisionsInfos(
   bsda: BsdaForElastic
 ): ReturnType<typeof getRevisionsInfos> {
-  return getRevisionsInfos(bsda.BsdaRevisionRequest);
+  return getRevisionsInfos(bsda.bsdaRevisionRequests);
 }

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -186,8 +186,13 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
 export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
   const where = getWhere(bsda);
 
-  const { isInRevisionFor, isRevisedFor, hasBeenRevised, activeRevisionInfos } =
-    getBsdaRevisionsInfos(bsda);
+  const {
+    isInRevisionFor,
+    isRevisedFor,
+    latestRevisionCreatedAt,
+    hasBeenRevised,
+    activeRevisionInfos
+  } = getBsdaRevisionsInfos(bsda);
 
   return {
     type: BsdType.BSDA,
@@ -269,6 +274,7 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
     ...where,
     isInRevisionFor,
     isRevisedFor,
+    latestRevisionCreatedAt: latestRevisionCreatedAt?.getTime(),
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsda),
     intermediaries: bsda.intermediaries,

--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -7,6 +7,7 @@ import {
 import { getBsdaOrNotFound } from "../database";
 import { parseBsdaInContext } from "../validation";
 import prisma from "../../prisma";
+import { RevisionRequestApprovalStatus } from "@prisma/client";
 
 function getNextSignature(bsda) {
   if (bsda.destinationOperationSignatureAuthor != null) return "OPERATION";
@@ -64,7 +65,12 @@ export const Metadata: BsdaMetadataResolvers = {
       activeRevision: activeRevision
         ? {
             author: activeRevision.authoringCompanyId,
-            approvedBy: activeRevision.approvals.map(a => a.approverSiret)
+            approvedBy: activeRevision.approvals
+              .filter(
+                approval =>
+                  approval.status === RevisionRequestApprovalStatus.ACCEPTED
+              )
+              .map(a => a.approverSiret)
           }
         : undefined
     };

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsdaFactory } from "../../../__tests__/factories";
+import prisma from "../../../../prisma";
 
 const GET_BSDAS = `
   query GetBsdas($after: ID, $first: Int, $before: ID, $last: Int, $where: BsdaWhere) {
@@ -20,6 +21,15 @@ const GET_BSDAS = `
           }
           forwarding {
             id
+          }
+          metadata {
+            revisionsInfos {
+              hasBeenRevised
+              activeRevision {
+                author
+                approvedBy
+              }
+            }
           }
         }
       }
@@ -278,5 +288,67 @@ describe("Query.bsdas", () => {
     );
 
     expect(data.bsdas.edges.length).toBe(0);
+  });
+
+  it("should return revisions infos as metadata", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const worker = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        destinationCompanySiret: destination.company.siret,
+        workerCompanySiret: worker.company.siret
+      }
+    });
+
+    // Accepted revision
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        comment: "a comment",
+        bsdaId: bsda.id,
+        authoringCompanyId: emitter.company.id,
+        wasteCode: "06 07 02*",
+        status: "ACCEPTED"
+      }
+    });
+    // Pending revision
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        comment: "a comment",
+        bsdaId: bsda.id,
+        authoringCompanyId: emitter.company.id,
+        wasteCode: "06 07 02*",
+        status: "PENDING",
+        approvals: {
+          createMany: {
+            data: [
+              {
+                status: "PENDING",
+                approverSiret: destination.company.siret!
+              },
+              { status: "ACCEPTED", approverSiret: worker.company.siret! }
+            ]
+          }
+        }
+      }
+    });
+
+    const { query } = makeClient(emitter.user);
+    const { data } = await query<Pick<Query, "bsdas">, QueryBsdasArgs>(
+      GET_BSDAS
+    );
+
+    expect(data.bsdas.edges.length).toBe(1);
+    expect(
+      data.bsdas.edges[0].node.metadata.revisionsInfos.hasBeenRevised
+    ).toBe(true);
+    expect(
+      data.bsdas.edges[0].node.metadata.revisionsInfos.activeRevision?.author
+    ).toBe(emitter.company.id);
+    expect(
+      data.bsdas.edges[0].node.metadata.revisionsInfos.activeRevision
+        ?.approvedBy
+    ).toEqual([worker.company.siret]);
   });
 });

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -320,6 +320,7 @@ type BsdaBroker {
 
 type BsdaMetadata {
   errors: [BsdaError]
+  revisionsInfos: RevisionsInfos!
 }
 
 type BsdaError {

--- a/back/src/bsda/types.ts
+++ b/back/src/bsda/types.ts
@@ -38,7 +38,7 @@ export type BsdaRevisionRequestWithAuthoringCompany =
 
 export const BsdaRevisionRequestWithApprovalsInclude =
   Prisma.validator<Prisma.BsdaRevisionRequestInclude>()({
-    approvals: { select: { approverSiret: true } }
+    approvals: { select: { approverSiret: true, status: true } }
   });
 
 export type BsdaRevisionRequestWithApprovals =

--- a/back/src/bsda/types.ts
+++ b/back/src/bsda/types.ts
@@ -48,7 +48,7 @@ export type BsdaRevisionRequestWithApprovals =
 
 export const BsdaWithRevisionRequestsInclude =
   Prisma.validator<Prisma.BsdaInclude>()({
-    BsdaRevisionRequest: {
+    bsdaRevisionRequests: {
       include: {
         ...BsdaRevisionRequestWithAuthoringCompanyInclude,
         ...BsdaRevisionRequestWithApprovalsInclude

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -34,7 +34,7 @@ export type EditableBsdaFields = Required<
     | "forwardingId"
     | "groupedIn"
     | "forwardedIn"
-    | "BsdaRevisionRequest"
+    | "bsdaRevisionRequests"
     | "intermediariesOrgIds"
   >
 >;

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -214,6 +214,7 @@ export function toBsdElastic(bsdasri: BsdasriForElastic): BsdElastic {
     ...where,
     isInRevisionFor: [],
     isRevisedFor: [],
+    latestRevisionCreatedAt: undefined,
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsdasri),
     rawBsd: bsdasri

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -1256,6 +1256,15 @@ describe("Bsda sub-resolvers in query bsds", () => {
               forwardedIn {
                 id
               }
+              metadata {
+                revisionsInfos {
+                  hasBeenRevised
+                  activeRevision {
+                    author
+                    approvedBy
+                  }
+                }
+              }
             }
           }
         }
@@ -1571,5 +1580,253 @@ describe("Bsda sub-resolvers in query bsds", () => {
     const queriedBsda = bsdas.find(bsd => bsd.id === bsda.id);
     expect(queriedBsda).toBeDefined();
     expect((queriedBsda as any)!.forwardedIn).toBeNull();
+  });
+
+  test("Bsda.revisionsInfos should resolve correctly when there are no revisions", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const worker = await userWithCompanyFactory(UserRole.ADMIN);
+    const { query, mutate } = makeClient(emitter.user);
+    await mutate<Pick<Mutation, "createBsda">, MutationCreateBsdaArgs>(
+      CREATE_BSDA,
+      {
+        variables: {
+          input: {
+            type: "OTHER_COLLECTIONS",
+            waste: { code: "06 07 01*" },
+            emitter: {
+              company: {
+                siret: emitter.company.siret,
+                name: emitter.company.name,
+                contact: emitter.company.contact,
+                phone: emitter.company.contactPhone,
+                mail: emitter.company.contactEmail,
+                address: emitter.company.address
+              }
+            },
+            destination: {
+              company: {
+                siret: destination.company.siret,
+                name: destination.company.name,
+                contact: destination.company.contact,
+                phone: destination.company.contactPhone,
+                mail: destination.company.contactEmail,
+                address: destination.company.address
+              },
+              cap: "CAP",
+              plannedOperationCode: "R 5"
+            },
+            worker: {
+              company: {
+                siret: worker.company.siret,
+                name: worker.company.name,
+                contact: worker.company.contact,
+                phone: worker.company.contactPhone,
+                mail: worker.company.contactEmail,
+                address: worker.company.address
+              }
+            }
+          }
+        }
+      }
+    );
+
+    await refreshElasticSearch();
+
+    const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+      GET_BSDS,
+      {}
+    );
+    const bsdas = data.bsds!.edges.map(e => e.node);
+    expect(bsdas).toHaveLength(1);
+    expect((bsdas[0] as any)!.metadata.revisionsInfos.hasBeenRevised).toBe(
+      false
+    );
+    expect(
+      (bsdas[0] as any)!.metadata.revisionsInfos.activeRevision
+    ).toBeNull();
+  });
+
+  test("Bsda.revisionsInfos should resolve correctly when there are past revisions but no active", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const worker = await userWithCompanyFactory(UserRole.ADMIN);
+    const { query, mutate } = makeClient(emitter.user);
+    const {
+      data: { createBsda }
+    } = await mutate<Pick<Mutation, "createBsda">, MutationCreateBsdaArgs>(
+      CREATE_BSDA,
+      {
+        variables: {
+          input: {
+            type: "OTHER_COLLECTIONS",
+            waste: { code: "06 07 01*" },
+            emitter: {
+              company: {
+                siret: emitter.company.siret,
+                name: emitter.company.name,
+                contact: emitter.company.contact,
+                phone: emitter.company.contactPhone,
+                mail: emitter.company.contactEmail,
+                address: emitter.company.address
+              }
+            },
+            destination: {
+              company: {
+                siret: destination.company.siret,
+                name: destination.company.name,
+                contact: destination.company.contact,
+                phone: destination.company.contactPhone,
+                mail: destination.company.contactEmail,
+                address: destination.company.address
+              },
+              cap: "CAP",
+              plannedOperationCode: "R 5"
+            },
+            worker: {
+              company: {
+                siret: worker.company.siret,
+                name: worker.company.name,
+                contact: worker.company.contact,
+                phone: worker.company.contactPhone,
+                mail: worker.company.contactEmail,
+                address: worker.company.address
+              }
+            }
+          }
+        }
+      }
+    );
+
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        comment: "a comment",
+        bsdaId: createBsda.id,
+        authoringCompanyId: emitter.company.id,
+        wasteCode: "06 07 02*",
+        status: "ACCEPTED"
+      }
+    });
+
+    const bsdaElastic = await getBsdaForElastic(createBsda);
+    await indexBsda(bsdaElastic);
+    await refreshElasticSearch();
+
+    const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+      GET_BSDS,
+      {}
+    );
+    const bsdas = data.bsds!.edges.map(e => e.node);
+    expect(bsdas).toHaveLength(1);
+    expect((bsdas[0] as any)!.metadata.revisionsInfos.hasBeenRevised).toBe(
+      true
+    );
+    expect(
+      (bsdas[0] as any)!.metadata.revisionsInfos.activeRevision
+    ).toBeNull();
+  });
+
+  test("Bsda.revisionsInfos should resolve correctly when there are past and active revisions", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const worker = await userWithCompanyFactory(UserRole.ADMIN);
+    const { query, mutate } = makeClient(emitter.user);
+    const {
+      data: { createBsda }
+    } = await mutate<Pick<Mutation, "createBsda">, MutationCreateBsdaArgs>(
+      CREATE_BSDA,
+      {
+        variables: {
+          input: {
+            type: "OTHER_COLLECTIONS",
+            waste: { code: "06 07 01*" },
+            emitter: {
+              company: {
+                siret: emitter.company.siret,
+                name: emitter.company.name,
+                contact: emitter.company.contact,
+                phone: emitter.company.contactPhone,
+                mail: emitter.company.contactEmail,
+                address: emitter.company.address
+              }
+            },
+            destination: {
+              company: {
+                siret: destination.company.siret,
+                name: destination.company.name,
+                contact: destination.company.contact,
+                phone: destination.company.contactPhone,
+                mail: destination.company.contactEmail,
+                address: destination.company.address
+              },
+              cap: "CAP",
+              plannedOperationCode: "R 5"
+            },
+            worker: {
+              company: {
+                siret: worker.company.siret,
+                name: worker.company.name,
+                contact: worker.company.contact,
+                phone: worker.company.contactPhone,
+                mail: worker.company.contactEmail,
+                address: worker.company.address
+              }
+            }
+          }
+        }
+      }
+    );
+
+    // Accepted revision
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        comment: "a comment",
+        bsdaId: createBsda.id,
+        authoringCompanyId: emitter.company.id,
+        wasteCode: "06 07 02*",
+        status: "ACCEPTED"
+      }
+    });
+    // Pending revision
+    await prisma.bsdaRevisionRequest.create({
+      data: {
+        comment: "a comment",
+        bsdaId: createBsda.id,
+        authoringCompanyId: emitter.company.id,
+        wasteCode: "06 07 02*",
+        status: "PENDING",
+        approvals: {
+          createMany: {
+            data: [
+              {
+                status: "PENDING",
+                approverSiret: destination.company.siret!
+              },
+              { status: "ACCEPTED", approverSiret: worker.company.siret! }
+            ]
+          }
+        }
+      }
+    });
+
+    const bsdaElastic = await getBsdaForElastic(createBsda);
+    await indexBsda(bsdaElastic);
+    await refreshElasticSearch();
+
+    const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+      GET_BSDS,
+      {}
+    );
+    const bsdas = data.bsds!.edges.map(e => e.node);
+    expect(bsdas).toHaveLength(1);
+    expect((bsdas[0] as any)!.metadata.revisionsInfos.hasBeenRevised).toBe(
+      true
+    );
+    expect(
+      (bsdas[0] as any)!.metadata.revisionsInfos.activeRevision.author
+    ).toBe(emitter.company.id);
+    expect(
+      (bsdas[0] as any)!.metadata.revisionsInfos.activeRevision.approvedBy
+    ).toEqual([worker.company.siret]);
   });
 });

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -179,6 +179,10 @@ function getKeywordFieldNameFromName(fieldName: keyof BsdElastic): string {
     return fieldName;
   }
 
+  if (property.type === "date") {
+    return fieldName;
+  }
+
   // look for a sub field with the type "keyword"
   const [subFieldName] =
     Object.entries(property.fields || {}).find(
@@ -346,13 +350,7 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
   } = toRawBsds(hits.map(hit => hit._source));
 
   const bsds: Record<BsdType, Bsd[]> = {
-    BSDD: (
-      await Promise.all(
-        concreteBsdds.map(bsdd =>
-          expandFormFromElastic(bsdd, context.dataloaders.forms)
-        )
-      )
-    ).filter(Boolean),
+    BSDD: concreteBsdds.map(expandFormFromElastic),
     BSDASRI: await buildDasris(concreteBsdasris),
     BSVHU: concreteBsvhus.map(expandVhuFormFromDb),
     BSDA: concreteBsdas.map(expandBsdaFromElastic),

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -25,10 +25,10 @@ import { bsdSearchSchema } from "../../validation";
 import { toElasticQuery } from "../../where";
 import { Permission, can, getUserRoles } from "../../../permissions";
 import { distinct } from "../../../common/arrays";
-import { FormForElastic } from "../../../forms/elastic";
+import { FormInElastic } from "../../../forms/elastic";
 import { BsdasriForElastic } from "../../../bsdasris/elastic";
 import { BsvhuForElastic } from "../../../bsvhu/elastic";
-import { BsdaForElastic } from "../../../bsda/elastic";
+import { BsdaInElastic } from "../../../bsda/elastic";
 import { BsffForElastic } from "../../../bsffs/elastic";
 import { QueryContainer } from "@elastic/elasticsearch/api/types";
 import { GraphQLContext } from "../../../types";
@@ -51,26 +51,26 @@ export interface GetResponse<T> {
 }
 
 type PrismaBsdMap = {
-  bsdds: FormForElastic[];
+  bsdds: FormInElastic[];
   bsdasris: BsdasriForElastic[];
   bsvhus: BsvhuForElastic[];
-  bsdas: BsdaForElastic[];
+  bsdas: BsdaInElastic[];
   bsffs: BsffForElastic[];
 };
 
 /**
  * Convert a list of BsdElastic to a mapping of prisma-like Bsds by retrieving rawBsd elastic field
  */
-async function toRawBsds(bsdsElastic: BsdElastic[]): Promise<PrismaBsdMap> {
+function toRawBsds(bsdsElastic: BsdElastic[]): PrismaBsdMap {
   const { BSDD, BSDA, BSDASRI, BSFF, BSVHU } = groupByBsdType(bsdsElastic);
 
   return {
-    bsdds: BSDD.map(bsdElastic => bsdElastic.rawBsd as FormForElastic),
+    bsdds: BSDD.map(bsdElastic => bsdElastic.rawBsd as FormInElastic),
     bsdasris: BSDASRI.map(
       bsdsElastic => bsdsElastic.rawBsd as BsdasriForElastic
     ),
     bsvhus: BSVHU.map(bsdElastic => bsdElastic.rawBsd as BsvhuForElastic),
-    bsdas: BSDA.map(bsdElastic => bsdElastic.rawBsd as BsdaForElastic),
+    bsdas: BSDA.map(bsdElastic => bsdElastic.rawBsd as BsdaInElastic),
     bsffs: BSFF.map(bsdsElastic => bsdsElastic.rawBsd as BsffForElastic)
   };
 }
@@ -343,7 +343,7 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
     bsvhus: concreteBsvhus,
     bsdas: concreteBsdas,
     bsffs: concreteBsffs
-  } = await toRawBsds(hits.map(hit => hit._source));
+  } = toRawBsds(hits.map(hit => hit._source));
 
   const bsds: Record<BsdType, Bsd[]> = {
     BSDD: (

--- a/back/src/bsds/typeDefs/bsd.objects.graphql
+++ b/back/src/bsds/typeDefs/bsd.objects.graphql
@@ -61,3 +61,19 @@ type Signature {
   date: DateTime
   author: String
 }
+
+type RevisionsInfos {
+  "La révision a-t-elle déjà été révisée ?"
+  hasBeenRevised: Boolean!
+  """
+  Sirets des entreprises ayant apposé une approbation sur la révision active.
+  Tableau vide si aucune approbation n'a été apposée.
+  Tableau nul s'il n'y a pas de révision active.
+  """
+  activeRevision: ActiveRevisionInfos
+}
+
+type ActiveRevisionInfos {
+  author: String!
+  approvedBy: [String!]!
+}

--- a/back/src/bsds/typeDefs/private/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.inputs.graphql
@@ -52,6 +52,7 @@ input OrderBy {
   emitterCompanyName: OrderType
   destinationCompanyName: OrderType
   wasteCode: OrderType
+  latestRevisionCreatedAt: OrderType
 }
 
 input BsdCompanyWhere {

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -109,6 +109,7 @@ export function toBsdElastic(bsff: BsffForElastic): BsdElastic {
     isCollectedFor: [] as string[],
     isInRevisionFor: [] as string[],
     isRevisedFor: [] as string[],
+    latestRevisionCreatedAt: undefined,
     sirets: [
       bsff.emitterCompanySiret,
       bsff.transporterCompanySiret,

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -176,6 +176,7 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
     ...where,
     isInRevisionFor: [],
     isRevisedFor: [],
+    latestRevisionCreatedAt: undefined,
     sirets: Object.values(where).flat(),
     ...getRegistryFields(bsvhu),
     rawBsd: bsvhu

--- a/back/src/commands/sendTestEmail.ts
+++ b/back/src/commands/sendTestEmail.ts
@@ -1,5 +1,5 @@
 import { sendMail } from "../mailer/mailing";
-import templateIds from "../mailer/templates/provider/templateIds";
+import { templateIds } from "@td/mail";
 
 /**
  * Send a test email to a given address from command line

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -6,8 +6,8 @@ import { AuthType } from "../auth";
 import { logger } from "@td/logger";
 import { BsdType, FormCompany } from "../generated/graphql/types";
 import { OperationMode } from "@prisma/client";
-import { FormForElastic } from "../forms/elastic";
-import { BsdaForElastic } from "../bsda/elastic";
+import { FormInElastic } from "../forms/elastic";
+import { BsdaInElastic } from "../bsda/elastic";
 import { BsdasriForElastic } from "../bsdasris/elastic";
 import { BsvhuForElastic } from "../bsvhu/elastic";
 import { BsffForElastic } from "../bsffs/elastic";
@@ -104,8 +104,8 @@ export interface BsdElastic {
   intermediaries?: FormCompany[] | null;
 
   rawBsd:
-    | FormForElastic
-    | BsdaForElastic
+    | FormInElastic
+    | BsdaInElastic
     | BsdasriForElastic
     | BsvhuForElastic
     | BsffForElastic;

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -100,6 +100,7 @@ export interface BsdElastic {
   isInRevisionFor: string[];
   // Liste des établissements concernés par une demande de révision passée sur ce bordereau
   isRevisedFor: string[];
+  latestRevisionCreatedAt: number | undefined;
 
   intermediaries?: FormCompany[] | null;
 
@@ -274,6 +275,7 @@ const properties: Record<keyof BsdElastic, Record<string, unknown>> = {
   isManagedWasteFor: stringField,
   isInRevisionFor: stringField,
   isRevisedFor: stringField,
+  latestRevisionCreatedAt: dateField,
 
   intermediaries: {
     properties: {

--- a/back/src/common/elasticHelpers.ts
+++ b/back/src/common/elasticHelpers.ts
@@ -11,46 +11,65 @@ type RevisionRequest = {
   };
 };
 
+export type ActiveRevisionInfos = {
+  author: string;
+  approvedBy: string[];
+};
+
 /**
  * Pour une liste de demandes de révisions BSDD ou BSDA, retourne l'ensemble
  * des identifiants d'établissements pour lesquels il y a une demande de révision
  * en cours ou passée.
  */
-export function getRevisionOrgIds(
-  revisionRequests: RevisionRequest[]
-): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
-  const { isInRevisionFor, isRevisedFor } = revisionRequests.reduce<
-    ReturnType<typeof getRevisionOrgIds>
-  >(
-    // Pour chaque demande de révision en cours ou passés sur le bordereau
-    ({ isInRevisionFor, isRevisedFor }, revisionRequest) => {
-      // On commence par calculer la liste des identifiants d'établissements
-      // concernés par la demande de révision. En théorie cette liste est plus ou
-      // moins la même d'une demande de révision à l'autre
-      const revisionRequestOrgIds = [
-        revisionRequest.authoringCompany.orgId,
-        ...revisionRequest.approvals.map(a => a.approverSiret)
-      ];
-      // En fonction du statut de la demande de révision, on affecte les identifiants
-      // d'établissements soit à `isInRevisionFor`, soit à `isRevisedFor`. L'utilisation
-      // de `new Set(...)` permet de s'assurer que les identifiants sont uniques dans la liste.
+export function getRevisionsInfos(revisionRequests: RevisionRequest[]): Pick<
+  BsdElastic,
+  "isInRevisionFor" | "isRevisedFor"
+> & {
+  activeRevisionInfos: ActiveRevisionInfos | undefined;
+} {
+  const { isInRevisionFor, isRevisedFor, activeRevisionInfos } =
+    revisionRequests.reduce<ReturnType<typeof getRevisionsInfos>>(
+      // Pour chaque demande de révision en cours ou passés sur le bordereau
+      (
+        { isInRevisionFor, isRevisedFor, activeRevisionInfos },
+        revisionRequest
+      ) => {
+        // On commence par calculer la liste des identifiants d'établissements
+        // concernés par la demande de révision. En théorie cette liste est plus ou
+        // moins la même d'une demande de révision à l'autre
+        const revisionRequestOrgIds = [
+          revisionRequest.authoringCompany.orgId,
+          ...revisionRequest.approvals.map(a => a.approverSiret)
+        ];
+        // En fonction du statut de la demande de révision, on affecte les identifiants
+        // d'établissements soit à `isInRevisionFor`, soit à `isRevisedFor`. L'utilisation
+        // de `new Set(...)` permet de s'assurer que les identifiants sont uniques dans la liste.
 
-      return revisionRequest.status === "PENDING"
-        ? {
-            isInRevisionFor: [
-              ...new Set([...isInRevisionFor, ...revisionRequestOrgIds])
-            ],
-            isRevisedFor
-          }
-        : {
-            isInRevisionFor,
-            isRevisedFor: [
-              ...new Set([...isRevisedFor, ...revisionRequestOrgIds])
-            ]
-          };
-    },
-    { isInRevisionFor: [], isRevisedFor: [] }
-  );
+        return revisionRequest.status === "PENDING"
+          ? {
+              isInRevisionFor: [
+                ...new Set([...isInRevisionFor, ...revisionRequestOrgIds])
+              ],
+              isRevisedFor,
+              activeRevisionInfos: {
+                author: revisionRequest.authoringCompany.orgId,
+                approvedBy: revisionRequest.approvals.map(a => a.approverSiret)
+              }
+            }
+          : {
+              isInRevisionFor,
+              isRevisedFor: [
+                ...new Set([...isRevisedFor, ...revisionRequestOrgIds])
+              ],
+              activeRevisionInfos
+            };
+      },
+      {
+        isInRevisionFor: [],
+        isRevisedFor: [],
+        activeRevisionInfos: undefined
+      }
+    );
 
   // Si on a à la fois une demande de révision en cours et des demandes de révision passées
   // on veut que le bordereau apparaisse uniquement dans l'onglet `En révision`. On ajoute donc
@@ -58,6 +77,9 @@ export function getRevisionOrgIds(
   // soit dans `isInRevisionFor`, soit dans `isRevisedFor` mais pas dans les deux.
   return {
     isInRevisionFor: isInRevisionFor,
-    isRevisedFor: isRevisedFor.filter(orgId => !isInRevisionFor.includes(orgId))
+    isRevisedFor: isRevisedFor.filter(
+      orgId => !isInRevisionFor.includes(orgId)
+    ),
+    activeRevisionInfos
   };
 }

--- a/back/src/common/elasticHelpers.ts
+++ b/back/src/common/elasticHelpers.ts
@@ -29,10 +29,13 @@ export function getRevisionsInfos(revisionRequests: RevisionRequest[]): Pick<
   BsdElastic,
   "isInRevisionFor" | "isRevisedFor"
 > & {
+  hasBeenRevised: boolean;
   activeRevisionInfos: ActiveRevisionInfos | undefined;
 } {
   const { isInRevisionFor, isRevisedFor, activeRevisionInfos } =
-    revisionRequests.reduce<ReturnType<typeof getRevisionsInfos>>(
+    revisionRequests.reduce<
+      Omit<ReturnType<typeof getRevisionsInfos>, "hasBeenRevised">
+    >(
       // Pour chaque demande de révision en cours ou passés sur le bordereau
       (
         { isInRevisionFor, isRevisedFor, activeRevisionInfos },
@@ -89,6 +92,7 @@ export function getRevisionsInfos(revisionRequests: RevisionRequest[]): Pick<
     isRevisedFor: isRevisedFor.filter(
       orgId => !isInRevisionFor.includes(orgId)
     ),
+    hasBeenRevised: isRevisedFor.length > 0,
     activeRevisionInfos
   };
 }

--- a/back/src/common/elasticHelpers.ts
+++ b/back/src/common/elasticHelpers.ts
@@ -1,10 +1,14 @@
 import { BsdElastic } from "./elastic";
-import { RevisionRequestStatus } from "@prisma/client";
+import {
+  RevisionRequestApprovalStatus,
+  RevisionRequestStatus
+} from "@prisma/client";
 
 type RevisionRequest = {
   status: RevisionRequestStatus;
   approvals: {
     approverSiret: string;
+    status: RevisionRequestApprovalStatus;
   }[];
   authoringCompany: {
     orgId: string;
@@ -53,7 +57,12 @@ export function getRevisionsInfos(revisionRequests: RevisionRequest[]): Pick<
               isRevisedFor,
               activeRevisionInfos: {
                 author: revisionRequest.authoringCompany.orgId,
-                approvedBy: revisionRequest.approvals.map(a => a.approverSiret)
+                approvedBy: revisionRequest.approvals
+                  .filter(
+                    approval =>
+                      approval.status === RevisionRequestApprovalStatus.ACCEPTED
+                  )
+                  .map(a => a.approverSiret)
               }
             }
           : {

--- a/back/src/forms/__tests__/elasticHelpers.integration.ts
+++ b/back/src/forms/__tests__/elasticHelpers.integration.ts
@@ -5,7 +5,7 @@ import {
   Mutation,
   MutationCreateFormRevisionRequestArgs
 } from "../../generated/graphql/types";
-import { getFormRevisionOrgIds } from "../elasticHelpers";
+import { getFormRevisionsInfos } from "../elasticHelpers";
 import { getFormForElastic } from "../elastic";
 import prisma from "../../prisma";
 import { resetDatabase } from "../../../integration-tests/helper";
@@ -18,7 +18,7 @@ const CREATE_FORM_REVISION_REQUEST = gql`
   }
 `;
 
-describe("getFormRevisionOrgIds", () => {
+describe("getFormRevisionsInfos", () => {
   afterEach(resetDatabase);
 
   it("should list organisation identifiers in `isInRevisionFor` and `isRevisedFor`", async () => {
@@ -44,7 +44,7 @@ describe("getFormRevisionOrgIds", () => {
     const { mutate } = makeClient(emitter.user);
 
     const formForElastic = await getFormForElastic(form);
-    const revisionOrgIds = getFormRevisionOrgIds(formForElastic);
+    const revisionOrgIds = getFormRevisionsInfos(formForElastic);
 
     expect(revisionOrgIds.isInRevisionFor).toHaveLength(0);
     expect(revisionOrgIds.isRevisedFor).toHaveLength(0);
@@ -68,7 +68,7 @@ describe("getFormRevisionOrgIds", () => {
     expect(errors).toBeUndefined();
 
     const formForElastic2 = await getFormForElastic(form);
-    const revisionOrgIds2 = getFormRevisionOrgIds(formForElastic2);
+    const revisionOrgIds2 = getFormRevisionsInfos(formForElastic2);
 
     // Une demande de révision est en cours, les bordereaux doivent apparaitre dans
     // l'onglet "Révision en cours"
@@ -83,7 +83,7 @@ describe("getFormRevisionOrgIds", () => {
     });
 
     const formForElastic3 = await getFormForElastic(form);
-    const revisionOrgIds3 = getFormRevisionOrgIds(formForElastic3);
+    const revisionOrgIds3 = getFormRevisionsInfos(formForElastic3);
 
     // La demande de révision a été accepté, les bordereaux doivent apparaitre
     // dans l'onglet "Révisions passés"
@@ -107,7 +107,7 @@ describe("getFormRevisionOrgIds", () => {
     });
 
     const formForElastic4 = await getFormForElastic(form);
-    const revisionOrgIds4 = getFormRevisionOrgIds(formForElastic4);
+    const revisionOrgIds4 = getFormRevisionsInfos(formForElastic4);
 
     // Une nouvelle demande de révision a été effectuée, le bordereau doit
     // rebasculer dans l'onglet "Révision en cours"

--- a/back/src/forms/__tests__/elasticHelpers.integration.ts
+++ b/back/src/forms/__tests__/elasticHelpers.integration.ts
@@ -48,6 +48,7 @@ describe("getFormRevisionsInfos", () => {
 
     expect(revisionOrgIds.isInRevisionFor).toHaveLength(0);
     expect(revisionOrgIds.isRevisedFor).toHaveLength(0);
+    expect(revisionOrgIds.activeRevisionInfos).toBeUndefined();
 
     const { errors, data } = await mutate<
       Pick<Mutation, "createFormRevisionRequest">,
@@ -76,6 +77,10 @@ describe("getFormRevisionsInfos", () => {
     expect(revisionOrgIds2.isInRevisionFor).toContain(emitter.company.siret);
     expect(revisionOrgIds2.isInRevisionFor).toContain(recipient.company.siret);
     expect(revisionOrgIds2.isRevisedFor).toHaveLength(0);
+    expect(revisionOrgIds2.activeRevisionInfos?.approvedBy).toEqual([]);
+    expect(revisionOrgIds2.activeRevisionInfos?.author).toBe(
+      emitter.company.siret
+    );
 
     await prisma.bsddRevisionRequest.update({
       where: { id: revisionRequest.id },
@@ -91,6 +96,7 @@ describe("getFormRevisionsInfos", () => {
     expect(revisionOrgIds3.isRevisedFor).toHaveLength(2);
     expect(revisionOrgIds3.isRevisedFor).toContain(emitter.company.siret);
     expect(revisionOrgIds3.isRevisedFor).toContain(recipient.company.siret);
+    expect(revisionOrgIds3.activeRevisionInfos).toBeUndefined();
 
     await mutate<
       Pick<Mutation, "createFormRevisionRequest">,
@@ -115,5 +121,9 @@ describe("getFormRevisionsInfos", () => {
     expect(revisionOrgIds4.isInRevisionFor).toContain(emitter.company.siret);
     expect(revisionOrgIds4.isInRevisionFor).toContain(recipient.company.siret);
     expect(revisionOrgIds4.isRevisedFor).toHaveLength(0);
+    expect(revisionOrgIds4.activeRevisionInfos?.approvedBy).toEqual([]);
+    expect(revisionOrgIds4.activeRevisionInfos?.author).toBe(
+      emitter.company.siret
+    );
   });
 });

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -60,7 +60,7 @@ import {
 import prisma from "../prisma";
 import { extractPostalCode } from "../utils";
 import { getFirstTransporterSync } from "./database";
-import { FormForElastic } from "./elastic";
+import { FormInElastic } from "./elastic";
 import DataLoader from "dataloader";
 
 function flattenDestinationInput(input: {
@@ -819,7 +819,7 @@ export function expandFormFromDb(
 }
 
 export async function expandFormFromElastic(
-  form: FormForElastic,
+  form: FormInElastic,
   formLoader?: DataLoader<
     string,
     PrismaFormWithForwardedInAndTransporters | undefined,
@@ -837,7 +837,15 @@ export async function expandFormFromElastic(
     return null;
   }
 
-  return expandFormFromDb(formWithInclude);
+  const expandedForm = expandFormFromDb(formWithInclude);
+
+  return {
+    ...expandedForm,
+    revisionsInfos: {
+      hasBeenRevised: form.isRevisedFor.length > 0,
+      activeRevision: form.activeRevisionInfos
+    }
+  };
 }
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -843,7 +843,7 @@ export async function expandFormFromElastic(
   return {
     ...expandedForm,
     revisionsInfos: {
-      hasBeenRevised: form.isRevisedFor.length > 0,
+      hasBeenRevised: form.hasBeenRevised,
       activeRevision: form.activeRevisionInfos
     }
   };

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -763,6 +763,7 @@ export function expandFormFromDb(
           quantity
         }))
       : null,
+    revisionsInfos: undefined as any, // This field will be loaded by a sub resolver on demand
     temporaryStorageDetail: forwardedIn
       ? {
           temporaryStorer: {

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -61,7 +61,6 @@ import prisma from "../prisma";
 import { extractPostalCode } from "../utils";
 import { getFirstTransporterSync } from "./database";
 import { FormInElastic } from "./elastic";
-import DataLoader from "dataloader";
 
 function flattenDestinationInput(input: {
   destination?: DestinationInput | null;
@@ -819,26 +818,8 @@ export function expandFormFromDb(
   };
 }
 
-export async function expandFormFromElastic(
-  form: FormInElastic,
-  formLoader?: DataLoader<
-    string,
-    PrismaFormWithForwardedInAndTransporters | undefined,
-    string
-  >
-): Promise<GraphQLForm | null> {
-  const formWithInclude = await (formLoader
-    ? formLoader.load(form.id)
-    : prisma.form.findUniqueOrThrow({
-        where: { id: form.id },
-        include: expandableFormIncludes
-      }));
-
-  if (!formWithInclude) {
-    return null;
-  }
-
-  const expandedForm = expandFormFromDb(formWithInclude);
+export function expandFormFromElastic(form: FormInElastic): GraphQLForm {
+  const expandedForm = expandFormFromDb(form);
 
   return {
     ...expandedForm,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -34,6 +34,7 @@ export type FormForElastic = Form &
 
 export type FormInElastic = FormForElastic &
   Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> & {
+    hasBeenRevised: boolean;
     activeRevisionInfos: ActiveRevisionInfos | undefined;
   };
 
@@ -63,7 +64,7 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
   const recipient = getRecipient(form);
 
   const transporter1 = getFirstTransporterSync(form);
-  const { isInRevisionFor, isRevisedFor, activeRevisionInfos } =
+  const { isInRevisionFor, isRevisedFor, hasBeenRevised, activeRevisionInfos } =
     getFormRevisionsInfos(form);
 
   return {
@@ -160,6 +161,7 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
       ...form,
       isInRevisionFor,
       isRevisedFor,
+      hasBeenRevised,
       activeRevisionInfos
     }
   };

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -64,8 +64,13 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
   const recipient = getRecipient(form);
 
   const transporter1 = getFirstTransporterSync(form);
-  const { isInRevisionFor, isRevisedFor, hasBeenRevised, activeRevisionInfos } =
-    getFormRevisionsInfos(form);
+  const {
+    isInRevisionFor,
+    isRevisedFor,
+    latestRevisionCreatedAt,
+    hasBeenRevised,
+    activeRevisionInfos
+  } = getFormRevisionsInfos(form);
 
   return {
     type: "BSDD",
@@ -154,6 +159,7 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
       : siretsByTab),
     isInRevisionFor,
     isRevisedFor,
+    latestRevisionCreatedAt: latestRevisionCreatedAt?.getTime(),
     sirets: Object.values(siretsByTab).flat(),
     ...getRegistryFields(form),
     intermediaries: form.intermediaries,

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -63,6 +63,8 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
   const recipient = getRecipient(form);
 
   const transporter1 = getFirstTransporterSync(form);
+  const { isInRevisionFor, isRevisedFor, activeRevisionInfos } =
+    getFormRevisionsInfos(form);
 
   return {
     type: "BSDD",
@@ -149,11 +151,17 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
           isInRevisionFor: []
         }
       : siretsByTab),
-    ...getFormRevisionsInfos(form),
+    isInRevisionFor,
+    isRevisedFor,
     sirets: Object.values(siretsByTab).flat(),
     ...getRegistryFields(form),
     intermediaries: form.intermediaries,
-    rawBsd: form
+    rawBsd: {
+      ...form,
+      isInRevisionFor,
+      isRevisedFor,
+      activeRevisionInfos
+    }
   };
 }
 

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -17,12 +17,13 @@ import { getRegistryFields } from "./registry";
 import {
   getSiretsByTab,
   getRecipient,
-  getFormRevisionOrgIds
+  getFormRevisionsInfos
 } from "./elasticHelpers";
 
 import { buildAddress } from "../companies/sirene/utils";
 import { getFirstTransporterSync } from "./database";
 import prisma from "../prisma";
+import { ActiveRevisionInfos } from "../common/elasticHelpers";
 
 export type FormForElastic = Form &
   FormWithTransporters &
@@ -30,6 +31,11 @@ export type FormForElastic = Form &
   FormWithIntermediaries &
   FormWithForwarding &
   FormWithRevisionRequests;
+
+export type FormInElastic = FormForElastic &
+  Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> & {
+    activeRevisionInfos: ActiveRevisionInfos | undefined;
+  };
 
 export const FormForElasticInclude = {
   ...FormWithForwardedInWithTransportersInclude,
@@ -143,7 +149,7 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
           isInRevisionFor: []
         }
       : siretsByTab),
-    ...getFormRevisionOrgIds(form),
+    ...getFormRevisionsInfos(form),
     sirets: Object.values(siretsByTab).flat(),
     ...getRegistryFields(form),
     intermediaries: form.intermediaries,

--- a/back/src/forms/elasticHelpers.ts
+++ b/back/src/forms/elasticHelpers.ts
@@ -5,7 +5,7 @@ import { FullForm } from "./types";
 import { getTransporterCompanyOrgId } from "shared/constants";
 import { getFirstTransporterSync } from "./database";
 import { FormForElastic } from "./elastic";
-import { getRevisionOrgIds } from "../common/elasticHelpers";
+import { getRevisionsInfos } from "../common/elasticHelpers";
 
 /**
  * Computes which SIRET or VAT number should appear on which tab in the frontend
@@ -245,8 +245,8 @@ function getFormSirets(form: FullForm) {
  * Pour un BSDD donné, retourne l'ensemble identifiants d'établissements
  * pour lesquels il y a une demande de révision en cours ou passé.
  */
-export function getFormRevisionOrgIds(
+export function getFormRevisionsInfos(
   form: FormForElastic
-): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
-  return getRevisionOrgIds(form.bsddRevisionRequests);
+): ReturnType<typeof getRevisionsInfos> {
+  return getRevisionsInfos(form.bsddRevisionRequests);
 }

--- a/back/src/forms/resolvers/Form.ts
+++ b/back/src/forms/resolvers/Form.ts
@@ -4,6 +4,7 @@ import appendix2Forms from "./forms/appendix2Forms";
 import groupedIn from "./forms/groupedIn";
 import grouping from "./forms/grouping";
 import intermediaries from "./forms/intermediary";
+import revisionsInfos from "./forms/revisionsInfos";
 
 const formResolvers: FormResolvers = {
   appendix2Forms,
@@ -11,7 +12,8 @@ const formResolvers: FormResolvers = {
   stateSummary,
   groupedIn,
   grouping,
-  intermediaries
+  intermediaries,
+  revisionsInfos
 };
 
 export default formResolvers;

--- a/back/src/forms/resolvers/forms/revisionsInfos.ts
+++ b/back/src/forms/resolvers/forms/revisionsInfos.ts
@@ -1,0 +1,32 @@
+import { FormResolvers } from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+
+const revisionsInfosResolver: FormResolvers["revisionsInfos"] = async form => {
+  // When we load a BSDA from ES, the revision infos are already hydrated
+  if (form.revisionsInfos) {
+    return form.revisionsInfos;
+  }
+
+  const revisions = await prisma.form
+    .findUnique({ where: { id: form.id } })
+    .bsddRevisionRequests({ include: { approvals: true } });
+
+  const hasBeenRevised = revisions?.some(
+    revision => revision.status !== "PENDING"
+  );
+  const activeRevision = revisions?.find(
+    revision => revision.status === "PENDING"
+  );
+
+  return {
+    hasBeenRevised: Boolean(hasBeenRevised),
+    activeRevision: activeRevision
+      ? {
+          author: activeRevision.authoringCompanyId,
+          approvedBy: activeRevision.approvals.map(a => a.approverSiret)
+        }
+      : undefined
+  };
+};
+
+export default revisionsInfosResolver;

--- a/back/src/forms/resolvers/forms/revisionsInfos.ts
+++ b/back/src/forms/resolvers/forms/revisionsInfos.ts
@@ -1,3 +1,4 @@
+import { RevisionRequestApprovalStatus } from "@prisma/client";
 import { FormResolvers } from "../../../generated/graphql/types";
 import prisma from "../../../prisma";
 
@@ -23,7 +24,12 @@ const revisionsInfosResolver: FormResolvers["revisionsInfos"] = async form => {
     activeRevision: activeRevision
       ? {
           author: activeRevision.authoringCompanyId,
-          approvedBy: activeRevision.approvals.map(a => a.approverSiret)
+          approvedBy: activeRevision.approvals
+            .filter(
+              approval =>
+                approval.status === RevisionRequestApprovalStatus.ACCEPTED
+            )
+            .map(a => a.approverSiret)
         }
       : undefined
   };

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -158,6 +158,9 @@ type Form {
   collectivité, etc.) Il pourra lire ce bordereau, sans étape de signature.
   """
   intermediaries: [FormCompany!]!
+
+  "Informations concerant les éventuelles demandes de révision liées à ce bordereau"
+  revisionsInfos: RevisionsInfos!
 }
 
 """

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -67,7 +67,7 @@ export type BsddRevisionRequestWithAuthoringCompany =
 
 export const BsddRevisionRequestWithApprovalsInclude =
   Prisma.validator<Prisma.BsddRevisionRequestInclude>()({
-    approvals: { select: { approverSiret: true } }
+    approvals: { select: { approverSiret: true, status: true } }
   });
 
 export type BsddRevisionRequestWithApprovals =

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "scalingo-postbuild": "bash scripts/build/scalingo.sh",
     "nx": "nx",
-    "dev": "npx nx run-many -t serve --parallel=6 --projects=front,api,tag:backend:background"
+    "dev": "npx nx run-many -t serve --parallel=6 --projects=front,api,tag:backend:background",
+    "bg:integration": "npx nx run-many -t serve --configuration=integration --projects=tag:backend:queues"
   },
   "engines": {
     "node": "^20"


### PR DESCRIPTION
⚠️ PR qui demande un reindex BSDD & BSDA !

Ajout sur les types `Bsda` et `Form` d'infos sur les révisions. Le but premier est d'avoir l'info sur le Dashboard, afin de pouvoir faire les nouveaux écrans révisions.

A chaque fois la structure est la suivante:
```
revisionsInfos {
  hasBeenRevised
  activeRevision {
    author
    approvedBy
  }
}
```

C'est dans les metadatas pour le BSDA et à la racine pour le BSDD.
Les données nécessaires sont ajoutées à ES, donc pas d'appel en DB pour le dashboard. Or ES, c'est chargé dans un resolver à part avec dataloader, donc chargé uniquement à la demande.

Ajout également de la possibilité de trier les résultats de `bsds()` par date de création de la dernière révision avec le param `latestRevisionCreatedAt: OrderType`.

Pour récupérer les bonnes données sur le dashboard, il faudra donc faire la query suivante:

```gql
{
  bsds(
    where: { isInRevisionFor: "mySiret", isRevisedFor: "mySiret" }
    orderBy: { latestRevisionCreatedAt: DESC }
  )
  {
    edges {
      node {
        __typename
        ... on Bsda {
          id
          metadata {
            revisionsInfos {
              hasBeenRevised
              activeRevision {
                author
                approvedBy
              }
            }
          }
        }
        ... on Form {
          id
          revisionsInfos {
            hasBeenRevised
            activeRevision {
              author
              approvedBy
            }
          }
        }
      }
    }
  }
}

```

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13215)
