### PR TITLE
Increase lock duration and paginate in `getBsdsIdentifiers`

### DIFF
--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -34,13 +34,89 @@ describe("processDbIdentifiersByChunk", () => {
 describe("getBsdIdentifiers", () => {
   afterEach(resetDatabase);
 
-  it("should return all identifiers of a bsd type", async () => {
-    const user = await userFactory();
+  it.each([1, 2, 3, 4, 5, 100])(
+    "should return all BSDD's identifiers when paginating by %p",
+    async paginateBy => {
+      const user = await userFactory();
 
-    const form = await formFactory({ ownerId: user.id });
-    const ids = await getBsdIdentifiers("bsdd");
-    expect(ids).toEqual([form.id]);
-  });
+      const form1 = await formFactory({ ownerId: user.id });
+      const form2 = await formFactory({ ownerId: user.id });
+      const form3 = await formFactory({ ownerId: user.id });
+      const form4 = await formFactory({ ownerId: user.id });
+      const form5 = await formFactory({ ownerId: user.id });
+
+      const ids = await getBsdIdentifiers("bsdd", { paginateBy });
+      expect(ids).toEqual([form1.id, form2.id, form3.id, form4.id, form5.id]);
+    }
+  );
+
+  it.each([1, 2, 3, 4, 5, 100])(
+    "should return all BSDA's identifiers when paginating by %p",
+    async paginateBy => {
+      const bsda1 = await bsdaFactory({});
+      const bsda2 = await bsdaFactory({});
+      const bsda3 = await bsdaFactory({});
+      const bsda4 = await bsdaFactory({});
+      const bsda5 = await bsdaFactory({});
+
+      const ids = await getBsdIdentifiers("bsda", { paginateBy });
+      expect(ids).toEqual([bsda1.id, bsda2.id, bsda3.id, bsda4.id, bsda5.id]);
+    }
+  );
+
+  it.each([1, 2, 3, 4, 5, 100])(
+    "should return all BSDASRI's identifiers when paginating by %p",
+    async paginateBy => {
+      const bsdasri1 = await bsdasriFactory({});
+      const bsdasri2 = await bsdasriFactory({});
+      const bsdasri3 = await bsdasriFactory({});
+      const bsdasri4 = await bsdasriFactory({});
+      const bsdasri5 = await bsdasriFactory({});
+
+      const ids = await getBsdIdentifiers("bsdasri", { paginateBy });
+      expect(ids).toEqual([
+        bsdasri1.id,
+        bsdasri2.id,
+        bsdasri3.id,
+        bsdasri4.id,
+        bsdasri5.id
+      ]);
+    }
+  );
+
+  it.each([1, 2, 3, 4, 5, 100])(
+    "should return all BSFF's identifiers when paginating by %p",
+    async paginateBy => {
+      const bsff1 = await createBsff();
+      const bsff2 = await createBsff({});
+      const bsff3 = await createBsff({});
+      const bsff4 = await createBsff({});
+      const bsff5 = await createBsff({});
+
+      const ids = await getBsdIdentifiers("bsff", { paginateBy });
+      expect(ids).toEqual([bsff1.id, bsff2.id, bsff3.id, bsff4.id, bsff5.id]);
+    }
+  );
+
+  it.each([1, 2, 3, 4, 5, 100])(
+    "should return all BSVHU's identifiers when paginating by %p",
+    async paginateBy => {
+      const bsvhu1 = await bsvhuFactory({});
+      const bsvhu2 = await bsvhuFactory({});
+      const bsvhu3 = await bsvhuFactory({});
+      const bsvhu4 = await bsvhuFactory({});
+      const bsvhu5 = await bsvhuFactory({});
+
+      const ids = await getBsdIdentifiers("bsvhu", { paginateBy });
+      expect(ids).toEqual([
+        bsvhu1.id,
+        bsvhu2.id,
+        bsvhu3.id,
+        bsvhu4.id,
+        bsvhu5.id
+      ]);
+    }
+  );
 
   it("should not return identifiers updated before since paramater", async () => {
     const user = await userFactory();
@@ -54,7 +130,9 @@ describe("getBsdIdentifiers", () => {
       ownerId: user.id,
       opt: { updatedAt: new Date("2023-02-01") }
     });
-    const ids = await getBsdIdentifiers("bsdd", new Date("2023-02-01"));
+    const ids = await getBsdIdentifiers("bsdd", {
+      since: new Date("2023-02-01")
+    });
     expect(ids).toEqual([form2.id]);
   });
 });

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -63,6 +63,13 @@ export const bulkIndexMasterQueue = new Queue<string>(
       // 24h pour prendre de la marge, les jobs de cette queue attendent que toutes les chunks
       // soit process lors d'un reindex global
       timeout: 24 * 3600 * 1000
+    },
+    settings: {
+      // https://github.com/OptimalBits/bull?tab=readme-ov-file#important-notes
+      // https://github.com/OptimalBits/bull/issues/1591
+      lockDuration: 2 * 60 * 1000, // 2 minutes - default 3000 (30s)
+      // prevent the job from being run twice if it is stalled
+      maxStalledCount: 0 // default is 1
     }
   }
 );

--- a/back/src/queue/producers/elastic.ts
+++ b/back/src/queue/producers/elastic.ts
@@ -74,6 +74,12 @@ export const bulkIndexMasterQueue = new Queue<string>(
   }
 );
 
+bulkIndexMasterQueue.on("stalled", opt => {
+  logger.warn(
+    `The job ${opt.id} in queue bulkIndexMasterQueue has been stalled`
+  );
+});
+
 indexQueue.on("completed", async job => {
   const id = job.data;
 


### PR DESCRIPTION
D'après https://github.com/OptimalBits/bull?tab=readme-ov-file#important-notes

> The queue aims for an "at least once" working strategy. This means that in some situations, a job could be processed more than once. This mostly happens when a worker fails to keep a lock for a given job during the total duration of the processing.

> When a worker is processing a job it will keep the job "locked" so other workers can't process it.

> It's important to understand how locking works to prevent your jobs from losing their lock - becoming stalled - and being restarted as a result. Locking is implemented internally by creating a lock for lockDuration on interval lockRenewTime (which is usually half lockDuration). If lockDuration elapses before the lock can be renewed, the job will be considered stalled and is automatically restarted; it will be double processed. This can happen when:

> 1 - The Node process running your job processor unexpectedly terminates.
> 2- Your job processor was too CPU-intensive and stalled the Node event loop, and as a result, Bull couldn't renew the job lock (see https://github.com/OptimalBits/bull/issues/488 for how we might better detect this). You can fix this by breaking your job processor into smaller parts so that no single part can block the Node event loop. Alternatively, you can pass a larger value for the lockDuration setting (with the tradeoff being that it will take longer to recognize a real stalled job).

> As such, you should always listen for the stalled event and log this to your error monitoring system, as this means your jobs are likely getting double-processed.

> As a safeguard so problematic jobs won't get restarted indefinitely (e.g. if the job processor always crashes its Node process), jobs will be recovered from a stalled state a maximum of maxStalledCount times (default: 1).

Dans l'indexation de cette nuit, on voit que l'event loop a été bloquée à plusieurs moment lors de la récupération des identifiants.

![Capture d’écran 2024-04-10 à 15 33 04](https://github.com/MTES-MCT/trackdechets/assets/2269165/e5a7a5fa-7576-4a18-a6a8-d2d185d4417c)

Ce blocage a certainement empêché le lock de se renouveler et le job master a été marqué comme stalled. Le comportement par défaut dans ce cas là est de réessayer de run le job (` maxStalledCount=1`) et la réindexation globale a donc eu lieu deux fois.

Cette PR inclut plusieurs corrections pour éviter que ça se reproduise : 
- Augmente légèrement la valeur de `lockDuration` (de 30s à 2 minutes).
- Ajout d'une pagination par curseur dans `getBsdIdentifiers`.
- Set `maxStalledCount=0` pour éviter que le job soit exécuté deux fois s'il se retrouve quand même`stalled` pour une raison ou une autre.
- Log l'événement en cas de job `stalled`

---

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
