### PR TITLE
[TRA-13767] Révision du titre "dangereux" / "non dangereux" des PDF des BSDD

### DIFF
--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -30,7 +30,7 @@ import {
 import { expandFormFromDb, expandableFormIncludes } from "../converter";
 import { prisma } from "@td/prisma";
 import { buildAddress } from "../../companies/sirene/utils";
-import { packagingsEqual } from "@td/constants";
+import { isDangerous, packagingsEqual } from "@td/constants";
 import { CancelationStamp } from "../../common/pdf/components/CancelationStamp";
 import { getOperationModeLabel } from "../../common/operationModes";
 
@@ -310,6 +310,12 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
       form.wasteDetails?.packagingInfos
     );
   const qrCode = await QRCode.toString(form.readableId, { type: "svg" });
+
+  const wasteIsDangerous =
+    Boolean(form.wasteDetails?.isDangerous) ||
+    isDangerous(form.wasteDetails?.code) ||
+    Boolean(form.wasteDetails?.pop);
+
   const html = ReactDOMServer.renderToStaticMarkup(
     <Document title={form.readableId}>
       <div className="Page">
@@ -320,7 +326,13 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
           </div>
           <div className="BoxCol TextAlignCenter">
             <p>Ministère de la Transition Ecologique</p>
-            <h1>Bordereau de suivi de déchets dangereux</h1>
+            <h1>Bordereau de suivi de déchets</h1>
+            <p>
+              <input type="checkbox" checked={wasteIsDangerous} readOnly />{" "}
+              dangereux{" "}
+              <input type="checkbox" checked={!wasteIsDangerous} readOnly /> non
+              dangereux{" "}
+            </p>
             <p>Récépissé Trackdéchets</p>
           </div>
           <div className="BoxCol TextAlignCenter">

--- a/libs/shared/constants/src/WASTES.ts
+++ b/libs/shared/constants/src/WASTES.ts
@@ -5646,9 +5646,10 @@ export function toWasteTree(
     });
 }
 
-export function isDangerous(wasteCode: string): boolean {
+export function isDangerous(wasteCode?: string | null): boolean {
   if (!wasteCode) {
     return false;
   }
+
   return wasteCode.endsWith("*");
 }


### PR DESCRIPTION
# Contexte

Clarification des titres des PDF de BSDD: mention "dangereux" / "non dangereux" qui prêtait à confusion.

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/23998896-4663-4ecc-885b-163dded2cd06)

# Ticket Favro

[Revoir le titre du PDF d'un BSDD, selon si le déchet est dangereux ou non ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/c8a4ba49bef65e4df0e515aa?card=tra-13767)
