### PR TITLE
Clarification du wording des boutons de création des établissements

### DIFF
--- a/e2e/src/utils/company.ts
+++ b/e2e/src/utils/company.ts
@@ -49,11 +49,17 @@ interface AmianteCertification {
   organisation: "QUALIBAT" | "AFNOR Certification" | "GLOBAL CERTIFICATION";
 }
 
+const isOnlyWasteProducter = (roles: CompanyRole[]): boolean => {
+  return (
+    roles.length === 1 &&
+    roles[0] === "Producteur de déchets : producteurs de déchets, y compris T&S"
+  );
+};
+
 /**
- * In the "/companies/create", returns the correct "Créer votre établissement" button index
- * matching company role.
+ * Return the correct create-button-label regarding company roles
  */
-export const getCreateButtonIndex = (roles: CompanyRole[]) => {
+export const getCreateButtonName = (roles: CompanyRole[]) => {
   // "La gestion des déchets fait partie de votre activité"
   for (const role of roles) {
     if (
@@ -69,7 +75,7 @@ export const getCreateButtonIndex = (roles: CompanyRole[]) => {
         "Entreprise de travaux amiante"
       ].includes(role)
     ) {
-      return 1;
+      return "Créer un établissement";
     }
   }
 
@@ -80,12 +86,12 @@ export const getCreateButtonIndex = (roles: CompanyRole[]) => {
         "Producteur de déchets : producteurs de déchets, y compris T&S"
       ].includes(role)
     ) {
-      return 0;
+      return "Créer votre établissement producteur";
     }
   }
 
   // "Transporteur hors France, Non-French carrier"
-  return 2;
+  return "Créer un établissement transporteur hors France";
 };
 
 /**
@@ -153,14 +159,11 @@ export const generateSiretAndInitiateCompanyCreation = async (
   }
 
   // "Créer votre établissement" button. Select correct one regarding company activity.
-  const createButtonIndex = getCreateButtonIndex(roles);
-  await page
-    .getByRole("button", { name: "Créer votre établissement" })
-    .nth(createButtonIndex)
-    .click();
+  const createButtonName = getCreateButtonName(roles);
+  await page.getByRole("button", { name: createButtonName }).click();
 
   // For waste producers...
-  if (createButtonIndex === 0) {
+  if (isOnlyWasteProducter(roles)) {
     // ...help message should be visible (and closable)
     const helpMessage = page.getByRole("heading", {
       name: "Vous rencontrez des difficultés dans la création d'un établissement ?"

--- a/e2e/src/utils/company.ts
+++ b/e2e/src/utils/company.ts
@@ -160,7 +160,9 @@ export const generateSiretAndInitiateCompanyCreation = async (
 
   // "Créer votre établissement" button. Select correct one regarding company activity.
   const createButtonName = getCreateButtonName(roles);
-  await page.getByRole("button", { name: createButtonName }).click();
+  await page
+    .getByRole("button", { name: createButtonName, exact: true })
+    .click();
 
   // For waste producers...
   if (isOnlyWasteProducter(roles)) {

--- a/front/src/Apps/Companies/AccountCompanyOrientation.tsx
+++ b/front/src/Apps/Companies/AccountCompanyOrientation.tsx
@@ -14,10 +14,8 @@ export default function AccountCompanyOrientation() {
           <CallOut
             title="Vous produisez des déchets dans le cadre de votre activité."
             buttonProps={{
-              title: "Créer votre établissement",
-              children: "Créer votre établissement",
-              iconId: "ri-arrow-right-line",
-              iconPosition: "right",
+              title: "Créer votre établissement producteur",
+              children: "Créer votre établissement producteur",
               onClick: () => {
                 navigate(routes.companies.create.simple);
               }
@@ -55,10 +53,8 @@ export default function AccountCompanyOrientation() {
           <CallOut
             title="La gestion des déchets fait partie de votre activité."
             buttonProps={{
-              title: "Créer votre établissement",
-              children: "Créer votre établissement",
-              iconId: "ri-arrow-right-line",
-              iconPosition: "right",
+              title: "Créer un établissement",
+              children: "Créer un établissement",
               onClick: () => {
                 navigate(routes.companies.create.pro);
               }
@@ -76,10 +72,8 @@ export default function AccountCompanyOrientation() {
           <CallOut
             title="Transporteur hors France, Non-French carrier"
             buttonProps={{
-              title: "Créer votre établissement",
-              children: "Créer votre établissement",
-              iconId: "ri-arrow-right-line",
-              iconPosition: "right",
+              title: "Créer un établissement transporteur hors France",
+              children: "Créer un établissement transporteur hors France",
               onClick: () => {
                 navigate(routes.companies.create.foreign);
               }


### PR DESCRIPTION
# Contexte

On a des utilisateurs qui clique immédiatement sur "Producteur de déchet" alors qu'ils sont aussi professionnels. Tentative de clarifier le wording pour éviter ça.

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/8ae000e1-bf5d-4495-9b78-61baa9caba1a)

# Ticket Favro

[Eviter que les utilisateurs se créent le mauvais profil, puis le mettent à jour](https://github.com/MTES-MCT/trackdechets/pull/3259)
