### PR TITLE
Correction du script de rattrapage SIRENE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -543,9 +543,9 @@ Depuis un one-off container de taille XL
 
 ## Rattrapage SIRENE
 
-Si les données de raison sociale et d'adresses enregistrés sur les bordereaux sont erronnées suite à un dysfonctionnement de l'index SIRENE, un rattrapage peut être effectué à postériori grâce au script :
+Si les données de raison sociale et d'adresses enregistrés sur les bordereaux sont erronnées suite à un dysfonctionnement de l'index SIRENE, un rattrapage peut être effectué à postériori grâce au script suivante. Tous les bordereaux qui ont été crées ou modifiés entre ces deux dates seront mis à jour.
 
-`npx nx run back:bulk-sirenify --since 2024-04-01 --before 2024-04-03`
+`npx nx run back:sirenify-bulk --since 2024-04-01 --before 2024-04-03`
 
 Les jobs de "sirenification" sont dépilés par le worker `bulkindexqueue` qui doit donc être démarré sur Scalingo avant de lancer le script.
 

--- a/back/src/scripts/bin/bulkSirenify.ts
+++ b/back/src/scripts/bin/bulkSirenify.ts
@@ -69,22 +69,29 @@ const keypress = async () => {
     `Mise à jour des bordereaux entre ${since.toISOString()} et ${before.toISOString()}`
   );
 
+  const where = {
+    OR: [
+      { updatedAt: { gte: since, lte: before } },
+      { createdAt: { gte: since, lte: before } }
+    ]
+  };
+
   const bsdds = await prisma.form.findMany({
-    where: { updatedAt: { gte: since, lte: before } },
+    where,
     select: { readableId: true }
   });
 
   console.log(`Il y a ${bsdds.length} BSDDs à mettre à jour`);
 
   const bsdas = await prisma.bsda.findMany({
-    where: { updatedAt: { gte: since, lte: before } },
+    where,
     select: { id: true }
   });
 
   console.log(`Il y a ${bsdas.length} BSDAs à mettre à jour`);
 
   const bsdasris = await prisma.bsdasri.findMany({
-    where: { updatedAt: { gte: since, lte: before } },
+    where,
     select: { id: true }
   });
 
@@ -98,14 +105,14 @@ const keypress = async () => {
   console.log(`Il y a ${bsffs.length} BSFFSs à mettre à jour`);
 
   const bsvhus = await prisma.bsvhu.findMany({
-    where: { updatedAt: { gte: since, lte: before } },
+    where,
     select: { id: true }
   });
 
   console.log(`Il y a ${bsvhus.length} BSVHUs à mettre à jour`);
 
   const bspaohs = await prisma.bspaoh.findMany({
-    where: { updatedAt: { gte: since, lte: before } },
+    where,
     select: { id: true }
   });
 


### PR DESCRIPTION
Les bordereaux avec des adresses erronées peuvent avoir été modifié entre temps.
Pour être exhaustif il faut viser tous les bordereaux qui ont été crée ou modifié pendant la période de l'incident SIRENE. 
