### PR TITLE
[TRA-13987] Vérifier qu'un établissement non diffusible n'est pas fermé à l'ajout du SIRET par l'utilisateur

### DIFF
--- a/back/src/companies/sirene/__tests__/redundancy.test.ts
+++ b/back/src/companies/sirene/__tests__/redundancy.test.ts
@@ -1,6 +1,10 @@
 import { redundant } from "../redundancy";
 import { ErrorCode } from "../../../common/errors";
-import { AnonymousCompanyError, SiretNotFoundError } from "../errors";
+import {
+  AnonymousCompanyError,
+  ClosedCompanyError,
+  SiretNotFoundError
+} from "../errors";
 
 const fn1 = jest.fn();
 const fn2 = jest.fn();
@@ -34,6 +38,22 @@ describe("redundant", () => {
       await fn("foo");
     } catch (err) {
       expect(err).toBeInstanceOf(AnonymousCompanyError);
+    }
+    // fn2 should not be called
+    expect(fn1).toHaveBeenCalled();
+    expect(fn2).not.toHaveBeenCalled();
+  });
+
+  it("should not call fallback function when the first function throws ClosedCompanyError", async () => {
+    const fn = redundant(fn1, fn2);
+
+    // test fn1 throws ClosedCompanyError
+    fn1.mockRejectedValueOnce(new ClosedCompanyError());
+
+    try {
+      await fn("foo");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClosedCompanyError);
     }
     // fn2 should not be called
     expect(fn1).toHaveBeenCalled();

--- a/back/src/companies/sirene/errors.ts
+++ b/back/src/companies/sirene/errors.ts
@@ -16,3 +16,9 @@ export class SiretNotFoundError extends UserInputError {
     });
   }
 }
+
+export class ClosedCompanyError extends Error {
+  constructor() {
+    super("Cet établissement est fermé");
+  }
+}

--- a/back/src/companies/sirene/redundancy.ts
+++ b/back/src/companies/sirene/redundancy.ts
@@ -1,5 +1,5 @@
 import type { AsyncReturnType } from "type-fest";
-import { AnonymousCompanyError } from "./errors";
+import { AnonymousCompanyError, ClosedCompanyError } from "./errors";
 
 /**
  * Loop over the functions until one of them returns a result
@@ -14,7 +14,10 @@ export function redundant<F extends (...args: any[]) => any>(...fns: F[]) {
         return response;
       } catch (error) {
         // fail fast for user-input errors
-        if (error instanceof AnonymousCompanyError) {
+        if (
+          error instanceof AnonymousCompanyError ||
+          error instanceof ClosedCompanyError
+        ) {
           throw error;
         }
 

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiret.tsx
@@ -17,6 +17,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import AccountCompanyAddAnonymousCompany from "./anonymous/AccountCompanyAddAnonymousCompany";
+import AccountCompanyAddSiretError from "./AccountCompanyAddSiretError";
 
 type IProps = {
   onCompanyInfos: (companyInfos) => void;
@@ -168,13 +169,6 @@ export default function AccountCompanyAddSiret({
     <div className="fr-container-fluid">
       <div className="fr-grid-row">
         <div className="fr-col-12">
-          {error && (
-            <Alert
-              severity="error"
-              title="Erreur"
-              description={error.message}
-            />
-          )}
           <Formik
             initialValues={{ siret: defaultQuery }}
             validate={values => {
@@ -316,6 +310,8 @@ export default function AccountCompanyAddSiret({
           )}
           {isClosed && closedCompanyError}
           {showIndividualInfo && !isDisabled && individualInfo}
+
+          {error && <AccountCompanyAddSiretError errorMsg={error.message} />}
         </div>
       </div>
     </div>

--- a/front/src/account/accountCompanyAdd/AccountCompanyAddSiretError.tsx
+++ b/front/src/account/accountCompanyAdd/AccountCompanyAddSiretError.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+
+const AccountCompanyAddSiretError = ({ errorMsg }) => {
+  if (errorMsg === "Cet établissement est fermé") {
+    return (
+      <Alert
+        severity="error"
+        title={errorMsg}
+        description={`Il ne peut pas être inscrit. Il est possible que votre SIRET ait changé. Pour vérifier s'il existe encore, RDV sur https://annuaire-entreprises.data.gouv.fr Pour déclarer un changement, RDV sur https://entreprendre.service-public.fr/vosdroits/F31479`}
+      />
+    );
+  }
+
+  return <Alert severity="error" title="Erreur" description={errorMsg} />;
+};
+
+export default AccountCompanyAddSiretError;


### PR DESCRIPTION
# Contexte

A la création d'une entreprise, lorsque l'utilisateur renseigne le SIRET, si l'entreprise est non-diffusible on ne regarde pas si elle est fermée. Correction de ce comportement et affichage du message d'erreur adéquat.

# Démo

![demo_closed_company](https://github.com/MTES-MCT/trackdechets/assets/45355989/36800e77-d970-4dfe-9b5a-889e76ec9a0e)

# Ticket Favro

[Vérifier qu'un établissement non diffusible n'est pas fermé à l'ajout du SIRET par l'utilisateur](https://favro.com/widget/ab14a4f0460a99a9d64d4945/c8a4ba49bef65e4df0e515aa?card=tra-13987)