### PR TITLE
[HOTFIX] Affiche des résultats partiel sur le dashboard

### DIFF
--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -78,7 +78,10 @@ const DashboardPage = () => {
     QueryBsdsArgs
   >(GET_BSDS, {
     fetchPolicy: "cache-and-network",
-    notifyOnNetworkStatusChange: true
+    notifyOnNetworkStatusChange: true,
+    // permet d'afficher les bordereaux (en plus de l'erreur)
+    // en cas de réponse partielle
+    errorPolicy: "all"
   });
 
   const tabs: Tabs = useMemo(


### PR DESCRIPTION
On a un bug qui cause une désynchronisation des bordereaux entre ES et la base de données : des demandes de révision apparaissent dans ES alors qu'elles ne sont plus en DB causant le bug suivant : 

https://sentry.incubateur.net/organizations/betagouv/issues/85336/?query=is%3Aunresolved&referrer=issue-stream 

Le dashboard de tous les utilisateurs qui ont ce bug ne s'affiche pas avec un message "Erreur Serveur" dans l'attente d'une résolution et d'un réindex globale.

Ce fix permet de quand même afficher les bordereaux lorsqu'on a des données partielles qui sont retournées en plus d'une erreur (ce qui est le cas quand une erreur est levée dans un sous-resolver). 

---

- [Zammad](https://trackdechets.zammad.com/#ticket/zoom/37342)
