### PR TITLE
Hotfix query Bsdas transporter

### DIFF
--- a/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
+++ b/back/src/bsda/resolvers/queries/__tests__/bsdas.integration.ts
@@ -22,6 +22,11 @@ const GET_BSDAS = `
           forwarding {
             id
           }
+          transporter {
+            company {
+              siret
+            }
+          }
           metadata {
             latestRevision {
               authoringCompany {
@@ -370,5 +375,24 @@ describe("Query.bsdas", () => {
     expect(
       data.bsdas.edges[0].node.metadata.latestRevision?.authoringCompany?.siret
     ).toBe(emitter.company.siret);
+  });
+
+  it("should return transporter of bsdas associated with the user company", async () => {
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "bsdas">, QueryBsdasArgs>(
+      GET_BSDAS
+    );
+
+    expect(data.bsdas.edges.length).toBe(1);
+    expect(data.bsdas.edges[0].node.transporter?.company?.siret).toBe(
+      bsda.transporters[0].transporterCompanySiret
+    );
   });
 });

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -60,7 +60,8 @@ export default async function bsdas(
     findMany: prismaPaginationArgs =>
       bsdaRepository.findMany(where, {
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
+        orderBy: { createdAt: "desc" },
+        include: { transporters: true }
       }),
     formatNode: expandBsdaFromDb,
     ...gqlPaginationArgs


### PR DESCRIPTION
Avec la query BSDAS, le transporteur est à null
 
![image](https://github.com/MTES-MCT/trackdechets/assets/76620/0d3e4055-9cd9-4fdd-a106-e27ea23f216b)

 
Avec la query BSDA, on récupère bien le transporteur :
 
![image](https://github.com/MTES-MCT/trackdechets/assets/76620/5d4e764e-9e23-4642-a61f-ceafa9597aac)


- [Ticket Zammad](https://trackdechets.zammad.com/#ticket/zoom/35851)
