### PR TITLE
Correction de la génération de SIRET de test

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/createTestCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createTestCompany.integration.ts
@@ -44,8 +44,8 @@ describe("createTestCompany", () => {
     await prisma.anonymousCompany.create({
       data: {
         name: "Test company",
-        siret: "00000000000001",
-        orgId: "00000000000001",
+        siret: "00000000000133", // 000001 + luhn
+        orgId: "00000000000133",
         address: "",
         codeNaf: "",
         libelleNaf: "",
@@ -55,8 +55,8 @@ describe("createTestCompany", () => {
     await prisma.anonymousCompany.create({
       data: {
         name: "Test company",
-        siret: "00000000000002",
-        orgId: "00000000000002",
+        siret: "00000000000224", // 000002 + luhn
+        orgId: "00000000000224",
         address: "",
         codeNaf: "",
         libelleNaf: "",
@@ -67,16 +67,16 @@ describe("createTestCompany", () => {
     // https://github.com/aelbore/esbuild-jest/issues/26#issuecomment-968853688
     const randomNbrChainSpy = jest.spyOn(utils, "randomNbrChain");
     (randomNbrChainSpy as jest.Mock)
-      .mockReturnValueOnce("00000001")
-      .mockReturnValueOnce("00000002")
-      .mockReturnValueOnce("00000003");
+      .mockReturnValueOnce("000001")
+      .mockReturnValueOnce("000002")
+      .mockReturnValueOnce("000003");
 
     // When
     const testSiret = await generateUniqueTestSiret();
 
     // Then
     expect(randomNbrChainSpy).toHaveBeenCalledTimes(3);
-    expect(testSiret).toEqual("00000000000003");
+    expect(testSiret).toEqual("00000000000323"); // 000003 + luhn
   });
 });
 

--- a/back/src/companies/resolvers/mutations/__tests__/createTestCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createTestCompany.integration.ts
@@ -4,7 +4,7 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { Mutation } from "../../../../generated/graphql/types";
 import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
-import { generateTestSiret } from "../createTestCompany";
+import { generateUniqueTestSiret } from "../createTestCompany";
 import * as utils from "../../../../utils";
 import { TEST_COMPANY_PREFIX } from "@td/constants";
 
@@ -26,12 +26,12 @@ describe("createTestCompany", () => {
     jest.restoreAllMocks();
   });
 
-  describe("generateTestSiret", () => {
+  describe("generateUniqueTestSiret", () => {
     it("should generate a random siret with 14 characters, and the first 6 should be the test prefix", async () => {
       // Given
 
       // When
-      const randomSiret = await generateTestSiret();
+      const randomSiret = await generateUniqueTestSiret();
 
       // Then
       expect(randomSiret.length).toEqual(14);
@@ -72,7 +72,7 @@ describe("createTestCompany", () => {
       .mockReturnValueOnce("00000003");
 
     // When
-    const testSiret = await generateTestSiret();
+    const testSiret = await generateUniqueTestSiret();
 
     // Then
     expect(randomNbrChainSpy).toHaveBeenCalledTimes(3);

--- a/back/src/companies/resolvers/mutations/__tests__/createTestCompany.test.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createTestCompany.test.ts
@@ -1,0 +1,25 @@
+import { TEST_COMPANY_PREFIX, isSiret } from "@td/constants";
+import { generateRandomTestSiret } from "../createTestCompany";
+
+describe("generateRandomTestSiret", () => {
+  it("should generate a random siret with 14 characters, and the first 6 should be the test prefix", async () => {
+    // Given
+
+    // When
+    const randomSiret = await generateRandomTestSiret();
+
+    // Then
+    expect(randomSiret.length).toEqual(14);
+    expect(randomSiret.startsWith(TEST_COMPANY_PREFIX)).toBeTruthy();
+  });
+
+  it("should generate a valid siret", async () => {
+    // Given
+
+    // When
+    const randomSiret = await generateRandomTestSiret();
+
+    // Then
+    expect(isSiret(randomSiret, false)).toBeTruthy();
+  });
+});

--- a/back/src/companies/resolvers/mutations/createTestCompany.ts
+++ b/back/src/companies/resolvers/mutations/createTestCompany.ts
@@ -2,15 +2,27 @@ import { prisma } from "@td/prisma";
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationResolvers } from "../../../generated/graphql/types";
-import { TEST_COMPANY_PREFIX } from "@td/constants";
+import { luhnCheckSum, TEST_COMPANY_PREFIX } from "@td/constants";
 import { randomNbrChain } from "../../../utils";
 
 /**
- * Generates a new test siret. Will create a random siret with a test prefix,
- * then check in the DB if such siret already exists. In that case, will try again.
+ * Generates a new test siret. Will create a random, VALID siret with a test prefix,.
  */
-export async function generateTestSiret() {
-  const randomSiret = `${TEST_COMPANY_PREFIX}${randomNbrChain(8)}`;
+export const generateRandomTestSiret = () => {
+  // https://github.com/MathieuDerelle/vat-siren-siret/blob/master/lib/vss.rb#L119
+  const chain = `${TEST_COMPANY_PREFIX}${randomNbrChain(6)}`;
+  const rest = 10 - (luhnCheckSum(chain) % 10);
+  const a = Math.floor(rest / 3);
+  const b = rest > 2 ? rest - 2 * a : rest;
+
+  return `${chain}${a}${b}`;
+};
+
+/**
+ * Generates a unique test siret. Will check in the DB if such siret already exists.
+ */
+export async function generateUniqueTestSiret() {
+  const randomSiret = generateRandomTestSiret();
 
   const testCompany = await prisma.anonymousCompany.findFirst({
     where: { siret: randomSiret }
@@ -19,7 +31,7 @@ export async function generateTestSiret() {
   // There's already a a company with this random siret.
   // Try again.
   if (testCompany) {
-    return generateTestSiret();
+    return generateUniqueTestSiret();
   }
 
   return randomSiret;
@@ -42,7 +54,7 @@ const createTestCompany: MutationResolvers["createTestCompany"] = async (
   applyAuthStrategies(context, [AuthType.Session]);
   checkIsAuthenticated(context);
   const createInput = {
-    siret: await generateTestSiret(),
+    siret: await generateUniqueTestSiret(),
     ...fixtures
   };
   const company = await prisma.anonymousCompany.create({

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -58,7 +58,7 @@ export { redisClient } from "./common/redis";
 export { client as esClient, index as esIndex } from "./common/elastic";
 export { closeMongoClient } from "./events/mongodb";
 export { hashPassword } from "./users/utils";
-export { generateTestSiret } from "./companies/resolvers/mutations/createTestCompany";
+export { generateUniqueTestSiret } from "./companies/resolvers/mutations/createTestCompany";
 export { createUser } from "./users/database";
 export { default as getReadableId, ReadableIdPrefix } from "./forms/readableId";
 export { reindex } from "./bsds/indexation/reindexBsdHelpers";

--- a/e2e/src/data/company.ts
+++ b/e2e/src/data/company.ts
@@ -1,10 +1,10 @@
 import { prisma } from "@td/prisma";
-import { generateTestSiret } from "back";
+import { generateUniqueTestSiret } from "back";
 import { CompanyType } from "@prisma/client";
 
 export const seedCompany = async company => {
   let siret: string | null = null;
-  if (!company.vatNumber) siret = await generateTestSiret();
+  if (!company.vatNumber) siret = await generateUniqueTestSiret();
 
   // Need to create an anonymous company so that fakeSirets increment
   await prisma.anonymousCompany.create({

--- a/libs/shared/constants/src/companySearchHelpers.ts
+++ b/libs/shared/constants/src/companySearchHelpers.ts
@@ -79,10 +79,7 @@ const ALLOW_TEST_COMPANY = process?.env?.["ALLOW_TEST_COMPANY"] === "true";
 
 export const BAD_CHARACTERS_REGEXP = /[\W_]/gim;
 
-/**
- * Implements the Luhn Algorithm used to validate SIRET or SIREN of identification numbers
- */
-export const luhnCheck = (num: string | number, modulo = 10): boolean => {
+export const luhnCheckSum = (num: string | number): number => {
   const arr = (num + "")
     .split("")
     .reverse()
@@ -94,7 +91,14 @@ export const luhnCheck = (num: string | number, modulo = 10): boolean => {
     0
   );
   sum += lastDigit ?? 0;
-  return sum % modulo === 0;
+  return sum;
+};
+
+/**
+ * Implements the Luhn Algorithm used to validate SIRET or SIREN of identification numbers
+ */
+export const luhnCheck = (num: string | number, modulo = 10): boolean => {
+  return luhnCheckSum(num) % modulo === 0;
 };
 
 export const cleanClue = (clue: string): string =>


### PR DESCRIPTION
# Contexte

Dernièrement j'ai modifié la façon dont on génère les SIRET de test, or cette modif n'est pas compatible avec l'algo de luhn (ni l'implémentation initiale je pense).

Je propose donc un correctif pour que les SIRET de test soient toujours des SIRET valides, parce que dans le cas contraire ça peut casser des fonctionnalités (par exemple, certains boutons dans l'interface d'admin ne s'affichent pas correctement, puisque `isSiret` retourne false).