### PR TITLE
Fix codegen-ui cache

### DIFF
--- a/libs/front/codegen-ui/project.json
+++ b/libs/front/codegen-ui/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "inputs": ["{workspaceRoot}/back/src/**/*.gql"],
+      "inputs": ["{workspaceRoot}/back/src/**/*.graphql"],
       "cache": true,
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Le chemin de mise en cache est faux. Ce sont des fichiers `.graphql` et non `.gql`