### PR TITLE
[BSDA] L'installation de destination ne peut pas signer l'opération du BSDA si un transporteur N>1 n'a pas signé et a des infos incomplètes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Fix de la redirection après signature d'un BSDASRI de groupement par l'émetteur [PR 3292](https://github.com/MTES-MCT/trackdechets/pull/3292)
 - Cacher liens PDF sur Annexes/Suite si le bordereau est un brouillon [PR 3310](https://github.com/MTES-MCT/trackdechets/pull/3310)
 - Au refus total d'un VHU, ne pas demander de compléter le code / mode de traitement [PR 3336](https://github.com/MTES-MCT/trackdechets/pull/3336)
+- Retirer le fait que les champs des transporteurs soient requis à la signature de la réception même lorsqu'ils n'ont pas signé l'enlèvement sur un BSDA [PR 3331](https://github.com/MTES-MCT/trackdechets/pull/3331)
 
 #### :boom: Breaking changes
 

--- a/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/sign.integration.ts
@@ -1421,13 +1421,18 @@ describe("Mutation.Bsda.sign", () => {
       // Crée un second transporteur qui n'a pas encore signé
       await bsdaTransporterFactory({
         bsdaId: bsda.id,
-        opts: { transporterTransportSignatureDate: null }
+        opts: {
+          transporterTransportSignatureDate: null,
+          // On enlève la plaque immat pour vérifier que les règles de validation
+          // ne sont pas appliqués pour les transporteurs N > 1
+          transporterTransportPlates: []
+        }
       });
 
       const { mutate } = makeClient(user);
 
       // Finalement le déchet va directement au centre de traitement
-      const { data } = await mutate<
+      const { data, errors } = await mutate<
         Pick<Mutation, "signBsda">,
         MutationSignBsdaArgs
       >(SIGN_BSDA, {
@@ -1440,6 +1445,7 @@ describe("Mutation.Bsda.sign", () => {
         }
       });
 
+      expect(errors).toBeUndefined();
       expect(data.signBsda.id).toBeTruthy();
 
       const updatedBsda = await prisma.bsda.findUniqueOrThrow({

--- a/back/src/bsda/validation/refinements.ts
+++ b/back/src/bsda/validation/refinements.ts
@@ -198,7 +198,17 @@ export const checkRequiredFields: (
       }
     }
 
-    (bsda.transporters ?? []).forEach((transporter, idx) => {
+    let checkableTransporters = bsda.transporters ?? [];
+
+    if (validationContext.currentSignatureType === "OPERATION") {
+      // Cas spécial permettant à l'installation de destination de valider l'opération
+      // même si tous les transporteurs multi-modaux n'ont pas signé.
+      checkableTransporters = checkableTransporters.filter(t =>
+        Boolean(t.transporterTransportSignatureDate)
+      );
+    }
+
+    checkableTransporters.forEach((transporter, idx) => {
       for (const bsdaTransporterField of Object.keys(
         bsdaTransporterEditionRules
       )) {


### PR DESCRIPTION
- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Retirer le fait que les champs des transporteurs soient requis à la signature de la réception même lorsqu'ils n'ont pas signé l'enlèvement sur un BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14387)
