### PR TITLE
[TRA-13275/TRA-14461] Mettre à jour le rôle d'un utilisateur depuis la liste de membres (page entreprise + TD Admin)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :rocket: Nouvelles fonctionnalités
 
+- Ajout de la possibilité de gérer les rôles des membres d'une entreprise depuis la liste des membres [PR 3384](https://github.com/MTES-MCT/trackdechets/pull/3384)
+- Ajout d'une gestion des membres d'entreprises pour les admin Trackdéchets [PR 3384](https://github.com/MTES-MCT/trackdechets/pull/3384)
+
 #### :bug: Corrections de bugs
 
 - Correctif de la mise à jour d'un paoh depuis la modale de publication [PR 3390](https://github.com/MTES-MCT/trackdechets/pull/3390)

--- a/back/src/companies/__tests__/database.test.ts
+++ b/back/src/companies/__tests__/database.test.ts
@@ -34,6 +34,7 @@ describe("getCompanyActiveUsers", () => {
     expect(users).toEqual(
       ASSOCIATIONS.map(association => ({
         ...association.user,
+        orgId: "123",
         role: association.role,
         isPendingInvitation: false
       }))

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -192,16 +192,13 @@ export const userNameDisplay = (
 export const userAssociationToCompanyMember = (
   companyAssociations: CompanyAssociation & { user: User },
   orgId: string,
+  requestingUserId?: string,
   isTDAdmin = false
 ) => {
   return {
     ...companyAssociations.user,
     orgId: orgId,
-    name: userNameDisplay(
-      companyAssociations,
-      companyAssociations.user.id,
-      isTDAdmin
-    ),
+    name: userNameDisplay(companyAssociations, requestingUserId, isTDAdmin),
     role: companyAssociations.role,
     isPendingInvitation: false
   };
@@ -234,7 +231,7 @@ export const userAccountHashToCompanyMember = (
  */
 export async function getCompanyActiveUsers(
   orgId: string,
-  requestingUserid?: string,
+  requestingUserId?: string,
   isTDAdmin?: boolean
 ): Promise<CompanyMember[]> {
   const associations = await prisma.company
@@ -242,7 +239,12 @@ export async function getCompanyActiveUsers(
     .companyAssociations({ include: { user: true } });
 
   return associations.map(a => {
-    return userAssociationToCompanyMember(a, orgId, isTDAdmin);
+    return userAssociationToCompanyMember(
+      a,
+      orgId,
+      requestingUserId,
+      isTDAdmin
+    );
   });
 }
 

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -125,9 +125,14 @@ export async function isCompanyMember(user: User, company: Company) {
 export async function getCompanyUsers(
   orgId: string,
   dataloaders: AppDataloaders,
-  requestingUserid: string
+  requestingUserid: string,
+  isTDAdmin?: boolean
 ): Promise<CompanyMember[]> {
-  const activeUsers = await getCompanyActiveUsers(orgId, requestingUserid);
+  const activeUsers = await getCompanyActiveUsers(
+    orgId,
+    requestingUserid,
+    isTDAdmin
+  );
   const invitedUsers = await getCompanyInvitedUsers(orgId, dataloaders);
 
   return [...activeUsers, ...invitedUsers];
@@ -144,7 +149,8 @@ export const userNameDisplay = (
   association: CompanyAssociation & {
     user: User;
   },
-  requestingUserid?: string
+  requestingUserid?: string,
+  isTDAdmin?: boolean
 ): string => {
   const today = new Date();
   // In the following cases, we return clear user name:
@@ -156,7 +162,8 @@ export const userNameDisplay = (
     !association.createdAt ||
     !association.automaticallyAccepted ||
     association.userId === requestingUserid ||
-    !requestingUserid
+    !requestingUserid ||
+    isTDAdmin
   ) {
     return association.user.name;
   }
@@ -176,7 +183,8 @@ export const userNameDisplay = (
  */
 export async function getCompanyActiveUsers(
   orgId: string,
-  requestingUserid?: string
+  requestingUserid?: string,
+  isTDAdmin?: boolean
 ): Promise<CompanyMember[]> {
   const associations = await prisma.company
     .findUniqueOrThrow({ where: { orgId } })
@@ -186,7 +194,7 @@ export async function getCompanyActiveUsers(
     return {
       ...a.user,
       orgId,
-      name: userNameDisplay(a, requestingUserid),
+      name: userNameDisplay(a, requestingUserid, isTDAdmin),
       role: a.role,
       isPendingInvitation: false
     };

--- a/back/src/companies/database.ts
+++ b/back/src/companies/database.ts
@@ -140,7 +140,7 @@ const OBFUSCATED_USER_NAME = "Temporairement masqué";
  * @param association
  * @returns
  */
-const userNameDisplay = (
+export const userNameDisplay = (
   association: CompanyAssociation & {
     user: User;
   },
@@ -185,6 +185,7 @@ export async function getCompanyActiveUsers(
   return associations.map(a => {
     return {
       ...a.user,
+      orgId,
       name: userNameDisplay(a, requestingUserid),
       role: a.role,
       isPendingInvitation: false
@@ -205,6 +206,7 @@ export async function getCompanyInvitedUsers(
   return hashes.map(h => {
     return {
       id: h.id,
+      orgId,
       name: "Invité",
       email: h.email,
       role: h.role,
@@ -398,4 +400,27 @@ export async function getUpdatedCompanyNameAndAddress(
   }
   // return existing and unchanged values
   return null;
+}
+
+/**
+ * get a CompanyAssociation by orgId + userId
+ * @param orgId
+ * @param userId
+ */
+export async function getCompanyAssociation({
+  orgId,
+  userId
+}: {
+  orgId: string;
+  userId: string;
+}) {
+  const association = await prisma.companyAssociation.findFirstOrThrow({
+    where: {
+      company: {
+        orgId
+      },
+      userId
+    }
+  });
+  return association;
 }

--- a/back/src/companies/resolvers/CompanyPrivate.ts
+++ b/back/src/companies/resolvers/CompanyPrivate.ts
@@ -6,7 +6,12 @@ import { getUserRole, grants, toGraphQLPermission } from "../../permissions";
 const companyPrivateResolvers: CompanyPrivateResolvers = {
   users: async (parent, _, context) => {
     const userId = context.user!.id;
-    return getCompanyUsers(parent.orgId, context.dataloaders, userId);
+    return getCompanyUsers(
+      parent.orgId,
+      context.dataloaders,
+      userId,
+      context.user!.isAdmin
+    );
   },
   userRole: async (parent, _, context) => {
     if (parent.userRole) {

--- a/back/src/companies/resolvers/CompanySearchPrivate.ts
+++ b/back/src/companies/resolvers/CompanySearchPrivate.ts
@@ -3,6 +3,7 @@ import { CompanySearchPrivateResolvers } from "../../generated/graphql/types";
 import { CompanyBaseIdentifiers } from "../types";
 import { whereSiretOrVatNumber } from "./CompanySearchResult";
 import { getUserRoles } from "../../permissions";
+import { getCompanyUsers } from "../database";
 
 const companySearchPrivateResolvers: CompanySearchPrivateResolvers = {
   transporterReceipt: async parent => {
@@ -75,16 +76,12 @@ const companySearchPrivateResolvers: CompanySearchPrivateResolvers = {
     if (!ctx.user?.isAdmin || !parent.trackdechetsId) {
       return [];
     }
-
-    const associations = await prisma.companyAssociation.findMany({
-      where: { companyId: parent.trackdechetsId },
-      include: { user: true }
-    });
-
-    return associations.map(association => ({
-      ...association.user,
-      role: association.role
-    }));
+    return getCompanyUsers(
+      parent.orgId,
+      ctx.dataloaders,
+      ctx.user.id,
+      ctx.user!.isAdmin
+    );
   }
 };
 

--- a/back/src/companies/resolvers/queries/companyPrivateInfos.ts
+++ b/back/src/companies/resolvers/queries/companyPrivateInfos.ts
@@ -38,7 +38,8 @@ const companyPrivateInfosResolvers: QueryResolvers["companyPrivateInfos"] =
           gerepId: true,
           securityCode: true,
           verificationCode: true,
-          givenName: true
+          givenName: true,
+          verificationStatus: true
         }
       })
     ]);
@@ -53,7 +54,8 @@ const companyPrivateInfosResolvers: QueryResolvers["companyPrivateInfos"] =
         gerepId: company?.gerepId,
         securityCode: userBelongsToCompany ? company?.securityCode : null,
         verificationCode: company?.verificationCode,
-        givenName: company?.givenName
+        givenName: company?.givenName,
+        verificationStatus: company?.verificationStatus
       },
       isAnonymousCompany: isAnonymousCompany > 0,
       receivedSignatureAutomations: []

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -561,6 +561,9 @@ type CompanyMember {
   "Identifiant opaque"
   id: ID!
 
+  "Identifiant de la company utile pour la gestion du cache"
+  orgId: ID!
+
   "Email"
   email: String!
 

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -57,7 +57,7 @@ type CompanySearchPrivate implements CompanySearchPrivateCommon {
   securityCode: Int
 
   "État du processus de vérification de l'établissement"
-  verificationStatus: CompanyVerificationStatus
+  verificationStatus: CompanyVerificationStatus!
 
   "Email de contact (visible sur la fiche entreprise)"
   contactEmail: String

--- a/back/src/permissions.ts
+++ b/back/src/permissions.ts
@@ -215,6 +215,28 @@ export function syncCheckUserPermissions(
   throw new ForbiddenError(errorMsg);
 }
 
+/**
+ * Same parameters as checkUserPermissions
+ * @param user
+ * @param orgIds
+ * @param permission
+ * @param errorMsg
+ * @returns true if admin, false if the user has permissions but isn't admin
+ * @throws if the user is not admin and doesn't have permissions
+ */
+export async function checkUserIsAdminOrPermissions(
+  user: Express.User,
+  orgIds: string | string[],
+  permission: Permission,
+  errorMsg: string
+): Promise<boolean> {
+  if (user.isAdmin) {
+    return true;
+  }
+  await checkUserPermissions(user, orgIds, permission, errorMsg);
+  return false;
+}
+
 type AllSignatureType =
   | BsdaSignatureType
   | BsdasriSignatureType

--- a/back/src/users/database.ts
+++ b/back/src/users/database.ts
@@ -4,7 +4,13 @@
 
 import { prisma } from "@td/prisma";
 
-import { User, UserRole, Prisma, Company } from "@prisma/client";
+import {
+  User,
+  UserRole,
+  Prisma,
+  Company,
+  UserAccountHash
+} from "@prisma/client";
 import { hash } from "bcrypt";
 import { getUid, sanitizeEmail, hashToken } from "../utils";
 import { deleteCachedUserRoles } from "../common/redis/users";
@@ -258,6 +264,53 @@ export async function updateUserPassword({
     where: { id: userId },
     data: { password: hashedPassword, passwordVersion }
   });
+}
+
+/**
+ * Update a CompanyAssociation
+ * @param associationId
+ * @param data
+ */
+export async function updateCompanyAssociation({
+  associationId,
+  data
+}: {
+  associationId: string;
+  data: Prisma.CompanyAssociationUpdateInput;
+}): Promise<Prisma.CompanyAssociationGetPayload<{
+  include: {
+    user: true;
+  };
+}> | null> {
+  const updatedAssociation = await prisma.companyAssociation.update({
+    where: {
+      id: associationId
+    },
+    data,
+    include: {
+      user: true
+    }
+  });
+  return updatedAssociation;
+}
+
+/**
+ * Update a UserAccountHash
+ * @param userId
+ * @param data
+ */
+export async function updateUserAccountHash({
+  userId,
+  data
+}: {
+  userId: string;
+  data: Prisma.UserAccountHashUpdateInput;
+}): Promise<UserAccountHash | null> {
+  const updatedUserAccountHash = await prisma.userAccountHash.update({
+    where: { id: userId },
+    data
+  });
+  return updatedUserAccountHash;
 }
 
 /**

--- a/back/src/users/resolvers/Mutation.ts
+++ b/back/src/users/resolvers/Mutation.ts
@@ -18,6 +18,7 @@ import createAccessToken from "./mutations/createAccessToken";
 import revokeAllAccessTokens from "./mutations/revokeAllAccessTokens";
 import resetPassword from "./mutations/resetPassword";
 import anonymizeUser from "./mutations/anonymizeUser";
+import changeUserRole from "./mutations/changeUserRole";
 
 const Mutation: MutationResolvers = {
   signup,
@@ -38,7 +39,8 @@ const Mutation: MutationResolvers = {
   revokeAuthorizedApplication,
   revokeAccessToken,
   createAccessToken,
-  revokeAllAccessTokens
+  revokeAllAccessTokens,
+  changeUserRole
 };
 
 export default Mutation;

--- a/back/src/users/resolvers/mutations/__tests__/changeUserRole.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/changeUserRole.integration.ts
@@ -5,13 +5,14 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { prisma } from "@td/prisma";
+import { hash } from "bcrypt";
 import { AuthType } from "../../../../auth";
 import { Mutation } from "../../../../generated/graphql/types";
 import { ErrorCode, NotCompanyAdminErrorMsg } from "../../../../common/errors";
 
 const CHANGE_USER_ROLE = `
-  mutation ChangeUserRole($userId: ID!, $siret: ID!, $role: UserRole!){
-    changeUserRole(userId: $userId, siret: $siret, role: $role){
+  mutation ChangeUserRole($userId: ID!, $orgId: ID!, $role: UserRole!){
+    changeUserRole(userId: $userId, orgId: $orgId, role: $role){
       email
       role
     }
@@ -38,7 +39,7 @@ describe("mutation changeUserRole", () => {
       {
         variables: {
           userId: userToModify.id,
-          siret: company.siret,
+          orgId: company.orgId,
           role: "ADMIN"
         }
       }
@@ -50,6 +51,44 @@ describe("mutation changeUserRole", () => {
       .companyAssociations();
     expect(companyAssociations).toHaveLength(1);
     expect(companyAssociations[0].role).toEqual("ADMIN");
+  });
+
+  test("admin can change an invited user's role", async () => {
+    const { user: admin, company } = await userWithCompanyFactory("ADMIN");
+    // Call the mutation to send an invitation
+    const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
+    const invitedUserEmail = "newuser@example.test";
+
+    const userAccoutHash = await hash(
+      new Date().valueOf().toString() + Math.random().toString(),
+      10
+    );
+
+    const invitedUser = await prisma.userAccountHash.create({
+      data: {
+        hash: userAccoutHash,
+        email: invitedUserEmail,
+        role: "MEMBER",
+        companySiret: company.siret!
+      }
+    });
+    const { data } = await mutate<Pick<Mutation, "changeUserRole">>(
+      CHANGE_USER_ROLE,
+      {
+        variables: {
+          userId: invitedUser!.id,
+          orgId: company.orgId,
+          role: "ADMIN"
+        }
+      }
+    );
+    expect(data.changeUserRole.email).toEqual(invitedUser.email);
+    expect(data.changeUserRole.role).toEqual("ADMIN");
+    const userHash = await prisma.userAccountHash.findMany({
+      where: { email: invitedUserEmail }
+    });
+    expect(userHash).toHaveLength(1);
+    expect(userHash[0].role).toEqual("ADMIN");
   });
 
   test("TD admin user can change a company user's role", async () => {
@@ -66,7 +105,7 @@ describe("mutation changeUserRole", () => {
       {
         variables: {
           userId: userToModify.id,
-          siret: company.siret,
+          orgId: company.siret,
           role: "ADMIN"
         }
       }
@@ -94,7 +133,42 @@ describe("mutation changeUserRole", () => {
       {
         variables: {
           userId: userToModify.id,
-          siret: company.siret,
+          orgId: company.orgId,
+          role: "ADMIN"
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: NotCompanyAdminErrorMsg(company.orgId),
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  test("user who is only a member of a company can't change a company user's role", async () => {
+    const { user: userToModify, company } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const notAdminUser = await userFactory({
+      isAdmin: false,
+      companyAssociations: {
+        create: {
+          company: { connect: { id: company.id } },
+          role: "MEMBER"
+        }
+      }
+    });
+    const { mutate } = makeClient({ ...notAdminUser, auth: AuthType.Session });
+
+    const { errors } = await mutate<Pick<Mutation, "changeUserRole">>(
+      CHANGE_USER_ROLE,
+      {
+        variables: {
+          userId: userToModify.id,
+          orgId: company.orgId,
           role: "ADMIN"
         }
       }

--- a/back/src/users/resolvers/mutations/__tests__/deleteInvitation.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/deleteInvitation.integration.ts
@@ -3,11 +3,23 @@ import { prisma } from "@td/prisma";
 import { AuthType } from "../../../../auth";
 import { ErrorCode } from "../../../../common/errors";
 import {
+  companyFactory,
   userFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { createUserAccountHash } from "../../../database";
+import { Mutation } from "../../../../generated/graphql/types";
+
+const DELETE_INVITATION = `
+  mutation DeleteInvitation($email: String!, $siret: String!){
+    deleteInvitation(email: $email, siret: $siret) {
+      users {
+        email
+      }
+    }
+  }
+`;
 
 describe("mutation deleteInvitation", () => {
   afterEach(resetDatabase);
@@ -25,15 +37,12 @@ describe("mutation deleteInvitation", () => {
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
     // Call the mutation to delete the invitation
-    // We pass company siret to allow permission to check requiring user is one admin of this company
-    const mutation = `
-        mutation {
-          deleteInvitation(email: "${usrToInvite.email}", siret: "${company.siret}") {
-            id
-          }
-        }
-      `;
-    await mutate(mutation);
+    const { data } = await mutate<Pick<Mutation, "deleteInvitation">>(
+      DELETE_INVITATION,
+      {
+        variables: { email: usrToInvite.email, siret: company.siret }
+      }
+    );
 
     // Check invitation has been successfully deleted
     const userAccountHashExists =
@@ -43,6 +52,7 @@ describe("mutation deleteInvitation", () => {
         }
       })) != null;
     expect(userAccountHashExists).toBeFalsy();
+    expect(data.deleteInvitation.users!.length).toBe(1);
   });
 
   it("should throw error if invitation does not exist", async () => {
@@ -51,16 +61,42 @@ describe("mutation deleteInvitation", () => {
 
     const { mutate } = makeClient({ ...admin, auth: AuthType.Session });
 
-    const mutation = `
-        mutation {
-          deleteInvitation(email: "${user.email}", siret: "${company.siret}") {
-            id
-          }
-        }
-      `;
-    const { errors } = await mutate(mutation);
+    const { errors } = await mutate(DELETE_INVITATION, {
+      variables: { email: user.email, siret: company.siret }
+    });
     expect(errors).toHaveLength(1);
     expect(errors[0].extensions?.code).toEqual(ErrorCode.BAD_USER_INPUT);
     expect(errors[0].message).toEqual("Cette invitation n'existe pas");
+  });
+
+  test("TD admin user can delete a pending invitation", async () => {
+    const company = await companyFactory();
+    const usrToInvite = "john.snow@trackdechets.fr";
+    const accountHash = await createUserAccountHash(
+      usrToInvite,
+      "MEMBER",
+      company.siret!
+    );
+    const tdAdminUser = await userFactory({
+      isAdmin: true
+    });
+    const { mutate } = makeClient({ ...tdAdminUser, auth: AuthType.Session });
+    // Call the mutation to delete the invitation
+    const { data } = await mutate<Pick<Mutation, "deleteInvitation">>(
+      DELETE_INVITATION,
+      {
+        variables: { email: usrToInvite, siret: company.siret }
+      }
+    );
+
+    // Check invitation has been successfully deleted
+    const userAccountHashExists =
+      (await prisma.userAccountHash.findFirst({
+        where: {
+          id: accountHash.id
+        }
+      })) != null;
+    expect(userAccountHashExists).toBeFalsy();
+    expect(data.deleteInvitation.users!.length).toBe(0);
   });
 });

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.test.ts
@@ -1,4 +1,3 @@
-import { User } from "@prisma/client";
 import { inviteUserToJoin, notifyUserOfInvite, renderMail } from "@td/mail";
 import { siretify } from "../../../../__tests__/factories";
 import { inviteUserToCompanyFn as inviteUserToCompany } from "../inviteUserToCompanyService";
@@ -46,9 +45,7 @@ describe("inviteUserToCompany", () => {
     const company = { siret, name: "Code en Stock" };
     companyMock.mockResolvedValueOnce(company);
 
-    const adminUser = { name: "John Snow" } as User;
-
-    await inviteUserToCompany(adminUser, {
+    await inviteUserToCompany({
       email: "arya.stark@trackdechets.fr",
       siret,
       role: "MEMBER"
@@ -78,9 +75,7 @@ describe("inviteUserToCompany", () => {
     const company = { siret, name: "Code en Stock" };
     companyMock.mockResolvedValueOnce(company);
 
-    const adminUser = { name: "John Snow" } as User;
-
-    await inviteUserToCompany(adminUser, {
+    await inviteUserToCompany({
       email: "arya.stark@trackdechets.fr",
       siret,
       role: "MEMBER"
@@ -121,9 +116,7 @@ describe("inviteUserToCompany", () => {
     const company = { siret, name: "Code en Stock" };
     companyMock.mockResolvedValueOnce(company);
 
-    const adminUser = { name: "John Snow" } as User;
-
-    await inviteUserToCompany(adminUser, {
+    await inviteUserToCompany({
       email: "arya.stark@trackdechets.fr",
       siret,
       role: "MEMBER"

--- a/back/src/users/resolvers/mutations/changeUserRole.ts
+++ b/back/src/users/resolvers/mutations/changeUserRole.ts
@@ -1,0 +1,93 @@
+import { GraphQLContext } from "../../../types";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import {
+  NotCompanyAdminErrorMsg,
+  UserInputError
+} from "../../../common/errors";
+
+import { checkIsAuthenticated } from "../../../common/permissions";
+import {
+  getCompanyOrCompanyNotFound,
+  userNameDisplay
+} from "../../../companies/database";
+import {
+  CompanyMember,
+  MutationResolvers,
+  UserRole
+} from "../../../generated/graphql/types";
+import { checkUserPermissions, Permission } from "../../../permissions";
+import {
+  getCompanyAssociationOrNotFound,
+  getUserAccountHashOrNotFound,
+  updateCompanyAssociation,
+  updateUserAccountHash
+} from "../../database";
+
+const changeUserRoleResolver: MutationResolvers["changeUserRole"] = async (
+  parent,
+  args: { userId: string; siret: string; role: UserRole },
+  context: GraphQLContext
+): Promise<CompanyMember> => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+  const company = await getCompanyOrCompanyNotFound({ orgId: args.siret });
+  await checkUserPermissions(
+    user,
+    company.orgId,
+    Permission.CompanyCanManageMembers,
+    NotCompanyAdminErrorMsg(company.orgId)
+  );
+  try {
+    const association = await getCompanyAssociationOrNotFound({
+      company: {
+        orgId: args.siret
+      },
+      userId: args.userId
+    });
+    const updatedAssociation = await updateCompanyAssociation({
+      associationId: association.id,
+      data: {
+        role: args.role
+      }
+    });
+    if (!updatedAssociation) {
+      throw new UserInputError(
+        `L'utilisateur n'est pas membre de l'entreprise`
+      );
+    }
+    return {
+      ...updatedAssociation.user,
+      orgId: company.orgId,
+      name: userNameDisplay(updatedAssociation, user.id),
+      role: updatedAssociation.role,
+      isPendingInvitation: false
+    };
+  } catch (error) {
+    //do nothing
+  }
+  const userAccountHash = await getUserAccountHashOrNotFound({
+    id: args.userId,
+    companySiret: args.siret,
+    acceptedAt: null
+  });
+
+  const updatedUserAccountHash = await updateUserAccountHash({
+    userId: userAccountHash.id,
+    data: {
+      role: args.role
+    }
+  });
+  if (!updatedUserAccountHash) {
+    throw new UserInputError(`L'utilisateur n'existe pas`);
+  }
+  return {
+    id: updatedUserAccountHash.id,
+    orgId: company.orgId,
+    name: "Invité",
+    email: updatedUserAccountHash.email,
+    role: updatedUserAccountHash.role,
+    isActive: false,
+    isPendingInvitation: true
+  };
+};
+export default changeUserRoleResolver;

--- a/back/src/users/resolvers/mutations/changeUserRole.ts
+++ b/back/src/users/resolvers/mutations/changeUserRole.ts
@@ -60,6 +60,7 @@ const changeUserRoleResolver: MutationResolvers["changeUserRole"] = async (
     return userAssociationToCompanyMember(
       updatedAssociation,
       company.orgId,
+      user.id,
       isTDAdmin
     );
   }

--- a/back/src/users/resolvers/mutations/deleteInvitation.ts
+++ b/back/src/users/resolvers/mutations/deleteInvitation.ts
@@ -1,6 +1,9 @@
 import { prisma } from "@td/prisma";
 import { applyAuthStrategies, AuthType } from "../../../auth";
-import { checkIsAuthenticated } from "../../../common/permissions";
+import {
+  checkIsAdmin,
+  checkIsAuthenticated
+} from "../../../common/permissions";
 import {
   convertUrls,
   getCompanyOrCompanyNotFound
@@ -18,12 +21,25 @@ const deleteInvitationResolver: MutationResolvers["deleteInvitation"] = async (
   applyAuthStrategies(context, [AuthType.Session]);
   const user = checkIsAuthenticated(context);
   const company = await getCompanyOrCompanyNotFound({ orgId: siret });
-  await checkUserPermissions(
-    user,
-    company.orgId,
-    Permission.CompanyCanManageMembers,
-    NotCompanyAdminErrorMsg(company.orgId)
-  );
+  let isTDAdmin = false;
+  try {
+    isTDAdmin = !!checkIsAdmin(context);
+  } catch (error) {
+    // do nothing
+  }
+  try {
+    await checkUserPermissions(
+      user,
+      company.orgId,
+      Permission.CompanyCanManageMembers,
+      NotCompanyAdminErrorMsg(company.orgId)
+    );
+  } catch (error) {
+    if (!isTDAdmin) {
+      throw error;
+    }
+  }
+
   const hash = await getUserAccountHashOrNotFound({
     email,
     companySiret: siret

--- a/back/src/users/resolvers/mutations/inviteUserToCompany.ts
+++ b/back/src/users/resolvers/mutations/inviteUserToCompany.ts
@@ -1,13 +1,13 @@
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { NotCompanyAdminErrorMsg } from "../../../common/errors";
 
-import {
-  checkIsAdmin,
-  checkIsAuthenticated
-} from "../../../common/permissions";
+import { checkIsAuthenticated } from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
 import { MutationResolvers } from "../../../generated/graphql/types";
-import { checkUserPermissions, Permission } from "../../../permissions";
+import {
+  checkUserIsAdminOrPermissions,
+  Permission
+} from "../../../permissions";
 import { inviteUserToCompanyFn } from "./inviteUserToCompanyService";
 
 const inviteUserToCompanyResolver: MutationResolvers["inviteUserToCompany"] =
@@ -15,25 +15,12 @@ const inviteUserToCompanyResolver: MutationResolvers["inviteUserToCompany"] =
     applyAuthStrategies(context, [AuthType.Session]);
     const user = checkIsAuthenticated(context);
     const company = await getCompanyOrCompanyNotFound({ orgId: args.siret });
-    let isTDAdmin = false;
-    try {
-      isTDAdmin = !!checkIsAdmin(context);
-    } catch (error) {
-      // do nothing
-    }
-    try {
-      await checkUserPermissions(
-        user,
-        company.orgId,
-        Permission.CompanyCanManageMembers,
-        NotCompanyAdminErrorMsg(company.orgId)
-      );
-    } catch (error) {
-      if (!isTDAdmin) {
-        throw error;
-      }
-    }
-
+    await checkUserIsAdminOrPermissions(
+      user,
+      company.orgId,
+      Permission.CompanyCanManageMembers,
+      NotCompanyAdminErrorMsg(company.orgId)
+    );
     return inviteUserToCompanyFn(args);
   };
 

--- a/back/src/users/resolvers/mutations/inviteUserToCompanyService.ts
+++ b/back/src/users/resolvers/mutations/inviteUserToCompanyService.ts
@@ -1,4 +1,3 @@
-import { User } from "@prisma/client";
 import { prisma } from "@td/prisma";
 
 import { sendMail } from "../../../mailer/mailing";
@@ -16,10 +15,11 @@ import { associateUserToCompany, createUserAccountHash } from "../../database";
 
 import { inviteUserToJoin, notifyUserOfInvite, renderMail } from "@td/mail";
 
-export async function inviteUserToCompanyFn(
-  adminUser: User,
-  { email: unsafeEmail, siret, role }: MutationInviteUserToCompanyArgs
-): Promise<CompanyPrivate> {
+export async function inviteUserToCompanyFn({
+  email: unsafeEmail,
+  siret,
+  role
+}: MutationInviteUserToCompanyArgs): Promise<CompanyPrivate> {
   const email = sanitizeEmail(unsafeEmail);
 
   const existingUser = await prisma.user.findUnique({ where: { email } });

--- a/back/src/users/resolvers/mutations/resendInvitation.ts
+++ b/back/src/users/resolvers/mutations/resendInvitation.ts
@@ -2,7 +2,10 @@ import { MutationResolvers } from "../../../generated/graphql/types";
 import { prisma } from "@td/prisma";
 import { sendMail } from "../../../mailer/mailing";
 import { applyAuthStrategies, AuthType } from "../../../auth";
-import { checkIsAuthenticated } from "../../../common/permissions";
+import {
+  checkIsAdmin,
+  checkIsAuthenticated
+} from "../../../common/permissions";
 import { getCompanyOrCompanyNotFound } from "../../../companies/database";
 import { renderMail, inviteUserToJoin } from "@td/mail";
 import { checkUserPermissions, Permission } from "../../../permissions";
@@ -19,12 +22,24 @@ const resendInvitationResolver: MutationResolvers["resendInvitation"] = async (
   applyAuthStrategies(context, [AuthType.Session]);
   const user = checkIsAuthenticated(context);
   const company = await getCompanyOrCompanyNotFound({ orgId: siret });
-  await checkUserPermissions(
-    user,
-    company.orgId,
-    Permission.CompanyCanManageMembers,
-    NotCompanyAdminErrorMsg(company.orgId)
-  );
+  let isTDAdmin = false;
+  try {
+    isTDAdmin = !!checkIsAdmin(context);
+  } catch (error) {
+    // do nothing
+  }
+  try {
+    await checkUserPermissions(
+      user,
+      company.orgId,
+      Permission.CompanyCanManageMembers,
+      NotCompanyAdminErrorMsg(company.orgId)
+    );
+  } catch (error) {
+    if (!isTDAdmin) {
+      throw error;
+    }
+  }
 
   const invitations = await prisma.userAccountHash.findMany({
     where: { email, companySiret: siret }

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -116,5 +116,5 @@ type Mutation {
   USAGE INTERNE
   Change le rôle d'un utilisateur de l'entreprise
   """
-  changeUserRole(userId: ID!, siret: ID!, role: UserRole!): CompanyMember!
+  changeUserRole(userId: ID!, orgId: ID!, role: UserRole!): CompanyMember!
 }

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -111,4 +111,10 @@ type Mutation {
   Tente de désactiver un compte utilisateur (soft-delete et anonymisation)
   """
   anonymizeUser(id: ID!): String!
+
+  """
+  USAGE INTERNE
+  Change le rôle d'un utilisateur de l'entreprise
+  """
+  changeUserRole(userId: ID!, siret: ID!, role: UserRole!): CompanyMember!
 }

--- a/front/src/Apps/Companies/CompanyMembers/CompanyMembers.tsx
+++ b/front/src/Apps/Companies/CompanyMembers/CompanyMembers.tsx
@@ -12,12 +12,21 @@ import CompanyMembersList from "./CompanyMembersList";
 
 const { VITE_VERIFY_COMPANY } = import.meta.env;
 
+export type CompanyPrivateMembers = Pick<
+  CompanyPrivate,
+  "userRole" | "companyTypes" | "verificationStatus" | "orgId" | "users"
+>;
+
 interface CompanyMembersProps {
-  company: CompanyPrivate;
+  company: CompanyPrivateMembers;
+  isTDAdmin?: boolean;
 }
 
-const CompanyMembers = ({ company }: CompanyMembersProps) => {
-  const isAdmin = company.userRole === UserRole.Admin;
+const CompanyMembers = ({
+  company,
+  isTDAdmin = false
+}: CompanyMembersProps) => {
+  const isAdmin = company.userRole === UserRole.Admin || isTDAdmin;
   const isProfessional = company.companyTypes.some(ct =>
     COMPANY_CONSTANTS.PROFESSIONALS.includes(ct)
   );
@@ -42,7 +51,7 @@ const CompanyMembers = ({ company }: CompanyMembersProps) => {
             </p>
           </div>
         ))}
-      <CompanyMembersList company={company} />
+      <CompanyMembersList company={company} isTDAdmin={isTDAdmin} />
     </div>
   );
 };

--- a/front/src/Apps/Companies/CompanyMembers/CompanyMembersInvite.tsx
+++ b/front/src/Apps/Companies/CompanyMembers/CompanyMembersInvite.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CompanyPrivate, UserRole } from "@td/codegen-ui";
+import { Query, UserRole } from "@td/codegen-ui";
 import { useForm } from "react-hook-form";
 import { object, string, ObjectSchema } from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -13,9 +13,10 @@ import { InlineLoader } from "../../common/Components/Loader/Loaders";
 import { userRoleSwitchOptions } from "./CompanyMembersList";
 import toast from "react-hot-toast";
 import { TOAST_DURATION } from "../../../common/config";
+import { CompanyPrivateMembers } from "./CompanyMembers";
 
 interface CompanyMembersInviteProps {
-  company: CompanyPrivate;
+  company: CompanyPrivateMembers;
 }
 interface CompanyMembersInviteFields {
   email: string;
@@ -52,6 +53,19 @@ const CompanyMembersInvite = ({ company }: CompanyMembersInviteProps) => {
       onCompleted: () => {
         toast.success("Invitation envoyée", { duration: TOAST_DURATION });
         reset();
+      },
+      updateQueries: {
+        CompanyPrivateInfos: (
+          prev: Pick<Query, "companyPrivateInfos">,
+          { mutationResult }
+        ) => {
+          return {
+            companyPrivateInfos: {
+              ...prev,
+              users: mutationResult.data?.inviteUserToCompany.users ?? []
+            }
+          };
+        }
       }
     });
   };

--- a/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
+++ b/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
@@ -286,7 +286,7 @@ const CompanyMembersList = ({
                         {user.isPendingInvitation && !user.isMe && (
                           <>
                             <button
-                              className="fr-btn fr-btn--secondary fr-icon-mail-line"
+                              className="fr-btn fr-btn--secondary fr-icon-mail-line fr-mr-1w"
                               onClick={() => onClickResendInvitation(user)}
                             >
                               Renvoyer l'invitation

--- a/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
+++ b/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
@@ -175,7 +175,7 @@ const CompanyMembersList = ({
     changeUserRole({
       variables: {
         userId: user.id,
-        siret: company.orgId,
+        orgId: company.orgId,
         role
       }
     });

--- a/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
+++ b/front/src/Apps/Companies/CompanyMembers/CompanyMembersList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useMutation } from "@apollo/client";
 import {
   CompanyPrivate,
@@ -58,9 +58,7 @@ const CompanyMembersList = ({ company }: CompanyMembersListProps) => {
   const [memberToDelete, setMemberToDelete] = useState<CompanyMember | null>(
     null
   );
-  const [filteredMembers, setFilteredMembers] = useState<
-    CompanyMember[] | null
-  >(null);
+  const [filter, setFilter] = useState<string>("");
 
   const isAdmin = company.userRole === UserRole.Admin;
 
@@ -152,24 +150,34 @@ const CompanyMembersList = ({ company }: CompanyMembersListProps) => {
     });
   };
 
-  const onFilterMembers = predicate => {
-    if (predicate.length === 0) {
-      setFilteredMembers(null);
-      return;
+  const filteredMembers = useMemo(() => {
+    if (filter.length === 0 || !company?.users?.length) {
+      return null;
     }
+    return company.users.filter(
+      user =>
+        user.name?.toLowerCase().includes(filter.toLowerCase()) ||
+        user.email.toLowerCase().includes(filter.toLowerCase())
+    );
+  }, [filter, company]);
+  // const onFilterMembers = predicate => {
+  //   if (predicate.length === 0) {
+  //     setFilteredMembers(null);
+  //     return;
+  //   }
 
-    function filterUsers(users: CompanyMember[], filterString: string) {
-      return users.filter(
-        user =>
-          user.name?.toLowerCase().includes(filterString.toLowerCase()) ||
-          user.email.toLowerCase().includes(filterString.toLowerCase())
-      );
-    }
+  //   function filterUsers(users: CompanyMember[], filterString: string) {
+  //     return users.filter(
+  //       user =>
+  //         user.name?.toLowerCase().includes(filterString.toLowerCase()) ||
+  //         user.email.toLowerCase().includes(filterString.toLowerCase())
+  //     );
+  //   }
 
-    if (company?.users?.length && company?.users?.length > 0) {
-      setFilteredMembers(filterUsers(company.users, predicate));
-    }
-  };
+  //   if (company?.users?.length && company?.users?.length > 0) {
+  //     setFilteredMembers(filterUsers(company.users, predicate));
+  //   }
+  // };
 
   return (
     <div className="company-members__list">
@@ -185,8 +193,9 @@ const CompanyMembersList = ({ company }: CompanyMembersListProps) => {
                   label="Filtrer"
                   nativeInputProps={{
                     type: "text",
+                    value: filter,
                     onChange: e => {
-                      onFilterMembers(e.target.value);
+                      setFilter(e.target.value);
                     }
                   }}
                 />

--- a/front/src/Apps/Companies/common/fragments.ts
+++ b/front/src/Apps/Companies/common/fragments.ts
@@ -247,6 +247,7 @@ export const AccountCompanyMemberFragment = {
   user: gql`
     fragment AccountCompanyMemberUserFragment on CompanyMember {
       id
+      orgId
       isMe
       email
       name

--- a/front/src/Apps/Companies/common/queries.ts
+++ b/front/src/Apps/Companies/common/queries.ts
@@ -83,6 +83,27 @@ export const MY_COMPANIES = gql`
   ${CompanyDetailsfragment.company}
 `;
 
+export const COMPANY_ADMIN_PRIVATE_INFOS = gql`
+  query CompanyPrivateInfos($clue: String!) {
+    companyPrivateInfos(clue: $clue) {
+      orgId
+      siret
+      name
+      address
+      isRegistered
+      vatNumber
+      codePaysEtrangerEtablissement
+      userRole
+      companyTypes
+      verificationStatus
+      users {
+        ...AccountCompanyMemberUserFragment
+      }
+    }
+  }
+  ${AccountCompanyMemberFragment.user}
+`;
+
 export const REMOVE_USER_FROM_COMPANY = gql`
   mutation RemoveUserFromCompany($userId: ID!, $siret: String!) {
     removeUserFromCompany(userId: $userId, siret: $siret) {

--- a/front/src/Apps/Companies/common/queries.ts
+++ b/front/src/Apps/Companies/common/queries.ts
@@ -508,3 +508,12 @@ export const REMOVE_SIGNATURE_DELEGATION = gql`
     }
   }
 `;
+
+export const CHANGE_USER_ROLE = gql`
+  mutation ChangeUserRole($userId: ID!, $siret: ID!, $role: UserRole!) {
+    changeUserRole(userId: $userId, siret: $siret, role: $role) {
+      ...AccountCompanyMemberUserFragment
+    }
+  }
+  ${AccountCompanyMemberFragment.user}
+`;

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -6,7 +6,8 @@ const routes = {
     reindex: "/admin/reindex",
     user: "/admin/user",
     impersonate: "/admin/impersonate",
-    registry: "/admin/registry"
+    registry: "/admin/registry",
+    membersAdmin: "admin/members"
   },
   login: "/login",
   invite: "/invite",

--- a/front/src/admin/Admin.tsx
+++ b/front/src/admin/Admin.tsx
@@ -10,6 +10,7 @@ import CompaniesVerification from "./verification/CompaniesVerification";
 import "../Apps/Dashboard/dashboard.scss";
 import { Impersonate } from "./user/impersonate";
 import { Registry } from "./registry/Registry";
+import { MembersAdmin } from "./company/MembersAdmin";
 
 const toRelative = route => {
   return getRelativeRoute(routes.admin.index, route);
@@ -96,6 +97,18 @@ export default function Admin() {
                 Registre
               </NavLink>
             </li>
+            <li className="tw-mb-1">
+              <NavLink
+                to={routes.admin.membersAdmin}
+                className={({ isActive }) =>
+                  isActive
+                    ? "sidebarv2__item sidebarv2__item--indented sidebarv2__item--active"
+                    : "sidebarv2__item sidebarv2__item--indented"
+                }
+              >
+                Gestion des admins
+              </NavLink>
+            </li>
           </ul>
         </Accordion>
       </SideBar>
@@ -130,6 +143,11 @@ export default function Admin() {
           <Route
             path={toRelative(routes.admin.registry)}
             element={<Registry />}
+          />
+
+          <Route
+            path={toRelative(routes.admin.membersAdmin)}
+            element={<MembersAdmin />}
           />
 
           <Route

--- a/front/src/admin/company/MembersAdmin.tsx
+++ b/front/src/admin/company/MembersAdmin.tsx
@@ -1,0 +1,77 @@
+import { useLazyQuery } from "@apollo/client";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { Query } from "@td/codegen-ui";
+import CompanyResults, {
+  CompanyResultBase
+} from "../../form/common/components/company/CompanyResults";
+import CompanyMembers, {
+  CompanyPrivateMembers
+} from "../../Apps/Companies/CompanyMembers/CompanyMembers";
+import { COMPANY_ADMIN_PRIVATE_INFOS } from "../../Apps/Companies/common/queries";
+import React, { useEffect, useState } from "react";
+
+type CompanyPrivateMembersAndResults = CompanyPrivateMembers &
+  CompanyResultBase;
+
+export function MembersAdmin() {
+  const [selectedCompany, selectCompany] =
+    useState<CompanyPrivateMembersAndResults | null>(null);
+  const [search, { loading, error, data }] = useLazyQuery<
+    Pick<Query, "companyPrivateInfos">
+  >(COMPANY_ADMIN_PRIVATE_INFOS);
+
+  const searchResults = data?.companyPrivateInfos
+    ? [data.companyPrivateInfos]
+    : [];
+  useEffect(() => {
+    if (data?.companyPrivateInfos) {
+      selectCompany(data.companyPrivateInfos);
+    }
+  }, [data]);
+  return (
+    <div>
+      <div>
+        <h3 className="fr-h3 fr-mt-4w">Recherche une entreprise</h3>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            const formData = new FormData(e.target as HTMLFormElement);
+
+            search({ variables: { clue: formData.get("clue") } });
+          }}
+        >
+          <div className="fr-grid-row fr-grid-row--bottom">
+            <div className="fr-col-8">
+              <Input
+                label="SIRET ou Numéro TVA"
+                nativeInputProps={{
+                  required: true,
+                  name: "clue"
+                }}
+              />
+            </div>
+            <div className="fr-col-4">
+              <Button size="medium">Rechercher</Button>
+            </div>
+          </div>
+        </form>
+      </div>
+      {loading && <div>Chargement...</div>}
+      {error && <div>Erreur</div>}
+      {searchResults && (
+        <CompanyResults<CompanyPrivateMembersAndResults>
+          onSelect={company => selectCompany(company)}
+          onUnselect={() => selectCompany(null)}
+          results={searchResults}
+          selectedItem={selectedCompany}
+        />
+      )}
+      {selectedCompany && (
+        <div>
+          <CompanyMembers company={selectedCompany} isTDAdmin={true} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/admin/user/impersonate.tsx
+++ b/front/src/admin/user/impersonate.tsx
@@ -14,6 +14,7 @@ const COMPANY_ACCOUNT_ADD_PRIVATE_INFOS = gql`
       name
       users {
         id
+        orgId
         name
         email
         role

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -17,7 +17,7 @@ interface CompanyResultsProps<T> {
   selectedItem: T | null;
 }
 
-type CompanyResultBase = Pick<
+export type CompanyResultBase = Pick<
   CompanySearchResult,
   | "siret"
   | "orgId"

--- a/front/src/graphql-client.ts
+++ b/front/src/graphql-client.ts
@@ -81,7 +81,7 @@ const apolloClient = new ApolloClient({
         }
       },
       CompanyMember: {
-        keyFields: ["id", "role"]
+        keyFields: ["id", "orgId"]
       }
     }
   }),


### PR DESCRIPTION
# Objectifs
1) Pouvoir mettre à jour le rôle d'un utilisateur depuis la page (existante) de liste des membres d'entreprise
2) Ajouter une page de gestion d'entreprise pour les admins TD, et pouvoir y mettre à jour le rôle des membres

# Modifications

## Changement de rôle utilisateur sur la page de liste de membres

### Mutation changeUserRole

Ajout d'une mutation `changeUserRole` en backend, avec quelques méthodes de database pour find/update le role des utilisateurs d'une Company (déjà inscrits ou non)

### Résolution de problème de cache Apollo

Un même utilisateur peut être CompanyMember sur plusieurs entreprises. Lors du passage d'une entreprise à l'autre, l'utilisation du cache pouvait causer un problème où un utilisateur était affiché avec le rôle qu'il avait dans l'entreprise affichée précédemment. Pour fix ce problème, @Riron avait ajouté une définition de keyField: 
```
CompanyMember: {
  keyFields: ["id", "role"]
}
```
Ce fix fonctionnait pour correctement mettre à jour la liste des membres, mais lors de l'update du cache après une mutation changeUserRole, le rôle retourné par la mutation est différent, donc l'utilisateur du cache n'est pas modifié, et donc la liste des utilisateurs non plus.
Pour résoudre le problème, j'ai ajouté un champ `orgId` sur CompanyMember, de façon à les rendre uniques au changement d'entreprise, mais à permettre la mise à jour du cache au retour de mutation. Je l'ai ajouté au fragment en front, aux resolvers en back, et changé la définition du keyField:
```
CompanyMember: {
  keyFields: ["id", "orgId"]
}
```

### Sélection du rôle dans la liste de membres

Rien de spécial là dessus (onChange sur le Select, appel de la mutation), mais j'ai dû changer la logique de filtrage de la liste qui utilisait un state qui ne se mettait pas à jour au retour de la mutation. J'ai enlevé le stockage de la liste filtrée dans un state et remplacé par un Memo qui se recalcule au changement de la liste d'utilisateurs.

## Page gestion membres admin

### Recherche d'entreprise

Pour la recherche d'entreprise, j'ai repris le champ de recherche utilisé dans Impersonate, avec une query CompanyPrivateInfos qui permet de chercher dans les entreprises TD plutôt que la base SIRENE.
Pour l'affichage des résultats, je reprends le composant CompanyResult qui est utilisé dans les formulaires de bordereau (pour coller aux Mockups).

### Intégration de la page de gestion des membres

J'ai intégré en dessous la page de gestion des membres qui existe déjà (celle à laquelle j'ai ajouté les changements de rôle). Il a fallut faire quelques changements de type, et ajouter un paramètre pour override la validation du statut d'admin.

### updateQueries

La page de gestion des membres est normalement chargée avec un paramètre *company* de type `CompanyPrivate`, venant de `myCompanies`. Lorsqu'elle est utilisée dans le contexte de l'admin trackdéchets, la company qui est descendue vient de *companyPrivateInfos* et est de type `CompanySearchPrivate`. Les mutations *inviteUserToCompany*, *removeUserFromCompany* et *deleteInvitation* renvoient un type `CompanyPrivate`, et donc la query ne s'update pas. J'ai donc ajouté des updateQueries à ces différentes mutation de façon à mettre à jour les informations sur la page admin.

### Autorisation des mutations pour un admin trackdéchets

Pour qu'elles puissent être appelées pas un admin trackdéchets qui n'est pas admin d'une entreprise, j'ai modifié la vérification des droits sur *inviteUserToCompany*, *removeUserFromCompany* et *deleteInvitation* pour autoriser les admins trackdéchets.

## Tests

J'ai ajouté des tests d'intégration pour les différentes mutations utilisées de façon à:
- tester que les mutations peuvent être appelées par un admin TD
- tester que les mutations fail pour un utilisateur non admin (ni de l'entreprise ni TD)

# Demo

https://github.com/MTES-MCT/trackdechets/assets/2432646/c073396a-03fd-4b41-887d-829499b6453b

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro 13275](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13275)
- [Ticket Favro 14461](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14461)
