### PR TITLE
[tra-14179] - Retirer la possibilité d'ajouter une Annexe 1 sur un BSD de tournée dédiée avant que celui-ci ne soit publié via API

### DIFF
--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1967,6 +1967,12 @@ export async function validateAppendix1Groupement(
   }
 
   const formIds = grouping.map(({ form }) => form.id);
+  if (form.status === Status.DRAFT) {
+    throw new UserInputError(
+      "Impossible de regrouper des BSDD d'annexe 1 sur un bordereau de tournée en brouillon"
+    );
+  }
+
   const duplicates = formIds.filter(
     (id, index) => formIds.indexOf(id) !== index
   );


### PR DESCRIPTION
Retirer la possibilité d'ajouter une Annexe 1 sur un BSD de tournée dédiée avant que celui-ci ne soit publié via API

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14179)
