### PR TITLE
[Recette - tra-13788] Champ de formulaire mulitple pour les plaques d'immatriculation

### DIFF
--- a/front/src/Apps/Forms/Components/TagsInput/TagsInput.stories.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInput.stories.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import TagsInput, { TagsInputProps } from "./TagsInput";
+
+const Comonent: React.FC<Pick<TagsInputProps, "label" | "maxTags">> = ({
+  label,
+  maxTags
+}) => {
+  const [tags, setTags] = useState<string[]>([]);
+
+  return (
+    <TagsInput
+      label={label}
+      maxTags={maxTags}
+      tags={tags}
+      onAddTag={tag => setTags([...tags, tag])}
+      onDeleteTag={idx => {
+        const updatedTags = [...tags];
+        updatedTags.splice(idx, 1);
+        setTags(updatedTags);
+      }}
+    />
+  );
+};
+
+export default {
+  title: "COMPONENTS/FORMS/TagsInput",
+  component: TagsInput,
+  design: {
+    type: "figma",
+    url: "https://www.figma.com/file/TZbRaWgchdAv8o7IxJWrKE/Trackd%C3%A9chets?type=design&node-id=9815%3A197969&mode=design&t=aipTGRtMXjPGwdhY-1"
+  }
+} as Meta<typeof Comonent>;
+
+const Template: StoryFn<typeof Comonent> = args => <Comonent {...args} />;
+
+export const TagsInputExample = Template.bind({});
+
+TagsInputExample.args = {
+  label: "Immatriculations",
+  maxTags: 2
+};

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Tag } from "@codegouvfr/react-dsfr/Tag";
+
+export type TagsInputProps = {
+  label: string;
+  readonly tags: string[];
+  readonly onAddTag: (tag: string) => void;
+  readonly onDeleteTag: (idx: number) => void;
+  readonly maxTags?: number;
+};
+
+/**
+ * Champ de formulaire permettant d'ajouter / supprimer des
+ * valeurs à une liste de chaines de caractères.
+ */
+const TagsInput: React.FC<TagsInputProps> = ({
+  label,
+  tags,
+  onAddTag,
+  onDeleteTag,
+  maxTags
+}) => {
+  const [tag, setTag] = useState("");
+
+  const addButtonIsDisabled = maxTags ? tags.length >= maxTags : false;
+
+  return (
+    <>
+      <Input
+        label={label}
+        style={{ marginBottom: "10px" }}
+        nativeInputProps={{
+          value: tag,
+          onChange: e => setTag(e.target.value)
+        }}
+        addon={
+          <Button
+            disabled={addButtonIsDisabled}
+            onClick={e => {
+              e.preventDefault();
+              if (tag.length > 0) {
+                onAddTag(tag);
+                setTag("");
+              }
+            }}
+          >
+            Ajouter
+          </Button>
+        }
+      />
+      <div style={{ display: "flex" }}>
+        {tags.map((plate, idx) => (
+          <div key={idx} style={{ padding: "0 2px" }}>
+            <Tag
+              dismissible
+              nativeButtonProps={{
+                onClick: () => {
+                  onDeleteTag(idx);
+                }
+              }}
+            >
+              {plate}
+            </Tag>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default TagsInput;

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.test.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Formik } from "formik";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TagsInputWrapper from "./TagsInputWrapper";
+
+describe("<TagsInput/> ", () => {
+  const component = () => (
+    <Formik initialValues={{ plates: [] }} onSubmit={jest.fn()}>
+      <TagsInputWrapper
+        fieldName="plates"
+        label="Immatriculations"
+        maxTags={2}
+      />
+    </Formik>
+  );
+
+  test("component without errors", () => {
+    const { container } = render(component());
+    expect(container).toBeTruthy();
+  });
+
+  test("clicking button should add tags until maxTags", () => {
+    render(component());
+    const plate1 = "AD-008-BG";
+    const plate2 = "AD-009-BG";
+    let plateInput = screen.getByLabelText("Immatriculations");
+    fireEvent.focus(plateInput);
+    fireEvent.change(plateInput, { target: { value: plate1 } });
+    let addButton = screen.getByText("Ajouter");
+    fireEvent.click(addButton);
+
+    let buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveTextContent("Ajouter");
+
+    // Les tags sont rendus comme des boutons
+    expect(buttons[1]).toHaveTextContent(plate1);
+
+    // vérifie que la valeur de l'input est bien vidée entre deux ajouts
+    plateInput = screen.getByLabelText("Immatriculations");
+    expect(plateInput).toHaveValue("");
+    fireEvent.focus(plateInput);
+    fireEvent.change(plateInput, { target: { value: plate2 } });
+    fireEvent.click(addButton);
+
+    buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+    expect(buttons[2]).toHaveTextContent(plate2);
+
+    // Vérifie que le bouton est disabled lorsque le nombre de tags est
+    // supérieur ou égal à maxTags=2
+    addButton = screen.getByText("Ajouter");
+    expect(addButton).toBeDisabled();
+
+    // Supprime le dernier tag
+    fireEvent.click(buttons[2]);
+    buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+
+    // Vérifie que le bouton Ajouter est de nouveau enabled
+    addButton = screen.getByText("Ajouter");
+    expect(addButton).toBeEnabled();
+  });
+});

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.tsx
@@ -1,0 +1,37 @@
+import { FieldArray, useField } from "formik";
+import TagsInput, { TagsInputProps } from "./TagsInput";
+import React from "react";
+
+type TagsInputWrapperProps = {
+  readonly fieldName: string;
+} & Pick<TagsInputProps, "label" | "maxTags">;
+
+/**
+ * Wrapper autour de TagsInput qui permet de contrôler son
+ * état via Formik
+ */
+const TagsInputWrapper: React.FC<TagsInputWrapperProps> = ({
+  fieldName,
+  label,
+  maxTags
+}) => {
+  const [tags] = useField<string[]>(fieldName);
+
+  return (
+    <FieldArray name={fieldName}>
+      {arrayHelpers => {
+        return (
+          <TagsInput
+            label={label}
+            maxTags={maxTags}
+            tags={tags.value}
+            onAddTag={tag => arrayHelpers.push(tag)}
+            onDeleteTag={idx => arrayHelpers.remove(idx)}
+          />
+        );
+      }}
+    </FieldArray>
+  );
+};
+
+export default TagsInputWrapper;

--- a/front/src/Apps/Forms/Components/TransportPlates/TransportPlates.tsx
+++ b/front/src/Apps/Forms/Components/TransportPlates/TransportPlates.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { BsdType } from "@td/codegen-ui";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Field } from "formik";
+import TagsInputWrapper from "../TagsInput/TagsInputWrapper";
+
+type TransporterTransportPlatesProps = {
+  readonly bsdType: BsdType;
+  readonly fieldName: string;
+};
+
+const TransportPlates: React.FC<TransporterTransportPlatesProps> = ({
+  bsdType,
+  fieldName
+}) => {
+  if (bsdType === BsdType.Bsdd) {
+    return (
+      <Field name={fieldName}>
+        {({ field }) => (
+          <Input label="Immatriculation" nativeInputProps={field} />
+        )}
+      </Field>
+    );
+  } else {
+    return (
+      <TagsInputWrapper
+        label="Immatriculations"
+        fieldName={fieldName}
+        maxTags={2}
+      />
+    );
+  }
+};
+
+export default TransportPlates;

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.test.tsx
@@ -57,7 +57,8 @@ const defaultBsdaTransporter: BsdaTransporter = {
     validityLimit: "2023-12-31T23:00:00.000Z"
   },
   transport: {
-    mode: TransportMode.Road
+    mode: TransportMode.Road,
+    plates: []
   }
 };
 
@@ -162,7 +163,9 @@ describe("TransporterForm", () => {
       expect(isExemptedOfReceiptInput).toBeInTheDocument();
       const transportModeInput = screen.getByLabelText("Mode de transport");
       expect(transportModeInput).toBeInTheDocument();
-      const plateInput = screen.getByLabelText("Immatriculation");
+      const plateInput = screen.getByLabelText("Immatriculation", {
+        exact: false
+      });
       expect(plateInput).toBeInTheDocument();
     }
   );
@@ -291,15 +294,22 @@ describe("TransporterForm", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "transporter recepisse error is not displayed if transport mode is not road and bsdType is %p",
     bsdType => {
+      const defaultTransporter = getDefaultTransporter(bsdType);
+
       const data =
         bsdType === BsdType.Bsdd
           ? { mode: TransportMode.Rail }
-          : { transport: { mode: TransportMode.Rail } };
+          : {
+              transport: {
+                ...(defaultTransporter as BsdaTransporter).transport,
+                mode: TransportMode.Rail
+              }
+            };
 
       render(
         Component({
           data: {
-            ...getDefaultTransporter(bsdType),
+            ...defaultTransporter,
             ...data
           },
           bsdType

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import CompanySelectorWrapper from "../../../../form/common/components/CompanySelectorWrapper/CompanySelectorWrapper";
-import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Select } from "@codegouvfr/react-dsfr/Select";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Field } from "formik";
@@ -16,6 +15,7 @@ import TransporterRecepisse from "../TransporterRecepisse/TransporterRecepisse";
 import { isForeignVat } from "@td/constants";
 import { useTransporter } from "../../hooks/useTransporter";
 import { AnyTransporterInput } from "../../types";
+import TransportPlates from "../TransportPlates/TransportPlates";
 
 type TransporterFormProps = {
   // SIRET ou VAT de l'établissement courant
@@ -39,9 +39,9 @@ export function TransporterForm<T extends AnyTransporterInput>({
     transporterOrgId,
     transporter,
     setTransporter,
-    transportPlatesField,
-    transportModeField,
-    transporterRecepisseIsExemptedField
+    transportPlatesFieldName,
+    transportModeFieldName,
+    transporterRecepisseIsExemptedFieldName
   } = useTransporter<T>(fieldName, bsdType);
 
   const isForeign = React.useMemo(
@@ -90,7 +90,7 @@ export function TransporterForm<T extends AnyTransporterInput>({
 
       <CompanyContactInfo fieldName={`${fieldName}.company`} />
 
-      <Field name={transporterRecepisseIsExemptedField}>
+      <Field name={transporterRecepisseIsExemptedFieldName}>
         {({ field, form }) => (
           <ToggleSwitch
             label={
@@ -111,7 +111,10 @@ export function TransporterForm<T extends AnyTransporterInput>({
             checked={field.value}
             disabled={isForeign}
             onChange={checked =>
-              form.setFieldValue(transporterRecepisseIsExemptedField, checked)
+              form.setFieldValue(
+                transporterRecepisseIsExemptedFieldName,
+                checked
+              )
             }
             defaultChecked={false}
           />
@@ -129,9 +132,9 @@ export function TransporterForm<T extends AnyTransporterInput>({
           />
         )}
 
-      <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
+      <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
         <div className="fr-col-12 fr-col-md-3">
-          <Field name={transportModeField}>
+          <Field name={transportModeFieldName}>
             {({ field }) => (
               <Select label="Mode de transport" nativeSelectProps={field}>
                 <option value="ROAD">Route</option>
@@ -144,11 +147,10 @@ export function TransporterForm<T extends AnyTransporterInput>({
           </Field>
         </div>
         <div className="fr-col-12 fr-col-md-3">
-          <Field name={transportPlatesField}>
-            {({ field }) => (
-              <Input label="Immatriculation" nativeInputProps={field} />
-            )}
-          </Field>
+          <TransportPlates
+            bsdType={bsdType}
+            fieldName={transportPlatesFieldName}
+          />
         </div>
       </div>
     </div>

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
@@ -67,6 +67,12 @@ function getBsdaTransporter(
   };
 }
 
+function getInitialTransporter(bsdType: BsdType) {
+  return bsdType === BsdType.Bsdd
+    ? initialFormTransporter
+    : initialBsdaTransporter;
+}
+
 describe("<TransporterList />", () => {
   const mocks = [];
 
@@ -85,7 +91,7 @@ describe("<TransporterList />", () => {
     "component renders without errors when bsdType is %p",
     bsdType => {
       const { container } = render(
-        component([initialFormTransporter], bsdType)
+        component([getInitialTransporter(bsdType)], bsdType)
       );
       expect(container).toBeTruthy();
     }
@@ -94,7 +100,7 @@ describe("<TransporterList />", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "delete button is disabled when there is only one transporter and bsdType is %p",
     bsdType => {
-      render(component([initialFormTransporter], bsdType));
+      render(component([getInitialTransporter(bsdType)], bsdType));
       const addButton = screen.getByTitle("Supprimer");
       expect(addButton).toBeDisabled();
     }
@@ -103,7 +109,7 @@ describe("<TransporterList />", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "up button is disabled when there is only one transporter and bsdType is %p",
     bsdType => {
-      render(component([initialFormTransporter], bsdType));
+      render(component([getInitialTransporter(bsdType)], bsdType));
       const upButton = screen.getByTitle("Remonter");
       expect(upButton).toBeDisabled();
     }
@@ -112,7 +118,7 @@ describe("<TransporterList />", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "down button is disabled when there is only one transporter and bsdType is %p",
     bsdType => {
-      render(component([initialFormTransporter], bsdType));
+      render(component([getInitialTransporter(bsdType)], bsdType));
       const downButton = screen.getByTitle("Descendre");
       expect(downButton).toBeDisabled();
     }
@@ -121,7 +127,7 @@ describe("<TransporterList />", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "new transporters can be added until 5 when bsdType is %p",
     async bsdType => {
-      render(component([initialFormTransporter], bsdType));
+      render(component([getInitialTransporter(bsdType)], bsdType));
       const addButton = screen.getByTitle("Ajouter");
       fireEvent.click(addButton);
       fireEvent.click(addButton);
@@ -150,7 +156,10 @@ describe("<TransporterList />", () => {
     "transporters can be deleted with the delete button when bsdType is %p",
     async bsdType => {
       render(
-        component([initialFormTransporter, initialFormTransporter], bsdType)
+        component(
+          [getInitialTransporter(bsdType), getInitialTransporter(bsdType)],
+          bsdType
+        )
       );
       expect(await screen.findByText("1 - Transporteur")).toBeInTheDocument();
       expect(await screen.findByText("2 - Transporteur")).toBeInTheDocument();
@@ -167,7 +176,10 @@ describe("<TransporterList />", () => {
     "up button is disabled for the first transporter when bsdType is %p",
     async bsdType => {
       render(
-        component([initialFormTransporter, initialFormTransporter], bsdType)
+        component(
+          [getInitialTransporter(bsdType), getInitialTransporter(bsdType)],
+          bsdType
+        )
       );
       const upButtons = screen.getAllByTitle("Remonter");
       expect(upButtons[0]).toBeDisabled();
@@ -179,7 +191,10 @@ describe("<TransporterList />", () => {
     "down button is disabled for the last transporter when bsdType is %p",
     async bsdType => {
       render(
-        component([initialFormTransporter, initialFormTransporter], bsdType)
+        component(
+          [getInitialTransporter(bsdType), getInitialTransporter(bsdType)],
+          bsdType
+        )
       );
       const upButtons = screen.getAllByTitle("Descendre");
       expect(upButtons[0]).not.toBeDisabled();
@@ -191,7 +206,10 @@ describe("<TransporterList />", () => {
     "accordions are folded by default when there is several transporters and bsdType is %p",
     bsdType => {
       render(
-        component([initialFormTransporter, initialFormTransporter], bsdType)
+        component(
+          [getInitialTransporter(bsdType), getInitialTransporter(bsdType)],
+          bsdType
+        )
       );
       const unfoldButtons = screen.getAllByTitle("Déplier");
       expect(unfoldButtons).toHaveLength(2);
@@ -201,7 +219,7 @@ describe("<TransporterList />", () => {
   test.each([BsdType.Bsdd, BsdType.Bsda])(
     "accordion is expanded by default when there is only one transporter and bsdType is %p",
     bsdType => {
-      render(component([initialFormTransporter], bsdType));
+      render(component([getInitialTransporter(bsdType)], bsdType));
       const foldButton = screen.getByTitle("Replier");
       expect(foldButton).toBeInTheDocument();
     }
@@ -211,7 +229,10 @@ describe("<TransporterList />", () => {
     "only one accordion can be expanded at once when bsdType is %p",
     async bsdType => {
       render(
-        component([initialFormTransporter, initialFormTransporter], bsdType)
+        component(
+          [getInitialTransporter(bsdType), getInitialTransporter(bsdType)],
+          bsdType
+        )
       );
       const expandButtons = screen.getAllByTitle("Déplier");
       expect(expandButtons).toHaveLength(2);
@@ -230,14 +251,13 @@ describe("<TransporterList />", () => {
           ? getBsddTransporter({ takenOverAt: new Date().toISOString() })
           : getBsdaTransporter({ takenOverAt: new Date().toISOString() });
 
-      const initialTransporter =
-        bsdType === BsdType.Bsdd
-          ? initialFormTransporter
-          : initialBsdaTransporter;
-
       render(
         component(
-          [transporter1, { ...initialTransporter }, { ...initialTransporter }],
+          [
+            transporter1,
+            getInitialTransporter(bsdType),
+            getInitialTransporter(bsdType)
+          ],
           bsdType
         )
       );
@@ -288,7 +308,9 @@ describe("<TransporterList />", () => {
 
       expect(screen.getByText("Récépissé valide jusqu'au")).toBeInTheDocument();
       expect(screen.getAllByText("Mode de transport")).toHaveLength(3);
-      expect(screen.getAllByText("Immatriculation")).toHaveLength(3);
+      expect(
+        screen.getAllByText("Immatriculation", { exact: false })
+      ).toHaveLength(3);
       expect(
         screen.getByText(
           bsdType === BsdType.Bsdd

--- a/front/src/Apps/Forms/hooks/useTransporter.tsx
+++ b/front/src/Apps/Forms/hooks/useTransporter.tsx
@@ -68,17 +68,17 @@ export function useTransporter<T extends AnyTransporterInput>(
     setValue(updatedTransporter);
   };
 
-  const transportPlatesField =
+  const transportPlatesFieldName =
     bsdType === BsdType.Bsdd
       ? `${fieldName}.numberPlate`
       : `${fieldName}.transport.plates`;
 
-  const transportModeField =
+  const transportModeFieldName =
     bsdType === BsdType.Bsdd
       ? `${fieldName}.mode`
       : `${fieldName}.transport.mode`;
 
-  const transporterRecepisseIsExemptedField =
+  const transporterRecepisseIsExemptedFieldName =
     bsdType === BsdType.Bsdd
       ? `${fieldName}.isExemptedOfReceipt`
       : `${fieldName}.recepisse.isExempted`;
@@ -87,8 +87,8 @@ export function useTransporter<T extends AnyTransporterInput>(
     transporterOrgId,
     transporter: mapBsdTransporter(transporter, bsdType),
     setTransporter,
-    transportPlatesField,
-    transportModeField,
-    transporterRecepisseIsExemptedField
+    transportPlatesFieldName,
+    transportModeFieldName,
+    transporterRecepisseIsExemptedFieldName
   };
 }


### PR DESCRIPTION
Création d'un composant DSFR `<TagsInput />` et utilisation pour les plaques d'immatriculation du formulaire Transporteur BSDA

https://github.com/MTES-MCT/trackdechets/assets/2269165/2de07ea1-c1bc-4ecd-af7f-eb5db18d7a38




![Capture d’écran 2024-04-03 à 11 38 41](https://github.com/MTES-MCT/trackdechets/assets/2269165/bf1ea1fc-feb7-4e6c-a2ba-ac583b78eb6e)


---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13788)
