### PR TITLE
DIVERS - Améliorations de performance

### DIFF
--- a/back/src/bsda/dataloader.ts
+++ b/back/src/bsda/dataloader.ts
@@ -1,0 +1,24 @@
+import DataLoader from "dataloader";
+import { prisma } from "@td/prisma";
+
+export function createBsdaDataLoaders() {
+  return {
+    bsdas: new DataLoader((bsdaIds: string[]) => getBsdas(bsdaIds))
+  };
+}
+
+async function getBsdas(bsdaIds: string[]) {
+  const bsdas = await prisma.bsda.findMany({
+    where: { id: { in: bsdaIds } },
+    include: {
+      intermediaries: true,
+      grouping: true,
+      forwarding: true,
+      transporters: true
+    }
+  });
+
+  const dict = Object.fromEntries(bsdas.map(bsda => [bsda.id, bsda]));
+
+  return bsdaIds.map(bsdaId => dict[bsdaId]);
+}

--- a/back/src/bsda/resolvers/BsdaMetadata.ts
+++ b/back/src/bsda/resolvers/BsdaMetadata.ts
@@ -3,8 +3,7 @@ import {
   BsdaMetadata,
   BsdaMetadataResolvers
 } from "../../generated/graphql/types";
-import { getBsdaOrNotFound } from "../database";
-import { parseBsdaInContext } from "../validation";
+import { syncParseBsdaInContext } from "../validation";
 import { prisma } from "@td/prisma";
 import { computeLatestRevision } from "../converter";
 
@@ -16,22 +15,19 @@ function getNextSignature(bsda) {
 }
 
 export const Metadata: BsdaMetadataResolvers = {
-  errors: async (metadata: BsdaMetadata & { id: string }) => {
-    const bsda = await getBsdaOrNotFound(metadata.id, {
-      include: {
-        intermediaries: true,
-        grouping: true,
-        forwarding: true,
-        transporters: true
-      }
-    });
+  errors: async (metadata: BsdaMetadata & { id: string }, _, context) => {
+    const bsda = await context.dataloaders.bsdas.load(metadata.id);
+    const userCompanies = await context.dataloaders.userCompanies.load(
+      context.user!.id
+    );
 
     const currentSignatureType = getNextSignature(bsda);
     try {
-      await parseBsdaInContext(
+      syncParseBsdaInContext(
         { persisted: bsda },
         {
-          currentSignatureType
+          currentSignatureType,
+          userCompanies
         }
       );
       return [];

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -241,8 +241,12 @@ describe("BSDA validation", () => {
     test("when foreign transporter is not registered in Trackdéchets", async () => {
       const data = {
         ...bsda,
-        trasnporterCompanySiret: null,
-        transporterCompanyVatNumber: "IT13029381004"
+        transporters: [
+          {
+            transporterCompanySiret: null,
+            transporterCompanyVatNumber: "IT13029381004"
+          }
+        ]
       };
 
       try {
@@ -268,7 +272,12 @@ describe("BSDA validation", () => {
       });
       const data = {
         ...bsda,
-        transporterCompanyVatNumber: company.vatNumber
+        transporters: [
+          {
+            transporterCompanySiret: null,
+            transporterCompanyVatNumber: company.vatNumber
+          }
+        ]
       };
 
       try {

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -244,15 +244,20 @@ describe("BSDA validation", () => {
         trasnporterCompanySiret: null,
         transporterCompanyVatNumber: "IT13029381004"
       };
-      const result = await bsdaSchema.safeParseAsync(data);
 
-      if (result.success) {
+      try {
+        await parseBsdaInContext(
+          {
+            persisted: data as any
+          },
+          {}
+        );
         throw new Error("Expected error.");
+      } catch (error) {
+        expect(error.issues[0].message).toBe(
+          "Le transporteur avec le n°de TVA IT13029381004 n'est pas inscrit sur Trackdéchets"
+        );
       }
-
-      expect(result.error.issues[0].message).toBe(
-        "Le transporteur avec le n°de TVA IT13029381004 n'est pas inscrit sur Trackdéchets"
-      );
     });
 
     test("when foreign transporter is registered with wrong profile", async () => {
@@ -265,17 +270,22 @@ describe("BSDA validation", () => {
         ...bsda,
         transporterCompanyVatNumber: company.vatNumber
       };
-      const result = await bsdaSchema.safeParseAsync(data);
 
-      if (result.success) {
+      try {
+        await parseBsdaInContext(
+          {
+            persisted: data as any
+          },
+          {}
+        );
         throw new Error("Expected error.");
+      } catch (error) {
+        expect(error.issues[0].message).toBe(
+          `Le transporteur saisi sur le bordereau (numéro de TVA: ${company.vatNumber}) n'est pas inscrit sur Trackdéchets en tant qu'entreprise de transport.` +
+            " Cette entreprise ne peut donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette entreprise pour" +
+            " qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+        );
       }
-
-      expect(result.error.issues[0].message).toBe(
-        `Le transporteur saisi sur le bordereau (numéro de TVA: ${company.vatNumber}) n'est pas inscrit sur Trackdéchets en tant qu'entreprise de transport.` +
-          " Cette entreprise ne peut donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette entreprise pour" +
-          " qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
-      );
     });
 
     test("when destination siret is not valid", async () => {
@@ -299,14 +309,20 @@ describe("BSDA validation", () => {
         ...bsda,
         destinationCompanySiret: "85001946400021"
       };
-      const result = await bsdaSchema.safeParseAsync(data);
-      if (result.success) {
-        throw new Error("Expected error.");
-      }
 
-      expect(result.error.issues[0].message).toBe(
-        "L'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
-      );
+      try {
+        await parseBsdaInContext(
+          {
+            persisted: data as any
+          },
+          {}
+        );
+        throw new Error("Expected error.");
+      } catch (error) {
+        expect(error.issues[0].message).toBe(
+          "L'établissement avec le SIRET 85001946400021 n'est pas inscrit sur Trackdéchets"
+        );
+      }
     });
 
     test("when destination is registered with wrong profile", async () => {
@@ -315,17 +331,23 @@ describe("BSDA validation", () => {
         ...bsda,
         destinationCompanySiret: company.siret
       };
-      const result = await bsdaSchema.safeParseAsync(data);
-      if (result.success) {
-        throw new Error("Expected error.");
-      }
 
-      expect(result.error.issues[0].message).toBe(
-        `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET \"${company.siret}\" n'est pas inscrite` +
-          " sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut donc" +
-          " pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il" +
-          " modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
-      );
+      try {
+        await parseBsdaInContext(
+          {
+            persisted: data as any
+          },
+          {}
+        );
+        throw new Error("Expected error.");
+      } catch (error) {
+        expect(error.issues[0].message).toBe(
+          `L'installation de destination ou d’entreposage ou de reconditionnement avec le SIRET \"${company.siret}\" n'est pas inscrite` +
+            " sur Trackdéchets en tant qu'installation de traitement ou de tri transit regroupement. Cette installation ne peut donc" +
+            " pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il" +
+            " modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements"
+        );
+      }
     });
 
     test("when there is a french transporter and recepisse fields are null", async () => {

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -102,30 +102,7 @@ export async function getUserFunctions(
   unparsedBsda: UnparsedBsda
 ) {
   const companies = user ? await getUserCompanies(user.id) : [];
-  const orgIds = companies.map(c => c.orgId);
-
-  return {
-    isEcoOrganisme:
-      unparsedBsda.ecoOrganismeSiret != null &&
-      orgIds.includes(unparsedBsda.ecoOrganismeSiret),
-    isBroker:
-      unparsedBsda.brokerCompanySiret != null &&
-      orgIds.includes(unparsedBsda.brokerCompanySiret),
-    isWorker:
-      unparsedBsda.workerCompanySiret != null &&
-      orgIds.includes(unparsedBsda.workerCompanySiret),
-    isEmitter:
-      unparsedBsda.emitterCompanySiret != null &&
-      orgIds.includes(unparsedBsda.emitterCompanySiret),
-    isDestination:
-      unparsedBsda.destinationCompanySiret != null &&
-      orgIds.includes(unparsedBsda.destinationCompanySiret),
-    isTransporter:
-      (unparsedBsda.transporterCompanySiret != null &&
-        orgIds.includes(unparsedBsda.transporterCompanySiret)) ||
-      (unparsedBsda.transporterCompanyVatNumber != null &&
-        orgIds.includes(unparsedBsda.transporterCompanyVatNumber))
-  };
+  return getCompaniesFunctions(companies, unparsedBsda);
 }
 
 export function getCompaniesFunctions(

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -1,4 +1,4 @@
-import { User } from "@prisma/client";
+import { Company, User } from "@prisma/client";
 import { objectDiff } from "../../forms/workflow/diff";
 import { BsdaSignatureType } from "../../generated/graphql/types";
 import { flattenBsdaInput, flattenBsdaTransporterInput } from "../converter";
@@ -102,6 +102,36 @@ export async function getUserFunctions(
   unparsedBsda: UnparsedBsda
 ) {
   const companies = user ? await getUserCompanies(user.id) : [];
+  const orgIds = companies.map(c => c.orgId);
+
+  return {
+    isEcoOrganisme:
+      unparsedBsda.ecoOrganismeSiret != null &&
+      orgIds.includes(unparsedBsda.ecoOrganismeSiret),
+    isBroker:
+      unparsedBsda.brokerCompanySiret != null &&
+      orgIds.includes(unparsedBsda.brokerCompanySiret),
+    isWorker:
+      unparsedBsda.workerCompanySiret != null &&
+      orgIds.includes(unparsedBsda.workerCompanySiret),
+    isEmitter:
+      unparsedBsda.emitterCompanySiret != null &&
+      orgIds.includes(unparsedBsda.emitterCompanySiret),
+    isDestination:
+      unparsedBsda.destinationCompanySiret != null &&
+      orgIds.includes(unparsedBsda.destinationCompanySiret),
+    isTransporter:
+      (unparsedBsda.transporterCompanySiret != null &&
+        orgIds.includes(unparsedBsda.transporterCompanySiret)) ||
+      (unparsedBsda.transporterCompanyVatNumber != null &&
+        orgIds.includes(unparsedBsda.transporterCompanyVatNumber))
+  };
+}
+
+export function getCompaniesFunctions(
+  companies: Company[],
+  unparsedBsda: UnparsedBsda
+) {
   const orgIds = companies.map(c => c.orgId);
 
   return {

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -12,11 +12,8 @@ import {
   intermediarySchema
 } from "../../common/validation/intermediaries";
 import {
-  isRegisteredVatNumberRefinement,
   siretSchema,
-  foreignVatNumberSchema,
-  isDestinationRefinement,
-  isWorkerRefinement
+  foreignVatNumberSchema
 } from "../../common/validation/siret";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { OPERATIONS, WORKER_CERTIFICATION_ORGANISM } from "./constants";
@@ -91,9 +88,7 @@ export const rawBsdaSchema = z.object({
   brokerRecepisseDepartment: z.string().nullish(),
   brokerRecepisseValidityLimit: z.coerce.date().nullish(),
   destinationCompanyName: z.string().nullish(),
-  destinationCompanySiret: siretSchema
-    .nullish()
-    .superRefine(isDestinationRefinement),
+  destinationCompanySiret: siretSchema.nullish(),
   destinationCompanyAddress: z.string().nullish(),
   destinationCompanyContact: z.string().nullish(),
   destinationCompanyPhone: z.string().nullish(),
@@ -118,9 +113,7 @@ export const rawBsdaSchema = z.object({
     }),
   destinationOperationSignatureAuthor: z.string().nullish(),
   destinationOperationSignatureDate: z.coerce.date().nullish(),
-  destinationOperationNextDestinationCompanySiret: siretSchema
-    .nullish()
-    .superRefine(isDestinationRefinement),
+  destinationOperationNextDestinationCompanySiret: siretSchema.nullish(),
   destinationOperationNextDestinationCompanyVatNumber:
     foreignVatNumberSchema.nullish(),
   destinationOperationNextDestinationCompanyName: z.string().nullish(),
@@ -137,9 +130,7 @@ export const rawBsdaSchema = z.object({
   transporterCompanyContact: z.string().nullish(),
   transporterCompanyPhone: z.string().nullish(),
   transporterCompanyMail: z.string().nullish(),
-  transporterCompanyVatNumber: foreignVatNumberSchema
-    .nullish()
-    .superRefine(isRegisteredVatNumberRefinement),
+  transporterCompanyVatNumber: foreignVatNumberSchema.nullish(),
   transporterCustomInfo: z.string().nullish(),
   transporterRecepisseIsExempted: z.coerce
     .boolean()
@@ -162,7 +153,7 @@ export const rawBsdaSchema = z.object({
     .nullish()
     .transform(v => Boolean(v)),
   workerCompanyName: z.string().nullish(),
-  workerCompanySiret: siretSchema.nullish().superRefine(isWorkerRefinement),
+  workerCompanySiret: siretSchema.nullish(),
   workerCompanyAddress: z.string().nullish(),
   workerCompanyContact: z.string().nullish(),
   workerCompanyPhone: z.string().nullish(),

--- a/back/src/common/validation/intermediaries.ts
+++ b/back/src/common/validation/intermediaries.ts
@@ -29,7 +29,7 @@ export const intermediarySchema = z.object({
   orgId: z.string().nullish() // is ignored in db schema
 });
 
-export async function intermediariesRefinement(
+export function intermediariesRefinement(
   intermediaries: z.infer<typeof intermediarySchema>[] | null | undefined,
   ctx: RefinementCtx
 ) {

--- a/back/src/forms/dataloader.ts
+++ b/back/src/forms/dataloader.ts
@@ -6,6 +6,9 @@ import { expandableFormIncludes } from "./converter";
 export function createFormDataLoaders() {
   return {
     forms: new DataLoader((formIds: string[]) => getForms(formIds)),
+    formsForReadCheck: new DataLoader((formIds: string[]) =>
+      getFormsForReadCheck(formIds)
+    ),
     forwardedIns: new DataLoader((formIds: string[]) =>
       getForwardedIns(formIds)
     ),
@@ -24,6 +27,22 @@ async function getForms(formIds: string[]) {
       id: { in: formIds }
     },
     include: expandableFormIncludes
+  });
+
+  return formIds.map(formId => forms.find(form => form.id === formId));
+}
+
+async function getFormsForReadCheck(formIds: string[]) {
+  const forms = await prisma.form.findMany({
+    where: {
+      id: { in: formIds }
+    },
+    include: {
+      forwardedIn: { include: { transporters: true } },
+      transporters: true,
+      grouping: { include: { initialForm: true } },
+      intermediaries: true
+    }
   });
 
   return formIds.map(formId => forms.find(form => form.id === formId));

--- a/back/src/forms/dataloader.ts
+++ b/back/src/forms/dataloader.ts
@@ -45,7 +45,9 @@ async function getFormsForReadCheck(formIds: string[]) {
     }
   });
 
-  return formIds.map(formId => forms.find(form => form.id === formId));
+  const dict = Object.fromEntries(forms.map(form => [form.id, form]));
+
+  return formIds.map(formId => dict[formId]);
 }
 
 async function getForwardedIns(formIds: string[]) {

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -35,9 +35,10 @@ export async function renderFormRefusedEmail(
     ? forwardedIn.wasteAcceptationStatus!
     : form.wasteAcceptationStatus!;
 
+  const { filename, data } = await generateBsddPdfToBase64(form);
   const attachmentData = {
-    file: await generateBsddPdfToBase64(form),
-    name: `${form.readableId}.pdf`
+    file: data,
+    name: filename
   };
 
   const emitterCompanyAdmins = await getCompanyAdminUsers(

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -285,18 +285,15 @@ function TransporterFormCompanyFields({
   );
 }
 
-export async function generateBsddPdf(prismaForm: PrismaForm) {
+export async function generateBsddPdf(id: PrismaForm["id"]) {
   const fullPrismaForm = await prisma.form.findUniqueOrThrow({
-    where: { id: prismaForm.id },
-    include: { ...expandableFormIncludes, intermediaries: true }
+    where: { id },
+    include: {
+      ...expandableFormIncludes,
+      intermediaries: true,
+      grouping: { include: { initialForm: true } }
+    }
   });
-
-  const grouping = (
-    await prisma.formGroupement.findMany({
-      where: { nextFormId: fullPrismaForm.id },
-      include: { initialForm: { include: expandableFormIncludes } }
-    })
-  ).map(g => ({ form: g.initialForm, quantity: g.quantity }));
 
   const groupedIn = (
     await prisma.formGroupement.findMany({
@@ -305,20 +302,7 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
     })
   ).map(g => ({ readableId: g.nextForm.readableId }));
 
-  const form: GraphQLForm = {
-    ...(await expandFormFromDb(fullPrismaForm)),
-    transportSegments: fullPrismaForm.transporters
-      ?.filter(transporter => transporter.number >= 2)
-      .map(expandTransportSegmentFromDb),
-    grouping: await Promise.all(
-      grouping.map(async ({ form, quantity }) => ({
-        form: await expandInitialFormFromDb(form),
-        quantity
-      }))
-    ),
-
-    intermediaries: fullPrismaForm.intermediaries ?? []
-  };
+  const form = expandFormFromDb(fullPrismaForm);
   const isRepackging =
     form.recipient?.isTempStorage &&
     !!form.temporaryStorageDetail?.wasteDetails?.packagingInfos &&
@@ -1105,18 +1089,21 @@ export async function generateBsddPdf(prismaForm: PrismaForm) {
       )}
     </Document>
   );
+  const stream = await generatePdf(html);
 
-  return generatePdf(html);
+  return { filename: `${form.readableId}.pdf`, stream };
 }
 
 export async function generateBsddPdfToBase64(
   prismaForm: PrismaForm
-): Promise<string> {
-  const readableStream = await generateBsddPdf(prismaForm);
+): Promise<{ filename: string; data: string }> {
+  const { filename, stream: readableStream } = await generateBsddPdf(
+    prismaForm.id
+  );
 
   return new Promise((resolve, reject) => {
     const convertToBase64 = concatStream(buffer =>
-      resolve(buffer.toString("base64"))
+      resolve({ filename, data: buffer.toString("base64") })
     );
 
     readableStream.on("error", reject);

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -27,12 +27,7 @@ import {
   Transporter,
   TransportSegment
 } from "../../generated/graphql/types";
-import {
-  expandInitialFormFromDb,
-  expandFormFromDb,
-  expandTransportSegmentFromDb,
-  expandableFormIncludes
-} from "../converter";
+import { expandFormFromDb, expandableFormIncludes } from "../converter";
 import { prisma } from "@td/prisma";
 import { buildAddress } from "../../companies/sirene/utils";
 import { packagingsEqual } from "@td/constants";

--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -15,6 +15,7 @@ import {
 import {
   Permission,
   checkUserPermissions,
+  syncCheckUserPermissions,
   getUserRoles,
   can
 } from "../permissions";
@@ -200,8 +201,22 @@ type FormForReadCheck = Prisma.FormGetPayload<{
   };
 }>;
 
-export function isFormReader(user: User, form: FormForReadCheck) {
-  return checkCanRead(user, form).catch(_ => false);
+export function isFormReader(
+  userRoles: Parameters<typeof syncCheckUserPermissions>["0"],
+  form: FormForReadCheck
+) {
+  const authorizedOrgIds = formReaders(form);
+
+  try {
+    return syncCheckUserPermissions(
+      userRoles,
+      authorizedOrgIds,
+      Permission.BsdCanRead,
+      "Vous n'êtes pas autorisé à accéder à ce bordereau"
+    );
+  } catch (_) {
+    return false;
+  }
 }
 
 export async function checkCanRead(user: User, form: FormForReadCheck) {

--- a/back/src/forms/repository/form/update.ts
+++ b/back/src/forms/repository/form/update.ts
@@ -73,16 +73,13 @@ const buildUpdateForm: (deps: RepositoryFnDeps) => UpdateFormFn =
           const deletedTransporter = oldForm.transporters.find(
             t => t.id === deletedTransporterId
           )!;
-          await Promise.all(
-            updatedForm.transporters
-              .filter(t => t.number > deletedTransporter.number)
-              .map(t =>
-                prisma.bsddTransporter.update({
-                  where: { id: t.id },
-                  data: { number: t.number - 1 }
-                })
-              )
-          );
+          const transporterIdsToDecrement = updatedForm.transporters
+            .filter(t => t.number > deletedTransporter.number)
+            .map(t => t.id);
+          await prisma.bsddTransporter.updateMany({
+            where: { id: { in: transporterIdsToDecrement } },
+            data: { number: { decrement: 1 } }
+          });
         }
       }
     }

--- a/back/src/forms/resolvers/InitialForm.ts
+++ b/back/src/forms/resolvers/InitialForm.ts
@@ -4,7 +4,8 @@ import { isFormReader } from "../permissions";
 const initialFormResolvers: InitialFormResolvers = {
   emitter: async (parent, _, { user, dataloaders }) => {
     const form = await dataloaders.formsForReadCheck.load(parent.id);
-    if (!form || !(await isFormReader(user!, form))) {
+    const userRoles = await dataloaders.userRoles.load(user!.id);
+    if (!form || !isFormReader(userRoles, form)) {
       return null;
     }
     return parent.emitter ?? null;

--- a/back/src/forms/resolvers/InitialForm.ts
+++ b/back/src/forms/resolvers/InitialForm.ts
@@ -1,18 +1,9 @@
 import { InitialFormResolvers } from "../../generated/graphql/types";
-import { prisma } from "@td/prisma";
 import { isFormReader } from "../permissions";
 
 const initialFormResolvers: InitialFormResolvers = {
-  emitter: async (parent, _, { user }) => {
-    const form = await prisma.form.findUnique({
-      where: { id: parent.id },
-      include: {
-        forwardedIn: { include: { transporters: true } },
-        transporters: true,
-        grouping: { include: { initialForm: true } },
-        intermediaries: true
-      }
-    });
+  emitter: async (parent, _, { user, dataloaders }) => {
+    const form = await dataloaders.formsForReadCheck.load(parent.id);
     if (!form || !(await isFormReader(user!, form))) {
       return null;
     }

--- a/back/src/forms/resolvers/forms/grouping.ts
+++ b/back/src/forms/resolvers/forms/grouping.ts
@@ -12,8 +12,11 @@ const groupingResolver: FormResolvers["grouping"] = async (
 
   const groupements = await dataloaders.nextFormGoupements.load(form.id);
   const initialFormIds = groupements.map(g => g.initialFormId);
+   // Expandable fields are enough here, but the emitter sub-resolver requires the full form.
+   // And because the dashboard uses this field, we use the formsForReadCheck dataloader instead of forms.
+   // So this overfetches for forms required without the emitter.
   const initialForms = await Promise.all(
-    initialFormIds.map(id => dataloaders.forms.load(id))
+    initialFormIds.map(id => dataloaders.formsForReadCheck.load(id))
   );
 
   return groupements.map(({ quantity, initialFormId }) => {

--- a/back/src/forms/resolvers/forms/grouping.ts
+++ b/back/src/forms/resolvers/forms/grouping.ts
@@ -12,15 +12,21 @@ const groupingResolver: FormResolvers["grouping"] = async (
 
   const groupements = await dataloaders.nextFormGoupements.load(form.id);
   const initialFormIds = groupements.map(g => g.initialFormId);
-   // Expandable fields are enough here, but the emitter sub-resolver requires the full form.
-   // And because the dashboard uses this field, we use the formsForReadCheck dataloader instead of forms.
-   // So this overfetches for forms required without the emitter.
-  const initialForms = await Promise.all(
-    initialFormIds.map(id => dataloaders.formsForReadCheck.load(id))
+  // Expandable fields are enough here, but the emitter sub-resolver requires the full form.
+  // And because the dashboard uses this field, we use the formsForReadCheck dataloader instead of forms.
+  // So this overfetches for forms required without the emitter.
+  const initialForms = await dataloaders.formsForReadCheck.loadMany(
+    initialFormIds.map(id => id)
   );
+  const initialFormsDictionnary = initialForms.reduce((dic, initialForm) => {
+    if (!(initialForm instanceof Error) && initialForm) {
+      dic[initialForm.id] = initialForm;
+    }
+    return dic;
+  }, {});
 
   return groupements.map(({ quantity, initialFormId }) => {
-    const initialForm = initialForms.find(f => f && f.id === initialFormId);
+    const initialForm = initialFormsDictionnary[initialFormId];
     if (!initialForm) {
       throw new Error(`Invalid initial form with id ${initialFormId}`);
     }

--- a/back/src/forms/resolvers/queries/formPdf.ts
+++ b/back/src/forms/resolvers/queries/formPdf.ts
@@ -14,10 +14,9 @@ import { createPDFResponse } from "../../../common/pdf";
 export const formPdfDownloadHandler: DownloadHandler<QueryFormPdfArgs> = {
   name: "formPdf",
   handler: async (req: Request, res: Response, { id }: { id: string }) => {
-    const form = await getFormOrFormNotFound({ id });
-    const readableStream = await generateBsddPdf(form);
+    const { filename, stream: readableStream } = await generateBsddPdf(id);
 
-    readableStream.pipe(createPDFResponse(res, form.readableId));
+    readableStream.pipe(createPDFResponse(res, filename));
   }
 };
 

--- a/back/src/permissions.ts
+++ b/back/src/permissions.ts
@@ -194,7 +194,7 @@ export async function checkUserPermissions(
 }
 
 export function syncCheckUserPermissions(
-  userRoles: Awaited<ReturnType<typeof getUserRoles>>,
+  userRoles: { [key: string]: UserRole },
   orgIds: string[],
   permission: Permission,
   errorMsg = "Vous n'êtes pas autorisé à effectuer cette action"

--- a/back/src/permissions.ts
+++ b/back/src/permissions.ts
@@ -190,6 +190,15 @@ export async function checkUserPermissions(
   }
 
   const userRoles = await getUserRoles(user.id);
+  return syncCheckUserPermissions(userRoles, orgIds, permission, errorMsg);
+}
+
+export function syncCheckUserPermissions(
+  userRoles: Awaited<ReturnType<typeof getUserRoles>>,
+  orgIds: string[],
+  permission: Permission,
+  errorMsg = "Vous n'êtes pas autorisé à effectuer cette action"
+) {
   for (const orgId of orgIds.filter(Boolean)) {
     if (
       Object.keys(userRoles).includes(orgId) &&

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -1,5 +1,9 @@
 import { Job } from "bull";
 import {
+  FormForElasticInclude,
+  toBsdElastic as toBsddElastic
+} from "../../forms/elastic";
+import {
   BsdaForElasticInclude,
   toBsdElastic as toBsdaElastic
 } from "../../bsda/elastic";
@@ -65,6 +69,15 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
       include: BspaohForElasticInclude
     });
     return toBspaohElastic(bspaoh);
+  }
+
+  // For Bsdds the id is a random uuid.
+  const bsdd = await prisma.form.findUniqueOrThrow({
+    where: { id: bsdId },
+    include: FormForElasticInclude
+  });
+  if (bsdd) {
+    return toBsddElastic(bsdd);
   }
 
   throw new Error("Indexing this type of BSD is not handled by this worker.");

--- a/back/src/registry/resolvers/queries/wastesRegistryCsv.ts
+++ b/back/src/registry/resolvers/queries/wastesRegistryCsv.ts
@@ -11,7 +11,7 @@ import { format } from "@fast-csv/format";
 import { wasteFormatter, wastesReader } from "../../streams";
 import { searchBsds } from "../../elastic";
 import { GraphQLContext } from "../../../types";
-import { Permission, checkUserPermissions } from "../../../permissions";
+import { Permission, syncCheckUserPermissions } from "../../../permissions";
 import { UserInputError } from "../../../common/errors";
 import { TotalHits } from "@elastic/elasticsearch/api/types";
 
@@ -40,9 +40,10 @@ export async function wastesRegistryCsvResolverFn(
   context: GraphQLContext
 ): Promise<FileDownload> {
   const user = checkIsAuthenticated(context);
+  const userRoles = await context.dataloaders.userRoles.load(user.id);
   for (const siret of args.sirets) {
-    await checkUserPermissions(
-      user,
+    syncCheckUserPermissions(
+      userRoles,
       [siret].filter(Boolean),
       Permission.RegistryCanRead,
       `Vous n'êtes pas autorisé à accéder au registre de l'établissement portant le n°SIRET ${siret}`

--- a/back/src/registry/resolvers/queries/wastesRegistryXls.ts
+++ b/back/src/registry/resolvers/queries/wastesRegistryXls.ts
@@ -12,7 +12,7 @@ import { wasteFormatter, wastesReader } from "../../streams";
 import { getXlsxHeaders } from "../../columns";
 import { searchBsds } from "../../elastic";
 import { GraphQLContext } from "../../../types";
-import { Permission, checkUserPermissions } from "../../../permissions";
+import { Permission, syncCheckUserPermissions } from "../../../permissions";
 import { UserInputError } from "../../../common/errors";
 import { TotalHits } from "@elastic/elasticsearch/api/types";
 
@@ -60,9 +60,10 @@ export async function wastesRegistryXlsResolverFn(
   context: GraphQLContext
 ): Promise<FileDownload> {
   const user = checkIsAuthenticated(context);
+  const userRoles = await context.dataloaders.userRoles.load(user.id);
   for (const siret of args.sirets) {
-    await checkUserPermissions(
-      user,
+    syncCheckUserPermissions(
+      userRoles,
       [siret].filter(Boolean),
       Permission.RegistryCanRead,
       `Vous n'êtes pas autorisé à accéder au registre de l'établissement portant le n°SIRET ${siret}`

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -36,6 +36,7 @@ import { redisClient } from "./common/redis";
 import { initSentry } from "./common/sentry";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
+import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { bullBoardPath, serverAdapter } from "./queue/bull-board";
 import { authRouter } from "./routers/auth-router";
 import { downloadRouter } from "./routers/downloadRouter";
@@ -337,6 +338,7 @@ export const getServerDataloaders = () => ({
   ...createUserDataLoaders(),
   ...createCompanyDataLoaders(),
   ...createFormDataLoaders(),
+  ...createBsdaDataLoaders(),
   ...createEventsDataLoaders()
 });
 

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -3,12 +3,14 @@ import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { GqlInfo } from "./common/plugins/gqlInfosPlugin";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
+import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 import "express-session";
 
 export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createCompanyDataLoaders> &
   ReturnType<typeof createFormDataLoaders> &
+  ReturnType<typeof createBsdaDataLoaders> &
   ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = {

--- a/back/src/users/dataloaders.ts
+++ b/back/src/users/dataloaders.ts
@@ -1,10 +1,14 @@
 import DataLoader from "dataloader";
 import { prisma } from "@td/prisma";
 import { getUserRoles } from "../permissions";
+import { Company } from "@prisma/client";
 
 export function createUserDataLoaders() {
   return {
     userRoles: new DataLoader((userIds: string[]) => getUsersRoles(userIds)),
+    userCompanies: new DataLoader((userIds: string[]) =>
+      getUsersCompanies(userIds)
+    ),
     activeUserAccountHashesBySiret: new DataLoader((sirets: string[]) =>
       genActiveUserAccountHashesBySiret(sirets)
     )
@@ -19,6 +23,20 @@ async function getUsersRoles(userIds: string[]) {
     const userRoles = await getUserRoles(userId);
     return userRoles;
   });
+}
+
+async function getUsersCompanies(userIds: string[]) {
+  const companyAssociations = await prisma.companyAssociation.findMany({
+    where: { userId: { in: userIds } },
+    select: { userId: true, company: true }
+  });
+
+  const companiesPerUser = companyAssociations.reduce((dict, association) => {
+    dict[association.userId] ??= [];
+    dict[association.userId].push(association.company);
+    return dict;
+  }, {} as Record<string, Company[]>);
+  return userIds.map(userId => companiesPerUser[userId]);
 }
 
 async function genActiveUserAccountHashesBySiret(companySirets: string[]) {

--- a/back/src/users/dataloaders.ts
+++ b/back/src/users/dataloaders.ts
@@ -1,12 +1,24 @@
 import DataLoader from "dataloader";
 import { prisma } from "@td/prisma";
+import { getUserRoles } from "../permissions";
 
 export function createUserDataLoaders() {
   return {
+    userRoles: new DataLoader((userIds: string[]) => getUsersRoles(userIds)),
     activeUserAccountHashesBySiret: new DataLoader((sirets: string[]) =>
       genActiveUserAccountHashesBySiret(sirets)
     )
   };
+}
+
+// User roles are already cached in Redis.
+// But this dataloader is still useful for cases where you need to load
+// user roles n times for the same user in a single HTTP request.
+async function getUsersRoles(userIds: string[]) {
+  return userIds.map(async userId => {
+    const userRoles = await getUserRoles(userId);
+    return userRoles;
+  });
 }
 
 async function genActiveUserAccountHashesBySiret(companySirets: string[]) {

--- a/scripts/deploy-db.sh
+++ b/scripts/deploy-db.sh
@@ -7,13 +7,11 @@ green=$(tput setaf 2)
 red=$(tput setaf 9)
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-USING_ENV_FILE=false
 
 if [ -z "$DATABASE_URL" ]
 then
   echo "${bold}! No ${green}\$DATABASE_URL${reset}${bold} env variable found.${reset}"
   integrationEnvPath="$(dirname "$SCRIPT_DIR")/.env.integration"
-  USING_ENV_FILE=true
 
   if [ -f "$integrationEnvPath" ]; then
     echo "${bold}! Sourcing ${green}$integrationEnvPath${reset}${bold}...${reset}"
@@ -63,6 +61,6 @@ until curl -XGET "$ELASTIC_SEARCH_URL" 2> /dev/null; do
 done
 
 echo "3/3 - Create tables & index";
-escapedDatabaseUrl="${DATABASE_URL%%\?*}?schema=default\$default"
 
-DATABASE_URL=$escapedDatabaseUrl npx nx run back:integration-setup
+npx prisma db push
+npx nx run back:reindex-all-bsds-bulk

--- a/scripts/deploy-db.sh
+++ b/scripts/deploy-db.sh
@@ -63,10 +63,6 @@ until curl -XGET "$ELASTIC_SEARCH_URL" 2> /dev/null; do
 done
 
 echo "3/3 - Create tables & index";
-if [ "$USING_ENV_FILE" = true ] ; then
-  escapedDatabaseUrl="${DATABASE_URL//$/\\$}"
-else
-  escapedDatabaseUrl=$DATABASE_URL
-fi
+escapedDatabaseUrl="${DATABASE_URL%%\?*}?schema=default\$default"
 
 DATABASE_URL=$escapedDatabaseUrl npx nx run back:integration-setup


### PR DESCRIPTION
Multiples améliorations de perf:

- Réduction du nombre de requêtes lors du téléchargement d'un PDF BSDD
- Amélioration du chargement du champ `InitialForm.Emitter` dans la query `forms` (et `getBsds`)grâce à un dataloader 
- Mini optim sur l'updat ede bordereau, en remplacant n update par un updateMany
- Réduction du nombre d'appels à `getUserRoles` pour  `InitialForm.Emitter`. On évite ainsi des milliers d'appels identiques dans certains cas
- Application de la même optim (passage de N à 1 getUserRoles) pour les waste registry
- Petite optim pour passer de O(n2) à O(n) dans un hotpath qui parcourt les bordereaux dans `form.grouping`
- On évite les long running transactions dans `form.delete` en passant en asynchrone la supression de bordereaux dans ES (on avait des transactions qui duraient facile 3,4,5 secondes à cause des delete ES à la chaine avec wait_for)
- Amélioration de `bsdas.metadata.errors` avec une version allégée (synchrone) de la validation qui peut être appelée sur des listes de bordereaux sans générer tout un tas de requêtes
