### PR TITLE
[FIX] Correctif de la vérification des operation modes / codes sur les DASRI / VHU

### DIFF
--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -539,11 +539,11 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
-    test("should work if operation mode is missing but step is not operation", async () => {
+    test("should work if operation code & mode are missing", async () => {
       const data = {
         ...bsdasri,
-        destinationOperationCode: "D10",
-        destinationOperationMode: undefined, // Correct mode is ELIMINATION
+        destinationOperationCode: undefined,
+        destinationOperationMode: undefined,
         destinationOperationDate: new Date(),
         destinationReceptionWasteWeightValue: 10
       };

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -742,4 +742,39 @@ describe("Mutation.updateBsdasri", () => {
     });
     expect(updatedDasri.destinationOperationCode).toEqual("D10");
   });
+
+  it.only("should not allow code D9 and mode ELIMINATION", async () => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const dasri = await bsdasriFactory({
+      opt: {
+        status: BsdasriStatus.RECEIVED,
+        emitterCompanySiret: company.siret,
+        destinationReceptionSignatureAuthor: user.name,
+        receptionSignatory: { connect: { id: user.id } },
+        destinationReceptionSignatureDate: new Date().toISOString(),
+        ...readyToPublishData(await companyFactory())
+      }
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const input = {
+      destination: {
+        operation: { code: "D9", mode: "ELIMINATION", weight: { value: 20 } }
+      }
+    };
+    const { errors } = await mutate<Pick<Mutation, "updateBsdasri">>(
+      UPDATE_DASRI,
+      {
+        variables: { id: dasri.id, input }
+      }
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
+    expect(errors[0].message).toBe(
+      "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie"
+    );
+  });
 });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
@@ -451,7 +451,7 @@ describe("Mutation.updateBsdasri", () => {
   );
 
   it.each([
-    ["D9", "ELIMINATION"],
+    ["D9", null],
     ["D10", "ELIMINATION"],
     ["R1", "VALORISATION_ENERGETIQUE"]
   ])(

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -645,7 +645,7 @@ export const operationSchema: FactorySchemaOf<
           return true;
         }
       ),
-    destinationOperationMode: destinationOperationModeValidation(context),
+    destinationOperationMode: destinationOperationModeValidation(),
     destinationOperationDate: yup
       .date()
       .label("Date de traitement")

--- a/back/src/bsvhu/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/__tests__/validation.integration.ts
@@ -390,11 +390,11 @@ describe("BSVHU validation", () => {
       expect(res).not.toBeUndefined();
     });
 
-    test("should work if operation mode is missing but step is not operation", async () => {
+    test("should work if operation code & mode are missing", async () => {
       const data = {
         ...bsvhu,
-        destinationOperationCode: "R 4",
-        destinationOperationMode: undefined, // Correct mode is REUTILISATION | RECYCLAGE
+        destinationOperationCode: undefined,
+        destinationOperationMode: undefined,
         destinationReceptionWeight: 10,
         destinationReceptionAcceptationStatus: "ACCEPTED"
       };

--- a/back/src/bsvhu/validation.ts
+++ b/back/src/bsvhu/validation.ts
@@ -200,7 +200,7 @@ const destinationSchema: FactorySchemaOf<
             .required(`Destinataire: l'opération réalisée est obligatoire`),
         otherwise: s => s.nullable().notRequired()
       }),
-    destinationOperationMode: destinationOperationModeValidation(context),
+    destinationOperationMode: destinationOperationModeValidation(),
     destinationPlannedOperationCode: yup
       .string()
       .oneOf([...PROCESSING_OPERATIONS_CODES, null, ""])

--- a/back/src/common/validation/operationMode.ts
+++ b/back/src/common/validation/operationMode.ts
@@ -11,8 +11,6 @@ export const destinationOperationModeValidation = context =>
       "processing-mode-matches-processing-operation",
       "Le mode de traitement n'est pas compatible avec l'opération de traitement choisie",
       function (item) {
-        if (!context.operationSignature) return true;
-
         const { destinationOperationCode } = this.parent;
         const destinationOperationMode = item;
 

--- a/back/src/common/validation/operationMode.ts
+++ b/back/src/common/validation/operationMode.ts
@@ -2,7 +2,7 @@ import * as yup from "yup";
 import { OperationMode } from "@prisma/client";
 import { getOperationModesFromOperationCode } from "../operationModes";
 
-export const destinationOperationModeValidation = context =>
+export const destinationOperationModeValidation = () =>
   yup
     .mixed<OperationMode | null | undefined>()
     .oneOf([...Object.values(OperationMode), null, undefined])


### PR DESCRIPTION
# Contexte

On vérifiait la compatibilité entre operationMode & operationCode uniquement en cas de signature. Maintenant on vérifie à partir du moment où il y a un operationCode.

# Ticket Favro

[[BUG] Erreurs sur les DASRI avec opérationCode = D9 et operationMode = ELIMINATION](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14585)
