### PR TITLE
[TRA-13611] Améliorer le contenu du mail en cas d'attente d'une validation (ou refus) d'une demande de révision

### DIFF
--- a/apps/cron/src/commands/onboarding.helpers.ts
+++ b/apps/cron/src/commands/onboarding.helpers.ts
@@ -335,12 +335,12 @@ export const sendPendingMembershipRequestToAdminDetailsEmail = async (
   await prisma.$disconnect();
 };
 
-export interface BsddRevisionRequestWithBsddIds extends BsddRevisionRequest {
-  bsdd: { id: string; readableId: string };
+export interface BsddRevisionRequestWithReadableId extends BsddRevisionRequest {
+  bsdd: { readableId: string };
 }
 
 type RequestWithApprovals =
-  | (BsddRevisionRequestWithBsddIds & {
+  | (BsddRevisionRequestWithReadableId & {
       approvals: BsddRevisionRequestApproval[];
     })
   | (BsdaRevisionRequest & {
@@ -348,7 +348,7 @@ type RequestWithApprovals =
     });
 
 type RequestWithWrappedApprovals =
-  | (BsddRevisionRequestWithBsddIds & {
+  | (BsddRevisionRequestWithReadableId & {
       approvals: (BsddRevisionRequestApproval & {
         admins: User[];
         company: Company;
@@ -416,10 +416,7 @@ export const getPendingBSDDRevisionRequestsWithAdmins = async (
       createdAt: { gte: requestDateGt, lt: requestDateLt },
       status: RevisionRequestStatus.PENDING
     },
-    include: {
-      approvals: true,
-      bsdd: { select: { id: true, readableId: true } }
-    }
+    include: { approvals: true, bsdd: { select: { readableId: true } } }
   });
 
   // Add admins to requests
@@ -472,10 +469,10 @@ export const sendPendingRevisionRequestToAdminDetailsEmail = async (
           const variables = {
             requestCreatedAt: formatDate(request.createdAt),
             bsdReadableId:
-              (request as BsddRevisionRequestWithBsddIds).bsdd?.readableId ??
+              (request as BsddRevisionRequestWithReadableId).bsdd?.readableId ??
               (request as BsdaRevisionRequest).bsdaId,
             bsdId:
-              (request as BsddRevisionRequestWithBsddIds).bsdd?.id ??
+              (request as BsddRevisionRequestWithReadableId).bsddId ??
               (request as BsdaRevisionRequest).bsdaId,
             companyName: approval.company.name,
             companyOrgId: approval.company.orgId

--- a/apps/cron/src/commands/onboarding.helpers.ts
+++ b/apps/cron/src/commands/onboarding.helpers.ts
@@ -335,12 +335,12 @@ export const sendPendingMembershipRequestToAdminDetailsEmail = async (
   await prisma.$disconnect();
 };
 
-export interface BsddRevisionRequestWithReadableId extends BsddRevisionRequest {
-  bsdd: { readableId: string };
+export interface BsddRevisionRequestWithBsddIds extends BsddRevisionRequest {
+  bsdd: { id: string; readableId: string };
 }
 
 type RequestWithApprovals =
-  | (BsddRevisionRequestWithReadableId & {
+  | (BsddRevisionRequestWithBsddIds & {
       approvals: BsddRevisionRequestApproval[];
     })
   | (BsdaRevisionRequest & {
@@ -348,7 +348,7 @@ type RequestWithApprovals =
     });
 
 type RequestWithWrappedApprovals =
-  | (BsddRevisionRequestWithReadableId & {
+  | (BsddRevisionRequestWithBsddIds & {
       approvals: (BsddRevisionRequestApproval & {
         admins: User[];
         company: Company;
@@ -416,7 +416,10 @@ export const getPendingBSDDRevisionRequestsWithAdmins = async (
       createdAt: { gte: requestDateGt, lt: requestDateLt },
       status: RevisionRequestStatus.PENDING
     },
-    include: { approvals: true, bsdd: { select: { readableId: true } } }
+    include: {
+      approvals: true,
+      bsdd: { select: { id: true, readableId: true } }
+    }
   });
 
   // Add admins to requests
@@ -469,7 +472,10 @@ export const sendPendingRevisionRequestToAdminDetailsEmail = async (
           const variables = {
             requestCreatedAt: formatDate(request.createdAt),
             bsdReadableId:
-              (request as BsddRevisionRequestWithReadableId).bsdd?.readableId ??
+              (request as BsddRevisionRequestWithBsddIds).bsdd?.readableId ??
+              (request as BsdaRevisionRequest).bsdaId,
+            bsdId:
+              (request as BsddRevisionRequestWithBsddIds).bsdd?.id ??
               (request as BsdaRevisionRequest).bsdaId,
             companyName: approval.company.name,
             companyOrgId: approval.company.orgId

--- a/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
@@ -95,7 +95,7 @@ function BsdCardList({
 
   // If URL specifies a BSD id, directly open the associated revision modal
   useEffect(() => {
-    if (Boolean(bsdId)) {
+    if (bsdId) {
       setIsModalOpen(true);
       setBsdClicked({ id: bsdId ?? "" } as unknown as Bsd);
       if (bsdId?.startsWith("BSDA-")) {

--- a/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   generatePath,
   useNavigate,
   useLocation,
-  useMatch
+  useMatch,
+  useParams
 } from "react-router-dom";
 import { BsdCardListProps } from "./bsdCardListTypes";
 import BsdCard from "../BsdCard/BsdCard";
@@ -57,6 +58,7 @@ function BsdCardList({
   siretsWithAutomaticSignature
 }: BsdCardListProps): JSX.Element {
   const navigate = useNavigate();
+  const { bsdId } = useParams();
   const location = useLocation();
   const isReviewsTab =
     bsdCurrentTab === "reviewedTab" || bsdCurrentTab === "toReviewTab";
@@ -90,6 +92,19 @@ function BsdCardList({
 
   const [hasEmitterSignSecondaryCta, setHasEmitterSignSecondaryCta] =
     useState(false);
+
+  // If URL specifies a BSD id, directly open the associated revision modal
+  useEffect(() => {
+    if (Boolean(bsdId)) {
+      setIsModalOpen(true);
+      setBsdClicked({ id: bsdId ?? "" } as unknown as Bsd);
+      if (bsdId?.startsWith("BSDA-")) {
+        setValidationWorkflowType("REVIEW_BSDA_APPROVE");
+      } else {
+        setValidationWorkflowType("REVIEW_BSDD_APPROVE");
+      }
+    }
+  }, [bsdId]);
 
   const onClose = () => {
     setIsModalOpen(false);

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
@@ -14,7 +14,6 @@ import { ReviewInterface, mapRevision } from "./revisionMapper";
 import RevisionList from "./RevisionList/RevisionList";
 import { Modal } from "../../../../common/components";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { Loader } from "../../../common/Components";
 import RevisionApproveFragment from "./RevisionApproveFragment";
 import "./revisionModal.scss";
 import RevisionCancelFragment from "./RevisionCancelFragment";
@@ -25,10 +24,7 @@ import {
   MODAL_TITLE_DELETE,
   MODAL_TITLE_UPDATE
 } from "./wordingsRevision";
-import {
-  InlineLoader,
-  ModalLoader
-} from "../../../common/Components/Loader/Loaders";
+import { InlineLoader } from "../../../common/Components/Loader/Loaders";
 
 const hasBeenUpdated = revision => {
   return (
@@ -135,7 +131,7 @@ const RevisionModal = ({
     ) {
       if (onModalCloseFromParent) onModalCloseFromParent();
     }
-  }, [reviews, dataForm, dataBsda]);
+  }, [reviews, dataForm, dataBsda, onModalCloseFromParent]);
 
   const ariaLabel =
     actualActionType === ActionType.CONSUlT

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
@@ -25,6 +25,10 @@ import {
   MODAL_TITLE_DELETE,
   MODAL_TITLE_UPDATE
 } from "./wordingsRevision";
+import {
+  InlineLoader,
+  ModalLoader
+} from "../../../common/Components/Loader/Loaders";
 
 const hasBeenUpdated = revision => {
   return (
@@ -154,7 +158,13 @@ const RevisionModal = ({
   return (
     <Modal onClose={onModalCloseFromParent!} ariaLabel={ariaLabel} isOpen>
       <div className="revision-modal">
-        {(loadingFormRevision || loadingBsdaRevision) && <Loader />}
+        {(loadingFormRevision || loadingBsdaRevision) && (
+          <div className="revision-modal-loader">
+            <div>
+              <InlineLoader />
+            </div>
+          </div>
+        )}
 
         {reviewList && (
           <RevisionList reviews={reviews} title={getModalTitlePrefix()} />

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
@@ -4,7 +4,8 @@ import {
   BsdType,
   Query,
   QueryBsdaRevisionRequestsArgs,
-  QueryFormRevisionRequestsArgs
+  QueryFormRevisionRequestsArgs,
+  RevisionRequestStatus
 } from "@td/codegen-ui";
 import { useLazyQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
@@ -24,6 +25,20 @@ import {
   MODAL_TITLE_DELETE,
   MODAL_TITLE_UPDATE
 } from "./wordingsRevision";
+
+const hasBeenUpdated = revision => {
+  return (
+    revision.status === RevisionRequestStatus.Accepted ||
+    revision.status === RevisionRequestStatus.Accepted
+  );
+};
+
+const noRevisionRequestsIn = (bsdRevisions, bsdaRevisions) => {
+  return (
+    !bsdRevisions?.formRevisionRequests?.edges?.length &&
+    !bsdaRevisions?.bsdaRevisionRequests?.edges?.length
+  );
+};
 
 export enum ActionType {
   CONSUlT = "CONSUlT",
@@ -90,27 +105,52 @@ const RevisionModal = ({
     });
   };
 
+  const latestRevision = reviewList?.[0] as ReviewInterface;
+
+  let actualActionType = actionType;
+  // User had a direct link to the revision, but it has been updated since.
+  // Show consultation modal instead
+  if (
+    latestRevision &&
+    actionType === ActionType.UPDATE &&
+    hasBeenUpdated(latestRevision)
+  ) {
+    actualActionType = ActionType.CONSUlT;
+  }
+
+  const reviews = (
+    actualActionType === ActionType.CONSUlT ? reviewList : [latestRevision]
+  )?.filter(Boolean);
+
+  // If the data sent by the API is void of revisions, the bsdId is probably wrong.
+  // Don't crash & close the modal
+  useEffect(() => {
+    if (
+      (dataForm || dataBsda) && // We've got the data back
+      noRevisionRequestsIn(dataForm, dataBsda) // But it's empty
+    ) {
+      if (onModalCloseFromParent) onModalCloseFromParent();
+    }
+  }, [reviews, dataForm, dataBsda]);
+
   const ariaLabel =
-    actionType === ActionType.CONSUlT
+    actualActionType === ActionType.CONSUlT
       ? MODAL_ARIA_LABEL_CONSULT
       : MODAL_ARIA_LABEL_UPDATE;
 
   const getModalTitlePrefix = () => {
-    if (actionType === ActionType.UPDATE) {
+    if (actualActionType === ActionType.UPDATE) {
       return MODAL_TITLE_UPDATE;
     }
-    if (actionType === ActionType.CONSUlT) {
+    if (actualActionType === ActionType.CONSUlT) {
       return MODAL_TITLE_CONSULT;
     }
-    if (actionType === ActionType.DELETE) {
+    if (actualActionType === ActionType.DELETE) {
       return MODAL_TITLE_DELETE;
     }
     return "";
   };
 
-  const latestRevision = reviewList?.[0] as ReviewInterface;
-  const reviews =
-    actionType === ActionType.CONSUlT ? reviewList : [latestRevision];
   return (
     <Modal onClose={onModalCloseFromParent!} ariaLabel={ariaLabel} isOpen>
       <div className="revision-modal">
@@ -120,14 +160,14 @@ const RevisionModal = ({
           <RevisionList reviews={reviews} title={getModalTitlePrefix()} />
         )}
         <div className="revision-modal__btn">
-          {actionType === ActionType.CONSUlT && (
+          {actualActionType === ActionType.CONSUlT && (
             <Button priority="primary" onClick={onModalCloseFromParent}>
               Fermer
             </Button>
           )}
 
           {(!loadingFormRevision || !loadingBsdaRevision) &&
-            actionType === ActionType.UPDATE && (
+            actualActionType === ActionType.UPDATE && (
               <RevisionApproveFragment
                 reviewId={latestRevision?.id}
                 bsdType={bsdType}
@@ -136,7 +176,7 @@ const RevisionModal = ({
               />
             )}
           {(!loadingFormRevision || !loadingBsdaRevision) &&
-            actionType === ActionType.DELETE && (
+            actualActionType === ActionType.DELETE && (
               <RevisionCancelFragment
                 reviewId={latestRevision?.id}
                 bsdType={bsdType}

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionModal.tsx
@@ -29,7 +29,7 @@ import { InlineLoader } from "../../../common/Components/Loader/Loaders";
 const hasBeenUpdated = revision => {
   return (
     revision.status === RevisionRequestStatus.Accepted ||
-    revision.status === RevisionRequestStatus.Accepted
+    revision.status === RevisionRequestStatus.Refused
   );
 };
 

--- a/front/src/Apps/Dashboard/Components/Revision/revisionModal.scss
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionModal.scss
@@ -7,3 +7,13 @@
     }
   }
 }
+
+.revision-modal-loader {
+  min-height: 30vh;
+  display: flex;
+  justify-content: center;
+
+  :first-child {
+    display: flex;
+  }
+}

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -30,7 +30,7 @@ const routes = {
       act: "/dashboard/:siret/bsds/act",
       follow: "/dashboard/:siret/bsds/follow",
       history: "/dashboard/:siret/bsds/history",
-      toReview: "/dashboard/:siret/bsds/to-review",
+      toReview: "/dashboard/:siret/bsds/to-review/:bsdId?",
       reviewed: "/dashboard/:siret/bsds/reviewed"
     },
     bsdds: {

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -232,6 +232,7 @@ export const producersSecondOnboardingEmail: MailTemplate = {
 export const pendingRevisionRequestAdminDetailsEmail: MailTemplate<{
   requestCreatedAt: string;
   bsdReadableId: string;
+  bsdId: string;
   companyName: string;
   companyOrgId: string;
 }> = {

--- a/libs/back/mail/src/templates/mustache/pending-revision-request-admin-details.html
+++ b/libs/back/mail/src/templates/mustache/pending-revision-request-admin-details.html
@@ -12,11 +12,29 @@
 <p>
   Pour retrouver cette demande, rendez vous sur la plateforme Trackdéchets, dans
   "Mon espace", et sélectionnez votre établissement {{{companyName}}}
-  {{{companyOrgId}}}, puis le dossier "Révisions".
+  {{{companyOrgId}}}, puis le dossier "Révisions". Pour retrouver cette demande,
+  rendez vous sur la plateforme Trackdéchets, dans "Mes bordereaux", et
+  sélectionnez votre établissement {{{companyName}}} {{{companyOrgId}}}, puis
+  l'onglet "En cours" dans "Révisions", ou cliquez sur
+  <a href="{{{UI_URL}}}/dashboard/{{{companyOrgId}}}/bsds/to-review/{{{bsdId}}}"
+    >ce lien</a
+  >.
 </p>
 <br />
 <p>
   Vous pouvez accepter ou refuser la demande qui vous est proposée. L'échange
   avec l'établissement qui a proposé la demande est à privilégier si vous ne la
   comprenez pas.
+</p>
+<p>
+  Pour plus d'informations concernant la révision d'un bordereau, veuillez
+  consulter la FAQ :
+  <a
+    href="https://faq.trackdechets.fr/dechets-dangereux-classiques/informations-generales/cycle-de-vie-du-bsd/modifier-ou-supprimer-un-bsdd#modifier-certains-champs-du-bsd-grace-a-la-revision"
+    >➡️&nbsp;Modifier certains champs du BSDD grâce à la révision</a
+  >
+  <a
+    href="https://faq.trackdechets.fr/amiante/informations-generales/le-bsda-simple-collecte-sur-chantier/modifier-ou-supprimer-un-bsda#modifier-certains-champs-du-bsda-grace-a-la-revision"
+    >➡️&nbsp;Modifier certains champs du BSDA grâce à la révision</a
+  >
 </p>


### PR DESCRIPTION
# Contexte

On veut modifier le mail de rappel pour les révisions, pour le rendre plus clair pour l'utilisateur et surtout pour inclure un lien direct vers la révision en question.

Exemple de liens:
http://trackdechets.local/dashboard/98254982600013/bsds/to-review/cltflcrgq000thfk9an2pvjlm
http://trackdechets.local/dashboard/98254982600013/bsds/to-review/BSDA-20240306-A924V2BR7

# Démo

![demo_revision_direct_link](https://github.com/MTES-MCT/trackdechets/assets/45355989/44bdaedf-215b-432a-b73a-d91102f4c72f)

# Ticket Favro

[Améliorer contenu du mailing en cas d'attente d'une validation ou d'un refus d'une demande de révision : (mail : "Votre action est attendue sur une demande de révision")](https://favro.com/widget/ab14a4f0460a99a9d64d4945/c8a4ba49bef65e4df0e515aa?card=tra-13611)
