### PR TITLE
[TRA-13421] Rendre obligatoire le champ "Numéro de notification" lorsque la destination ultérieure renseignée est étrangère

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Retrait de la possibilité de sélectionner un mode de traitement pour le code non final D9 [PR 3308](https://github.com/MTES-MCT/trackdechets/pull/3308)
 - Le SIRET de destination ultérieure doit obligatoirement être inscrit sur Trackdéchets [PR 3355](https://github.com/MTES-MCT/trackdechets/pull/3355)
+- Rendre obligatoire le champ "Numéro de notification" lorsque la destination ultérieure renseignée est étrangère [PR 3332](https://github.com/MTES-MCT/trackdechets/pull/3332)
 
 #### :nail_care: Améliorations
 

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1545,22 +1545,186 @@ describe("processedInfoSchema", () => {
       "Destination ultérieure : le code du pays de l'entreprise ne correspond pas au numéro de TVA entré"
     );
   });
+  // NotificationNumber tests
+  // non-UE company
 
-  it("nextDestinationCompany return an error when waste is not dangerous with a foreign extraEuropeanId is given without notificationNumber", async () => {
+  const testMatrix = [
+    //  Traceability
+    {
+      // traceability, dangerous*, non EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07*",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    {
+      // traceability, pop, non EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: true,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    {
+      // traceability, isDangerous, non EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: true,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    // european countries
+    {
+      // traceability, dangerous*,  EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07*",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    },
+    {
+      // traceability, pop, EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: true,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    },
+    {
+      // traceability,isDangerous, EU country
+      noTraceability: false,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: true,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    },
+    // No Traceability
+    {
+      // no traceability, dangerous*,  EU country
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07*",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    {
+      // not traceability, pop, non EU country
+
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: true,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    {
+      // not traceability, isDangerous, non EU country
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: true,
+      nextDestinationCompanyCountry: "BY",
+      nextDestinationCompanyExtraEuropeanId: "BRU0541696005" // Non eu company
+    },
+    // european countries
+    {
+      // no traceability, dangerous*,  EU country
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07*",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    },
+    {
+      // no traceability, pop,  EU country
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: true,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    },
+    {
+      // no traceability, isDangerous,  EU country
+      noTraceability: true,
+      wasteDetailsCode: "07 07 07",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: true,
+      nextDestinationCompanyCountry: "BE",
+      nextDestinationCompanyVatNumber: "BE0541696005" // EU company
+    }
+  ];
+
+  it.each(testMatrix)(
+    "should throw when `nextDestinationNotificationNumber` is missing %o",
+    async ({
+      noTraceability,
+      wasteDetailsCode,
+      wasteDetailsPop,
+      wasteDetailsIsDangerous,
+      nextDestinationCompanyCountry,
+      nextDestinationCompanyExtraEuropeanId = null,
+      nextDestinationCompanyVatNumber = null
+    }) => {
+      const processedInfo = {
+        processedBy: "John Snow",
+        processedAt: new Date(),
+        processingOperationDone: "D 13", // non final
+        processingOperationDescription: "Regroupement",
+        noTraceability,
+        nextDestinationProcessingOperation: "D 8",
+        nextDestinationCompanyName: "Exutoire",
+        nextDestinationCompanyAddress: "4 rue du déchet",
+        nextDestinationCompanyCountry,
+        nextDestinationCompanyVatNumber,
+        nextDestinationCompanyExtraEuropeanId,
+        nextDestinationCompanyContact: "Arya Stark",
+        nextDestinationCompanyPhone: "06 XX XX XX XX",
+        nextDestinationCompanyMail: "arya.stark@trackdechets.fr",
+        wasteDetailsCode,
+        wasteDetailsPop,
+        wasteDetailsIsDangerous
+        // missing nextDestinationNotificationNumber
+      };
+      const validateFn = () => processedInfoSchema.validate(processedInfo);
+
+      await expect(validateFn()).rejects.toThrow(
+        "Destination ultérieure : le numéro de notification est obligatoire"
+      );
+    }
+  );
+
+  it("should also throw when `nextDestinationNotificationNumber` is null", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),
-      processingOperationDone: "D 13",
+      processingOperationDone: "D 13", // non final
       processingOperationDescription: "Regroupement",
+
       nextDestinationProcessingOperation: "D 8",
       nextDestinationCompanyName: "Exutoire",
       nextDestinationCompanyAddress: "4 rue du déchet",
-      nextDestinationCompanyCountry: "FR",
+
+      wasteDetailsCode: "07 07 07*",
+      wasteDetailsPop: false,
+      wasteDetailsIsDangerous: false,
+      nextDestinationCompanyCountry: "BY",
       nextDestinationCompanyExtraEuropeanId: "BRU0541696005",
+
       nextDestinationCompanyContact: "Arya Stark",
       nextDestinationCompanyPhone: "06 XX XX XX XX",
       nextDestinationCompanyMail: "arya.stark@trackdechets.fr",
-      wasteDetailsCode: "07 07 07*"
+
+      nextDestinationNotificationNumber: null
     };
     const validateFn = () => processedInfoSchema.validate(processedInfo);
 
@@ -1569,26 +1733,38 @@ describe("processedInfoSchema", () => {
     );
   });
 
-  it("nextDestinationCompany not return an error when waste is not dangerous with a foreign extraEuropeanId", async () => {
-    const processedInfo = {
-      processedBy: "John Snow",
-      processedAt: new Date(),
-      processingOperationDone: "D 13",
-      processingOperationDescription: "Regroupement",
-      nextDestinationProcessingOperation: "D 8",
-      nextDestinationCompanyName: "Exutoire",
-      nextDestinationCompanyAddress: "4 rue du déchet",
-      nextDestinationCompanyCountry: "FR",
-      nextDestinationCompanyExtraEuropeanId: "BRU0541696005",
-      nextDestinationCompanyContact: "Arya Stark",
-      nextDestinationCompanyPhone: "06 XX XX XX XX",
-      nextDestinationCompanyMail: "arya.stark@trackdechets.fr",
-      wasteDetailsCode: "07 07 07"
-    };
-    const validateFn = () => processedInfoSchema.validate(processedInfo);
-
-    await expect(validateFn()).resolves.toMatchObject({});
-  });
+  it.each(testMatrix)(
+    "should pas when `nextDestinationNotificationNumber` is provided %o",
+    async ({
+      wasteDetailsCode,
+      wasteDetailsPop,
+      wasteDetailsIsDangerous,
+      nextDestinationCompanyCountry,
+      nextDestinationCompanyExtraEuropeanId = null,
+      nextDestinationCompanyVatNumber = null
+    }) => {
+      const processedInfo = {
+        processedBy: "John Snow",
+        processedAt: new Date(),
+        processingOperationDone: "D 13", // non final
+        processingOperationDescription: "Regroupement",
+        nextDestinationProcessingOperation: "D 8",
+        nextDestinationCompanyName: "Exutoire",
+        nextDestinationCompanyAddress: "4 rue du déchet",
+        nextDestinationCompanyCountry,
+        nextDestinationCompanyVatNumber,
+        nextDestinationCompanyExtraEuropeanId,
+        nextDestinationCompanyContact: "Arya Stark",
+        nextDestinationCompanyPhone: "06 XX XX XX XX",
+        nextDestinationCompanyMail: "arya.stark@trackdechets.fr",
+        wasteDetailsCode,
+        wasteDetailsPop,
+        wasteDetailsIsDangerous,
+        nextDestinationNotificationNumber: "xyz"
+      };
+      expect(await processedInfoSchema.isValid(processedInfo)).toEqual(true);
+    }
+  );
 
   it("nextDestinationCompany return an error when a foreign extraEuropeanId is given with a VAT number", async () => {
     const processedInfo = {

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -44,7 +44,6 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
     {
       // required for nextDestination validation
       wasteDetailsCode: form.wasteDetailsCode,
-
       wasteDetailsPop: form.wasteDetailsPop,
       wasteDetailsIsDangerous: form.wasteDetailsIsDangerous,
       ...formUpdateInput

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -168,7 +168,13 @@ input NextDestinationInput {
   N° du document prévu à l'annexe I-B du règlement n°1013/2006
   ou le numéro de notification et numéro de saisie du document
   prévue à l'annexe I-B du règlement N°1013/2006 (si connu).
-  Format: PPNNNN, avec PP le code pays et NNNN un numéro d'ordre
+  Format: PPNNNN, avec PP le code pays et NNNN un numéro d'ordre.
+
+  Obligatoire quand:
+  - avec ou sans rupture de traçabilité
+  - code déchet dangereux, ou signalé comme dangereux (isDangerous), ou présence de POP
+  - et le  traitement est non final
+  - et la destination ultérieure est à l'étranger ( UE et non UE)
   """
   notificationNumber: String
 

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/ProcessedInfo.tsx
@@ -38,6 +38,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
     }),
     []
   );
+
   const [isExtraEuropeanCompany, setIsExtraEuropeanCompany] = useState(
     nextDestination?.company?.extraEuropeanId ? true : false
   );
@@ -102,22 +103,41 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
   const TODAY = new Date();
   const isFRCompany = Boolean(nextDestination?.company?.siret);
   const hasVatNumber = Boolean(nextDestination?.company?.vatNumber);
-  const showNotificationNumber =
-    isExtraEuropeanCompany || (!isFRCompany && noTraceability) || hasVatNumber;
+
   const isDangerousWaste =
     isDangerous(form.wasteDetails?.code ?? "") ||
     (form.wasteDetails?.isDangerous && " (dangereux)");
   const isPop = form?.wasteDetails?.pop;
-  const notificationNumberPlaceHolder =
-    isDangerousWaste || isPop ? "PP AAAA DDDRRR" : "A7E AAAA DDDRRR";
-  const notificationNumberLabel =
-    isDangerousWaste || isPop
-      ? "Numéro de notification"
-      : "Numéro de déclaration Annexe 7 (optionnel)";
-  const notificationNumberTooltip =
-    isDangerousWaste || isPop
-      ? "En cas d'export, indiquer ici le N° de notification prévu à l'annexe 1-B du règlement N°1013/2006, au format PP AAAA DDDRRR avec PP pour le code pays, AAAA pour l'année du dossier, DDD pour le département de départ et RRR pour le numéro d'ordre."
-      : "En cas d'export, indiquer ici le N° de déclaration Annexe 7 (optionnel) prévu à l'annexe 1-B du règlement N°1013/2006, au format A7E AAAA DDDRRR avec A7E pour Annexe 7 Export (ou A7I pour Annexe 7 Import), AAAA pour l'année du dossier, DDD pour le département de départ et RRR pour le numéro d'ordre. ";
+
+  // le déchet: comporte un code * || est marqué comme dangereux || est marqué POP
+  const isDangerousOrPop = isDangerousWaste || isPop;
+
+  // Notification number
+  const showNotificationNumber =
+    isExtraEuropeanCompany || (!isFRCompany && noTraceability) || hasVatNumber;
+
+  // Le numéro de notif est obligatoire quand : (-avec ou sans rupture de traçabilité)
+  // - le code de traitement est non final
+  // - que le déchet est DD, pop ou marqué comme dangereux
+  // - entreprise (destination ultérieure) hors ue
+  // - ou entreprise (destination ultérieure) UE non française
+  const notificationNumberIsMandatory =
+    (nextDestination && isExtraEuropeanCompany && isDangerousOrPop) ||
+    (nextDestination && hasVatNumber && isDangerousOrPop);
+
+  const notificationNumberIsOptional = !notificationNumberIsMandatory;
+  // nextDestination + hasVatNumber + isDangerousOrPop
+  const notificationNumberPlaceHolder = isDangerousOrPop
+    ? "PP AAAA DDDRRR"
+    : "A7E AAAA DDDRRR";
+  const notificationNumberLabel = isDangerousOrPop
+    ? `Numéro de notification ${
+        notificationNumberIsOptional ? "(Optionnel)" : ""
+      }`
+    : "Numéro de déclaration Annexe 7 (optionnel)";
+  const notificationNumberTooltip = isDangerousOrPop
+    ? "En cas d'export, indiquer ici le N° de notification prévu à l'annexe 1-B du règlement N°1013/2006, au format PP AAAA DDDRRR avec PP pour le code pays, AAAA pour l'année du dossier, DDD pour le département de départ et RRR pour le numéro d'ordre."
+    : "En cas d'export, indiquer ici le N° de déclaration Annexe 7 (optionnel) prévu à l'annexe 1-B du règlement N°1013/2006, au format A7E AAAA DDDRRR avec A7E pour Annexe 7 Export (ou A7I pour Annexe 7 Import), AAAA pour l'année du dossier, DDD pour le département de départ et RRR pour le numéro d'ordre. ";
 
   return (
     <Form>
@@ -277,7 +297,7 @@ function ProcessedInfo({ form, close }: { form: TdForm; close: () => void }) {
                   name="nextDestination.notificationNumber"
                   className="td-input"
                   placeholder={notificationNumberPlaceHolder}
-                  required={isExtraEuropeanCompany}
+                  required={notificationNumberIsMandatory}
                 />
               </>
             )}


### PR DESCRIPTION
Rendre obligatoire le champ "Numéro de notification" lorsque la destination ultérieure renseignée est étrangère

  Obligatoire quand:
  - avec ou sans rupture de traçabilité
  - code déchet dangereux, ou signalé comme dangereux (isDangerous), ou présence de POP
  - et le  traitement est non final
  - et la destination ultérieure est à l'étranger ( UE et non UE)


https://github.com/MTES-MCT/trackdechets/assets/878396/5dca7b9a-958b-409e-9ae7-ef9090b261f3




- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13421)
