### PR TITLE
Increase script timeout

### DIFF
--- a/libs/back/scripts/src/runner.ts
+++ b/libs/back/scripts/src/runner.ts
@@ -62,31 +62,36 @@ async function runScripts() {
     const fileName = parse(file).name;
     console.info(`⌛️ Running script "${fileName}"`);
 
-    await prisma.$transaction(async tx => {
-      const migrationScript = await tx.migrationScript.create({
-        data: {
-          name: fileName,
-          startedAt: new Date()
+    await prisma.$transaction(
+      async tx => {
+        const migrationScript = await tx.migrationScript.create({
+          data: {
+            name: fileName,
+            startedAt: new Date()
+          }
+        });
+
+        try {
+          await scriptModule.run(tx);
+
+          await tx.migrationScript.update({
+            where: { id: migrationScript.id },
+            data: { finishedAt: new Date() }
+          });
+          console.log(`✅ Completed execution of "${fileName}"`);
+        } catch (error) {
+          console.error(`🚨 Error executing script "${fileName}"`, error);
+
+          await tx.migrationScript.update({
+            where: { id: migrationScript.id },
+            data: { error: String(error) }
+          });
         }
-      });
-
-      try {
-        await scriptModule.run(tx);
-
-        await tx.migrationScript.update({
-          where: { id: migrationScript.id },
-          data: { finishedAt: new Date() }
-        });
-        console.log(`✅ Completed execution of "${fileName}"`);
-      } catch (error) {
-        console.error(`🚨 Error executing script "${fileName}"`, error);
-
-        await tx.migrationScript.update({
-          where: { id: migrationScript.id },
-          data: { error: String(error) }
-        });
+      },
+      {
+        timeout: 600_000
       }
-    });
+    );
   }
 
   console.info("✅ Data migrations completed.");


### PR DESCRIPTION
Les scripts d'update tournant dans des transactions, le timeout par defaut est de 5s. En attendant d'être sûrs que les transactions sont souhaitables, on passe le timeout à 10mn

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
