### PR TITLE
[BUG | TRA-14543] Le volume total d'un DASRI devrait être un Float, et déprécié

### DIFF
--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -240,7 +240,12 @@ input BsdasriDestinationInput {
 }
 
 input BsdasriReceptionInput {
-  volume: Int
+  "Volume total de tous les contenants"
+  volume: Float
+    @deprecated(
+      reason: "Ignoré - Calculé par Trackdéchets en faisant la somme des volumes des contenants"
+    )
+
   packagings: [BsdasriPackagingsInput!]
   date: DateTime
   acceptation: BsdasriAcceptationInput


### PR DESCRIPTION
# Contexte

Par souci de cohérence, le champ volume du BsdasriReceptionInput devrait être un Float. Il devrait aussi être déprécié puisque de toute façon ce champ est calculé côté backend, il est inutile de l'envoyer.

# Ticket Favro

[[BUG] Passer le volume de réception d'un DASRI en Float](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14543)
