### PR TITLE
[BUG] Crash sur la page de signature transporteur sur un BSD suite, avec transporteur étranger

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignTransportFormModalContent.tsx
@@ -112,8 +112,15 @@ export default function SignTransportFormModalContent({
   }
   const form = data?.form;
 
-  const signingTransporter = form.transporters.find(
-    t => !t.takenOverAt && t.company?.orgId === siret
+  const signingTransporter = [
+    ...form.transporters,
+    form.temporaryStorageDetail?.transporter
+  ].find(
+    t =>
+      t !== null &&
+      t !== undefined &&
+      !t.takenOverAt &&
+      t.company?.orgId === siret
   );
 
   const TODAY = new Date();


### PR DESCRIPTION
Bug remonté lors de la recette.

Lorsqu'un transporteur étranger essaie de signer un bordereau suite, ça plante.

# Trace Sentry

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/5876290c-dc7a-4a2c-be2b-fb395d1a8cce)

# Démo

https://github.com/MTES-MCT/trackdechets/assets/45355989/2c0789b1-51a4-47d2-afcd-605a50f4eb6a

