### PR TITLE
[HOTFIX] Problème modification entreprise de travaux amiante & Numéro de scellé non requis

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -368,7 +368,12 @@ describe("Mutation.Bsda.sign", () => {
           status: "SIGNED_BY_PRODUCER",
           emitterEmissionSignatureAuthor: "Emétteur",
           emitterEmissionSignatureDate: new Date(),
-          workerCompanySiret: worker.company.siret
+          workerCompanySiret: worker.company.siret,
+          // vérifie que les numéros de scellés ne sont pas obligatoires
+          // > selon l'exutoire, le numéro est obligatoire ou pas (ISDD oui, ISDND non)
+          // > et comme on ne sait pas si il va dans l'un ou l'autre, du moins auj.
+          // > on ne peut pas le rendre obligatoire"
+          wasteSealNumbers: []
         }
       });
 

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -675,11 +675,7 @@ export const editionRules: EditionRules = {
   },
   wasteSealNumbers: {
     readableFieldName: "le(s) numéro(s) de scellés",
-    sealed: { from: "WORK" },
-    required: {
-      from: "WORK",
-      when: bsda => bsda.type !== BsdaType.COLLECTION_2710
-    }
+    sealed: { from: "WORK" }
   },
   wastePop: {
     readableFieldName: "le champ sur les polluants organiques persistants",

--- a/front/src/account/fields/forms/AccountFormCompanyWorkerCertification.tsx
+++ b/front/src/account/fields/forms/AccountFormCompanyWorkerCertification.tsx
@@ -15,7 +15,7 @@ type V = {
   hasSubSectionFour: boolean;
   hasSubSectionThree: boolean;
   certificationNumber?: string | null;
-  validityLimit?: Date | null;
+  validityLimit?: string | null;
   organisation?: string | null;
 };
 
@@ -114,9 +114,7 @@ export default function AccountFormCompanyAddWorkerCertification({
         hasSubSectionFour: workerCertification.hasSubSectionFour,
         hasSubSectionThree: workerCertification.hasSubSectionThree,
         certificationNumber: workerCertification.certificationNumber,
-        validityLimit: workerCertification.validityLimit
-          ? new Date(workerCertification.validityLimit)
-          : null,
+        validityLimit: workerCertification.validityLimit ?? null,
         organisation: workerCertification.organisation
       }
     : {


### PR DESCRIPTION
### Impossible de modifier la catégorie d'entreprise de travaux amiante

https://github.com/MTES-MCT/trackdechets/assets/2269165/7dbc1cfb-daa2-4441-b859-b342b8928d42


Ça ne me semble pas être une régression de la MEP mais plutôt un bug déjà présent. Le composant `DateInput` stocke les données sous forme de string mais lors d'une modification on lui affectait un objet Date. 


- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14075)

### Le numéro de scellé BSDA ne devrait pas être obligatoire

Cf discussion https://mattermost.incubateur.net/fabnum-mte/pl/ybgpqd54ijfqbx5ydangu9ia9w

