### PR TITLE
[tra-13265] Afficher le bon statut sur le BSDA initial, selon le traitement du BSDA suite (suppression et refus)

### DIFF
--- a/back/src/bsda/repository/bsda/update.ts
+++ b/back/src/bsda/repository/bsda/update.ts
@@ -86,10 +86,7 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
       }
     }
 
-    if (
-      data.forwarding !== undefined &&
-      forwarding?.id !== updatedBsda.forwardingId
-    ) {
+    if (forwarding?.id !== updatedBsda.forwardingId) {
       // Identifiants des bordereaux qui doivent être réindexés pour que rawBsd.forwardedIn
       // ne soit pas désynchronisé
       const dirtyIds = [forwarding?.id, updatedBsda.forwardingId].filter(


### PR DESCRIPTION
Afficher le bon statut sur le BSDA initial, selon le traitement du BSDA suite (suppression et refus).
Le problème était lié au fait que le sbordereaux initiaux n'étaient pas correctement réindexés dans le cas ou le bordereau suite est refusé (réexpédition) ou annulé (groupement & réexpédition).

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13265)
