### PR TITLE
Fix infinite rendering in BSDASRI form due to useEffect dependencies list

### DIFF
--- a/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
@@ -56,6 +56,10 @@ export default function BsdasriTableGrouping({
   selectedItems,
   onToggle,
   regroupedInDB
+}: {
+  selectedItems: string[];
+  onToggle: (payload: Bsdasri | Bsdasri[]) => void;
+  regroupedInDB: string[];
 }) {
   const { values, setFieldValue } = useFormikContext<
     Bsdasri & { dbRegroupedBsdasris: string[] }
@@ -94,18 +98,18 @@ export default function BsdasriTableGrouping({
     const selectedDasris = bsdasris
       .filter(bsd => selectedItems.indexOf(bsd.node.id) >= 0)
       .map(edge => edge?.node);
-    setFieldValue(
-      "emitter.emission.weight.value",
-      selectedDasris.reduce(
-        (prev, cur) => prev + (cur?.destination?.operation?.weight?.value ?? 0),
-        0
-      ) ?? 0
-    );
+    // compute the total weight and assume that if some weights are missing, the total is estimated
+    let isEstimate = false;
+    const weight = selectedDasris.reduce((prev, cur) => {
+      if (cur?.destination?.operation?.weight?.value) {
+        return prev + cur.destination.operation.weight.value;
+      }
+      isEstimate = true;
+      return prev;
+    }, 0);
+    setFieldValue("emitter.emission.weight.value", weight);
     // Manually set isEstimate which is usually handled by the weight widget main switch
-    setFieldValue(
-      "emitter.emission.weight.isEstimate",
-      values?.emitter?.emission?.weight?.isEstimate ?? false
-    );
+    setFieldValue("emitter.emission.weight.isEstimate", isEstimate);
 
     const packagings: BsdasriPackaging[][] = selectedDasris.map(
       item => item?.destination?.reception?.packagings ?? []
@@ -113,7 +117,6 @@ export default function BsdasriTableGrouping({
     const aggregatedPackagings = aggregatePackagings(packagings);
 
     setFieldValue("emitter.emission.packagings", aggregatedPackagings);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedItems, data, setFieldValue]);
 
   if (loading) return <p>Chargement...</p>;

--- a/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
@@ -113,7 +113,8 @@ export default function BsdasriTableGrouping({
     const aggregatedPackagings = aggregatePackagings(packagings);
 
     setFieldValue("emitter.emission.packagings", aggregatedPackagings);
-  }, [selectedItems, data, setFieldValue, values]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedItems, data, setFieldValue]);
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <InlineError apolloError={error} />;


### PR DESCRIPTION
Supprime la dependence sur "values" qui entraînait une boucle de render et n'est pas utile. Ajout d'un eslint-disable-next-line pour éviter un warning de liste de dépendances incomplète.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

