### PR TITLE
[TRA-14181] Correctif de l'extension '.pdf' qui était en double lors du téléchargement d'un PDF de BSDD

### DIFF
--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -38,7 +38,7 @@ export async function renderFormRefusedEmail(
   const { filename, data } = await generateBsddPdfToBase64(form);
   const attachmentData = {
     file: data,
-    name: filename
+    name: `${filename}.pdf`
   };
 
   const emitterCompanyAdmins = await getCompanyAdminUsers(

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -1168,7 +1168,7 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
   );
   const stream = await generatePdf(html);
 
-  return { filename: `${form.readableId}.pdf`, stream };
+  return { filename: form.readableId, stream };
 }
 
 export async function generateBsddPdfToBase64(


### PR DESCRIPTION
# Ticket Favro

[Modifier l'extension du PDF BSDD qui sont téléchargés avec une double extension ".pdf.pdf"](https://favro.com/widget/ab14a4f0460a99a9d64d4945/4186f94658c16a1334e47546?card=tra-14181)
