### PR TITLE
[TRA-13705] Cadre 1.1 du PDF d'un BSDD: revoir l'ordre des options, renommer Entreprise française et supprimer Entreprise étrangère 

### DIFF
--- a/back/src/bsdasris/pdf/components/FormCompanyFields.tsx
+++ b/back/src/bsdasris/pdf/components/FormCompanyFields.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { getcompanyCountry } from "../../../common/pdf/components/FormCompanyFields";
 import { FormCompany } from "../../../generated/graphql/types";
+import { getcompanyCountry } from "../../../companies/validation";
 
 type FormCompanyFieldsProps = {
   company?: FormCompany | null;

--- a/back/src/bspaoh/pdf/components/FormCompanyFields.tsx
+++ b/back/src/bspaoh/pdf/components/FormCompanyFields.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { getcompanyCountry } from "../../../common/pdf/components/FormCompanyFields";
 import { FormCompany } from "../../../generated/graphql/types";
+import { getcompanyCountry } from "../../../companies/validation";
 
 type FormCompanyFieldsProps = {
   readonly company?: FormCompany | null;

--- a/back/src/common/pdf/components/FormCompanyDetails.tsx
+++ b/back/src/common/pdf/components/FormCompanyDetails.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { FormCompany } from "../../../generated/graphql/types";
+import {
+  getReadableCompanyCountry,
+  isEUCompany,
+  isFrenchCompany
+} from "../../../companies/validation";
+
+type FormCompanyDetailsProps = {
+  company?: FormCompany | null;
+  isForeignShip?: boolean;
+  isPrivateIndividual?: boolean;
+};
+
+/**
+ * Common PDF Company formatting
+ * @param company FormCompany
+ * @param isForeignShip boolean Emitter is a Foreign Ship
+ * @param isPrivateIndividual boolean Emitter is a private person not a company
+ */
+export function FormCompanyDetails({
+  company,
+  isForeignShip,
+  isPrivateIndividual
+}: FormCompanyDetailsProps) {
+  return (
+    <>
+      <p>
+        {isFrenchCompany({ company, isForeignShip, isPrivateIndividual }) && (
+          <div>
+            N° SIRET : {company?.siret}
+            <br />
+          </div>
+        )}
+        {isEUCompany({ company, isForeignShip, isPrivateIndividual }) && (
+          <div>
+            N° TVA intracommunautaire (le cas échéant) : {company?.vatNumber}
+            <br />
+          </div>
+        )}
+        {company?.extraEuropeanId && (
+          <div>
+            Identifiant d'entreprise extra-européenne :{" "}
+            {company?.extraEuropeanId}
+            <br />
+          </div>
+        )}
+        {company?.omiNumber && (
+          <div>
+            Numéro navire OMI : {company?.omiNumber}
+            <br />
+          </div>
+        )}
+        {isPrivateIndividual ||
+        (!company?.siret && !company?.vatNumber && !company?.extraEuropeanId)
+          ? "Nom Prénom"
+          : "RAISON SOCIALE"}{" "}
+        : {company?.name}
+        <br />
+        Adresse complète : {company?.address}
+        <br />
+        Pays (le cas échéant) : {getReadableCompanyCountry(company)}
+      </p>
+      <p>
+        Tel : {company?.phone}
+        <br />
+        {`Mail : `}
+        {company?.mail}
+        {!isPrivateIndividual && (
+          <>
+            <br />
+            Personne à contacter : {company?.contact}
+          </>
+        )}
+      </p>
+    </>
+  );
+}

--- a/back/src/common/pdf/components/FormCompanyFields.tsx
+++ b/back/src/common/pdf/components/FormCompanyFields.tsx
@@ -1,15 +1,10 @@
 import * as React from "react";
-import countries, { Country } from "world-countries";
-import { checkVAT } from "jsvat";
-import {
-  countries as vatCountries,
-  isVat,
-  isSiret,
-  cleanClue
-} from "@td/constants";
 import { FormCompany } from "../../../generated/graphql/types";
-
-const FRENCH_COUNTRY = countries.find(country => country.cca2 === "FR");
+import { FormCompanyDetails } from "./FormCompanyDetails";
+import {
+  isForeignCompany,
+  isFrenchCompany
+} from "../../../companies/validation";
 
 type FormCompanyFieldsProps = {
   company?: FormCompany | null;
@@ -28,105 +23,33 @@ export function FormCompanyFields({
   isForeignShip,
   isPrivateIndividual
 }: FormCompanyFieldsProps) {
-  const companyCountry = getcompanyCountry(company);
-
-  const isFrenchCompany =
-    isSiret(company?.siret) &&
-    !isForeignShip &&
-    !isPrivateIndividual &&
-    companyCountry?.cca2 === "FR";
-
-  const isEUCompany =
-    isVat(company?.vatNumber) && !isForeignShip && !isPrivateIndividual;
-
   return (
     <>
       <p>
-        <input type="checkbox" checked={isFrenchCompany} readOnly /> Entreprise
-        française
+        <input
+          type="checkbox"
+          checked={isFrenchCompany({
+            company,
+            isForeignShip,
+            isPrivateIndividual
+          })}
+          readOnly
+        />{" "}
+        Entreprise française
         <br />
         <input
           type="checkbox"
-          checked={
-            Boolean(
-              company?.extraEuropeanId || company?.vatNumber || isForeignShip
-            ) && companyCountry?.cca2 !== "FR"
-          }
+          checked={isForeignCompany({ company, isForeignShip })}
           readOnly
         />{" "}
         Entreprise étrangère
       </p>
-      <p>
-        {isFrenchCompany && (
-          <div>
-            N° SIRET : {company?.siret}
-            <br />
-          </div>
-        )}
-        {isEUCompany && (
-          <div>
-            N° TVA intracommunautaire (le cas échéant) : {company?.vatNumber}
-            <br />
-          </div>
-        )}
-        {company?.extraEuropeanId && (
-          <div>
-            Identifiant d'entreprise extra-européenne :{" "}
-            {company?.extraEuropeanId}
-            <br />
-          </div>
-        )}
-        {company?.omiNumber && (
-          <div>
-            Numéro navire OMI : {company?.omiNumber}
-            <br />
-          </div>
-        )}
-        {isPrivateIndividual ||
-        (!company?.siret && !company?.vatNumber && !company?.extraEuropeanId)
-          ? "Nom Prénom"
-          : "RAISON SOCIALE"}{" "}
-        : {company?.name}
-        <br />
-        Adresse complète : {company?.address}
-        <br />
-        Pays (le cas échéant) :{" "}
-        {!companyCountry || companyCountry?.cca2 === "FR"
-          ? "France"
-          : companyCountry?.name.common}
-      </p>
-      <p>
-        Tel : {company?.phone}
-        <br />
-        {`Mail : `}
-        {company?.mail}
-        {!isPrivateIndividual && (
-          <>
-            <br />
-            Personne à contacter : {company?.contact}
-          </>
-        )}
-      </p>
+
+      <FormCompanyDetails
+        company={company}
+        isForeignShip={isForeignShip}
+        isPrivateIndividual={isPrivateIndividual}
+      />
     </>
   );
-}
-
-export function getcompanyCountry(
-  company: FormCompany | null | undefined
-): Country | undefined {
-  if (!company) return FRENCH_COUNTRY; // default
-
-  // forcer FR si le siret est valide
-  if (company.siret && isSiret(company.siret)) {
-    return countries.find(country => country.cca2 === "FR");
-  } else if (company.vatNumber && isVat(company.vatNumber)) {
-    // trouver automatiquement le pays selon le numéro de TVA
-    const vatCountryCode = checkVAT(cleanClue(company.vatNumber), vatCountries)
-      ?.country?.isoCode.short;
-
-    return countries.find(country => country.cca2 === vatCountryCode);
-  }
-
-  // reconnaitre le pays directement dans le champ country
-  return countries.find(country => country.cca2 === company.country);
 }

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -1,6 +1,15 @@
 import * as yup from "yup";
 import { Company, CompanyType } from "@prisma/client";
-import { isForeignVat } from "@td/constants";
+import {
+  cleanClue,
+  isForeignVat,
+  isSiret,
+  isVat,
+  countries as vatCountries
+} from "@td/constants";
+import { checkVAT } from "jsvat";
+import { FormCompany } from "../generated/graphql/types";
+import countries, { Country } from "world-countries";
 
 export const receiptSchema = yup.object().shape({
   validityLimit: yup.date().required()
@@ -46,3 +55,75 @@ export function isWorker(company: Company) {
 export function isCrematorium(company: Company) {
   return company.companyTypes.includes(CompanyType.CREMATORIUM);
 }
+
+const FRENCH_COUNTRY = countries.find(country => country.cca2 === "FR");
+export const getcompanyCountry = (
+  company: FormCompany | null | undefined
+): Country | undefined => {
+  if (!company) return FRENCH_COUNTRY; // default
+
+  // forcer FR si le siret est valide
+  if (company.siret && isSiret(company.siret)) {
+    return countries.find(country => country.cca2 === "FR");
+  } else if (company.vatNumber && isVat(company.vatNumber)) {
+    // trouver automatiquement le pays selon le numéro de TVA
+    const vatCountryCode = checkVAT(cleanClue(company.vatNumber), vatCountries)
+      ?.country?.isoCode.short;
+
+    return countries.find(country => country.cca2 === vatCountryCode);
+  }
+
+  // reconnaitre le pays directement dans le champ country
+  return countries.find(country => country.cca2 === company.country);
+};
+
+export const getReadableCompanyCountry = (company?: FormCompany | null) => {
+  const companyCountry = getcompanyCountry(company);
+
+  if (!companyCountry || companyCountry?.cca2 === "FR") {
+    return "France";
+  }
+
+  return companyCountry?.name.common;
+};
+
+interface IsCompanyProps {
+  company?: FormCompany | null;
+  isForeignShip?: boolean;
+  isPrivateIndividual?: boolean;
+}
+
+export const isFrenchCompany = ({
+  company,
+  isForeignShip,
+  isPrivateIndividual
+}: IsCompanyProps) => {
+  const companyCountry = getcompanyCountry(company);
+
+  return (
+    isSiret(company?.siret) &&
+    !isForeignShip &&
+    !isPrivateIndividual &&
+    companyCountry?.cca2 === "FR"
+  );
+};
+
+export const isEUCompany = ({
+  company,
+  isForeignShip,
+  isPrivateIndividual
+}: IsCompanyProps) => {
+  return isVat(company?.vatNumber) && !isForeignShip && !isPrivateIndividual;
+};
+
+export const isForeignCompany = ({
+  company,
+  isForeignShip
+}: Omit<IsCompanyProps, "isPrivateIndividual">) => {
+  const companyCountry = getcompanyCountry(company);
+
+  return (
+    Boolean(company?.extraEuropeanId || company?.vatNumber || isForeignShip) &&
+    companyCountry?.cca2 !== "FR"
+  );
+};

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -33,6 +33,8 @@ import { buildAddress } from "../../companies/sirene/utils";
 import { packagingsEqual } from "@td/constants";
 import { CancelationStamp } from "../../common/pdf/components/CancelationStamp";
 import { getOperationModeLabel } from "../../common/operationModes";
+import { FormCompanyDetails } from "../../common/pdf/components/FormCompanyDetails";
+import { isFrenchCompany } from "../../companies/validation";
 
 type ReceiptFieldsProps = Partial<
   Pick<
@@ -400,6 +402,20 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
             <p>
               <input
                 type="checkbox"
+                checked={isFrenchCompany({
+                  company: form.emitter?.company,
+                  isForeignShip: Boolean(form.emitter?.isForeignShip),
+                  isPrivateIndividual: Boolean(
+                    form.emitter?.isPrivateIndividual
+                  )
+                })}
+                readOnly
+              />{" "}
+              L'émetteur est un établissement français
+            </p>
+            <p>
+              <input
+                type="checkbox"
                 checked={Boolean(form.emitter?.isPrivateIndividual)}
                 readOnly
               />{" "}
@@ -413,7 +429,7 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
               />{" "}
               L'émetteur est un navire étranger
             </p>
-            <FormCompanyFields
+            <FormCompanyDetails
               company={form.emitter?.company}
               isPrivateIndividual={Boolean(form.emitter?.isPrivateIndividual)}
               isForeignShip={Boolean(form.emitter?.isForeignShip)}


### PR DESCRIPTION
# Contexte

Pour le cadre 1.1 des PDF de BSDD, on veut: 
- Retirer la mention "Entreprise étrangère" qui n'est jamais complétée (car un producteur est obligatoire FR et inscrit sur Trackdéchets)
- Revoir l'ordre des différentes options 
- Renommer Entreprise française par "L'émetteur est un établissement français"

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/40f27122-c61a-4b6c-88c7-fe1fdd5c9823)

# Ticket Favro

[Dans le cadre 1.1 du PDF d'un BSDD, revoir l'ordre des options, renommer Entreprise française et supprimer Entreprise étrangère ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/c8a4ba49bef65e4df0e515aa?card=tra-13705)
