### PR TITLE
Script de nettoyage des évènements Mongo

### DIFF
--- a/back/src/activity-events/data.ts
+++ b/back/src/activity-events/data.ts
@@ -12,7 +12,7 @@ export async function getStream(
   const events: EventCollection[] = [];
   // Events might be dispatched between Psql & Mongo so we fetch from both
   const [stream, psqlEvents] = await Promise.all([
-    getStreamEvents(streamId, until),
+    getStreamEvents(streamId, until).stream(),
     prisma.event.findMany({
       where: {
         streamId,

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -22,8 +22,7 @@ export async function closeMongoClient() {
 
 export const getStreamEvents = (streamId: string, lte?: Date) =>
   eventsCollection
-    .find({ streamId, ...(lte && { createdAt: { $lte: lte } }) })
-    .stream();
+    .find({ streamId, ...(lte && { createdAt: { $lte: lte } }) });
 
 export const getStreamsEvents = (streamIds: string[]) =>
   eventsCollection

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -21,8 +21,7 @@ export async function closeMongoClient() {
 }
 
 export const getStreamEvents = (streamId: string, lte?: Date) =>
-  eventsCollection
-    .find({ streamId, ...(lte && { createdAt: { $lte: lte } }) });
+  eventsCollection.find({ streamId, ...(lte && { createdAt: { $lte: lte } }) });
 
 export const getStreamsEvents = (streamIds: string[]) =>
   eventsCollection

--- a/back/src/events/mongodb.ts
+++ b/back/src/events/mongodb.ts
@@ -32,6 +32,16 @@ export const getStreamsEvents = (streamIds: string[]) =>
     })
     .stream();
 
+export function deleteStreamEvent({
+  streamId,
+  eventId
+}: {
+  streamId: string;
+  eventId: string;
+}) {
+  return eventsCollection.deleteOne({ streamId, _id: eventId });
+}
+
 export async function insertStreamEvents(tdEvents: Event[]) {
   try {
     await eventsCollection.bulkWrite(

--- a/back/src/scripts/bin/__tests__/cleanMongoEvents.integration.ts
+++ b/back/src/scripts/bin/__tests__/cleanMongoEvents.integration.ts
@@ -3,6 +3,7 @@ import { userWithCompanyFactory } from "../../../__tests__/factories";
 import { bsdasriFactory } from "../../../bsdasris/__tests__/factories";
 import { getStreamEvents, insertStreamEvents } from "../../../events/mongodb";
 import { cleanMongoEvents } from "../cleanMongoEvents.helper";
+import { randomUUID } from "node:crypto";
 
 describe("cleanMongoEvents script", () => {
   afterEach(resetDatabase);
@@ -18,8 +19,8 @@ describe("cleanMongoEvents script", () => {
     });
 
     // Simulate 10 updates
-    const events = Array.from({ length: 10 }).map((_, index) => ({
-      id: `event-${index}`,
+    const events = Array.from({ length: 10 }).map(() => ({
+      id: randomUUID(),
       streamId: dasri.id,
       data: { emitterCompanyMail: "test@test.test" },
       createdAt: new Date(),
@@ -29,15 +30,15 @@ describe("cleanMongoEvents script", () => {
     }));
     await insertStreamEvents(events);
 
-    // Check that we have 11 events
+    // Check that we have 10 events
     const eventsBeforeClean = await getStreamEvents(dasri.id).toArray();
-    expect(eventsBeforeClean).toBe(10);
+    expect(eventsBeforeClean.length).toBe(10);
 
     // Run the script
     await cleanMongoEvents();
 
-    // Check that we have 2 events remaining
+    // Check that we have 1 event remaining
     const eventsAfterClean = await getStreamEvents(dasri.id).toArray();
-    expect(eventsAfterClean).toBe(1);
+    expect(eventsAfterClean.length).toBe(1);
   });
 });

--- a/back/src/scripts/bin/__tests__/cleanMongoEvents.integration.ts
+++ b/back/src/scripts/bin/__tests__/cleanMongoEvents.integration.ts
@@ -1,0 +1,43 @@
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { userWithCompanyFactory } from "../../../__tests__/factories";
+import { bsdasriFactory } from "../../../bsdasris/__tests__/factories";
+import { getStreamEvents, insertStreamEvents } from "../../../events/mongodb";
+import { cleanMongoEvents } from "../cleanMongoEvents.helper";
+
+describe("cleanMongoEvents script", () => {
+  afterEach(resetDatabase);
+
+  it("should remove duplicate events", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    // Create a BSDASRI
+    const dasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret
+      }
+    });
+
+    // Simulate 10 updates
+    const events = Array.from({ length: 10 }).map((_, index) => ({
+      id: `event-${index}`,
+      streamId: dasri.id,
+      data: { emitterCompanyMail: "test@test.test" },
+      createdAt: new Date(),
+      type: "BsdasriUpdate",
+      metadata: {},
+      actor: user.id
+    }));
+    await insertStreamEvents(events);
+
+    // Check that we have 11 events
+    const eventsBeforeClean = await getStreamEvents(dasri.id).toArray();
+    expect(eventsBeforeClean).toBe(10);
+
+    // Run the script
+    await cleanMongoEvents();
+
+    // Check that we have 2 events remaining
+    const eventsAfterClean = await getStreamEvents(dasri.id).toArray();
+    expect(eventsAfterClean).toBe(1);
+  });
+});

--- a/back/src/scripts/bin/cleanMongoEvents.helper.ts
+++ b/back/src/scripts/bin/cleanMongoEvents.helper.ts
@@ -11,7 +11,7 @@ export async function cleanMongoEvents() {
     prisma.bsdasri.findMany({
       take: PAGE_SIZE,
       orderBy: { rowNumber: "asc" },
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+      ...(cursor ? { skip: 1, cursor: { rowNumber: cursor } } : {})
     })
   );
 
@@ -19,7 +19,7 @@ export async function cleanMongoEvents() {
     prisma.form.findMany({
       take: PAGE_SIZE,
       orderBy: { rowNumber: "asc" },
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+      ...(cursor ? { skip: 1, cursor: { rowNumber: cursor } } : {})
     })
   );
 
@@ -27,7 +27,7 @@ export async function cleanMongoEvents() {
     prisma.bsda.findMany({
       take: PAGE_SIZE,
       orderBy: { rowNumber: "asc" },
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+      ...(cursor ? { skip: 1, cursor: { rowNumber: cursor } } : {})
     })
   );
 
@@ -35,7 +35,7 @@ export async function cleanMongoEvents() {
     prisma.bsff.findMany({
       take: PAGE_SIZE,
       orderBy: { rowNumber: "asc" },
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+      ...(cursor ? { skip: 1, cursor: { rowNumber: cursor } } : {})
     })
   );
 
@@ -43,25 +43,27 @@ export async function cleanMongoEvents() {
     prisma.bsvhu.findMany({
       take: PAGE_SIZE,
       orderBy: { rowNumber: "asc" },
-      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+      ...(cursor ? { skip: 1, cursor: { rowNumber: cursor } } : {})
     })
   );
 }
 
 async function iterateOverModelAndCleanEvents(
   modelName: string,
-  getter: (cursor: string | null) => Promise<{ id: string }[]>
+  getter: (
+    cursor: number | null
+  ) => Promise<{ id: string; rowNumber: number }[]>
 ) {
   console.info(`Starting to clean events for ${modelName}...`);
 
   let bsdProcessedCounter = 0;
   let bsdDeletedEventsCounter = 0;
-  let cursor: string | null = null;
+  let cursor: number | null = null;
 
   /*eslint no-constant-condition: ["error", { "checkLoops": false }]*/
   while (true) {
     const bsds = await getter(cursor);
-    cursor = bsds[bsds.length - 1]?.id;
+    cursor = bsds[bsds.length - 1]?.rowNumber;
 
     for (const bsd of bsds) {
       bsdDeletedEventsCounter += await cleanStreamEvents(bsd.id);

--- a/back/src/scripts/bin/cleanMongoEvents.helper.ts
+++ b/back/src/scripts/bin/cleanMongoEvents.helper.ts
@@ -1,0 +1,101 @@
+import { deleteStreamEvent, getStreamEvents } from "../../events/mongodb";
+import { prisma } from "@td/prisma";
+
+const PAGE_SIZE = 1_000; // Keep it relatively small as iterating over all events can be slow
+
+export async function cleanMongoEvents() {
+  console.info(`Buckle up, you're in for a while...`);
+
+  await iterateOverModelAndCleanEvents("BSDASRI", cursor =>
+    prisma.bsdasri.findMany({
+      take: PAGE_SIZE,
+      orderBy: { rowNumber: "asc" },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+  );
+
+  await iterateOverModelAndCleanEvents("BSDD", cursor =>
+    prisma.form.findMany({
+      take: PAGE_SIZE,
+      orderBy: { rowNumber: "asc" },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+  );
+
+  await iterateOverModelAndCleanEvents("BSDA", cursor =>
+    prisma.bsda.findMany({
+      take: PAGE_SIZE,
+      orderBy: { rowNumber: "asc" },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+  );
+
+  await iterateOverModelAndCleanEvents("BSFF", cursor =>
+    prisma.bsff.findMany({
+      take: PAGE_SIZE,
+      orderBy: { rowNumber: "asc" },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+  );
+
+  await iterateOverModelAndCleanEvents("BSVHU", cursor =>
+    prisma.bsvhu.findMany({
+      take: PAGE_SIZE,
+      orderBy: { rowNumber: "asc" },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    })
+  );
+}
+
+async function iterateOverModelAndCleanEvents(
+  modelName: string,
+  getter: (cursor: string | null) => Promise<{ id: string }[]>
+) {
+  console.info(`Starting to clean events for ${modelName}...`);
+
+  let bsdProcessedCounter = 0;
+  let bsdDeletedEventsCounter = 0;
+  let cursor: string | null = null;
+  let reachedEnd = false;
+
+  do {
+    const bsds = await getter(cursor);
+
+    cursor = bsds[bsds.length - 1].id;
+    if (bsds.length < PAGE_SIZE) {
+      reachedEnd = true;
+    }
+
+    for (const bsd of bsds) {
+      bsdDeletedEventsCounter += await cleanStreamEvents(bsd.id);
+      printProgress(
+        `Processed ${modelName}: \x1b[32m${++bsdProcessedCounter}\x1b[0m - Deleted events: \x1b[31m${bsdDeletedEventsCounter}\x1b[0m`
+      );
+    }
+  } while (!reachedEnd);
+}
+
+async function cleanStreamEvents(streamId: string): Promise<number> {
+  let nbOfDeletedEvents = 0;
+  const eventsStream = await getStreamEvents(streamId);
+
+  let previousEvent;
+  for await (const event of eventsStream) {
+    if (
+      previousEvent &&
+      JSON.stringify(previousEvent.data) === JSON.stringify(event.data)
+    ) {
+      await deleteStreamEvent({ streamId, eventId: event._id });
+      nbOfDeletedEvents++;
+    } else {
+      previousEvent = event;
+    }
+  }
+  return nbOfDeletedEvents;
+}
+
+function printProgress(text: string) {
+  process.stdout.clearLine(0);
+  process.stdout.cursorTo(0);
+  process.stdout.write(text);
+}

--- a/back/src/scripts/bin/cleanMongoEvents.helper.ts
+++ b/back/src/scripts/bin/cleanMongoEvents.helper.ts
@@ -1,5 +1,6 @@
 import { deleteStreamEvent, getStreamEvents } from "../../events/mongodb";
 import { prisma } from "@td/prisma";
+import { cursorTo, clearLine } from "node:readline";
 
 const PAGE_SIZE = 1_000; // Keep it relatively small as iterating over all events can be slow
 
@@ -99,7 +100,7 @@ async function cleanStreamEvents(streamId: string): Promise<number> {
 }
 
 function printProgress(text: string) {
-  process.stdout.clearLine(0);
-  process.stdout.cursorTo(0);
+  clearLine(process.stdout, 0);
+  cursorTo(process.stdout, 0);
   process.stdout.write(text);
 }

--- a/back/src/scripts/bin/cleanMongoEvents.ts
+++ b/back/src/scripts/bin/cleanMongoEvents.ts
@@ -1,0 +1,11 @@
+import { closeMongoClient } from "../../events/mongodb";
+import { prisma } from "@td/prisma";
+import { cleanMongoEvents } from "./cleanMongoEvents.helper";
+
+cleanMongoEvents()
+  .then(() => process.exit())
+  .catch(e => console.error(e))
+  .finally(async () => {
+    await prisma.$disconnect();
+    await closeMongoClient();
+  });


### PR DESCRIPTION
Script pour nettoyer les évènements consécutifs identiques.
On a des bordereaux avec jusqu'à 263K events associés

![image](https://github.com/MTES-MCT/trackdechets/assets/5145523/10c642a1-7c77-47c2-bc8d-6a003a049079)


