### PR TITLE
[tra-14285] - Corretion sur le takenOverAt des chapeaux

### DIFF
--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -195,6 +195,8 @@ const signTransportFn = async (
         include
       );
       const appendix1ContainerId = groupedIn?.[0]?.nextFormId;
+      const appendix1ContainerTakenOverAt =
+        groupedIn?.[0]?.nextForm.takenOverAt;
       if (!appendix1ContainerId) {
         throw new ForbiddenError(
           "Impossible de signer un bordereau d'annexe 1 si cette annexe n'est pas rattachée à un bordereau chapeau."
@@ -227,7 +229,9 @@ const signTransportFn = async (
           }),
           emittedAt: formUpdateInput.sentAt,
           sentAt: formUpdateInput.sentAt,
-          takenOverAt: formUpdateInput.takenOverAt,
+          ...(!appendix1ContainerTakenOverAt // Only the first appendix 1 signature should fill this field
+            ? { takenOverAt: formUpdateInput.takenOverAt }
+            : undefined),
           takenOverBy: formUpdateInput.takenOverBy,
           ...(appendix1ContainerTransporter
             ? {


### PR DESCRIPTION
Bug décrit: Impossible d'ajouter des annexes 1 sur un BSD de tournée dédiée alors que le délai de 5 jours après signature du transporteur n'est pas dépassé

En réalité ça fonctionne bien. En revanche la date "takenOverAt" était mise à jour à chaque signature, ce qui était trompeur car on pensait que la prise en charge datait de moins de 5 jours alors que pas forcément.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14285)
