### PR TITLE
Fix UI appendix 1 signature button

### DIFF
--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -20,7 +20,9 @@ import {
   InitialFormFraction,
   Query,
   QueryCompanyPrivateInfosArgs,
-  OperationMode
+  OperationMode,
+  QuerySearchCompaniesArgs,
+  CompanyType
 } from "@td/codegen-ui";
 import { emitterTypeLabels, getTransportModeLabel } from "../../constants";
 import {
@@ -64,7 +66,10 @@ import {
 } from "@td/constants";
 import { Appendix1ProducerForm } from "../../../form/bsdd/appendix1Producer/form";
 import { useQuery } from "@apollo/client";
-import { COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS } from "../../../Apps/common/queries/company/query";
+import {
+  COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS,
+  SEARCH_COMPANIES
+} from "../../../Apps/common/queries/company/query";
 import { formTransportIsPipeline } from "../../../form/bsdd/utils/packagings";
 import { getOperationModeLabel } from "../../../common/operationModes";
 import { mapBsdd } from "../../../Apps/Dashboard/bsdMapper";
@@ -485,6 +490,40 @@ const Appendix1 = ({
     : [];
 
   const formToBsdDisplay = mapBsdd(container);
+
+  const hasEcoOrganisme = Boolean(container.ecoOrganisme?.siret);
+  const { data: companiesInfos } = useQuery<
+    Pick<Query, "searchCompanies">,
+    QuerySearchCompaniesArgs
+  >(SEARCH_COMPANIES, {
+    variables: {
+      clue:
+        container?.grouping
+          ?.map(g => g.form.emitter?.company?.siret)
+          .filter(Boolean)
+          .join(",") ?? ""
+    },
+    skip: !container?.grouping?.length || !hasEcoOrganisme
+  });
+
+  const canSkipEmission =
+    container?.grouping?.reduce((dic, { form }) => {
+      const emitterSiret = form.emitter?.company?.siret;
+      const siretIsExutoire =
+        emitterSiret != null &&
+        [CompanyType.Wasteprocessor, CompanyType.Collector].every(
+          profile =>
+            !companiesInfos?.searchCompanies
+              ?.find(sc => sc.siret === emitterSiret)
+              ?.companyTypes?.includes(profile as CompanyType)
+        );
+      dic[form.readableId] =
+        (hasEcoOrganisme && !siretIsExutoire) ||
+        siretsWithAutomaticSignature.includes(emitterSiret) ||
+        Boolean(form.emitter?.isPrivateIndividual);
+      return dic;
+    }, {}) ?? {};
+
   return (
     <div className="tw-w-full">
       {container.status === FormStatus.Draft && (
@@ -540,12 +579,7 @@ const Appendix1 = ({
                     siret={siret}
                     form={form as any}
                     options={{
-                      canSkipEmission:
-                        Boolean(container.ecoOrganisme?.siret) ||
-                        siretsWithAutomaticSignature.includes(
-                          form.emitter?.company?.siret
-                        ) ||
-                        Boolean(form.emitter?.isPrivateIndividual)
+                      canSkipEmission: canSkipEmission[form.readableId]
                     }}
                   />
                 </td>


### PR DESCRIPTION
cf le bug en commentaire ici: https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13797

![image](https://github.com/MTES-MCT/trackdechets/assets/5145523/fe81efa5-a8f6-4c29-a9dd-646577c26470)


Ce problème d'affichage dérange pas mal de gens au support qui ne comprennent pas pourquoi ils ont le bouton mais ne peuvent pas signer derrière.
Le but est de tester en recette puis passer dans la foulée en hotfix.

J'ai le besoin de récupérer le companyTypes de beaucoup d'entreprises en front d'un seul coup. Après discussion avec Elias j'ai modifié `searchCompanies` pour supporter un cas particulier de sirets séparés par des virgules.