### PR TITLE
Fix receivedSignatureAutomation sentry error

### DIFF
--- a/back/src/companies/resolvers/CompanySearchPrivate.ts
+++ b/back/src/companies/resolvers/CompanySearchPrivate.ts
@@ -41,14 +41,15 @@ const companySearchPrivateResolvers: CompanySearchPrivateResolvers = {
       })
       .vhuAgrementDemolisseur();
   },
-  receivedSignatureAutomations: parent => {
-    return prisma.company
+  receivedSignatureAutomations: async parent => {
+    const automations = await prisma.company
       .findUnique({
         where: whereSiretOrVatNumber(parent as CompanyBaseIdentifiers)
       })
       .receivedSignatureAutomations({
         include: { from: true, to: true }
-      }) as any;
+      });
+    return (automations as any) ?? [];
   },
   workerCertification: parent =>
     prisma.company


### PR DESCRIPTION
Fix d'une erreur qu'on voit beaucoup sur Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/61125/?project=19&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d

Il ne faut pas retourner null dans receivedSignatureAutomations mais un tableau vide