### PR TITLE
Forcer la saisie d'un transporteur après entreposage provisoire dans "Compléter le BSD suite"

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
@@ -23,6 +23,8 @@ import React, { useState } from "react";
 import EstimatedQuantityTooltip from "../../../../../common/components/EstimatedQuantityTooltip";
 import { TransporterForm } from "../../../../../Apps/Forms/Components/TransporterForm/TransporterForm";
 import { useParams } from "react-router-dom";
+import * as yup from "yup";
+import { companySchema } from "../../../../../common/validation/schema";
 
 const MARK_RESEALED = gql`
   mutation MarkAsResealed($id: ID!, $resealedInfos: ResealedFormInput!) {
@@ -68,6 +70,10 @@ const emptyState = {
   }
 };
 
+const validationSchema = yup.object({
+  transporter: yup.object({ company: companySchema })
+});
+
 const MarkAsResealedModalContent = ({ bsd, onClose }) => {
   const initialValues = mergeDefaults(
     emptyState,
@@ -103,8 +109,8 @@ const MarkAsResealedModalContent = ({ bsd, onClose }) => {
     <div>
       <Formik<ResealedFormInput>
         initialValues={initialValues}
+        validationSchema={validationSchema}
         onSubmit={async ({ wasteDetails, ...values }) => {
-          console.log(values);
           const { errors } = await markAsResealed({
             variables: {
               id: bsd.id,
@@ -230,6 +236,7 @@ const MarkAsResealedModalContent = ({ bsd, onClose }) => {
               Collecteur-transporteur après entreposage ou reconditionnement
             </h5>
 
+            <RedErrorMessage name="transporter.company.name" />
             <TransporterForm fieldName="transporter" orgId={orgId!} />
 
             <div className="form__actions">


### PR DESCRIPTION
Suite au passage au formulaire transporteur v2 dans la modale "Compléter le BSD suite", on avait perdu des validations qui se faisaient côté front. On pouvait dès lors ne pas saisir de transporteur sur le BSD suite, signer en tant qu'entreposage provisoire et le BSDD se retrouve bloqué car pas de transporteur et plus aucun moyen d'en ajouter. Cette PR vise à remettre en place cette validation front. C'est du quick & dirty, la "bonne solution" serait de revoir un peu le workflow back pour permettre d'ajouter un transporteur après la signature entreposage provisoire. J'ai écarté aussi la solution consistant à vérifier côté back la présence d'un transporteur au moment de l'appel à `markAsResealed` car ce serait breaking (il est possible d'appeler `markAsResealed` plusieurs fois pour ajouter le transporteur en deux temps, chose qu'on ne peut pas faire côté UI).

![Capture d’écran 2024-01-11 à 15 49 37](https://github.com/MTES-MCT/trackdechets/assets/2269165/605e0068-73ed-40ab-bac4-d8e119f05ef8)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Rendre obligatoire la saisie de SIRET lors de la complétion du BSD suite](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13665)
