### PR TITLE
Recette - FIX BSDA indexation

### DIFF
--- a/back/src/bsda/repository/bsda/updateMany.ts
+++ b/back/src/bsda/repository/bsda/updateMany.ts
@@ -19,16 +19,16 @@ export function buildUpdateManyBsdas(deps: RepositoryFnDeps): UpdateManyBsdaFn {
   return async (where, data, logMetadata) => {
     const { prisma, user } = deps;
 
-    const update = await prisma.bsda.updateMany({
-      where,
-      data
-    });
-
     const updatedBsdas = await prisma.bsda.findMany({
       where,
       select: { id: true }
     });
     const ids = updatedBsdas.map(({ id }) => id);
+
+    const update = await prisma.bsda.updateMany({
+      where,
+      data
+    });
 
     for (const id of ids) {
       await prisma.event.create({


### PR DESCRIPTION
Correction de recette.
Lorsqu'on fait un updateMany, il faut récupérer les ids des bordereaux modifiés **avant** l'update et non après.
Sinon, le where qui a servi à faire la MAJ peut ne retourner aucun résultat => lorsque l'update sert à vider le champ groupedIn par exemple. Et dans ce cas l'indexation n'est pas à jour.