### PR TITLE
[TRA-13277] Nouveau statut STANDBY pour les entreprises qui n'ont pas pu être vérifiées

### DIFF
--- a/back/src/companies/resolvers/Mutation.ts
+++ b/back/src/companies/resolvers/Mutation.ts
@@ -25,6 +25,7 @@ import deleteCompany from "./mutations/deleteCompany";
 import createAnonymousCompany from "./mutations/createAnonymousCompany";
 import { addSignatureAutomation } from "./mutations/addSignatureAutomation";
 import { removeSignatureAutomation } from "./mutations/removeSignatureAutomation";
+import standbyCompanyByAdmin from "./mutations/standbyCompanyByAdmin";
 
 const Mutation: MutationResolvers = {
   createCompany,
@@ -47,6 +48,7 @@ const Mutation: MutationResolvers = {
   updateWorkerCertification,
   deleteWorkerCertification,
   verifyCompanyByAdmin,
+  standbyCompanyByAdmin,
   sendVerificationCodeLetter,
   createTestCompany,
   deleteCompany,

--- a/back/src/companies/resolvers/mutations/__tests__/standbyCompanyByAdmin.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/standbyCompanyByAdmin.integration.ts
@@ -1,0 +1,103 @@
+import { CompanyVerificationStatus, UserRole } from "@prisma/client";
+import { gql } from "graphql-tag";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import {
+  userFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import { Mutation } from "../../../../generated/graphql/types";
+import makeClient from "../../../../__tests__/testClient";
+
+const STANDBY_COMPANY_BY_ADMIN = gql`
+  mutation StandbyCompanyByAdmin($input: StandbyCompanyByAdminInput!) {
+    standbyCompanyByAdmin(input: $input) {
+      id
+      verificationStatus
+      verificationComment
+      verificationMode
+    }
+  }
+`;
+
+describe("mutation standbyCompanyByAdmin", () => {
+  afterAll(resetDatabase);
+
+  it("should deny access to non admin users", async () => {
+    // Given
+    const admin = await userFactory({ isAdmin: false });
+
+    const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+      verificationStatus: CompanyVerificationStatus.TO_BE_VERIFIED
+    });
+
+    // When
+    const { mutate } = makeClient(admin);
+    const { errors } = await mutate(STANDBY_COMPANY_BY_ADMIN, {
+      variables: {
+        input: {
+          orgId: company.orgId,
+          standby: true
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toEqual([
+      expect.objectContaining({ message: "Vous n'êtes pas administrateur" })
+    ]);
+  });
+
+  it("should put the company in standby", async () => {
+    // Given
+    const admin = await userFactory({ isAdmin: false });
+
+    const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+      verificationStatus: CompanyVerificationStatus.TO_BE_VERIFIED
+    });
+
+    // When
+    const { mutate } = makeClient(admin);
+    const { data, errors } = await mutate<
+      Pick<Mutation, "standbyCompanyByAdmin">
+    >(STANDBY_COMPANY_BY_ADMIN, {
+      variables: {
+        input: {
+          orgId: company.orgId,
+          standby: true
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(data.standbyCompanyByAdmin.verificationStatus).toEqual("STANDBY");
+  });
+
+  it("should get the company out of standby", async () => {
+    // Given
+    const admin = await userFactory({ isAdmin: false });
+
+    const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+      verificationStatus: CompanyVerificationStatus.STANDBY
+    });
+
+    // When
+    const { mutate } = makeClient(admin);
+    const { data, errors } = await mutate<
+      Pick<Mutation, "standbyCompanyByAdmin">
+    >(STANDBY_COMPANY_BY_ADMIN, {
+      variables: {
+        input: {
+          orgId: company.orgId,
+          standby: false
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(data.standbyCompanyByAdmin.verificationStatus).toEqual(
+      "TO_BE_VERIFIED"
+    );
+  });
+});

--- a/back/src/companies/resolvers/mutations/__tests__/standbyCompanyByAdmin.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/standbyCompanyByAdmin.integration.ts
@@ -49,7 +49,7 @@ describe("mutation standbyCompanyByAdmin", () => {
 
   it("should put the company in standby", async () => {
     // Given
-    const admin = await userFactory({ isAdmin: false });
+    const admin = await userFactory({ isAdmin: true });
 
     const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
       verificationStatus: CompanyVerificationStatus.TO_BE_VERIFIED
@@ -75,7 +75,7 @@ describe("mutation standbyCompanyByAdmin", () => {
 
   it("should get the company out of standby", async () => {
     // Given
-    const admin = await userFactory({ isAdmin: false });
+    const admin = await userFactory({ isAdmin: true });
 
     const { user: _, company } = await userWithCompanyFactory(UserRole.ADMIN, {
       verificationStatus: CompanyVerificationStatus.STANDBY

--- a/back/src/companies/resolvers/mutations/standbyCompanyByAdmin.ts
+++ b/back/src/companies/resolvers/mutations/standbyCompanyByAdmin.ts
@@ -1,0 +1,27 @@
+import { CompanyVerificationStatus } from "@prisma/client";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { checkIsAdmin } from "../../../common/permissions";
+import { MutationResolvers } from "../../../generated/graphql/types";
+import { prisma } from "@td/prisma";
+import { getCompanyOrCompanyNotFound } from "../../database";
+
+const standbyCompanyByAdminResolver: MutationResolvers["standbyCompanyByAdmin"] =
+  async (parent, { input: { orgId, standby } }, context) => {
+    applyAuthStrategies(context, [AuthType.Session]);
+    checkIsAdmin(context);
+
+    const company = await getCompanyOrCompanyNotFound({ orgId });
+
+    const verifiedCompany = await prisma.company.update({
+      where: { id: company.id },
+      data: {
+        verificationStatus: standby
+          ? CompanyVerificationStatus.STANDBY
+          : CompanyVerificationStatus.TO_BE_VERIFIED
+      }
+    });
+
+    return verifiedCompany;
+  };
+
+export default standbyCompanyByAdminResolver;

--- a/back/src/companies/typeDefs/company.enums.graphql
+++ b/back/src/companies/typeDefs/company.enums.graphql
@@ -45,4 +45,8 @@ enum CompanyVerificationStatus {
   auprès du registre du commerce et des sociétés
   """
   LETTER_SENT
+  """
+  Vérification mise en pause / archivée
+  """
+  STANDBY
 }

--- a/back/src/companies/typeDefs/private/company.inputs.graphql
+++ b/back/src/companies/typeDefs/private/company.inputs.graphql
@@ -318,6 +318,11 @@ input VerifyCompanyByAdminInput {
   verificationComment: String
 }
 
+input StandbyCompanyByAdminInput {
+  orgId: String!
+  standby: Boolean!
+}
+
 input SendVerificationCodeLetterInput {
   siret: String!
 }

--- a/back/src/companies/typeDefs/private/company.mutations.graphql
+++ b/back/src/companies/typeDefs/private/company.mutations.graphql
@@ -114,6 +114,10 @@ type Mutation {
     input: SendVerificationCodeLetterInput!
   ): CompanyForVerification!
 
+  standbyCompanyByAdmin(
+    input: StandbyCompanyByAdminInput!
+  ): CompanyForVerification!
+
   """
   USAGE INTERNE
   Génère un N°SIRET factice pouvant être utilisé pour le

--- a/front/src/admin/Admin.tsx
+++ b/front/src/admin/Admin.tsx
@@ -73,7 +73,7 @@ export default function Admin() {
         </Accordion>
       </SideBar>
 
-      <div className="dashboard-content">
+      <div className="dashboard-content fr-p-4w">
         <Routes>
           <Route
             path={toRelative(routes.admin.verification)}

--- a/front/src/admin/reindex/Reindex.tsx
+++ b/front/src/admin/reindex/Reindex.tsx
@@ -53,7 +53,7 @@ function Reindex() {
   };
 
   return (
-    <div className="fr-px-4w fr-py-2w">
+    <div>
       <Formik
         initialValues={{
           ids: ""

--- a/front/src/admin/user/anonymizeUser.tsx
+++ b/front/src/admin/user/anonymizeUser.tsx
@@ -19,7 +19,7 @@ function AnonymizeUser() {
   >(ANONYMIZE_USER);
 
   return (
-    <div className="tw-mx-2">
+    <div>
       <Formik
         initialValues={{
           id: ""

--- a/front/src/admin/verification/CompaniesVerificationTable.scss
+++ b/front/src/admin/verification/CompaniesVerificationTable.scss
@@ -30,3 +30,7 @@
     padding: 0.5rem;
   }
 }
+
+.textCenter {
+  text-align: center;
+}

--- a/front/src/admin/verification/CompaniesVerificationTable.tsx
+++ b/front/src/admin/verification/CompaniesVerificationTable.tsx
@@ -85,6 +85,8 @@ export default function CompaniesVerificationTable({
             verificationStatus === CompanyVerificationStatus.LetterSent
           ) {
             return <>Courrier envoyé</>;
+          } else if (verificationStatus === CompanyVerificationStatus.Standby) {
+            return <>En standby</>;
           } else {
             const verificationMode = row.original.verificationMode;
             if (verificationMode === CompanyVerificationMode.Letter) {
@@ -169,10 +171,7 @@ export default function CompaniesVerificationTable({
     prepareRow(row);
     return [
       ...row.cells.map(cell => cell.render("Cell")),
-      row.values.verificationStatus ===
-        CompanyVerificationStatus.ToBeVerified && (
-        <CompanyVerificationActions company={row.original} />
-      )
+      <CompanyVerificationActions company={row.original} />
     ];
   });
 
@@ -211,7 +210,8 @@ function VerificationStatusFilter({ column: { filterValue, setFilter } }) {
       label: "Vérifié"
     },
     { value: CompanyVerificationStatus.ToBeVerified, label: "À vérifier" },
-    { value: CompanyVerificationStatus.LetterSent, label: "Courrier envoyé" }
+    { value: CompanyVerificationStatus.LetterSent, label: "Courrier envoyé" },
+    { value: CompanyVerificationStatus.Standby, label: "En standby" }
   ];
 
   return (

--- a/front/src/admin/verification/CompaniesVerificationTable.tsx
+++ b/front/src/admin/verification/CompaniesVerificationTable.tsx
@@ -86,7 +86,7 @@ export default function CompaniesVerificationTable({
           ) {
             return <>Courrier envoyé</>;
           } else if (verificationStatus === CompanyVerificationStatus.Standby) {
-            return <>En standby</>;
+            return <>Stand by</>;
           } else {
             const verificationMode = row.original.verificationMode;
             if (verificationMode === CompanyVerificationMode.Letter) {

--- a/front/src/admin/verification/CompaniesVerificationTable.tsx
+++ b/front/src/admin/verification/CompaniesVerificationTable.tsx
@@ -163,7 +163,7 @@ export default function CompaniesVerificationTable({
       </>
     )),
     "Actions"
-  ];
+  ].map(c => <div className="textCenter fr-text--lg">{c}</div>);
 
   const tableData = page.map(row => {
     prepareRow(row);
@@ -179,10 +179,11 @@ export default function CompaniesVerificationTable({
   return (
     <>
       <Table
-        caption={`Établissements (${page.length} sur ${totalCount})`}
+        caption={`Affichage de ${page.length} établissements sur ${totalCount}`}
         data={tableData}
         headers={tableHeaders}
         fixed
+        bottomCaption
       />
 
       <Pagination

--- a/front/src/admin/verification/CompaniesVerificationTable.tsx
+++ b/front/src/admin/verification/CompaniesVerificationTable.tsx
@@ -211,7 +211,7 @@ function VerificationStatusFilter({ column: { filterValue, setFilter } }) {
     },
     { value: CompanyVerificationStatus.ToBeVerified, label: "À vérifier" },
     { value: CompanyVerificationStatus.LetterSent, label: "Courrier envoyé" },
-    { value: CompanyVerificationStatus.Standby, label: "En standby" }
+    { value: CompanyVerificationStatus.Standby, label: "Stand by" }
   ];
 
   return (

--- a/front/src/admin/verification/actions/CompanyVerificationActions.tsx
+++ b/front/src/admin/verification/actions/CompanyVerificationActions.tsx
@@ -169,7 +169,7 @@ export default function CompanyVerificationActions({
           onClick={() => {
             onStandbyCompanyByAdmin(false);
           }}
-          title="Mettre en standby"
+          title="Rétablir"
           size="large"
           className="fr-mx-1w"
           disabled={loadingStandby}
@@ -184,7 +184,7 @@ export default function CompanyVerificationActions({
           onClick={() => {
             onStandbyCompanyByAdmin(true);
           }}
-          title="Rétablir"
+          title="Mettre en standby"
           size="large"
           className="fr-mx-1w"
           disabled={loadingStandby}

--- a/front/src/admin/verification/actions/CompanyVerificationActions.tsx
+++ b/front/src/admin/verification/actions/CompanyVerificationActions.tsx
@@ -184,7 +184,7 @@ export default function CompanyVerificationActions({
           onClick={() => {
             onStandbyCompanyByAdmin(true);
           }}
-          title="Mettre en standby"
+          title="Mettre en stand by"
           size="large"
           className="fr-mx-1w"
           disabled={loadingStandby}

--- a/front/src/admin/verification/actions/CompanyVerificationActions.tsx
+++ b/front/src/admin/verification/actions/CompanyVerificationActions.tsx
@@ -8,6 +8,7 @@ import { isSiret } from "@td/constants";
 import { gql, useMutation } from "@apollo/client";
 import toast from "react-hot-toast";
 import { TOAST_DURATION } from "../../../common/config";
+import { Button } from "@codegouvfr/react-dsfr/Button";
 
 const VERIFY_COMPANY_BY_ADMIN = gql`
   mutation VerifyCompanyByAdmin($input: VerifyCompanyByAdminInput!) {
@@ -97,23 +98,28 @@ export default function CompanyVerificationActions({
   }
 
   return (
-    <div className="tw-flex tw-flex-col ">
-      <button
-        className="btn btn--primary"
-        disabled={loadingVerify}
-        onClick={onVerify}
-      >
-        Vérifier
-      </button>
+    <div className="tw-flex" style={{ justifyContent: "center" }}>
       {isSiret(company.orgId) && (
-        <button
-          disabled={loadingLetter}
-          className="btn btn--primary tw-mt-1"
+        <Button
+          priority="secondary"
+          iconId="fr-icon-mail-line"
           onClick={onSendVerificationCodeLetter}
-        >
-          Envoyer un courrier
-        </button>
+          title="Envoyer un courrier"
+          size="large"
+          className="fr-mx-1w"
+          disabled={loadingLetter}
+        />
       )}
+
+      <Button
+        priority="primary"
+        iconId="fr-icon-success-line"
+        onClick={onVerify}
+        disabled={loadingVerify}
+        title="Vérifier"
+        size="large"
+        className="fr-mx-1w"
+      />
     </div>
   );
 }

--- a/front/src/admin/verification/actions/CompanyVerifyModal.module.scss
+++ b/front/src/admin/verification/actions/CompanyVerifyModal.module.scss
@@ -1,6 +1,0 @@
-.VerifyModal {
-  textarea {
-    border: 1px black solid;
-    width: 100%;
-  }
-}

--- a/libs/back/prisma/src/migrate/migrations/169_standby_verification_status.sql
+++ b/libs/back/prisma/src/migrate/migrations/169_standby_verification_status.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "default$default"."CompanyVerificationStatus" ADD VALUE 'STANDBY';

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -32,6 +32,7 @@ enum CompanyVerificationStatus {
   TO_BE_VERIFIED
   LETTER_SENT
   VERIFIED
+  STANDBY
 }
 
 enum Seveso {


### PR DESCRIPTION
# Contexte

L'équipe support aimerait pouvoir archiver les entreprises dont la vérification est impossible (notamment, les entreprises pour lesquelles envoyer un courrier échoue).

Ces entreprises polluent le tableau de vérification et empêchent l'équipe support d'avoir une vision claire sur les nouvelles entreprises à vérifier ou les anciennes qui sont coincées.

J'ajoute donc une fonctionnalité "stand by" (wording discuté avec Anne-Sophie) pour pouvoir les archiver. Aussi, je fais passer le tableau au DSFR. 

# Démo

![demo_standby](https://github.com/MTES-MCT/trackdechets/assets/45355989/dd92237d-ec41-43ed-94b6-1b3549a3adc2)

# Ticket Favro

[Vérification Établissement : Arrivée par défaut sur le filtre "À vérifier" et créer un nouveau statut En attente avec une icône dédiée pour les demandes qui n'ont pas pu être vérifiées ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/812f76c7447d8c51e7511056?card=tra-13277)
