### PR TITLE
Utilisation d'erreurs typées pour qu'elles remontent au front

### DIFF
--- a/back/src/bsds/indexation/reindexBsdsUtils.ts
+++ b/back/src/bsds/indexation/reindexBsdsUtils.ts
@@ -1,3 +1,5 @@
+import { UserInputError } from "../../common/errors";
+
 export const extractPrefix = (chunk: string) => {
   const VALID_PREFIXES = ["BSDA", "DASRI", "FF", "VHU", "BSD", "TD", "PAOH"];
 
@@ -63,7 +65,9 @@ export const toBsdId = (chunk: string) => {
 
     return `${prefix}-${date}-${suffix}`;
   } catch (e) {
-    throw new Error(`"${chunk}" n'est pas un identifiant de bordereau valide`);
+    throw new UserInputError(
+      `"${chunk}" n'est pas un identifiant de bordereau valide`
+    );
   }
 };
 

--- a/back/src/companies/resolvers/mutations/createAnonymousCompanyRequest.helpers.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompanyRequest.helpers.ts
@@ -1,6 +1,7 @@
 import pdfParser from "pdf-parse";
 import { isSiret, nafCodes } from "@td/constants";
 import { looksHacky } from "../../../utils";
+import { UserInputError } from "../../../common/errors";
 
 export interface Info {
   PDFFormatVersion: string;
@@ -304,7 +305,7 @@ export const parseBase64 = async (pdf: string): Promise<ParsedPdf> => {
 
     return data;
   } catch (e) {
-    throw new Error(
+    throw new UserInputError(
       "Le fichier téléchargé est illisible ou n'est pas un certificat valide"
     );
   }
@@ -322,7 +323,7 @@ export const validateAndExtractSireneDataFromPDFInBase64 = async (
 
   // If it looks fishy, don't even go further. Not storing dangerous stuff
   if (looksHacky(JSON.stringify({ text, info, metadata }))) {
-    throw new Error(
+    throw new UserInputError(
       "Le fichier téléchargé est illisible ou n'est pas un certificat valide"
     );
   }
@@ -336,7 +337,7 @@ export const validateAndExtractSireneDataFromPDFInBase64 = async (
     // Get data
     data = extractData(text);
   } catch (e) {
-    throw new Error(
+    throw new UserInputError(
       "Le fichier téléchargé est illisible ou n'est pas un certificat valide"
     );
   }
@@ -345,7 +346,7 @@ export const validateAndExtractSireneDataFromPDFInBase64 = async (
 
   // Company should not be closed
   if (closedAt) {
-    throw new Error(
+    throw new UserInputError(
       `Cet établissement est fermé depuis le ${closedAt.toLocaleDateString(
         "fr-FR"
       )}`
@@ -356,7 +357,7 @@ export const validateAndExtractSireneDataFromPDFInBase64 = async (
   const now = new Date();
   const threeMonthsAgo = new Date(now.setMonth(now.getMonth() - 3));
   if (!pdfEmittedAt || pdfEmittedAt.getTime() < threeMonthsAgo.getTime()) {
-    throw new Error(
+    throw new UserInputError(
       "Le certificat d'inscription n'est pas daté de moins de trois mois"
     );
   }

--- a/back/src/companies/resolvers/mutations/createAnonymousCompanyRequest.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompanyRequest.ts
@@ -11,6 +11,7 @@ import { sendMail } from "../../../mailer/mailing";
 import { getCodeCommune } from "../../geo/getCodeCommune";
 import { validateAndExtractSireneDataFromPDFInBase64 } from "./createAnonymousCompanyRequest.helpers";
 import { base64, siret } from "../../../common/validation";
+import { UserInputError } from "../../../common/errors";
 
 const anonymousCompanyRequestInputSchema: yup.SchemaOf<CreateAnonymousCompanyRequestInput> =
   yup.object({
@@ -32,7 +33,7 @@ const createAnonymousCompanyRequestResolver: MutationResolvers["createAnonymousC
     const data = await validateAndExtractSireneDataFromPDFInBase64(pdf);
 
     if (data.siret !== siret) {
-      throw new Error(
+      throw new UserInputError(
         `Le certificat d'inscription ne correspond pas au SIRET renseigné`
       );
     }
@@ -49,7 +50,9 @@ const createAnonymousCompanyRequestResolver: MutationResolvers["createAnonymousC
       }
     });
     if (anonymousCompany || company) {
-      throw new Error(`L'entreprise avec le SIRET ${data.siret} existe déjà`);
+      throw new UserInputError(
+        `L'entreprise avec le SIRET ${data.siret} existe déjà`
+      );
     }
 
     // Verify creation request does not already exist
@@ -59,7 +62,7 @@ const createAnonymousCompanyRequestResolver: MutationResolvers["createAnonymousC
       }
     });
     if (request) {
-      throw new Error(
+      throw new UserInputError(
         `Une demande pour l'entreprise ${data.siret} est déjà en cours`
       );
     }


### PR DESCRIPTION
# Contexte

Dans mes précédentes PRs j'ai beaucoup utilisé d'`Error`, mais celles-ci sont bloquées par l'API qui renvoie un message générique "Erreur serveur".

J'utilise donc  des erreurs typées.
