### PR TITLE
[Fix TRA-13926] Ajout d'un sous-type "Regroupement" pour le BSFF dans le registre

### DIFF
--- a/back/src/bsffs/__tests__/registry.integration.ts
+++ b/back/src/bsffs/__tests__/registry.integration.ts
@@ -110,7 +110,7 @@ describe("getSubType", () => {
   it.each([
     [BsffType.COLLECTE_PETITES_QUANTITES, "INITIAL"],
     [BsffType.TRACER_FLUIDE, "INITIAL"],
-    [BsffType.GROUPEMENT, "GATHERING"],
+    [BsffType.GROUPEMENT, "GROUPEMENT"],
     [BsffType.RECONDITIONNEMENT, "RECONDITIONNEMENT"],
     [BsffType.REEXPEDITION, "RESHIPMENT"]
   ])("type is %p > should return %p", async (type, expectedSubType) => {

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -106,7 +106,7 @@ export function getRegistryFields(
 
 export const getSubType = (bsff: RegistryBsff): BsdSubType => {
   if (bsff.type === "GROUPEMENT") {
-    return "GATHERING";
+    return "GROUPEMENT";
   } else if (bsff.type === "RECONDITIONNEMENT") {
     return "RECONDITIONNEMENT";
   } else if (bsff.type === "REEXPEDITION") {

--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -1,5 +1,5 @@
-import { IncomingWaste } from "../../generated/graphql/types";
-import { CUSTOM_WASTE_COLUMNS, formatRow } from "../columns";
+import { BsdSubType, IncomingWaste } from "../../generated/graphql/types";
+import { CUSTOM_WASTE_COLUMNS, formatRow, formatSubType } from "../columns";
 
 describe("formatRow", () => {
   it("should format waste", () => {
@@ -113,5 +113,31 @@ describe("formatRow", () => {
     expect(Object.keys(formattedWithLabels).length).toEqual(
       Object.keys(waste).length + CUSTOM_WASTE_COLUMNS.length
     );
+  });
+});
+
+describe("formatSubType", () => {
+  it.each([
+    [null, ""],
+    [undefined, ""],
+    ["", ""],
+    ["NOT_A_BSD_SUBTYPE", ""],
+    ["INITIAL", "Initial"],
+    ["TOURNEE", "Tournée dédiée"],
+    ["APPENDIX1", "Annexe 1"],
+    ["APPENDIX2", "Annexe 2"],
+    ["TEMP_STORED", "Entreposage provisoire"],
+    ["COLLECTION_2710", "Collecte en déchetterie"],
+    ["GATHERING", "Groupement"],
+    ["GROUPEMENT", "Regroupement"],
+    ["RESHIPMENT", "Réexpédition"],
+    ["RECONDITIONNEMENT", "Reconditionnement"],
+    ["SYNTHESIS", "Synthèse"]
+  ])("%p should return %p", (input, expected) => {
+    // When
+    const result = formatSubType(input as BsdSubType);
+
+    // Then
+    expect(result).toEqual(expected);
   });
 });

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -54,7 +54,7 @@ const formatFinalOperations = (val?: string[]) =>
   val ? val.map(quant => quant.replace(/ /g, "")).join("; ") : ""; // be consistent and remove all white spaces
 const formatFinalOperationWeights = (val?: number[]) =>
   val ? val.map(quant => quant.toFixed(2)).join("; ") : "";
-const formatSubType = (subType?: BsdSubType) => {
+export const formatSubType = (subType?: BsdSubType) => {
   if (!subType) return "";
 
   switch (subType) {
@@ -72,6 +72,8 @@ const formatSubType = (subType?: BsdSubType) => {
       return "Collecte en déchetterie";
     case "GATHERING":
       return "Groupement";
+    case "GROUPEMENT":
+      return "Regroupement";
     case "RESHIPMENT":
       return "Réexpédition";
     case "RECONDITIONNEMENT":

--- a/back/src/registry/typeDefs/registry.enums.graphql
+++ b/back/src/registry/typeDefs/registry.enums.graphql
@@ -62,6 +62,9 @@ enum BsdSubType {
   "Groupement"
   GATHERING
 
+  "Regroupement"
+  GROUPEMENT
+
   "Réexpédition"
   RESHIPMENT
 


### PR DESCRIPTION
# Contexte

Je n'avais pas compris qu'il y avait une subtilité entre le type `GATHERING` ("Groupement") et `GROUPEMENT` ("Regroupement"). J'ajoute donc ce deuxième type pour les BSFF.

# Ticket original

[Ajouter une colonne "sous-type" de bordereau dans tous les registres](https://favro.com/widget/ab14a4f0460a99a9d64d4945/4186f94658c16a1334e47546?card=tra-13926)
