### PR TITLE
[TRA-13700] Correction du wording pour le mode de traitement 'Elimination'

### DIFF
--- a/back/src/common/operationModes.ts
+++ b/back/src/common/operationModes.ts
@@ -52,7 +52,7 @@ export const getOperationModesFromOperationCode = (
 export const getOperationModeLabel = (operationMode: OperationMode) => {
   switch (operationMode) {
     case OperationMode.ELIMINATION:
-      return "Elimination (incinération sans valorisation énergétique et stockage en décharge)";
+      return "Elimination";
     case OperationMode.RECYCLAGE:
       return "Recyclage et les autres formes de valorisation de la matière";
     case OperationMode.REUTILISATION:

--- a/front/src/common/operationModes.ts
+++ b/front/src/common/operationModes.ts
@@ -52,7 +52,7 @@ export const getOperationModesFromOperationCode = (
 export const getOperationModeLabel = (operationMode: OperationMode) => {
   switch (operationMode) {
     case OperationMode.Elimination:
-      return "Elimination (incinération sans valorisation énergétique et stockage en décharge)";
+      return "Elimination";
     case OperationMode.Recyclage:
       return "Recyclage et les autres formes de valorisation de la matière";
     case OperationMode.Reutilisation:


### PR DESCRIPTION
# Contexte

On veut simplifier le libellé parce que non pertinent pour certains codes de traitement.
```
// Avant
Elimination (incinération sans valorisation énergétique et stockage en décharge)

// Après
Elimination
```

# Ticket Favro

[Modif Wording](https://favro.com/widget/ab14a4f0460a99a9d64d4945/887cda40286970b352f00a37?card=tra-13700)
