### PR TITLE
[TRA-14325] Ajout d'une colonne avec l'adresse email du destinataire, négociant & courtier dans tous les registres

### DIFF
--- a/back/src/bsda/__tests__/registry.integration.ts
+++ b/back/src/bsda/__tests__/registry.integration.ts
@@ -91,6 +91,29 @@ describe("toAllWaste", () => {
   );
 });
 
+describe("toGenericWaste", () => {
+  it("should return destinationCompanyEmail & brokerCompanyMail", async () => {
+    // Given
+    const form = await bsdaFactory({
+      opt: {
+        destinationCompanyMail: "destination@mail.com",
+        brokerCompanyMail: "broker@mail.com"
+      }
+    });
+
+    // When
+    const bsdaForRegistry = await prisma.bsda.findUniqueOrThrow({
+      where: { id: form.id },
+      include: RegistryBsdaInclude
+    });
+    const waste = toAllWaste(bsdaForRegistry);
+
+    // Then
+    expect(waste.destinationCompanyMail).toStrictEqual("destination@mail.com");
+    expect(waste.brokerCompanyMail).toStrictEqual("broker@mail.com");
+  });
+});
+
 describe("getSubType", () => {
   afterAll(resetDatabase);
 

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -170,7 +170,9 @@ function toGenericWaste(bsda: RegistryBsda): GenericWaste {
     workerCompanyName: bsda.workerCompanyName,
     workerCompanySiret: bsda.workerCompanySiret,
     workerCompanyAddress: bsda.workerCompanyAddress,
-    ...getTransportersData(bsda)
+    ...getTransportersData(bsda),
+    destinationCompanyMail: bsda.destinationCompanyMail,
+    brokerCompanyMail: bsda.brokerCompanyMail
   };
 }
 
@@ -298,7 +300,6 @@ export function toOutgoingWaste(bsda: RegistryBsda): Required<OutgoingWaste> {
       ? bsda.weightValue.dividedBy(1000).toNumber()
       : null,
     emitterCustomInfo: bsda.emitterCustomInfo,
-    destinationCompanyMail: bsda.destinationCompanyMail,
     ...getOperationData(bsda),
     ...getFinalOperationsData(bsda)
   };
@@ -366,8 +367,7 @@ export function toTransportedWaste(
     destinationCompanyName: bsda.destinationCompanyName,
     destinationCompanySiret: bsda.destinationCompanySiret,
     destinationCompanyAddress: bsda.destinationCompanyAddress,
-    emitterCompanyMail: bsda.emitterCompanyMail,
-    destinationCompanyMail: bsda.destinationCompanyMail
+    emitterCompanyMail: bsda.emitterCompanyMail
   };
 }
 
@@ -428,8 +428,7 @@ export function toManagedWaste(bsda: RegistryBsda): Required<ManagedWaste> {
       ].filter(Boolean)
     ),
     ...initialEmitter,
-    emitterCompanyMail: bsda.emitterCompanyMail,
-    destinationCompanyMail: bsda.destinationCompanyMail
+    emitterCompanyMail: bsda.emitterCompanyMail
   };
 }
 
@@ -498,7 +497,6 @@ export function toAllWaste(bsda: RegistryBsda): Required<AllWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     emitterCompanyMail: bsda.emitterCompanyMail,
-    destinationCompanyMail: bsda.destinationCompanyMail,
     ...getOperationData(bsda),
     ...getFinalOperationsData(bsda)
   };

--- a/back/src/bsdasris/__tests__/registry.integration.ts
+++ b/back/src/bsdasris/__tests__/registry.integration.ts
@@ -91,6 +91,25 @@ describe("toAllWaste", () => {
   );
 });
 
+describe("toGenericWaste", () => {
+  it("should contain destinationCompanyMail", async () => {
+    // Given
+    const bsdasri = await bsdasriFactory({
+      opt: { destinationCompanyMail: "destination@mail.com" }
+    });
+
+    // When
+    const bsdasriForRegistry = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: bsdasri.id },
+      include: RegistryBsdasriInclude
+    });
+    const waste = toAllWaste(bsdasriForRegistry);
+
+    // Then
+    expect(waste.destinationCompanyMail).toBe("destination@mail.com");
+  });
+});
+
 describe("getSubType", () => {
   afterAll(resetDatabase);
 

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -135,7 +135,8 @@ function toGenericWaste(bsdasri: Bsdasri): GenericWaste {
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
-    ...getTransporterData(bsdasri)
+    ...getTransporterData(bsdasri),
+    destinationCompanyMail: bsdasri.destinationCompanyMail
   };
 }
 
@@ -245,7 +246,6 @@ export function toOutgoingWaste(
       ? bsdasri.emitterWasteWeightValue.dividedBy(1000).toNumber()
       : null,
     emitterCustomInfo: bsdasri.emitterCustomInfo,
-    destinationCompanyMail: bsdasri.destinationCompanyMail,
     ...getOperationData(bsdasri),
     ...getFinalOperationsData(bsdasri)
   };
@@ -302,8 +302,7 @@ export function toTransportedWaste(
     destinationCompanyName: bsdasri.destinationCompanyName,
     destinationCompanySiret: bsdasri.destinationCompanySiret,
     destinationCompanyAddress: bsdasri.destinationCompanyAddress,
-    emitterCompanyMail: bsdasri.emitterCompanyMail,
-    destinationCompanyMail: bsdasri.destinationCompanyMail
+    emitterCompanyMail: bsdasri.emitterCompanyMail
   };
 }
 
@@ -359,8 +358,7 @@ export function toManagedWaste(
       bsdasri.emitterPickupSiteCity
     ]),
     ...initialEmitter,
-    emitterCompanyMail: bsdasri.emitterCompanyMail,
-    destinationCompanyMail: bsdasri.destinationCompanyMail
+    emitterCompanyMail: bsdasri.emitterCompanyMail
   };
 }
 
@@ -418,7 +416,6 @@ export function toAllWaste(bsdasri: RegistryBsdasri): Required<AllWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     emitterCompanyMail: bsdasri.emitterCompanyMail,
-    destinationCompanyMail: bsdasri.destinationCompanyMail,
     ...getOperationData(bsdasri),
     ...getFinalOperationsData(bsdasri)
   };

--- a/back/src/bsffs/__tests__/registry.integration.ts
+++ b/back/src/bsffs/__tests__/registry.integration.ts
@@ -104,6 +104,26 @@ describe("toAllWaste", () => {
   );
 });
 
+describe("toGenericWaste", () => {
+  it("should contain destinationCompanyMail", async () => {
+    // Given
+    const bsff = await createBsff(
+      {},
+      { data: { destinationCompanyMail: "destination@mail.com" } }
+    );
+
+    // When
+    const bsffForRegistry = await prisma.bsff.findUniqueOrThrow({
+      where: { id: bsff.id },
+      include: RegistryBsffInclude
+    });
+    const waste = toOutgoingWaste(bsffForRegistry);
+
+    // Then
+    expect(waste.destinationCompanyMail).toBe("destination@mail.com");
+  });
+});
+
 describe("getSubType", () => {
   afterAll(resetDatabase);
 

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -146,7 +146,8 @@ function toGenericWaste(bsff: RegistryBsff): GenericWaste {
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
-    ...(transporter ? getTransporterData(transporter) : {})
+    ...(transporter ? getTransporterData(transporter) : {}),
+    destinationCompanyMail: bsff.destinationCompanyMail
   };
 }
 
@@ -271,7 +272,6 @@ export function toOutgoingWaste(bsff: RegistryBsff): Required<OutgoingWaste> {
       ? bsff.weightValue.dividedBy(1000).toNumber()
       : null,
     emitterCustomInfo: bsff.emitterCustomInfo,
-    destinationCompanyMail: bsff.destinationCompanyMail,
     ...getOperationData(bsff),
     ...getFinalOperationsData(bsff)
   };
@@ -334,8 +334,7 @@ export function toTransportedWaste(
     destinationCompanyName: bsff.destinationCompanyName,
     destinationCompanySiret: bsff.destinationCompanySiret,
     destinationCompanyAddress: bsff.destinationCompanyAddress,
-    emitterCompanyMail: bsff.emitterCompanyMail,
-    destinationCompanyMail: bsff.destinationCompanyMail
+    emitterCompanyMail: bsff.emitterCompanyMail
   };
 }
 
@@ -397,8 +396,7 @@ export function toManagedWaste(bsff: RegistryBsff): Required<ManagedWaste> {
     emitterCompanySiret: bsff.emitterCompanySiret,
     emitterPickupsiteAddress: null,
     ...initialEmitter,
-    emitterCompanyMail: bsff.emitterCompanyMail,
-    destinationCompanyMail: bsff.destinationCompanyMail
+    emitterCompanyMail: bsff.emitterCompanyMail
   };
 }
 
@@ -462,7 +460,6 @@ export function toAllWaste(bsff: RegistryBsff): Required<AllWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     emitterCompanyMail: bsff.emitterCompanyMail,
-    destinationCompanyMail: bsff.destinationCompanyMail,
     ...getOperationData(bsff),
     ...getFinalOperationsData(bsff)
   };

--- a/back/src/bspaoh/__tests__/registry.integration.ts
+++ b/back/src/bspaoh/__tests__/registry.integration.ts
@@ -1,0 +1,23 @@
+import { prisma } from "../../../../libs/back/prisma/src";
+import { RegistryBspaohInclude } from "../../registry/elastic";
+import { toOutgoingWaste } from "../registry";
+import { bspaohFactory } from "./factories";
+
+describe("toGenericWaste", () => {
+  it("should contain destinationCompanyMail", async () => {
+    // Given
+    const paoh = await bspaohFactory({
+      opt: { destinationCompanyMail: "destination@mail.com" }
+    });
+
+    // When
+    const paohForRegistry = await prisma.bspaoh.findUniqueOrThrow({
+      where: { id: paoh.id },
+      include: RegistryBspaohInclude
+    });
+    const waste = toOutgoingWaste(paohForRegistry);
+
+    // Then
+    expect(waste.destinationCompanyMail).toBe("destination@mail.com");
+  });
+});

--- a/back/src/bspaoh/__tests__/registry.integration.ts
+++ b/back/src/bspaoh/__tests__/registry.integration.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../../../../libs/back/prisma/src";
+import { prisma } from "@td/prisma";
 import { RegistryBspaohInclude } from "../../registry/elastic";
 import { toOutgoingWaste } from "../registry";
 import { bspaohFactory } from "./factories";

--- a/back/src/bspaoh/registry.ts
+++ b/back/src/bspaoh/registry.ts
@@ -119,7 +119,8 @@ function toGenericWaste(
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
-    ...getTransporterData(bspaoh)
+    ...getTransporterData(bspaoh),
+    destinationCompanyMail: bspaoh.destinationCompanyMail
   };
 }
 
@@ -212,8 +213,7 @@ export function toOutgoingWaste(
       ? bspaoh.emitterWasteWeightValue / 1000
       : bspaoh.emitterWasteWeightValue,
     emitterCustomInfo: bspaoh.emitterCustomInfo,
-    transporterCompanyMail: transporter?.transporterCompanyMail,
-    destinationCompanyMail: bspaoh.destinationCompanyMail
+    transporterCompanyMail: transporter?.transporterCompanyMail
   };
 }
 
@@ -261,8 +261,7 @@ export function toTransportedWaste(
     destinationCompanySiret: bspaoh.destinationCompanySiret,
     destinationCompanyAddress: bspaoh.destinationCompanyAddress,
     transporterCustomInfo: transporter?.transporterCustomInfo,
-    emitterCompanyMail: bspaoh.emitterCompanyMail,
-    destinationCompanyMail: bspaoh.destinationCompanyMail
+    emitterCompanyMail: bspaoh.emitterCompanyMail
   };
 }
 
@@ -310,8 +309,7 @@ export function toManagedWaste(
     transporterCompanySiret: getTransporterCompanyOrgId(transporter),
     transporterRecepisseNumber: transporter?.transporterRecepisseNumber,
     emitterCompanyMail: bspaoh.emitterCompanyMail,
-    transporterCompanyMail: transporter?.transporterCompanyMail,
-    destinationCompanyMail: bspaoh.destinationCompanyMail
+    transporterCompanyMail: transporter?.transporterCompanyMail
   };
 }
 
@@ -366,7 +364,6 @@ export function toAllWaste(
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     emitterCompanyMail: bspaoh.emitterCompanyMail,
-    transporterCompanyMail: transporter?.transporterCompanyMail,
-    destinationCompanyMail: bspaoh.destinationCompanyMail
+    transporterCompanyMail: transporter?.transporterCompanyMail
   };
 }

--- a/back/src/bsvhu/__tests__/registry.integration.ts
+++ b/back/src/bsvhu/__tests__/registry.integration.ts
@@ -1,4 +1,4 @@
-import { prisma } from "../../../../libs/back/prisma/src";
+import { prisma } from "@td/prisma";
 import { toOutgoingWaste } from "../registry";
 import { bsvhuFactory } from "./factories.vhu";
 

--- a/back/src/bsvhu/__tests__/registry.integration.ts
+++ b/back/src/bsvhu/__tests__/registry.integration.ts
@@ -1,0 +1,21 @@
+import { prisma } from "../../../../libs/back/prisma/src";
+import { toOutgoingWaste } from "../registry";
+import { bsvhuFactory } from "./factories.vhu";
+
+describe("toGenericWaste", () => {
+  it("should contain destinationCompanyMail", async () => {
+    // Given
+    const bsvhu = await bsvhuFactory({
+      opt: { destinationCompanyMail: "destination@mail.com" }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id }
+    });
+    const waste = toOutgoingWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste.destinationCompanyMail).toBe("destination@mail.com");
+  });
+});

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -101,7 +101,8 @@ function toGenericWaste(bsvhu: Bsvhu): GenericWaste {
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
-    ...getTransporterData(bsvhu)
+    ...getTransporterData(bsvhu),
+    destinationCompanyMail: bsvhu.destinationCompanyMail
   };
 }
 
@@ -183,7 +184,6 @@ export function toOutgoingWaste(bsvhu: Bsvhu): Required<OutgoingWaste> {
     traderRecepisseNumber: null,
     weight: bsvhu.weightValue ? bsvhu.weightValue / 1000 : bsvhu.weightValue,
     emitterCustomInfo: bsvhu.emitterCustomInfo,
-    destinationCompanyMail: bsvhu.destinationCompanyMail,
     ...getOperationData(bsvhu)
   };
 }
@@ -223,8 +223,7 @@ export function toTransportedWaste(bsvhu: Bsvhu): Required<TransportedWaste> {
     destinationCompanyName: bsvhu.destinationCompanyName,
     destinationCompanySiret: bsvhu.destinationCompanySiret,
     destinationCompanyAddress: bsvhu.destinationCompanyAddress,
-    emitterCompanyMail: bsvhu.emitterCompanyMail,
-    destinationCompanyMail: bsvhu.destinationCompanyMail
+    emitterCompanyMail: bsvhu.emitterCompanyMail
   };
 }
 
@@ -267,8 +266,7 @@ export function toManagedWaste(bsvhu: Bsvhu): Required<ManagedWaste> {
     emitterCompanySiret: bsvhu.emitterCompanySiret,
     emitterPickupsiteAddress: null,
     ...initialEmitter,
-    emitterCompanyMail: bsvhu.emitterCompanyMail,
-    destinationCompanyMail: bsvhu.destinationCompanyMail
+    emitterCompanyMail: bsvhu.emitterCompanyMail
   };
 }
 
@@ -313,7 +311,6 @@ export function toAllWaste(bsvhu: Bsvhu): Required<AllWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     emitterCompanyMail: bsvhu.emitterCompanyMail,
-    destinationCompanyMail: bsvhu.destinationCompanyMail,
     ...getOperationData(bsvhu)
   };
 }

--- a/back/src/forms/__tests__/registry.integration.ts
+++ b/back/src/forms/__tests__/registry.integration.ts
@@ -8,6 +8,7 @@ import { formToBsdd } from "../compat";
 import {
   getSubType,
   toAllWaste,
+  toGenericWaste,
   toIncomingWaste,
   toOutgoingWaste
 } from "../registry";
@@ -274,6 +275,33 @@ describe("toAllWaste", () => {
     expect(wasteRegistry.initialEmitterCompanySiret).toBe(
       bdd.emitterCompanySiret
     );
+  });
+});
+
+describe("toGenericWaste", () => {
+  it("should contain the destination, trader & broker email addresses", async () => {
+    // Given
+    const user = await userFactory();
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        brokerCompanyMail: "broker@mail.com",
+        recipientCompanyMail: "destination@mail.com",
+        traderCompanyMail: "trader@mail.com"
+      }
+    });
+
+    // When
+    const formForRegistry = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id },
+      include: RegistryFormInclude
+    });
+    const waste = toGenericWaste(formToBsdd(formForRegistry));
+
+    // Then
+    expect(waste.destinationCompanyMail).toEqual("destination@mail.com");
+    expect(waste.brokerCompanyMail).toEqual("broker@mail.com");
+    expect(waste.traderCompanyMail).toEqual("trader@mail.com");
   });
 });
 

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -154,7 +154,9 @@ export const getSubType = (bsdd: Bsdd): BsdSubType => {
   return "INITIAL";
 };
 
-function toGenericWaste(bsdd: ReturnType<typeof formToBsdd>): GenericWaste {
+export function toGenericWaste(
+  bsdd: ReturnType<typeof formToBsdd>
+): GenericWaste {
   const initialEmitter: Record<string, string | string[] | null> = {
     initialEmitterCompanyAddress: null,
     initialEmitterCompanyName: null,
@@ -191,10 +193,13 @@ function toGenericWaste(bsdd: ReturnType<typeof formToBsdd>): GenericWaste {
       bsdd.destinationReceptionAcceptationStatus,
     destinationOperationDate: bsdd.destinationOperationDate,
     destinationReceptionWeight: bsdd.destinationReceptionWeight,
+    destinationCompanyMail: bsdd.destinationCompanyMail,
     wasteAdr: bsdd.wasteAdr,
     workerCompanyName: null,
     workerCompanySiret: null,
     workerCompanyAddress: null,
+    brokerCompanyMail: bsdd.brokerCompanyMail,
+    traderCompanyMail: bsdd.traderCompanyMail,
     ...getTransportersData(bsdd),
     ...initialEmitter
   };
@@ -296,7 +301,6 @@ export function toOutgoingWaste(
     traderRecepisseNumber: bsdd.traderRecepisseNumber,
     weight: bsdd.weightValue,
     emitterCustomInfo: null,
-    destinationCompanyMail: bsdd.destinationCompanyMail,
     ...getOperationData(bsdd),
     ...getFinalOperationsData(bsdd)
   };
@@ -354,8 +358,7 @@ export function toTransportedWaste(
     destinationCompanyName: bsdd.destinationCompanyName,
     destinationCompanySiret: bsdd.destinationCompanySiret,
     destinationCompanyAddress: bsdd.destinationCompanyAddress,
-    emitterCompanyMail: bsdd.emitterCompanyMail,
-    destinationCompanyMail: bsdd.destinationCompanyMail
+    emitterCompanyMail: bsdd.emitterCompanyMail
   };
 }
 
@@ -410,8 +413,7 @@ export function toManagedWaste(
       bsdd.emitterPickupSiteCity
     ]),
     ...initialEmitter,
-    emitterCompanyMail: bsdd.emitterCompanyMail,
-    destinationCompanyMail: bsdd.destinationCompanyMail
+    emitterCompanyMail: bsdd.emitterCompanyMail
   };
 }
 
@@ -469,7 +471,6 @@ export function toAllWaste(
     traderCompanySiret: bsdd.traderCompanySiret,
     traderRecepisseNumber: bsdd.traderRecepisseNumber,
     emitterCompanyMail: bsdd.emitterCompanyMail,
-    destinationCompanyMail: bsdd.destinationCompanyMail,
     ...getOperationData(bsdd),
     ...getFinalOperationsData(bsdd)
   };

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -165,9 +165,11 @@ export const columns: Column[] = [
   },
   { field: "traderCompanyName", label: "Négociant raison sociale" },
   { field: "traderCompanySiret", label: "Négociant SIRET" },
+  { field: "traderCompanyMail", label: "Négociant contact" },
   { field: "traderRecepisseNumber", label: "Négociant récépissé " },
   { field: "brokerCompanyName", label: "Courtier raison sociale" },
   { field: "brokerCompanySiret", label: "Courtier SIRET" },
+  { field: "brokerCompanyMail", label: "Courtier contact" },
   { field: "brokerRecepisseNumber", label: "Courtier N°récepissé" },
   // Transport du déchet
 
@@ -204,6 +206,7 @@ export const columns: Column[] = [
   { field: "destinationCompanyName", label: "Destination raison sociale" },
   { field: "destinationCompanySiret", label: "Destination SIRET" },
   { field: "destinationCompanyAddress", label: "Destination adresse" },
+  { field: "destinationCompanyMail", label: "Destination Contact" },
   {
     field: "destinationReceptionAcceptationStatus",
     label: "Statut d'acceptation du déchet"

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -165,6 +165,9 @@ type IncomingWaste {
   "Extra - Date de réalisation de l'opération"
   destinationOperationDate: DateTime
 
+  "Extra - L'adresse email du contact de l'établissement de destination"
+  destinationCompanyMail: String
+
   "Extra - Adresse email de contact de l'expéditeur du déchet"
   emitterCompanyMail: String
 
@@ -185,6 +188,12 @@ type IncomingWaste {
 
   "Extra - Exemption de récépissé transporteur n°3"
   transporter3RecepisseIsExempted: Boolean
+
+  "Extra - L'adresse email du contact du négociant"
+  traderCompanyMail: String
+
+  "Extra - L'adresse email du contact du courtier"
+  brokerCompanyMail: String
 
   """
   Extra - Dans le cas de déchets dangereux, selon le cas, le code transport lié aux réglementations internationales
@@ -409,6 +418,12 @@ type OutgoingWaste {
   "Extra - Adresse email de contact de l'installation de destination"
   destinationCompanyMail: String
 
+  "Extra - L'adresse email du contact du négociant"
+  traderCompanyMail: String
+
+  "Extra - L'adresse email du contact du courtier"
+  brokerCompanyMail: String
+
   "Extra - Exemption de récépissé transporteur"
   transporterRecepisseIsExempted: Boolean
 
@@ -629,6 +644,12 @@ type TransportedWaste {
   "Extra - Adresse email de contact de l'installation de destination"
   destinationCompanyMail: String
 
+  "Extra - L'adresse email du contact du négociant"
+  traderCompanyMail: String
+
+  "Extra - L'adresse email du contact du courtier"
+  brokerCompanyMail: String
+
   "Extra - La raison sociale de l'entreprise de travaux (amiante uniquement)"
   workerCompanyName: String
   "Extra - Le numéro SIRET de l'entreprise de travaux (amiante uniquement)"
@@ -828,6 +849,12 @@ type ManagedWaste {
 
   "Extra - Adresse email de contact de l'installation de destination"
   destinationCompanyMail: String
+
+  "Extra - L'adresse email du contact du négociant"
+  traderCompanyMail: String
+
+  "Extra - L'adresse email du contact du courtier"
+  brokerCompanyMail: String
 
   "Extra - Exemption de récépissé transporteur"
   transporterRecepisseIsExempted: Boolean
@@ -1086,6 +1113,12 @@ type AllWaste {
 
   "Extra - Adresse email de contact de l'installation de destination"
   destinationCompanyMail: String
+
+  "Extra - L'adresse email du contact du négociant"
+  traderCompanyMail: String
+
+  "Extra - L'adresse email du contact du courtier"
+  brokerCompanyMail: String
 
   "Extra - Exemption de récépissé transporteur"
   transporterRecepisseIsExempted: Boolean

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -115,7 +115,10 @@ export const emptyIncomingWaste: Required<IncomingWaste> = {
   wasteIsDangerous: null,
   workerCompanyName: null,
   workerCompanySiret: null,
-  workerCompanyAddress: null
+  workerCompanyAddress: null,
+  brokerCompanyMail: null,
+  destinationCompanyMail: null,
+  traderCompanyMail: null
 };
 
 export const emptyOutgoingWaste: Required<OutgoingWaste> = {
@@ -187,7 +190,9 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   workerCompanySiret: null,
   workerCompanyAddress: null,
   destinationFinalOperationCodes: [],
-  destinationFinalOperationWeights: []
+  destinationFinalOperationWeights: [],
+  brokerCompanyMail: null,
+  traderCompanyMail: null
 };
 
 export const emptyTransportedWaste: Required<TransportedWaste> = {
@@ -250,7 +255,9 @@ export const emptyTransportedWaste: Required<TransportedWaste> = {
   workerCompanyName: null,
   workerCompanySiret: null,
   workerCompanyAddress: null,
-  wasteIsDangerous: null
+  wasteIsDangerous: null,
+  brokerCompanyMail: null,
+  traderCompanyMail: null
 };
 
 export const emptyManagedWaste: Required<ManagedWaste> = {
@@ -316,10 +323,12 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   wasteIsDangerous: null,
   workerCompanyName: null,
   workerCompanySiret: null,
-  workerCompanyAddress: null
+  workerCompanyAddress: null,
   // En attente des correctifs recette sur TRA-12745
   // finalOperationCodes: null,
   // finalReceptionWeights: null
+  brokerCompanyMail: null,
+  traderCompanyMail: null
 };
 
 export const emptyAllWaste: Required<AllWaste> = {
@@ -397,5 +406,7 @@ export const emptyAllWaste: Required<AllWaste> = {
   workerCompanySiret: null,
   workerCompanyAddress: null,
   destinationFinalOperationCodes: [],
-  destinationFinalOperationWeights: []
+  destinationFinalOperationWeights: [],
+  brokerCompanyMail: null,
+  traderCompanyMail: null
 };


### PR DESCRIPTION
# Contexte

On souhaite ajouter à TOUS les registres, quand c'est possible:
- L'adresse mail du contact du destinataire
- L'adresse mail du contact du courtier
- L'adresse mail du contact du négociant

# Démo

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/4f07b56f-0db6-448b-a4ad-1fcb77238f58)

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/c196f20b-f4b3-4b5e-bbd1-41084e82e2c0)

![image](https://github.com/MTES-MCT/trackdechets/assets/45355989/469cfa0f-fee4-41b4-bcdc-12628c07aed6)

# Ticket Favro

[Ajouter une colonne Contact pour le destinataire, le négociant et le courtier sur tous les registres](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14325)