### PR TITLE
Afficher le champ plaque d'immat dans la modale de modif si pas de mode de transport

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -2745,6 +2745,14 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
+    await prisma.ecoOrganisme.create({
+      data: {
+        address: "",
+        name: ecoOrganisme.company.name,
+        siret: ecoOrganisme.company.siret!
+      }
+    });
+
     const { mutate } = makeClient(user);
 
     const appendix1_1 = await prisma.form.create({
@@ -2759,8 +2767,6 @@ describe("Mutation.updateForm", () => {
         emitterCompanyPhone: "01 01 01 01 01",
         emitterCompanyMail: "annexe1@test.com",
         wasteDetailsCode: "16 06 01*",
-        ecoOrganismeName: ecoOrganisme.company.name,
-        ecoOrganismeSiret: ecoOrganisme.company.siret,
         owner: { connect: { id: user.id } }
       }
     });
@@ -2772,7 +2778,9 @@ describe("Mutation.updateForm", () => {
         status: Status.SEALED,
         wasteDetailsCode: "16 06 01*",
         emitterCompanySiret: company.siret,
-        emitterType: EmitterType.APPENDIX1
+        emitterType: EmitterType.APPENDIX1,
+        ecoOrganismeName: ecoOrganisme.company.name,
+        ecoOrganismeSiret: ecoOrganisme.company.siret
       }
     });
 

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -398,7 +398,7 @@ async function canTransporterSignWithoutEmitterSignature(existingForm: Form) {
     });
 
     if (
-      emitterProfile &&
+      !emitterProfile ||
       [CompanyType.WASTEPROCESSOR, CompanyType.COLLECTOR].every(
         profile => !emitterProfile.companyTypes.includes(profile)
       )

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -2025,7 +2025,7 @@ export async function validateAppendix1Groupement(
   });
 
   for (const initialForm of initialForms) {
-    if (initialForm.ecoOrganismeSiret || !initialForm.emitterCompanySiret) {
+    if (form.ecoOrganismeSiret || !initialForm.emitterCompanySiret) {
       continue;
     }
 

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
@@ -106,7 +106,8 @@ const TransporterInfoEditForm = ({
         }}
       />
 
-      {currentTransporter.transporterMode === TransportMode.Road ? (
+      {currentTransporter.transporterMode === TransportMode.Road ||
+      !currentTransporter.transporterMode ? (
         <div className="transporterInfoEditForm__plates">
           <TagsInput
             label="Immatriculations"


### PR DESCRIPTION
Hotfix pour rendre possible l'update de plaque si il n'y a pas de mode de transport renseigné

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---
