### PR TITLE
[TRA-14055] Modification des infos transporteur affichées sur BsdCard + leur mise à jour

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Renommer Transit par Réexpédition (sous-type de BSDA) [PR 3351](https://github.com/MTES-MCT/trackdechets/pull/3351)
 - Rendre les liens de FAQ cliquable dans l'ajout d'établissement [PR 3342](https://github.com/MTES-MCT/trackdechets/pull/3342)
 - Faire remonter BSD dans dashboard à la création de demande de révision [PR 3315](https://github.com/MTES-MCT/trackdechets/pull/3315)
+- Afficher infos du transporteur actuel sur BsdCard + permettre leur mise à jour [PR 3309](https://github.com/MTES-MCT/trackdechets/pull/3309)
 
 #### :house: Interne
 

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -119,7 +119,7 @@ type BsdasriTransport {
   handedOverAt: DateTime
   takenOverAt: DateTime
   signature: BsdasriSignature
-  mode: TransportMode!
+  mode: TransportMode
   "Plaque(s) d'immatriculation"
   plates: [String!]
 }

--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -189,6 +189,29 @@ function BsdCard({
     return getCurrentTransporterInfos(bsd, currentSiret, isToCollectTab);
   }, [bsd, currentSiret, isToCollectTab, isCollectedTab]);
 
+  // display the transporter's custom info if:
+  // - we are in the "To Collect" tab
+  // OR
+  // - we are in the "Collected" tab and there is a custom info
+  const displayTransporterCustomInfo =
+    !!currentTransporterInfos &&
+    (isToCollectTab ||
+      (isCollectedTab &&
+        !!currentTransporterInfos?.transporterCustomInfo?.length));
+
+  // display the transporter's number plate if:
+  // - the mode of transport is ROAD
+  // AND
+  // - we are in the "To Collect" tab
+  // OR
+  // - we are in the "Collected" tab and there is a number plate
+  const displayTransporterNumberPlate =
+    !!currentTransporterInfos &&
+    currentTransporterInfos.transporterMode === TransportMode.Road &&
+    (isToCollectTab ||
+      (isCollectedTab &&
+        !!currentTransporterInfos?.transporterNumberPlate?.length));
+
   const handleValidationClick = (
     _: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
@@ -349,46 +372,36 @@ function BsdCard({
                       info={pickupSiteName}
                     />
                   )}
-                  {!!currentTransporterInfos &&
-                    (isToCollectTab ||
-                      (isCollectedTab &&
-                        !!currentTransporterInfos?.transporterCustomInfo
-                          ?.length)) && (
-                      <InfoWithIcon
-                        labelCode={InfoIconCode.CustomInfo}
-                        editableInfos={{
-                          customInfo:
-                            currentTransporterInfos?.transporterCustomInfo
-                        }}
-                        hasEditableInfos
-                        isDisabled={
-                          isCollectedTab ||
-                          !permissions.includes(UserPermission.BsdCanUpdate)
-                        }
-                        onClick={handleEditableInfoClick}
-                      />
-                    )}
-                  {!!currentTransporterInfos &&
-                    currentTransporterInfos.transporterMode ===
-                      TransportMode.Road &&
-                    (isToCollectTab ||
-                      (isCollectedTab &&
-                        !!currentTransporterInfos?.transporterNumberPlate
-                          ?.length)) && (
-                      <InfoWithIcon
-                        labelCode={InfoIconCode.TransporterNumberPlate}
-                        editableInfos={{
-                          transporterNumberPlate:
-                            currentTransporterInfos?.transporterNumberPlate
-                        }}
-                        hasEditableInfos
-                        isDisabled={
-                          isCollectedTab ||
-                          !permissions.includes(UserPermission.BsdCanUpdate)
-                        }
-                        onClick={handleEditableInfoClick}
-                      />
-                    )}
+                  {displayTransporterCustomInfo && (
+                    <InfoWithIcon
+                      labelCode={InfoIconCode.CustomInfo}
+                      editableInfos={{
+                        customInfo:
+                          currentTransporterInfos?.transporterCustomInfo
+                      }}
+                      hasEditableInfos
+                      isDisabled={
+                        isCollectedTab ||
+                        !permissions.includes(UserPermission.BsdCanUpdate)
+                      }
+                      onClick={handleEditableInfoClick}
+                    />
+                  )}
+                  {displayTransporterNumberPlate && (
+                    <InfoWithIcon
+                      labelCode={InfoIconCode.TransporterNumberPlate}
+                      editableInfos={{
+                        transporterNumberPlate:
+                          currentTransporterInfos?.transporterNumberPlate
+                      }}
+                      hasEditableInfos
+                      isDisabled={
+                        isCollectedTab ||
+                        !permissions.includes(UserPermission.BsdCanUpdate)
+                      }
+                      onClick={handleEditableInfoClick}
+                    />
+                  )}
                 </div>
                 {isMobile && <div className="bsd-card-border" />}
               </div>

--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -186,7 +186,7 @@ function BsdCard({
     if (!isToCollectTab && !isCollectedTab) {
       return null;
     }
-    return getCurrentTransporterInfos(bsd, currentSiret);
+    return getCurrentTransporterInfos(bsd, currentSiret, isToCollectTab);
   }, [bsd, currentSiret, isToCollectTab, isCollectedTab]);
 
   const handleValidationClick = (

--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -16,7 +16,6 @@ import {
   getWorkflowLabel,
   isBsdasri,
   isBsff,
-  isBsvhu,
   isBspaoh
 } from "../../dashboardServices";
 import BsdAdditionalActionsButton from "../BsdAdditionalActionsButton/BsdAdditionalActionsButton";
@@ -57,6 +56,7 @@ import TransporterInfoEditModal from "../TransporterInfoEditModal/TransporterInf
 import { NON_RENSEIGNE } from "../../../common/wordings/dashboard/wordingsDashboard";
 
 import "./bsdCard.scss";
+import { getCurrentTransporterInfos } from "../../bsdMapper";
 
 function BsdCard({
   bsd,
@@ -181,6 +181,13 @@ function BsdCard({
   const ctaPrimaryReviewLabel = bsdDisplay?.type
     ? getPrimaryActionsReviewsLabel(bsdDisplay, currentSiret)
     : "";
+
+  const currentTransporterInfos = useMemo(() => {
+    if (!isToCollectTab && !isCollectedTab) {
+      return null;
+    }
+    return getCurrentTransporterInfos(bsd, currentSiret);
+  }, [bsd, currentSiret, isToCollectTab, isCollectedTab]);
 
   const handleValidationClick = (
     _: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -342,45 +349,50 @@ function BsdCard({
                       info={pickupSiteName}
                     />
                   )}
-                  {((isToCollectTab && !isBsvhu(bsdDisplay.type)) ||
-                    (isCollectedTab &&
-                      Boolean(bsdDisplay?.transporterCustomInfo?.length))) && (
-                    <InfoWithIcon
-                      labelCode={InfoIconCode.CustomInfo}
-                      editableInfos={{
-                        customInfo: bsdDisplay?.transporterCustomInfo
-                      }}
-                      hasEditableInfos
-                      isDisabled={
-                        isCollectedTab ||
-                        !canEditCustomInfoOrTransporterNumberPlate(
-                          bsdDisplay,
-                          permissions
-                        )
-                      }
-                      onClick={handleEditableInfoClick}
-                    />
-                  )}
-                  {((isToCollectTab && !isBsvhu(bsdDisplay.type)) ||
-                    (isCollectedTab &&
-                      Boolean(bsdDisplay?.transporterNumberPlate?.length))) && (
-                    <InfoWithIcon
-                      labelCode={InfoIconCode.TransporterNumberPlate}
-                      editableInfos={{
-                        transporterNumberPlate:
-                          bsdDisplay?.transporterNumberPlate
-                      }}
-                      hasEditableInfos
-                      isDisabled={
-                        isCollectedTab ||
-                        !canEditCustomInfoOrTransporterNumberPlate(
-                          bsdDisplay,
-                          permissions
-                        )
-                      }
-                      onClick={handleEditableInfoClick}
-                    />
-                  )}
+                  {!!currentTransporterInfos &&
+                    (isToCollectTab ||
+                      (isCollectedTab &&
+                        !!currentTransporterInfos?.transporterCustomInfo
+                          ?.length)) && (
+                      <InfoWithIcon
+                        labelCode={InfoIconCode.CustomInfo}
+                        editableInfos={{
+                          customInfo:
+                            currentTransporterInfos?.transporterCustomInfo
+                        }}
+                        hasEditableInfos
+                        isDisabled={
+                          isCollectedTab ||
+                          !canEditCustomInfoOrTransporterNumberPlate(
+                            bsdDisplay,
+                            permissions
+                          )
+                        }
+                        onClick={handleEditableInfoClick}
+                      />
+                    )}
+                  {!!currentTransporterInfos &&
+                    (isToCollectTab ||
+                      (isCollectedTab &&
+                        !!currentTransporterInfos?.transporterNumberPlate
+                          ?.length)) && (
+                      <InfoWithIcon
+                        labelCode={InfoIconCode.TransporterNumberPlate}
+                        editableInfos={{
+                          transporterNumberPlate:
+                            currentTransporterInfos?.transporterNumberPlate
+                        }}
+                        hasEditableInfos
+                        isDisabled={
+                          isCollectedTab ||
+                          !canEditCustomInfoOrTransporterNumberPlate(
+                            bsdDisplay,
+                            permissions
+                          )
+                        }
+                        onClick={handleEditableInfoClick}
+                      />
+                    )}
                 </div>
                 {isMobile && <div className="bsd-card-border" />}
               </div>
@@ -491,6 +503,7 @@ function BsdCard({
 
       <TransporterInfoEditModal
         bsd={bsdDisplay!}
+        currentTransporter={currentTransporterInfos!}
         isOpen={isTransportEditModalOpen}
         onClose={onCloseTransportEditModal}
       />

--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -8,7 +8,6 @@ import { InfoIconCode } from "../InfoWithIcon/infoWithIconTypes";
 import { BsdCardProps } from "./bsdCardTypes";
 import WasteDetails from "../WasteDetails/WasteDetails";
 import {
-  canEditCustomInfoOrTransporterNumberPlate,
   canPublishBsd,
   getBsdView,
   getPrimaryActionsLabelFromBsdStatus,
@@ -35,6 +34,7 @@ import {
   Query,
   QueryCompanyPrivateInfosArgs,
   RevisionRequestStatus,
+  TransportMode,
   UserPermission
 } from "@td/codegen-ui";
 import {
@@ -363,15 +363,14 @@ function BsdCard({
                         hasEditableInfos
                         isDisabled={
                           isCollectedTab ||
-                          !canEditCustomInfoOrTransporterNumberPlate(
-                            bsdDisplay,
-                            permissions
-                          )
+                          !permissions.includes(UserPermission.BsdCanUpdate)
                         }
                         onClick={handleEditableInfoClick}
                       />
                     )}
                   {!!currentTransporterInfos &&
+                    currentTransporterInfos.transporterMode ===
+                      TransportMode.Road &&
                     (isToCollectTab ||
                       (isCollectedTab &&
                         !!currentTransporterInfos?.transporterNumberPlate
@@ -385,10 +384,7 @@ function BsdCard({
                         hasEditableInfos
                         isDisabled={
                           isCollectedTab ||
-                          !canEditCustomInfoOrTransporterNumberPlate(
-                            bsdDisplay,
-                            permissions
-                          )
+                          !permissions.includes(UserPermission.BsdCanUpdate)
                         }
                         onClick={handleEditableInfoClick}
                       />

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
@@ -2,13 +2,13 @@ import React, { useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { BsdDisplay } from "../../../common/types/bsdTypes";
+import { BsdCurrentTransporterInfos } from "../../../common/types/bsdTypes";
 import TagsInput from "../../../Forms/Components/TagsInput/TagsInput";
 
 import "./transporterInfoEditForm.scss";
 
 interface TransporterInfoEditFormProps {
-  bsd: BsdDisplay;
+  currentTransporter: BsdCurrentTransporterInfos;
   onClose: () => void;
   onSubmitForm: (data) => Promise<void>;
 }
@@ -18,12 +18,12 @@ type TransporterFormInputs = {
 };
 
 const TransporterInfoEditForm = ({
-  bsd,
+  currentTransporter,
   onClose,
   onSubmitForm
 }: TransporterInfoEditFormProps) => {
   const formatInitialPlates = () => {
-    const transporterNumberPlate = bsd?.transporterNumberPlate;
+    const transporterNumberPlate = currentTransporter.transporterNumberPlate;
 
     if (typeof transporterNumberPlate === "string") {
       const regex = /,+|,\s+/;
@@ -42,7 +42,7 @@ const TransporterInfoEditForm = ({
   const initialPlates = formatInitialPlates();
   const [platesTags, setPlatestags] = useState<string[]>(initialPlates);
   const defaultValues = {
-    customInfo: bsd?.transporterCustomInfo as string,
+    customInfo: currentTransporter.transporterCustomInfo as string,
     plates: initialPlates
   };
   const { register, handleSubmit, reset, formState, setValue } =

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
@@ -6,6 +6,7 @@ import { BsdCurrentTransporterInfos } from "../../../common/types/bsdTypes";
 import TagsInput from "../../../Forms/Components/TagsInput/TagsInput";
 
 import "./transporterInfoEditForm.scss";
+import { TransportMode } from "@td/codegen-ui";
 
 interface TransporterInfoEditFormProps {
   currentTransporter: BsdCurrentTransporterInfos;
@@ -105,21 +106,23 @@ const TransporterInfoEditForm = ({
         }}
       />
 
-      <div className="transporterInfoEditForm__plates">
-        <TagsInput
-          label="Immatriculations"
-          onAddTag={handleAddPlate}
-          onDeleteTag={dismissTag}
-          tags={platesTags}
-        />
-        {/* hidden tag field registered */}
-        <input
-          id="inputPlateHidden"
-          {...register("plates")}
-          className="sr-only"
-          aria-hidden
-        />
-      </div>
+      {currentTransporter.transporterMode === TransportMode.Road ? (
+        <div className="transporterInfoEditForm__plates">
+          <TagsInput
+            label="Immatriculations"
+            onAddTag={handleAddPlate}
+            onDeleteTag={dismissTag}
+            tags={platesTags}
+          />
+          {/* hidden tag field registered */}
+          <input
+            id="inputPlateHidden"
+            {...register("plates")}
+            className="sr-only"
+            aria-hidden
+          />
+        </div>
+      ) : null}
 
       <div className="transporterInfoEditForm__cta">
         <Button

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
@@ -3,42 +3,54 @@ import { useMutation } from "@apollo/client";
 import {
   BsdType,
   Mutation,
-  MutationUpdateBsdaArgs,
+  MutationUpdateBsdaTransporterArgs,
   MutationUpdateBsdasriArgs,
-  MutationUpdateBsffArgs
+  MutationUpdateBsffArgs,
+  MutationUpdateBspaohArgs,
+  MutationUpdateFormTransporterArgs
 } from "@td/codegen-ui";
-import { UPDATE_BSDA } from "../../../common/queries/bsda/queries";
 import TdModal from "../../../common/Components/Modal/Modal";
 import { NotificationError } from "../../../common/Components/Error/Error";
-import { BsdDisplay } from "../../../common/types/bsdTypes";
-import { UPDATE_TRANSPORT_INFO } from "../../../common/queries/bsdd/queries";
+import {
+  BsdCurrentTransporterInfos,
+  BsdDisplay
+} from "../../../common/types/bsdTypes";
+import { UPDATE_BSDA_TRANSPORTER } from "../../../common/queries/bsda/queries";
+import { UPDATE_BSDD_TRANSPORTER } from "../../../common/queries/bsdd/queries";
 import { UPDATE_BSFF_FORM } from "../../../common/queries/bsff/queries";
 import { UPDATE_BSDASRI } from "../../../common/queries/bsdasri/queries";
+import { UPDATE_BSPAOH } from "../../../common/queries/bspaoh/queries";
 import TransporterInfoEditForm from "./TransporterInfoEditForm";
 import { Loader } from "../../../common/Components";
 
 interface TransporterInfoEditModalProps {
   bsd: BsdDisplay;
+  currentTransporter: BsdCurrentTransporterInfos;
   isOpen: boolean;
   onClose: () => void;
 }
 
 const TransporterInfoEditModal = ({
   bsd,
+  currentTransporter,
   isOpen,
   onClose
 }: TransporterInfoEditModalProps) => {
   const [
     updateTransporterInfoBsda,
     { error: errorBsda, loading: loadingBsda }
-  ] = useMutation<Pick<Mutation, "updateBsda">, MutationUpdateBsdaArgs>(
-    UPDATE_BSDA
-  );
+  ] = useMutation<
+    Pick<Mutation, "updateBsdaTransporter">,
+    MutationUpdateBsdaTransporterArgs
+  >(UPDATE_BSDA_TRANSPORTER);
 
   const [
     updateTransporterInfoBsdd,
     { error: errorBsdd, loading: loadingBsdd }
-  ] = useMutation(UPDATE_TRANSPORT_INFO);
+  ] = useMutation<
+    Pick<Mutation, "updateFormTransporter">,
+    MutationUpdateFormTransporterArgs
+  >(UPDATE_BSDD_TRANSPORTER);
 
   const [
     updateTransporterInfoBsff,
@@ -54,19 +66,28 @@ const TransporterInfoEditModal = ({
     UPDATE_BSDASRI
   );
 
+  const [
+    updateTransporterInfoBspaoh,
+    { error: errorBspaoh, loading: loadingBspaoh }
+  ] = useMutation<Pick<Mutation, "updateBspaoh">, MutationUpdateBspaohArgs>(
+    UPDATE_BSPAOH
+  );
+
   const onSubmitForm = async data => {
     if (bsd.type === BsdType.Bsdd) {
       await updateTransporterInfoBsdd({
         variables: {
-          id: bsd.id,
-          transporterNumberPlate: data.plates?.toString(),
-          transporterCustomInfo: data.customInfo
+          id: currentTransporter.transporterId!,
+          input: {
+            numberPlate: data.plates?.toString(),
+            customInfo: data.customInfo
+          }
         }
       });
       return;
     }
     const formattedPlates =
-      typeof data.plates === "string" && Boolean(data.plates)
+      typeof data.plates === "string" && data.plates
         ? data.plates?.split(",")
         : data.plates?.length
         ? data.plates
@@ -74,20 +95,16 @@ const TransporterInfoEditModal = ({
     if (bsd.type === BsdType.Bsda) {
       await updateTransporterInfoBsda({
         variables: {
-          id: bsd.id,
+          id: currentTransporter.transporterId!,
           input: {
-            transporter: {
-              customInfo: data.customInfo,
-              transport: {
-                plates: formattedPlates
-              }
+            customInfo: data.customInfo,
+            transport: {
+              plates: formattedPlates
             }
           }
         }
       });
-      return;
-    }
-    if (bsd.type === BsdType.Bsff) {
+    } else if (bsd.type === BsdType.Bsff) {
       await updateTransporterInfoBsff({
         variables: {
           id: bsd.id,
@@ -99,9 +116,7 @@ const TransporterInfoEditModal = ({
           }
         }
       });
-      return;
-    }
-    if (bsd.type === BsdType.Bsdasri) {
+    } else if (bsd.type === BsdType.Bsdasri) {
       await updateTransporterInfoBsdasri({
         variables: {
           id: bsd.id,
@@ -113,19 +128,36 @@ const TransporterInfoEditModal = ({
           }
         }
       });
-      return;
+    } else if (bsd.type === BsdType.Bspaoh) {
+      await updateTransporterInfoBspaoh({
+        variables: {
+          id: bsd.id,
+          input: {
+            transporter: {
+              customInfo: data.customInfo,
+              transport: { plates: formattedPlates }
+            }
+          }
+        }
+      });
     }
   };
 
-  const error = errorBsdd || errorBsda || errorBsdasri || errorBsff;
-  const loading = loadingBsdd || loadingBsda || loadingBsdasri || loadingBsff;
+  const error =
+    errorBsdd || errorBsda || errorBsdasri || errorBsff || errorBspaoh;
+  const loading =
+    loadingBsdd ||
+    loadingBsda ||
+    loadingBsdasri ||
+    loadingBsff ||
+    loadingBspaoh;
 
-  if (
-    bsd.type === BsdType.Bsda &&
-    !["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(bsd.status)
-  ) {
-    return null;
-  }
+  // if (
+  //   bsd.type === BsdType.Bsda &&
+  //   !["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(bsd.status)
+  // ) {
+  //   return null;
+  // }
   return (
     <TdModal
       isOpen={isOpen}
@@ -133,7 +165,7 @@ const TransporterInfoEditModal = ({
       onClose={onClose}
     >
       <TransporterInfoEditForm
-        bsd={bsd}
+        currentTransporter={currentTransporter}
         onSubmitForm={onSubmitForm}
         onClose={onClose}
       />

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
@@ -152,12 +152,6 @@ const TransporterInfoEditModal = ({
     loadingBsff ||
     loadingBspaoh;
 
-  // if (
-  //   bsd.type === BsdType.Bsda &&
-  //   !["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(bsd.status)
-  // ) {
-  //   return null;
-  // }
   return (
     <TdModal
       isOpen={isOpen}

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -11,6 +11,7 @@ import {
 } from "@td/codegen-ui";
 
 import {
+  BsdCurrentTransporterInfos,
   BsdDisplay,
   BsdStatusCode,
   BsdTypename,
@@ -62,6 +63,104 @@ export const formatBsd = (bsd: Bsd): BsdDisplay | null => {
     default:
       return null;
   }
+};
+
+export const getCurrentTransporterInfos = (
+  bsd: Bsd,
+  currentSiret: string
+): BsdCurrentTransporterInfos | null => {
+  switch (bsd.__typename) {
+    case BsdTypename.Bsdd:
+      return getBsddCurrentTransporterInfos(bsd, currentSiret);
+    case BsdTypename.Bsda:
+      return getBsdaCurrentTransporterInfos(bsd, currentSiret);
+    case BsdTypename.Bsdasri:
+      return getBsdasriCurrentTransporterInfos(bsd, currentSiret);
+    case BsdTypename.Bsvhu:
+      return null;
+    case BsdTypename.Bsff:
+      return getBsffCurrentTransporterInfos(bsd, currentSiret);
+    case BsdTypename.Bspaoh:
+      return getBspaohCurrentTransporterInfos(bsd, currentSiret);
+    default:
+      return null;
+  }
+};
+
+export const getBsddCurrentTransporterInfos = (
+  bsdd: Form,
+  currentSiret: string
+): BsdCurrentTransporterInfos => {
+  const currentTransporter = bsdd.transporters?.find(
+    transporter => transporter.company?.orgId === currentSiret
+  );
+  if (!currentTransporter) {
+    return {};
+  }
+  return {
+    transporterId: currentTransporter?.id,
+    transporterNumberPlate: currentTransporter?.numberPlate,
+    transporterCustomInfo: currentTransporter?.customInfo
+  };
+};
+
+export const getBsdaCurrentTransporterInfos = (
+  bsda: Bsda,
+  currentSiret: string
+): BsdCurrentTransporterInfos => {
+  const currentTransporter = bsda.transporters?.find(
+    transporter => transporter.company?.orgId === currentSiret
+  );
+  if (!currentTransporter) {
+    return {};
+  }
+  return {
+    transporterId: currentTransporter?.id,
+    transporterNumberPlate: currentTransporter?.transport?.plates,
+    transporterCustomInfo: currentTransporter?.customInfo
+  };
+};
+
+export const getBsdasriCurrentTransporterInfos = (
+  bsdasri: Bsdasri,
+  currentSiret: string
+): BsdCurrentTransporterInfos => {
+  const currentTransporter = bsdasri.transporter;
+  if (currentTransporter?.company?.orgId !== currentSiret) {
+    return {};
+  }
+  return {
+    transporterNumberPlate: currentTransporter?.transport?.plates,
+    transporterCustomInfo: currentTransporter?.customInfo
+  };
+};
+
+export const getBsffCurrentTransporterInfos = (
+  bsff: Bsff,
+  currentSiret: string
+): BsdCurrentTransporterInfos => {
+  const currentTransporter = bsff.transporter || bsff["bsffTransporter"];
+  if (currentTransporter?.company?.orgId !== currentSiret) {
+    return {};
+  }
+  return {
+    transporterNumberPlate: currentTransporter?.transport?.plates,
+    transporterCustomInfo: currentTransporter?.customInfo
+  };
+};
+
+export const getBspaohCurrentTransporterInfos = (
+  bspaoh: Bspaoh,
+  currentSiret: string
+): BsdCurrentTransporterInfos => {
+  const currentTransporter = bspaoh.transporter;
+  if (currentTransporter?.company?.orgId !== currentSiret) {
+    return {};
+  }
+  return {
+    transporterNumberPlate: currentTransporter?.transport?.plates,
+    transporterCustomInfo: currentTransporter?.customInfo
+  };
 };
 
 export const mapBsdd = (bsdd: Form): BsdDisplay => {

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -136,7 +136,8 @@ export const getBsddCurrentTransporterInfos = (
   return {
     transporterId: currentTransporter?.id,
     transporterNumberPlate: currentTransporter?.numberPlate,
-    transporterCustomInfo: currentTransporter?.customInfo
+    transporterCustomInfo: currentTransporter?.customInfo,
+    transporterMode: currentTransporter?.mode ?? undefined
   };
 };
 
@@ -169,7 +170,8 @@ export const getBsdaCurrentTransporterInfos = (
   return {
     transporterId: currentTransporter?.id,
     transporterNumberPlate: currentTransporter?.transport?.plates,
-    transporterCustomInfo: currentTransporter?.customInfo
+    transporterCustomInfo: currentTransporter?.customInfo,
+    transporterMode: currentTransporter?.transport?.mode ?? undefined
   };
 };
 
@@ -185,7 +187,8 @@ export const getBsdasriCurrentTransporterInfos = (
   // the update is done through the BSD using its id
   return {
     transporterNumberPlate: currentTransporter?.transport?.plates,
-    transporterCustomInfo: currentTransporter?.customInfo
+    transporterCustomInfo: currentTransporter?.customInfo,
+    transporterMode: currentTransporter?.transport?.mode ?? undefined
   };
 };
 
@@ -199,7 +202,8 @@ export const getBsffCurrentTransporterInfos = (
   }
   return {
     transporterNumberPlate: currentTransporter?.transport?.plates,
-    transporterCustomInfo: currentTransporter?.customInfo
+    transporterCustomInfo: currentTransporter?.customInfo,
+    transporterMode: currentTransporter?.transport?.mode ?? undefined
   };
 };
 
@@ -213,7 +217,8 @@ export const getBspaohCurrentTransporterInfos = (
   }
   return {
     transporterNumberPlate: currentTransporter?.transport?.plates,
-    transporterCustomInfo: currentTransporter?.customInfo
+    transporterCustomInfo: currentTransporter?.customInfo,
+    transporterMode: currentTransporter?.transport?.mode ?? undefined
   };
 };
 

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -152,7 +152,7 @@ export const getBsdaCurrentTransporterInfos = (
     currentTransporter = bsda.transporters?.find(
       transporter =>
         transporter.company?.orgId === currentSiret &&
-        !transporter.transport?.takenOverAt
+        !transporter.transport?.signature?.date
     );
   } else {
     // find the last transporter with this SIRET who has taken over
@@ -161,7 +161,7 @@ export const getBsdaCurrentTransporterInfos = (
       .find(
         transporter =>
           transporter.company?.orgId === currentSiret &&
-          !!transporter.transport?.takenOverAt
+          !!transporter.transport?.signature?.date
       );
   }
   if (!currentTransporter) {

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -7,7 +7,9 @@ import {
   Bsd,
   Bsda,
   Bspaoh,
-  BsdasriType
+  BsdasriType,
+  FormStatus,
+  Transporter
 } from "@td/codegen-ui";
 
 import {
@@ -91,9 +93,24 @@ export const getBsddCurrentTransporterInfos = (
   bsdd: Form,
   currentSiret: string
 ): BsdCurrentTransporterInfos => {
-  const currentTransporter = bsdd.transporters?.find(
-    transporter => transporter.company?.orgId === currentSiret
-  );
+  let currentTransporter: Transporter | undefined;
+  if (
+    bsdd.status === FormStatus.Resealed ||
+    bsdd.status === FormStatus.Resent ||
+    bsdd.status === FormStatus.SignedByTempStorer ||
+    bsdd.status === FormStatus.TempStored ||
+    bsdd.status === FormStatus.TempStorerAccepted
+  ) {
+    currentTransporter =
+      bsdd.temporaryStorageDetail?.transporter &&
+      bsdd.temporaryStorageDetail?.transporter.company?.orgId === currentSiret
+        ? bsdd.temporaryStorageDetail?.transporter
+        : undefined;
+  } else {
+    currentTransporter = bsdd.transporters?.find(
+      transporter => transporter.company?.orgId === currentSiret
+    );
+  }
   if (!currentTransporter) {
     return {};
   }

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1410,23 +1410,24 @@ export const canEditCustomInfoOrTransporterNumberPlate = (
   if (!permissions.includes(UserPermission.BsdCanUpdate)) {
     return false;
   }
-  if (isBsdd(bsd.type)) {
-    return ["SEALED", "RESEALED", "SIGNED_BY_PRODUCER"].includes(bsd.status);
-  }
+  return true;
+  // if (isBsdd(bsd.type)) {
+  //   return ["SEALED", "RESEALED", "SIGNED_BY_PRODUCER"].includes(bsd.status);
+  // }
 
-  if (isBsda(bsd.type)) {
-    return ["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(
-      bsd.status
-    );
-  }
-  if (isBsff(bsd.type)) {
-    return ["INITIAL", "SIGNED_BY_EMITTER"].includes(bsd.status);
-  }
-  if (isBsdasri(bsd.type)) {
-    return ["SIGNED_BY_PRODUCER", "INITIAL"].includes(bsd.status);
-  }
+  // if (isBsda(bsd.type)) {
+  //   return ["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(
+  //     bsd.status
+  //   );
+  // }
+  // if (isBsff(bsd.type)) {
+  //   return ["INITIAL", "SIGNED_BY_EMITTER"].includes(bsd.status);
+  // }
+  // if (isBsdasri(bsd.type)) {
+  //   return ["SIGNED_BY_PRODUCER", "INITIAL"].includes(bsd.status);
+  // }
 
-  return false;
+  // return false;
 };
 
 export const getOperationCodesFromSearchString = (value: any): string[] => {

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1403,33 +1403,6 @@ export const hasRoadControlButton = (
   return ["SENT", "RESENT"].includes(bsd.status) && isCollectedTab;
 };
 
-export const canEditCustomInfoOrTransporterNumberPlate = (
-  bsd: BsdDisplay,
-  permissions: UserPermission[]
-): boolean => {
-  if (!permissions.includes(UserPermission.BsdCanUpdate)) {
-    return false;
-  }
-  return true;
-  // if (isBsdd(bsd.type)) {
-  //   return ["SEALED", "RESEALED", "SIGNED_BY_PRODUCER"].includes(bsd.status);
-  // }
-
-  // if (isBsda(bsd.type)) {
-  //   return ["SIGNED_BY_PRODUCER", "SIGNED_BY_WORKER", "INITIAL"].includes(
-  //     bsd.status
-  //   );
-  // }
-  // if (isBsff(bsd.type)) {
-  //   return ["INITIAL", "SIGNED_BY_EMITTER"].includes(bsd.status);
-  // }
-  // if (isBsdasri(bsd.type)) {
-  //   return ["SIGNED_BY_PRODUCER", "INITIAL"].includes(bsd.status);
-  // }
-
-  // return false;
-};
-
 export const getOperationCodesFromSearchString = (value: any): string[] => {
   const searchCodes: string[] = [];
 

--- a/front/src/Apps/common/queries/bsda/queries.ts
+++ b/front/src/Apps/common/queries/bsda/queries.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { FullBsdaFragment } from "../fragments";
+import { FullBsdaFragment, FullBsdaTransporterFragment } from "../fragments";
 
 export const GET_BSDA = gql`
   query Bsda($id: ID!) {
@@ -59,10 +59,10 @@ export const UPDATE_BSDA = gql`
 export const UPDATE_BSDA_TRANSPORTER = gql`
   mutation UpdateBsdaTransporter($id: ID!, $input: BsdaTransporterInput!) {
     updateBsdaTransporter(id: $id, input: $input) {
-      ...FullBsda
+      ...FullBsdaTransporter
     }
   }
-  ${FullBsdaFragment}
+  ${FullBsdaTransporterFragment}
 `;
 
 export const SIGN_BSDA = gql`

--- a/front/src/Apps/common/queries/bsdd/queries.ts
+++ b/front/src/Apps/common/queries/bsdd/queries.ts
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { transporterFragment } from "../fragments";
 
 export const UPDATE_TRANSPORT_INFO = gql`
   mutation updateTransporterFields(
@@ -23,4 +24,13 @@ export const UPDATE_TRANSPORT_INFO = gql`
       }
     }
   }
+`;
+
+export const UPDATE_BSDD_TRANSPORTER = gql`
+  mutation updateFormTransporter($id: ID!, $input: TransporterInput!) {
+    updateFormTransporter(id: $id, input: $input) {
+      ...TransporterFragment
+    }
+  }
+  ${transporterFragment}
 `;

--- a/front/src/Apps/common/queries/bspaoh/queries.ts
+++ b/front/src/Apps/common/queries/bspaoh/queries.ts
@@ -1,0 +1,11 @@
+import { gql } from "@apollo/client";
+import { fullBspaohFragment } from "../fragments";
+
+export const UPDATE_BSPAOH = gql`
+  mutation UpdateBspaoh($id: ID!, $input: BspaohInput!) {
+    updateBspaoh(id: $id, input: $input) {
+      ...FullBspaoh
+    }
+  }
+  ${fullBspaohFragment}
+`;

--- a/front/src/Apps/common/queries/fragments/bsda.ts
+++ b/front/src/Apps/common/queries/fragments/bsda.ts
@@ -110,6 +110,7 @@ export const bsdaFragment = gql`
       }
       transport {
         plates
+        mode
         signature {
           date
         }

--- a/front/src/Apps/common/queries/fragments/bsda.ts
+++ b/front/src/Apps/common/queries/fragments/bsda.ts
@@ -1,6 +1,32 @@
 import { gql } from "@apollo/client";
 import { companyFragment } from "./company";
 
+export const FullBsdaTransporterFragment = gql`
+  fragment FullBsdaTransporter on BsdaTransporter {
+    id
+    company {
+      ...CompanyFragment
+    }
+    customInfo
+    recepisse {
+      number
+      department
+      validityLimit
+      isExempted
+    }
+    transport {
+      mode
+      plates
+      takenOverAt
+      signature {
+        author
+        date
+      }
+    }
+  }
+  ${companyFragment}
+`;
+
 export const bsdaFragment = gql`
   fragment BsdaFragment on Bsda {
     id
@@ -48,32 +74,34 @@ export const bsdaFragment = gql`
       siret
     }
     transporter {
+      id
       company {
         name
         siret
         orgId
       }
       customInfo
-      transport {
-        plates
-      }
       recepisse {
         number
         department
         validityLimit
         isExempted
+      }
+      transport {
+        plates
+        signature {
+          date
+        }
       }
     }
     transporters {
+      id
       company {
         name
         siret
         orgId
       }
       customInfo
-      transport {
-        plates
-      }
       recepisse {
         number
         department
@@ -81,6 +109,7 @@ export const bsdaFragment = gql`
         isExempted
       }
       transport {
+        plates
         signature {
           date
         }
@@ -238,47 +267,10 @@ export const FullBsdaFragment = gql`
       }
     }
     transporter {
-      company {
-        ...CompanyFragment
-      }
-      customInfo
-      recepisse {
-        number
-        department
-        validityLimit
-        isExempted
-      }
-      transport {
-        mode
-        plates
-        takenOverAt
-        signature {
-          author
-          date
-        }
-      }
+      ...FullBsdaTransporter
     }
     transporters {
-      id
-      company {
-        ...CompanyFragment
-      }
-      customInfo
-      recepisse {
-        number
-        department
-        validityLimit
-        isExempted
-      }
-      transport {
-        mode
-        plates
-        takenOverAt
-        signature {
-          author
-          date
-        }
-      }
+      ...FullBsdaTransporter
     }
     ecoOrganisme {
       name
@@ -364,4 +356,5 @@ export const FullBsdaFragment = gql`
     }
   }
   ${companyFragment}
+  ${FullBsdaTransporterFragment}
 `;

--- a/front/src/Apps/common/queries/fragments/bsdasri.ts
+++ b/front/src/Apps/common/queries/fragments/bsdasri.ts
@@ -114,6 +114,7 @@ export const dashboardDasriFragment = gql`
       customInfo
       transport {
         plates
+        mode
       }
       recepisse {
         number

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -446,6 +446,7 @@ export const dashboardFormFragment = gql`
       numberPlate
       customInfo
       takenOverAt
+      mode
     }
     ecoOrganisme {
       siret
@@ -497,6 +498,7 @@ export const dashboardFormFragment = gql`
         }
         numberPlate
         customInfo
+        mode
       }
       wasteDetails {
         packagingInfos {

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -429,6 +429,7 @@ export const dashboardFormFragment = gql`
       isTempStorage
     }
     transporter {
+      id
       company {
         siret
         orgId
@@ -438,9 +439,12 @@ export const dashboardFormFragment = gql`
       customInfo
     }
     transporters {
+      id
       company {
         orgId
       }
+      numberPlate
+      customInfo
       takenOverAt
     }
     ecoOrganisme {

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -484,6 +484,7 @@ export const dashboardFormFragment = gql`
         processingOperation
       }
       transporter {
+        id
         company {
           siret
           orgId
@@ -494,6 +495,8 @@ export const dashboardFormFragment = gql`
           phone
           mail
         }
+        numberPlate
+        customInfo
       }
       wasteDetails {
         packagingInfos {

--- a/front/src/Apps/common/queries/fragments/bsff.ts
+++ b/front/src/Apps/common/queries/fragments/bsff.ts
@@ -24,6 +24,7 @@ export const dashboardBsffFragment = gql`
       }
       transport {
         plates
+        mode
       }
       customInfo
     }

--- a/front/src/Apps/common/queries/fragments/bspaoh.ts
+++ b/front/src/Apps/common/queries/fragments/bspaoh.ts
@@ -29,6 +29,7 @@ export const dashboardBspaohFragment = gql`
       customInfo
       transport {
         plates
+        mode
       }
       recepisse {
         number

--- a/front/src/Apps/common/types/bsdTypes.ts
+++ b/front/src/Apps/common/types/bsdTypes.ts
@@ -149,3 +149,9 @@ export enum WorkflowDisplayType {
 
   DEFAULT = ""
 }
+
+export type BsdCurrentTransporterInfos = {
+  transporterId?: string;
+  transporterCustomInfo?: string | Maybe<string[]>;
+  transporterNumberPlate?: string | Maybe<string[]>;
+};

--- a/front/src/Apps/common/types/bsdTypes.ts
+++ b/front/src/Apps/common/types/bsdTypes.ts
@@ -42,7 +42,8 @@ import {
   RevisionRequestStatus,
   Scalars,
   TemporaryStorageDetail,
-  Transporter
+  Transporter,
+  TransportMode
 } from "@td/codegen-ui";
 
 export enum BsdTypename {
@@ -154,4 +155,5 @@ export type BsdCurrentTransporterInfos = {
   transporterId?: string;
   transporterCustomInfo?: string | Maybe<string[]>;
   transporterNumberPlate?: string | Maybe<string[]>;
+  transporterMode?: TransportMode;
 };


### PR DESCRIPTION
## Objectif

Il faut afficher la bonne plaque d'immatriculation et champ libre sur les BsdCard dans les rubriques "A collecter" et "Collectés" d'un transporteur. Précédemment, seulement le premier transporteur concerné par le bordereau était affiché. C'est un problème avec l'ajout du multimodal ou avec l'entreposage temporaire.

<img width="882" alt="Capture d’écran 2024-05-10 à 01 41 50" src="https://github.com/MTES-MCT/trackdechets/assets/2432646/2ce29f7f-2f75-4a12-bd93-ae1e6d1db2d1">

### En résumé

On veut donc:
- afficher la plaque/champ libre correspondant au transporteur connecté et qui doit transporter le déchet
- lui donner la possibilité de modifier ces champs tant que le BSD est "A collecter" (et si il a les droits)
- gérer ça pour le multimodal
- gérer aussi pour l'entreposage temporaire
- gérer pour tous les types de bordereaux

## Les modifications

### Récupération des infos du transporteur

Les infos étaient auparavant récupérées depuis la propriété "transporter" des BSD, qui est générée par la backend en prenant le premier transporteur de la liste des transporteurs liés au bordereau. Cette propriété étant utilisée ailleurs dans le code, je ne pouvais pas modifier la façon dont elle était générée en back au risque de tout péter. Donc j'ai plutôt utilisé l'array "transporters", et ajouté une méthode "getCurrentTransporterInfos" pour en sortir les infos du bon transporteur.

**BSDD et entreposage temporaire**

Le cas du BSDD est particulier car le déchet peut être à collecter par un transporteur alors qu'il est entreposé temporairement, il faut donc aller aussi chercher le transporteur lié à cet entreposage temporaire (BSD forwardedIn). Pour ça, j'ai ajouté une condition sur le statut du bordereau pour déterminer où aller chercher les infos transporteur en fonction du statut.

**BSDD/BSDA et transporteur récurrent**

Il est possible qu'une même entreprise se charge de plusieurs portions du transport multimodal. Il n'est donc pas possible de faire un simple find du transporteur avec le SIRET. Il y a donc une logique qui est:
- si on est sur "A collecter", trouver le premier transporteur ayant ce SIRET et n'ayant pas encore pris en charge le déchet
- si on est sur "Collectés", trouver le dernier transporteur avec ce SIRET ayant pris en charge le déchet

**Affichage pour transport routier uniquement et conflit GraphQL**

Même si ça ne rentre pas dans le scope du ticket de base, j'ai retiré l'affichage et la modification de la plaque d'immatriculation pour les transports autre que la route. Pour ce faire, il a fallut récupérer l'info transport.mode sur tous les types de bordereau dans la query des BSD du Dashboard. Cette query utilisant un union des différents types de bordereaux, il y a un conflit sur le type de transport.mode (qui est TransportMode! sur le BSDASRI et TransportMode (sans point d'exclamation) ailleurs.
```
GraphQLError: Fields "transporter" conflict because subfields "transport" conflict because subfields "mode" conflict because they return conflicting types "TransportMode!" and "TransportMode". Use different aliases on the fields to fetch both if this was intentional.
```

Il y a 2 solutions à ce problème:
- Utiliser des alias pour le mode
- retirer le "!" du type sur BsdasriTransport

La propriété correspondant au mode de transport sur BSDASRI a cette définition Prisma:
```
  transporterTransportMode                    TransportMode?          @default(ROAD)
```
et sa valeur peut donc être nulle (même si un default est utilisé, si un objet en db n'a pas été écrit en passant par Prisma ou avant que la propriété ait été rajoutée au schema, elle peut être nulle).

Donc j'ai choisi d'harmoniser les types GraphQL et de retirer le "!", ce qui est cohérent avec les modèles de db, plutôt que d'utiliser des alias. Je ne pense pas que ce soit un breaking change puisque ce n'est pas un type d'input.

### Modification des infos

L'update du transporteur pour BSDA et BSDD se fait via une mutation spécifique (updateBsdaTransporter/updateFormTransporter), les autres bordereaux sont fait avec la mutation d'update du bordereau.

**BSDD forwardedIn et indexation**

Dans le cas de l'update du transporteur BSDD, si il s'agit du transporteur du bordereau forwardedIn (entreposage), il y avait un problème d'indexation: le resolver utilise l'update du repository pour réindexer le bordereau lié au transporteur, mais ça n'entraînait pas la réindexation du bordereau forwarding. J'ai donc modifié l'update pour récupérer l'info de si il y a un bordereau forwarding (en ajoutant un include à l'update, pas de requête DB supplémentaire), et si c'est le cas, réindexer le bordereau forwarding plutôt que le bordereau qui est updaté. La routine de réindexation va se charger de lancer l'index du bordereau forwardedIn.

## Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/4db5d8c3-ef7a-4cf1-b36a-3ebaaaaa9c6d



---

- [x] Mettre à jour la documentation -> TransportMode(!) MàJ automatiquement sur la doc
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14055)
