### PR TITLE
Ajout d'une action Github pour ajouter un label "ready for merge" après 2 approvals

### DIFF
--- a/.github/workflows/add-ready-to-merge-label.yml
+++ b/.github/workflows/add-ready-to-merge-label.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: jsryudev/pr-review-labeler@v0.2.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        target-approved-count: 2
+        label-to-be-added: 'ready for merge'
+        label-to-be-removed: 'ready for review'

--- a/.github/workflows/add-ready-to-merge-label.yml
+++ b/.github/workflows/add-ready-to-merge-label.yml
@@ -1,16 +1,26 @@
 on:
-  pull_request:
-    types: [synchronize]
   pull_request_review:
-    types: [submitted]
-
+    types:
+      - 'edited'
+      - 'dismissed'
+      - 'submitted'
 jobs:
-  labeler:
-    runs-on: ubuntu-latest
+  your-action:
+    runs-on: 'ubuntu-latest'
     steps:
-    - uses: jsryudev/pr-review-labeler@v0.2.2
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        target-approved-count: 2
-        label-to-be-added: 'ready for merge'
-        label-to-be-removed: 'ready for review'
+      - id: 'reviews'
+        uses: 'jrylan/github-action-reviews-counter@main'
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Add Label if 2 Approvals
+        if: 'steps.reviews.outputs.approved >= 2 && steps.reviews.outputs.changes_requested == 0'
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["ready to merge"]
+            })

--- a/.github/workflows/add-ready-to-merge-label.yml
+++ b/.github/workflows/add-ready-to-merge-label.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - id: 'reviews'
-        uses: 'jrylan/github-action-reviews-counter@main'
+        uses: 'jrylan/github-action-reviews-counter@v1.0.0'
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
       - name: Add Label if 2 Approvals


### PR DESCRIPTION
J'en ai eu marre de devoir cliquer sur toutes mes PRs pour savoir combien d'approvals elles ont et savoir si je peux les merger. Cette action automatise l'ajout du label "ready for merge" lorsque 2 reviewers ont approuvé la PR.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---
