### PR TITLE
[Hotfix] Arrondi des décimaux lors d'une comparaison dans le calcul du diff d'un BSDD

### DIFF
--- a/back/src/forms/workflow/__tests__/diff.test.ts
+++ b/back/src/forms/workflow/__tests__/diff.test.ts
@@ -1,4 +1,5 @@
-import { arraysEqual, objectDiff, stringEqual } from "../diff";
+import Decimal from "decimal.js";
+import { arraysEqual, numberEqual, objectDiff, stringEqual } from "../diff";
 
 describe("arrayEquals", () => {
   test("arrays are equal", () => {
@@ -209,5 +210,19 @@ describe("dateDiff", () => {
     expect(objectDiff(o1, o2)).toEqual({});
     expect(objectDiff(o2, o1)).toEqual({});
     expect(objectDiff(o1, { a: "another" })).toEqual({ a: "another" });
+  });
+});
+
+describe("numberEqual", () => {
+  test("numbers with ridiculous number of decimals shoud be rounded and equal", () => {
+    // Given
+    const number1 = new Decimal("9.604");
+    const number2 = new Decimal("9.6039999999999990");
+
+    // When
+    const areEqual = numberEqual(number1, number2);
+
+    // Then
+    expect(areEqual).toBeTruthy();
   });
 });

--- a/back/src/forms/workflow/diff.ts
+++ b/back/src/forms/workflow/diff.ts
@@ -45,7 +45,10 @@ export function numberEqual(
   n2: number | Decimal | null | undefined
 ) {
   if (n1 && n2) {
-    return new Decimal(n1).equals(new Decimal(n2));
+    // Because of decimal issues in the DB, we round up
+    return new Decimal(n1)
+      .toDecimalPlaces(6)
+      .equals(new Decimal(n2).toDecimalPlaces(6));
   }
   return n1 === n2;
 }


### PR DESCRIPTION
# Contexte

Dans la DB, nous avons des chiffres aberrant avec des décimales à n'en plus finir, comme `9.6039999999999990`. Cela pose problème lors de calcul de diff dans le cas du BSDD. Si l'utilisateur envoie 9.604, l'API considère que les chiffres sont différents.

On arrondit pour éviter l'erreur.

# Ticket Favro

[Multimodal : Impossible d'ajouter d'autres transporteurs successifs après la signature du 1er transporteur sur le BSDD (Erreur : Des champs ont été verrouillés via signature et ne peuvent plus être modifiés : wasteDetailsQuantity)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14528)
