### PR TITLE
Renvoie les champs transporteurs sur la requête bspaohs

### DIFF
--- a/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
@@ -163,6 +163,8 @@ describe("Mutation.Bspaoh.create", () => {
       );
       expect(created.status).toBe("INITIAL");
       expect(created.isDraft).toBe(false);
+      // check transporter is populated
+      expect(created.transporter?.company?.siret).toEqual(company.siret);
     }
   );
 

--- a/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
@@ -13,17 +13,18 @@ import {
   Mutation
 } from "../../../../generated/graphql/types";
 import { searchCompany } from "../../../../companies/search";
+import { fullBspaoh } from "../../../fragments";
+import { gql } from "graphql-tag";
 
 jest.mock("../../../../companies/search");
 
-const DUPLICATE_BSPAOH = `
-mutation DuplicateBspaoh($id: ID!){
-  duplicateBspaoh(id: $id)  {
-    id
-    status
-    isDraft
+const DUPLICATE_BSPAOH = gql`
+  mutation DuplicateBspaoh($id: ID!) {
+    duplicateBspaoh(id: $id) {
+      ...FullBspaoh
+    }
   }
-}
+  ${fullBspaoh}
 `;
 
 const TODAY = new Date();
@@ -122,6 +123,8 @@ describe("Mutation.duplicateBspaoh", () => {
     expect(duplicated?.transporters[0]?.transporterCompanySiret).toEqual(
       bspaoh.transporters[0]?.transporterCompanySiret
     );
+    // check transporter is populated
+    expect(data.duplicateBspaoh?.transporter?.company?.siret).toBeTruthy();
   });
 
   test("duplicated BSPAOH should have the updated data when company info changes", async () => {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/publishBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/publishBspaoh.integration.ts
@@ -5,15 +5,16 @@ import makeClient from "../../../../__tests__/testClient";
 import { bspaohFactory } from "../../../__tests__/factories";
 import { Mutation } from "../../../../generated/graphql/types";
 import { BspaohStatus } from "@prisma/client";
+import { fullBspaoh } from "../../../fragments";
+import { gql } from "graphql-tag";
 
-const PUBLISH_BSPAOH = `
-mutation PublishBspaoh($id: ID!){
-  publishBspaoh(id: $id)  {
-    id
-    status
-    isDraft
+const PUBLISH_BSPAOH = gql`
+  ${fullBspaoh}
+  mutation PublishBspaoh($id: ID!) {
+    publishBspaoh(id: $id) {
+      ...FullBspaoh
+    }
   }
-}
 `;
 describe("Mutation.publishBspaoh", () => {
   afterEach(resetDatabase);
@@ -70,6 +71,8 @@ describe("Mutation.publishBspaoh", () => {
 
     expect(data.publishBspaoh.status).toBe("INITIAL");
     expect(data.publishBspaoh.isDraft).toBe(false);
+    // check transporter is populated
+    expect(data.publishBspaoh?.transporter?.company?.siret).toBeTruthy();
   });
 
   it("should forbid users other than inital creator to publish a draft bspaoh", async () => {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohEmission.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohEmission.integration.ts
@@ -49,6 +49,8 @@ describe("Mutation.Bspaoh.sign", () => {
       });
 
       expect(data.signBspaoh.id).toBeTruthy();
+      // check transporter is populated
+      expect(data.signBspaoh?.transporter?.company?.siret).toBeTruthy();
     });
 
     it("should throw an error if the bspaoh is missing required data when the emitter tries to sign", async () => {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/updateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/updateBspaoh.integration.ts
@@ -64,6 +64,8 @@ describe("Mutation.updateBspaoh", () => {
     });
 
     expect(data.updateBspaoh.id).toBeTruthy();
+    // check transporter is populated
+    expect(data.updateBspaoh?.transporter?.company?.siret).toBeTruthy();
 
     // check input is sirenified
     expect(sirenifyBspaohInput as jest.Mock).toHaveBeenCalledTimes(1);

--- a/back/src/bspaoh/resolvers/queries/__tests__/bspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/queries/__tests__/bspaoh.integration.ts
@@ -79,6 +79,8 @@ describe("Query.Bspaoh", () => {
     });
 
     expect(data.bspaoh.id).toBe(bsd.id);
+    // check transporter is populated
+    expect(data.bspaoh.transporter?.company?.siret).toBeTruthy();
   });
 
   it("should not get a draft bspaoh if user siret does not belong to allowed draft sirets", async () => {

--- a/back/src/bspaoh/resolvers/queries/__tests__/bspaohs.integration.ts
+++ b/back/src/bspaoh/resolvers/queries/__tests__/bspaohs.integration.ts
@@ -94,6 +94,12 @@ describe("Query.Bspaohs", () => {
     expect(data.bspaohs.pageInfo.startCursor).toBe(paoh3.id);
     expect(data.bspaohs.pageInfo.endCursor).toBe(paoh1.id);
     expect(data.bspaohs.pageInfo.hasNextPage).toBe(false);
+    // check transporters are populated
+    const trsSirets = data.bspaohs.edges
+      .map(edge => edge.node.transporter?.company?.siret)
+      .filter(Boolean);
+
+    expect(trsSirets.length).toBe(3);
   });
 
   it("should not return deleted bspaohs", async () => {

--- a/back/src/bspaoh/resolvers/queries/bspaohs.ts
+++ b/back/src/bspaoh/resolvers/queries/bspaohs.ts
@@ -51,6 +51,7 @@ export default async function bspaohs(
     totalCount,
     findMany: prismaPaginationArgs =>
       bspaohRepository.findMany(where, {
+        include: { transporters: true },
         ...prismaPaginationArgs,
         orderBy: { createdAt: "desc" }
       }),


### PR DESCRIPTION
Correctif paoh, le champ transporter n'était pas rempli sur la requête bspaohs.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

 
