### PR TITLE
HOTFIX - Correction des A1 orphelines supprimées par erreyr

### DIFF
--- a/apps/cron/src/commands/appendix1.helpers.ts
+++ b/apps/cron/src/commands/appendix1.helpers.ts
@@ -73,7 +73,7 @@ async function cleanOrphanAppendix1() {
     emitterType: EmitterType.APPENDIX1_PRODUCER,
     createdAt: { lte: limitDate },
     isDeleted: false,
-    grouping: { none: { nextForm: {} } }
+    groupedIn: { none: {} }
   };
 
   const orphansCount = await prisma.form.count({ where });

--- a/back/prisma/scripts/clean-orphan-appendix1.ts
+++ b/back/prisma/scripts/clean-orphan-appendix1.ts
@@ -15,7 +15,7 @@ export class UnindexOrphanAppendix1 implements Updater {
 
       const where: Prisma.FormWhereInput = {
         emitterType: EmitterType.APPENDIX1_PRODUCER,
-        grouping: { none: { nextForm: {} } }
+        groupedIn: { none: {} }
       };
 
       const orphansCount = await prisma.form.count({ where });

--- a/libs/back/tests-integration/src/index.ts
+++ b/libs/back/tests-integration/src/index.ts
@@ -4,8 +4,7 @@ import {
   esIndex,
   indexQueue,
   closeMongoClient,
-  closeQueues,
-  server
+  closeQueues
 } from "back";
 import { prisma } from "@td/prisma";
 
@@ -15,8 +14,7 @@ afterAll(async () => {
     closeQueues(),
     esClient.close(),
     redisClient.disconnect(),
-    prisma.$disconnect(),
-    server.stop()
+    prisma.$disconnect()
   ]);
 });
 


### PR DESCRIPTION
La correction de l'autre jour n'était pas complète et des A1 non orphelines continuaient à être marquées comme supprimées par erreur