### PR TITLE
[tra-10109] Rendre obligatoire la sélection de BSD initiaux dans une annexe 2

### DIFF
--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -1,22 +1,22 @@
+import { EmitterType, Form, Status } from "@prisma/client";
+import { contentAwaitsGuest, renderMail } from "@td/mail";
+import { prisma } from "@td/prisma";
+import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { runInTransaction } from "../../../common/repository/helper";
 import { MutationResolvers } from "../../../generated/graphql/types";
-import { getFirstTransporter, getFormOrFormNotFound } from "../../database";
+import { sendMail } from "../../../mailer/mailing";
 import { getAndExpandFormFromDb } from "../../converter";
+import { getFirstTransporter, getFormOrFormNotFound } from "../../database";
 import { checkCanMarkAsSealed } from "../../permissions";
+import { FormRepository, getFormRepository } from "../../repository";
 import {
   checkCanBeSealed,
-  validateForwardedInCompanies,
-  validateBeforeEmission
+  validateBeforeEmission,
+  validateForwardedInCompanies
 } from "../../validation";
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
-import { sendMail } from "../../../mailer/mailing";
-import { renderMail, contentAwaitsGuest } from "@td/mail";
-import { EmitterType, Form, Status } from "@prisma/client";
-import { FormRepository, getFormRepository } from "../../repository";
-import { prisma } from "@td/prisma";
-import { runInTransaction } from "../../../common/repository/helper";
-import { UserInputError } from "back/src/common/errors";
 
 const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   parent,

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -16,6 +16,7 @@ import { EmitterType, Form, Status } from "@prisma/client";
 import { FormRepository, getFormRepository } from "../../repository";
 import { prisma } from "@td/prisma";
 import { runInTransaction } from "../../../common/repository/helper";
+import { UserInputError } from "back/src/common/errors";
 
 const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   parent,
@@ -74,6 +75,11 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
 
     if (sealedForm.emitterType === EmitterType.APPENDIX2) {
       const groupedForms = await formRepository.findGroupedFormsById(form.id);
+      if (groupedForms.length === 0) {
+        throw new UserInputError(
+          "Veuillez sélectionner des bordereaux à regrouper afin de pouvoir publier ce bordereau de regroupement (Annexe 2)."
+        );
+      }
       // mark appendix2Forms as GROUPED if all its grouping forms are sealed
       // and quantityGrouped is equal to quantityReceived
       await formRepository.updateAppendix2Forms(groupedForms);


### PR DESCRIPTION
Message d'erreur si on tente de sceller un bsdd de groupement sans annexe 2

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-10109)
