### PR TITLE
Un transporteur ne doit pas pouvoir s'enlever d'un BSDD sur lequel il apparait

### DIFF
--- a/back/src/forms/resolvers/mutations/updateFormTransporter.ts
+++ b/back/src/forms/resolvers/mutations/updateFormTransporter.ts
@@ -8,7 +8,7 @@ import {
 } from "../../converter";
 import { transporterSchemaFn } from "../../validation";
 import { getFormTransporterOrNotFound } from "../../database";
-import { checkCanUpdate } from "../../permissions";
+import { checkCanUpdateFormTransporter } from "../../permissions";
 import { UserInputError } from "../../../common/errors";
 import { sirenifyTransporterInput } from "../../sirenify";
 import { recipifyTransporterInput } from "../../recipify";
@@ -29,8 +29,8 @@ const updateFormTransporterResolver: MutationResolvers["updateFormTransporter"] 
         .findUniqueOrThrow({
           where: { id }
         })
-        .form({ include: { transporters: true } });
-      await checkCanUpdate(user, form!, { id: form!.id });
+        .form();
+      await checkCanUpdateFormTransporter(user, form!, id, input);
     }
     const isUpdatingCompany =
       input?.company?.siret || input?.company?.vatNumber;


### PR DESCRIPTION
https://trackdechets.zammad.com/#ticket/zoom/33574 

Depuis le passage au nouveau formulaire transporteur, il est possible pour un transporteur de s'enlever d'un BSDD sur lequel il apparait. Le bordereau reste dans le tableau de bord du transporteur mais il ne peut plus le consulter ou le supprimer.


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Le transporteur qui a crée le BSDD peut s'enlever du BSDD ce qui lui retire les droits](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13447)
