### PR TITLE
Perf - Sort by rowNumber for all bsds

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -240,6 +240,7 @@ describe("Mutation.Bsda.duplicate", () => {
       "id",
       "createdAt",
       "updatedAt",
+      "rowNumber",
       "isDraft",
       "isDeleted",
       "status",

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -51,7 +51,7 @@ export default async function bsdas(
     findMany: prismaPaginationArgs =>
       bsdaRepository.findMany(where, {
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" },
+        orderBy: { rowNumber: "desc" },
         include: { transporters: true }
       }),
     formatNode: expandBsdaFromDb,

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -75,6 +75,9 @@ export function graphQlInputToZodBsda(
  */
 export function prismaToZodBsda(bsda: PrismaBsdaForParsing): ZodBsda {
   const {
+    createdAt,
+    updatedAt,
+    rowNumber,
     transporters,
     wasteCode,
     destinationPlannedOperationCode,

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -554,7 +554,7 @@ export function flattenBsdasriInput(
     | "grouping"
     | "synthesizing"
   >
-): Partial<Prisma.BsdasriCreateInput> {
+) {
   return safeInput({
     ...flattenWasteInput(formInput),
 

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -38,7 +38,7 @@ import {
   chain,
   undefinedOrDefault
 } from "../common/converter";
-import { Prisma, Bsdasri, BsdasriStatus } from "@prisma/client";
+import { Bsdasri, BsdasriStatus } from "@prisma/client";
 import { Decimal } from "decimal.js-light";
 import { getTransporterCompanyOrgId } from "@td/constants";
 import { BsdasriForElastic } from "./elastic";

--- a/back/src/bsdasris/edition.ts
+++ b/back/src/bsdasris/edition.ts
@@ -13,6 +13,7 @@ type EditableBsdasriFields = Required<
     | "id"
     | "createdAt"
     | "updatedAt"
+    | "rowNumber"
     | "isDraft"
     | "isDeleted"
     | "status"

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -50,6 +50,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     id,
     createdAt,
     updatedAt,
+    rowNumber,
 
     emissionSignatoryId,
     emitterEmissionSignatureDate,

--- a/back/src/bsdasris/resolvers/queries/bsdasris.ts
+++ b/back/src/bsdasris/resolvers/queries/bsdasris.ts
@@ -50,7 +50,7 @@ const bsdasrisResolver: QueryResolvers["bsdasris"] = async (
     findMany: prismaPaginationArgs =>
       bsdasriRepository.findMany(where, {
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
+        orderBy: { rowNumber: "desc" }
       }),
     formatNode: expandBsdasriFromDB,
     ...gqlPaginationArgs

--- a/back/src/bsffs/edition/bsffEdition.ts
+++ b/back/src/bsffs/edition/bsffEdition.ts
@@ -20,6 +20,7 @@ type EditableBsffFields = Required<
     | "id"
     | "createdAt"
     | "updatedAt"
+    | "rowNumber"
     | "isDraft"
     | "isDeleted"
     | "status"

--- a/back/src/bsffs/resolvers/queries/bsffs.ts
+++ b/back/src/bsffs/resolvers/queries/bsffs.ts
@@ -48,7 +48,7 @@ const bsffs: QueryResolvers["bsffs"] = async (
       findManyBsff({
         where,
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
+        orderBy: { rowNumber: "desc" }
       }),
     formatNode: expandBsffFromDB,
     ...gqlPaginationArgs

--- a/back/src/bspaoh/resolvers/queries/bspaohs.ts
+++ b/back/src/bspaoh/resolvers/queries/bspaohs.ts
@@ -53,7 +53,7 @@ export default async function bspaohs(
       bspaohRepository.findMany(where, {
         include: { transporters: true },
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
+        orderBy: { rowNumber: "desc" }
       }),
     formatNode: expandBspaohFromDb,
     ...gqlPaginationArgs

--- a/back/src/bspaoh/validation/rules.ts
+++ b/back/src/bspaoh/validation/rules.ts
@@ -26,6 +26,7 @@ type EditableBspaohFields = Required<
     | "id"
     | "createdAt"
     | "updatedAt"
+    | "rowNumber"
     | "isDeleted"
     | "status"
     | "emitterEmissionSignatureDate"

--- a/back/src/bsvhu/edition.ts
+++ b/back/src/bsvhu/edition.ts
@@ -11,6 +11,7 @@ type EditableBsvhuFields = Required<
     | "id"
     | "createdAt"
     | "updatedAt"
+    | "rowNumber"
     | "isDraft"
     | "isDeleted"
     | "status"

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -37,6 +37,7 @@ async function getDuplicateData(
     id,
     createdAt,
     updatedAt,
+    rowNumber,
     emitterEmissionSignatureAuthor,
     emitterEmissionSignatureDate,
     transporterTransportSignatureAuthor,

--- a/back/src/bsvhu/resolvers/queries/bsvhus.ts
+++ b/back/src/bsvhu/resolvers/queries/bsvhus.ts
@@ -44,7 +44,7 @@ export default async function bsvhus(
     findMany: prismaPaginationArgs =>
       bsvhuRepository.findMany(where, {
         ...prismaPaginationArgs,
-        orderBy: { createdAt: "desc" }
+        orderBy: { rowNumber: "desc" }
       }),
     formatNode: expandVhuFormFromDb,
     ...gqlPaginationArgs

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -64,7 +64,17 @@ import { FormForElastic } from "./elastic";
 
 function flattenDestinationInput(input: {
   destination?: DestinationInput | null;
-}): Partial<Prisma.FormCreateInput> {
+}): Pick<
+  Prisma.FormCreateInput,
+  | "recipientCompanyName"
+  | "recipientCompanySiret"
+  | "recipientCompanyAddress"
+  | "recipientCompanyContact"
+  | "recipientCompanyPhone"
+  | "recipientCompanyMail"
+  | "recipientCap"
+  | "recipientProcessingOperation"
+> {
   return {
     recipientCompanyName: chain(input.destination, d =>
       chain(d.company, c => c.name)
@@ -457,7 +467,7 @@ function flattenReceivedInfo(receivedInfo: ReceivedFormInput) {
 
 export function flattenTemporaryStorageDetailInput(
   tempStorageInput: TemporaryStorageDetailInput
-): Partial<Prisma.FormCreateInput> {
+) {
   return safeInput(flattenDestinationInput(tempStorageInput));
 }
 

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -19,6 +19,7 @@ type EditableBsddFields = Required<
     | "id"
     | "createdAt"
     | "updatedAt"
+    | "rowNumber"
     | "readableId"
     | "status"
     | "emittedBy"

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -242,6 +242,7 @@ describe("Mutation.duplicateForm", () => {
     const expectedSkipped = [
       "createdAt",
       "updatedAt",
+      "rowNumber",
       "readableId",
       "status",
       "emittedBy",
@@ -528,6 +529,7 @@ describe("Mutation.duplicateForm", () => {
       "id",
       "createdAt",
       "updatedAt",
+      "rowNumber",
       "readableId",
       "status",
       "recipientIsTempStorage",

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -53,7 +53,7 @@ const formsResolver: QueryResolvers["forms"] = async (_, args, context) => {
 
   const queriedForms = await prisma.form.findMany({
     ...paginationArgs,
-    orderBy: { createdAt: "desc" },
+    orderBy: { rowNumber: "desc" },
     where: {
       ...(rest.updatedAfter && {
         updatedAt: { gte: new Date(rest.updatedAfter) }

--- a/libs/back/prisma/src/migrate/migrations/171_bsdas_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/171_bsdas_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Bsda"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Bsda"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Bsda"
+) AS subquery
+WHERE "default$default"."Bsda".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Bsda"
+ADD CONSTRAINT "Bsda_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/migrate/migrations/172_forms_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/172_forms_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Form"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Form"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Form"
+) AS subquery
+WHERE "default$default"."Form".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Form"
+ADD CONSTRAINT "Form_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/migrate/migrations/173_bsffs_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/173_bsffs_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Bsff"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Bsff"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Bsff"
+) AS subquery
+WHERE "default$default"."Bsff".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Bsff"
+ADD CONSTRAINT "Bsff_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/migrate/migrations/174_bsvhus_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/174_bsvhus_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Bsvhu"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Bsvhu"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Bsvhu"
+) AS subquery
+WHERE "default$default"."Bsvhu".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Bsvhu"
+ADD CONSTRAINT "Bsvhu_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/migrate/migrations/175_bsdasris_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/175_bsdasris_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Bsdasri"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Bsdasri"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Bsdasri"
+) AS subquery
+WHERE "default$default"."Bsdasri".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Bsdasri"
+ADD CONSTRAINT "Bsdasri_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/migrate/migrations/176_bspaohs_sort.sql
+++ b/libs/back/prisma/src/migrate/migrations/176_bspaohs_sort.sql
@@ -1,0 +1,16 @@
+-- Step 1: Add the new column
+ALTER TABLE "default$default"."Bspaoh"
+ADD COLUMN IF NOT EXISTS "rowNumber" SERIAL;
+
+-- Step 2: Update the new column with auto-incremented values based on the createdAt column
+UPDATE "default$default"."Bspaoh"
+SET "rowNumber" = subquery."row_number"
+FROM (
+  SELECT id, ROW_NUMBER() OVER (ORDER BY "createdAt") AS row_number
+  FROM "default$default"."Bspaoh"
+) AS subquery
+WHERE "default$default"."Bspaoh".id = subquery.id;
+
+-- Step 3: Add a unique constraint on the new column
+ALTER TABLE "default$default"."Bspaoh"
+ADD CONSTRAINT "Bspaoh_rowNumber_ukey" UNIQUE ("rowNumber");

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -343,6 +343,7 @@ model FinalOperation {
 
 model Form {
   id                                    String                  @id @default(cuid())
+  rowNumber                             Int                     @default(autoincrement()) @unique
   createdAt                             DateTime                @default(now()) @db.Timestamptz(6)
   updatedAt                             DateTime                @updatedAt @db.Timestamptz(6)
   emitterType                           EmitterType?
@@ -899,6 +900,7 @@ enum BsvhuDestinationType {
 
 model Bsvhu {
   id        String   @id
+  rowNumber Int      @default(autoincrement()) @unique
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)
   isDraft   Boolean  @default(false)
@@ -1013,6 +1015,7 @@ model Bsdasri {
   id                                  String                  @unique
   type                                BsdasriType             @default(SIMPLE)
   status                              BsdasriStatus           @default(INITIAL)
+  rowNumber                           Int                     @default(autoincrement()) @unique
   createdAt                           DateTime                @default(now()) @db.Timestamptz(6)
   updatedAt                           DateTime                @updatedAt @db.Timestamptz(6)
   isDeleted                           Boolean?                @default(false)
@@ -1142,6 +1145,7 @@ model Bsdasri {
 
 model Bsff {
   id        String     @id
+  rowNumber Int        @default(autoincrement()) @unique
   createdAt DateTime   @default(now()) @db.Timestamptz(6)
   updatedAt DateTime   @updatedAt @db.Timestamptz(6)
   isDeleted Boolean    @default(false)
@@ -1364,6 +1368,7 @@ enum BsdaConsistence {
 
 model Bsda {
   id        String   @id
+  rowNumber Int      @default(autoincrement()) @unique
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)
   isDraft   Boolean  @default(false)
@@ -1649,6 +1654,7 @@ enum BspaohType {
 model Bspaoh {
   id String @id
 
+  rowNumber Int          @default(autoincrement()) @unique
   createdAt DateTime     @default(now()) @db.Timestamptz(6)
   updatedAt DateTime     @updatedAt @db.Timestamptz(6)
   isDeleted Boolean      @default(false)

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -327,23 +327,24 @@ model EcoOrganisme {
 // Modèle qui peut être partagé entre tous les
 // bordereaux pour calculcer la traçabilité finale
 model FinalOperation {
-  id                      String    @id @default(cuid())
-  createdAt               DateTime  @default(now()) @db.Timestamptz(6)
-  updatedAt               DateTime  @updatedAt @db.Timestamptz(6)
+  id                      String   @id @default(cuid())
+  createdAt               DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt               DateTime @updatedAt @db.Timestamptz(6)
   finalBsdReadableId      String
   operationCode           String
   quantity                Float
   destinationCompanySiret String
   destinationCompanyName  String
   // Champs spécifiques pour Form
-  Form                    Form?     @relation(fields: [formId], references: [id])
+  Form                    Form?    @relation(fields: [formId], references: [id])
   formId                  String?
+
   @@unique([formId, finalBsdReadableId])
 }
 
 model Form {
   id                                    String                  @id @default(cuid())
-  rowNumber                             Int                     @default(autoincrement()) @unique
+  rowNumber                             Int                     @unique @default(autoincrement())
   createdAt                             DateTime                @default(now()) @db.Timestamptz(6)
   updatedAt                             DateTime                @updatedAt @db.Timestamptz(6)
   emitterType                           EmitterType?
@@ -473,7 +474,7 @@ model Form {
   // Relation vers les infos de traçabilité finales
   // Cas particulier sur le BSDD avec la ventilation des quantités en plusieurs groupement
   // il peut y avoir plusieurs traitements en bout de chaîne
-  finalOperations   FinalOperation[]
+  finalOperations FinalOperation[]
 
   // partial index _FormIsDeletedIdx see migration82_missing_indices.sql
   // partial index _FormRecipientIsTempStorageIdx see 99_add_form_indices.sql
@@ -900,7 +901,7 @@ enum BsvhuDestinationType {
 
 model Bsvhu {
   id        String   @id
-  rowNumber Int      @default(autoincrement()) @unique
+  rowNumber Int      @unique @default(autoincrement())
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)
   isDraft   Boolean  @default(false)
@@ -1015,7 +1016,7 @@ model Bsdasri {
   id                                  String                  @unique
   type                                BsdasriType             @default(SIMPLE)
   status                              BsdasriStatus           @default(INITIAL)
-  rowNumber                           Int                     @default(autoincrement()) @unique
+  rowNumber                           Int                     @unique @default(autoincrement())
   createdAt                           DateTime                @default(now()) @db.Timestamptz(6)
   updatedAt                           DateTime                @updatedAt @db.Timestamptz(6)
   isDeleted                           Boolean?                @default(false)
@@ -1145,7 +1146,7 @@ model Bsdasri {
 
 model Bsff {
   id        String     @id
-  rowNumber Int        @default(autoincrement()) @unique
+  rowNumber Int        @unique @default(autoincrement())
   createdAt DateTime   @default(now()) @db.Timestamptz(6)
   updatedAt DateTime   @updatedAt @db.Timestamptz(6)
   isDeleted Boolean    @default(false)
@@ -1368,7 +1369,7 @@ enum BsdaConsistence {
 
 model Bsda {
   id        String   @id
-  rowNumber Int      @default(autoincrement()) @unique
+  rowNumber Int      @unique @default(autoincrement())
   createdAt DateTime @default(now()) @db.Timestamptz(6)
   updatedAt DateTime @updatedAt @db.Timestamptz(6)
   isDraft   Boolean  @default(false)
@@ -1654,7 +1655,7 @@ enum BspaohType {
 model Bspaoh {
   id String @id
 
-  rowNumber Int          @default(autoincrement()) @unique
+  rowNumber Int          @unique @default(autoincrement())
   createdAt DateTime     @default(now()) @db.Timestamptz(6)
   updatedAt DateTime     @updatedAt @db.Timestamptz(6)
   isDeleted Boolean      @default(false)


### PR DESCRIPTION
Suite aux problèmes de perfs observés, ajout d'une colonne `rowNumber` sur tous les bordereaux.
Elle permet de trier par cette colonne qui est unique, et donc de ne pas avoir de problème de performance lors de la pagination