### PR TITLE
[TRA-13965] Incrémenter les registres Exhaustif, Sortant, Transport, Gestion dès la signature transporteur et le registre entrant dès la signature réception 

### DIFF
--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -91,6 +91,9 @@ export function getRegistryFields(
   const transporter = getFirstTransporterSync(bsda);
 
   if (transporter?.transporterTransportSignatureDate) {
+    if (bsda.destinationCompanySiret) {
+      registryFields.isAllWasteFor.push(bsda.destinationCompanySiret);
+    }
     if (bsda.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.emitterCompanySiret);
       registryFields.isAllWasteFor.push(bsda.emitterCompanySiret);
@@ -132,7 +135,6 @@ export function getRegistryFields(
   // There is no signature at reception on the BSDA so we use the operation signature
   if (bsda.destinationOperationSignatureDate && bsda.destinationCompanySiret) {
     registryFields.isIncomingWasteFor.push(bsda.destinationCompanySiret);
-    registryFields.isAllWasteFor.push(bsda.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -11,6 +11,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -71,12 +72,6 @@ const getTransportersData = (bsda: RegistryBsda): Partial<GenericWaste> => {
   };
 };
 
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 export function getRegistryFields(
   bsda: BsdaForElastic
 ): Pick<BsdElastic, RegistryFields> {

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -86,26 +86,24 @@ export function getRegistryFields(
   const transporter = getFirstTransporterSync(bsda);
 
   if (transporter?.transporterTransportSignatureDate) {
-    if (bsda.destinationCompanySiret) {
-      registryFields.isAllWasteFor.push(bsda.destinationCompanySiret);
-    }
-    if (bsda.emitterCompanySiret) {
-      registryFields.isOutgoingWasteFor.push(bsda.emitterCompanySiret);
-      registryFields.isAllWasteFor.push(bsda.emitterCompanySiret);
-    }
-    if (bsda.ecoOrganismeSiret) {
-      registryFields.isOutgoingWasteFor.push(bsda.ecoOrganismeSiret);
-      registryFields.isAllWasteFor.push(bsda.ecoOrganismeSiret);
-    }
+    registryFields.isOutgoingWasteFor = [
+      bsda.emitterCompanySiret,
+      bsda.ecoOrganismeSiret,
+      bsda.workerCompanySiret
+    ].filter(Boolean);
 
-    if (bsda.workerCompanySiret) {
-      registryFields.isOutgoingWasteFor.push(bsda.workerCompanySiret);
-      registryFields.isAllWasteFor.push(bsda.workerCompanySiret);
-    }
+    registryFields.isAllWasteFor = [
+      bsda.destinationCompanySiret,
+      bsda.emitterCompanySiret,
+      bsda.ecoOrganismeSiret,
+      bsda.workerCompanySiret,
+      bsda.brokerCompanySiret
+    ].filter(Boolean);
+
     if (bsda.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
-      registryFields.isAllWasteFor.push(bsda.brokerCompanySiret);
     }
+
     if (bsda.intermediaries?.length) {
       for (const intermediary of bsda.intermediaries) {
         const intermediaryOrgId = intermediary.siret ?? intermediary.vatNumber;

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -75,7 +75,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 export function getRegistryFields(
   bsda: BsdaForElastic
 ): Pick<BsdElastic, RegistryFields> {
@@ -83,7 +84,8 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
 
   const transporter = getFirstTransporterSync(bsda);
@@ -91,22 +93,27 @@ export function getRegistryFields(
   if (transporter?.transporterTransportSignatureDate) {
     if (bsda.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(bsda.emitterCompanySiret);
     }
     if (bsda.ecoOrganismeSiret) {
       registryFields.isOutgoingWasteFor.push(bsda.ecoOrganismeSiret);
+      registryFields.isAllWasteFor.push(bsda.ecoOrganismeSiret);
     }
 
     if (bsda.workerCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsda.workerCompanySiret);
+      registryFields.isAllWasteFor.push(bsda.workerCompanySiret);
     }
     if (bsda.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(bsda.brokerCompanySiret);
+      registryFields.isAllWasteFor.push(bsda.brokerCompanySiret);
     }
     if (bsda.intermediaries?.length) {
       for (const intermediary of bsda.intermediaries) {
         const intermediaryOrgId = intermediary.siret ?? intermediary.vatNumber;
         if (intermediaryOrgId) {
           registryFields.isManagedWasteFor.push(intermediaryOrgId);
+          registryFields.isAllWasteFor.push(intermediaryOrgId);
         }
       }
     }
@@ -117,6 +124,7 @@ export function getRegistryFields(
       const transporterCompanyOrgId = getTransporterCompanyOrgId(transporter);
       if (transporterCompanyOrgId) {
         registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
+        registryFields.isAllWasteFor.push(transporterCompanyOrgId);
       }
     }
   }
@@ -124,6 +132,7 @@ export function getRegistryFields(
   // There is no signature at reception on the BSDA so we use the operation signature
   if (bsda.destinationOperationSignatureDate && bsda.destinationCompanySiret) {
     registryFields.isIncomingWasteFor.push(bsda.destinationCompanySiret);
+    registryFields.isAllWasteFor.push(bsda.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -72,6 +72,9 @@ export function getRegistryFields(
   };
 
   if (bsdasri.transporterTransportSignatureDate) {
+    if (bsdasri.destinationCompanySiret) {
+      registryFields.isAllWasteFor.push(bsdasri.destinationCompanySiret);
+    }
     if (bsdasri.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsdasri.emitterCompanySiret);
       registryFields.isAllWasteFor.push(bsdasri.emitterCompanySiret);
@@ -92,7 +95,6 @@ export function getRegistryFields(
     bsdasri.destinationCompanySiret
   ) {
     registryFields.isIncomingWasteFor.push(bsdasri.destinationCompanySiret);
-    registryFields.isAllWasteFor.push(bsdasri.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -11,6 +11,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -52,13 +53,6 @@ const getTransporterData = (bsdasri: Bsdasri) => ({
   transporterCustomInfo: bsdasri.transporterCustomInfo,
   transporterTakenOverAt: bsdasri.transporterTakenOverAt
 });
-
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 
 export function getRegistryFields(
   bsdasri: Bsdasri

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -57,7 +57,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 
 export function getRegistryFields(
   bsdasri: Bsdasri
@@ -66,19 +67,23 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
 
   if (bsdasri.transporterTransportSignatureDate) {
     if (bsdasri.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsdasri.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(bsdasri.emitterCompanySiret);
     }
     if (bsdasri.ecoOrganismeSiret) {
       registryFields.isOutgoingWasteFor.push(bsdasri.ecoOrganismeSiret);
+      registryFields.isAllWasteFor.push(bsdasri.ecoOrganismeSiret);
     }
     const transporterCompanyOrgId = getTransporterCompanyOrgId(bsdasri);
     if (transporterCompanyOrgId) {
       registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
+      registryFields.isAllWasteFor.push(transporterCompanyOrgId);
     }
   }
 
@@ -87,6 +92,7 @@ export function getRegistryFields(
     bsdasri.destinationCompanySiret
   ) {
     registryFields.isIncomingWasteFor.push(bsdasri.destinationCompanySiret);
+    registryFields.isAllWasteFor.push(bsdasri.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -81,6 +81,9 @@ export function getRegistryFields(
     bsff.emitterEmissionSignatureDate &&
     bsff.transporterTransportSignatureDate
   ) {
+    if (bsff.destinationCompanySiret) {
+      registryFields.isAllWasteFor.push(bsff.destinationCompanySiret);
+    }
     if (bsff.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsff.emitterCompanySiret);
       registryFields.isAllWasteFor.push(bsff.emitterCompanySiret);
@@ -97,7 +100,6 @@ export function getRegistryFields(
 
   if (bsff.destinationReceptionSignatureDate && bsff.destinationCompanySiret) {
     registryFields.isIncomingWasteFor.push(bsff.destinationCompanySiret);
-    registryFields.isAllWasteFor.push(bsff.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -63,7 +63,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 
 export function getRegistryFields(
   bsff: Bsff
@@ -72,7 +73,8 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
 
   if (
@@ -81,17 +83,21 @@ export function getRegistryFields(
   ) {
     if (bsff.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsff.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(bsff.emitterCompanySiret);
     }
     registryFields.isOutgoingWasteFor.push(...bsff.detenteurCompanySirets);
+    registryFields.isAllWasteFor.push(...bsff.detenteurCompanySirets);
 
     const transporterOrgId = getTransporterCompanyOrgId(bsff);
     if (transporterOrgId) {
       registryFields.isTransportedWasteFor.push(transporterOrgId);
+      registryFields.isAllWasteFor.push(transporterOrgId);
     }
   }
 
   if (bsff.destinationReceptionSignatureDate && bsff.destinationCompanySiret) {
     registryFields.isIncomingWasteFor.push(bsff.destinationCompanySiret);
+    registryFields.isAllWasteFor.push(bsff.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -10,6 +10,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -58,13 +59,6 @@ const getTransporterData = (bsff: Bsff) => ({
   transporterCustomInfo: bsff.transporterCustomInfo,
   transporterNumberPlates: bsff.transporterTransportPlates
 });
-
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 
 export function getRegistryFields(
   bsff: Bsff

--- a/back/src/bspaoh/registry.ts
+++ b/back/src/bspaoh/registry.ts
@@ -44,7 +44,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 
 export function getRegistryFields(
   bspaoh: Bspaoh & {
@@ -55,15 +56,20 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
   const transporter = getFirstTransporterSync(bspaoh);
   if (
     bspaoh.emitterEmissionSignatureDate &&
     transporter?.transporterTransportSignatureDate
   ) {
+    if (bspaoh.destinationCompanySiret) {
+      registryFields.isAllWasteFor.push(bspaoh.destinationCompanySiret);
+    }
     if (bspaoh.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bspaoh.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(bspaoh.emitterCompanySiret);
     }
 
     if (bspaoh.transporters?.length) {
@@ -71,6 +77,7 @@ export function getRegistryFields(
         const transporterCompanyOrgId = getTransporterCompanyOrgId(transporter);
         if (transporterCompanyOrgId) {
           registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
+          registryFields.isAllWasteFor.push(transporterCompanyOrgId);
         }
       }
     }

--- a/back/src/bspaoh/registry.ts
+++ b/back/src/bspaoh/registry.ts
@@ -11,6 +11,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -39,13 +40,6 @@ const getTransporterData = (
     transporterTakenOverAt: transporter?.transporterTakenOverAt
   };
 };
-
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 
 export function getRegistryFields(
   bspaoh: Bspaoh & {

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -9,6 +9,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -35,12 +36,6 @@ const getTransporterData = (bsvhu: Bsvhu) => ({
   transporterCompanyAddress: bsvhu.transporterCompanyAddress
 });
 
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 export function getRegistryFields(
   bsvhu: Bsvhu
 ): Pick<BsdElastic, RegistryFields> {

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -56,6 +56,9 @@ export function getRegistryFields(
     bsvhu.emitterEmissionSignatureDate &&
     bsvhu.transporterTransportSignatureDate
   ) {
+    if (bsvhu.destinationCompanySiret) {
+      registryFields.isAllWasteFor.push(bsvhu.destinationCompanySiret);
+    }
     if (bsvhu.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsvhu.emitterCompanySiret);
       registryFields.isAllWasteFor.push(bsvhu.emitterCompanySiret);
@@ -71,7 +74,6 @@ export function getRegistryFields(
     bsvhu.destinationCompanySiret
   ) {
     registryFields.isIncomingWasteFor.push(bsvhu.destinationCompanySiret);
-    registryFields.isAllWasteFor.push(bsvhu.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -39,7 +39,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 export function getRegistryFields(
   bsvhu: Bsvhu
 ): Pick<BsdElastic, RegistryFields> {
@@ -47,7 +48,8 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
 
   if (
@@ -56,9 +58,11 @@ export function getRegistryFields(
   ) {
     if (bsvhu.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(bsvhu.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(bsvhu.emitterCompanySiret);
     }
     if (bsvhu.transporterCompanySiret) {
       registryFields.isTransportedWasteFor.push(bsvhu.transporterCompanySiret);
+      registryFields.isAllWasteFor.push(bsvhu.transporterCompanySiret);
     }
   }
 
@@ -67,6 +71,7 @@ export function getRegistryFields(
     bsvhu.destinationCompanySiret
   ) {
     registryFields.isIncomingWasteFor.push(bsvhu.destinationCompanySiret);
+    registryFields.isAllWasteFor.push(bsvhu.destinationCompanySiret);
   }
 
   return registryFields;

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -286,6 +286,7 @@ const properties: Record<keyof BsdElastic, Record<string, unknown>> = {
   isOutgoingWasteFor: stringField,
   isTransportedWasteFor: stringField,
   isManagedWasteFor: stringField,
+  isAllWasteFor: stringField,
   isInRevisionFor: stringField,
   isRevisedFor: stringField,
 

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -101,6 +101,8 @@ export interface BsdElastic {
   isOutgoingWasteFor: string[];
   isTransportedWasteFor: string[];
   isManagedWasteFor: string[];
+  isAllWasteFor: string[];
+
   // Liste des établissements concernés par une demande de révision en cours sur ce bordereau
   isInRevisionFor: string[];
   // Liste des établissements concernés par une demande de révision passée sur ce bordereau

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -55,7 +55,8 @@ type RegistryFields =
   | "isIncomingWasteFor"
   | "isOutgoingWasteFor"
   | "isTransportedWasteFor"
-  | "isManagedWasteFor";
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
 
 export function getRegistryFields(
   form: FormForElastic
@@ -64,7 +65,8 @@ export function getRegistryFields(
     isIncomingWasteFor: [],
     isOutgoingWasteFor: [],
     isTransportedWasteFor: [],
-    isManagedWasteFor: []
+    isManagedWasteFor: [],
+    isAllWasteFor: []
   };
 
   if (form.receivedAt) {
@@ -74,17 +76,24 @@ export function getRegistryFields(
   }
 
   if (form.sentAt) {
+    if (form.recipientCompanySiret) {
+      registryFields.isAllWasteFor.push(form.recipientCompanySiret);
+    }
     if (form.emitterCompanySiret) {
       registryFields.isOutgoingWasteFor.push(form.emitterCompanySiret);
+      registryFields.isAllWasteFor.push(form.emitterCompanySiret);
     }
     if (form.ecoOrganismeSiret) {
       registryFields.isOutgoingWasteFor.push(form.ecoOrganismeSiret);
+      registryFields.isAllWasteFor.push(form.ecoOrganismeSiret);
     }
     if (form.traderCompanySiret) {
       registryFields.isManagedWasteFor.push(form.traderCompanySiret);
+      registryFields.isAllWasteFor.push(form.traderCompanySiret);
     }
     if (form.brokerCompanySiret) {
       registryFields.isManagedWasteFor.push(form.brokerCompanySiret);
+      registryFields.isAllWasteFor.push(form.brokerCompanySiret);
     }
 
     if (form.intermediaries?.length) {
@@ -92,6 +101,7 @@ export function getRegistryFields(
         const intermediaryOrgId = intermediary.siret ?? intermediary.vatNumber;
         if (intermediaryOrgId) {
           registryFields.isManagedWasteFor.push(intermediaryOrgId);
+          registryFields.isAllWasteFor.push(intermediaryOrgId);
         }
       }
     }
@@ -102,6 +112,7 @@ export function getRegistryFields(
       const transporterCompanyOrgId = getTransporterCompanyOrgId(transporter);
       if (transporterCompanyOrgId) {
         registryFields.isTransportedWasteFor.push(transporterCompanyOrgId);
+        registryFields.isAllWasteFor.push(transporterCompanyOrgId);
       }
     }
   }

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -11,6 +11,7 @@ import {
 } from "../generated/graphql/types";
 import {
   GenericWaste,
+  RegistryFields,
   emptyAllWaste,
   emptyIncomingWaste,
   emptyManagedWaste,
@@ -50,13 +51,6 @@ const getTransportersData = (bsdd: Bsdd) => ({
   transporter3NumberPlates: bsdd.transporter3NumberPlates,
   transporter3CompanyMail: bsdd.transporter3CompanyMail
 });
-
-type RegistryFields =
-  | "isIncomingWasteFor"
-  | "isOutgoingWasteFor"
-  | "isTransportedWasteFor"
-  | "isManagedWasteFor"
-  | "isAllWasteFor";
 
 export function getRegistryFields(
   form: FormForElastic

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -70,25 +70,23 @@ export function getRegistryFields(
   }
 
   if (form.sentAt) {
-    if (form.recipientCompanySiret) {
-      registryFields.isAllWasteFor.push(form.recipientCompanySiret);
-    }
-    if (form.emitterCompanySiret) {
-      registryFields.isOutgoingWasteFor.push(form.emitterCompanySiret);
-      registryFields.isAllWasteFor.push(form.emitterCompanySiret);
-    }
-    if (form.ecoOrganismeSiret) {
-      registryFields.isOutgoingWasteFor.push(form.ecoOrganismeSiret);
-      registryFields.isAllWasteFor.push(form.ecoOrganismeSiret);
-    }
-    if (form.traderCompanySiret) {
-      registryFields.isManagedWasteFor.push(form.traderCompanySiret);
-      registryFields.isAllWasteFor.push(form.traderCompanySiret);
-    }
-    if (form.brokerCompanySiret) {
-      registryFields.isManagedWasteFor.push(form.brokerCompanySiret);
-      registryFields.isAllWasteFor.push(form.brokerCompanySiret);
-    }
+    registryFields.isAllWasteFor = [
+      form.recipientCompanySiret,
+      form.emitterCompanySiret,
+      form.ecoOrganismeSiret,
+      form.traderCompanySiret,
+      form.brokerCompanySiret
+    ].filter(Boolean);
+
+    registryFields.isOutgoingWasteFor = [
+      form.emitterCompanySiret,
+      form.ecoOrganismeSiret
+    ].filter(Boolean);
+
+    registryFields.isManagedWasteFor = [
+      form.traderCompanySiret,
+      form.brokerCompanySiret
+    ].filter(Boolean);
 
     if (form.intermediaries?.length) {
       for (const intermediary of form.intermediaries) {

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -1,4 +1,13 @@
-import { Company, Status, User, UserRole } from "@prisma/client";
+import {
+  BsdasriStatus,
+  BsdaStatus,
+  BsffStatus,
+  BsvhuStatus,
+  Company,
+  Status,
+  User,
+  UserRole
+} from "@prisma/client";
 import {
   refreshElasticSearch,
   resetDatabase
@@ -110,1227 +119,1456 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
   }
 
   // REGISTRE DÉCHETS ENTRANTS
-
-  it("should list a BSDD in destination's incoming wastes once it has been received", async () => {
-    // BSDD after reception
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: destination.company.siret,
-        status: Status.ACCEPTED,
-        receivedAt: new Date(),
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1
+  describe("Incoming", () => {
+    it("should list a BSDD in destination's incoming wastes once it has been received", async () => {
+      // BSDD after reception
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: destination.company.siret,
+          status: Status.ACCEPTED,
+          receivedAt: new Date(),
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1
+            }
           }
         }
-      }
+      });
+
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
+    it("should list a BSDD in ttr's incoming wastes once it has been temp stored", async () => {
+      // BSDD after temp storage
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: ttr.company.siret,
+          status: Status.TEMP_STORER_ACCEPTED,
+          receivedAt: new Date(),
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1
+            }
+          }
+        },
+        forwardedInOpts: {
+          recipientCompanySiret: destination.company.siret
+        }
+      });
 
-  it("it should list a BSDD in ttr's incoming wastes once it has been temp stored", async () => {
-    // BSDD after temp storage
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: ttr.company.siret,
-        status: Status.TEMP_STORER_ACCEPTED,
-        receivedAt: new Date(),
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [ttr.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+
+    it("should list a BSDD in final destination's incoming wastes once it has been received", async () => {
+      // BSDD after final reception
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: ttr.company.siret,
+          status: Status.ACCEPTED,
+          receivedAt: new Date(),
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1
+            }
+          }
+        },
+        forwardedInOpts: {
+          recipientCompanySiret: destination.company.siret,
+          receivedAt: new Date()
+        }
+      });
+
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
+    });
+
+    it("should not list a BSDD in destination's incoming wastes before it has been received", async () => {
+      // BSDD before reception
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: destination.company.siret,
+          status: Status.SENT,
+          receivedAt: null,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1
+            }
           }
         }
-      },
-      forwardedInOpts: {
-        recipientCompanySiret: destination.company.siret
-      }
+      });
+
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
     });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [ttr.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-
-  it("it should list a BSDD in final destination's incoming wastes once it has been received", async () => {
-    // BSDD after final reception
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: ttr.company.siret,
-        status: Status.ACCEPTED,
-        receivedAt: new Date(),
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1
-          }
+    it("should list a BSDD in destination's incoming wastes once it has been received", async () => {
+      const form = await formFactory({
+        ownerId: destination.user.id,
+        opt: {
+          recipientCompanySiret: destination.company.siret,
+          receivedAt: new Date()
         }
-      },
-      forwardedInOpts: {
-        recipientCompanySiret: destination.company.siret,
-        receivedAt: new Date()
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
-  });
-
-  it("it should not list a BSDD in destination's incoming wastes before it has been received", async () => {
-    // BSDD before reception
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: destination.company.siret,
-        status: Status.SENT,
-        receivedAt: null,
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1
-          }
+    it("should not list a BSDD in destination's incoming wastes before it has been received", async () => {
+      const form = await formFactory({
+        ownerId: destination.user.id,
+        opt: {
+          recipientCompanySiret: destination.company.siret,
+          receivedAt: null
         }
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
-
-  it("should list a BSDD in destination's incoming wastes once it has been received", async () => {
-    const form = await formFactory({
-      ownerId: destination.user.id,
-      opt: {
-        recipientCompanySiret: destination.company.siret,
-        receivedAt: new Date()
-      }
+    it("should list a BSDA in destination's incoming wastes once it has been received", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationReceptionDate: new Date(),
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should not list a BSDD in destination's incoming wastes before it has been received", async () => {
-    const form = await formFactory({
-      ownerId: destination.user.id,
-      opt: {
-        recipientCompanySiret: destination.company.siret,
-        receivedAt: null
-      }
+    it("should not list a BSDA in destination's incoming wastes before it has been received", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationReceptionDate: null,
+          destinationOperationSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSDA in destination's incoming wastes once it has been received", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationReceptionDate: new Date(),
-        destinationOperationSignatureDate: new Date()
-      }
+    it("should list a BSDASRI in destination's incoming wastes once it has been received", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationReceptionDate: new Date(),
+          destinationReceptionSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should not list a BSDA in destination's incoming wastes before it has been received", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationReceptionDate: null,
-        destinationOperationSignatureDate: null
-      }
+    it("should not list a BSDASRI in destination's incoming wastes before it has been received", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationReceptionSignatureDate: null
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSDASRI in destination's incoming wastes once it has been received", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationReceptionDate: new Date(),
-        destinationReceptionSignatureDate: new Date()
-      }
+    it("should list a BSVHU in destination's incoming wastes once it has been received", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationReceptionDate: new Date(),
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
-  it("should not list a BSDASRI in destination's incoming wastes before it has been received", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationReceptionSignatureDate: null
-      }
+    it("should not list a BSVHU in destination's incoming wastes before it has been received", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          destinationOperationSignatureDate: null
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSVHU in destination's incoming wastes once it has been received", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationReceptionDate: new Date(),
-        destinationOperationSignatureDate: new Date()
-      }
+    it("should list a BSFF in destination's incoming wastes once it has been received", async () => {
+      const bsff = await createBsffAfterReception({
+        emitter,
+        transporter,
+        destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should not list a BSVHU in destination's incoming wastes before it has been received", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        destinationOperationSignatureDate: null
-      }
+    it("should not list a BSFF in destination's incoming wastes before it has been received", async () => {
+      const bsff = await createBsffAfterEmission({
+        emitter,
+        transporter,
+        destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSFF in destination's incoming wastes once it has been received", async () => {
-    const bsff = await createBsffAfterReception({
-      emitter,
-      transporter,
-      destination
-    });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
-  it("should not list a BSFF in destination's incoming wastes before it has been received", async () => {
-    const bsff = await createBsffAfterEmission({
-      emitter,
-      transporter,
-      destination
-    });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
-    expect(bsds).toEqual([]);
   });
 
   // REGISTRE DÉCHETS SORTANTS
-
-  it("should list a BSDD in emitter's outgoing wastes once it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        sentAt: new Date()
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-
-  it("should list a BSDD in eco-organisme's outgoing wastes once it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        ecoOrganismeSiret: ecoOrganisme.company.siret,
-        sentAt: new Date()
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-
-  it("should not list a BSDD in emitter's outgoing wastes before it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        sentAt: null
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSDD in ttr's outgoing wastes once it has been sent after temporary storage", async () => {
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: ttr.company.siret,
-        status: Status.RESENT,
-        receivedAt: new Date(),
-        signedAt: new Date(),
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1
-          }
+  describe("Outgoing", () => {
+    it("should list a BSDD in emitter's outgoing wastes once it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          sentAt: new Date()
         }
-      },
-      forwardedInOpts: {
-        emitterCompanySiret: ttr.company.siret,
-        recipientCompanySiret: destination.company.siret,
-        sentAt: new Date(),
-        status: Status.SENT
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [ttr.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
-  });
-  it("should list a BSDA in emitter's outgoing wastes once it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        status: "SENT",
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportTakenOverAt: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDD in eco-organisme's outgoing wastes once it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          ecoOrganismeSiret: ecoOrganisme.company.siret,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
 
-  it("should list a BSDA in ecoOrganisme's outgoing wastes once it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        status: "SENT",
-        ecoOrganismeSiret: ecoOrganisme.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportTakenOverAt: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should not list a BSDD in emitter's outgoing wastes before it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          sentAt: null
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
+    it("should list a BSDD in ttr's outgoing wastes once it has been sent after temporary storage", async () => {
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: ttr.company.siret,
+          status: Status.RESENT,
+          receivedAt: new Date(),
+          signedAt: new Date(),
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1
+            }
+          }
+        },
+        forwardedInOpts: {
+          emitterCompanySiret: ttr.company.siret,
+          recipientCompanySiret: destination.company.siret,
+          sentAt: new Date(),
+          status: Status.SENT
+        }
+      });
 
-  it("should not list a BSDA in emitter's outgoing wastes before it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [ttr.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSDA in worker's outgoing wastes once it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        status: "SENT",
-        workerCompanySiret: worker.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportTakenOverAt: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in emitter's outgoing wastes once it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should not list a BSDA in worker's outgoing wastes before it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        workerCompanySiret: worker.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
-    });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSDASRI in emitter's outgoing wastes once it has been sent", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
-    });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
 
-  it("should list a BSDASRI in ecoOrganisme's outgoing wastes once it has been sent", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        ecoOrganismeSiret: ecoOrganisme.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in ecoOrganisme's outgoing wastes once it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          ecoOrganismeSiret: ecoOrganisme.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
 
-  it("should not list a BSDASRI in emitter's outgoing wastes before it has been sent", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSDA in emitter's outgoing wastes before it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSVHU in emitter's outgoing wastes once it has been sent", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in worker's outgoing wastes once it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          workerCompanySiret: worker.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should not list a BSVHU in emitter's outgoing wastes before it has been sent", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSDA in worker's outgoing wastes before it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          workerCompanySiret: worker.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [worker.company.siret!]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSFF in emitter's outgoing wastes once it has been sent", async () => {
-    const bsff = await createBsffAfterTransport({
-      emitter,
-      transporter,
-      destination
+    it("should list a BSDASRI in emitter's outgoing wastes once it has been sent", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
 
-  it("should list a BSFF in detenteur's outgoing wastes once it has been sent", async () => {
-    const detenteur = await userWithCompanyFactory("MEMBER");
-    const ficheIntervention = await createFicheIntervention({
-      detenteur,
-      operateur: emitter
+    it("should list a BSDASRI in ecoOrganisme's outgoing wastes once it has been sent", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          ecoOrganismeSiret: ecoOrganisme.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [ecoOrganisme.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    const bsff = await createBsffAfterTransport(
-      {
+
+    it("should not list a BSDASRI in emitter's outgoing wastes before it has been sent", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds).toEqual([]);
+    });
+    it("should list a BSVHU in emitter's outgoing wastes once it has been sent", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
+    });
+    it("should not list a BSVHU in emitter's outgoing wastes before it has been sent", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds).toEqual([]);
+    });
+    it("should list a BSFF in emitter's outgoing wastes once it has been sent", async () => {
+      const bsff = await createBsffAfterTransport({
         emitter,
         transporter,
         destination
-      },
-      {
-        detenteurCompanySirets: [detenteur.company.siret!],
-        ficheInterventions: { connect: { id: ficheIntervention.id } }
-      }
-    );
-
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [detenteur.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
-
-  it("should not list a BSFF in emitter's outgoing wastes before it has been sent", async () => {
-    const bsff = await createBsffBeforeEmission({
-      emitter,
-      transporter,
-      destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
     });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
-    expect(bsds).toEqual([]);
+
+    it("should list a BSFF in detenteur's outgoing wastes once it has been sent", async () => {
+      const detenteur = await userWithCompanyFactory("MEMBER");
+      const ficheIntervention = await createFicheIntervention({
+        detenteur,
+        operateur: emitter
+      });
+      const bsff = await createBsffAfterTransport(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          detenteurCompanySirets: [detenteur.company.siret!],
+          ficheInterventions: { connect: { id: ficheIntervention.id } }
+        }
+      );
+
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [detenteur.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    });
+
+    it("should not list a BSFF in emitter's outgoing wastes before it has been sent", async () => {
+      const bsff = await createBsffBeforeEmission({
+        emitter,
+        transporter,
+        destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
+      expect(bsds).toEqual([]);
+    });
   });
 
   // REGISTRE DÉCHETS TRANSPORTÉS
-
-  it("should list a BSDD in transporter's transported wastes once it has been taken over", async () => {
-    const form = await formFactory({
-      ownerId: transporter.user.id,
-      opt: {
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1,
-            takenOverAt: new Date()
+  describe("Transported", () => {
+    it("should list a BSDD in transporter's transported wastes once it has been taken over", async () => {
+      const form = await formFactory({
+        ownerId: transporter.user.id,
+        opt: {
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1,
+              takenOverAt: new Date()
+            }
           }
         }
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in 2nd transporter transported wastes once it has been taken over", async () => {
-    const form = await formFactory({
-      ownerId: transporter.user.id
+    it("should list a BSDD in 2nd transporter transported wastes once it has been taken over", async () => {
+      const form = await formFactory({
+        ownerId: transporter.user.id
+      });
+      await bsddTransporterFactory({
+        formId: form.id,
+        opts: {
+          transporterCompanySiret: transporter2.company.siret,
+          takenOverAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter2.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await bsddTransporterFactory({
-      formId: form.id,
-      opts: {
-        transporterCompanySiret: transporter2.company.siret,
-        takenOverAt: new Date()
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should not list a BSDD in transporter' transported wastes before it has been taken over", async () => {
-    const form = await formFactory({
-      ownerId: transporter.user.id,
-      opt: {
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1,
-            takenOverAt: null
+    it("should not list a BSDD in transporter' transported wastes before it has been taken over", async () => {
+      const form = await formFactory({
+        ownerId: transporter.user.id,
+        opt: {
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1,
+              takenOverAt: null
+            }
           }
         }
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds).toEqual([]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should not list a BSDD in 2nd transporter transported before it has been taken over", async () => {
-    const form = await formFactory({
-      ownerId: transporter.user.id
+    it("should not list a BSDD in 2nd transporter transported before it has been taken over", async () => {
+      const form = await formFactory({
+        ownerId: transporter.user.id
+      });
+      await bsddTransporterFactory({
+        formId: form.id,
+        opts: {
+          transporterCompanySiret: transporter2.company.siret,
+          takenOverAt: null
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter2.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
     });
-    await bsddTransporterFactory({
-      formId: form.id,
-      opts: {
-        transporterCompanySiret: transporter2.company.siret,
-        takenOverAt: null
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
-  it("should list a BSDD in transporter's transported wastes once it has been resent after temp storage", async () => {
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        recipientCompanySiret: ttr.company.siret,
-        status: Status.RESENT,
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1,
-            takenOverAt: new Date()
+    it("should list a BSDD in transporter's transported wastes once it has been resent after temp storage", async () => {
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          recipientCompanySiret: ttr.company.siret,
+          status: Status.RESENT,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1,
+              takenOverAt: new Date()
+            }
+          }
+        },
+        forwardedInOpts: {
+          recipientCompanySiret: destination.company.siret,
+          status: Status.SENT,
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter2.company.siret,
+              number: 1,
+              takenOverAt: new Date()
+            }
           }
         }
-      },
-      forwardedInOpts: {
-        recipientCompanySiret: destination.company.siret,
-        status: Status.SENT,
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter2.company.siret,
-            number: 1,
-            takenOverAt: new Date()
-          }
+      });
+
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter2.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
+    });
+    it("should list a BSDA in transporter's transported wastes once it has been taken over", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportSignatureDate: new Date()
         }
-      }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
+    });
+    it("should list a BSDA in 2nd transporter's transported wastes once it has been taken over", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await bsdaTransporterFactory({
+        bsdaId: bsda.id,
+        opts: {
+          transporterCompanySiret: transporter2.company.siret,
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter2.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.forwardedIn!.id]);
-  });
-  it("should list a BSDA in transporter's transported wastes once it has been taken over", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterCompanySiret: transporter.company.siret,
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should not list a BSDA in transporter'transported wastes before it has been taken over", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should list a BSDA in 2nd transporter's transported wastes once it has been taken over", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterCompanySiret: transporter.company.siret,
-        transporterTransportSignatureDate: new Date()
-      }
-    });
-    await bsdaTransporterFactory({
-      bsdaId: bsda.id,
-      opts: {
-        transporterCompanySiret: transporter2.company.siret,
-        transporterTransportSignatureDate: new Date()
-      }
-    });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
 
-  it("should not list a BSDA in transporter'transported wastes before it has been taken over", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      },
-      transporterOpt: {
-        transporterCompanySiret: transporter.company.siret,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSDA in 2nd transporter's transported wastes before it has been taken over", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await bsdaTransporterFactory({
+        bsdaId: bsda.id,
+        opts: {
+          transporterCompanySiret: transporter2.company.siret,
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter2.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
 
-  it("should not list a BSDA in 2nd transporter's transported wastes before it has been taken over", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterCompanySiret: transporter.company.siret,
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDASRI in transporter's transported wastes once it has been taken over", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    await bsdaTransporterFactory({
-      bsdaId: bsda.id,
-      opts: {
-        transporterCompanySiret: transporter2.company.siret,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSDASRI in transporter'transported wastes before it has been taken over", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter2.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
-
-  it("should list a BSDASRI in transporter's transported wastes once it has been taken over", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSVHU in transporter's transported wastes once it has been taken over", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
-  it("should not list a BSDASRI in transporter'transported wastes before it has been taken over", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSVHU in transporter'transported wastes before it has been delivered", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSVHU in transporter's transported wastes once it has been taken over", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSFF in transporter's transported wastes once it has been taken over", async () => {
+      const bsff = await createBsffAfterTransport({
+        emitter,
+        transporter,
+        destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should not list a BSVHU in transporter'transported wastes before it has been delivered", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
+    it("should not list a BSFF in transporter'transported wastes before it has been taken over", async () => {
+      const bsff = await createBsffBeforeEmission({
+        emitter,
+        transporter,
+        destination
+      });
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("TRANSPORTED", [
+        transporter.company.siret!
+      ]);
+      expect(bsds).toEqual([]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds).toEqual([]);
-  });
-  it("should list a BSFF in transporter's transported wastes once it has been taken over", async () => {
-    const bsff = await createBsffAfterTransport({
-      emitter,
-      transporter,
-      destination
-    });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
-  it("should not list a BSFF in transporter'transported wastes before it has been taken over", async () => {
-    const bsff = await createBsffBeforeEmission({
-      emitter,
-      transporter,
-      destination
-    });
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("TRANSPORTED", [transporter.company.siret!]);
-    expect(bsds).toEqual([]);
   });
 
   // REGISTRE DÉCHETS GÉRÉS
-  it("should list a BSDD in trader's managed wastes after it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: trader.user.id,
-      opt: {
-        traderCompanySiret: trader.company.siret,
-        sentAt: new Date()
-      }
+  describe("Managed", () => {
+    it("should list a BSDD in trader's managed wastes after it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: trader.user.id,
+        opt: {
+          traderCompanySiret: trader.company.siret,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in broker's managed wastes after it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: broker.user.id,
-      opt: {
-        brokerCompanySiret: broker.company.siret,
-        sentAt: new Date()
-      }
+    it("should list a BSDD in broker's managed wastes after it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: broker.user.id,
+        opt: {
+          brokerCompanySiret: broker.company.siret,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
 
-  it("should list a BSDD in intermediary's managed wastes before it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: broker.user.id,
-      opt: {
-        intermediaries: {
-          create: {
-            siret: intermediary!.company!.siret!,
-            name: "Intermédiaire",
-            contact: "M Intermédiaire"
-          }
+    it("should list a BSDD in intermediary's managed wastes before it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: broker.user.id,
+        opt: {
+          intermediaries: {
+            create: {
+              siret: intermediary!.company!.siret!,
+              name: "Intermédiaire",
+              contact: "M Intermédiaire"
+            }
+          },
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [intermediary.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+
+    it("should not list a BSDD in trader's managed wastes before it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: trader.user.id,
+        opt: {
+          traderCompanySiret: trader.company.siret,
+          sentAt: null
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
+    });
+    it("should not list a BSDD in broker's managed wastes before it has been sent", async () => {
+      const form = await formFactory({
+        ownerId: broker.user.id,
+        opt: {
+          brokerCompanySiret: broker.company.siret,
+          sentAt: null
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
+    });
+    it("should list a BSDA in broker's managed wastes after it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          brokerCompanySiret: broker.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
         },
-        sentAt: new Date()
-      }
+        transporterOpt: {
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [intermediary.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
 
-  it("should not list a BSDD in trader's managed wastes before it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: trader.user.id,
-      opt: {
-        traderCompanySiret: trader.company.siret,
-        sentAt: null
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [trader.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
-  it("should not list a BSDD in broker's managed wastes before it has been sent", async () => {
-    const form = await formFactory({
-      ownerId: broker.user.id,
-      opt: {
-        brokerCompanySiret: broker.company.siret,
-        sentAt: null
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
-  it("should list a BSDA in broker's managed wastes after it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        status: "SENT",
-        brokerCompanySiret: broker.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportTakenOverAt: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
-    });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-
-  it("should list a BSDA in intermediary's managed wastes after it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        status: "SENT",
-        intermediaries: {
-          create: {
-            siret: intermediary!.company!.siret!,
-            name: "Intermédiaire",
-            contact: "M Intermédiaire"
-          }
+    it("should list a BSDA in intermediary's managed wastes after it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SENT",
+          intermediaries: {
+            create: {
+              siret: intermediary!.company!.siret!,
+              name: "Intermédiaire",
+              contact: "M Intermédiaire"
+            }
+          },
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
         },
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportTakenOverAt: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+        transporterOpt: {
+          transporterTransportTakenOverAt: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [intermediary.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [intermediary.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
+
+    it("should not list a BSDA in broker's managed wastes before it has been sent", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          brokerCompanySiret: broker.company.siret,
+          emitterEmissionSignatureDate: null,
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([]);
+    });
   });
 
-  it("should not list a BSDA in broker's managed wastes before it has been sent", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        brokerCompanySiret: broker.company.siret,
-        emitterEmissionSignatureDate: null,
-        transporterTransportSignatureDate: null
-      }
-    });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("MANAGED", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([]);
-  });
   // REGISTRE EXHAUSTIF
-  it("should list a BSDD in emitter's all wastes", async () => {
-    const form = await formFactory({
-      ownerId: emitter.user.id,
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        sentAt: new Date()
-      }
+  describe("All", () => {
+    it("should list a BSDD in emitter's all wastes as soon as transporter has signed", async () => {
+      const form = await formFactory({
+        ownerId: emitter.user.id,
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in transporter's all wastes", async () => {
-    const form = await formFactory({
-      ownerId: transporter.user.id,
-      opt: {
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1,
-            takenOverAt: new Date()
+    it("should list a BSDD in transporter's all wastes", async () => {
+      const form = await formFactory({
+        ownerId: transporter.user.id,
+        opt: {
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1,
+              takenOverAt: new Date()
+            }
           }
         }
-      }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
     });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in destination's all wastes", async () => {
-    const form = await formFactory({
-      ownerId: destination.user.id,
-      opt: {
-        recipientCompanySiret: destination.company.siret,
-        sentAt: new Date(),
-        receivedAt: new Date()
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in trader's all wastes", async () => {
-    const form = await formFactory({
-      ownerId: trader.user.id,
-      opt: {
-        traderCompanySiret: trader.company.siret,
-        sentAt: new Date()
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [trader.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in broker's all wastes", async () => {
-    const form = await formFactory({
-      ownerId: broker.user.id,
-      opt: {
-        brokerCompanySiret: broker.company.siret
-      }
-    });
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in ttr's all wastes", async () => {
-    const form = await formWithTempStorageFactory({
-      ownerId: ttr.user.id,
-      opt: {
-        recipientCompanySiret: ttr.company.siret,
-        sentAt: new Date(),
-        receivedAt: new Date()
-      }
-    });
+    it("should list a BSDD in destination's all wastes as soon as transporter has signed", async () => {
+      // Given
+      const form = await formFactory({
+        ownerId: destination.user.id,
+        opt: {
+          recipientCompanySiret: destination.company.siret,
+          status: Status.SENT,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [ttr.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
-  });
-  it("should list a BSDD in transporter after temp storage 's all wastes", async () => {
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      forwardedInOpts: {
-        transporters: {
-          create: {
-            transporterCompanySiret: transporter.company.siret,
-            number: 1,
-            takenOverAt: new Date()
+      // When
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+
+      // Then
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+    it("should NOT list a BSDD in destination's all wastes if transporter hasn't signed", async () => {
+      // Given
+      const form = await formFactory({
+        ownerId: destination.user.id,
+        opt: {
+          recipientCompanySiret: destination.company.siret,
+          status: Status.DRAFT,
+          sentAt: null,
+          sentBy: null
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+
+      // Then
+      expect(bsds).toEqual([]);
+    });
+    it("should list a BSDD in trader's all wastes", async () => {
+      const form = await formFactory({
+        ownerId: trader.user.id,
+        opt: {
+          traderCompanySiret: trader.company.siret,
+          sentAt: new Date()
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [trader.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+    it("should list a BSDD in broker's all wastes", async () => {
+      const form = await formFactory({
+        ownerId: broker.user.id,
+        opt: {
+          brokerCompanySiret: broker.company.siret
+        }
+      });
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+    it("should list a BSDD in ttr's all wastes", async () => {
+      const form = await formWithTempStorageFactory({
+        ownerId: ttr.user.id,
+        opt: {
+          recipientCompanySiret: ttr.company.siret,
+          sentAt: new Date(),
+          receivedAt: new Date()
+        }
+      });
+
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [ttr.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([form.id]);
+    });
+    it("should list a BSDD in transporter after temp storage 's all wastes", async () => {
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        forwardedInOpts: {
+          transporters: {
+            create: {
+              transporterCompanySiret: transporter.company.siret,
+              number: 1,
+              takenOverAt: new Date()
+            }
           }
         }
-      }
-    });
+      });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    const ids = bsds.map(bsd => bsd.id);
-    expect(ids).toContain(form.forwardedIn!.id);
-  });
-  it("should list a BSDD in final destination's all wastes", async () => {
-    const form = await formWithTempStorageFactory({
-      ownerId: emitter.user.id,
-      forwardedInOpts: {
-        recipientCompanySiret: destination.company.siret,
-        sentAt: new Date()
-      }
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      const ids = bsds.map(bsd => bsd.id);
+      expect(ids).toContain(form.forwardedIn!.id);
     });
+    it("should list a BSDD in final destination's all wastes", async () => {
+      const form = await formWithTempStorageFactory({
+        ownerId: emitter.user.id,
+        forwardedInOpts: {
+          recipientCompanySiret: destination.company.siret,
+          sentAt: new Date()
+        }
+      });
 
-    await indexForm(await getFormForElastic(form));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    const ids = bsds.map(bsd => bsd.id);
-    expect(ids).toContain(form.forwardedIn!.id);
-  });
-  it("should list a BSDA in emitter's all wastes", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportSignatureDate: new Date(),
-        transporterTransportTakenOverAt: new Date()
-      }
+      await indexForm(await getFormForElastic(form));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+      const ids = bsds.map(bsd => bsd.id);
+      expect(ids).toContain(form.forwardedIn!.id);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should list a BSDA in transporter's all wastes", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterCompanySiret: transporter.company.siret,
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in destination's all wastes as soon as transporter has signed", async () => {
+      // Given
+      const bsda = await bsdaFactory({
+        opt: {
+          status: BsdaStatus.SENT,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportSignatureDate: new Date(),
+          transporterTransportTakenOverAt: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should list a BSDA in destination's all wastes", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date(),
-        destinationOperationSignatureDate: new Date()
-      }
+    it("should NOT list a BSDA in destination's all wastes if transporter hasn't signed", async () => {
+      // Given
+      const bsda = await bsdaFactory({
+        opt: {
+          status: BsdaStatus.INITIAL,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: null
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds).toEqual([]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should list a BSDA in broker's all wastes", async () => {
-    const bsda = await bsdaFactory({
-      opt: {
-        brokerCompanySiret: broker.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      },
-      transporterOpt: {
-        transporterTransportSignatureDate: new Date(),
-        transporterTransportTakenOverAt: new Date()
-      }
+    it("should list a BSDA in emitter's all wastes", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportSignatureDate: new Date(),
+          transporterTransportTakenOverAt: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    const bsdaForElastic = await getBsdaForElastic(bsda);
-    await indexBsda(bsdaForElastic);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [broker.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
-  });
-  it("should list a BSDASRI in emitter's all wastes", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in transporter's all wastes", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.company.siret,
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
-  it("should list a BSDASRI in transporter's all wastes", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDA in destination's all wastes", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date(),
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
-  it("should list a BSDASRI in destination's all wastes", async () => {
-    const bsdasri = await bsdasriFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date(),
-        destinationReceptionSignatureDate: new Date()
-      }
+    it("should list a BSDA in broker's all wastes", async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          brokerCompanySiret: broker.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        },
+        transporterOpt: {
+          transporterTransportSignatureDate: new Date(),
+          transporterTransportTakenOverAt: new Date()
+        }
+      });
+      const bsdaForElastic = await getBsdaForElastic(bsda);
+      await indexBsda(bsdaForElastic);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [broker.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsda.id]);
     });
-    await indexBsdasri(await getBsdasriForElastic(bsdasri));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
-  });
-  it("should list a BSVHU in emitter's all wastes", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        emitterCompanySiret: emitter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should list a BSDASRI in destination's all wastes as soon as transporter has signed", async () => {
+      // Given
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          status: BsdasriStatus.SENT,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should list a BSVHU in transporter's all wastes", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        transporterCompanySiret: transporter.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
+    it("should NOT list a BSDASRI in destination's all wastes if transporter hasn't signed", async () => {
+      // Given
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          status: BsdasriStatus.INITIAL,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds).toEqual([]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should list a BSVHU in destination's all wastes", async () => {
-    const bsvhu = await bsvhuFactory({
-      opt: {
-        destinationCompanySiret: destination.company.siret,
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date(),
-        destinationOperationSignatureDate: new Date()
-      }
+    it("should list a BSDASRI in emitter's all wastes", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
     });
-    await indexBsvhu(bsvhu);
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
-  });
-  it("should list a BSFF in emitter's all wastes", async () => {
-    const bsff = await createBsff(
-      {
-        emitter,
-        transporter,
-        destination
-      },
-      {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
-    );
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [emitter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
-  it("should list a BSFF in transporter's all wastes", async () => {
-    const bsff = await createBsff(
-      {
-        emitter,
-        transporter,
-        destination
-      },
-      {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date()
-      }
-    );
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [transporter.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
-  });
-  it("should list a BSFF in destination's all wastes", async () => {
-    const bsff = await createBsff(
-      {
-        emitter,
-        transporter,
-        destination
-      },
-      {
-        emitterEmissionSignatureDate: new Date(),
-        transporterTransportSignatureDate: new Date(),
-        destinationReceptionSignatureDate: new Date()
-      }
-    );
-    await indexBsff(await getBsffForElastic(bsff));
-    await refreshElasticSearch();
-    const bsds = await searchBsds("ALL", [destination.company.siret!]);
-    expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    it("should list a BSDASRI in transporter's all wastes", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
+    });
+    it("should list a BSDASRI in destination's all wastes", async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date(),
+          destinationReceptionSignatureDate: new Date()
+        }
+      });
+      await indexBsdasri(await getBsdasriForElastic(bsdasri));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsdasri.id]);
+    });
+    it("should list a BSVHU in destination's all wastes as soon as transporter has signed", async () => {
+      // Given
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          status: BsvhuStatus.SENT,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
+    });
+    it("should NOT list a BSVHU in destination's all wastes if transporter hasn't signed", async () => {
+      // Given
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          status: BsvhuStatus.INITIAL,
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: null
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds).toEqual([]);
+    });
+    it("should list a BSVHU in emitter's all wastes", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
+    });
+    it("should list a BSVHU in transporter's all wastes", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          transporterCompanySiret: transporter.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
+    });
+    it("should list a BSVHU in destination's all wastes", async () => {
+      const bsvhu = await bsvhuFactory({
+        opt: {
+          destinationCompanySiret: destination.company.siret,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date(),
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+      await indexBsvhu(bsvhu);
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
+    });
+    it("should list a BSFF in destination's all wastes as soon as transporter has signed", async () => {
+      // Given
+      const bsff = await createBsff(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          status: BsffStatus.SENT,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      );
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    });
+    it("should NOT list a BSFF in destination's all wastes if transporter hasn't signed", async () => {
+      // Given
+      const bsff = await createBsff(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          status: BsffStatus.INITIAL,
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: null
+        }
+      );
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+
+      // When
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+
+      // Then
+      expect(bsds).toEqual([]);
+    });
+    it("should list a BSFF in emitter's all wastes", async () => {
+      const bsff = await createBsff(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      );
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [emitter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    });
+    it("should list a BSFF in transporter's all wastes", async () => {
+      const bsff = await createBsff(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date()
+        }
+      );
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [transporter.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    });
+    it("should list a BSFF in destination's all wastes", async () => {
+      const bsff = await createBsff(
+        {
+          emitter,
+          transporter,
+          destination
+        },
+        {
+          emitterEmissionSignatureDate: new Date(),
+          transporterTransportSignatureDate: new Date(),
+          destinationReceptionSignatureDate: new Date()
+        }
+      );
+      await indexBsff(await getBsffForElastic(bsff));
+      await refreshElasticSearch();
+      const bsds = await searchBsds("ALL", [destination.company.siret!]);
+      expect(bsds.map(bsd => bsd.id)).toEqual([bsff.id]);
+    });
   });
 });

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -21,25 +21,12 @@ export function buildQuery(
     OUTGOING: "isOutgoingWasteFor",
     INCOMING: "isIncomingWasteFor",
     TRANSPORTED: "isTransportedWasteFor",
-    MANAGED: "isManagedWasteFor"
+    MANAGED: "isManagedWasteFor",
+    ALL: "isAllWasteFor"
   };
 
   // Fonction permettant de construire le filtre ES pour un type de registre donné.
-  // On considère qu'un BSD doit apparaitre dans le registre exhaustif d'un établissement
-  // s'il apparait dans au moins un des registres classiques (entrants, sortants, transportés, gérés)
   function registryTypeFilter(type: WasteRegistryType): estypes.QueryContainer {
-    if (type === "ALL") {
-      return {
-        bool: {
-          should: [
-            registryTypeFilter("OUTGOING"),
-            registryTypeFilter("INCOMING"),
-            registryTypeFilter("TRANSPORTED"),
-            registryTypeFilter("MANAGED")
-          ]
-        }
-      };
-    }
     return { terms: { [elasticKey[type]!]: sirets } };
   }
 

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -147,6 +147,7 @@ describe("All wastes registry", () => {
       opt: {
         emitterCompanySiret: emitter.company.siret,
         transporterCompanySiret: transporter.company.siret,
+        emitterEmissionSignatureDate: new Date("2021-07-01"),
         transporterTransportSignatureDate: new Date("2021-07-01"),
         destinationCompanySiret: destination.company.siret,
         wasteCode: "16 01 04*",
@@ -170,6 +171,7 @@ describe("All wastes registry", () => {
         wasteCode: "14 06 01*",
         createdAt: new Date("2021-08-01"),
         transporterTransportTakenOverAt: new Date("2021-08-02"),
+        transporterTransportSignatureDate: new Date("2021-08-02"),
         destinationReceptionDate: new Date("2021-08-03")
       },
       {
@@ -183,7 +185,7 @@ describe("All wastes registry", () => {
       opt: {
         status: BspaohStatus.PROCESSED,
         emitterCompanySiret: emitter.company.siret,
-
+        emitterEmissionSignatureDate: new Date("2021-09-02"),
         destinationCompanySiret: destination.company.siret,
 
         destinationReceptionDate: new Date("2021-09-01"),
@@ -194,7 +196,8 @@ describe("All wastes registry", () => {
         transporters: {
           create: {
             number: 1,
-            transporterCompanySiret: transporter.company.siret
+            transporterCompanySiret: transporter.company.siret,
+            transporterTransportSignatureDate: new Date("2021-09-02")
           }
         }
       }

--- a/back/src/registry/typeDefs/registry.enums.graphql
+++ b/back/src/registry/typeDefs/registry.enums.graphql
@@ -1,30 +1,41 @@
 "Type de registre"
 enum WasteRegistryType {
   """
-  Registre de déchets sortants, trié par date d'expédition du déchet
+  Registre sortant.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884583
   """
   OUTGOING
   """
-  Registre de déchets entrants, trié par date de réception
+  Registre entrant.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date de réception du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884574
   """
   INCOMING
   """
-  Registre de déchets collectés, trié par date de prise en charge du déchet
+  Registre de transport.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884592
   """
   TRANSPORTED
   """
-  Registre de déchets gérés, trié par date d'acquisition ou de début de gestion du déchet
+  Registre de gestion.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet (la date d'acquisition ou
+  de début de gestion du déchet n'apparaissant pas sur les bordereaux de suivi de déchet,
+  il n'est pas possible de trier le registre suivant cette date).
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884599
   """
   MANAGED
-
   """
-  Registre exhaustif (non règlementaire), trié par date d'expédition du déchet.
-  Permet d'exporter l'ensemble des données de bordereaux liées à un ou plusieurs
-  établissements
+  Registre exhaustif.
+  Registre qui n'est pas réglementaire et qui est indépendant des autres registres. Il permet
+  d'exporter un nombre d'informations conséquent sur l'ensemble des bordereaux sur lesquels un
+  acteur a été visé à partir du moment où l'enlèvement a été signé. Dans cet export, les bordereaux
+  sont triés par date d'enlèvement du déchet.
   """
   ALL
 }

--- a/back/src/registry/typeDefs/registry.queries.graphql
+++ b/back/src/registry/typeDefs/registry.queries.graphql
@@ -2,7 +2,9 @@
 
 type Query {
   """
-  Registre de déchets entrants, trié par date de réception
+  Registre entrant.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date de réception du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884574
   """
   incomingWastes(
@@ -21,7 +23,9 @@ type Query {
   ): IncomingWasteConnection!
 
   """
-  Registre de déchets sortants, trié par date d'expédition du déchet
+  Registre sortant.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884583
   """
   outgoingWastes(
@@ -40,7 +44,9 @@ type Query {
   ): OutgoingWasteConnection!
 
   """
-  Registre de déchets collectés, trié par date de prise en charge du déchet
+  Registre de transport.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet.
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884592
   """
   transportedWastes(
@@ -59,10 +65,11 @@ type Query {
   ): TransportedWasteConnection!
 
   """
-  Registre de déchets gérés, trié par date d'expédition du déchet
-  (la date d'acquisition ou de début de gestion du déchet n'apparaissant pas
-  sur les bordereaux de suivi de déchet, il n'est pas possible de trier
-  le registre suivant cette date)
+  Registre de gestion.
+  Registre réglementaire, les déchets apparaissent à partir du moment où l'enlèvement
+  a été signé et sont triés par date d'enlèvement du déchet (la date d'acquisition ou
+  de début de gestion du déchet n'apparaissant pas sur les bordereaux de suivi de déchet,
+  il n'est pas possible de trier le registre suivant cette date).
   https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043884599
   """
   managedWastes(
@@ -81,9 +88,11 @@ type Query {
   ): ManagedWasteConnection!
 
   """
-  Registre de déchets "exhaustif" permettant d'exporter l'intégralité
-  des déchets sortants, entrants, collectés ou gérés, trié par la date
-  d'expédition du déchet.
+  Registre exhaustif.
+  Registre qui n'est pas réglementaire et qui est indépendant des autres registres. Il permet
+  d'exporter un nombre d'informations conséquent sur l'ensemble des bordereaux sur lesquels un
+  acteur a été visé à partir du moment où l'enlèvement a été signé. Dans cet export, les bordereaux
+  sont triés par date d'enlèvement du déchet.
   """
   allWastes(
     "Liste d'établissements à inclure dans le registre de déchets exhaustifs"

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -12,6 +12,13 @@ import {
 } from "../generated/graphql/types";
 import { estypes } from "@elastic/elasticsearch";
 
+export type RegistryFields =
+  | "isIncomingWasteFor"
+  | "isOutgoingWasteFor"
+  | "isTransportedWasteFor"
+  | "isManagedWasteFor"
+  | "isAllWasteFor";
+
 export type GenericWaste =
   | IncomingWaste
   | OutgoingWaste


### PR DESCRIPTION
# Contexte

Correctif sur le registre, à savoir:
- Un destinataire doit voir un BSD apparaître dans son registre **entrant** si le BSD a été réceptionné
- Un destinataire doit voir un BSD apparaître dans son registre **exhaustif** si le BSD a été enlevé.

A cause de cette décision, le registre exhaustif **n'est plus** un registre 'compilant' les autres registres. Il a ses propres règles métier, donc j'ai créé une nouvelle variable `isAllWasteFor` dans ES.

# MEP

Il faudra ré-indexer la totalité des bordereaux, pour que le champ `isAllWasteFor` se remplisse (le schéma ES est donc **modifié**).

# Ticket Favro

[Incrémenter les registres Exhaustif, Sortant, Transport, Gestion dès la signature transporteur et le registre entrant dès la signature réception ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/4186f94658c16a1334e47546?card=tra-13965)
