### PR TITLE
[HOTFIX BSDA] Correction mauvais poids en cas d'update multiple avant opération

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -2135,4 +2135,57 @@ describe("Mutation.updateBsda", () => {
       })
     ]);
   });
+
+  it("should be possible to update destination without erasing destination reception weight", async () => {
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const destination = await userWithCompanyFactory("MEMBER");
+
+    // Create a form that has already been sent
+    const bsda = await bsdaFactory({
+      opt: {
+        status: "SENT",
+        weightValue: 1000,
+        emitterEmissionSignatureDate: new Date(),
+        emitterCompanySiret: emitter.company.siret,
+        destinationCompanySiret: destination.company.siret
+      }
+    });
+
+    const { mutate } = makeClient(destination.user);
+
+    let input: BsdaInput = {
+      destination: { reception: { weight: 2 } }
+    };
+    const { errors: errors1 } = await mutate<Pick<Mutation, "updateBsda">>(
+      UPDATE_BSDA,
+      {
+        variables: { id: bsda.id, input }
+      }
+    );
+    expect(errors1).toBeUndefined();
+
+    let updatedBsda = await prisma.bsda.findUniqueOrThrow({
+      where: { id: bsda.id }
+    });
+    expect(updatedBsda.destinationReceptionWeight!.toNumber()).toEqual(
+      2000 // 2 * 1000
+    );
+    input = {
+      destination: { operation: { code: "D 5" } }
+    };
+    const { errors: errors2 } = await mutate<Pick<Mutation, "updateBsda">>(
+      UPDATE_BSDA,
+      {
+        variables: { id: bsda.id, input }
+      }
+    );
+    expect(errors2).toBeUndefined();
+
+    updatedBsda = await prisma.bsda.findUniqueOrThrow({
+      where: { id: bsda.id }
+    });
+    expect(updatedBsda.destinationReceptionWeight!.toNumber()).toEqual(
+      2000 // 2 * 1000
+    );
+  });
 });

--- a/back/src/bsda/validation/helpers.ts
+++ b/back/src/bsda/validation/helpers.ts
@@ -148,7 +148,7 @@ export function prismaToZodBsda(bsda: PrismaBsdaForParsing): ZodBsda {
   return {
     ...data,
     weightValue: data.weightValue?.toNumber(),
-    destinationReceptionWeight: data.weightValue?.toNumber(),
+    destinationReceptionWeight: data.destinationReceptionWeight?.toNumber(),
     wasteCode: wasteCode as ZodWasteCodeEnum,
     destinationPlannedOperationCode:
       destinationPlannedOperationCode as ZodOperationEnum,


### PR DESCRIPTION
Bug introduit par le refacto Decimal lié à prisma migrate. 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14223)
