### PR TITLE
Fix annexe2 grouping issues

### DIFF
--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -11,6 +11,8 @@ type FormForUpdateAppendix2Forms = Form & FormWithForwardedIn;
 
 export const FormForUpdateAppendix2FormsInclude = FormWithForwardedInInclude;
 
+const DECIMAL_WEIGHT_PRECISION = 6; // gramme
+
 export type UpdateAppendix2Forms = (
   forms: FormForUpdateAppendix2Forms[]
 ) => Promise<void>;
@@ -46,7 +48,7 @@ const buildUpdateAppendix2Forms: (
         .filter(grp => grp.initialFormId === form.id)
         .map(grp => grp.quantity)
         .reduce((prev, cur) => prev + cur, 0) ?? 0
-    ).toDecimalPlaces(6); // set precision to gramme
+    ).toDecimalPlaces(DECIMAL_WEIGHT_PRECISION); // set precision to gramme
 
     quantitGroupedByFormId[form.id] = quantityGrouped.toNumber();
 
@@ -54,9 +56,12 @@ const buildUpdateAppendix2Forms: (
       .filter(grp => grp.initialFormId === form.id)
       .map(g => g.nextForm);
 
+    // on a quelques quantityReceived avec des décimales au delà du gramme
     const groupedInTotality =
       quantityReceived &&
-      quantityGrouped.greaterThanOrEqualTo(quantityReceived); // case > should not happen
+      quantityGrouped.greaterThanOrEqualTo(
+        new Decimal(quantityReceived).toDecimalPlaces(DECIMAL_WEIGHT_PRECISION) // limit precision to circumvent rogue decimal digits
+      ); // case > should not happen
 
     const allSealed =
       groupementForms.length &&

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -869,28 +869,44 @@ describe("mutation.markAsProcessed", () => {
     });
     expect(updatedGroupedForm2.status).toEqual("PROCESSED");
   });
-
-  it("should not mark appendix2 forms as processed if they are partially grouped", async () => {
+  it("should mark appendix2 forms as processed  despite rogue decimal digits", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
 
-    const appendix2 = await formFactory({
+    const groupedForm1 = await formFactory({
       ownerId: user.id,
       opt: {
-        status: "AWAITING_GROUP",
-        quantityReceived: 1
+        status: "GROUPED",
+        quantityReceived: 1.000000000000001 // decimal digits after 6th place
       }
     });
+
+    // it should also work for BSD with temporary storage
+    const groupedForm2 = await formWithTempStorageFactory({
+      ownerId: user.id,
+      opt: {
+        status: "GROUPED",
+        quantityReceived: 0.02
+      }
+    });
+
     const form = await formFactory({
       ownerId: user.id,
       opt: {
         status: "ACCEPTED",
+        emitterType: "APPENDIX2",
         recipientCompanyName: company.name,
         recipientCompanySiret: company.siret,
         grouping: {
-          create: {
-            initialFormId: appendix2.id,
-            quantity: 0.1
-          }
+          create: [
+            {
+              initialFormId: groupedForm1.id,
+              quantity: 1
+            },
+            {
+              initialFormId: groupedForm2.id,
+              quantity: groupedForm2.forwardedIn!.quantityReceived!.toNumber()
+            }
+          ]
         }
       }
     });
@@ -910,11 +926,65 @@ describe("mutation.markAsProcessed", () => {
       }
     });
 
-    const appendix2grouped = await prisma.form.findUniqueOrThrow({
-      where: { id: appendix2.id }
+    const updatedGroupedForm1 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm1.id }
     });
-    expect(appendix2grouped.status).toEqual("AWAITING_GROUP");
+    expect(updatedGroupedForm1.status).toEqual("PROCESSED");
+
+    const updatedGroupedForm2 = await prisma.form.findUniqueOrThrow({
+      where: { id: groupedForm2.id }
+    });
+    expect(updatedGroupedForm2.status).toEqual("PROCESSED");
   });
+
+  it.each([0.1, 1])(
+    "should not mark appendix2 forms as processed if they are partially grouped - quantity grouped:  %p",
+    async quantityGrouped => {
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+
+      const appendix2 = await formFactory({
+        ownerId: user.id,
+        opt: {
+          status: "AWAITING_GROUP",
+          quantityReceived: 1.0000001
+        }
+      });
+      const form = await formFactory({
+        ownerId: user.id,
+        opt: {
+          status: "ACCEPTED",
+          recipientCompanyName: company.name,
+          recipientCompanySiret: company.siret,
+          grouping: {
+            create: {
+              initialFormId: appendix2.id,
+              quantity: quantityGrouped
+            }
+          }
+        }
+      });
+
+      const { mutate } = makeClient(user);
+
+      await mutate(MARK_AS_PROCESSED, {
+        variables: {
+          id: form.id,
+          processedInfo: {
+            processingOperationDescription: "Une description",
+            processingOperationDone: "D 1",
+            destinationOperationMode: OperationMode.ELIMINATION,
+            processedBy: "A simple bot",
+            processedAt: "2018-12-11T00:00:00.000Z"
+          }
+        }
+      });
+
+      const appendix2grouped = await prisma.form.findUniqueOrThrow({
+        where: { id: appendix2.id }
+      });
+      expect(appendix2grouped.status).toEqual("AWAITING_GROUP");
+    }
+  );
 
   test.each(allowedFormats)("%p is a valid format for processedAt", async f => {
     const { user, company } = await userWithCompanyFactory("ADMIN");


### PR DESCRIPTION
On se retrouve en db avec des valeurs décimales comportant des digits bien après la précision souhaitées.
Ces valeurs causent des problèmes sur les opérations de regroupement d'ennexe2 où l'on calcule la somme des quantités groupées pour la comparer à la quantité reçue. Le micro-delta bloque les changement de statut de bsd.
En attendant de pouvoir corriger le format des colonnes de db, cette PR limite la précision de la différence au gramme

 ---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14292)
