### PR TITLE
[TRA-14394] Rendre les liens FAQ clickable dans les messages d'erreur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Renommer Regroupement par Annexe 2 (sous-type de BSDD) [PR 3352](https://github.com/MTES-MCT/trackdechets/pull/3352)
 - Ajout du nom usuel de l'établissement dans l'email de demande de rattachement [PR 3343](https://github.com/MTES-MCT/trackdechets/pull/3343)
 - Renommer Transit par Réexpédition (sous-type de BSDA) [PR 3351](https://github.com/MTES-MCT/trackdechets/pull/3351)
+- Rendre les liens de FAQ cliquable dans l'ajout d'établissement [PR 3342](https://github.com/MTES-MCT/trackdechets/pull/3342)
 
 #### :house: Interne
 

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/AccountCompanyAddSiret.tsx
@@ -212,15 +212,15 @@ export default function AccountCompanyAddSiret({
                   return {
                     siret: (
                       <span>
-                        {`Vous devez entrer un numéro de TVA intracommunautaire valide. Veuillez nous contacter via la FAQ `}
+                        {`Vous devez entrer un numéro de TVA intracommunautaire valide. Si vous continuez à rencontrer un souci de création avec votre numéro, veuillez nous partager un justificatif légal du pays d'origine via `}
                         <a
                           href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
                           target="_blank"
                           rel="noreferrer"
+                          className="fr-link--xs"
                         >
-                          https://faq.trackdechets.fr/pour-aller-plus-loin/assistance
+                          la FAQ
                         </a>
-                        {` avec un justificatif légal du pays d'origine.`}
                       </span>
                     )
                   };

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/AccountCompanyAddSiret.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/AccountCompanyAddSiret.tsx
@@ -210,7 +210,19 @@ export default function AccountCompanyAddSiret({
                 }
                 if (!isValidVat && !/^[0-9]{14}$/.test(values.siret)) {
                   return {
-                    siret: `Vous devez entrer un numéro de TVA intracommunautaire valide. Veuillez nous contacter via la FAQ https://faq.trackdechets.fr/pour-aller-plus-loin/assistance avec un justificatif légal du pays d'origine.`
+                    siret: (
+                      <span>
+                        {`Vous devez entrer un numéro de TVA intracommunautaire valide. Veuillez nous contacter via la FAQ `}
+                        <a
+                          href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          https://faq.trackdechets.fr/pour-aller-plus-loin/assistance
+                        </a>
+                        {` avec un justificatif légal du pays d'origine.`}
+                      </span>
+                    )
                   };
                 }
                 if (isValidVat && isFRVat(values.siret)) {

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFError.tsx
@@ -14,8 +14,14 @@ export const InvalidSirenePDFError = ({
         <span>
           Le fichier que vous tentez de charger comporte une erreur. Veuillez
           vérifier le fichier et réessayer avec un fichier PDF valide. Pour plus
-          d'informations, veuillez consulter cet article :
-          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          d'informations, veuillez consulter cet article :{" "}
+          <a
+            href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          </a>
         </span>
       }
     />

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFError.tsx
@@ -14,13 +14,14 @@ export const InvalidSirenePDFError = ({
         <span>
           Le fichier que vous tentez de charger comporte une erreur. Veuillez
           vérifier le fichier et réessayer avec un fichier PDF valide. Pour plus
-          d'informations, veuillez consulter cet article :{" "}
+          d'informations, veuillez consulter{" "}
           <a
             href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
             target="_blank"
             rel="noreferrer"
+            className="fr-link"
           >
-            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+            cet article sur la foire aux questions Trackdéchets
           </a>
         </span>
       }

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFFormatError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFFormatError.tsx
@@ -10,13 +10,14 @@ export const InvalidSirenePDFFormatError = () => {
         <span>
           Le fichier que vous tentez de charger n'est pas au format PDF.
           Veuillez vérifier le format du fichier et réessayer avec un fichier
-          PDF valide. Pour plus d'informations, veuillez consulter cet article :{" "}
+          PDF valide. Pour plus d'informations, veuillez consulter{" "}
           <a
             href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
             target="_blank"
             rel="noreferrer"
+            className="fr-link"
           >
-            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+            cet article sur la foire aux questions Trackdéchets
           </a>
         </span>
       }

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFFormatError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFFormatError.tsx
@@ -10,8 +10,14 @@ export const InvalidSirenePDFFormatError = () => {
         <span>
           Le fichier que vous tentez de charger n'est pas au format PDF.
           Veuillez vérifier le format du fichier et réessayer avec un fichier
-          PDF valide. Pour plus d'informations, veuillez consulter cet article :
-          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          PDF valide. Pour plus d'informations, veuillez consulter cet article :{" "}
+          <a
+            href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          </a>
         </span>
       }
     />

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFSizeError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFSizeError.tsx
@@ -10,8 +10,14 @@ export const InvalidSirenePDFSizeError = () => {
         <span>
           Le fichier que vous tentez de charger est trop lourd. Veuillez
           réessayer avec un fichier PDF conforme. Pour plus d'informations,
-          veuillez consulter cet article :
-          https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          veuillez consulter cet article :{" "}
+          <a
+            href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
+            target="_blank"
+            rel="noreferrer"
+          >
+            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+          </a>
         </span>
       }
     />

--- a/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFSizeError.tsx
+++ b/front/src/Apps/Companies/AccountCompanyAdd/companyAdd/anonymous/InvalidSirenePDFSizeError.tsx
@@ -10,13 +10,14 @@ export const InvalidSirenePDFSizeError = () => {
         <span>
           Le fichier que vous tentez de charger est trop lourd. Veuillez
           réessayer avec un fichier PDF conforme. Pour plus d'informations,
-          veuillez consulter cet article :{" "}
+          veuillez consulter{" "}
           <a
             href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire"
             target="_blank"
             rel="noreferrer"
+            className="fr-link"
           >
-            https://faq.trackdechets.fr/inscription-et-gestion-de-compte/questions-frequentes#lors-de-la-creation-de-mon-etablissement-non-diffusible-mon-fichier-na-pas-ete-valide.-que-faire
+            cet article sur la foire aux questions Trackdéchets
           </a>
         </span>
       }


### PR DESCRIPTION
# Objectif

Rendre le lien vers la FAQ dans cette erreur cliquable

![image](https://github.com/MTES-MCT/trackdechets/assets/2432646/5a60b966-3b46-4d2d-b5f9-45e255f3b05b)

# Modifications

Le ticket mentionne un seul lien de FAQ non cliquable dans un message d'erreur à l'ajout d'établissement. J'ai donc rendu le lien cliquable, et ai cherché pour voir si il y avait d'autres occurences. J'ai trouvé 2 autres cas similaires + une erreur de validation Formik qui contient aussi un lien. J'ai donc aussi fait le remplacement pour ces autres éléments.

# Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/4e39412f-9161-415b-802c-f203ad13bf4c



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14394)
