### PR TITLE
Les transporteurs étrangers multi-modaux N > 1 n'ont pas accès au BSDD

### DIFF
--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -105,9 +105,10 @@ function formContributors(form: FullForm, input?: UpdateFormInput): string[] {
       ? form.intermediaries.flatMap(i => [i.siret, i.vatNumber])
       : [];
 
-  const multiModalTransporters = (form.transporters ?? []).map(
-    s => s.transporterCompanySiret
-  );
+  const multiModalTransporters = (form.transporters ?? []).flatMap(s => [
+    s.transporterCompanySiret,
+    s.transporterCompanyVatNumber
+  ]);
 
   const contributors = [
     emitterCompanySiret,
@@ -179,7 +180,10 @@ function formReaders(form: FormForReadCheck): string[] {
   return [
     ...formContributors(form),
     ...(form.transporters
-      ? form.transporters.map(s => s.transporterCompanySiret)
+      ? form.transporters.flatMap(s => [
+          s.transporterCompanySiret,
+          s.transporterCompanyVatNumber
+        ])
       : []),
     ...(form.grouping
       ? form.grouping.map(f => f.initialForm.emitterCompanySiret)

--- a/back/src/forms/resolvers/queries/__tests__/form.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/form.integration.ts
@@ -93,6 +93,33 @@ describe("Query.form", () => {
     expect(data.form.id).toBe(form.id);
   });
 
+  it("should allow a foreign multi-modal transporter N>1 to read their form", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      siret: null,
+      vatNumber: "IT13029381004"
+    });
+    const form = await createForm({});
+
+    await bsddTransporterFactory({
+      formId: form.id,
+      opts: {
+        transporterCompanySiret: null,
+        transporterCompanyVatNumber: company.vatNumber
+      }
+    });
+
+    const { query } = makeClient(user);
+    const { data, errors } = await query<Pick<Query, "form">>(GET_FORM_QUERY, {
+      variables: {
+        id: form.id
+      }
+    });
+
+    expect(errors).toBeUndefined();
+
+    expect(data.form.id).toBe(form.id);
+  });
+
   it("should disallow a user with no meaningful relation to read a form", async () => {
     const user = await userFactory();
     const form = await createForm({});


### PR DESCRIPTION
https://trackdechets.zammad.com/#ticket/zoom/33695

Les transporteurs multi-modaux **étrangers** n'étaient pas inclut dans le système de permissions

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Un transporteur étranger multi-modal (N > 1) n'a pas accès au bordereau"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13450)
