### PR TITLE
[TRA-14343] Au refus total d'un VHU, ne pas demander de compléter le code / mode de traitement 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Fix statut des annexes lorsque l'émetteur est un particulier [PR 3287](https://github.com/MTES-MCT/trackdechets/pull/3287)
 - Fix de la redirection après signature d'un BSDASRI de groupement par l'émetteur [PR 3292](https://github.com/MTES-MCT/trackdechets/pull/3292)
 - Cacher liens PDF sur Annexes/Suite si le bordereau est un brouillon [PR 3310](https://github.com/MTES-MCT/trackdechets/pull/3310)
+- Au refus total d'un VHU, ne pas demander de compléter le code / mode de traitement [PR 3336](https://github.com/MTES-MCT/trackdechets/pull/3336)
 
 #### :boom: Breaking changes
 

--- a/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.mutations.graphql
@@ -55,6 +55,7 @@ type Mutation {
       mail
       phone
     }
+    agrementNumber
   }
   ```
 
@@ -84,14 +85,13 @@ type Mutation {
   ```
   destination {
     reception {
-      weight
+      weight # doit être 0 si acceptationStatus est REFUSED
       acceptationStatus
     }
     operation {
-      code
-      mode
+      code # requis sauf si acceptationStatus est REFUSED
+      mode # requis sauf si acceptationStatus est REFUSED
     }
-    agrementNumber
   }
   ```
   """

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -221,7 +221,7 @@ const destinationSchema: FactorySchemaOf<
         context.emissionSignature,
         `Destinataire: ${MISSING_COMPANY_SIRET}`
       ),
-    destinationCompanyAddress: yup.string().when("$emitterSignature", {
+    destinationCompanyAddress: yup.string().when("$emissionSignature", {
       is: true,
       then: s => s.required(`Destination: ${MISSING_COMPANY_ADDRESS}`),
       otherwise: s => s.nullable()

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -185,10 +185,21 @@ const destinationSchema: FactorySchemaOf<
     destinationOperationCode: yup
       .string()
       .oneOf([...PROCESSING_OPERATIONS_CODES, null, ""])
-      .requiredIf(
-        context.operationSignature,
-        `Destinataire: l'opération réalisée est obligatoire`
-      ),
+      .when("destinationReceptionAcceptationStatus", {
+        is: (
+          destinationReceptionAcceptationStatus:
+            | WasteAcceptationStatus
+            | undefined
+        ) =>
+          !!context.operationSignature &&
+          destinationReceptionAcceptationStatus !==
+            WasteAcceptationStatus.REFUSED,
+        then: s =>
+          s
+            .nullable()
+            .required(`Destinataire: l'opération réalisée est obligatoire`),
+        otherwise: s => s.nullable().notRequired()
+      }),
     destinationOperationMode: destinationOperationModeValidation(context),
     destinationPlannedOperationCode: yup
       .string()

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from "react";
-import { Field, Form, useFormikContext } from "formik";
+import { Field, useFormikContext } from "formik";
 import { RadioButton } from "../../form/common/components/custom-inputs/RadioButton";
 import RedErrorMessage from "./RedErrorMessage";
 import {
@@ -32,29 +32,27 @@ const OperationModeSelect = ({ operationCode, name }) => {
   if (!modes.length) return null;
 
   return (
-    <Form>
-      <div className="form__row">
-        <fieldset>
-          <legend>
-            Mode de traitement{" "}
-            <Tooltip msg="Le mode de traitement correspond à un des 4 choix de la hiérarchie des modes de traitement, il s'impose de lui même ou doit être précisé selon l'opération réalisée" />
-          </legend>
-          <div className="tw-flex">
-            {modes.map(mode => (
-              <Field
-                key={mode}
-                name={name}
-                id={mode}
-                label={getOperationModeLabel(mode)}
-                component={RadioButton}
-              />
-            ))}
-          </div>
-        </fieldset>
+    <div className="form__row">
+      <fieldset>
+        <legend>
+          Mode de traitement{" "}
+          <Tooltip msg="Le mode de traitement correspond à un des 4 choix de la hiérarchie des modes de traitement, il s'impose de lui même ou doit être précisé selon l'opération réalisée" />
+        </legend>
+        <div className="tw-flex">
+          {modes.map(mode => (
+            <Field
+              key={mode}
+              name={name}
+              id={mode}
+              label={getOperationModeLabel(mode)}
+              component={RadioButton}
+            />
+          ))}
+        </div>
+      </fieldset>
 
-        <RedErrorMessage name={name} />
-      </div>
-    </Form>
+      <RedErrorMessage name={name} />
+    </div>
   );
 };
 export default OperationModeSelect;

--- a/front/src/form/bsvhu/Operation.tsx
+++ b/front/src/form/bsvhu/Operation.tsx
@@ -1,5 +1,5 @@
 import { Field, useFormikContext } from "formik";
-import React, { lazy } from "react";
+import React, { lazy, useEffect } from "react";
 import { RedErrorMessage } from "../../common/components";
 import Tooltip from "../../common/components/Tooltip";
 import DateInput from "../common/components/custom-inputs/DateInput";
@@ -13,9 +13,15 @@ const TagsInput = lazy(
 );
 
 export default function Operation() {
-  const { values } = useFormikContext<Bsvhu>();
+  const { values, setFieldValue } = useFormikContext<Bsvhu>();
 
   const TODAY = new Date();
+
+  useEffect(() => {
+    if (values.destination?.reception?.acceptationStatus === "REFUSED") {
+      setFieldValue("destination.reception.weight", 0);
+    }
+  }, [values.destination?.reception?.acceptationStatus, setFieldValue]);
 
   return (
     <>
@@ -82,6 +88,9 @@ export default function Operation() {
           Poids accepté en tonnes
           <Field
             component={NumberInput}
+            disabled={
+              values.destination?.reception?.acceptationStatus === "REFUSED"
+            }
             name="destination.reception.weight"
             className="td-input td-input--small"
             placeholder="0"
@@ -92,62 +101,64 @@ export default function Operation() {
 
         <RedErrorMessage name="destination.reception.weight" />
       </div>
-
-      {values.destination?.type === BsvhuDestinationType.Demolisseur && (
+      {values.destination?.reception?.acceptationStatus !== "REFUSED" && (
         <>
-          <h4 className="form__section-heading">Identification</h4>
+          {values.destination?.type === BsvhuDestinationType.Demolisseur && (
+            <>
+              <h4 className="form__section-heading">Identification</h4>
+              <div className="form__row">
+                <label htmlFor="destination.reception.identification.numbers">
+                  Identification des numeros entrant des lots ou des VHU (livre
+                  de police)
+                  <Tooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
+                </label>
+                <TagsInput name="destination.reception.identification.numbers" />
+              </div>
+            </>
+          )}
+
+          <h4 className="form__section-heading">Opération</h4>
           <div className="form__row">
-            <label htmlFor="destination.reception.identification.numbers">
-              Identification des numeros entrant des lots ou des VHU (livre de
-              police)
-              <Tooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
+            <label>
+              Date de l'opération
+              <Field
+                component={DateInput}
+                name="destination.operation.date"
+                className="td-input td-input--small"
+                minDate={subMonths(TODAY, 2)}
+                maxDate={TODAY}
+                required
+              />
             </label>
-            <TagsInput name="destination.reception.identification.numbers" />
+
+            <RedErrorMessage name="destination.operation.date" />
           </div>
+
+          <div className="form__row tw-pb-6">
+            <label>Opération d’élimination / valorisation effectuée</label>
+            <Field
+              as="select"
+              name="destination.operation.code"
+              className="td-select"
+            >
+              <option value="...">Sélectionnez une valeur...</option>
+              <option value="R 4">
+                R 4 - Recyclage ou récupération des métaux et des composés
+                métalliques
+              </option>
+              <option value="R 12">
+                R 12 - Échange de déchets en vue de les soumettre à l'une des
+                opérations numérotées R1 à R11
+              </option>
+            </Field>
+          </div>
+
+          <OperationModeSelect
+            operationCode={values?.destination?.operation?.code}
+            name="destination.operation.mode"
+          />
         </>
       )}
-
-      <h4 className="form__section-heading">Opération</h4>
-      <div className="form__row">
-        <label>
-          Date de l'opération
-          <Field
-            component={DateInput}
-            name="destination.operation.date"
-            className="td-input td-input--small"
-            minDate={subMonths(TODAY, 2)}
-            maxDate={TODAY}
-            required
-          />
-        </label>
-
-        <RedErrorMessage name="destination.operation.date" />
-      </div>
-
-      <div className="form__row tw-pb-6">
-        <label>Opération d’élimination / valorisation effectuée</label>
-        <Field
-          as="select"
-          name="destination.operation.code"
-          className="td-select"
-        >
-          <option value="...">Sélectionnez une valeur...</option>
-          <option value="R 4">
-            R 4 - Recyclage ou récupération des métaux et des composés
-            métalliques
-          </option>
-          <option value="R 12">
-            R 12 - Échange de déchets en vue de les soumettre à l'une des
-            opérations numérotées R1 à R11
-          </option>
-        </Field>
-      </div>
-
-      <OperationModeSelect
-        operationCode={values?.destination?.operation?.code}
-        name="destination.operation.mode"
-      />
-
       <br />
     </>
   );

--- a/front/src/form/bsvhu/Operation.tsx
+++ b/front/src/form/bsvhu/Operation.tsx
@@ -108,8 +108,8 @@ export default function Operation() {
               <h4 className="form__section-heading">Identification</h4>
               <div className="form__row">
                 <label htmlFor="destination.reception.identification.numbers">
-                  Identification des numeros entrant des lots ou des VHU (livre
-                  de police)
+                  Identification des numeros entrant des lots ou de véhicules
+                  hors d'usage (livre de police)
                   <Tooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
                 </label>
                 <TagsInput name="destination.reception.identification.numbers" />


### PR DESCRIPTION
## Modifications

### Front

Lorsqu'un BSVHU est refusé totalement :
- afficher le champ "motif du refus" (c'était déjà fait)
- mettre un 0 dans le champ de Poids, et le désactiver
- cacher les champs opération

### Back

Modification de la condition de validation du BSVHU
Avant: Si signature d'opération + pas de code d'opération -> erreur
Maintenant: Si signature d'opération ET le statut n'est pas REFUSED + pas de code d'opération -> erreur

### Bonus

#### Form in Form warning

Le sous-formulaire OperationModeSelect créait des warnings car il utilisait un élément `<Form>` alors qu'il est lui même utilisé (partout) comme enfant d'autres `<Form>`. Or un élément form ne peut pas être enfant d'un autre form. Après vérification que cet élément était partout utilisé comme enfant de Form, j'ai retiré l'élément `<Form>` qu'il créait, car inutile.

#### Docs pas à jour

En faisant l'update des champs requis pour la doc (dans les commentaires de _bsvhu.mutation.graphql_) j'ai remarqué que `destinationAgrementNumber` qui était marqué comme requis pour une signature OPERATION était en fait requis pour une signature EMISSION
 
<img width="461" alt="Capture d’écran 2024-05-16 à 22 01 09" src="https://github.com/MTES-MCT/trackdechets/assets/2432646/bf320f7e-4f11-434b-885b-4cf1791adc6b">

J'ai donc mis à jour la documentation en conséquence.

#### Check de contexte invalide

Lors de la mise à jour de la doc, j'ai fait le tour des différents champs pour vérifier leurs conditions de validation et ai remarqué que le champ `destinationCompanyAddress` avait une condition dépendant de `$emitterSignature`, ce qui correspond dans Yup à `context.emitterSignature`. Or le contexte ne contient pas `emitterSignature` mais `emissionSignature`.

<img width="512" alt="Capture d’écran 2024-05-16 à 22 02 51" src="https://github.com/MTES-MCT/trackdechets/assets/2432646/fb850d47-e672-43b8-a94b-34c9cc5a0c23">
<img width="272" alt="Capture d’écran 2024-05-16 à 22 03 00" src="https://github.com/MTES-MCT/trackdechets/assets/2432646/3d40ff2b-12d2-4d35-91bc-a1c33ae4e2a2">

J'ai donc modifié la condition pour utiliser la bonne valeur de contexte.

## Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/6066ccd2-3bd3-40c7-89ef-4018bdf50d92



<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14343)
