### PR TITLE
Hotfix/ Annexe 1

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -2745,6 +2745,14 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
+    await prisma.ecoOrganisme.create({
+      data: {
+        address: "",
+        name: ecoOrganisme.company.name,
+        siret: ecoOrganisme.company.siret!
+      }
+    });
+
     const { mutate } = makeClient(user);
 
     const appendix1_1 = await prisma.form.create({
@@ -2759,8 +2767,6 @@ describe("Mutation.updateForm", () => {
         emitterCompanyPhone: "01 01 01 01 01",
         emitterCompanyMail: "annexe1@test.com",
         wasteDetailsCode: "16 06 01*",
-        ecoOrganismeName: ecoOrganisme.company.name,
-        ecoOrganismeSiret: ecoOrganisme.company.siret,
         owner: { connect: { id: user.id } }
       }
     });
@@ -2772,7 +2778,9 @@ describe("Mutation.updateForm", () => {
         status: Status.SEALED,
         wasteDetailsCode: "16 06 01*",
         emitterCompanySiret: company.siret,
-        emitterType: EmitterType.APPENDIX1
+        emitterType: EmitterType.APPENDIX1,
+        ecoOrganismeName: ecoOrganisme.company.name,
+        ecoOrganismeSiret: ecoOrganisme.company.siret
       }
     });
 

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -2730,7 +2730,7 @@ describe("Mutation.updateForm", () => {
 
     expect(errors).toEqual([
       expect.objectContaining({
-        message: `L'émetteur du bordereau d'annexe 1 ${appendix1_1.id} n'est pas inscrit sur Trackdéchets. Il est impossible de joindre cette annexe à un bordereau chapeau sans éco-organisme.`,
+        message: `L'émetteur du bordereau d'annexe 1 ${appendix1_1.readableId} n'est pas inscrit sur Trackdéchets. Il est impossible de joindre cette annexe à un bordereau chapeau sans éco-organisme.`,
         extensions: {
           code: "BAD_USER_INPUT"
         }

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -398,7 +398,7 @@ async function canTransporterSignWithoutEmitterSignature(existingForm: Form) {
     });
 
     if (
-      emitterProfile &&
+      !emitterProfile ||
       [CompanyType.WASTEPROCESSOR, CompanyType.COLLECTOR].every(
         profile => !emitterProfile.companyTypes.includes(profile)
       )

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -2035,7 +2035,7 @@ export async function validateAppendix1Groupement(
     });
     if (!company) {
       throw new UserInputError(
-        `L'émetteur du bordereau d'annexe 1 ${initialForm.id} n'est pas inscrit sur Trackdéchets. Il est impossible de joindre cette annexe à un bordereau chapeau sans éco-organisme.`
+        `L'émetteur du bordereau d'annexe 1 ${initialForm.readableId} n'est pas inscrit sur Trackdéchets. Il est impossible de joindre cette annexe à un bordereau chapeau sans éco-organisme.`
       );
     }
   }

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -2025,7 +2025,7 @@ export async function validateAppendix1Groupement(
   });
 
   for (const initialForm of initialForms) {
-    if (initialForm.ecoOrganismeSiret || !initialForm.emitterCompanySiret) {
+    if (form.ecoOrganismeSiret || !initialForm.emitterCompanySiret) {
       continue;
     }
 


### PR DESCRIPTION
- correction pour permettre de lier une annexe 1 avec un producteur non inscrit à TD si le chapeau a un EO
- correction sur la signature transporteur d'une annexe 1 lorsque l'émetteur n'est pas inscrit
- amélioration du message d'erreur