### PR TITLE
[TRA-7432] Révisions dasris

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajouter des profils et sous-types de profils (TTR et Installation de traitement) FRONT - T1 [PR 3350](https://github.com/MTES-MCT/trackdechets/pull/3350).
 - Mise à niveau au DSFR de la partie "Membres" des établissements [PR 3345](https://github.com/MTES-MCT/trackdechets/pull/3345)
 - Mise à niveau au DSFR de la partie "Signature" des établissements [PR 3354](https://github.com/MTES-MCT/trackdechets/pull/3354)
+- Permettre la révision d'un DASRI initial[PR 3341](https://github.com/MTES-MCT/trackdechets/pull/3341).
 
 #### :bug: Corrections de bugs
 

--- a/apps/cron/src/commands/__tests__/sendmails.integration.ts
+++ b/apps/cron/src/commands/__tests__/sendmails.integration.ts
@@ -18,10 +18,9 @@ import {
   sendPendingMembershipRequestDetailsEmail,
   sendPendingMembershipRequestToAdminDetailsEmail,
   sendPendingRevisionRequestToAdminDetailsEmail,
-  sendSecondOnboardingEmail,
-  xDaysAgo
+  sendSecondOnboardingEmail
 } from "../onboarding.helpers";
-
+import { xDaysAgo } from "../helpers";
 // Intercept calls
 // Simulate queue error in order to test with sendMailSync
 jest.mock("back");
@@ -444,9 +443,9 @@ describe("sendPendingRevisionRequestToAdminDetailsEmail", () => {
     // BSDA
     const bsda = await bsdaFactory({
       opt: {
-        emitterCompanySiret: company2.siret,
-        transporterCompanySiret: companyOfSomeoneElse2.siret
-      }
+        emitterCompanySiret: company2.siret
+      },
+      transporterOpt: { transporterCompanySiret: companyOfSomeoneElse2.siret }
     });
 
     await prisma.bsdaRevisionRequest.create({

--- a/back/src/activity-events/bsdasri/__tests__/bsdasri.integration.ts
+++ b/back/src/activity-events/bsdasri/__tests__/bsdasri.integration.ts
@@ -1,0 +1,350 @@
+import {
+  BsdasriRevisionRequestApplied,
+  getBsdasriFromActivityEvents
+} from "..";
+import { resetDatabase } from "../../../../integration-tests/helper";
+import { bsdasriFactory } from "../../../bsdasris/__tests__/factories";
+import {
+  Mutation,
+  MutationCreateBsdasriArgs,
+  MutationSignBsdasriArgs,
+  MutationSubmitBsdasriRevisionRequestApprovalArgs,
+  MutationUpdateBsdasriArgs
+} from "../../../generated/graphql/types";
+import { prisma } from "@td/prisma";
+import {
+  transporterReceiptFactory,
+  userWithCompanyFactory
+} from "../../../__tests__/factories";
+import makeClient from "../../../__tests__/testClient";
+import { getStream } from "../../data";
+
+const CREATE_BSDASRI = `
+  mutation CreateBsdasri($input: BsdasriInput!) {
+    createBsdasri(input: $input) {
+      id
+    }
+}`;
+
+const UPDATE_BSDASRI = `
+  mutation UpdateBsdasri($id: ID!, $input: BsdasriInput!) {
+    updateBsdasri(id: $id, input: $input) {
+      id
+    }
+  }
+`;
+
+const SIGN_BSDASRI = `
+  mutation SignBsdasri($id: ID!, $input: BsdasriSignatureInput!) {
+    signBsdasri(id: $id, input: $input) {
+      id
+    }
+  }
+`;
+
+const SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL = `
+  mutation SubmitBsdasriRevisionRequestApproval($id: ID!, $isApproved: Boolean!) {
+    submitBsdasriRevisionRequestApproval(id: $id, isApproved: $isApproved) {
+      id
+    }
+  }
+`;
+
+describe("ActivityEvent.Bsdasri", () => {
+  afterEach(resetDatabase);
+
+  it("should create events during the workflow", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: { set: ["WASTEPROCESSOR", "TRANSPORTER"] }
+      }
+    );
+    await transporterReceiptFactory({ company: destinationCompany });
+    const { mutate } = makeClient(user);
+
+    // Create Bsdasri
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasri">,
+      MutationCreateBsdasriArgs
+    >(CREATE_BSDASRI, {
+      variables: {
+        input: {
+          waste: {
+            adr: "xyz 33",
+            code: "18 01 03*"
+          },
+          emitter: {
+            pickupSite: {
+              name: "",
+              address: "",
+              city: "",
+              postalCode: "",
+              infos: ""
+            },
+            company: {
+              name: company.name,
+              siret: company.siret,
+              address: company.address,
+              contact: "Emetteur",
+              phone: "01",
+              mail: "e@e.fr"
+            },
+            emission: {
+              packagings: [
+                {
+                  type: "BOITE_CARTON",
+                  volume: 22,
+                  quantity: 3
+                }
+              ]
+            }
+          },
+
+          destination: {
+            company: {
+              name: destinationCompany.name,
+              siret: destinationCompany.siret,
+              address: "8 rue du Général de Gaulle",
+              contact: "Destination",
+              phone: "02",
+              mail: "d@d.fr"
+            }
+          },
+          transporter: {
+            transport: {
+              plates: ["12345"]
+            },
+            company: {
+              name: destinationCompany.name,
+              siret: destinationCompany.siret,
+              address: "8 rue du Général de Gaulle",
+              contact: "Transporteur",
+              phone: "03",
+              mail: "t@t.fr"
+            }
+          }
+        }
+      }
+    });
+
+    const bsdasriId = data.createBsdasri.id;
+
+    const bsdasriAfterCreate = await prisma.bsdasri.findUnique({
+      where: { id: bsdasriId }
+    });
+    const bsdasriFromEventsAfterCreate = await getBsdasriFromActivityEvents({
+      bsdasriId
+    });
+
+    // Cannot use toMatchObject() when hydrating Decimal from events
+
+    bsdasriAfterCreate!.transporterRecepisseValidityLimit = null;
+    bsdasriFromEventsAfterCreate.transporterRecepisseValidityLimit = null;
+
+    expect(bsdasriAfterCreate).toMatchObject(bsdasriFromEventsAfterCreate);
+    expect(bsdasriFromEventsAfterCreate.emitterCompanyName).toBe(company.name);
+
+    const eventsAfterCreate = await getStream(bsdasriId);
+    expect(eventsAfterCreate.length).toBe(1);
+
+    // Update Bsdasri
+    await mutate<Pick<Mutation, "updateBsdasri">, MutationUpdateBsdasriArgs>(
+      UPDATE_BSDASRI,
+      {
+        variables: {
+          id: bsdasriId,
+          input: {
+            waste: {
+              code: "18 02 02*"
+            }
+          }
+        }
+      }
+    );
+
+    const bsdasriAfterUpdate = await prisma.bsdasri.findUnique({
+      where: { id: bsdasriId }
+    });
+    const bsdasriFromEventsAfterUpdate = await getBsdasriFromActivityEvents({
+      bsdasriId
+    });
+
+    // Cannot use toMatchObject() when hydrating Decimal from events
+    bsdasriAfterUpdate!.transporterRecepisseValidityLimit = null;
+    bsdasriFromEventsAfterUpdate.transporterRecepisseValidityLimit = null;
+
+    expect(bsdasriAfterUpdate).toMatchObject(bsdasriFromEventsAfterUpdate);
+    expect(bsdasriFromEventsAfterUpdate.wasteCode).toBe("18 02 02*");
+
+    const eventsAfterUpdate = await getStream(bsdasriId);
+    expect(eventsAfterUpdate.length).toBe(2);
+
+    // Mark as sealed
+    await mutate<Pick<Mutation, "signBsdasri">, MutationSignBsdasriArgs>(
+      SIGN_BSDASRI,
+      {
+        variables: {
+          id: bsdasriId,
+          input: { type: "EMISSION", author: "Jean Emet" }
+        }
+      }
+    );
+
+    const bsdasriAfterSealed = await prisma.bsdasri.findUnique({
+      where: { id: bsdasriId }
+    });
+    const bsdasriFromEventsAfterSealed = await getBsdasriFromActivityEvents({
+      bsdasriId
+    });
+
+    // Cannot use toMatchObject() when hydrating Decimal from events
+    bsdasriAfterSealed!.transporterRecepisseValidityLimit = null;
+    bsdasriFromEventsAfterSealed.transporterRecepisseValidityLimit = null;
+
+    expect(bsdasriAfterSealed).toMatchObject(bsdasriFromEventsAfterSealed);
+    expect(bsdasriFromEventsAfterSealed.status).toBe("SIGNED_BY_PRODUCER");
+
+    const eventsAfterSealed = await getStream(bsdasriId);
+    expect(eventsAfterSealed.length).toBe(3); // +2, signature
+  }, 10000);
+
+  it("should create a bsdasri event when a revision request is applied", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        wasteCode: "18 01 03*",
+        comment: ""
+      }
+    });
+
+    // There is only 1 approval. This will apply the revision onto the bsdasri
+    await mutate<
+      Pick<Mutation, "submitBsdaRevisionRequestApproval">,
+      MutationSubmitBsdasriRevisionRequestApprovalArgs
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    const eventsAfterBsdasriApplied = await prisma.event.findMany({
+      where: { streamId: bsdasri.id }
+    });
+
+    expect(eventsAfterBsdasriApplied.length).toBe(1);
+    expect(eventsAfterBsdasriApplied[0].type).toBe(
+      "BsdasriRevisionRequestApplied"
+    );
+    const eventData = eventsAfterBsdasriApplied[0]
+      .data as BsdasriRevisionRequestApplied["data"];
+    expect(eventData.content.wasteCode).toBe("18 01 03*");
+  });
+
+  it("should enable getting a bsdasri at a certain moment in time", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const { mutate } = makeClient(user);
+
+    // Create Bsdasri
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasri">,
+      MutationCreateBsdasriArgs
+    >(CREATE_BSDASRI, {
+      variables: {
+        input: {
+          emitter: {
+            company: {
+              name: company.name,
+              siret: company.siret,
+              address: company.address,
+              contact: "Emetteur",
+              phone: "01",
+              mail: "e@e.fr"
+            },
+            emission: {
+              weight: { value: 23.2, isEstimate: false },
+
+              packagings: [
+                {
+                  type: "BOITE_CARTON",
+                  volume: 22,
+                  quantity: 3
+                }
+              ]
+            }
+          },
+
+          destination: {
+            company: {
+              name: company.name,
+              siret: company.siret,
+              address: "8 rue du Général de Gaulle",
+              contact: "Destination",
+              phone: "02",
+              mail: "d@d.fr"
+            }
+          },
+          transporter: {
+            transport: {
+              plates: ["12345"]
+            },
+            company: {
+              name: company.name,
+              siret: company.siret,
+              address: "8 rue du Général de Gaulle",
+              contact: "Transporteur",
+              phone: "03",
+              mail: "t@t.fr"
+            }
+          },
+          waste: {
+            adr: "xyz",
+            code: "18 01 03*"
+          }
+        }
+      }
+    });
+
+    const bsdasriId = data.createBsdasri.id;
+
+    const justAfterCreate = new Date();
+
+    // Update Bsdasri
+    await mutate<Pick<Mutation, "updateBsda">>(UPDATE_BSDASRI, {
+      variables: {
+        id: bsdasriId,
+        input: {
+          waste: {
+            code: "18 02 02*"
+          }
+        }
+      }
+    });
+
+    // We should now be able to get the bsdasri at different stages
+    const bsdasriAfterUpdate = await prisma.bsdasri.findUnique({
+      where: { id: bsdasriId }
+    });
+    const bsdasriFromEventsAfterCreate = await getBsdasriFromActivityEvents({
+      bsdasriId,
+      at: justAfterCreate
+    });
+    expect(bsdasriFromEventsAfterCreate.wasteCode).toBe("18 01 03*");
+    expect(bsdasriAfterUpdate!.wasteCode).toBe("18 02 02*");
+  });
+});

--- a/back/src/activity-events/bsdasri/__tests__/bsdasri.test.ts
+++ b/back/src/activity-events/bsdasri/__tests__/bsdasri.test.ts
@@ -1,0 +1,60 @@
+import { bsdasriReducer } from "../reducer";
+import { aggregateStream } from "../../aggregator";
+import {
+  BsdasriCreated,
+  BsdasriEvent,
+  BsdasriUpdated,
+  BsdasriSigned
+} from "../types";
+import { Bsdasri } from "@prisma/client";
+import { siretify } from "../../../__tests__/factories";
+
+describe("ActivityEvent.Bsdasri", () => {
+  it("should get proper state when all events are aggregated", () => {
+    const userId = "aaa";
+    const bsdasriId = "TD-TEST-0001";
+
+    const bsdasriCreated: BsdasriCreated = {
+      actor: userId,
+      streamId: bsdasriId,
+      type: "BsdasriCreated",
+      data: {
+        id: bsdasriId,
+        emitterCompanyName: "Test company"
+      }
+    };
+    const emitterCompanySiret = siretify(5);
+    const bsdasriUpdated: BsdasriUpdated = {
+      actor: userId,
+      streamId: bsdasriId,
+      type: "BsdasriUpdated",
+      data: {
+        id: bsdasriId,
+        emitterCompanySiret
+      }
+    };
+
+    const bsdasriSigned: BsdasriSigned = {
+      actor: userId,
+      streamId: bsdasriId,
+      type: "BsdasriSigned",
+      data: {
+        status: "PROCESSED"
+      }
+    };
+
+    const events = [bsdasriCreated, bsdasriUpdated, bsdasriSigned];
+
+    const bsdasri = aggregateStream<Bsdasri, BsdasriEvent>(
+      events,
+      bsdasriReducer
+    );
+
+    expect(bsdasri).toMatchObject({
+      id: bsdasriId,
+      status: "PROCESSED",
+      emitterCompanyName: "Test company",
+      emitterCompanySiret
+    });
+  });
+});

--- a/back/src/activity-events/bsdasri/index.ts
+++ b/back/src/activity-events/bsdasri/index.ts
@@ -1,0 +1,25 @@
+import { Bsdasri } from "@prisma/client";
+import { AppDataloaders } from "../../types";
+import { aggregateStream } from "../aggregator";
+import { getStream } from "../data";
+import { bsdasriReducer } from "./reducer";
+import { BsdasriEvent } from "./types";
+
+export * from "./types";
+export * from "./reducer";
+
+type BsdasriEventsParams = { bsdasriId: string; at?: Date };
+
+export async function getBsdasriFromActivityEvents(
+  { bsdasriId, at }: BsdasriEventsParams,
+  options?: { dataloader: AppDataloaders["events"] }
+) {
+  const events = await (options?.dataloader
+    ? options.dataloader.load({ streamId: bsdasriId, lte: at })
+    : getStream(bsdasriId, at ? { until: at } : undefined));
+
+  return aggregateStream<Bsdasri, BsdasriEvent>(
+    events as BsdasriEvent[],
+    bsdasriReducer
+  );
+}

--- a/back/src/activity-events/bsdasri/reducer.ts
+++ b/back/src/activity-events/bsdasri/reducer.ts
@@ -1,0 +1,90 @@
+import { Bsdasri, Prisma } from "@prisma/client";
+import { BsdasriEvent } from "./types";
+
+export function bsdasriReducer(
+  currentState: Partial<Bsdasri>,
+  event: BsdasriEvent
+): Partial<Bsdasri> {
+  switch (event.type) {
+    case "BsdasriCreated": {
+      const {
+        updatedAt,
+        createdAt,
+        grouping,
+
+        ...bsdasri
+      } = event.data;
+
+      return {
+        id: event.streamId,
+        ...fixMissTypings(bsdasri)
+      };
+    }
+    case "BsdasriUpdated": {
+      const {
+        id,
+        updatedAt,
+        createdAt,
+        grouping,
+
+        ...bsdasri
+      } = event.data;
+
+      return {
+        ...currentState,
+        ...fixMissTypings(bsdasri as Prisma.BsdasriCreateInput)
+      };
+    }
+    case "BsdasriSigned":
+      return {
+        ...currentState,
+        status: event.data.status
+      };
+
+    case "BsdasriDeleted":
+      return { ...currentState, isDeleted: true };
+
+    case "BsdasriRevisionRequestApplied": {
+      const { ...bsdasri } = event.data.content;
+      return {
+        ...currentState,
+        ...fixMissTypings(bsdasri as Partial<Prisma.BsdasriCreateInput>)
+      };
+    }
+
+    default:
+      throw new Error("Unexpected event type");
+  }
+}
+
+function fixMissTypings(
+  update: Partial<
+    Omit<Prisma.BsdasriCreateInput, "updatedAt" | "createdAt" | "grouping">
+  >
+) {
+  const patch = {
+    ...update,
+
+    // packagings: update.packagings as Prisma.JsonValue,
+    emitterEmissionSignatureDate: update.emitterEmissionSignatureDate
+      ? new Date(update.emitterEmissionSignatureDate.toString())
+      : undefined,
+
+    destinationReceptionDate: update.destinationReceptionDate
+      ? new Date(update.destinationReceptionDate.toString())
+      : undefined,
+    destinationOperationDate: update.destinationOperationDate
+      ? new Date(update.destinationOperationDate.toString())
+      : undefined,
+    destinationOperationSignatureDate: update.destinationOperationSignatureDate
+      ? new Date(update.destinationOperationSignatureDate.toString())
+      : undefined
+  };
+
+  return Object.keys(patch).reduce((prev, cur) => {
+    if (patch[cur]) {
+      prev[cur] = patch[cur];
+    }
+    return prev;
+  }, {});
+}

--- a/back/src/activity-events/bsdasri/types.ts
+++ b/back/src/activity-events/bsdasri/types.ts
@@ -1,0 +1,61 @@
+import { Prisma, BsdasriStatus } from "@prisma/client";
+import { ActivityEvent } from "..";
+import { RevisionRequestContent } from "../../bsda/resolvers/mutations/revisionRequest/createRevisionRequest";
+
+export type BsdasriEvent =
+  | BsdasriCreated
+  | BsdasriUpdated
+  | BsdasriSigned
+  | BsdasriDeleted
+  | BsdasriRevisionRequestApplied;
+
+export type BsdasriRevisionRequestEvent =
+  | BsdasriRevisionRequestCreated
+  | BsdasriRevisionRequestApproved
+  | BsdasriRevisionRequestRefused;
+
+export type BsdasriCreated = ActivityEvent<
+  "BsdasriCreated",
+  Prisma.BsdasriCreateInput
+>;
+export type BsdasriUpdated = ActivityEvent<
+  "BsdasriUpdated",
+  Prisma.BsdasriUpdateInput
+>;
+export type BsdasriSigned = ActivityEvent<
+  "BsdasriSigned",
+  {
+    status: BsdasriStatus;
+  }
+>;
+export type BsdasriDeleted = ActivityEvent<
+  "BsdasriDeleted",
+  Record<string, never>
+>;
+export type BsdasriRevisionRequestApplied = ActivityEvent<
+  "BsdasriRevisionRequestApplied",
+  {
+    revisionRequestId: string;
+    content: RevisionRequestContent;
+  }
+>;
+
+export type BsdasriRevisionRequestCreated = ActivityEvent<
+  "BsdasriRevisionRequestCreated",
+  {
+    authoringSiret: string;
+    content: RevisionRequestContent;
+  }
+>;
+export type BsdasriRevisionRequestApproved = ActivityEvent<
+  "BsdasriRevisionRequestApproved",
+  {
+    authoringSiret: string;
+  }
+>;
+export type BsdasriRevisionRequestRefused = ActivityEvent<
+  "BsdasriRevisionRequestRefused",
+  {
+    authoringSiret: string;
+  }
+>;

--- a/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
@@ -193,6 +193,10 @@ async function getAuthoringCompany(
 async function getFlatContent(
   content: BsdaRevisionRequestContentInput,
   bsda: Bsda
+);
+async function getFlatContent(
+  content: BsdaRevisionRequestContentInput,
+  bsda: Bsda
 ): Promise<RevisionRequestContent> {
   const flatContent = flattenBsdaRevisionRequestInput(content);
   const { isCanceled, ...fields } = flatContent;

--- a/back/src/bsdasris/edition.ts
+++ b/back/src/bsdasris/edition.ts
@@ -39,6 +39,7 @@ type EditableBsdasriFields = Required<
     | "emittedByEcoOrganisme"
     | "finalOperations"
     | "FinalOperationToFinalBsdasri"
+    | "bsdasriRevisionRequests"
   >
 >;
 // Defines until which signature BSDASRI fields can be modified

--- a/back/src/bsdasris/permissions.ts
+++ b/back/src/bsdasris/permissions.ts
@@ -216,3 +216,19 @@ export function checkCanEditBsdasri(bsdasri: Bsdasri) {
     );
   return true;
 }
+
+export async function checkCanRequestRevision(user: User, bsdasri: Bsdasri) {
+  const authorizedOrgIds = [
+    bsdasri.emitterCompanySiret,
+
+    bsdasri.destinationCompanySiret,
+    bsdasri.ecoOrganismeSiret
+  ].filter(Boolean);
+
+  return checkUserPermissions(
+    user,
+    authorizedOrgIds,
+    Permission.BsdCanRevise,
+    `Vous n'êtes pas autorisé à réviser ce bordereau`
+  );
+}

--- a/back/src/bsdasris/repository/index.ts
+++ b/back/src/bsdasris/repository/index.ts
@@ -9,6 +9,13 @@ import { buildCreateBsdasri } from "./bsdasri/create";
 import { buildDeleteBsdasri } from "./bsdasri/delete";
 import { buildUpdateBsdasri } from "./bsdasri/update";
 import { buildUpdateManyBsdasris } from "./bsdasri/updateMany";
+import { buildAcceptRevisionRequestApproval } from "./revisionRequest/accept";
+import { buildCancelRevisionRequest } from "./revisionRequest/cancel";
+import { buildCountRevisionRequests } from "./revisionRequest/count";
+import { buildCreateRevisionRequest } from "./revisionRequest/create";
+import { buildFindManyBsdasriRevisionRequest } from "./revisionRequest/findMany";
+import { buildFindUniqueRevisionRequest } from "./revisionRequest/findUnique";
+import { buildRefuseRevisionRequestApproval } from "./revisionRequest/refuse";
 import {
   RepositoryFnBuilder,
   RepositoryTransaction
@@ -20,7 +27,12 @@ export function getReadonlyBsdasriRepository() {
     count: buildCountBsdasris({ prisma }),
     findUnique: buildFindUniqueBsdasri({ prisma }),
     findMany: buildFindManyBsdasri({ prisma }),
-    findRelatedEntity: buildFindRelatedBsdasriEntity({ prisma })
+    findRelatedEntity: buildFindRelatedBsdasriEntity({ prisma }),
+    countRevisionRequests: buildCountRevisionRequests({ prisma }),
+    findUniqueRevisionRequest: buildFindUniqueRevisionRequest({ prisma }),
+    findManyBsdasriRevisionRequest: buildFindManyBsdasriRevisionRequest({
+      prisma
+    })
   };
 }
 
@@ -37,6 +49,14 @@ export function getBsdasriRepository(
     create: useTransaction(buildCreateBsdasri),
     delete: useTransaction(buildDeleteBsdasri),
     update: useTransaction(buildUpdateBsdasri),
-    updateMany: useTransaction(buildUpdateManyBsdasris)
+    updateMany: useTransaction(buildUpdateManyBsdasris),
+    createRevisionRequest: useTransaction(buildCreateRevisionRequest),
+    cancelRevisionRequest: useTransaction(buildCancelRevisionRequest),
+    acceptRevisionRequestApproval: useTransaction(
+      buildAcceptRevisionRequestApproval
+    ),
+    refuseRevisionRequestApproval: useTransaction(
+      buildRefuseRevisionRequestApproval
+    )
   };
 }

--- a/back/src/bsdasris/repository/revisionRequest/accept.ts
+++ b/back/src/bsdasris/repository/revisionRequest/accept.ts
@@ -1,0 +1,206 @@
+import {
+  BsdasriRevisionRequest,
+  BsdasriStatus,
+  RevisionRequestApprovalStatus,
+  RevisionRequestStatus
+} from "@prisma/client";
+import { removeEmpty } from "../../../common/converter";
+import {
+  LogMetadata,
+  PrismaTransaction,
+  RepositoryFnDeps,
+  RepositoryTransaction
+} from "../../../common/repository/types";
+import { NON_CANCELLABLE_BSDASRI_STATUSES } from "../../resolvers/mutations/revisionRequest/createRevisionRequest";
+import { ForbiddenError } from "../../../common/errors";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
+import { operationHook } from "../../operationHook";
+import { isFinalOperationCode } from "../../../common/operationCodes";
+
+export type AcceptRevisionRequestApprovalFn = (
+  revisionRequestApprovalId: string,
+  { comment }: { comment?: string | null },
+  logMetadata?: LogMetadata
+) => Promise<void>;
+
+export function buildAcceptRevisionRequestApproval(
+  deps: RepositoryFnDeps
+): AcceptRevisionRequestApprovalFn {
+  return async (revisionRequestApprovalId, { comment }, logMetadata) => {
+    const { prisma, user } = deps;
+
+    const updatedApproval = await prisma.bsdasriRevisionRequestApproval.update({
+      where: { id: revisionRequestApprovalId },
+      data: {
+        status: RevisionRequestApprovalStatus.ACCEPTED,
+        comment
+      }
+    });
+
+    await prisma.event.create({
+      data: {
+        streamId: updatedApproval.revisionRequestId,
+        actor: user.id,
+        type: "BsdasriRevisionRequestAccepted",
+        data: {
+          status: RevisionRequestApprovalStatus.ACCEPTED,
+          comment
+        },
+        metadata: { ...logMetadata, authType: user.auth }
+      }
+    });
+
+    // If it was the last approval:
+    // - mark the revision as approved
+    // - apply the revision to the Bsdasri
+    const remainingApprovals =
+      await prisma.bsdasriRevisionRequestApproval.count({
+        where: {
+          revisionRequestId: updatedApproval.revisionRequestId,
+          status: RevisionRequestApprovalStatus.PENDING
+        }
+      });
+    if (remainingApprovals > 0) return;
+
+    await approveAndApplyRevisionRequest(updatedApproval.revisionRequestId, {
+      prisma,
+      user,
+      logMetadata
+    });
+  };
+}
+
+async function getUpdateFromRevisionRequest(
+  revisionRequest: BsdasriRevisionRequest,
+  prisma: PrismaTransaction
+) {
+  const {
+    bsdasriId,
+    comment,
+    updatedAt,
+    authoringCompanyId,
+    createdAt,
+    id,
+    status,
+    isCanceled,
+    ...bsdasriUpdate
+  } = revisionRequest;
+
+  const { status: currentStatus } = await prisma.bsdasri.findUniqueOrThrow({
+    where: { id: bsdasriId },
+    select: { status: true }
+  });
+  const newStatus = getNewStatus(
+    currentStatus,
+
+    isCanceled
+  );
+
+  const result = removeEmpty({
+    ...bsdasriUpdate,
+    status: newStatus
+  });
+
+  // Careful. Some operation codes explicitely need a null operation mode (ex: D15)
+  if (
+    bsdasriUpdate.destinationOperationCode &&
+    !bsdasriUpdate.destinationOperationMode
+  ) {
+    return {
+      ...result,
+      destinationOperationMode: null
+    };
+  }
+
+  return result;
+}
+
+function getNewStatus(
+  status: BsdasriStatus,
+  // newOperationCode: string | null,
+  isCanceled = false
+): BsdasriStatus {
+  if (isCanceled) {
+    if (NON_CANCELLABLE_BSDASRI_STATUSES.includes(status)) {
+      throw new ForbiddenError(
+        "Impossible d'annuler un bordereau qui a été réceptionné sur l'installation de destination."
+      );
+    }
+
+    return BsdasriStatus.CANCELED;
+  }
+
+  return status;
+}
+
+export async function approveAndApplyRevisionRequest(
+  revisionRequestId: string,
+  context: {
+    prisma: RepositoryTransaction;
+    user: Express.User;
+    logMetadata?: LogMetadata;
+  }
+): Promise<BsdasriRevisionRequest> {
+  const { prisma, user, logMetadata } = context;
+
+  const updatedRevisionRequest = await prisma.bsdasriRevisionRequest.update({
+    where: { id: revisionRequestId },
+    data: { status: RevisionRequestStatus.ACCEPTED }
+  });
+
+  const bsdasriBeforeRevision = await prisma.bsdasri.findUniqueOrThrow({
+    where: { id: updatedRevisionRequest.bsdasriId }
+  });
+  const updateData = await getUpdateFromRevisionRequest(
+    updatedRevisionRequest,
+    prisma
+  );
+
+  if (!updateData) {
+    throw new Error(
+      `Empty BSDASRI revision cannot be applied. Id #${updatedRevisionRequest.id}, BSDASRI id #${updatedRevisionRequest.bsdasriId}`
+    );
+  }
+
+  const updatedBsdasri = await prisma.bsdasri.update({
+    where: { id: updatedRevisionRequest.bsdasriId },
+    data: { ...updateData }
+  });
+
+  if (updateData?.destinationOperationCode) {
+    const beforeRevisionOperationIsFinal = isFinalOperationCode(
+      bsdasriBeforeRevision.destinationOperationCode
+    );
+    const updatedOperationIsFinal = isFinalOperationCode(
+      updateData.destinationOperationCode
+    );
+    if (updatedOperationIsFinal && !beforeRevisionOperationIsFinal) {
+      prisma.addAfterCommitCallback?.(async () => {
+        await operationHook(updatedBsdasri, { runSync: false });
+      });
+    } else if (!updatedOperationIsFinal && beforeRevisionOperationIsFinal) {
+      await prisma.bsdasriFinalOperation.deleteMany({
+        where: { finalBsdasriId: updatedBsdasri.id }
+      });
+    }
+  }
+
+  await prisma.event.create({
+    data: {
+      streamId: updatedRevisionRequest.bsdasriId,
+      actor: user.id,
+      type: "BsdasriRevisionRequestApplied",
+      data: {
+        content: updateData,
+        revisionRequestId: updatedRevisionRequest.id
+      },
+      metadata: { ...logMetadata, authType: user.auth }
+    }
+  });
+
+  prisma.addAfterCommitCallback?.(() =>
+    enqueueUpdatedBsdToIndex(updatedRevisionRequest.bsdasriId)
+  );
+
+  return updatedRevisionRequest;
+}

--- a/back/src/bsdasris/repository/revisionRequest/cancel.ts
+++ b/back/src/bsdasris/repository/revisionRequest/cancel.ts
@@ -1,0 +1,42 @@
+import { BsdasriRevisionRequest, Prisma } from "@prisma/client";
+import {
+  LogMetadata,
+  RepositoryFnDeps
+} from "../../../common/repository/types";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
+
+export type CancelRevisionRequestFn = (
+  where: Prisma.BsdasriRevisionRequestWhereUniqueInput,
+  logMetadata?: LogMetadata
+) => Promise<BsdasriRevisionRequest>;
+
+export function buildCancelRevisionRequest(
+  deps: RepositoryFnDeps
+): CancelRevisionRequestFn {
+  return async (where, logMetadata) => {
+    const { prisma, user } = deps;
+
+    await prisma.bsdasriRevisionRequestApproval.deleteMany({
+      where: { revisionRequest: where }
+    });
+    const deletedRevisionRequest = await prisma.bsdasriRevisionRequest.delete({
+      where
+    });
+
+    await prisma.event.create({
+      data: {
+        streamId: deletedRevisionRequest.id,
+        actor: user.id,
+        type: "BsdasriRevisionRequestCancelled",
+        data: {},
+        metadata: { ...logMetadata, authType: user.auth }
+      }
+    });
+
+    prisma.addAfterCommitCallback(() =>
+      enqueueUpdatedBsdToIndex(deletedRevisionRequest.bsdasriId)
+    );
+
+    return deletedRevisionRequest;
+  };
+}

--- a/back/src/bsdasris/repository/revisionRequest/count.ts
+++ b/back/src/bsdasris/repository/revisionRequest/count.ts
@@ -1,0 +1,14 @@
+import { Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+export type CountRevisionRequestFn = (
+  where: Prisma.BsdasriRevisionRequestWhereInput
+) => Promise<number>;
+
+export function buildCountRevisionRequests({
+  prisma
+}: ReadRepositoryFnDeps): CountRevisionRequestFn {
+  return where => {
+    return prisma.bsdasriRevisionRequest.count({ where });
+  };
+}

--- a/back/src/bsdasris/repository/revisionRequest/create.ts
+++ b/back/src/bsdasris/repository/revisionRequest/create.ts
@@ -1,0 +1,63 @@
+import { BsdasriRevisionRequest, Prisma } from "@prisma/client";
+import {
+  LogMetadata,
+  RepositoryFnDeps
+} from "../../../common/repository/types";
+import { approveAndApplyRevisionRequest } from "./accept";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
+
+export type CreateRevisionRequestFn = (
+  data: Prisma.BsdasriRevisionRequestCreateInput,
+  logMetadata?: LogMetadata
+) => Promise<BsdasriRevisionRequest>;
+
+export function buildCreateRevisionRequest(
+  deps: RepositoryFnDeps
+): CreateRevisionRequestFn {
+  return async (data, logMetadata?) => {
+    const { prisma, user } = deps;
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data,
+      include: { approvals: true }
+    });
+
+    await prisma.event.create({
+      data: {
+        streamId: revisionRequest.id,
+        actor: user.id,
+        type: "BsdasriRevisionRequestCreated",
+        data: data as Prisma.InputJsonObject,
+        metadata: { ...logMetadata, authType: user.auth }
+      }
+    });
+
+    // touch the bsd to make it come up in the dashboard
+    await prisma.bsdasri.update({
+      where: {
+        id: revisionRequest.bsdasriId
+      },
+      data: {
+        updatedAt: new Date()
+      },
+      select: {
+        id: true
+      }
+    });
+
+    prisma.addAfterCommitCallback(() =>
+      enqueueUpdatedBsdToIndex(revisionRequest.bsdasriId)
+    );
+
+    if (revisionRequest.approvals.length > 0) {
+      return revisionRequest;
+    }
+
+    // 0 approvals, auto-approve
+    return approveAndApplyRevisionRequest(revisionRequest.id, {
+      prisma,
+      user,
+      logMetadata
+    });
+  };
+}

--- a/back/src/bsdasris/repository/revisionRequest/findMany.ts
+++ b/back/src/bsdasris/repository/revisionRequest/findMany.ts
@@ -1,0 +1,16 @@
+import { BsdasriRevisionRequest, Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+export type FindManyBsdasriRevisionRequestFn = (
+  where: Prisma.BsdasriRevisionRequestWhereInput,
+  options?: Omit<Prisma.BsdasriRevisionRequestFindManyArgs, "where">
+) => Promise<BsdasriRevisionRequest[]>;
+
+export function buildFindManyBsdasriRevisionRequest({
+  prisma
+}: ReadRepositoryFnDeps): FindManyBsdasriRevisionRequestFn {
+  return (where, options?) => {
+    const input = { where, ...options };
+    return prisma.bsdasriRevisionRequest.findMany(input);
+  };
+}

--- a/back/src/bsdasris/repository/revisionRequest/findUnique.ts
+++ b/back/src/bsdasris/repository/revisionRequest/findUnique.ts
@@ -1,0 +1,18 @@
+import { BsdasriRevisionRequest, Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+export type FindUniqueRevisionRequestFn = (
+  where: Prisma.BsdasriRevisionRequestWhereUniqueInput,
+  options?: Omit<Prisma.BsdasriRevisionRequestFindUniqueArgs, "where">
+) => Promise<BsdasriRevisionRequest | null>;
+
+export function buildFindUniqueRevisionRequest({
+  prisma
+}: ReadRepositoryFnDeps): FindUniqueRevisionRequestFn {
+  return async (where, options) => {
+    return prisma.bsdasriRevisionRequest.findUnique({
+      where,
+      ...options
+    });
+  };
+}

--- a/back/src/bsdasris/repository/revisionRequest/refuse.ts
+++ b/back/src/bsdasris/repository/revisionRequest/refuse.ts
@@ -1,0 +1,65 @@
+import {
+  RevisionRequestApprovalStatus,
+  RevisionRequestStatus
+} from "@prisma/client";
+import {
+  LogMetadata,
+  RepositoryFnDeps
+} from "../../../common/repository/types";
+import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
+
+export type RefuseRevisionRequestApprovalFn = (
+  revisionRequestApprovalId: string,
+  { comment }: { comment?: string | null },
+  logMetadata?: LogMetadata
+) => Promise<void>;
+
+export function buildRefuseRevisionRequestApproval(
+  deps: RepositoryFnDeps
+): RefuseRevisionRequestApprovalFn {
+  return async (revisionRequestApprovalId, { comment }, logMetadata) => {
+    const { prisma, user } = deps;
+    const revisionRequestApproval =
+      await prisma.bsdasriRevisionRequestApproval.update({
+        where: { id: revisionRequestApprovalId },
+        data: {
+          status: RevisionRequestApprovalStatus.REFUSED,
+          comment
+        }
+      });
+
+    // We have a refusal:
+    // - mark revision as refused
+    // - mark every awaiting approval as skipped
+    const revisionRequest = await prisma.bsdasriRevisionRequest.update({
+      where: { id: revisionRequestApproval.revisionRequestId },
+      data: { status: RevisionRequestStatus.REFUSED }
+    });
+    await prisma.bsdasriRevisionRequestApproval.updateMany({
+      where: {
+        revisionRequestId: revisionRequestApproval.revisionRequestId,
+        status: RevisionRequestApprovalStatus.PENDING
+      },
+      data: { status: RevisionRequestApprovalStatus.CANCELED }
+    });
+
+    await prisma.event.create({
+      data: {
+        streamId: revisionRequestApproval.revisionRequestId,
+        actor: user.id,
+        type: "BsdasriRevisionRequestRefused",
+        data: {
+          content: {
+            status: RevisionRequestApprovalStatus.REFUSED,
+            comment
+          }
+        },
+        metadata: { ...logMetadata, authType: user.auth }
+      }
+    });
+
+    prisma.addAfterCommitCallback(() =>
+      enqueueUpdatedBsdToIndex(revisionRequest.bsdasriId)
+    );
+  };
+}

--- a/back/src/bsdasris/repository/types.ts
+++ b/back/src/bsdasris/repository/types.ts
@@ -6,6 +6,13 @@ import { FindRelatedEntityFn } from "./bsdasri/findRelatedEntity";
 import { FindUniqueBsdasriFn } from "./bsdasri/findUnique";
 import { UpdateBsdasriFn } from "./bsdasri/update";
 import { UpdateManyBsdasriFn } from "./bsdasri/updateMany";
+import { AcceptRevisionRequestApprovalFn } from "./revisionRequest/accept";
+import { CancelRevisionRequestFn } from "./revisionRequest/cancel";
+import { CountRevisionRequestFn } from "./revisionRequest/count";
+import { CreateRevisionRequestFn } from "./revisionRequest/create";
+import { FindManyBsdasriRevisionRequestFn } from "./revisionRequest/findMany";
+import { FindUniqueRevisionRequestFn } from "./revisionRequest/findUnique";
+import { RefuseRevisionRequestApprovalFn } from "./revisionRequest/refuse";
 
 export type BsdasriActions = {
   findUnique: FindUniqueBsdasriFn;
@@ -16,4 +23,12 @@ export type BsdasriActions = {
   updateMany: UpdateManyBsdasriFn;
   delete: DeleteBsdasriFn;
   count: CountBsdasrisFn;
+
+  countRevisionRequests: CountRevisionRequestFn;
+  findUniqueRevisionRequest: FindUniqueRevisionRequestFn;
+  findManyBsdasriRevisionRequest: FindManyBsdasriRevisionRequestFn;
+  createRevisionRequest: CreateRevisionRequestFn;
+  cancelRevisionRequest: CancelRevisionRequestFn;
+  acceptRevisionRequestApproval: AcceptRevisionRequestApprovalFn;
+  refuseRevisionRequestApproval: RefuseRevisionRequestApprovalFn;
 };

--- a/back/src/bsdasris/resolvers/BsdasriRevisionRequest.ts
+++ b/back/src/bsdasris/resolvers/BsdasriRevisionRequest.ts
@@ -1,0 +1,53 @@
+import { getBsdasriFromActivityEvents } from "../../activity-events/bsdasri";
+import {
+  BsdasriRevisionRequest,
+  BsdasriRevisionRequestResolvers
+} from "../../generated/graphql/types";
+import { prisma } from "@td/prisma";
+import {
+  expandBsdasriRevisionRequestContent,
+  expandBsdasriFromDB
+} from "../converter";
+
+const bsdasriRevisionRequestResolvers: BsdasriRevisionRequestResolvers = {
+  approvals: async parent => {
+    const approvals = await prisma.bsdasriRevisionRequest
+      .findUnique({ where: { id: parent.id } })
+      .approvals();
+    return approvals ?? [];
+  },
+  content: parent => {
+    return expandBsdasriRevisionRequestContent(parent as any);
+  },
+  authoringCompany: async parent => {
+    const authoringCompany = await prisma.bsdasriRevisionRequest
+      .findUnique({ where: { id: parent.id } })
+      .authoringCompany();
+
+    if (!authoringCompany) {
+      throw new Error(
+        `BsdasriRevisionRequest ${parent.id} has no authoring company.`
+      );
+    }
+    return authoringCompany;
+  },
+  bsdasri: async (
+    parent: BsdasriRevisionRequest & { bsdasriId: string },
+    _,
+    { dataloaders }
+  ) => {
+    const actualBsdasri = await prisma.bsdasriRevisionRequest
+      .findUnique({ where: { id: parent.id } })
+      .bsdasri();
+    const bsdasriFromEvents = await getBsdasriFromActivityEvents(
+      { bsdasriId: parent.bsdasriId, at: parent.createdAt },
+      { dataloader: dataloaders.events }
+    );
+    return expandBsdasriFromDB({
+      ...actualBsdasri,
+      ...bsdasriFromEvents
+    });
+  }
+};
+
+export default bsdasriRevisionRequestResolvers;

--- a/back/src/bsdasris/resolvers/Metadata.ts
+++ b/back/src/bsdasris/resolvers/Metadata.ts
@@ -6,6 +6,8 @@ import {
 import { getBsdasriOrNotFound } from "../database";
 import { validateBsdasri, getRequiredFor } from "../validation";
 import { ValidationError } from "yup";
+import { prisma } from "@td/prisma";
+import { computeLatestRevision } from "../converter";
 
 const bsdasriMetadataResolvers: BsdasriMetadataResolvers = {
   errors: async (metadata: BsdasriMetadata & { id: string }) => {
@@ -26,6 +28,19 @@ const bsdasriMetadataResolvers: BsdasriMetadataResolvers = {
         requiredFor: getRequiredFor(e.path)
       }));
     }
+  },
+  latestRevision: async (metadata: BsdasriMetadata & { id: string }) => {
+    // When loaded from ES, this field is already populated
+    // We check only for undefined as the field can be null
+    if (metadata.latestRevision !== undefined) {
+      return metadata.latestRevision;
+    }
+
+    const revisions = await prisma.bsdasri
+      .findUnique({ where: { id: metadata.id } })
+      .bsdasriRevisionRequests();
+
+    return computeLatestRevision(revisions) as any;
   }
 };
 

--- a/back/src/bsdasris/resolvers/Mutation.ts
+++ b/back/src/bsdasris/resolvers/Mutation.ts
@@ -8,6 +8,10 @@ import signBsdasriEmissionWithSecretCode from "./mutations/signBsdasriEmissionWi
 import duplicateBsdasri from "./mutations/duplicateBsdasri";
 import { MutationResolvers } from "../../generated/graphql/types";
 
+import { createBsdasriRevisionRequest } from "./mutations/revisionRequest/createRevisionRequest";
+import { cancelBsdasriRevisionRequest } from "./mutations/revisionRequest/cancelRevisionRequest";
+import { submitBsdasriRevisionRequestApproval } from "./mutations/revisionRequest/submitRevisionRequestApproval";
+
 const Mutation: MutationResolvers = {
   createDraftBsdasri,
   createBsdasri,
@@ -16,7 +20,11 @@ const Mutation: MutationResolvers = {
   signBsdasri,
   signBsdasriEmissionWithSecretCode,
   duplicateBsdasri,
-  deleteBsdasri
+  deleteBsdasri,
+  createBsdasriRevisionRequest: createBsdasriRevisionRequest as any,
+  cancelBsdasriRevisionRequest,
+  submitBsdasriRevisionRequestApproval:
+    submitBsdasriRevisionRequestApproval as any
 };
 
 export default Mutation;

--- a/back/src/bsdasris/resolvers/Query.ts
+++ b/back/src/bsdasris/resolvers/Query.ts
@@ -2,10 +2,13 @@ import bsdasris from "./queries/bsdasris";
 import bsdasri from "./queries/bsdasri";
 import bsdasriPdf from "./queries/bsdasriPdf";
 import { QueryResolvers } from "../../generated/graphql/types";
+import { bsdasriRevisionRequests } from "./queries/revisionRequests";
+
 const Query: QueryResolvers = {
   bsdasris,
   bsdasri,
-  bsdasriPdf
+  bsdasriPdf,
+  bsdasriRevisionRequests
 };
 
 export default Query;

--- a/back/src/bsdasris/resolvers/index.ts
+++ b/back/src/bsdasris/resolvers/index.ts
@@ -2,10 +2,12 @@ import Query from "./Query";
 import Mutation from "./Mutation";
 import Bsdasri from "./Bsdasri";
 import BsdasriMetadata from "./Metadata";
+import BsdasriRevisionRequest from "./BsdasriRevisionRequest";
 
 export default {
   Query,
   Mutation,
   Bsdasri,
-  BsdasriMetadata
+  BsdasriMetadata,
+  BsdasriRevisionRequest
 };

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/cancelFormRevisionRequest.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/cancelFormRevisionRequest.integration.ts
@@ -1,0 +1,126 @@
+import { RevisionRequestStatus } from "@prisma/client";
+import { resetDatabase } from "../../../../../../integration-tests/helper";
+import {
+  Mutation,
+  MutationCancelBsdaRevisionRequestArgs
+} from "../../../../../generated/graphql/types";
+import { prisma } from "@td/prisma";
+import { userWithCompanyFactory } from "../../../../../__tests__/factories";
+import makeClient from "../../../../../__tests__/testClient";
+import { bsdasriFactory } from "../../../../__tests__/factories";
+
+const CANCEL_BSDASRI_REVISION_REQUEST = `
+  mutation CancelBsdasriRevisionRequest($id: ID!) {
+    cancelBsdasriRevisionRequest(id: $id)
+  }
+`;
+
+describe("Mutation.cancelBsdasriRevisionRequest", () => {
+  afterEach(() => resetDatabase());
+
+  it("should fail if revision doesnt exist", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate<
+      Pick<Mutation, "cancelBsdasriRevisionRequest">,
+      MutationCancelBsdaRevisionRequestArgs
+    >(CANCEL_BSDASRI_REVISION_REQUEST, {
+      variables: { id: "i dont exist" }
+    });
+
+    expect(errors[0].message).toBe(`Révision introuvable.`);
+  });
+
+  it("should fail if current user is not the revision author", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
+    const { company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        comment: ""
+      }
+    });
+
+    const { errors } = await mutate<
+      Pick<Mutation, "cancelBsdasriRevisionRequest">,
+      MutationCancelBsdaRevisionRequestArgs
+    >(CANCEL_BSDASRI_REVISION_REQUEST, {
+      variables: { id: revisionRequest.id }
+    });
+
+    expect(errors[0].message).toBe(
+      `Vous n'êtes pas l'auteur de cette révision.`
+    );
+  });
+
+  it("should fail if revision is not pending", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        comment: "",
+        status: RevisionRequestStatus.ACCEPTED
+      }
+    });
+
+    const { errors } = await mutate<
+      Pick<Mutation, "cancelBsdasriRevisionRequest">,
+      MutationCancelBsdaRevisionRequestArgs
+    >(CANCEL_BSDASRI_REVISION_REQUEST, {
+      variables: { id: revisionRequest.id }
+    });
+
+    expect(errors[0].message).toBe(
+      `La révision n'est pas annulable. Elle a déjà été acceptée ou refusée.`
+    );
+  });
+
+  it("should delete revision", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        comment: ""
+      }
+    });
+
+    const revisionsCountBefore = await prisma.bsdasriRevisionRequest.count({
+      where: { authoringCompanyId: company.id }
+    });
+    expect(revisionsCountBefore).toBe(1);
+
+    await mutate<
+      Pick<Mutation, "cancelBsdasriRevisionRequest">,
+      MutationCancelBsdaRevisionRequestArgs
+    >(CANCEL_BSDASRI_REVISION_REQUEST, {
+      variables: { id: revisionRequest.id }
+    });
+
+    const revisionsCountAfter = await prisma.bsdasriRevisionRequest.count({
+      where: { authoringCompanyId: company.id }
+    });
+    expect(revisionsCountAfter).toBe(0);
+  });
+});

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/createRevisionRequest.integration.ts
@@ -1,0 +1,719 @@
+import { resetDatabase } from "../../../../../../integration-tests/helper";
+import {
+  Mutation,
+  MutationCreateBsdasriRevisionRequestArgs
+} from "../../../../../generated/graphql/types";
+import { userWithCompanyFactory } from "../../../../../__tests__/factories";
+import makeClient from "../../../../../__tests__/testClient";
+import { bsdasriFactory } from "../../../../__tests__/factories";
+import { prisma } from "@td/prisma";
+import {
+  CANCELLABLE_BSDASRI_STATUSES,
+  NON_CANCELLABLE_BSDASRI_STATUSES
+} from "../createRevisionRequest";
+import { BsdasriStatus } from "@prisma/client";
+
+const CREATE_BSDASRI_REVISION_REQUEST = `
+  mutation CreateBsdasriRevisionRequest($input: CreateBsdasriRevisionRequestInput!) {
+    createBsdasriRevisionRequest(input: $input) {
+      id
+      bsdasri {
+        id
+      }
+      content {
+        waste { code }
+      }
+      authoringCompany {
+        siret
+      }
+      approvals {
+        approverSiret
+        status
+      }
+      status
+    }
+  }
+`;
+
+describe("Mutation.createBsdasriRevisionRequest", () => {
+  afterEach(() => resetDatabase());
+
+  it("should fail if bsdasri doesnt exist", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasriId = "123";
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId,
+          content: {},
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      `Le bordereau avec l'identifiant "${bsdasriId}" n'existe pas.`
+    );
+  });
+
+  it("should fail if revision is empty", async () => {
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: destinationCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {},
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      "Impossible de créer une révision sans modifications."
+    );
+  });
+
+  it("should fail if current user is neither emitter or recipient of the bsdasri", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: emitterCompany.siret }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {},
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      `Vous n'êtes pas autorisé à réviser ce bordereau`
+    );
+  });
+
+  it("should create a revisionRequest and identifying current user as the requester", async () => {
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: destinationCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(data.createBsdasriRevisionRequest.bsdasri.id).toBe(bsdasri.id);
+    expect(data.createBsdasriRevisionRequest.authoringCompany.siret).toBe(
+      company.siret
+    );
+  });
+
+  it("should create a revisionRequest and an approval targetting the company not requesting the revisionRequest", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(data.createBsdasriRevisionRequest.bsdasri.id).toBe(bsdasri.id);
+    expect(data.createBsdasriRevisionRequest.approvals.length).toBe(1);
+    expect(data.createBsdasriRevisionRequest.approvals[0].approverSiret).toBe(
+      recipientCompany.siret
+    );
+    expect(data.createBsdasriRevisionRequest.approvals[0].status).toBe(
+      "PENDING"
+    );
+  });
+
+  it("should fail if unknown fields are provided", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: "",
+          content: { waste: { name: "I cannot change the name" } },
+          comment: "A comment",
+          authoringCompanySiret: "a siret"
+        }
+      }
+    });
+    const error = errors[0];
+    expect(error.extensions!.code).toContain("BAD_USER_INPUT");
+    expect(error.message).toContain(
+      'Field "name" is not defined by type "BsdasriRevisionRequestWasteInput".'
+    );
+  });
+
+  it("should fail if fields validation fails", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret, status: "SENT" }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "Made up code" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      "Invalid enum value. Expected '18 01 03*' | '18 02 02*', received 'Made up code'"
+    );
+  });
+
+  it("should store flattened input in revision content - waste code", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(data.createBsdasriRevisionRequest.content).toEqual({
+      waste: { code: "18 02 02*" }
+    });
+  });
+
+  it("should store flattened input in revision content - weight", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "PROCESSED"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { destination: { operation: { weight: 1234 } } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    const revision = await prisma.bsdasriRevisionRequest.findUnique({
+      where: {
+        id: data.createBsdasriRevisionRequest.id
+      }
+    });
+
+    expect(revision?.destinationReceptionWasteWeightValue).toEqual(1234);
+  });
+
+  it("should create an auto-approved revisionRequest all roles have the same siret", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: company.siret,
+
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(data.createBsdasriRevisionRequest.bsdasri.id).toBe(bsdasri.id);
+    expect(data.createBsdasriRevisionRequest.approvals.length).toBe(0);
+    expect(data.createBsdasriRevisionRequest.status).toBe("ACCEPTED");
+  });
+
+  it("should only create one approval if two approving roles have the same siret", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(data.createBsdasriRevisionRequest.bsdasri.id).toBe(bsdasri.id);
+    expect(data.createBsdasriRevisionRequest.approvals.length).toBe(1);
+  });
+
+  it("should fail if trying to cancel AND modify the bsdasri", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { isCanceled: true, waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      `Impossible d'annuler et de modifier un bordereau.`
+    );
+  });
+
+  it("should fail if the bsdasri is canceled", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "CANCELED"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors, data } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "18 02 02*" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    console.log(data);
+
+    expect(errors[0].message).toBe(
+      `Impossible de créer une révision sur ce bordereau, il a été annulé.`
+    );
+  });
+
+  it.each(CANCELLABLE_BSDASRI_STATUSES)(
+    "should succeed if status is cancellable",
+    async (status: BsdasriStatus) => {
+      const { company: recipientCompany } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: company.siret,
+          destinationCompanySiret: recipientCompany.siret,
+
+          status
+        }
+      });
+
+      const { mutate } = makeClient(user);
+      const { data, errors } = await mutate<
+        Pick<Mutation, "createBsdasriRevisionRequest">,
+        MutationCreateBsdasriRevisionRequestArgs
+      >(CREATE_BSDASRI_REVISION_REQUEST, {
+        variables: {
+          input: {
+            bsdasriId: bsdasri.id,
+            content: { isCanceled: true },
+            comment: "A comment",
+            authoringCompanySiret: company.siret!
+          }
+        }
+      });
+
+      expect(data.createBsdasriRevisionRequest.bsdasri.id).toBe(bsdasri.id);
+      expect(errors).toBeUndefined();
+    }
+  );
+
+  it.each(NON_CANCELLABLE_BSDASRI_STATUSES)(
+    "should fail if status is in non-cancellable list",
+    async (status: BsdasriStatus) => {
+      const { company: recipientCompany } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: company.siret,
+          destinationCompanySiret: recipientCompany.siret,
+
+          status
+        }
+      });
+
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "createBsdasriRevisionRequest">,
+        MutationCreateBsdasriRevisionRequestArgs
+      >(CREATE_BSDASRI_REVISION_REQUEST, {
+        variables: {
+          input: {
+            bsdasriId: bsdasri.id,
+            content: { isCanceled: true },
+            comment: "A comment",
+            authoringCompanySiret: company.siret!
+          }
+        }
+      });
+
+      // Because the error messages vary depending on the status,
+      // let's just check that there is an error and not focus on the msg
+      expect(errors.length).toBeGreaterThan(0);
+    }
+  );
+
+  it("should fail if operation mode and code are not compatible", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {
+            destination: {
+              operation: {
+                code: "D10",
+                mode: "VALORISATION_ENERGETIQUE"
+              }
+            }
+          },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors).not.toBeUndefined();
+    expect(errors[0].message).toBe(
+      "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
+    );
+  });
+
+  it("should fail if operation mode is missing", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "SENT"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {
+            destination: {
+              operation: {
+                code: "D10"
+              }
+            }
+          },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors).not.toBeUndefined();
+    expect(errors[0].message).toBe("Vous devez préciser un mode de traitement");
+  });
+
+  it("should succeed if operation mode & code are compatible", async () => {
+    const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+        destinationCompanySiret: recipientCompany.siret,
+        status: "PROCESSED"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {
+            destination: {
+              operation: {
+                code: "D10",
+                mode: "ELIMINATION"
+              }
+            }
+          },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors).toBeUndefined();
+  });
+
+  // it("should succeed if operation code has no corresponding mode", async () => {
+  //   const { company: recipientCompany } = await userWithCompanyFactory("ADMIN");
+  //   const { user, company } = await userWithCompanyFactory("ADMIN");
+  //   const bsdasri = await bsdasriFactory({
+  //     opt: {
+  //       emitterCompanySiret: company.siret,
+  //       destinationCompanySiret: recipientCompany.siret,
+  //       status: "SENT"
+  //     }
+  //   });
+
+  //   const { mutate } = makeClient(user);
+  //   const { errors } = await mutate<
+  //     Pick<Mutation, "createBsdasriRevisionRequest">,
+  //     MutationCreateBsdasriRevisionRequestArgs
+  //   >(CREATE_BSDASRI_REVISION_REQUEST, {
+  //     variables: {
+  //       input: {
+  //         bsdasriId: bsdasri.id,
+  //         content: {
+  //           destination: {
+  //             operation: {
+  //               code: "R12"
+  //             }
+  //           }
+  //         },
+  //         comment: "A comment",
+  //         authoringCompanySiret: company.siret!
+  //       }
+  //     }
+  //   });
+
+  //   expect(errors).toBeUndefined();
+  // });
+
+  it("should fail if all fields are empty", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret, status: "SENT" }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: { waste: { code: "" } },
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe("Le code déchet ne peut pas être vide");
+  });
+
+  it("should fail if the packaging is other with no description", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret, status: "SENT" }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createBsdasriRevisionRequest">,
+      MutationCreateBsdasriRevisionRequestArgs
+    >(CREATE_BSDASRI_REVISION_REQUEST, {
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: {
+            destination: {
+              reception: {
+                packagings: [
+                  { type: "AUTRE", quantity: 1, other: "", volume: 10 }
+                ]
+              }
+            }
+          },
+
+          comment: "A comment",
+          authoringCompanySiret: company.siret!
+        }
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      "Vous devez saisir la description du conditionnement quand le type de conditionnement est 'Autre'"
+    );
+  });
+});

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -1,0 +1,767 @@
+import { resetDatabase } from "../../../../../../integration-tests/helper";
+import { userWithCompanyFactory } from "../../../../../__tests__/factories";
+import makeClient from "../../../../../__tests__/testClient";
+import { bsdasriFactory } from "../../../../__tests__/factories";
+import { prisma } from "@td/prisma";
+import {
+  Mutation,
+  MutationSubmitBsdasriRevisionRequestApprovalArgs,
+  BsdasriStatus
+} from "../../../../../generated/graphql/types";
+import { NON_CANCELLABLE_BSDASRI_STATUSES } from "../../revisionRequest/createRevisionRequest";
+
+import { operationHook } from "../../../../operationHook";
+import { operationHooksQueue } from "../../../../../queue/producers/operationHook";
+
+const SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL = `
+  mutation SubmitBsdasriRevisionRequestApproval($id: ID!, $isApproved: Boolean!) {
+    submitBsdasriRevisionRequestApproval(id: $id, isApproved: $isApproved) {
+      id
+      bsdasri {
+        id
+      }
+      content {
+        waste { code }
+      }
+      approvals {
+        approverSiret
+        status
+      }
+      status
+    }
+  }
+`;
+
+describe("Mutation.submitBsdasriRevisionRequestApproval", () => {
+  afterEach(() => resetDatabase());
+
+  it("should fail if revisionRequest doesnt exist", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const { errors } = await mutate(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: "inexistant revisionRequest",
+        isApproved: true
+      }
+    });
+
+    expect(errors[0].message).toBe("Révision introuvable.");
+  });
+
+  it("should fail if user is not allowed on revisionRequest", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        comment: ""
+      }
+    });
+
+    const { errors } = await mutate(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      "Vous n'êtes pas destinataire de cette révision, ou alors cette révision a déjà été approuvée."
+    );
+  });
+
+  it("should fail if requester tries to approve its own revisionRequest", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: companyOfSomeoneElse.siret! } },
+        comment: ""
+      }
+    });
+
+    const { errors } = await mutate(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(errors[0].message).toBe(
+      "Vous n'êtes pas destinataire de cette révision, ou alors cette révision a déjà été approuvée."
+    );
+  });
+
+  it("should work if the only approver approves the revisionRequest", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        wasteCode: "10 13 09*"
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(data.submitBsdasriRevisionRequestApproval.status).toBe("ACCEPTED");
+  });
+
+  it("should work if one of the approvers approves the revisionRequest, but not mark the revisionRequest as accepted", async () => {
+    const { company: secondCompany } = await userWithCompanyFactory("ADMIN");
+    const { company: thirdCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: secondCompany.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: secondCompany.id,
+        approvals: {
+          create: [
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
+          ]
+        },
+        comment: ""
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(data.submitBsdasriRevisionRequestApproval.status).toBe("PENDING");
+
+    expect(
+      data.submitBsdasriRevisionRequestApproval.approvals.find(
+        val => val.approverSiret === company.siret
+      )!.status
+    ).toBe("ACCEPTED");
+
+    expect(
+      data.submitBsdasriRevisionRequestApproval.approvals!.find(
+        val => val.approverSiret === thirdCompany.siret
+      )!.status
+    ).toBe("PENDING");
+  });
+
+  it("should mark the revisionRequest as refused if one of the approvers refused the revisionRequest", async () => {
+    const { company: secondCompany } = await userWithCompanyFactory("ADMIN");
+    const { company: thirdCompany } = await userWithCompanyFactory("ADMIN");
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: secondCompany.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: secondCompany.id,
+        approvals: {
+          create: [
+            { approverSiret: company.siret! },
+            { approverSiret: thirdCompany.siret! }
+          ]
+        },
+        comment: ""
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: false
+      }
+    });
+
+    expect(
+      data.submitBsdasriRevisionRequestApproval.approvals.find(
+        val => val.approverSiret === company.siret
+      )!.status
+    ).toBe("REFUSED");
+    expect(data.submitBsdasriRevisionRequestApproval.status).toBe("REFUSED");
+    expect(
+      data.submitBsdasriRevisionRequestApproval.approvals.find(
+        val => val.approverSiret === thirdCompany.siret
+      )!.status
+    ).toBe("CANCELED");
+  });
+
+  it("should work if only validator refuses the revisionRequest", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: ""
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: false
+      }
+    });
+
+    expect(data.submitBsdasriRevisionRequestApproval.status).toBe("REFUSED");
+  });
+
+  it("should edit bsdasri accordingly when accepted", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    expect(bsdasri.wasteCode).not.toBe("01 03 08");
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        wasteCode: "01 03 08",
+        comment: ""
+      }
+    });
+
+    await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+      MutationSubmitBsdasriRevisionRequestApprovalArgs
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.wasteCode).toBe("01 03 08");
+  });
+
+  it("should not edit bsdasri when refused", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: companyOfSomeoneElse.siret }
+    });
+
+    expect(bsdasri.wasteCode).not.toBe("01 03 08");
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        wasteCode: "01 03 08",
+        comment: ""
+      }
+    });
+
+    await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+      MutationSubmitBsdasriRevisionRequestApprovalArgs
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: false
+      }
+    });
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.wasteCode).not.toBe("01 03 08");
+  });
+
+  //   it("should change the bsdasri status if the bsdasri is PROCESSED and the new operation code implies a next bsdasri", async () => {
+  //     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+  //       "ADMIN"
+  //     );
+  //     const { user, company } = await userWithCompanyFactory("ADMIN");
+  //     const { mutate } = makeClient(user);
+
+  //     const bsdasri = await bsdasriFactory({
+  //       opt: {
+  //         emitterCompanySiret: companyOfSomeoneElse.siret,
+  //         status: "PROCESSED",
+  //         destinationOperationCode: "D10"
+  //       }
+  //     });
+
+  //     const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+  //       data: {
+  //         bsdasriId: bsdasri.id,
+  //         authoringCompanyId: companyOfSomeoneElse.id,
+  //         approvals: { create: { approverSiret: company.siret! } },
+  //         destinationOperationCode: "R 13",
+  //         comment: "Operation code error"
+  //       }
+  //     });
+
+  //     await mutate<
+  //       Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+  //       MutationSubmitBsdasriRevisionRequestApprovalArgs
+  //     >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+  //       variables: {
+  //         id: revisionRequest.id,
+  //         isApproved: true
+  //       }
+  //     });
+
+  //     const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+  //       where: { id: bsdasri.id }
+  //     });
+
+  //     expect(updatedBsdasri.status).toBe("AWAITING_CHILD");
+  //   });
+
+  //   it("should change the bsdasri status if the bsdasri is AWAITING_CHILD and the new operation code does not imply a next bsdasri", async () => {
+  //     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+  //       "ADMIN"
+  //     );
+  //     const { user, company } = await userWithCompanyFactory("ADMIN");
+  //     const { mutate } = makeClient(user);
+
+  //     const bsdasri = await bsdasriFactory({
+  //       opt: {
+  //         emitterCompanySiret: companyOfSomeoneElse.siret,
+  //         status: "AWAITING_CHILD",
+  //         destinationOperationCode: "R 13"
+  //       }
+  //     });
+
+  //     const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+  //       data: {
+  //         bsdasriId: bsdasri.id,
+  //         authoringCompanyId: companyOfSomeoneElse.id,
+  //         approvals: { create: { approverSiret: company.siret! } },
+  //         destinationOperationCode: "R 5",
+  //         comment: "Operation code error"
+  //       }
+  //     });
+
+  //     await mutate<
+  //       Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+  //       MutationSubmitBsdasriRevisionRequestApprovalArgs
+  //     >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+  //       variables: {
+  //         id: revisionRequest.id,
+  //         isApproved: true
+  //       }
+  //     });
+
+  //     const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+  //       where: { id: bsdasri.id }
+  //     });
+
+  //     expect(updatedBsdasri.status).toBe("PROCESSED");
+  //   });
+
+  it("should change not the bsdasri status if the new operation code implies a next bsdasri but the bsdasri is not PROCESSED", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: companyOfSomeoneElse.siret,
+        status: "SENT",
+        destinationOperationCode: "R 5"
+      }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        destinationOperationCode: "R 13",
+        comment: "Operation code error"
+      }
+    });
+
+    await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+      MutationSubmitBsdasriRevisionRequestApprovalArgs
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.status).toBe("SENT");
+  });
+
+  it("should change the bsdasri status to CANCELED if revision asks for cancellation", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: companyOfSomeoneElse.siret,
+        status: "SENT"
+      }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "Cancel",
+        isCanceled: true
+      }
+    });
+
+    await mutate<
+      Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+      MutationSubmitBsdasriRevisionRequestApprovalArgs
+    >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.status).toBe("CANCELED");
+  });
+
+  it.each(NON_CANCELLABLE_BSDASRI_STATUSES)(
+    "should fail if request is about cancelation & the BSDASRI has a non-cancellable status",
+    async (status: BsdasriStatus) => {
+      const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { user, company } = await userWithCompanyFactory("ADMIN");
+      const { mutate } = makeClient(user);
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: companyOfSomeoneElse.siret,
+          status
+        }
+      });
+
+      const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+        data: {
+          bsdasriId: bsdasri.id,
+          authoringCompanyId: companyOfSomeoneElse.id,
+          approvals: { create: { approverSiret: company.siret! } },
+          comment: "Cancel",
+          isCanceled: true
+        }
+      });
+
+      const { errors } = await mutate<
+        Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+        MutationSubmitBsdasriRevisionRequestApprovalArgs
+      >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+        variables: {
+          id: revisionRequest.id,
+          isApproved: true
+        }
+      });
+
+      expect(errors[0].message).toBe(
+        "Impossible d'annuler un bordereau qui a été réceptionné sur l'installation de destination."
+      );
+    }
+  );
+
+  // todo: grouped - synthesis
+
+  it("should update the operation code & mode", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: companyOfSomeoneElse.siret,
+        destinationOperationCode: "D9"
+      }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        destinationOperationCode: "D10",
+        destinationOperationMode: "ELIMINATION"
+      }
+    });
+
+    await mutate<Pick<Mutation, "submitBsdasriRevisionRequestApproval">>(
+      SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL,
+      {
+        variables: {
+          id: revisionRequest.id,
+          isApproved: true
+        }
+      }
+    );
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.destinationOperationCode).toBe("D10");
+    expect(updatedBsdasri.destinationOperationMode).toBe("ELIMINATION");
+  });
+
+  it.each([null, undefined])("should nullify the operation mode", async () => {
+    const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsdasri = await bsdasriFactory({
+      opt: {
+        emitterCompanySiret: companyOfSomeoneElse.siret,
+        destinationOperationCode: "D 10",
+        destinationOperationMode: "ELIMINATION"
+      }
+    });
+
+    const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: companyOfSomeoneElse.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        destinationOperationCode: "D 9"
+      }
+    });
+
+    await mutate<Pick<Mutation, "submitBsdasriRevisionRequestApproval">>(
+      SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL,
+      {
+        variables: {
+          id: revisionRequest.id,
+          isApproved: true
+        }
+      }
+    );
+
+    const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id }
+    });
+
+    expect(updatedBsdasri.destinationOperationCode).toBe("D 9");
+    expect(updatedBsdasri.destinationOperationMode).toBeNull();
+  });
+
+  it.skip(
+    "should delete the finalOperations rows when changing operation " +
+      "code from a final to a non-final code",
+    async () => {
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const destination = await userWithCompanyFactory("ADMIN");
+
+      const { mutate } = makeClient(emitter.user);
+
+      const initialBsdasri = await bsdasriFactory({
+        opt: { destinationOperationCode: "D 10" }
+      });
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          destinationCompanySiret: destination.company.siret,
+          destinationOperationCode: "R 1",
+          destinationOperationSignatureDate: new Date(),
+          destinationOperationMode: "VALORISATION_ENERGETIQUE",
+          grouping: { connect: { id: initialBsdasri.id } }
+        }
+      });
+
+      await operationHook(bsdasri, { runSync: true });
+
+      const initialBsdasriWithFinalOperations =
+        await prisma.bsdasri.findUniqueOrThrow({
+          where: { id: initialBsdasri.id },
+          include: { finalOperations: true }
+        });
+
+      expect(initialBsdasriWithFinalOperations.finalOperations).toHaveLength(1);
+
+      const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+        data: {
+          bsdasriId: bsdasri.id,
+          authoringCompanyId: destination.company.id,
+          approvals: { create: { approverSiret: emitter.company.siret! } },
+          comment: "",
+          destinationOperationCode: "D 9"
+        }
+      });
+
+      await mutate<Pick<Mutation, "submitBsdasriRevisionRequestApproval">>(
+        SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL,
+        {
+          variables: {
+            id: revisionRequest.id,
+            isApproved: true
+          }
+        }
+      );
+
+      const updatedInitialBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+        where: { id: initialBsdasri.id },
+        include: { finalOperations: true }
+      });
+
+      expect(updatedInitialBsdasri.finalOperations).toHaveLength(0);
+    }
+  );
+  it(
+    "should create the final operation using the job queue" +
+      " when changing operation code to a final one",
+    async () => {
+      const emitter = await userWithCompanyFactory("ADMIN");
+      const destination = await userWithCompanyFactory("ADMIN");
+
+      const { mutate } = makeClient(emitter.user);
+
+      const initialBsdasri = await bsdasriFactory({
+        opt: { destinationOperationCode: "D 15" }
+      });
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          emitterCompanySiret: emitter.company.siret,
+          destinationCompanySiret: destination.company.siret,
+          destinationOperationCode: "D 15",
+          destinationOperationSignatureDate: new Date(),
+          destinationOperationMode: "VALORISATION_ENERGETIQUE",
+          grouping: { connect: { id: initialBsdasri.id } }
+        }
+      });
+
+      const revisionRequest = await prisma.bsdasriRevisionRequest.create({
+        data: {
+          bsdasriId: bsdasri.id,
+          authoringCompanyId: destination.company.id,
+          approvals: { create: { approverSiret: emitter.company.siret! } },
+          comment: "",
+          destinationOperationCode: "R 1"
+        }
+      });
+
+      await mutate<Pick<Mutation, "submitBsdasriRevisionRequestApproval">>(
+        SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL,
+        {
+          variables: {
+            id: revisionRequest.id,
+            isApproved: true
+          }
+        }
+      );
+
+      await new Promise(resolve => {
+        operationHooksQueue.once("global:drained", () => resolve(true));
+      });
+
+      const updatedInitialBsdasri = await prisma.bsdasri.findUniqueOrThrow({
+        where: { id: initialBsdasri.id },
+        include: { finalOperations: true }
+      });
+
+      expect(updatedInitialBsdasri.finalOperations).toHaveLength(1);
+    }
+  );
+});

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/cancelRevisionRequest.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/cancelRevisionRequest.ts
@@ -1,0 +1,46 @@
+import { RevisionRequestStatus } from "@prisma/client";
+import { checkIsAuthenticated } from "../../../../common/permissions";
+import { MutationCancelBsdaRevisionRequestArgs } from "../../../../generated/graphql/types";
+import { GraphQLContext } from "../../../../types";
+import { getBsdasriRepository } from "../../../repository";
+import { Permission, can, getUserRoles } from "../../../../permissions";
+import { prisma } from "@td/prisma";
+import { ForbiddenError, UserInputError } from "../../../../common/errors";
+
+export async function cancelBsdasriRevisionRequest(
+  _,
+  { id }: MutationCancelBsdaRevisionRequestArgs,
+  context: GraphQLContext
+) {
+  const user = checkIsAuthenticated(context);
+  const bsdasriRepository = getBsdasriRepository(user);
+
+  const revisionRequest = await bsdasriRepository.findUniqueRevisionRequest({
+    id
+  });
+
+  if (!revisionRequest) {
+    throw new UserInputError("Révision introuvable.");
+  }
+
+  if (revisionRequest.status !== RevisionRequestStatus.PENDING) {
+    throw new UserInputError(
+      "La révision n'est pas annulable. Elle a déjà été acceptée ou refusée."
+    );
+  }
+
+  const authoringCompany = await prisma.company.findUniqueOrThrow({
+    where: { id: revisionRequest.authoringCompanyId }
+  });
+
+  const userRoles = await getUserRoles(user.id);
+  if (
+    !userRoles[authoringCompany.orgId] ||
+    !can(userRoles[authoringCompany.orgId], Permission.BsdCanRevise)
+  ) {
+    throw new ForbiddenError("Vous n'êtes pas l'auteur de cette révision.");
+  }
+
+  await bsdasriRepository.cancelRevisionRequest({ id });
+  return true;
+}

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/createRevisionRequest.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/createRevisionRequest.ts
@@ -1,0 +1,216 @@
+import {
+  Bsdasri,
+  BsdasriStatus,
+  Prisma,
+  RevisionRequestStatus,
+  BsdasriType
+} from "@prisma/client";
+
+import { ForbiddenError, UserInputError } from "../../../../common/errors";
+
+import { checkIsAuthenticated } from "../../../../common/permissions";
+import {
+  BsdasriRevisionRequestContentInput,
+  MutationCreateBsdasriRevisionRequestArgs
+} from "../../../../generated/graphql/types";
+import { GraphQLContext } from "../../../../types";
+import { getUserCompanies } from "../../../../users/database";
+import { flattenBsdasriRevisionRequestInput } from "../../../converter";
+import { getBsdasriOrNotFound } from "../../../database";
+import { checkCanRequestRevision } from "../../../permissions";
+import { getBsdasriRepository } from "../../../repository";
+
+import { revisionSchema, checkRevisionRules } from "../../../zodSchema";
+
+// If you modify this, also modify it in the frontend
+export const CANCELLABLE_BSDASRI_STATUSES: BsdasriStatus[] = [
+  // BsdasriStatus.INITIAL,
+  // BsdasriStatus.SIGNED_BY_PRODUCER,
+  BsdasriStatus.SENT
+  // BsdasriStatus.RECEIVED,
+  // BsdasriStatus.PROCESSED,
+  // BsdasriStatus.AWAITING_GROUP,
+  // BsdasriStatus.CANCELED
+  // BsdasriStatus.REFUSED,
+  // BsdasriStatus.REFUSED_BY_RECIPIENT
+];
+
+export const NON_CANCELLABLE_BSDASRI_STATUSES: BsdasriStatus[] = Object.values(
+  BsdasriStatus
+).filter(status => !CANCELLABLE_BSDASRI_STATUSES.includes(status));
+
+const BSDASRI_REVISION_REQUESTER_FIELDS = [
+  "emitterCompanySiret",
+  "destinationCompanySiret",
+  "ecoOrganismeSiret"
+];
+
+export type RevisionRequestContent = Pick<
+  Prisma.BsdasriRevisionRequestCreateInput,
+  | "wasteCode"
+  | "destinationWastePackagings"
+  | "destinationReceptionWasteWeightValue"
+  | "destinationOperationCode"
+  | "emitterPickupSiteName"
+  | "emitterPickupSiteAddress"
+  | "emitterPickupSiteCity"
+  | "emitterPickupSitePostalCode"
+  | "emitterPickupSiteInfos"
+>;
+
+export async function createBsdasriRevisionRequest(
+  _,
+  { input }: MutationCreateBsdasriRevisionRequestArgs,
+  context: GraphQLContext
+) {
+  const { bsdasriId, content, comment, authoringCompanySiret } = input;
+
+  const user = checkIsAuthenticated(context);
+  const bsdasri = await getBsdasriOrNotFound({ id: bsdasriId });
+
+  const bsdasriRepository = getBsdasriRepository(user);
+
+  await checkIfUserCanRequestRevisionOnBsdasri(user, bsdasri);
+  const authoringCompany = await getAuthoringCompany(
+    user,
+    bsdasri,
+    authoringCompanySiret
+  );
+
+  if (!authoringCompany.siret) {
+    throw new Error(
+      `Authoring company ${authoringCompany.id} has no siret. Cannot create BSDASRI revision request.`
+    );
+  }
+  const approversSirets = await getApproversSirets(
+    bsdasri,
+    authoringCompany.siret
+  );
+
+  const flatContent = await getFlatContent(content, bsdasri);
+
+  return bsdasriRepository.createRevisionRequest({
+    bsdasri: { connect: { id: bsdasri.id } },
+    ...flatContent,
+    authoringCompany: { connect: { id: authoringCompany.id } },
+    approvals: {
+      create: approversSirets.map(approverSiret => ({ approverSiret }))
+    },
+    comment
+  });
+}
+
+async function checkIfUserCanRequestRevisionOnBsdasri(
+  user: Express.User,
+  bsdasri: Bsdasri
+): Promise<void> {
+  await checkCanRequestRevision(user, bsdasri);
+  if ([BsdasriType.GROUPING, BsdasriType.SYNTHESIS].includes(bsdasri.type)) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur un bordereau de synthèse ou de groupement."
+    );
+  }
+  if (bsdasri.status === BsdasriStatus.INITIAL) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur ce bordereau. Vous pouvez le modifier directement, aucune signature bloquante n'a encore été apposée."
+    );
+  }
+
+  if (bsdasri.status === BsdasriStatus.REFUSED || bsdasri.isDeleted) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur ce bordereau, il a été refusé ou supprimé."
+    );
+  }
+
+  if (bsdasri.status === BsdasriStatus.CANCELED) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur ce bordereau, il a été annulé."
+    );
+  }
+
+  const unsettledRevisionRequestsOnbsdasri = await getBsdasriRepository(
+    user
+  ).countRevisionRequests({
+    bsdasriId: bsdasri.id,
+    status: RevisionRequestStatus.PENDING
+  });
+  if (unsettledRevisionRequestsOnbsdasri > 0) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur ce bordereau. Une autre révision est déjà en attente de validation."
+    );
+  }
+}
+
+async function getApproversSirets(
+  bsdasri: Bsdasri,
+  authoringCompanySiret: string
+) {
+  // Requesters and approvers are the same persona
+  const approversSirets = BSDASRI_REVISION_REQUESTER_FIELDS.map(
+    field => bsdasri[field]
+  ).filter(siret => Boolean(siret) && siret !== authoringCompanySiret);
+
+  // Remove duplicates
+  return [...new Set(approversSirets)];
+}
+
+async function getAuthoringCompany(
+  user: Express.User,
+  bsdasri: Bsdasri,
+  authoringCompanySiret: string
+) {
+  const siretConcernedByRevision = BSDASRI_REVISION_REQUESTER_FIELDS.map(
+    field => bsdasri[field]
+  );
+
+  if (!siretConcernedByRevision.includes(authoringCompanySiret)) {
+    throw new UserInputError(
+      `Le SIRET "${authoringCompanySiret}" ne peut pas être auteur de la révision. Il n'apparait pas avec un rôle lui donnant ce droit sur le bordereau.`
+    );
+  }
+
+  const userCompanies = await getUserCompanies(user.id);
+  const authoringCompany = userCompanies.find(
+    company => company.siret === authoringCompanySiret
+  );
+
+  if (!authoringCompany) {
+    throw new UserInputError(
+      `Vous n'avez pas les droits suffisants pour déclarer le SIRET "${authoringCompanySiret}" comme auteur de la révision.`
+    );
+  }
+
+  return authoringCompany;
+}
+
+async function getFlatContent(
+  content: BsdasriRevisionRequestContentInput,
+  bsdasri: Bsdasri
+): Promise<RevisionRequestContent> {
+  const flatContent = flattenBsdasriRevisionRequestInput(content);
+  const { isCanceled, ...fields } = flatContent;
+
+  if (!isCanceled && Object.keys(fields).length === 0) {
+    throw new UserInputError(
+      "Impossible de créer une révision sans modifications."
+    );
+  }
+
+  if (isCanceled && Object.values(fields).length > 0) {
+    throw new UserInputError(
+      "Impossible d'annuler et de modifier un bordereau."
+    );
+  }
+
+  // One cannot request a CANCELATION if the dasri has advanced too far in the workflow
+  if (isCanceled && NON_CANCELLABLE_BSDASRI_STATUSES.includes(bsdasri.status)) {
+    throw new ForbiddenError(
+      "Impossible d'annuler un bordereau qui a été réceptionné sur l'installation de destination."
+    );
+  }
+  revisionSchema.parse(flatContent); // Validate but don't parse as we want to keep empty fields empty
+
+  checkRevisionRules(fields, bsdasri.status);
+
+  return flatContent;
+}

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/submitRevisionRequestApproval.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/submitRevisionRequestApproval.ts
@@ -1,0 +1,100 @@
+import {
+  Prisma,
+  RevisionRequestApprovalStatus as Status,
+  RevisionRequestStatus,
+  User
+} from "@prisma/client";
+import { checkIsAuthenticated } from "../../../../common/permissions";
+import { MutationSubmitBsdaRevisionRequestApprovalArgs } from "../../../../generated/graphql/types";
+import { GraphQLContext } from "../../../../types";
+import { getBsdasriRepository } from "../../../repository";
+import { Permission, can, getUserRoles } from "../../../../permissions";
+import { ForbiddenError, UserInputError } from "../../../../common/errors";
+
+const bsdasriRevisionRequestWithApprovals =
+  Prisma.validator<Prisma.BsdasriRevisionRequestArgs>()({
+    include: { approvals: true }
+  });
+type BsdasriRevisionRequestWithApprovals =
+  Prisma.BsdasriRevisionRequestGetPayload<
+    typeof bsdasriRevisionRequestWithApprovals
+  >;
+
+export async function submitBsdasriRevisionRequestApproval(
+  _,
+  { id, isApproved, comment }: MutationSubmitBsdaRevisionRequestApprovalArgs,
+  context: GraphQLContext
+) {
+  const user = checkIsAuthenticated(context);
+  const bsdasriRepository = getBsdasriRepository(user);
+
+  const revisionRequest = (await bsdasriRepository.findUniqueRevisionRequest(
+    { id },
+    bsdasriRevisionRequestWithApprovals
+  )) as BsdasriRevisionRequestWithApprovals;
+
+  if (!revisionRequest) {
+    throw new UserInputError("Révision introuvable.");
+  }
+
+  if (revisionRequest.status === RevisionRequestStatus.REFUSED) {
+    throw new ForbiddenError(
+      "Cette révision n'est plus approuvable, au moins un acteur l'a refusée."
+    );
+  }
+
+  const currentApproverSirets = await getCurrentApproverSirets(
+    user,
+    revisionRequest
+  );
+
+  for (const currentApproverSiret of currentApproverSirets) {
+    const approval = revisionRequest.approvals.find(
+      approval => approval.approverSiret === currentApproverSiret
+    );
+
+    if (!approval) {
+      throw new UserInputError(
+        "Vous n'êtes pas approbateur de cette révision."
+      );
+    }
+
+    if (isApproved) {
+      await bsdasriRepository.acceptRevisionRequestApproval(approval.id, {
+        comment
+      });
+    } else {
+      await bsdasriRepository.refuseRevisionRequestApproval(approval.id, {
+        comment
+      });
+    }
+  }
+
+  return bsdasriRepository.findUniqueRevisionRequest({ id });
+}
+
+async function getCurrentApproverSirets(
+  user: User,
+  revisionRequest: BsdasriRevisionRequestWithApprovals
+): Promise<string[]> {
+  const remainingApproverSirets = revisionRequest.approvals
+    .filter(approval => approval.status === Status.PENDING)
+    .map(approvals => approvals.approverSiret);
+
+  const roles = await getUserRoles(user.id);
+  const userOrgIds = Object.keys(roles).filter(orgId =>
+    can(roles[orgId], Permission.BsdCanRevise)
+  );
+
+  const approvingCompaniesCandidates = userOrgIds.filter(orgId =>
+    remainingApproverSirets.includes(orgId)
+  );
+
+  if (!approvingCompaniesCandidates.length) {
+    throw new ForbiddenError(
+      "Vous n'êtes pas destinataire de cette révision, ou alors cette révision a déjà été approuvée."
+    );
+  }
+
+  return approvingCompaniesCandidates;
+}

--- a/back/src/bsdasris/resolvers/queries/__tests__/revisionRequests.integration.ts
+++ b/back/src/bsdasris/resolvers/queries/__tests__/revisionRequests.integration.ts
@@ -1,0 +1,215 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import {
+  Query,
+  QueryBsdasriRevisionRequestsArgs
+} from "../../../../generated/graphql/types";
+import { prisma } from "@td/prisma";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+import { bsdasriFactory } from "../../../__tests__/factories";
+
+const BSDASRI_REVISION_REQUESTS = `
+  query BsdaRevisionRequests($siret: String!, $where:BsdasriRevisionRequestWhere) {
+    bsdasriRevisionRequests(siret: $siret, where: $where) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        startCursor
+      }
+      edges {
+        node {
+          id
+          bsdasri {
+            id
+          }
+          status
+        }
+      }
+    }
+  }
+`;
+
+describe("Mutation.bsdasriRevisionRequests", () => {
+  afterEach(() => resetDatabase());
+
+  it("should list every revisionRequest from and to company", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const { company: otherCompany } = await userWithCompanyFactory("ADMIN");
+    const { query } = makeClient(user);
+
+    const bsdasri1 = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+    const bsdasri2 = await bsdasriFactory({
+      opt: { destinationCompanySiret: company.siret }
+    });
+
+    // 2 unsettled
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri1.id,
+        authoringCompanyId: otherCompany.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: ""
+      }
+    });
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri2.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: otherCompany.siret! } },
+        comment: ""
+      }
+    });
+
+    // 2 settled revisionRequests
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri2.id,
+        authoringCompanyId: company.id,
+        approvals: {
+          create: {
+            approverSiret: otherCompany.siret!,
+            status: "ACCEPTED"
+          }
+        },
+        comment: ""
+      }
+    });
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri2.id,
+        authoringCompanyId: company.id,
+        approvals: {
+          create: {
+            approverSiret: otherCompany.siret!,
+            status: "REFUSED"
+          }
+        },
+        comment: ""
+      }
+    });
+
+    const { data } = await query<Pick<Query, "bsdasriRevisionRequests">>(
+      BSDASRI_REVISION_REQUESTS,
+      {
+        variables: { siret: company.siret }
+      }
+    );
+
+    expect(data.bsdasriRevisionRequests.totalCount).toBe(4);
+    expect(data.bsdasriRevisionRequests.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it("should fail if requesting a siret current user is not part of", async () => {
+    const { user } = await userWithCompanyFactory("ADMIN");
+    const { company } = await userWithCompanyFactory("ADMIN");
+    const { query } = makeClient(user);
+
+    const { errors } = await query<Pick<Query, "bsdasriRevisionRequests">>(
+      BSDASRI_REVISION_REQUESTS,
+      {
+        variables: { siret: company.siret }
+      }
+    );
+
+    expect(errors[0].message).toBe(
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${company.siret}`
+    );
+  });
+
+  it("should filter based on status", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdasri = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    // should be included
+    const bsdasri1RevisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    // should not be included
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "REFUSED"
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<
+      Pick<Query, "bsdasriRevisionRequests">,
+      QueryBsdasriRevisionRequestsArgs
+    >(BSDASRI_REVISION_REQUESTS, {
+      variables: { siret: company.orgId, where: { status: "ACCEPTED" } }
+    });
+
+    expect(data.bsdasriRevisionRequests.totalCount).toBe(1);
+    expect(data.bsdasriRevisionRequests.edges.map(_ => _.node)[0].id).toEqual(
+      bsdasri1RevisionRequest.id
+    );
+  });
+
+  it("should filter based on bsdasriId", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const bsdasri1 = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    const bsdasri2 = await bsdasriFactory({
+      opt: { emitterCompanySiret: company.siret }
+    });
+
+    // should be included
+    const bsdasri1RevisionRequest = await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri1.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    // should not be included
+    await prisma.bsdasriRevisionRequest.create({
+      data: {
+        bsdasriId: bsdasri2.id,
+        authoringCompanyId: company.id,
+        approvals: { create: { approverSiret: company.siret! } },
+        comment: "",
+        status: "ACCEPTED"
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<
+      Pick<Query, "bsdasriRevisionRequests">,
+      QueryBsdasriRevisionRequestsArgs
+    >(BSDASRI_REVISION_REQUESTS, {
+      variables: {
+        siret: company.orgId,
+        where: { bsdasriId: { _eq: bsdasri1.id } }
+      }
+    });
+
+    expect(data.bsdasriRevisionRequests.totalCount).toBe(1);
+    expect(data.bsdasriRevisionRequests.edges.map(_ => _.node)[0].id).toEqual(
+      bsdasri1RevisionRequest.id
+    );
+  });
+});

--- a/back/src/bsdasris/resolvers/queries/revisionRequests.ts
+++ b/back/src/bsdasris/resolvers/queries/revisionRequests.ts
@@ -1,0 +1,68 @@
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { getCompanyOrCompanyNotFound } from "../../../companies/database";
+import {
+  Bsdasri,
+  BsdasriRevisionRequestContent,
+  FormCompany,
+  QueryResolvers
+} from "../../../generated/graphql/types";
+import { getReadonlyBsdasriRepository } from "../../repository";
+import { getConnection } from "../../../common/pagination";
+import { Prisma } from "@prisma/client";
+import { Permission, checkUserPermissions } from "../../../permissions";
+import { toPrismaStringFilter } from "../../../common/where";
+
+const MIN_SIZE = 0;
+const MAX_SIZE = 50;
+
+export const bsdasriRevisionRequests: QueryResolvers["bsdasriRevisionRequests"] =
+  async (_, args, context) => {
+    const { siret, after, first = MAX_SIZE, where } = args;
+    const user = checkIsAuthenticated(context);
+    await checkUserPermissions(
+      user,
+      siret,
+      Permission.BsdCanList,
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${siret}`
+    );
+    const company = await getCompanyOrCompanyNotFound(
+      { orgId: siret },
+      { id: true, orgId: true }
+    );
+
+    const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
+
+    const prismaWhere: Prisma.BsdasriRevisionRequestWhereInput = {
+      OR: [
+        { authoringCompanyId: company.id },
+        { approvals: { some: { approverSiret: company.orgId } } }
+      ],
+      ...(where?.status ? { status: where.status } : {}),
+      ...(where?.bsdasriId
+        ? { bsdasriId: toPrismaStringFilter(where.bsdasriId) }
+        : {})
+    };
+
+    const bsdasriRepository = getReadonlyBsdasriRepository();
+    const revisionRequestsTotalCount =
+      await bsdasriRepository.countRevisionRequests(prismaWhere);
+
+    return getConnection({
+      totalCount: revisionRequestsTotalCount,
+      findMany: prismaPaginationArgs =>
+        bsdasriRepository.findManyBsdasriRevisionRequest(prismaWhere, {
+          ...prismaPaginationArgs,
+
+          orderBy: { createdAt: "desc" }
+        }),
+      formatNode: node => ({
+        ...node,
+        // the following fields will be resolved in BsdasriRevisionRequest resolver
+        approvals: [],
+        content: {} as BsdasriRevisionRequestContent,
+        authoringCompany: {} as FormCompany,
+        bsdasri: {} as Bsdasri
+      }),
+      ...{ after, first: pageSize }
+    });
+  };

--- a/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
@@ -28,6 +28,9 @@ enum BsdasriStatus {
 
   "En attente de groupement"
   AWAITING_GROUP
+
+  "Bordereau annulé. L'annulation peut être demandée via le processus de révision"
+  CANCELED
 }
 
 "Type de packaging du déchet"

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -315,3 +315,69 @@ input BsdasriSignatureWithSecretCodeInput {
   "Dénomination de l'auteur de la signature, par défaut il s'agit de l'émetteur"
   signatureAuthor: SignatureAuthor
 }
+
+"Payload de révision d'un bordereau."
+input CreateBsdasriRevisionRequestInput {
+  "Identifiant du bordereau à réviser"
+  bsdasriId: ID!
+  "Numéro SIRET du demandeur"
+  authoringCompanySiret: String!
+  "Contenu de la révision"
+  content: BsdasriRevisionRequestContentInput!
+  "Commentaire pour expliquer la demande de révision"
+  comment: String!
+}
+
+"Payload de révision d'un bordereau. Disponible sur une liste restreinte de champs."
+input BsdasriRevisionRequestContentInput {
+  "Maitre d'ouvrage ou détenteur du déchet"
+  emitter: BsdasriRevisionRequestEmitterInput
+
+  "Installation de destination"
+  destination: BsdasriRevisionRequestDestinationInput
+
+  "Description du déchet"
+  waste: BsdasriRevisionRequestWasteInput
+
+  "NON ACTIF  Annuler le bordereau. Exclusif des autres opérations. "
+  isCanceled: Boolean
+}
+
+input BsdasriRevisionRequestEmitterInput {
+  "Informations chantier (si différente de l'adresse de l'entreprise)"
+  pickupSite: PickupSiteInput
+}
+
+input BsdasriRevisionRequestDestinationInput {
+  "Réception"
+  reception: BsdasriRevisionRequestReceptionInput
+  "Réalisation du traitement"
+  operation: BsdasriRevisionRequestOperationInput
+}
+
+input BsdasriRevisionRequestOperationInput {
+  "Poids présenté"
+  weight: Float
+  "Code D/R"
+  code: String
+
+  "Mode de traitement"
+  mode: OperationMode
+}
+
+input BsdasriRevisionRequestReceptionInput {
+  "Conditionnement"
+  packagings: [BsdasriPackagingsInput!]
+}
+
+input BsdasriRevisionRequestWasteInput {
+  "Rubrique Déchet"
+  code: String
+}
+
+input BsdasriRevisionRequestWhere {
+  "Permet de filtrer sur un statut de demande de révision"
+  status: RevisionRequestStatus
+  "Permet de filtrer sur un numéro de bordereau"
+  bsdasriId: StringFilter
+}

--- a/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.mutations.graphql
@@ -149,4 +149,34 @@ type Mutation {
   Supprime un BSDASRI
   """
   deleteBsdasri("ID d'un Dasri" id: ID!): Bsdasri!
+
+  """
+  Crée une demande de révision sur un Bsdasri existant
+  """
+  createBsdasriRevisionRequest(
+    input: CreateBsdasriRevisionRequestInput!
+  ): BsdasriRevisionRequest!
+
+  """
+  Annule une demande de révision de Bsdasri.
+  Peut être fait uniquement par l'auteur de la révision, si celle-ci n'a pas encore été acceptée
+  """
+  cancelBsdasriRevisionRequest(
+    "Identifiant de la demande de révision"
+    id: ID!
+  ): Boolean!
+
+  """
+  Répond à une demande d'approbation d'une révision.
+  En cas de refus, la révision associée est automatiquement refusée et les autres validations supprimées.
+  En cas d'acceptation, si c'était la dernière approbation attendue, la révision associée est automatiquement approuvée et appliquée sur le Bsdasri.
+  """
+  submitBsdasriRevisionRequestApproval(
+    "Identifiant de la validation"
+    id: ID!
+    "Indique si la révision est acceptée ou non"
+    isApproved: Boolean!
+    "Commentaire facultatif"
+    comment: String
+  ): BsdasriRevisionRequest!
 }

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -233,8 +233,11 @@ type BsdasriError {
   path: String!
   requiredFor: [BsdasriSignatureType!]!
 }
+
 type BsdasriMetadata {
-  errors: [BsdasriError]!
+  errors: [BsdasriError]
+  "EXPERIMENTAL, ne pas utiliser - Dernière révision du bordereau"
+  latestRevision: BsdasriRevisionRequest
 }
 
 type BsdasriConnection {
@@ -242,7 +245,106 @@ type BsdasriConnection {
   pageInfo: PageInfo!
   edges: [BsdasriEdge!]!
 }
+
 type BsdasriEdge {
   cursor: String!
   node: Bsdasri!
+}
+
+"Demande de révision Bsdasri"
+type BsdasriRevisionRequest {
+  "Identifiant de la demande de révison"
+  id: ID!
+
+  "Aperçu du bordereau concerné au moment de la création de la demande de révision. Il ne reflète pas le bordereau actuel."
+  bsdasri: Bsdasri!
+
+  "Date de création de la demande"
+  createdAt: DateTime!
+
+  "Entreprise à l'origine de la demande de révision"
+  authoringCompany: FormCompany!
+
+  "Liste des approbations apposées sur la révision"
+  approvals: [BsdasriRevisionRequestApproval!]!
+
+  "Contenu de la révision"
+  content: BsdasriRevisionRequestContent!
+
+  "Commentaire explicatif, saisi par l'auteur de la demande de révision"
+  comment: String!
+
+  "Statut d'acceptation de la révision"
+  status: RevisionRequestStatus!
+}
+
+"Approbation d'une demande de révision"
+type BsdasriRevisionRequestApproval {
+  "Siret de l'entreprise responsable de cette approbation"
+  approverSiret: String!
+
+  "Commentaire explicatif, saisi par l'approbateur"
+  comment: String
+
+  "Statut d'acceptation de l'approbation"
+  status: RevisionRequestApprovalStatus!
+}
+
+"Payload de révision d'un bordereau. Disponible sur une liste restreinte de champs."
+type BsdasriRevisionRequestContent {
+  "Maitre d'ouvrage ou détenteur du déchet"
+  emitter: BsdasriRevisionRequestEmitter
+
+  "Installation de destination"
+  destination: BsdasriRevisionRequestDestination
+
+  "Description du déchet"
+  waste: BsdasriRevisionRequestWaste
+
+  "Demande d'annulation du bordereau"
+  isCanceled: Boolean
+}
+
+type BsdasriRevisionRequestEmitter {
+  "Informations site d'enlèvement"
+  pickupSite: PickupSite
+}
+
+type BsdasriRevisionRequestDestination {
+  "Réception"
+  reception: BsdasriRevisionRequestReception
+  "Réalisation de l'opération"
+  operation: BsdasriRevisionRequestOperation
+}
+
+type BsdasriRevisionRequestReception {
+  "Conditionnement"
+  packagings: [BsdasriPackaging!]
+}
+
+type BsdasriRevisionRequestOperation {
+  "Poids de déchets traité"
+  weight: Float
+
+  "Code de traitement"
+  code: String
+
+  "Mode de traitement"
+  mode: OperationMode
+}
+
+type BsdasriRevisionRequestWaste {
+  "Rubrique Déchet"
+  code: String
+}
+
+type BsdasriRevisionRequestConnection {
+  totalCount: Int!
+  pageInfo: PageInfo!
+  edges: [BsdasriRevisionRequestEdge!]!
+}
+
+type BsdasriRevisionRequestEdge {
+  cursor: String!
+  node: BsdasriRevisionRequest!
 }

--- a/back/src/bsdasris/typeDefs/bsdasri.queries.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.queries.graphql
@@ -60,4 +60,32 @@ type Query {
   Il est valable 10 secondes
   """
   bsdasriPdf("ID d'un bordereau" id: ID!): FileDownload!
+
+  """
+  Renvoie les demandes de révisions Bsdasri associées à un SIRET (demandes soumises et approbations requises)
+  """
+  bsdasriRevisionRequests(
+    "SIRET d'un établissement dont je suis membre"
+    siret: String!
+    "(Optionnel) Filtres"
+    where: BsdasriRevisionRequestWhere
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `first` de paginer "en avant"
+    (des révisions les plus récentes aux révisions les plus ancienness)
+    Curseur après lequel les révisions doivent être retournées
+    Attend un identifiant (propriété `id`) de révision
+    Défaut à vide, pour retourner les révisions les plus récentes
+    La révision précisée dans le curseur ne fait pas partie du résultat
+    """
+    after: String
+    """
+    (Optionnel) PAGINATION
+    Permet en conjonction avec `after` de paginer "en avant"
+    (des révisions les plus récentes aux révisions les plus anciennes)
+    Nombre de révisions retournées après le `after`
+    Défaut à 50
+    """
+    first: Int
+  ): BsdasriRevisionRequestConnection!
 }

--- a/back/src/bsdasris/types.ts
+++ b/back/src/bsdasris/types.ts
@@ -35,3 +35,26 @@ export const BsdasriWithSynthesizingInclude =
 export type BsdasriWithSynthesizing = Prisma.BsdasriGetPayload<{
   include: typeof BsdasriWithSynthesizingInclude;
 }>;
+
+export const BsdasriRevisionRequestWithAuthoringCompanyInclude =
+  Prisma.validator<Prisma.BsdasriRevisionRequestInclude>()({
+    authoringCompany: { select: { orgId: true } }
+  });
+export const BsdasriRevisionRequestWithApprovalsInclude =
+  Prisma.validator<Prisma.BsdasriRevisionRequestInclude>()({
+    approvals: { select: { approverSiret: true } }
+  });
+
+export const BsdasriWithRevisionRequestsInclude =
+  Prisma.validator<Prisma.BsdasriInclude>()({
+    bsdasriRevisionRequests: {
+      include: {
+        ...BsdasriRevisionRequestWithAuthoringCompanyInclude,
+        ...BsdasriRevisionRequestWithApprovalsInclude
+      }
+    }
+  });
+
+export type BsdasriWithRevisionRequests = Prisma.BsdasriGetPayload<{
+  include: typeof BsdasriWithRevisionRequestsInclude;
+}>;

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -173,7 +173,7 @@ export const emitterSchema: FactorySchemaOf<
     emitterPickupSiteInfos: yup.string().nullable()
   });
 
-const packagingsTypes: BsdasriPackagingType[] = [
+export const packagingsTypes: BsdasriPackagingType[] = [
   "BOITE_CARTON",
   "FUT",
   "BOITE_PERFORANTS",

--- a/back/src/bsdasris/zodSchema.ts
+++ b/back/src/bsdasris/zodSchema.ts
@@ -1,0 +1,195 @@
+import { z } from "zod";
+import { BsdasriStatus, OperationMode } from "@prisma/client";
+
+import { getOperationModesFromOperationCode } from "../common/operationModes";
+import { capitalize } from "../common/strings";
+
+// Dasri still uses yup for main validation but migration to zod is on its way
+const ZodWasteCodeEnum = z.enum(["18 01 03*", "18 02 02*"]).nullish();
+const ZodOperationEnum = z.enum(["D9", "D10", "R1"]).nullish();
+
+const ZodBsdasriPackagingEnum = z.enum([
+  "BOITE_CARTON",
+  "FUT",
+  "BOITE_PERFORANTS",
+  "GRAND_EMBALLAGE",
+  "GRV",
+  "AUTRE"
+]);
+export type ZodBsdasriPackagingEnum = z.infer<typeof ZodBsdasriPackagingEnum>;
+
+const revisionRules: RevisionRules = {
+  emitterPickupSiteName: {
+    readableFieldName: "le nom du site d'enlèvement",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+  emitterPickupSiteAddress: {
+    readableFieldName: "l'adresse du site d'enlèvement",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+  emitterPickupSiteCity: {
+    readableFieldName: "la ville du site d'enlèvement",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+  emitterPickupSitePostalCode: {
+    readableFieldName: "le doe postal du site d'enlèvement",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+  emitterPickupSiteInfos: {
+    readableFieldName: "les informations relatives aux site d'enlèvement",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+
+  wasteCode: {
+    readableFieldName: "le code déchet",
+    revisable: [
+      BsdasriStatus.SENT,
+      BsdasriStatus.RECEIVED,
+      BsdasriStatus.PROCESSED
+    ]
+  },
+
+  destinationWastePackagings: {
+    readableFieldName: "le conditionnement",
+    revisable: [BsdasriStatus.RECEIVED, BsdasriStatus.PROCESSED]
+  },
+  destinationOperationCode: {
+    readableFieldName: "le code de traitement",
+    revisable: [BsdasriStatus.PROCESSED]
+  },
+  destinationOperationMode: {
+    readableFieldName: "le mode de traitement",
+    revisable: [BsdasriStatus.PROCESSED]
+  },
+  destinationReceptionWasteWeightValue: {
+    readableFieldName: "le poids de déchet traité",
+    revisable: [BsdasriStatus.PROCESSED]
+  }
+};
+
+export const bsdasriPackagingSchema = z
+  .object({
+    type: ZodBsdasriPackagingEnum.nullish(),
+    other: z.string().nullish(),
+    quantity: z.number().nullish()
+  })
+  .refine(val => val.type !== "AUTRE" || !!val.other, {
+    message:
+      "Vous devez saisir la description du conditionnement quand le type de conditionnement est 'Autre'"
+  });
+
+export const revisionSchema = z
+  .object({
+    isCanceled: z.boolean().nullish(),
+
+    wasteCode: ZodWasteCodeEnum,
+
+    destinationWastePackagings: z
+      .array(bsdasriPackagingSchema)
+
+      .default([])
+      .transform(val => val ?? [])
+      .nullish(),
+
+    destinationReceptionWasteWeightValue: z.number().nullish(),
+
+    destinationOperationCode: ZodOperationEnum.nullish(),
+    destinationOperationMode: z.nativeEnum(OperationMode).nullish(),
+
+    emitterPickupSiteName: z.string().nullish(),
+    emitterPickupSiteAddress: z.string().nullish(),
+    emitterPickupSiteCity: z.string().nullish(),
+    emitterPickupSitePostalCode: z.string().nullish(),
+    emitterPickupSiteInfos: z.string().nullish()
+  })
+  .superRefine((val, ctx) => {
+    const { destinationOperationCode, destinationOperationMode } = val;
+    if (destinationOperationCode) {
+      const modes = getOperationModesFromOperationCode(
+        destinationOperationCode
+      );
+
+      if (modes.length && !destinationOperationMode) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Vous devez préciser un mode de traitement"
+        });
+      } else if (
+        (modes.length &&
+          destinationOperationMode &&
+          !modes.includes(destinationOperationMode)) ||
+        (!modes.length && destinationOperationMode)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
+        });
+      }
+    }
+
+    // The difference with the raw bsdasri schema is that most fields must not be empty
+    const nonEmptyFields = [
+      "wasteCode",
+      "destinationWastePackagings",
+      "destinationOperationCode",
+      "destinationOperationMode",
+      "destinationReceptionWasteWeightValue"
+    ] as const;
+
+    for (const field of nonEmptyFields) {
+      if (field in val && val[field] === null) {
+        const readableFieldName = revisionRules[field].readableFieldName;
+
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${
+            readableFieldName ? capitalize(readableFieldName) : field
+          } ne peut pas être vide`
+        });
+      }
+    }
+  });
+
+export type ZodBsdariRevision = z.infer<typeof revisionSchema>;
+
+type RevisionRules = Record<
+  keyof Omit<ZodBsdariRevision, "isCanceled">,
+  { readableFieldName: string; revisable: Array<BsdasriStatus> }
+>;
+
+export const checkRevisionRules = (flatContent, status: BsdasriStatus) => {
+  // check if fields are editable
+  const errors: string[] = [];
+  for (const [field, value] of Object.entries(flatContent)) {
+    if (value !== null) {
+      if (!revisionRules[field]?.revisable?.includes(status))
+        errors.push(revisionRules[field]?.readableFieldName);
+    }
+  }
+  if (errors.length) {
+    throw new Error(
+      `Les champs suivants ne sont pas révisables : ${errors.join(",")}`
+    );
+  }
+};

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -13,7 +13,9 @@ import {
   MutationPublishBsdasriArgs,
   MutationSignBsdasriArgs,
   MutationDeleteBsdasriArgs,
-  MutationDuplicateBsdasriArgs
+  MutationDuplicateBsdasriArgs,
+  MutationCreateBsdasriRevisionRequestArgs,
+  MutationSubmitBsdasriRevisionRequestApprovalArgs
 } from "../../../../generated/graphql/types";
 import {
   resetDatabase,
@@ -76,7 +78,9 @@ describe("Query.bsds.dasris base workflow", () => {
   let emitter: { user: User; company: Company };
   let transporter: { user: User; company: Company };
   let destination: { user: User; company: Company };
-  let dasriId: string;
+  let bsdasriId: string;
+
+  let revisionRequestId: string;
 
   beforeAll(async () => {
     emitter = await userWithCompanyFactory(UserRole.ADMIN, {
@@ -180,7 +184,7 @@ describe("Query.bsds.dasris base workflow", () => {
           }
         }
       });
-      dasriId = id;
+      bsdasriId = id;
       await refreshElasticSearch();
     });
 
@@ -207,7 +211,7 @@ describe("Query.bsds.dasris base workflow", () => {
       ]);
     });
 
-    it("draft dasri should be isDraftFor emitter", async () => {
+    it("draft bsdasri should be isDraftFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -221,10 +225,10 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
-    it("draft dasri should be isDraftFor transporter", async () => {
+    it("draft bsdasri should be isDraftFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -238,10 +242,10 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
-    it("draft dasri should be isDraftFor destination", async () => {
+    it("draft bsdasri should be isDraftFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -255,12 +259,12 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
 
-  describe("when the dasri is published", () => {
+  describe("when the bsdasri is published", () => {
     beforeAll(async () => {
       const { mutate } = makeClient(emitter.user);
 
@@ -269,14 +273,14 @@ describe("Query.bsds.dasris base workflow", () => {
         MutationPublishBsdasriArgs
       >(PUBLISH_DASRI, {
         variables: {
-          id: dasriId
+          id: bsdasriId
         }
       });
 
       await refreshElasticSearch();
     });
 
-    it("published dasri should be isForActionFor emitter", async () => {
+    it("published bsdasri should be isForActionFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -290,11 +294,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("published dasri should be isToCollectFor transporter", async () => {
+    it("published bsdasri should be isToCollectFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -308,11 +312,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("published dasri should be isFollowFor destination", async () => {
+    it("published bsdasri should be isFollowFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -326,7 +330,7 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
@@ -339,7 +343,7 @@ describe("Query.bsds.dasris base workflow", () => {
         SIGN_DASRI,
         {
           variables: {
-            id: dasriId,
+            id: bsdasriId,
             input: { type: "EMISSION", author: "Marcel" }
           }
         }
@@ -348,7 +352,7 @@ describe("Query.bsds.dasris base workflow", () => {
       await refreshElasticSearch();
     });
 
-    it("signed by emitter dasri should be isFollowFor emitter", async () => {
+    it("signed by emitter bsdasri should be isFollowFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -362,11 +366,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("signed by emitter dasri should be isToCollectFor transporter", async () => {
+    it("signed by emitter bsdasri should be isToCollectFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -380,11 +384,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("signed by emitter dasri should be isFollowFor destination", async () => {
+    it("signed by emitter bsdasri should be isFollowFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -398,7 +402,7 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
@@ -411,7 +415,7 @@ describe("Query.bsds.dasris base workflow", () => {
         SIGN_DASRI,
         {
           variables: {
-            id: dasriId,
+            id: bsdasriId,
             input: { type: "TRANSPORT", author: "Bill" }
           }
         }
@@ -420,7 +424,7 @@ describe("Query.bsds.dasris base workflow", () => {
       await refreshElasticSearch();
     });
 
-    it("sent dasri should be isFollowFor emitter", async () => {
+    it("sent bsdasri should be isFollowFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -434,11 +438,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("sent by emitter dasri should be isCollectedFor transporter", async () => {
+    it("sent by emitter bsdasri should be isCollectedFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -452,11 +456,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("sent by emitter dasri should be isForActionFor destination", async () => {
+    it("sent by emitter bsdasri should be isForActionFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -470,12 +474,12 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
 
-  describe("when the dasri reception is signed by the destination", () => {
+  describe("when the bsdasri reception is signed by the destination", () => {
     beforeAll(async () => {
       const { mutate } = makeClient(destination.user);
 
@@ -483,7 +487,7 @@ describe("Query.bsds.dasris base workflow", () => {
         SIGN_DASRI,
         {
           variables: {
-            id: dasriId,
+            id: bsdasriId,
             input: { type: "RECEPTION", author: "Bill" }
           }
         }
@@ -492,7 +496,7 @@ describe("Query.bsds.dasris base workflow", () => {
       await refreshElasticSearch();
     });
 
-    it("received dasri should be isFollowFor emitter", async () => {
+    it("received bsdasri should be isFollowFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -506,11 +510,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("received by emitter dasri should be isFollowFor transporter", async () => {
+    it("received by emitter bsdasri should be isFollowFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -524,11 +528,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("received by emitter dasri should be isForActionFor destination", async () => {
+    it("received by emitter bsdasri should be isForActionFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -542,12 +546,12 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
 
-  describe("when the dasri operation is signed by the destination", () => {
+  describe("when the bsdasri operation is signed by the destination", () => {
     beforeAll(async () => {
       const { mutate } = makeClient(destination.user);
 
@@ -555,7 +559,7 @@ describe("Query.bsds.dasris base workflow", () => {
         SIGN_DASRI,
         {
           variables: {
-            id: dasriId,
+            id: bsdasriId,
             input: { type: "OPERATION", author: "Bill" }
           }
         }
@@ -564,7 +568,7 @@ describe("Query.bsds.dasris base workflow", () => {
       await refreshElasticSearch();
     });
 
-    it("processed dasri should be isArchivedFor emitter", async () => {
+    it("processed bsdasri should be isArchivedFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -578,11 +582,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("processed dasri should be isArchivedFor transporter", async () => {
+    it("processed bsdasri should be isArchivedFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -596,11 +600,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("processed  dasri should be isArchivedFor destination", async () => {
+    it("processed bsdasri should be isArchivedFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -614,15 +618,156 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
 
-  describe("when the dasri is refused", () => {
+  describe("when the bsdasri is under revision", () => {
+    beforeAll(async () => {
+      expect(bsdasriId).toBeDefined();
+      const { mutate } = makeClient(destination.user);
+      const CREATE_BSDASRI_REVISION_REQUEST = gql`
+        mutation CreateBsdasriRevisionRequest(
+          $input: CreateBsdasriRevisionRequestInput!
+        ) {
+          createBsdasriRevisionRequest(input: $input) {
+            id
+          }
+        }
+      `;
+
+      const { errors, data } = await mutate<
+        Pick<Mutation, "createBsdasriRevisionRequest">,
+        MutationCreateBsdasriRevisionRequestArgs
+      >(CREATE_BSDASRI_REVISION_REQUEST, {
+        variables: {
+          input: {
+            bsdasriId,
+            authoringCompanySiret: destination.company.siret!,
+            comment: "oups",
+            content: { waste: { code: "18 02 02*" } }
+          }
+        }
+      });
+      expect(errors).toBeUndefined();
+      revisionRequestId = data.createBsdasriRevisionRequest.id;
+      await refreshElasticSearch();
+    });
+
+    it("should list bsd in emitter `isIsRevisionFor` bsdasris", async () => {
+      const { query } = makeClient(emitter.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [emitter.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: bsdasriId } })
+      ]);
+    });
+
+    it("should list bsd in destination `isIsRevisionFor` bsdasris", async () => {
+      const { query } = makeClient(destination.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isInRevisionFor: [destination.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: bsdasriId } })
+      ]);
+    });
+  });
+
+  describe("when the bsdasri revision has been accepted", () => {
+    beforeAll(async () => {
+      expect(bsdasriId).toBeDefined();
+      const SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL = gql`
+        mutation SubmitBsdasriRevisionRequestApproval(
+          $id: ID!
+          $isApproved: Boolean!
+          $comment: String
+        ) {
+          submitBsdasriRevisionRequestApproval(
+            id: $id
+            isApproved: $isApproved
+            comment: $comment
+          ) {
+            id
+          }
+        }
+      `;
+      const { mutate: mutateByEmitter } = makeClient(emitter.user);
+
+      const { errors: emitterErrors } = await mutateByEmitter<
+        Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+        MutationSubmitBsdasriRevisionRequestApprovalArgs
+      >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+        variables: {
+          id: revisionRequestId,
+          isApproved: true
+        }
+      });
+      expect(emitterErrors).toBeUndefined();
+
+      await refreshElasticSearch();
+    });
+
+    it("should list bsd in emitter `isRevisedFor` bsdasris", async () => {
+      const { query } = makeClient(emitter.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isRevisedFor: [emitter.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: bsdasriId } })
+      ]);
+    });
+
+    it("should list bsd in destination `isRevisedFor` bsdas", async () => {
+      const { query } = makeClient(destination.user);
+      const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
+        GET_BSDS,
+        {
+          variables: {
+            where: {
+              isRevisedFor: [destination.company.siret!]
+            }
+          }
+        }
+      );
+
+      expect(data.bsds.edges).toEqual([
+        expect.objectContaining({ node: { id: bsdasriId } })
+      ]);
+    });
+  });
+
+  describe("when the bsdasri is refused", () => {
+    // should be run after revisions tests
     beforeAll(async () => {
       const refusedDasri = await prisma.bsdasri.update({
-        where: { id: dasriId },
+        where: { id: bsdasriId },
         data: { status: "REFUSED" },
         include: BsdasriForElasticInclude
       });
@@ -630,7 +775,7 @@ describe("Query.bsds.dasris base workflow", () => {
       await refreshElasticSearch();
     });
 
-    it("refused dasri should be isArchivedFor emitter", async () => {
+    it("refused bsdasri should be isArchivedFor emitter", async () => {
       const { query } = makeClient(emitter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -644,11 +789,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("refused dasri should be isArchivedFor transporter", async () => {
+    it("refused bsdasri should be isArchivedFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -662,11 +807,11 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
 
-    it("refused  dasri should be isArchivedFor destination", async () => {
+    it("refused  bsdasri should be isArchivedFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -680,7 +825,7 @@ describe("Query.bsds.dasris base workflow", () => {
       );
 
       expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: dasriId } })
+        expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
   });
@@ -689,31 +834,31 @@ describe("Query.bsds.dasris base workflow", () => {
 describe("Query.bsds.dasris mutations", () => {
   afterAll(resetDatabase);
 
-  it("deleted dasri should be removed from es index", async () => {
+  it("deleted bsdasri should be removed from es index", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["PRODUCER"]
       }
     });
 
-    const dasri = await bsdasriFactory({
+    const bsdasri = await bsdasriFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret
       }
     });
 
-    await indexBsdasri(await getBsdasriForElastic(dasri));
+    await indexBsdasri(await getBsdasriForElastic(bsdasri));
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);
     let res = await query<Pick<Query, "bsds">, QueryBsdsArgs>(GET_BSDS, {});
 
-    // created dasri is indexed
+    // created bsdasri is indexed
     expect(res.data.bsds.edges).toEqual([
-      expect.objectContaining({ node: { id: dasri.id } })
+      expect.objectContaining({ node: { id: bsdasri.id } })
     ]);
 
-    // let's delete this dasri
+    // let's delete this bsdasri
     const { mutate } = makeClient(emitter.user);
     const DELETE_DASRI = `
       mutation DeleteDasri($id: ID!){
@@ -727,7 +872,7 @@ describe("Query.bsds.dasris mutations", () => {
       DELETE_DASRI,
       {
         variables: {
-          id: dasri.id
+          id: bsdasri.id
         }
       }
     );
@@ -735,25 +880,25 @@ describe("Query.bsds.dasris mutations", () => {
     await refreshElasticSearch();
 
     res = await query<Pick<Query, "bsds">, QueryBsdsArgs>(GET_BSDS, {});
-    // dasri si not indexed anymore
+    // bsdasri si not indexed anymore
     expect(res.data.bsds.edges).toEqual([]);
   });
 
-  it("duplicated dasri should be indexed", async () => {
+  it("duplicated bsdasri should be indexed", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
         set: ["PRODUCER"]
       }
     });
 
-    const dasri = await bsdasriFactory({
+    const bsdasri = await bsdasriFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret
       }
     });
-    await indexBsdasri(await getBsdasriForElastic(dasri));
+    await indexBsdasri(await getBsdasriForElastic(bsdasri));
 
-    //duplicate dasri
+    //duplicate bsdasri
     const { mutate } = makeClient(emitter.user);
 
     const DUPLICATE_DASRI = `
@@ -773,11 +918,11 @@ describe("Query.bsds.dasris mutations", () => {
       MutationDuplicateBsdasriArgs
     >(DUPLICATE_DASRI, {
       variables: {
-        id: dasri.id
+        id: bsdasri.id
       }
     });
 
-    await indexBsdasri(await getBsdasriForElastic(dasri));
+    await indexBsdasri(await getBsdasriForElastic(bsdasri));
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);
@@ -786,11 +931,11 @@ describe("Query.bsds.dasris mutations", () => {
       {}
     );
 
-    // duplicated dasri is indexed
-    expect(data.bsds.edges.length).toEqual(2); // initial + duplicated dasri
+    // duplicated bsdasri is indexed
+    expect(data.bsds.edges.length).toEqual(2); // initial + duplicated bsdasri
     expect(data.bsds.edges).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ node: { id: dasri.id } }),
+        expect.objectContaining({ node: { id: bsdasri.id } }),
         expect.objectContaining({ node: { id: duplicateBsdasri!.id } })
       ])
     );

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -8,6 +8,7 @@ import { BsdType, FormCompany } from "../generated/graphql/types";
 import {
   BsdaRevisionRequest,
   BsddRevisionRequest,
+  BsdasriRevisionRequest,
   OperationMode
 } from "@prisma/client";
 import { FormForElastic } from "../forms/elastic";
@@ -114,7 +115,10 @@ export interface BsdElastic {
   companyNames: string;
   companyOrgIds: string[];
 
-  revisionRequests: BsdaRevisionRequest[] | BsddRevisionRequest[];
+  revisionRequests:
+    | BsdaRevisionRequest[]
+    | BsddRevisionRequest[]
+    | BsdasriRevisionRequest[];
 
   rawBsd:
     | FormForElastic

--- a/back/src/common/elasticHelpers.ts
+++ b/back/src/common/elasticHelpers.ts
@@ -12,7 +12,7 @@ type RevisionRequest = {
 };
 
 /**
- * Pour une liste de demandes de révisions BSDD ou BSDA, retourne l'ensemble
+ * Pour une liste de demandes de révisions BSDD, BSDA ou Bsdasri, retourne l'ensemble
  * des identifiants d'établissements pour lesquels il y a une demande de révision
  * en cours ou passée.
  */

--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -3,7 +3,10 @@ import {
   getBsdaForElastic,
   toBsdElastic as toBsdaElastic
 } from "../../bsda/elastic";
-import { toBsdElastic as toBsdasriElastic } from "../../bsdasris/elastic";
+import {
+  toBsdElastic as toBsdasriElastic,
+  getBsdasriForElastic
+} from "../../bsdasris/elastic";
 import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
 import { toBsdElastic as toBsffElastic } from "../../bsffs/elastic";
 import { toBsdElastic as toBspaohElastic } from "../../bspaoh/elastic";
@@ -37,14 +40,7 @@ export async function indexBsdJob(
   }
 
   if (bsdId.startsWith("DASRI-")) {
-    const bsdasri = await prisma.bsdasri.findUniqueOrThrow({
-      where: { id: bsdId },
-      include: {
-        // required for dashboard queries
-        grouping: { select: { id: true } },
-        synthesizing: { select: { id: true } }
-      }
-    });
+    const bsdasri = await getBsdasriForElastic({ id: bsdId });
 
     const elasticBsdasri = toBsdasriElastic(bsdasri);
     await indexBsd(elasticBsdasri);

--- a/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
@@ -225,7 +225,7 @@ function BsdCardList({
   );
 
   const handleReviewsValidation = useCallback(
-    (bsd: Form | Bsda, siret: string) => {
+    (bsd: Form | Bsda | Bsdasri, siret: string) => {
       if (canApproveOrRefuseReview(bsd, siret)) {
         setBsdClicked(bsd);
         if (bsd.__typename === "Form") {
@@ -234,6 +234,10 @@ function BsdCardList({
         }
         if (bsd.__typename === "Bsda") {
           setValidationWorkflowType("REVIEW_BSDA_APPROVE");
+          setIsModalOpen(true);
+        }
+        if (bsd.__typename === "Bsdasri") {
+          setValidationWorkflowType("REVIEW_BSDASRI_APPROVE");
           setIsModalOpen(true);
         }
       } else {
@@ -255,6 +259,14 @@ function BsdCardList({
           }
           setIsModalOpen(true);
         }
+        if (bsd.__typename === "Bsdasri") {
+          if (canDeleteReview(bsdDisplay!, siret)) {
+            setValidationWorkflowType("REVIEW_BSDASRI_DELETE");
+          } else {
+            setValidationWorkflowType("REVIEW_BSDASRI_CONSULT");
+          }
+          setIsModalOpen(true);
+        }
       }
     },
     []
@@ -263,7 +275,7 @@ function BsdCardList({
   const onBsdValidation = useCallback(
     (bsd: Bsd) => {
       if (isReviewsTab) {
-        handleReviewsValidation(bsd as Form | Bsda, siret);
+        handleReviewsValidation(bsd as Form | Bsda | Bsdasri, siret);
       } else {
         const status =
           bsd.status ||
@@ -345,6 +357,10 @@ function BsdCardList({
     }
     if (bsd.type === BsdType.Bsda) {
       setValidationWorkflowType("REVIEW_BSDA_CONSULT");
+    }
+
+    if (bsd.type === BsdType.Bsdasri) {
+      setValidationWorkflowType("REVIEW_BSDASRI_CONSULT");
     }
     setBsdClicked(bsd);
     setIsModalOpen(true);
@@ -482,10 +498,26 @@ function BsdCardList({
           actionType={ActionType.UPDATE}
         />
       )}
+      {validationWorkflowType === "REVIEW_BSDASRI_DELETE" && isModalOpen && (
+        <RevisionModal
+          bsdId={bsdClicked?.id!}
+          bsdType={BsdType.Bsdasri}
+          onModalCloseFromParent={onClose}
+          actionType={ActionType.DELETE}
+        />
+      )}
       {validationWorkflowType === "REVIEW_BSDA_APPROVE" && isModalOpen && (
         <RevisionModal
           bsdId={bsdClicked?.id!}
           bsdType={BsdType.Bsda}
+          onModalCloseFromParent={onClose}
+          actionType={ActionType.UPDATE}
+        />
+      )}
+      {validationWorkflowType === "REVIEW_BSDASRI_APPROVE" && isModalOpen && (
+        <RevisionModal
+          bsdId={bsdClicked?.id!}
+          bsdType={BsdType.Bsdasri}
           onModalCloseFromParent={onClose}
           actionType={ActionType.UPDATE}
         />
@@ -502,6 +534,15 @@ function BsdCardList({
         <RevisionModal
           bsdId={bsdClicked?.id!}
           bsdType={BsdType.Bsda}
+          onModalCloseFromParent={onClose}
+          actionType={ActionType.CONSUlT}
+        />
+      )}
+
+      {validationWorkflowType === "REVIEW_BSDASRI_CONSULT" && isModalOpen && (
+        <RevisionModal
+          bsdId={bsdClicked?.id!}
+          bsdType={BsdType.Bsdasri}
           onModalCloseFromParent={onClose}
           actionType={ActionType.CONSUlT}
         />

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionApproveFragment.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionApproveFragment.tsx
@@ -4,7 +4,8 @@ import {
   BsdType,
   Mutation,
   MutationSubmitBsdaRevisionRequestApprovalArgs,
-  MutationSubmitFormRevisionRequestApprovalArgs
+  MutationSubmitFormRevisionRequestApprovalArgs,
+  MutationSubmitBsdasriRevisionRequestApprovalArgs
 } from "@td/codegen-ui";
 import { useMutation } from "@apollo/client";
 import {
@@ -15,6 +16,10 @@ import {
   GET_FORM_REVISION_REQUESTS,
   SUBMIT_FORM_REVISION_REQUEST_APPROVAL
 } from "../../../common/queries/reviews/BsddReviewsQuery";
+import {
+  GET_BSDASRI_REVISION_REQUESTS,
+  SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL
+} from "../../../common/queries/reviews/BsdasriReviewQuery";
 
 interface RevisionApproveFragmentProps {
   reviewId: string;
@@ -52,6 +57,18 @@ const RevisionApproveFragment = ({
     ]
   });
 
+  const [
+    submitBsdasriRevisionRequestApproval,
+    { loading: updatingBsdasri, error: errorBsdasri }
+  ] = useMutation<
+    Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
+    MutationSubmitBsdasriRevisionRequestApprovalArgs
+  >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
+    refetchQueries: [
+      { query: GET_BSDASRI_REVISION_REQUESTS, variables: { siret } }
+    ]
+  });
+
   const handleClose = () => onClose!();
 
   const handleRevisionReject = async () => {
@@ -66,6 +83,13 @@ const RevisionApproveFragment = ({
         variables: { id: reviewId, isApproved: false }
       });
     }
+
+    if (bsdType === BsdType.Bsdasri) {
+      await submitBsdasriRevisionRequestApproval({
+        variables: { id: reviewId, isApproved: false }
+      });
+    }
+
     handleClose();
   };
 
@@ -81,31 +105,38 @@ const RevisionApproveFragment = ({
         variables: { id: reviewId, isApproved: true }
       });
     }
+
+    if (bsdType === BsdType.Bsdasri) {
+      await submitBsdasriRevisionRequestApproval({
+        variables: { id: reviewId, isApproved: true }
+      });
+    }
     handleClose();
   };
 
   return (
     <>
-      {(errorBsda || errorForm) && (
+      {(errorBsda || errorForm || errorBsdasri) && (
         <div
           style={{ marginTop: "2em", marginBottom: "2em" }}
           className="notification notification--warning"
         >
           {errorForm?.message}
           {errorBsda?.message}
+          {errorBsdasri?.message}
         </div>
       )}
       <Button
         priority="primary"
         onClick={handleRevisionReject}
-        disabled={updatingForm || updatingBsda}
+        disabled={updatingForm || updatingBsda || updatingBsdasri}
       >
         Refuser
       </Button>
       <Button
         priority="primary"
         onClick={handleRevisionApprove}
-        disabled={updatingForm || updatingBsda}
+        disabled={updatingForm || updatingBsda || updatingBsdasri}
       >
         Approuver
       </Button>

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionCancelFragment.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionCancelFragment.tsx
@@ -12,6 +12,10 @@ import {
   GET_BSDA_REVISION_REQUESTS
 } from "../../../common/queries/reviews/BsdaReviewQuery";
 import {
+  CANCEL_BSDASRI_REVISION_REQUEST,
+  GET_BSDASRI_REVISION_REQUESTS
+} from "../../../common/queries/reviews/BsdasriReviewQuery";
+import {
   CANCEL_FORM_REVISION_REQUEST,
   GET_FORM_REVISION_REQUESTS
 } from "../../../common/queries/reviews/BsddReviewsQuery";
@@ -44,6 +48,16 @@ const RevisionCancelFragment = ({
     ]
   });
 
+  const [cancelBsdasriRevisionRequest, { loading: cancelingBsdasri }] =
+    useMutation<
+      Pick<Mutation, "cancelBsdasriRevisionRequest">,
+      MutationCancelBsdaRevisionRequestArgs
+    >(CANCEL_BSDASRI_REVISION_REQUEST, {
+      refetchQueries: [
+        { query: GET_BSDASRI_REVISION_REQUESTS, variables: { siret } }
+      ]
+    });
+
   const handleClose = () => onClose!();
 
   const handleRevisionCancel = async () => {
@@ -58,6 +72,13 @@ const RevisionCancelFragment = ({
         variables: { id: reviewId }
       });
     }
+
+    if (bsdType === BsdType.Bsdasri) {
+      await cancelBsdasriRevisionRequest({
+        variables: { id: reviewId }
+      });
+    }
+
     handleClose();
   };
 
@@ -69,7 +90,7 @@ const RevisionCancelFragment = ({
       <Button
         priority="primary"
         onClick={handleRevisionCancel}
-        disabled={cancelingForm || cancelingBsda}
+        disabled={cancelingForm || cancelingBsda || cancelingBsdasri}
       >
         Annuler la révision
       </Button>

--- a/front/src/Apps/Dashboard/Components/Revision/RevisionList/RevisionList.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/RevisionList/RevisionList.tsx
@@ -13,6 +13,7 @@ interface RevisionListProps {
 }
 const RevisionList = ({ reviews, title }: RevisionListProps) => {
   const latestRevision = reviews?.[0];
+
   return (
     <div className="revision-list">
       <p className="revision-list__title">

--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -2,8 +2,11 @@ import {
   Broker,
   Bsda,
   BsdaPackagingType,
+  BsdasriPackagingType,
   BsdaRevisionRequest,
+  BsdasriRevisionRequest,
   BsdaRevisionRequestApproval,
+  BsdasriRevisionRequestApproval,
   Form,
   FormCompany,
   FormRevisionRequest,
@@ -22,7 +25,12 @@ import {
   DEPOT_BAG,
   OTHER,
   PALETTE_FILME,
-  SAC_RENFORCE
+  SAC_RENFORCE,
+  BOITE_CARTON,
+  BOITE_PERFORANTS,
+  GRAND_EMBALLAGE,
+  GRV,
+  FUT
 } from "./wordingsRevision";
 
 export enum DataNameEnum {
@@ -40,6 +48,7 @@ export enum DataNameEnum {
   QTY_ESTIMATED = "Poids estimé (en tonnes)",
   QTY_RECEIVED = "Quantité reçue (tonnes)",
   QTY_PROCESSED = "Quantité traitée (en tonnes)",
+  QTY_PROCESSED_KG = "Quantité traitée (en kg)",
   QTY_RECEIVED_TEMP_STORAGE = "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)",
   OPERATION_CODE = "Code d'opération réalisée",
   OPERATION_DONE = "Opération réalisée",
@@ -73,13 +82,14 @@ export interface ReviewInterface {
   authoringCompany: FormCompany;
   approvals:
     | Array<BsdaRevisionRequestApproval>
+    | Array<BsdasriRevisionRequestApproval>
     | Array<FormRevisionRequestApproval>;
   comment: string;
   bsdContent: Form | Bsda;
   details: ReviewDetailInterface[];
 }
 
-const PACKAGINGS_NAMES = {
+const BSDA_PACKAGINGS_NAMES = {
   [BsdaPackagingType.BigBag]: BIGBAG,
   [BsdaPackagingType.DepotBag]: DEPOT_BAG,
   [BsdaPackagingType.PaletteFilme]: PALETTE_FILME,
@@ -88,208 +98,253 @@ const PACKAGINGS_NAMES = {
   [BsdaPackagingType.Other]: OTHER
 };
 
+const BSDASRI_PACKAGINGS_NAMES = {
+  [BsdasriPackagingType.BoiteCarton]: BOITE_CARTON,
+  [BsdasriPackagingType.Fut]: FUT,
+  [BsdasriPackagingType.BoitePerforants]: BOITE_PERFORANTS,
+  [BsdasriPackagingType.GrandEmballage]: GRAND_EMBALLAGE,
+  [BsdasriPackagingType.Grv]: GRV,
+  [BsdasriPackagingType.Autre]: OTHER
+};
+
 const formatPackagingName = packaging => {
   const formattedName =
     packaging.type === BsdaPackagingType.Other
-      ? `${packaging.quantity} ${PACKAGINGS_NAMES[packaging.type]} ${
+      ? `${packaging.quantity} ${BSDA_PACKAGINGS_NAMES[packaging.type]} ${
           packaging.other ? `(${packaging.other})` : ""
         }`
-      : `${packaging.quantity} ${PACKAGINGS_NAMES[packaging.type]}`;
+      : `${packaging.quantity} ${BSDA_PACKAGINGS_NAMES[packaging.type]}`;
 
   return formattedName;
 };
 
+const formatBsdasriPackagingName = packaging => {
+  const formattedName =
+    packaging.type === BsdasriPackagingType.Autre
+      ? `${packaging.quantity} ${BSDASRI_PACKAGINGS_NAMES[packaging.type]} ${
+          packaging.other ? `(${packaging.other})` : ""
+        }`
+      : `${packaging.quantity} ${BSDASRI_PACKAGINGS_NAMES[packaging.type]}`;
+
+  return `${formattedName} - ${packaging.volume} l`;
+};
+
 export const mapRevision = (
-  review: FormRevisionRequest & BsdaRevisionRequest,
+  review: FormRevisionRequest & BsdaRevisionRequest & BsdasriRevisionRequest,
   bsdName: string
-): ReviewInterface => ({
-  id: review?.id,
-  readableId: review?.[bsdName]?.readableId || review?.[bsdName]?.id,
-  createdAt: review?.createdAt,
-  status: review?.status,
-  isCanceled: review?.content?.isCanceled,
-  authoringCompany: review?.authoringCompany,
-  comment: review?.comment,
-  bsdContent: review?.[bsdName],
-  approvals: review.approvals,
-  details: [
-    {
-      dataName: DataNameEnum.ADRESS_COLLECT,
-      dataOldValue: review?.[bsdName]?.emitter?.pickupSite
-        ? `${review?.[bsdName]?.emitter?.pickupSite?.address}, ${review?.[bsdName]?.emitter?.pickupSite?.postalCode} ${review?.[bsdName]?.emitter?.pickupSite?.city} ${review?.[bsdName]?.emitter?.pickupSite?.infos}`
-        : "",
-      dataNewValue: review?.content?.emitter?.pickupSite
-        ? `${review?.content?.emitter?.pickupSite?.address}, ${review?.content?.emitter?.pickupSite?.postalCode} ${review?.content?.emitter?.pickupSite?.city} ${review?.content?.emitter?.pickupSite?.infos}`
-        : ""
-    },
-    {
-      dataName: DataNameEnum.WASTE_CODE,
-      dataOldValue: review?.[bsdName]?.wasteDetails?.code,
-      dataNewValue: review?.content?.wasteDetails?.code
-    },
-    {
-      dataName: DataNameEnum.WASTE_CODE,
-      dataOldValue: review?.bsda?.waste?.code,
-      dataNewValue: review?.content?.waste?.code
-    },
-    {
-      dataName: DataNameEnum.POP,
-      dataOldValue: review?.bsda?.waste?.pop
-        ? review?.bsda?.waste?.pop
-          ? BOOLEAN_TRUE_LABEL
-          : BOOLEAN_FALSE_LABEL
-        : "",
-      dataNewValue:
-        review?.content?.waste?.pop != null
-          ? review?.content?.waste?.code
+): ReviewInterface => {
+  return {
+    id: review?.id,
+    readableId: review?.[bsdName]?.readableId || review?.[bsdName]?.id,
+    createdAt: review?.createdAt,
+    status: review?.status,
+    isCanceled: review?.content?.isCanceled,
+    authoringCompany: review?.authoringCompany,
+    comment: review?.comment,
+    bsdContent: review?.[bsdName],
+    approvals: review.approvals,
+    details: [
+      {
+        dataName: DataNameEnum.ADRESS_COLLECT,
+        dataOldValue: review?.[bsdName]?.emitter?.pickupSite
+          ? `${review?.[bsdName]?.emitter?.pickupSite?.address}, ${
+              review?.[bsdName]?.emitter?.pickupSite?.postalCode
+            } ${review?.[bsdName]?.emitter?.pickupSite?.city} ${
+              review?.[bsdName]?.emitter?.pickupSite?.infos ?? ""
+            }`
+          : "",
+        dataNewValue: review?.content?.emitter?.pickupSite
+          ? `${review?.content?.emitter?.pickupSite?.address}, ${
+              review?.content?.emitter?.pickupSite?.postalCode
+            } ${review?.content?.emitter?.pickupSite?.city} ${
+              review?.content?.emitter?.pickupSite?.infos ?? ""
+            }`
+          : ""
+      },
+      {
+        dataName: DataNameEnum.WASTE_CODE,
+        dataOldValue: review?.[bsdName]?.wasteDetails?.code,
+        dataNewValue: review?.content?.wasteDetails?.code
+      },
+      {
+        dataName: DataNameEnum.WASTE_CODE,
+        dataOldValue: review?.bsda?.waste?.code,
+        dataNewValue: review?.content?.waste?.code
+      },
+      {
+        dataName: DataNameEnum.POP,
+        dataOldValue: review?.bsda?.waste?.pop
+          ? review?.bsda?.waste?.pop
             ? BOOLEAN_TRUE_LABEL
             : BOOLEAN_FALSE_LABEL
+          : "",
+        dataNewValue:
+          review?.content?.waste?.pop != null
+            ? review?.content?.waste?.code
+              ? BOOLEAN_TRUE_LABEL
+              : BOOLEAN_FALSE_LABEL
+            : ""
+      },
+      {
+        dataName: DataNameEnum.WASTE_DESC,
+        dataOldValue: review?.[bsdName]?.wasteDetails?.name,
+        dataNewValue: review?.content?.wasteDetails?.name
+      },
+      {
+        dataName: DataNameEnum.WASTE_DESC,
+        dataOldValue: review?.[bsdName]?.wasteDetails?.packagingInfos
+          ? getPackagingInfosSummary(
+              review?.[bsdName]?.wasteDetails?.packagingInfos
+            )
+          : "",
+        dataNewValue: review?.content?.wasteDetails?.packagingInfos
+          ? getPackagingInfosSummary(
+              review?.content?.wasteDetails?.packagingInfos
+            )
           : ""
-    },
-    {
-      dataName: DataNameEnum.WASTE_DESC,
-      dataOldValue: review?.[bsdName]?.wasteDetails?.name,
-      dataNewValue: review?.content?.wasteDetails?.name
-    },
-    {
-      dataName: DataNameEnum.WASTE_DESC,
-      dataOldValue: review?.[bsdName]?.wasteDetails?.packagingInfos
-        ? getPackagingInfosSummary(
-            review?.[bsdName]?.wasteDetails?.packagingInfos
-          )
-        : "",
-      dataNewValue: review?.content?.wasteDetails?.packagingInfos
-        ? getPackagingInfosSummary(
-            review?.content?.wasteDetails?.packagingInfos
-          )
-        : ""
-    },
-    {
-      dataName: DataNameEnum.WASTE_DESC,
-      dataOldValue: review?.bsda?.waste?.materialName,
-      dataNewValue: review?.content?.waste?.materialName
-    },
-    {
-      dataName: DataNameEnum.SEALED_NUMBER,
-      dataOldValue: review?.bsda?.waste?.sealNumbers?.join(", "),
-      dataNewValue: review?.content?.waste?.sealNumbers?.join(", ")
-    },
-    {
-      dataName: DataNameEnum.PACKAGING,
-      dataOldValue: review?.[bsdName]?.packagings
-        ?.map(p => formatPackagingName(p))
-        .join(", "),
-      dataNewValue: review?.content?.packagings
-        ?.map(p => formatPackagingName(p))
-        .join(", ")
-    },
-    {
-      dataName: DataNameEnum.QTY_ESTIMATED,
-      dataOldValue: review?.[bsdName]?.content?.wasteDetails?.quantity,
-      dataNewValue: review?.content?.wasteDetails?.quantity
-    },
-    {
-      dataName: DataNameEnum.SAMPLE_NUMBER,
-      dataOldValue: review?.[bsdName]?.content?.wasteDetails?.sampleNumber,
-      dataNewValue: review?.content?.wasteDetails?.sampleNumber
-    },
-    {
-      dataName: DataNameEnum.POLLUANTS_ORG,
-      dataOldValue: review?.form?.wasteDetails?.pop
-        ? review?.form?.wasteDetails?.pop
-          ? BOOLEAN_TRUE_LABEL
-          : BOOLEAN_FALSE_LABEL
-        : "",
-      dataNewValue:
-        review?.content?.wasteDetails?.pop != null
-          ? review?.content?.wasteDetails?.pop
+      },
+      {
+        dataName: DataNameEnum.WASTE_DESC,
+        dataOldValue: review?.bsda?.waste?.materialName,
+        dataNewValue: review?.content?.waste?.materialName
+      },
+      {
+        dataName: DataNameEnum.SEALED_NUMBER,
+        dataOldValue: review?.bsda?.waste?.sealNumbers?.join(", "),
+        dataNewValue: review?.content?.waste?.sealNumbers?.join(", ")
+      },
+      {
+        dataName: DataNameEnum.PACKAGING,
+        dataOldValue: review?.[bsdName]?.packagings
+          ?.map(p => formatPackagingName(p))
+          .join(", "),
+        dataNewValue: review?.content?.packagings
+          ?.map(p => formatPackagingName(p))
+          .join(", ")
+      },
+      {
+        dataName: DataNameEnum.PACKAGING,
+        dataOldValue: review?.[bsdName]?.destination?.reception?.packagings
+          ?.map(p => formatBsdasriPackagingName(p))
+          .join(", "),
+        dataNewValue: review?.content?.destination?.reception?.packagings
+          ?.map(p => formatBsdasriPackagingName(p))
+          .join(", ")
+      },
+      {
+        dataName: DataNameEnum.QTY_ESTIMATED,
+        dataOldValue: review?.[bsdName]?.content?.wasteDetails?.quantity,
+        dataNewValue: review?.content?.wasteDetails?.quantity
+      },
+      {
+        dataName: DataNameEnum.SAMPLE_NUMBER,
+        dataOldValue: review?.[bsdName]?.content?.wasteDetails?.sampleNumber,
+        dataNewValue: review?.content?.wasteDetails?.sampleNumber
+      },
+      {
+        dataName: DataNameEnum.POLLUANTS_ORG,
+        dataOldValue: review?.form?.wasteDetails?.pop
+          ? review?.form?.wasteDetails?.pop
             ? BOOLEAN_TRUE_LABEL
             : BOOLEAN_FALSE_LABEL
-          : ""
-    },
-    {
-      dataName: DataNameEnum.CAP_FINAL_DEST,
-      dataOldValue: review?.[bsdName]?.temporaryStorageDetail?.destination?.cap,
-      dataNewValue: review?.content?.temporaryStorageDetail?.destination?.cap
-    },
-    {
-      dataName: DataNameEnum.CAP,
-      dataOldValue: review?.[bsdName]?.destination?.cap,
-      dataNewValue: review?.content?.destination?.cap
-    },
-    {
-      dataName: review?.[bsdName]?.form?.temporaryStorageDetail
-        ? DataNameEnum.CAP_TEMP_STORAGE
-        : DataNameEnum.CAP,
-      dataOldValue: review?.[bsdName]?.recipient?.cap,
-      dataNewValue: review?.content?.recipient?.cap
-    },
-    {
-      dataName: DataNameEnum.QTY_RECEIVED,
-      dataOldValue: review?.[bsdName]?.quantityReceived,
-      dataNewValue: review?.content?.quantityReceived
-    },
-    {
-      dataName: DataNameEnum.QTY_PROCESSED,
-      dataOldValue: review?.[bsdName]?.destination?.reception?.weight,
-      dataNewValue: review?.content?.destination?.reception?.weight
-    },
-    {
-      dataName: DataNameEnum.QTY_RECEIVED_TEMP_STORAGE,
-      dataOldValue:
-        review?.[bsdName]?.temporaryStorageDetail?.temporaryStorer
-          ?.quantityReceived,
-      dataNewValue:
-        review?.content?.temporaryStorageDetail?.temporaryStorer
-          ?.quantityReceived
-    },
-    {
-      dataName: DataNameEnum.OPERATION_CODE,
-      dataOldValue: review?.[bsdName]?.destination?.operation?.code,
-      dataNewValue:
-        [
-          review?.content?.destination?.operation?.code,
-          review?.content?.destination?.operation?.mode &&
-            `(${getOperationModeLabel(
-              review?.content?.destination?.operation?.mode ?? ""
-            )})`
-        ]
-          .filter(Boolean)
-          .join(" ") || null
-    },
-    {
-      dataName: DataNameEnum.OPERATION_DONE,
-      dataOldValue: review?.[bsdName]?.processingOperationDone,
-      dataNewValue:
-        [
-          review?.content?.processingOperationDone,
-          review?.content?.destinationOperationMode &&
-            `(${getOperationModeLabel(
-              review?.content?.destinationOperationMode ?? ""
-            )})`
-        ]
-          .filter(Boolean)
-          .join(" ") || null
-    },
-    {
-      dataName: DataNameEnum.OPERATION_DONE_DESC,
-      dataOldValue: review?.[bsdName]?.processingOperationDescription,
-      dataNewValue: review?.content?.processingOperationDescription
-    },
-    {
-      dataName: DataNameEnum.OPERATION_DONE_DESC,
-      dataOldValue: review?.[bsdName]?.destination?.operation?.description,
-      dataNewValue: review?.content?.destination?.operation?.description
-    },
-    {
-      dataName: DataNameEnum.BROKER,
-      dataOldValue: review?.[bsdName]?.broker,
-      dataNewValue: review?.content?.broker
-    },
-    {
-      dataName: DataNameEnum.TRADER,
-      dataOldValue: review?.[bsdName]?.trader,
-      dataNewValue: review?.content?.trader
-    }
-  ]
-});
+          : "",
+        dataNewValue:
+          review?.content?.wasteDetails?.pop != null
+            ? review?.content?.wasteDetails?.pop
+              ? BOOLEAN_TRUE_LABEL
+              : BOOLEAN_FALSE_LABEL
+            : ""
+      },
+      {
+        dataName: DataNameEnum.CAP_FINAL_DEST,
+        dataOldValue:
+          review?.[bsdName]?.temporaryStorageDetail?.destination?.cap,
+        dataNewValue: review?.content?.temporaryStorageDetail?.destination?.cap
+      },
+      {
+        dataName: DataNameEnum.CAP,
+        dataOldValue: review?.[bsdName]?.destination?.cap,
+        dataNewValue: review?.content?.destination?.cap
+      },
+      {
+        dataName: review?.[bsdName]?.form?.temporaryStorageDetail
+          ? DataNameEnum.CAP_TEMP_STORAGE
+          : DataNameEnum.CAP,
+        dataOldValue: review?.[bsdName]?.recipient?.cap,
+        dataNewValue: review?.content?.recipient?.cap
+      },
+      {
+        dataName: DataNameEnum.QTY_RECEIVED,
+        dataOldValue: review?.[bsdName]?.quantityReceived,
+        dataNewValue: review?.content?.quantityReceived
+      },
+      {
+        dataName: DataNameEnum.QTY_PROCESSED,
+        dataOldValue: review?.[bsdName]?.destination?.reception?.weight,
+        dataNewValue: review?.content?.destination?.reception?.weight
+      },
+      {
+        dataName: DataNameEnum.QTY_PROCESSED_KG,
+        dataOldValue: review?.[bsdName]?.destination?.operation?.weight?.value,
+        dataNewValue: review?.content?.destination?.operation?.weight
+      },
+      {
+        dataName: DataNameEnum.QTY_RECEIVED_TEMP_STORAGE,
+        dataOldValue:
+          review?.[bsdName]?.temporaryStorageDetail?.temporaryStorer
+            ?.quantityReceived,
+        dataNewValue:
+          review?.content?.temporaryStorageDetail?.temporaryStorer
+            ?.quantityReceived
+      },
+      {
+        dataName: DataNameEnum.OPERATION_CODE,
+        dataOldValue: review?.[bsdName]?.destination?.operation?.code,
+        dataNewValue:
+          [
+            review?.content?.destination?.operation?.code,
+            review?.content?.destination?.operation?.mode &&
+              `(${getOperationModeLabel(
+                review?.content?.destination?.operation?.mode ?? ""
+              )})`
+          ]
+            .filter(Boolean)
+            .join(" ") || null
+      },
+      {
+        dataName: DataNameEnum.OPERATION_DONE,
+        dataOldValue: review?.[bsdName]?.processingOperationDone,
+        dataNewValue:
+          [
+            review?.content?.processingOperationDone,
+            review?.content?.destinationOperationMode &&
+              `(${getOperationModeLabel(
+                review?.content?.destinationOperationMode ?? ""
+              )})`
+          ]
+            .filter(Boolean)
+            .join(" ") || null
+      },
+      {
+        dataName: DataNameEnum.OPERATION_DONE_DESC,
+        dataOldValue: review?.[bsdName]?.processingOperationDescription,
+        dataNewValue: review?.content?.processingOperationDescription
+      },
+      {
+        dataName: DataNameEnum.OPERATION_DONE_DESC,
+        dataOldValue: review?.[bsdName]?.destination?.operation?.description,
+        dataNewValue: review?.content?.destination?.operation?.description
+      },
+      {
+        dataName: DataNameEnum.BROKER,
+        dataOldValue: review?.[bsdName]?.broker,
+        dataNewValue: review?.content?.broker
+      },
+      {
+        dataName: DataNameEnum.TRADER,
+        dataOldValue: review?.[bsdName]?.trader,
+        dataNewValue: review?.content?.trader
+      }
+    ]
+  };
+};

--- a/front/src/Apps/Dashboard/Components/Revision/wordingsRevision.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/wordingsRevision.ts
@@ -8,6 +8,14 @@ export const DEPOT_BAG = "Dépôt-bag";
 export const PALETTE_FILME = "Palette filmée";
 export const SAC_RENFORCE = "Sac renforcé";
 export const CONTENEUR_BAG = "Conteneur-bag";
+
+export const BOITE_CARTON = "Caisse(s) en carton avec sac en plastique";
+export const BOITE_PERFORANTS =
+  "Boîte(s) et Mini-collecteurs pour déchets perforants";
+export const GRAND_EMBALLAGE = "Grand(s) emballage(s)";
+export const GRV = "Grand(s) récipient(s) pour vrac";
+export const FUT = "Fût(s)";
+
 export const OTHER = "Autre(s)";
 export const MODAL_ARIA_LABEL_CONSULT = "Consultation d'une révision";
 export const MODAL_ARIA_LABEL_UPDATE = "Gestion d'une révision";

--- a/front/src/Apps/Dashboard/DashboardRoutes.tsx
+++ b/front/src/Apps/Dashboard/DashboardRoutes.tsx
@@ -22,6 +22,7 @@ import {
 import Loader from "../common/Components/Loader/Loaders";
 import { ExtraSignatureType } from "../../dashboard/components/BSDList/BSDasri/types";
 import { RouteBsdaRequestRevision } from "../../dashboard/components/RevisionRequestList/bsda/request";
+import { RouteBsdasriRequestRevision } from "../../dashboard/components/RevisionRequestList/bsdasri/request";
 import { RouteBsddRequestRevision } from "../../dashboard/components/RevisionRequestList/bsdd/request/RouteBsddRequestRevision";
 import {
   RouteBSDasrisView,
@@ -210,6 +211,10 @@ function DashboardRoutes() {
             element={<RouteBsdaRequestRevision />}
           />
 
+          <Route
+            path={toRelative(routes.dashboard.bsdasris.review)}
+            element={<RouteBsdasriRequestRevision />}
+          />
           <Route
             path={toRelative(routes.dashboard.bsffs.view)}
             element={<RouteBsffsView />}
@@ -503,7 +508,20 @@ function DashboardRoutes() {
                 </Modal>
               }
             />
-
+            <Route
+              path={toRelative(routes.dashboard.bsdasris.review)}
+              element={
+                <Modal
+                  onClose={goBack}
+                  ariaLabel="Demande de révision"
+                  isOpen
+                  padding={false}
+                  wide={true}
+                >
+                  <RouteBsdasriRequestRevision />
+                </Modal>
+              }
+            />
             <Route
               path={toRelative(routes.dashboard.bsffs.view)}
               element={

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -332,7 +332,8 @@ export const mapBsdasri = (bsdasri: Bsdasri): BsdDisplay => {
     transporterNumberPlate:
       bsdasri.transporter?.transport?.plates ||
       bsdasri["bsdasriTransporter"]?.transport?.plates,
-    synthesizedIn: bsdasri.synthesizedIn
+    synthesizedIn: bsdasri.synthesizedIn,
+    metadata: bsdasri.metadata
   };
   return bsdasriFormatted;
 };

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -8,6 +8,7 @@ import { formatBsd } from "./bsdMapper";
 import {
   Bsda,
   BsdasriType,
+  Bsdasri,
   BsdaType,
   BsdType,
   BsffType,
@@ -214,8 +215,13 @@ const hasEmitterTransporterAndEcoOrgSiret = (
   ].includes(siret);
 };
 
-const isSameSiretEmmiter = (currentSiret: string, bsd: BsdDisplay): boolean =>
+const isSameSiretEmitter = (currentSiret: string, bsd: BsdDisplay): boolean =>
   currentSiret === bsd.emitter?.company?.siret;
+
+const isSameSiretEcorganisme = (
+  currentSiret: string,
+  bsd: BsdDisplay
+): boolean => currentSiret === bsd.ecoOrganisme?.siret;
 
 const isSameSiretDestination = (
   currentSiret: string,
@@ -325,7 +331,7 @@ export const isBsdaSignWorker = (bsd: BsdDisplay, currentSiret: string) => {
 };
 
 export const isBsvhuSign = (bsd: BsdDisplay, currentSiret: string) =>
-  isBsvhu(bsd.type) && isSameSiretEmmiter(currentSiret, bsd);
+  isBsvhu(bsd.type) && isSameSiretEmitter(currentSiret, bsd);
 
 export const isBsffSign = (
   bsd: BsdDisplay,
@@ -333,7 +339,7 @@ export const isBsffSign = (
   bsdCurrentTab: BsdCurrentTab
 ) => {
   const isActTab = bsdCurrentTab === "actTab" || bsdCurrentTab === "allBsdsTab";
-  return isBsff(bsd.type) && !isActTab && isSameSiretEmmiter(currentSiret, bsd);
+  return isBsff(bsd.type) && !isActTab && isSameSiretEmitter(currentSiret, bsd);
 };
 
 export const isEmetteurSign = (bsd: BsdDisplay, isTransporter: boolean) =>
@@ -355,7 +361,7 @@ export const getIsNonDraftLabel = (
   if (
     isBsda(bsd.type) &&
     isCollection_2710(bsd.bsdWorkflowType?.toString()) &&
-    isSameSiretEmmiter(currentSiret, bsd) &&
+    isSameSiretEmitter(currentSiret, bsd) &&
     !isSameSiretDestination(currentSiret, bsd) &&
     bsd.ecoOrganisme?.siret !== currentSiret
   ) {
@@ -381,7 +387,7 @@ export const getIsNonDraftLabel = (
 
   if (isBsdasri(bsd.type)) {
     const isEcoOrganisme = currentSiret === bsd.ecoOrganisme?.siret;
-    const isHolder = isSameSiretEmmiter(currentSiret, bsd) || isEcoOrganisme;
+    const isHolder = isSameSiretEmitter(currentSiret, bsd) || isEcoOrganisme;
     const isTransporter = isSameSiretTransporter(currentSiret, bsd);
 
     if (
@@ -423,7 +429,7 @@ export const getIsNonDraftLabel = (
 
   if (
     !isFollowTab &&
-    isSameSiretEmmiter(currentSiret, bsd) &&
+    isSameSiretEmitter(currentSiret, bsd) &&
     permissions.includes(UserPermission.BsdCanSignEmission)
   ) {
     return SIGNER;
@@ -552,7 +558,7 @@ export const getSealedBtnLabel = (
         return FAIRE_SIGNER;
       }
     }
-    if (isSameSiretEmmiter(currentSiret, bsd)) {
+    if (isSameSiretEmitter(currentSiret, bsd)) {
       return SIGNER;
     }
     if (hasEmitterTransporterAndEcoOrgSiret(bsd, currentSiret)) {
@@ -891,7 +897,7 @@ export const getResealedBtnLabel = (
     (permissions.includes(UserPermission.BsdCanSignEmission) ||
       permissions.includes(UserPermission.BsdCanSignTransport))
   ) {
-    if (isSameSiretEmmiter(currentSiret, bsd)) {
+    if (isSameSiretEmitter(currentSiret, bsd)) {
       return SIGNER;
     }
     if (currentSiret === bsd.destination?.company?.siret) {
@@ -952,7 +958,7 @@ export const getSignTempStorerBtnLabel = (
 };
 
 const getReviewCurrentApproval = (
-  bsd: BsdDisplay | Form | Bsda,
+  bsd: BsdDisplay | Form | Bsda | Bsdasri,
   siret: string
 ) => {
   return bsd?.metadata?.latestRevision?.approvals?.find(
@@ -961,7 +967,7 @@ const getReviewCurrentApproval = (
 };
 
 export const canApproveOrRefuseReview = (
-  bsd: BsdDisplay | Form | Bsda,
+  bsd: BsdDisplay | Form | Bsda | Bsdasri,
   siret: string
 ) => {
   const currentApproval = getReviewCurrentApproval(bsd, siret);
@@ -1180,7 +1186,7 @@ const canDeleteBsdd = (bsd, siret) =>
   bsd.emitterType !== EmitterType.Appendix1Producer &&
   ([BsdStatusCode.Draft, BsdStatusCode.Sealed].includes(bsd.status) ||
     (bsd.status === BsdStatusCode.SignedByProducer &&
-      isSameSiretEmmiter(siret, bsd)));
+      isSameSiretEmitter(siret, bsd)));
 
 const canDeleteBsda = (bsd, siret) =>
   bsd.type === BsdType.Bsda &&
@@ -1191,7 +1197,7 @@ const canDeleteBsda = (bsd, siret) =>
 const canDeleteBsdasri = (bsd, siret) =>
   bsd.type === BsdType.Bsdasri &&
   (bsd.status === BsdStatusCode.Initial ||
-    (isSameSiretEmmiter(siret, bsd) &&
+    (isSameSiretEmitter(siret, bsd) &&
       bsd.status === BsdStatusCode.SignedByProducer));
 
 const canDeleteBsvhu = bsd =>
@@ -1234,7 +1240,7 @@ export const canDuplicate = (bsd, siret) =>
 const canDeleteBsff = (bsd, siret) =>
   bsd.type === BsdType.Bsff &&
   (bsd.status === BsdStatusCode.Initial ||
-    (isSameSiretEmmiter(siret, bsd) &&
+    (isSameSiretEmitter(siret, bsd) &&
       bsd.status === BsdStatusCode.SignedByEmitter)) &&
   canDuplicateBsff(bsd, siret);
 
@@ -1254,7 +1260,7 @@ const canUpdateBsff = (bsd, siret) =>
 const canReviewBsda = (bsd, siret) => {
   const isTransporter = isSameSiretTransporter(siret, bsd);
   const isDestination = isSameSiretDestination(siret, bsd);
-  const isProducer = isSameSiretEmmiter(siret, bsd);
+  const isProducer = isSameSiretEmitter(siret, bsd);
   const isWorker = isSameSiretWorker(siret, bsd);
 
   return (
@@ -1263,6 +1269,26 @@ const canReviewBsda = (bsd, siret) => {
     (isTransporter || isDestination || isProducer || isWorker)
   );
 };
+
+const canReviewBsdasri = (bsd, siret) => {
+  // these types are not implemented yet
+  if ([BsdasriType.Synthesis, BsdasriType.Grouping].includes(bsd.type)) {
+    return false;
+  }
+  if (bsd.groupedInId || bsd.synthesizedInId) {
+    return false;
+  }
+  const isDestination = isSameSiretDestination(siret, bsd);
+  const isProducer = isSameSiretEmitter(siret, bsd);
+  const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
+
+  return (
+    bsd.type === BsdType.Bsdasri &&
+    !canDeleteBsdasri(bsd, siret) &&
+    (isDestination || isProducer || isEcoOrganisme)
+  );
+};
+
 export const canReviewBsdd = (bsd, siret) => {
   const isSentStatus = BsdStatusCode.Sent === bsd.status;
   return (
@@ -1275,7 +1301,7 @@ export const canReviewBsdd = (bsd, siret) => {
     !(
       bsd.emitterType === EmitterType.Producer &&
       !isSentStatus &&
-      isSameSiretEmmiter(siret, bsd) &&
+      isSameSiretEmitter(siret, bsd) &&
       canUpdateBsd(bsd, siret)
     ) &&
     !(
@@ -1286,7 +1312,7 @@ export const canReviewBsdd = (bsd, siret) => {
     ) &&
     !(
       bsd.emitterType === EmitterType.Appendix2 &&
-      isSameSiretEmmiter(siret, bsd) &&
+      isSameSiretEmitter(siret, bsd) &&
       canUpdateBsd(bsd, siret) &&
       bsd.status === BsdStatusCode.SignedByProducer
     )
@@ -1296,13 +1322,15 @@ export const canReviewBsdd = (bsd, siret) => {
 export const canReviewBsd = (bsd, siret) => {
   const isTransporter = isSameSiretTransporter(siret, bsd);
   const isDestination = isSameSiretDestination(siret, bsd);
-  const isProducer = isSameSiretEmmiter(siret, bsd);
+  const isProducer = isSameSiretEmitter(siret, bsd);
   const isWorker = isSameSiretWorker(siret, bsd);
   const isTransporterOnly =
     isTransporter && !isDestination && !isProducer && !isWorker;
 
   return (
-    (canReviewBsdd(bsd, siret) || canReviewBsda(bsd, siret)) &&
+    (canReviewBsdd(bsd, siret) ||
+      canReviewBsda(bsd, siret) ||
+      canReviewBsdasri(bsd, siret)) &&
     !isTransporterOnly
   );
 };

--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -540,7 +540,8 @@ export const getRevisionPath = bsd => {
       return routes.dashboard.bsdds.review;
     case BsdType.Bsda:
       return routes.dashboard.bsdas.review;
-
+    case BsdType.Bsdasri:
+      return routes.dashboard.bsdasris.review;
     default:
       break;
   }

--- a/front/src/Apps/common/queries/fragments/bsdasri.ts
+++ b/front/src/Apps/common/queries/fragments/bsdasri.ts
@@ -152,6 +152,20 @@ export const dashboardDasriFragment = gql`
     synthesizedIn {
       id
     }
+    metadata {
+      latestRevision {
+        id
+        status
+        authoringCompany {
+          siret
+          name
+        }
+        approvals {
+          approverSiret
+          status
+        }
+      }
+    }
   }
   ${dashboardCompanyFragment}
 `;

--- a/front/src/Apps/common/queries/reviews/BsdasriReviewQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsdasriReviewQuery.ts
@@ -1,0 +1,152 @@
+import { gql } from "@apollo/client";
+
+const reviewFragment = gql`
+  fragment BsdasriRevisionRequestFragment on BsdasriRevisionRequest {
+    id
+    createdAt
+    bsdasri {
+      id
+      status
+      updatedAt
+      type
+      emitter {
+        company {
+          name
+          siret
+          orgId
+        }
+        pickupSite {
+          name
+          address
+          city
+          postalCode
+          infos
+        }
+      }
+      waste {
+        code
+      }
+
+      transporter {
+        company {
+          name
+          siret
+          orgId
+        }
+      }
+
+      destination {
+        company {
+          name
+          siret
+          orgId
+        }
+        reception {
+          packagings {
+            type
+            other
+            quantity
+            volume
+          }
+        }
+        operation {
+          weight {
+            value
+          }
+          code
+          mode
+        }
+      }
+    }
+    authoringCompany {
+      siret
+      name
+    }
+    approvals {
+      approverSiret
+      status
+    }
+    content {
+      emitter {
+        pickupSite {
+          name
+          address
+          city
+          postalCode
+          infos
+        }
+      }
+      waste {
+        code
+      }
+
+      destination {
+        reception {
+          packagings {
+            type
+            other
+            quantity
+            volume
+          }
+        }
+        operation {
+          weight
+          code
+          mode
+        }
+      }
+      isCanceled
+    }
+    status
+    comment
+  }
+`;
+
+export const GET_BSDASRI_REVISION_REQUESTS = gql`
+  query BsdasriRevisionRequests(
+    $siret: String!
+    $where: BsdasriRevisionRequestWhere
+    $after: String
+  ) {
+    bsdasriRevisionRequests(siret: $siret, where: $where, after: $after) {
+      edges {
+        node {
+          ...BsdasriRevisionRequestFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  ${reviewFragment}
+`;
+
+export const CREATE_BSDASRI_REVISION_REQUEST = gql`
+  mutation CreateBsdasriRevisionRequest(
+    $input: CreateBsdasriRevisionRequestInput!
+  ) {
+    createBsdasriRevisionRequest(input: $input) {
+      id
+    }
+  }
+`;
+
+export const CANCEL_BSDASRI_REVISION_REQUEST = gql`
+  mutation CancelBsdasriRevisionRequest($id: ID!) {
+    cancelBsdasriRevisionRequest(id: $id)
+  }
+`;
+
+export const SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL = gql`
+  mutation SubmitBsdasriRevisionRequestApproval(
+    $id: ID!
+    $isApproved: Boolean!
+  ) {
+    submitBsdasriRevisionRequestApproval(id: $id, isApproved: $isApproved) {
+      id
+      status
+    }
+  }
+`;

--- a/front/src/Apps/common/types/bsdTypes.ts
+++ b/front/src/Apps/common/types/bsdTypes.ts
@@ -43,7 +43,8 @@ import {
   Scalars,
   TemporaryStorageDetail,
   Transporter,
-  TransportMode
+  TransportMode,
+  BsdasriMetadata
 } from "@td/codegen-ui";
 
 export enum BsdTypename {
@@ -135,7 +136,7 @@ export interface BsdDisplay {
   transporterNumberPlate?: string | Maybe<string[]>;
   packagings?: Array<BsffPackaging>;
   synthesizedIn?: Maybe<Bsdasri>;
-  metadata?: FormMetadata | BsdaMetadata;
+  metadata?: FormMetadata | BsdaMetadata | BsdasriMetadata;
 }
 
 export enum WorkflowDisplayType {

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -56,7 +56,9 @@ const routes = {
         transporter: "/dashboard/:siret/bsdasris/sign-transporter/:id",
         reception: "/dashboard/:siret/bsdasris/sign-reception/:id",
         operation: "/dashboard/:siret/bsdasris/sign-operation/:id"
-      }
+      },
+
+      review: "/dashboard/:siret/bsdasris/review/:id"
     },
     bsvhus: {
       create: "/dashboard/:siret/bsvhus/create",

--- a/front/src/common/components/DsfrSearchInput.tsx
+++ b/front/src/common/components/DsfrSearchInput.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { SearchBar } from "@codegouvfr/react-dsfr/SearchBar";
+
+export default function SearchInput({
+  onChange,
+
+  placeholder = "",
+  className = "",
+  value = "",
+  disabled = false
+}: {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  id: string;
+  className?: string;
+  placeholder?: string;
+  value?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div>
+      <SearchBar
+        className={className}
+        renderInput={({ className, id }) => (
+          <input
+            value={value}
+            className={className}
+            disabled={disabled}
+            id={id}
+            placeholder={placeholder}
+            onChange={e => onChange(e)}
+          />
+        )}
+      />
+    </div>
+  );
+}

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -1,3 +1,4 @@
+// See RhfOperation mode for an amazing, breath-taking react-hook-form compliant component
 import React, { useEffect, useMemo } from "react";
 import { Field, useFormikContext } from "formik";
 import { RadioButton } from "../../form/common/components/custom-inputs/RadioButton";

--- a/front/src/common/components/RhfOperationModeSelect.tsx
+++ b/front/src/common/components/RhfOperationModeSelect.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useMemo } from "react";
+
+import { useFormContext } from "react-hook-form";
+import {
+  getOperationModeLabel,
+  getOperationModesFromOperationCode
+} from "../operationModes";
+import Tooltip from "./Tooltip";
+import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
+
+const RhfOperationModeSelect = ({ operationCode, path }) => {
+  const { setValue, watch, getFieldState } = useFormContext();
+  const { error: fieldError } = getFieldState(path);
+  const modes = useMemo(
+    () => getOperationModesFromOperationCode(operationCode),
+    [operationCode]
+  );
+  const fieldValue = watch(path);
+  useEffect(() => {
+    // No mode possible. Still, explicitely set to null
+    if (!modes.length) {
+      setValue(path, null);
+    }
+    // If the available modes change, and only ONE option is available,
+    // select it by default. Else, reset the selection
+    else if (modes.length > 1) {
+      setValue(path, undefined);
+    } else {
+      setValue(path, modes[0]);
+    }
+  }, [modes, path, setValue]);
+
+  if (!modes.length) return null;
+
+  return (
+    <div className="form__row">
+      <fieldset>
+        <legend className="fr-mb-2w fr-grid-row">
+          Mode de traitement{" "}
+          <Tooltip msg="Le mode de traitement correspond à un des 4 choix de la hiérarchie des modes de traitement, il s'impose de lui même ou doit être précisé selon l'opération réalisée" />
+        </legend>
+
+        <RadioButtons
+          orientation="horizontal"
+          state={fieldError && "error"}
+          stateRelatedMessage={(fieldError?.message as string) ?? ""}
+          options={modes.map(mode => ({
+            label: getOperationModeLabel(mode),
+            nativeInputProps: {
+              value: mode,
+              onChange: () => setValue(path, mode),
+
+              checked: fieldValue === mode
+            }
+          }))}
+        />
+      </fieldset>
+
+      {/* <RedErrorMessage name={name} /> */}
+    </div>
+  );
+};
+export default RhfOperationModeSelect;

--- a/front/src/dashboard/components/BSDList/BSDasri/index.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/index.tsx
@@ -10,7 +10,8 @@ const dasriVerboseStatuses: Record<BsdasriStatus, string> = {
   RECEIVED: "Reçu",
   PROCESSED: "Traité",
   REFUSED: "Refusé",
-  AWAITING_GROUP: "En attente de regroupement"
+  AWAITING_GROUP: "En attente de regroupement",
+  CANCELED: "Annulé"
 };
 
 const getDasriVerboseStatus = (bsdasri: Bsdasri): string => {

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/BsdasriRequestRevisionCancelationInput.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/BsdasriRequestRevisionCancelationInput.tsx
@@ -1,0 +1,51 @@
+import { Bsdasri, BsdasriStatus } from "@td/codegen-ui";
+import React from "react";
+
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+
+// If you modify this, also modify it in the backend
+export const CANCELLABLE_BSDASRI_STATUSES: BsdasriStatus[] = [
+  // BsdasriStatus.INITIAL,
+  // BsdasriStatus.SIGNED_BY_PRODUCER,
+  BsdasriStatus.Sent
+  // BsdasriStatus.RECEIVED,
+  // BsdasriStatus.PROCESSED,
+  // BsdasriStatus.AWAITING_GROUP,
+  // BsdasriStatus.CANCELED
+  // BsdasriStatus.REFUSED,
+  // BsdasriStatus.REFUSED_BY_RECIPIENT
+];
+
+interface Props {
+  bsdasri: Bsdasri;
+  onChange: (value) => void;
+}
+
+const CANCELATION_MSG = `Si votre demande d'annulation est approuvée, ce bordereau passera au 
+statut Annulé pour tous les acteurs du bordereau.`;
+
+const CANCELATION_NOT_POSSIBLE_MSG = `Impossible d'annuler ce bordereau. Il est à un statut trop avancé.`;
+
+export function BsdasriRequestRevisionCancelationInput({
+  bsdasri,
+  onChange
+}: Props) {
+  const canBeCancelled = CANCELLABLE_BSDASRI_STATUSES.includes(
+    bsdasri["bsdasriStatus"]
+  );
+
+  return (
+    <div>
+      <ToggleSwitch
+        label="Annuler le bordereau"
+        disabled={!canBeCancelled}
+        inputTitle="cancellation"
+        onChange={onChange}
+        showCheckedHint={false}
+        helperText="Un bordereau annulé n’est pas supprimé mais il n’apparait plus dans
+          les différents dossiers."
+      />
+      {canBeCancelled ? CANCELATION_MSG : CANCELATION_NOT_POSSIBLE_MSG}
+    </div>
+  );
+}

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/RhfReviewableField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/RhfReviewableField.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+
+type Props = {
+  readonly title: string;
+  readonly suffix?: string;
+
+  // help text
+  readonly hint?: string;
+  // The variable path: eg; `destination.operation.weight`
+  readonly path: string;
+  // Value coming from revised bsd, allowing reset when component is closed
+  readonly defaultValue: any;
+  // Optional value to initialize children field value, useful for booleans
+  readonly initialValue?: any;
+  readonly value: string | number | React.ReactNode;
+  // is the field disabled
+  readonly disabled?: boolean;
+
+  children: React.ReactNode;
+};
+
+const LabelContent = ({
+  labelText,
+  suffix,
+
+  value
+}: {
+  labelText: string;
+  value: string | number | React.ReactNode;
+  defaultValue?: string | number | React.ReactNode;
+  suffix?: string;
+}) =>
+  !!value ? (
+    <span>
+      {labelText} :{" "}
+      <strong>
+        {value} {suffix}
+      </strong>
+    </span>
+  ) : (
+    <span>{labelText}</span>
+  );
+
+export function RhfReviewableField({
+  title,
+  suffix,
+  defaultValue,
+  value,
+  path,
+  hint,
+  initialValue,
+
+  children,
+  disabled = false
+}: Props) {
+  const { setValue } = useFormContext(); // retrieve all hook methods
+  const [isEditing, setIsEditing] = useState(false);
+
+  function handleIsEditingChange() {
+    if (isEditing) {
+      // When toggling visibility to off, set children value to pre-existing value
+
+      setValue(path, defaultValue);
+    } else {
+      // When toggling visibility to on, set children value to optional initialValue (to tell apart empty strings from boolean)
+      if (initialValue !== undefined) setValue(path, initialValue);
+    }
+    setIsEditing(!isEditing);
+  }
+
+  return (
+    <div>
+      <ToggleSwitch
+        label={<LabelContent labelText={title} value={value} suffix={suffix} />}
+        inputTitle="terms" // todo: change
+        defaultChecked={false}
+        showCheckedHint={false}
+        helperText={hint}
+        onChange={handleIsEditingChange}
+        disabled={disabled}
+      />
+      {isEditing && (
+        <>
+          <div className="fr-ml-9w">{children} </div>{" "}
+          <hr className="fr-mt-1w" />
+        </>
+      )}
+    </div>
+  );
+}

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.module.scss
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.module.scss
@@ -1,0 +1,43 @@
+@import "../../../../../scss/Constants.scss";
+@import "../../../../../scss/Breakpoints.scss";
+
+.container {
+  padding: 2rem 1rem;
+}
+
+.title {
+  font-weight: bold;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.fields {
+  margin-bottom: 2rem;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid $grey;
+  padding: 1rem;
+
+  @include phone {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+  > * {
+    // space buttons and divs
+    margin-left: 1rem;
+    margin-bottom: 1rem;
+    @include phone {
+      margin-bottom: 0;
+    }
+  }
+}
+
+@media only screen and (min-width: 640px) {
+  .actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.tsx
@@ -1,0 +1,445 @@
+import { useMutation } from "@apollo/client";
+
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import RhfOperationModeSelect from "../../../../../common/components/RhfOperationModeSelect";
+
+import { getDasriPackagingInfosSummary } from "../../../../../form/bsdasri/utils/packagings";
+
+import DsfrfWorkSiteAddress from "../../../../../form/common/components/dsfr-work-site/DsfrfWorkSiteAddress";
+import {
+  Bsdasri,
+  BsdasriType,
+  Mutation,
+  MutationCreateBsdasriRevisionRequestArgs,
+  BsdasriStatus
+} from "@td/codegen-ui";
+import { removeEmptyKeys } from "../../../../../common/helper";
+
+import { CREATE_BSDASRI_REVISION_REQUEST } from "../../../../../Apps/common/queries/reviews/BsdasriReviewQuery";
+import styles from "./BsdasriRequestRevision.module.scss";
+
+import { BsdasriRequestRevisionCancelationInput } from "../BsdasriRequestRevisionCancelationInput";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
+import { useForm, FormProvider, SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+
+import { RhfReviewableField } from "../RhfReviewableField";
+
+import { BsdasriPackagings } from "../../../../../form/bsdasri/components/packagings/RhfPackagings";
+
+type Props = {
+  readonly bsdasri: Bsdasri;
+};
+
+const bsdasriPackagingSchema = z.object({
+  type: z.enum(
+    [
+      "BOITE_CARTON",
+      "FUT",
+      "BOITE_PERFORANTS",
+      "GRAND_EMBALLAGE",
+      "GRV",
+      "AUTRE"
+    ],
+    {
+      required_error: "Ce champ est requis",
+      invalid_type_error: "Ce champ est requis"
+    }
+  ),
+  other: z.string(),
+  volume: z.coerce.number().positive().nullish(),
+
+  quantity: z.coerce.number().positive()
+});
+
+const getSchema = () =>
+  z.object({
+    emitter: z
+      .object({
+        pickupSite: z.object({
+          name: z.string().nullish(),
+          address: z.string().nullish(),
+          city: z.string().nullish(),
+          postalCode: z.string().nullish(),
+          infos: z.string().nullish()
+        })
+      })
+      .nullish(),
+    destination: z
+      .object({
+        reception: z.object({
+          packagings: z.array(bsdasriPackagingSchema).nullish()
+        }),
+        operation: z.object({
+          weight: z.coerce.number().nonnegative().nullish(),
+
+          code: z.string().nullish(),
+          mode: z.string().nullish()
+        })
+      })
+      .nullish(),
+    waste: z.object({ code: z.string().nullish() }),
+    isCanceled: z.boolean().nullish(),
+    comment: z.string().min(3)
+  });
+
+const revisionRules = {
+  "emitter.pickupSite": {
+    revisable: [
+      BsdasriStatus.Sent,
+      BsdasriStatus.Received,
+      BsdasriStatus.Processed
+    ]
+  },
+
+  "waste.code": {
+    revisable: [
+      BsdasriStatus.Sent,
+      BsdasriStatus.Received,
+      BsdasriStatus.Processed
+    ]
+  },
+
+  "destination.reception.packagings": {
+    revisable: [BsdasriStatus.Received, BsdasriStatus.Processed]
+  },
+  "destination.operation.code": {
+    revisable: [BsdasriStatus.Processed]
+  },
+
+  "destination.operation.weight": {
+    revisable: [BsdasriStatus.Processed]
+  }
+};
+
+const isDisabled = (path: string, status: BsdasriStatus) =>
+  !(revisionRules?.[path] ?? [])?.revisable?.includes(status);
+
+export function BsdasriRequestRevision({ bsdasri }: Props) {
+  const { siret } = useParams<{ siret: string }>();
+  const navigate = useNavigate();
+  const [createBsdasriRevisionRequest, { loading, error }] = useMutation<
+    Pick<Mutation, "createBsdasriRevisionRequest">,
+    MutationCreateBsdasriRevisionRequestArgs
+  >(CREATE_BSDASRI_REVISION_REQUEST);
+
+  // const defaultValues = {
+  //   emitter: {
+  //     pickupSite: {
+  //       name: "",
+  //       address: "",
+  //       city: "",
+  //       postalCode: "",
+  //       infos: ""
+  //     }
+  //   },
+  //   destination: {
+  //     reception: { packagings: [] },
+  //     operation: {
+  //       weight: null,
+  //       code: null,
+  //       mode: null
+  //     }
+  //   },
+  //   waste: { code: null },
+  //   isCanceled: false
+  // };
+
+  const initialReview = {
+    emitter: {
+      pickupSite: {
+        name: null,
+        address: null,
+        city: null,
+        postalCode: null,
+        infos: null
+      }
+    },
+    destination: {
+      reception: { packagings: null },
+      operation: {
+        weight: null,
+        code: null,
+        mode: null
+      }
+    },
+    waste: { code: null },
+    comment: ""
+  };
+
+  const zodValidationSchema = getSchema();
+
+  type ValidationSchema = z.infer<typeof zodValidationSchema>;
+
+  const methods = useForm<ValidationSchema>({
+    mode: "onTouched",
+    values: initialReview,
+
+    resolver: zodResolver(zodValidationSchema)
+  });
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    reset,
+    formState: { errors, isSubmitting, isDirty }
+  } = methods;
+
+  const resetAndClose = () => {
+    reset();
+    navigate(-1);
+  };
+
+  const onSubmitForm = async data => {
+    const { comment, ...content } = data;
+    const cleanedContent = removeEmptyKeys(content);
+
+    await createBsdasriRevisionRequest({
+      variables: {
+        input: {
+          bsdasriId: bsdasri.id,
+          content: cleanedContent ?? {},
+          comment,
+          authoringCompanySiret: siret!
+        }
+      }
+    });
+    navigate(-1);
+  };
+
+  const onSubmit: SubmitHandler<ValidationSchema> = async data => {
+    await onSubmitForm(data);
+    resetAndClose();
+  };
+
+  // live form values
+  const formValues = watch();
+
+  if ([BsdasriType.Synthesis, BsdasriType.Grouping].includes(bsdasri.type)) {
+    return (
+      <p>
+        La révision n'est pas encore possible sur le dasri de groupement et de
+        synthèse
+      </p>
+    );
+  }
+
+  const packagingsSummary = getDasriPackagingInfosSummary(
+    bsdasri?.destination?.reception?.packagings || []
+  );
+
+  const pickuSiteSummary = [
+    bsdasri.emitter?.pickupSite?.address,
+    bsdasri.emitter?.pickupSite?.postalCode,
+    bsdasri.emitter?.pickupSite?.city
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>
+        Demander une révision du bordereau {bsdasri.id}
+      </h2>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <BsdasriRequestRevisionCancelationInput
+            bsdasri={bsdasri}
+            onChange={value => setValue("isCanceled", value)}
+          />
+
+          <RhfReviewableField
+            title="Adresse d'enlèvement"
+            path="emitter.pickupSite"
+            value={pickuSiteSummary}
+            defaultValue={initialReview?.emitter?.pickupSite}
+            disabled={isDisabled(
+              "emitter.pickupSite",
+              bsdasri["bsdasriStatus"]
+            )}
+          >
+            <Input
+              label="Nom du site d'enlèvement"
+              className="fr-col-9"
+              nativeInputProps={{
+                ...register("emitter.pickupSite.name"),
+                value: formValues?.emitter?.pickupSite?.name || ""
+              }}
+            />
+            <DsfrfWorkSiteAddress
+              address={initialReview?.emitter?.pickupSite?.address}
+              city={initialReview?.emitter?.pickupSite?.city}
+              postalCode={initialReview?.emitter?.pickupSite?.postalCode}
+              designation="du site d'enlèvement"
+              onAddressSelection={details => {
+                // `address` is passed as `name` because of adresse api return fields
+                setValue(`emitter.pickupSite.address`, details.name);
+                setValue(`emitter.pickupSite.city`, details.city);
+                setValue(`emitter.pickupSite.postalCode`, details.postcode);
+              }}
+            />
+
+            <div className="form__row">
+              <Input
+                label="Informations complémentaires (optionnel)"
+                textArea
+                nativeTextAreaProps={{
+                  placeholder: "Champ libre pour préciser…",
+                  ...register("emitter.pickupSite.infos"),
+                  value: formValues?.emitter?.pickupSite?.infos || ""
+                }}
+              />
+            </div>
+          </RhfReviewableField>
+
+          <RhfReviewableField
+            title="Conditionnement"
+            path="destination.reception.packagings"
+            value={packagingsSummary}
+            defaultValue={initialReview?.destination?.reception?.packagings}
+            disabled={isDisabled(
+              "destination.reception.packagings",
+              bsdasri["bsdasriStatus"]
+            )}
+          >
+            <BsdasriPackagings />
+          </RhfReviewableField>
+
+          <RhfReviewableField
+            title="Code déchet"
+            path="waste.code"
+            value={bsdasri?.waste?.code}
+            defaultValue={initialReview?.waste?.code}
+            initialValue={null}
+            disabled={isDisabled("waste.code", bsdasri["bsdasriStatus"])}
+          >
+            <RadioButtons
+              options={[
+                {
+                  label: "18 01 03* DASRI d'origine humaine",
+                  nativeInputProps: {
+                    onChange: () => setValue("waste.code", "18 01 03*"),
+                    disabled: bsdasri?.waste?.code === "18 01 03*",
+                    checked: formValues?.waste?.code === "18 01 03*"
+                  }
+                },
+                {
+                  label: "18 02 02* DASRI d'origine animale",
+                  nativeInputProps: {
+                    onChange: () => setValue("waste.code", "18 02 02*"),
+                    disabled: bsdasri?.waste?.code === "18 02 02*",
+                    checked: formValues?.waste?.code === "18 02 02*"
+                  }
+                }
+              ]}
+            />
+          </RhfReviewableField>
+
+          <RhfReviewableField
+            title="Quantité reçue"
+            suffix="kg"
+            path="destination.operation.weight"
+            value={bsdasri?.destination?.operation?.weight?.value}
+            defaultValue={initialReview?.destination?.operation?.weight}
+            disabled={isDisabled(
+              "destination.operation.weight",
+              bsdasri["bsdasriStatus"]
+            )}
+          >
+            <Input
+              label="Poids en kilos"
+              className="fr-col-2"
+              state={errors?.destination?.operation?.weight && "error"}
+              stateRelatedMessage={
+                (errors?.destination?.operation?.weight?.message as string) ??
+                ""
+              }
+              nativeInputProps={{
+                type: "number",
+                ...register("destination.operation.weight"),
+                value: formValues?.destination?.operation?.weight ?? undefined,
+                inputMode: "decimal",
+                step: "1"
+              }}
+            />
+            <p className="fr-info-text">
+              {formValues?.destination?.operation?.weight
+                ? `Soit ${
+                    formValues?.destination?.operation?.weight / 1000
+                  } tonnes`
+                : "Poids en tonnes"}{" "}
+            </p>
+          </RhfReviewableField>
+          <RhfReviewableField
+            title="Code de l’opération D/R"
+            path="destination.operation.code"
+            value={bsdasri?.destination?.operation?.code}
+            defaultValue={initialReview?.destination?.operation?.code}
+            disabled={isDisabled(
+              "destination.operation.code",
+              bsdasri["bsdasriStatus"]
+            )}
+          >
+            <Select
+              label="Code de l'opération"
+              className="fr-col-8"
+              nativeSelectProps={{ ...register("destination.operation.code") }}
+            >
+              <option value="D9">
+                D9 - Prétraitement par désinfection - Banaliseur
+              </option>
+              <option value="D10">D10 - Incinération</option>
+              <option value="R1">
+                R1 - Incinération + valorisation énergétique
+              </option>
+            </Select>
+            <RhfOperationModeSelect
+              operationCode={formValues?.destination?.operation?.code}
+              path={"destination.operation.mode"}
+            />
+          </RhfReviewableField>
+
+          <Input
+            textArea
+            label="Commentaire à propos de la révision"
+            state={errors?.comment && "error"}
+            stateRelatedMessage={(errors?.comment?.message as string) ?? ""}
+            nativeTextAreaProps={{
+              ...register("comment")
+            }}
+          />
+          {error && (
+            <Alert
+              description={error.message}
+              severity="error"
+              title="Erreur"
+            />
+          )}
+
+          <div className="transporterInfoEditForm__cta">
+            <Button
+              priority="secondary"
+              nativeButtonProps={{ type: "button" }}
+              onClick={resetAndClose}
+            >
+              Annuler
+            </Button>
+            <Button
+              nativeButtonProps={{ type: "submit" }}
+              disabled={!isDirty || loading || isSubmitting}
+            >
+              Demander
+            </Button>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+}

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/request/RouteBsdasriRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/request/RouteBsdasriRequestRevision.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "@apollo/client";
+import { Loader } from "../../../../../Apps/common/Components";
+import { InlineError } from "../../../../../Apps/common/Components/Error/Error";
+import { GET_BSDASRI } from "../../../../../Apps/common/queries/bsdasri/queries";
+import { Query, QueryBsdaArgs } from "@td/codegen-ui";
+import React from "react";
+import { useParams } from "react-router-dom";
+import { BsdasriRequestRevision } from "./BsdasriRequestRevision";
+
+export function RouteBsdasriRequestRevision() {
+  const { id } = useParams<{ id: string }>();
+  const { error, data, loading } = useQuery<
+    Pick<Query, "bsdasri">,
+    QueryBsdaArgs
+  >(GET_BSDASRI, {
+    variables: {
+      id: id!
+    }
+  });
+
+  if (error) return <InlineError apolloError={error} />;
+  if (loading) return <Loader />;
+  if (!data?.bsdasri) return null;
+
+  return <BsdasriRequestRevision bsdasri={data?.bsdasri} />;
+}

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/request/index.ts
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/request/index.ts
@@ -1,0 +1,1 @@
+export * from "./RouteBsdasriRequestRevision";

--- a/front/src/form/bsdasri/components/packagings/RhfPackagings.module.scss
+++ b/front/src/form/bsdasri/components/packagings/RhfPackagings.module.scss
@@ -1,0 +1,21 @@
+.multiTags {
+  display: flex;
+  width: 100%;
+  border-radius: 0.25rem 0.25rem 0 0;
+  font-size: 1rem;
+  line-height: 1.2rem;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  color: var(--text-default-grey);
+  background-color: rgb(238, 238, 238);
+  --idle: transparent;
+  --hover: var(--background-contrast-grey-hover);
+  --active: var(--background-contrast-grey-active);
+  box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);
+  row-gap: 10px;
+}
+
+.multiTagsInput {
+  line-height: 1.8rem;
+  background-color: transparent;
+  padding: 0 0.4rem;
+}

--- a/front/src/form/bsdasri/components/packagings/RhfPackagings.tsx
+++ b/front/src/form/bsdasri/components/packagings/RhfPackagings.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+
+import { useFormContext, useFieldArray } from "react-hook-form";
+import { PACKAGINGS_NAMES } from "../../utils/packagings";
+
+export const emptyPackaging = {
+  quantity: 1,
+  type: null,
+  volume: null,
+  other: ""
+};
+
+const path = "destination.reception.packagings";
+
+const PaohPackaging = ({ idx, remove, disabled }) => {
+  const { register, getFieldState } = useFormContext();
+  const name = `${path}.${idx}`;
+
+  const { error: typeError } = getFieldState(`${name}.type`);
+
+  return (
+    <div>
+      {idx > 0 && <hr />}
+      <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-mb-1v">
+        <div className="fr-col-12 fr-col-md-2">
+          <Input
+            label="Nombre de coli(s)"
+            nativeInputProps={{
+              defaultValue: 1,
+              ...register(`${name}.quantity`)
+            }}
+          />
+        </div>
+        <div className="fr-col-12 fr-col-md-3">
+          <Select
+            label="Type"
+            disabled={disabled}
+            nativeSelectProps={{ ...register(`${name}.type`) }}
+            state={typeError && "error"}
+            stateRelatedMessage={(typeError?.message as string) ?? ""}
+          >
+            <option value="">…</option>
+
+            {(
+              Object.entries(PACKAGINGS_NAMES) as Array<
+                [keyof typeof PACKAGINGS_NAMES, string]
+              >
+            ).map(([optionValue, optionLabel]) => (
+              <option key={optionValue} value={optionValue} disabled={disabled}>
+                {optionLabel}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="fr-col-12 fr-col-md-2">
+          <Input
+            label="Précisez"
+            nativeInputProps={{
+              defaultValue: "",
+              ...register(`${name}.other`)
+            }}
+          />
+        </div>
+        <div className="fr-col-12 fr-col-md-2">
+          <Input
+            label="Volume unitaire (l)"
+            disabled={disabled}
+            nativeInputProps={{
+              ...register(`${name}.volume`),
+              inputMode: "numeric",
+              pattern: "[0-9]*",
+              type: "number"
+            }}
+          ></Input>
+        </div>
+
+        <div className="fr-col-12 fr-col-md-1">
+          {idx > 0 && !disabled && (
+            <Button
+              priority="tertiary"
+              type="button"
+              iconId="fr-icon-delete-bin-line"
+              title="Supprimer ce conditionnement"
+              nativeButtonProps={{ onClick: () => remove(idx) }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const BsdasriPackagings = ({ disabled = false }) => {
+  const { fields, append, remove } = useFieldArray({
+    name: path
+  });
+
+  return (
+    <div>
+      {fields.map((packaging, index) => (
+        <PaohPackaging
+          idx={index}
+          key={packaging.id}
+          remove={remove}
+          disabled={disabled}
+        />
+      ))}
+      {!disabled && (
+        <div className="fr-col-12 fr-col-offset-6">
+          <Button
+            priority="secondary"
+            type="button"
+            onClick={() => append(emptyPackaging)}
+          >
+            Ajouter un conditionnement
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
+++ b/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useReducer, useState } from "react";
+import * as Sentry from "@sentry/browser";
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+import SearchInput from "../../../../common/components/DsfrSearchInput";
+import styles from "./WorkSiteAddress.module.scss";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+
+function init({ address, city, postalCode }) {
+  const selectedAdress = [address, postalCode, city].filter(Boolean).join(" ");
+  return {
+    selectedAdress,
+    searchInput: selectedAdress,
+    searchResults: [],
+    address,
+    postalCode,
+    city
+  };
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "search_input":
+      return { ...state, searchInput: action.payload };
+    case "search_done":
+      return { ...state, searchResults: action.payload };
+    case "set_fields":
+      return {
+        ...state,
+        ...action.payload
+      };
+    case "select_address":
+      return {
+        ...state,
+        selectedAdress: action.payload,
+        searchInput: action.payload
+      };
+  }
+}
+
+export default function DsfrfWorkSiteAddress({
+  address,
+  city,
+  postalCode,
+  onAddressSelection,
+  designation,
+  disabled = false
+}) {
+  const [state, dispatch] = useReducer(
+    reducer,
+    { address, city, postalCode },
+    init
+  );
+
+  const [showAdressFields, setShowAdressFields] = useState(false);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (!state.searchInput || state.searchInput === state.selectedAdress) {
+        dispatch({ type: "search_done", payload: [] });
+        return;
+      }
+      fetch(`https://api-adresse.data.gouv.fr/search/?q=${state.searchInput}`)
+        .then(res => res.json())
+        .then(res => dispatch({ type: "search_done", payload: res.features }))
+        .catch(error => {
+          Sentry.captureException(error);
+        });
+    }, 300);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [state.searchInput, state.selectedAdress]);
+
+  function selectAddress(feature) {
+    onAddressSelection(feature.properties);
+    dispatch({
+      type: "select_address",
+      payload: feature.properties.label
+    });
+  }
+  function setManualAddress(payload) {
+    const { city, address, postalCode } = payload;
+
+    dispatch({
+      type: "set_fields",
+      payload: { city, address, postalCode }
+    });
+
+    // beware postCode/postalCode & name/address (former fields returned by address api)
+    onAddressSelection({
+      city: city,
+      name: address,
+      postcode: postalCode
+    });
+  }
+
+  return (
+    <div className="form__row">
+      <label>Adresse {designation}</label>
+
+      <SearchInput
+        id="eco-search"
+        placeholder="Recherchez une adresse puis sélectionnez un des choix qui apparait..."
+        className="fr-col-7"
+        onChange={e =>
+          dispatch({ type: "search_input", payload: e.target.value })
+        }
+        value={state.searchInput}
+        disabled={disabled || showAdressFields}
+      />
+      <ToggleSwitch
+        inputTitle="showAdressFields"
+        defaultChecked={false}
+        showCheckedHint={showAdressFields}
+        onChange={e => {
+          setShowAdressFields(e);
+        }}
+        label={"Je veux entrer l'adresse manuellement"}
+      />
+
+      {showAdressFields && (
+        <div>
+          <div>
+            <Input
+              label="N° et libellé de voie ou lieu-dit"
+              nativeInputProps={{
+                defaultValue: address,
+                onChange: e =>
+                  setManualAddress({
+                    city: state.city,
+                    postalCode: state.postalCode,
+                    address: e.target.value
+                  })
+              }}
+            />
+          </div>
+          <div>
+            <Input
+              label="Ville"
+              nativeInputProps={{
+                defaultValue: city,
+                onChange: e =>
+                  setManualAddress({
+                    address: state.address,
+                    postalCode: state.postalCode,
+                    city: e.target.value
+                  })
+              }}
+            />
+          </div>
+          <div>
+            <Input
+              label="Code postal"
+              nativeInputProps={{
+                defaultValue: city,
+                onChange: e =>
+                  setManualAddress({
+                    address: state.address,
+                    city: state.city,
+                    postalCode: e.target.value
+                  })
+              }}
+            />
+          </div>
+        </div>
+      )}
+      {state.searchResults.map(feature => (
+        <div
+          className={styles.worksiteSearchResult}
+          key={feature.properties.id}
+          onClick={_ => selectAddress(feature)}
+        >
+          {feature.properties.label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/front/src/form/common/components/dsfr-work-site/WorkSiteAddress.module.scss
+++ b/front/src/form/common/components/dsfr-work-site/WorkSiteAddress.module.scss
@@ -1,0 +1,13 @@
+.worksite {
+  &SearchResult {
+    background-color: #ebeff3;
+    margin: 10px 0;
+    padding: 10px;
+    cursor: pointer;
+  }
+
+  &SearchInput {
+    max-width: 590px;
+    display: inline-block;
+  }
+}

--- a/libs/back/prisma/src/migrations/20240520080613_bsdasri_revisions/migration.sql
+++ b/libs/back/prisma/src/migrations/20240520080613_bsdasri_revisions/migration.sql
@@ -1,0 +1,60 @@
+-- CreateTable
+CREATE TABLE "BsdasriRevisionRequest" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "status" "RevisionRequestStatus" NOT NULL DEFAULT 'PENDING',
+    "comment" TEXT NOT NULL,
+    "isCanceled" BOOLEAN NOT NULL DEFAULT false,
+    "bsdasriId" TEXT NOT NULL,
+    "authoringCompanyId" TEXT NOT NULL,
+    "wasteCode" TEXT,
+    "destinationWastePackagings" JSONB,
+    "destinationReceptionWasteWeightValue" DOUBLE PRECISION,
+    "destinationOperationCode" TEXT,
+    "destinationOperationMode" "OperationMode",
+    "emitterPickupSiteName" TEXT,
+    "emitterPickupSiteAddress" TEXT,
+    "emitterPickupSiteCity" TEXT,
+    "emitterPickupSitePostalCode" TEXT,
+    "emitterPickupSiteInfos" TEXT,
+
+    CONSTRAINT "BsdasriRevisionRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BsdasriRevisionRequestApproval" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "revisionRequestId" TEXT NOT NULL,
+    "approverSiret" TEXT NOT NULL,
+    "status" "RevisionRequestApprovalStatus" NOT NULL DEFAULT 'PENDING',
+    "comment" TEXT,
+
+    CONSTRAINT "BsdasriRevisionRequestApproval_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_BsdasriRevisionRequestAuthoringCompanyIdIdx" ON "BsdasriRevisionRequest"("authoringCompanyId");
+
+-- CreateIndex
+CREATE INDEX "_BsdasriRevisionRequestStatusIdx" ON "BsdasriRevisionRequest"("status");
+
+-- CreateIndex
+CREATE INDEX "_BsdasriRevisionRequestBsdaIdIdx" ON "BsdasriRevisionRequest"("bsdasriId");
+
+-- CreateIndex
+CREATE INDEX "_BsdasriRevisionRequestApprovalRevisionRequestIdIdx" ON "BsdasriRevisionRequestApproval"("revisionRequestId");
+
+-- CreateIndex
+CREATE INDEX "_BsdasriRevisionRequestApprovalApproverSiretIdx" ON "BsdasriRevisionRequestApproval"("approverSiret");
+
+-- AddForeignKey
+ALTER TABLE "BsdasriRevisionRequest" ADD CONSTRAINT "BsdasriRevisionRequest_bsdasriId_fkey" FOREIGN KEY ("bsdasriId") REFERENCES "Bsdasri"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BsdasriRevisionRequest" ADD CONSTRAINT "BsdasriRevisionRequest_authoringCompanyId_fkey" FOREIGN KEY ("authoringCompanyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BsdasriRevisionRequestApproval" ADD CONSTRAINT "BsdasriRevisionRequestApproval_revisionRequestId_fkey" FOREIGN KEY ("revisionRequestId") REFERENCES "BsdasriRevisionRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/back/prisma/src/migrations/20240523093704_add_bsdasri_cancelled_status/migration.sql
+++ b/libs/back/prisma/src/migrations/20240523093704_add_bsdasri_cancelled_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "BsdasriStatus" ADD VALUE 'CANCELED';

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -289,11 +289,14 @@ model Company {
   companyAssociations                  CompanyAssociation[]
   allowBsdasriTakeOverWithoutSignature Boolean                   @default(false)
   MembershipRequest                    MembershipRequest[]
+  // Révisions
   bsdaRevisionRequests                 BsdaRevisionRequest[]
   bsddRevisionRequests                 BsddRevisionRequest[]
-  givenSignatureAutomations            SignatureAutomation[]     @relation("SignatureAutomationFrom")
-  receivedSignatureAutomations         SignatureAutomation[]     @relation("SignatureAutomationTo")
-  webhookSettingsLimit                 Int                       @default(1)
+  bsdasriRevisionRequests              BsdasriRevisionRequest[]
+
+  givenSignatureAutomations    SignatureAutomation[] @relation("SignatureAutomationFrom")
+  receivedSignatureAutomations SignatureAutomation[] @relation("SignatureAutomationTo")
+  webhookSettingsLimit         Int                   @default(1)
 
   @@index([name], map: "_CompanyNameIdx")
   @@index([givenName], map: "_CompanyGivenNameIdx")
@@ -1102,6 +1105,8 @@ model Bsdasri {
   synthesizedIn   Bsdasri?  @relation("BsdasriSynthesizing", fields: [synthesizedInId], references: [id])
   synthesizedInId String?
 
+  bsdasriRevisionRequests BsdasriRevisionRequest[]
+
   // Denormalized fields, storing associated dasri sirets to speed up some queries
   // Emitter sirets list in case of synthesis bsd
   groupingEmitterSirets  String[] @default([])
@@ -1149,6 +1154,62 @@ model BsdasriFinalOperation {
   @@index([initialBsdasriId], map: "_FinalOperationInitialBsdasriIdIdx")
   @@index([finalBsdasriId], map: "_FinalOperationFinalBsdasriIdIdx")
 }
+
+// dasri revisions
+model BsdasriRevisionRequest {
+  id                 String                @id @default(cuid())
+  createdAt          DateTime              @default(now())
+  updatedAt          DateTime              @updatedAt
+  status             RevisionRequestStatus @default(PENDING)
+  comment            String
+  isCanceled         Boolean               @default(false)
+  bsdasriId          String
+  bsdasri            Bsdasri               @relation(fields: [bsdasriId], references: [id], onDelete: Cascade)
+  authoringCompanyId String
+  authoringCompany   Company               @relation(fields: [authoringCompanyId], references: [id], onDelete: Cascade)
+
+  approvals BsdasriRevisionRequestApproval[]
+
+  // Code déchet
+  wasteCode String?
+
+  // Conditionnement
+  destinationWastePackagings Json?
+
+  // Quantité traitée
+  destinationReceptionWasteWeightValue Float?
+
+  // Code de l'opération D/R et mode de traitement 
+  destinationOperationCode String?
+  destinationOperationMode OperationMode?
+
+  // Adresse de collecte ou d'enlèvement
+  emitterPickupSiteName       String?
+  emitterPickupSiteAddress    String?
+  emitterPickupSiteCity       String?
+  emitterPickupSitePostalCode String?
+  emitterPickupSiteInfos      String?
+
+  @@index([authoringCompanyId], map: "_BsdasriRevisionRequestAuthoringCompanyIdIdx")
+  @@index([status], map: "_BsdasriRevisionRequestStatusIdx")
+  @@index([bsdasriId], map: "_BsdasriRevisionRequestBsdaIdIdx")
+}
+
+model BsdasriRevisionRequestApproval {
+  id                String                        @id @default(cuid())
+  createdAt         DateTime                      @default(now())
+  updatedAt         DateTime                      @updatedAt
+  revisionRequestId String
+  revisionRequest   BsdasriRevisionRequest        @relation(fields: [revisionRequestId], references: [id], onDelete: Cascade)
+  approverSiret     String
+  status            RevisionRequestApprovalStatus @default(PENDING)
+  comment           String?
+
+  @@index([revisionRequestId], map: "_BsdasriRevisionRequestApprovalRevisionRequestIdIdx")
+  @@index([approverSiret], map: "_BsdasriRevisionRequestApprovalApproverSiretIdx")
+}
+
+// end dasri revisions
 
 model Bsff {
   id        String     @id
@@ -1811,6 +1872,7 @@ enum BsdasriStatus {
   PROCESSED
   REFUSED
   AWAITING_GROUP
+  CANCELED
 }
 
 enum BsdasriEmitterType {


### PR DESCRIPTION
Permet la révision d'un bsdasri simple:
- même principe que le bsda pour le back
- front en dsfr, react-hook-form et zod

Cette PR ajoute le statut CANCELED au dasri.
Lors de la création d'une révision le bsd est remonté dans le tableau de bord (cf. https://github.com/MTES-MCT/trackdechets/pull/3315)


### Révision avec acceptation

https://github.com/MTES-MCT/trackdechets/assets/878396/8f31e59d-dcfb-4d42-a7f7-db035b6e1479

### Révision avec refus

https://github.com/MTES-MCT/trackdechets/assets/878396/5c51e759-589f-4eb5-8591-21f1ba4cf49f

### Révision avec annulation acceptée

https://github.com/MTES-MCT/trackdechets/assets/878396/185f63b4-e7ea-42b2-ac5c-e48c231f98db



- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7432)
