### PR TITLE
Recette- refacto transporteurs BSDA

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -1328,4 +1328,38 @@ describe("Mutation.updateBsda", () => {
     expect(updatedBsda?.workerCertificationValidityLimit).toBeNull();
     expect(updatedBsda?.workerCertificationOrganisation).toBeNull();
   });
+
+  it("should be possible to re-send same transporter data after transporter signature", async () => {
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        status: "SENT",
+        transporterTransportSignatureDate: new Date()
+      },
+      transporterOpt: {
+        transporterTransportSignatureDate: new Date(),
+        transporterTransportTakenOverAt: new Date()
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsda">,
+      MutationUpdateBsdaArgs
+    >(UPDATE_BSDA, {
+      variables: {
+        id: bsda.id,
+        input: {
+          transporter: {
+            company: {
+              siret: bsda.transporters[0].transporterCompanySiret
+            }
+          }
+        }
+      }
+    });
+
+    expect(errors).toBeUndefined();
+  });
 });

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -74,7 +74,7 @@ export function getUpdatedFields({
       : {})
   };
 
-  const diff = objectDiff(flatInput, compareTo);
+  const diff = objectDiff({ ...flatInput, ...flatTransporterInput }, compareTo);
 
   return Object.keys(diff);
 }


### PR DESCRIPTION
On ne pouvait plus modifier un BSDA après signature transporteur.

![Capture d’écran 2024-02-07 à 14 59 33](https://github.com/MTES-MCT/trackdechets/assets/2269165/8380fdf5-a913-4b76-81f9-491b51a89884)

