### PR TITLE
[TRA-13844] Fix après recette (rendre possible changement de BSDASRIs groupés après signature producteur)

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
@@ -1,5 +1,5 @@
 import { expandBsdasriFromDB, flattenBsdasriInput } from "../../converter";
-import { BsdasriStatus, BsdasriType, Bsdasri } from "@prisma/client";
+import { BsdasriType, Bsdasri } from "@prisma/client";
 
 import { BsdasriInput } from "../../../generated/graphql/types";
 import { validateBsdasri } from "../../validation";
@@ -73,22 +73,6 @@ const updateBsdasri = async ({
     const newDasrisToGroup = inputGrouping.filter(
       id => !dbGrouping.some(({ id: dbId }) => dbId === id)
     );
-    // there is a difference between existing grouping DASRIs and input
-    // if there are new ones or some were removed.
-    // checking if there are new ones or the arrays are of different size is equivalent
-    // but less costly
-    const hasGroupingDiff =
-      newDasrisToGroup.length > 0 || inputGrouping.length !== dbGrouping.length;
-
-    if (
-      hasGroupingDiff &&
-      dbBsdasri.status !== BsdasriStatus.INITIAL &&
-      dbBsdasri.status !== BsdasriStatus.SIGNED_BY_PRODUCER
-    ) {
-      throw new UserInputError(
-        "Les bordereaux associés à ce bsd ne sont plus modifiables"
-      );
-    }
 
     await emitterIsAllowedToGroup(
       flattenedInput?.emitterCompanySiret ?? dbBsdasri?.emitterCompanySiret

--- a/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSimpleBsdasri.ts
@@ -80,7 +80,11 @@ const updateBsdasri = async ({
     const hasGroupingDiff =
       newDasrisToGroup.length > 0 || inputGrouping.length !== dbGrouping.length;
 
-    if (hasGroupingDiff && dbBsdasri.status !== BsdasriStatus.INITIAL) {
+    if (
+      hasGroupingDiff &&
+      dbBsdasri.status !== BsdasriStatus.INITIAL &&
+      dbBsdasri.status !== BsdasriStatus.SIGNED_BY_PRODUCER
+    ) {
       throw new UserInputError(
         "Les bordereaux associés à ce bsd ne sont plus modifiables"
       );

--- a/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
@@ -73,29 +73,25 @@ const updateSynthesisBsdasri = async ({
   }
 
   if (inputSynthesizing !== undefined) {
+    if (dbBsdasri.status !== BsdasriStatus.INITIAL) {
+      throw new UserInputError(
+        "Les bordereaux associés à ce bsd ne sont plus modifiables"
+      );
+    }
     // Forbid empty associated dasris
     if (!inputSynthesizing?.length) {
       throw new UserInputError(
         "Un bordereau de synthèse doit comporter des bordereaux associés"
       );
     }
+  }
+
+  if (!!inputSynthesizing?.length) {
     // filter dasris already associated to current dasri
     const newDasrisToAssociate = inputSynthesizing.filter(
       el => !dbSynthesizing.map(el => el.id).includes(el)
     );
-    // there is a difference between existing synthesised DASRIs and input
-    // if there are new ones or some were removed.
-    // checking if there are new ones or the arrays are of different size is equivalent
-    // but less costly
-    const hasSynthesisDiff =
-      newDasrisToAssociate.length > 0 ||
-      inputSynthesizing.length !== dbSynthesizing.length;
-
-    if (hasSynthesisDiff && dbBsdasri.status !== BsdasriStatus.INITIAL) {
-      throw new UserInputError(
-        "Les bordereaux associés à ce bsd ne sont plus modifiables"
-      );
-    }
+    // check associated dasris meet eligibility criteria
     await getEligibleDasrisForSynthesis(newDasrisToAssociate, dbBsdasri);
   }
 

--- a/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/updateSynthesisBsdasri.ts
@@ -73,25 +73,29 @@ const updateSynthesisBsdasri = async ({
   }
 
   if (inputSynthesizing !== undefined) {
-    if (dbBsdasri.status !== BsdasriStatus.INITIAL) {
-      throw new UserInputError(
-        "Les bordereaux associés à ce bsd ne sont plus modifiables"
-      );
-    }
     // Forbid empty associated dasris
     if (!inputSynthesizing?.length) {
       throw new UserInputError(
         "Un bordereau de synthèse doit comporter des bordereaux associés"
       );
     }
-  }
-
-  if (!!inputSynthesizing?.length) {
     // filter dasris already associated to current dasri
     const newDasrisToAssociate = inputSynthesizing.filter(
       el => !dbSynthesizing.map(el => el.id).includes(el)
     );
-    // check associated dasris meet eligibility criteria
+    // there is a difference between existing synthesised DASRIs and input
+    // if there are new ones or some were removed.
+    // checking if there are new ones or the arrays are of different size is equivalent
+    // but less costly
+    const hasSynthesisDiff =
+      newDasrisToAssociate.length > 0 ||
+      inputSynthesizing.length !== dbSynthesizing.length;
+
+    if (hasSynthesisDiff && dbBsdasri.status !== BsdasriStatus.INITIAL) {
+      throw new UserInputError(
+        "Les bordereaux associés à ce bsd ne sont plus modifiables"
+      );
+    }
     await getEligibleDasrisForSynthesis(newDasrisToAssociate, dbBsdasri);
   }
 


### PR DESCRIPTION
PR originale : #3330 

# Modifications
Je pensais à la lecture du code et du ticket qu'on voulait permettre la mise à jour de toutes les infos du BSDASRI de groupement sauf la liste des bordereaux regroupés après signature producteur. Le retour de recette est qu'on veut aussi permettre l'update de la liste des bordereaux groupés après cette signature. Au final celà correspond aux tests qui sont faits en aval dans la méthode `checkEditionRules` (qui fait un deep check de modification de l'array inputGrouping), donc j'ai enlevé la validation dans le resolver qui était redondante.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13844) -> voir le commentaire avec vidéo
