### PR TITLE
[Tra-13453] Corrections bugs registre exhaustif d'un BSDD avec entreposage provisoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,20 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2024.2.1] 13/02/2024
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+- Registre exhaustif du BSDD suite entreposage provisoire : les informations relatives à la destination finale et au 2e transporteur n'apparaissent pas + lignes en double [PR 3051](https://github.com/MTES-MCT/trackdechets/pull/3051)
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :house: Interne
+
 # [2024.1.1] 16/01/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -1,6 +1,6 @@
 import { hash } from "bcrypt";
 import { faker } from "@faker-js/faker";
-import getReadableId from "../forms/readableId";
+import getReadableId, { ReadableIdPrefix } from "../forms/readableId";
 import {
   CompanyType,
   Consistence,
@@ -454,13 +454,16 @@ export const formWithTempStorageFactory = async ({
     }
   };
 
+  const readableId = getReadableId(ReadableIdPrefix.BSD);
+
   return formFactory({
     ownerId,
     opt: {
+      readableId,
       recipientIsTempStorage: true,
       forwardedIn: {
         create: {
-          readableId: getReadableId(),
+          readableId: `${readableId}-suite`,
           owner: { connect: { id: ownerId } },
           ...forwardedCreateInput
         }

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -21,7 +21,7 @@ export function simpleFormToBsdd(
   const [transporter, transporter2, transporter3] = transporters;
 
   return {
-    id: tov1ReadableId(form.readableId),
+    id: form.readableId,
     customId: form.customId,
     createdAt: form.createdAt,
     updatedAt: form.updatedAt,
@@ -191,13 +191,6 @@ export function formToBsdd(form: RegistryForm): Bsdd & {
       : { forwarding: null }),
     grouping
   };
-}
-
-/**
- * Do not expose BSD suite id (ex : BSD-20220603-PDTKKH7W2-suite) to end user
- */
-export function tov1ReadableId(readableId: string) {
-  return readableId.replace("-suite", "");
 }
 
 export function appendix2toFormFractions(

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -896,7 +896,6 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [transporter.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
-    expect(ids).toContain(form.id);
     expect(ids).toContain(form.forwardedIn!.id);
   });
   it("should list a BSDD in final destination's all wastes", async () => {
@@ -912,7 +911,6 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
     await refreshElasticSearch();
     const bsds = await searchBsds("ALL", [destination.company.siret!]);
     const ids = bsds.map(bsd => bsd.id);
-    expect(ids).toContain(form.id);
     expect(ids).toContain(form.forwardedIn!.id);
   });
   it("should list a BSDA in emitter's all wastes", async () => {

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -14,22 +14,39 @@ export function buildQuery(
   sirets: string[],
   where: WasteRegistryWhere | undefined | null
 ): estypes.QueryContainer {
-  const elasticKey: { [key in WasteRegistryType]: keyof BsdElastic } = {
+  // Associe un type de registre au champ ES permettant de stocker
+  // la liste des établissements concerné par ce type de registre sur un
+  // BSD donnée
+  const elasticKey: { [key in WasteRegistryType]?: keyof BsdElastic } = {
     OUTGOING: "isOutgoingWasteFor",
     INCOMING: "isIncomingWasteFor",
     TRANSPORTED: "isTransportedWasteFor",
-    MANAGED: "isManagedWasteFor",
-    ALL: "sirets"
+    MANAGED: "isManagedWasteFor"
   };
+
+  // Fonction permettant de construire le filtre ES pour un type de registre donné.
+  // On considère qu'un BSD doit apparaitre dans le registre exhaustif d'un établissement
+  // s'il apparait dans au moins un des registres classiques (entrants, sortants, transportés, gérés)
+  function registryTypeFilter(type: WasteRegistryType): estypes.QueryContainer {
+    if (type === "ALL") {
+      return {
+        bool: {
+          should: [
+            registryTypeFilter("OUTGOING"),
+            registryTypeFilter("INCOMING"),
+            registryTypeFilter("TRANSPORTED"),
+            registryTypeFilter("MANAGED")
+          ]
+        }
+      };
+    }
+    return { terms: { [elasticKey[type]!]: sirets } };
+  }
 
   return {
     bool: {
       filter: [
-        {
-          terms: {
-            [elasticKey[registryType]]: sirets
-          }
-        },
+        registryTypeFilter(registryType),
         ...(where ? toElasticFilter(where) : [])
       ]
     }

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -32,6 +32,7 @@ import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
 import {
   formFactory,
+  formWithTempStorageFactory,
   userWithAccessTokenFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
@@ -109,7 +110,9 @@ describe("All wastes registry", () => {
         createdAt: new Date("2021-05-01"),
         destinationReceptionWeight: 500,
         transporterTransportTakenOverAt: new Date("2021-05-01"),
+        transporterTransportSignatureDate: new Date(),
         destinationReceptionDate: new Date("2021-05-01"),
+        destinationOperationSignatureDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
         destinationOperationCode: "D 5"
       }
@@ -124,7 +127,9 @@ describe("All wastes registry", () => {
         createdAt: new Date("2021-06-01"),
         destinationReceptionWasteWeightValue: 10,
         transporterTakenOverAt: new Date("2021-06-01"),
+        transporterTransportSignatureDate: new Date("2021-06-01"),
         destinationReceptionDate: new Date("2021-06-01"),
+        destinationReceptionSignatureDate: new Date("2021-06-01"),
         destinationOperationDate: new Date("2021-06-01"),
         destinationOperationCode: "R 13"
       }
@@ -133,6 +138,7 @@ describe("All wastes registry", () => {
       opt: {
         emitterCompanySiret: emitter.company.siret,
         transporterCompanySiret: transporter.company.siret,
+        transporterTransportSignatureDate: new Date("2021-07-01"),
         destinationCompanySiret: destination.company.siret,
         wasteCode: "16 01 04*",
         status: BsvhuStatus.PROCESSED,
@@ -140,6 +146,7 @@ describe("All wastes registry", () => {
         destinationReceptionWeight: 3000,
         transporterTransportTakenOverAt: new Date("2021-07-01"),
         destinationReceptionDate: new Date("2021-07-01"),
+        destinationOperationSignatureDate: new Date("2021-07-01"),
         destinationOperationDate: new Date("2021-07-01"),
         destinationOperationCode: "R 8"
       }
@@ -316,5 +323,191 @@ describe("All wastes registry", () => {
     expect(page3.allWastes.totalCount).toEqual(5);
     expect(page3.allWastes.pageInfo.startCursor).toEqual(bsd1.id);
     expect(page3.allWastes.pageInfo.hasPreviousPage).toEqual(false);
+  });
+});
+
+describe("Registre exhaustif > BSDD avec entreposage provisoire", () => {
+  let emitter: { user: User; company: Company };
+  let transporter: { user: User; company: Company };
+  let transporter2: { user: User; company: Company };
+  let destination: { user: User; company: Company };
+  let ttr: { user: User; company: Company };
+  let bsdd: Form;
+
+  beforeAll(async () => {
+    emitter = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["PRODUCER"]
+      }
+    });
+
+    transporter = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["TRANSPORTER"]
+      }
+    });
+
+    transporter2 = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["TRANSPORTER"]
+      }
+    });
+
+    destination = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["WASTEPROCESSOR"]
+      }
+    });
+
+    ttr = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: {
+        set: ["WASTEPROCESSOR"]
+      }
+    });
+    bsdd = await formWithTempStorageFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "PROCESSED",
+        emittedAt: new Date(),
+        sentAt: new Date(),
+        takenOverAt: new Date(),
+        receivedAt: new Date(),
+        processedAt: new Date(),
+        emitterCompanySiret: emitter.company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: transporter.company.siret,
+            takenOverAt: new Date(),
+            number: 1
+          }
+        },
+        recipientCompanySiret: ttr.company.siret
+      },
+      forwardedInOpts: {
+        status: "PROCESSED",
+        emittedAt: new Date(),
+        sentAt: new Date(),
+        takenOverAt: new Date(),
+        receivedAt: new Date(),
+        processedAt: new Date(),
+        emitterCompanySiret: ttr.company.siret,
+        transporters: {
+          create: {
+            transporterCompanySiret: transporter2.company.siret,
+            takenOverAt: new Date(),
+            number: 1
+          }
+        },
+        recipientCompanySiret: destination.company.siret
+      }
+    });
+
+    await indexForm(await getFormForElastic(bsdd));
+    await refreshElasticSearch();
+  });
+
+  afterAll(resetDatabase);
+
+  test("BSDD should appear once in emitter's all waste registry", async () => {
+    const { query } = makeClient(emitter.user);
+    const { data, errors } = await query<Pick<Query, "allWastes">>(ALL_WASTES, {
+      variables: { sirets: [emitter.company.siret] }
+    });
+    expect(errors).toBeUndefined();
+    const wastes = data.allWastes.edges.map(edge => edge.node);
+    expect(wastes).toHaveLength(1);
+    expect(wastes).toEqual([
+      // une ligne avec la première partie du trajet
+      expect.objectContaining({
+        id: bsdd.readableId,
+        emitterCompanySiret: emitter.company.siret,
+        transporterCompanySiret: transporter.company.siret,
+        destinationCompanySiret: ttr.company.siret
+      })
+    ]);
+  });
+
+  test("BSDD should appear once in transporter's all waste registry", async () => {
+    const { query } = makeClient(transporter.user);
+    const { data, errors } = await query<Pick<Query, "allWastes">>(ALL_WASTES, {
+      variables: { sirets: [transporter.company.siret] }
+    });
+    expect(errors).toBeUndefined();
+    const wastes = data.allWastes.edges.map(edge => edge.node);
+    expect(wastes).toHaveLength(1);
+    expect(wastes).toEqual([
+      // une ligne avec la première partie du trajet
+      expect.objectContaining({
+        id: bsdd.readableId,
+        emitterCompanySiret: emitter.company.siret,
+        transporterCompanySiret: transporter.company.siret,
+        destinationCompanySiret: ttr.company.siret
+      })
+    ]);
+  });
+
+  test("BSDD should appear twice in ttr's all waste registry", async () => {
+    const { query } = makeClient(ttr.user);
+    const { data, errors } = await query<Pick<Query, "allWastes">>(ALL_WASTES, {
+      variables: { sirets: [ttr.company.siret] }
+    });
+    expect(errors).toBeUndefined();
+    const wastes = data.allWastes.edges.map(edge => edge.node);
+    expect(wastes).toHaveLength(2);
+
+    expect(wastes).toEqual([
+      // une ligne avec la deuxième partie du trajet
+      expect.objectContaining({
+        id: `${bsdd.readableId}-suite`,
+        emitterCompanySiret: ttr.company.siret,
+        transporterCompanySiret: transporter2.company.siret,
+        destinationCompanySiret: destination.company.siret
+      }),
+      // une ligne avec la première partie du trajet
+      expect.objectContaining({
+        id: bsdd.readableId,
+        emitterCompanySiret: emitter.company.siret,
+        transporterCompanySiret: transporter.company.siret,
+        destinationCompanySiret: ttr.company.siret
+      })
+    ]);
+  });
+
+  test("BSDD should appear once in destination all waste registry", async () => {
+    const { query } = makeClient(destination.user);
+    const { data, errors } = await query<Pick<Query, "allWastes">>(ALL_WASTES, {
+      variables: { sirets: [destination.company.siret] }
+    });
+    expect(errors).toBeUndefined();
+    const wastes = data.allWastes.edges.map(edge => edge.node);
+    expect(wastes).toHaveLength(1);
+    expect(wastes).toEqual([
+      // une ligne avec la deuxième partie du trajet
+      expect.objectContaining({
+        id: `${bsdd.readableId}-suite`,
+        emitterCompanySiret: ttr.company.siret,
+        transporterCompanySiret: transporter2.company.siret,
+        destinationCompanySiret: destination.company.siret
+      })
+    ]);
+  });
+
+  test("BSDD should appear once in transporter after temp storage's all waste registry", async () => {
+    const { query } = makeClient(transporter2.user);
+    const { data, errors } = await query<Pick<Query, "allWastes">>(ALL_WASTES, {
+      variables: { sirets: [transporter2.company.siret] }
+    });
+    expect(errors).toBeUndefined();
+    const wastes = data.allWastes.edges.map(edge => edge.node);
+    expect(wastes).toHaveLength(1);
+    expect(wastes).toEqual([
+      // une ligne avec la deuxième partie du trajet
+      expect.objectContaining({
+        id: `${bsdd.readableId}-suite`,
+        emitterCompanySiret: ttr.company.siret,
+        transporterCompanySiret: transporter2.company.siret,
+        destinationCompanySiret: destination.company.siret
+      })
+    ]);
   });
 });

--- a/back/src/registry/resolvers/queries/__tests__/queries.ts
+++ b/back/src/registry/resolvers/queries/__tests__/queries.ts
@@ -169,6 +169,9 @@ export const ALL_WASTES = gql`
         cursor
         node {
           id
+          emitterCompanySiret
+          transporterCompanySiret
+          destinationCompanySiret
         }
       }
     }

--- a/back/src/registry/wastes.ts
+++ b/back/src/registry/wastes.ts
@@ -1,5 +1,4 @@
 import { TotalHits } from "@elastic/elasticsearch/api/types";
-import { tov1ReadableId } from "../forms/compat";
 import { WasteRegistryType } from "../generated/graphql/types";
 import { toWastes } from "./converters";
 import { searchBsds, toPrismaBsds } from "./elastic";
@@ -62,9 +61,7 @@ async function getWasteConnection<WasteType extends GenericWaste>(
       }
       const { type, id, readableId } = bsd;
       const waste = wastes[type].find(waste =>
-        type === "BSDD"
-          ? waste.id === tov1ReadableId(readableId)
-          : waste.id === id
+        type === "BSDD" ? waste.id === readableId : waste.id === id
       );
 
       if (waste) {


### PR DESCRIPTION
### Critères d'acceptation et bugs qui était constaté : 

✅ Le registre exhaustif de l'émetteur doit faire apparaitre une ligne correspondant à la première partie du trajet 

✅ Le registre exhaustif du transporteur doit faire apparaitre une ligne correspondant à la première partie du trajet

❌ Le registre exhaustif de l'entreposage provisoire doit faire apparaitre deux lignes correspondant aux deux parties du trajets  
=> _Le registre exhaustif de l'entreposage provisoire fait bien apparaitre deux lignes, mais les deux correspondent à la première partie du trajet_

❌ Le registre exhaustif du transporteur après entreposage provisoire doit faire apparaitre une ligne correspondant à la deuxième partie du trajet 
=> _Le registre exhaustif du transporteur après entreposage provisoire fait apparaitre deux lignes, les deux correspondants à la première partie du trajet_

❌ Le registre exhaustif du destinataire finale doit faire apparaitre une ligne correspondant à la deuxième partie du trajet
=> _Le registre exhaustif du destinataire finale fait apparaitre deux lignes, les deux correspondant à la première partie du trajet_ 

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Registre exhaustif du BSDD Suite entreposage provisoire : les informations relatives à la destination finale et au 2e transporteur n'apparaissent pas + lignes en double](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13453)
