### PR TITLE
Migrate - Fix for sandbox & prod

### DIFF
--- a/libs/back/prisma/src/migrations/0_init/migration.sql
+++ b/libs/back/prisma/src/migrations/0_init/migration.sql
@@ -126,7 +126,7 @@ CREATE TABLE "AccessToken" (
 
 -- CreateTable
 CREATE TABLE "Application" (
-    "id" TEXT NOT NULL,
+    "id" VARCHAR(30) NOT NULL,
     "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMPTZ(6) NOT NULL,
     "clientSecret" TEXT NOT NULL,
@@ -554,7 +554,7 @@ CREATE TABLE "StatusLog" (
 
 -- CreateTable
 CREATE TABLE "TraderReceipt" (
-    "id" TEXT NOT NULL,
+    "id" VARCHAR(30) NOT NULL,
     "receiptNumber" TEXT NOT NULL,
     "validityLimit" TIMESTAMPTZ(6) NOT NULL,
     "department" TEXT NOT NULL,
@@ -574,7 +574,7 @@ CREATE TABLE "BrokerReceipt" (
 
 -- CreateTable
 CREATE TABLE "TransporterReceipt" (
-    "id" TEXT NOT NULL,
+    "id" VARCHAR(30) NOT NULL,
     "receiptNumber" TEXT NOT NULL,
     "validityLimit" TIMESTAMPTZ(6) NOT NULL,
     "department" TEXT NOT NULL,
@@ -634,7 +634,7 @@ CREATE TABLE "BsddTransporter" (
 
 -- CreateTable
 CREATE TABLE "User" (
-    "id" TEXT NOT NULL,
+    "id" VARCHAR(30) NOT NULL,
     "email" TEXT NOT NULL,
     "password" TEXT NOT NULL,
     "passwordVersion" INTEGER,
@@ -645,7 +645,7 @@ CREATE TABLE "User" (
     "activatedAt" TIMESTAMPTZ(6),
     "firstAssociationDate" TIMESTAMPTZ(6),
     "isActive" BOOLEAN DEFAULT false,
-    "isAdmin" BOOLEAN DEFAULT false,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
     "isRegistreNational" BOOLEAN NOT NULL DEFAULT false,
     "governmentAccountId" TEXT,
 
@@ -1586,6 +1586,9 @@ CREATE INDEX "_BsvhuDestinationCompanySiretIdx" ON "Bsvhu"("destinationCompanySi
 CREATE INDEX "_BsvhuTransporterCompanySiretIdx" ON "Bsvhu"("transporterCompanySiret");
 
 -- CreateIndex
+CREATE INDEX "_BsvhuTransporterCompanyVatNumberIdx" ON "Bsvhu"("transporterCompanyVatNumber");
+
+-- CreateIndex
 CREATE INDEX "_BsvhuStatusIdx" ON "Bsvhu"("status");
 
 -- CreateIndex
@@ -1599,6 +1602,9 @@ CREATE INDEX "_BsdasriEmitterCompanySiretIdx" ON "Bsdasri"("emitterCompanySiret"
 
 -- CreateIndex
 CREATE INDEX "_BsdasriTransporterCompanySiretIdx" ON "Bsdasri"("transporterCompanySiret");
+
+-- CreateIndex
+CREATE INDEX "_BsdasriTransporterCompanyVatNumberIdx" ON "Bsdasri"("transporterCompanyVatNumber");
 
 -- CreateIndex
 CREATE INDEX "_BsdasriDestinationCompanySiretIdx" ON "Bsdasri"("destinationCompanySiret");
@@ -1635,6 +1641,9 @@ CREATE INDEX "_BsffEmitterCompanySiretIdx" ON "Bsff"("emitterCompanySiret");
 
 -- CreateIndex
 CREATE INDEX "_BsffTransporterCompanySiretIdx" ON "Bsff"("transporterCompanySiret");
+
+-- CreateIndex
+CREATE INDEX "_BsffTransporterCompanyVatNumberIdx" ON "Bsff"("transporterCompanyVatNumber");
 
 -- CreateIndex
 CREATE INDEX "_BsffDestinationCompanySiretIdx" ON "Bsff"("destinationCompanySiret");

--- a/libs/back/prisma/src/migrations/0_init/migration.sql
+++ b/libs/back/prisma/src/migrations/0_init/migration.sql
@@ -106,9 +106,6 @@ CREATE TYPE "BspaohStatus" AS ENUM ('DRAFT', 'INITIAL', 'SIGNED_BY_PRODUCER', 'S
 -- CreateEnum
 CREATE TYPE "BspaohType" AS ENUM ('PAOH', 'FOETUS');
 
--- CreateEnum
-CREATE TYPE "BsvhuRecipientType" AS ENUM ('BROYEUR', 'DEMOLISSEUR');
-
 -- CreateTable
 CREATE TABLE "AccessToken" (
     "id" VARCHAR(30) NOT NULL,

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -786,7 +786,7 @@ model User {
   activatedAt             DateTime?                 @db.Timestamptz(6)
   firstAssociationDate    DateTime?                 @db.Timestamptz(6)
   isActive                Boolean?                  @default(false)
-  isAdmin                 Boolean?                  @default(false)
+  isAdmin                 Boolean                   @default(false)
   // TODO champ à supprimer suite à la création des comptes gouvernementaux
   isRegistreNational      Boolean                   @default(false)
   governmentAccountId     String?                   @unique
@@ -956,6 +956,7 @@ model Bsvhu {
   @@index([emitterCompanySiret], map: "_BvhuEmitterCompanySirettIdx")
   @@index([destinationCompanySiret], map: "_BsvhuDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsvhuTransporterCompanySiretIdx")
+  @@index([transporterCompanyVatNumber], map: "_BsvhuTransporterCompanyVatNumberIdx")
   @@index([status], map: "_BsvhuStatusIdx")
   @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
 }
@@ -1070,6 +1071,7 @@ model Bsdasri {
 
   @@index([emitterCompanySiret], map: "_BsdasriEmitterCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsdasriTransporterCompanySiretIdx")
+  @@index([transporterCompanyVatNumber], map: "_BsdasriTransporterCompanyVatNumberIdx")
   @@index([destinationCompanySiret], map: "_BsdasriDestinationCompanySiretIdx")
   @@index([ecoOrganismeSiret], map: "_BsdasriEcoOrganismeSiretIdx")
   @@index([synthesizedInId], map: "_BsdasriSynthesizedInIdIdx")
@@ -1144,6 +1146,7 @@ model Bsff {
 
   @@index([emitterCompanySiret], map: "_BsffEmitterCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsffTransporterCompanySiretIdx")
+  @@index([transporterCompanyVatNumber], map: "_BsffTransporterCompanyVatNumberIdx")
   @@index([destinationCompanySiret], map: "_BsffDestinationCompanySiretIdx")
   @@index([status], map: "_BsffStatusIdx")
   @@index([updatedAt], map: "_BsffUpdatedAtIdx")
@@ -1739,9 +1742,4 @@ enum BspaohStatus {
 enum BspaohType {
   PAOH
   FOETUS
-}
-
-enum BsvhuRecipientType {
-  BROYEUR
-  DEMOLISSEUR
 }


### PR DESCRIPTION
Les dbs de sandbox & prod diffèrent de celle de recette sur lequel avait été testé le passage à prisma migrate.
Corrections pour en ce sens.

SQL pour migrer la recette
```
ALTER TABLE "default$default"."Application"
ALTER COLUMN id TYPE VARCHAR(30);

ALTER TABLE "default$default"."TraderReceipt"
ALTER COLUMN id TYPE VARCHAR(30);

ALTER TABLE "default$default"."TransporterReceipt"
ALTER COLUMN id TYPE VARCHAR(30);

ALTER TABLE "default$default"."User"
ALTER COLUMN id TYPE VARCHAR(30),
ALTER COLUMN "isAdmin" SET NOT NULL;
```
