### PR TITLE
Correctifs révisions bsdasris

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/createRevisionRequest.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/createRevisionRequest.ts
@@ -110,6 +110,11 @@ async function checkIfUserCanRequestRevisionOnBsdasri(
       "Impossible de créer une révision sur un bordereau de synthèse ou de groupement."
     );
   }
+  if (bsdasri.groupedInId || bsdasri.synthesizedInId) {
+    throw new ForbiddenError(
+      "Impossible de créer une révision sur un bordereau inclus dans une synthèse ou un groupement."
+    );
+  }
   if (bsdasri.status === BsdasriStatus.INITIAL) {
     throw new ForbiddenError(
       "Impossible de créer une révision sur ce bordereau. Vous pouvez le modifier directement, aucune signature bloquante n'a encore été apposée."

--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -152,7 +152,7 @@ export const mapRevision = (
             } ${review?.[bsdName]?.emitter?.pickupSite?.city} ${
               review?.[bsdName]?.emitter?.pickupSite?.infos ?? ""
             }`
-          : "",
+          : "Non renseigné",
         dataNewValue: review?.content?.emitter?.pickupSite
           ? `${review?.content?.emitter?.pickupSite?.address}, ${
               review?.content?.emitter?.pickupSite?.postalCode
@@ -166,11 +166,13 @@ export const mapRevision = (
         dataOldValue: review?.[bsdName]?.wasteDetails?.code,
         dataNewValue: review?.content?.wasteDetails?.code
       },
+
       {
         dataName: DataNameEnum.WASTE_CODE,
-        dataOldValue: review?.bsda?.waste?.code,
+        dataOldValue: review?.[bsdName]?.waste?.code,
         dataNewValue: review?.content?.waste?.code
       },
+
       {
         dataName: DataNameEnum.POP,
         dataOldValue: review?.bsda?.waste?.pop

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/RhfReviewableField.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/RhfReviewableField.tsx
@@ -10,11 +10,13 @@ type Props = {
   readonly hint?: string;
   // The variable path: eg; `destination.operation.weight`
   readonly path: string;
+  // The value to display
+  readonly value: string | number | React.ReactNode;
   // Value coming from revised bsd, allowing reset when component is closed
   readonly defaultValue: any;
   // Optional value to initialize children field value, useful for booleans
   readonly initialValue?: any;
-  readonly value: string | number | React.ReactNode;
+
   // is the field disabled
   readonly disabled?: boolean;
 
@@ -24,7 +26,6 @@ type Props = {
 const LabelContent = ({
   labelText,
   suffix,
-
   value
 }: {
   labelText: string;
@@ -46,11 +47,11 @@ const LabelContent = ({
 export function RhfReviewableField({
   title,
   suffix,
-  defaultValue,
   value,
+  defaultValue,
+  initialValue,
   path,
   hint,
-  initialValue,
 
   children,
   disabled = false
@@ -61,7 +62,6 @@ export function RhfReviewableField({
   function handleIsEditingChange() {
     if (isEditing) {
       // When toggling visibility to off, set children value to pre-existing value
-
       setValue(path, defaultValue);
     } else {
       // When toggling visibility to on, set children value to optional initialValue (to tell apart empty strings from boolean)

--- a/libs/back/mail/src/templates/mustache/pending-revision-request-admin-details.html
+++ b/libs/back/mail/src/templates/mustache/pending-revision-request-admin-details.html
@@ -36,4 +36,9 @@
     href="https://faq.trackdechets.fr/amiante/informations-generales/le-bsda-simple-collecte-sur-chantier/modifier-ou-supprimer-un-bsda#modifier-certains-champs-du-bsda-grace-a-la-revision"
     >➡️&nbsp;Modifier certains champs du BSDA grâce à la révision</a
   >
+  <br />
+  <a
+    href="https://faq.trackdechets.fr/dasri/reglementation/le-parcours-du-bsdasri-simple/modifier-ou-supprimer-un-bsdasri#comment-modifier-certains-champs-du-bsda-grace-a-la-revision"
+    >➡️&nbsp;Modifier certains champs du DASRI grâce à la révision</a
+  >
 </p>


### PR DESCRIPTION
Post-recette:
- indiquer ancien code déchet sur la consultation de révision
- afficher "non renseigné" quand l'adresse de collecte n'existe pas
- packagings: prérempli le packaging avec la valeur actuelle
- griser le champ prévisions si le type n'est pas "autre"
- ajout du lien vers la faq dans le mail de relance

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-7432)
