### PR TITLE
[TRA-14219] fix status lorsque l'émetteur est un particulier dans les annexes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Modification de la validation de mot de passe sur page Invite [PR 3278](https://github.com/MTES-MCT/trackdechets/pull/3278)
 - La date de prise en charge initiale des BSD initiaux sur le PDF de l'Annexe 2 est complétée avec la date d'enlèvement initiale et non la date de la signature [PR 3280](https://github.com/MTES-MCT/trackdechets/pull/3280)
 - Correctif de l'extension '.pdf' qui était en double lors du téléchargement d'un PDF de BSDD [PR 3279](https://github.com/MTES-MCT/trackdechets/pull/3279)
+- Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,20 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2024.6.1] 04/06/2024
+
+#### :rocket: Nouvelles fonctionnalités
+
+#### :bug: Corrections de bugs
+
+- Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
+
+#### :boom: Breaking changes
+
+#### :nail_care: Améliorations
+
+#### :house: Interne
+
 # [2024.5.1] 07/05/2024
 
 #### :rocket: Nouvelles fonctionnalités
@@ -18,7 +32,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Modification de la validation de mot de passe sur page Invite [PR 3278](https://github.com/MTES-MCT/trackdechets/pull/3278)
 - La date de prise en charge initiale des BSD initiaux sur le PDF de l'Annexe 2 est complétée avec la date d'enlèvement initiale et non la date de la signature [PR 3280](https://github.com/MTES-MCT/trackdechets/pull/3280)
 - Correctif de l'extension '.pdf' qui était en double lors du téléchargement d'un PDF de BSDD [PR 3279](https://github.com/MTES-MCT/trackdechets/pull/3279)
-- Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
 
 #### :boom: Breaking changes
 

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -590,9 +590,10 @@ const Appendix1 = ({
                 </td>
                 <td>
                   {form.status
-                    ? !Boolean(form.emitter?.isPrivateIndividual)
-                      ? STATUS_LABELS[form.status]
-                      : STATUS_LABELS["SEALED_PRIVATE_INDIVIDUAL"]
+                    ? form.emitter?.isPrivateIndividual &&
+                      form.status === FormStatus.Sealed
+                      ? STATUS_LABELS["SEALED_PRIVATE_INDIVIDUAL"]
+                      : STATUS_LABELS[form.status]
                     : "-"}
                 </td>
                 <td>
@@ -689,13 +690,13 @@ export default function BSDDetailContent({
             <IconBSDD className="tw-mr-2" />
 
             <span className={styles.detailStatus}>
-              {!isAppendix1Producer
-                ? [STATUS_LABELS[form.status]]
-                : Boolean(form.emitter?.isPrivateIndividual)
-                ? [STATUS_LABELS["SEALED_PRIVATE_INDIVIDUAL"]]
-                : [STATUS_LABELS[form.status]]}
+              {isAppendix1Producer &&
+              form.emitter?.isPrivateIndividual &&
+              form.status === FormStatus.Sealed
+                ? STATUS_LABELS["SEALED_PRIVATE_INDIVIDUAL"]
+                : STATUS_LABELS[form.status]}
             </span>
-            {form.status !== "DRAFT" && <span>{form.readableId}</span>}
+            {form.status !== FormStatus.Draft && <span>{form.readableId}</span>}
 
             {!!form.customId && (
               <span className="tw-ml-auto">Numéro libre: {form.customId}</span>
@@ -704,7 +705,7 @@ export default function BSDDetailContent({
 
           <div className={styles.detailContent}>
             <div className={`${styles.detailQRCodeIcon}`}>
-              {form.status !== "DRAFT" && (
+              {form.status !== FormStatus.Draft && (
                 <div className={styles.detailQRCode}>
                   <QRCodeIcon value={form.readableId} size={96} />
                   <span>Ce QR code contient le numéro du bordereau </span>


### PR DESCRIPTION
Le status des annexe 1 était forcé à :
```
STATUS_LABELS["SEALED_PRIVATE_INDIVIDUAL"]
```
Qui affiche

> En attente de signature transporteur

Dans le cas où l'émetteur est un particulier (`form.emitter.isPrivateIndividual`), et ce quel que soit le statut réel de l'annexe.

Je suppose que la volonté de départ était de forcer ce statut seulement lorsque le statut du bordereau annexe est à SEALED (affichant normalement "En attente de signature par l'émetteur") car le particulier n'est pas à même de signer lui-même le bordereau. Mais ça n'a pas de sens de forcer ce statut pour tous les autres status (d'où le ticket).

J'ai donc remplacé la condition d'affichage par cette condition, et en ai profité pour retirer une autre instance de "magic string" dans le fichier.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14219)
