### PR TITLE
Corrections sur l'indexation

### DIFF
--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -229,7 +229,7 @@ function getFieldNameFromKeyword(keywordFieldName: string): keyof BsdElastic {
 
 function buildSort({ orderBy = {} }: QueryBsdsArgs) {
   const sort: Array<Record<string, OrderType>> = [
-    { createdAt: "DESC" },
+    { updatedAt: "DESC" },
     // id is used as last sort to deal with ties
     // (for documents whose sorting result is equal)
     { id: "ASC" }

--- a/back/src/forms/elasticHelpers.ts
+++ b/back/src/forms/elasticHelpers.ts
@@ -198,7 +198,6 @@ export function getSiretsByTab(form: FullForm): Pick<BsdElastic, WhereKeys> {
 
       break;
     }
-    case Status.GROUPED:
     case Status.REFUSED:
     case Status.PROCESSED:
     case Status.FOLLOWED_WITH_PNTTD:
@@ -209,6 +208,7 @@ export function getSiretsByTab(form: FullForm): Pick<BsdElastic, WhereKeys> {
       }
       break;
     }
+    case Status.GROUPED:
     case Status.AWAITING_GROUP:
     default:
       break;
@@ -226,10 +226,11 @@ export function getSiretsByTab(form: FullForm): Pick<BsdElastic, WhereKeys> {
 function getFormSirets(form: FullForm) {
   const transporter = getFirstTransporterSync(form);
 
-  // Appendix 1 only appears in the dashboard for emitters & transporters
+  // Appendix 1 only appears in the dashboard for emitters & transporters & EO
   if (form.emitterType === EmitterType.APPENDIX1_PRODUCER) {
     return {
       emitterCompanySiret: form.emitterCompanySiret,
+      ecoOrganismeSiret: form.ecoOrganismeSiret,
       ...(transporter
         ? {
             [transporterCompanyOrgIdKey(transporter)]:

--- a/e2e/src/utils/bsvhu.ts
+++ b/e2e/src/utils/bsvhu.ts
@@ -1,5 +1,5 @@
 import { Page, expect } from "@playwright/test";
-import { expectInputValue } from "./utils";
+import { expectInputValue, navigateInDashboard } from "./utils";
 import { toDDMMYYYY } from "./time";
 
 /**
@@ -393,16 +393,18 @@ export const verifyOverviewData = async (
  * Publish a VHU
  */
 export const publishBsvhu = async (page: Page, { id }) => {
-  await page.getByRole("link", { name: "Brouillons" }).click();
+  await navigateInDashboard(page, "Brouillons", "**/bsds/drafts");
 
-  const vhuDiv = getVHUCardDiv(page, id);
+  let vhuDiv = getVHUCardDiv(page, id);
 
   // Try to publish
   await vhuDiv.getByRole("button").getByText("Publier").click();
   // Confirm publication in modal
   await page.getByRole("button", { name: "Publier le bordereau" }).click();
 
-  await page.getByRole("link", { name: "Tous les bordereaux" }).click();
+  await navigateInDashboard(page, "Tous les bordereaux", "**/bsds/all");
+  vhuDiv = getVHUCardDiv(page, id);
+
   await expect(vhuDiv).toBeVisible();
 
   // Status should be updated
@@ -421,7 +423,7 @@ export const publishBsvhu = async (page: Page, { id }) => {
  * Fix VHU adding missing data, then publish
  */
 export const fixAndPublishBsvhu = async (page: Page, { id }) => {
-  await page.getByRole("link", { name: "Brouillons" }).click();
+  await navigateInDashboard(page, "Brouillons", "**/bsds/drafts");
 
   const vhuDiv = getVHUCardDiv(page, id);
 
@@ -453,7 +455,7 @@ export const fixAndPublishBsvhu = async (page: Page, { id }) => {
  * Duplicate a VHU
  */
 export const duplicateBsvhu = async (page: Page, { id }) => {
-  await page.getByRole("link", { name: "Tous les bordereaux" }).click();
+  await navigateInDashboard(page, "Tous les bordereaux", "**/bsds/all");
 
   const vhuDiv = getVHUCardDiv(page, id);
 
@@ -462,7 +464,7 @@ export const duplicateBsvhu = async (page: Page, { id }) => {
   await vhuDiv.getByRole("button").getByText("Dupliquer").click();
 
   // Check in drafts
-  await page.getByRole("link", { name: "Brouillons" }).click();
+  await navigateInDashboard(page, "Brouillons", "**/bsds/drafts");
 
   // Make sure VHU pops out in results list
   const duplicatedVhuDiv = page.locator(".bsd-card-list li").first();
@@ -479,7 +481,7 @@ export const duplicateBsvhu = async (page: Page, { id }) => {
  * Delete a VHU
  */
 export const deleteBsvhu = async (page: Page, { id }) => {
-  await page.getByRole("link", { name: "Tous les bordereaux" }).click();
+  await navigateInDashboard(page, "Tous les bordereaux", "**/bsds/all");
 
   const vhuDiv = getVHUCardDiv(page, id);
 

--- a/e2e/src/utils/utils.ts
+++ b/e2e/src/utils/utils.ts
@@ -12,3 +12,12 @@ export const expectInputValue = async (
 
   expect(value).toEqual(expectedValue);
 };
+
+export const navigateInDashboard = async (
+  page: Page,
+  tabName: string,
+  url: string
+) => {
+  await page.getByRole("link", { name: tabName }).click();
+  await page.waitForURL(url);
+};

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -262,8 +262,7 @@ export const filterPredicates: {
           ]
         }
       ]
-    }),
-    orderBy: "wasteCode"
+    })
   },
   {
     filterName: FilterName.readableId,
@@ -280,8 +279,7 @@ export const filterPredicates: {
           ]
         }
       ]
-    }),
-    orderBy: "readableId"
+    })
   },
   {
     filterName: FilterName.transporterNumberPlate,

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -249,8 +249,7 @@ export const filterPredicates: {
 }[] = [
   {
     filterName: FilterName.types,
-    where: value => ({ type: { _in: value } }),
-    orderBy: "type"
+    where: value => ({ type: { _in: value } })
   },
   {
     filterName: FilterName.waste,


### PR DESCRIPTION
- [Remonter les A1 sur le tableau de bord de l'EO](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14057)
- [Tri par updatedAt sur le dashboard](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13885)
- [Améliorer le tri de l'affichage des BSD lors de l'utilisation du filtre avancé Type de bordereau](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13989)
- [Le BSDD initial devrait se trouver dans l'onglet Suivis et non Archives, tant que le BSD suite n'a pas été traité](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13456)

Combinaison de fix d'indexations.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---
