### PR TITLE
[tra-14435] Revoir les messages d'erreur à l'ajout d'un Crématorium non inscrit / n'ayant pas le bon profil 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
+- Amélioration du message d'erreur à l'ajout d'un Crématorium non inscrit / n'ayant pas le bon profil [PR 3401](https://github.com/MTES-MCT/trackdechets/pull/3401)
+
 #### :house: Interne
 
 # [2024.6.1] 04/06/2024

--- a/back/src/bspaoh/validation/__tests__/validation.integration.ts
+++ b/back/src/bspaoh/validation/__tests__/validation.integration.ts
@@ -360,7 +360,7 @@ describe("BSPAOH validation", () => {
 
       expect(result.error.issues[0].message).toBe(
         `L'entreprise avec le SIRET "${company.siret}" n'est pas inscrite` +
-          ` sur Trackdéchets en tant que crématorium. Cette installation ne peut` +
+          ` sur Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut` +
           ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
           ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
       );

--- a/back/src/common/validation/siret.ts
+++ b/back/src/common/validation/siret.ts
@@ -7,7 +7,8 @@ import {
   isWasteProcessor,
   isWasteVehicles,
   isWorker,
-  isCrematorium
+  isCrematorium,
+  hasCremationProfile
 } from "../../companies/validation";
 import { CompanyVerificationStatus } from "@prisma/client";
 import { prisma } from "@td/prisma";
@@ -123,12 +124,12 @@ export async function isDestinationRefinement(
 
 export async function isCrematoriumRefinement(siret: string, ctx) {
   const company = await refineSiretAndGetCompany(siret, ctx);
-  if (company && !isCrematorium(company)) {
+  if (company && !isCrematorium(company) && !hasCremationProfile(company)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message:
         `L'entreprise avec le SIRET "${siret}" n'est pas inscrite` +
-        ` sur Trackdéchets en tant que crématorium. Cette installation ne peut` +
+        ` sur Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut` +
         ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
         ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
     });

--- a/back/src/companies/__tests__/search.test.ts
+++ b/back/src/companies/__tests__/search.test.ts
@@ -325,7 +325,10 @@ describe("searchCompanies", () => {
       contactPhone: undefined,
       ecoOrganismeAgreements: [],
       etatAdministratif: "A",
-      isRegistered: true
+      isRegistered: true,
+      collectorTypes: [],
+      wasteProcessorTypes: [],
+      website: undefined
     };
     expect(companiesSearched[0]).toEqual(expected);
     expect(mockSearchCompaniesBackend).toHaveBeenCalledTimes(1);

--- a/back/src/companies/search.ts
+++ b/back/src/companies/search.ts
@@ -48,6 +48,8 @@ export const mergeCompanyToCompanySearchResult = (
   address: trackdechetsCompanyInfo?.address,
   vatNumber: trackdechetsCompanyInfo?.vatNumber,
   companyTypes: trackdechetsCompanyInfo?.companyTypes ?? [],
+  wasteProcessorTypes: trackdechetsCompanyInfo?.wasteProcessorTypes ?? [],
+  collectorTypes: trackdechetsCompanyInfo?.collectorTypes ?? [],
   contact: trackdechetsCompanyInfo?.contact,
   contactEmail: trackdechetsCompanyInfo?.contactEmail,
   contactPhone: trackdechetsCompanyInfo?.contactPhone,
@@ -71,6 +73,8 @@ const companySelectedFields = {
   address: true,
   vatNumber: true,
   companyTypes: true,
+  collectorTypes: true,
+  wasteProcessorTypes: true,
   contact: true,
   contactEmail: true,
   contactPhone: true,
@@ -94,6 +98,7 @@ async function findCompanyAndMergeInfos(
     ...where,
     select: companySelectedFields
   });
+
   return mergeCompanyToCompanySearchResult(
     orgId,
     trackdechetsCompanyInfo,

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -138,6 +138,7 @@ export const searchCompanies = (
   requestOptions?
 ): Promise<SireneSearchResult[]> => {
   const qs = removeDiacritics(clue);
+
   // Match query on the merged field td_search_companies
   const must: estypes.QueryContainer[] = [
     {

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -369,6 +369,12 @@ type CompanySearchResult implements CompanySearchPrivateCommon {
   """
   companyTypes: [CompanyType!]
 
+  "Sous-types d'entreprises pour les installation de Tri, Transit Regroupement de déchets"
+  collectorTypes: [CollectorType!]
+
+  "Sous-types d'entreprises pour les installation de traitement de déchets"
+  wasteProcessorTypes: [WasteProcessorType!]
+
   """
   Liste des agréments de l'éco-organisme
   """

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -60,6 +60,9 @@ export function isWorker(company: Company) {
 export function isCrematorium(company: Company) {
   return company.companyTypes.includes(CompanyType.CREMATORIUM);
 }
+export function hasCremationProfile(company: Company) {
+  return company.wasteProcessorTypes.includes(WasteProcessorType.CREMATION);
+}
 
 const toSet = (_, value) => [...new Set(value?.filter(Boolean))];
 

--- a/front/src/Apps/common/queries/company/query.ts
+++ b/front/src/Apps/common/queries/company/query.ts
@@ -27,7 +27,9 @@ trackdechetsId
 contact
 contactPhone
 contactEmail
-companyTypes`;
+companyTypes
+collectorTypes
+wasteProcessorTypes`;
 
 const transporterReceiptCompanySearchString = `
 transporterReceipt {

--- a/front/src/form/bspaoh/steps/Destination.tsx
+++ b/front/src/form/bspaoh/steps/Destination.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo, useEffect, useContext } from "react";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { FavoriteType } from "@td/codegen-ui";
+import {
+  FavoriteType,
+  CompanyType,
+  CompanySearchResult,
+  WasteProcessorType
+} from "@td/codegen-ui";
 import { useFormContext, useWatch } from "react-hook-form";
 import CompanySelectorWrapper from "../../../form/common/components/CompanySelectorWrapper/RhfCompanySelectorWrapper";
 import { useParams } from "react-router-dom";
@@ -32,6 +37,22 @@ export function Destination() {
     () => destination?.company?.orgId ?? destination?.company?.siret ?? null,
     [destination?.company?.orgId, destination?.company?.siret]
   );
+
+  const selectedCompanyError = (company?: CompanySearchResult) => {
+    // Le destinatiare doi être inscrit et avec un profil crématorium ou sous-type crémation
+    // Le profil crématorium sera bientôt supprimé
+    if (company) {
+      if (!company.isRegistered) {
+        return "Cet établissement n'est pas inscrit sur Trackdéchets, il ne peut pas être ajouté sur le bordereau.";
+      } else if (
+        !company.companyTypes?.includes(CompanyType.Crematorium) &&
+        !company.wasteProcessorTypes?.includes(WasteProcessorType.Cremation)
+      ) {
+        return "Cet établissement n'a pas le profil Crématorium (et cimetières pour la Guyane).";
+      }
+    }
+    return null;
+  };
   return (
     <div>
       <CompanySelectorWrapper
@@ -39,6 +60,7 @@ export function Destination() {
         favoriteType={FavoriteType.Transporter}
         disabled={sealedFields.includes(`${actor}.company.siret`)}
         selectedCompanyOrgId={orgId}
+        selectedCompanyError={selectedCompanyError}
         onCompanySelected={company => {
           if (company) {
             setValue(`${actor}.company.orgId`, company.orgId);


### PR DESCRIPTION
Modification de la validation du destinataire PAOH pour des message dans le company selector en lieu et place des toasts.

Le profil CREMATORIUM est remplacé par collectorTypes.CREMATION, c'est un br annoncé. Dans l'attente on accepte les 2.

Le informations de `wasteProcessorTypes` et `collectorTypes` ont été ajoutés à searchCompanies pour que le front dispose des données.
 
<img width="798" alt="Capture d’écran 2024-06-17 à 10 57 29" src="https://github.com/MTES-MCT/trackdechets/assets/878396/a245ad5b-f7a4-475f-9967-4cdf33d75ff7">
<img width="859" alt="Capture d’écran 2024-06-17 à 10 27 46" src="https://github.com/MTES-MCT/trackdechets/assets/878396/61424ab4-bf9c-4b1f-9727-435186f7feee">

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
