### PR TITLE
[TRA-14516] Hotfix : Hide sensitive informations in companyPrivateInfos query

### DIFF
--- a/back/src/companies/resolvers/queries/companyPrivateInfos.ts
+++ b/back/src/companies/resolvers/queries/companyPrivateInfos.ts
@@ -1,6 +1,7 @@
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { isSiret, cleanClue as cleanClueFn } from "@td/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { getUserRoles } from "../../../permissions";
 import {
   CompanySearchPrivate,
   QueryResolvers
@@ -8,49 +9,55 @@ import {
 import { prisma } from "@td/prisma";
 import { getCompanyInfos } from "./companyInfos";
 
-const companyInfosResolvers: QueryResolvers["companyPrivateInfos"] = async (
-  _,
-  args,
-  context
-) => {
-  applyAuthStrategies(context, [AuthType.Session]);
-  checkIsAuthenticated(context);
+const companyPrivateInfosResolvers: QueryResolvers["companyPrivateInfos"] =
+  async (_, args, context) => {
+    // Warning: this query could expose sensitive informations if not handled properly,
+    //double check the returned data and subresolvers (CompanySearchPrivate)
+    applyAuthStrategies(context, [AuthType.Session]);
+    const user = checkIsAuthenticated(context);
 
-  const cleanClue = cleanClueFn(args.clue);
-  const where = isSiret(cleanClue)
-    ? { siret: cleanClue }
-    : { vatNumber: cleanClue };
+    const roles = await getUserRoles(user.id);
 
-  const [companyInfos, isAnonymousCompany, company] = await Promise.all([
-    getCompanyInfos(cleanClue),
-    prisma.anonymousCompany.count({
-      where: { siret: cleanClue }
-    }),
-    prisma.company.findUnique({
-      where,
-      select: {
-        id: true,
-        orgId: true,
-        gerepId: true,
-        securityCode: true,
-        verificationCode: true,
-        givenName: true
-      }
-    })
-  ]);
-  return {
-    ...(companyInfos as CompanySearchPrivate),
-    ...{
-      trackdechetsId: company?.id,
-      orgId: company?.orgId ?? companyInfos.orgId,
-      gerepId: company?.gerepId,
-      securityCode: company?.securityCode,
-      verificationCode: company?.verificationCode,
-      givenName: company?.givenName
-    },
-    isAnonymousCompany: isAnonymousCompany > 0,
-    receivedSignatureAutomations: []
-  } as CompanySearchPrivate;
-};
+    const userCompanies = Object.keys(roles);
 
-export default companyInfosResolvers;
+    const cleanClue = cleanClueFn(args.clue);
+    const where = isSiret(cleanClue)
+      ? { siret: cleanClue }
+      : { vatNumber: cleanClue };
+
+    const [companyInfos, isAnonymousCompany, company] = await Promise.all([
+      getCompanyInfos(cleanClue),
+      prisma.anonymousCompany.count({
+        where: { siret: cleanClue }
+      }),
+      prisma.company.findUnique({
+        where,
+        select: {
+          id: true,
+          orgId: true,
+          gerepId: true,
+          securityCode: true,
+          verificationCode: true,
+          givenName: true
+        }
+      })
+    ]);
+
+    const userBelongsToCompany = userCompanies.includes(company?.orgId ?? "");
+
+    return {
+      ...(companyInfos as CompanySearchPrivate),
+      ...{
+        trackdechetsId: company?.id,
+        orgId: company?.orgId ?? companyInfos.orgId,
+        gerepId: company?.gerepId,
+        securityCode: userBelongsToCompany ? company?.securityCode : null,
+        verificationCode: company?.verificationCode,
+        givenName: company?.givenName
+      },
+      isAnonymousCompany: isAnonymousCompany > 0,
+      receivedSignatureAutomations: []
+    } as CompanySearchPrivate;
+  };
+
+export default companyPrivateInfosResolvers;


### PR DESCRIPTION
La query companyPrivateInfos expose les codes de signature et les signatureAutomations des établissements sans contrôle de permissions.
Ce hotfix: 
- corrige la visibilité des codes et asignatureAutomations
- ajoute des tests pour vérifier que ces comportements sont maintenus, et que le champ users est correctement gérés

Sur le screenshot ci-dessous je suis loggué avec un compte distinct du siret requêté:

<img width="1220" alt="Capture d’écran 2024-06-06 à 09 26 58" src="https://github.com/MTES-MCT/trackdechets/assets/878396/14a4df91-de93-4c9a-bad9-edf845947458">

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14516)
