### PR TITLE
Corrections pour la création d'entreprises non-diffusibles

### DIFF
--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -196,7 +196,7 @@ app.use(
         fontSrc: ["'self'", "https:", "data:"],
         frameAncestors: ["'self'"],
         imgSrc: ["'self'"],
-        objectSrc: [process.env.API_HOST, process.env.UI_HOST],
+        objectSrc: ["'self'", "data:"],
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
         styleSrc: [

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -196,7 +196,7 @@ app.use(
         fontSrc: ["'self'", "https:", "data:"],
         frameAncestors: ["'self'"],
         imgSrc: ["'self'"],
-        objectSrc: ["'none'"],
+        objectSrc: [process.env.API_HOST, process.env.UI_HOST],
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
         styleSrc: [

--- a/front/src/account/accountCompanyAdd/anonymous/AlreadyPendingAnonymousCompanyRequestInfo.tsx
+++ b/front/src/account/accountCompanyAdd/anonymous/AlreadyPendingAnonymousCompanyRequestInfo.tsx
@@ -10,8 +10,8 @@ export const AlreadyPendingAnonymousCompanyRequestInfo = () => {
         <span>
           Le SIRET renseigné correspond à celui d'une entreprise anonyme pour
           lequel une demande de création d'établissement est en cours. Pour plus
-          d'informations, veuillez contacter l'assistance Trackdéchets :
-          contact@trackdechets.beta.gouv.fr
+          d'informations, veuillez consulter cet article :
+          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
         </span>
       }
     />

--- a/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFError.tsx
+++ b/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFError.tsx
@@ -14,8 +14,8 @@ export const InvalidSirenePDFError = ({
         <span>
           Le fichier que vous tentez de charger comporte une erreur. Veuillez
           vérifier le fichier et réessayer avec un fichier PDF valide. Pour plus
-          d'informations, veuillez contacter l'assistance Trackdéchets :
-          contact@trackdechets.beta.gouv.fr
+          d'informations, veuillez consulter cet article :
+          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
         </span>
       }
     />

--- a/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFFormatError.tsx
+++ b/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFFormatError.tsx
@@ -10,8 +10,8 @@ export const InvalidSirenePDFFormatError = () => {
         <span>
           Le fichier que vous tentez de charger n'est pas au format PDF.
           Veuillez vérifier le format du fichier et réessayer avec un fichier
-          PDF valide. Pour plus d'informations, veuillez contacter l'assistance
-          Trackdéchets : contact@trackdechets.beta.gouv.fr
+          PDF valide. Pour plus d'informations, veuillez consulter cet article :
+          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
         </span>
       }
     />

--- a/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFSizeError.tsx
+++ b/front/src/account/accountCompanyAdd/anonymous/InvalidSirenePDFSizeError.tsx
@@ -10,8 +10,8 @@ export const InvalidSirenePDFSizeError = () => {
         <span>
           Le fichier que vous tentez de charger est trop lourd. Veuillez
           réessayer avec un fichier PDF conforme. Pour plus d'informations,
-          veuillez contacter l'assistance Trackdéchets :
-          contact@trackdechets.beta.gouv.fr
+          veuillez consulter cet article :
+          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
         </span>
       }
     />


### PR DESCRIPTION
# Contexte

### Problème de CORS

En recette les PDF ne s'affichent pas, avec l'erreur suivante dans la console:
```
Refused to load plugin data from 'data:application/pdf;base64,JVBERi0....' because it violates the following Content Security Policy directive: "object-src 'none'".
```

A priori cela vient d'une configuration inadaptée au niveau du `Content-Security-Policy: object-src` (explications [ici](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src)).

J'ai trouvé un thread SO qui suggère la modif à faire [ici](https://stackoverflow.com/questions/35461636/content-security-policy-syntax-for-base64-data-uris), mais je suis sûr de rien, il faudra peut-être faire des essais.

### Wording

Petits fix de wording pour éviter que les utilisateurs trouvent trop facilement le lien vers le support (on redirige plutôt vers la FAQ).

# Ticket Favro

[Entreprise Anonyme : Simplifier le processus de création d'un établissement non diffusible](https://favro.com/widget/ab14a4f0460a99a9d64d4945/812f76c7447d8c51e7511056?card=tra-13282)
