### PR TITLE
[BUG  | TRA-14549] ETQ utilisateur je dois pouvoir renseigner un nombre négatif dans les champs "coordonnée longitude" ou dans "Coordonnée latitude"

### DIFF
--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1275,6 +1275,22 @@ describe("draftFormSchema", () => {
     expect(isValid).toBe(true);
   });
 
+  it("should be valid when passing a parcelNumber negative coordinates", async () => {
+    const isValid = await draftFormSchema.isValid({
+      ...form,
+      wasteDetailsParcelNumbers: [
+        {
+          city: "Paris",
+          postalCode: "750012",
+          x: -1.2,
+          y: -1.3
+        }
+      ]
+    });
+
+    expect(isValid).toBe(true);
+  });
+
   it("should be invalid when passing an incomplete parcelNumber number", async () => {
     const validateFn = () =>
       draftFormSchema.validate({

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -650,7 +650,7 @@ const parcelNumber = yup.object({
     .max(5)
     .required("Parcelle: le numéro de parcelle est obligatoire")
 });
-const patternSixDigisAfterComma = /^\d+(\.\d{0,6})?$/;
+const patternSixDigisAfterComma = /^[-+]?\d+(\.\d{0,6})?$/;
 const parcelCoordinates = yup.object({
   x: yup
     .number()


### PR DESCRIPTION
# Contexte

La régex pour les latitudes / longitudes n'accepte pas les nombres négatifs. J'ai corrigé la regex.

# Ticket Favro

[Pouvoir renseigner un nombre négatif dans les champs "coordonnée longitude" ou dans "Coordonnée latitude"](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14549)
