### PR TITLE
Hotfix release 2024.2.1 Bsda Transporters

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -97,6 +97,7 @@ describe("Mutation.Bsda.create", () => {
     const { company: destinationCompany } = await userWithCompanyFactory(
       "MEMBER"
     );
+    const transporter = await companyFactory();
     const worker = await companyFactory();
 
     const input: BsdaInput = {
@@ -121,6 +122,9 @@ describe("Mutation.Bsda.create", () => {
           phone: "contactPhone",
           mail: "contactEmail@mail.com"
         }
+      },
+      transporter: {
+        company: { siret: transporter.siret }
       },
       waste: {
         code: "06 07 01*",
@@ -160,6 +164,12 @@ describe("Mutation.Bsda.create", () => {
     expect(data.createBsda.destination!.company!.siret).toBe(
       input.destination!.company!.siret
     );
+
+    const createdBsda = await prisma.bsda.findUniqueOrThrow({
+      where: { id: data.createBsda.id }
+    });
+    // le champ dénormalisé `transportersOrgIds`doit être rempli
+    expect(createdBsda.transportersOrgIds).toEqual([transporter.siret]);
   });
 
   it("should allow creating a valid form with null sealNumbers field", async () => {

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -213,6 +213,7 @@ describe("Mutation.Bsda.duplicate", () => {
       workerCertificationCertificationNumber,
       workerCertificationValidityLimit,
       workerCertificationOrganisation,
+      transportersOrgIds,
       ...rest
     } = bsda;
 
@@ -346,7 +347,8 @@ describe("Mutation.Bsda.duplicate", () => {
       workerCertificationHasSubSectionThree,
       workerCertificationCertificationNumber,
       workerCertificationValidityLimit,
-      workerCertificationOrganisation
+      workerCertificationOrganisation,
+      transportersOrgIds
     });
 
     expect(duplicatedTransporter).toMatchObject({

--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -521,6 +521,7 @@ describe("Mutation.updateBsda", () => {
 
   it("should allow updating transporter if they didn't sign", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await companyFactory();
     const bsda = await bsdaFactory({
       opt: {
         status: "SIGNED_BY_PRODUCER",
@@ -533,6 +534,7 @@ describe("Mutation.updateBsda", () => {
 
     const input = {
       transporter: {
+        company: { siret: transporter.siret },
         transport: {
           mode: TransportMode.AIR
         }
@@ -551,6 +553,12 @@ describe("Mutation.updateBsda", () => {
     expect(data.updateBsda.transporter!.transport!.mode).toEqual(
       TransportMode.AIR
     );
+
+    const updatedBsda = await prisma.bsda.findUniqueOrThrow({
+      where: { id: bsda.id }
+    });
+    // le champ dénormalisé `transporterOrgIds` doit être mis à jour
+    expect(updatedBsda.transportersOrgIds).toEqual([transporter.siret]);
   });
 
   it("should not allow the transporter to update the worker if already signed by the producer", async () => {

--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -55,6 +55,21 @@ describe("Query.bsdas", () => {
     expect(data.bsdas.edges.length).toBe(1);
   });
 
+  it("should return bsdas associated with the user company if he is transporter", async () => {
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    await bsdaFactory({
+      opt: { transportersOrgIds: [company.siret!] },
+      transporterOpt: { transporterCompanySiret: company.siret }
+    });
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "bsdas">, QueryBsdasArgs>(
+      GET_BSDAS
+    );
+
+    expect(data.bsdas.edges.length).toBe(1);
+  });
+
   it("should return bsdas where user company is an intermediary", async () => {
     const otherCompany = await companyFactory();
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
@@ -183,6 +198,7 @@ describe("Query.bsdas", () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
 
     await bsdaFactory({
+      opt: { transportersOrgIds: [company.siret!] },
       transporterOpt: {
         transporterCompanySiret: company.siret
       }

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -26,16 +26,7 @@ export default async function bsdas(
       { emitterCompanySiret: { in: orgIdsWithListPermission } },
       { destinationCompanySiret: { in: orgIdsWithListPermission } },
       { workerCompanySiret: { in: orgIdsWithListPermission } },
-      {
-        transporters: {
-          some: {
-            OR: [
-              { transporterCompanySiret: { in: orgIdsWithListPermission } },
-              { transporterCompanyVatNumber: { in: orgIdsWithListPermission } }
-            ]
-          }
-        }
-      },
+      { transportersOrgIds: { hasSome: orgIdsWithListPermission } },
       { brokerCompanySiret: { in: orgIdsWithListPermission } },
       {
         destinationOperationNextDestinationCompanySiret: {

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -1054,4 +1054,14 @@ describe("BSDA Sealed rules checks", () => {
       {}
     );
   });
+
+  it("should auto-complete transportersOrgIds", async () => {
+    const transporter = await companyFactory();
+    const bsda = await bsdaFactory({
+      opt: { transportersOrgIds: [] },
+      transporterOpt: { transporterCompanySiret: transporter.siret }
+    });
+    const parsed = await parseBsdaInContext({ persisted: bsda }, {});
+    expect(parsed.bsda.transportersOrgIds).toEqual([transporter.siret]);
+  });
 });

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -27,6 +27,7 @@ export type EditableBsdaFields = Required<
     | "workerWorkSignatureAuthor"
     | "workerWorkSignatureDate"
     | "intermediariesOrgIds"
+    | "transportersOrgIds"
     | "transporterId"
   >
 >;

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -183,7 +183,8 @@ export const rawBsdaSchema = z.object({
     .array(intermediarySchema)
     .nullish()
     .superRefine(intermediariesRefinement),
-  intermediariesOrgIds: z.array(z.string()).optional()
+  intermediariesOrgIds: z.array(z.string()).optional(),
+  transportersOrgIds: z.array(z.string()).optional()
 });
 
 export const bsdaSchema = rawBsdaSchema
@@ -286,6 +287,16 @@ export const bsdaSchema = rawBsdaSchema
           .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
           .filter(Boolean)
       : undefined;
+
+    return val;
+  })
+  .transform(val => {
+    val.transportersOrgIds = [
+      val.transporterCompanySiret,
+      val.transporterCompanyVatNumber
+    ]
+      .filter(Boolean)
+      .filter(orgId => orgId.length > 0);
 
     return val;
   });

--- a/back/src/bsda/where.ts
+++ b/back/src/bsda/where.ts
@@ -27,26 +27,30 @@ function toPrismaBsdaWhereInput(where: BsdaWhere): Prisma.BsdaWhereInput {
     workerWorkSignatureDate: toPrismaDateFilter(
       where.worker?.work?.signature?.date
     ),
-    transporters: {
-      some: {
-        transporterCompanySiret: toPrismaStringFilter(
-          where.transporter?.company?.siret
-        ),
-        transporterCompanyVatNumber: toPrismaStringFilter(
-          where.transporter?.company?.vatNumber
-        ),
-        transporterTransportSignatureDate: toPrismaDateFilter(
-          where.transporter?.transport?.signature?.date
-        ),
-        transporterCustomInfo: toPrismaStringFilter(
-          where.transporter?.customInfo
-        ),
+    ...(where.transporter
+      ? {
+          transporters: {
+            some: {
+              transporterCompanySiret: toPrismaStringFilter(
+                where.transporter?.company?.siret
+              ),
+              transporterCompanyVatNumber: toPrismaStringFilter(
+                where.transporter?.company?.vatNumber
+              ),
+              transporterTransportSignatureDate: toPrismaDateFilter(
+                where.transporter?.transport?.signature?.date
+              ),
+              transporterCustomInfo: toPrismaStringFilter(
+                where.transporter?.customInfo
+              ),
 
-        transporterTransportPlates: toPrismaStringNullableListFilter(
-          where.transporter?.transport?.plates
-        )
-      }
-    },
+              transporterTransportPlates: toPrismaStringNullableListFilter(
+                where.transporter?.transport?.plates
+              )
+            }
+          }
+        }
+      : {}),
     destinationCompanySiret: toPrismaStringFilter(
       where.destination?.company?.siret
     ),

--- a/libs/back/prisma/src/migrate/migrations/168_add_bsda_transporterOrgIds.sql
+++ b/libs/back/prisma/src/migrate/migrations/168_add_bsda_transporterOrgIds.sql
@@ -1,0 +1,29 @@
+ALTER TABLE
+  "default$default"."Bsda"
+ADD
+  COLUMN IF NOT EXISTS "transportersOrgIds" text [] DEFAULT '{}';
+
+UPDATE
+  "default$default"."Bsda" AS Bsda
+SET
+  "transportersOrgIds" = ARRAY (
+    SELECT
+      Transporter."transporterCompanySiret"
+    FROM
+      "default$default"."BsdaTransporter" AS Transporter
+    WHERE
+      Transporter."bsdaId" = Bsda."id"
+      AND Transporter."transporterCompanySiret" IS NOT NULL
+      AND Transporter."transporterCompanySiret" <> ''
+    UNION
+    SELECT
+      Transporter."transporterCompanyVatNumber"
+    FROM
+      "default$default"."BsdaTransporter" AS Transporter
+    WHERE
+      Transporter."bsdaId" = Bsda."id"
+      AND Transporter."transporterCompanyVatNumber" IS NOT NULL
+      AND Transporter."transporterCompanyVatNumber" <> ''
+  );
+
+CREATE INDEX IF NOT EXISTS "_BsdaTransportersOrgIdsIdx" ON "default$default"."Bsda" USING GIN ("transportersOrgIds");

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1457,8 +1457,9 @@ model Bsda {
   bsdaRevisionRequests BsdaRevisionRequest[]
   intermediaries       IntermediaryBsdaAssociation[]
 
-  // denormalization - sirets and vats from intermediaries
+  // Denormalized fields, storing sirets to speed up queries and avoid expensive joins
   intermediariesOrgIds String[] @default([])
+  transportersOrgIds   String[] @default([])
 
   // partial indices _BsdaIsDeletedIdx, _BsdaIsDraftIdx see migration82_missing_indices.sql
   // array index _BsdaIntermediariesOrgIdsIdx: see 119_denormalize_bsdas_sirets.sql


### PR DESCRIPTION
# Problème de performance dans la query bsdas.


- Utilisation d'un champ dénormalisé `transporterOrgIds` sur le BSDA
https://trackdechets.zammad.com/#ticket/zoom/35831

- Fix query `bsdas` où manquaient `transporter`

