### PR TITLE
[tra-10310] fix date de prise en charge initiale dans table Annexe 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Modification de la validation de mot de passe sur page Invite [PR 3278](https://github.com/MTES-MCT/trackdechets/pull/3278)
+- La date de prise en charge initiale des BSD initiaux sur le PDF de l'Annexe 2 est complétée avec la date d'enlèvement initiale et non la date de la signature [PR 3280](https://github.com/MTES-MCT/trackdechets/pull/3280)
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -1120,11 +1120,7 @@ export async function generateBsddPdf(id: PrismaForm["id"]) {
                       {form?.emitter?.type !== EmitterType.APPENDIX1 && (
                         <td>{quantity}</td>
                       )}
-                      <td>
-                        {form?.emitter?.type === EmitterType.APPENDIX1
-                          ? formatDate(groupedForm?.takenOverAt)
-                          : formatDate(groupedForm?.signedAt)}
-                      </td>
+                      <td>{formatDate(groupedForm?.takenOverAt)}</td>
                       <td>{groupedForm?.emitterPostalCode}</td>
                       {form?.emitter?.type === EmitterType.APPENDIX1 && (
                         <td>{groupedForm?.wasteDetails?.sampleNumber}</td>


### PR DESCRIPTION
Utiliser la date de prise en charge initiale au lieu de la date de signature dans la table d'annexe 2.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-10310)
