### PR TITLE
[TRA-14042] Appliquer le traitement Annexe 2 récursivement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Correctif de la mise à jour d'un paoh depuis la modale de publication [PR 3390](https://github.com/MTES-MCT/trackdechets/pull/3390)
+- Appliquer le traitement d'Annexes 2 récursivement [PR 3402](https://github.com/MTES-MCT/trackdechets/pull/3402)
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/repository/form/updateAppendix2Forms.ts
+++ b/back/src/forms/repository/form/updateAppendix2Forms.ts
@@ -6,6 +6,7 @@ import { EventType } from "../../workflow/types";
 import buildUpdateManyForms from "./updateMany";
 import { FormWithForwardedIn, FormWithForwardedInInclude } from "../../types";
 import { processDbIdentifiersByChunk } from "../../../bsds/indexation/bulkIndexBsds";
+import buildFindGroupedFormsById from "./findGroupedFormsById";
 
 type FormForUpdateAppendix2Forms = Form & FormWithForwardedIn;
 
@@ -19,130 +20,149 @@ export type UpdateAppendix2Forms = (
 
 const buildUpdateAppendix2Forms: (
   deps: RepositoryFnDeps
-) => UpdateAppendix2Forms = deps => async forms => {
+) => UpdateAppendix2Forms = deps => {
   const { user, prisma } = deps;
   const updateManyForms = buildUpdateManyForms({ prisma, user });
+  const findGroupedFormsById = buildFindGroupedFormsById({ prisma });
+  const recursiveUpdate = async (forms: FormForUpdateAppendix2Forms[]) => {
+    const formIds = forms.map(form => form.id);
+    const formGroupements = await prisma.formGroupement.findMany({
+      where: { initialFormId: { in: formIds } },
+      include: { nextForm: { select: { status: true } } }
+    });
 
-  const formIds = forms.map(form => form.id);
-  const formGroupements = await prisma.formGroupement.findMany({
-    where: { initialFormId: { in: formIds } },
-    include: { nextForm: { select: { status: true } } }
-  });
+    const formUpdatesByStatus = new Map<Status, string[]>();
 
-  const formUpdatesByStatus = new Map<Status, string[]>();
+    // Quantité regroupée par identifiant de bordereau
+    const quantitGroupedByFormId: { [key: string]: number } = {};
+    const groupedFormsByFormId: {
+      [key: string]: FormForUpdateAppendix2Forms[];
+    } = {};
 
-  // Quantité regroupée par identifiant de bordereau
-  const quantitGroupedByFormId: { [key: string]: number } = {};
+    for (const form of forms) {
+      if (
+        ![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)
+      ) {
+        continue;
+      }
 
-  for (const form of forms) {
-    if (![Status.AWAITING_GROUP, Status.GROUPED].includes(form.status as any)) {
-      continue;
-    }
+      const quantityReceived = form.forwardedIn
+        ? form.forwardedIn.quantityReceived
+        : form.quantityReceived;
 
-    const quantityReceived = form.forwardedIn
-      ? form.forwardedIn.quantityReceived
-      : form.quantityReceived;
+      const quantityGrouped = new Decimal(
+        formGroupements
+          .filter(grp => grp.initialFormId === form.id)
+          .map(grp => grp.quantity)
+          .reduce((prev, cur) => prev + cur, 0) ?? 0
+      ).toDecimalPlaces(DECIMAL_WEIGHT_PRECISION); // set precision to gramme
 
-    const quantityGrouped = new Decimal(
-      formGroupements
+      quantitGroupedByFormId[form.id] = quantityGrouped.toNumber();
+
+      const groupementForms = formGroupements
         .filter(grp => grp.initialFormId === form.id)
-        .map(grp => grp.quantity)
-        .reduce((prev, cur) => prev + cur, 0) ?? 0
-    ).toDecimalPlaces(DECIMAL_WEIGHT_PRECISION); // set precision to gramme
+        .map(g => g.nextForm);
 
-    quantitGroupedByFormId[form.id] = quantityGrouped.toNumber();
+      // on a quelques quantityReceived avec des décimales au delà du gramme
+      const groupedInTotality =
+        quantityReceived &&
+        quantityGrouped.greaterThanOrEqualTo(
+          new Decimal(quantityReceived).toDecimalPlaces(
+            DECIMAL_WEIGHT_PRECISION
+          ) // limit precision to circumvent rogue decimal digits
+        ); // case > should not happen
 
-    const groupementForms = formGroupements
-      .filter(grp => grp.initialFormId === form.id)
-      .map(g => g.nextForm);
+      const allSealed =
+        groupementForms.length &&
+        groupedInTotality &&
+        groupementForms.reduce(
+          (acc, form) => acc && form.status !== Status.DRAFT,
+          true
+        );
 
-    // on a quelques quantityReceived avec des décimales au delà du gramme
-    const groupedInTotality =
-      quantityReceived &&
-      quantityGrouped.greaterThanOrEqualTo(
-        new Decimal(quantityReceived).toDecimalPlaces(DECIMAL_WEIGHT_PRECISION) // limit precision to circumvent rogue decimal digits
-      ); // case > should not happen
+      const allProcessed =
+        groupementForms.length &&
+        groupedInTotality &&
+        groupementForms.reduce(
+          (acc, form) =>
+            acc &&
+            [
+              Status.PROCESSED,
+              Status.NO_TRACEABILITY,
+              Status.FOLLOWED_WITH_PNTTD
+            ].includes(form.status as any),
+          true
+        );
 
-    const allSealed =
-      groupementForms.length &&
-      groupedInTotality &&
-      groupementForms.reduce(
-        (acc, form) => acc && form.status !== Status.DRAFT,
-        true
-      );
+      const nextStatus = allProcessed
+        ? Status.PROCESSED
+        : allSealed
+        ? Status.GROUPED
+        : Status.AWAITING_GROUP;
 
-    const allProcessed =
-      groupementForms.length &&
-      groupedInTotality &&
-      groupementForms.reduce(
-        (acc, form) =>
-          acc &&
-          [
-            Status.PROCESSED,
-            Status.NO_TRACEABILITY,
-            Status.FOLLOWED_WITH_PNTTD
-          ].includes(form.status as any),
-        true
-      );
+      if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
+        const status = transitionForm(form, {
+          type: EventType.MarkAsProcessed
+        });
 
-    const nextStatus = allProcessed
-      ? Status.PROCESSED
-      : allSealed
-      ? Status.GROUPED
-      : Status.AWAITING_GROUP;
+        formUpdatesByStatus.set(status, [
+          ...(formUpdatesByStatus.get(status) ?? []),
+          form.id
+        ]);
+      } else if (
+        form.status === Status.AWAITING_GROUP &&
+        nextStatus === Status.GROUPED
+      ) {
+        const status = transitionForm(form, {
+          type: EventType.MarkAsGrouped
+        });
+        formUpdatesByStatus.set(status, [
+          ...(formUpdatesByStatus.get(status) ?? []),
+          form.id
+        ]);
+      } else {
+        formUpdatesByStatus.set(nextStatus, [
+          ...(formUpdatesByStatus.get(nextStatus) ?? []),
+          form.id
+        ]);
+      }
 
-    if (form.status === Status.GROUPED && nextStatus === Status.PROCESSED) {
-      const status = transitionForm(form, {
-        type: EventType.MarkAsProcessed
-      });
-
-      formUpdatesByStatus.set(status, [
-        ...(formUpdatesByStatus.get(status) ?? []),
-        form.id
-      ]);
-    } else if (
-      form.status === Status.AWAITING_GROUP &&
-      nextStatus === Status.GROUPED
-    ) {
-      const status = transitionForm(form, {
-        type: EventType.MarkAsGrouped
-      });
-      formUpdatesByStatus.set(status, [
-        ...(formUpdatesByStatus.get(status) ?? []),
-        form.id
-      ]);
-    } else {
-      formUpdatesByStatus.set(nextStatus, [
-        ...(formUpdatesByStatus.get(nextStatus) ?? []),
-        form.id
-      ]);
+      const groupedForms = await findGroupedFormsById(form.id);
+      if (groupedForms?.length) {
+        groupedFormsByFormId[form.id] = groupedForms;
+      }
     }
-  }
 
-  const promises: Promise<Prisma.BatchPayload>[] = [];
-  for (const [status, ids] of formUpdatesByStatus.entries()) {
-    promises.push(updateManyForms(ids, { status }));
-  }
+    const promises: Promise<Prisma.BatchPayload>[] = [];
+    for (const [status, ids] of formUpdatesByStatus.entries()) {
+      promises.push(updateManyForms(ids, { status }));
+    }
 
-  await Promise.all(promises);
+    await Promise.all(promises);
 
-  // Ici on peut avoir 250 bordereaux à mettre à jour dans le pire des cas
-  // On batche donc les updates par 50 pour éviter un bottleneck
-  await processDbIdentifiersByChunk(
-    Object.keys(quantitGroupedByFormId),
-    async formIds => {
-      // met à jour la quantité regroupée sur chaque bordereau
-      await Promise.all(
-        formIds.map(formId => {
-          return prisma.form.update({
-            where: { id: formId },
-            data: { quantityGrouped: quantitGroupedByFormId[formId] }
-          });
-        })
-      );
-    },
-    50
-  );
+    // Ici on peut avoir 250 bordereaux à mettre à jour dans le pire des cas
+    // On batche donc les updates par 50 pour éviter un bottleneck
+    await processDbIdentifiersByChunk(
+      Object.keys(quantitGroupedByFormId),
+      async formIds => {
+        // met à jour la quantité regroupée sur chaque bordereau
+        await Promise.all(
+          formIds.map(formId => {
+            return prisma.form.update({
+              where: { id: formId },
+              data: { quantityGrouped: quantitGroupedByFormId[formId] }
+            });
+          })
+        );
+      },
+      50
+    );
+
+    for (const formId in groupedFormsByFormId) {
+      await recursiveUpdate(groupedFormsByFormId[formId]);
+    }
+  };
+  return recursiveUpdate;
 };
 
 export default buildUpdateAppendix2Forms;


### PR DESCRIPTION
# Objectif

Dans le cas où un bordereau regroupe en Annexe 2 d'autres bordereaux, qui eux même regroupent des bordereaux, etc, Le traitement appliqué au dernier bordereau était remonté sur le bordereau précédent, mais pas ceux d'avant.

# Modification

J'ai rendu la logique d'update des Annexes 2 récursive, de façon à remonter les Annexes et appliquer les update de statut.
Le diff de la PR est assez illisible, mais le changement consiste simplement à:
- Donner un nom à la fonction d'update (*recursiveUpdate*) (au lieu de la renvoyer directement anonymement)
- Aller chercher les bordereaux groupés dans les bordereaux en cours d'update
- Si il y en a, rappeler la fonction d'update pour ces bordereaux

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14042)
