### PR TITLE
[tra-14072] Annexe1: l'émetteur doit être inscrit sur TD

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -2368,5 +2368,39 @@ describe("Mutation.createForm", () => {
         })
       ]);
     });
+
+    it("should not allow to create a APPENDIX1_PRODUCER form with an emitter that is not registered", async () => {
+      const destination = await userWithCompanyFactory(UserRole.MEMBER);
+      const { mutate } = makeClient(destination.user);
+      const { errors } = await mutate<Pick<Mutation, "createForm">>(
+        CREATE_FORM,
+        {
+          variables: {
+            createFormInput: {
+              recipient: {
+                company: {
+                  siret: destination.company.siret
+                }
+              },
+              emitter: {
+                type: "APPENDIX1_PRODUCER",
+                company: {
+                  siret: "42172923700022"
+                }
+              }
+            }
+          }
+        }
+      );
+      expect(errors).toEqual([
+        expect.objectContaining({
+          message:
+            "L'émetteur doit être inscrit sur Trackdéchets pour apparaitre sur une annexe 1 sans éco-organisme",
+          extensions: {
+            code: "BAD_USER_INPUT"
+          }
+        })
+      ]);
+    });
   });
 });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -312,6 +312,21 @@ const emitterSchemaFn: FactorySchemaOf<FormValidationContext, Emitter> = ({
       .when("emitterIsForeignShip", siretConditions.isForeignShip)
       .when("emitterIsPrivateIndividual", siretConditions.isPrivateIndividual)
       .test(
+        "emitter-is-registered-for-appendix1-producer",
+        "L'émetteur doit être inscrit sur Trackdéchets pour apparaitre sur une annexe 1 sans éco-organisme",
+        async function (value) {
+          const { emitterType } = this.parent;
+          if (!value || emitterType !== EmitterType.APPENDIX1_PRODUCER) {
+            return true;
+          }
+
+          const company = await prisma.company.findFirst({
+            where: { orgId: value }
+          });
+          return company != null;
+        }
+      )
+      .test(
         "is-not-eco-organisme",
         "L'émetteur ne peut pas être un éco-organisme. Merci de bien vouloir renseigner l'émetteur effectif de ce déchet (ex: déchetterie, producteur, TTR...). Un autre champ dédié existe et doit être utilisé pour viser l'éco-organisme concerné : https://faq.trackdechets.fr/dechets-dangereux-classiques/les-eco-organismes-sur-trackdechets#ou-etre-vise-en-tant-queco-organisme",
         async value => {

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -321,7 +321,8 @@ const emitterSchemaFn: FactorySchemaOf<FormValidationContext, Emitter> = ({
           }
 
           const company = await prisma.company.findFirst({
-            where: { orgId: value }
+            where: { orgId: value },
+            select: { id: true }
           });
           return company != null;
         }


### PR DESCRIPTION
Ne pas permettre de créer une Annexe 1 sur un BSD de tournée dédiée sans EO si le producteur n'est pas inscrit sur TD

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14072)
