### PR TITLE
Fixes a refresh on BSDA creation / update

### DIFF
--- a/front/src/Apps/Dashboard/Components/DeleteModal/DeleteModal.tsx
+++ b/front/src/Apps/Dashboard/Components/DeleteModal/DeleteModal.tsx
@@ -13,7 +13,6 @@ import {
 } from "@td/codegen-ui";
 import toast from "react-hot-toast";
 import TdModal from "../../../common/Components/Modal/Modal";
-import { GET_BSDS } from "../../../common/queries";
 import { Loader } from "../../../common/Components";
 
 const DELETE_BSDA = gql`
@@ -68,8 +67,6 @@ function DeleteModal({ bsdId, bsdType, isOpen, onClose }) {
     MutationDeleteBsdaArgs
   >(DELETE_BSDA, {
     variables: { id: bsdId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success(messageSuccess, { duration: TOAST_DURATION });
       !!onClose && onClose();
@@ -84,8 +81,6 @@ function DeleteModal({ bsdId, bsdType, isOpen, onClose }) {
     MutationDeleteBsdasriArgs
   >(DELETE_BSDASRI, {
     variables: { id: bsdId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success(messageSuccess, { duration: TOAST_DURATION });
       !!onClose && onClose();
@@ -101,8 +96,6 @@ function DeleteModal({ bsdId, bsdType, isOpen, onClose }) {
     MutationDeleteFormArgs
   >(DELETE_FORM, {
     variables: { id: bsdId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success(messageSuccess, { duration: TOAST_DURATION });
       !!onClose && onClose();
@@ -118,8 +111,6 @@ function DeleteModal({ bsdId, bsdType, isOpen, onClose }) {
     MutationDeleteBsffArgs
   >(DELETE_BSFF, {
     variables: { id: bsdId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success(messageSuccess, { duration: TOAST_DURATION });
       !!onClose && onClose();
@@ -135,8 +126,6 @@ function DeleteModal({ bsdId, bsdType, isOpen, onClose }) {
     MutationDeleteBsvhuArgs
   >(DELETE_BSVHU, {
     variables: { id: bsdId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success(messageSuccess, { duration: TOAST_DURATION });
       !!onClose && onClose();

--- a/front/src/Apps/Dashboard/Components/Duplicate/useDuplicate.tsx
+++ b/front/src/Apps/Dashboard/Components/Duplicate/useDuplicate.tsx
@@ -13,7 +13,6 @@ import {
   fullFormFragment,
   vhuFragment
 } from "../../../common/queries/fragments";
-import { GET_BSDS } from "../../../common/queries";
 import { toastApolloError } from "../../../../form/common/stepper/toaster";
 
 const DUPLICATE_BSDASRI = gql`
@@ -73,8 +72,6 @@ export function useBsdasriDuplicate(
     MutationDuplicateBsdasriArgs
   >(DUPLICATE_BSDASRI, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(message);
 
@@ -99,8 +96,6 @@ export function useBsdaDuplicate(
     MutationDuplicateBsdaArgs
   >(DUPLICATE_BSDA, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(message);
 
@@ -125,8 +120,6 @@ export function useBsddDuplicate(
     MutationDuplicateFormArgs
   >(DUPLICATE_FORM, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(message);
 
@@ -151,8 +144,6 @@ export function useBsffDuplicate(
     MutationDuplicateBsdaArgs
   >(DUPLICATE_BSFF, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(message);
 
@@ -177,8 +168,6 @@ export function useBsvhuDuplicate(
     MutationDuplicateBsvhuArgs
   >(DUPLICATE_BSVHU, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(message);
 

--- a/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Act/ActBsddValidation.tsx
@@ -4,7 +4,6 @@ import { Loader } from "../../../../common/Components";
 import { NotificationError } from "../../../../common/Components/Error/Error";
 import TdModal from "../../../../common/Components/Modal/Modal";
 import { statusChangeFragment } from "../../../../common/queries/fragments";
-import { GET_BSDS } from "../../../../common/queries";
 import AcceptedInfo from "../../../../../dashboard/components/BSDList/BSDD/WorkflowAction/AcceptedInfo";
 import ReceivedInfo from "../../../../../dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo";
 import { GET_FORM } from "../../../../../form/bsdd/utils/queries";
@@ -84,8 +83,6 @@ const ActBsddValidation = ({
     Pick<Mutation, "markAsTempStorerAccepted">,
     MutationMarkAsTempStorerAcceptedArgs
   >(MARK_TEMP_STORER_ACCEPTED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onError: () => {
       // The error is handled in the UI
     }
@@ -94,8 +91,6 @@ const ActBsddValidation = ({
     useMutation<Pick<Mutation, "markAsAccepted">, MutationMarkAsAcceptedArgs>(
       MARK_AS_ACCEPTED,
       {
-        refetchQueries: [GET_BSDS],
-        awaitRefetchQueries: true,
         onError: () => {
           // The error is handled in the UI
         }

--- a/front/src/Apps/Dashboard/Components/Validation/Draft/DraftValidation.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/Draft/DraftValidation.tsx
@@ -9,7 +9,6 @@ import {
   MutationPublishBsvhuArgs
 } from "@td/codegen-ui";
 import { statusChangeFragment } from "../../../../common/queries/fragments";
-import { GET_BSDS } from "../../../../common/queries";
 import toast from "react-hot-toast";
 import { NotificationError } from "../../../../common/Components/Error/Error";
 import { Loader } from "../../../../common/Components";
@@ -66,8 +65,6 @@ const DraftValidation = ({ bsd, currentSiret, isOpen, onClose }) => {
     MARK_AS_SEALED,
     {
       variables: { id: bsd.id },
-      refetchQueries: [GET_BSDS],
-      awaitRefetchQueries: true,
       onCompleted: data => {
         if (data.markAsSealed) {
           const sealedForm = data.markAsSealed;
@@ -90,8 +87,6 @@ const DraftValidation = ({ bsd, currentSiret, isOpen, onClose }) => {
     PUBLISH_BSDA,
     {
       variables: { id: bsd.id },
-      refetchQueries: [GET_BSDS],
-      awaitRefetchQueries: true,
       onCompleted: () => {
         toast.success(`Bordereau ${bsd.id} publié`, {
           duration: TOAST_DURATION
@@ -108,9 +103,7 @@ const DraftValidation = ({ bsd, currentSiret, isOpen, onClose }) => {
     Pick<Mutation, "publishBsff">,
     MutationPublishBsffArgs
   >(PUBLISH_BSFF, {
-    variables: { id: bsd.id },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
+    variables: { id: bsd.id }
   });
 
   const [publishBsvhu, { loading: loadingBsvhu, error: errorBsvhu }] =
@@ -118,8 +111,6 @@ const DraftValidation = ({ bsd, currentSiret, isOpen, onClose }) => {
       PUBLISH_BSVHU,
       {
         variables: { id: bsd.id },
-        refetchQueries: [GET_BSDS],
-        awaitRefetchQueries: true,
         onCompleted: () => {
           toast.success(`Bordereau ${bsd.id} publié`, {
             duration: TOAST_DURATION

--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/DeleteModal.tsx
@@ -4,7 +4,6 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteFormArgs } from "@td/codegen-ui";
 import toast from "react-hot-toast";
 import TdModal from "../../../../../Apps/common/Components/Modal/Modal";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { Loader } from "../../../../../Apps/common/Components";
 import { TOAST_DURATION } from "../../../../../common/config";
 
@@ -31,8 +30,6 @@ export function DeleteModal({
     MutationDeleteFormArgs
   >(DELETE_FORM, {
     variables: { id: formId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success("Bordereau supprimé", { duration: TOAST_DURATION });
       !!onClose && onClose();

--- a/front/src/dashboard/components/BSDList/BSDD/BSDDActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/BSDDActions/useDuplicate.tsx
@@ -2,7 +2,6 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { Mutation, MutationDuplicateFormArgs } from "@td/codegen-ui";
 import { fullFormFragment } from "../../../../../Apps/common/queries/fragments";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const DUPLICATE_FORM = gql`
   mutation DuplicateForm($id: ID!) {
@@ -24,8 +23,6 @@ export function useDuplicate(
     MutationDuplicateFormArgs
   >(DUPLICATE_FORM, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsAccepted.tsx
@@ -14,7 +14,6 @@ import { Loader } from "../../../../../Apps/common/Components";
 import { IconWaterDam } from "../../../../../Apps/common/Components/Icons/Icons";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import AcceptedInfo from "./AcceptedInfo";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { GET_FORM } from "../../../../../form/bsdd/utils/queries";
 
 const MARK_AS_ACCEPTED = gql`
@@ -39,8 +38,6 @@ export default function MarkAsAccepted({ form }: WorkflowActionProps) {
     Pick<Mutation, "markAsAccepted">,
     MutationMarkAsAcceptedArgs
   >(MARK_AS_ACCEPTED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onError: () => {
       // The error is handled in the UI
     }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessedModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsProcessedModalContent.tsx
@@ -11,7 +11,6 @@ import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "../../../../../Apps/common/queries/fragments";
 import ProcessedInfo from "./ProcessedInfo";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import toast from "react-hot-toast";
 
 const MARK_AS_PROCESSED = gql`
@@ -28,8 +27,6 @@ function MarkAsProcessedModalContent({ data, onClose }) {
     Pick<Mutation, "markAsProcessed">,
     MutationMarkAsProcessedArgs
   >(MARK_AS_PROCESSED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: data => {
       if (
         data.markAsProcessed &&

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsResealedModalContent.tsx
@@ -5,7 +5,6 @@ import { NotificationError } from "../../../../../Apps/common/Components/Error/E
 import ProcessingOperationSelect from "../../../../../common/components/ProcessingOperationSelect";
 import { statusChangeFragment } from "../../../../../Apps/common/queries/fragments";
 import { mergeDefaults } from "../../../../../common/helper";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import Packagings from "../../../../../form/bsdd/components/packagings/Packagings";
 import CompanySelector from "../../../../../form/common/components/company/CompanySelector";
 import NumberInput from "../../../../../form/common/components/custom-inputs/NumberInput";
@@ -96,8 +95,6 @@ const MarkAsResealedModalContent = ({ bsd, onClose }) => {
   const [markAsResealed, { error, loading }] = useMutation<
     Pick<Mutation, "markAsResealed">
   >(MARK_RESEALED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onError: () => {
       // The error is handled in the UI
     }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsSealed.tsx
@@ -9,7 +9,6 @@ import { WorkflowActionProps } from "./WorkflowAction";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import { TdModalTrigger } from "../../../../../Apps/common/Components/Modal/Modal";
 import toast from "react-hot-toast";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const MARK_AS_SEALED = gql`
   mutation MarkAsSealed($id: ID!) {
@@ -27,8 +26,6 @@ export default function MarkAsSealed({ form }: WorkflowActionProps) {
     MutationMarkAsSealedArgs
   >(MARK_AS_SEALED, {
     variables: { id: form.id },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: data => {
       if (data.markAsSealed) {
         const sealedForm = data.markAsSealed;

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/MarkAsTempStorerAccepted.tsx
@@ -16,7 +16,6 @@ import { Loader } from "../../../../../Apps/common/Components";
 import { IconWarehouseStorage } from "../../../../../Apps/common/Components/Icons/Icons";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import AcceptedInfo from "./AcceptedInfo";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { GET_FORM } from "../../../../../form/bsdd/utils/queries";
 
 const MARK_TEMP_STORER_ACCEPTED = gql`
@@ -49,8 +48,6 @@ export default function MarkAsTempStorerAccepted({
     Pick<Mutation, "markAsTempStorerAccepted">,
     MutationMarkAsTempStorerAcceptedArgs
   >(MARK_TEMP_STORER_ACCEPTED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onError: () => {
       // The error is handled in the UI
     }

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ReceivedInfo.tsx
@@ -22,7 +22,6 @@ import {
 } from "@td/codegen-ui";
 import { gql, useMutation } from "@apollo/client";
 import { statusChangeFragment } from "../../../../../Apps/common/queries/fragments";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import EstimatedQuantityTooltip from "../../../../../common/components/EstimatedQuantityTooltip";
 
@@ -137,8 +136,6 @@ export default function ReceivedInfo({
   ] = useMutation<Pick<Mutation, "markAsReceived">, MutationMarkAsReceivedArgs>(
     MARK_AS_RECEIVED,
     {
-      refetchQueries: [GET_BSDS],
-      awaitRefetchQueries: true,
       onError: () => {
         // The error is handled in the UI
       },
@@ -153,8 +150,6 @@ export default function ReceivedInfo({
     Pick<Mutation, "markAsTempStored">,
     MutationMarkAsTempStoredArgs
   >(MARK_AS_TEMP_STORED, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onError: () => {
       // The error is handled in the UI
     }

--- a/front/src/dashboard/components/BSDList/BSDa/BSDaActions/useDuplicate.ts
+++ b/front/src/dashboard/components/BSDList/BSDa/BSDaActions/useDuplicate.ts
@@ -2,7 +2,6 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { Mutation, MutationDuplicateBsdaArgs } from "@td/codegen-ui";
 import { bsdaFragment } from "../../../../../Apps/common/queries/fragments";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const DUPLICATE_BSDA = gql`
   mutation DuplicateBsda($id: ID!) {
@@ -24,8 +23,6 @@ export function useDuplicate(
     MutationDuplicateBsdaArgs
   >(DUPLICATE_BSDA, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignEmission.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -41,10 +40,7 @@ export function SignEmission({
   const [signBsda, { loading, error }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
-  });
+  >(SIGN_BSDA, {});
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignOperation.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { format, subMonths } from "date-fns";
 import { UPDATE_BSDA } from "../../../../../form/bsda/stepper/queries";
@@ -50,10 +49,7 @@ export function SignOperation({
   const [signBsda, { loading, error: signatureError }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
-  });
+  >(SIGN_BSDA);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignTransport.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { UPDATE_BSDA } from "../../../../../form/bsda/stepper/queries";
 import { Transport } from "../../../../../form/bsda/stepper/steps/Transport";
@@ -51,7 +50,7 @@ export function SignTransport({
   const [signBsda, { loading, error: signatureError }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSDA);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/SignWork.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { UPDATE_BSDA } from "../../../../../form/bsda/stepper/queries";
 import { WasteInfoWorker } from "../../../../../form/bsda/stepper/steps/WasteInfo";
@@ -50,7 +49,7 @@ export function SignWork({
   const [signBsda, { loading, error: signatureError }] = useMutation<
     Pick<Mutation, "signBsda">,
     MutationSignBsdaArgs
-  >(SIGN_BSDA, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSDA);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/useDuplicate.tsx
@@ -2,7 +2,6 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { Mutation, MutationDuplicateBsdasriArgs } from "@td/codegen-ui";
 import { fullDasriFragment } from "../../../../../Apps/common/queries/fragments";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const DUPLICATE_BSDASRI = gql`
   mutation DuplicateBsdasri($id: ID!) {
@@ -24,8 +23,6 @@ export function useBsdasriDuplicate(
     MutationDuplicateBsdasriArgs
   >(DUPLICATE_BSDASRI, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RoutePublishBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RoutePublishBsdasri.tsx
@@ -15,10 +15,7 @@ import Loader from "../../../../../Apps/common/Components/Loader/Loaders";
 import { useQuery, useMutation, gql } from "@apollo/client";
 import routes from "../../../../../Apps/routes";
 import { useParams, useNavigate, generatePath, Link } from "react-router-dom";
-import {
-  GET_DETAIL_DASRI_WITH_METADATA,
-  GET_BSDS
-} from "../../../../../Apps/common/queries";
+import { GET_DETAIL_DASRI_WITH_METADATA } from "../../../../../Apps/common/queries";
 import { TOAST_DURATION } from "../../../../../common/config";
 
 import EmptyDetail from "../../../../detail/common/EmptyDetailView";
@@ -54,8 +51,6 @@ export function RoutePublishBsdasri() {
       PUBLISH_BSDASRI,
       {
         variables: { id: formId! },
-        refetchQueries: [GET_BSDS],
-        awaitRefetchQueries: true,
         onCompleted: () => {
           toast.success(`Bordereau ${formId} publié`, {
             duration: TOAST_DURATION

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -17,10 +17,7 @@ import { ExtraSignatureType, SignatureType } from "../types";
 import Loader from "../../../../../Apps/common/Components/Loader/Loaders";
 import { useQuery, useMutation } from "@apollo/client";
 import { useParams, useNavigate, generatePath } from "react-router-dom";
-import {
-  GET_DETAIL_DASRI_WITH_METADATA,
-  GET_BSDS
-} from "../../../../../Apps/common/queries";
+import { GET_DETAIL_DASRI_WITH_METADATA } from "../../../../../Apps/common/queries";
 
 import EmptyDetail from "../../../../detail/common/EmptyDetailView";
 import { Formik, Field, Form } from "formik";
@@ -196,9 +193,7 @@ export function RouteSignBsdasri({
             variables: {
               id: bsdasri.id,
               input: { ...signature, type: config.signatureType }
-            },
-            refetchQueries: [GET_BSDS],
-            awaitRefetchQueries: true
+            }
           });
           nextPage();
         }}

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/DeleteModal.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/DeleteModal.tsx
@@ -4,7 +4,6 @@ import { gql, useMutation } from "@apollo/client";
 import { Mutation, MutationDeleteBsffArgs } from "@td/codegen-ui";
 import toast from "react-hot-toast";
 import TdModal from "../../../../../Apps/common/Components/Modal/Modal";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { Loader } from "../../../../../Apps/common/Components";
 import { TOAST_DURATION } from "../../../../../common/config";
 
@@ -31,8 +30,6 @@ export function DeleteBsffModal({
     MutationDeleteBsffArgs
   >(DELETE_BSFF, {
     variables: { id: formId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: () => {
       toast.success("Bordereau supprimé", { duration: TOAST_DURATION });
       !!onClose && onClose();

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/useDuplicate.tsx
@@ -1,7 +1,6 @@
 import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { Mutation, MutationDuplicateBsdaArgs } from "@td/codegen-ui";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const DUPLICATE_BSFF = gql`
   mutation DuplicateBsff($id: ID!) {
@@ -22,8 +21,6 @@ export function useDuplicate(
     MutationDuplicateBsdaArgs
   >(DUPLICATE_BSFF, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PublishBsff.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/PublishBsff.tsx
@@ -5,7 +5,6 @@ import { ActionButton } from "../../../../../common/components";
 import { Loader } from "../../../../../Apps/common/Components";
 import { TdModalTrigger } from "../../../../../Apps/common/Components/Modal/Modal";
 import { IconPaperWrite } from "../../../../../Apps/common/Components/Icons/Icons";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 
 const PUBLISH_BSFF = gql`
@@ -26,9 +25,7 @@ export function PublishBsff({ bsffId }: PublishBsffProps) {
     Pick<Mutation, "publishBsff">,
     MutationPublishBsffArgs
   >(PUBLISH_BSFF, {
-    variables: { id: bsffId },
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
+    variables: { id: bsffId }
   });
 
   const actionLabel = "Publier le bordereau";

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignAcceptation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignAcceptation.tsx
@@ -27,7 +27,6 @@ import {
   SIGN_BSFF,
   UPDATE_BSFF_PACKAGING
 } from "../../../../../form/bsff/utils/queries";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import NumberInput from "../../../../../form/common/components/custom-inputs/NumberInput";
 import { BSFF_WASTES } from "@td/constants";
 import { IconCheckCircle1 } from "../../../../../Apps/common/Components/Icons/Icons";
@@ -176,7 +175,7 @@ export function SignBsffAcceptationOnePackagingModalContent({
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSFF);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignEmission.tsx
@@ -12,7 +12,6 @@ import { RedErrorMessage } from "../../../../../common/components";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import { SIGN_BSFF } from "../../../../../form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import DateInput from "../../../../../form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 
@@ -33,7 +32,7 @@ function SignEmissionForm({ bsff, onCancel }: SignEmissionFormProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSFF);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignOperation.tsx
@@ -29,7 +29,6 @@ import {
   SIGN_BSFF,
   UPDATE_BSFF_PACKAGING
 } from "../../../../../form/bsff/utils/queries";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { IconCheckCircle1 } from "../../../../../Apps/common/Components/Icons/Icons";
 import { BsffSummary } from "./BsffSummary";
 import { BsffPackagingSummary } from "./BsffPackagingSummary";
@@ -269,7 +268,7 @@ export function SignBsffOperationOnePackagingModalContent({
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSFF);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignReception.tsx
@@ -17,7 +17,6 @@ import {
   UPDATE_BSFF_FORM
 } from "../../../../../form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { subMonths } from "date-fns";
 
 const validationSchema = yup.object({
@@ -41,7 +40,7 @@ function SignReceptionModal({ bsff, onCancel }: SignReceptionModalProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSFF);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -17,7 +17,6 @@ import {
   UPDATE_BSFF_FORM
 } from "../../../../../form/bsff/utils/queries";
 import { SignBsff } from "./SignBsff";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import DateInput from "../../../../../form/common/components/custom-inputs/DateInput";
 import TransporterRecepisseWrapper from "../../../../../form/common/components/company/TransporterRecepisseWrapper";
 import { subMonths } from "date-fns";
@@ -45,7 +44,7 @@ function SignTransportForm({ bsff, onCancel }: SignTransportFormProps) {
   const [signBsff, signBsffResult] = useMutation<
     Pick<Mutation, "signBsff">,
     MutationSignBsffArgs
-  >(SIGN_BSFF, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSFF);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/useDuplicate.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/BSVhuActions/useDuplicate.tsx
@@ -2,7 +2,6 @@ import { gql, MutationHookOptions, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { Mutation, MutationDuplicateBsvhuArgs } from "@td/codegen-ui";
 import { vhuFragment } from "../../../../../Apps/common/queries/fragments";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 
 const DUPLICATE_BSVHU = gql`
   mutation DuplicateBsvhu($id: ID!) {
@@ -24,8 +23,6 @@ export function useDuplicate(
     MutationDuplicateBsvhuArgs
   >(DUPLICATE_BSVHU, {
     ...options,
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true,
     onCompleted: (...args) => {
       toast.success(
         `Le bordereau a été dupliqué, il est disponible dans l'onglet "Brouillons"`

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { Field, Form, Formik } from "formik";
 import {
@@ -40,7 +39,7 @@ export function SignEmission({
   const [signBsvhu, { loading }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
-  >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSVHU);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import { getInitialCompany } from "../../../../../form/bsdd/utils/initial-state";
 import Operation from "../../../../../form/bsvhu/Operation";
 import { UPDATE_VHU_FORM } from "../../../../../form/bsvhu/utils/queries";
@@ -46,7 +45,7 @@ export function SignOperation({
   const [signBsvhu, { loading, error: signError }] = useMutation<
     Pick<Mutation, "signBsvhu">,
     MutationSignBsvhuArgs
-  >(SIGN_BSVHU, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(SIGN_BSVHU);
 
   const TODAY = new Date();
 

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -1,6 +1,5 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
-import { GET_BSDS } from "../../../../../Apps/common/queries";
 import routes from "../../../../../Apps/routes";
 import { UPDATE_VHU_FORM } from "../../../../../form/bsvhu/utils/queries";
 import TransporterRecepisseWrapper from "../../../../../form/common/components/company/TransporterRecepisseWrapper";
@@ -46,10 +45,7 @@ export function SignTransport({
     );
 
   const [signBsvhu, { loading: loadingSign, error: signatureError }] =
-    useMutation<Pick<Mutation, "signBsvhu">, MutationSignBsvhuArgs>(
-      SIGN_BSVHU,
-      { refetchQueries: [GET_BSDS], awaitRefetchQueries: true }
-    );
+    useMutation<Pick<Mutation, "signBsvhu">, MutationSignBsvhuArgs>(SIGN_BSVHU);
 
   const loading = loadingUpdate || loadingSign;
 

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -2,7 +2,6 @@ import { useMutation, useQuery } from "@apollo/client";
 import React, { lazy, ReactElement, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader } from "../../../Apps/common/Components";
-import { GET_BSDS } from "../../../Apps/common/queries";
 import { getComputedState } from "../../common/getComputedState";
 
 import { IStepContainerProps } from "../../common/stepper/Step";
@@ -83,18 +82,12 @@ export default function BsdaStepsList(props: Props) {
   const [createBsda, { loading: creating }] = useMutation<
     Pick<Mutation, "createBsda">,
     MutationCreateBsdaArgs
-  >(CREATE_BSDA, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
-  });
+  >(CREATE_BSDA);
 
   const [updateBsda, { loading: updating }] = useMutation<
     Pick<Mutation, "updateBsda">,
     MutationUpdateBsdaArgs
-  >(UPDATE_BSDA, {
-    refetchQueries: [GET_BSDS],
-    awaitRefetchQueries: true
-  });
+  >(UPDATE_BSDA);
 
   const cleanupFields = (input: BsdaInput): BsdaInput => {
     // When created through api, this field might be null in db

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -20,7 +20,6 @@ import {
 } from "./utils/initial-state";
 import { formSchema } from "./utils/schema";
 import { CREATE_FORM, GET_FORM, UPDATE_FORM } from "./utils/queries";
-import { GET_BSDS } from "../../Apps/common/queries";
 import { Loader } from "../../Apps/common/Components";
 import { toastApolloError } from "../common/stepper/toaster";
 import { IStepContainerProps } from "../common/stepper/Step";
@@ -55,12 +54,12 @@ export default function StepsList(props: Props) {
   const [createForm, { loading: creating }] = useMutation<
     Pick<Mutation, "createForm">,
     MutationCreateFormArgs
-  >(CREATE_FORM, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(CREATE_FORM);
 
   const [updateForm, { loading: updating }] = useMutation<
     Pick<Mutation, "updateForm">,
     MutationUpdateFormArgs
-  >(UPDATE_FORM, { refetchQueries: [GET_BSDS], awaitRefetchQueries: true });
+  >(UPDATE_FORM);
 
   const [createFormTransporter, { loading: creatingFormTransporter }] =
     useMutation<


### PR DESCRIPTION
Le `refetchQueries` n'est plus nécessaire avec le notifier et causait des soucis à la création / modification des BSD.
J'ai peut être été un peu agressif sur le retrait, mais c'est plutôt du job du notifier que du refetch pour pas doubler les calls, je vous laisse juger !