### PR TITLE
[tra-13669] ETQ installation de destination je ne peux pas signer l'opération/le traitement du BSFF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :bug: Corrections de bugs
 
+- ETQ installation de destination je ne peux pas signer l'opération/le traitement du BSFF [PR 3026](https://github.com/MTES-MCT/trackdechets/pull/3026)
+
 #### :boom: Breaking changes
 
 - Modifier les variables INSEE sur statutDiffusionEtablissement / Répercuter les changements INSEE dans notre API[PR 2973](https://github.com/MTES-MCT/trackdechets/pull/2973)

--- a/back/src/bsffs/edition/__tests__/bsffEdition.integration.ts
+++ b/back/src/bsffs/edition/__tests__/bsffEdition.integration.ts
@@ -15,10 +15,10 @@ describe("edition rules", () => {
 
   it("should be possible to update any fields when BSFF status is INITIAL", async () => {
     const bsff = await createBsff({}, { status: "INITIAL" });
-    const checked = await checkEditionRules(bsff, {
+    const updateFields = await checkEditionRules(bsff, {
       emitter: { company: { name: "ACME" } }
     });
-    expect(checked).toBe(true);
+    expect(updateFields).toEqual(["emitterCompanyName"]);
   });
 
   it("should not be possible to update a field sealed by emission signature", async () => {
@@ -37,7 +37,7 @@ describe("edition rules", () => {
   it("should be possible for the emitter to update a field sealed by emission signature", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsffAfterEmission({ emitter });
-    const checked = await checkEditionRules(
+    const updateFields = await checkEditionRules(
       bsff,
       {
         emitter: { company: { name: "ACME" } }
@@ -45,7 +45,7 @@ describe("edition rules", () => {
       emitter.user
     );
 
-    expect(checked).toBe(true);
+    expect(updateFields).toEqual(["emitterCompanyName"]);
   });
 
   it("should be possible to re-send same data on a field sealed by emission signature", async () => {
@@ -60,7 +60,7 @@ describe("edition rules", () => {
       where: { id: bsff.id },
       data: { ficheInterventions: { connect: { id: ficheIntervention.id } } }
     });
-    const checked = await checkEditionRules(bsff, {
+    const updateFields = await checkEditionRules(bsff, {
       emitter: { company: { siret: bsff.emitterCompanySiret } },
       packagings: bsff.packagings.map(p => ({
         type: p.type,
@@ -70,16 +70,16 @@ describe("edition rules", () => {
       })),
       ficheInterventions: [ficheIntervention.id]
     });
-    expect(checked).toBe(true);
+    expect(updateFields).toEqual([]);
   });
 
   it("should be possible to update a field not yet sealed by emission signature", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsffAfterEmission({ emitter });
-    const checked = await checkEditionRules(bsff, {
+    const updatedFields = await checkEditionRules(bsff, {
       transporter: { transport: { plates: ["AD-008-TS"] } }
     });
-    expect(checked).toBe(true);
+    expect(updatedFields).toEqual(["transporterTransportPlates"]);
   });
 
   it("should not be possible to update a field sealed by transporter signature", async () => {
@@ -105,20 +105,20 @@ describe("edition rules", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsffAfterTransport({ emitter, transporter });
-    const checked = await checkEditionRules(bsff, {
+    const updatedFields = await checkEditionRules(bsff, {
       transporter: { company: { siret: bsff.transporterCompanySiret } }
     });
-    expect(checked).toBe(true);
+    expect(updatedFields).toEqual([]);
   });
 
   it("should be possible to update a field not yet sealed by transport signature", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsffAfterTransport({ emitter, transporter });
-    const checked = await checkEditionRules(bsff, {
+    const updatedFields = await checkEditionRules(bsff, {
       destination: { reception: { date: new Date("2021-01-01") } }
     });
-    expect(checked).toBe(true);
+    expect(updatedFields).toEqual(["destinationReceptionDate"]);
   });
 
   it("should not be possible to update a field sealed by reception signature", async () => {

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -31,7 +31,8 @@ import {
   createBsffAfterTransport,
   createBsffBeforeEmission,
   createBsffAfterReception,
-  createFicheIntervention
+  createFicheIntervention,
+  createBsffAfterAcceptation
 } from "../../../__tests__/factories";
 import { sirenifyBsffInput } from "../../../sirenify";
 
@@ -478,6 +479,64 @@ describe("Mutation.updateBsff", () => {
       }
     });
     expect(errors).toBeUndefined();
+  });
+
+  it("[tra-13669] should not erase packaging signature when resending same packagings data after acceptation", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN, {
+      transporterReceipt: {
+        create: {
+          receiptNumber: "rec",
+          department: "07",
+          validityLimit: new Date()
+        }
+      }
+    });
+
+    const bsff = await createBsffAfterAcceptation({
+      emitter,
+      destination,
+      transporter
+    });
+
+    const packagings = await prisma.bsff
+      .findUniqueOrThrow({ where: { id: bsff.id } })
+      .packagings();
+
+    expect(packagings.length).toEqual(1);
+
+    const packaging = packagings[0];
+
+    expect(packaging.acceptationSignatureDate).not.toBeNull();
+
+    const { mutate } = makeClient(destination.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          packagings: [
+            {
+              type: packaging.type,
+              other: packaging.other,
+              weight: packaging.weight,
+              volume: packaging.volume,
+              numero: packaging.numero
+            }
+          ]
+        }
+      }
+    });
+    expect(errors).toBeUndefined();
+
+    const updatedPackaging = await prisma.bsffPackaging.findUniqueOrThrow({
+      where: { id: packaging.id }
+    });
+
+    expect(updatedPackaging.acceptationSignatureDate).not.toBeNull();
   });
 
   it("should update fiche d'interventions", async () => {

--- a/back/src/bsffs/resolvers/mutations/updateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/updateBsff.ts
@@ -66,13 +66,14 @@ const updateBsff: MutationResolvers["updateBsff"] = async (
       input.packagings?.map(toBsffPackagingWithType) ?? existingBsff.packagings
   };
 
-  await checkEditionRules(existingBsff, input, user);
+  const updatedFields = await checkEditionRules(existingBsff, input, user);
 
-  const packagingHasChanged =
-    !!input.forwarding ||
-    !!input.grouping ||
-    !!input.repackaging ||
-    !!input.packagings;
+  const packagingHasChanged = [
+    "forwarding",
+    "grouping",
+    "repackaging",
+    "packagings"
+  ].some(f => updatedFields.includes(f));
 
   await validateBsff(futureBsff, {
     isDraft: existingBsff.isDraft,

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1117,7 +1117,13 @@ export const canDeleteBsd = (bsd, siret) =>
 
 const canUpdateBsff = (bsd, siret) =>
   bsd.type === BsdType.Bsff &&
-  ![BsdStatusCode.Processed, BsdStatusCode.Refused].includes(bsd.status) &&
+  ![
+    BsdStatusCode.Sent,
+    BsdStatusCode.Received,
+    BsdStatusCode.Accepted,
+    BsdStatusCode.Processed,
+    BsdStatusCode.Refused
+  ].includes(bsd.status) &&
   canDuplicateBsff(bsd, siret);
 
 const canReviewBsda = (bsd, siret) =>

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1117,13 +1117,7 @@ export const canDeleteBsd = (bsd, siret) =>
 
 const canUpdateBsff = (bsd, siret) =>
   bsd.type === BsdType.Bsff &&
-  ![
-    BsdStatusCode.Sent,
-    BsdStatusCode.Received,
-    BsdStatusCode.Accepted,
-    BsdStatusCode.Processed,
-    BsdStatusCode.Refused
-  ].includes(bsd.status) &&
+  [BsdStatusCode.Initial, BsdStatusCode.SignedByEmitter].includes(bsd.status) &&
   canDuplicateBsff(bsd, siret);
 
 const canReviewBsda = (bsd, siret) =>


### PR DESCRIPTION
Depuis le passage à la v2, le bouton "Modifier" était présent sur le BSFF après la signature transporteur alors qu'il n'aurait pas dû. Les champs du formulaire étaient grisées mais on pouvait quand même cliquer sur le bouton. Or si on clique sur le bouton "Modifier" après l'acceptation du déchet, on avait un effet de bord qui réinitialisait les données du packaging. Dès lors l'erreur suivante apparait au moment du traitement.

![image001](https://github.com/MTES-MCT/trackdechets/assets/2269165/33286a58-1be1-45e2-9e1d-5ad828548d17)


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [ETQ installation de destination je ne peux pas signer l'opération/le traitement du BSFF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13669)
