### PR TITLE
Fix recette - modal récépissé transporteur

### DIFF
--- a/front/src/form/common/components/company/TransporterRecepisseWrapper.tsx
+++ b/front/src/form/common/components/company/TransporterRecepisseWrapper.tsx
@@ -12,7 +12,8 @@ import {
   BsvhuTransporter,
   TransporterReceipt,
   Query,
-  QueryCompanyPrivateInfosArgs
+  QueryCompanyPrivateInfosArgs,
+  TransportMode
 } from "@td/codegen-ui";
 import { isForeignVat } from "@td/constants";
 import { TRANSPORTER_RECEIPT } from "../../../../Apps/common/queries/company/query";
@@ -64,6 +65,30 @@ export default function TransporterRecepisseWrapper({
     }
   }, [transporter]);
 
+  const isRoadTransport: boolean = useMemo(() => {
+    if ((transporter as Transporter)?.mode) {
+      return (transporter as Transporter).mode === TransportMode.Road;
+    } else if (
+      (
+        transporter as
+          | BsdaTransporter
+          | BsdasriTransporter
+          | BsffTransporterInput
+      )?.transport?.mode
+    ) {
+      return (
+        (
+          transporter as
+            | BsdaTransporter
+            | BsdasriTransporter
+            | BsffTransporterInput
+        )?.transport?.mode === TransportMode.Road
+      );
+    } else {
+      return true; // BSVHU has no transport mode, it's always road. And if we don't have a transport mode, we default to showing the alert
+    }
+  }, [transporter]);
+
   /**
    * CompanyPrivateInfos pour completer les informations
    */
@@ -83,6 +108,7 @@ export default function TransporterRecepisseWrapper({
 
   return !loading &&
     !isExemptedOfReceipt &&
+    isRoadTransport &&
     !isForeignVat(transporter.company?.vatNumber!) ? (
     <TransporterRecepisse
       number={receipt?.receiptNumber}


### PR DESCRIPTION
Correction de recette.
cf https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13172

Les modales de signature avaient encore le message d'erreur:
![image](https://github.com/MTES-MCT/trackdechets/assets/5145523/091020a9-04ce-49e7-adb0-3d5a9aa1af1d)
