### PR TITLE
Correction des RevisionRequests avec un mode d'opération NULL

### DIFF
--- a/back/src/bsda/repository/revisionRequest/accept.ts
+++ b/back/src/bsda/repository/revisionRequest/accept.ts
@@ -94,12 +94,25 @@ async function getUpdateFromRevisionRequest(
     isCanceled
   );
 
-  return removeEmpty({
+  const result = removeEmpty({
     ...bsdaUpdate,
     status: newStatus,
     brokerRecepisseValidityLimit:
       bsdaUpdate.brokerRecepisseValidityLimit?.toISOString()
   });
+
+  // Careful. Some operation codes explicitely need a null operation mode (ex: D15)
+  if (
+    bsdaUpdate.destinationOperationCode &&
+    !bsdaUpdate.destinationOperationMode
+  ) {
+    return {
+      ...result,
+      destinationOperationMode: null
+    };
+  }
+
+  return result;
 }
 
 function getNewStatus(

--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -825,7 +825,7 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
     expect(updatedBsda.destinationOperationMode).toBe("RECYCLAGE");
   });
 
-  it("should nullify the operation mode", async () => {
+  it.each([null, undefined])("should nullify the operation mode", async () => {
     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
       "ADMIN"
     );

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -246,7 +246,25 @@ async function getUpdateFromFormRevisionRequest(
     }
   }
 
-  return [removeEmpty(bsddUpdate), removeEmpty(forwardedInUpdate)];
+  // Remove empty keys
+  const emptyBsddUpdate = removeEmpty(bsddUpdate);
+  const emptyForwardedInUpdate = removeEmpty(forwardedInUpdate);
+
+  // Careful. Some operation codes explicitely need a null operation mode (ex: D15)
+  if (
+    bsddUpdate.processingOperationDone &&
+    !bsddUpdate.destinationOperationMode
+  ) {
+    return [
+      {
+        ...emptyBsddUpdate,
+        destinationOperationMode: null
+      },
+      emptyForwardedInUpdate
+    ];
+  }
+
+  return [emptyBsddUpdate, emptyForwardedInUpdate];
 }
 
 function getNewStatus(

--- a/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
@@ -995,6 +995,52 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
     expect(updatedBsdd.destinationOperationMode).toBe("RECYCLAGE");
   });
 
+  it("should nullify the operation mode", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: companyOfSomeoneElse.siret,
+        processingOperationDone: "R 1",
+        destinationOperationMode: "VALORISATION_ENERGETIQUE"
+      }
+    });
+
+    const revisionRequest = await prisma.bsddRevisionRequest.create({
+      data: {
+        bsddId: bsdd.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        processingOperationDone: "D 15",
+        comment: "test"
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitFormRevisionRequestApproval">,
+      MutationSubmitFormRevisionRequestApprovalArgs
+    >(SUBMIT_BSDD_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(data.submitFormRevisionRequestApproval.status).toBe("ACCEPTED");
+
+    const updatedBsdd = await prisma.form.findUniqueOrThrow({
+      where: { id: bsdd.id }
+    });
+
+    expect(updatedBsdd.processingOperationDone).toBe("D 15");
+    expect(updatedBsdd.destinationOperationMode).toBeNull();
+  });
+
   it("should delete the finalOperations rows when changing operation code from a final to a non-final code", async () => {
     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
       "ADMIN"

--- a/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
@@ -995,51 +995,55 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
     expect(updatedBsdd.destinationOperationMode).toBe("RECYCLAGE");
   });
 
-  it("should nullify the operation mode", async () => {
-    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
-      "ADMIN"
-    );
-    const { user, company } = await userWithCompanyFactory("ADMIN");
-    const { mutate } = makeClient(user);
+  it.each([null, undefined])(
+    "should nullify the operation mode",
+    async mode => {
+      const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+      const { mutate } = makeClient(user);
 
-    const bsdd = await formFactory({
-      ownerId: user.id,
-      opt: {
-        emitterCompanySiret: companyOfSomeoneElse.siret,
-        processingOperationDone: "R 1",
-        destinationOperationMode: "VALORISATION_ENERGETIQUE"
-      }
-    });
+      const bsdd = await formFactory({
+        ownerId: user.id,
+        opt: {
+          emitterCompanySiret: companyOfSomeoneElse.siret,
+          processingOperationDone: "R 1",
+          destinationOperationMode: "VALORISATION_ENERGETIQUE"
+        }
+      });
 
-    const revisionRequest = await prisma.bsddRevisionRequest.create({
-      data: {
-        bsddId: bsdd.id,
-        authoringCompanyId: companyOfSomeoneElse.id,
-        approvals: { create: { approverSiret: company.siret! } },
-        processingOperationDone: "D 15",
-        comment: "test"
-      }
-    });
+      const revisionRequest = await prisma.bsddRevisionRequest.create({
+        data: {
+          bsddId: bsdd.id,
+          authoringCompanyId: companyOfSomeoneElse.id,
+          approvals: { create: { approverSiret: company.siret! } },
+          processingOperationDone: "D 15",
+          destinationOperationMode: mode,
+          comment: "test"
+        }
+      });
 
-    const { data } = await mutate<
-      Pick<Mutation, "submitFormRevisionRequestApproval">,
-      MutationSubmitFormRevisionRequestApprovalArgs
-    >(SUBMIT_BSDD_REVISION_REQUEST_APPROVAL, {
-      variables: {
-        id: revisionRequest.id,
-        isApproved: true
-      }
-    });
+      const { data } = await mutate<
+        Pick<Mutation, "submitFormRevisionRequestApproval">,
+        MutationSubmitFormRevisionRequestApprovalArgs
+      >(SUBMIT_BSDD_REVISION_REQUEST_APPROVAL, {
+        variables: {
+          id: revisionRequest.id,
+          isApproved: true
+        }
+      });
 
-    expect(data.submitFormRevisionRequestApproval.status).toBe("ACCEPTED");
+      expect(data.submitFormRevisionRequestApproval.status).toBe("ACCEPTED");
 
-    const updatedBsdd = await prisma.form.findUniqueOrThrow({
-      where: { id: bsdd.id }
-    });
+      const updatedBsdd = await prisma.form.findUniqueOrThrow({
+        where: { id: bsdd.id }
+      });
 
-    expect(updatedBsdd.processingOperationDone).toBe("D 15");
-    expect(updatedBsdd.destinationOperationMode).toBeNull();
-  });
+      expect(updatedBsdd.processingOperationDone).toBe("D 15");
+      expect(updatedBsdd.destinationOperationMode).toBeNull();
+    }
+  );
 
   it("should delete the finalOperations rows when changing operation code from a final to a non-final code", async () => {
     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -16,9 +16,14 @@ const OperationModeSelect = ({ operationCode, name }) => {
   );
 
   useEffect(() => {
+    // No mode possible. Still, explicitely set to null
+    if(!modes.length){
+      setFieldValue(name, null);
+      return;
+    }
     // If the available modes change, and only ONE option is available,
     // select it by default. Else, reset the selection
-    if (modes.length > 1) {
+    else if (modes.length > 1) {
       setFieldValue(name, undefined);
     } else {
       setFieldValue(name, modes[0]);

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -17,7 +17,7 @@ const OperationModeSelect = ({ operationCode, name }) => {
 
   useEffect(() => {
     // No mode possible. Still, explicitely set to null
-    if(!modes.length){
+    if (!modes.length) {
       setFieldValue(name, null);
       return;
     }

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -19,7 +19,6 @@ const OperationModeSelect = ({ operationCode, name }) => {
     // No mode possible. Still, explicitely set to null
     if (!modes.length) {
       setFieldValue(name, null);
-      return;
     }
     // If the available modes change, and only ONE option is available,
     // select it by default. Else, reset the selection


### PR DESCRIPTION
# Contexte

Lorsqu'une RevisionRequest est appliquée, on ne considère que ses champs non-nulls, pour éviter de modifier tout le BSD original avec des valeurs nulles. 

Or dans le cas d'une modification d'un code de traitement, parfois on veut modifier le mode de traitement pour le mettre à null. 

Il faut donc ajouter une exception pour ce use-case.
