### PR TITLE
Fix recette GetBsds

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -539,7 +539,7 @@ export function expandTransporterFromDb(
       transporter.transporterTransportMode === TransportMode.ROAD
         ? null
         : transporter.transporterTransportMode,
-    takenOverAt: transporter.takenOverAt,
+    takenOverAt: processDate(transporter.takenOverAt),
     takenOverBy: transporter.takenOverBy
   });
 }


### PR DESCRIPTION
Le champ `transporter.takenOverAt` peut parfois venir d'ES, on le passe donc par `processDate` pour ne pas avoir de problème de typage.