### PR TITLE
HOTFIX - Entreprises qui n'apparaissent plus dans le company selector

### DIFF
--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -43,7 +43,9 @@ const searchResponseToCompany = (
 
   const company: SireneSearchResult = {
     siret: etablissement.siret,
-    etatAdministratif: etablissement.etatAdministratifEtablissement,
+    etatAdministratif:
+      etablissement.etatAdministratifEtablissement ||
+      etablissement.etatAdministratifUniteLegale,
     address: fullAddress,
     addressVoie,
     addressPostalCode: etablissement.codePostalEtablissement,
@@ -83,6 +85,7 @@ export const searchCompany = async (
         }
       }
     });
+    console.log("td response", response);
     if (!response.body.hits.hits || !response.body.hits.hits[0]?._source) {
       throw new SiretNotFoundError();
     }
@@ -95,6 +98,7 @@ export const searchCompany = async (
     }
     return company;
   } catch (error) {
+    console.log("td error", error);
     if (error instanceof ResponseError && error.meta.statusCode === 404) {
       throw new SiretNotFoundError();
     }


### PR DESCRIPTION
On a pas mal d'entreprises avec `etatAdministratifEtablissement = ""` depuis l'indexation d'avril, ce qui fait que les résultats ne remontent plus.
On fallback sur l'état de l'unité légale.

La doc dit:
> Lors de son inscription au répertoire, un établissement est, sauf exception, à l'état Actif. Le passage à l'état Fermé découle de la prise en compte d'une déclaration de fermeture. Un établissement fermé peut être rouvert. En règle générale, la première période d'historique d'un établissement correspond à un etatAdministratifUniteLegale égal à Actif. Toutefois, l'état administratif peut être à null (première date de début de l'état postérieure à la première date de début d'une autre variable historisée).

Je ne suis pas certain de vraiment comprendre dans quel cas c'est nul et ce que ca veut dire sur l'établissement...
