### PR TITLE
[TRA-14056] Cacher liens PDF sur Annexes/Suite si le bordereau est un brouillon

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
 - Fix de la redirection après signature d'un BSDASRI de groupement par l'émetteur [PR 3292](https://github.com/MTES-MCT/trackdechets/pull/3292)
+- Cacher liens PDF sur Annexes/Suite si le bordereau est un brouillon [PR 3310](https://github.com/MTES-MCT/trackdechets/pull/3310)
 
 #### :boom: Breaking changes
 

--- a/front/src/Apps/Forms/Components/query.ts
+++ b/front/src/Apps/Forms/Components/query.ts
@@ -1,29 +1,5 @@
 import gql from "graphql-tag";
-
-export const TransporterFragment = gql`
-  fragment TransporterFragment on Transporter {
-    id
-    company {
-      name
-      orgId
-      siret
-      address
-      country
-      contact
-      phone
-      mail
-      vatNumber
-      omiNumber
-    }
-    isExemptedOfReceipt
-    receipt
-    department
-    validityLimit
-    numberPlate
-    customInfo
-    mode
-  }
-`;
+import { transporterFragment } from "../../common/queries/fragments";
 
 export const CREATE_FORM_TRANSPORTER = gql`
   mutation CreateFormTransporter($input: TransporterInput!) {
@@ -31,7 +7,7 @@ export const CREATE_FORM_TRANSPORTER = gql`
       ...TransporterFragment
     }
   }
-  ${TransporterFragment}
+  ${transporterFragment}
 `;
 
 export const UPDATE_FORM_TRANSPORTER = gql`
@@ -40,7 +16,7 @@ export const UPDATE_FORM_TRANSPORTER = gql`
       ...TransporterFragment
     }
   }
-  ${TransporterFragment}
+  ${transporterFragment}
 `;
 
 export const DELETE_FORM_TRANSPORTER = gql`

--- a/front/src/Apps/common/queries/fragments/bsda.ts
+++ b/front/src/Apps/common/queries/fragments/bsda.ts
@@ -333,6 +333,7 @@ export const FullBsdaFragment = gql`
     }
     forwardedIn {
       id
+      isDraft
       waste {
         code
       }
@@ -350,6 +351,7 @@ export const FullBsdaFragment = gql`
     }
     groupedIn {
       id
+      isDraft
       waste {
         code
       }

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -332,6 +332,7 @@ export const detailFormFragment = gql`
       form {
         id
         readableId
+        status
       }
     }
     grouping {

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -383,18 +383,21 @@ const NextBsda = ({ bsda }: { bsda: Bsda }) => {
 
         <dt>CAP</dt>
         <dd>{bsda.destination?.cap}</dd>
-
-        <dt>PDF</dt>
-        <dd>
-          <button
-            type="button"
-            className="btn btn--slim btn--small btn--outline-primary"
-            onClick={() => downloadPdf({ variables: { id: bsda.id } })}
-          >
-            <IconPdf size="18px" color="blueLight" />
-            <span>Pdf</span>
-          </button>
-        </dd>
+        {!bsda.isDraft ? (
+          <>
+            <dt>PDF</dt>
+            <dd>
+              <button
+                type="button"
+                className="btn btn--slim btn--small btn--outline-primary"
+                onClick={() => downloadPdf({ variables: { id: bsda.id } })}
+              >
+                <IconPdf size="18px" color="blueLight" />
+                <span>Pdf</span>
+              </button>
+            </dd>
+          </>
+        ) : null}
       </div>
     </div>
   );

--- a/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
+++ b/front/src/dashboard/detail/bsda/BsdaDetailContent.tsx
@@ -383,7 +383,7 @@ const NextBsda = ({ bsda }: { bsda: Bsda }) => {
 
         <dt>CAP</dt>
         <dd>{bsda.destination?.cap}</dd>
-        {!bsda.isDraft ? (
+        {!bsda.isDraft && (
           <>
             <dt>PDF</dt>
             <dd>
@@ -397,7 +397,7 @@ const NextBsda = ({ bsda }: { bsda: Bsda }) => {
               </button>
             </dd>
           </>
-        ) : null}
+        )}
       </div>
     </div>
   );

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -331,7 +331,7 @@ const GroupedIn = ({ form }: { form: Form }) => {
       value={
         <span>
           {form.readableId}
-          {showPDFDownload ? (
+          {showPDFDownload && (
             <>
               {" ("}
               <button
@@ -342,7 +342,7 @@ const GroupedIn = ({ form }: { form: Form }) => {
               </button>
               {")"}
             </>
-          ) : null}
+          )}
         </span>
       }
       label={`Annexé au bordereau n°`}

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -325,15 +325,24 @@ const GroupedIn = ({ form }: { form: Form }) => {
   const [downloadPdf] = useDownloadPdf({
     variables: { id: form.id }
   });
+  const showPDFDownload = form.status !== FormStatus.Draft;
   return (
     <DetailRow
       value={
         <span>
-          {form.readableId} (
-          <button className={styles.downloadLink} onClick={() => downloadPdf()}>
-            Télécharger le PDF
-          </button>
-          )
+          {form.readableId}
+          {showPDFDownload ? (
+            <>
+              {" ("}
+              <button
+                className={styles.downloadLink}
+                onClick={() => downloadPdf()}
+              >
+                Télécharger le PDF
+              </button>
+              {")"}
+            </>
+          ) : null}
         </span>
       }
       label={`Annexé au bordereau n°`}


### PR DESCRIPTION
Ne pas afficher le lien de téléchargement des PDFs auxquels sont annexés des BSD si ces bordereaux sont en brouillon. Modification faite pour BSDD et BSDA.

+ Unification du fragment Transporter sur BSDD qui était en double et créait un warning Apollo

## Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/047b4671-a119-4922-88cd-51f346609d88



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14056)
