### PR TITLE
Afficher le champ plaque d'immat dans la modale de modif si pas de mode de transport

### DIFF
--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditForm.tsx
@@ -106,7 +106,8 @@ const TransporterInfoEditForm = ({
         }}
       />
 
-      {currentTransporter.transporterMode === TransportMode.Road ? (
+      {currentTransporter.transporterMode === TransportMode.Road ||
+      !currentTransporter.transporterMode ? (
         <div className="transporterInfoEditForm__plates">
           <TagsInput
             label="Immatriculations"


### PR DESCRIPTION
Hotfix pour rendre possible l'update de plaque si il n'y a pas de mode de transport renseigné