### PR TITLE
[TRA-13359] Correction du champ "Date d'expédition" des BSDA au registre

### DIFF
--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -26,6 +26,7 @@ const getOperationData = (bsda: Bsda) => ({
 });
 
 const getTransporterData = (bsda: Bsda) => ({
+  transporterTakenOverAt: bsda.transporterTransportTakenOverAt,
   transporterRecepisseIsExempted: bsda.transporterRecepisseIsExempted,
   transporterNumberPlates: bsda.transporterTransportPlates,
   transporterCompanyAddress: bsda.transporterCompanyAddress,


### PR DESCRIPTION
# Contexte

Dans le registre il manque la date d'expédition pour les BSDA. Le champ a été oublié dans `getTransporterData`.

# Ticket Favro

[Registre : date d'expédition manquante sur BSDA](https://favro.com/widget/ab14a4f0460a99a9d64d4945/887cda40286970b352f00a37?card=tra-13359)
