### PR TITLE
Désactive  Ajouter l'information du traitement final sur le registre sortant et exhaustif pour les BSD ayant un BSD suite

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Afficher le statut avec rupture de traçabilité lorsque mentionné lors du traitement [PR 3120](https://github.com/MTES-MCT/trackdechets/pull/3120)
 - Ajouter la possibilité de Supprimer le BSDASRI pour l'émetteur lorsqu'il est Signé par l'émetteur [PR 3115](https://github.com/MTES-MCT/trackdechets/pull/3115)
 - Permettre au transporteur de modifier son champs libre / immatriculation après signature de l'entreposage provisoire depuis le tableau de bord [PR 3114](https://github.com/MTES-MCT/trackdechets/pull/3114)
-- Registres sortant et exhaustif : ajout poids et code destination finale [PR 3058](https://github.com/MTES-MCT/trackdechets/pull/3058)
 - Nouveau composant de sélection d'entreprise sur le dashboard [PR 3134](https://github.com/MTES-MCT/trackdechets/pull/3134)
 
 #### :nail_care: Améliorations

--- a/back/prisma/scripts/update-final-operations.ts
+++ b/back/prisma/scripts/update-final-operations.ts
@@ -8,7 +8,7 @@ import { operationHooksQueue } from "../../src/queue/producers/operationHook";
 @registerUpdater(
   "Update FinalOperation table",
   "Update the list of final operation code and quantity in the database",
-  true
+  false
 )
 export class UpdateFinalOperationUpdater implements Updater {
   async run() {

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -22,7 +22,6 @@ import {
   isVat,
   PROCESSING_OPERATIONS
 } from "@td/constants";
-import { operationHooksQueue } from "../../../queue/producers/operationHook";
 
 const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
   parent,
@@ -133,10 +132,12 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     return processedForm;
   });
 
-  await operationHooksQueue.add({
-    finalFormId: processedForm.id,
-    initialFormId: processedForm.id
-  });
+  // En attente des correctifs recette sur TRA-12745
+  //
+  // await operationHooksQueue.add({
+  //   finalFormId: processedForm.id,
+  //   initialFormId: processedForm.id
+  // });
 
   return getAndExpandFormFromDb(processedForm.id);
 };

--- a/back/src/queue/jobs/__tests__/operationHook.integration.ts
+++ b/back/src/queue/jobs/__tests__/operationHook.integration.ts
@@ -36,7 +36,7 @@ describe("Test Form OperationHook job", () => {
     });
   });
 
-  it("updates final operations for two temporary storages with a final operation code", async () => {
+  it.skip("updates final operations for temporary storages of 2 levels with a final operation code", async () => {
     const { user: ttrUser, company: ttr } = await userWithCompanyFactory(
       UserRole.MEMBER,
       {
@@ -194,7 +194,7 @@ describe("Test Form OperationHook job", () => {
     });
   });
 
-  it("updates final operations for temporary storage of 1 level with a final operation code only at the end", async () => {
+  it.skip("updates final operations for temporary storage of 1 level with a final operation code only at the end", async () => {
     const { user: ttrUser, company: ttr } = await userWithCompanyFactory(
       UserRole.MEMBER,
       {
@@ -276,7 +276,7 @@ describe("Test Form OperationHook job", () => {
     });
   });
 
-  it("updates final operations for noTraceability = true", async () => {
+  it.skip("updates final operations for noTraceability = true", async () => {
     const { user: ttrUser, company: ttr } = await userWithCompanyFactory(
       UserRole.MEMBER,
       {
@@ -340,7 +340,7 @@ describe("Test Form OperationHook job", () => {
     });
   });
 
-  it("updates final operations of an appendix2", async () => {
+  it.skip("updates final operations of an appendix2", async () => {
     const { user: emitter, company: emitterCompany } =
       await userWithCompanyFactory(UserRole.MEMBER);
 

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -41,10 +41,10 @@ const formatOperationCode = (code?: string) =>
 /**
  * Clean Final Operation lists
  */
-const formatFinalOperations = (val?: string[]) =>
-  val ? val.map(quant => quant.replace(/ /g, "")).join("; ") : ""; // be consistent and remove all white spaces
-const formatFinalReceptionWeights = (val?: number[]) =>
-  val ? val.map(quant => quant.toFixed(2)).join("; ") : "";
+// const formatFinalOperations = (val?: string[]) =>
+//   val ? val.map(quant => quant.replace(/ /g, "")).join("; ") : ""; // be consistent and remove all white spaces
+// const formatFinalReceptionWeights = (val?: number[]) =>
+//   val ? val.map(quant => quant.toFixed(2)).join("; ") : "";
 
 export const columns: Column[] = [
   // Dénomination, nature et quantité :
@@ -194,17 +194,18 @@ export const columns: Column[] = [
     label: "Rupture de traçabilité autorisée",
     format: formatBoolean
   },
-  {
-    field: "finalOperationCodes",
-    label:
-      "Opération(s) finale(s) réalisée(s) par la traçabilité suite (le(s) code(s) de traitement renseigné(s) par l'exutoire)",
-    format: formatFinalOperations
-  },
-  {
-    field: "finalReceptionWeights",
-    label: "Quantité(s) liée(s)",
-    format: formatFinalReceptionWeights
-  },
+  // En attente des correctifs recette sur TRA-12745
+  // {
+  //   field: "finalOperationCodes",
+  //   label:
+  //     "Opération(s) finale(s) réalisée(s) par la traçabilité suite (le(s) code(s) de traitement renseigné(s) par l'exutoire)",
+  //   format: formatFinalOperations
+  // },
+  // {
+  //   field: "finalReceptionWeights",
+  //   label: "Quantité(s) liée(s)",
+  //   format: formatFinalReceptionWeights
+  // },
   {
     field: "transporter2CompanyName",
     label: "Transporteur n°2 raison sociale"

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -331,7 +331,7 @@ describe("All wastes registry", () => {
     expect(page3.allWastes.pageInfo.hasPreviousPage).toEqual(false);
   });
 
-  it("should export the quantity received of the final destination in case of transit", async () => {
+  it.skip("should export the quantity received of the final destination in case of transit", async () => {
     const { query } = makeClient(emitter.user);
     const { user: ttrUser, company: ttr } = await userWithCompanyFactory(
       UserRole.MEMBER,

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -449,7 +449,7 @@ describe("Outgoing wastes registry", () => {
     });
   });
 
-  it("should export the quantity received of the final destination in case of transit", async () => {
+  it.skip("should export the quantity received of the final destination in case of transit", async () => {
     const { query } = makeClient(emitter.user);
     const { user: ttrUser, company: ttr } = await userWithCompanyFactory(
       UserRole.MEMBER,

--- a/back/src/registry/resolvers/queries/__tests__/queries.ts
+++ b/back/src/registry/resolvers/queries/__tests__/queries.ts
@@ -206,8 +206,9 @@ export const ALL_WASTES_TTR = gql`
         cursor
         node {
           id
-          finalReceptionWeights
-          finalOperationCodes
+          # En attente des correctifs recette sur TRA-12745
+          # finalReceptionWeights
+          # finalOperationCodes
         }
       }
     }

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -339,10 +339,7 @@ type OutgoingWaste {
   destinationCompanyAddress: String
   "Le code du traitement qui va être opéré dans l'établissement selon les annexes I et II de la directive 2008/98/CE relative aux déchets"
   destinationOperationCode: String
-  "Extra - Opération(s) finale(s) réalisée(s) par la traçabilité suite (le(s) code(s) de traitement renseigné(s) par l'exutoire)"
-  finalOperationCodes: [String]
-  "Extra - Quantité(s) liée(s) traitée(s) par la traçabilité suite, c'est à dire par l'exutoire"
-  finalReceptionWeights: [Float]
+
   "Qualification du traitement final vis-à-vis de la hiérarchie des modes de traitement définie à l'article L. 541-1 du code de l'environnement"
   destinationOperationMode: OperationMode
 
@@ -793,11 +790,6 @@ type ManagedWaste {
   "Extra - Autorisation par arrêté préfectoral, à la perte d'identification de la provenance à l'origine"
   destinationOperationNoTraceability: Boolean
 
-  "Extra - Opération(s) finale(s) réalisée(s) par la traçabilité suite (le(s) code(s) de traitement renseigné(s) par l'exutoire)"
-  finalOperationCodes: [String]
-  "Extra - Quantité(s) liée(s) traitée(s) par la traçabilité suite, c'est à dire par l'exutoire"
-  finalReceptionWeights: [Float]
-
   "Extra - Statut d'acceptation du déchet"
   destinationReceptionAcceptationStatus: WasteAcceptationStatus
 
@@ -1049,11 +1041,6 @@ type AllWaste {
 
   "Extra - Autorisation par arrêté préfectoral, à la perte d'identification de la provenance à l'origine"
   destinationOperationNoTraceability: Boolean
-
-  "Extra - Opération(s) finale(s) réalisée(s) par la traçabilité suite (le(s) code(s) de traitement renseigné(s) par l'exutoire)"
-  finalOperationCodes: [String]
-  "Extra - Quantité(s) liée(s) traitée(s) par la traçabilité suite, c'est à dire par l'exutoire"
-  finalReceptionWeights: [Float]
 
   "Extra - Statut d'acceptation du déchet"
   destinationReceptionAcceptationStatus: WasteAcceptationStatus

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -176,9 +176,10 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   wasteIsDangerous: null,
   workerCompanyName: null,
   workerCompanySiret: null,
-  workerCompanyAddress: null,
-  finalOperationCodes: null,
-  finalReceptionWeights: null
+  workerCompanyAddress: null
+  // En attente des correctifs recette sur TRA-12745
+  // finalOperationCodes: null,
+  // finalReceptionWeights: null
 };
 
 export const emptyTransportedWaste: Required<TransportedWaste> = {
@@ -305,9 +306,10 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   wasteIsDangerous: null,
   workerCompanyName: null,
   workerCompanySiret: null,
-  workerCompanyAddress: null,
-  finalOperationCodes: null,
-  finalReceptionWeights: null
+  workerCompanyAddress: null
+  // En attente des correctifs recette sur TRA-12745
+  // finalOperationCodes: null,
+  // finalReceptionWeights: null
 };
 
 export const emptyAllWaste: Required<AllWaste> = {
@@ -382,7 +384,8 @@ export const emptyAllWaste: Required<AllWaste> = {
   transporter3RecepisseIsExempted: null,
   workerCompanyName: null,
   workerCompanySiret: null,
-  workerCompanyAddress: null,
-  finalOperationCodes: null,
-  finalReceptionWeights: null
+  workerCompanyAddress: null
+  // En attente des correctifs recette sur TRA-12745
+  // finalOperationCodes: null,
+  // finalReceptionWeights: null
 };


### PR DESCRIPTION
PR permettant de désactiver la fonctionnalité [Ajouter l'information du traitement final sur le registre sortant et exhaustif pour les BSD ayant un BSD suite](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b34c3fc79210a83db2dc1238?card=tra-12745) si on n'arrive pas à corriger d'ici mardi 12/03.
