### PR TITLE
[TRA-12092][BSDA] Migrer les données transporteur dans une table à part (refacto interne du code)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+- [BSDA] Migrer les données transporteur dans une table à part (refacto interne du code) [PR 3055](https://github.com/MTES-MCT/trackdechets/pull/3055)
+
 # [2024.1.1] 16/01/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -50,7 +50,7 @@ const SUBMIT_BSDA_REVISION_REQUEST_APPROVAL = `
 describe("ActivityEvent.Bsda", () => {
   afterEach(resetDatabase);
 
-  it.only("should create events during the workflow", async () => {
+  it("should create events during the workflow", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const { company: destinationCompany } = await userWithCompanyFactory(
       "MEMBER",

--- a/back/src/activity-events/bsda/__tests__/bsda.integration.ts
+++ b/back/src/activity-events/bsda/__tests__/bsda.integration.ts
@@ -50,7 +50,7 @@ const SUBMIT_BSDA_REVISION_REQUEST_APPROVAL = `
 describe("ActivityEvent.Bsda", () => {
   afterEach(resetDatabase);
 
-  it("should create events during the workflow", async () => {
+  it.only("should create events during the workflow", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const { company: destinationCompany } = await userWithCompanyFactory(
       "MEMBER",

--- a/back/src/activity-events/bsda/reducer.ts
+++ b/back/src/activity-events/bsda/reducer.ts
@@ -68,7 +68,6 @@ function fixMissTypings(
   const patch = {
     ...update,
     wasteSealNumbers: update.wasteSealNumbers as string[],
-    transporterTransportPlates: update.transporterTransportPlates as string[],
     packagings: update.packagings as Prisma.JsonValue,
     emitterEmissionSignatureDate: update.emitterEmissionSignatureDate
       ? new Date(update.emitterEmissionSignatureDate.toString())
@@ -84,15 +83,6 @@ function fixMissTypings(
       : undefined,
     destinationOperationSignatureDate: update.destinationOperationSignatureDate
       ? new Date(update.destinationOperationSignatureDate.toString())
-      : undefined,
-    transporterRecepisseValidityLimit: update.transporterRecepisseValidityLimit
-      ? new Date(update.transporterRecepisseValidityLimit.toString())
-      : undefined,
-    transporterTransportTakenOverAt: update.transporterTransportTakenOverAt
-      ? new Date(update.transporterTransportTakenOverAt.toString())
-      : undefined,
-    transporterTransportSignatureDate: update.transporterTransportSignatureDate
-      ? new Date(update.transporterTransportSignatureDate.toString())
       : undefined,
     workerWorkSignatureDate: update.workerWorkSignatureDate
       ? new Date(update.workerWorkSignatureDate.toString())

--- a/back/src/activity-events/bsda/reducer.ts
+++ b/back/src/activity-events/bsda/reducer.ts
@@ -70,7 +70,6 @@ function fixMissTypings(
   const patch = {
     ...update,
     wasteSealNumbers: update.wasteSealNumbers as string[],
-    transporterTransportPlates: "",
     packagings: update.packagings as Prisma.JsonValue,
     emitterEmissionSignatureDate: update.emitterEmissionSignatureDate
       ? new Date(update.emitterEmissionSignatureDate.toString())

--- a/back/src/activity-events/bsda/reducer.ts
+++ b/back/src/activity-events/bsda/reducer.ts
@@ -14,6 +14,7 @@ export function bsdaReducer(
         intermediaries,
         wasteSealNumbers,
         intermediariesOrgIds,
+        transporters,
         ...bsda
       } = event.data;
 
@@ -30,6 +31,7 @@ export function bsdaReducer(
         grouping,
         intermediaries,
         intermediariesOrgIds,
+        transporters,
         ...bsda
       } = event.data;
 
@@ -68,6 +70,7 @@ function fixMissTypings(
   const patch = {
     ...update,
     wasteSealNumbers: update.wasteSealNumbers as string[],
+    transporterTransportPlates: "",
     packagings: update.packagings as Prisma.JsonValue,
     emitterEmissionSignatureDate: update.emitterEmissionSignatureDate
       ? new Date(update.emitterEmissionSignatureDate.toString())

--- a/back/src/bsda/__tests__/elastic.integration.ts
+++ b/back/src/bsda/__tests__/elastic.integration.ts
@@ -42,9 +42,6 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
         emitterCompanySiret: emitter.siret,
         workerCompanyName: worker.name,
         workerCompanySiret: worker.siret,
-        transporterCompanyName: transporter.name,
-        transporterCompanySiret: transporter.siret,
-        transporterCompanyVatNumber: transporter.vatNumber,
         destinationCompanyName: destination.name,
         destinationCompanySiret: destination.siret,
         destinationOperationNextDestinationCompanyName: nextDestination.name,
@@ -53,6 +50,11 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
         ecoOrganismeSiret: ecoOrganisme.siret,
         brokerCompanyName: broker.name,
         brokerCompanySiret: broker.siret
+      },
+      transporterOpt: {
+        transporterCompanyName: transporter.name,
+        transporterCompanySiret: transporter.siret,
+        transporterCompanyVatNumber: transporter.vatNumber
       }
     });
 

--- a/back/src/bsda/__tests__/factories.ts
+++ b/back/src/bsda/__tests__/factories.ts
@@ -12,6 +12,15 @@ export const bsdaFactory = async ({
 }) => {
   const bsdaObject = getBsdaObject();
 
+  await upsertBaseSiret(
+    (
+      bsdaObject.transporters!
+        .create! as Prisma.BsdaTransporterCreateWithoutBsdaInput
+    ).transporterCompanySiret // Prisma.BsdaTransporterCreateWithoutBsdaInput[] is wrongly infered
+  );
+  await upsertBaseSiret(bsdaObject.destinationCompanySiret);
+  await upsertBaseSiret(bsdaObject.workerCompanySiret);
+
   const data: Prisma.BsdaCreateInput = {
     ...bsdaObject,
     ...opt,
@@ -19,13 +28,6 @@ export const bsdaFactory = async ({
       create: { ...bsdaObject.transporters!.create!, ...transporterOpt }
     }
   };
-
-  await upsertBaseSiret(
-    (data.transporters!.create! as Prisma.BsdaTransporterCreateWithoutBsdaInput) // Prisma.BsdaTransporterCreateWithoutBsdaInput[] is wrongly infered
-      .transporterCompanySiret
-  );
-  await upsertBaseSiret(data.destinationCompanySiret);
-  await upsertBaseSiret(data.workerCompanySiret);
 
   const created = await prisma.bsda.create({
     data: data,

--- a/back/src/bsda/__tests__/factories.ts
+++ b/back/src/bsda/__tests__/factories.ts
@@ -5,7 +5,7 @@ import { siretify, upsertBaseSiret } from "../../__tests__/factories";
 
 /**
  * Permet de créer un BSDA avec des données par défaut et
- * un premier trnsporteur. Les données du BSDA et du premier
+ * un premier transporteur. Les données du BSDA et du premier
  * transporteur peuvent être modifiées grâce aux paramètres
  * `opt` et `transporterOpt`.
  *

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -42,185 +42,195 @@ import {
 } from "../generated/graphql/types";
 import {
   Prisma,
-  Bsda as PrismaBsda,
+  BsdaTransporter as PrismaBsdaTransporter,
   BsdaRevisionRequest
 } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 import { Decimal } from "decimal.js-light";
 import { BsdaForElastic } from "./elastic";
+import { BsdaWithTransporters } from "./types";
+import { getFirstTransporterSync } from "./database";
 
-export function expandBsdaFromDb(form: PrismaBsda): GraphqlBsda {
+export function expandBsdaFromDb(bsda: BsdaWithTransporters): GraphqlBsda {
+  const transporter = getFirstTransporterSync(bsda);
   return {
-    id: form.id,
-    createdAt: processDate(form.createdAt),
-    updatedAt: processDate(form.updatedAt),
-    isDraft: form.isDraft,
-    status: form.status,
-    type: form.type,
+    id: bsda.id,
+    createdAt: processDate(bsda.createdAt),
+    updatedAt: processDate(bsda.updatedAt),
+    isDraft: bsda.isDraft,
+    status: bsda.status,
+    type: bsda.type,
     emitter: nullIfNoValues<BsdaEmitter>({
-      isPrivateIndividual: form.emitterIsPrivateIndividual,
+      isPrivateIndividual: bsda.emitterIsPrivateIndividual,
       company: nullIfNoValues<FormCompany>({
-        name: form.emitterCompanyName,
-        siret: form.emitterCompanySiret,
-        address: form.emitterCompanyAddress,
-        contact: form.emitterCompanyContact,
-        phone: form.emitterCompanyPhone,
-        mail: form.emitterCompanyMail
+        name: bsda.emitterCompanyName,
+        siret: bsda.emitterCompanySiret,
+        address: bsda.emitterCompanyAddress,
+        contact: bsda.emitterCompanyContact,
+        phone: bsda.emitterCompanyPhone,
+        mail: bsda.emitterCompanyMail
       }),
-      customInfo: form.emitterCustomInfo,
+      customInfo: bsda.emitterCustomInfo,
       emission: nullIfNoValues<BsdaEmission>({
         signature: nullIfNoValues<Signature>({
-          author: form.emitterEmissionSignatureAuthor,
-          date: processDate(form.emitterEmissionSignatureDate)
+          author: bsda.emitterEmissionSignatureAuthor,
+          date: processDate(bsda.emitterEmissionSignatureDate)
         })
       }),
       pickupSite: nullIfNoValues<BsdaPickupSite>({
-        address: form.emitterPickupSiteAddress,
-        city: form.emitterPickupSiteCity,
-        infos: form.emitterPickupSiteInfos,
-        name: form.emitterPickupSiteName,
-        postalCode: form.emitterPickupSitePostalCode
+        address: bsda.emitterPickupSiteAddress,
+        city: bsda.emitterPickupSiteCity,
+        infos: bsda.emitterPickupSiteInfos,
+        name: bsda.emitterPickupSiteName,
+        postalCode: bsda.emitterPickupSitePostalCode
       })
     }),
     ecoOrganisme: nullIfNoValues<BsdaEcoOrganisme>({
-      name: form.ecoOrganismeName,
-      siret: form.ecoOrganismeSiret
+      name: bsda.ecoOrganismeName,
+      siret: bsda.ecoOrganismeSiret
     }),
-    packagings: form.packagings as BsdaPackaging[],
+    packagings: bsda.packagings as BsdaPackaging[],
     waste: nullIfNoValues<BsdaWaste>({
-      code: form.wasteCode,
-      name: form.wasteMaterialName, // TODO To remove - keeps support for `name` for now
-      consistence: form.wasteConsistence,
-      familyCode: form.wasteFamilyCode,
-      materialName: form.wasteMaterialName,
-      sealNumbers: form.wasteSealNumbers,
-      adr: form.wasteAdr,
-      pop: form.wastePop
+      code: bsda.wasteCode,
+      name: bsda.wasteMaterialName, // TODO To remove - keeps support for `name` for now
+      consistence: bsda.wasteConsistence,
+      familyCode: bsda.wasteFamilyCode,
+      materialName: bsda.wasteMaterialName,
+      sealNumbers: bsda.wasteSealNumbers,
+      adr: bsda.wasteAdr,
+      pop: bsda.wastePop
     }),
     weight: nullIfNoValues<BsdaWeight>({
-      isEstimate: form.weightIsEstimate,
-      value: form.weightValue
-        ? new Decimal(form.weightValue).dividedBy(1000).toNumber()
-        : form.weightValue
+      isEstimate: bsda.weightIsEstimate,
+      value: bsda.weightValue
+        ? new Decimal(bsda.weightValue).dividedBy(1000).toNumber()
+        : bsda.weightValue
     }),
     destination: nullIfNoValues<BsdaDestination>({
       company: nullIfNoValues<FormCompany>({
-        name: form.destinationCompanyName,
-        siret: form.destinationCompanySiret,
-        address: form.destinationCompanyAddress,
-        contact: form.destinationCompanyContact,
-        phone: form.destinationCompanyPhone,
-        mail: form.destinationCompanyMail
+        name: bsda.destinationCompanyName,
+        siret: bsda.destinationCompanySiret,
+        address: bsda.destinationCompanyAddress,
+        contact: bsda.destinationCompanyContact,
+        phone: bsda.destinationCompanyPhone,
+        mail: bsda.destinationCompanyMail
       }),
-      customInfo: form.destinationCustomInfo,
-      cap: form.destinationCap,
-      plannedOperationCode: form.destinationPlannedOperationCode,
+      customInfo: bsda.destinationCustomInfo,
+      cap: bsda.destinationCap,
+      plannedOperationCode: bsda.destinationPlannedOperationCode,
       reception: nullIfNoValues<BsdaReception>({
-        acceptationStatus: form.destinationReceptionAcceptationStatus,
-        refusalReason: form.destinationReceptionRefusalReason,
-        date: processDate(form.destinationReceptionDate),
-        weight: form.destinationReceptionWeight
-          ? new Decimal(form.destinationReceptionWeight)
+        acceptationStatus: bsda.destinationReceptionAcceptationStatus,
+        refusalReason: bsda.destinationReceptionRefusalReason,
+        date: processDate(bsda.destinationReceptionDate),
+        weight: bsda.destinationReceptionWeight
+          ? new Decimal(bsda.destinationReceptionWeight)
               .dividedBy(1000)
               .toNumber()
-          : form.destinationReceptionWeight
+          : bsda.destinationReceptionWeight
       }),
       operation: nullIfNoValues<BsdaOperation>({
-        code: form.destinationOperationCode,
-        mode: form.destinationOperationMode,
-        description: form.destinationOperationDescription,
-        date: form.destinationOperationDate,
+        code: bsda.destinationOperationCode,
+        mode: bsda.destinationOperationMode,
+        description: bsda.destinationOperationDescription,
+        date: bsda.destinationOperationDate,
         signature: nullIfNoValues<Signature>({
-          author: form.destinationOperationSignatureAuthor,
-          date: processDate(form.destinationOperationSignatureDate)
+          author: bsda.destinationOperationSignatureAuthor,
+          date: processDate(bsda.destinationOperationSignatureDate)
         }),
         nextDestination: nullIfNoValues<BsdaNextDestination>({
           company: nullIfNoValues<FormCompany>({
-            name: form.destinationOperationNextDestinationCompanyName,
-            siret: form.destinationOperationNextDestinationCompanySiret,
-            address: form.destinationOperationNextDestinationCompanyAddress,
-            contact: form.destinationOperationNextDestinationCompanyContact,
-            phone: form.destinationOperationNextDestinationCompanyPhone,
-            mail: form.destinationOperationNextDestinationCompanyMail
+            name: bsda.destinationOperationNextDestinationCompanyName,
+            siret: bsda.destinationOperationNextDestinationCompanySiret,
+            address: bsda.destinationOperationNextDestinationCompanyAddress,
+            contact: bsda.destinationOperationNextDestinationCompanyContact,
+            phone: bsda.destinationOperationNextDestinationCompanyPhone,
+            mail: bsda.destinationOperationNextDestinationCompanyMail
           }),
-          cap: form.destinationOperationNextDestinationCap,
+          cap: bsda.destinationOperationNextDestinationCap,
           plannedOperationCode:
-            form.destinationOperationNextDestinationPlannedOperationCode
+            bsda.destinationOperationNextDestinationPlannedOperationCode
         })
       })
     }),
     worker: nullIfNoValues<BsdaWorker>({
-      isDisabled: Boolean(form.workerIsDisabled),
+      isDisabled: Boolean(bsda.workerIsDisabled),
       company: nullIfNoValues<FormCompany>({
-        name: form.workerCompanyName,
-        siret: form.workerCompanySiret,
-        address: form.workerCompanyAddress,
-        contact: form.workerCompanyContact,
-        phone: form.workerCompanyPhone,
-        mail: form.workerCompanyMail
+        name: bsda.workerCompanyName,
+        siret: bsda.workerCompanySiret,
+        address: bsda.workerCompanyAddress,
+        contact: bsda.workerCompanyContact,
+        phone: bsda.workerCompanyPhone,
+        mail: bsda.workerCompanyMail
       }),
       certification: nullIfNoValues<BsdaWorkerCertification>({
-        hasSubSectionFour: form.workerCertificationHasSubSectionFour,
-        hasSubSectionThree: form.workerCertificationHasSubSectionThree,
-        certificationNumber: form.workerCertificationCertificationNumber,
-        validityLimit: form.workerCertificationValidityLimit,
-        organisation: form.workerCertificationOrganisation
+        hasSubSectionFour: bsda.workerCertificationHasSubSectionFour,
+        hasSubSectionThree: bsda.workerCertificationHasSubSectionThree,
+        certificationNumber: bsda.workerCertificationCertificationNumber,
+        validityLimit: bsda.workerCertificationValidityLimit,
+        organisation: bsda.workerCertificationOrganisation
       }),
       work: nullIfNoValues<BsdaWork>({
-        hasEmitterPaperSignature: form.workerWorkHasEmitterPaperSignature,
+        hasEmitterPaperSignature: bsda.workerWorkHasEmitterPaperSignature,
         signature: nullIfNoValues<Signature>({
-          author: form.workerWorkSignatureAuthor,
-          date: processDate(form.workerWorkSignatureDate)
+          author: bsda.workerWorkSignatureAuthor,
+          date: processDate(bsda.workerWorkSignatureDate)
         })
       })
     }),
     broker: nullIfNoValues<BsdaBroker>({
       company: nullIfNoValues<FormCompany>({
-        name: form.brokerCompanyName,
-        siret: form.brokerCompanySiret,
-        address: form.brokerCompanyAddress,
-        contact: form.brokerCompanyContact,
-        phone: form.brokerCompanyPhone,
-        mail: form.brokerCompanyMail
+        name: bsda.brokerCompanyName,
+        siret: bsda.brokerCompanySiret,
+        address: bsda.brokerCompanyAddress,
+        contact: bsda.brokerCompanyContact,
+        phone: bsda.brokerCompanyPhone,
+        mail: bsda.brokerCompanyMail
       }),
       recepisse: nullIfNoValues<BsdaRecepisse>({
-        department: form.brokerRecepisseDepartment,
-        number: form.brokerRecepisseNumber,
-        validityLimit: processDate(form.brokerRecepisseValidityLimit)
+        department: bsda.brokerRecepisseDepartment,
+        number: bsda.brokerRecepisseNumber,
+        validityLimit: processDate(bsda.brokerRecepisseValidityLimit)
       })
     }),
-    transporter: nullIfNoValues<BsdaTransporter>({
-      company: nullIfNoValues<FormCompany>({
-        name: form.transporterCompanyName,
-        orgId: getTransporterCompanyOrgId(form),
-        siret: form.transporterCompanySiret,
-        vatNumber: form.transporterCompanyVatNumber,
-        address: form.transporterCompanyAddress,
-        contact: form.transporterCompanyContact,
-        phone: form.transporterCompanyPhone,
-        mail: form.transporterCompanyMail
-      }),
-      customInfo: form.transporterCustomInfo,
-      recepisse: nullIfNoValues<BsdaRecepisse>({
-        department: form.transporterRecepisseDepartment,
-        number: form.transporterRecepisseNumber,
-        validityLimit: processDate(form.transporterRecepisseValidityLimit),
-        isExempted: form.transporterRecepisseIsExempted
-      }),
-      transport: nullIfNoValues<BsdaTransport>({
-        mode: form.transporterTransportMode,
-        plates: form.transporterTransportPlates,
-        takenOverAt: processDate(form.transporterTransportTakenOverAt),
-        signature: nullIfNoValues<Signature>({
-          author: form.transporterTransportSignatureAuthor,
-          date: processDate(form.transporterTransportSignatureDate)
-        })
-      })
-    }),
+    transporter: transporter ? expandTransporterFromDb(transporter) : null,
     grouping: [],
     metadata: undefined as any
   };
 }
+
+export function expandTransporterFromDb(
+  transporter: PrismaBsdaTransporter
+): BsdaTransporter | null {
+  return nullIfNoValues<BsdaTransporter>({
+    company: nullIfNoValues<FormCompany>({
+      name: transporter.transporterCompanyName,
+      orgId: getTransporterCompanyOrgId(transporter),
+      siret: transporter.transporterCompanySiret,
+      vatNumber: transporter.transporterCompanyVatNumber,
+      address: transporter.transporterCompanyAddress,
+      contact: transporter.transporterCompanyContact,
+      phone: transporter.transporterCompanyPhone,
+      mail: transporter.transporterCompanyMail
+    }),
+    customInfo: transporter.transporterCustomInfo,
+    recepisse: nullIfNoValues<BsdaRecepisse>({
+      department: transporter.transporterRecepisseDepartment,
+      number: transporter.transporterRecepisseNumber,
+      validityLimit: processDate(transporter.transporterRecepisseValidityLimit),
+      isExempted: transporter.transporterRecepisseIsExempted
+    }),
+    transport: nullIfNoValues<BsdaTransport>({
+      mode: transporter.transporterTransportMode,
+      plates: transporter.transporterTransportPlates,
+      takenOverAt: processDate(transporter.transporterTransportTakenOverAt),
+      signature: nullIfNoValues<Signature>({
+        author: transporter.transporterTransportSignatureAuthor,
+        date: processDate(transporter.transporterTransportSignatureDate)
+      })
+    })
+  });
+}
+
 export function expandBsdaFromElastic(bsda: BsdaForElastic): GraphqlBsda {
   const expanded = expandBsdaFromDb(bsda);
 
@@ -274,7 +284,6 @@ export function flattenBsdaInput(formInput: BsdaInput) {
     ...flattenBsdaEmitterInput(formInput),
     ...flattenBsdaEcoOrganismeInput(formInput),
     ...flattenBsdaDestinationInput(formInput),
-    ...flattenBsdaTransporterInput(formInput),
     ...flattenBsdaWorkerInput(formInput),
     ...flattenBsdaBrokerInput(formInput),
     ...flattenBsdaWasteInput(formInput),
@@ -432,10 +441,10 @@ function flattenBsdaDestinationInput({
   };
 }
 
-function flattenBsdaTransporterInput({
+export function flattenBsdaTransporterInput({
   transporter
 }: Pick<BsdaInput, "transporter">) {
-  return {
+  return safeInput({
     transporterCompanyName: chain(transporter, t =>
       chain(t.company, c => c.name)
     ),
@@ -480,7 +489,7 @@ function flattenBsdaTransporterInput({
     transporterTransportTakenOverAt: chain(transporter, t =>
       chain(t.transport, tr => tr.takenOverAt)
     )
-  };
+  });
 }
 
 function flattenBsdaWorkerInput({ worker }: Pick<BsdaInput, "worker">) {

--- a/back/src/bsda/database.ts
+++ b/back/src/bsda/database.ts
@@ -1,56 +1,53 @@
-import { Bsda, Prisma } from "@prisma/client";
+import { Bsda, BsdaTransporter, Prisma } from "@prisma/client";
 import { FormNotFound } from "../forms/errors";
 import { getReadonlyBsdaRepository } from "./repository";
+import { prisma } from "@td/prisma";
 
-export async function getBsdaOrNotFound<Include extends Prisma.BsdaInclude>(
+export async function getBsdaOrNotFound<Args extends Prisma.BsdaDefaultArgs>(
   id: string,
-  { include }: { include?: Include } = {}
-) {
-  const bsda = await getReadonlyBsdaRepository().findUnique<{
-    include: Include;
-  }>({ id }, include ? { include } : undefined);
-
+  args?: Args
+): Promise<Prisma.BsdaGetPayload<Args>> {
+  const bsda = await getReadonlyBsdaRepository().findUnique({ id }, args);
   if (bsda == null || bsda.isDeleted) {
     throw new FormNotFound(id.toString());
   }
-
   return bsda;
 }
 
 /**
  * Returns direct parents of a BSDA
  */
-export async function getPreviousBsdas(
-  bsda: Pick<Bsda, "id" | "forwardingId">
+export async function getPreviousBsdas<Args extends Prisma.BsdaDefaultArgs>(
+  bsda: Pick<Bsda, "id" | "forwardingId">,
+  args?: Args
 ) {
-  const bsdaWithItermediaries = Prisma.validator<Prisma.BsdaArgs>()({
-    include: { intermediaries: true }
-  });
-
   const bsdaRepository = getReadonlyBsdaRepository();
   const forwardedBsda = bsda.forwardingId
-    ? await bsdaRepository.findUnique(
-        { id: bsda.forwardingId },
-        bsdaWithItermediaries
-      )
+    ? await bsdaRepository.findUnique({ id: bsda.forwardingId }, args)
     : null;
 
   const groupedBsdas = await bsdaRepository
     .findRelatedEntity({ id: bsda.id })
-    .grouping(bsdaWithItermediaries);
+    .grouping(args);
 
   return [forwardedBsda, ...(groupedBsdas ?? [])].filter(
     Boolean
-  ) as Prisma.BsdaGetPayload<typeof bsdaWithItermediaries>[];
+  ) as Prisma.BsdaGetPayload<Args>[];
 }
 
 /**
  * Return all the BSDAs in the traceability history of this one
  */
-export async function getBsdaHistory(bsda: Bsda): Promise<Bsda[]> {
-  async function recursiveGetBsdaHistory(bsdas: Bsda[], history: Bsda[]) {
+export async function getBsdaHistory<Args extends Prisma.BsdaDefaultArgs>(
+  bsda: Bsda,
+  args?: Args
+): Promise<Prisma.BsdaGetPayload<Args>[]> {
+  async function recursiveGetBsdaHistory(
+    bsdas: Bsda[],
+    history: Prisma.BsdaGetPayload<Args>[]
+  ) {
     const previous = await Promise.all(
-      bsdas.map(bsda => getPreviousBsdas(bsda))
+      bsdas.map(bsda => getPreviousBsdas(bsda, args))
     );
     const previousFlattened = previous.reduce((ps, curr) => {
       return [...ps, ...curr];
@@ -65,4 +62,46 @@ export async function getBsdaHistory(bsda: Bsda): Promise<Bsda[]> {
   }
 
   return recursiveGetBsdaHistory([bsda], []);
+}
+
+export async function getTransporters(
+  form: Pick<Bsda, "id">
+): Promise<BsdaTransporter[]> {
+  const transporters = await prisma.bsda
+    .findUnique({ where: { id: form.id } })
+    .transporters({ orderBy: { number: "asc" } });
+  return transporters ?? [];
+}
+
+export function getTransportersSync(bsda: {
+  transporters: BsdaTransporter[] | null;
+}): BsdaTransporter[] {
+  return (bsda.transporters ?? []).sort((t1, t2) => t1.number - t2.number);
+}
+
+export async function getFirstTransporter(
+  bsda: Pick<Bsda, "id">
+): Promise<BsdaTransporter | null> {
+  const transporters = await getTransporters(bsda);
+  const firstTransporter = transporters.find(t => t.number === 1);
+  return firstTransporter ?? null;
+}
+
+export function getFirstTransporterSync(bsda: {
+  transporters: BsdaTransporter[] | null;
+}): BsdaTransporter | null {
+  const transporters = getTransportersSync(bsda);
+  const firstTransporter = transporters.find(t => t.number === 1);
+  return firstTransporter ?? null;
+}
+
+// Renvoie le premier transporteur qui n'a pas encore signé
+export function getNextTransporterSync(bsda: {
+  transporters: BsdaTransporter[] | null;
+}): BsdaTransporter | null {
+  const transporters = getTransportersSync(bsda);
+  const nextTransporter = transporters.find(
+    t => !t.transporterTransportSignatureDate
+  );
+  return nextTransporter ?? null;
 }

--- a/back/src/bsda/database.ts
+++ b/back/src/bsda/database.ts
@@ -65,10 +65,10 @@ export async function getBsdaHistory<Args extends Prisma.BsdaDefaultArgs>(
 }
 
 export async function getTransporters(
-  form: Pick<Bsda, "id">
+  bsda: Pick<Bsda, "id">
 ): Promise<BsdaTransporter[]> {
   const transporters = await prisma.bsda
-    .findUnique({ where: { id: form.id } })
+    .findUnique({ where: { id: bsda.id } })
     .transporters({ orderBy: { number: "asc" } });
   return transporters ?? [];
 }
@@ -82,9 +82,13 @@ export function getTransportersSync(bsda: {
 export async function getFirstTransporter(
   bsda: Pick<Bsda, "id">
 ): Promise<BsdaTransporter | null> {
-  const transporters = await getTransporters(bsda);
-  const firstTransporter = transporters.find(t => t.number === 1);
-  return firstTransporter ?? null;
+  const transporters = await prisma.bsda
+    .findUnique({ where: { id: bsda.id } })
+    .transporters({ where: { number: 1 } });
+  if (transporters && transporters.length > 0) {
+    return transporters[0];
+  }
+  return null;
 }
 
 export function getFirstTransporterSync(bsda: {
@@ -93,15 +97,4 @@ export function getFirstTransporterSync(bsda: {
   const transporters = getTransportersSync(bsda);
   const firstTransporter = transporters.find(t => t.number === 1);
   return firstTransporter ?? null;
-}
-
-// Renvoie le premier transporteur qui n'a pas encore signé
-export function getNextTransporterSync(bsda: {
-  transporters: BsdaTransporter[] | null;
-}): BsdaTransporter | null {
-  const transporters = getTransportersSync(bsda);
-  const nextTransporter = transporters.find(
-    t => !t.transporterTransportSignatureDate
-  );
-  return nextTransporter ?? null;
 }

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -87,7 +87,7 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
 
   const transporter = getFirstTransporterSync(bsda);
 
-  const formSirets: Partial<
+  const bsdaSirets: Partial<
     Record<keyof Bsda | "transporterCompanySiret", string | null | undefined>
   > = {
     emitterCompanySiret: bsda.emitterCompanySiret,
@@ -101,7 +101,7 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
   };
 
   const siretsFilters = new Map<string, keyof typeof where>(
-    Object.entries(formSirets)
+    Object.entries(bsdaSirets)
       .filter(([_, siret]) => Boolean(siret))
       .map(([actor, _]) => [actor, "isFollowFor"])
   );
@@ -176,7 +176,7 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
 
   for (const [fieldName, filter] of siretsFilters.entries()) {
     if (fieldName) {
-      where[filter].push(formSirets[fieldName]);
+      where[filter].push(bsdaSirets[fieldName]);
     }
   }
 

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -12,18 +12,23 @@ import {
   BsdaWithIntermediaries,
   BsdaWithIntermediariesInclude,
   BsdaWithRevisionRequests,
-  BsdaWithRevisionRequestsInclude
+  BsdaWithRevisionRequestsInclude,
+  BsdaWithTransporters,
+  BsdaWithTransportersInclude
 } from "./types";
 import { prisma } from "@td/prisma";
 import { getRevisionOrgIds } from "../common/elasticHelpers";
+import { getFirstTransporterSync } from "./database";
 
 export type BsdaForElastic = Bsda &
+  BsdaWithTransporters &
   BsdaWithIntermediaries &
   BsdaWithForwardedIn &
   BsdaWithGroupedIn &
   BsdaWithRevisionRequests;
 
 export const BsdaForElasticInclude = {
+  ...BsdaWithTransportersInclude,
   ...BsdaWithIntermediariesInclude,
   ...BsdaWithForwardedInInclude,
   ...BsdaWithGroupedInInclude,
@@ -80,11 +85,15 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
     {}
   );
 
-  const formSirets: Partial<Record<keyof Bsda, string | null | undefined>> = {
+  const transporter = getFirstTransporterSync(bsda);
+
+  const formSirets: Partial<
+    Record<keyof Bsda | "transporterCompanySiret", string | null | undefined>
+  > = {
     emitterCompanySiret: bsda.emitterCompanySiret,
     workerCompanySiret: bsda.workerCompanySiret,
     destinationCompanySiret: bsda.destinationCompanySiret,
-    transporterCompanySiret: getTransporterCompanyOrgId(bsda),
+    transporterCompanySiret: getTransporterCompanyOrgId(transporter),
     brokerCompanySiret: bsda.brokerCompanySiret,
     destinationOperationNextDestinationCompanySiret:
       bsda.destinationOperationNextDestinationCompanySiret,
@@ -177,6 +186,8 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
 export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
   const where = getWhere(bsda);
 
+  const transporter = getFirstTransporterSync(bsda);
+
   return {
     type: BsdType.BSDA,
     createdAt: bsda.createdAt?.getTime(),
@@ -208,14 +219,14 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
     workerCompanySiret: bsda.workerCompanySiret ?? "",
     workerCompanyAddress: bsda.workerCompanyAddress ?? "",
 
-    transporterCompanyName: bsda.transporterCompanyName ?? "",
-    transporterCompanySiret: bsda.transporterCompanySiret ?? "",
-    transporterCompanyVatNumber: bsda.transporterCompanyVatNumber ?? "",
+    transporterCompanyName: transporter?.transporterCompanyName ?? "",
+    transporterCompanySiret: transporter?.transporterCompanySiret ?? "",
+    transporterCompanyVatNumber: transporter?.transporterCompanyVatNumber ?? "",
 
-    transporterCompanyAddress: bsda.transporterCompanyAddress ?? "",
-    transporterCustomInfo: bsda.transporterCustomInfo ?? "",
+    transporterCompanyAddress: transporter?.transporterCompanyAddress ?? "",
+    transporterCustomInfo: transporter?.transporterCustomInfo ?? "",
     transporterTransportPlates:
-      bsda.transporterTransportPlates.map(transportPlateFilter) ?? [],
+      transporter?.transporterTransportPlates.map(transportPlateFilter) ?? [],
 
     destinationCompanyName: bsda.destinationCompanyName ?? "",
     destinationCompanySiret: bsda.destinationCompanySiret ?? "",
@@ -248,8 +259,8 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
     emitterEmissionDate: bsda.emitterEmissionSignatureDate?.getTime(),
     workerWorkDate: bsda.workerWorkSignatureDate?.getTime(),
     transporterTransportTakenOverAt:
-      bsda.transporterTransportTakenOverAt?.getTime() ??
-      bsda.transporterTransportSignatureDate?.getTime(),
+      transporter?.transporterTransportTakenOverAt?.getTime() ??
+      transporter?.transporterTransportSignatureDate?.getTime(),
     destinationReceptionDate: bsda.destinationReceptionDate?.getTime(),
     destinationAcceptationDate: bsda.destinationReceptionDate?.getTime(),
     destinationAcceptationWeight: bsda.destinationReceptionWeight,
@@ -266,7 +277,7 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
     companyNames: [
       bsda.emitterCompanyName,
       bsda.workerCompanyName,
-      bsda.transporterCompanyName,
+      ...bsda.transporters.map(b => b.transporterCompanyName),
       bsda.destinationCompanyName,
       bsda.brokerCompanyName,
       bsda.ecoOrganismeName,
@@ -278,8 +289,10 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
     companyOrgIds: [
       bsda.emitterCompanySiret,
       bsda.workerCompanySiret,
-      bsda.transporterCompanySiret,
-      bsda.transporterCompanyVatNumber,
+      ...bsda.transporters.flatMap(transporter => [
+        transporter.transporterCompanySiret,
+        transporter.transporterCompanyVatNumber
+      ]),
       bsda.destinationCompanySiret,
       bsda.brokerCompanySiret,
       bsda.ecoOrganismeSiret,

--- a/back/src/bsda/repository/bsda/create.ts
+++ b/back/src/bsda/repository/bsda/create.ts
@@ -1,15 +1,16 @@
-import { Bsda, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import {
   LogMetadata,
   RepositoryFnDeps
 } from "../../../common/repository/types";
 import { enqueueCreatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdaEventTypes } from "./eventTypes";
+import { BsdaWithTransporters } from "../../types";
 
 export type CreateBsdaFn = (
   data: Prisma.BsdaCreateInput,
   logMetadata?: LogMetadata
-) => Promise<Bsda>;
+) => Promise<BsdaWithTransporters>;
 
 export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
   return async (data, logMetadata?) => {
@@ -18,7 +19,8 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
     const bsda = await prisma.bsda.create({
       data,
       include: {
-        grouping: { select: { id: true } }
+        grouping: { select: { id: true } },
+        transporters: true
       }
     });
 

--- a/back/src/bsda/repository/bsda/delete.ts
+++ b/back/src/bsda/repository/bsda/delete.ts
@@ -1,4 +1,4 @@
-import { Bsda, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import {
   LogMetadata,
   RepositoryFnDeps
@@ -8,11 +8,12 @@ import {
   enqueueUpdatedBsdToIndex
 } from "../../../queue/producers/elastic";
 import { bsdaEventTypes } from "./eventTypes";
+import { BsdaWithTransporters } from "../../types";
 
 export type DeleteBsdaFn = (
   where: Prisma.BsdaWhereUniqueInput,
   logMetadata?: LogMetadata
-) => Promise<Bsda>;
+) => Promise<BsdaWithTransporters>;
 
 export function buildDeleteBsda(deps: RepositoryFnDeps): DeleteBsdaFn {
   return async (where, logMetadata) => {
@@ -25,7 +26,8 @@ export function buildDeleteBsda(deps: RepositoryFnDeps): DeleteBsdaFn {
 
     const deletedBsda = await prisma.bsda.update({
       where,
-      data: { isDeleted: true, forwardingId: null }
+      data: { isDeleted: true, forwardingId: null },
+      include: { transporters: true }
     });
 
     await prisma.bsda.updateMany({

--- a/back/src/bsda/repository/bsda/findUnique.ts
+++ b/back/src/bsda/repository/bsda/findUnique.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
-export type FindUniqueBsdaFn = <Args extends Prisma.BsdaArgs>(
+export type FindUniqueBsdaFn = <Args extends Prisma.BsdaDefaultArgs>(
   where: Prisma.BsdaWhereUniqueInput,
   options?: Args
 ) => Promise<Prisma.BsdaGetPayload<Args>>;
@@ -9,7 +9,7 @@ export type FindUniqueBsdaFn = <Args extends Prisma.BsdaArgs>(
 export function buildFindUniqueBsda({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsdaFn {
-  return async <Args extends Prisma.BsdaArgs>(where, options?) => {
+  return async <Args extends Prisma.BsdaDefaultArgs>(where, options?) => {
     const input = { where, ...options };
     const bsda = await prisma.bsda.findUnique(input);
     return bsda as Prisma.BsdaGetPayload<Args>;

--- a/back/src/bsda/repository/bsda/update.ts
+++ b/back/src/bsda/repository/bsda/update.ts
@@ -1,16 +1,17 @@
-import { Bsda, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import {
   LogMetadata,
   RepositoryFnDeps
 } from "../../../common/repository/types";
 import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdaEventTypes } from "./eventTypes";
+import { BsdaWithTransporters } from "../../types";
 
 export type UpdateBsdaFn = (
   where: Prisma.BsdaWhereUniqueInput,
   data: Prisma.XOR<Prisma.BsdaUpdateInput, Prisma.BsdaUncheckedUpdateInput>,
   logMetadata?: LogMetadata
-) => Promise<Bsda>;
+) => Promise<BsdaWithTransporters>;
 
 export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
   return async (where, data, logMetadata?) => {
@@ -35,7 +36,7 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
     const updatedBsda = await prisma.bsda.update({
       where,
       data,
-      include: previousBsdaInclude
+      include: { ...previousBsdaInclude, transporters: true }
     });
 
     await prisma.event.create({

--- a/back/src/bsda/resolvers/Bsda.ts
+++ b/back/src/bsda/resolvers/Bsda.ts
@@ -12,14 +12,14 @@ export const Bsda: BsdaResolvers = {
     }
     const forwardingBsda = await getReadonlyBsdaRepository()
       .findRelatedEntity({ id: bsda.id })
-      .forwardedIn();
+      .forwardedIn({ include: { transporters: true } });
 
     return forwardingBsda ? expandBsdaFromDb(forwardingBsda) : null;
   },
   forwarding: async ({ id }) => {
     const forwardedBsda = await getReadonlyBsdaRepository()
       .findRelatedEntity({ id })
-      .forwarding();
+      .forwarding({ include: { transporters: true } });
     return forwardedBsda
       ? toInitialBsda(expandBsdaFromDb(forwardedBsda))
       : null;
@@ -27,7 +27,7 @@ export const Bsda: BsdaResolvers = {
   grouping: async ({ id }) => {
     const grouping = await getReadonlyBsdaRepository()
       .findRelatedEntity({ id })
-      .grouping();
+      .grouping({ include: { transporters: true } });
     return grouping?.map(bsda => toInitialBsda(expandBsdaFromDb(bsda))) ?? [];
   },
   groupedIn: async (bsda, _, ctx) => {
@@ -37,7 +37,7 @@ export const Bsda: BsdaResolvers = {
     }
     const groupedIn = await getReadonlyBsdaRepository()
       .findRelatedEntity({ id: bsda.id })
-      .groupedIn();
+      .groupedIn({ include: { transporters: true } });
     return groupedIn ? expandBsdaFromDb(groupedIn) : null;
   },
   intermediaries: async bsda => {

--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -18,7 +18,12 @@ function getNextSignature(bsda) {
 export const Metadata: BsdaMetadataResolvers = {
   errors: async (metadata: BsdaMetadata & { id: string }) => {
     const bsda = await getBsdaOrNotFound(metadata.id, {
-      include: { intermediaries: true, grouping: true, forwarding: true }
+      include: {
+        intermediaries: true,
+        grouping: true,
+        forwarding: true,
+        transporters: true
+      }
     });
 
     const currentSignatureType = getNextSignature(bsda);

--- a/back/src/bsda/resolvers/BsdaRevisionRequest.ts
+++ b/back/src/bsda/resolvers/BsdaRevisionRequest.ts
@@ -8,6 +8,7 @@ import {
   expandBsdaRevisionRequestContent,
   expandBsdaFromDb
 } from "../converter";
+import { BsdaWithTransporters } from "../types";
 
 const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   approvals: async parent => {
@@ -38,12 +39,15 @@ const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   ) => {
     const actualBsda = await prisma.bsdaRevisionRequest
       .findUnique({ where: { id: parent.id } })
-      .bsda();
+      .bsda({ include: { transporters: true } });
     const bsdaFromEvents = await getBsdaFromActivityEvents(
       { bsdaId: parent.bsdaId, at: parent.createdAt },
       { dataloader: dataloaders.events }
     );
-    return expandBsdaFromDb({ ...actualBsda, ...bsdaFromEvents });
+    return expandBsdaFromDb({
+      ...actualBsda,
+      ...bsdaFromEvents
+    } as BsdaWithTransporters);
   }
 };
 

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -1389,11 +1389,13 @@ describe("Mutation.Bsda.create", () => {
     const bsda = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.siret,
-        transporterCompanySiret: transporter.siret,
         destinationCompanySiret: ttr.siret,
         status: BsdaStatus.AWAITING_CHILD,
         destinationOperationCode: "D 15",
         wasteConsistence: "PULVERULENT"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret
       }
     });
 
@@ -1478,11 +1480,13 @@ describe("Mutation.Bsda.create", () => {
     const bsda = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.siret,
-        transporterCompanySiret: transporter.siret,
         destinationCompanySiret: ttr.siret,
         status: BsdaStatus.AWAITING_CHILD,
         destinationOperationCode: "D 15",
         wasteConsistence: "SOLIDE"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret
       }
     });
 

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -91,15 +91,6 @@ async function createBsda(opt: Partial<Prisma.BsdaCreateInput> = {}) {
       workerCertificationHasSubSectionThree:
         workerCertification.hasSubSectionThree,
       workerCertificationValidityLimit: workerCertification.validityLimit,
-      transporterCompanySiret: transporter.company.siret,
-      transporterCompanyName: transporter.company.name,
-      transporterCompanyAddress: transporter.company.address,
-      transporterCompanyContact: transporter.company.contact,
-      transporterCompanyPhone: transporter.company.contactPhone,
-      transporterCompanyMail: transporter.company.contactEmail,
-      transporterRecepisseNumber: transporterReceipt.receiptNumber,
-      transporterRecepisseDepartment: transporterReceipt.department,
-      transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
       destinationCompanySiret: destination.company.siret,
       destinationCompanyName: destination.company.name,
       destinationCompanyAddress: destination.company.address,
@@ -116,6 +107,17 @@ async function createBsda(opt: Partial<Prisma.BsdaCreateInput> = {}) {
       brokerRecepisseDepartment: brokerReceipt.department,
       brokerRecepisseValidityLimit: brokerReceipt.validityLimit,
       ...opt
+    },
+    transporterOpt: {
+      transporterCompanySiret: transporter.company.siret,
+      transporterCompanyName: transporter.company.name,
+      transporterCompanyAddress: transporter.company.address,
+      transporterCompanyContact: transporter.company.contact,
+      transporterCompanyPhone: transporter.company.contactPhone,
+      transporterCompanyMail: transporter.company.contactEmail,
+      transporterRecepisseNumber: transporterReceipt.receiptNumber,
+      transporterRecepisseDepartment: transporterReceipt.department,
+      transporterRecepisseValidityLimit: transporterReceipt.validityLimit
     }
   });
 

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -196,7 +196,9 @@ describe("Mutation.Bsda.sign", () => {
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const bsda = await bsdaFactory({
         opt: {
-          emitterCompanySiret: emitter.company.siret,
+          emitterCompanySiret: emitter.company.siret
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret
         }
       });
@@ -224,7 +226,9 @@ describe("Mutation.Bsda.sign", () => {
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const bsda = await bsdaFactory({
         opt: {
-          emitterCompanySiret: emitter.company.siret,
+          emitterCompanySiret: emitter.company.siret
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret
         }
       });
@@ -257,7 +261,9 @@ describe("Mutation.Bsda.sign", () => {
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const bsda = await bsdaFactory({
         opt: {
-          emitterCompanySiret: emitter.company.siret,
+          emitterCompanySiret: emitter.company.siret
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret
         }
       });
@@ -323,7 +329,9 @@ describe("Mutation.Bsda.sign", () => {
         opt: {
           emitterCompanySiret: emitter.company.siret,
           emitterEmissionSignatureDate: null,
-          emitterEmissionSignatureAuthor: null,
+          emitterEmissionSignatureAuthor: null
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret
         }
       });
@@ -454,7 +462,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "worker",
-          workerWorkSignatureDate: new Date(),
+          workerWorkSignatureDate: new Date()
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseIsExempted: true,
           transporterTransportMode: "ROAD",
@@ -491,7 +501,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "worker",
-          workerWorkSignatureDate: new Date(),
+          workerWorkSignatureDate: new Date()
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseIsExempted: true,
           transporterTransportMode: "ROAD",
@@ -534,7 +546,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "worker",
-          workerWorkSignatureDate: new Date(),
+          workerWorkSignatureDate: new Date()
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterTransportMode: "ROAD",
           transporterTransportPlates: ["AA-00-XX"],
@@ -576,7 +590,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "worker",
-          workerWorkSignatureDate: new Date(),
+          workerWorkSignatureDate: new Date()
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseNumber: null // Missing recepisse
         }
@@ -618,7 +634,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "worker",
-          workerWorkSignatureDate: new Date(),
+          workerWorkSignatureDate: new Date()
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseNumber: transporterReceipt.receiptNumber,
           transporterRecepisseDepartment: transporterReceipt.department,
@@ -660,7 +678,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureDate: new Date(),
           workerIsDisabled: true,
           workerCompanySiret: null,
-          workerCompanyName: null,
+          workerCompanyName: null
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseNumber: transporterReceipt.receiptNumber,
           transporterRecepisseDepartment: transporterReceipt.department,
@@ -699,7 +719,9 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: null,
           workerIsDisabled: true,
           workerCompanySiret: null,
-          workerCompanyName: null,
+          workerCompanyName: null
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterRecepisseNumber: transporterReceipt.receiptNumber,
           transporterRecepisseDepartment: transporterReceipt.department,
@@ -741,13 +763,15 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "Worker",
           workerWorkSignatureDate: new Date(),
+          destinationCompanySiret: company.siret
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterTransportSignatureAuthor: "Transporter",
           transporterTransportSignatureDate: new Date(),
           transporterRecepisseNumber: transporterReceipt.receiptNumber,
           transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
-          destinationCompanySiret: company.siret
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
@@ -781,15 +805,17 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "Worker",
           workerWorkSignatureDate: new Date(),
+          destinationCompanySiret: company.siret,
+          destinationOperationCode: "D 15",
+          destinationOperationMode: undefined
+        },
+        transporterOpt: {
           transporterCompanySiret: transporter.company.siret,
           transporterTransportSignatureAuthor: "Transporter",
           transporterTransportSignatureDate: new Date(),
           transporterRecepisseNumber: transporterReceipt.receiptNumber,
           transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
-          destinationCompanySiret: company.siret,
-          destinationOperationCode: "D 15",
-          destinationOperationMode: undefined
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
@@ -819,10 +845,12 @@ describe("Mutation.Bsda.sign", () => {
           status: "INITIAL",
           type: "COLLECTION_2710",
           destinationCompanySiret: company.siret,
-          transporterCompanyName: null,
-          transporterCompanySiret: null,
           workerCompanyName: null,
           workerCompanySiret: null
+        },
+        transporterOpt: {
+          transporterCompanyName: null,
+          transporterCompanySiret: null
         }
       });
 
@@ -853,10 +881,12 @@ describe("Mutation.Bsda.sign", () => {
           emitterEmissionSignatureDate: new Date(),
           workerWorkSignatureAuthor: "Worker",
           workerWorkSignatureDate: new Date(),
-          transporterTransportSignatureAuthor: "Transporter",
-          transporterTransportSignatureDate: new Date(),
           destinationCompanySiret: company.siret,
           destinationOperationCode: null // Missing operation code
+        },
+        transporterOpt: {
+          transporterTransportSignatureAuthor: "Transporter",
+          transporterTransportSignatureDate: new Date()
         }
       });
 
@@ -900,14 +930,16 @@ describe("Mutation.Bsda.sign", () => {
       const bsda1 = await bsdaFactory({
         opt: {
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: ttr1.siret,
           status: BsdaStatus.AWAITING_CHILD,
           destinationOperationCode: "D 9",
           destinationOperationMode: "ELIMINATION"
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
@@ -915,15 +947,17 @@ describe("Mutation.Bsda.sign", () => {
       const bsda2 = await bsdaFactory({
         opt: {
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: ttr2.siret,
           destinationOperationCode: "D 9",
           destinationOperationMode: "ELIMINATION",
           status: BsdaStatus.AWAITING_CHILD,
           forwarding: { connect: { id: bsda1.id } }
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
       // bsda1 => bsda2 => bsda3
@@ -931,14 +965,16 @@ describe("Mutation.Bsda.sign", () => {
         opt: {
           status: BsdaStatus.SENT,
           emitterCompanySiret: ttr2.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: destination.siret,
           destinationOperationCode: "D 9",
           destinationOperationMode: "ELIMINATION",
           forwarding: { connect: { id: bsda2.id } }
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
@@ -976,10 +1012,12 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: company.siret,
           status: "INITIAL",
           type: "COLLECTION_2710",
-          transporterCompanyName: null,
-          transporterCompanySiret: null,
           workerCompanyName: null,
           workerCompanySiret: null
+        },
+        transporterOpt: {
+          transporterCompanyName: null,
+          transporterCompanySiret: null
         }
       });
 
@@ -1054,43 +1092,49 @@ describe("Mutation.Bsda.sign", () => {
       const bsda = await bsdaFactory({
         opt: {
           emitterCompanySiret: ttr1.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: destination.siret,
           status: BsdaStatus.SENT,
           destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
           destinationReceptionRefusalReason: "Invalid bsda, cant accept",
           destinationReceptionWeight: 0,
           destinationOperationCode: null
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
       const grouped1 = await bsdaFactory({
         opt: {
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: ttr1.siret,
           destinationOperationCode: "R 13",
           status: BsdaStatus.AWAITING_CHILD,
           groupedIn: { connect: { id: bsda.id } }
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
       const grouped2 = await bsdaFactory({
         opt: {
           status: BsdaStatus.AWAITING_CHILD,
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: ttr1.siret,
           destinationOperationCode: "R 13",
           groupedIn: { connect: { id: bsda.id } }
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
@@ -1140,23 +1184,21 @@ describe("Mutation.Bsda.sign", () => {
       const forwarded = await bsdaFactory({
         opt: {
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: ttr1.siret,
           status: BsdaStatus.AWAITING_CHILD,
           destinationOperationCode: "R 13"
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 
       const forwarding = await bsdaFactory({
         opt: {
           emitterCompanySiret: emitter.siret,
-          transporterCompanySiret: transporter.siret,
-          transporterRecepisseNumber: transporterReceipt.receiptNumber,
-          transporterRecepisseDepartment: transporterReceipt.department,
-          transporterRecepisseValidityLimit: transporterReceipt.validityLimit,
           destinationCompanySiret: destination.siret,
           destinationReceptionWeight: 0,
           destinationReceptionAcceptationStatus: WasteAcceptationStatus.REFUSED,
@@ -1164,6 +1206,12 @@ describe("Mutation.Bsda.sign", () => {
           destinationOperationCode: null,
           status: BsdaStatus.SENT,
           forwarding: { connect: { id: forwarded.id } }
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterRecepisseNumber: transporterReceipt.receiptNumber,
+          transporterRecepisseDepartment: transporterReceipt.department,
+          transporterRecepisseValidityLimit: transporterReceipt.validityLimit
         }
       });
 

--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -398,9 +398,12 @@ describe("Mutation.updateBsda", () => {
         status: "SENT",
         destinationCompanySiret: destination.siret,
         emitterCompanySiret: emitter.siret,
-        transporterCompanySiret: transporter.siret,
         emitterEmissionSignatureDate: new Date(),
         workerWorkSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret,
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -562,7 +565,9 @@ describe("Mutation.updateBsda", () => {
         emitterCompanySiret: company.siret,
         emitterEmissionSignatureDate: new Date(),
         workerCompanySiret: company2.siret,
-        destinationCompanySiret: company2.siret,
+        destinationCompanySiret: company2.siret
+      },
+      transporterOpt: {
         transporterCompanySiret: company2.siret
       }
     });
@@ -601,7 +606,9 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SIGNED_BY_PRODUCER",
         emitterCompanySiret: company.siret,
-        emitterEmissionSignatureDate: new Date(),
+        emitterEmissionSignatureDate: new Date()
+      },
+      transporterOpt: {
         transporterCompanySiret: company.siret
       }
     });
@@ -684,7 +691,9 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SIGNED_BY_PRODUCER",
         emitterCompanySiret: company.siret,
-        emitterEmissionSignatureDate: new Date(),
+        emitterEmissionSignatureDate: new Date()
+      },
+      transporterOpt: {
         transporterCompanySiret: company.siret
       }
     });
@@ -726,8 +735,11 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SENT",
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -769,8 +781,10 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
     const bsdaToGroup = await bsdaFactory({
@@ -779,8 +793,10 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -825,9 +841,11 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15",
         destinationOperationMode: undefined
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -836,10 +854,12 @@ describe("Mutation.updateBsda", () => {
         status: "INITIAL",
         emitterCompanySiret: ttr.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15",
         destinationOperationMode: undefined,
         forwarding: { connect: { id: oldForwarded.id } }
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -848,9 +868,11 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: ttr.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15",
         destinationOperationMode: undefined
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -886,9 +908,11 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15",
         destinationOperationMode: undefined
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
     const associatedBsda2 = await bsdaFactory({
@@ -896,9 +920,11 @@ describe("Mutation.updateBsda", () => {
         status: "AWAITING_CHILD",
         emitterCompanySiret: emitter.company.siret,
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationCode: "D 15",
         destinationOperationMode: undefined
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -1099,10 +1125,12 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SIGNED_BY_WORKER",
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         workerCompanySiret: worker.siret,
         emitterEmissionSignatureDate: new Date(),
         workerWorkSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -1155,9 +1183,11 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SIGNED_BY_WORKER",
         destinationCompanySiret: destination.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         emitterEmissionSignatureDate: new Date(),
         workerWorkSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 
@@ -1206,11 +1236,13 @@ describe("Mutation.updateBsda", () => {
       opt: {
         status: "SIGNED_BY_WORKER",
         destinationCompanySiret: transporter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationOperationNextDestinationCompanySiret:
           destination.company.siret,
         emitterEmissionSignatureDate: new Date(),
         workerWorkSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret
       }
     });
 

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -42,7 +42,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     );
   }
 
-  const bsda = await parseBsdaInContext(
+  const { bsda, transporter } = await parseBsdaInContext(
     { input, isDraft },
     {
       enableCompletionTransformers: true,
@@ -67,12 +67,18 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
         }
       : undefined;
 
+  // On crée un premier transporteur par défaut (même si tous les champs sont nuls)
+  // Cela permet dans un premier temps d'être raccord avec le modèle "à plat"
+  // en attendant l'implémentation du multi-modal
+  const transporters = { create: { ...transporter, number: 1 } };
+
   const bsdaRepository = getBsdaRepository(user);
   const newBsda = await bsdaRepository.create({
     ...bsda,
     forwarding,
     grouping,
-    intermediaries
+    intermediaries,
+    transporters
   });
 
   return expandBsdaFromDb(newBsda);

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -67,10 +67,12 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
         }
       : undefined;
 
+  const { id: transporterId, ...transporterData } = transporter;
+
   // On crée un premier transporteur par défaut (même si tous les champs sont nuls)
   // Cela permet dans un premier temps d'être raccord avec le modèle "à plat"
   // en attendant l'implémentation du multi-modal
-  const transporters = { create: { ...transporter, number: 1 } };
+  const transporters = { create: { ...transporterData, number: 1 } };
 
   const bsdaRepository = getBsdaRepository(user);
   const newBsda = await bsdaRepository.create({

--- a/back/src/bsda/resolvers/mutations/delete.ts
+++ b/back/src/bsda/resolvers/mutations/delete.ts
@@ -5,6 +5,7 @@ import { getBsdaOrNotFound } from "../../database";
 import { GraphQLContext } from "../../../types";
 import { getBsdaRepository } from "../../repository";
 import { checkCanDelete } from "../../permissions";
+import { getBsdaForElastic } from "../../elastic";
 
 export default async function deleteBsda(
   _,
@@ -14,11 +15,11 @@ export default async function deleteBsda(
   const user = checkIsAuthenticated(context);
 
   const bsda = await getBsdaOrNotFound(id, {
-    include: { intermediaries: true }
+    include: { intermediaries: true, transporters: true }
   });
   await checkCanDelete(user, bsda);
 
   const bsdaRepository = getBsdaRepository(user);
   const deletedBsda = await bsdaRepository.delete({ id });
-  return expandBsdaFromDb(deletedBsda);
+  return expandBsdaFromDb(await getBsdaForElastic(deletedBsda));
 }

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -26,8 +26,8 @@ export default async function duplicate(
 
   // FIXME - En attente d'une meilleure solution lors de l'implémentation du
   // multi-modal.
-  // Sirenify s'applique normalement sur les données transporteur "à plat"
-  // dans le contact de la validation Zod. Pour pouvoir l'utiliser ici on
+  // Sirenify s'applique sur les données transporteur "à plat"
+  // dans le contexte de la validation Zod. Pour pouvoir l'utiliser ici on
   // doit remettre les données à plat puis reconstruire une version de `transporters`
   // avec les données transporteurs "sirenified".
   const {

--- a/back/src/bsda/resolvers/mutations/publish.ts
+++ b/back/src/bsda/resolvers/mutations/publish.ts
@@ -16,7 +16,12 @@ export default async function publish(
   const user = checkIsAuthenticated(context);
 
   const bsda = await getBsdaOrNotFound(id, {
-    include: { intermediaries: true, grouping: true, forwarding: true }
+    include: {
+      intermediaries: true,
+      grouping: true,
+      forwarding: true,
+      transporters: true
+    }
   });
 
   await checkCanUpdate(user, bsda);

--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -571,30 +571,36 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
     const bsda = await bsdaFactory({
       opt: {
         emitterCompanySiret: ttr1.siret,
-        transporterCompanySiret: transporter.siret,
         destinationCompanySiret: destination.siret,
         status: BsdaStatus.SENT
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret
       }
     });
 
     const grouped1 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.siret,
-        transporterCompanySiret: transporter.siret,
         destinationCompanySiret: ttr1.siret,
         destinationOperationCode: "R 13",
         status: BsdaStatus.SENT,
         groupedIn: { connect: { id: bsda.id } }
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret
       }
     });
     const grouped2 = await bsdaFactory({
       opt: {
         status: BsdaStatus.SENT,
         emitterCompanySiret: emitter.siret,
-        transporterCompanySiret: transporter.siret,
         destinationCompanySiret: ttr1.siret,
         destinationOperationCode: "R 13",
         groupedIn: { connect: { id: bsda.id } }
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.siret
       }
     });
 
@@ -726,10 +732,12 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
       const bsda = await bsdaFactory({
         opt: {
           emitterCompanySiret: producerCompany.siret,
-          transporterCompanySiret: transporterCompany.siret,
           workerCompanySiret: workCompany.siret,
           destinationCompanySiret: destinationCompany.siret,
           status: "SENT"
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporterCompany.siret
         }
       });
 

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -58,10 +58,12 @@ export default async function edit(
       }
     : undefined;
 
+  const { id: transporterId, ...transporterData } = transporter;
+
   const transporters = {
     update: {
       where: { id: existingTransporter.id },
-      data: transporter
+      data: transporterData
     }
   };
 

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -2,7 +2,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationUpdateBsdaArgs } from "../../../generated/graphql/types";
 import { GraphQLContext } from "../../../types";
 import { companyToIntermediaryInput, expandBsdaFromDb } from "../../converter";
-import { getBsdaOrNotFound } from "../../database";
+import { getBsdaOrNotFound, getFirstTransporterSync } from "../../database";
 import { checkCanUpdate } from "../../permissions";
 import { getBsdaRepository } from "../../repository";
 import { parseBsdaInContext } from "../../validation";
@@ -14,12 +14,21 @@ export default async function edit(
 ) {
   const user = checkIsAuthenticated(context);
   const existingBsda = await getBsdaOrNotFound(id, {
-    include: { intermediaries: true, grouping: true, forwarding: true }
+    include: {
+      intermediaries: true,
+      grouping: true,
+      forwarding: true,
+      transporters: true
+    }
   });
+
+  // Un premier transporteur est initialisé dans la mutation `createBsda`
+  // ce qui permet d'être certain que `transporter` est défini
+  const existingTransporter = getFirstTransporterSync(existingBsda)!;
 
   await checkCanUpdate(user, existingBsda, input);
 
-  const bsda = await parseBsdaInContext(
+  const { bsda, transporter } = await parseBsdaInContext(
     { input, persisted: existingBsda },
     {
       enableCompletionTransformers: true,
@@ -49,6 +58,13 @@ export default async function edit(
       }
     : undefined;
 
+  const transporters = {
+    update: {
+      where: { id: existingTransporter.id },
+      data: transporter
+    }
+  };
+
   const bsdaRepository = getBsdaRepository(user);
   const updatedBsda = await bsdaRepository.update(
     { id },
@@ -56,7 +72,8 @@ export default async function edit(
       ...bsda,
       forwarding,
       grouping,
-      intermediaries
+      intermediaries,
+      transporters
     }
   );
 

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -142,7 +142,6 @@ describe("Query.bsdas", () => {
   const contributorsFields = {
     emitter: "emitterCompanySiret",
     destination: "destinationCompanySiret",
-    transporter: "transporterCompanySiret",
     worker: "workerCompanySiret",
     broker: "brokerCompanySiret"
   };
@@ -179,6 +178,34 @@ describe("Query.bsdas", () => {
       expect(data.bsdas.edges.length).toBe(1);
     }
   );
+
+  it("should filter bsdas where user appears as transporter", async () => {
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+
+    await bsdaFactory({
+      transporterOpt: {
+        transporterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "bsdas">, QueryBsdasArgs>(
+      GET_BSDAS,
+      {
+        variables: {
+          where: {
+            transporter: {
+              company: {
+                siret: { _eq: company.siret }
+              }
+            }
+          }
+        }
+      }
+    );
+
+    expect(data.bsdas.edges.length).toBe(1);
+  });
 
   it("should not return deleted bsdas", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);

--- a/back/src/bsda/resolvers/queries/bsda.ts
+++ b/back/src/bsda/resolvers/queries/bsda.ts
@@ -12,7 +12,8 @@ export default async function bsda(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const bsda = await getBsdaOrNotFound(id);
+  const bsda = await getBsdaOrNotFound(id, { include: { transporters: true } });
+
   await checkCanRead(user, bsda);
 
   return expandBsdaFromDb(bsda);

--- a/back/src/bsda/resolvers/queries/bsdaPdf.ts
+++ b/back/src/bsda/resolvers/queries/bsdaPdf.ts
@@ -3,7 +3,7 @@ import { getFileDownload } from "../../../common/fileDownload";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { createPDFResponse } from "../../../common/pdf";
 import { getBsdaOrNotFound } from "../../database";
-import { buildPdf } from "../../pdf/generator";
+import { BsdaForPDFInclude, buildPdf } from "../../pdf/generator";
 import { DownloadHandler } from "../../../routers/downloadRouter";
 import { getReadonlyBsdaRepository } from "../../repository";
 import { checkCanReadPdf } from "../../permissions";
@@ -11,7 +11,10 @@ import { checkCanReadPdf } from "../../permissions";
 export const bsdaPdfDownloadHandler: DownloadHandler<QueryBsdaPdfArgs> = {
   name: "bsdaPdf",
   handler: async (_, res, { id }) => {
-    const bsda = await getReadonlyBsdaRepository().findUnique({ id });
+    const bsda = await getReadonlyBsdaRepository().findUnique(
+      { id },
+      { include: BsdaForPDFInclude }
+    );
     const readableStream = await buildPdf(bsda);
     readableStream.pipe(createPDFResponse(res, bsda.id));
   }
@@ -19,7 +22,7 @@ export const bsdaPdfDownloadHandler: DownloadHandler<QueryBsdaPdfArgs> = {
 
 export default async function bsdaPdf(_, { id }: QueryBsdaPdfArgs, context) {
   const user = checkIsAuthenticated(context);
-  const bsda = await getBsdaOrNotFound(id);
+  const bsda = await getBsdaOrNotFound(id, { include: { transporters: true } });
 
   await checkCanReadPdf(user, bsda);
 

--- a/back/src/bsda/types.ts
+++ b/back/src/bsda/types.ts
@@ -1,5 +1,14 @@
 import { Prisma } from "@prisma/client";
 
+export const BsdaWithTransportersInclude =
+  Prisma.validator<Prisma.BsdaInclude>()({
+    transporters: true
+  });
+
+export type BsdaWithTransporters = Prisma.BsdaGetPayload<{
+  include: typeof BsdaWithTransportersInclude;
+}>;
+
 export const BsdaWithIntermediariesInclude =
   Prisma.validator<Prisma.BsdaInclude>()({
     intermediaries: true

--- a/back/src/bsda/validation/__tests__/transformers.integration.ts
+++ b/back/src/bsda/validation/__tests__/transformers.integration.ts
@@ -4,6 +4,7 @@ import {
   transporterReceiptFactory
 } from "../../../__tests__/factories";
 import { bsdaFactory } from "../../__tests__/factories";
+import { getUnparsedBsda } from "../helpers";
 
 describe("BSDA Zod transformers", () => {
   describe("recipisseTransporterTransformer", () => {
@@ -11,7 +12,7 @@ describe("BSDA Zod transformers", () => {
       const company = await companyFactory();
       const receipt = await transporterReceiptFactory({ company });
       const bsda = await bsdaFactory({
-        opt: {
+        transporterOpt: {
           transporterCompanySiret: company.siret,
           transporterCompanyVatNumber: company.vatNumber,
           transporterRecepisseIsExempted: false,
@@ -20,8 +21,12 @@ describe("BSDA Zod transformers", () => {
           transporterRecepisseValidityLimit: null
         }
       });
+      const beforeParsingBsda = getUnparsedBsda({ persisted: bsda });
 
-      const completedInput = await runTransformers(bsda as any, []);
+      const completedInput = await runTransformers(
+        beforeParsingBsda as any,
+        []
+      );
       expect(completedInput).toMatchObject({
         transporterRecepisseIsExempted: false,
         transporterRecepisseNumber: receipt.receiptNumber,
@@ -33,7 +38,7 @@ describe("BSDA Zod transformers", () => {
     it("runTransformers should remove receipt from BSDA when TransporterReceipt does not exist", async () => {
       const company = await companyFactory();
       const bsda = await bsdaFactory({
-        opt: {
+        transporterOpt: {
           transporterCompanySiret: company.siret,
           transporterCompanyVatNumber: company.vatNumber,
           transporterRecepisseIsExempted: false,
@@ -43,7 +48,12 @@ describe("BSDA Zod transformers", () => {
         }
       });
 
-      const completedInput = await runTransformers(bsda as any, []);
+      const beforeParsingBsda = getUnparsedBsda({ persisted: bsda });
+
+      const completedInput = await runTransformers(
+        beforeParsingBsda as any,
+        []
+      );
       expect(completedInput).toMatchObject({
         transporterRecepisseIsExempted: false,
         transporterRecepisseNumber: null,
@@ -54,7 +64,7 @@ describe("BSDA Zod transformers", () => {
     it("runTransformers should correctly process Input with isExempted true and return completedInput without transporter recepisse", async () => {
       const company = await companyFactory();
       const bsda = await bsdaFactory({
-        opt: {
+        transporterOpt: {
           transporterCompanySiret: company.siret,
           transporterCompanyVatNumber: company.vatNumber,
           transporterRecepisseIsExempted: true,
@@ -63,8 +73,12 @@ describe("BSDA Zod transformers", () => {
           transporterRecepisseValidityLimit: null
         }
       });
+      const beforeParsingBsda = getUnparsedBsda({ persisted: bsda });
 
-      const completedInput = await runTransformers(bsda as any, []);
+      const completedInput = await runTransformers(
+        beforeParsingBsda as any,
+        []
+      );
       expect(completedInput).toMatchObject({
         transporterRecepisseIsExempted: true,
         transporterRecepisseNumber: null,

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -1,4 +1,4 @@
-import { Bsda, BsdaType, UserRole } from "@prisma/client";
+import { BsdaType, UserRole } from "@prisma/client";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import {
   companyFactory,

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -6,7 +6,6 @@ import { SIGNATURES_HIERARCHY } from "./constants";
 import { UnparsedInputs } from "./index";
 import { getUserCompanies } from "../../users/database";
 import { getFirstTransporterSync } from "../database";
-import { ZodBsda } from "./schema";
 
 /**
  * Computes an unparsed BSDA by merging the GQL input and

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -16,7 +16,7 @@ export function getUnparsedBsda({ input, persisted, isDraft }: UnparsedInputs) {
 
   const { transporters, ...persistedData } = persisted ?? {};
 
-  const transporter = {
+  const { id: transporterId, ...transporter } = {
     ...transporters?.[0],
     ...(input ? flattenBsdaTransporterInput(input) : {})
   };
@@ -28,7 +28,8 @@ export function getUnparsedBsda({ input, persisted, isDraft }: UnparsedInputs) {
     intermediaries: input?.intermediaries ?? persisted?.intermediaries,
     grouping: input?.grouping ?? persisted?.grouping.map(bsda => bsda.id),
     forwarding: input?.forwarding ?? persisted?.forwarding?.id,
-    ...transporter
+    ...transporter,
+    transporterId
   };
 }
 

--- a/back/src/bsda/validation/index.ts
+++ b/back/src/bsda/validation/index.ts
@@ -8,7 +8,7 @@ import {
   getUserFunctions
 } from "./helpers";
 import { checkSealedAndRequiredFields, getSealedFields } from "./rules";
-import { ZodBsda, bsdaSchema } from "./schema";
+import { bsdaSchema } from "./schema";
 import { runTransformers } from "./transformers";
 
 export type BsdaValidationContext = {

--- a/back/src/bsda/validation/index.ts
+++ b/back/src/bsda/validation/index.ts
@@ -97,6 +97,9 @@ export async function parseBsdaInContext(
     transporterTransportMode,
     transporterTransportPlates,
     transporterTransportTakenOverAt,
+    transporterTransportSignatureAuthor,
+    transporterTransportSignatureDate,
+    transporterId,
     ...bsda
   } = zodBsda;
 
@@ -105,8 +108,9 @@ export async function parseBsdaInContext(
   // On renvoie séparement les données du bsda et les données du transporteur
   // car elles font ensuite l'objet de traitement séparé pour construire les payloads de création / update
   return {
-    bsda,
+    bsda: { ...bsda, transporterTransportSignatureDate },
     transporter: {
+      id: transporterId,
       transporterCompanySiret,
       transporterCompanyName,
       transporterCompanyVatNumber,
@@ -121,7 +125,9 @@ export async function parseBsdaInContext(
       transporterRecepisseValidityLimit,
       transporterTransportMode,
       transporterTransportPlates,
-      transporterTransportTakenOverAt
+      transporterTransportTakenOverAt,
+      transporterTransportSignatureAuthor,
+      transporterTransportSignatureDate
     }
   };
 }

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -27,6 +27,7 @@ export type EditableBsdaFields = Required<
     | "workerWorkSignatureAuthor"
     | "workerWorkSignatureDate"
     | "intermediariesOrgIds"
+    | "transporterId"
   >
 >;
 

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -1,7 +1,6 @@
 import {
   BsdaType,
   TransportMode,
-  Prisma,
   WasteAcceptationStatus
 } from "@prisma/client";
 import { RefinementCtx, z } from "zod";
@@ -15,26 +14,18 @@ import { UnparsedInputs } from ".";
 
 export type EditableBsdaFields = Required<
   Omit<
-    Prisma.BsdaCreateInput,
+    ZodBsda,
     | "id"
-    | "createdAt"
-    | "updatedAt"
     | "isDraft"
     | "isDeleted"
-    | "status"
-    | "emitterEmissionSignatureDate"
     | "emitterEmissionSignatureAuthor"
+    | "emitterEmissionSignatureDate"
+    | "destinationOperationSignatureAuthor"
+    | "destinationOperationSignatureDate"
     | "transporterTransportSignatureAuthor"
     | "transporterTransportSignatureDate"
     | "workerWorkSignatureAuthor"
     | "workerWorkSignatureDate"
-    | "destinationOperationSignatureAuthor"
-    | "destinationOperationSignatureDate"
-    | "groupedInId"
-    | "forwardingId"
-    | "groupedIn"
-    | "forwardedIn"
-    | "bsdaRevisionRequests"
     | "intermediariesOrgIds"
   >
 >;

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -130,6 +130,7 @@ export const rawBsdaSchema = z.object({
   destinationOperationNextDestinationCompanyMail: z.string().nullish(),
   destinationOperationNextDestinationCap: z.string().nullish(),
   destinationOperationNextDestinationPlannedOperationCode: z.string().nullish(),
+  transporterId: z.string().nullish(),
   transporterCompanyName: z.string().nullish(),
   transporterCompanySiret: siretSchema.nullish(), // Further verifications done here under in superRefine
   transporterCompanyAddress: z.string().nullish(),

--- a/back/src/bsda/validation/sirenify.ts
+++ b/back/src/bsda/validation/sirenify.ts
@@ -1,6 +1,6 @@
 import { nextBuildSirenify } from "../../companies/sirenify";
 import { CompanyInput } from "../../generated/graphql/types";
-import { flattenBsdaInput } from "../converter";
+import { ZodBsda } from "./schema";
 
 type SiretInfos = {
   name: string | null | undefined;
@@ -8,7 +8,7 @@ type SiretInfos = {
 };
 
 const accessors = (
-  input: ReturnType<typeof flattenBsdaInput>,
+  input: ZodBsda,
   sealedFields: string[] // Tranformations should not be run on sealed fields
 ) => [
   {

--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -23,23 +23,30 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
       where.emitter?.emission?.signature?.date
     ),
     emitterCustomInfo: toPrismaStringFilter(where.emitter?.customInfo),
-    transporterCompanySiret: toPrismaStringFilter(
-      where.transporter?.company?.siret
-    ),
-    transporterCompanyVatNumber: toPrismaStringFilter(
-      where.transporter?.company?.vatNumber
-    ),
-    transporterTransportSignatureDate: toPrismaDateFilter(
-      where.transporter?.transport?.signature?.date
-    ),
-    transporterCustomInfo: toPrismaStringFilter(where.transporter?.customInfo),
     workerCompanySiret: toPrismaStringFilter(where.worker?.company?.siret),
     workerWorkSignatureDate: toPrismaDateFilter(
       where.worker?.work?.signature?.date
     ),
-    transporterTransportPlates: toPrismaStringNullableListFilter(
-      where.transporter?.transport?.plates
-    ),
+    transporters: {
+      some: {
+        transporterCompanySiret: toPrismaStringFilter(
+          where.transporter?.company?.siret
+        ),
+        transporterCompanyVatNumber: toPrismaStringFilter(
+          where.transporter?.company?.vatNumber
+        ),
+        transporterTransportSignatureDate: toPrismaDateFilter(
+          where.transporter?.transport?.signature?.date
+        ),
+        transporterCustomInfo: toPrismaStringFilter(
+          where.transporter?.customInfo
+        ),
+
+        transporterTransportPlates: toPrismaStringNullableListFilter(
+          where.transporter?.transport?.plates
+        )
+      }
+    },
     destinationCompanySiret: toPrismaStringFilter(
       where.destination?.company?.siret
     ),

--- a/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
+++ b/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
@@ -162,8 +162,10 @@ describe("Mutation.creatPdfAccessToken", () => {
     const user = await userFactory();
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: company.siret,
         status: BsdaStatus.SENT
+      },
+      transporterOpt: {
+        transporterCompanySiret: company.siret
       }
     });
     const { mutate } = makeClient(user);
@@ -189,8 +191,10 @@ describe("Mutation.creatPdfAccessToken", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: company.siret,
         status: BsdaStatus.PROCESSED
+      },
+      transporterOpt: {
+        transporterCompanySiret: company.siret
       }
     });
     const { mutate } = makeClient(user);
@@ -218,8 +222,10 @@ describe("Mutation.creatPdfAccessToken", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: company.siret,
         status: BsdaStatus.SENT
+      },
+      transporterOpt: {
+        transporterCompanySiret: company.siret
       }
     });
     const { mutate } = makeClient(user);

--- a/back/src/bsds/resolvers/mutations/createPdfAccessToken.ts
+++ b/back/src/bsds/resolvers/mutations/createPdfAccessToken.ts
@@ -36,7 +36,8 @@ const accessors = {
         intermediaries: true
       }
     ),
-  [BsdType.BSDA]: id => getBsdaOrNotFound(id),
+  [BsdType.BSDA]: id =>
+    getBsdaOrNotFound(id, { include: { transporters: true } }),
   [BsdType.BSDASRI]: id => getBsdasriOrNotFound({ id }),
   [BsdType.BSFF]: id => getBsffOrNotFound({ id }),
   [BsdType.BSVHU]: id => getBsvhuOrNotFound(id)

--- a/back/src/companies/recipify.ts
+++ b/back/src/companies/recipify.ts
@@ -3,7 +3,14 @@ import {
   BsdasriRecepisseInput
 } from "../generated/graphql/types";
 import { prisma } from "@td/prisma";
-import { Bsda, Bsdasri, Bsff, Bsvhu, BspaohTransporter } from "@prisma/client";
+import {
+  Bsda,
+  Bsdasri,
+  Bsff,
+  Bsvhu,
+  BspaohTransporter,
+  BsdaTransporter
+} from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 
 type RecipifyOutput = {
@@ -105,7 +112,7 @@ export interface BsdTransporterReceiptPart {
 }
 
 export async function getTransporterReceipt(
-  existingBsd: Bsdasri | Bsvhu | Bsda | Bsff | BspaohTransporter
+  existingBsd: Bsdasri | Bsvhu | BsdaTransporter | Bsff | BspaohTransporter
 ): Promise<BsdTransporterReceiptPart> {
   // fetch TransporterReceipt
   const orgId = getTransporterCompanyOrgId(existingBsd);

--- a/back/src/companies/recipify.ts
+++ b/back/src/companies/recipify.ts
@@ -4,7 +4,6 @@ import {
 } from "../generated/graphql/types";
 import { prisma } from "@td/prisma";
 import {
-  Bsda,
   Bsdasri,
   Bsff,
   Bsvhu,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -399,7 +399,6 @@ export function flattenFormInput(
     | "customId"
     | "emitter"
     | "recipient"
-    | "transporter"
     | "wasteDetails"
     | "trader"
     | "broker"

--- a/back/src/forms/resolvers/mutations/markAsResent.ts
+++ b/back/src/forms/resolvers/mutations/markAsResent.ts
@@ -37,7 +37,7 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
 
   await checkCanMarkAsResent(user, form);
 
-  const { destination, transporter, wasteDetails } = resentInfos;
+  const { destination, wasteDetails } = resentInfos;
 
   // copy basic info from initial BSD and overwrite it with resealedInfos
   const updateInput: Prisma.FormUpdateInput = {
@@ -54,7 +54,7 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
     wasteDetailsName: form.wasteDetailsName,
     wasteDetailsOnuCode: form.wasteDetailsOnuCode,
     wasteDetailsPop: form.wasteDetailsPop,
-    ...flattenFormInput({ transporter, wasteDetails, recipient: destination })
+    ...flattenFormInput({ wasteDetails, recipient: destination })
   };
 
   // validate input

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -385,8 +385,13 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should list a BSDA in emitter's outgoing wastes once it has been sent", async () => {
     const bsda = await bsdaFactory({
       opt: {
+        status: "SENT",
         emitterCompanySiret: emitter.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date(),
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -413,8 +418,13 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should list a BSDA in worker's outgoing wastes once it has been sent", async () => {
     const bsda = await bsdaFactory({
       opt: {
+        status: "SENT",
         workerCompanySiret: worker.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date(),
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -611,8 +621,11 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should list a BSDA in transporter's transported wastes once it has been taken over", async () => {
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: transporter.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -625,8 +638,11 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should not list a BSDA in transporter'transported wastes before it has been taken over", async () => {
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: transporter.company.siret,
         emitterEmissionSignatureDate: null,
+        transporterTransportSignatureDate: null
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
         transporterTransportSignatureDate: null
       }
     });
@@ -767,8 +783,13 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should list a BSDA in broker's managed wastes after it has been sent", async () => {
     const bsda = await bsdaFactory({
       opt: {
+        status: "SENT",
         brokerCompanySiret: broker.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date(),
         transporterTransportSignatureDate: new Date()
       }
     });
@@ -930,8 +951,11 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   it("should list a BSDA in transporter's all wastes", async () => {
     const bsda = await bsdaFactory({
       opt: {
-        transporterCompanySiret: transporter.company.siret,
         emitterEmissionSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
         transporterTransportSignatureDate: new Date()
       }
     });

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -940,6 +940,10 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         emitterCompanySiret: emitter.company.siret,
         emitterEmissionSignatureDate: new Date(),
         transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date(),
+        transporterTransportTakenOverAt: new Date()
       }
     });
     const bsdaForElastic = await getBsdaForElastic(bsda);
@@ -986,6 +990,10 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
         brokerCompanySiret: broker.company.siret,
         emitterEmissionSignatureDate: new Date(),
         transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date(),
+        transporterTransportTakenOverAt: new Date()
       }
     });
     const bsdaForElastic = await getBsdaForElastic(bsda);

--- a/back/src/registry/__tests__/where.dates.integration.ts
+++ b/back/src/registry/__tests__/where.dates.integration.ts
@@ -90,7 +90,6 @@ describe("toElasticFilter", () => {
 
   it.each([
     "createdAt",
-    "transporterTakenOverAt",
     "destinationReceptionDate",
     "destinationOperationDate"
   ])("should filter BSDAs between two %p dates (strict)", async date => {
@@ -99,7 +98,6 @@ describe("toElasticFilter", () => {
       [P in keyof WasteRegistryWhere]?: keyof Bsda;
     } = {
       createdAt: "createdAt",
-      transporterTakenOverAt: "transporterTransportTakenOverAt",
       destinationReceptionDate: "destinationReceptionDate",
       destinationOperationDate: "destinationOperationDate"
     };
@@ -130,6 +128,51 @@ describe("toElasticFilter", () => {
 
     const where: WasteRegistryWhere = {
       [date]: {
+        _gt: new Date("2021-01-01"),
+        _lt: new Date("2021-01-04")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsda2.id, bsda3.id]);
+  });
+
+  it("should filter BSDAs between two transporterTakenOverAt dates (strict)", async () => {
+    const bsda1 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-01")
+      }
+    });
+
+    const bsda2 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-02")
+      }
+    });
+
+    const bsda3 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-03")
+      }
+    });
+
+    const bsda4 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-04")
+      }
+    });
+
+    await Promise.all(
+      [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
         _gt: new Date("2021-01-01"),
         _lt: new Date("2021-01-04")
       }
@@ -419,7 +462,6 @@ describe("toElasticFilter", () => {
 
   it.each([
     "createdAt",
-    "transporterTakenOverAt",
     "destinationReceptionDate",
     "destinationOperationDate"
   ])("should filter BSDAs between two %p dates (not strict)", async date => {
@@ -428,7 +470,6 @@ describe("toElasticFilter", () => {
       [P in keyof WasteRegistryWhere]?: keyof Bsda;
     } = {
       createdAt: "createdAt",
-      transporterTakenOverAt: "transporterTransportTakenOverAt",
       destinationReceptionDate: "destinationReceptionDate",
       destinationOperationDate: "destinationOperationDate"
     };
@@ -459,6 +500,51 @@ describe("toElasticFilter", () => {
 
     const where: WasteRegistryWhere = {
       [date]: {
+        _gte: new Date("2021-01-02"),
+        _lte: new Date("2021-01-04")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsda2.id, bsda3.id, bsda4.id]);
+  });
+
+  it("should filter BSDAs between two transporterTakenOverAt dates (not strict)", async () => {
+    const bsda1 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-01")
+      }
+    });
+
+    const bsda2 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-02")
+      }
+    });
+
+    const bsda3 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-03")
+      }
+    });
+
+    const bsda4 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-04")
+      }
+    });
+
+    await Promise.all(
+      [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
         _gte: new Date("2021-01-02"),
         _lte: new Date("2021-01-04")
       }
@@ -806,7 +892,6 @@ describe("toElasticFilter", () => {
 
   it.each([
     "createdAt",
-    "transporterTakenOverAt",
     "destinationReceptionDate",
     "destinationOperationDate"
   ])("should filter BSDAs on %p (exact date)", async date => {
@@ -815,7 +900,6 @@ describe("toElasticFilter", () => {
       [P in keyof WasteRegistryWhere]?: keyof Bsda;
     } = {
       createdAt: "createdAt",
-      transporterTakenOverAt: "transporterTransportTakenOverAt",
       destinationReceptionDate: "destinationReceptionDate",
       destinationOperationDate: "destinationOperationDate"
     };
@@ -846,6 +930,50 @@ describe("toElasticFilter", () => {
 
     const where: WasteRegistryWhere = {
       [date]: {
+        _eq: new Date("2021-01-02")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsda2.id]);
+  });
+
+  it("should filter BSDAs on transporterTakenOverAt (exact date)", async () => {
+    const bsda1 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-01")
+      }
+    });
+
+    const bsda2 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-02")
+      }
+    });
+
+    const bsda3 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-03")
+      }
+    });
+
+    const bsda4 = await bsdaFactory({
+      transporterOpt: {
+        transporterTransportTakenOverAt: new Date("2021-01-04")
+      }
+    });
+
+    await Promise.all(
+      [bsda1, bsda2, bsda3, bsda4].map(async bsda => {
+        const bsdaForElastic = await getBsdaForElastic(bsda);
+        return indexBsda(bsdaForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
         _eq: new Date("2021-01-02")
       }
     };

--- a/back/src/registry/__tests__/where.transporter.integration.ts
+++ b/back/src/registry/__tests__/where.transporter.integration.ts
@@ -83,15 +83,15 @@ describe("toElasticFilter", () => {
   it("should filter BSDAs on transporterCompanySiret (exact)", async () => {
     const testInput = { transporterCompanySiret: siretify(1) };
     const bsda1 = await bsdaFactory({
-      opt: testInput
+      transporterOpt: testInput
     });
 
     const bsda2 = await bsdaFactory({
-      opt: { transporterCompanySiret: siretify(2) }
+      transporterOpt: { transporterCompanySiret: siretify(2) }
     });
 
     const bsda3 = await bsdaFactory({
-      opt: { transporterCompanySiret: siretify(3) }
+      transporterOpt: { transporterCompanySiret: siretify(3) }
     });
 
     await Promise.all(
@@ -293,16 +293,16 @@ describe("toElasticFilter", () => {
   it("should filter BSDAs on a list of transporterCompanySiret", async () => {
     const testInput_2 = { transporterCompanySiret: siretify(1) };
     const bsda1 = await bsdaFactory({
-      opt: testInput_2
+      transporterOpt: testInput_2
     });
 
     const testInput = { transporterCompanySiret: siretify(2) };
     const bsda2 = await bsdaFactory({
-      opt: testInput
+      transporterOpt: testInput
     });
 
     const bsda3 = await bsdaFactory({
-      opt: { transporterCompanySiret: siretify(3) }
+      transporterOpt: { transporterCompanySiret: siretify(3) }
     });
 
     await Promise.all(
@@ -516,15 +516,15 @@ describe("toElasticFilter", () => {
   it("should filter BSDAs on a substring of transporterCompanySiret", async () => {
     const testInput = { transporterCompanySiret: siretify(1) };
     const bsda1 = await bsdaFactory({
-      opt: testInput
+      transporterOpt: testInput
     });
 
     const bsda2 = await bsdaFactory({
-      opt: { transporterCompanySiret: siretify(2) }
+      transporterOpt: { transporterCompanySiret: siretify(2) }
     });
 
     const bsda3 = await bsdaFactory({
-      opt: { transporterCompanySiret: siretify(3) }
+      transporterOpt: { transporterCompanySiret: siretify(3) }
     });
 
     await Promise.all(

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -103,9 +103,13 @@ export type RegistryForm = Prisma.FormGetPayload<{
   include: typeof RegistryFormInclude;
 }>;
 
-const RegistryBsdaInclude = { grouping: true, forwarding: true };
+export const RegistryBsdaInclude = Prisma.validator<Prisma.BsdaInclude>()({
+  grouping: true,
+  forwarding: true,
+  transporters: true
+});
 
-type RegistryBsda = Prisma.BsdaGetPayload<{
+export type RegistryBsda = Prisma.BsdaGetPayload<{
   include: typeof RegistryBsdaInclude;
 }>;
 

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -103,18 +103,21 @@ describe("All wastes registry", () => {
     bsd2 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationCompanySiret: destination.company.siret,
         wasteCode: "08 01 17*",
         status: BsdaStatus.PROCESSED,
         createdAt: new Date("2021-05-01"),
         destinationReceptionWeight: 500,
-        transporterTransportTakenOverAt: new Date("2021-05-01"),
-        transporterTransportSignatureDate: new Date(),
         destinationReceptionDate: new Date("2021-05-01"),
         destinationOperationSignatureDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
-        destinationOperationCode: "D 5"
+        destinationOperationCode: "D 5",
+        transporterTransportSignatureDate: new Date("2021-05-01")
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date("2021-05-01"),
+        transporterTransportTakenOverAt: new Date("2021-05-01"),
+        transporterCompanySiret: transporter.company.siret
       }
     });
     bsd3 = await bsdasriFactory({

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -109,7 +109,6 @@ describe("Incoming wastes registry", () => {
     bsd2 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationCompanySiret: destination.company.siret,
         wasteCode: "08 01 17*",
         status: BsdaStatus.PROCESSED,
@@ -117,11 +116,15 @@ describe("Incoming wastes registry", () => {
         destinationReceptionWeight: 500,
         emitterEmissionSignatureDate: new Date("2021-05-01"),
         transporterTransportSignatureDate: new Date("2021-05-01"),
-        transporterTransportTakenOverAt: new Date("2021-05-01"),
         destinationReceptionDate: new Date("2021-05-01"),
         destinationOperationSignatureDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
         destinationOperationCode: "D 5"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
+        transporterTransportSignatureDate: new Date("2021-05-01"),
+        transporterTransportTakenOverAt: new Date("2021-05-01")
       }
     });
     bsd3 = await bsdasriFactory({

--- a/back/src/registry/resolvers/queries/__tests__/managedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/managedWastes.integration.ts
@@ -95,7 +95,6 @@ describe("Managed wastes registry", () => {
     bsd2 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationCompanySiret: destination.company.siret,
         brokerCompanySiret: broker.company.siret,
         wasteCode: "08 01 17*",
@@ -104,10 +103,14 @@ describe("Managed wastes registry", () => {
         destinationReceptionWeight: 500,
         emitterEmissionSignatureDate: new Date("2021-05-01"),
         transporterTransportSignatureDate: new Date("2021-05-01"),
-        transporterTransportTakenOverAt: new Date("2021-05-01"),
         destinationReceptionDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
         destinationOperationCode: "D 5"
+      },
+      transporterOpt: {
+        transporterCompanySiret: transporter.company.siret,
+        transporterTransportSignatureDate: new Date("2021-05-01"),
+        transporterTransportTakenOverAt: new Date("2021-05-01")
       }
     });
 

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -102,7 +102,6 @@ describe("Outgoing wastes registry", () => {
     bsd2 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationCompanySiret: destination.company.siret,
         wasteCode: "08 01 17*",
         status: BsdaStatus.PROCESSED,
@@ -110,10 +109,14 @@ describe("Outgoing wastes registry", () => {
         destinationReceptionWeight: 500,
         emitterEmissionSignatureDate: new Date("2021-05-01"),
         transporterTransportSignatureDate: new Date("2021-05-01"),
-        transporterTransportTakenOverAt: new Date("2021-05-01"),
         destinationReceptionDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
         destinationOperationCode: "D 5"
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date("2021-05-01"),
+        transporterCompanySiret: transporter.company.siret,
+        transporterTransportTakenOverAt: new Date("2021-05-01")
       }
     });
     bsd3 = await bsdasriFactory({

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -102,7 +102,6 @@ describe("Transported wastes registry", () => {
     bsd2 = await bsdaFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
-        transporterCompanySiret: transporter.company.siret,
         destinationCompanySiret: destination.company.siret,
         wasteCode: "08 01 17*",
         status: BsdaStatus.PROCESSED,
@@ -110,10 +109,14 @@ describe("Transported wastes registry", () => {
         destinationReceptionWeight: 500,
         emitterEmissionSignatureDate: new Date("2021-05-01"),
         transporterTransportSignatureDate: new Date("2021-05-01"),
-        transporterTransportTakenOverAt: new Date("2021-05-01"),
         destinationReceptionDate: new Date("2021-05-01"),
         destinationOperationDate: new Date("2021-05-01"),
         destinationOperationCode: "D 5"
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date("2021-05-01"),
+        transporterCompanySiret: transporter.company.siret,
+        transporterTransportTakenOverAt: new Date("2021-05-01")
       }
     });
     bsd3 = await bsdasriFactory({

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryCsv.integration.ts
@@ -179,15 +179,18 @@ describe("query { wastesRegistryCsv }", () => {
           createdAt: new Date(),
           destinationCompanySiret: company.siret,
           emitterCompanySiret: company.siret,
-          transporterCompanySiret: company.siret,
           destinationReceptionWeight: 500,
           emitterEmissionSignatureDate: new Date(),
           transporterTransportSignatureDate: new Date(),
-          transporterTransportTakenOverAt: new Date(),
           destinationReceptionDate: new Date(),
           destinationOperationSignatureDate: new Date(),
           destinationOperationDate: new Date(),
           destinationOperationCode: "D 5"
+        },
+        transporterOpt: {
+          transporterCompanySiret: company.siret,
+          transporterTransportSignatureDate: new Date(),
+          transporterTransportTakenOverAt: new Date()
         }
       });
       await indexBsda(await getBsdaForElastic(bsda));

--- a/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/wastesRegistryXls.integration.ts
@@ -191,15 +191,18 @@ describe("query { wastesRegistryXls }", () => {
           createdAt: new Date(),
           destinationCompanySiret: company.siret,
           emitterCompanySiret: company.siret,
-          transporterCompanySiret: company.siret,
           destinationReceptionWeight: 500,
           emitterEmissionSignatureDate: new Date(),
           transporterTransportSignatureDate: new Date(),
-          transporterTransportTakenOverAt: new Date(),
           destinationReceptionDate: new Date(),
           destinationOperationSignatureDate: new Date(),
           destinationOperationDate: new Date(),
           destinationOperationCode: "D 5"
+        },
+        transporterOpt: {
+          transporterCompanySiret: company.siret,
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
         }
       });
       await indexBsda(await getBsdaForElastic(bsda));

--- a/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
+++ b/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
@@ -115,5 +115,4 @@ ALTER TABLE
     DROP COLUMN "transporterTransportMode",
     DROP COLUMN "transporterTransportPlates",
     DROP COLUMN "transporterTransportSignatureAuthor",
-    DROP COLUMN "transporterTransportSignatureDate",
     DROP COLUMN "transporterTransportTakenOverAt";

--- a/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
+++ b/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
@@ -1,0 +1,119 @@
+-- DropIndex
+DROP INDEX "_BsdaTransporterCompanySiretIdx";
+
+-- DropIndex
+DROP INDEX "_BsdaTransporterCompanyVatNumberIdx";
+
+-- CreateTable
+CREATE TABLE "BsdaTransporter" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "number" INTEGER NOT NULL,
+    "bsdaId" TEXT,
+    "transporterCompanySiret" TEXT,
+    "transporterCompanyName" TEXT,
+    "transporterCompanyVatNumber" TEXT,
+    "transporterCompanyAddress" TEXT,
+    "transporterCompanyContact" TEXT,
+    "transporterCompanyPhone" TEXT,
+    "transporterCompanyMail" TEXT,
+    "transporterCustomInfo" TEXT,
+    "transporterRecepisseIsExempted" BOOLEAN,
+    "transporterRecepisseNumber" TEXT,
+    "transporterRecepisseDepartment" TEXT,
+    "transporterRecepisseValidityLimit" TIMESTAMPTZ(6),
+    "transporterTransportMode" "TransportMode" DEFAULT 'ROAD',
+    "transporterTransportPlates" TEXT [],
+    "transporterTransportTakenOverAt" TIMESTAMPTZ(6),
+    "transporterTransportSignatureAuthor" TEXT,
+    "transporterTransportSignatureDate" TIMESTAMPTZ(6),
+    CONSTRAINT "BsdaTransporter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_BsdaTransporterFormIdIdx" ON "BsdaTransporter"("bsdaId");
+
+-- CreateIndex
+CREATE INDEX "_BsdaTransporterCompanySiretIdx" ON "BsdaTransporter"("transporterCompanySiret");
+
+-- CreateIndex
+CREATE INDEX "_BsdaTransporterCompanyVatNumberIdx" ON "BsdaTransporter"("transporterCompanyVatNumber");
+
+-- AddForeignKey
+ALTER TABLE
+    "BsdaTransporter"
+ADD
+    CONSTRAINT "BsdaTransporter_bsdaId_fkey" FOREIGN KEY ("bsdaId") REFERENCES "Bsda"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Migrate first transporter from Bsda table to BsdaTransporter table
+INSERT INTO
+    "default$default"."BsdaTransporter" (
+        "id",
+        "createdAt",
+        "updatedAt",
+        "number",
+        "bsdaId",
+        "transporterCompanySiret",
+        "transporterCompanyName",
+        "transporterCompanyVatNumber",
+        "transporterCompanyAddress",
+        "transporterCompanyContact",
+        "transporterCompanyPhone",
+        "transporterCompanyMail",
+        "transporterCustomInfo",
+        "transporterRecepisseIsExempted",
+        "transporterRecepisseNumber",
+        "transporterRecepisseDepartment",
+        "transporterRecepisseValidityLimit",
+        "transporterTransportMode",
+        "transporterTransportPlates",
+        "transporterTransportTakenOverAt",
+        "transporterTransportSignatureAuthor",
+        "transporterTransportSignatureDate",
+    )
+SELECT
+    "id",
+    "createdAt",
+    "updatedAt",
+    1,
+    "id",
+    "transporterCompanySiret",
+    "transporterCompanyName",
+    "transporterCompanyVatNumber",
+    "transporterCompanyAddress",
+    "transporterCompanyContact",
+    "transporterCompanyPhone",
+    "transporterCompanyMail",
+    "transporterCustomInfo",
+    "transporterRecepisseIsExempted",
+    "transporterRecepisseNumber",
+    "transporterRecepisseDepartment",
+    "transporterRecepisseValidityLimit",
+    "transporterTransportMode",
+    "transporterTransportPlates",
+    "transporterTransportTakenOverAt",
+    "transporterTransportSignatureAuthor",
+    "transporterTransportSignatureDate",
+FROM
+    "default$default"."Bsda";
+
+-- AlterTable
+ALTER TABLE
+    "Bsda" DROP COLUMN "transporterCompanyAddress",
+    DROP COLUMN "transporterCompanyContact",
+    DROP COLUMN "transporterCompanyMail",
+    DROP COLUMN "transporterCompanyName",
+    DROP COLUMN "transporterCompanyPhone",
+    DROP COLUMN "transporterCompanySiret",
+    DROP COLUMN "transporterCompanyVatNumber",
+    DROP COLUMN "transporterCustomInfo",
+    DROP COLUMN "transporterRecepisseDepartment",
+    DROP COLUMN "transporterRecepisseIsExempted",
+    DROP COLUMN "transporterRecepisseNumber",
+    DROP COLUMN "transporterRecepisseValidityLimit",
+    DROP COLUMN "transporterTransportMode",
+    DROP COLUMN "transporterTransportPlates",
+    DROP COLUMN "transporterTransportSignatureAuthor",
+    DROP COLUMN "transporterTransportSignatureDate",
+    DROP COLUMN "transporterTransportTakenOverAt";

--- a/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
+++ b/libs/back/prisma/src/migrate/migrations/165_migrate_to_bsda_transporter.sql
@@ -1,11 +1,11 @@
 -- DropIndex
-DROP INDEX "_BsdaTransporterCompanySiretIdx";
+DROP INDEX IF EXISTS "default$default"."_BsdaTransporterCompanySiretIdx";
 
 -- DropIndex
-DROP INDEX "_BsdaTransporterCompanyVatNumberIdx";
+DROP INDEX IF EXISTS "default$default"."_BsdaTransporterCompanyVatNumberIdx";
 
 -- CreateTable
-CREATE TABLE "BsdaTransporter" (
+CREATE TABLE "default$default"."BsdaTransporter" (
     "id" TEXT NOT NULL,
     "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMPTZ(6) NOT NULL,
@@ -23,7 +23,7 @@ CREATE TABLE "BsdaTransporter" (
     "transporterRecepisseNumber" TEXT,
     "transporterRecepisseDepartment" TEXT,
     "transporterRecepisseValidityLimit" TIMESTAMPTZ(6),
-    "transporterTransportMode" "TransportMode" DEFAULT 'ROAD',
+    "transporterTransportMode" "default$default"."TransportMode" DEFAULT 'ROAD',
     "transporterTransportPlates" TEXT [],
     "transporterTransportTakenOverAt" TIMESTAMPTZ(6),
     "transporterTransportSignatureAuthor" TEXT,
@@ -32,19 +32,19 @@ CREATE TABLE "BsdaTransporter" (
 );
 
 -- CreateIndex
-CREATE INDEX "_BsdaTransporterFormIdIdx" ON "BsdaTransporter"("bsdaId");
+CREATE INDEX "_BsdaTransporterFormIdIdx" ON "default$default"."BsdaTransporter"("bsdaId");
 
 -- CreateIndex
-CREATE INDEX "_BsdaTransporterCompanySiretIdx" ON "BsdaTransporter"("transporterCompanySiret");
+CREATE INDEX "_BsdaTransporterCompanySiretIdx" ON "default$default"."BsdaTransporter"("transporterCompanySiret");
 
 -- CreateIndex
-CREATE INDEX "_BsdaTransporterCompanyVatNumberIdx" ON "BsdaTransporter"("transporterCompanyVatNumber");
+CREATE INDEX "_BsdaTransporterCompanyVatNumberIdx" ON "default$default"."BsdaTransporter"("transporterCompanyVatNumber");
 
 -- AddForeignKey
 ALTER TABLE
-    "BsdaTransporter"
+    "default$default"."BsdaTransporter"
 ADD
-    CONSTRAINT "BsdaTransporter_bsdaId_fkey" FOREIGN KEY ("bsdaId") REFERENCES "Bsda"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    CONSTRAINT "BsdaTransporter_bsdaId_fkey" FOREIGN KEY ("bsdaId") REFERENCES "default$default"."Bsda"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- Migrate first transporter from Bsda table to BsdaTransporter table
 INSERT INTO
@@ -70,7 +70,7 @@ INSERT INTO
         "transporterTransportPlates",
         "transporterTransportTakenOverAt",
         "transporterTransportSignatureAuthor",
-        "transporterTransportSignatureDate",
+        "transporterTransportSignatureDate"
     )
 SELECT
     "id",
@@ -94,13 +94,13 @@ SELECT
     "transporterTransportPlates",
     "transporterTransportTakenOverAt",
     "transporterTransportSignatureAuthor",
-    "transporterTransportSignatureDate",
+    "transporterTransportSignatureDate"
 FROM
     "default$default"."Bsda";
 
 -- AlterTable
 ALTER TABLE
-    "Bsda" DROP COLUMN "transporterCompanyAddress",
+    "default$default"."Bsda" DROP COLUMN "transporterCompanyAddress",
     DROP COLUMN "transporterCompanyContact",
     DROP COLUMN "transporterCompanyMail",
     DROP COLUMN "transporterCompanyName",

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1388,6 +1388,11 @@ model Bsda {
   brokerRecepisseDepartment    String?
   brokerRecepisseValidityLimit DateTime? @db.Timestamptz(6)
 
+  // Date de signature du premier transporteur 
+  // Cette valeur est dupliqué entre le modèle Bsda et BsdaTransporter[0]
+  // pour optimiser certains calculs
+  transporterTransportSignatureDate DateTime? @db.Timestamptz(6)
+
   destinationCompanyName          String?
   destinationCompanySiret         String?
   destinationCompanyAddress       String?

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1420,26 +1420,7 @@ model Bsda {
   destinationOperationNextDestinationCap                  String?
   destinationOperationNextDestinationPlannedOperationCode String?
 
-  transporterCompanyName      String?
-  transporterCompanySiret     String?
-  transporterCompanyAddress   String?
-  transporterCompanyContact   String?
-  transporterCompanyPhone     String?
-  transporterCompanyMail      String?
-  transporterCompanyVatNumber String?
-
-  transporterCustomInfo String?
-
-  transporterRecepisseIsExempted    Boolean?
-  transporterRecepisseNumber        String?
-  transporterRecepisseDepartment    String?
-  transporterRecepisseValidityLimit DateTime? @db.Timestamptz(6)
-
-  transporterTransportMode            TransportMode? @default(ROAD)
-  transporterTransportPlates          String[]
-  transporterTransportTakenOverAt     DateTime?      @db.Timestamptz(6)
-  transporterTransportSignatureAuthor String?
-  transporterTransportSignatureDate   DateTime?      @db.Timestamptz(6)
+  transporters BsdaTransporter[]
 
   workerIsDisabled Boolean?
 
@@ -1479,13 +1460,42 @@ model Bsda {
   @@index([emitterCompanySiret], map: "_BsdaEmitterCompanySiretIdx")
   @@index([brokerCompanySiret], map: "_BsdaBrokerCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsdaDestinationCompanySiretIdx")
-  @@index([transporterCompanySiret], map: "_BsdaTransporterCompanySiretIdx")
-  @@index([transporterCompanyVatNumber], map: "_BsdaTransporterCompanyVatNumberIdx")
   @@index([workerCompanySiret], map: "_BsdaWorkerCompanySiretIdx")
   @@index([destinationOperationNextDestinationCompanySiret], map: "_BsdaDestinationOperationNextDestinationCompanySiretIdx")
   @@index([status], map: "_BsdaStatusIdx")
   @@index([groupedInId], map: "_BsdaGroupedInIdIdx")
   @@index([updatedAt], map: "_BsdaUpdatedAtIdx")
+}
+
+model BsdaTransporter {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @db.Timestamptz(6)
+  number    Int
+  bsdaId    String?
+  bsda      Bsda?    @relation(fields: [bsdaId], references: [id], onDelete: Cascade)
+
+  transporterCompanySiret             String?
+  transporterCompanyName              String?
+  transporterCompanyVatNumber         String?
+  transporterCompanyAddress           String?
+  transporterCompanyContact           String?
+  transporterCompanyPhone             String?
+  transporterCompanyMail              String?
+  transporterCustomInfo               String?
+  transporterRecepisseIsExempted      Boolean?
+  transporterRecepisseNumber          String?
+  transporterRecepisseDepartment      String?
+  transporterRecepisseValidityLimit   DateTime?      @db.Timestamptz(6)
+  transporterTransportMode            TransportMode? @default(ROAD)
+  transporterTransportPlates          String[]
+  transporterTransportTakenOverAt     DateTime?      @db.Timestamptz(6)
+  transporterTransportSignatureAuthor String?
+  transporterTransportSignatureDate   DateTime?      @db.Timestamptz(6)
+
+  @@index([bsdaId], map: "_BsdaTransporterFormIdIdx")
+  @@index([transporterCompanySiret], map: "_BsdaTransporterCompanySiretIdx")
+  @@index([transporterCompanyVatNumber], map: "_BsdaTransporterCompanyVatNumberIdx")
 }
 
 model BsdaRevisionRequest {

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1389,7 +1389,7 @@ model Bsda {
   brokerRecepisseValidityLimit DateTime? @db.Timestamptz(6)
 
   // Date de signature du premier transporteur 
-  // Cette valeur est dupliqué entre le modèle Bsda et BsdaTransporter[0]
+  // Cette valeur est dupliquée entre le modèle Bsda et BsdaTransporter[0]
   // pour optimiser certains calculs
   transporterTransportSignatureDate DateTime? @db.Timestamptz(6)
 


### PR DESCRIPTION
Migration des données transporteur BSDA dans une table à part en gardant le même fonctionnement côté API. C'est une étape préalable à l'implémentation du multi-modal sur le BSDA.  

Beaucoup de fichiers modifiés mais l'essentiel des modifications sont les suivantes :
 
- Modification du schéma prisma avec création d'un nouveau modèle `BsdaTransporter`.
- Ajout d'une migration permettant de copier les données de la table `Bsda` vers la table `BsdaTransporter`.
- Modification des `includes` dans les appels à prisma pour aller chercher la liste des transporteurs lorsqu'on en a besoin. 
- Modification de `bsdaFactory` avec un nouveau paramètre `transporterOpt` permettant d'override les données du premier transporteur (d'où les nombreux fichiers de tests modifiés). 

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12092)
