### PR TITLE
[tra-13724] Cap & operation scellés après signature émetteur (sans TTR)

### DIFF
--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -423,7 +423,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationCap: {
     readableFieldName: "le CAP du destinataire",
-    sealed: { from: "TRANSPORT" },
+    sealed: { from: sealedFromEmissionExceptAddOrRemoveNextDestination },
     required: {
       from: "EMISSION",
       when: bsda =>
@@ -433,7 +433,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationPlannedOperationCode: {
     readableFieldName: "le code d'opération prévu",
-    sealed: { from: "TRANSPORT" },
+    sealed: { from: sealedFromEmissionExceptAddOrRemoveNextDestination },
     required: { from: "EMISSION" }
   },
   destinationReceptionDate: {


### PR DESCRIPTION
Le CAP et le code d'opération prévus doivent être scellés à la signature émetteur si aucun TTR n'a été ajouté

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13724)
