### PR TITLE
Amélioration des events d'update 

### DIFF
--- a/back/src/activity-events/bsdd/index.ts
+++ b/back/src/activity-events/bsdd/index.ts
@@ -1,8 +1,8 @@
 import { Form } from "@prisma/client";
-import { aggregateStream, getStream, persistEvent } from "..";
+import { aggregateStream, getStream } from "..";
 import { AppDataloaders } from "../../types";
 import { bsddReducer } from "./reducer";
-import { BsddEvent, BsddRevisionRequestEvent } from "./types";
+import { BsddEvent } from "./types";
 
 export * from "./types";
 export * from "./reducer";
@@ -11,16 +11,6 @@ type BsddEventsParams = {
   bsddId: string;
   at?: Date;
 };
-
-export function persistBsddEvent(bsddEvent: BsddEvent) {
-  return persistEvent(bsddEvent);
-}
-
-export function persistBsddRevisionRequestEvent(
-  bsddRevisionRequestEvent: BsddRevisionRequestEvent
-) {
-  return persistEvent(bsddRevisionRequestEvent);
-}
 
 export async function getBsddFromActivityEvents(
   { bsddId, at }: BsddEventsParams,

--- a/back/src/activity-events/data.ts
+++ b/back/src/activity-events/data.ts
@@ -1,6 +1,6 @@
 import { ActivityEvent } from ".";
 import { prisma } from "@td/prisma";
-import { Event, Prisma } from "@prisma/client";
+import { Event } from "@prisma/client";
 import { getStreamEvents } from "../events/mongodb";
 import { EventCollection } from "../events/types";
 
@@ -62,16 +62,4 @@ export function dbEventToActivityEvent(
     data: event.data as Record<string, unknown>,
     metadata: event.metadata as Record<string, unknown>
   };
-}
-
-export function persistEvent(event: ActivityEvent): Promise<Event> {
-  return prisma.event.create({
-    data: {
-      streamId: event.streamId,
-      actor: event.actor,
-      type: event.type,
-      data: event.data as Prisma.InputJsonObject,
-      metadata: (event.metadata as Prisma.InputJsonObject) ?? Prisma.DbNull
-    }
-  });
 }

--- a/back/src/bsdasris/repository/bsdasri/update.ts
+++ b/back/src/bsdasris/repository/bsdasri/update.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../common/repository/types";
 import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdasriEventTypes } from "./eventTypes";
+import { objectDiff } from "../../../forms/workflow/diff";
 
 export type UpdateBsdasriFn = (
   where: Prisma.BsdasriWhereUniqueInput,
@@ -18,6 +19,14 @@ export type UpdateBsdasriFn = (
 export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
+    const previousBsdasri = await prisma.bsdasri.findUnique({
+      where,
+      include: {
+        synthesizing: true,
+        grouping: true
+      }
+    });
+
     const bsdasri = await prisma.bsdasri.update({
       where,
       data,
@@ -50,28 +59,19 @@ export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
         data: { groupingEmitterSirets }
       });
     }
+
+    const updateDiff = objectDiff(previousBsdasri, bsdasri);
     await prisma.event.create({
       data: {
         streamId: bsdasri.id,
         actor: user.id,
-        type: bsdasriEventTypes.updated,
-        data: data as Prisma.InputJsonObject,
+        type: data.status
+          ? bsdasriEventTypes.signed
+          : bsdasriEventTypes.updated,
+        data: updateDiff,
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
-
-    // Status updates are done only through signature
-    if (data.status) {
-      await prisma.event.create({
-        data: {
-          streamId: bsdasri.id,
-          actor: user.id,
-          type: bsdasriEventTypes.signed,
-          data: { status: data.status },
-          metadata: { ...logMetadata, authType: user.auth }
-        }
-      });
-    }
 
     prisma.addAfterCommitCallback(() => enqueueUpdatedBsdToIndex(bsdasri.id));
 

--- a/back/src/forms/repository/form/update.ts
+++ b/back/src/forms/repository/form/update.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../common/repository/types";
 import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { getFormSiretsByRole, SIRETS_BY_ROLE_INCLUDE } from "../../database";
-import { formDiff } from "../../workflow/diff";
+import { formDiff, objectDiff } from "../../workflow/diff";
 import { getUserCompanies } from "../../../users/database";
 import { FormWithTransporters } from "../../types";
 
@@ -116,12 +116,13 @@ const buildUpdateForm: (deps: RepositoryFnDeps) => UpdateFormFn =
       });
     }
 
+    const updateDiff = objectDiff(oldForm, updatedForm);
     await prisma.event.create({
       data: {
         streamId: updatedForm.id,
         actor: user.id,
         type: "BsddUpdated",
-        data: { content: data } as Prisma.InputJsonObject,
+        data: { content: updateDiff } as Prisma.InputJsonObject,
         metadata: { ...logMetadata, authType: user.auth }
       }
     });


### PR DESCRIPTION
Calcul d'un diff lors du stockage des données dans les events.
Ca évite de stocker de la donnée inutilement, et ça permet de débuguer plus facilement en sachant précisément ce qui a été modifié à chaque fois.

WIP