### PR TITLE
[HOTFIX] Le numéro d'échantillon doit pouvoir être modifié jusqu'à la signature transporteur

### DIFF
--- a/back/src/forms/__tests__/edition.integration.ts
+++ b/back/src/forms/__tests__/edition.integration.ts
@@ -161,7 +161,6 @@ describe("checkEditionRules", () => {
         "wasteDetailsParcelNumbers, " +
         "wasteDetailsAnalysisReferences, " +
         "wasteDetailsLandIdentifiers, " +
-        "wasteDetailsSampleNumber, " +
         "traderCompanyName, " +
         "traderCompanySiret, " +
         "traderCompanyAddress, " +

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -121,7 +121,7 @@ export const editionRules: {
   wasteDetailsParcelNumbers: "EMISSION",
   wasteDetailsAnalysisReferences: "EMISSION",
   wasteDetailsLandIdentifiers: "EMISSION",
-  wasteDetailsSampleNumber: "EMISSION",
+  wasteDetailsSampleNumber: "TRANSPORT",
   traderCompanyName: "EMISSION",
   traderCompanySiret: "EMISSION",
   traderCompanyAddress: "EMISSION",


### PR DESCRIPTION
Le numéro d'échantillon pour les huiles noires peut être utilisé dans le cadre d'un BSD chapeau avec annexe 1 mais également dans le cas d'un BSDD classique. Dans ce second cas, ça bloque à la signature transporteur lorsque le transporteur souhaite modifier le numéro d'échantillon.

---

- [Le transporteur ne peut pas signer le bordereau - erreur "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés WasteDetailsSampleNumber"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14079)
