### PR TITLE
Fix searchCompanies quand VIES down, ne pas afficher "aucun établissement trouvé"

### DIFF
--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -21,6 +21,7 @@ import { UserInputError } from "../common/errors";
 import { SearchOptions } from "./sirene/trackdechets/types";
 import { Company } from "@prisma/client";
 import { StatutDiffusionEtablissement } from "../generated/graphql/types";
+import { ViesClientError } from "./vat/vies/client";
 
 interface SearchCompaniesDeps {
   injectedSearchCompany: (clue: string) => Promise<CompanySearchResult>;
@@ -204,7 +205,13 @@ export const makeSearchCompanies =
               .filter(c => c.etatAdministratif && c.etatAdministratif === "A")
           );
         })
-        .catch(_ => []);
+        .catch(err => {
+          if (err instanceof ViesClientError) {
+            throw err;
+          } else {
+            return [];
+          }
+        });
     }
     // fuzzy searching only for French companies
     return injectedSearchCompanies(clue, department).then(


### PR DESCRIPTION
# Situation rencontrée 

Sur l'édition de BSD, sur transporteur le companyselector (v1 et v2) interprêtent mal le code d'erreur serveur et n'affiche pas l'indispo côté VIES

![image](https://github.com/MTES-MCT/trackdechets/assets/76620/721c5f2d-92a6-4c40-8000-30ae3cdc5da2)

# Comportement attendu

Lorsque je recherche un établissement étranger européen via le Company Selector (appel à la base VIES), et qu'aucun résultat ne m'est remonté, je souhaite que le message d'erreur qui apparaît soit représentatif de la situation rencontrée 


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/95baff048704d6b9e0adbd28?card=tra-13426)
