### PR TITLE
[TRA-14393] Réinitialiser correctement emitterCompany lors du switch en tre privateIndividual/foreignShip/company

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,7 +23,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Retirer le fait que les champs des transporteurs soient requis à la signature de la réception même lorsqu'ils n'ont pas signé l'enlèvement sur un BSDA [PR 3331](https://github.com/MTES-MCT/trackdechets/pull/3331)
 - Ne pas afficher les pastilles d'alertes pour le profil Lecteur [PR 3353](https://github.com/MTES-MCT/trackdechets/pull/3353)
 - Correction de l'affichage de la parte "Mes établissements" [PRA 3328](https://github.com/MTES-MCT/trackdechets/pull/3328)
-- Réinitialiser correctement emitterCompany lors du switch en tre privateIndividual/foreignShip/company [PR 3344](https://github.com/MTES-MCT/trackdechets/pull/3344)
+- Réinitialiser correctement emitterCompany lors du switch entre privateIndividual/foreignShip/company [PR 3344](https://github.com/MTES-MCT/trackdechets/pull/3344)
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Retirer le fait que les champs des transporteurs soient requis à la signature de la réception même lorsqu'ils n'ont pas signé l'enlèvement sur un BSDA [PR 3331](https://github.com/MTES-MCT/trackdechets/pull/3331)
 - Ne pas afficher les pastilles d'alertes pour le profil Lecteur [PR 3353](https://github.com/MTES-MCT/trackdechets/pull/3353)
 - Correction de l'affichage de la parte "Mes établissements" [PRA 3328](https://github.com/MTES-MCT/trackdechets/pull/3328)
+- Réinitialiser correctement emitterCompany lors du switch en tre privateIndividual/foreignShip/company [PR 3344](https://github.com/MTES-MCT/trackdechets/pull/3344)
 
 #### :boom: Breaking changes
 

--- a/front/src/form/bsdd/Emitter.tsx
+++ b/front/src/form/bsdd/Emitter.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from "react";
 import EcoOrganismes from "./components/eco-organismes/EcoOrganismes";
 import WorkSite from "../common/components/work-site/WorkSite";
 import {
+  getInitialCompany,
   getInitialEmitterWorkSite,
   initialFormTransporter
 } from "./utils/initial-state";
@@ -157,7 +158,7 @@ export default function Emitter({ disabled }) {
               className="td-checkbox"
               onChange={e => {
                 handleChange(e);
-                setFieldValue("emitter.company", null);
+                setFieldValue("emitter.company", getInitialCompany(null));
                 setFieldValue("emitter.isForeignShip", false);
               }}
             />
@@ -171,7 +172,7 @@ export default function Emitter({ disabled }) {
               className="td-checkbox"
               onChange={e => {
                 handleChange(e);
-                setFieldValue("emitter.company", null);
+                setFieldValue("emitter.company", getInitialCompany(null));
                 setFieldValue("emitter.isPrivateIndividual", false);
               }}
             />


### PR DESCRIPTION
# Objectif

Le bug report du ticket est le suivant:

> Lorsque je duplique un BSDD ayant pour producteur un établissement (SIRET), que je modifie le BSDD en brouillon et que je mets un particulier à la place du producteur initial, j'ai un message d'erreur "Émetteur : vous ne pouvez pas enregistrer une personne contact en cas d'émetteur particulier"

Après investigation, le problème est plus large: il y a cette erreur lorsque l'on modifie un BSDD qui a une entreprise renseignée en émetteur et que l'on change le type d'émetteur (entreprise ou navire étranger). Le problème arrive car les infos de l'entreprise sont complètements vidées du formulaire lors du changement de type d'émetteur, et lors du merge ancien BSD + nouveau BSD dans updateForm, les anciennes infos de l'entreprise émettrice sont reprises et pas écrasées par des null ou "".

# Modifications

J'ai changé la réinitialisation du formulaire emitter.company en utilisant la fonction d'initialisation utilisée lors du chargement initial plutôt que de vider tout l'objet. De cette manière, lors du merge ancien BSD + nouveau BSD dans updateForm, les anciennes infos de company sont écrasées.

# Demo


https://github.com/MTES-MCT/trackdechets/assets/2432646/e5e59a0c-9983-4f88-8a10-dad0dc8f8588



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14393)
