### PR TITLE
Retrait de la possibilité de sélectionner un mode de traitement pour le code non final D9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
+- Retrait de la possibilité de sélectionner un mode de traitement pour le code non final D9 [PR 3308](https://github.com/MTES-MCT/trackdechets/pull/3308
+
 #### :nail_care: Améliorations
 
 - Ajout de la mise à jour de l'immatriculation dans la modale de signature du bordereau de synthèse BSDASRI [PR 3290](https://github.com/MTES-MCT/trackdechets/pull/3290)

--- a/apps/doc/docs/reference/operationModes.md
+++ b/apps/doc/docs/reference/operationModes.md
@@ -13,9 +13,9 @@ Les BSDs ont donc un champ qui permet de renseigner le mode de traitement choisi
 - BSFF : `packaging.operationMode`
 
 Les modes de traitement dépendent directement du code de traitement sélectionné. Voici les correspondances possibles :
-- D1, D2, D3, D4, D5, D6, D7, D8, D9, D9F, D10, D11, D12 : Elimination
+- D1, D2, D3, D4, D5, D6, D7, D8, D9F, D10, D11, D12 : Elimination
 - R0 : Réutilisation
 - R1 : Valorisation énergétique
 - R2, R3, R4, R5, R7, R9, R11 : Réutilisation ou recyclage
 - R6, R8, R10 : Recyclage
-- D13, D14, D15, R12, R13 : Aucun mode possible
+- D9, D13, D14, D15, R12, R13 : Aucun mode possible

--- a/back/src/bsda/__tests__/factories.ts
+++ b/back/src/bsda/__tests__/factories.ts
@@ -146,7 +146,7 @@ const getBsdaObject = (): Prisma.BsdaCreateInput => ({
   destinationReceptionWeight: 1.2,
   destinationReceptionAcceptationStatus: "ACCEPTED",
   destinationReceptionRefusalReason: null,
-  destinationOperationCode: "D 9",
+  destinationOperationCode: "D 5",
   destinationOperationMode: "ELIMINATION",
   destinationOperationDate: "2019-11-28T00:00:00.000Z",
 

--- a/back/src/bsda/__tests__/workflow.integration.ts
+++ b/back/src/bsda/__tests__/workflow.integration.ts
@@ -82,7 +82,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                   acceptationStatus: ACCEPTED
               }
               operation: {
-                  code: "D 9"
+                  code: "D 5"
                   mode: ELIMINATION
                   date: "2020-06-30"
               }
@@ -243,7 +243,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "D 9"
+                      code: "D 5"
                       mode: ELIMINATION
                       date: "2020-06-30"
                   }
@@ -433,7 +433,7 @@ describe("Exemples de circuit du bordereau de suivi des déchets d'amiante", () 
                       acceptationStatus: ACCEPTED
                   }
                   operation: {
-                      code: "D 9"
+                      code: "D 5"
                       mode: ELIMINATION
                       date: "2020-06-30"
                   }

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -1086,7 +1086,7 @@ describe("Mutation.Bsda.sign", () => {
           emitterCompanySiret: emitter.siret,
           destinationCompanySiret: ttr1.siret,
           status: BsdaStatus.AWAITING_CHILD,
-          destinationOperationCode: "D 9",
+          destinationOperationCode: "D 5",
           destinationOperationMode: "ELIMINATION"
         },
         transporterOpt: {
@@ -1102,7 +1102,7 @@ describe("Mutation.Bsda.sign", () => {
         opt: {
           emitterCompanySiret: emitter.siret,
           destinationCompanySiret: ttr2.siret,
-          destinationOperationCode: "D 9",
+          destinationOperationCode: "D 5",
           destinationOperationMode: "ELIMINATION",
           status: BsdaStatus.AWAITING_CHILD,
           forwarding: { connect: { id: bsda1.id } }
@@ -1120,7 +1120,7 @@ describe("Mutation.Bsda.sign", () => {
           status: BsdaStatus.SENT,
           emitterCompanySiret: ttr2.siret,
           destinationCompanySiret: destination.siret,
-          destinationOperationCode: "D 9",
+          destinationOperationCode: "D 5",
           destinationOperationMode: "ELIMINATION",
           forwarding: { connect: { id: bsda2.id } }
         },

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -519,7 +519,8 @@ describe("BSDA parsing", () => {
   describe("Operation modes", () => {
     test.each([
       ["R 5", "REUTILISATION"],
-      ["R 13", undefined]
+      ["R 13", undefined],
+      ["D 9", undefined]
     ])(
       "should work if operation code & mode are compatible (code: %p, mode: %p)",
       (code, mode: OperationMode) => {
@@ -538,7 +539,8 @@ describe("BSDA parsing", () => {
 
     test.each([
       ["R 5", "REUTILISATION"],
-      ["R 13", undefined]
+      ["R 13", undefined],
+      ["D 9", undefined]
     ])(
       "should work if operation code & mode are compatible (code: %p, mode: %p)",
       (code, mode: OperationMode) => {
@@ -557,7 +559,8 @@ describe("BSDA parsing", () => {
 
     test.each([
       ["R 5", "VALORISATION_ENERGETIQUE"], // Correct modes are REUTILISATION or RECYCLAGE
-      ["R 13", "VALORISATION_ENERGETIQUE"] // R 13 has no associated mode
+      ["R 13", "VALORISATION_ENERGETIQUE"], // R 13 has no associated mode,
+      ["D 9", "VALORISATION_ENERGETIQUE"] // D 9 has no associated mode,
     ])(
       "should fail if operation mode is not compatible with operation code (code: %p, mode: %p)",
       (code, mode: OperationMode) => {

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -455,7 +455,7 @@ describe("Mutation.signBsdasri emission", () => {
     test("if operation code has associated operation modes but none is specified", async () => {
       const data = {
         ...bsdasri,
-        destinationOperationCode: "D9",
+        destinationOperationCode: "D10",
         destinationOperationMode: undefined,
         destinationReceptionWasteWeightValue: 10
       };
@@ -516,7 +516,10 @@ describe("Mutation.signBsdasri emission", () => {
 
   describe("Operation modes", () => {
     test.each([
-      ["D9", "ELIMINATION"],
+      ["D9", undefined],
+      ["D10", "ELIMINATION"],
+      ["R1", "VALORISATION_ENERGETIQUE"],
+      ["D12", "ELIMINATION"],
       ["R12", undefined]
     ])(
       "should work if operation code & mode are compatible (code: %p, mode: %p)",
@@ -539,7 +542,7 @@ describe("Mutation.signBsdasri emission", () => {
     test("should work if operation mode is missing but step is not operation", async () => {
       const data = {
         ...bsdasri,
-        destinationOperationCode: "D9",
+        destinationOperationCode: "D10",
         destinationOperationMode: undefined, // Correct mode is ELIMINATION
         destinationOperationDate: new Date(),
         destinationReceptionWasteWeightValue: 10
@@ -552,7 +555,10 @@ describe("Mutation.signBsdasri emission", () => {
     });
 
     test.each([
-      ["D9", "VALORISATION_ENERGETIQUE"], // Correct mode is ELIMINATION
+      ["D9", "VALORISATION_ENERGETIQUE"], // No mode is expected
+      ["D10", "VALORISATION_ENERGETIQUE"], // Correct mode is ELIMINATION
+      ["R1", "ELIMINATION"], //  Correct mode is VALORISATION_ENERGETIQUE
+      ["D12", "VALORISATION_ENERGETIQUE"], //  Correct mode is ELIMINATION
       ["R12", "VALORISATION_ENERGETIQUE"] // R12 has no associated mode
     ])(
       "should not be valid if operation mode is not compatible with operation code (mode: %p, code: %p)",
@@ -578,23 +584,28 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
-    test("should not be valid if operation code has associated operation modes but none is specified", async () => {
-      const data = {
-        ...bsdasri,
-        destinationOperationCode: "D9",
-        destinationOperationMode: undefined,
-        destinationOperationDate: new Date(),
-        destinationReceptionWasteWeightValue: 10
-      };
+    test.each(["D10", "R1", "D12"])(
+      "should not be valid if operation code has associated operation modes but none is specified (code: %p)",
+      async code => {
+        const data = {
+          ...bsdasri,
+          destinationOperationCode: code,
+          destinationOperationMode: undefined,
+          destinationOperationDate: new Date(),
+          destinationReceptionWasteWeightValue: 10
+        };
 
-      expect.assertions(2);
+        expect.assertions(2);
 
-      try {
-        await validateBsdasri(data as any, { operationSignature: true });
-      } catch (err) {
-        expect(err.errors.length).toBeTruthy();
-        expect(err.errors[0]).toBe("Vous devez préciser un mode de traitement");
+        try {
+          await validateBsdasri(data as any, { operationSignature: true });
+        } catch (err) {
+          expect(err.errors.length).toBeTruthy();
+          expect(err.errors[0]).toBe(
+            "Vous devez préciser un mode de traitement"
+          );
+        }
       }
-    });
+    );
   });
 });

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -198,7 +198,7 @@ describe("Query.bsds.bsda base workflow", () => {
                 weight: 1
               },
               operation: {
-                code: "D 9",
+                code: "D 5",
                 mode: "ELIMINATION",
                 date: new Date().toISOString() as any
               }

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -363,7 +363,22 @@ describe("BSVHU validation", () => {
     test("should work if operation code & mode are compatible", async () => {
       const data = {
         ...bsvhu,
-        destinationOperationCode: "D 9",
+        destinationOperationCode: "R 4",
+        destinationOperationMode: "REUTILISATION",
+        destinationReceptionWeight: 10,
+        destinationReceptionAcceptationStatus: "ACCEPTED"
+      };
+
+      const res = await validateBsvhu(data as any, {
+        operationSignature: true
+      });
+      expect(res).not.toBeUndefined();
+    });
+
+    test("should FAIL", async () => {
+      const data = {
+        ...bsvhu,
+        destinationOperationCode: "D 1",
         destinationOperationMode: "ELIMINATION",
         destinationReceptionWeight: 10,
         destinationReceptionAcceptationStatus: "ACCEPTED"
@@ -378,8 +393,8 @@ describe("BSVHU validation", () => {
     test("should work if operation mode is missing but step is not operation", async () => {
       const data = {
         ...bsvhu,
-        destinationOperationCode: "D 9",
-        destinationOperationMode: undefined, // Correct modes is ELIMINATION
+        destinationOperationCode: "R 4",
+        destinationOperationMode: undefined, // Correct mode is REUTILISATION | RECYCLAGE
         destinationReceptionWeight: 10,
         destinationReceptionAcceptationStatus: "ACCEPTED"
       };
@@ -391,8 +406,8 @@ describe("BSVHU validation", () => {
     });
 
     test.each([
-      ["D 9", OperationMode.VALORISATION_ENERGETIQUE], // Correct modes is ELIMINATION
-      ["R 12", OperationMode.VALORISATION_ENERGETIQUE] // R12 has no associated mode
+      ["R 4", OperationMode.ELIMINATION], // Correct mode is  REUTILISATION | RECYCLAGE
+      ["R 12", OperationMode.REUTILISATION] // R12 has no associated mode
     ])(
       "should not be valid if operation mode is not compatible with operation code (mode: %p, code: %p)",
       async (code, mode) => {

--- a/back/src/common/__tests__/operationModes.test.ts
+++ b/back/src/common/__tests__/operationModes.test.ts
@@ -22,7 +22,7 @@ describe("getOperationModesFromOperationCode", () => {
     "D 6",
     "D 7",
     "D 8",
-    "D 9",
+
     "D 9 F",
     "D 10",
     "D 11",
@@ -31,7 +31,7 @@ describe("getOperationModesFromOperationCode", () => {
     test(code, [OperationMode.ELIMINATION]);
   });
 
-  it.each(["D 13", "D 14", "D 15", "R 12", "R 13"])(
+  it.each(["D 13", "D 14", "D 15", "R 12", "R 13", "D 9"])(
     "Regroupement code %p > []",
     code => {
       test(code, []);

--- a/back/src/common/operationModes.ts
+++ b/back/src/common/operationModes.ts
@@ -20,7 +20,7 @@ export const getOperationModesFromOperationCode = (
       "D6",
       "D7",
       "D8",
-      "D9",
+      // "D9" traitement non final
       "D9F",
       "D10",
       "D11",
@@ -47,6 +47,7 @@ export const getOperationModesFromOperationCode = (
   }
 
   // Regroupements: D13, D14, D15, R12, R13
+  // D9 traitement non final
   return [];
 };
 

--- a/back/src/common/typeDefs/common.enums.graphql
+++ b/back/src/common/typeDefs/common.enums.graphql
@@ -3,12 +3,12 @@ Qualification du traitement final vis-à-vis de la hiérarchie des modes
 de traitement définie à l'article L. 541-1 du code de l'environnement
 
 Les correspondances entre les codes D/R & modes de traitement sont:
-- D1, D2, D3, D4, D5, D6, D7, D8, D9, D9F, D10, D11, D12: Elimination
+- D1, D2, D3, D4, D5, D6, D7, D8, D9F, D10, D11, D12: Elimination
 - R0: Réutilisation
 - R1: Valorisation énergétique
 - R2, R3, R4, R5, R7, R9, R11: Réutilisation ou recyclage
 - R6, R8, R10: Recyclage
-- D13, D14, D15, R12, R13: aucun mode possible.
+- D9, D13, D14, D15, R12, R13: aucun mode possible.
 """
 enum OperationMode {
   "Réutilisation"

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1856,7 +1856,8 @@ describe("processedInfoSchema", () => {
     });
 
     test.each([
-      ["D9", "VALORISATION_ENERGETIQUE"], // Correct modes are ELIMINATION
+      ["D8", "VALORISATION_ENERGETIQUE"], // correct mode is ELIMINATION
+      ["D9", "VALORISATION_ENERGETIQUE"], // D9 has no associated mode
       ["R12", "VALORISATION_ENERGETIQUE"] // R12 has no associated mode
     ])(
       "should not be valid if operation mode is not compatible with operation code (mode: %p, code: %p)",
@@ -1897,24 +1898,27 @@ describe("processedInfoSchema", () => {
       );
     });
 
-    it("should be valid if operationCode has no potential operationModes associated and none is specified", async () => {
-      const processedInfo = {
-        processedBy: "John Snow",
-        processedAt: new Date(),
-        processingOperationDone: "D 13",
-        processingOperationDescription: "Regroupement",
-        noTraceability: false,
-        nextDestinationProcessingOperation: "D 8",
-        nextDestinationCompanyName: "Exutoire",
-        nextDestinationCompanySiret: siretify(1),
-        nextDestinationCompanyAddress: "4 rue du déchet",
-        nextDestinationCompanyCountry: "FR",
-        nextDestinationCompanyContact: "Arya Stark",
-        nextDestinationCompanyPhone: "06 XX XX XX XX",
-        nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
-      };
+    it.each(["D 9", "D 13"])(
+      "should be valid if operationCode has no potential operationModes associated and none is specified",
+      async code => {
+        const processedInfo = {
+          processedBy: "John Snow",
+          processedAt: new Date(),
+          processingOperationDone: code,
+          processingOperationDescription: "test",
+          noTraceability: false,
+          nextDestinationProcessingOperation: "D 8",
+          nextDestinationCompanyName: "Exutoire",
+          nextDestinationCompanySiret: siretify(1),
+          nextDestinationCompanyAddress: "4 rue du déchet",
+          nextDestinationCompanyCountry: "FR",
+          nextDestinationCompanyContact: "Arya Stark",
+          nextDestinationCompanyPhone: "06 XX XX XX XX",
+          nextDestinationCompanyMail: "arya.stark@trackdechets.fr"
+        };
 
-      expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
-    });
+        expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
+      }
+    );
   });
 });

--- a/front/src/common/__tests__/operationModes.test.ts
+++ b/front/src/common/__tests__/operationModes.test.ts
@@ -23,7 +23,7 @@ describe("getOperationModesFromOperationCode", () => {
     "D 6",
     "D 7",
     "D 8",
-    "D 9",
+
     "D 9 F",
     "D 10",
     "D 11",
@@ -32,7 +32,7 @@ describe("getOperationModesFromOperationCode", () => {
     test(code, [OperationMode.Elimination]);
   });
 
-  it.each(["D 13", "D 14", "D 15", "R 12", "R 13"])(
+  it.each(["D 13", "D 14", "D 15", "R 12", "R 13", "D 9"])(
     "Regroupement code %p > []",
     code => {
       test(code, []);

--- a/front/src/common/operationModes.ts
+++ b/front/src/common/operationModes.ts
@@ -19,7 +19,7 @@ export const getOperationModesFromOperationCode = (
       "D6",
       "D7",
       "D8",
-      "D9",
+      // "D9", non final
       "D9F",
       "D10",
       "D11",
@@ -45,7 +45,7 @@ export const getOperationModesFromOperationCode = (
     return [OperationMode.Recyclage];
   }
 
-  // Regroupements: D13, D14, D15, R12, R13
+  // Regroupements: D13, D14, D15, R12, R13 and D9
   return [];
 };
 

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -198,12 +198,12 @@ enum BsdType {
 // Qualification du traitement final vis-à-vis de la hiérarchie des modes
 // de traitement définie à l'article L. 541-1 du code de l'environnement
 // Les correspondances entre les codes D/R & modes de traitement sont:
-// - D1, D2, D3, D4, D5, D6, D7, D8, D9, D9F, D10, D11, D12: Elimination
+// - D1, D2, D3, D4, D5, D6, D7, D8, D9F, D10, D11, D12: Elimination
 // - R0: Réutilisation
 // - R1: Valorisation énergétique
 // - R2, R3, R4, R5, R7, R9, R11: Réutilisation ou recyclage
 // - R6, R8, R10: Recyclage
-// - D13, D14, D15, R12, R13: aucun mode possible.
+// - D9, D13, D14, D15, R12, R13: aucun mode possible.
 enum OperationMode {
   // Réutilisation
   REUTILISATION

--- a/libs/back/scripts/src/runner.ts
+++ b/libs/back/scripts/src/runner.ts
@@ -36,7 +36,7 @@ async function runScripts() {
   const newScripts = scriptFiles.filter(file => {
     const fileInfo = parse(file);
 
-    if (fileInfo.ext !== "ts") {
+    if (fileInfo.ext !== ".ts") {
       throw new Error("❌ Only .ts files are supported for migration scripts");
     }
 

--- a/libs/back/scripts/src/scripts/20240527094034108_update-d9-operation-code.ts
+++ b/libs/back/scripts/src/scripts/20240527094034108_update-d9-operation-code.ts
@@ -1,0 +1,107 @@
+import { logger } from "@td/logger";
+import { prisma } from "@td/prisma";
+
+const codesD9 = ["D9", "D 9"];
+const commonSelectArgs = {
+  destinationOperationCode: { in: codesD9 },
+  destinationOperationMode: { not: null }
+};
+
+export class UpdateD9perationMode {
+  // On met à jour le mode d'opération des  bsds dont le code d'opération est D9
+  // Le code D9 étant non final,  il n'y a plus de mode d'opération correspondant
+
+  async run() {
+    // On gère tous les bsds et leur révisions sauf les bsffs et paohs qui n'acceptent pas le D9.
+    // Les vhus ne devraient pas  accepter D9 mais la validation actuelle peut laisser passer
+    // Les bsds concernés seront réindexés par la réindexation globale prévue dans la mep
+
+    await this.processBsdasris();
+    await this.processBsdas();
+    await this.processBsdds();
+    await this.processBsvhus();
+    await this.processBsdaRevisionRequest();
+    await this.processBsddRevisionRequest();
+
+    logger.info(`Completed update`);
+  }
+
+  async processBsdasris() {
+    logger.info(`Processing bsdasris`);
+
+    const { count } = await prisma.bsdasri.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        ...commonSelectArgs
+      }
+    });
+
+    logger.info(`${count} processed bsdasris`);
+  }
+
+  async processBsdas() {
+    logger.info(`Processing bsdas`);
+
+    const { count } = await prisma.bsda.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        ...commonSelectArgs
+      }
+    });
+
+    logger.info(`${count} processed bsdas`);
+  }
+  async processBsvhus() {
+    logger.info(`Processing vhus`);
+
+    const { count } = await prisma.bsvhu.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        ...commonSelectArgs
+      }
+    });
+    logger.info(`${count} processed vhus`);
+  }
+
+  async processBsdds() {
+    logger.info(`Processing bsdd`);
+
+    const { count } = await prisma.form.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        processingOperationDone: { in: codesD9 },
+        destinationOperationMode: { not: null }
+      }
+    });
+    logger.info(`${count} processed bsdds`);
+  }
+
+  async processBsdaRevisionRequest() {
+    logger.info(`Processing bsda revisions`);
+
+    const { count } = await prisma.bsdaRevisionRequest.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        ...commonSelectArgs
+      }
+    });
+    logger.info(`${count} processed bsda revisions`);
+  }
+  async processBsddRevisionRequest() {
+    logger.info(`Processing bsdds révisions`);
+
+    const { count } = await prisma.bsddRevisionRequest.updateMany({
+      data: { destinationOperationMode: null },
+      where: {
+        processingOperationDone: { in: codesD9 },
+        destinationOperationMode: { not: null }
+      }
+    });
+
+    logger.info(`${count} processed bsdd revisions`);
+  }
+}
+
+export async function run() {
+  await new UpdateD9perationMode().run();
+}


### PR DESCRIPTION
Le mode de traitement est le code de traitement sont corrélées. Le code D9 était jusqu'alors considéré comme un code final (Élimination), mais ce n'est plus le cas.
Cette PR:
- modifie la validation back et front de tous les bsds concernés et de leurs révisions
- comporte un script de mise à jour des bsds & révisions considérés
- maj la documentation
 

https://github.com/MTES-MCT/trackdechets/assets/878396/acb2f9df-a8da-4f96-a70d-115d2ddf6aa8



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
 
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13841)
