### PR TITLE
Correction post recette relative au numéro de notification

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -515,7 +515,7 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  it("should mark a form as NO_TRACEABILITY when user declares it and with non-french EU destination", async () => {
+  it("should mark a form as NO_TRACEABILITY when user declares it, next destination is not provided and notificationNumber is missing", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -537,11 +537,9 @@ describe("mutation.markAsProcessed", () => {
           processedAt: "2018-12-11T00:00:00.000Z",
           noTraceability: true,
           nextDestination: {
-            notificationNumber: "abc",
-            processingOperation: "D 1",
-            company: {
-              vatNumber: "IE9513674T"
-            }
+            processingOperation: "D 1"
+            // next destination is not provided
+            // notification number not provided
           }
         }
       }
@@ -678,6 +676,7 @@ describe("mutation.markAsProcessed", () => {
           nextDestination: {
             processingOperation: "D 1",
             company: null
+            // no notification number
           }
         }
       }


### PR DESCRIPTION
Retours de recette:
- dans le cas d'une rupture de traçabilité avec destination ultérieure hors France (UE ou hors UE), le champ Numéro de notification doit être obligatoire uniquement si un n° de TVA intracommunautaire ou si une Destination ultérieure a été complétée
- afficher un message d'erreur de validation plutôt qu'un hint navigateur quand le champ requis n'est pas renseigné
- 
Le front passait un extraEuropeanCompany = `UNIDENTIFIED_EXTRA_EUROPEAN_COMPANY` pour forcer la validation du notificationNumber, ce qui devient inutile, les companies UE et non UE étant traitées de la même manière (le notificationNumber est requis)


<img width="619" alt="Capture d’écran 2024-06-03 à 11 36 57" src="https://github.com/MTES-MCT/trackdechets/assets/878396/1a2c0eaf-e12f-42f5-8931-d9792535ec8e">

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13421)
