### PR TITLE
Fix Jest Flaky tests (timeouts)

### DIFF
--- a/libs/back/tests-integration/jest.config.ts
+++ b/libs/back/tests-integration/jest.config.ts
@@ -7,5 +7,6 @@ export default {
     "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   },
   moduleFileExtensions: ["ts", "js", "html"],
-  coverageDirectory: "../../../coverage/libs/back/tests-integration"
+  coverageDirectory: "../../../coverage/libs/back/tests-integration",
+  testTimeout: 10000
 };


### PR DESCRIPTION
# impossible d'upgrade jest à 30.0.0-alpha2 car ts-jest n'est pas prêt.
# Pour le moment = timeout => 10000ms

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
