### PR TITLE
Correction des registres éco-organisme et intermédiaires

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Le siret de l'établissement est précisé dans les emails d'invitation [PR 3151](https://github.com/MTES-MCT/trackdechets/pull/3151)
 
+#### :bug: Corrections de bugs
+
+- Correction des registres éco-organisme et intermédiaires [PR 3196](https://github.com/MTES-MCT/trackdechets/pull/3196/)
+
 #### :house: Interne
 
 - Permettre au comptes de service de télécharger les registres csv and xls de tous les sirets P[R 3207](https://github.com/MTES-MCT/trackdechets/pull/3207)

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -18,9 +18,9 @@ import {
   emptyTransportedWaste
 } from "../registry/types";
 import { extractPostalCode } from "../utils";
-import { BsdaWithTransporters } from "./types";
 import { getFirstTransporterSync } from "./database";
 import { RegistryBsda } from "../registry/elastic";
+import { BsdaForElastic } from "./elastic";
 
 const getOperationData = (bsda: Bsda) => ({
   destinationPlannedOperationCode: bsda.destinationPlannedOperationCode,
@@ -46,7 +46,7 @@ type RegistryFields =
   | "isTransportedWasteFor"
   | "isManagedWasteFor";
 export function getRegistryFields(
-  bsda: BsdaWithTransporters
+  bsda: BsdaForElastic
 ): Pick<BsdElastic, RegistryFields> {
   const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
@@ -61,17 +61,29 @@ export function getRegistryFields(
     if (bsda.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.emitterCompanySiret);
     }
+    if (bsda.ecoOrganismeSiret) {
+      registryFields.isOutgoingWasteFor.push(bsda.ecoOrganismeSiret);
+    }
+
     if (bsda.workerCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.workerCompanySiret);
+    }
+    if (bsda.brokerCompanySiret) {
+      registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
+    }
+    if (bsda.intermediaries?.length) {
+      for (const intermediary of bsda.intermediaries) {
+        const intermediaryOrgId = intermediary.siret ?? intermediary.vatNumber;
+        if (intermediaryOrgId) {
+          registryFields.isManagedWasteFor.push(intermediaryOrgId);
+        }
+      }
     }
 
     const transporterCompanyOrgId = getTransporterCompanyOrgId(transporter);
 
     if (transporterCompanyOrgId) {
       registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
-    }
-    if (bsda.brokerCompanySiret) {
-      registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
     }
   }
 

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -61,6 +61,9 @@ export function getRegistryFields(
     if (bsdasri.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsdasri.emitterCompanySiret);
     }
+    if (bsdasri.ecoOrganismeSiret) {
+      registryFields.isOutgoingWasteFor.push(bsdasri.ecoOrganismeSiret);
+    }
     const transporterCompanyOrgId = getTransporterCompanyOrgId(bsdasri);
     if (transporterCompanyOrgId) {
       registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -1,4 +1,4 @@
-import { Form, BsddTransporter, FinalOperation } from "@prisma/client";
+import { FinalOperation } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 import { BsdElastic } from "../common/elastic";
 import { buildAddress } from "../companies/sirene/utils";
@@ -19,6 +19,7 @@ import {
 } from "../registry/types";
 import { extractPostalCode } from "../utils";
 import { Bsdd } from "./types";
+import { FormForElastic } from "./elastic";
 
 const getOperationData = (bsdd: Bsdd) => ({
   destinationPlannedOperationCode: bsdd.destinationPlannedOperationCode,
@@ -56,9 +57,7 @@ type RegistryFields =
   | "isManagedWasteFor";
 
 export function getRegistryFields(
-  form: Form & {
-    transporters: BsddTransporter[] | null;
-  }
+  form: FormForElastic
 ): Pick<BsdElastic, RegistryFields> {
   const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
@@ -77,11 +76,23 @@ export function getRegistryFields(
     if (form.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(form.emitterCompanySiret);
     }
+    if (form.ecoOrganismeSiret) {
+      registryFields.isOutgoingWasteFor.push(form.ecoOrganismeSiret);
+    }
     if (form.traderCompanySiret) {
       registryFields.isManagedWasteFor.push(form.traderCompanySiret);
     }
     if (form.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(form.brokerCompanySiret);
+    }
+
+    if (form.intermediaries?.length) {
+      for (const intermediary of form.intermediaries) {
+        const intermediaryOrgId = intermediary.siret ?? intermediary.vatNumber;
+        if (intermediaryOrgId) {
+          registryFields.isManagedWasteFor.push(intermediaryOrgId);
+        }
+      }
     }
 
     if (form.transporters?.length) {


### PR DESCRIPTION
## ❗ Nécessite un full reindex❗

Suite à [Registre exhaustif du BSDD Suite entreposage provisoire : les informations relatives à la destination finale et au 2e transporteur n'apparaissent pas + lignes en double](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13965), j'avais modifié la façon de calculer le registre exhaustif pour se baser sur l'union de `isIncomingWasteFor`, `isOutgoingWasteFor`, etc plutôt que `sirets`.

Cette mise à jour a eu pour effet de bord que les éco-organismes et les intermédiaires n'ont plus accès à leur données dans le registre exhaustif. Afin de rétablir le fonctionnement précédent sans reproduire le bug initial, on ajoute l'éco-organisme au registre de déchets sortants et les intermédiaires au registre de déchets gérés. Cela rétablira au passage l'accès au registre exhastif.

---

- [Problèmes d'extraction du registre exhaustif d'un Eco organisme ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14097)
