### PR TITLE
HOTFIX - Mauvaise sql query

### DIFF
--- a/apps/cron/src/commands/appendix1.helpers.ts
+++ b/apps/cron/src/commands/appendix1.helpers.ts
@@ -72,7 +72,8 @@ async function cleanOrphanAppendix1() {
   const where: Prisma.FormWhereInput = {
     emitterType: EmitterType.APPENDIX1_PRODUCER,
     createdAt: { lte: limitDate },
-    grouping: { none: { initialForm: {} } }
+    isDeleted: false,
+    grouping: { none: { nextForm: {} } }
   };
 
   const orphansCount = await prisma.form.count({ where });

--- a/back/prisma/scripts/clean-orphan-appendix1.ts
+++ b/back/prisma/scripts/clean-orphan-appendix1.ts
@@ -15,7 +15,7 @@ export class UnindexOrphanAppendix1 implements Updater {
 
       const where: Prisma.FormWhereInput = {
         emitterType: EmitterType.APPENDIX1_PRODUCER,
-        grouping: { none: { initialForm: {} } }
+        grouping: { none: { nextForm: {} } }
       };
 
       const orphansCount = await prisma.form.count({ where });


### PR DESCRIPTION
Problème de sql query pour le netoyage des annexes 1 orphelines.
La query sql donnait une condition sur nextFormId au lieu de initialFormId => toutes les annexes n'étant pas bordereau suite, au lieu de toutes les annexes n'ayant pas de bordereau suite