### PR TITLE
Fix signature

### DIFF
--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -398,7 +398,7 @@ async function canTransporterSignWithoutEmitterSignature(existingForm: Form) {
     });
 
     if (
-      emitterProfile &&
+      !emitterProfile ||
       [CompanyType.WASTEPROCESSOR, CompanyType.COLLECTOR].every(
         profile => !emitterProfile.companyTypes.includes(profile)
       )


### PR DESCRIPTION
Fix signature annexe 1 par un transporteur lorsque l'émetteur n'est pas inscrit et qu(il y a un EO sur le chapeau.

Lié à https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14471