### PR TITLE
Correction de la réindexation admin: parsing des BSD legacy en "TD-"

### DIFF
--- a/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
+++ b/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
@@ -6,6 +6,8 @@ describe("reindexBsdsUtils", () => {
       input                                                                        | expected
       ${"BSDA-20221109-9B4SV145H"}                                                 | ${["BSDA-20221109-9B4SV145H"]}
       ${"FF-20231128-KFAYQC3M0"}                                                   | ${["FF-20231128-KFAYQC3M0"]}
+      ${"TD-20-TCG03421"}                                                          | ${["TD-20-TCG03421"]}
+      ${"TD-21-AAA00792"}                                                          | ${["TD-21-AAA00792"]}
       ${""}                                                                        | ${[]}
       ${"    "}                                                                    | ${[]}
       ${"FF-20231128-KFAYQC3M0-suite"}                                             | ${["FF-20231128-KFAYQC3M0-suite"]}
@@ -34,6 +36,7 @@ describe("reindexBsdsUtils", () => {
       ${"BSDA-20221109-9B4SV145H    FF-20231128-KFAYQC3M0"}                        | ${["BSDA-20221109-9B4SV145H", "FF-20231128-KFAYQC3M0"]}
       ${"BSDA-20221109-9B4SV145H    FF-20231128-KFAYQC3M0 VHU-20220128-1HXF2PPPR"} | ${["BSDA-20221109-9B4SV145H", "FF-20231128-KFAYQC3M0", "VHU-20220128-1HXF2PPPR"]}
       ${"BSDA-202211099B4SV145H,    fF-20231128-kFayQC3M0 , vhu202201281HXF2pppr"} | ${["BSDA-20221109-9B4SV145H", "FF-20231128-KFAYQC3M0", "VHU-20220128-1HXF2PPPR"]}
+      ${"TD-20-TCG03420,    td-21-aaa00346 , vhu202201281HXF2pppr"}                | ${["TD-20-TCG03420", "TD-21-AAA00346", "VHU-20220128-1HXF2PPPR"]}
     `('"$input" should become $expected', ({ input, expected }) => {
       expect(splitIntoBsdIds(input)).toEqual(expected);
     });
@@ -50,7 +53,11 @@ describe("reindexBsdsUtils", () => {
       "BSDA-20221109-9B4SV14577",
       "BSDA-20221109-9B4SV1457-souite",
       "BSDA-20221109-9B4SV1457-ste",
-      "BSDA-20221109-9B4SV1457-ste"
+      "BSDA-20221109-9B4SV1457-ste",
+      "TD-22-TCG03420",
+      "TD-19-TCG03420",
+      "TD-20-TCG034201",
+      "TD-20-TCG0342"
     ])("%p should throw error", input => {
       expect.assertions(1);
 

--- a/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
+++ b/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
@@ -8,6 +8,7 @@ describe("reindexBsdsUtils", () => {
       ${"FF-20231128-KFAYQC3M0"}                                                   | ${["FF-20231128-KFAYQC3M0"]}
       ${"TD-20-TCG03421"}                                                          | ${["TD-20-TCG03421"]}
       ${"TD-21-AAA00792"}                                                          | ${["TD-21-AAA00792"]}
+      ${"td21aaa00792"}                                                            | ${["TD-21-AAA00792"]}
       ${""}                                                                        | ${[]}
       ${"    "}                                                                    | ${[]}
       ${"FF-20231128-KFAYQC3M0-suite"}                                             | ${["FF-20231128-KFAYQC3M0-suite"]}
@@ -57,7 +58,8 @@ describe("reindexBsdsUtils", () => {
       "TD-22-TCG03420",
       "TD-19-TCG03420",
       "TD-20-TCG034201",
-      "TD-20-TCG0342"
+      "TD-20-TCG0342",
+      "TB-20-TCG03421"
     ])("%p should throw error", input => {
       expect.assertions(1);
 

--- a/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
+++ b/back/src/bsds/indexation/__tests__/reindexBsdsUtils.test.ts
@@ -7,6 +7,7 @@ describe("reindexBsdsUtils", () => {
       ${"BSDA-20221109-9B4SV145H"}                                                 | ${["BSDA-20221109-9B4SV145H"]}
       ${"FF-20231128-KFAYQC3M0"}                                                   | ${["FF-20231128-KFAYQC3M0"]}
       ${"TD-20-TCG03421"}                                                          | ${["TD-20-TCG03421"]}
+      ${"TD-19-TCG03421"}                                                          | ${["TD-19-TCG03421"]}
       ${"TD-21-AAA00792"}                                                          | ${["TD-21-AAA00792"]}
       ${"td21aaa00792"}                                                            | ${["TD-21-AAA00792"]}
       ${""}                                                                        | ${[]}
@@ -56,10 +57,12 @@ describe("reindexBsdsUtils", () => {
       "BSDA-20221109-9B4SV1457-ste",
       "BSDA-20221109-9B4SV1457-ste",
       "TD-22-TCG03420",
-      "TD-19-TCG03420",
+      "TD-18-TCG03420",
       "TD-20-TCG034201",
       "TD-20-TCG0342",
-      "TB-20-TCG03421"
+      "TB-20-TCG03421",
+      "TD-2000-TCG03421",
+      "TD-2021-TCG03421"
     ])("%p should throw error", input => {
       expect.assertions(1);
 

--- a/back/src/bsds/indexation/reindexBsdsUtils.ts
+++ b/back/src/bsds/indexation/reindexBsdsUtils.ts
@@ -19,7 +19,7 @@ export const extractDate = (prefix: string, chunk: string) => {
   // Legacy
   if (prefix === "TD") {
     expectedLength = 2;
-    expectedRegex = new RegExp(/20|21/);
+    expectedRegex = new RegExp(/19|20|21/);
   }
 
   if (chunk.length < expectedLength) {


### PR DESCRIPTION
# Contexte

L'outil de ré-indexation admin effectue un parsing des ids envoyés par le front, or ce parsing est mal configuré pour les ID en "TD-", comme par exemple:
```
TD-20-TCG03421        
TD-20-TCG03836        
TD-21-AAA00792        
TD-20-TCG03958        
TD-20-TCG03389        
TD-20-TCG03419        
TD-20-TCG04088        
TD-20-TCG03381        
TD-20-TCG02856   
```


