### PR TITLE
[tra-13791] Modification de la validation de mdp sur page Invite + refacto suppression utilisateur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,11 +5,13 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-# [2024.45.1] 07/05/2024
+# [2024.5.1] 07/05/2024
 
 #### :rocket: Nouvelles fonctionnalités
 
 #### :bug: Corrections de bugs
+
+- Modification de la validation de mot de passe sur page Invite [PR 3278](https://github.com/MTES-MCT/trackdechets/pull/3278)
 
 #### :boom: Breaking changes
 
@@ -18,6 +20,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :house: Interne
 
 - ETQ admin je peux télécharger le registre d'un utilisateur [PR 3267](https://github.com/MTES-MCT/trackdechets/pull/3267)
+- Refacto des méthodes de suppressions d'objets liés à l'utilisateur pour pouvoir utiliser le script de suppression d'utilisateur en standalone
 
 # [2024.4.1] 09/04/2024
 

--- a/back/src/scripts/bin/hardDeleteUser.ts
+++ b/back/src/scripts/bin/hardDeleteUser.ts
@@ -40,4 +40,5 @@ import deleteUser from "../prisma/hardDeleteUser";
     process.exit(0);
   }
   await deleteUser(user);
+  process.exit(0);
 })();

--- a/back/src/scripts/prisma/hardDeleteUser.ts
+++ b/back/src/scripts/prisma/hardDeleteUser.ts
@@ -7,8 +7,9 @@ import {
   deleteUserAccessTokens,
   deleteUserActivationHashes,
   deleteUserCompanyAssociations,
-  deleteUserGrants
-} from "../../users/resolvers/mutations/anonymizeUser";
+  deleteUserGrants,
+  deleteUserAccountHash
+} from "../../users/database";
 import { clearUserSessions } from "../../users/clearUserSessions";
 
 /**
@@ -31,6 +32,7 @@ export default async function deleteUser(user: User) {
   await deleteUserAccessTokens(user, prisma);
   await deleteUserGrants(user, prisma);
   await deleteMembershipRequest(user, prisma);
+  await deleteUserAccountHash(user, prisma);
 
   await prisma.user.delete({
     where: { id: user.id }

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -59,7 +59,8 @@ export async function createUserAccountHash(
 }
 
 /**
- * Delete UserAccountHash objects linked to a user's mail (association between user and siret with a hash)
+ * Delete UserAccountHash objects linked to a user's mail
+ * (association between user and siret with a hash used for invitations)
  * @param user
  * @param prisma
  */
@@ -259,6 +260,11 @@ export async function updateUserPassword({
   });
 }
 
+/**
+ * Determine if a user is the sole admin for a company
+ * used in deletion pipeline to prevent deleting a user
+ * @param user
+ */
 export async function checkCompanyAssociations(user: User): Promise<string[]> {
   const errors: string[] = [];
   const companyAssociations = await prisma.companyAssociation.findMany({
@@ -302,6 +308,11 @@ export async function checkCompanyAssociations(user: User): Promise<string[]> {
   return errors;
 }
 
+/**
+ * Determine if a user is the sole admin for an application
+ * used in deletion pipeline to prevent deleting a user
+ * @param user
+ */
 export async function checkApplications(user: User): Promise<string[]> {
   const errors: string[] = [];
   const applications = await prisma.application.findMany({
@@ -318,6 +329,11 @@ export async function checkApplications(user: User): Promise<string[]> {
   return errors;
 }
 
+/**
+ * Delete all associations between a user and companies
+ * @param user
+ * @param prisma
+ */
 export async function deleteUserCompanyAssociations(
   user: User,
   prisma: PrismaTransaction
@@ -331,6 +347,11 @@ export async function deleteUserCompanyAssociations(
   });
 }
 
+/**
+ * Delete all membership requests from a user
+ * @param user
+ * @param prisma
+ */
 export async function deleteMembershipRequest(
   user: User,
   prisma: PrismaTransaction
@@ -344,6 +365,11 @@ export async function deleteMembershipRequest(
   });
 }
 
+/**
+ * Delete all UserActivationHashes of a user
+ * @param user
+ * @param prisma
+ */
 export async function deleteUserActivationHashes(
   user: User,
   prisma: PrismaTransaction
@@ -357,6 +383,11 @@ export async function deleteUserActivationHashes(
   });
 }
 
+/**
+ * Delete all access tokens of a user
+ * @param user
+ * @param prisma
+ */
 export async function deleteUserAccessTokens(
   user: User,
   prisma: PrismaTransaction
@@ -370,6 +401,11 @@ export async function deleteUserAccessTokens(
   });
 }
 
+/**
+ * Delete all grants of a user
+ * @param user
+ * @param prisma
+ */
 export async function deleteUserGrants(user: User, prisma: PrismaTransaction) {
   await prisma.grant.deleteMany({
     where: {

--- a/front/src/common/components/PasswordHelper.tsx
+++ b/front/src/common/components/PasswordHelper.tsx
@@ -19,7 +19,7 @@ export const getPasswordHint = (password: string): PasswordHintResult => {
     return {
       title: "Trop court",
       hintType: "error",
-      message: `Votre mot de passe est trop court (${password.length} caractères), la longueur minimale est de 10 caractères`
+      message: `Votre mot de passe est trop court (${password.length} caractères), la longueur minimale est de ${MIN_LENGTH} caractères`
     };
   const { score } = zxcvbn(password);
   return score >= MIN_SCORE

--- a/front/src/login/Invite.tsx
+++ b/front/src/login/Invite.tsx
@@ -114,8 +114,8 @@ export default function Invite() {
             </p>
             <ul className="bullets">
               {user.companies?.map(company => (
-                <li key={company.orgId}>
-                  {company.name} - ({company.orgId})
+                <li key={company.siret}>
+                  {company.name} - ({company.siret})
                 </li>
               ))}
             </ul>
@@ -225,7 +225,7 @@ export default function Invite() {
           }).then(_ => setSubmitting(false));
         }}
       >
-        {({ isSubmitting, errors, touched, isValid, submitForm }) => (
+        {({ isSubmitting, errors, touched, isValid }) => (
           <Form>
             <div className="fr-grid-row fr-grid-row--center fr-mb-2w">
               <div className="fr-col fr-m-auto">
@@ -290,7 +290,6 @@ export default function Invite() {
                   iconId="ri-arrow-right-line"
                   iconPosition="right"
                   size="medium"
-                  onClick={submitForm}
                   disabled={!isValid}
                   title={
                     isSubmitting ? "Création en cours..." : "Créer mon compte"

--- a/front/src/login/Invite.tsx
+++ b/front/src/login/Invite.tsx
@@ -39,7 +39,7 @@ const JOIN_WITH_INVITE = gql`
       email
       companies {
         name
-        siret
+        orgId
       }
     }
   }
@@ -114,8 +114,8 @@ export default function Invite() {
             </p>
             <ul className="bullets">
               {user.companies?.map(company => (
-                <li key={company.siret}>
-                  {company.name} - ({company.siret})
+                <li key={company.orgId}>
+                  {company.name} - ({company.orgId})
                 </li>
               ))}
             </ul>

--- a/front/src/login/Invite.tsx
+++ b/front/src/login/Invite.tsx
@@ -7,6 +7,9 @@ import { Mutation, MutationJoinWithInviteArgs, Query } from "@td/codegen-ui";
 import Loader from "../Apps/common/Components/Loader/Loaders";
 import * as queryString from "query-string";
 import { decodeHash } from "../common/helper";
+import PasswordHelper, {
+  getPasswordHint
+} from "../common/components/PasswordHelper";
 import routes from "../Apps/routes";
 
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
@@ -201,7 +204,19 @@ export default function Invite() {
           password: yup
             .string()
             .required("Le mot de passe est un champ requis")
-            .min(8, "Le mot de passe doit faire au moins 8 caractères")
+            .test({
+              name: "is-valid-password",
+              test: value => {
+                if (!value) {
+                  return false;
+                }
+                const { hintType } = getPasswordHint(value);
+                if (hintType === "error") {
+                  return false;
+                }
+                return true;
+              }
+            })
         })}
         onSubmit={(values, { setSubmitting }) => {
           const { name, password } = values;
@@ -257,26 +272,13 @@ export default function Invite() {
                 <Field name="password">
                   {({ field }) => {
                     return (
-                      <PasswordInput
-                        label="Mot de passe"
-                        messages={[
-                          {
-                            severity: "info",
-                            message: "8 caractères minimum"
-                          },
-                          {
-                            severity:
-                              errors.password && touched.password
-                                ? "error"
-                                : "info",
-                            message:
-                              errors.password && touched.password
-                                ? errors.password
-                                : ""
-                          }
-                        ]}
-                        nativeInputProps={{ required: true, ...field }}
-                      />
+                      <>
+                        <PasswordInput
+                          label="Mot de passe"
+                          nativeInputProps={{ required: true, ...field }}
+                        />
+                        <PasswordHelper password={field.value} />
+                      </>
                     );
                   }}
                 </Field>


### PR DESCRIPTION
## Changements principaux

Comme remonté dans le ticket par YesWeHack, la validation du mot de passe sur la page d'invitation n'est pas cohérente avec celle faite sur la page de Signup. J'ai donc repris le composant de Hint pour l'affichage ainisi que sa logique de validation que j'ai rentré dans une fonction de test Yup.


https://github.com/MTES-MCT/trackdechets/assets/2432646/896dd0bb-54ae-4f9a-a19e-a1f1a40d0664

## Changements secondaires

En testant ces modifications, je suis tombé sur quelques problèmes que j'ai fix au passage:
- les SIRET des entreprises de l'utilisateur n'apparaissaient pas dans la liste de la page suivant le join (utilisation de company.orgId à la place de company.siret)
- le script hardDeleteUser ne pouvait plus être appelé en standalone en raison de dépendances non résolues. J'ai donc refacto les méthodes de suppression utilisateur en déplaçant les accesseurs dans le fichier database.ts. On évite ainsi de charger un résolveur et les soucis de dépendances non résolues.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13791)
