### PR TITLE
[tra-11634]Retirer le champ 'Numéro de notification ou de document' lorsque l'entreprise est française

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
@@ -95,7 +95,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
   ]);
 
   const TODAY = new Date();
-  const isFRCompany = nextDestination?.company?.siret ? true : false;
+  const isFRCompany = Boolean(nextDestination?.company?.siret);
   const showNotificationNumber =
     (!isFRCompany && noTraceability) || isExtraEuropeanCompany;
 

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
@@ -95,6 +95,9 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
   ]);
 
   const TODAY = new Date();
+  const isFRCompany = nextDestination?.company?.siret ? true : false;
+  const showNotificationNumber =
+    (!isFRCompany && noTraceability) || isExtraEuropeanCompany;
 
   return (
     <Form>
@@ -235,18 +238,22 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
             />
           )}
           <div className="form__row">
-            <label>
-              Numéro de notification ou de document{" "}
-              {!isExtraEuropeanCompany ? "(optionnel)" : ""}{" "}
-              <Tooltip msg="En cas d'export, indiquer ici le N° du document prévu ou le numéro de notification prévue à l'annexe I-B du règlement N°1013/2006 - Format PPNNNN (PP: code pays NNNN: numéro d'ordre)" />
-            </label>
-            <Field
-              type="text"
-              name="nextDestination.notificationNumber"
-              className="td-input"
-              placeholder="PPNNNN (PP: code pays, NNNN: numéro d'ordre)"
-              required={isExtraEuropeanCompany}
-            />
+            {showNotificationNumber && (
+              <>
+                <label>
+                  Numéro de notification ou de document{" "}
+                  {!isExtraEuropeanCompany ? "(optionnel)" : ""}{" "}
+                  <Tooltip msg="En cas d'export, indiquer ici le N° du document prévu ou le numéro de notification prévue à l'annexe I-B du règlement N°1013/2006 - Format PPNNNN (PP: code pays NNNN: numéro d'ordre)" />
+                </label>
+                <Field
+                  type="text"
+                  name="nextDestination.notificationNumber"
+                  className="td-input"
+                  placeholder="PPNNNN (PP: code pays, NNNN: numéro d'ordre)"
+                  required={isExtraEuropeanCompany}
+                />
+              </>
+            )}
             {isExtraEuropeanCompany && (
               <ExtraEuropeanCompanyManualInput
                 name="nextDestination.company"


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-11634) lié avec [[tra-13776]Revoir le format du champ 'Numéro de notification et de document' lors d'un envoi à l'étranger](https://github.com/MTES-MCT/trackdechets/pull/3107)

<img width="677" alt="Screenshot 2024-02-20 at 12 16 17" src="https://github.com/MTES-MCT/trackdechets/assets/37509748/b796a15b-4e38-44ab-833c-199b87877666">

