### PR TITLE
[TRA-14323] Suppression de la colonne "Producteurs initiaux code postaux" de l'ensemble des registres, et toutes les colonnes Producteurs initiaux des registres gestion et transport

### DIFF
--- a/back/src/forms/__tests__/registry.integration.ts
+++ b/back/src/forms/__tests__/registry.integration.ts
@@ -1,9 +1,122 @@
-import { formFactory, userFactory } from "../../__tests__/factories";
+import {
+  companyFactory,
+  formFactory,
+  formWithTempStorageFactory,
+  userFactory,
+  userWithCompanyFactory
+} from "../../__tests__/factories";
 import { formToBsdd } from "../compat";
-import { toAllWaste, toOutgoingWaste } from "../registry";
+import { toAllWaste, toIncomingWaste, toOutgoingWaste } from "../registry";
 import { prisma } from "@td/prisma";
 import { RegistryFormInclude } from "../../registry/elastic";
-import { resetDatabase } from "../../../integration-tests/helper";
+import {
+  refreshElasticSearch,
+  resetDatabase
+} from "../../../integration-tests/helper";
+import { CompanyType, Status, UserRole } from "@prisma/client";
+import makeClient from "../../__tests__/testClient";
+import { indexForm, getFormForElastic } from "../elastic";
+
+const createTmpStorageBsdd = async () => {
+  const emitter = await userWithCompanyFactory(UserRole.ADMIN, {
+    companyTypes: {
+      set: ["PRODUCER"]
+    }
+  });
+
+  const transporter = await userWithCompanyFactory(UserRole.ADMIN, {
+    companyTypes: {
+      set: ["TRANSPORTER"]
+    }
+  });
+
+  const transporter2 = await userWithCompanyFactory(UserRole.ADMIN, {
+    companyTypes: {
+      set: ["TRANSPORTER"]
+    }
+  });
+
+  const destination = await userWithCompanyFactory(UserRole.ADMIN, {
+    companyTypes: {
+      set: ["WASTEPROCESSOR"]
+    }
+  });
+
+  const ttr = await userWithCompanyFactory(UserRole.ADMIN, {
+    companyTypes: {
+      set: ["WASTEPROCESSOR"]
+    }
+  });
+  const bsdd = await formWithTempStorageFactory({
+    ownerId: emitter.user.id,
+    opt: {
+      status: "PROCESSED",
+      emittedAt: new Date(),
+      sentAt: new Date(),
+      takenOverAt: new Date(),
+      receivedAt: new Date(),
+      processedAt: new Date(),
+      emitterCompanySiret: emitter.company.siret,
+      transporters: {
+        create: {
+          transporterCompanySiret: transporter.company.siret,
+          takenOverAt: new Date(),
+          number: 1
+        }
+      },
+      recipientCompanySiret: ttr.company.siret
+    },
+    forwardedInOpts: {
+      status: "PROCESSED",
+      emittedAt: new Date(),
+      sentAt: new Date(),
+      takenOverAt: new Date(),
+      receivedAt: new Date(),
+      processedAt: new Date(),
+      emitterCompanySiret: ttr.company.siret,
+      transporters: {
+        create: {
+          transporterCompanySiret: transporter2.company.siret,
+          takenOverAt: new Date(),
+          number: 1
+        }
+      },
+      recipientCompanySiret: destination.company.siret
+    }
+  });
+
+  await indexForm(await getFormForElastic(bsdd));
+  await refreshElasticSearch();
+
+  return bsdd;
+};
+
+describe("toIncomingWaste", () => {
+  afterAll(resetDatabase);
+
+  it("initial producer should be filled when forwarded BSD", async () => {
+    // Given
+    const bdd = await createTmpStorageBsdd();
+
+    // When
+    const formForRegistry = await prisma.form.findUniqueOrThrow({
+      where: { readableId: `${bdd.readableId}-suite` },
+      include: RegistryFormInclude
+    });
+    const wasteRegistry = toIncomingWaste(formToBsdd(formForRegistry));
+
+    // Then
+    expect(wasteRegistry.initialEmitterCompanyAddress).toBe(
+      bdd.emitterCompanyAddress
+    );
+    expect(wasteRegistry.initialEmitterCompanyName).toBe(
+      bdd.emitterCompanyName
+    );
+    expect(wasteRegistry.initialEmitterCompanySiret).toBe(
+      bdd.emitterCompanySiret
+    );
+  });
+});
 
 describe("toOutgoingWaste", () => {
   afterAll(resetDatabase);
@@ -59,6 +172,29 @@ describe("toOutgoingWaste", () => {
       expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2, 3]);
     }
   );
+
+  it("initial producer should be filled when forwarded BSD", async () => {
+    // Given
+    const bdd = await createTmpStorageBsdd();
+
+    // When
+    const formForRegistry = await prisma.form.findUniqueOrThrow({
+      where: { readableId: `${bdd.readableId}-suite` },
+      include: RegistryFormInclude
+    });
+    const wasteRegistry = toOutgoingWaste(formToBsdd(formForRegistry));
+
+    // Then
+    expect(wasteRegistry.initialEmitterCompanyAddress).toBe(
+      bdd.emitterCompanyAddress
+    );
+    expect(wasteRegistry.initialEmitterCompanyName).toBe(
+      bdd.emitterCompanyName
+    );
+    expect(wasteRegistry.initialEmitterCompanySiret).toBe(
+      bdd.emitterCompanySiret
+    );
+  });
 });
 
 describe("toAllWaste", () => {
@@ -113,4 +249,27 @@ describe("toAllWaste", () => {
       expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2, 3]);
     }
   );
+
+  it("initial producer should be filled when forwarded BSD", async () => {
+    // Given
+    const bdd = await createTmpStorageBsdd();
+
+    // When
+    const formForRegistry = await prisma.form.findUniqueOrThrow({
+      where: { readableId: `${bdd.readableId}-suite` },
+      include: RegistryFormInclude
+    });
+    const wasteRegistry = toAllWaste(formToBsdd(formForRegistry));
+
+    // Then
+    expect(wasteRegistry.initialEmitterCompanyAddress).toBe(
+      bdd.emitterCompanyAddress
+    );
+    expect(wasteRegistry.initialEmitterCompanyName).toBe(
+      bdd.emitterCompanyName
+    );
+    expect(wasteRegistry.initialEmitterCompanySiret).toBe(
+      bdd.emitterCompanySiret
+    );
+  });
 });

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -134,7 +134,23 @@ const getFinalOperationsData = (
   return { destinationFinalOperationCodes, destinationFinalOperationWeights };
 };
 
-function toGenericWaste(bsdd: Bsdd): GenericWaste {
+function toGenericWaste(bsdd: ReturnType<typeof formToBsdd>): GenericWaste {
+  const initialEmitter: Record<string, string | string[] | null> = {
+    initialEmitterCompanyAddress: null,
+    initialEmitterCompanyName: null,
+    initialEmitterCompanySiret: null
+  };
+
+  // Bsd suite. Fill initial emitter data.
+  if (bsdd.forwarding) {
+    initialEmitter.initialEmitterCompanyAddress =
+      bsdd.forwarding.emitterCompanyAddress;
+    initialEmitter.initialEmitterCompanyName =
+      bsdd.forwarding.emitterCompanyName;
+    initialEmitter.initialEmitterCompanySiret =
+      bsdd.forwarding.emitterCompanySiret;
+  }
+
   return {
     wasteDescription: bsdd.wasteDescription,
     wasteCode: bsdd.wasteCode,
@@ -158,17 +174,15 @@ function toGenericWaste(bsdd: Bsdd): GenericWaste {
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
-    ...getTransportersData(bsdd)
+    ...getTransportersData(bsdd),
+    ...initialEmitter
   };
 }
 
 export function toIncomingWaste(
   bsdd: ReturnType<typeof formToBsdd>
 ): Required<IncomingWaste> {
-  const initialEmitter: Record<string, string[] | null> = {
-    initialEmitterCompanyAddress: null,
-    initialEmitterCompanyName: null,
-    initialEmitterCompanySiret: null,
+  const initialEmitter: Record<string, string | string[] | null> = {
     initialEmitterPostalCodes: null
   };
 
@@ -224,20 +238,8 @@ export function toOutgoingWaste(
   bsdd: ReturnType<typeof formToBsdd>
 ): Required<OutgoingWaste> {
   const initialEmitter: Record<string, string | string[] | null> = {
-    initialEmitterCompanyAddress: null,
-    initialEmitterCompanyName: null,
-    initialEmitterCompanySiret: null,
     initialEmitterPostalCodes: null
   };
-
-  if (bsdd.forwarding) {
-    initialEmitter.initialEmitterCompanyAddress =
-      bsdd.forwarding.emitterCompanyAddress;
-    initialEmitter.initialEmitterCompanyName =
-      bsdd.forwarding.emitterCompanyName;
-    initialEmitter.initialEmitterCompanySiret =
-      bsdd.forwarding.emitterCompanySiret;
-  }
 
   if (bsdd.grouping?.length > 0) {
     initialEmitter.initialEmitterPostalCodes = bsdd.grouping
@@ -396,9 +398,6 @@ export function toAllWaste(
   bsdd: ReturnType<typeof formToBsdd>
 ): Required<AllWaste> {
   const initialEmitter: Record<string, string[] | null> = {
-    initialEmitterCompanyAddress: null,
-    initialEmitterCompanyName: null,
-    initialEmitterCompanySiret: null,
     initialEmitterPostalCodes: null
   };
 


### PR DESCRIPTION
# Contexte

# Ticket Favro

[Supprimer la colonne "Producteurs initiaux code postaux" de l'ensemble des registres, et toutes les colonnes Producteurs initiaux des registres gestion et transport](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14323)
