### PR TITLE
[HOTFIX | TRA-14584] Correction de la méthode de comparaison des intermédiaires 

### DIFF
--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -313,6 +313,10 @@ export async function getUpdatedFields(
   return Object.keys(diff);
 }
 
+const stringsNonNullAndEqual = (str1, str2) => {
+  return Boolean(str1) && Boolean(str2) && str1 === str2;
+};
+
 /**
  * Computes the diff on `intermediaries` input
  * This is not trivial because it is an array of `CompanyInput`
@@ -331,8 +335,8 @@ function intermediariesDiff(
       for (const intermediary of existingIntermediaries) {
         const inputIntermediary = input.intermediaries.find(
           i =>
-            i.siret === intermediary.siret ||
-            i.vatNumber === intermediary.vatNumber
+            stringsNonNullAndEqual(i.siret, intermediary.siret) ||
+            stringsNonNullAndEqual(i.vatNumber, intermediary.vatNumber)
         );
         if (!inputIntermediary) {
           // un intermédiaire est présent dans l'input mais pas dans les données existantes


### PR DESCRIPTION
# Contexte

On a une petite coquille dans la méthode de comparaison des intermédiaires qui fait qu'elle remonte des diffs non pertinents.

# Ticket Favro

[Multimodal/ annexe 2 : Impossible d'ajouter un transporteur sur des BSDD avec intermédiaires](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14584)
