### PR TITLE
[BUG | TRA-14545] Le champ allowBsdasriTakeOverWithoutSignature devrait être retourné par la requête companyInfos même pour des entreprises non-diffusibles

### DIFF
--- a/back/src/companies/resolvers/queries/__tests__/companyInfos.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyInfos.integration.ts
@@ -415,6 +415,32 @@ describe("query { companyInfos(siret: <SIRET>) }", () => {
     });
   });
 
+  it("should return TD-specific infos even if company is anonymous", async () => {
+    // Given
+    mockSearchSirene.mockRejectedValueOnce(new AnonymousCompanyError());
+    const siret = siretify(8);
+
+    await companyFactory({
+      siret,
+      allowBsdasriTakeOverWithoutSignature: true,
+      companyTypes: {
+        set: [CompanyType.WASTEPROCESSOR]
+      }
+    });
+    const gqlquery = `
+      query {
+        companyInfos(siret: "${siret}") {
+          allowBsdasriTakeOverWithoutSignature
+        }
+      }`;
+
+    // When
+    const { data } = await query<any>(gqlquery);
+
+    // Then
+    expect(data.companyInfos.allowBsdasriTakeOverWithoutSignature).toBeTruthy();
+  });
+
   it("should return explicit error if non-diffusible AND closed", async () => {
     // Given
     mockSearchSirene.mockRejectedValueOnce(new ClosedCompanyError());

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -86,7 +86,9 @@ const companyInfosResolvers: QueryResolvers["companyInfos"] = async (
       companyTypes: companyInfos.companyTypes,
       ecoOrganismeAgreements: companyInfos.ecoOrganismeAgreements,
       statutDiffusionEtablissement: companyInfos.statutDiffusionEtablissement,
-      etatAdministratif: companyInfos.etatAdministratif
+      etatAdministratif: companyInfos.etatAdministratif,
+      allowBsdasriTakeOverWithoutSignature:
+        companyInfos.allowBsdasriTakeOverWithoutSignature
     };
   }
 };


### PR DESCRIPTION
# Contexte

La requête `companyInfos` ne renvoie pas le champ `allowBsdasriTakeOverWithoutSignature` si l'entreprise ciblée est non-diffusible. C'est une information propre à TrackDéchets non confidentielle, donc on pourrait la renvoyer et ainsi faciliter la vie des utilisateurs.

# Ticket Favro

[[BUG] Le champ allowBsdasriTakeOverWithoutSignature devrait être retourné par la requête companyInfos même pour des entreprises non-diffusibles](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14545)