### PR TITLE
Améliorationss script d'indexation en masse

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
           TERM=xterm bash ./scripts/deploy-db.sh
       - name: Start queues
         run: |
-          npx nx run-many -t serve --projects=tag:backend:queues --configuration=integration &
+          npx nx run-many -t serve --projects=tag:backend:queues --parallel=6 --configuration=integration &
           sleep 5
       - name: Run integration tests
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -409,7 +409,7 @@ Depuis un one-off container de taille XL
 - Se rendre sur Scalingo pour ajouter 1 worker `bulkindexqueuemaster` (en charge d'ajouter les chunks) en 2XL et plusieurs workers `bulkindexqueue` (en charge de process les chunks).
 - On peut retenir la configuration suivante pour les workers `bulkindexqueue` :
   - 4 workers de taille 2XL
-  - BULK_INDEX_BATCH_SIZE=2500
+  - BULK_INDEX_BATCH_SIZE=1000
   - BULK_INDEX_JOB_CONCURRENCY=1
 - Se connecter à la prod avec un one-off container de taille XL
 - Lancer la commande `FORCE_LOGGER_CONSOLE=true npx nx run back:reindex-all-bsds-bulk -- --useQueue -f` (si la version de l'index a été bump, on peut omettre le `-f`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,9 +406,9 @@ Depuis un one-off container de taille XL
 
 ### Réindexation complète sans downtime lors d'une mise en production
 
-- Se rendre sur Scalingo pour augmenter la taille des workers "indexqueue" et leur nombre.
-- On peut retenir la configuration suivante :
-  - 4 workers indexqueue de taille 2XL
+- Se rendre sur Scalingo pour ajouter 1 worker `bulkindexqueuemaster` (en charge d'ajouter les chunks) en 2XL et plusieurs workers `bulkindexqueue` (en charge de process les chunks).
+- On peut retenir la configuration suivante pour les workers `bulkindexqueue` :
+  - 4 workers de taille 2XL
   - BULK_INDEX_BATCH_SIZE=2500
   - BULK_INDEX_JOB_CONCURRENCY=1
 - Se connecter à la prod avec un one-off container de taille XL
@@ -418,6 +418,7 @@ Depuis un one-off container de taille XL
 - Relancer au besoin les "indexChunk" jobs qui ont failed (c'est possible si ES se retrouve momentanément surchargé).
 - Si les workers d'indexation crashent avec une erreur mémoire, ce sera visible dans les logs Scalingo. Il est possible alors que la taille des chunks soient trop importante. Diminuer alors la valeur BULK_INDEX_BATCH_SIZE, cleaner tous les jobs de la queue avant de relancer une réindexation complète. Il peut être opportun de de diminuer la taille des chunks.
 - Si ES est surchargé, il peut être opportun de diminuer le nombre de workers.
+- À la fin de la réindexation, set le nombre de workers `bulkindexqueuemaster` et `bulkindexqueue` à 0.
 
 ## Guides
 

--- a/apps/Procfile.back
+++ b/apps/Procfile.back
@@ -2,4 +2,5 @@ web: node dist/apps/api/main.js
 clock: node dist/apps/cron/main.js
 queue: node dist/apps/queues-runner/main.js
 indexqueue: node dist/apps/queues-indexation/main.js
+bulkindexqueue: node dist/apps/queues-bulk-indexation/main.js
 webhooksqueue: node dist/apps/queues-webhooks/main.js

--- a/apps/Procfile.back
+++ b/apps/Procfile.back
@@ -3,4 +3,5 @@ clock: node dist/apps/cron/main.js
 queue: node dist/apps/queues-runner/main.js
 indexqueue: node dist/apps/queues-indexation/main.js
 bulkindexqueue: node dist/apps/queues-bulk-indexation/main.js
+bulkindexqueuemaster: node dist/apps/queues-bulk-indexation-master/main.js
 webhooksqueue: node dist/apps/queues-webhooks/main.js

--- a/apps/queues-bulk-indexation-master/.eslintrc.json
+++ b/apps/queues-bulk-indexation-master/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/queues-bulk-indexation-master/jest.config.ts
+++ b/apps/queues-bulk-indexation-master/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: "apps/queues-bulk-indexation-master",
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../coverage/apps/queues-bulk-indexation"
+};

--- a/apps/queues-bulk-indexation-master/project.json
+++ b/apps/queues-bulk-indexation-master/project.json
@@ -1,7 +1,7 @@
 {
-  "name": "queues-bulk-indexation",
+  "name": "queues-bulk-indexation-master",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "apps/queues-bulk-indexation/src",
+  "sourceRoot": "apps/queues-bulk-indexation-master/src",
   "projectType": "application",
   "targets": {
     "build": {
@@ -21,13 +21,13 @@
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
-        "outputPath": "dist/apps/queues-bulk-indexation",
+        "outputPath": "dist/apps/queues-bulk-indexation-master",
         "format": [
           "cjs"
         ],
         "bundle": false,
-        "main": "apps/queues-bulk-indexation/src/main.ts",
-        "tsConfig": "apps/queues-bulk-indexation/tsconfig.app.json",
+        "main": "apps/queues-bulk-indexation-master/src/main.ts",
+        "tsConfig": "apps/queues-bulk-indexation-master/tsconfig.app.json",
         "assets": [
           {
             "input": "./libs/back/mail/src",
@@ -79,19 +79,19 @@
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
       "options": {
-        "buildTarget": "queues-bulk-indexation:build",
+        "buildTarget": "queues-bulk-indexation-master:build",
         "inspect": false
       },
       "configurations": {
         "development": {
-          "buildTarget": "queues-bulk-indexation:build:development"
+          "buildTarget": "queues-bulk-indexation-master:build:development"
         },
         "integration": {
           "watch": false,
-          "buildTarget": "queues-bulk-indexation:build:integration"
+          "buildTarget": "queues-bulk-indexation-master:build:integration"
         },
         "production": {
-          "buildTarget": "queues-bulk-indexation:build:production"
+          "buildTarget": "queues-bulk-indexation-master:build:production"
         }
       }
     },
@@ -102,7 +102,7 @@
       ],
       "options": {
         "lintFilePatterns": [
-          "apps/queues-bulk-indexation/**/*.ts"
+          "apps/queues-bulk-indexation-master/**/*.ts"
         ]
       }
     },
@@ -112,7 +112,7 @@
         "{workspaceRoot}/coverage/{projectRoot}"
       ],
       "options": {
-        "jestConfig": "apps/queues-bulk-indexation/jest.config.ts",
+        "jestConfig": "apps/queues-bulk-indexation-master/jest.config.ts",
         "passWithNoTests": true
       },
       "configurations": {

--- a/apps/queues-bulk-indexation-master/project.json
+++ b/apps/queues-bulk-indexation-master/project.json
@@ -9,22 +9,16 @@
       "dependsOn": [
         "^codegen",
         {
-          "projects": [
-            "@td/prisma"
-          ],
+          "projects": ["@td/prisma"],
           "target": "generate"
         }
       ],
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/apps/queues-bulk-indexation-master",
-        "format": [
-          "cjs"
-        ],
+        "format": ["cjs"],
         "bundle": false,
         "main": "apps/queues-bulk-indexation-master/src/main.ts",
         "tsConfig": "apps/queues-bulk-indexation-master/tsconfig.app.json",
@@ -97,20 +91,14 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "apps/queues-bulk-indexation-master/**/*.ts"
-        ]
+        "lintFilePatterns": ["apps/queues-bulk-indexation-master/**/*.ts"]
       }
     },
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}"
-      ],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "apps/queues-bulk-indexation-master/jest.config.ts",
         "passWithNoTests": true
@@ -123,7 +111,5 @@
       }
     }
   },
-  "tags": [
-    "backend:queues"
-  ]
+  "tags": ["backend:queues"]
 }

--- a/apps/queues-bulk-indexation-master/src/main.ts
+++ b/apps/queues-bulk-indexation-master/src/main.ts
@@ -1,0 +1,8 @@
+import { bulkIndexMasterQueue, indexAllInBulkJob } from "back";
+
+function startConsumers() {
+  console.info(`Bulk indexation master queues consumers started`);
+  bulkIndexMasterQueue.process("indexAllInBulk", indexAllInBulkJob);
+}
+
+startConsumers();

--- a/apps/queues-bulk-indexation-master/tsconfig.app.json
+++ b/apps/queues-bulk-indexation-master/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/apps/queues-bulk-indexation-master/tsconfig.json
+++ b/apps/queues-bulk-indexation-master/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/apps/queues-bulk-indexation-master/tsconfig.spec.json
+++ b/apps/queues-bulk-indexation-master/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"],
+    "sourceMap": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/apps/queues-bulk-indexation/.eslintrc.json
+++ b/apps/queues-bulk-indexation/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/queues-bulk-indexation/jest.config.ts
+++ b/apps/queues-bulk-indexation/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: "apps/queues-bulk-indexation",
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../coverage/apps/queues-bulk-indexation"
+};

--- a/apps/queues-bulk-indexation/project.json
+++ b/apps/queues-bulk-indexation/project.json
@@ -1,0 +1,130 @@
+{
+  "name": "queues-bulk-indexation",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/queues-bulk-indexation/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": [
+        "^codegen",
+        {
+          "projects": [
+            "@td/prisma"
+          ],
+          "target": "generate"
+        }
+      ],
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/apps/queues-bulk-indexation",
+        "format": [
+          "cjs"
+        ],
+        "bundle": false,
+        "main": "apps/queues-bulk-indexation/src/main.ts",
+        "tsConfig": "apps/queues-bulk-indexation/tsconfig.app.json",
+        "assets": [
+          {
+            "input": "./libs/back/mail/src",
+            "glob": "**/*.html",
+            "output": "./libs/back/mail/src"
+          },
+          {
+            "input": "./back/src",
+            "glob": "**/*.{graphql,pdf,png,ttf,html,css,svg,wsdl,mp3}",
+            "output": "./back/src"
+          },
+          {
+            "input": "./back/src",
+            "glob": "**/assets/*.js",
+            "output": "./back/src"
+          },
+          {
+            "input": "./libs/back/prisma/src",
+            "glob": "**/*.{prisma,sql}",
+            "output": "./libs/back/prisma/src"
+          }
+        ],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {
+          "skipTypeCheck": true
+        },
+        "integration": {
+          "skipTypeCheck": true
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "queues-bulk-indexation:build",
+        "inspect": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "queues-bulk-indexation:build:development"
+        },
+        "integration": {
+          "watch": false,
+          "buildTarget": "queues-bulk-indexation:build:integration"
+        },
+        "production": {
+          "buildTarget": "queues-bulk-indexation:build:production"
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "apps/queues-bulk-indexation/**/*.ts"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": [
+        "{workspaceRoot}/coverage/{projectRoot}"
+      ],
+      "options": {
+        "jestConfig": "apps/queues-bulk-indexation/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": [
+    "backend:queues",
+    "backend:background"
+  ]
+}

--- a/apps/queues-bulk-indexation/project.json
+++ b/apps/queues-bulk-indexation/project.json
@@ -9,22 +9,16 @@
       "dependsOn": [
         "^codegen",
         {
-          "projects": [
-            "@td/prisma"
-          ],
+          "projects": ["@td/prisma"],
           "target": "generate"
         }
       ],
-      "outputs": [
-        "{options.outputPath}"
-      ],
+      "outputs": ["{options.outputPath}"],
       "defaultConfiguration": "production",
       "options": {
         "platform": "node",
         "outputPath": "dist/apps/queues-bulk-indexation",
-        "format": [
-          "cjs"
-        ],
+        "format": ["cjs"],
         "bundle": false,
         "main": "apps/queues-bulk-indexation/src/main.ts",
         "tsConfig": "apps/queues-bulk-indexation/tsconfig.app.json",
@@ -97,20 +91,14 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint",
-      "outputs": [
-        "{options.outputFile}"
-      ],
+      "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": [
-          "apps/queues-bulk-indexation/**/*.ts"
-        ]
+        "lintFilePatterns": ["apps/queues-bulk-indexation/**/*.ts"]
       }
     },
     "test": {
       "executor": "@nx/jest:jest",
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}"
-      ],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "apps/queues-bulk-indexation/jest.config.ts",
         "passWithNoTests": true
@@ -123,7 +111,5 @@
       }
     }
   },
-  "tags": [
-    "backend:queues"
-  ]
+  "tags": ["backend:queues"]
 }

--- a/apps/queues-bulk-indexation/src/main.ts
+++ b/apps/queues-bulk-indexation/src/main.ts
@@ -1,11 +1,14 @@
 import { bulkIndexQueue, indexChunkBsdJob } from "back";
 
+// Ne pas dépasser 1 en prod avec plusieurs workers
+const BULK_INDEX_JOB_CONCURRENCY = process.env.BULK_INDEX_JOB_CONCURRENCY;
+
 function startConsumers() {
   console.info(`Bulk indexation queues consumers started`);
 
   bulkIndexQueue.process(
     "indexChunk",
-    parseInt(process.env.BULK_INDEX_JOB_CONCURRENCY, 10) || 1,
+    parseInt(BULK_INDEX_JOB_CONCURRENCY, 10) || 1,
     indexChunkBsdJob
   );
 }

--- a/apps/queues-bulk-indexation/src/main.ts
+++ b/apps/queues-bulk-indexation/src/main.ts
@@ -1,0 +1,13 @@
+import { bulkIndexQueue, indexChunkBsdJob } from "back";
+
+function startConsumers() {
+  console.info(`Bulk indexation queues consumers started`);
+
+  bulkIndexQueue.process(
+    "indexChunk",
+    parseInt(process.env.BULK_INDEX_JOB_CONCURRENCY, 10) || 1,
+    indexChunkBsdJob
+  );
+}
+
+startConsumers();

--- a/apps/queues-bulk-indexation/tsconfig.app.json
+++ b/apps/queues-bulk-indexation/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/apps/queues-bulk-indexation/tsconfig.json
+++ b/apps/queues-bulk-indexation/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/apps/queues-bulk-indexation/tsconfig.spec.json
+++ b/apps/queues-bulk-indexation/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"],
+    "sourceMap": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/apps/queues-indexation/src/main.ts
+++ b/apps/queues-indexation/src/main.ts
@@ -8,18 +8,11 @@ import {
   INDEX_UPDATED_JOB_NAME,
   deleteBsdJob,
   indexFavoritesJob,
-  indexChunkBsdJob,
   indexAllInBulkJob
 } from "back";
 
 function startConsumers() {
   console.info(`Indexation queues consumers started`);
-
-  indexQueue.process(
-    "indexChunk",
-    parseInt(process.env.BULK_INDEX_JOB_CONCURRENCY, 10) || 1,
-    indexChunkBsdJob
-  );
   indexQueue.process("indexAllInBulk", indexAllInBulkJob);
   indexQueue.process(INDEX_JOB_NAME, indexBsdJob);
   indexQueue.process(INDEX_CREATED_JOB_NAME, indexBsdJob);

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -343,13 +343,7 @@ export async function indexAllBsdTypeConcurrentJobs({
         index,
         ids: chunk,
         elasticSearchUrl: indexConfig.elasticSearchUrl
-      }),
-      opts: {
-        lifo: true,
-        stackTraceLimit: 100,
-        attempts: 1,
-        timeout: 600_000 // 10 min
-      }
+      })
     });
   });
 

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -26,7 +26,7 @@ import {
   toBsdElastic as formToBsdElastic
 } from "../../forms/elastic";
 import { toBsdElastic as bsvhuToBsdElastic } from "../../bsvhu/elastic";
-import { indexQueue } from "../../queue/producers/elastic";
+import { bulkIndexQueue } from "../../queue/producers/elastic";
 import { IndexAllFnSignature, FindManyAndIndexBsdsFnSignature } from "./types";
 
 /**
@@ -358,7 +358,7 @@ export async function indexAllBsdTypeConcurrentJobs({
   for (let i = 0; i < data.length; i += chunkSize) {
     const chunk = data.slice(i, i + chunkSize);
     // all jobs are succesfully added in bulk or all jobs will fail
-    const bulkJobs = await indexQueue.addBulk(chunk);
+    const bulkJobs = await bulkIndexQueue.addBulk(chunk);
     jobs.push(...bulkJobs);
   }
 

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -21,7 +21,11 @@ export { formatDate } from "./common/pdf";
 export { sendMail } from "./mailer/mailing";
 export { BsdUpdateQueueItem, updatesQueue } from "./queue/producers/bsdUpdate";
 export { sendMailJob } from "./queue/jobs";
-export { indexQueue, bulkIndexQueue } from "./queue/producers/elastic";
+export {
+  indexQueue,
+  bulkIndexQueue,
+  bulkIndexMasterQueue
+} from "./queue/producers/elastic";
 export { mailQueue } from "./queue/producers/mail";
 export { syncEventsQueue } from "./queue/producers/events";
 export {

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -21,7 +21,7 @@ export { formatDate } from "./common/pdf";
 export { sendMail } from "./mailer/mailing";
 export { BsdUpdateQueueItem, updatesQueue } from "./queue/producers/bsdUpdate";
 export { sendMailJob } from "./queue/jobs";
-export { indexQueue } from "./queue/producers/elastic";
+export { indexQueue, bulkIndexQueue } from "./queue/producers/elastic";
 export { mailQueue } from "./queue/producers/mail";
 export { syncEventsQueue } from "./queue/producers/events";
 export {

--- a/back/src/queue/bull-board.ts
+++ b/back/src/queue/bull-board.ts
@@ -6,7 +6,11 @@ import {
   geocodeCompanyQueue,
   setCompanyDepartementQueue
 } from "./producers/company";
-import { indexQueue, bulkIndexQueue } from "./producers/elastic";
+import {
+  indexQueue,
+  bulkIndexQueue,
+  bulkIndexMasterQueue
+} from "./producers/elastic";
 import { updatesQueue } from "./producers/bsdUpdate";
 import { webhooksQueue } from "./producers/webhooks";
 import { syncEventsQueue } from "./producers/events";
@@ -20,6 +24,7 @@ createBullBoard({
     new BullAdapter(mailQueue),
     new BullAdapter(indexQueue),
     new BullAdapter(bulkIndexQueue),
+    new BullAdapter(bulkIndexMasterQueue),
     new BullAdapter(updatesQueue),
     new BullAdapter(geocodeCompanyQueue),
     new BullAdapter(setCompanyDepartementQueue),

--- a/back/src/queue/bull-board.ts
+++ b/back/src/queue/bull-board.ts
@@ -6,7 +6,7 @@ import {
   geocodeCompanyQueue,
   setCompanyDepartementQueue
 } from "./producers/company";
-import { indexQueue } from "./producers/elastic";
+import { indexQueue, bulkIndexQueue } from "./producers/elastic";
 import { updatesQueue } from "./producers/bsdUpdate";
 import { webhooksQueue } from "./producers/webhooks";
 import { syncEventsQueue } from "./producers/events";
@@ -19,6 +19,7 @@ createBullBoard({
   queues: [
     new BullAdapter(mailQueue),
     new BullAdapter(indexQueue),
+    new BullAdapter(bulkIndexQueue),
     new BullAdapter(updatesQueue),
     new BullAdapter(geocodeCompanyQueue),
     new BullAdapter(setCompanyDepartementQueue),

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -37,9 +37,10 @@ export const bulkIndexQueue = new Queue<string>(
       // le dashboard bull
       attempts: 1,
       backoff: { type: "fixed", delay: 100 },
+      stackTraceLimit: 100,
       removeOnComplete: 10_000,
-      // timeout d'1 minute  pour prendre de la marge
-      timeout: 60000
+      // 10 minutes
+      timeout: 10 * 60 * 1000
     }
   }
 );

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -22,7 +22,7 @@ export const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
   }
 });
 
-// On gère l'indexation en bulk dans une queue séparée afin de
+// On gère l'indexation en bulk dans une queue et un worker séparée afin de
 // ne pas bloquer les jobs d'indexation "courants" lors d'un réindex
 // global
 export const BULK_INDEX_QUEUE_NAME = `queue_bulk_index_elastic_${NODE_ENV}`;
@@ -38,8 +38,29 @@ export const bulkIndexQueue = new Queue<string>(
       attempts: 1,
       backoff: { type: "fixed", delay: 100 },
       removeOnComplete: 10_000,
-      // tiemout de 20 secondes pour prendre de la marge
-      timeout: 20000
+      // timeout d'1 minute  pour prendre de la marge
+      timeout: 60000
+    }
+  }
+);
+
+// Cette queue permet de process le job qui enqueue toutes les chunks et attend qu'elles soient
+// toutes terminées pour lancer un rattrapage (Cf fonction indexAllBsdTypeConcurrentJobs).
+// Elle est également démarré sur un worker séparé pour l'isoler du reste et éviter que le job soit
+// relancé en cas de crash d'un worker de bulk indexation
+export const BULK_INDEX_MASTER_QUEUE_NAME = `queue_bulk_index_master_elastic_${NODE_ENV}`;
+
+export const bulkIndexMasterQueue = new Queue<string>(
+  BULK_INDEX_MASTER_QUEUE_NAME,
+  REDIS_URL!,
+  {
+    defaultJobOptions: {
+      attempts: 1,
+      backoff: { type: "fixed", delay: 100 },
+      removeOnComplete: 10_000,
+      // 24h pour prendre de la marge, les jobs de cette queue attendent que toutes les chunks
+      // soit process lors d'un reindex global
+      timeout: 24 * 3600 * 1000
     }
   }
 );


### PR DESCRIPTION
Deux améliorations pour le script de réindexation en masse : 
- les jobs `indexChunk` sont gérés dans une queue et un worker séparé ce qui permet de ne pas interférer avec les jobs d'indexation "courants" et de mieux suivre ce qui se passe.
- les jobs `indexAllInBulk` en charge d'ajouter les chunks et d'attendre la fin pour faire un rattrapage sont également gérés dans une queue et un worker séparé pour les isoler et être certains qu'ils ne soient pas redémarrés en cas de crash d'un worker qui index les chunks (ce qui a pour conséquence de recréer un index et de remettre des chunks dans la queue).

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
