### PR TITLE
Corrige l'affichage des champs scellés sur le PAOH et corrige la documentation.

### DIFF
--- a/apps/doc/docs/reference/statuts/bspaoh.mdx
+++ b/apps/doc/docs/reference/statuts/bspaoh.mdx
@@ -4,11 +4,11 @@ title: BSPAOH
 
 import Mermaid from '../../../src/components/Mermaid';
 
-Au cours de son cycle de vie, le BSPAOH peut passer par différents états décrits [ici](../api-reference/bspaoh/enums#bspaohstatus).
+Au cours de son cycle de vie, le BSPAOH peut passer par différents états décrits [ici](../api-reference/bspaoh/enums/#bspaohstatus).
 
 
-- `INITIAL` (initial): C'est l'état dans lequel le dasri est créé.
-- `SIGNED_BY_PRODUCER` (prêt à être emporté) : Dasri signé par l'émetteur
+- `INITIAL` (initial): C'est l'état dans lequel le PAOH est créé.
+- `SIGNED_BY_PRODUCER` (prêt à être emporté) : PAOH signé par l'émetteur
 - `SENT` (envoyé): BSPAOH en transit vers l'installation de destination, d'entreposage ou de reconditionnement
 - `RECEIVED` (reçu): BSPAOH reçu sur l'installation de destination, d'entreposage ou de reconditionnement
 - `ACCEPTED` (accepté): BSPAOH accepté sur l'installation de destination, d'entreposage ou de reconditionnement
@@ -40,7 +40,7 @@ D -->|"signBspaoh (RECEPTION *)"| G(REFUSED)
 
  
 
-- `INITIAL` (initial): C'est l'état dans lequel le dasri est créé. `readableId` est affecté.
+- `INITIAL` (initial): C'est l'état dans lequel le PAOH est créé. `readableId` est affecté.
 - `SENT` (envoyé): BSPAOH en transit vers l'installation de destination, d'entreposage ou de reconditionnement
 - `RECEIVED` (reçu): BSPAOH reçu sur l'installation de destination, d'entreposage ou de reconditionnement
 - `PROCESSED` (traité): BSPAOH dont l'opération de traitement a été effectué

--- a/back/src/bspaoh/resolvers/queries/__tests__/bspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/queries/__tests__/bspaoh.integration.ts
@@ -139,6 +139,7 @@ describe("Query.Bspaoh", () => {
     BspaohStatus.SIGNED_BY_PRODUCER,
     BspaohStatus.SENT,
     BspaohStatus.RECEIVED,
+    BspaohStatus.PROCESSED,
     BspaohStatus.REFUSED,
     BspaohStatus.PARTIALLY_REFUSED
   ])("should forbid access to a deleted bspaoh", async status => {

--- a/back/src/bspaoh/resolvers/queries/__tests__/bspaohmetadata.integration.ts
+++ b/back/src/bspaoh/resolvers/queries/__tests__/bspaohmetadata.integration.ts
@@ -1,0 +1,127 @@
+import { UserRole, BspaohStatus } from "@prisma/client";
+import { gql } from "graphql-tag";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+import { bspaohFactory } from "../../../__tests__/factories";
+
+const GET_BSPAOH = gql`
+  query GetBpaoh($id: ID!) {
+    bspaoh(id: $id) {
+      id
+      status
+      metadata {
+        fields {
+          sealed {
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
+describe("Query.Bspaoh", () => {
+  afterEach(resetDatabase);
+
+  it("should return INITIAL bspaoh sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsd = await bspaohFactory({
+      opt: {
+        status: BspaohStatus.INITIAL,
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bspaoh">>(GET_BSPAOH, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bspaoh.metadata?.fields?.sealed?.length).toBe(0);
+  });
+
+  it("should return SIGNED_BY_PRODUCER bspaoh sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsd = await bspaohFactory({
+      opt: {
+        status: BspaohStatus.SIGNED_BY_PRODUCER,
+        emitterCompanySiret: company.siret,
+        emitterEmissionSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bspaoh">>(GET_BSPAOH, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bspaoh.metadata?.fields?.sealed?.length).toBe(25);
+  });
+
+  it("should return SENT bspaoh sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsd = await bspaohFactory({
+      opt: {
+        status: BspaohStatus.SENT,
+
+        transporters: {
+          create: {
+            transporterCompanySiret: company.siret,
+            transporterTransportSignatureDate: new Date(),
+            number: 1
+          }
+        }
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bspaoh">>(GET_BSPAOH, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bspaoh.metadata?.fields?.sealed?.length).toBe(41);
+  });
+  it("should return RECEIVED bspaoh sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsd = await bspaohFactory({
+      opt: {
+        status: BspaohStatus.RECEIVED,
+        emitterCompanySiret: company.siret,
+        destinationReceptionSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bspaoh">>(GET_BSPAOH, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bspaoh.metadata?.fields?.sealed?.length).toBe(48);
+  });
+
+  it("should return PROCESSED bspaoh sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsd = await bspaohFactory({
+      opt: {
+        status: BspaohStatus.PROCESSED,
+        emitterCompanySiret: company.siret,
+        destinationOperationSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bspaoh">>(GET_BSPAOH, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bspaoh.metadata?.fields?.sealed?.length).toBe(51);
+  });
+});

--- a/back/src/bspaoh/validation/rules.ts
+++ b/back/src/bspaoh/validation/rules.ts
@@ -5,7 +5,7 @@ import { capitalize } from "../../common/strings";
 import { ZodFullBspaoh } from "./schema";
 import { isForeignVat } from "@td/constants";
 import { UnparsedInputs } from ".";
-import { getUserFunctions } from "./helpers";
+import { getUserFunctions, getSignatureAncestors } from "./helpers";
 
 type EditableBspaohTransporterFields = Required<
   Omit<
@@ -589,8 +589,11 @@ export function getSealedFieldsForSignature(signature?: BspaohSignatureType) {
   if (!signature) {
     return res;
   }
+
+  const ancestors = getSignatureAncestors(signature);
+
   for (const [k, v] of Object.entries(editionRules)) {
-    if (v?.sealed?.from === signature) {
+    if (ancestors.includes(v?.sealed?.from)) {
       res.push(k);
     }
   }


### PR DESCRIPTION
Les metadata incluent les champs verrouillés. Seuls les champs verrouillés par la dernière signature y figuraient, cette PR corrige le problème

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
