### PR TITLE
[tra-14054]Prendre en compte la sélection du SIRET après avoir décoché la case 'Destination hors UE' lors d'un code de traitement non final

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
@@ -63,6 +63,9 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
           ? "UNIDENTIFIED_EXTRA_EUROPEAN_COMPANY"
           : extraEuropeanCompany
       );
+    } else {
+      setIsExtraEuropeanCompany(false);
+      setFieldValue("nextDestination.company.extraEuropeanId", "");
     }
   }, [
     isExtraEuropeanCompany,


### PR DESCRIPTION
Il y a un message sur la destination ultérieure qui apparait lorsqu'on decoche "destinataire hors ue" alors qu'il ne devrait pas.
Il manquait la modification du state pour ne plus prendre en compte les valeur inhérantes à la desti hors ue.
Dans la démo ci-dessous on voit que le message n'apparait plus contrairement à la video demo du bug présent dans le ticket.

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14054)



https://github.com/MTES-MCT/trackdechets/assets/37509748/7aca83b5-b918-4dfc-96dd-966df5a03f3d

