### PR TITLE
[TRA 9139] - localisation des terres (parcelles) dans les registres

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Amélioration du message d'erreur à l'ajout d'un Crématorium non inscrit / n'ayant pas le bon profil [PR 3401](https://github.com/MTES-MCT/trackdechets/pull/3401)
 - Ajout d'informations relatives au transport sur l'ensemble des registres [PR 3409](https://github.com/MTES-MCT/trackdechets/pull/3409)
+- Ajout d'informations relatives à la localisation des terres (parcelles) sur les registres Entrant, Sortant, Exhaustif et Gestion [PR 3410](https://github.com/MTES-MCT/trackdechets/pull/3410)
 
 #### :house: Interne
 

--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -286,10 +286,10 @@ describe("simpleFormToBsdd", () => {
       finalOperations: [],
       intermediaries: [],
       forwardedIn: null,
-      parcelCity: null,
+      parcelCities: null,
       parcelCoordinates: null,
-      parcelNumber: null,
-      parcelPostalCode: null
+      parcelNumbers: null,
+      parcelPostalCodes: null
     });
   });
 
@@ -403,13 +403,13 @@ describe("simpleFormToBsdd", () => {
     const bsdd = formToBsdd(fullForm);
 
     // check transporters are returned in the right order
-    expect(bsdd.parcelCity).toEqual(
+    expect(bsdd.parcelCities).toEqual(
       expect.arrayContaining(["Orléans", "Olivet"])
     );
-    expect(bsdd.parcelPostalCode).toEqual(
+    expect(bsdd.parcelPostalCodes).toEqual(
       expect.arrayContaining(["45100", "45160"])
     );
-    expect(bsdd.parcelNumber).toEqual(
+    expect(bsdd.parcelNumbers).toEqual(
       expect.arrayContaining(["000-EW-8", null])
     );
     expect(bsdd.parcelCoordinates).toEqual(
@@ -622,10 +622,10 @@ describe("simpleFormToBsdd", () => {
       intermediaries: [],
       finalOperations: [],
       forwardedIn: null,
-      parcelCity: null,
+      parcelCities: null,
       parcelCoordinates: null,
-      parcelNumber: null,
-      parcelPostalCode: null,
+      parcelNumbers: null,
+      parcelPostalCodes: null,
       forwardedInId: null,
       forwarding: {
         id: form.readableId,
@@ -803,10 +803,10 @@ describe("simpleFormToBsdd", () => {
         destinationOperationNextDestinationCompanyContact: null,
         destinationOperationNextDestinationCompanyPhone: null,
         destinationOperationNextDestinationCompanyMail: null,
-        parcelCity: null,
+        parcelCities: null,
         parcelCoordinates: null,
-        parcelNumber: null,
-        parcelPostalCode: null,
+        parcelNumbers: null,
+        parcelPostalCodes: null,
         forwardedInId: fullForwardedInForm.id,
         grouping: []
       }

--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -285,7 +285,11 @@ describe("simpleFormToBsdd", () => {
       grouping: [],
       finalOperations: [],
       intermediaries: [],
-      forwardedIn: null
+      forwardedIn: null,
+      parcelCity: null,
+      parcelCoordinates: null,
+      parcelNumber: null,
+      parcelPostalCode: null
     });
   });
 
@@ -365,6 +369,52 @@ describe("simpleFormToBsdd", () => {
     // check transporters are returned in the right order
     expect(bsdd.transporterCompanySiret).toEqual(transporter1.siret);
     expect(bsdd.transporter2CompanySiret).toEqual(transporter2.siret);
+  });
+
+  it("should convert a Form with waste parcel infos to a Bsdd", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        emitterCompanySiret: company.siret,
+        wasteDetailsParcelNumbers: [
+          {
+            city: "Orléans",
+            postalCode: "45100",
+            prefix: "000",
+            section: "EW",
+            number: "8"
+          },
+          {
+            city: "Olivet",
+            postalCode: "45160",
+            x: 47.853807,
+            y: 1.895882
+          }
+        ]
+      }
+    });
+
+    const fullForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id },
+      include: RegistryFormInclude
+    });
+
+    const bsdd = formToBsdd(fullForm);
+
+    // check transporters are returned in the right order
+    expect(bsdd.parcelCity).toEqual(
+      expect.arrayContaining(["Orléans", "Olivet"])
+    );
+    expect(bsdd.parcelPostalCode).toEqual(
+      expect.arrayContaining(["45100", "45160"])
+    );
+    expect(bsdd.parcelNumber).toEqual(
+      expect.arrayContaining(["000-EW-8", null])
+    );
+    expect(bsdd.parcelCoordinates).toEqual(
+      expect.arrayContaining([null, "N 47.853807 E 1.895882"])
+    );
   });
 
   it("should convert a forwarding Form to a Bsdd", async () => {
@@ -572,6 +622,10 @@ describe("simpleFormToBsdd", () => {
       intermediaries: [],
       finalOperations: [],
       forwardedIn: null,
+      parcelCity: null,
+      parcelCoordinates: null,
+      parcelNumber: null,
+      parcelPostalCode: null,
       forwardedInId: null,
       forwarding: {
         id: form.readableId,
@@ -749,6 +803,10 @@ describe("simpleFormToBsdd", () => {
         destinationOperationNextDestinationCompanyContact: null,
         destinationOperationNextDestinationCompanyPhone: null,
         destinationOperationNextDestinationCompanyMail: null,
+        parcelCity: null,
+        parcelCoordinates: null,
+        parcelNumber: null,
+        parcelPostalCode: null,
         forwardedInId: fullForwardedInForm.id,
         grouping: []
       }

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -6,7 +6,8 @@ import {
 } from "@prisma/client";
 import {
   AppendixFormInput,
-  InitialFormFractionInput
+  InitialFormFractionInput,
+  ParcelNumber
 } from "../generated/graphql/types";
 import { Bsdd } from "./types";
 import { RegistryForm } from "../registry/elastic";
@@ -32,6 +33,8 @@ export function simpleFormToBsdd(
 
   const [transporter, transporter2, transporter3, transporter4, transporter5] =
     transporters;
+
+  const parcels = form.wasteDetailsParcelNumbers as ParcelNumber[] | null;
 
   return {
     id: form.readableId,
@@ -223,7 +226,27 @@ export function simpleFormToBsdd(
     destinationOperationNextDestinationCompanyPhone:
       form.nextDestinationCompanyPhone,
     destinationOperationNextDestinationCompanyMail:
-      form.nextDestinationCompanyMail
+      form.nextDestinationCompanyMail,
+    parcelCity: parcels?.length ? parcels.map(parcel => parcel.city) : null,
+    parcelPostalCode: parcels?.length
+      ? parcels.map(parcel => parcel.postalCode)
+      : null,
+    parcelNumber: parcels?.length
+      ? parcels.map(parcel => {
+          if (parcel.prefix && parcel.section && parcel.number) {
+            return `${parcel.prefix}-${parcel.section}-${parcel.number}`;
+          }
+          return null;
+        })
+      : null,
+    parcelCoordinates: parcels?.length
+      ? parcels.map(parcel => {
+          if (typeof parcel.x === "number" && typeof parcel.y === "number") {
+            return `N ${parcel.x} E ${parcel.y}`;
+          }
+          return null;
+        })
+      : null
   };
 }
 

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -227,11 +227,11 @@ export function simpleFormToBsdd(
       form.nextDestinationCompanyPhone,
     destinationOperationNextDestinationCompanyMail:
       form.nextDestinationCompanyMail,
-    parcelCity: parcels?.length ? parcels.map(parcel => parcel.city) : null,
-    parcelPostalCode: parcels?.length
+    parcelCities: parcels?.length ? parcels.map(parcel => parcel.city) : null,
+    parcelPostalCodes: parcels?.length
       ? parcels.map(parcel => parcel.postalCode)
       : null,
-    parcelNumber: parcels?.length
+    parcelNumbers: parcels?.length
       ? parcels.map(parcel => {
           if (parcel.prefix && parcel.section && parcel.number) {
             return `${parcel.prefix}-${parcel.section}-${parcel.number}`;

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -244,6 +244,10 @@ export function toGenericWaste(
     workerCompanyAddress: null,
     brokerCompanyMail: bsdd.brokerCompanyMail,
     traderCompanyMail: bsdd.traderCompanyMail,
+    parcelCity: bsdd.parcelCity,
+    parcelPostalCode: bsdd.parcelPostalCode,
+    parcelNumber: bsdd.parcelNumber,
+    parcelCoordinates: bsdd.parcelCoordinates,
     ...getTransportersData(bsdd),
     ...initialEmitter
   };

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -244,9 +244,9 @@ export function toGenericWaste(
     workerCompanyAddress: null,
     brokerCompanyMail: bsdd.brokerCompanyMail,
     traderCompanyMail: bsdd.traderCompanyMail,
-    parcelCity: bsdd.parcelCity,
-    parcelPostalCode: bsdd.parcelPostalCode,
-    parcelNumber: bsdd.parcelNumber,
+    parcelCities: bsdd.parcelCities,
+    parcelPostalCodes: bsdd.parcelPostalCodes,
+    parcelNumbers: bsdd.parcelNumbers,
     parcelCoordinates: bsdd.parcelCoordinates,
     ...getTransportersData(bsdd),
     ...initialEmitter

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -299,4 +299,8 @@ export type Bsdd = {
   destinationOperationDate: Date | null;
   destinationOperationSignatureDate: Date | null;
   destinationCap: string | null;
+  parcelCity: string[] | null;
+  parcelPostalCode: string[] | null;
+  parcelNumber: (string | null)[] | null;
+  parcelCoordinates: (string | null)[] | null;
 };

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -299,8 +299,8 @@ export type Bsdd = {
   destinationOperationDate: Date | null;
   destinationOperationSignatureDate: Date | null;
   destinationCap: string | null;
-  parcelCity: string[] | null;
-  parcelPostalCode: string[] | null;
-  parcelNumber: (string | null)[] | null;
+  parcelCities: string[] | null;
+  parcelPostalCodes: string[] | null;
+  parcelNumbers: (string | null)[] | null;
   parcelCoordinates: (string | null)[] | null;
 };

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -185,17 +185,17 @@ export const columns: Column[] = [
   { field: "workerCompanySiret", label: "Entreprise de travaux SIRET" },
   { field: "workerCompanyAddress", label: "Entreprise de travaux adresse" },
   {
-    field: "parcelCity",
+    field: "parcelCities",
     label: "Parcelle commune",
     format: formatArray
   },
   {
-    field: "parcelPostalCode",
+    field: "parcelPostalCodes",
     label: "Parcelle code postal",
     format: formatArray
   },
   {
-    field: "parcelNumber",
+    field: "parcelNumbers",
     label: "Parcelle numéro",
     format: formatArrayWithMissingElements
   },

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -46,6 +46,12 @@ const formatBoolean = (b: boolean | null) => {
 };
 const formatNumber = (n: number) => (!!n ? parseFloat(n.toFixed(3)) : null); // return as a number to allow xls cells formulas
 const formatArray = (arr: any[]) => (Array.isArray(arr) ? arr.join(",") : "");
+const formatArrayWithMissingElements = (arr: any[]) => {
+  if (!Array.isArray(arr)) {
+    return "";
+  }
+  return arr.map(elem => elem ?? "").join(",");
+};
 const formatOperationCode = (code?: string) =>
   code ? code.replace(/ /g, "") : ""; // be consistent and remove all white spaces
 
@@ -178,6 +184,26 @@ export const columns: Column[] = [
   { field: "workerCompanyName", label: "Entreprise de travaux raison sociale" },
   { field: "workerCompanySiret", label: "Entreprise de travaux SIRET" },
   { field: "workerCompanyAddress", label: "Entreprise de travaux adresse" },
+  {
+    field: "parcelCity",
+    label: "Parcelle commune",
+    format: formatArray
+  },
+  {
+    field: "parcelPostalCode",
+    label: "Parcelle code postal",
+    format: formatArray
+  },
+  {
+    field: "parcelNumber",
+    label: "Parcelle numéro",
+    format: formatArrayWithMissingElements
+  },
+  {
+    field: "parcelCoordinates",
+    label: "Parcelle coordonnées",
+    format: formatArrayWithMissingElements
+  },
   // Gestion du déchets
   { field: "ecoOrganismeName", label: "Éco-organisme raison sociale" },
   { field: "ecoOrganismeSiren", label: "Éco-organisme SIREN" },

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -161,11 +161,11 @@ type IncomingWaste {
   #########################################################################
 
   "La ville de localisation de la/des parcelles"
-  parcelCity: [String!]
+  parcelCities: [String!]
   "Le code postal de la/des parcelles"
-  parcelPostalCode: [String!]
+  parcelPostalCodes: [String!]
   "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
-  parcelNumber: [String]
+  parcelNumbers: [String]
   "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
   parcelCoordinates: [String]
 
@@ -340,11 +340,11 @@ type OutgoingWaste {
   #########################################################################
 
   "La ville de localisation de la/des parcelles"
-  parcelCity: [String!]
+  parcelCities: [String!]
   "Le code postal de la/des parcelles"
-  parcelPostalCode: [String!]
+  parcelPostalCodes: [String!]
   "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
-  parcelNumber: [String]
+  parcelNumbers: [String]
   "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
   parcelCoordinates: [String]
 
@@ -918,11 +918,11 @@ type ManagedWaste {
   #########################################################################
 
   "La ville de localisation de la/des parcelles"
-  parcelCity: [String!]
+  parcelCities: [String!]
   "Le code postal de la/des parcelles"
-  parcelPostalCode: [String!]
+  parcelPostalCodes: [String!]
   "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
-  parcelNumber: [String]
+  parcelNumbers: [String]
   "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
   parcelCoordinates: [String]
 
@@ -1191,11 +1191,11 @@ type AllWaste {
   #########################################################################
 
   "La ville de localisation de la/des parcelles"
-  parcelCity: [String!]
+  parcelCities: [String!]
   "Le code postal de la/des parcelles"
-  parcelPostalCode: [String!]
+  parcelPostalCodes: [String!]
   "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
-  parcelNumber: [String]
+  parcelNumbers: [String]
   "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
   parcelCoordinates: [String]
 

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -164,9 +164,17 @@ type IncomingWaste {
   parcelCities: [String!]
   "Le code postal de la/des parcelles"
   parcelPostalCodes: [String!]
-  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  """
+  Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par coordonnées.
+  """
   parcelNumbers: [String]
-  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  """
+  Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par leur numéro.
+  """
   parcelCoordinates: [String]
 
   ###########################################################
@@ -343,9 +351,17 @@ type OutgoingWaste {
   parcelCities: [String!]
   "Le code postal de la/des parcelles"
   parcelPostalCodes: [String!]
-  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  """
+  Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par coordonnées.
+  """
   parcelNumbers: [String]
-  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  """
+  Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par leur numéro.
+  """
   parcelCoordinates: [String]
 
   ######################################################
@@ -921,9 +937,17 @@ type ManagedWaste {
   parcelCities: [String!]
   "Le code postal de la/des parcelles"
   parcelPostalCodes: [String!]
-  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  """
+  Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par coordonnées.
+  """
   parcelNumbers: [String]
-  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  """
+  Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par leur numéro.
+  """
   parcelCoordinates: [String]
 
   #################################################################
@@ -1194,9 +1218,17 @@ type AllWaste {
   parcelCities: [String!]
   "Le code postal de la/des parcelles"
   parcelPostalCodes: [String!]
-  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  """
+  Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par coordonnées.
+  """
   parcelNumbers: [String]
-  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  """
+  Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'.
+  Une parcelle peut être localisée par son numéro ou par ses coordonnées,
+  donc cette liste peut contenir des valeurs null si certaines parcelles sont localisées par leur numéro.
+  """
   parcelCoordinates: [String]
 
   #################################################################

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -156,6 +156,19 @@ type IncomingWaste {
   "Qualification du traitement final vis-à-vis de la hiérarchie des modes de traitement définie à l'article L. 541-1 du code de l'environnement"
   destinationOperationMode: OperationMode
 
+  #########################################################################
+  # e) Concernant la localisation des terres (parcelles) pour la traçabilité des terres et sédiments
+  #########################################################################
+
+  "La ville de localisation de la/des parcelles"
+  parcelCity: [String!]
+  "Le code postal de la/des parcelles"
+  parcelPostalCode: [String!]
+  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  parcelNumber: [String]
+  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  parcelCoordinates: [String]
+
   ###########################################################
   # Champs additionnels non mentionnés dans l'arrêté registre
   ###########################################################
@@ -322,8 +335,21 @@ type OutgoingWaste {
   "Lorsque les déchets apportés proviennent de plusieurs producteurs, le ou les codes postaux de la commune de collecte des déchets "
   initialEmitterPostalCodes: [String!]
 
+  #########################################################################
+  # d) Concernant la localisation des terres (parcelles) pour la traçabilité des terres et sédiments
+  #########################################################################
+
+  "La ville de localisation de la/des parcelles"
+  parcelCity: [String!]
+  "Le code postal de la/des parcelles"
+  parcelPostalCode: [String!]
+  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  parcelNumber: [String]
+  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  parcelCoordinates: [String]
+
   ######################################################
-  # d) Concernant la gestion et le transport du déchet :
+  # e) Concernant la gestion et le transport du déchet :
   ######################################################
 
   """
@@ -408,7 +434,7 @@ type OutgoingWaste {
   transporter5TransportMode: TransportMode
 
   ##########################################
-  # e) Concernant la destination du déchet :
+  # f) Concernant la destination du déchet :
   ##########################################
 
   "La raison sociale de l'établissement vers lequel le déchet est expédié"
@@ -887,8 +913,21 @@ type ManagedWaste {
   "La quantité de déchet entrant exprimée en tonne"
   destinationReceptionWeight: Float
 
+  #########################################################################
+  # c) Concernant la localisation des terres (parcelles) pour la traçabilité des terres et sédiments
+  #########################################################################
+
+  "La ville de localisation de la/des parcelles"
+  parcelCity: [String!]
+  "Le code postal de la/des parcelles"
+  parcelPostalCode: [String!]
+  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  parcelNumber: [String]
+  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  parcelCoordinates: [String]
+
   #################################################################
-  # c) Concernant l'origine, la gestion et le transport du déchet :
+  # d) Concernant l'origine, la gestion et le transport du déchet :
   #################################################################
 
   """
@@ -979,7 +1018,7 @@ type ManagedWaste {
   transporter5TransportMode: TransportMode
 
   ##########################################
-  # d) Concernant la destination du déchet :
+  # e) Concernant la destination du déchet :
   ##########################################
 
   "La raison sociale de l'établissement vers lequel le déchet est expédié"
@@ -1146,6 +1185,19 @@ type AllWaste {
   https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006074220&idArticle=LEGIARTI000006839071&dateTexte=&categorieLien=cid
   """
   pop: Boolean
+
+  #########################################################################
+  # Concernant la localisation des terres (parcelles) pour la traçabilité des terres et sédiments
+  #########################################################################
+
+  "La ville de localisation de la/des parcelles"
+  parcelCity: [String!]
+  "Le code postal de la/des parcelles"
+  parcelPostalCode: [String!]
+  "Le numéro identifiant la/les parcelles, sous la forme 'préfixe-section-n° de parcelle'"
+  parcelNumber: [String]
+  "Les coordonnées Lat/Long de la/des parcelles au format WGS 84 sous la forme 'N latitude E longitude'"
+  parcelCoordinates: [String]
 
   #################################################################
   # Concernant l'origine, la gestion et le transport du déchet :

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -136,9 +136,9 @@ export const emptyIncomingWaste: Required<IncomingWaste> = {
   brokerCompanyMail: null,
   destinationCompanyMail: null,
   traderCompanyMail: null,
-  parcelCity: null,
-  parcelPostalCode: null,
-  parcelNumber: null,
+  parcelCities: null,
+  parcelPostalCodes: null,
+  parcelNumbers: null,
   parcelCoordinates: null
 };
 
@@ -237,9 +237,9 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   postTempStorageDestinationCountry: null,
   brokerCompanyMail: null,
   traderCompanyMail: null,
-  parcelCity: null,
-  parcelPostalCode: null,
-  parcelNumber: null,
+  parcelCities: null,
+  parcelPostalCodes: null,
+  parcelNumbers: null,
   parcelCoordinates: null
 };
 
@@ -419,9 +419,9 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   workerCompanyName: null,
   workerCompanySiret: null,
   workerCompanyAddress: null,
-  parcelCity: null,
-  parcelPostalCode: null,
-  parcelNumber: null,
+  parcelCities: null,
+  parcelPostalCodes: null,
+  parcelNumbers: null,
   parcelCoordinates: null
   // En attente des correctifs recette sur TRA-12745
   // finalOperationCodes: null,
@@ -542,8 +542,8 @@ export const emptyAllWaste: Required<AllWaste> = {
   postTempStorageDestinationCountry: null,
   brokerCompanyMail: null,
   traderCompanyMail: null,
-  parcelCity: null,
-  parcelPostalCode: null,
-  parcelNumber: null,
+  parcelCities: null,
+  parcelPostalCodes: null,
+  parcelNumbers: null,
   parcelCoordinates: null
 };

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -135,7 +135,11 @@ export const emptyIncomingWaste: Required<IncomingWaste> = {
   workerCompanyAddress: null,
   brokerCompanyMail: null,
   destinationCompanyMail: null,
-  traderCompanyMail: null
+  traderCompanyMail: null,
+  parcelCity: null,
+  parcelPostalCode: null,
+  parcelNumber: null,
+  parcelCoordinates: null
 };
 
 export const emptyOutgoingWaste: Required<OutgoingWaste> = {
@@ -232,7 +236,11 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   postTempStorageDestinationSiret: null,
   postTempStorageDestinationCountry: null,
   brokerCompanyMail: null,
-  traderCompanyMail: null
+  traderCompanyMail: null,
+  parcelCity: null,
+  parcelPostalCode: null,
+  parcelNumber: null,
+  parcelCoordinates: null
 };
 
 export const emptyTransportedWaste: Required<TransportedWaste> = {
@@ -411,6 +419,10 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   workerCompanyName: null,
   workerCompanySiret: null,
   workerCompanyAddress: null,
+  parcelCity: null,
+  parcelPostalCode: null,
+  parcelNumber: null,
+  parcelCoordinates: null
   // En attente des correctifs recette sur TRA-12745
   // finalOperationCodes: null,
   // finalReceptionWeights: null
@@ -529,5 +541,9 @@ export const emptyAllWaste: Required<AllWaste> = {
   postTempStorageDestinationSiret: null,
   postTempStorageDestinationCountry: null,
   brokerCompanyMail: null,
-  traderCompanyMail: null
+  traderCompanyMail: null,
+  parcelCity: null,
+  parcelPostalCode: null,
+  parcelNumber: null,
+  parcelCoordinates: null
 };

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -422,7 +422,7 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   parcelCities: null,
   parcelPostalCodes: null,
   parcelNumbers: null,
-  parcelCoordinates: null
+  parcelCoordinates: null,
   // En attente des correctifs recette sur TRA-12745
   // finalOperationCodes: null,
   // finalReceptionWeights: null


### PR DESCRIPTION
# Objectif

Ajouter les infos de parcelle du BSDD dans les registres Entrant, Sortant, Exhaustif et Gestion.
Etant donné qu'il peut y avoir un nombre illimité de parcelles, le choix a été fait de ne pas faire comme les transporteurs (parcelle1City, parcelle2City, ...) mais de rassembler les infos dans les mêmes colonnes, en séparant les infos de chaque parcelle par des virgules (la spec dit des points virgules mais c'est déjà le séparateur des colonnes).

Les infos de parcelles peuvent prendre 2 formes:
soit:
```
city: "Orléans",
postalCode: "45100",
prefix: "000",
section: "EW",
number: "8"
```
soit:
```
city: "Olivet",
postalCode: "45160",
x: 47.853807,
y: 1.895882
```

Les colonnes à mettre dans les registres doivent donc prendre la forme suivante :

| Parcelle commune | Parcelle code postal | Parcelle numéro | Parcelle coordonnées    |
|------------------|----------------------|-----------------|-------------------------|
| Orléans,Olivet   | 45100,45160          | 000-EW-8,       | ,N 47.853807 E 1.895882 |

Les virgules permettent donc de signaler des éléments manquants dans les colonnes numéro/coordonnées.

# Modifications

Les infos du registre doivent se retrouver sur l'API et dans les exports csv/xlsx. La spec ne précise pas la forme que doivent prendre les données sur l'API, j'ai donc essayé de trouer le bon compromis.
-> La structure des données sur les IncomingWaste,OutgoingWaste,... est flat, donc j'ai supposé que laisser une array de ParcelNumber n'était pas le format attendu
-> J'ai aussi supposé que renvoyer le format qui se trouve dans les exports de registres (valeurs séparées par virgules) n'était pas très pratique.

J'ai donc choisi le format:

```gql
parcelCity: [String!]
parcelPostalCode: [String!]
parcelNumber: [String]
parcelCoordinates: [String]
```

Ce qui donnerait pour l'exemple précédent:

```js
{
  parcelCity: ["Orléans", "Olivet"],
  parcelPostalCode: ["45100", "45160"],
  parcelNumber: ["000-EW-8", null],
  parcelCoordinates: [null, "N 47.853807 E 1.895882"],
}
```

Ce flattening est fait dans *compat*, et la mise en format "séparé par virgules" est fait dans *columns*.

# Tests

Les tests compat ont été adaptés pour les nouvelles données, et j'ai rajouté un test pour valider que la fonction de formattage renvoit le bon format de données pour les parcelles.

# Demo

<img width="628" alt="Capture d’écran 2024-06-19 à 00 46 22" src="https://github.com/MTES-MCT/trackdechets/assets/2432646/547b38a8-c2d4-4ea0-9a3a-e5d44e4c5ffd">

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-9139)
