### PR TITLE
[TRA-13089] Ajout update immatriculation dans modale de signature bordereau de synthèse BSDASRI

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Ajout de la mise à jour de l'immatriculation dans la modale de signature du bordereau de synthèse BSDASRI [PR 3290](https://github.com/MTES-MCT/trackdechets/pull/3290)
+
 #### :house: Interne
 
 # [2024.5.1] 07/05/2024

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { lazy, useEffect } from "react";
 import { RedErrorMessage } from "../../../../../common/components";
 import {
   BsdasriSignatureType,
@@ -11,6 +11,7 @@ import WeightWidget from "../../../../../form/bsdasri/components/Weight";
 import DateInput from "../../../../../form/common/components/custom-inputs/DateInput";
 import Acceptation from "../../../../../form/bsdasri/components/acceptation/Acceptation";
 import NumberInput from "../../../../../form/common/components/custom-inputs/NumberInput";
+import { customInfoToolTip } from "../../../../../form/bsdasri/steps/Emitter";
 import { ExtraSignatureType, SignatureType } from "../types";
 import { Field, useFormikContext } from "formik";
 import omitDeep from "omit-deep-lodash";
@@ -19,7 +20,10 @@ import Transport from "../../../../../form/bsdasri/steps/Transport";
 import TransporterRecepisseWrapper from "../../../../../form/common/components/company/TransporterRecepisseWrapper";
 import { subMonths } from "date-fns";
 import OperationModeSelect from "../../../../../common/components/OperationModeSelect";
-
+import Tooltip from "../../../../../common/components/Tooltip";
+const TagsInput = lazy(
+  () => import("../../../../../common/components/tags-input/TagsInput")
+);
 export function EmitterSignatureForm() {
   return (
     <>
@@ -128,6 +132,15 @@ export function SynthesisTransportSignatureForm() {
           </div>
         </label>
       </div>
+      {values.transporter?.transport?.mode === "ROAD" ? (
+        <div className="form__row">
+          <label htmlFor="transporter.transport.plates">
+            Immatriculations
+            <Tooltip msg={customInfoToolTip} />
+          </label>
+          <TagsInput name="transporter.transport.plates" />
+        </div>
+      ) : null}
       <div className="form__row">
         <Field
           name="transporter.transport.packagingInfos"


### PR DESCRIPTION
Ajout d'un champ "Immatriculations" à la modale de signature de synthèse BSDASRI. Affiché uniquement si le transport se fait par la route, et pré-rempli si le bordereau contient déjà l'information des plaques d'immatriculation du transporteur.

https://github.com/MTES-MCT/trackdechets/assets/2432646/c5b3bd72-d496-4c73-8885-801409ca2578



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-13089)
