### PR TITLE
[TRA-14327] Fix redirection après signature BSDASRI groupement par émetteur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
+- Fix de la redirection après signature d'un BSDASRI de groupement par l'émetteur [PR 3292](https://github.com/MTES-MCT/trackdechets/pull/3292)
 
 #### :boom: Breaking changes
 

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
@@ -138,7 +138,9 @@ export function RouteBSDasrisSignEmissionSecretCode() {
             }
           });
 
-          navigate(signTransporterRedirection);
+          navigate(signTransporterRedirection.pathname, {
+            state: signTransporterRedirection.state
+          });
         }}
       >
         {({ isSubmitting, handleReset }) => {


### PR DESCRIPTION
Fix de la redirection à laquelle le state "background" était passé en premier paramètre au lieu de 2e.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14327)
