### PR TITLE
[TRA-14515 - hotfix] Afficher la plaque sur BsdCard même si pas de mode de transport

### DIFF
--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -207,7 +207,6 @@ function BsdCard({
   // - we are in the "Collected" tab and there is a number plate
   const displayTransporterNumberPlate =
     !!currentTransporterInfos &&
-    // currentTransporterInfos.transporterMode === TransportMode.Road &&
     (currentTransporterInfos.transporterMode === TransportMode.Road ||
       // permet de gérer un trou dans la raquette en terme de validation des données
       // qui ne rend pas le mode de transport obligatoire à la signature transporteur


### PR DESCRIPTION
Lorsqu'un BSD est créé via l'API, le mode de transport n'est pas obligatoire. Il y a donc des utilisateurs qui créent leur BSD sans mode de transport mais souhaitent rajouter la plaque depuis la BsdCard, ce qui n'est pas possible car elle n'est pas affichée.
Ce hotfix revient à l'état d'avant ma modif (#3309) en terme d'affichage. C'est une solution temporaire, on verra pour forcer le mode de transport via API dans un second temps

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14515)
