### PR TITLE
[TRA-12093] [Multi-modal BSFF] Migrer les données transporteur dans une table à part (refacto interne du code)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -37,6 +37,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :house: Interne
 
+- Multi-modal BSFF : migrer les données transporteur dans une table à part (refacto interne du code) [PR 3340](https://github.com/MTES-MCT/trackdechets/pull/3340)
+
 # [2024.5.1] 07/05/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -88,10 +88,10 @@ describe("getBsdIdentifiers", () => {
     "should return all BSFF's identifiers when paginating by %p",
     async paginateBy => {
       const bsff1 = await createBsff();
-      const bsff2 = await createBsff({});
-      const bsff3 = await createBsff({});
-      const bsff4 = await createBsff({});
-      const bsff5 = await createBsff({});
+      const bsff2 = await createBsff();
+      const bsff3 = await createBsff();
+      const bsff4 = await createBsff();
+      const bsff5 = await createBsff();
 
       const ids = await getBsdIdentifiers("bsff", { paginateBy });
       expect(ids).toEqual([bsff1.id, bsff2.id, bsff3.id, bsff4.id, bsff5.id]);

--- a/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
+++ b/back/src/bsds/resolvers/mutations/__tests__/createPdfAccessToken.integration.ts
@@ -339,7 +339,7 @@ describe("Mutation.creatPdfAccessToken", () => {
     const currentUser = await userFactory();
     const bsff = await createBsff(
       { emitter: { user, company } },
-      { status: BsffStatus.SENT }
+      { data: { status: BsffStatus.SENT } }
     );
     const { mutate } = makeClient(currentUser);
 
@@ -364,7 +364,7 @@ describe("Mutation.creatPdfAccessToken", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsff(
       { emitter: { user, company } },
-      { status: BsffStatus.RECEIVED }
+      { data: { status: BsffStatus.RECEIVED } }
     );
     const { mutate } = makeClient(user);
 
@@ -391,7 +391,7 @@ describe("Mutation.creatPdfAccessToken", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsff(
       { emitter: { user, company } },
-      { status: BsffStatus.SENT }
+      { data: { status: BsffStatus.SENT } }
     );
     const { mutate } = makeClient(user);
 

--- a/back/src/bsffs/__tests__/database.integration.ts
+++ b/back/src/bsffs/__tests__/database.integration.ts
@@ -7,36 +7,35 @@ describe("findPreviousPackagings", () => {
   afterAll(resetDatabase);
 
   it("should return previous packagings according to the number of hops", async () => {
-    const bsff1 = await createBsff({}, { id: "bsff1" });
+    const bsff1 = await createBsff();
 
     // bsff2 is forwarding bsff1
     const bsff2 = await createBsff(
+      {},
       {
-        previousPackagings: bsff1.packagings
-      },
-      { id: "bsff2", type: BsffType.REEXPEDITION }
-    );
-
-    const bsff3 = await createBsff({}, { id: "bsff3" });
-    // bsff4 is repackaging bsff2 and bsff3
-    const bsff4 = await createBsff(
-      {
-        previousPackagings: [...bsff2.packagings, ...bsff3.packagings]
-      },
-      {
-        id: "bsff4",
-        type: BsffType.RECONDITIONNEMENT
+        previousPackagings: bsff1.packagings,
+        data: { type: BsffType.REEXPEDITION }
       }
     );
-    const bsff5 = await createBsff({}, { id: "bsff5" });
+
+    const bsff3 = await createBsff();
+    // bsff4 is repackaging bsff2 and bsff3
+    const bsff4 = await createBsff(
+      {},
+      {
+        previousPackagings: [...bsff2.packagings, ...bsff3.packagings],
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        }
+      }
+    );
+    const bsff5 = await createBsff();
     // bsff6 is grouping bsff5 and bsff4
     const bsff6 = await createBsff(
+      {},
       {
-        previousPackagings: [...bsff4.packagings, ...bsff5.packagings]
-      },
-      {
-        id: "bsff6",
-        type: BsffType.GROUPEMENT
+        previousPackagings: [...bsff4.packagings, ...bsff5.packagings],
+        data: { type: BsffType.GROUPEMENT }
       }
     );
 
@@ -70,36 +69,35 @@ describe("getNextPackagings", () => {
   afterAll(resetDatabase);
 
   it("should return next packagings according to the number of hops", async () => {
-    const bsff1 = await createBsff({}, { id: "bsff1" });
+    const bsff1 = await createBsff();
 
     // bsff2 is forwarding bsff1
     const bsff2 = await createBsff(
+      {},
       {
-        previousPackagings: bsff1.packagings
-      },
-      { id: "bsff2", type: BsffType.REEXPEDITION }
-    );
-
-    const bsff3 = await createBsff({}, { id: "bsff3" });
-    // bsff4 is repackaging bsff2 and bsff3
-    const bsff4 = await createBsff(
-      {
-        previousPackagings: [...bsff2.packagings, ...bsff3.packagings]
-      },
-      {
-        id: "bsff4",
-        type: BsffType.RECONDITIONNEMENT
+        previousPackagings: bsff1.packagings,
+        data: {
+          type: BsffType.REEXPEDITION
+        }
       }
     );
-    const bsff5 = await createBsff({}, { id: "bsff5" });
+
+    const bsff3 = await createBsff();
+    // bsff4 is repackaging bsff2 and bsff3
+    const bsff4 = await createBsff(
+      {},
+      {
+        previousPackagings: [...bsff2.packagings, ...bsff3.packagings],
+        data: { type: BsffType.RECONDITIONNEMENT }
+      }
+    );
+    const bsff5 = await createBsff();
     // bsff6 is grouping bsff5 and bsff4
     const bsff6 = await createBsff(
+      {},
       {
-        previousPackagings: [...bsff4.packagings, ...bsff5.packagings]
-      },
-      {
-        id: "bsff6",
-        type: BsffType.GROUPEMENT
+        previousPackagings: [...bsff4.packagings, ...bsff5.packagings],
+        data: { type: BsffType.GROUPEMENT }
       }
     );
 

--- a/back/src/bsffs/__tests__/operationHook.integration.ts
+++ b/back/src/bsffs/__tests__/operationHook.integration.ts
@@ -36,8 +36,7 @@ describe("BSFF operationHook job", () => {
         transporter,
         destination
       },
-      {},
-      operationData
+      { packagingData: operationData }
     );
 
     const packaging = bsff.packagings[0];
@@ -70,8 +69,7 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        {},
-        operationData
+        { packagingData: operationData }
       );
 
       const packaging = bsff.packagings[0];
@@ -108,11 +106,12 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        {},
         {
-          ...operationData,
-          operationCode: "D 13",
-          operationNoTraceability: true
+          packagingData: {
+            ...operationData,
+            operationCode: "D 13",
+            operationNoTraceability: true
+          }
         }
       );
 
@@ -150,10 +149,11 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        {},
         {
-          ...operationData,
-          operationCode: "D 13"
+          packagingData: {
+            ...operationData,
+            operationCode: "D 13"
+          }
         }
       );
 
@@ -180,10 +180,11 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination: ttr
         },
-        {},
         {
-          ...operationData,
-          operationCode: "D 15"
+          packagingData: {
+            ...operationData,
+            operationCode: "D 15"
+          }
         }
       );
       const packaging = bsff.packagings[0];
@@ -194,12 +195,14 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        { type: "REEXPEDITION" },
         {
-          ...operationData,
-          acceptationWeight: 120,
-          operationCode: "R 1",
-          previousPackagings: { connect: { id: packaging.id } }
+          data: { type: "REEXPEDITION" },
+          packagingData: {
+            ...operationData,
+            acceptationWeight: 120,
+            operationCode: "R 1",
+            previousPackagings: { connect: { id: packaging.id } }
+          }
         }
       );
 
@@ -237,10 +240,11 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination: ttr
         },
-        {},
         {
-          ...operationData,
-          operationCode: "D 15"
+          packagingData: {
+            ...operationData,
+            operationCode: "D 15"
+          }
         }
       );
       const packaging = bsff.packagings[0];
@@ -251,12 +255,14 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        { type: "GROUPEMENT" },
         {
-          ...operationData,
-          acceptationWeight: 120,
-          operationCode: "R 1",
-          previousPackagings: { connect: { id: packaging.id } }
+          data: { type: "GROUPEMENT" },
+          packagingData: {
+            ...operationData,
+            acceptationWeight: 120,
+            operationCode: "R 1",
+            previousPackagings: { connect: { id: packaging.id } }
+          }
         }
       );
 
@@ -294,10 +300,11 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination: ttr
         },
-        {},
         {
-          ...operationData,
-          operationCode: "D 15"
+          packagingData: {
+            ...operationData,
+            operationCode: "D 15"
+          }
         }
       );
       const packaging = bsff.packagings[0];
@@ -308,12 +315,14 @@ describe("BSFF operationHook job", () => {
           transporter,
           destination
         },
-        { type: "RECONDITIONNEMENT" },
         {
-          ...operationData,
-          acceptationWeight: 120,
-          operationCode: "R 1",
-          previousPackagings: { connect: { id: packaging.id } }
+          data: { type: "RECONDITIONNEMENT" },
+          packagingData: {
+            ...operationData,
+            acceptationWeight: 120,
+            operationCode: "R 1",
+            previousPackagings: { connect: { id: packaging.id } }
+          }
         }
       );
 

--- a/back/src/bsffs/__tests__/registry.integration.ts
+++ b/back/src/bsffs/__tests__/registry.integration.ts
@@ -32,14 +32,15 @@ describe("toOutgoingWaste", () => {
           transporter,
           destination
         },
-        {},
         {
-          finalOperations: {
-            create: {
-              finalBsffPackagingId: finalPackaging.id,
-              quantity: 1,
-              operationCode: "R 1",
-              noTraceability: false
+          packagingData: {
+            finalOperations: {
+              create: {
+                finalBsffPackagingId: finalPackaging.id,
+                quantity: 1,
+                operationCode: "R 1",
+                noTraceability: false
+              }
             }
           }
         }
@@ -79,14 +80,15 @@ describe("toAllWaste", () => {
           transporter,
           destination: ttr
         },
-        {},
         {
-          finalOperations: {
-            create: {
-              finalBsffPackagingId: finalPackaging.id,
-              quantity: 1,
-              operationCode: "R 1",
-              noTraceability: false
+          packagingData: {
+            finalOperations: {
+              create: {
+                finalBsffPackagingId: finalPackaging.id,
+                quantity: 1,
+                operationCode: "R 1",
+                noTraceability: false
+              }
             }
           }
         }
@@ -113,7 +115,7 @@ describe("getSubType", () => {
     [BsffType.REEXPEDITION, "RESHIPMENT"]
   ])("type is %p > should return %p", async (type, expectedSubType) => {
     // Given
-    const bsff = await createBsff({}, { type });
+    const bsff = await createBsff({}, { data: { type } });
 
     // When
     const bsffForRegistry = await prisma.bsff.findUniqueOrThrow({

--- a/back/src/bsffs/__tests__/validation.integration.ts
+++ b/back/src/bsffs/__tests__/validation.integration.ts
@@ -13,8 +13,7 @@ import {
   wasteDetailsSchemaFn,
   acceptationSchema,
   operationSchema,
-  ficheInterventionSchema,
-  validateBsff
+  ficheInterventionSchema
 } from "../validation";
 
 describe("emitterSchema", () => {
@@ -77,7 +76,10 @@ describe("transporterSchema", () => {
       transporterCompanyMail: "john@clim.com",
       transporterRecepisseNumber: "receiptNumber",
       transporterRecepisseDepartment: "25",
-      transporterRecepisseValidityLimit: new Date()
+      transporterRecepisseValidityLimit: new Date(),
+      transporterTransportMode: "ROAD",
+      transporterTransportTakenOverAt: new Date(),
+      transporterTransportPlates: ["AD-008-TS"]
     };
   });
 
@@ -116,25 +118,27 @@ describe("transporterSchema", () => {
     );
   });
 
-  test("missing Receipt", async () => {
-    expect.assertions(1);
-    try {
-      await validateBsff(
+  test("missing recepisse", async () => {
+    const validateFn = () =>
+      transporterSchema.validate(
         {
           ...transporterData,
           transporterRecepisseNumber: null,
           transporterRecepisseDepartment: null,
           transporterRecepisseValidityLimit: null
         },
-        {
-          isDraft: false,
-          transporterSignature: true
-        }
+        { abortEarly: false }
       );
+
+    expect.assertions(1);
+    try {
+      await validateFn();
     } catch (err) {
-      expect(err.message).toEqual(
-        "Erreur de validation des données. Des champs sont manquants ou mal formatés : \nDestination : le nom de l'établissement est requis\nDestination : le numéro SIRET est requis\nDestination : l'adresse de l'établissement est requise\nDestination : le nom du contact est requis\nDestination : le numéro de téléphone est requis\nDestination : l'adresse email est requise\nLe code de l'opération de traitement prévu est requis\nTransporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets\nTransporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets\nTransporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets\nLe code déchet est requis\nLa dénomination usuelle du déchet est obligatoire\nLa mention ADR est requise\nLe poids total est requis\nLe type de poids (estimé ou non) est un requis\nÉmetteur : le nom de l'établissement est requis\nÉmetteur : le n°SIRET de l'établissement est requis\nÉmetteur : l'adresse de l'établissement est requise\nÉmetteur : le nom du contact est requis\nÉmetteur : le numéro de téléphone est requis\nÉmetteur : l'adresse email est requise"
-      );
+      expect(err.errors).toEqual([
+        "Transporteur: le département associé au récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+        "Transporteur: le numéro de récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets",
+        "Transporteur: la date limite de validité du récépissé est obligatoire - l'établissement doit renseigner son récépissé dans Trackdéchets"
+      ]);
     }
   });
 

--- a/back/src/bsffs/edition/__tests__/bsffEdition.integration.ts
+++ b/back/src/bsffs/edition/__tests__/bsffEdition.integration.ts
@@ -9,12 +9,13 @@ import {
 import { userWithCompanyFactory } from "../../../__tests__/factories";
 import { resetDatabase } from "../../../../integration-tests/helper";
 import { checkEditionRules } from "../bsffEdition";
+import { getFirstTransporterSync } from "../../database";
 
 describe("edition rules", () => {
   afterAll(resetDatabase);
 
   it("should be possible to update any fields when BSFF status is INITIAL", async () => {
-    const bsff = await createBsff({}, { status: "INITIAL" });
+    const bsff = await createBsff({}, { data: { status: "INITIAL" } });
     const updateFields = await checkEditionRules(bsff, {
       emitter: { company: { name: "ACME" } }
     });
@@ -75,9 +76,10 @@ describe("edition rules", () => {
 
   it("should be possible to update a field not yet sealed by emission signature", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
-    const bsff = await createBsffAfterEmission({ emitter });
+    const transporter = await userWithCompanyFactory("MEMBER");
+    const bsff = await createBsffAfterEmission({ emitter, transporter });
     const updatedFields = await checkEditionRules(bsff, {
-      transporter: { transport: { plates: ["AD-008-TS"] } }
+      transporter: { transport: { plates: ["AD-008-BX"] } }
     });
     expect(updatedFields).toEqual(["transporterTransportPlates"]);
   });
@@ -105,8 +107,11 @@ describe("edition rules", () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await userWithCompanyFactory("MEMBER");
     const bsff = await createBsffAfterTransport({ emitter, transporter });
+    const bsffTransporter = getFirstTransporterSync(bsff)!;
     const updatedFields = await checkEditionRules(bsff, {
-      transporter: { company: { siret: bsff.transporterCompanySiret } }
+      transporter: {
+        company: { siret: bsffTransporter.transporterCompanySiret }
+      }
     });
     expect(updatedFields).toEqual([]);
   });

--- a/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/delete.integration.ts
@@ -36,7 +36,11 @@ describe("bsffRepository.delete", () => {
 
     const bsff = await prisma.bsff.create({
       data: { id: getReadableId(ReadableIdPrefix.FF), wasteCode: "14 06 01*" },
-      include: { packagings: true, ficheInterventions: true }
+      include: {
+        packagings: true,
+        ficheInterventions: true,
+        transporters: true
+      }
     });
 
     await indexBsd(toBsdElastic(bsff));

--- a/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
+++ b/back/src/bsffs/repository/bsff/__tests__/update.integration.ts
@@ -36,7 +36,11 @@ describe("bsffRepository.update", () => {
 
     const bsff = await prisma.bsff.create({
       data: { id: getReadableId(ReadableIdPrefix.FF), wasteCode: "14 06 01*" },
-      include: { packagings: true, ficheInterventions: true }
+      include: {
+        packagings: true,
+        ficheInterventions: true,
+        transporters: true
+      }
     });
 
     await indexBsd(toBsdElastic(bsff));

--- a/back/src/bsffs/repository/bsff/delete.ts
+++ b/back/src/bsffs/repository/bsff/delete.ts
@@ -1,4 +1,4 @@
-import { Bsff, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import {
   LogMetadata,
   RepositoryFnDeps
@@ -8,13 +8,16 @@ import { buildUpdateManyBsffPackagings } from "../bsffPackaging/updateMany";
 import { bsffEventTypes } from "../types";
 import { buildFindUniqueBsffGetPackagings } from "./findUnique";
 
-export type DeleteBsffFn = (
-  args: Prisma.BsffDeleteArgs,
+export type DeleteBsffFn = <Args extends Prisma.BsffDeleteArgs>(
+  args: Args,
   logMetadata?: LogMetadata
-) => Promise<Bsff>;
+) => Promise<Prisma.BsffGetPayload<Args>>;
 
 export function buildDeleteBsff(deps: RepositoryFnDeps): DeleteBsffFn {
-  return async (args, logMetadata?) => {
+  return async <Args extends Prisma.BsffDeleteArgs>(
+    args: Args,
+    logMetadata?: LogMetadata
+  ) => {
     const { prisma, user } = deps;
 
     const findUniqueGetPackagings = buildFindUniqueBsffGetPackagings(deps);
@@ -49,6 +52,6 @@ export function buildDeleteBsff(deps: RepositoryFnDeps): DeleteBsffFn {
     });
     prisma.addAfterCommitCallback(() => enqueueBsdToDelete(deletedBsff.id));
 
-    return deletedBsff;
+    return deletedBsff as Prisma.BsffGetPayload<Args>;
   };
 }

--- a/back/src/bsffs/repository/bsff/findMany.ts
+++ b/back/src/bsffs/repository/bsff/findMany.ts
@@ -1,15 +1,18 @@
-import { Bsff, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
-export type FindManyBsffFn = (args: Prisma.BsffFindManyArgs) => Promise<Bsff[]>;
+export type FindManyBsffFn = <Args extends Prisma.BsffFindManyArgs>(
+  args: Args
+) => Promise<Prisma.BsffGetPayload<Args>[]>;
 
 export function buildFindManyBsff({
   prisma
 }: ReadRepositoryFnDeps): FindManyBsffFn {
-  return args => {
-    return prisma.bsff.findMany({
+  return async <Args extends Prisma.BsffFindManyArgs>(args: Args) => {
+    const bsffs = await prisma.bsff.findMany({
       ...args,
       where: { ...(args.where ?? {}), isDeleted: false }
     });
+    return bsffs as Prisma.BsffGetPayload<Args>[];
   };
 }

--- a/back/src/bsffs/repository/bsff/findUnique.ts
+++ b/back/src/bsffs/repository/bsff/findUnique.ts
@@ -1,17 +1,9 @@
-import {
-  Bsff,
-  BsffFicheIntervention,
-  BsffPackaging,
-  Prisma
-} from "@prisma/client";
+import { BsffFicheIntervention, BsffPackaging, Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
 
-export type FindUniqueBsffFn = (args: Prisma.BsffFindUniqueArgs) => Promise<
-  | (Bsff & { packagings: BsffPackaging[] } & {
-      ficheInterventions: BsffFicheIntervention[];
-    })
-  | null
->;
+export type FindUniqueBsffFn = <Args extends Prisma.BsffFindUniqueArgs>(
+  args: Args
+) => Promise<Prisma.BsffGetPayload<Args>>;
 
 export type FindUniqueBsffGetPackagingsFn = (
   bsffFindUniqueArgs: Prisma.BsffFindUniqueArgs,
@@ -26,17 +18,13 @@ export type FindUniqueBsffGetFicheInterventionsFn = (
 export function buildFinduniqueBsff({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsffFn {
-  return async args => {
+  return async <Args extends Prisma.BsffFindUniqueArgs>(args: Args) => {
     const bsff = await prisma.bsff.findFirst({
-      where: { ...args.where, isDeleted: false },
-      include: {
-        packagings: true,
-        ficheInterventions: true,
-        ...(args.include ?? {})
-      }
+      ...args,
+      where: { ...args.where, isDeleted: false }
     });
 
-    return bsff;
+    return bsff as Prisma.BsffGetPayload<Args>;
   };
 }
 

--- a/back/src/bsffs/repository/bsffPackaging/findUnique.ts
+++ b/back/src/bsffs/repository/bsffPackaging/findUnique.ts
@@ -1,26 +1,29 @@
-import { Bsff, BsffPackaging, Prisma } from "@prisma/client";
+import { BsffPackaging, Prisma } from "@prisma/client";
 import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+import { BsffWithTransporters } from "../../types";
 
-export type FindUniqueBsffPackagingFn = (
-  args: Prisma.BsffPackagingFindUniqueArgs
-) => Promise<(BsffPackaging & { bsff: Bsff }) | null>;
+export type FindUniqueBsffPackagingFn = <
+  Args extends Prisma.BsffPackagingFindUniqueArgs
+>(
+  args: Args
+) => Promise<Prisma.BsffPackagingGetPayload<Args>>;
 
 export type FindUniqueBsffPackagingGetBsffFn = (
   args: Prisma.BsffPackagingFindUniqueArgs
-) => Promise<Bsff | null>;
+) => Promise<BsffWithTransporters | null>;
 
 export type FindUniqueBsffPackagingGetNextPackagingFn = (
   args: Prisma.BsffPackagingFindUniqueArgs
-) => Promise<(BsffPackaging & { bsff: Bsff }) | null>;
+) => Promise<(BsffPackaging & { bsff: BsffWithTransporters }) | null>;
 
 export function buildFindUniqueBsffPackaging({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsffPackagingFn {
-  return async args => {
-    return prisma.bsffPackaging.findUnique({
-      where: args.where,
-      include: { bsff: true, ...(args.include ?? {}) }
-    });
+  return async <Args extends Prisma.BsffPackagingFindUniqueArgs>(
+    args: Args
+  ) => {
+    const p = await prisma.bsffPackaging.findUnique(args);
+    return p as Prisma.BsffPackagingGetPayload<Args>;
   };
 }
 
@@ -28,7 +31,9 @@ export function buildFindUniqueBsffPackagingGetBsff({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsffPackagingGetBsffFn {
   return async args => {
-    return prisma.bsffPackaging.findUnique(args).bsff();
+    return prisma.bsffPackaging
+      .findUnique(args)
+      .bsff({ include: { transporters: true } });
   };
 }
 
@@ -36,8 +41,8 @@ export function buildFindUniqueBsffPackagingGetNextPackaging({
   prisma
 }: ReadRepositoryFnDeps): FindUniqueBsffPackagingGetNextPackagingFn {
   return async args => {
-    return prisma.bsffPackaging
-      .findUnique(args)
-      .nextPackaging({ include: { bsff: true } });
+    return prisma.bsffPackaging.findUnique(args).nextPackaging({
+      include: { bsff: { include: { transporters: true } } }
+    });
   };
 }

--- a/back/src/bsffs/repository/index.ts
+++ b/back/src/bsffs/repository/index.ts
@@ -5,8 +5,8 @@ import {
   BsffFicheInterventionActions,
   BsffPackagingActions
 } from "./types";
-import { buildCreateBsff } from "./bsff/create";
-import { buildUpdateBsff } from "./bsff/update";
+import { CreateBsffFn, buildCreateBsff } from "./bsff/create";
+import { UpdateBsffFn, buildUpdateBsff } from "./bsff/update";
 import { buildUpdateBsffPackaging } from "./bsffPackaging/update";
 import {
   PrismaTransaction,
@@ -22,7 +22,7 @@ import {
   buildFindUniqueBsffGetPackagings
 } from "./bsff/findUnique";
 import { buildFindNextPackagings } from "./bsffPackaging/findNextPackagings";
-import { buildDeleteBsff } from "./bsff/delete";
+import { DeleteBsffFn, buildDeleteBsff } from "./bsff/delete";
 import { buildCreateBsffFicheIntervention } from "./bsffFicheIntervention/create";
 import { buildUpdateBsffFicheIntervention } from "./bsffFicheIntervention/update";
 import { buildFindManyBsffFicheIntervention } from "./bsffFicheIntervention/findMany";
@@ -87,9 +87,9 @@ export function getBsffRepository(
   }
   return {
     ...getReadonlyBsffRepository(transaction),
-    create: useTransaction(buildCreateBsff),
-    update: useTransaction(buildUpdateBsff),
-    delete: useTransaction(buildDeleteBsff)
+    create: useTransaction(buildCreateBsff) as CreateBsffFn,
+    update: useTransaction(buildUpdateBsff) as UpdateBsffFn,
+    delete: useTransaction(buildDeleteBsff) as DeleteBsffFn
   };
 }
 

--- a/back/src/bsffs/resolvers/Bsff.ts
+++ b/back/src/bsffs/resolvers/Bsff.ts
@@ -8,12 +8,14 @@ import {
   getReadonlyBsffRepository
 } from "../repository";
 import { isGetBsdsQuery } from "../../bsds/resolvers/queries/bsds";
+import { BsffWithTransportersInclude } from "../types";
 
 export const Bsff: BsffResolvers = {
   ficheInterventions: async ({ id }, _, context) => {
     const { findUnique } = getReadonlyBsffRepository();
     const prismaBsff = await findUnique({
-      where: { id }
+      where: { id },
+      include: BsffWithTransportersInclude
     });
     const ficheInterventions = await getFicheInterventions({
       bsff: prismaBsff!,

--- a/back/src/bsffs/resolvers/BsffPackaging.ts
+++ b/back/src/bsffs/resolvers/BsffPackaging.ts
@@ -4,6 +4,7 @@ import {
   getReadonlyBsffPackagingRepository,
   getReadonlyBsffRepository
 } from "../repository";
+import { BsffWithTransportersInclude } from "../types";
 
 export const BsffPackaging: BsffPackagingResolvers = {
   bsff: async packaging => {
@@ -42,7 +43,8 @@ export const BsffPackaging: BsffPackagingResolvers = {
     const nextPackagings = await findNextPackagings(packaging.id);
     const nextBsffIds = nextPackagings.map(p => p.bsffId);
     const bsffs = await findManyBsff({
-      where: { id: { in: nextPackagings.map(p => p.bsffId) } }
+      where: { id: { in: nextPackagings.map(p => p.bsffId) } },
+      include: BsffWithTransportersInclude
     });
     return nextBsffIds
       .map(id => bsffs.find(bsff => bsff.id === id))
@@ -62,7 +64,8 @@ export const BsffPackaging: BsffPackagingResolvers = {
     const previousPackagings = await findPreviousPackagings([packaging.id]);
     const previousBsffIds = [...new Set(previousPackagings.map(p => p.bsffId))];
     const bsffs = await findManyBsff({
-      where: { id: { in: previousBsffIds } }
+      where: { id: { in: previousBsffIds } },
+      include: BsffWithTransportersInclude
     });
     return previousBsffIds
       .map(id => bsffs.find(bsff => bsff.id === id))

--- a/back/src/bsffs/resolvers/InitialBsff.ts
+++ b/back/src/bsffs/resolvers/InitialBsff.ts
@@ -10,7 +10,8 @@ export const InitialBsff: BsffResolvers = {
   emitter: async ({ id, emitter }, _, { user }) => {
     const { findUnique } = getReadonlyBsffRepository();
     const bsff = await findUnique({
-      where: { id }
+      where: { id },
+      include: { transporters: true }
     });
     try {
       await checkCanRead(user!, bsff!);

--- a/back/src/bsffs/resolvers/__tests__/Bsff.integration.ts
+++ b/back/src/bsffs/resolvers/__tests__/Bsff.integration.ts
@@ -130,10 +130,9 @@ describe("Bsff.ficheInterventions", () => {
     const nextBsff = await createBsff(
       {
         emitter: ttr,
-        destination: traiteur,
-        previousPackagings: bsff.packagings
+        destination: traiteur
       },
-      { type: "REEXPEDITION" }
+      { data: { type: "REEXPEDITION" }, previousPackagings: bsff.packagings }
     );
     const { query } = makeClient(traiteur.user);
     const { errors } = await query<Pick<Query, "bsff">>(GET_NEXT_BSFF, {

--- a/back/src/bsffs/resolvers/mutations/__tests__/createDraftBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/createDraftBsff.integration.ts
@@ -149,9 +149,11 @@ describe("Mutation.createDraftBsff", () => {
     await createBsffBeforeEmission(
       { emitter },
       {
-        ficheInterventions: {
-          connect: {
-            id: ficheIntervention.id
+        data: {
+          ficheInterventions: {
+            connect: {
+              id: ficheIntervention.id
+            }
           }
         }
       }
@@ -236,9 +238,13 @@ describe("Mutation.createDraftBsff", () => {
       const previousBsff = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: {
+            operationCode: OPERATION.R12.code
+          }
+        }
       );
 
       const { mutate } = makeClient(destination.user);
@@ -283,9 +289,11 @@ describe("Mutation.createDraftBsff", () => {
       const forwarded = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
       const { mutate } = makeClient(destination.user);
       const { data, errors } = await mutate<
@@ -324,16 +332,18 @@ describe("Mutation.createDraftBsff", () => {
       const bsff1 = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
       const bsff2 = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
       const { mutate } = makeClient(destination.user);
       const { errors } = await mutate<
@@ -372,9 +382,14 @@ describe("Mutation.createDraftBsff", () => {
       let bsff = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code, acceptationWasteCode: "14 06 01*" }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: {
+            operationCode: OPERATION.R13.code,
+            acceptationWasteCode: "14 06 01*"
+          }
+        }
       );
 
       const { id, ...packagingData } = bsff.packagings[0];
@@ -384,7 +399,7 @@ describe("Mutation.createDraftBsff", () => {
 
       bsff = await prisma.bsff.findUniqueOrThrow({
         where: { id: bsff.id },
-        include: { packagings: true }
+        include: { packagings: true, transporters: true }
       });
 
       const { mutate } = makeClient(destination.user);
@@ -422,9 +437,13 @@ describe("Mutation.createDraftBsff", () => {
         createBsffAfterOperation(
           { emitter, transporter, destination },
           {
-            status: BsffStatus.INTERMEDIATELY_PROCESSED
-          },
-          { operationCode: OPERATION.D14.code }
+            data: {
+              status: BsffStatus.INTERMEDIATELY_PROCESSED
+            },
+            packagingData: {
+              operationCode: OPERATION.D14.code
+            }
+          }
         )
       ]);
 
@@ -524,9 +543,11 @@ describe("Mutation.createDraftBsff", () => {
       const previousBsff = await createBsffAfterOperation(
         { emitter, transporter, destination: otherDestination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       );
 
       const { mutate } = makeClient(destination.user);
@@ -564,13 +585,11 @@ describe("Mutation.createDraftBsff", () => {
       const previousBsffs = await Promise.all([
         createBsff(
           { emitter, transporter, destination },
-          {},
-          { acceptationWasteCode: "14 06 01*" }
+          { packagingData: { acceptationWasteCode: "14 06 01*" } }
         ),
         createBsff(
           { emitter, transporter, destination },
-          {},
-          { acceptationWasteCode: "14 06 02*" }
+          { packagingData: { acceptationWasteCode: "14 06 02*" } }
         )
       ]);
 
@@ -612,16 +631,18 @@ describe("Mutation.createDraftBsff", () => {
       const previousBsff1 = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       );
       const previousBsff2 = await createBsffAfterOperation(
         { emitter, transporter, destination },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       );
       const previousBsffs = [previousBsff1, previousBsff2];
 

--- a/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
@@ -113,7 +113,7 @@ describe("Mutation.deleteBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const { mutate } = makeClient(emitter.user);
 
-    const bsff = await createBsff({ emitter }, { isDeleted: true });
+    const bsff = await createBsff({ emitter }, { data: { isDeleted: true } });
     const { errors } = await mutate<
       Pick<Mutation, "deleteBsff">,
       MutationDeleteBsffArgs
@@ -247,7 +247,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {
@@ -273,7 +273,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {
@@ -317,7 +317,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {
@@ -343,7 +343,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {
@@ -387,7 +387,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {
@@ -413,7 +413,7 @@ describe("Mutation.deleteBsff", () => {
 
     initialBsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: initialBsff.id },
-      include: { packagings: true }
+      include: { packagings: true, transporters: true }
     });
 
     for (const packaging of initialBsff.packagings) {

--- a/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
@@ -12,6 +12,7 @@ import { createBsff } from "../../../__tests__/factories";
 import { xDaysAgo } from "../../../../utils";
 import { prisma } from "@td/prisma";
 import { searchCompany } from "../../../../companies/search";
+import { getFirstTransporterSync } from "../../../database";
 
 jest.mock("../../../../companies/search");
 
@@ -113,7 +114,7 @@ describe("Mutation.duplicateBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const { mutate } = makeClient(emitter.user);
 
-    const bsff = await createBsff({ emitter }, { isDeleted: true });
+    const bsff = await createBsff({ emitter }, { data: { isDeleted: true } });
     const { errors } = await mutate<
       Pick<Mutation, "duplicateBsff">,
       MutationDuplicateBsffArgs
@@ -199,8 +200,11 @@ describe("Mutation.duplicateBsff", () => {
     });
 
     const duplicatedBsff = await prisma.bsff.findUniqueOrThrow({
-      where: { id: data.duplicateBsff.id }
+      where: { id: data.duplicateBsff.id },
+      include: { transporters: true }
     });
+
+    const bsffTransporter = getFirstTransporterSync(duplicatedBsff)!;
 
     expect(duplicatedBsff.emitterCompanyName).toEqual("UPDATED-EMITTER-NAME");
     expect(duplicatedBsff.emitterCompanyAddress).toEqual(
@@ -212,29 +216,29 @@ describe("Mutation.duplicateBsff", () => {
     expect(duplicatedBsff.emitterCompanyMail).toEqual("UPDATED-EMITTER-MAIL");
     expect(duplicatedBsff.emitterCompanyPhone).toEqual("UPDATED-EMITTER-PHONE");
 
-    expect(duplicatedBsff.transporterCompanyName).toEqual(
+    expect(bsffTransporter.transporterCompanyName).toEqual(
       "UPDATED-TRANSPORTER-NAME"
     );
-    expect(duplicatedBsff.transporterCompanyAddress).toEqual(
+    expect(bsffTransporter.transporterCompanyAddress).toEqual(
       "UPDATED-TRANSPORTER-ADDRESS"
     );
-    expect(duplicatedBsff.transporterCompanyContact).toEqual(
+    expect(bsffTransporter.transporterCompanyContact).toEqual(
       "UPDATED-TRANSPORTER-CONTACT"
     );
-    expect(duplicatedBsff.transporterCompanyMail).toEqual(
+    expect(bsffTransporter.transporterCompanyMail).toEqual(
       "UPDATED-TRANSPORTER-MAIL"
     );
-    expect(duplicatedBsff.transporterCompanyPhone).toEqual(
+    expect(bsffTransporter.transporterCompanyPhone).toEqual(
       "UPDATED-TRANSPORTER-PHONE"
     );
 
-    expect(duplicatedBsff.transporterRecepisseNumber).toEqual(
+    expect(bsffTransporter.transporterRecepisseNumber).toEqual(
       "UPDATED-TRANSPORTER-RECEIPT-NUMBER"
     );
-    expect(duplicatedBsff.transporterRecepisseValidityLimit).toEqual(
+    expect(bsffTransporter.transporterRecepisseValidityLimit).toEqual(
       FOUR_DAYS_AGO
     );
-    expect(duplicatedBsff.transporterRecepisseDepartment).toEqual(
+    expect(bsffTransporter.transporterRecepisseDepartment).toEqual(
       "UPDATED-TRANSPORTER-RECEIPT-DEPARTMENT"
     );
 
@@ -267,12 +271,15 @@ describe("Mutation.duplicateBsff", () => {
     });
 
     const duplicatedBsff2 = await prisma.bsff.findUniqueOrThrow({
-      where: { id: data2.duplicateBsff.id }
+      where: { id: data2.duplicateBsff.id },
+      include: { transporters: true }
     });
 
-    expect(duplicatedBsff2.transporterRecepisseNumber).toBeNull();
-    expect(duplicatedBsff2.transporterRecepisseValidityLimit).toBeNull();
-    expect(duplicatedBsff2.transporterRecepisseDepartment).toBeNull();
+    const bsffTransporter2 = getFirstTransporterSync(duplicatedBsff2)!;
+
+    expect(bsffTransporter2.transporterRecepisseNumber).toBeNull();
+    expect(bsffTransporter2.transporterRecepisseValidityLimit).toBeNull();
+    expect(bsffTransporter2.transporterRecepisseDepartment).toBeNull();
   });
 
   test("duplicated BSFF should have the updated SIRENE data when company info changes", async () => {
@@ -320,8 +327,11 @@ describe("Mutation.duplicateBsff", () => {
     });
 
     const duplicatedBsff = await prisma.bsff.findUniqueOrThrow({
-      where: { id: data.duplicateBsff.id }
+      where: { id: data.duplicateBsff.id },
+      include: { transporters: true }
     });
+
+    const bsffTransporter = getFirstTransporterSync(duplicatedBsff)!;
 
     // Emitter
     expect(duplicatedBsff.emitterCompanyName).toEqual("updated emitter name");
@@ -330,10 +340,10 @@ describe("Mutation.duplicateBsff", () => {
     );
 
     // Transporter
-    expect(duplicatedBsff.transporterCompanyName).toEqual(
+    expect(bsffTransporter.transporterCompanyName).toEqual(
       "updated transporter name"
     );
-    expect(duplicatedBsff.transporterCompanyAddress).toEqual(
+    expect(bsffTransporter.transporterCompanyAddress).toEqual(
       "updated transporter address"
     );
 

--- a/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/publishBsff.integration.ts
@@ -80,12 +80,6 @@ describe("publishBsff", () => {
         emitterCompanyContact: "John Snow",
         emitterCompanyPhone: "0000000000",
         emitterCompanyMail: "john.snow@trackdechets.fr",
-        transporterCompanySiret: transporter.company.siret,
-        transporterCompanyName: transporter.company.name,
-        transporterCompanyAddress: transporter.company.address,
-        transporterCompanyContact: "John Snow",
-        transporterCompanyPhone: "0000000000",
-        transporterCompanyMail: "john.snow@trackdechets.fr",
         destinationCompanySiret: destination.company.siret,
         destinationCompanyName: destination.company.name,
         destinationCompanyAddress: destination.company.address,
@@ -105,6 +99,17 @@ describe("publishBsff", () => {
             emissionNumero: "123",
             weight: 1,
             volume: 1
+          }
+        },
+        transporters: {
+          create: {
+            number: 1,
+            transporterCompanySiret: transporter.company.siret,
+            transporterCompanyName: transporter.company.name,
+            transporterCompanyAddress: transporter.company.address,
+            transporterCompanyContact: "John Snow",
+            transporterCompanyPhone: "0000000000",
+            transporterCompanyMail: "john.snow@trackdechets.fr"
           }
         }
       }

--- a/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/signBsff.integration.ts
@@ -268,8 +268,10 @@ describe("Mutation.signBsff", () => {
       const bsff = await createBsffBeforeTransport(
         { emitter, transporter, destination },
         {
-          emitterEmissionSignatureDate: null,
-          emitterEmissionSignatureAuthor: null
+          data: {
+            emitterEmissionSignatureDate: null,
+            emitterEmissionSignatureAuthor: null
+          }
         }
       );
 
@@ -334,8 +336,10 @@ describe("Mutation.signBsff", () => {
       const bsff = await createBsffBeforeEmission(
         { emitter, destination },
         {
-          emitterEmissionSignatureDate: null,
-          emitterEmissionSignatureAuthor: null
+          data: {
+            emitterEmissionSignatureDate: null,
+            emitterEmissionSignatureAuthor: null
+          }
         }
       );
 
@@ -524,17 +528,23 @@ describe("Mutation.signBsff", () => {
       const bsff = await createBsffAfterOperation(
         { emitter, transporter, destination: ttr },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
 
-      const nextBsff = await createBsffBeforeRefusal({
-        emitter: ttr,
-        transporter,
-        destination,
-        previousPackagings: bsff.packagings
-      });
+      const nextBsff = await createBsffBeforeRefusal(
+        {
+          emitter: ttr,
+          transporter,
+          destination
+        },
+        {
+          previousPackagings: bsff.packagings
+        }
+      );
 
       const { mutate } = makeClient(destination.user);
       await mutate<Pick<Mutation, "signBsff">, MutationSignBsffArgs>(SIGN, {
@@ -564,17 +574,21 @@ describe("Mutation.signBsff", () => {
       const bsff = await createBsffAfterOperation(
         { emitter, transporter, destination: ttr },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
 
-      const nextBsff = await createBsffBeforeRefusal({
-        emitter: ttr,
-        transporter,
-        destination,
-        previousPackagings: bsff.packagings
-      });
+      const nextBsff = await createBsffBeforeRefusal(
+        {
+          emitter: ttr,
+          transporter,
+          destination
+        },
+        {
+          previousPackagings: bsff.packagings
+        }
+      );
 
       const { mutate } = makeClient(destination.user);
       await mutate<Pick<Mutation, "signBsff">, MutationSignBsffArgs>(SIGN, {
@@ -613,7 +627,7 @@ describe("Mutation.signBsff", () => {
             transporter,
             destination
           },
-          { wasteCode: "14 06 01*" }
+          { data: { wasteCode: "14 06 01*" } }
         );
 
         // make sure packaging acceptation waste code is not defined
@@ -657,7 +671,7 @@ describe("Mutation.signBsff", () => {
             transporter,
             destination
           },
-          { wasteCode: "14 06 01*" }
+          { data: { wasteCode: "14 06 01*" } }
         );
 
         // make sure packaging acceptation waste code is not defined
@@ -801,19 +815,20 @@ describe("Mutation.signBsff", () => {
           transporter,
           destination
         },
-        {},
         {
-          operationCode: OPERATION.R13.code,
-          operationMode: null,
-          operationNextDestinationCompanyName: "ACME INC",
-          operationNextDestinationPlannedOperationCode: "R2",
-          operationNextDestinationCap: "cap",
-          operationNextDestinationCompanySiret: null,
-          operationNextDestinationCompanyVatNumber: "IE9513674T",
-          operationNextDestinationCompanyAddress: "Quelque part",
-          operationNextDestinationCompanyContact: "Mr Déchet",
-          operationNextDestinationCompanyPhone: "01 00 00 00 00",
-          operationNextDestinationCompanyMail: "contact@trackdechets.fr"
+          packagingData: {
+            operationCode: OPERATION.R13.code,
+            operationMode: null,
+            operationNextDestinationCompanyName: "ACME INC",
+            operationNextDestinationPlannedOperationCode: "R2",
+            operationNextDestinationCap: "cap",
+            operationNextDestinationCompanySiret: null,
+            operationNextDestinationCompanyVatNumber: "IE9513674T",
+            operationNextDestinationCompanyAddress: "Quelque part",
+            operationNextDestinationCompanyContact: "Mr Déchet",
+            operationNextDestinationCompanyPhone: "01 00 00 00 00",
+            operationNextDestinationCompanyMail: "contact@trackdechets.fr"
+          }
         }
       );
 
@@ -843,9 +858,11 @@ describe("Mutation.signBsff", () => {
       const bsff1 = await createBsffAfterOperation(
         { emitter, transporter, destination: ttr1 },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
 
       // bsff1 => bsff2
@@ -853,14 +870,16 @@ describe("Mutation.signBsff", () => {
         {
           emitter: ttr1,
           transporter,
-          destination: ttr2,
-          previousPackagings: bsff1.packagings
+          destination: ttr2
         },
         {
-          type: BsffType.REEXPEDITION,
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R13.code }
+          previousPackagings: bsff1.packagings,
+          data: {
+            type: BsffType.REEXPEDITION,
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R13.code }
+        }
       );
 
       // bsff1 => bsff2 => bsff3
@@ -868,11 +887,13 @@ describe("Mutation.signBsff", () => {
         {
           emitter: ttr2,
           transporter,
-          destination,
-          previousPackagings: bsff2.packagings
+          destination
         },
-        { type: BsffType.REEXPEDITION },
-        { operationCode: OPERATION.R2.code }
+        {
+          previousPackagings: bsff2.packagings,
+          data: { type: BsffType.REEXPEDITION },
+          packagingData: { operationCode: OPERATION.R2.code }
+        }
       );
 
       const { mutate } = makeClient(destination.user);

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -35,6 +35,7 @@ import {
   createBsffAfterAcceptation
 } from "../../../__tests__/factories";
 import { sirenifyBsffInput } from "../../../sirenify";
+import { getFirstTransporterSync } from "../../../database";
 
 jest.mock("../../../sirenify");
 (sirenifyBsffInput as jest.Mock).mockImplementation(input =>
@@ -58,7 +59,7 @@ describe("Mutation.updateBsff", () => {
 
   it("should allow user to update a bsff", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { isDraft: true });
+    const bsff = await createBsff({ emitter }, { data: { isDraft: true } });
 
     const { mutate } = makeClient(emitter.user);
     const { data, errors } = await mutate<
@@ -87,7 +88,7 @@ describe("Mutation.updateBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const bsff = await createBsff(
       { emitter, transporter: emitter },
-      { isDraft: true }
+      { data: { isDraft: true } }
     );
 
     const transporter = await companyFactory({
@@ -129,16 +130,15 @@ describe("Mutation.updateBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const bsff = await createBsff(
       { emitter, transporter: emitter },
-      { isDraft: true }
-    );
-    await prisma.bsff.update({
-      where: { id: bsff.id },
-      data: {
-        transporterRecepisseNumber: "abc",
-        transporterRecepisseDepartment: "13",
-        transporterRecepisseValidityLimit: new Date()
+      {
+        data: { isDraft: true },
+        transporterData: {
+          transporterRecepisseNumber: "abc",
+          transporterRecepisseDepartment: "13",
+          transporterRecepisseValidityLimit: new Date()
+        }
       }
-    });
+    );
 
     const transporter = await companyFactory({
       companyTypes: ["TRANSPORTER"]
@@ -168,17 +168,15 @@ describe("Mutation.updateBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const bsff = await createBsff(
       { emitter, transporter: emitter },
-      { isDraft: true }
-    );
-    // write a receipt to the bsff
-    await prisma.bsff.update({
-      where: { id: bsff.id },
-      data: {
-        transporterRecepisseNumber: "abc",
-        transporterRecepisseDepartment: "13",
-        transporterRecepisseValidityLimit: new Date()
+      {
+        data: { isDraft: true },
+        transporterData: {
+          transporterRecepisseNumber: "abc",
+          transporterRecepisseDepartment: "13",
+          transporterRecepisseValidityLimit: new Date()
+        }
       }
-    });
+    );
 
     const transporter = await companyFactory({
       companyTypes: ["TRANSPORTER"]
@@ -213,14 +211,13 @@ describe("Mutation.updateBsff", () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const bsff = await createBsff(
       { emitter, transporter: emitter },
-      { isDraft: true }
-    );
-    await prisma.bsff.update({
-      where: { id: bsff.id },
-      data: {
-        transporterRecepisseIsExempted: true
+      {
+        data: { isDraft: true },
+        transporterData: {
+          transporterRecepisseIsExempted: true
+        }
       }
-    });
+    );
 
     const transporter = await companyFactory({
       companyTypes: ["TRANSPORTER"]
@@ -254,15 +251,13 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsff(
       { emitter },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            weight: 1,
-            numero: "1",
-            emissionNumero: "1"
-          }
-        },
-        isDraft: true
+        data: { isDraft: true },
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          weight: 1,
+          numero: "1",
+          emissionNumero: "1"
+        }
       }
     );
 
@@ -318,13 +313,11 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter, destination },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            weight: 1,
-            numero: "1",
-            emissionNumero: "1"
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          weight: 1,
+          numero: "1",
+          emissionNumero: "1"
         }
       }
     );
@@ -383,13 +376,11 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter, destination },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            weight: 1,
-            numero: "1",
-            emissionNumero: "1"
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          weight: 1,
+          numero: "1",
+          emissionNumero: "1"
         }
       }
     );
@@ -441,14 +432,12 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter, destination },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            weight: 1,
-            numero: "1",
-            emissionNumero: "1",
-            volume: 1
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          weight: 1,
+          numero: "1",
+          emissionNumero: "1",
+          volume: 1
         }
       }
     );
@@ -555,9 +544,11 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsff(
       { emitter: operateur },
       {
-        type: "COLLECTE_PETITES_QUANTITES",
-        ficheInterventions: { connect: { id: ficheIntervention1.id } },
-        isDraft: true
+        data: {
+          type: "COLLECTE_PETITES_QUANTITES",
+          ficheInterventions: { connect: { id: ficheIntervention1.id } },
+          isDraft: true
+        }
       }
     );
 
@@ -606,8 +597,10 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter: operateur, destination },
       {
-        type: "COLLECTE_PETITES_QUANTITES",
-        ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        data: {
+          type: "COLLECTE_PETITES_QUANTITES",
+          ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        }
       }
     );
 
@@ -656,8 +649,10 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter: operateur, destination },
       {
-        type: "COLLECTE_PETITES_QUANTITES",
-        ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        data: {
+          type: "COLLECTE_PETITES_QUANTITES",
+          ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        }
       }
     );
 
@@ -694,8 +689,10 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffAfterEmission(
       { emitter: operateur, destination },
       {
-        type: "COLLECTE_PETITES_QUANTITES",
-        ficheInterventions: { connect: { id: ficheIntervention.id } }
+        data: {
+          type: "COLLECTE_PETITES_QUANTITES",
+          ficheInterventions: { connect: { id: ficheIntervention.id } }
+        }
       }
     );
 
@@ -782,7 +779,7 @@ describe("Mutation.updateBsff", () => {
 
   it("should throw an error if the bsff being updated is deleted", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { isDeleted: true });
+    const bsff = await createBsff({ emitter }, { data: { isDeleted: true } });
 
     const { mutate } = makeClient(emitter.user);
     const { errors } = await mutate<
@@ -810,7 +807,7 @@ describe("Mutation.updateBsff", () => {
 
   it("prevent user from removing their own company from the bsff", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { isDraft: true });
+    const bsff = await createBsff({ emitter }, { data: { isDraft: true } });
 
     const { mutate } = makeClient(emitter.user);
     const { errors } = await mutate<
@@ -1049,10 +1046,46 @@ describe("Mutation.updateBsff", () => {
     expect(errors).toEqual([
       expect.objectContaining({
         message:
-          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés :" +
-          " transporterTransportPlates, transporterTransportTakenOverAt"
+          "Des champs ont été verrouillés via signature et ne peuvent plus être modifiés : transporterTransportPlates, transporterTransportTakenOverAt"
       })
     ]);
+  });
+
+  test("after transporter signature > it should be possible to resend same transporter data", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN, {
+      transporterReceipt: {
+        create: {
+          receiptNumber: "receipt",
+          department: "13",
+          validityLimit: new Date()
+        }
+      }
+    });
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsff = await createBsffAfterTransport({
+      emitter,
+      transporter,
+      destination
+    });
+    const bsffTransporter = getFirstTransporterSync(bsff)!;
+    const { mutate } = makeClient(emitter.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          transporter: {
+            transport: {
+              mode: bsffTransporter.transporterTransportMode
+            }
+          }
+        }
+      }
+    });
+    expect(errors).toBeUndefined();
   });
 
   test("after transporter signature > it should be possible to update reception fields", async () => {
@@ -1128,9 +1161,11 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
     const newGroupingBsffs = await Promise.all([
@@ -1141,9 +1176,11 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
 
@@ -1151,11 +1188,13 @@ describe("Mutation.updateBsff", () => {
       {
         emitter,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.GROUPEMENT
+        data: {
+          type: BsffType.GROUPEMENT
+        },
+        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
       }
     );
 
@@ -1205,9 +1244,11 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
     const newGroupingBsffs = await Promise.all([
@@ -1218,9 +1259,9 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
 
@@ -1228,11 +1269,13 @@ describe("Mutation.updateBsff", () => {
       {
         emitter,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.GROUPEMENT
+        data: {
+          type: BsffType.GROUPEMENT
+        },
+        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
       }
     );
 
@@ -1283,9 +1326,11 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
     const newGroupingBsffs = await Promise.all([
@@ -1296,9 +1341,9 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
 
@@ -1306,11 +1351,11 @@ describe("Mutation.updateBsff", () => {
       {
         emitter,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
+        destination
       },
       {
-        type: BsffType.GROUPEMENT
+        data: { type: BsffType.GROUPEMENT },
+        previousPackagings: oldGroupingBsffs.flatMap(bsff => bsff.packagings)
       }
     );
 
@@ -1349,9 +1394,11 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
 
@@ -1359,11 +1406,13 @@ describe("Mutation.updateBsff", () => {
       {
         emitter,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: groupingBsffs.flatMap(bsff => bsff.packagings)
+        destination
       },
       {
-        type: BsffType.GROUPEMENT
+        data: {
+          type: BsffType.GROUPEMENT
+        },
+        previousPackagings: groupingBsffs.flatMap(bsff => bsff.packagings)
       }
     );
 
@@ -1394,20 +1443,24 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const bsff = await createBsffBeforeEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldForwarded.packagings
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.REEXPEDITION
+        data: {
+          type: BsffType.REEXPEDITION
+        },
+        previousPackagings: oldForwarded.packagings
       }
     );
 
@@ -1418,9 +1471,13 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: {
+          operationCode: OPERATION.R13.code
+        }
+      }
     );
 
     const { mutate } = makeClient(ttr.user);
@@ -1462,9 +1519,11 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const newForwarded = await createBsffAfterOperation(
@@ -1474,20 +1533,24 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldForwarded.packagings
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.REEXPEDITION
+        data: {
+          type: BsffType.REEXPEDITION
+        },
+        previousPackagings: oldForwarded.packagings
       }
     );
 
@@ -1531,9 +1594,11 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const newForwarded = await createBsffAfterOperation(
@@ -1543,20 +1608,22 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: { status: BsffStatus.INTERMEDIATELY_PROCESSED },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: oldForwarded.packagings
+        destination
       },
       {
-        type: BsffType.REEXPEDITION
+        data: {
+          type: BsffType.REEXPEDITION
+        },
+        previousPackagings: oldForwarded.packagings
       }
     );
 
@@ -1591,20 +1658,24 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: forwarded.packagings
+        destination
       },
       {
-        type: BsffType.REEXPEDITION
+        data: {
+          type: BsffType.REEXPEDITION
+        },
+        previousPackagings: forwarded.packagings
       }
     );
 
@@ -1633,30 +1704,32 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
 
     const bsff = await createBsffBeforeEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldRepackaged.packagings
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.RECONDITIONNEMENT,
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "numero",
-            emissionNumero: "numero",
-            volume: 1,
-            weight: 1,
-            previousPackagings: {
-              connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
-            }
+        previousPackagings: oldRepackaged.packagings,
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        },
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "numero",
+          emissionNumero: "numero",
+          volume: 1,
+          weight: 1,
+          previousPackagings: {
+            connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
           }
         }
       }
@@ -1669,9 +1742,13 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: {
+          operationCode: OPERATION.D14.code
+        }
+      }
     );
 
     const { mutate } = makeClient(ttr.user);
@@ -1711,30 +1788,32 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination: await userWithCompanyFactory(UserRole.ADMIN),
-        previousPackagings: oldRepackaged.packagings
+        destination: await userWithCompanyFactory(UserRole.ADMIN)
       },
       {
-        type: BsffType.RECONDITIONNEMENT,
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "numero",
-            emissionNumero: "numero",
-            volume: 1,
-            weight: 1,
-            previousPackagings: {
-              connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
-            }
+        previousPackagings: oldRepackaged.packagings,
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        },
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "numero",
+          emissionNumero: "numero",
+          volume: 1,
+          weight: 1,
+          previousPackagings: {
+            connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
           }
         }
       }
@@ -1747,9 +1826,13 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: {
+          operationCode: OPERATION.D14.code
+        }
+      }
     );
 
     const { mutate } = makeClient(ttr.user);
@@ -1790,30 +1873,32 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: oldRepackaged.packagings
+        destination
       },
       {
-        type: BsffType.RECONDITIONNEMENT,
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "numero",
-            emissionNumero: "numero",
-            volume: 1,
-            weight: 1,
-            previousPackagings: {
-              connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
-            }
+        previousPackagings: oldRepackaged.packagings,
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        },
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "numero",
+          emissionNumero: "numero",
+          volume: 1,
+          weight: 1,
+          previousPackagings: {
+            connect: oldRepackaged.packagings.map(p => ({ id: p.id }))
           }
         }
       }
@@ -1826,9 +1911,11 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
 
     const { mutate } = makeClient(destination.user);
@@ -1862,30 +1949,32 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
 
     const bsff = await createBsffAfterEmission(
       {
         emitter: ttr,
         transporter: await userWithCompanyFactory(UserRole.ADMIN),
-        destination,
-        previousPackagings: repackaged.packagings
+        destination
       },
       {
-        type: BsffType.RECONDITIONNEMENT,
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "numero",
-            emissionNumero: "numero",
-            volume: 1,
-            weight: 1,
-            previousPackagings: {
-              connect: repackaged.packagings.map(p => ({ id: p.id }))
-            }
+        previousPackagings: repackaged.packagings,
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        },
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "numero",
+          emissionNumero: "numero",
+          volume: 1,
+          weight: 1,
+          previousPackagings: {
+            connect: repackaged.packagings.map(p => ({ id: p.id }))
           }
         }
       }
@@ -1954,19 +2043,23 @@ describe("Mutation.updateBsff", () => {
           destination: emitter
         },
         {
-          status: BsffStatus.INTERMEDIATELY_PROCESSED
-        },
-        { operationCode: OPERATION.R12.code }
+          data: {
+            status: BsffStatus.INTERMEDIATELY_PROCESSED
+          },
+          packagingData: { operationCode: OPERATION.R12.code }
+        }
       )
     ]);
     const bsff = await createBsffBeforeEmission(
       {
-        emitter,
-        previousPackagings: groupingBsffs.flatMap(bsff => bsff.packagings)
+        emitter
       },
       {
-        type: BsffType.GROUPEMENT,
-        isDraft: true
+        previousPackagings: groupingBsffs.flatMap(bsff => bsff.packagings),
+        data: {
+          type: BsffType.GROUPEMENT,
+          isDraft: true
+        }
       }
     );
 
@@ -2000,15 +2093,21 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.R13.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.R13.code }
+      }
     );
     const bsff = await createBsffBeforeEmission(
-      { emitter: ttr, previousPackagings: forwardedBsff.packagings },
+      { emitter: ttr },
+
       {
-        type: BsffType.REEXPEDITION,
-        isDraft: true
+        previousPackagings: forwardedBsff.packagings,
+        data: {
+          type: BsffType.REEXPEDITION,
+          isDraft: true
+        }
       }
     );
 
@@ -2042,15 +2141,20 @@ describe("Mutation.updateBsff", () => {
         destination: ttr
       },
       {
-        status: BsffStatus.INTERMEDIATELY_PROCESSED
-      },
-      { operationCode: OPERATION.D14.code }
+        data: {
+          status: BsffStatus.INTERMEDIATELY_PROCESSED
+        },
+        packagingData: { operationCode: OPERATION.D14.code }
+      }
     );
     const bsff = await createBsffBeforeEmission(
-      { emitter: ttr, previousPackagings: repackagingBsff.packagings },
+      { emitter: ttr },
       {
-        type: BsffType.RECONDITIONNEMENT,
-        isDraft: true
+        data: {
+          type: BsffType.RECONDITIONNEMENT,
+          isDraft: true
+        },
+        previousPackagings: repackagingBsff.packagings
       }
     );
 
@@ -2091,11 +2195,13 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffBeforeEmission(
       { emitter },
       {
-        isDraft: true,
-        type: "COLLECTE_PETITES_QUANTITES",
-        detenteurCompanySirets: [detenteur1.company.siret!],
-        ficheInterventions: {
-          connect: ficheInterventions.map(({ id }) => ({ id }))
+        data: {
+          isDraft: true,
+          type: "COLLECTE_PETITES_QUANTITES",
+          detenteurCompanySirets: [detenteur1.company.siret!],
+          ficheInterventions: {
+            connect: ficheInterventions.map(({ id }) => ({ id }))
+          }
         }
       }
     );
@@ -2136,8 +2242,10 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffBeforeEmission(
       { emitter },
       {
-        type: BsffType.GROUPEMENT,
-        isDraft: true
+        data: {
+          type: BsffType.GROUPEMENT,
+          isDraft: true
+        }
       }
     );
     const { mutate } = makeClient(emitter.user);
@@ -2170,8 +2278,10 @@ describe("Mutation.updateBsff", () => {
     const bsff = await createBsffBeforeEmission(
       { emitter },
       {
-        type: BsffType.GROUPEMENT,
-        isDraft: true
+        data: {
+          type: BsffType.GROUPEMENT,
+          isDraft: true
+        }
       }
     );
     const { mutate } = makeClient(emitter.user);

--- a/back/src/bsffs/resolvers/mutations/deleteBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/deleteBsff.ts
@@ -4,6 +4,7 @@ import { expandBsffFromDB } from "../../converter";
 import { checkCanDelete } from "../../permissions";
 import { getBsffOrNotFound } from "../../database";
 import { getBsffRepository } from "../../repository";
+import { BsffWithTransportersInclude } from "../../types";
 
 const deleteBsff: MutationResolvers["deleteBsff"] = async (
   _,
@@ -17,7 +18,10 @@ const deleteBsff: MutationResolvers["deleteBsff"] = async (
 
   const { delete: deleteBsff } = getBsffRepository(user);
 
-  const deletedBsff = await deleteBsff({ where: { id } });
+  const deletedBsff = await deleteBsff({
+    where: { id },
+    include: BsffWithTransportersInclude
+  });
 
   return expandBsffFromDB(deletedBsff);
 };

--- a/back/src/bsffs/resolvers/mutations/publishBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/publishBsff.ts
@@ -14,6 +14,7 @@ import {
   getBsffPackagingRepository,
   getBsffRepository
 } from "../../repository";
+import { BsffWithTransportersInclude } from "../../types";
 
 const publishBsffResolver: MutationResolvers["publishBsff"] = async (
   _,
@@ -66,6 +67,7 @@ const publishBsffResolver: MutationResolvers["publishBsff"] = async (
     where: {
       id: existingBsff.id
     },
+    include: BsffWithTransportersInclude,
     data: {
       isDraft: false
     }

--- a/back/src/bsffs/resolvers/queries/__tests__/bsff.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsff.integration.ts
@@ -10,7 +10,6 @@ import {
   createBsff,
   createBsffAfterOperation
 } from "../../../__tests__/factories";
-import getReadableId, { ReadableIdPrefix } from "../../../../forms/readableId";
 import { gql } from "graphql-tag";
 import { fullBsff } from "../../../fragments";
 
@@ -71,7 +70,7 @@ describe("Query.bsff", () => {
 
   it("should throw an error not found if the bsff is deleted", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { isDeleted: true });
+    const bsff = await createBsff({ emitter }, { data: { isDeleted: true } });
 
     const { query } = makeClient(emitter.user);
     const { errors } = await query<Pick<Query, "bsff">, QueryBsffArgs>(
@@ -115,8 +114,6 @@ describe("Query.bsff", () => {
 
   it("should list the bsff's fiche d'interventions", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-
-    const bsffId = getReadableId(ReadableIdPrefix.FF);
     const ficheInterventionNumero = "0000001";
     const siret = siretify(3);
     const bsff = await createBsff(
@@ -124,27 +121,28 @@ describe("Query.bsff", () => {
         emitter
       },
       {
-        id: bsffId,
-        ficheInterventions: {
-          create: [
-            {
-              numero: ficheInterventionNumero,
-              weight: 2,
-              detenteurCompanyName: "Acme",
-              detenteurCompanySiret: siret,
-              detenteurCompanyAddress: "12 rue de la Tige, 69000",
-              detenteurCompanyMail: "contact@gmail.com",
-              detenteurCompanyPhone: "06",
-              detenteurCompanyContact: "Jeanne Michelin",
-              operateurCompanyName: "Clim'op",
-              operateurCompanySiret: siret,
-              operateurCompanyAddress: "12 rue de la Tige, 69000",
-              operateurCompanyMail: "contact@climop.com",
-              operateurCompanyPhone: "06",
-              operateurCompanyContact: "Jean Dupont",
-              postalCode: "69000"
-            }
-          ]
+        data: {
+          ficheInterventions: {
+            create: [
+              {
+                numero: ficheInterventionNumero,
+                weight: 2,
+                detenteurCompanyName: "Acme",
+                detenteurCompanySiret: siret,
+                detenteurCompanyAddress: "12 rue de la Tige, 69000",
+                detenteurCompanyMail: "contact@gmail.com",
+                detenteurCompanyPhone: "06",
+                detenteurCompanyContact: "Jeanne Michelin",
+                operateurCompanyName: "Clim'op",
+                operateurCompanySiret: siret,
+                operateurCompanyAddress: "12 rue de la Tige, 69000",
+                operateurCompanyMail: "contact@climop.com",
+                operateurCompanyPhone: "06",
+                operateurCompanyContact: "Jean Dupont",
+                postalCode: "69000"
+              }
+            ]
+          }
         }
       }
     );
@@ -178,15 +176,16 @@ describe("Query.bsff", () => {
         transporter,
         destination
       },
-      {},
-      { operationCode: "R13" }
+      { packagingData: { operationCode: "R13" } }
     );
     const bsff = await createBsff(
       {
-        emitter: destination,
-        previousPackagings: previousBsff.packagings
+        emitter: destination
       },
-      { type: "GROUPEMENT" }
+      {
+        previousPackagings: previousBsff.packagings,
+        data: { type: "GROUPEMENT" }
+      }
     );
 
     const { query } = makeClient(destination.user);
@@ -218,10 +217,12 @@ describe("Query.bsff", () => {
     });
     const bsff = await createBsff(
       {
-        emitter: destination,
-        previousPackagings: forwardedBsff.packagings
+        emitter: destination
       },
-      { type: "REEXPEDITION" }
+      {
+        previousPackagings: forwardedBsff.packagings,
+        data: { type: "REEXPEDITION" }
+      }
     );
     const { query } = makeClient(destination.user);
     const { data, errors } = await query<Pick<Query, "bsff">, QueryBsffArgs>(

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffPackaging.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffPackaging.integration.ts
@@ -59,42 +59,43 @@ describe("Query.bsffPackaging", () => {
     const destination1 = await userWithCompanyFactory(UserRole.MEMBER);
     const destination2 = await userWithCompanyFactory(UserRole.MEMBER);
 
-    const bsff1 = await createBsff(
-      { emitter: emitter1, destination: destination1 },
-      { id: "bsff1" }
-    );
+    const bsff1 = await createBsff({
+      emitter: emitter1,
+      destination: destination1
+    });
 
     // bsff2 is forwarding bsff1
     const bsff2 = await createBsff(
       {
         emitter: destination1,
-        destination: destination2,
-        previousPackagings: bsff1.packagings
+        destination: destination2
       },
-      { id: "bsff2", type: BsffType.REEXPEDITION }
+      {
+        previousPackagings: bsff1.packagings,
+        data: { type: BsffType.REEXPEDITION }
+      }
     );
 
-    const bsff3 = await createBsff({}, { id: "bsff3" });
+    const bsff3 = await createBsff();
     // bsff4 is repackaging bsff2 and bsff3
     const bsff4 = await createBsff(
       {
-        emitter: destination2,
-        previousPackagings: [...bsff2.packagings, ...bsff3.packagings]
+        emitter: destination2
       },
       {
-        id: "bsff4",
-        type: BsffType.RECONDITIONNEMENT
+        previousPackagings: [...bsff2.packagings, ...bsff3.packagings],
+        data: {
+          type: BsffType.RECONDITIONNEMENT
+        }
       }
     );
-    const bsff5 = await createBsff({}, { id: "bsff5" });
+    const bsff5 = await createBsff();
     // bsff6 is grouping bsff5 and bsff4
     const bsff6 = await createBsff(
+      {},
       {
-        previousPackagings: [...bsff4.packagings, ...bsff5.packagings]
-      },
-      {
-        id: "bsff6",
-        type: BsffType.GROUPEMENT
+        previousPackagings: [...bsff4.packagings, ...bsff5.packagings],
+        data: { type: BsffType.GROUPEMENT }
       }
     );
 

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffPackagings.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffPackagings.integration.ts
@@ -85,8 +85,11 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      {},
-      { operationCode: OPERATION.R12.code }
+      {
+        packagingData: {
+          operationCode: OPERATION.R12.code
+        }
+      }
     );
 
     // this bsff packagings should not be included
@@ -96,8 +99,11 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      {},
-      { operationCode: OPERATION.R2.code }
+      {
+        packagingData: {
+          operationCode: OPERATION.R2.code
+        }
+      }
     );
 
     const { query } = makeClient(emitter.user);
@@ -127,7 +133,7 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      { isDraft: false }
+      { data: { isDraft: false } }
     );
 
     // this bsff packagings should not be included
@@ -137,7 +143,7 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      { isDraft: true }
+      { data: { isDraft: true } }
     );
 
     const { query } = makeClient(emitter.user);
@@ -168,17 +174,21 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      {},
-      { operationCode: OPERATION.R12.code }
+
+      { packagingData: { operationCode: OPERATION.R12.code } }
     );
 
     // this bsff packagings should  be included
-    const bsff2 = await createBsff({
-      emitter,
-      transporter,
-      destination,
-      previousPackagings: bsff.packagings
-    });
+    const bsff2 = await createBsff(
+      {
+        emitter,
+        transporter,
+        destination
+      },
+      {
+        previousPackagings: bsff.packagings
+      }
+    );
 
     const { query } = makeClient(emitter.user);
 
@@ -207,17 +217,18 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      {},
-      { operationCode: OPERATION.R12.code }
+      { packagingData: { operationCode: OPERATION.R12.code } }
     );
 
     // this bsff packagings should not be included
-    const bsff2 = await createBsff({
-      emitter,
-      transporter,
-      destination,
-      previousPackagings: bsff.packagings
-    });
+    const bsff2 = await createBsff(
+      {
+        emitter,
+        transporter,
+        destination
+      },
+      { previousPackagings: bsff.packagings }
+    );
 
     const { query } = makeClient(emitter.user);
 

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
@@ -1,7 +1,6 @@
 import { BsffPackagingType, UserRole } from "@prisma/client";
 import { gql } from "graphql-tag";
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import getReadableId, { ReadableIdPrefix } from "../../../../forms/readableId";
 import { Query, QueryBsffsArgs } from "../../../../generated/graphql/types";
 import {
   userWithCompanyFactory,
@@ -66,8 +65,10 @@ describe("Query.bsffs", () => {
     const bsff = await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention.id } },
-        detenteurCompanySirets: [detenteur.company.siret!]
+        data: {
+          ficheInterventions: { connect: { id: ficheIntervention.id } },
+          detenteurCompanySirets: [detenteur.company.siret!]
+        }
       }
     );
     const { query } = makeClient(detenteur.user);
@@ -145,7 +146,7 @@ describe("Query.bsffs", () => {
 
   it("should not return deleted bsffs", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    await createBsff({ emitter }, { isDeleted: true });
+    await createBsff({ emitter }, { data: { isDeleted: true } });
 
     const { query } = makeClient(emitter.user);
     const { data } = await query<Pick<Query, "bsffs">, QueryBsffsArgs>(
@@ -158,34 +159,34 @@ describe("Query.bsffs", () => {
   it("should list the fiche d'interventions", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
 
-    const bsffId = getReadableId(ReadableIdPrefix.FF);
     const ficheInterventionNumero = "0000001";
     await createBsff(
       {
         emitter
       },
       {
-        id: bsffId,
-        ficheInterventions: {
-          create: [
-            {
-              numero: ficheInterventionNumero,
-              weight: 2,
-              detenteurCompanyName: "Acme",
-              detenteurCompanySiret: siretify(1),
-              detenteurCompanyAddress: "12 rue de la Tige, 69000",
-              detenteurCompanyMail: "contact@gmail.com",
-              detenteurCompanyPhone: "06",
-              detenteurCompanyContact: "Jeanne Michelin",
-              operateurCompanyName: "Clim'op",
-              operateurCompanySiret: siretify(2),
-              operateurCompanyAddress: "12 rue de la Tige, 69000",
-              operateurCompanyMail: "contact@climop.com",
-              operateurCompanyPhone: "06",
-              operateurCompanyContact: "Jean Dupont",
-              postalCode: "69000"
-            }
-          ]
+        data: {
+          ficheInterventions: {
+            create: [
+              {
+                numero: ficheInterventionNumero,
+                weight: 2,
+                detenteurCompanyName: "Acme",
+                detenteurCompanySiret: siretify(1),
+                detenteurCompanyAddress: "12 rue de la Tige, 69000",
+                detenteurCompanyMail: "contact@gmail.com",
+                detenteurCompanyPhone: "06",
+                detenteurCompanyContact: "Jeanne Michelin",
+                operateurCompanyName: "Clim'op",
+                operateurCompanySiret: siretify(2),
+                operateurCompanyAddress: "12 rue de la Tige, 69000",
+                operateurCompanyMail: "contact@climop.com",
+                operateurCompanyPhone: "06",
+                operateurCompanyContact: "Jean Dupont",
+                postalCode: "69000"
+              }
+            ]
+          }
         }
       }
     );
@@ -211,39 +212,33 @@ describe("Query.bsffs", () => {
     const bsff1 = await createBsff(
       { emitter },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "AAAAA",
-            emissionNumero: "AAAAA",
-            weight: 1
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "AAAAA",
+          emissionNumero: "AAAAA",
+          weight: 1
         }
       }
     );
     const bsff2 = await createBsff(
       { emitter },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "BBBBB",
-            emissionNumero: "BBBBB",
-            weight: 1
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "BBBBB",
+          emissionNumero: "BBBBB",
+          weight: 1
         }
       }
     );
     const bsff3 = await createBsff(
       { emitter },
       {
-        packagings: {
-          create: {
-            type: BsffPackagingType.BOUTEILLE,
-            numero: "CCCCC",
-            emissionNumero: "CCCCC",
-            weight: 1
-          }
+        packagingData: {
+          type: BsffPackagingType.BOUTEILLE,
+          numero: "CCCCC",
+          emissionNumero: "CCCCC",
+          weight: 1
         }
       }
     );
@@ -335,19 +330,21 @@ describe("Query.bsffs", () => {
     const bsff1 = await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        data: {
+          ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        }
       }
     );
     await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention2.id } }
+        data: { ficheInterventions: { connect: { id: ficheIntervention2.id } } }
       }
     );
     await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention3.id } }
+        data: { ficheInterventions: { connect: { id: ficheIntervention3.id } } }
       }
     );
 
@@ -396,19 +393,19 @@ describe("Query.bsffs", () => {
     const bsff1 = await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention1.id } }
+        data: { ficheInterventions: { connect: { id: ficheIntervention1.id } } }
       }
     );
     await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention2.id } }
+        data: { ficheInterventions: { connect: { id: ficheIntervention2.id } } }
       }
     );
     await createBsff(
       { emitter: operateur },
       {
-        ficheInterventions: { connect: { id: ficheIntervention3.id } }
+        data: { ficheInterventions: { connect: { id: ficheIntervention3.id } } }
       }
     );
 
@@ -435,15 +432,15 @@ describe("Query.bsffs", () => {
     const newDestination = {
       destinationCompanySiret: siretify(1)
     };
-    const bsff1 = await createBsff({ emitter }, newDestination);
+    const bsff1 = await createBsff({ emitter }, { data: newDestination });
     const newDestination_1 = {
       destinationCompanySiret: siretify(2)
     };
-    const bsff2 = await createBsff({ emitter }, newDestination_1);
+    const bsff2 = await createBsff({ emitter }, { data: newDestination_1 });
     const newDestination_2 = {
       destinationCompanySiret: siretify(3)
     };
-    await createBsff({ emitter }, newDestination_2);
+    await createBsff({ emitter }, { data: newDestination_2 });
 
     const { query } = makeClient(emitter.user);
     const { data } = await query<Pick<Query, "bsffs">, QueryBsffsArgs>(

--- a/back/src/bsffs/resolvers/queries/bsffPackagings.ts
+++ b/back/src/bsffs/resolvers/queries/bsffPackagings.ts
@@ -24,8 +24,7 @@ const bsffPackagings: QueryResolvers["bsffPackagings"] = async (
     bsff: {
       OR: [
         { emitterCompanySiret: { in: orgIdsWithListPermission } },
-        { transporterCompanySiret: { in: orgIdsWithListPermission } },
-        { transporterCompanyVatNumber: { in: orgIdsWithListPermission } },
+        { transportersOrgIds: { hasSome: orgIdsWithListPermission } },
         { destinationCompanySiret: { in: orgIdsWithListPermission } }
       ]
     }

--- a/back/src/bsffs/resolvers/queries/bsffs.ts
+++ b/back/src/bsffs/resolvers/queries/bsffs.ts
@@ -23,8 +23,7 @@ const bsffs: QueryResolvers["bsffs"] = async (
   const mask: Prisma.Enumerable<Prisma.BsffWhereInput> = {
     OR: [
       { emitterCompanySiret: { in: orgIdsWithListPermission } },
-      { transporterCompanySiret: { in: orgIdsWithListPermission } },
-      { transporterCompanyVatNumber: { in: orgIdsWithListPermission } },
+      { transportersOrgIds: { hasSome: orgIdsWithListPermission } },
       { destinationCompanySiret: { in: orgIdsWithListPermission } },
       { detenteurCompanySirets: { hasSome: orgIdsWithListPermission } }
     ]
@@ -48,9 +47,10 @@ const bsffs: QueryResolvers["bsffs"] = async (
       findManyBsff({
         where,
         ...prismaPaginationArgs,
-        orderBy: { rowNumber: "desc" }
+        orderBy: { rowNumber: "desc" },
+        include: { transporters: true }
       }),
-    formatNode: expandBsffFromDB,
+    formatNode: bsff => expandBsffFromDB(bsff),
     ...gqlPaginationArgs
   });
 };

--- a/back/src/bsffs/sirenify.ts
+++ b/back/src/bsffs/sirenify.ts
@@ -93,14 +93,6 @@ const bsffCreateInputAccessors = (
     }
   },
   {
-    siret: input?.transporterCompanySiret,
-    skip: sealedFields.includes("transporterCompanySiret"),
-    setter: (input: Prisma.BsffCreateInput, companyInput: CompanyInput) => {
-      input.transporterCompanyName = companyInput.name;
-      input.transporterCompanyAddress = companyInput.address;
-    }
-  },
-  {
     siret: input?.destinationCompanySiret,
     skip: sealedFields.includes("destinationCompanySiret"),
     setter: (input: Prisma.BsffCreateInput, companyInput: CompanyInput) => {
@@ -112,4 +104,25 @@ const bsffCreateInputAccessors = (
 
 export const sirenifyBsffCreateInput = nextBuildSirenify(
   bsffCreateInputAccessors
+);
+
+const bsffTransporterCreateInputAccessors = (
+  input: Prisma.BsffTransporterCreateInput,
+  sealedFields: string[] = []
+) => [
+  {
+    siret: input?.transporterCompanySiret,
+    skip: sealedFields.includes("transporterCompanySiret"),
+    setter: (
+      input: Prisma.BsffTransporterCreateInput,
+      companyInput: CompanyInput
+    ) => {
+      input.transporterCompanyName = companyInput.name;
+      input.transporterCompanyAddress = companyInput.address;
+    }
+  }
+];
+
+export const sirenifyBsffTransporterCreateInput = nextBuildSirenify(
+  bsffTransporterCreateInputAccessors
 );

--- a/back/src/bsffs/types.ts
+++ b/back/src/bsffs/types.ts
@@ -1,5 +1,14 @@
 import { Prisma } from "@prisma/client";
 
+export const BsffWithTransportersInclude =
+  Prisma.validator<Prisma.BsffInclude>()({
+    transporters: true
+  });
+
+export type BsffWithTransporters = Prisma.BsffGetPayload<{
+  include: typeof BsffWithTransportersInclude;
+}>;
+
 export const BsffWithPackagingsInclude = Prisma.validator<Prisma.BsffInclude>()(
   {
     packagings: true

--- a/back/src/bsffs/where.ts
+++ b/back/src/bsffs/where.ts
@@ -17,15 +17,23 @@ function toPrismaBsffSimpleWhereInput(where: BsffWhere): Prisma.BsffWhereInput {
     emitterEmissionSignatureDate: toPrismaDateFilter(
       where.emitter?.emission?.signature?.date
     ),
-    transporterCompanySiret: toPrismaStringFilter(
-      where.transporter?.company?.siret
-    ),
-    transporterCompanyVatNumber: toPrismaStringFilter(
-      where.transporter?.company?.vatNumber
-    ),
-    transporterTransportSignatureDate: toPrismaDateFilter(
-      where.transporter?.transport?.signature?.date
-    ),
+    ...(where.transporter
+      ? {
+          transporters: {
+            some: {
+              transporterCompanySiret: toPrismaStringFilter(
+                where.transporter?.company?.siret
+              ),
+              transporterCompanyVatNumber: toPrismaStringFilter(
+                where.transporter?.company?.vatNumber
+              ),
+              transporterTransportSignatureDate: toPrismaDateFilter(
+                where.transporter?.transport?.signature?.date
+              )
+            }
+          }
+        }
+      : {}),
     destinationCompanySiret: toPrismaStringFilter(
       where.destination?.company?.siret
     ),

--- a/back/src/companies/recipify.ts
+++ b/back/src/companies/recipify.ts
@@ -5,10 +5,10 @@ import {
 import { prisma } from "@td/prisma";
 import {
   Bsdasri,
-  Bsff,
   Bsvhu,
   BspaohTransporter,
-  BsdaTransporter
+  BsdaTransporter,
+  BsffTransporter
 } from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 
@@ -111,7 +111,12 @@ export interface BsdTransporterReceiptPart {
 }
 
 export async function getTransporterReceipt(
-  existingBsd: Bsdasri | Bsvhu | BsdaTransporter | Bsff | BspaohTransporter
+  existingBsd:
+    | Bsdasri
+    | Bsvhu
+    | BsdaTransporter
+    | BsffTransporter
+    | BspaohTransporter
 ): Promise<BsdTransporterReceiptPart> {
   // fetch TransporterReceipt
   const orgId = getTransporterCompanyOrgId(existingBsd);

--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -66,7 +66,11 @@ export async function indexBsdJob(
   if (bsdId.startsWith("FF-")) {
     const bsff = await prisma.bsff.findUniqueOrThrow({
       where: { id: bsdId },
-      include: { packagings: true, ficheInterventions: true }
+      include: {
+        packagings: true,
+        ficheInterventions: true,
+        transporters: true
+      }
     });
 
     const elasticBsff = toBsffElastic(bsff);

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -645,8 +645,14 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          detenteurCompanySirets: [detenteur.company.siret!],
-          ficheInterventions: { connect: { id: ficheIntervention.id } }
+          data: {
+            detenteurCompanySirets: [detenteur.company.siret!],
+            ficheInterventions: { connect: { id: ficheIntervention.id } },
+            transporterTransportSignatureDate: new Date()
+          },
+          transporterData: {
+            transporterTransportSignatureDate: new Date()
+          }
         }
       );
 
@@ -1512,9 +1518,14 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          status: BsffStatus.SENT,
-          emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: new Date()
+          data: {
+            status: BsffStatus.SENT,
+            emitterEmissionSignatureDate: new Date(),
+            transporterTransportSignatureDate: new Date()
+          },
+          transporterData: {
+            transporterTransportSignatureDate: new Date()
+          }
         }
       );
       await indexBsff(await getBsffForElastic(bsff));
@@ -1535,9 +1546,14 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          status: BsffStatus.INITIAL,
-          emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: null
+          data: {
+            status: BsffStatus.INITIAL,
+            emitterEmissionSignatureDate: new Date(),
+            transporterTransportSignatureDate: null
+          },
+          transporterData: {
+            transporterTransportSignatureDate: null
+          }
         }
       );
       await indexBsff(await getBsffForElastic(bsff));
@@ -1557,8 +1573,13 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: new Date()
+          data: {
+            emitterEmissionSignatureDate: new Date(),
+            transporterTransportSignatureDate: new Date()
+          },
+          transporterData: {
+            transporterTransportSignatureDate: new Date()
+          }
         }
       );
       await indexBsff(await getBsffForElastic(bsff));
@@ -1574,8 +1595,13 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: new Date()
+          data: {
+            emitterEmissionSignatureDate: new Date(),
+            transporterTransportSignatureDate: new Date()
+          },
+          transporterData: {
+            transporterTransportSignatureDate: new Date()
+          }
         }
       );
       await indexBsff(await getBsffForElastic(bsff));
@@ -1591,9 +1617,14 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destination
         },
         {
-          emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: new Date(),
-          destinationReceptionSignatureDate: new Date()
+          data: {
+            emitterEmissionSignatureDate: new Date(),
+            transporterTransportSignatureDate: new Date(),
+            destinationReceptionSignatureDate: new Date()
+          },
+          transporterData: {
+            transporterTransportSignatureDate: new Date()
+          }
         }
       );
       await indexBsff(await getBsffForElastic(bsff));

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -129,9 +129,11 @@ describe("wastesReader", () => {
           createBsffAfterReception(
             { emitter, transporter, destination },
             {
-              destinationCompanySiret: destination.company.siret,
-              destinationReceptionDate: new Date(),
-              destinationReceptionSignatureDate: new Date()
+              data: {
+                destinationCompanySiret: destination.company.siret,
+                destinationReceptionDate: new Date(),
+                destinationReceptionSignatureDate: new Date()
+              }
             }
           )
         )

--- a/back/src/registry/__tests__/where.dates.integration.ts
+++ b/back/src/registry/__tests__/where.dates.integration.ts
@@ -285,7 +285,7 @@ describe("toElasticFilter", () => {
     expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu2.id, bsvhu3.id]);
   });
 
-  it.each(["createdAt", "transporterTakenOverAt", "destinationReceptionDate"])(
+  it.each(["createdAt", "destinationReceptionDate"])(
     "should filter BSFFs between two %p dates (strict)",
     async date => {
       // convert elastic key to bsff key
@@ -293,33 +293,32 @@ describe("toElasticFilter", () => {
         [P in keyof WasteRegistryWhere]?: keyof Bsff;
       } = {
         createdAt: "createdAt",
-        transporterTakenOverAt: "transporterTransportTakenOverAt",
         destinationReceptionDate: "destinationReceptionDate"
       };
 
       const bsff1 = await createBsff(
         {},
-        { [toBsffKey[date]]: new Date("2021-01-01") }
+        { data: { [toBsffKey[date]]: new Date("2021-01-01") } }
       );
 
       const bsff2 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-02")
+          data: { [toBsffKey[date]]: new Date("2021-01-02") }
         }
       );
 
       const bsff3 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-03")
+          data: { [toBsffKey[date]]: new Date("2021-01-03") }
         }
       );
 
       const bsff4 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-04")
+          data: { [toBsffKey[date]]: new Date("2021-01-04") }
         }
       );
 
@@ -343,44 +342,105 @@ describe("toElasticFilter", () => {
     }
   );
 
-  it("should filter BSFF between two operation dates (strict)", async () => {
+  it("should filter BSFFs between two transporterTakenOverAt dates (strict)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-01"),
-        operationSignatureDate: new Date("2021-01-01"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-01")
+        }
       }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-02"),
-        operationSignatureDate: new Date("2021-01-02"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-02")
+        }
       }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-03"),
-        operationSignatureDate: new Date("2021-01-03"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-03")
+        }
       }
     );
 
     const bsff4 = await createBsff(
       {},
+      {
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-04")
+        }
+      }
+    );
+
+    await Promise.all(
+      [bsff1, bsff2, bsff3, bsff4].map(async bsff => {
+        const bsffForElastic = await getBsffForElastic(bsff);
+        return indexBsff(bsffForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
+        _gt: new Date("2021-01-01"),
+        _lt: new Date("2021-01-04")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsff2.id, bsff3.id]);
+  });
+
+  it("should filter BSFF between two operation dates (strict)", async () => {
+    const bsff1 = await createBsff(
       {},
       {
-        operationDate: new Date("2021-01-04"),
-        operationSignatureDate: new Date("2021-01-04"),
-        operationCode: "R2"
+        packagingData: {
+          operationDate: new Date("2021-01-01"),
+          operationSignatureDate: new Date("2021-01-01"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff2 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-02"),
+          operationSignatureDate: new Date("2021-01-02"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff3 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-03"),
+          operationSignatureDate: new Date("2021-01-03"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff4 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-04"),
+          operationSignatureDate: new Date("2021-01-04"),
+          operationCode: "R2"
+        }
       }
     );
 
@@ -716,7 +776,7 @@ describe("toElasticFilter", () => {
     ]);
   });
 
-  it.each(["createdAt", "transporterTakenOverAt", "destinationReceptionDate"])(
+  it.each(["createdAt", "destinationReceptionDate"])(
     "should filter BSFFs between two %p dates (not strict)",
     async date => {
       // convert elastic key to bsff key
@@ -724,33 +784,32 @@ describe("toElasticFilter", () => {
         [P in keyof WasteRegistryWhere]?: keyof Bsff;
       } = {
         createdAt: "createdAt",
-        transporterTakenOverAt: "transporterTransportTakenOverAt",
         destinationReceptionDate: "destinationReceptionDate"
       };
 
       const bsff1 = await createBsff(
         {},
-        { [toBsffKey[date]]: new Date("2021-01-01") }
+        { data: { [toBsffKey[date]]: new Date("2021-01-01") } }
       );
 
       const bsff2 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-02")
+          data: { [toBsffKey[date]]: new Date("2021-01-02") }
         }
       );
 
       const bsff3 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-03")
+          data: { [toBsffKey[date]]: new Date("2021-01-03") }
         }
       );
 
       const bsff4 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-04")
+          data: { [toBsffKey[date]]: new Date("2021-01-04") }
         }
       );
 
@@ -774,44 +833,105 @@ describe("toElasticFilter", () => {
     }
   );
 
-  it("should filter BSFF between two operation dates (not strict)", async () => {
+  it("should filter BSFFs between two transporterTakenOverAt dates (not strict)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-01"),
-        operationSignatureDate: new Date("2021-01-01"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-01")
+        }
       }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-02"),
-        operationSignatureDate: new Date("2021-01-02"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-02")
+        }
       }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-03"),
-        operationSignatureDate: new Date("2021-01-03"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-03")
+        }
       }
     );
 
     const bsff4 = await createBsff(
       {},
+      {
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-04")
+        }
+      }
+    );
+
+    await Promise.all(
+      [bsff1, bsff2, bsff3, bsff4].map(async bsff => {
+        const bsffForElastic = await getBsffForElastic(bsff);
+        return indexBsff(bsffForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
+        _gte: new Date("2021-01-02"),
+        _lte: new Date("2021-01-04")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsff2.id, bsff3.id, bsff4.id]);
+  });
+
+  it("should filter BSFF between two operation dates (not strict)", async () => {
+    const bsff1 = await createBsff(
       {},
       {
-        operationDate: new Date("2021-01-04"),
-        operationSignatureDate: new Date("2021-01-04"),
-        operationCode: "R2"
+        packagingData: {
+          operationDate: new Date("2021-01-01"),
+          operationSignatureDate: new Date("2021-01-01"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff2 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-02"),
+          operationSignatureDate: new Date("2021-01-02"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff3 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-03"),
+          operationSignatureDate: new Date("2021-01-03"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff4 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-04"),
+          operationSignatureDate: new Date("2021-01-04"),
+          operationCode: "R2"
+        }
       }
     );
 
@@ -1133,7 +1253,7 @@ describe("toElasticFilter", () => {
     expect(bsds.map(bsd => bsd.id)).toEqual([bspaoh2.id]);
   });
 
-  it.each(["createdAt", "transporterTakenOverAt", "destinationReceptionDate"])(
+  it.each(["createdAt", "destinationReceptionDate"])(
     "should filter BSFFs on %p (exact date)",
     async date => {
       // convert elastic key to bsff key
@@ -1141,33 +1261,32 @@ describe("toElasticFilter", () => {
         [P in keyof WasteRegistryWhere]?: keyof Bsff;
       } = {
         createdAt: "createdAt",
-        transporterTakenOverAt: "transporterTransportTakenOverAt",
         destinationReceptionDate: "destinationReceptionDate"
       };
 
       const bsff1 = await createBsff(
         {},
-        { [toBsffKey[date]]: new Date("2021-01-01") }
+        { data: { [toBsffKey[date]]: new Date("2021-01-01") } }
       );
 
       const bsff2 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-02")
+          data: { [toBsffKey[date]]: new Date("2021-01-02") }
         }
       );
 
       const bsff3 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-03")
+          data: { [toBsffKey[date]]: new Date("2021-01-03") }
         }
       );
 
       const bsff4 = await createBsff(
         {},
         {
-          [toBsffKey[date]]: new Date("2021-01-04")
+          data: { [toBsffKey[date]]: new Date("2021-01-04") }
         }
       );
 
@@ -1190,44 +1309,104 @@ describe("toElasticFilter", () => {
     }
   );
 
-  it("should filter BSFF between two operation dates (exact date)", async () => {
+  it("should filter BSFFs between two transporterTakenOverAt dates (exact dates)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-01"),
-        operationSignatureDate: new Date("2021-01-01"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-01")
+        }
       }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-02"),
-        operationSignatureDate: new Date("2021-01-02"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-02")
+        }
       }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
       {
-        operationDate: new Date("2021-01-03"),
-        operationSignatureDate: new Date("2021-01-03"),
-        operationCode: "R2"
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-03")
+        }
       }
     );
 
     const bsff4 = await createBsff(
       {},
+      {
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-01-04")
+        }
+      }
+    );
+
+    await Promise.all(
+      [bsff1, bsff2, bsff3, bsff4].map(async bsff => {
+        const bsffForElastic = await getBsffForElastic(bsff);
+        return indexBsff(bsffForElastic);
+      })
+    );
+    await refreshElasticSearch();
+
+    const where: WasteRegistryWhere = {
+      transporterTakenOverAt: {
+        _eq: new Date("2021-01-02")
+      }
+    };
+
+    const bsds = await searchBsds(where);
+
+    expect(bsds.map(bsd => bsd.id)).toEqual([bsff2.id]);
+  });
+
+  it("should filter BSFF between two operation dates (exact date)", async () => {
+    const bsff1 = await createBsff(
       {},
       {
-        operationDate: new Date("2021-01-04"),
-        operationSignatureDate: new Date("2021-01-04"),
-        operationCode: "R2"
+        packagingData: {
+          operationDate: new Date("2021-01-01"),
+          operationSignatureDate: new Date("2021-01-01"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff2 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-02"),
+          operationSignatureDate: new Date("2021-01-02"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff3 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-03"),
+          operationSignatureDate: new Date("2021-01-03"),
+          operationCode: "R2"
+        }
+      }
+    );
+
+    const bsff4 = await createBsff(
+      {},
+      {
+        packagingData: {
+          operationDate: new Date("2021-01-04"),
+          operationSignatureDate: new Date("2021-01-04"),
+          operationCode: "R2"
+        }
       }
     );
 

--- a/back/src/registry/__tests__/where.destination.integration.ts
+++ b/back/src/registry/__tests__/where.destination.integration.ts
@@ -157,16 +157,16 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on destinationCompanySiret (exact)", async () => {
     const testInput = { destinationCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput);
+    const bsff1 = await createBsff({}, { data: testInput });
 
     const bsff2 = await createBsff(
       {},
-      { destinationCompanySiret: siretify(2) }
+      { data: { destinationCompanySiret: siretify(2) } }
     );
 
     const bsff3 = await createBsff(
       {},
-      { destinationCompanySiret: siretify(3) }
+      { data: { destinationCompanySiret: siretify(3) } }
     );
 
     await Promise.all(
@@ -386,14 +386,14 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a list of destinationCompanySiret", async () => {
     const testInput_1 = { destinationCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_1);
+    const bsff1 = await createBsff({}, { data: testInput_1 });
 
     const testInput = { destinationCompanySiret: siretify(2) };
-    const bsff2 = await createBsff({}, testInput);
+    const bsff2 = await createBsff({}, { data: testInput });
 
     const bsff3 = await createBsff(
       {},
-      { destinationCompanySiret: siretify(3) }
+      { data: { destinationCompanySiret: siretify(3) } }
     );
 
     await Promise.all(
@@ -561,16 +561,16 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a substring of destinationCompanySiret", async () => {
     const testInput_1 = { destinationCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_1);
+    const bsff1 = await createBsff({}, { data: testInput_1 });
 
     const bsff2 = await createBsff(
       {},
-      { destinationCompanySiret: siretify(2) }
+      { data: { destinationCompanySiret: siretify(2) } }
     );
 
     const bsff3 = await createBsff(
       {},
-      { destinationCompanySiret: siretify(3) }
+      { data: { destinationCompanySiret: siretify(3) } }
     );
 
     await Promise.all(

--- a/back/src/registry/__tests__/where.emitter.integration.ts
+++ b/back/src/registry/__tests__/where.emitter.integration.ts
@@ -196,11 +196,17 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on emitterCompanySiret (exact)", async () => {
     const testInput_3 = { emitterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_3);
+    const bsff1 = await createBsff({}, { data: testInput_3 });
 
-    const bsff2 = await createBsff({}, { emitterCompanySiret: siretify(2) });
+    const bsff2 = await createBsff(
+      {},
+      { data: { emitterCompanySiret: siretify(2) } }
+    );
 
-    const bsff3 = await createBsff({}, { emitterCompanySiret: siretify(3) });
+    const bsff3 = await createBsff(
+      {},
+      { data: { emitterCompanySiret: siretify(3) } }
+    );
 
     await Promise.all(
       [bsff1, bsff2, bsff3].map(async bsff => {
@@ -379,12 +385,15 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a list of emitterCompanySiret", async () => {
     const testInput = { emitterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput);
+    const bsff1 = await createBsff({}, { data: testInput });
 
     const testInput_1 = { emitterCompanySiret: siretify(2) };
-    const bsff2 = await createBsff({}, testInput_1);
+    const bsff2 = await createBsff({}, { data: testInput_1 });
 
-    const bsff3 = await createBsff({}, { emitterCompanySiret: siretify(3) });
+    const bsff3 = await createBsff(
+      {},
+      { data: { emitterCompanySiret: siretify(3) } }
+    );
 
     await Promise.all(
       [bsff1, bsff2, bsff3].map(async bsff => {
@@ -553,11 +562,17 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a substring of emitterCompanySiret", async () => {
     const testInput = { emitterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput);
+    const bsff1 = await createBsff({}, { data: testInput });
 
-    const bsff2 = await createBsff({}, { emitterCompanySiret: siretify(2) });
+    const bsff2 = await createBsff(
+      {},
+      { data: { emitterCompanySiret: siretify(2) } }
+    );
 
-    const bsff3 = await createBsff({}, { emitterCompanySiret: siretify(3) });
+    const bsff3 = await createBsff(
+      {},
+      { data: { emitterCompanySiret: siretify(3) } }
+    );
 
     await Promise.all(
       [bsff1, bsff2, bsff3].map(async bsff => {

--- a/back/src/registry/__tests__/where.transporter.integration.ts
+++ b/back/src/registry/__tests__/where.transporter.integration.ts
@@ -221,16 +221,16 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on transporterCompanySiret (exact)", async () => {
     const testInput_1 = { transporterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_1);
+    const bsff1 = await createBsff({}, { transporterData: testInput_1 });
 
     const bsff2 = await createBsff(
       {},
-      { transporterCompanySiret: siretify(2) }
+      { transporterData: { transporterCompanySiret: siretify(2) } }
     );
 
     const bsff3 = await createBsff(
       {},
-      { transporterCompanySiret: siretify(3) }
+      { transporterData: { transporterCompanySiret: siretify(3) } }
     );
 
     await Promise.all(
@@ -443,14 +443,14 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a list of transporterCompanySiret", async () => {
     const testInput_1 = { transporterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_1);
+    const bsff1 = await createBsff({}, { transporterData: testInput_1 });
 
     const testInput = { transporterCompanySiret: siretify(2) };
-    const bsff2 = await createBsff({}, testInput);
+    const bsff2 = await createBsff({}, { transporterData: testInput });
 
     const bsff3 = await createBsff(
       {},
-      { transporterCompanySiret: siretify(3) }
+      { transporterData: { transporterCompanySiret: siretify(3) } }
     );
 
     await Promise.all(
@@ -652,16 +652,16 @@ describe("toElasticFilter", () => {
   });
   it("should filter BSFFs on a substring of transporterCompanySiret", async () => {
     const testInput_1 = { transporterCompanySiret: siretify(1) };
-    const bsff1 = await createBsff({}, testInput_1);
+    const bsff1 = await createBsff({}, { transporterData: testInput_1 });
 
     const bsff2 = await createBsff(
       {},
-      { transporterCompanySiret: siretify(2) }
+      { transporterData: { transporterCompanySiret: siretify(2) } }
     );
 
     const bsff3 = await createBsff(
       {},
-      { transporterCompanySiret: siretify(3) }
+      { transporterData: { transporterCompanySiret: siretify(3) } }
     );
 
     await Promise.all(

--- a/back/src/registry/__tests__/where.weight.integration.ts
+++ b/back/src/registry/__tests__/where.weight.integration.ts
@@ -220,26 +220,42 @@ describe("toElasticFilter", () => {
   it("should filter BSFFs between two reception weights (strict)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 1, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 1,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 2, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 2,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 3, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 3,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff4 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 4, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 4,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     await Promise.all(
@@ -450,26 +466,42 @@ describe("toElasticFilter", () => {
   it("should filter BSFFs between two reception weights (not strict)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 1, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 1,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 2, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 2,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 3, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 3,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff4 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 4, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 4,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     await Promise.all(
@@ -673,26 +705,42 @@ describe("toElasticFilter", () => {
   it("should filter BSFFs on reception weight (exact)", async () => {
     const bsff1 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 1, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 1,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff2 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 2, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 2,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff3 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 3, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 3,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     const bsff4 = await createBsff(
       {},
-      {},
-      { acceptationWeight: 4, acceptationSignatureDate: new Date() }
+      {
+        packagingData: {
+          acceptationWeight: 4,
+          acceptationSignatureDate: new Date()
+        }
+      }
     );
 
     await Promise.all(

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -116,7 +116,8 @@ export type RegistryBspaoh = Prisma.BspaohGetPayload<{
   include: typeof RegistryBspaohInclude;
 }>;
 
-export const RegistryBsffInclude = {
+export const RegistryBsffInclude = Prisma.validator<Prisma.BsffInclude>()({
+  transporters: true,
   packagings: {
     include: {
       finalOperations: true,
@@ -125,7 +126,7 @@ export const RegistryBsffInclude = {
       }
     }
   }
-};
+});
 
 export type RegistryBsff = Prisma.BsffGetPayload<{
   include: typeof RegistryBsffInclude;

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -168,17 +168,22 @@ describe("All wastes registry", () => {
         destination
       },
       {
-        wasteCode: "14 06 01*",
-        createdAt: new Date("2021-08-01"),
-        transporterTransportTakenOverAt: new Date("2021-08-02"),
-        transporterTransportSignatureDate: new Date("2021-08-02"),
-        destinationReceptionDate: new Date("2021-08-03")
-      },
-      {
-        acceptationWeight: 200,
-        acceptationDate: new Date("2021-08-03"),
-        operationSignatureDate: new Date("2021-08-04"),
-        operationCode: "R2"
+        data: {
+          wasteCode: "14 06 01*",
+          createdAt: new Date("2021-08-01"),
+          transporterTransportSignatureDate: new Date("2021-08-02"),
+          destinationReceptionDate: new Date("2021-08-03")
+        },
+        packagingData: {
+          acceptationWeight: 200,
+          acceptationDate: new Date("2021-08-03"),
+          operationSignatureDate: new Date("2021-08-04"),
+          operationCode: "R2"
+        },
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-08-02"),
+          transporterTransportSignatureDate: new Date("2021-08-02")
+        }
       }
     );
     bsd6 = await bspaohFactory({

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -175,18 +175,22 @@ describe("Incoming wastes registry", () => {
         destination
       },
       {
-        wasteCode: "14 06 01*",
-        createdAt: new Date("2021-08-01"),
-        emitterEmissionSignatureDate: new Date("2021-08-01"),
-        transporterTransportSignatureDate: new Date("2021-08-01"),
-        transporterTransportTakenOverAt: new Date("2021-08-01"),
-        destinationReceptionDate: new Date("2021-08-01")
-      },
-      {
-        acceptationWeight: 200,
-        acceptationDate: new Date("2021-08-01"),
-        operationCode: "R2",
-        operationSignatureDate: new Date("2021-08-01")
+        data: {
+          wasteCode: "14 06 01*",
+          createdAt: new Date("2021-08-01"),
+          emitterEmissionSignatureDate: new Date("2021-08-01"),
+          transporterTransportSignatureDate: new Date("2021-08-01"),
+          destinationReceptionDate: new Date("2021-08-01")
+        },
+        packagingData: {
+          acceptationWeight: 200,
+          acceptationDate: new Date("2021-08-01"),
+          operationCode: "R2",
+          operationSignatureDate: new Date("2021-08-01")
+        },
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-08-01")
+        }
       }
     );
     bsd6 = await bspaohFactory({

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -167,18 +167,21 @@ describe("Outgoing wastes registry", () => {
         destination
       },
       {
-        wasteCode: "14 06 01*",
-
-        createdAt: new Date("2021-08-01"),
-        emitterEmissionSignatureDate: new Date("2021-08-01"),
-        transporterTransportSignatureDate: new Date("2021-08-01"),
-        transporterTransportTakenOverAt: new Date("2021-08-01"),
-        destinationReceptionDate: new Date("2021-08-01")
-      },
-      {
-        acceptationWeight: 200,
-        operationCode: "R2",
-        operationSignatureDate: new Date("2021-08-01")
+        data: {
+          wasteCode: "14 06 01*",
+          createdAt: new Date("2021-08-01"),
+          emitterEmissionSignatureDate: new Date("2021-08-01"),
+          transporterTransportSignatureDate: new Date("2021-08-01"),
+          destinationReceptionDate: new Date("2021-08-01")
+        },
+        packagingData: {
+          acceptationWeight: 200,
+          operationCode: "R2",
+          operationSignatureDate: new Date("2021-08-01")
+        },
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-08-01")
+        }
       }
     );
     bsd6 = await bspaohFactory({

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -166,17 +166,21 @@ describe("Transported wastes registry", () => {
         destination
       },
       {
-        wasteCode: "14 06 01*",
-        createdAt: new Date("2021-08-01"),
-        emitterEmissionSignatureDate: new Date("2021-08-01"),
-        transporterTransportSignatureDate: new Date("2021-08-01"),
-        transporterTransportTakenOverAt: new Date("2021-08-01"),
-        destinationReceptionDate: new Date("2021-08-01")
-      },
-      {
-        acceptationWeight: 200,
-        operationSignatureDate: new Date("2021-08-01"),
-        operationCode: "R2"
+        data: {
+          wasteCode: "14 06 01*",
+          createdAt: new Date("2021-08-01"),
+          emitterEmissionSignatureDate: new Date("2021-08-01"),
+          transporterTransportSignatureDate: new Date("2021-08-01"),
+          destinationReceptionDate: new Date("2021-08-01")
+        },
+        packagingData: {
+          acceptationWeight: 200,
+          operationSignatureDate: new Date("2021-08-01"),
+          operationCode: "R2"
+        },
+        transporterData: {
+          transporterTransportTakenOverAt: new Date("2021-08-01")
+        }
       }
     );
 

--- a/e2e/src/data/bsff.ts
+++ b/e2e/src/data/bsff.ts
@@ -33,9 +33,14 @@ const optToBsffCreateInput = (opt: BsffOpt): Prisma.BsffCreateInput => {
     destinationCompanyName: opt.destination?.name,
     emitterCompanyName: opt.emitter?.name,
     emitterCompanySiret: opt.emitter?.siret,
-    transporterCompanySiret: opt.transporter?.siret,
-    transporterCompanyName: opt.transporter?.name,
     detenteurCompanySirets: opt.detenteur ? [opt.detenteur.siret!] : [],
+    transporters: {
+      create: {
+        number: 1,
+        transporterCompanySiret: opt.transporter?.siret,
+        transporterCompanyName: opt.transporter?.name
+      }
+    },
     ...(opt.packagings
       ? {
           packagings: {

--- a/libs/back/prisma/src/migrations/20240515125054_migrate_bsff_transporter/migration.sql
+++ b/libs/back/prisma/src/migrations/20240515125054_migrate_bsff_transporter/migration.sql
@@ -19,6 +19,31 @@
  - You are about to drop the column `transporterTransportTakenOverAt` on the `Bsff` table. All the data in the column will be lost.
  
  */
+ALTER TABLE
+  "Bsff"
+ADD
+  COLUMN "transportersOrgIds" TEXT [] DEFAULT ARRAY [] :: TEXT [];
+
+UPDATE
+  "Bsff"
+SET
+  "transportersOrgIds" = ARRAY_REMOVE(
+    ARRAY_REMOVE (
+      ARRAY ["transporterCompanySiret", "transporterCompanyVatNumber"],
+      NULL
+    ),
+    ''
+  )
+WHERE
+  (
+    "transporterCompanySiret" IS NOT NULL
+    OR "transporterCompanySiret" <> ''
+  )
+  OR (
+    "transporterCompanyVatNumber" IS NOT NULL
+    OR "transporterCompanyVatNumber" <> ''
+  );
+
 -- DropIndex
 DROP INDEX IF EXISTS "_BsffTransporterCompanySiretIdx";
 

--- a/libs/back/prisma/src/migrations/20240515125054_migrate_bsff_transporter/migration.sql
+++ b/libs/back/prisma/src/migrations/20240515125054_migrate_bsff_transporter/migration.sql
@@ -1,0 +1,139 @@
+/*
+ Warnings:
+ 
+ - You are about to drop the column `transporterCompanyAddress` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanyContact` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanyMail` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanyName` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanyPhone` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanySiret` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCompanyVatNumber` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterCustomInfo` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterRecepisseDepartment` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterRecepisseIsExempted` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterRecepisseNumber` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterRecepisseValidityLimit` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterTransportMode` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterTransportPlates` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterTransportSignatureAuthor` on the `Bsff` table. All the data in the column will be lost.
+ - You are about to drop the column `transporterTransportTakenOverAt` on the `Bsff` table. All the data in the column will be lost.
+ 
+ */
+-- DropIndex
+DROP INDEX IF EXISTS "_BsffTransporterCompanySiretIdx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "_BsffTransporterCompanyVatNumberIdx";
+
+-- CreateTable
+CREATE TABLE "BsffTransporter" (
+  "id" TEXT NOT NULL,
+  "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+  "number" INTEGER NOT NULL,
+  "bsffId" TEXT,
+  "transporterCompanySiret" TEXT,
+  "transporterCompanyName" TEXT,
+  "transporterCompanyVatNumber" TEXT,
+  "transporterCompanyAddress" TEXT,
+  "transporterCompanyContact" TEXT,
+  "transporterCompanyPhone" TEXT,
+  "transporterCompanyMail" TEXT,
+  "transporterCustomInfo" TEXT,
+  "transporterRecepisseIsExempted" BOOLEAN,
+  "transporterRecepisseNumber" TEXT,
+  "transporterRecepisseDepartment" TEXT,
+  "transporterRecepisseValidityLimit" TIMESTAMPTZ(6),
+  "transporterTransportMode" "TransportMode" DEFAULT 'ROAD',
+  "transporterTransportPlates" TEXT [],
+  "transporterTransportTakenOverAt" TIMESTAMPTZ(6),
+  "transporterTransportSignatureAuthor" TEXT,
+  "transporterTransportSignatureDate" TIMESTAMPTZ(6),
+  CONSTRAINT "BsffTransporter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_BsffTransporterBsffIdIdx" ON "BsffTransporter"("bsffId");
+
+-- CreateIndex
+CREATE INDEX "_BsffTransporterCompanySiretIdx" ON "BsffTransporter"("transporterCompanySiret");
+
+-- CreateIndex
+CREATE INDEX "_BsffTransporterCompanyVatNumberIdx" ON "BsffTransporter"("transporterCompanyVatNumber");
+
+-- AddForeignKey
+ALTER TABLE
+  "BsffTransporter"
+ADD
+  CONSTRAINT "BsffTransporter_bsffId_fkey" FOREIGN KEY ("bsffId") REFERENCES "Bsff"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Migrate first transporter from Bsff table to BsffTransporter table
+INSERT INTO
+  "default$default"."BsffTransporter" (
+    "id",
+    "createdAt",
+    "updatedAt",
+    "number",
+    "bsffId",
+    "transporterCompanySiret",
+    "transporterCompanyName",
+    "transporterCompanyVatNumber",
+    "transporterCompanyAddress",
+    "transporterCompanyContact",
+    "transporterCompanyPhone",
+    "transporterCompanyMail",
+    "transporterCustomInfo",
+    "transporterRecepisseIsExempted",
+    "transporterRecepisseNumber",
+    "transporterRecepisseDepartment",
+    "transporterRecepisseValidityLimit",
+    "transporterTransportMode",
+    "transporterTransportPlates",
+    "transporterTransportTakenOverAt",
+    "transporterTransportSignatureAuthor",
+    "transporterTransportSignatureDate"
+  )
+SELECT
+  "id",
+  "createdAt",
+  "updatedAt",
+  1,
+  "id",
+  "transporterCompanySiret",
+  "transporterCompanyName",
+  "transporterCompanyVatNumber",
+  "transporterCompanyAddress",
+  "transporterCompanyContact",
+  "transporterCompanyPhone",
+  "transporterCompanyMail",
+  "transporterCustomInfo",
+  "transporterRecepisseIsExempted",
+  "transporterRecepisseNumber",
+  "transporterRecepisseDepartment",
+  "transporterRecepisseValidityLimit",
+  "transporterTransportMode",
+  "transporterTransportPlates",
+  "transporterTransportTakenOverAt",
+  "transporterTransportSignatureAuthor",
+  "transporterTransportSignatureDate"
+FROM
+  "default$default"."Bsff";
+
+-- AlterTable
+ALTER TABLE
+  "Bsff" DROP COLUMN "transporterCompanyAddress",
+  DROP COLUMN "transporterCompanyContact",
+  DROP COLUMN "transporterCompanyMail",
+  DROP COLUMN "transporterCompanyName",
+  DROP COLUMN "transporterCompanyPhone",
+  DROP COLUMN "transporterCompanySiret",
+  DROP COLUMN "transporterCompanyVatNumber",
+  DROP COLUMN "transporterCustomInfo",
+  DROP COLUMN "transporterRecepisseDepartment",
+  DROP COLUMN "transporterRecepisseIsExempted",
+  DROP COLUMN "transporterRecepisseNumber",
+  DROP COLUMN "transporterRecepisseValidityLimit",
+  DROP COLUMN "transporterTransportMode",
+  DROP COLUMN "transporterTransportPlates",
+  DROP COLUMN "transporterTransportSignatureAuthor",
+  DROP COLUMN "transporterTransportTakenOverAt";

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1193,11 +1193,14 @@ model Bsff {
   destinationReceptionSignatureDate   DateTime? @db.Timestamptz(6)
   destinationPlannedOperationCode     String?
 
+  ficheInterventions BsffFicheIntervention[] @relation("BsffToBsffFicheIntervention")
+  packagings         BsffPackaging[]
+  transporters       BsffTransporter[]
+
   // Denormalized detenteur sirets to speed up query `bsffs`
-  detenteurCompanySirets String[]                @default([])
-  ficheInterventions     BsffFicheIntervention[] @relation("BsffToBsffFicheIntervention")
-  packagings             BsffPackaging[]
-  transporters           BsffTransporter[]
+  detenteurCompanySirets String[] @default([])
+  // Denormalized transporter sirets to speed up query `bsffs`
+  transportersOrgIds     String[] @default([])
 
   // partial _BsffIsDeletedIdx, _BsffIsDraftIdx index see migration82_missing_indices.sql
   @@index([emitterCompanySiret], map: "_BsffEmitterCompanySiretIdx")

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -817,30 +817,30 @@ model BsddTransporter {
 }
 
 model User {
-  id                      String                    @id @default(cuid()) @db.VarChar(30)
-  email                   String                    @unique(map: "User.email_unique")
-  password                String
-  passwordVersion         Int?
-  name                    String
-  phone                   String?
-  createdAt               DateTime                  @default(now()) @db.Timestamptz(6)
-  updatedAt               DateTime                  @updatedAt @db.Timestamptz(6)
-  activatedAt             DateTime?                 @db.Timestamptz(6)
-  firstAssociationDate    DateTime?                 @db.Timestamptz(6)
-  isActive                Boolean?                  @default(false)
-  isAdmin                 Boolean                   @default(false)
+  id                    String                  @id @default(cuid()) @db.VarChar(30)
+  email                 String                  @unique(map: "User.email_unique")
+  password              String
+  passwordVersion       Int?
+  name                  String
+  phone                 String?
+  createdAt             DateTime                @default(now()) @db.Timestamptz(6)
+  updatedAt             DateTime                @updatedAt @db.Timestamptz(6)
+  activatedAt           DateTime?               @db.Timestamptz(6)
+  firstAssociationDate  DateTime?               @db.Timestamptz(6)
+  isActive              Boolean?                @default(false)
+  isAdmin               Boolean                 @default(false)
   // TODO champ à supprimer suite à la création des comptes gouvernementaux
-  isRegistreNational      Boolean                   @default(false)
-  governmentAccountId     String?                   @unique
-  governmentAccount       GovernmentAccount?        @relation(fields: [governmentAccountId], references: [id])
-  AccessToken             AccessToken[]
-  applications            Application[]
-  companyAssociations     CompanyAssociation[]
-  featureFlags            FeatureFlag[]
-  Grant                   Grant[]
-  MembershipRequest       MembershipRequest[]
-  StatusLog               StatusLog[]
-  UserResetPasswordHash   UserResetPasswordHash[]
+  isRegistreNational    Boolean                 @default(false)
+  governmentAccountId   String?                 @unique
+  governmentAccount     GovernmentAccount?      @relation(fields: [governmentAccountId], references: [id])
+  AccessToken           AccessToken[]
+  applications          Application[]
+  companyAssociations   CompanyAssociation[]
+  featureFlags          FeatureFlag[]
+  Grant                 Grant[]
+  MembershipRequest     MembershipRequest[]
+  StatusLog             StatusLog[]
+  UserResetPasswordHash UserResetPasswordHash[]
 
   bsdasriEmissionSignatures  Bsdasri[]            @relation("BsdasriEmissionSignature")
   bsdasriTransportSignatures Bsdasri[]            @relation("BsdasriTransportSignature")
@@ -1160,37 +1160,26 @@ model Bsff {
   type      BsffType   @default(TRACER_FLUIDE)
   isDeleted Boolean    @default(false)
 
-  emitterCompanyName                  String?
-  emitterCompanySiret                 String?
-  emitterCompanyAddress               String?
-  emitterCompanyContact               String?
-  emitterCompanyPhone                 String?
-  emitterCompanyMail                  String?
-  emitterCustomInfo                   String?
-  emitterEmissionSignatureAuthor      String?
-  emitterEmissionSignatureDate        DateTime?      @db.Timestamptz(6)
-  wasteCode                           String?
-  wasteAdr                            String?
-  weightValue                         Decimal?       @db.Decimal(65, 30)
-  weightIsEstimate                    Boolean?
-  wasteDescription                    String?
-  transporterCompanyName              String?
-  transporterCompanySiret             String?
-  transporterCompanyAddress           String?
-  transporterCompanyContact           String?
-  transporterCompanyPhone             String?
-  transporterCompanyMail              String?
-  transporterCompanyVatNumber         String?
-  transporterCustomInfo               String?
-  transporterTransportTakenOverAt     DateTime?      @db.Timestamptz(6)
-  transporterTransportPlates          String[]
-  transporterRecepisseIsExempted      Boolean?
-  transporterRecepisseNumber          String?
-  transporterRecepisseDepartment      String?
-  transporterRecepisseValidityLimit   DateTime?      @db.Timestamptz(6)
-  transporterTransportMode            TransportMode? @default(ROAD)
-  transporterTransportSignatureAuthor String?
-  transporterTransportSignatureDate   DateTime?      @db.Timestamptz(6)
+  emitterCompanyName             String?
+  emitterCompanySiret            String?
+  emitterCompanyAddress          String?
+  emitterCompanyContact          String?
+  emitterCompanyPhone            String?
+  emitterCompanyMail             String?
+  emitterCustomInfo              String?
+  emitterEmissionSignatureAuthor String?
+  emitterEmissionSignatureDate   DateTime? @db.Timestamptz(6)
+  wasteCode                      String?
+  wasteAdr                       String?
+  weightValue                    Decimal?  @db.Decimal(65, 30)
+  weightIsEstimate               Boolean?
+  wasteDescription               String?
+
+  // Date de signature du premier transporteur 
+  // Cette valeur est dupliquée entre le modèle Bsff et BsffTransporter[0]
+  // pour optimiser certains calculs
+  transporterTransportSignatureDate DateTime? @db.Timestamptz(6)
+
   destinationCompanyName              String?
   destinationCompanySiret             String?
   destinationCompanyAddress           String?
@@ -1199,20 +1188,19 @@ model Bsff {
   destinationCompanyMail              String?
   destinationCustomInfo               String?
   destinationCap                      String?
-  destinationReceptionDate            DateTime?      @db.Timestamptz(6)
+  destinationReceptionDate            DateTime? @db.Timestamptz(6)
   destinationReceptionSignatureAuthor String?
-  destinationReceptionSignatureDate   DateTime?      @db.Timestamptz(6)
+  destinationReceptionSignatureDate   DateTime? @db.Timestamptz(6)
   destinationPlannedOperationCode     String?
 
   // Denormalized detenteur sirets to speed up query `bsffs`
   detenteurCompanySirets String[]                @default([])
   ficheInterventions     BsffFicheIntervention[] @relation("BsffToBsffFicheIntervention")
   packagings             BsffPackaging[]
+  transporters           BsffTransporter[]
 
   // partial _BsffIsDeletedIdx, _BsffIsDraftIdx index see migration82_missing_indices.sql
   @@index([emitterCompanySiret], map: "_BsffEmitterCompanySiretIdx")
-  @@index([transporterCompanySiret], map: "_BsffTransporterCompanySiretIdx")
-  @@index([transporterCompanyVatNumber], map: "_BsffTransporterCompanyVatNumberIdx")
   @@index([destinationCompanySiret], map: "_BsffDestinationCompanySiretIdx")
   @@index([status], map: "_BsffStatusIdx")
   @@index([updatedAt], map: "_BsffUpdatedAtIdx")
@@ -1220,6 +1208,37 @@ model Bsff {
   @@index([emitterEmissionSignatureDate], map: "_BsffEmitterEmissionSignatureDateIdx")
   @@index([transporterTransportSignatureDate], map: "_BsffTransporterTransportSignatureDateIdx")
   @@index([detenteurCompanySirets], map: "_BsffDetenteurSiretsIdx", type: Gin)
+}
+
+model BsffTransporter {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @db.Timestamptz(6)
+  number    Int
+  bsff      Bsff?    @relation(fields: [bsffId], references: [id], onDelete: Cascade)
+  bsffId    String?
+
+  transporterCompanySiret             String?
+  transporterCompanyName              String?
+  transporterCompanyVatNumber         String?
+  transporterCompanyAddress           String?
+  transporterCompanyContact           String?
+  transporterCompanyPhone             String?
+  transporterCompanyMail              String?
+  transporterCustomInfo               String?
+  transporterRecepisseIsExempted      Boolean?
+  transporterRecepisseNumber          String?
+  transporterRecepisseDepartment      String?
+  transporterRecepisseValidityLimit   DateTime?      @db.Timestamptz(6)
+  transporterTransportMode            TransportMode? @default(ROAD)
+  transporterTransportPlates          String[]
+  transporterTransportTakenOverAt     DateTime?      @db.Timestamptz(6)
+  transporterTransportSignatureAuthor String?
+  transporterTransportSignatureDate   DateTime?      @db.Timestamptz(6)
+
+  @@index([bsffId], map: "_BsffTransporterBsffIdIdx")
+  @@index([transporterCompanySiret], map: "_BsffTransporterCompanySiretIdx")
+  @@index([transporterCompanyVatNumber], map: "_BsffTransporterCompanyVatNumberIdx")
 }
 
 model BsffPackagingFinalOperation {
@@ -1637,14 +1656,14 @@ model Bspaoh {
 
   transporterTransportTakenOverAt DateTime? @db.Timestamptz(6)
 
-  destinationCompanyName                         String?
-  destinationCompanySiret                        String?
-  destinationCompanyAddress                      String?
-  destinationCompanyContact                      String?
-  destinationCompanyPhone                        String?
-  destinationCompanyMail                         String?
-  destinationCustomInfo                          String?
-  destinationCap                                 String?
+  destinationCompanyName    String?
+  destinationCompanySiret   String?
+  destinationCompanyAddress String?
+  destinationCompanyContact String?
+  destinationCompanyPhone   String?
+  destinationCompanyMail    String?
+  destinationCustomInfo     String?
+  destinationCap            String?
 
   handedOverToDestinationSignatureDate           DateTime?               @db.Timestamptz(6)
   handedOverToDestinationSignatureAuthor         String?


### PR DESCRIPTION
Migration des données transporteur BSFF dans une table à part en gardant le même fonctionnement côté API. C'est une étape préalable à l'implémentation du multi-modal sur le BSFF.

Beaucoup de fichiers modifiés mais l'essentiel des modifications sont les suivantes :

- Modification du schéma prisma avec création d'un nouveau modèle `BsffTransporter`.
- Ajout du champ dénormalisé `transporterOrgIds` qui est utilisé dans la query `bsffs` notamment pour booster les perfs. On s'assure que `transporterOrgIds` est bien initialisé et que sa valeur est bien mise à jour dans les fonctions `create` et `update` du repository. 
- Ajout d'une migration permettant de copier les données de la table `Bsff` vers la table `BsffTransporter`.
 - Modification des includes dans les appels à prisma pour aller chercher la liste des transporteurs lorsqu'on en a besoin.
 - Refacto des factories utilisées dans les tests pour pouvoir plus facilement modifier les données du premier transporteur (ce qui explique le diff important)

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB

---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-12093)
