### PR TITLE
Recette multi modal v2

### DIFF
--- a/back/src/forms/database.ts
+++ b/back/src/forms/database.ts
@@ -216,3 +216,12 @@ export function getFirstTransporterSync(form: {
   const firstTransporter = transporters.find(t => t.number === 1);
   return firstTransporter ?? null;
 }
+
+// Renvoie le premier transporteur qui n'a pas encor signé
+export function getNextTransporterSync(form: {
+  transporters: BsddTransporter[] | null;
+}): BsddTransporter | null {
+  const transporters = getTransportersSync(form);
+  const nextTransporter = transporters.find(t => !t.takenOverAt);
+  return nextTransporter ?? null;
+}

--- a/back/src/forms/resolvers/mutations/__tests__/deleteFormTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/deleteFormTransporter.integration.ts
@@ -136,6 +136,15 @@ describe("Mutation.deleteFormTransporter", () => {
         transporterCompanySiret: transporter4.siret
       })
     ]);
+
+    const updatedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id }
+    });
+    expect(updatedForm.transportersSirets).toEqual([
+      transporter1.siret,
+      transporter3.siret,
+      transporter4.siret
+    ]);
   });
 
   it("should not allow a user to delete a transporter from a form he is not part of", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/updateFormTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateFormTransporter.integration.ts
@@ -23,7 +23,7 @@ const UPDATE_FORM_TRANSPORTER = gql`
   }
 `;
 
-describe("Mutation.createFormTransporter", () => {
+describe("Mutation.updateFormTransporter", () => {
   afterEach(resetDatabase);
 
   it("should disallow unauthenticated user", async () => {
@@ -117,12 +117,11 @@ describe("Mutation.createFormTransporter", () => {
       transporter.siret
     );
 
-    /// TODO vérifier ici que :
-    // - transportersSirets est bien mis à jour
-    // - le BSDD est réindexé
-    // Le problème n'est pas très grave pour l'instant car depuis l'UI Trackdéchets l'update d'un
-    // transporteur BSDD est toujours suivi d'un update BSDD qui met à jour `transporterSiets` et
-    // réindexe le BSDD.
+    // S'assure que le champ dé-normalisé `transporterSirets` soit bien à jour
+    const updatedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id }
+    });
+    expect(updatedForm.transportersSirets).toEqual([transporter.siret]);
   });
 
   it("should throw error if data does not pass validation", async () => {

--- a/back/src/forms/resolvers/mutations/updateFormTransporter.ts
+++ b/back/src/forms/resolvers/mutations/updateFormTransporter.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { BsddTransporter, Prisma } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { prisma } from "@td/prisma";
@@ -7,11 +7,12 @@ import {
   flattenTransporterInput
 } from "../../converter";
 import { transporterSchemaFn } from "../../validation";
-import { getFormTransporterOrNotFound } from "../../database";
+import { getFormTransporterOrNotFound, getTransporters } from "../../database";
 import { checkCanUpdateFormTransporter } from "../../permissions";
 import { UserInputError } from "../../../common/errors";
 import { sirenifyTransporterInput } from "../../sirenify";
 import { recipifyTransporterInput } from "../../recipify";
+import { getFormRepository } from "../../repository";
 
 const updateFormTransporterResolver: MutationResolvers["updateFormTransporter"] =
   async (parent, { id, input }, context) => {
@@ -58,11 +59,27 @@ const updateFormTransporterResolver: MutationResolvers["updateFormTransporter"] 
       { ...existingTransporter, ...data },
       { abortEarly: false }
     );
-    const transporter = await prisma.bsddTransporter.update({
-      where: { id },
-      data
-    });
-    return expandTransporterFromDb(transporter);
+
+    let updatedTransporter: BsddTransporter;
+
+    if (existingTransporter.formId) {
+      // Si le transporteur est déjà associé à un bordereau, on passe par l'update
+      // du form repository pour être certain que l'événement soit loggué, que le
+      // réindex ait lieu, et que `Form.transporterSirets` soit recalculé.
+      const { update: updateForm } = getFormRepository(user);
+      const updatedForm = await updateForm(
+        { id: existingTransporter.formId },
+        { transporters: { update: { where: { id }, data } } }
+      );
+      const updatedTransporters = await getTransporters(updatedForm);
+      updatedTransporter = updatedTransporters.find(t => t.id === id)!;
+    } else {
+      updatedTransporter = await prisma.bsddTransporter.update({
+        where: { id },
+        data
+      });
+    }
+    return expandTransporterFromDb(updatedTransporter);
   };
 
 export default updateFormTransporterResolver;

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -313,12 +313,18 @@ const ActBsddValidation = ({
   const renderContentSent = () => {
     const isTempStorage = bsd.recipient?.isTempStorage;
 
+    // Renvoie la modale de signature transporteur en cas de transport
+    // multi-modal si l'établissement courant est le prochain transporter à devoir signer
     const nextTransporter = (bsd.transporters ?? []).find(t => !t.takenOverAt);
 
     if (nextTransporter && nextTransporter.company?.orgId === currentSiret) {
       return renderSignTransportFormModal();
     }
 
+    // Renvoie la modale de signature de la réception si l'établissement courant
+    // correspond à l'installation de destination. Si l'établissement courant est
+    // à la fois le prochain transporteur multi-modal et l'installation de destination
+    // on donne la priorité à la signature transporteur pour respecter le workflow.
     if (currentSiret === bsd.recipient?.company?.siret) {
       if (!!bsddGetLoading) {
         return <Loader />;

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -312,6 +312,13 @@ const ActBsddValidation = ({
 
   const renderContentSent = () => {
     const isTempStorage = bsd.recipient?.isTempStorage;
+
+    const nextTransporter = (bsd.transporters ?? []).find(t => !t.takenOverAt);
+
+    if (nextTransporter && nextTransporter.company?.orgId === currentSiret) {
+      return renderSignTransportFormModal();
+    }
+
     if (currentSiret === bsd.recipient?.company?.siret) {
       if (!!bsddGetLoading) {
         return <Loader />;
@@ -341,12 +348,6 @@ const ActBsddValidation = ({
           return renderAddAppendix1Modal();
         }
       }
-    }
-
-    const nextTransporter = (bsd.transporters ?? []).find(t => !t.takenOverAt);
-
-    if (nextTransporter && nextTransporter.company?.orgId === currentSiret) {
-      return renderSignTransportFormModal();
     }
   };
 

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
@@ -7,6 +7,7 @@ import {
   CompanySearchResult,
   CompanyType,
   FavoriteType,
+  TransportMode,
   Transporter
 } from "@td/codegen-ui";
 import { formatDate } from "../../../../common/datetime";
@@ -31,7 +32,8 @@ const defaultTransporter: Transporter = {
   },
   receipt: "0101010101",
   department: "13",
-  validityLimit: "2023-12-31T23:00:00.000Z"
+  validityLimit: "2023-12-31T23:00:00.000Z",
+  mode: TransportMode.Road
 };
 
 const searchCompaniesMock = (

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
@@ -186,6 +186,21 @@ describe("TransporterForm", () => {
     ).not.toBeInTheDocument();
   });
 
+  test("transporter recepisse error is not displayed if transport mode is not road", () => {
+    render(
+      Component({
+        data: {
+          ...defaultTransporter,
+          mode: TransportMode.Rail
+        }
+      })
+    );
+
+    expect(
+      screen.queryByText("Récépissé de déclaration de transport de déchets")
+    ).not.toBeInTheDocument();
+  });
+
   test("transporter recepisse is updated based on searchCompanies result", async () => {
     render(
       Component({

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
@@ -9,6 +9,7 @@ import {
   CompanyType,
   FavoriteType,
   Transporter as FormTransporter,
+  TransportMode,
   Transporter
 } from "@td/codegen-ui";
 import CompanyContactInfo from "../CompanyContactInfo/CompanyContactInfo";
@@ -154,13 +155,16 @@ export function TransporterForm({ orgId, fieldName }: TransporterFormProps) {
         )}
       </Field>
 
-      {!!transporterOrgId && !isForeign && !transporter.isExemptedOfReceipt && (
-        <TransporterRecepisse
-          number={transporter.receipt}
-          department={transporter.department}
-          validityLimit={transporter.validityLimit}
-        />
-      )}
+      {!!transporterOrgId &&
+        !isForeign &&
+        !transporter.isExemptedOfReceipt &&
+        transporter.mode === TransportMode.Road && (
+          <TransporterRecepisse
+            number={transporter.receipt}
+            department={transporter.department}
+            validityLimit={transporter.validityLimit}
+          />
+        )}
 
       <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
         <div className="fr-col-12 fr-col-md-3">

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
@@ -181,4 +181,49 @@ describe("<TransporterList />", () => {
     // on ne peut pas permuter un transporteur qui a déjà signé
     expect(upButtons[1]).toBeDisabled();
   });
+
+  test("Add button is disabled when next transporter has already signed", async () => {
+    const transporter1: CreateOrUpdateTransporterInput = {
+      id: "id",
+      mode: TransportMode.Road,
+      isExemptedOfReceipt: false,
+      company: {
+        siret: "11111111111111",
+        name: "Transporteur 1",
+        contact: "Mr T1",
+        phone: "01 01 01 01 01",
+        mail: "contact@ttransporter1.fr",
+        address: "Somewhere"
+      },
+      receipt: "Rec",
+      department: "07",
+      validityLimit: new Date().toISOString(),
+      takenOverAt: new Date().toISOString(),
+      numberPlate: "FOO"
+    };
+
+    const transporter2: CreateOrUpdateTransporterInput = {
+      id: "id",
+      mode: TransportMode.Road,
+      isExemptedOfReceipt: false,
+      company: {
+        siret: "22222222222222",
+        name: "Transporteur 2",
+        contact: "Mr T2",
+        phone: "01 01 01 01 01",
+        mail: "contact@transporter2.fr",
+        address: "Somewhere"
+      },
+      receipt: "Rec",
+      department: "07",
+      validityLimit: new Date().toISOString(),
+      takenOverAt: new Date().toISOString(),
+      numberPlate: "FOO"
+    };
+
+    render(component([transporter1, transporter2]));
+    const addButtons = screen.getAllByTitle("Ajouter");
+    expect(addButtons[0]).toBeDisabled();
+    expect(addButtons[1]).not.toBeDisabled();
+  });
 });

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
@@ -45,8 +45,6 @@ export function TransporterList({ orgId, fieldName }: TransporterListProps) {
     transporters.length === 1 ? 0 : null
   );
 
-  const disableAdd = transporters.length >= 5;
-
   return (
     <>
       <FieldArray
@@ -78,6 +76,14 @@ export function TransporterList({ orgId, fieldName }: TransporterListProps) {
               const hasTakenOver = Boolean(t.takenOverAt);
               const previousHasTakenOver =
                 idx > 0 ? Boolean(transporters[idx - 1].takenOverAt) : false;
+              const nextHasTakenOver =
+                idx < transporters.length - 1 &&
+                Boolean(transporters[idx + 1].takenOverAt);
+
+              // Désactive la possiblité d'ajouter un transporteur après le transporteur courant
+              // si le nombre total de transporteurs est égal à 5 ou si le transporteur d'après
+              // a pris en charge le déchet.
+              const disableAdd = transporters.length >= 5 || nextHasTakenOver;
 
               // Désactive la possibilité de supprimer le transporteur
               // s'il est le seul dans la liste ou s'il a déjà pris en charge le déchet

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
@@ -47,7 +47,6 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
         )}
       </JourneyStop>
       {form.transporters.map((transporter, idx) => {
-        console.log(transporter);
         return (
           <JourneyStop
             key={idx}
@@ -88,7 +87,7 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
             variant={
               form.temporaryStorageDetail.emittedAt
                 ? "complete"
-                : form.takenOverAt
+                : (form.transporters ?? []).every(t => Boolean(t.takenOverAt))
                 ? "active"
                 : "incomplete"
             }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
@@ -88,7 +88,8 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
               form.temporaryStorageDetail.emittedAt
                 ? "complete"
                 : (form.transporters ?? []).every(t => Boolean(t.takenOverAt))
-                ? "active"
+                ? // Actif si tous les transporteurs ont signé, sinon en attente
+                  "active"
                 : "incomplete"
             }
           >

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -112,6 +112,10 @@ export default function SignTransportFormModalContent({
   }
   const form = data?.form;
 
+  const signingTransporter = form.transporters.find(
+    t => !t.takenOverAt && t.company?.orgId === siret
+  );
+
   const TODAY = new Date();
 
   return (
@@ -120,7 +124,7 @@ export default function SignTransportFormModalContent({
         takenOverBy: "",
         takenOverAt: TODAY.toISOString(),
         securityCode: "",
-        transporterNumberPlate: form.stateSummary?.transporterNumberPlate ?? "",
+        transporterNumberPlate: signingTransporter!.numberPlate ?? "",
         emitter: { type: form?.emitter?.type },
         update: {
           quantity: form.wasteDetails?.quantity ?? 0,
@@ -179,7 +183,7 @@ export default function SignTransportFormModalContent({
           <FormWasteTransportSummary form={form} />
           <FormJourneySummary form={form} />
           {form.emitter?.type !== EmitterType.Appendix1Producer && (
-            <TransporterRecepisseWrapper transporter={form.transporter!} />
+            <TransporterRecepisseWrapper transporter={signingTransporter!} />
           )}
           <p>
             En qualité de <strong>transporteur du déchet</strong>, j'atteste que
@@ -217,7 +221,6 @@ export default function SignTransportFormModalContent({
           </div>
 
           {![
-            form.transporter?.company?.orgId,
             ...(form.transporters ?? []).map(t => t.company?.orgId),
             form.temporaryStorageDetail?.transporter?.company?.orgId
           ].includes(siret) && (

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/WorkflowAction.tsx
@@ -85,6 +85,16 @@ export function WorkflowAction(props: WorkflowActionProps) {
         return <MarkAsReceived {...props} />;
       }
 
+      if (form.transporters?.length > 1) {
+        // Premier transporteur de la liste qui n'a pas encore pris en charge le déchet.
+        const nextTransporter = (form.transporters ?? []).find(
+          t => !t.takenOverAt
+        );
+        if (nextTransporter && siret === nextTransporter.company?.orgId) {
+          return <SignTransportForm {...props} />;
+        }
+      }
+
       return null;
     }
     case FormStatus.TempStored: {

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -577,6 +577,20 @@ export default function BSDDetailContent({
   const isAppendix1Producer: boolean =
     form?.emitter?.type === EmitterType.Appendix1Producer;
 
+  const canDelete =
+    [FormStatus.Draft, FormStatus.Sealed].includes(form.status) ||
+    (form.status === FormStatus.SignedByProducer &&
+      siret === form.emitter?.company?.orgId);
+
+  const canUpdate =
+    [
+      FormStatus.Draft,
+      FormStatus.Sealed,
+      FormStatus.SignedByProducer,
+      FormStatus.Sent
+    ].includes(form.status) &&
+    EmitterType.Appendix1Producer !== form.emitter?.type;
+
   return (
     <>
       <div className={styles.detail}>
@@ -932,35 +946,27 @@ export default function BSDDetailContent({
             <IconDuplicateFile size="24px" color="blueLight" />
             <span>Dupliquer</span>
           </button>
-          {[
-            FormStatus.Draft,
-            FormStatus.Sealed,
-            FormStatus.SignedByProducer
-          ].includes(form.status) && (
-            <>
-              <button
-                className="btn btn--outline-primary"
-                onClick={() => setIsDeleting(true)}
-              >
-                <IconTrash color="blueLight" size="24px" />
-                <span>Supprimer</span>
-              </button>
-
-              {EmitterType.Appendix1Producer !== form.emitter?.type && (
-                <Link
-                  to={generatePath(routes.dashboard.bsdds.edit, {
-                    siret,
-                    id: form.id
-                  })}
-                  className="btn btn--outline-primary"
-                >
-                  <IconPaperWrite size="24px" color="blueLight" />
-                  <span>Modifier</span>
-                </Link>
-              )}
-            </>
+          {canDelete && (
+            <button
+              className="btn btn--outline-primary"
+              onClick={() => setIsDeleting(true)}
+            >
+              <IconTrash color="blueLight" size="24px" />
+              <span>Supprimer</span>
+            </button>
           )}
-
+          {canUpdate && (
+            <Link
+              to={generatePath(routes.dashboard.bsdds.edit, {
+                siret,
+                id: form.id
+              })}
+              className="btn btn--outline-primary"
+            >
+              <IconPaperWrite size="24px" color="blueLight" />
+              <span>Modifier</span>
+            </Link>
+          )}
           <WorkflowAction siret={siret!} form={form} />
           {children}
         </div>

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -8,7 +8,8 @@ import {
   MutationUpdateFormArgs,
   MutationUpdateFormTransporterArgs,
   Query,
-  QueryFormArgs
+  QueryFormArgs,
+  TransportMode
 } from "@td/codegen-ui";
 import React, { ReactElement, useMemo, lazy } from "react";
 import { useNavigate } from "react-router-dom";
@@ -90,11 +91,16 @@ export default function StepsList(props: Props) {
   ): Promise<string> {
     const { id, takenOverAt, ...input } = transporterInput;
 
-    // S'assure que les données de récépissé transport sont nulles
-    // lorsque l'exemption est cochée ou que le transporteur est étranger
+    // S'assure que les données de récépissé transport sont nulles dans les
+    // cas suivants :
+    // - l'exemption est cochée
+    // - le transporteur est étranger
+    // - le transport ne se fait pas par la route
     const cleanInput = {
       ...input,
-      ...(input.isExemptedOfReceipt || isForeignVat(input?.company?.vatNumber)
+      ...(input.isExemptedOfReceipt ||
+      isForeignVat(input?.company?.vatNumber) ||
+      input.mode !== TransportMode.Road
         ? {
             receipt: null,
             validityLimit: null,


### PR DESCRIPTION
- Correction de la pré-completion de la plaque d'immatricualtion et du récepissé transport dans la modale de signature transport. 
- S'assure qu'on ne peut pas ajouter un transporteur avant un transporteur qui a déjà signé.
- Fix `<FormJourneySummay/>` en cas de transport multi-modal avant entreposage provisoire.
- Le récépissé n'est pas obligatoire quand le transporteur ne se fait pas par la route.
- Gestion du cas où le transporteur N+1 est également le destinataire : il ne faut pas afficher le bordereau dans "Pour Action"
- Les boutons "Signer" et "Modifier" doivent apparaitre également dans l'Aperçu.
- Passe par la méthode update du form repository pour mettre à jour un transporteur qui est déjà associé à un bordereau dans `updateFormTransporter` ou pour le supprimer via `deleteFormTransporter`.

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB

---

- [Multimodal - Création et modification d'un BSDD, Onglet Transport - FRONT](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12096)
- [Multimodal - Bouton d'action de prise en charge "Signer", Transporteur N+1 - FRONT](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12939)
- [Multi-modal - Mise à jour des Menus V2](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12941)
- [Multi-modal - Bouton d'action Valider la réception, Installation finale - FRONT](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12940)