### PR TITLE
[TRA-13987][Fix recette] Erreur explicite en cas d'établissement non-diffusible fermé

### DIFF
--- a/back/src/companies/sirene/errors.ts
+++ b/back/src/companies/sirene/errors.ts
@@ -17,7 +17,7 @@ export class SiretNotFoundError extends UserInputError {
   }
 }
 
-export class ClosedCompanyError extends Error {
+export class ClosedCompanyError extends UserInputError {
   constructor() {
     super("Cet établissement est fermé");
   }


### PR DESCRIPTION
# Contexte

Si un établissement non-diffusible est fermé, on doit retourner une erreur. J'avais retourné une erreur générique qui du coup ne s'affiche pas côté front en recette:
![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/a037dfdb-0a20-4d8d-867d-8b2b88a35031)

# Ticket Favro

[Vérifier qu'un établissement non diffusible n'est pas fermé à l'ajout du SIRET par l'utilisateur](https://favro.com/widget/ab14a4f0460a99a9d64d4945/c8a4ba49bef65e4df0e515aa?card=tra-13987)