### PR TITLE
Ajout de la possibilité de créer plusieurs webhooks par entreprise

### DIFF
--- a/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
+++ b/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
@@ -8,6 +8,19 @@ import { resetDatabase } from "../../../../integration-tests/helper";
 import { companyFactory } from "../../../__tests__/factories";
 import { prisma } from "@td/prisma";
 
+const sort = array => array.sort((a, b) => a.localeCompare(b));
+
+const expectWebhookSettingsEndpointUrisToBe = (
+  webhookSettings,
+  expectedUris
+) => {
+  expect(webhookSettings.length).toBe(expectedUris.length);
+
+  const uris = webhookSettings.map(w => w.endpointUri);
+
+  expect(sort(uris)).toEqual(sort(expectedUris));
+};
+
 describe("webhooksettings redis", () => {
   afterEach(async () => {
     await resetDatabase();
@@ -25,9 +38,7 @@ describe("webhooksettings redis", () => {
     });
     expect(whs.activated).toBe(true);
     let redisWhs = await getWebhookSettings(company.orgId);
-
-    expect(redisWhs.length).toBe(1);
-    expect(redisWhs[0].endpointUri).toBe("https://lorem.ipsum");
+    expectWebhookSettingsEndpointUrisToBe(redisWhs, ["https://lorem.ipsum"]);
 
     // When
     await handleWebhookFail(company.orgId, "https://lorem.ipsum");
@@ -38,9 +49,7 @@ describe("webhooksettings redis", () => {
 
     // Then
     redisWhs = await getWebhookSettings(company.orgId);
-
-    expect(redisWhs.length).toBe(1);
-    expect(redisWhs[0].endpointUri).toBe("https://lorem.ipsum");
+    expectWebhookSettingsEndpointUrisToBe(redisWhs, ["https://lorem.ipsum"]);
 
     // Go over limit
     await handleWebhookFail(company.orgId, "https://lorem.ipsum");
@@ -75,17 +84,15 @@ describe("webhooksettings redis", () => {
     });
 
     let redisWhsCompany1 = await getWebhookSettings(company1.orgId);
-    expect(redisWhsCompany1.length).toBe(2);
-    let endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
-    expect(endpointUris1.sort()).toEqual([
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany1, [
       "https://url1.fr",
       "https://url2.fr"
     ]);
 
     let redisWhsCompany2 = await getWebhookSettings(company2.orgId);
-    expect(redisWhsCompany2.length).toBe(1);
-    let endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
-    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany2, [
+      "https://url3.fr"
+    ]);
 
     // When
     await handleWebhookFail(company1.orgId, "https://url2.fr");
@@ -96,17 +103,15 @@ describe("webhooksettings redis", () => {
 
     // Then
     redisWhsCompany1 = await getWebhookSettings(company1.orgId);
-    expect(redisWhsCompany1.length).toBe(2);
-    endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
-    expect(endpointUris1.sort()).toEqual([
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany1, [
       "https://url1.fr",
       "https://url2.fr"
     ]);
 
     redisWhsCompany2 = await getWebhookSettings(company2.orgId);
-    expect(redisWhsCompany2.length).toBe(1);
-    endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
-    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany2, [
+      "https://url3.fr"
+    ]);
 
     // Go over limit
     await handleWebhookFail(company1.orgId, "https://url2.fr");
@@ -118,13 +123,13 @@ describe("webhooksettings redis", () => {
     expect(updatedWhs.activated).toBe(false);
 
     redisWhsCompany1 = await getWebhookSettings(company1.orgId);
-    expect(redisWhsCompany1.length).toBe(1);
-    endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
-    expect(endpointUris1.sort()).toEqual(["https://url1.fr"]);
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany1, [
+      "https://url1.fr"
+    ]);
 
     redisWhsCompany2 = await getWebhookSettings(company2.orgId);
-    expect(redisWhsCompany2.length).toBe(1);
-    endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
-    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
+    expectWebhookSettingsEndpointUrisToBe(redisWhsCompany2, [
+      "https://url3.fr"
+    ]);
   });
 });

--- a/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
+++ b/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
@@ -13,7 +13,9 @@ describe("webhooksettings redis", () => {
     await resetDatabase();
     await clearWebhookSetting();
   });
-  it("should deactivate db whebook and remove redis webhook", async () => {
+
+  it("should deactivate db webhook and remove redis webhook", async () => {
+    // Given
     const company = await companyFactory();
 
     const whs = await webhookSettingFactory({
@@ -27,15 +29,21 @@ describe("webhooksettings redis", () => {
     expect(redisWhs.length).toBe(1);
     expect(redisWhs[0].endpointUri).toBe("https://lorem.ipsum");
 
-    await handleWebhookFail(company.orgId);
-    await handleWebhookFail(company.orgId);
-    await handleWebhookFail(company.orgId);
-    await handleWebhookFail(company.orgId);
-    await handleWebhookFail(company.orgId);
+    // When
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
+
+    // Then
     redisWhs = await getWebhookSettings(company.orgId);
+
     expect(redisWhs.length).toBe(1);
     expect(redisWhs[0].endpointUri).toBe("https://lorem.ipsum");
-    await handleWebhookFail(company.orgId);
+
+    // Go over limit
+    await handleWebhookFail(company.orgId, "https://lorem.ipsum");
 
     const updatedWhs = await prisma.webhookSetting.findUniqueOrThrow({
       where: { id: whs.id }
@@ -43,5 +51,80 @@ describe("webhooksettings redis", () => {
     expect(updatedWhs.activated).toBe(false);
     redisWhs = await getWebhookSettings(company.orgId);
     expect(redisWhs.length).toBe(0);
+  });
+
+  it("should deactivate targeted webhook and no other", async () => {
+    // Given
+    const company1 = await companyFactory({ webhookSettingsLimit: 2 });
+    await webhookSettingFactory({
+      company: company1,
+      token: "secret",
+      endpointUri: "https://url1.fr"
+    });
+    const whs2 = await webhookSettingFactory({
+      company: company1,
+      token: "secret",
+      endpointUri: "https://url2.fr"
+    });
+
+    const company2 = await companyFactory({ webhookSettingsLimit: 2 });
+    await webhookSettingFactory({
+      company: company2,
+      token: "secret",
+      endpointUri: "https://url3.fr"
+    });
+
+    let redisWhsCompany1 = await getWebhookSettings(company1.orgId);
+    expect(redisWhsCompany1.length).toBe(2);
+    let endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
+    expect(endpointUris1.sort()).toEqual([
+      "https://url1.fr",
+      "https://url2.fr"
+    ]);
+
+    let redisWhsCompany2 = await getWebhookSettings(company2.orgId);
+    expect(redisWhsCompany2.length).toBe(1);
+    let endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
+    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
+
+    // When
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+
+    // Then
+    redisWhsCompany1 = await getWebhookSettings(company1.orgId);
+    expect(redisWhsCompany1.length).toBe(2);
+    endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
+    expect(endpointUris1.sort()).toEqual([
+      "https://url1.fr",
+      "https://url2.fr"
+    ]);
+
+    redisWhsCompany2 = await getWebhookSettings(company2.orgId);
+    expect(redisWhsCompany2.length).toBe(1);
+    endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
+    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
+
+    // Go over limit
+    await handleWebhookFail(company1.orgId, "https://url2.fr");
+
+    // Then
+    const updatedWhs = await prisma.webhookSetting.findUniqueOrThrow({
+      where: { id: whs2.id, endpointUri: whs2.endpointUri }
+    });
+    expect(updatedWhs.activated).toBe(false);
+
+    redisWhsCompany1 = await getWebhookSettings(company1.orgId);
+    expect(redisWhsCompany1.length).toBe(1);
+    endpointUris1 = redisWhsCompany1.map(r => r.endpointUri);
+    expect(endpointUris1.sort()).toEqual(["https://url1.fr"]);
+
+    redisWhsCompany2 = await getWebhookSettings(company2.orgId);
+    expect(redisWhsCompany2.length).toBe(1);
+    endpointUris2 = redisWhsCompany2.map(r => r.endpointUri);
+    expect(endpointUris2.sort()).toEqual(["https://url3.fr"]);
   });
 });

--- a/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
+++ b/back/src/common/redis/__tests__/redisWebhooksettings.integration.ts
@@ -10,7 +10,7 @@ import { prisma } from "@td/prisma";
 
 const sort = array => array.sort((a, b) => a.localeCompare(b));
 
-const expectCompanyWebhookSettingsEndpointUrisToBe = async (
+export const expectCompanyWebhookSettingsEndpointUrisToBe = async (
   companyOrgId,
   expectedUris
 ) => {

--- a/back/src/common/redis/webhooksettings.ts
+++ b/back/src/common/redis/webhooksettings.ts
@@ -90,7 +90,12 @@ export async function handleWebhookFail(
 
     if (wehbookSetting) {
       await prisma.webhookSetting.update({
-        where: { endpointUri, orgId },
+        where: {
+          WebhookSetting_orgId_endpointUri_unique_together: {
+            orgId,
+            endpointUri
+          }
+        },
         data: { activated: false }
       });
       await delWebhookSetting(wehbookSetting);

--- a/back/src/common/redis/webhooksettings.ts
+++ b/back/src/common/redis/webhooksettings.ts
@@ -1,8 +1,8 @@
 import { redisClient } from "./redis";
 import { WebhookSetting } from "@prisma/client";
-
 import { prisma } from "@td/prisma";
-type WebhookInfo = { endpointUri: string; token: string };
+
+export type WebhookInfo = { endpointUri: string; token: string };
 
 export const WEBHOOK_SETTING_CACHE_KEY = "webhooks_setting";
 const WEBHOOK_FAIL_CACHE_KEY = "webhook_fail";
@@ -18,13 +18,15 @@ export async function getWebhookSettings(
   orgId: string
 ): Promise<WebhookInfo[]> {
   const key = genWebhookKey(orgId);
-
   const storedWebhooks = await redisClient.smembers(key);
 
   return storedWebhooks
     .map(el => el.split(separator))
     .map(el => ({ endpointUri: el[0], token: el[1] }));
 }
+
+const smember = (webhookSetting: WebhookSetting) =>
+  `${webhookSetting.endpointUri}${separator}${webhookSetting.token}`;
 
 /**
  * Store a redis webhook setting - key : uri|token
@@ -33,11 +35,7 @@ export async function setWebhookSetting(
   webhookSetting: WebhookSetting
 ): Promise<void> {
   const key = genWebhookKey(webhookSetting.orgId);
-
-  await redisClient.sadd(
-    key,
-    `${webhookSetting.endpointUri}${separator}${webhookSetting.token}`
-  );
+  await redisClient.sadd(key, smember(webhookSetting));
 }
 
 /**Delete all redis webhooks settings */
@@ -59,31 +57,45 @@ export async function clearWebhookSetting(cursor = 0): Promise<void> {
   }
 }
 
-export async function delWebhookSetting(orgId: string): Promise<void> {
-  const key = genWebhookKey(orgId);
-  await redisClient.del(key);
+export async function delWebhookSetting(
+  webhookSetting: WebhookSetting
+): Promise<void> {
+  const key = genWebhookKey(webhookSetting.orgId);
+  await redisClient.srem(key, smember(webhookSetting));
 }
+// How many failed webhook for a given orgId before deactivation
 const WEBHOOK_FAIL_ACCEPTED = parseInt(
   process.env.WEBHOOK_FAIL_ACCEPTED || "5",
   10
-); // how many failed webhook ofor a given orgId before deactivation
+);
+// How long after the last fail the counter is reset
 const WEBHOOK_FAIL_RESET_DELAY = parseInt(
   process.env.WEBHOOK_FAIL_RESET_DELAY || "600",
   10
-); // how long after the last fail the counter is reset
+);
 
-const genWebhookFailKey = (orgId: string): string =>
-  `${WEBHOOK_FAIL_CACHE_KEY}:${orgId}`;
+const genWebhookFailKey = (orgId: string, endpointUri: string): string =>
+  `${WEBHOOK_FAIL_CACHE_KEY}:${orgId}:${endpointUri}`;
 
-export async function handleWebhookFail(orgId: string): Promise<void> {
-  const key = genWebhookFailKey(orgId);
+export async function handleWebhookFail(
+  orgId: string,
+  endpointUri: string
+): Promise<void> {
+  const key = genWebhookFailKey(orgId, endpointUri);
   const failCount = await redisClient.get(key);
   if (failCount && parseInt(failCount, 10) >= WEBHOOK_FAIL_ACCEPTED) {
-    await prisma.webhookSetting.update({
-      where: { orgId },
-      data: { activated: false }
+    const wehbookSetting = await prisma.webhookSetting.findFirst({
+      where: { endpointUri, orgId }
     });
-    await delWebhookSetting(orgId);
+
+    if (wehbookSetting) {
+      await prisma.webhookSetting.update({
+        where: { endpointUri, orgId },
+        data: { activated: false }
+      });
+      await delWebhookSetting(wehbookSetting);
+    }
+
     await redisClient.del(key);
     return;
   }

--- a/back/src/queue/jobs/__tests__/sendHook.integration.ts
+++ b/back/src/queue/jobs/__tests__/sendHook.integration.ts
@@ -1,0 +1,255 @@
+import { Job } from "bull";
+import axios from "axios";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { companyFactory } from "../../../__tests__/factories";
+import { clearWebhookSetting } from "../../../common/redis/webhooksettings";
+import { webhookSettingFactory } from "../../../webhooks/__tests__/factories";
+import { WebhookQueueItem } from "../../producers/webhooks";
+import { sendHookJob } from "../sendHook";
+
+jest.mock("axios");
+
+describe("sendHook", () => {
+  beforeEach(() => {
+    (axios.post as jest.Mock).mockClear();
+  });
+
+  afterEach(async () => {
+    await resetDatabase();
+    await clearWebhookSetting();
+  });
+
+  describe("sendHookJob", () => {
+    it("should send a request with BSDD id to active webhook", async () => {
+      // Given
+      const company = await companyFactory();
+
+      await webhookSettingFactory({
+        company: company,
+        token: "secret",
+        endpointUri: "https://company.fr/endpoint"
+      });
+
+      (axios.post as jest.Mock<any>).mockImplementation(() =>
+        Promise.resolve({ status: 200 })
+      );
+
+      // When
+      await sendHookJob({
+        data: {
+          id: "bsd-id",
+          sirets: [company.siret!],
+          action: "CREATE"
+        }
+      } as Job<WebhookQueueItem>);
+
+      // Then
+      expect(axios.post as jest.Mock<any>).toHaveBeenCalledTimes(1);
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company.fr/endpoint",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret" } }
+      );
+    });
+
+    it("should NOT send a request with BSDD id to inactive webhook", async () => {
+      // Given
+      const company = await companyFactory();
+
+      await webhookSettingFactory({
+        company: company,
+        token: "secret",
+        endpointUri: "https://company.fr/endpoint",
+        activated: false
+      });
+
+      (axios.post as jest.Mock<any>).mockImplementation(() =>
+        Promise.resolve({ status: 200 })
+      );
+
+      // When
+      await sendHookJob({
+        data: {
+          id: "bsd-id",
+          sirets: [company.siret!],
+          action: "CREATE"
+        }
+      } as Job<WebhookQueueItem>);
+
+      // Then
+      expect(axios.post as jest.Mock<any>).toHaveBeenCalledTimes(0);
+    });
+
+    it("should send a request with BSDD id to all active webhooks", async () => {
+      // Given
+      const company1 = await companyFactory({ webhookSettingsLimit: 2 });
+      const company2 = await companyFactory();
+
+      await webhookSettingFactory({
+        company: company1,
+        token: "secret-wh1",
+        endpointUri: "https://company1.fr/endpoint1"
+      });
+      await webhookSettingFactory({
+        company: company1,
+        token: "secret-wh2",
+        endpointUri: "https://company1.fr/endpoint2"
+      });
+      await webhookSettingFactory({
+        company: company2,
+        token: "secret-wh3",
+        endpointUri: "https://company2.fr/endpoint1"
+      });
+
+      (axios.post as jest.Mock<any>).mockImplementation(() =>
+        Promise.resolve({ status: 200 })
+      );
+
+      // When
+      await sendHookJob({
+        data: {
+          id: "bsd-id",
+          sirets: [company1.siret!, company2.siret!],
+          action: "CREATE"
+        }
+      } as Job<WebhookQueueItem>);
+
+      // Then
+      expect(axios.post as jest.Mock<any>).toHaveBeenCalledTimes(3);
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company1.fr/endpoint1",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh1" } }
+      );
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company1.fr/endpoint2",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh2" } }
+      );
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company2.fr/endpoint1",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh3" } }
+      );
+    });
+
+    it("should send a request with BSDD id to all active webhooks and skip inactive ones", async () => {
+      // Given
+      const company1 = await companyFactory({ webhookSettingsLimit: 2 });
+      const company2 = await companyFactory();
+      const company3 = await companyFactory();
+
+      await webhookSettingFactory({
+        company: company1,
+        token: "secret-wh1",
+        endpointUri: "https://company1.fr/endpoint1"
+      });
+      await webhookSettingFactory({
+        company: company1,
+        token: "secret-wh2",
+        endpointUri: "https://company1.fr/endpoint2"
+      });
+      await webhookSettingFactory({
+        company: company1,
+        token: "secret",
+        endpointUri: "https://company1.fr/endpoint3",
+        activated: false
+      });
+      await webhookSettingFactory({
+        company: company2,
+        token: "secret-wh3",
+        endpointUri: "https://company2.fr/endpoint1"
+      });
+      await webhookSettingFactory({
+        company: company3,
+        token: "secret",
+        endpointUri: "https://company3.fr/endpoint1",
+        activated: false
+      });
+
+      (axios.post as jest.Mock<any>).mockImplementation(() =>
+        Promise.resolve({ status: 200 })
+      );
+
+      // When
+      await sendHookJob({
+        data: {
+          id: "bsd-id",
+          sirets: [company1.siret!, company2.siret!],
+          action: "CREATE"
+        }
+      } as Job<WebhookQueueItem>);
+
+      // Then
+      expect(axios.post as jest.Mock<any>).toHaveBeenCalledTimes(3);
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company1.fr/endpoint1",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh1" } }
+      );
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company1.fr/endpoint2",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh2" } }
+      );
+      expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+        "https://company2.fr/endpoint1",
+        [{ action: "CREATE", id: "bsd-id" }],
+        { timeout: 5000, headers: { Authorization: "Bearer: secret-wh3" } }
+      );
+    });
+
+    // TODO: what's the expected behaviour???
+    // it("if the call to one webhook fails, should still call the others", async () => {
+    //     // Given
+    //     const company1 = await companyFactory({ webhookSettingsLimit: 2 });
+    //     const company2 = await companyFactory();
+
+    //     await webhookSettingFactory({
+    //         company: company1,
+    //         token: "secret-wh1",
+    //         endpointUri: "https://company1.fr/endpoint1"
+    //     });
+    //     await webhookSettingFactory({
+    //         company: company1,
+    //         token: "secret-wh2",
+    //         endpointUri: "https://company1.fr/endpoint2"
+    //     });
+    //     await webhookSettingFactory({
+    //         company: company2,
+    //         token: "secret-wh3",
+    //         endpointUri: "https://company2.fr/endpoint1"
+    //     });
+
+    //     (axios.post as jest.Mock<any>).mockImplementation((url) => {
+    //         if(url === "https://company1.fr/endpoint1") return Promise.resolve({ status: 404 });
+    //         return Promise.resolve({ status: 200 });
+    //     });
+
+    //     // When
+    //     await sendHookJob({data: {
+    //         id: "bsd-id",
+    //         sirets: [company1.siret!, company2.siret!],
+    //         action: "CREATE",
+    //     }} as Job<WebhookQueueItem>);
+
+    //     // Then
+    //     expect(axios.post as jest.Mock<any>).toHaveBeenCalledTimes(3);
+    //     expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+    //         "https://company1.fr/endpoint1",
+    //         [ { action: 'CREATE', id: 'bsd-id' } ],
+    //         { timeout: 5000, headers: { Authorization: 'Bearer: secret-wh1' } }
+    //     );
+    //     expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+    //         "https://company1.fr/endpoint2",
+    //         [ { action: 'CREATE', id: 'bsd-id' } ],
+    //         { timeout: 5000, headers: { Authorization: 'Bearer: secret-wh2' } }
+    //     );
+    //     expect(axios.post as jest.Mock).toHaveBeenCalledWith(
+    //         "https://company2.fr/endpoint1",
+    //         [ { action: 'CREATE', id: 'bsd-id' } ],
+    //         { timeout: 5000, headers: { Authorization: 'Bearer: secret-wh3' } }
+    //     );
+    // });
+  });
+});

--- a/back/src/queue/jobs/sendHook.ts
+++ b/back/src/queue/jobs/sendHook.ts
@@ -69,6 +69,7 @@ const apiCallProcessor = async ({
   // throw to trigger bull retry mechanism
   throw new WebhookRequestError(`Webhook requets fail for orgId ${orgId}`);
 };
+
 export async function sendHookJob(job: Job<WebhookQueueItem>) {
   const { id, sirets, action } = job.data;
 

--- a/back/src/webhooks/repository/webhookSetting/delete.ts
+++ b/back/src/webhooks/repository/webhookSetting/delete.ts
@@ -30,7 +30,7 @@ export function buildDeleteWebhookSetting(
       }
     });
 
-    await delWebhookSetting(deletedWebhookSetting.orgId);
+    await delWebhookSetting(deletedWebhookSetting);
 
     return deletedWebhookSetting;
   };

--- a/back/src/webhooks/repository/webhookSetting/update.ts
+++ b/back/src/webhooks/repository/webhookSetting/update.ts
@@ -26,7 +26,7 @@ export function buildUpdatWebhookSettings(
     const { prisma, user } = deps;
 
     const webhookSetting = await prisma.webhookSetting.update({ where, data });
-    await delWebhookSetting(webhookSetting.orgId);
+    await delWebhookSetting(webhookSetting);
 
     if (webhookSetting.activated) {
       await setWebhookSetting(webhookSetting);

--- a/back/src/webhooks/repository/webhookSetting/update.ts
+++ b/back/src/webhooks/repository/webhookSetting/update.ts
@@ -9,6 +9,7 @@ import {
   delWebhookSetting,
   setWebhookSetting
 } from "../../../common/redis/webhooksettings";
+import { UserInputError } from "../../../common/errors";
 
 export type UpdateWebhookSettingFn = (
   where: Prisma.WebhookSettingWhereUniqueInput,
@@ -25,15 +26,42 @@ export function buildUpdatWebhookSettings(
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
 
-    const webhookSetting = await prisma.webhookSetting.update({ where, data });
+    // First, check if another webhook has the same endpointUri
+    if (data.endpointUri) {
+      const existingWebhookSettingCount = await prisma.webhookSetting.count({
+        where: {
+          id: { not: where.id },
+          endpointUri: data.endpointUri.toString()
+        }
+      });
+
+      if (existingWebhookSettingCount) {
+        throw new UserInputError(
+          `Cet établissement a déjà un webhook avec l'endpoint "${data.endpointUri}"`
+        );
+      }
+    }
+
+    // Remove the webhook from Redis
+    const webhookSetting = await prisma.webhookSetting.findFirstOrThrow({
+      where: { id: where.id }
+    });
     await delWebhookSetting(webhookSetting);
 
-    if (webhookSetting.activated) {
-      await setWebhookSetting(webhookSetting);
+    // Update in DB
+    const updatedWebhookSetting = await prisma.webhookSetting.update({
+      where,
+      data
+    });
+
+    // If activated, add back to Redis
+    if (updatedWebhookSetting.activated) {
+      await setWebhookSetting(updatedWebhookSetting);
     }
+
     await prisma.event.create({
       data: {
-        streamId: webhookSetting.id,
+        streamId: updatedWebhookSetting.id,
         actor: user.id,
         type: webhookSettingEventTypes.updated,
         data: data as Prisma.InputJsonObject,
@@ -41,6 +69,6 @@ export function buildUpdatWebhookSettings(
       }
     });
 
-    return webhookSetting;
+    return updatedWebhookSetting;
   };
 }

--- a/back/src/webhooks/repository/webhookSetting/update.ts
+++ b/back/src/webhooks/repository/webhookSetting/update.ts
@@ -30,6 +30,7 @@ export function buildUpdatWebhookSettings(
     if (data.endpointUri) {
       const existingWebhookSettingCount = await prisma.webhookSetting.count({
         where: {
+          orgId: where.orgId,
           id: { not: where.id },
           endpointUri: data.endpointUri.toString()
         }

--- a/back/src/webhooks/resolvers/mutations/__tests__/createWebhookSetting.integration.ts
+++ b/back/src/webhooks/resolvers/mutations/__tests__/createWebhookSetting.integration.ts
@@ -125,7 +125,7 @@ describe("Mutation.createWebhookSetting", () => {
       })
     ]);
   });
-  it("should forbid non htpps uri", async () => {
+  it("should forbid non https uri", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
 
     const { mutate } = makeClient(user);
@@ -240,11 +240,99 @@ describe("Mutation.createWebhookSetting", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: "Un webhook est déjà programmé pour cet établissement.",
+        message: "Cet établissement ne peut pas créer davantage de webhooks.",
         extensions: expect.objectContaining({
           code: ErrorCode.BAD_USER_INPUT
         })
       })
     ]);
+  });
+
+  it("if company webhook limit has been increased, should allow to create several webhook settings for the same company", async () => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      webhookSettingsLimit: 2
+    });
+    await webhookSettingFactory({
+      company,
+      token: "secret",
+      endpointUri: "https://url1.com"
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const { data, errors } = await mutate<
+      Pick<Mutation, "createWebhookSetting">
+    >(CREATE_WEBHOOK_SETTING, {
+      variables: {
+        input: {
+          companyId: company.id,
+          endpointUri: "https://url2.com",
+          token: "secret_secret_secret",
+          activated: true
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toBeUndefined();
+    expect(data.createWebhookSetting.orgId).toEqual(company.orgId);
+
+    // 2nd time should fail
+    const { errors: secondTryErrors } = await mutate<
+      Pick<Mutation, "createWebhookSetting">
+    >(CREATE_WEBHOOK_SETTING, {
+      variables: {
+        input: {
+          companyId: company.id,
+          endpointUri: "https://url3.com",
+          token: "secret_secret_secret",
+          activated: true
+        }
+      }
+    });
+
+    expect(secondTryErrors).toEqual([
+      expect.objectContaining({
+        message: "Cet établissement ne peut pas créer davantage de webhooks.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("a company should not be able to create several webhookSettings with the same endpointUri", async () => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      webhookSettingsLimit: 2
+    });
+    await webhookSettingFactory({
+      company,
+      token: "secret",
+      endpointUri: "https://url1.com"
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createWebhookSetting">>(
+      CREATE_WEBHOOK_SETTING,
+      {
+        variables: {
+          input: {
+            companyId: company.id,
+            endpointUri: "https://url1.com",
+            token: "secret_secret_secret",
+            activated: true
+          }
+        }
+      }
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
+    expect(errors[0].message).toBe(
+      `Cet établissement a déjà un webhook avec l'endpoint "https://url1.com"`
+    );
   });
 });

--- a/back/src/webhooks/resolvers/mutations/__tests__/updateWebHookSettings.integration.ts
+++ b/back/src/webhooks/resolvers/mutations/__tests__/updateWebHookSettings.integration.ts
@@ -8,10 +8,7 @@ import makeClient from "../../../../__tests__/testClient";
 import { Mutation } from "../../../../generated/graphql/types";
 import { gql } from "graphql-tag";
 import { webhookSettingFactory } from "../../../__tests__/factories";
-import {
-  getWebhookSettings,
-  clearWebhookSetting
-} from "../../../../common/redis/webhooksettings";
+import { clearWebhookSetting } from "../../../../common/redis/webhooksettings";
 import { prisma } from "@td/prisma";
 import { expectCompanyWebhookSettingsEndpointUrisToBe } from "../../../../common/redis/__tests__/redisWebhooksettings.integration";
 
@@ -250,6 +247,7 @@ describe("Mutation.updateWebhookSetting", () => {
     );
 
     // Then
+    expect(errors).toBeUndefined();
     await expectCompanyWebhookSettingsEndpointUrisToBe(company.orgId, [
       "https://url1.fr"
     ]);

--- a/back/src/webhooks/resolvers/mutations/__tests__/updateWebHookSettings.integration.ts
+++ b/back/src/webhooks/resolvers/mutations/__tests__/updateWebHookSettings.integration.ts
@@ -12,7 +12,8 @@ import {
   getWebhookSettings,
   clearWebhookSetting
 } from "../../../../common/redis/webhooksettings";
-import { prisma } from "../../../../../../libs/back/prisma/src";
+import { prisma } from "@td/prisma";
+
 const UPDATE_WEBHOOK_SETTING = gql`
   mutation UpdateWebhookSetting($id: ID!, $input: WebhookSettingUpdateInput!) {
     updateWebhookSetting(id: $id, input: $input) {
@@ -152,7 +153,7 @@ describe("Mutation.updateWebhookSetting", () => {
     const { user, company } = await userWithCompanyFactory("ADMIN", {
       webhookSettingsLimit: 2
     });
-    const whs1 = await webhookSettingFactory({
+    await webhookSettingFactory({
       company,
       endpointUri: "https://url1.fr"
     });
@@ -196,7 +197,7 @@ describe("Mutation.updateWebhookSetting", () => {
       company: company1,
       endpointUri: "https://url1.fr"
     });
-    const whs2 = await webhookSettingFactory({
+    await webhookSettingFactory({
       company: company2,
       endpointUri: "https://url1.fr"
     });

--- a/back/src/webhooks/resolvers/mutations/create.ts
+++ b/back/src/webhooks/resolvers/mutations/create.ts
@@ -48,7 +48,7 @@ const createWebhookSettingResolver = async (
   }
 
   if (
-    companyWebhookSettings.find(
+    companyWebhookSettings.some(
       settings => settings.endpointUri === endpointUri
     )
   ) {

--- a/back/src/webhooks/resolvers/mutations/create.ts
+++ b/back/src/webhooks/resolvers/mutations/create.ts
@@ -30,25 +30,30 @@ const createWebhookSettingResolver = async (
 
   const company = await getCompanyOrCompanyNotFound({ id: companyId });
 
-  if (!allowedCompaniesOrgIds.includes(company.orgId)) {
+  if (!allowedCompaniesOrgIds.includes(company.orgId) || !company) {
     throw new UserInputError(
       "Vous n'avez pas la permission de gérer les webhooks de cet établissement."
     );
   }
 
-  if (!company) {
+  const webhookSettingRepository = getWebhookSettingRepository(user);
+  const companyWebhookSettings = await webhookSettingRepository.findMany(
+    { orgId: company.orgId },
+    { select: { endpointUri: true } }
+  );
+  if (companyWebhookSettings.length >= company.webhookSettingsLimit) {
     throw new UserInputError(
-      "Vous n'avez pas la permission de gérer les webhooks de cet établissement"
+      "Cet établissement ne peut pas créer davantage de webhooks."
     );
   }
-  const webhookSettingRepository = getWebhookSettingRepository(user);
-  const hasWebhookSettings = await webhookSettingRepository.count({
-    orgId: company.orgId
-  });
 
-  if (hasWebhookSettings) {
+  if (
+    companyWebhookSettings.find(
+      settings => settings.endpointUri === endpointUri
+    )
+  ) {
     throw new UserInputError(
-      "Un webhook est déjà programmé pour cet établissement."
+      `Cet établissement a déjà un webhook avec l'endpoint "${endpointUri}"`
     );
   }
 

--- a/back/src/webhooks/resolvers/mutations/update.ts
+++ b/back/src/webhooks/resolvers/mutations/update.ts
@@ -36,7 +36,7 @@ const updateWebhookSettingResolver = async (
   const webhookSettingRepository = getWebhookSettingRepository(user);
 
   const updatedWebhookSetting = await webhookSettingRepository.update(
-    { id: id },
+    { id: id, orgId: webhookSetting.orgId },
     {
       ...(endpointUri ? { endpointUri } : {}),
       ...(token ? { token: aesEncrypt(token) } : {}),

--- a/back/src/webhooks/validation.ts
+++ b/back/src/webhooks/validation.ts
@@ -21,7 +21,6 @@ const webhookSettingUpdateSchema: yup.SchemaOf<WebhookSettingUpdateInput> =
         "L'url doit être en https",
         value => value === undefined || value.startsWith("https://")
       ),
-    // TODO: required in Graphql..
     token: yup.string().notRequired().min(20).max(100),
     activated: yup.boolean()
   });
@@ -37,7 +36,7 @@ const webhookSettingCreateSchema: yup.SchemaOf<WebhookSettingCreateInput> =
       .test("webhook-url-https", "L'url doit être en https", (value: string) =>
         value.startsWith("https://")
       ),
-    token: yup.string().notRequired().min(20).max(100) as any,
+    token: yup.string().required().min(20).max(100) as any,
     activated: yup.boolean()
   });
 

--- a/back/src/webhooks/validation.ts
+++ b/back/src/webhooks/validation.ts
@@ -31,12 +31,12 @@ const webhookSettingCreateSchema: yup.SchemaOf<WebhookSettingCreateInput> =
     companyId: yup.string().required("L'id de l'établissement est requis'"),
     endpointUri: yup
       .string()
-      // .url()
+      .url()
       .max(300)
-      .required("L'url de notification du webhook est requise"),
-    // .test("webhook-url-https", "L'url doit être en https", (value: string) =>
-    //   value.startsWith("https://")
-    // ),
+      .required("L'url de notification du webhook est requise")
+      .test("webhook-url-https", "L'url doit être en https", (value: string) =>
+        value.startsWith("https://")
+      ),
     token: yup.string().notRequired().min(20).max(100) as any,
     activated: yup.boolean()
   });

--- a/back/src/webhooks/validation.ts
+++ b/back/src/webhooks/validation.ts
@@ -21,6 +21,7 @@ const webhookSettingUpdateSchema: yup.SchemaOf<WebhookSettingUpdateInput> =
         "L'url doit être en https",
         value => value === undefined || value.startsWith("https://")
       ),
+    // TODO: required in Graphql..
     token: yup.string().notRequired().min(20).max(100),
     activated: yup.boolean()
   });
@@ -30,12 +31,12 @@ const webhookSettingCreateSchema: yup.SchemaOf<WebhookSettingCreateInput> =
     companyId: yup.string().required("L'id de l'établissement est requis'"),
     endpointUri: yup
       .string()
-      .url()
+      // .url()
       .max(300)
-      .required("L'url de notification du webhook est requise")
-      .test("webhook-url-https", "L'url doit être en https", (value: string) =>
-        value.startsWith("https://")
-      ),
+      .required("L'url de notification du webhook est requise"),
+    // .test("webhook-url-https", "L'url doit être en https", (value: string) =>
+    //   value.startsWith("https://")
+    // ),
     token: yup.string().notRequired().min(20).max(100) as any,
     activated: yup.boolean()
   });

--- a/libs/back/prisma/src/migrations/20240408075446_webhooks_settings_limit/migration.sql
+++ b/libs/back/prisma/src/migrations/20240408075446_webhooks_settings_limit/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[orgId,endpointUri]` on the table `WebhookSetting` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "WebhookSetting_orgId_key";
+
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "webhookSettingsLimit" INTEGER NOT NULL DEFAULT 1;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookSetting_orgId_endpointUri_key" ON "WebhookSetting"("orgId", "endpointUri");

--- a/libs/back/prisma/src/migrations/20240409083512_webhook_settings_limit/migration.sql
+++ b/libs/back/prisma/src/migrations/20240409083512_webhook_settings_limit/migration.sql
@@ -5,7 +5,8 @@
 
 */
 -- DropIndex
-DROP INDEX "WebhookSetting_orgId_key";
+alter table "WebhookSetting" drop constraint if exists "WebhookSetting_orgId_key";
+DROP INDEX if exists "WebhookSetting_orgId_key";
 
 -- AlterTable
 ALTER TABLE "Company" ADD COLUMN     "webhookSettingsLimit" INTEGER NOT NULL DEFAULT 1;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -293,6 +293,7 @@ model Company {
   bsddRevisionRequests                 BsddRevisionRequest[]
   givenSignatureAutomations            SignatureAutomation[]     @relation("SignatureAutomationFrom")
   receivedSignatureAutomations         SignatureAutomation[]     @relation("SignatureAutomationTo")
+  webhookSettingsLimit                 Int @default(1)
 
   @@index([name], map: "_CompanyNameIdx")
   @@index([givenName], map: "_CompanyGivenNameIdx")
@@ -1662,10 +1663,11 @@ model WebhookSetting {
   createdAt   DateTime @default(now()) @db.Timestamptz(6)
   endpointUri String
   token       String
-  orgId       String   @unique
+  orgId       String
   activated   Boolean  @default(false)
 
   @@index([orgId], map: "_WebhookSettingOrgIdIdx")
+  @@unique([orgId, endpointUri], name: "WebhookSetting_orgId_endpointUri_unique_together")
 }
 
 enum RevisionRequestStatus {


### PR DESCRIPTION
# Contexte

Les webhooks sont notre meilleure solution pour avoir une vue en temps réel sur les bordereaux. Dans le cadre de notre chasse au gaspillage, nous demandons aux entreprises de les utiliser pour réduire le nombre de requêtes qu'elles nous adressent.

Après discussion avec un gros acteur, il est ressorti que la limite d'un seul webhook par entreprise est contraignante. En l'occurrence l'acteur concerné a plusieurs applications, écrites dans différents langages et gérées par différentes équipes. La seule solution technique faisable, à savoir, une gateway pour recevoir et dispatcher les webhooks, semblait difficile à réaliser.

Cette PR vise à essayer d'allouer un nombre de webhooks paramétrable aux entreprises, au cas par cas, pour voir si cela résout le problème: à savoir, que l'intégration est plus facile et plus rapide, mais que la charge engendrée de notre bord reste minime.

# Démo

### Création et envoi de notifications

![demo_create_webhooks](https://github.com/MTES-MCT/trackdechets/assets/45355989/82c39165-a98f-401b-8bc8-09b7f2c014df)

### Mécanisme de retry, désactivation si trop de fails

![demo_fail](https://github.com/MTES-MCT/trackdechets/assets/45355989/c49d569f-856a-457c-8075-eeda05c58bfc)

### Update & delete

![demo_update_delete](https://github.com/MTES-MCT/trackdechets/assets/45355989/040ea5c3-49b7-4c30-be4e-36f1907f5a1f)



