### PR TITLE
Correction des CSP pour Chrome avec (frame-src)

### DIFF
--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -40,7 +40,7 @@ app.use(
         fontSrc: ["'self'", "https:", "data:"],
         objectSrc: ["'self'", "data:"],
         frameAncestors: "'none'",
-        frameSrc: ["'self'"],
+        frameSrc: ["'self'", "data:"],
         imgSrc: ["'self'", "data:", "http:"], // allow oauth applications logos
         scriptSrc: ["'self'", "https:", "'unsafe-inline'", "'unsafe-eval'"],
         styleSrc: ["'self'", "https:", "'unsafe-inline'"],


### PR DESCRIPTION
# Contexte

Pour lire les PDF il faut l'attribut `objectSrc: ["'self'", "data:"]`. ça marche dans Firefox.

Mais Chrome se plaint d'une autre erreur:
![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/5e587369-5534-45ba-8a92-0adf5b12aaeb)

Apparemment c'est un bug connu ([thread SO ici](https://stackoverflow.com/questions/57826510/chrome-shows-frame-src-error-even-if-using-object)).

Je fais donc une nouvelle tentative avec `frameSrc: ["'self'", "data:"]`

