### PR TITLE
[TRA-14208] Faire remonter BSD dans dashboard à la création de demande de révision

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout du nom usuel de l'établissement dans l'email de demande de rattachement [PR 3343](https://github.com/MTES-MCT/trackdechets/pull/3343)
 - Renommer Transit par Réexpédition (sous-type de BSDA) [PR 3351](https://github.com/MTES-MCT/trackdechets/pull/3351)
 - Rendre les liens de FAQ cliquable dans l'ajout d'établissement [PR 3342](https://github.com/MTES-MCT/trackdechets/pull/3342)
+- Faire remonter BSD dans dashboard à la création de demande de révision [PR 3315](https://github.com/MTES-MCT/trackdechets/pull/3315)
 
 #### :house: Interne
 

--- a/back/src/bsda/repository/revisionRequest/create.ts
+++ b/back/src/bsda/repository/revisionRequest/create.ts
@@ -31,6 +31,18 @@ export function buildCreateRevisionRequest(
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
+    // touch the bsd to make it come up in the dashboard
+    await prisma.bsda.update({
+      where: {
+        id: revisionRequest.bsdaId
+      },
+      data: {
+        updatedAt: new Date()
+      },
+      select: {
+        id: true
+      }
+    });
 
     prisma.addAfterCommitCallback(() =>
       enqueueUpdatedBsdToIndex(revisionRequest.bsdaId)

--- a/back/src/forms/repository/formRevisionRequest/createRevisionRequest.ts
+++ b/back/src/forms/repository/formRevisionRequest/createRevisionRequest.ts
@@ -30,6 +30,18 @@ const buildCreateRevisionRequest: (
         metadata: { ...logMetadata, authType: user.auth }
       }
     });
+    // touch the bsd to make it come up in the dashboard
+    await prisma.form.update({
+      where: {
+        readableId: createdRevisionRequest.bsdd.readableId
+      },
+      data: {
+        updatedAt: new Date()
+      },
+      select: {
+        id: true
+      }
+    });
 
     prisma.addAfterCommitCallback(() =>
       enqueueUpdatedBsdToIndex(createdRevisionRequest.bsdd.readableId)


### PR DESCRIPTION
### Modification

Afin de faire remonter le bordereau en cas de demande de révision, on va le "touch" en mettant à jour sa propriété updatedAt (avec un select minimal puisque le résultat ne nous intéresse pas).

### Webhook?

Cette demande originale amène possiblement à un autre ticket, où est faite la demande d'avoir un appel webhook en cas de revisionRequest (voir 2e lien de ticket). C'est déjà le cas avec un appel UPDATED concernant le bordereau (puisqu'un reindex est fait dessus, ce qui déclenche un webhook). Celà dit il est envisageable de rajouter un nouveau type d'évènement, ou bien des détails sur l'update qui a eu lieu en modifiant le type d'objet, etc. Celà dit ce sont des breaking changes, donc à discuter (question abordée avec @GaelFerrand )

--> A discuter et spec (nouveau type d'évènement, ajout de qq infos sur les updates,...)
--> @GaelFerrand Le webhook est bian appelé avec un event UPDATE dans le cas create/cancel/accept des revisionRequest

### Date de modification

Comme remonté à @providenz les dates affichées dans "Modifié le" sur les BsdCard ne correspondent pas au updatedAt des BSD (utilise le stateSummary pour l'affichage), ce qui amène à un classement qui peut sembler aléatoire. Il faudrait peut-être harmoniser l'affichage et l'ordre des BSD, soit en utilisant updatedAt pour l'affichage, soit en essayant de voir pourquoi la date remontée dans stateSummary ne correspond pas (je n'ai pas encore cherché).

--> A discuter et spec (la date du stateSummary correspond bien à qqch de concret, mais mismatch avec le classement des bordereaux, donc possiblement changer le wording "Modifié le" ou ajouter updatedAt qq part)

## Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/65203305-0714-45de-9091-097b15d2c55b

---
- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14208)
- [Ticket Favro webhooks](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14202)
