### PR TITLE
RevisionRequests on Form & Bsda

### DIFF
--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -1465,8 +1465,8 @@ model Bsda {
   forwardingId String? @unique
   forwardedIn  Bsda?   @relation("BsdaForwarding")
 
-  BsdaRevisionRequest BsdaRevisionRequest[]
-  intermediaries      IntermediaryBsdaAssociation[]
+  bsdaRevisionRequests BsdaRevisionRequest[]
+  intermediaries       IntermediaryBsdaAssociation[]
 
   // denormalization - sirets and vats from intermediaries
   intermediariesOrgIds String[] @default([])

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -238,7 +238,7 @@ model Company {
   MembershipRequest                    MembershipRequest[]
   allowBsdasriTakeOverWithoutSignature Boolean                   @default(false)
   bsddRevisionRequests                 BsddRevisionRequest[]
-  BsdaRevisionRequest                  BsdaRevisionRequest[]
+  bsdaRevisionRequests                 BsdaRevisionRequest[]
   givenSignatureAutomations            SignatureAutomation[]     @relation("SignatureAutomationFrom")
   receivedSignatureAutomations         SignatureAutomation[]     @relation("SignatureAutomationTo")
 

--- a/back/project.json
+++ b/back/project.json
@@ -16,7 +16,7 @@
       "command": "tsc -p back/tsconfig.lib.json --noEmit"
     },
     "codegen": {
-      "inputs": ["{projectRoot}/**/*.gql"],
+      "inputs": ["{projectRoot}/**/*.graphql"],
       "cache": true,
       "executor": "nx:run-commands",
       "options": {

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -274,5 +274,5 @@ export function indexBsda(bsda: BsdaForElastic, ctx?: GraphQLContext) {
 export function getBsdaRevisionOrgIds(
   bsda: BsdaForElastic
 ): Pick<BsdElastic, "isInRevisionFor" | "isRevisedFor"> {
-  return getRevisionOrgIds(bsda.BsdaRevisionRequest);
+  return getRevisionOrgIds(bsda.bsdaRevisionRequests);
 }

--- a/back/src/bsda/repository/bsda/findRelatedEntity.ts
+++ b/back/src/bsda/repository/bsda/findRelatedEntity.ts
@@ -3,7 +3,12 @@ import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
 type ChainableBsda = Pick<
   Prisma.Prisma__BsdaClient<Bsda | null, null>,
-  "forwardedIn" | "forwarding" | "groupedIn" | "grouping" | "intermediaries" | "bsdaRevisionRequests"
+  | "forwardedIn"
+  | "forwarding"
+  | "groupedIn"
+  | "grouping"
+  | "intermediaries"
+  | "bsdaRevisionRequests"
 >;
 
 export type FindRelatedEntityFn = (

--- a/back/src/bsda/repository/bsda/findRelatedEntity.ts
+++ b/back/src/bsda/repository/bsda/findRelatedEntity.ts
@@ -3,7 +3,7 @@ import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
 type ChainableBsda = Pick<
   Prisma.Prisma__BsdaClient<Bsda | null, null>,
-  "forwardedIn" | "forwarding" | "groupedIn" | "grouping" | "intermediaries"
+  "forwardedIn" | "forwarding" | "groupedIn" | "grouping" | "intermediaries" | "bsdaRevisionRequests"
 >;
 
 export type FindRelatedEntityFn = (

--- a/back/src/bsda/resolvers/Bsda.ts
+++ b/back/src/bsda/resolvers/Bsda.ts
@@ -52,5 +52,17 @@ export const Bsda: BsdaResolvers = {
       id: bsda.id,
       status: bsda.status
     } as any;
+  },
+  revisionRequests: async (bsda, _, ctx) => {
+    // use ES indexed field when requested from dashboard
+    if (isGetBsdsQuery(ctx) && isSessionUser(ctx)) {
+      return (bsda as any)?.bsdaRevisionRequests ?? [];
+    }
+
+    // Subfields are loaded by a separate resolver, and are missing in the return type.
+    // Hence the any.
+    return getReadonlyBsdaRepository()
+      .findRelatedEntity({ id: bsda.id })
+      .bsdaRevisionRequests() as any;
   }
 };

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -74,6 +74,9 @@ type Bsda {
   collectivité, etc.) Il pourra lire ce bordereau, sans étape de signature.
   """
   intermediaries: [FormCompany!]
+
+  "Révisions associées au bordereau"
+  revisionRequests: [BsdaRevisionRequest!]
 }
 
 type InitialBsda {

--- a/back/src/bsda/types.ts
+++ b/back/src/bsda/types.ts
@@ -48,7 +48,7 @@ export type BsdaRevisionRequestWithApprovals =
 
 export const BsdaWithRevisionRequestsInclude =
   Prisma.validator<Prisma.BsdaInclude>()({
-    BsdaRevisionRequest: {
+    bsdaRevisionRequests: {
       include: {
         ...BsdaRevisionRequestWithAuthoringCompanyInclude,
         ...BsdaRevisionRequestWithApprovalsInclude

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -34,7 +34,7 @@ export type EditableBsdaFields = Required<
     | "forwardingId"
     | "groupedIn"
     | "forwardedIn"
-    | "BsdaRevisionRequest"
+    | "bsdaRevisionRequests"
     | "intermediariesOrgIds"
   >
 >;

--- a/back/src/commands/sendTestEmail.ts
+++ b/back/src/commands/sendTestEmail.ts
@@ -1,5 +1,5 @@
 import { sendMail } from "../mailer/mailing";
-import templateIds from "../mailer/templates/provider/templateIds";
+import { templateIds } from "@td/mail";
 
 /**
  * Send a test email to a given address from command line

--- a/back/src/forms/resolvers/Form.ts
+++ b/back/src/forms/resolvers/Form.ts
@@ -4,6 +4,7 @@ import appendix2Forms from "./forms/appendix2Forms";
 import groupedIn from "./forms/groupedIn";
 import grouping from "./forms/grouping";
 import intermediaries from "./forms/intermediary";
+import revisionRequests from "./forms/revisionRequests";
 
 const formResolvers: FormResolvers = {
   appendix2Forms,
@@ -11,7 +12,8 @@ const formResolvers: FormResolvers = {
   stateSummary,
   groupedIn,
   grouping,
-  intermediaries
+  intermediaries,
+  revisionRequests
 };
 
 export default formResolvers;

--- a/back/src/forms/resolvers/forms/revisionRequests.ts
+++ b/back/src/forms/resolvers/forms/revisionRequests.ts
@@ -1,0 +1,22 @@
+import { isSessionUser } from "../../../auth";
+import { isGetBsdsQuery } from "../../../bsds/resolvers/queries/bsds";
+import { FormResolvers } from "../../../generated/graphql/types";
+import prisma from "../../../prisma";
+
+const revisionRequestsResolver: FormResolvers["revisionRequests"] = async (
+  form,
+  _,
+  ctx
+) => {
+  if (isGetBsdsQuery(ctx) && isSessionUser(ctx)) {
+    return (form as any)?.bsddRevisionRequests ?? [];
+  }
+
+  return prisma.form
+    .findUnique({
+      where: { id: form.id }
+    })
+    .bsddRevisionRequests();
+};
+
+export default revisionRequestsResolver;

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -158,6 +158,9 @@ type Form {
   collectivité, etc.) Il pourra lire ce bordereau, sans étape de signature.
   """
   intermediaries: [FormCompany!]!
+
+  "Révisions associées au bordereau"
+  revisionRequests: [FormRevisionRequest!]
 }
 
 """


### PR DESCRIPTION
Proposition alternative d'ajout de `revisionRequests` à `Form` & `Bsda`.
C'est très flexible et permet de faire absolument ce que l'on veut en front, mais dangereux en terme de perfs selon moi.