### PR TITLE
[tra-14215] Téléchargement des fiches établissement

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -210,3 +210,12 @@ OTEL_ENVIRONMENT=development
 
 # display logs in the console instead of sending them over network
 FORCE_LOGGER_CONSOLE=false|true
+
+# Gerico api url
+GERICO_API_URL="***"
+# Auth token for Gerico api
+GERICO_API_KEY="***"
+# Slug to receive gerico webhooks
+GERICO_WEBHOOK_SLUG="/lorem"
+# Token to authenticate gerico webhooks
+GERICO_WEBHOOK_TOKEN="***"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -263,3 +263,8 @@ env:
     -----END PUBLIC KEY-----
   WEBHOOK_TOKEN_ENCRYPTION_KEY: abcdefgh12345678abcdefgh12345678
   
+  # Gerico
+  GERICO_API_URL: http://gerico.test/api
+  GERICO_API_KEY: xyz
+  GERICO_WEBHOOK_SLUG: secret-slug
+  GERICO_WEBHOOK_TOKEN: abcdef

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,5 +105,6 @@ env:
     SwIDAQAB
     -----END PUBLIC KEY-----
   WEBHOOK_TOKEN_ENCRYPTION_KEY: abcdefgh12345678abcdefgh12345678
-
-
+  GERICO_WEBHOOK_SLUG: secret-slug-lorem
+  GERICO_WEBHOOK_TOKEN: wxcfdzr
+  

--- a/apps/queues-gerico/.eslintrc.json
+++ b/apps/queues-gerico/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/queues-gerico/jest.config.ts
+++ b/apps/queues-gerico/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: "apps/queues-webhooks",
+  preset: "../../jest.preset.js",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
+  },
+  moduleFileExtensions: ["ts", "js", "html"],
+  coverageDirectory: "../../coverage/apps/queues-webhooks"
+};

--- a/apps/queues-gerico/project.json
+++ b/apps/queues-gerico/project.json
@@ -1,0 +1,105 @@
+{
+  "name": "queues-gerico",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/queues-gerico/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": [
+        "^codegen",
+        {
+          "projects": ["@td/prisma"],
+          "target": "generate"
+        }
+      ],
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/apps/queues-gerico",
+        "format": ["cjs"],
+        "bundle": false,
+        "main": "apps/queues-gerico/src/main.ts",
+        "tsConfig": "apps/queues-gerico/tsconfig.app.json",
+        "assets": [
+          {
+            "input": "./libs/back/mail/src",
+            "glob": "**/*.html",
+            "output": "./libs/back/mail/src"
+          },
+          {
+            "input": "./back/src",
+            "glob": "**/*.{graphql,pdf,png,ttf,html,css,svg,wsdl,mp3}",
+            "output": "./back/src"
+          },
+          {
+            "input": "./back/src",
+            "glob": "**/assets/*.js",
+            "output": "./back/src"
+          },
+          {
+            "input": "./libs/back/prisma/src",
+            "glob": "**/*.{prisma,sql}",
+            "output": "./libs/back/prisma/src"
+          }
+        ],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {
+          "skipTypeCheck": true
+        },
+        "integration": {
+          "skipTypeCheck": true
+        },
+        "production": {
+          "esbuildOptions": {
+            "sourcemap": false,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "queues-gerico:build",
+        "inspect": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "queues-gerico:build:development"
+        },
+        "integration": {
+          "watch": false,
+          "buildTarget": "queues-gerico:build:integration"
+        },
+        "production": {
+          "buildTarget": "queues-gerico:build:production"
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "apps/queues-gerico/jest.config.ts"
+      }
+    }
+  },
+  "tags": ["backend:queues", "backend:background"]
+}

--- a/apps/queues-gerico/src/main.ts
+++ b/apps/queues-gerico/src/main.ts
@@ -1,0 +1,13 @@
+import {
+  postGericoJob,
+  gericoQueue,
+  SEND_GERICO_API_REQUEST_JOB_NAME
+} from "back";
+
+function startGericoConsumers() {
+  console.info(`Gerico queue consumers started`);
+
+  gericoQueue.process(SEND_GERICO_API_REQUEST_JOB_NAME, postGericoJob);
+}
+
+startGericoConsumers();

--- a/apps/queues-gerico/tsconfig.app.json
+++ b/apps/queues-gerico/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/apps/queues-gerico/tsconfig.json
+++ b/apps/queues-gerico/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/apps/queues-gerico/tsconfig.spec.json
+++ b/apps/queues-gerico/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"],
+    "sourceMap": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/apps/queues-webhooks/src/main.ts
+++ b/apps/queues-webhooks/src/main.ts
@@ -1,9 +1,13 @@
-import { sendHookJob, webhooksQueue, SEND_WEBHOOK_JOB_NAME } from "back";
+import {
+  sendHookJob,
+  webhooksQueue,
+  SEND_GERICO_API_REQUEST_JOB_NAME
+} from "back";
 
 function startWebhooksConsumers() {
   console.info(`Webhook queue consumers started`);
 
-  webhooksQueue.process(SEND_WEBHOOK_JOB_NAME, sendHookJob);
+  webhooksQueue.process(SEND_GERICO_API_REQUEST_JOB_NAME, sendHookJob);
 }
 
 startWebhooksConsumers();

--- a/apps/queues-webhooks/src/main.ts
+++ b/apps/queues-webhooks/src/main.ts
@@ -1,13 +1,9 @@
-import {
-  sendHookJob,
-  webhooksQueue,
-  SEND_GERICO_API_REQUEST_JOB_NAME
-} from "back";
+import { sendHookJob, webhooksQueue, SEND_WEBHOOK_JOB_NAME } from "back";
 
 function startWebhooksConsumers() {
   console.info(`Webhook queue consumers started`);
 
-  webhooksQueue.process(SEND_GERICO_API_REQUEST_JOB_NAME, sendHookJob);
+  webhooksQueue.process(SEND_WEBHOOK_JOB_NAME, sendHookJob);
 }
 
 startWebhooksConsumers();

--- a/back/src/common/post/backends/gerico/index.ts
+++ b/back/src/common/post/backends/gerico/index.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+
+const { GERICO_API_KEY, GERICO_API_URL } = process.env;
+
+const config = {
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Token ${GERICO_API_KEY}`
+  }
+};
+
+const gericoBackend = {
+  create: async function (orgId, year) {
+    const resp = await axios.post(
+      `${GERICO_API_URL}/create/`,
+      { orgId, year },
+      config
+    );
+
+    return resp.data;
+  }
+};
+
+export default gericoBackend;

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -127,6 +127,11 @@ type CompanyPrivate {
   Liste des automatisations de signature reçues par l'entreprise
   """
   receivedSignatureAutomations: [SignatureAutomation!]!
+
+  """
+  Liste des featureFlags
+  """
+  featureFlags: [String]!
 }
 
 type CompanyPrivateEdge {

--- a/back/src/companydigest/__tests__/factories.companydigest.ts
+++ b/back/src/companydigest/__tests__/factories.companydigest.ts
@@ -1,0 +1,19 @@
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@td/prisma";
+
+import { siretify } from "../../__tests__/factories";
+export const companyDigestFactory = async ({
+  opt = {}
+}: {
+  opt?: Partial<Prisma.CompanyDigestCreateInput>;
+}) => {
+  return prisma.companyDigest.create({
+    data: {
+      orgId: siretify(1),
+      year: new Date().getFullYear(),
+
+      ...opt
+    }
+  });
+};

--- a/back/src/companydigest/database.ts
+++ b/back/src/companydigest/database.ts
@@ -6,7 +6,7 @@ import { prisma } from "@td/prisma";
 import { CompanyDigest } from "@prisma/client";
 
 /**
- * Retrieves a companyDigest by id or throw a BsdasriNotFound error
+ * Retrieves a companyDigest by id or throw a CompanyDigestNotFound error
  */
 export async function getCompanyDigestOrNotFound({
   id

--- a/back/src/companydigest/database.ts
+++ b/back/src/companydigest/database.ts
@@ -1,0 +1,27 @@
+import { CompanyDigestNotFound } from "./errors";
+
+import { UserInputError } from "../common/errors";
+import { prisma } from "@td/prisma";
+
+import { CompanyDigest } from "@prisma/client";
+
+/**
+ * Retrieves a companyDigest by id or throw a BsdasriNotFound error
+ */
+export async function getCompanyDigestOrNotFound({
+  id
+}: {
+  id: string;
+}): Promise<CompanyDigest> {
+  if (!id) {
+    throw new UserInputError("You should specify an id");
+  }
+  const companyDigest = await prisma.companyDigest.findUnique({
+    where: { id }
+  });
+
+  if (companyDigest == null) {
+    throw new CompanyDigestNotFound(id.toString());
+  }
+  return companyDigest;
+}

--- a/back/src/companydigest/developper_doc.md
+++ b/back/src/companydigest/developper_doc.md
@@ -1,0 +1,57 @@
+# Gerico
+
+NB: Fonctionalités en beta
+
+Les utilisateurs ont la possibilité de télécharger des fiches d'établissment en pdf.
+
+### Principes techniques
+
+L'application Gerico (fiche établissment) dispose d'une api rest nantie de 3 endpoints:
+
+- /<secret-slug>/api/v1/create: POST {orgId, year} création d'une fiche établissment dont la génration se fera en asynchrone
+- /<secret-slug>/api/v1/sheet/<sheetId> : GET récupère le statut de la fiche
+- /<secret-slug>/api/v1/pdf/<sheetId> : GET télécharge le pdf de la fiche
+
+Gerico envoie un webhook sur le back de Trackdechets (POST, {sheetId, status}) pour le notifier de la fin de la génération de la fiche
+
+### Beta
+
+La fonctionalité sera ouverte progressivement pour permettre d'ajuster les capacités de l'infrastructure.
+
+### Limitations
+
+La fonctionalité est réservée aux utilisateurs UI disposant de l'accès à la fonctionalité.
+L'utilisateur doit être membre de l'établissement concerné.
+Seules les années N et N-1 sont accessibles.
+Une seule fiche est générable par jour et par établisesment.
+Chaque établissement est autorisé par un featureFlag.
+
+### Base de données
+
+Le modèle CompanyDigest centralise les données persistés necessaires à cette fonctionalité.
+Le modèle Compay reçoit une nouvelle colonne featureFlags (string[]) dans lequel la présence de la chaine `COMPANY_DIGEST` détermine l'accès à la fonctionalité.
+CompanyDigest comporte user pour suivre l'utilisateur à l'origine de la demande
+
+### Webhook
+
+Le router présent back/src/routers/gericoWebhookRouter.ts gère les webhooks envoyés par gérico.
+Les webhooks sont authentifiés par un header contenant un token hardcodé en variable d'environnement
+
+### Api Trackdéchets
+
+L'api TD reçoit 1 mutations et 2 queries privées.
+
+### Api Gerico
+
+Les requêtes sont authentifiées par un token renseigné en variable d'env
+
+### Recette et developpement
+
+Il n'existe à ce jour qu'une seule instance de Gerico, aussi le webhook ne sera adressé que vers une seule instance de Trackdéchets. En recette, penser à utiliser des entreprises existantes en production, les entreprises fictives où non inscrites en production ne fonctionneront pas
+
+### Variables d'environnement
+
+GERICO_API_URL=http://fiche.beta.gouv/secret/api/v1
+GERICO_API_KEY=xyz
+GERICO_WEBHOOK_SLUG=secret-slug
+GERICO_WEBHOOK_TOKEN=abcd

--- a/back/src/companydigest/developper_doc.md
+++ b/back/src/companydigest/developper_doc.md
@@ -39,7 +39,7 @@ Les webhooks sont authentifiés par un header contenant un token hardcodé en va
 
 ### Api Trackdéchets
 
-L'api TD reçoit 1 mutations et 2 queries privées.
+L'api TD reçoit 1 mutation et 2 queries privées.
 
 ### Api Gerico
 

--- a/back/src/companydigest/developper_doc.md
+++ b/back/src/companydigest/developper_doc.md
@@ -23,18 +23,18 @@ La fonctionalité sera ouverte progressivement pour permettre d'ajuster les capa
 La fonctionalité est réservée aux utilisateurs UI disposant de l'accès à la fonctionalité.
 L'utilisateur doit être membre de l'établissement concerné.
 Seules les années N et N-1 sont accessibles.
-Une seule fiche est générable par jour et par établisesment.
+Une seule fiche est générable par jour et par établissement.
 Chaque établissement est autorisé par un featureFlag.
 
 ### Base de données
 
 Le modèle CompanyDigest centralise les données persistés necessaires à cette fonctionalité.
-Le modèle Compay reçoit une nouvelle colonne featureFlags (string[]) dans lequel la présence de la chaine `COMPANY_DIGEST` détermine l'accès à la fonctionalité.
+Le modèle Company reçoit une nouvelle colonne featureFlags (string[]) dans lequel la présence de la chaine `COMPANY_DIGEST` détermine l'accès à la fonctionalité.
 CompanyDigest comporte user pour suivre l'utilisateur à l'origine de la demande
 
 ### Webhook
 
-Le router présent back/src/routers/gericoWebhookRouter.ts gère les webhooks envoyés par gérico.
+Le router présent dans back/src/routers/gericoWebhookRouter.ts gère les webhooks envoyés par gérico.
 Les webhooks sont authentifiés par un header contenant un token hardcodé en variable d'environnement
 
 ### Api Trackdéchets

--- a/back/src/companydigest/errors.ts
+++ b/back/src/companydigest/errors.ts
@@ -1,0 +1,7 @@
+import { UserInputError } from "../common/errors";
+
+export class CompanyDigestNotFound extends UserInputError {
+  constructor(id: string) {
+    super(`La fiche d'inspection avec l'identifiant "${id}" n'existe pas.`);
+  }
+}

--- a/back/src/companydigest/resolvers/Mutation.ts
+++ b/back/src/companydigest/resolvers/Mutation.ts
@@ -1,0 +1,9 @@
+import createCompanyDigest from "./mutations/create";
+
+import { MutationResolvers } from "../../generated/graphql/types";
+
+const Mutation: MutationResolvers = {
+  createCompanyDigest
+};
+
+export default Mutation;

--- a/back/src/companydigest/resolvers/Query.ts
+++ b/back/src/companydigest/resolvers/Query.ts
@@ -1,0 +1,10 @@
+import companyDigests from "./queries/companyDigests";
+import companyDigestPdf from "./queries/companyDigestPdf";
+import { QueryResolvers } from "../../generated/graphql/types";
+
+const Query: QueryResolvers = {
+  companyDigests,
+  companyDigestPdf
+};
+
+export default Query;

--- a/back/src/companydigest/resolvers/index.ts
+++ b/back/src/companydigest/resolvers/index.ts
@@ -1,0 +1,7 @@
+import Query from "./Query";
+import Mutation from "./Mutation";
+
+export default {
+  Query,
+  Mutation
+};

--- a/back/src/companydigest/resolvers/mutations/__tests__/companyDigestCreate.integration.ts
+++ b/back/src/companydigest/resolvers/mutations/__tests__/companyDigestCreate.integration.ts
@@ -1,0 +1,163 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Mutation } from "../../../../generated/graphql/types";
+
+import makeClient from "../../../../__tests__/testClient";
+
+import { gql } from "graphql-tag";
+import { ErrorCode } from "../../../../common/errors";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+
+export const CREATE_COMPANY_DIGEST = gql`
+  mutation CreateCompanyDigest($input: CompanyDigestCreateInput!) {
+    createCompanyDigest(input: $input) {
+      id
+      createdAt
+      updatedAt
+      year
+      orgId
+      distantId
+      state
+    }
+  }
+`;
+
+describe("Mutation.createCompanyDigest", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const { mutate } = makeClient();
+    const { errors } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: new Date().getFullYear() }
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+
+  it("should raise an error if requested siret does not belong to user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: new Date().getFullYear() }
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez générer une fiche établissement que pour les établissements auxquels vous appartenez.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should raise an error if company has no relevant featureFlag", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: new Date().getFullYear() }
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous nêtes pas autorisé à utiliser cette fonctionalité sur cet établissement.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should raise an error if year is too old", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      featureFlags: ["COMPANY_DIGEST"]
+    });
+
+    const { mutate } = makeClient(user);
+    const year = new Date().getFullYear() - 2;
+    const { errors } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: year }
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez générer une fiche établissement que pour l'année en cours et l'année précédente.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should create a companyDigest for current year", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      featureFlags: ["COMPANY_DIGEST"]
+    });
+    const year = new Date().getFullYear();
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: year }
+        }
+      }
+    );
+
+    expect(data.createCompanyDigest.year).toEqual(year);
+    expect(data.createCompanyDigest.orgId).toEqual(company.siret);
+  });
+
+  it("should create a companyDigest for last year", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER", {
+      featureFlags: ["COMPANY_DIGEST"]
+    });
+    const year = new Date().getFullYear() - 1;
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<Pick<Mutation, "createCompanyDigest">>(
+      CREATE_COMPANY_DIGEST,
+      {
+        variables: {
+          input: { orgId: company.siret, year: year }
+        }
+      }
+    );
+
+    expect(data.createCompanyDigest.year).toEqual(year);
+    expect(data.createCompanyDigest.orgId).toEqual(company.siret);
+  });
+});

--- a/back/src/companydigest/resolvers/mutations/create.ts
+++ b/back/src/companydigest/resolvers/mutations/create.ts
@@ -1,0 +1,78 @@
+import {
+  MutationCreateCompanyDigestArgs,
+  ResolversParentTypes
+} from "../../../generated/graphql/types";
+import { GraphQLContext } from "../../../types";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { UserInputError } from "../../../common/errors";
+import { getUserRoles } from "../../../permissions";
+import { format } from "date-fns";
+import { prisma } from "@td/prisma";
+import { sendGericoApiRequest } from "../../../queue/producers/gerico";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { CompanyDigestStatus } from "@prisma/client";
+const COMPANY_DIGEST_FLAG = "COMPANY_DIGEST";
+
+const createCompanyDigestResolver = async (
+  _: ResolversParentTypes["Mutation"],
+  args: MutationCreateCompanyDigestArgs,
+  context: GraphQLContext
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+
+  const user = checkIsAuthenticated(context);
+  const { input } = args;
+  const { orgId, year } = input;
+  const roles = await getUserRoles(user.id);
+  const companies = Object.keys(roles);
+  if (!companies.includes(orgId)) {
+    throw new UserInputError(
+      "Vous ne pouvez générer une fiche établissement que pour les établissements auxquels vous appartenez."
+    );
+  }
+  const today = format(new Date(), "yyyy-MM-dd");
+  const currentYear = new Date().getFullYear();
+  const allowedYears = [currentYear - 1, currentYear];
+  if (!allowedYears.includes(year)) {
+    throw new UserInputError(
+      "Vous ne pouvez générer une fiche établissement que pour l'année en cours et l'année précédente."
+    );
+  }
+
+  const alreadyExists = await prisma.companyDigest.count({
+    where: {
+      orgId,
+      year,
+      createdAt: { gte: new Date(today) },
+      state: { not: CompanyDigestStatus.ERROR }
+    }
+  });
+
+  if (alreadyExists) {
+    throw new UserInputError(
+      "Une fiche établissement a déjà été créée aujourd'hui"
+    );
+  }
+
+  const companyHasFeatureFlag = await prisma.company.findFirst({
+    where: { orgId, featureFlags: { has: COMPANY_DIGEST_FLAG } },
+    select: { id: true }
+  });
+
+  if (!companyHasFeatureFlag) {
+    throw new UserInputError(
+      "Vous nêtes pas autorisé à utiliser cette fonctionalité sur cet établissement."
+    );
+  }
+  const companyDigest = await prisma.companyDigest.create({
+    data: {
+      orgId,
+      year,
+      userId: user.id
+    }
+  });
+  sendGericoApiRequest(companyDigest.id);
+  return companyDigest;
+};
+
+export default createCompanyDigestResolver;

--- a/back/src/companydigest/resolvers/queries/__tests__/companyDigestPdf.integration.ts
+++ b/back/src/companydigest/resolvers/queries/__tests__/companyDigestPdf.integration.ts
@@ -1,0 +1,121 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+
+import makeClient from "../../../../__tests__/testClient";
+import { companyDigestFactory } from "../../../__tests__/factories.companydigest";
+import { gql } from "graphql-tag";
+import { ErrorCode } from "../../../../common/errors";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+import { CompanyDigestStatus } from "@prisma/client";
+
+const GET_COMPANY_DIGEST_PDF = gql`
+  query CompanyDigestPdf($id: ID!) {
+    companyDigestPdf(id: $id) {
+      downloadLink
+      token
+    }
+  }
+`;
+
+describe("Query.companyDigestpdf", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const cd = await companyDigestFactory({
+      opt: { orgId: company.siret! }
+    });
+    const { query } = makeClient();
+    const { errors } = await query<Pick<Query, "companyDigestPdf">>(
+      GET_COMPANY_DIGEST_PDF,
+      {
+        variables: { id: cd.id }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+
+  it("should raise an error if requested siret does not belong to user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    const cd = await companyDigestFactory({ opt: { orgId: company.siret! } });
+
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const { query } = makeClient(user);
+    const { errors } = await query<Pick<Query, "companyDigestPdf">>(
+      GET_COMPANY_DIGEST_PDF,
+      {
+        variables: { id: cd.id }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Cette fiche établissement n'existe pas ou vous n'avez pas les droits nécessaires pour la consulter.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it.each([
+    CompanyDigestStatus.INITIAL,
+    CompanyDigestStatus.ERROR,
+    CompanyDigestStatus.PENDING
+  ])(
+    "should raise an error if company digest is not PROCESSED ",
+    async state => {
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+
+      const cd = await companyDigestFactory({
+        opt: { orgId: company.siret!, state }
+      });
+
+      const { query } = makeClient(user);
+
+      const { errors } = await query<Pick<Query, "companyDigestPdf">>(
+        GET_COMPANY_DIGEST_PDF,
+        {
+          variables: { id: cd.id }
+        }
+      );
+
+      expect(errors).toEqual([
+        expect.objectContaining({
+          message: "Cette fiche établissement n'est pas consultable.",
+          extensions: expect.objectContaining({
+            code: ErrorCode.BAD_USER_INPUT
+          })
+        })
+      ]);
+    }
+  );
+
+  it("should return a token for requested id ", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const cd = await companyDigestFactory({
+      opt: { orgId: company.siret!, state: CompanyDigestStatus.PROCESSED }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "companyDigestPdf">>(
+      GET_COMPANY_DIGEST_PDF,
+      {
+        variables: { id: cd.id }
+      }
+    );
+
+    expect(data.companyDigestPdf.token).toBeTruthy();
+  });
+});

--- a/back/src/companydigest/resolvers/queries/__tests__/companydIgest.integration.ts
+++ b/back/src/companydigest/resolvers/queries/__tests__/companydIgest.integration.ts
@@ -1,0 +1,129 @@
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+
+import makeClient from "../../../../__tests__/testClient";
+import { companyDigestFactory } from "../../../__tests__/factories.companydigest";
+import { gql } from "graphql-tag";
+import { ErrorCode } from "../../../../common/errors";
+import { userWithCompanyFactory } from "../../../../__tests__/factories";
+
+const GET_COMPANY_DIGEST = gql`
+  query companyDigests($orgId: String!) {
+    companyDigests(orgId: $orgId) {
+      id
+      createdAt
+      updatedAt
+      year
+      orgId
+      distantId
+      state
+    }
+  }
+`;
+
+describe("Query.companyDigests", () => {
+  afterEach(resetDatabase);
+
+  it("should disallow unauthenticated user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const { query } = makeClient();
+    const { errors } = await query<Pick<Query, "companyDigests">>(
+      GET_COMPANY_DIGEST,
+      {
+        variables: { orgId: company.siret }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous n'êtes pas connecté.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.UNAUTHENTICATED
+        })
+      })
+    ]);
+  });
+
+  it("should raise an error if requested siret does not belong to user", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    await companyDigestFactory({ opt: { orgId: company.siret! } });
+
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const { query } = makeClient(user);
+    const { errors } = await query<Pick<Query, "companyDigests">>(
+      GET_COMPANY_DIGEST,
+      {
+        variables: { orgId: company.siret }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez requêter un établissement dont vous n'êtes pas membre.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
+  it("should return the last companyDigest of each year (year and year-1)", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const currentYear = new Date().getFullYear();
+    const lastYear = currentYear - 1;
+
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const cd1 = await companyDigestFactory({ opt: { orgId: company.siret! } });
+    const cd2 = await companyDigestFactory({
+      opt: { orgId: company.siret!, year: lastYear }
+    });
+    // older companyDigests
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, createdAt: yesterday }
+    });
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, year: lastYear, createdAt: yesterday }
+    });
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "companyDigests">>(
+      GET_COMPANY_DIGEST,
+      {
+        variables: { orgId: company.siret }
+      }
+    );
+
+    expect(data.companyDigests.length).toEqual(2);
+    expect(data.companyDigests.map(c => c?.id).sort()).toEqual(
+      [cd1.id, cd2.id].sort()
+    );
+  });
+
+  it("should return the last companyDigest of each year (year and year-1)ss", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const cd1 = await companyDigestFactory({
+      opt: { orgId: company.siret! }
+    });
+
+    // older companyDigest
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, createdAt: yesterday }
+    });
+
+    const { query } = makeClient(user);
+    const { data } = await query<Pick<Query, "companyDigests">>(
+      GET_COMPANY_DIGEST,
+      {
+        variables: { orgId: company.siret }
+      }
+    );
+
+    expect(data.companyDigests.length).toEqual(1);
+    expect(data.companyDigests.map(c => c?.id)).toEqual([cd1.id]);
+  });
+});

--- a/back/src/companydigest/resolvers/queries/companyDigestPdf.ts
+++ b/back/src/companydigest/resolvers/queries/companyDigestPdf.ts
@@ -15,6 +15,7 @@ import { getUserRoles } from "../../../permissions";
 
 import { UserInputError } from "../../../common/errors";
 import { CompanyDigestStatus } from "@prisma/client";
+import { logger } from "@td/logger";
 
 const { GERICO_API_KEY, GERICO_API_URL } = process.env;
 
@@ -41,7 +42,9 @@ export const companyDigestPdfDownloadHandler: DownloadHandler<QueryCompanyDigest
           createPDFResponse(res, `fiche-${companyDigest.orgId}.pdf`)
         );
       } catch (e) {
-        console.log("error");
+        logger.error(
+          `Failed to retrieve companyDigest ${companyDigest.distantId}`
+        );
       }
     }
   };

--- a/back/src/companydigest/resolvers/queries/companyDigestPdf.ts
+++ b/back/src/companydigest/resolvers/queries/companyDigestPdf.ts
@@ -1,0 +1,77 @@
+import {
+  QueryCompanyDigestPdfArgs,
+  QueryResolvers
+} from "../../../generated/graphql/types";
+import { getFileDownload } from "../../../common/fileDownload";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { getCompanyDigestOrNotFound } from "../../database";
+
+import { createPDFResponse } from "../../../common/pdf";
+import { DownloadHandler } from "../../../routers/downloadRouter";
+
+import axios from "axios";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { getUserRoles } from "../../../permissions";
+
+import { UserInputError } from "../../../common/errors";
+import { CompanyDigestStatus } from "@prisma/client";
+
+const { GERICO_API_KEY, GERICO_API_URL } = process.env;
+
+export const companyDigestPdfDownloadHandler: DownloadHandler<QueryCompanyDigestPdfArgs> =
+  {
+    name: "companyDigestPdf",
+    handler: async (_, res, { id }) => {
+      const companyDigest = await getCompanyDigestOrNotFound({ id });
+
+      try {
+        const resp = await axios(
+          `${GERICO_API_URL}/pdf/${companyDigest.distantId}`,
+          {
+            method: "GET",
+            responseType: "stream",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Token ${GERICO_API_KEY}`
+            }
+          }
+        );
+
+        resp.data.pipe(
+          createPDFResponse(res, `fiche-${companyDigest.orgId}.pdf`)
+        );
+      } catch (e) {
+        console.log("error");
+      }
+    }
+  };
+
+const companyDigestPdfResolver: QueryResolvers["companyDigestPdf"] = async (
+  _,
+  { id }: QueryCompanyDigestPdfArgs,
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+  const companyDigest = await getCompanyDigestOrNotFound({ id });
+
+  const roles = await getUserRoles(user.id);
+  const companies = Object.keys(roles);
+  if (!companies.includes(companyDigest.orgId)) {
+    throw new UserInputError(
+      "Cette fiche établissement n'existe pas ou vous n'avez pas les droits nécessaires pour la consulter."
+    );
+  }
+  if (companyDigest.state !== CompanyDigestStatus.PROCESSED) {
+    throw new UserInputError(
+      "Cette fiche établissement n'est pas consultable."
+    );
+  }
+
+  return getFileDownload({
+    handler: companyDigestPdfDownloadHandler.name,
+    params: { id }
+  });
+};
+
+export default companyDigestPdfResolver;

--- a/back/src/companydigest/resolvers/queries/companyDigests.ts
+++ b/back/src/companydigest/resolvers/queries/companyDigests.ts
@@ -1,0 +1,49 @@
+import { checkIsAuthenticated } from "../../../common/permissions";
+import { GraphQLContext } from "../../../types";
+
+import { QueryResolvers } from "../../../generated/graphql/types";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+
+import { UserInputError } from "../../../common/errors";
+import { getUserRoles } from "../../../permissions";
+import { format } from "date-fns";
+import { prisma } from "@td/prisma";
+
+const companyDigestResolver: QueryResolvers["companyDigests"] = async (
+  _,
+  args,
+  context: GraphQLContext
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  const user = checkIsAuthenticated(context);
+
+  const { orgId } = args;
+
+  const roles = await getUserRoles(user.id);
+  const companies = Object.keys(roles);
+  if (!companies.includes(orgId)) {
+    throw new UserInputError(
+      "Vous ne pouvez requêter un établissement dont vous n'êtes pas membre."
+    );
+  }
+  const today = format(new Date(), "yyyy-MM-dd");
+  const currentYear = new Date().getFullYear();
+  const lastYear = currentYear - 1;
+
+  const currentYearCompanyDigest = await prisma.companyDigest.findFirst({
+    where: { orgId, year: currentYear, createdAt: { gte: new Date(today) } },
+    orderBy: {
+      createdAt: "desc"
+    }
+  });
+  const lastYearCompanyDigest = await prisma.companyDigest.findFirst({
+    where: { orgId, year: lastYear, createdAt: { gte: new Date(today) } },
+    orderBy: {
+      createdAt: "desc"
+    }
+  });
+
+  return [currentYearCompanyDigest, lastYearCompanyDigest].filter(Boolean);
+};
+
+export default companyDigestResolver;

--- a/back/src/companydigest/resolvers/queries/companyDigests.ts
+++ b/back/src/companydigest/resolvers/queries/companyDigests.ts
@@ -27,6 +27,7 @@ const companyDigestResolver: QueryResolvers["companyDigests"] = async (
     );
   }
   const today = format(new Date(), "yyyy-MM-dd");
+
   const currentYear = new Date().getFullYear();
   const lastYear = currentYear - 1;
 

--- a/back/src/companydigest/typeDefs/private/companydigest.enums.graphql
+++ b/back/src/companydigest/typeDefs/private/companydigest.enums.graphql
@@ -1,0 +1,11 @@
+"Représente les differents étapes du company digest au cours de son cycle de vie."
+enum CompanyDigestStatus {
+  "Création en db"
+  INITIAL
+  "Lancé sur le service distant"
+  PENDING
+  "Calcule, prêt à etre téléchargé"
+  PROCESSED
+  "Erreur"
+  ERROR
+}

--- a/back/src/companydigest/typeDefs/private/companydigest.inputs.graphql
+++ b/back/src/companydigest/typeDefs/private/companydigest.inputs.graphql
@@ -1,0 +1,6 @@
+input CompanyDigestCreateInput {
+  "Id de l'établissement"
+  orgId: String!
+  "Année demandée"
+  year: Int!
+}

--- a/back/src/companydigest/typeDefs/private/companydigest.mutations.graphql
+++ b/back/src/companydigest/typeDefs/private/companydigest.mutations.graphql
@@ -1,0 +1,9 @@
+type Mutation {
+  """
+  Crée un nouveau CompanyDigest
+  """
+  createCompanyDigest(
+    "Payload de création d'un CompanyDigest"
+    input: CompanyDigestCreateInput!
+  ): CompanyDigest!
+}

--- a/back/src/companydigest/typeDefs/private/companydigest.objects.graphql
+++ b/back/src/companydigest/typeDefs/private/companydigest.objects.graphql
@@ -1,0 +1,14 @@
+"Suivi des fiches établissements"
+type CompanyDigest {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  "Année demandée"
+  year: Int!
+  "Siret de l'établissement"
+  orgId: String!
+  "Id de la fiche sur le service distant"
+  distantId: String
+  "etat de la fiche au cours de son cycle de vie"
+  state: CompanyDigestStatus
+}

--- a/back/src/companydigest/typeDefs/private/companydigest.queries.graphql
+++ b/back/src/companydigest/typeDefs/private/companydigest.queries.graphql
@@ -1,0 +1,24 @@
+type Query {
+  """
+  Renvoie les CompanyDigests.
+  Au maximum 2 CompanyDigests (annee en cours et annee precedente) sont renvoyes pour etablissmeent, la requête n'est pas paginee.
+  """
+  companyDigests(orgId: String!): [CompanyDigest]!
+
+  companyDigest(
+    """
+    Identifiant de l'objet CompanyDigest
+    """
+    id: ID!
+  ): CompanyDigest
+
+  """
+  Renvoie un token pour télécharger un pdf de fiche établissement
+  Ce token doit être transmis à la route /xxx pour obtenir le fichier.
+  Il est valable 10 secondes
+  """
+  companyDigestPdf(
+    "Identifiant de l'objet CompanyDigest"
+    id: ID!
+  ): FileDownload!
+}

--- a/back/src/companydigest/validation.ts
+++ b/back/src/companydigest/validation.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+import { CompanyDigestStatus } from "@prisma/client";
+
+export const webhookPayloadSchema = z.object({
+  distantId: z.string(),
+  status: z.enum([CompanyDigestStatus.PROCESSED, CompanyDigestStatus.ERROR])
+});

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -21,7 +21,13 @@ export { formatDate } from "./common/pdf";
 export { sendMail } from "./mailer/mailing";
 export { BsdUpdateQueueItem, updatesQueue } from "./queue/producers/bsdUpdate";
 export { operationHooksQueue } from "./queue/producers/operationHook";
-export { indexBsdJob, operationHookJob, sendMailJob } from "./queue/jobs";
+export {
+  indexBsdJob,
+  operationHookJob,
+  sendMailJob,
+  postGericoJob
+} from "./queue/jobs";
+
 export {
   indexQueue,
   bulkIndexQueue,
@@ -30,6 +36,7 @@ export {
 export { sirenifyQueue } from "./queue/producers/sirenify";
 export { mailQueue } from "./queue/producers/mail";
 export { syncEventsQueue } from "./queue/producers/events";
+
 export {
   geocodeCompanyQueue,
   setCompanyDepartementQueue
@@ -44,12 +51,14 @@ export {
   INDEX_JOB_NAME,
   INDEX_CREATED_JOB_NAME,
   INDEX_UPDATED_JOB_NAME,
-  SIRENIFY_JOB_NAME
+  SIRENIFY_JOB_NAME,
+  SEND_GERICO_API_REQUEST_JOB_NAME
 } from "./queue/producers/jobNames";
 export { deleteBsdJob } from "./queue/jobs/deleteBsd";
 export { indexFavoritesJob } from "./queue/jobs/indexFavorites";
 export { indexChunkBsdJob, indexAllInBulkJob } from "./queue/jobs/indexAllBsds";
 export { sendHookJob } from "./queue/jobs/sendHook";
+
 export {
   webhooksQueue,
   SEND_WEBHOOK_JOB_NAME
@@ -65,3 +74,4 @@ export { generateUniqueTestSiret } from "./companies/resolvers/mutations/createT
 export { createUser } from "./users/database";
 export { default as getReadableId, ReadableIdPrefix } from "./forms/readableId";
 export { reindex } from "./bsds/indexation/reindexBsdHelpers";
+export { gericoQueue } from "./queue/producers/gerico";

--- a/back/src/queue/bull-board.ts
+++ b/back/src/queue/bull-board.ts
@@ -14,6 +14,7 @@ import {
 import { updatesQueue } from "./producers/bsdUpdate";
 import { operationHooksQueue } from "./producers/operationHook";
 import { webhooksQueue } from "./producers/webhooks";
+import { gericoQueue } from "./producers/gerico";
 import { syncEventsQueue } from "./producers/events";
 import { mailQueue } from "./producers/mail";
 import { sirenifyQueue } from "./producers/sirenify";
@@ -34,7 +35,8 @@ createBullBoard({
     new BullAdapter(syncEventsQueue),
     new BullAdapter(webhooksQueue),
     new BullAdapter(operationHooksQueue),
-    new BullAdapter(sirenifyQueue)
+    new BullAdapter(sirenifyQueue),
+    new BullAdapter(gericoQueue)
   ],
   serverAdapter: serverAdapter
 });

--- a/back/src/queue/jobs/__tests__/sendHook.integration.ts
+++ b/back/src/queue/jobs/__tests__/sendHook.integration.ts
@@ -242,7 +242,7 @@ describe("sendHook", () => {
 
         // Company1 endpoint1 should have failed
         expect(e.message).toContain(
-          `Webhook requets fail for orgId ${company1.orgId} and endpoint ${whs1.endpointUri}`
+          `Webhook request fail for orgId ${company1.orgId} and endpoint ${whs1.endpointUri}`
         );
 
         // Other endpoints should be ok
@@ -312,10 +312,10 @@ describe("sendHook", () => {
 
         // Company1 endpoints should have failed
         expect(e.message).toContain(
-          `Webhook requets fail for orgId ${company1.orgId} and endpoint ${whs1.endpointUri}`
+          `Webhook request fail for orgId ${company1.orgId} and endpoint ${whs1.endpointUri}`
         );
         expect(e.message).toContain(
-          `Webhook requets fail for orgId ${company1.orgId} and endpoint ${whs2.endpointUri}`
+          `Webhook request fail for orgId ${company1.orgId} and endpoint ${whs2.endpointUri}`
         );
 
         // Company2 endpoint should be ok

--- a/back/src/queue/jobs/gerico.ts
+++ b/back/src/queue/jobs/gerico.ts
@@ -13,8 +13,6 @@ const Sentry = initSentry();
  * create a sheet computation  on Gerico and update companyDigest state
  */
 export async function postGericoJob(job: Job<GericoQueueItem>) {
-  console.log("postGericoJob");
-
   const companyDigest = await prisma.companyDigest.findUnique({
     where: { id: job.data.companyDigestId }
   });
@@ -28,7 +26,6 @@ export async function postGericoJob(job: Job<GericoQueueItem>) {
       companyDigest.year
     );
 
-    console.log(responseData);
     // gerico companyDigest might be already ready
     const state =
       responseData.state == CompanyDigestStatus.PROCESSED

--- a/back/src/queue/jobs/gerico.ts
+++ b/back/src/queue/jobs/gerico.ts
@@ -1,0 +1,52 @@
+import { Job } from "bull";
+import { GericoQueueItem } from "../producers/gerico";
+import { CompanyDigestStatus } from "@prisma/client";
+import { initSentry } from "../../common/sentry";
+import gericoBackend from "../../common/post/backends/gerico";
+import { prisma } from "@td/prisma";
+
+const Sentry = initSentry();
+
+/**
+ *
+ * @param job
+ * create a sheet computation  on Gerico and update companyDigest state
+ */
+export async function postGericoJob(job: Job<GericoQueueItem>) {
+  console.log("postGericoJob");
+
+  const companyDigest = await prisma.companyDigest.findUnique({
+    where: { id: job.data.companyDigestId }
+  });
+
+  if (!companyDigest) {
+    return;
+  }
+  try {
+    const responseData = await gericoBackend.create(
+      companyDigest?.orgId,
+      companyDigest.year
+    );
+
+    console.log(responseData);
+    // gerico companyDigest might be already ready
+    const state =
+      responseData.state == CompanyDigestStatus.PROCESSED
+        ? CompanyDigestStatus.PROCESSED
+        : CompanyDigestStatus.PENDING;
+
+    await prisma.companyDigest.update({
+      where: { id: companyDigest.id },
+      data: { state, distantId: responseData.id }
+    });
+    return responseData;
+  } catch (err) {
+    await prisma.companyDigest.update({
+      where: { id: companyDigest.id },
+      data: {
+        state: CompanyDigestStatus.ERROR
+      }
+    });
+    Sentry?.captureException(err);
+  }
+}

--- a/back/src/queue/jobs/index.ts
+++ b/back/src/queue/jobs/index.ts
@@ -3,3 +3,4 @@ export { indexBsdJob } from "./indexBsd";
 export { operationHookJob } from "./operationHook";
 export { sendHookJob } from "./sendHook";
 export { sirenifyBsdJob } from "./sirenifyBsd";
+export { postGericoJob } from "./gerico";

--- a/back/src/queue/jobs/sendHook.ts
+++ b/back/src/queue/jobs/sendHook.ts
@@ -68,7 +68,7 @@ const apiCallProcessor = async ({
   await handleWebhookFail(orgId, endpointUri);
   // throw to trigger bull retry mechanism
   throw new WebhookRequestError(
-    `Webhook requets fail for orgId ${orgId} and endpoint ${endpointUri}`
+    `Webhook request fail for orgId ${orgId} and endpoint ${endpointUri}`
   );
 };
 

--- a/back/src/queue/producers/gerico.ts
+++ b/back/src/queue/producers/gerico.ts
@@ -1,0 +1,32 @@
+import Queue from "bull";
+import { SEND_GERICO_API_REQUEST_JOB_NAME } from "./jobNames";
+
+const { REDIS_URL, NODE_ENV } = process.env;
+
+export type GericoQueueItem = {
+  companyDigestId: string;
+
+  jobName?: string;
+};
+
+const GERICHO_QUEUE_NAME = `queue_gerico_${NODE_ENV}`;
+
+export const gericoQueue = new Queue<GericoQueueItem>(
+  GERICHO_QUEUE_NAME,
+  REDIS_URL!,
+  {
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: { type: "fixed", delay: 1000 },
+      removeOnComplete: 100
+    }
+  }
+);
+
+export const sendGericoApiRequest = (companyDigestId: string) => {
+  gericoQueue.add(SEND_GERICO_API_REQUEST_JOB_NAME, {
+    companyDigestId
+  });
+};
+
+export const closeGericoQueue = () => gericoQueue.close();

--- a/back/src/queue/producers/index.ts
+++ b/back/src/queue/producers/index.ts
@@ -3,6 +3,7 @@ import { closeIndexAndUpdatesQueue } from "./elastic";
 import { closeSyncEventsQueue } from "./events";
 import { closeMailQueue } from "./mail";
 import { closeWebhooksQueue } from "./webhooks";
+import { closeGericoQueue } from "./gerico";
 
 export function closeQueues() {
   return Promise.all([
@@ -10,6 +11,7 @@ export function closeQueues() {
     closeMailQueue(),
     closeCompanyQueues(),
     closeSyncEventsQueue(),
-    closeWebhooksQueue()
+    closeWebhooksQueue(),
+    closeGericoQueue()
   ]);
 }

--- a/back/src/queue/producers/jobNames.ts
+++ b/back/src/queue/producers/jobNames.ts
@@ -3,3 +3,4 @@ export const INDEX_CREATED_JOB_NAME = "index_created";
 export const INDEX_UPDATED_JOB_NAME = "index_updated";
 export const DELETE_JOB_NAME = "delete";
 export const SIRENIFY_JOB_NAME = "sirenify";
+export const SEND_GERICO_API_REQUEST_JOB_NAME = "send_gerico";

--- a/back/src/routers/__tests__/gerico.integration.ts
+++ b/back/src/routers/__tests__/gerico.integration.ts
@@ -1,0 +1,130 @@
+import { resetDatabase } from "../../../integration-tests/helper";
+import { userWithCompanyFactory } from "../../__tests__/factories";
+import { CompanyDigestStatus } from "@prisma/client";
+import supertest from "supertest";
+import { app } from "../../server";
+import { prisma } from "@td/prisma";
+import { companyDigestFactory } from "../../companydigest/__tests__/factories.companydigest";
+
+const { GERICO_WEBHOOK_TOKEN, GERICO_WEBHOOK_SLUG } = process.env;
+
+const request = supertest(app);
+
+describe("Gerico Router", () => {
+  afterEach(resetDatabase);
+
+  it("should fail if no auth header is provided ", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, distantId: "abcd" }
+    });
+
+    const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+    const res = await request
+      .post(url)
+      .set("Accept", "application/json")
+      .send({ distantId: "abcd", status: "PROCESSED" });
+
+    expect(res.status).toEqual(403); // forbidden
+  });
+
+  it("should fail if auth header is malformed ", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, distantId: "abcd" }
+    });
+
+    const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+    const res = await request
+      .post(url)
+      .set("Accept", "application/json")
+      .set("Authorization", "Lorem")
+      .send({ distantId: "abcd", status: "PROCESSED" });
+
+    expect(res.status).toEqual(403); // forbidden
+  });
+
+  it("should fail if auth token is not valid ", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, distantId: "abcd" }
+    });
+
+    const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+    const res = await request
+      .post(url)
+      .set("Accept", "application/json")
+      .set("Authorization", "Token lorem")
+      .send({ distantId: "abcd", status: "PROCESSED" });
+
+    expect(res.status).toEqual(403); // forbidden
+  });
+
+  it("should fail if  company digest does not exist", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    await companyDigestFactory({
+      opt: { orgId: company.siret!, distantId: "abcd" }
+    });
+
+    const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+    const res = await request
+      .post(url)
+      .set("Accept", "application/json")
+      .set("Authorization", `Token ${GERICO_WEBHOOK_TOKEN}`)
+      .send({ distantId: "random", status: "PROCESSED" });
+
+    expect(res.status).toEqual(404); // does not exist
+  });
+
+  it.each([CompanyDigestStatus.PROCESSED, CompanyDigestStatus.ERROR])(
+    "should fail if company digest state is %p",
+    async state => {
+      const { company } = await userWithCompanyFactory("MEMBER");
+
+      await companyDigestFactory({
+        opt: { orgId: company.siret!, distantId: "abcd", state }
+      });
+
+      const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+      const res = await request
+        .post(url)
+        .set("Accept", "application/json")
+        .set("Authorization", `Token ${GERICO_WEBHOOK_TOKEN}`)
+        .send({ distantId: "abcd", status: "PROCESSED" });
+
+      expect(res.status).toEqual(404);
+    }
+  );
+  it("should udpate company digest status", async () => {
+    const { company } = await userWithCompanyFactory("MEMBER");
+
+    const cd = await companyDigestFactory({
+      opt: { orgId: company.siret!, distantId: "abcd" }
+    });
+
+    const url = `/${GERICO_WEBHOOK_SLUG}`;
+
+    const res = await request
+      .post(url)
+      .set("Accept", "application/json")
+      .set("Authorization", `Token ${GERICO_WEBHOOK_TOKEN}`)
+      .send({ distantId: "abcd", status: "PROCESSED" });
+
+    expect(res.status).toEqual(200);
+
+    const updated = await prisma.companyDigest.findUnique({
+      where: { id: cd.id }
+    });
+
+    expect(updated?.state).toEqual("PROCESSED");
+  });
+});

--- a/back/src/routers/downloadRouter.ts
+++ b/back/src/routers/downloadRouter.ts
@@ -4,6 +4,7 @@ import { bsdasriPdfDownloadHandler } from "../bsdasris/resolvers/queries/bsdasri
 import { bsffPdfDownloadHandler } from "../bsffs/resolvers/queries/bsffPdf";
 import { bsvhuPdfDownloadHandler } from "../bsvhu/resolvers/queries/bsvhuPdf";
 import { bspaohPdfDownloadHandler } from "../bspaoh/resolvers/queries/bspaohPdf";
+import { companyDigestPdfDownloadHandler } from "../companydigest/resolvers/queries/companyDigestPdf";
 import { redisClient } from "../common/redis";
 import { formPdfDownloadHandler } from "../forms/resolvers/queries/formPdf";
 import { wastesRegistryCsvDownloadHandler } from "../registry/resolvers/queries/wastesRegistryCsv";
@@ -43,6 +44,7 @@ type DownloadHandlerName = keyof Pick<
   | "wastesRegistryXls"
   | "myCompaniesCsv"
   | "myCompaniesXls"
+  | "companyDigestPdf"
 >;
 
 // List all different params that can be passed to a download handler
@@ -88,6 +90,7 @@ const downloadHandlers: DownloadHandlers = [
   bsffPdfDownloadHandler,
   bsvhuPdfDownloadHandler,
   bspaohPdfDownloadHandler,
+  companyDigestPdfDownloadHandler,
   wastesRegistryCsvDownloadHandler,
   wastesRegistryXlsDownloadHandler,
   myCompaniesCsvDownloadHandler,

--- a/back/src/routers/gericoWebhookRouter.ts
+++ b/back/src/routers/gericoWebhookRouter.ts
@@ -7,7 +7,13 @@ import { CompanyDigestStatus } from "@prisma/client";
 const { GERICO_WEBHOOK_TOKEN } = process.env;
 
 export const gericoWebhookHandler = async (req, res) => {
-  const token = req.headers.authorization.split(" ")[1];
+  const { authorization } = req.headers;
+
+  if (!authorization) {
+    return res.status(403).send("Forbidden");
+  }
+
+  const token = authorization.split(" ")[1];
 
   if (!token || token !== GERICO_WEBHOOK_TOKEN) {
     return res.status(403).send("Forbidden");

--- a/back/src/routers/gericoWebhookRouter.ts
+++ b/back/src/routers/gericoWebhookRouter.ts
@@ -1,0 +1,35 @@
+import { prisma } from "@td/prisma";
+
+import { webhookPayloadSchema } from "../companydigest/validation";
+
+import { CompanyDigestStatus } from "@prisma/client";
+
+const { GERICO_WEBHOOK_TOKEN } = process.env;
+
+export const gericoWebhookHandler = async (req, res) => {
+  const token = req.headers.authorization.split(" ")[1];
+
+  if (!token || token !== GERICO_WEBHOOK_TOKEN) {
+    return res.status(403).send("Forbidden");
+  }
+
+  const { distantId, status } = webhookPayloadSchema.parse(req.body);
+
+  const companyDigest = await prisma.companyDigest.findFirst({
+    where: {
+      distantId: distantId,
+      state: {
+        notIn: [CompanyDigestStatus.PROCESSED, CompanyDigestStatus.ERROR]
+      }
+    }
+  });
+
+  if (!companyDigest) {
+    return res.status(404).send("Not found");
+  }
+  await prisma.companyDigest.update({
+    where: { id: companyDigest.id },
+    data: { state: status }
+  });
+  res.send("ok");
+};

--- a/back/src/schema.ts
+++ b/back/src/schema.ts
@@ -13,6 +13,7 @@ import bspaohResolvers from "./bspaoh/resolvers";
 import registerResolvers from "./registry/resolvers";
 import applicationResolvers from "./applications/resolvers";
 import webhookResolvers from "./webhooks/resolvers";
+import companyDigestResolvers from "./companydigest/resolvers";
 
 // Merge GraphQL schema by merging types definitions and resolvers
 // from differents modules
@@ -30,7 +31,8 @@ const repositories = [
   "bspaoh",
   "registry",
   "applications",
-  "webhooks"
+  "webhooks",
+  "companydigest"
 ];
 
 const typeDefsPath = repositories.map(
@@ -54,7 +56,8 @@ const resolvers = [
   bspaohResolvers,
   registerResolvers,
   applicationResolvers,
-  webhookResolvers
+  webhookResolvers,
+  companyDigestResolvers
 ];
 
 export { typeDefs, resolvers };

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -44,6 +44,7 @@ import { authRouter } from "./routers/auth-router";
 import { downloadRouter } from "./routers/downloadRouter";
 import { oauth2Router } from "./routers/oauth2-router";
 import { oidcRouter } from "./routers/oidc-router";
+import { gericoWebhookHandler } from "./routers/gericoWebhookRouter";
 import { roadControlPdfHandler } from "./routers/roadControlPdfRouter";
 import { resolvers, typeDefs } from "./schema";
 import { GraphQLContext } from "./types";
@@ -60,7 +61,8 @@ const {
   UI_HOST,
   MAX_REQUESTS_PER_WINDOW = "1000",
   NODE_ENV,
-  TRUST_PROXY_HOPS
+  TRUST_PROXY_HOPS,
+  GERICO_WEBHOOK_SLUG
 } = process.env;
 
 const Sentry = initSentry();
@@ -310,6 +312,8 @@ app.get("/exports", (_, res) =>
 );
 
 app.get(`/${ROAD_CONTROL_SLUG}/:token`, roadControlPdfHandler);
+
+app.post(`/${GERICO_WEBHOOK_SLUG}`, gericoWebhookHandler);
 
 app.use(
   "/graphiql",

--- a/back/src/webhooks/typeDefs/webhooks.objects.graphql
+++ b/back/src/webhooks/typeDefs/webhooks.objects.graphql
@@ -1,4 +1,4 @@
-"Configuration wehook"
+"Configuration webHook"
 type WebhookSetting {
   id: ID!
   createdAt: DateTime!

--- a/e2e/src/utils/company.ts
+++ b/e2e/src/utils/company.ts
@@ -135,7 +135,11 @@ export const getCompanyDiv = async (
   // Select tab
   await page.getByRole("tab", { name: tab }).click();
 
-  return page.getByTestId("company-details");
+  // Select content div right behind
+  const contentDiv = await page.getByLabel(tab, { exact: true });
+  await expect(contentDiv).toBeVisible();
+
+  return contentDiv;
 };
 
 /**
@@ -346,13 +350,14 @@ export const submitAndVerifyGenericInfo = async (
 
   // Contact info
   if (contact) {
-    await companyDiv.getByRole("tab", { name: "Contact" }).click();
+    const contactDiv = await getCompanyDiv(page, { siret, tab: "Contact" });
+
     await expect(
-      companyDiv.getByText(`Prénom et nom${contact.name}`)
+      contactDiv.getByText(`Prénom et nom${contact.name}`)
     ).toBeVisible();
-    await expect(companyDiv.getByText(`Email${contact.email}`)).toBeVisible();
+    await expect(contactDiv.getByText(`Email${contact.email}`)).toBeVisible();
     await expect(
-      companyDiv.getByText(`Téléphone${contact.phone}`)
+      contactDiv.getByText(`Téléphone${contact.phone}`)
     ).toBeVisible();
   }
 

--- a/front/src/Apps/Companies/CompanyDetails.tsx
+++ b/front/src/Apps/Companies/CompanyDetails.tsx
@@ -117,8 +117,6 @@ export default function CompanyDetails() {
     return <Navigate to={{ pathname: routes.companies.index }} />;
   }
 
-  company.featureFlags.includes(COMPANY_DIGEST_FLAG);
-
   const { tabs, tabsContent } = buildTabs(company);
 
   const CurrenComponent = tabsContent[selectedTabId] ?? Dummy;

--- a/front/src/Apps/Companies/CompanyDetails.tsx
+++ b/front/src/Apps/Companies/CompanyDetails.tsx
@@ -22,7 +22,7 @@ import CompanyDigestSheetForm from "./CompanyDigestSheet/CompanyDigestSheet";
 import { Tabs, TabsProps } from "@codegouvfr/react-dsfr/Tabs";
 import { FrIconClassName } from "@codegouvfr/react-dsfr";
 
-export type TheProps = {
+export type TabContentProps = {
   company: CompanyPrivate;
 };
 
@@ -32,7 +32,7 @@ const buildTabs = (
   company: CompanyPrivate
 ): {
   tabs: TabsProps.Controlled["tabs"];
-  tabsContent: Record<string, React.FC<TheProps>>;
+  tabsContent: Record<string, React.FC<TabContentProps>>;
 } => {
   const isAdmin = company.userRole === UserRole.Admin;
   const isMember = company.userRole === UserRole.Member;

--- a/front/src/Apps/Companies/CompanyDigestSheet/CompanyDigestSheet.tsx
+++ b/front/src/Apps/Companies/CompanyDigestSheet/CompanyDigestSheet.tsx
@@ -1,0 +1,216 @@
+import React from "react";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { format } from "date-fns";
+import { useQuery, useMutation, useLazyQuery } from "@apollo/client";
+import {
+  Query,
+  QueryCompanyDigestsArgs,
+  Mutation,
+  MutationCreateCompanyDigestArgs,
+  QueryCompanyDigestPdfArgs
+} from "@td/codegen-ui";
+import { NotificationError } from "../../common/Components/Error/Error";
+import { Loader } from "../../common/Components";
+import {
+  CREATE_COMPANY_DIGEST,
+  COMPANY_DIGEST_PDF,
+  COMPANY_DIGEST
+} from "./queries";
+
+const Description = () => (
+  <div>
+    <p>
+      La génération de la fiche établissement est particulièrement coûteuse en
+      ressources informatiques, c'est pourquoi elle ne peut être générée qu'une
+      fois par jour et par établissement mais reste consultable.
+    </p>
+    <br />
+    <p>Les sources des données sont multiples:</p>
+    <br />
+    <ul className="fr-ml-2w">
+      <li>
+        - Trackdéchets pour les déchets tracés et pour vos informations
+        établissements (profils, agréments, etc)
+      </li>
+      <li>- RNDTS pour les déchets déclarés</li>
+      <li>
+        - GUN (outil de l'inspection des installations classées) pour les
+        données ICPE (rubriques, capacités etc)
+      </li>
+    </ul>
+    <br />
+    <p>
+      En cas de constat d'erreur sur le fiche, il convient donc de procéder aux
+      révisions prévues dans les outils, en aucun cas, le support n'interviendra
+      pour des corrections de fiche.
+    </p>
+    <br />
+    <p>
+      Si une fiche est en erreur, inutile de nous en informer, nous sommes en
+      copie des remontées d'erreurs.
+    </p>
+    <br />
+    <p>
+      Les données sont encore sous beta-test et vous pouvez consulter la
+      documentation en FAQ pour savoir à quoi elle correspondent.
+    </p>
+    <br />
+    <p>
+      Les données sont mises à jour toutes les 24h concernant Trackdéchets, et
+      peuvent être mise à jour tous les mois, ou trimestres, concernant les
+      autres sources.
+    </p>
+  </div>
+);
+
+const CompanyDigestDownload = ({ companyDigests, year, onClick }) => {
+  const [getPdf] = useLazyQuery<
+    Pick<Query, "companyDigestPdf">,
+    QueryCompanyDigestPdfArgs
+  >(COMPANY_DIGEST_PDF);
+
+  const companyDigest = companyDigests.find(el => el?.year === year);
+
+  const downloadIsReady = companyDigest?.state === "PROCESSED";
+  const downloadIsPending = companyDigest?.state === "PENDING";
+  const downloadIsFailing = companyDigest?.state === "ERROR";
+
+  const label = `${
+    downloadIsReady ? "Télécharger" : `Générer l'année ${year}`
+  }  `;
+
+  const generatedLabel = downloadIsReady
+    ? `Générée aujourd'hui à ${format(
+        new Date(companyDigest.updatedAt),
+        "HH:mm"
+      )} `
+    : "Non générée aujourd'hui";
+
+  const iconId = downloadIsPending
+    ? "fr-icon-refresh-line"
+    : "fr-icon-file-download-line";
+
+  const action = downloadIsReady
+    ? () =>
+        getPdf({
+          variables: { id: companyDigest.id },
+          onCompleted: r => {
+            if (r.companyDigestPdf.downloadLink == null) {
+              return;
+            }
+
+            window.open(r.companyDigestPdf.downloadLink, "_blank");
+          }
+        })
+    : onClick;
+
+  return (
+    <div>
+      <Button
+        onClick={action}
+        priority="secondary"
+        iconId={iconId}
+        iconPosition="right"
+        disabled={downloadIsPending}
+      >
+        {label}
+      </Button>
+      {downloadIsPending && (
+        <Alert
+          severity="warning"
+          className="fr-mt-2w"
+          small
+          description="La génération de la fiche est en file d’attente. Elle sera disponible dans quelques minutes. "
+        />
+      )}
+      {downloadIsFailing && (
+        <Alert
+          severity="error"
+          className="fr-mt-2w"
+          small
+          description="La génération de la fiche a échoué. Vous pouvez essayer à nouveau."
+        />
+      )}
+      <p className="fr-mt-2w">{generatedLabel}</p>
+    </div>
+  );
+};
+
+const CompanyDigestSheetForm = ({ company }) => {
+  const { data, loading, error, refetch, startPolling, stopPolling } = useQuery<
+    Pick<Query, "companyDigests">,
+    QueryCompanyDigestsArgs
+  >(COMPANY_DIGEST, {
+    fetchPolicy: "network-only",
+    variables: { orgId: company.siret }
+  });
+
+  const [createCompanyDigest] = useMutation<
+    Pick<Mutation, "createCompanyDigest">,
+    MutationCreateCompanyDigestArgs
+  >(CREATE_COMPANY_DIGEST);
+
+  const currentYear = new Date().getFullYear();
+  const lastYear = currentYear - 1;
+
+  if (error) {
+    return <NotificationError apolloError={error} />;
+  }
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (data?.companyDigests) {
+    if (
+      data?.companyDigests.some(c =>
+        ["PENDING", "INITIAL"].includes(c?.state ?? "")
+      )
+    ) {
+      console.log(data?.companyDigests);
+
+      startPolling(500);
+    } else {
+      stopPolling();
+    }
+  }
+  return (
+    <div>
+      <h1 className="fr-h5">
+        Fiche établissement{" "}
+        <span className="fr-badge fr-badge--purple-glycine">VERSION BETA</span>
+      </h1>
+
+      <Alert description={Description()} severity="info" small />
+      <div className="fr-my-2w">
+        <CompanyDigestDownload
+          companyDigests={data?.companyDigests}
+          year={lastYear}
+          onClick={async () => {
+            await createCompanyDigest({
+              variables: { input: { year: lastYear, orgId: company.siret } }
+            });
+            refetch();
+          }}
+        />
+      </div>
+      <div>
+        <CompanyDigestDownload
+          companyDigests={data?.companyDigests}
+          year={currentYear}
+          onClick={async () => {
+            await createCompanyDigest({
+              variables: {
+                input: { year: currentYear, orgId: company.siret }
+              }
+            });
+            refetch();
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CompanyDigestSheetForm;

--- a/front/src/Apps/Companies/CompanyDigestSheet/queries.ts
+++ b/front/src/Apps/Companies/CompanyDigestSheet/queries.ts
@@ -1,0 +1,35 @@
+import { gql } from "@apollo/client";
+export const COMPANY_DIGEST = gql`
+  query CompanyDigests($orgId: String!) {
+    companyDigests(orgId: $orgId) {
+      id
+      createdAt
+      updatedAt
+      year
+      orgId
+      distantId
+      state
+    }
+  }
+`;
+export const CREATE_COMPANY_DIGEST = gql`
+  mutation CreateCompanyDigest($input: CompanyDigestCreateInput!) {
+    createCompanyDigest(input: $input) {
+      id
+      createdAt
+      updatedAt
+      year
+      orgId
+      distantId
+      state
+    }
+  }
+`;
+export const COMPANY_DIGEST_PDF = gql`
+  query CompanyDigestPdf($id: ID!) {
+    companyDigestPdf(id: $id) {
+      downloadLink
+      token
+    }
+  }
+`;

--- a/front/src/Apps/Companies/common/fragments.ts
+++ b/front/src/Apps/Companies/common/fragments.ts
@@ -356,6 +356,7 @@ export const CompanyDetailsfragment = {
       siret
       vatNumber
       userRole
+      featureFlags
       ...AccountCompanyInfoFragment
       ...AccountCompanySecurityFragment
       ...AccountCompanyMemberListFragment

--- a/front/src/scss/Spinner.scss
+++ b/front/src/scss/Spinner.scss
@@ -1,0 +1,12 @@
+.spinning {
+  display: inline-block;
+  animation: rotating 1s infinite linear;
+}
+@keyframes rotating {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}

--- a/front/src/scss/index.scss
+++ b/front/src/scss/index.scss
@@ -13,6 +13,7 @@
 @import "./Notifications.scss";
 @import "./Panels.scss";
 @import "./Dashboard.scss";
+@import "./Spinner.scss";
 
 @font-face {
   font-family: "marianne-td";

--- a/libs/back/env/src/index.ts
+++ b/libs/back/env/src/index.ts
@@ -133,7 +133,11 @@ export const schema = z.object({
     .optional()
     .default("false")
     .refine(isBoolean),
-  MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER: z.string().datetime().optional()
+  MAX_WEIGHT_BY_ROAD_VALIDATE_AFTER: z.string().datetime().optional(),
+  GERICO_API_URL: z.string().optional(),
+  GERICO_API_KEY: z.string().optional(),
+  GERICO_WEBHOOK_SLUG: z.string(),
+  GERICO_WEBHOOK_TOKEN: z.string()
 });
 
 export const envVariables = schema.superRefine((val, ctx) => {

--- a/libs/back/prisma/src/migrations/20240618130754_add_company_digest/migration.sql
+++ b/libs/back/prisma/src/migrations/20240618130754_add_company_digest/migration.sql
@@ -1,0 +1,28 @@
+-- CreateEnum
+CREATE TYPE "CompanyDigestStatus" AS ENUM ('INITIAL', 'PENDING', 'PROCESSED', 'ERROR');
+
+-- CreateTable
+CREATE TABLE "CompanyDigest" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "distantId" TEXT,
+    "state" "CompanyDigestStatus" NOT NULL DEFAULT 'INITIAL',
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "userId" VARCHAR(30),
+
+    CONSTRAINT "CompanyDigest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_CompanyDigestOrgIdIdx" ON "CompanyDigest"("orgId");
+
+-- CreateIndex
+CREATE INDEX "_CompanyDigestYearIdx" ON "CompanyDigest"("year");
+
+-- CreateIndex
+CREATE INDEX "_CompanyDigestStatedIdx" ON "CompanyDigest"("state");
+
+-- AddForeignKey
+ALTER TABLE "CompanyDigest" ADD CONSTRAINT "CompanyDigest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/libs/back/prisma/src/migrations/20240618145537_company_feature_flags/migration.sql
+++ b/libs/back/prisma/src/migrations/20240618145537_company_feature_flags/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "featureFlags" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -289,6 +289,7 @@ model Company {
   companyAssociations                  CompanyAssociation[]
   allowBsdasriTakeOverWithoutSignature Boolean                   @default(false)
   allowAppendix1SignatureAutomation    Boolean                   @default(false)
+  featureFlags                         String[]                  @default([])
   MembershipRequest                    MembershipRequest[]
   // Révisions
   bsdaRevisionRequests                 BsdaRevisionRequest[]
@@ -852,6 +853,7 @@ model User {
   bsdasriOperationignatures  Bsdasri[]            @relation("BsdasriOperationSignature")
   Form                       Form[]
   UserActivationHash         UserActivationHash[]
+  CompanyDigest              CompanyDigest[]
 }
 
 enum GovernmentPermission {
@@ -1826,6 +1828,31 @@ model MigrationScript {
   startedAt  DateTime  @default(now()) @db.Timestamptz(6)
   finishedAt DateTime? @db.Timestamptz(6)
   error      String?
+}
+
+model CompanyDigest {
+  id        String              @id @default(cuid())
+  orgId     String
+  year      Int
+  distantId String?
+  state     CompanyDigestStatus @default(INITIAL)
+
+  createdAt DateTime @default(now()) @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @db.Timestamptz(6)
+  userId    String?  @db.VarChar(30)
+  user      User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([orgId], map: "_CompanyDigestOrgIdIdx")
+  @@index([year], map: "_CompanyDigestYearIdx")
+  @@index([state], map: "_CompanyDigestStatedIdx")
+  @@index([distantId], map: "_CompanyDigestdDstantIdIdx")
+}
+
+enum CompanyDigestStatus {
+  INITIAL
+  PENDING
+  PROCESSED
+  ERROR
 }
 
 enum RevisionRequestStatus {


### PR DESCRIPTION


 

https://github.com/MTES-MCT/trackdechets/assets/878396/7b052617-2ed8-4f97-8e7f-7256e30121b9


 

NB: Fonctionalités en beta

Les utilisateurs ont la possibilité de télécharger des fiches d'établissment en pdf.

### Principes techniques

L'application Gerico (fiche établissement) dispose d'une api rest nantie de 3 endpoints:

- /<secret-slug>/api/v1/create: POST {orgId, year} création d'une fiche établissment dont la génration se fera en asynchrone
- /<secret-slug>/api/v1/sheet/<sheetId> : GET récupère le statut de la fiche
- /<secret-slug>/api/v1/pdf/<sheetId> : GET télécharge le pdf de la fiche

Gerico envoie un webhook sur le back de Trackdechets (POST, {sheetId, status}) pour le notifier de la fin de la génération de la fiche

### Beta

La fonctionnalité sera ouverte progressivement pour permettre d'ajuster les capacités de l'infrastructure.

### Limitations

La fonctionnalité est réservée aux utilisateurs UI.
L'utilisateur doit être membre de l'établissement concerné.
Seules les années N et N-1 sont accessibles.
Une seule fiche est générable par jour et par établissement.
Chaque établissement est autorisé par un featureFlag.

### Base de données

Le modèle CompanyDigest centralise les données persistés necessaires à cette fonctionalité.
Le modèle Compay reçoit une nouvelle colonne featureFlags (string[]) dans lequel la présence de la chaine `COMPANY_DIGEST` détermine l'accès à la fonctionalité.
CompanyDigest comporte user pour suivre l'utilisateur à l'origine de la demande

### Webhook

Le router présent back/src/routers/gericoWebhookRouter.ts gère les webhooks envoyés par gérico.
Les webhooks sont authentifiés par un header contenant un token hardcodé en variable d'environnement

### Api Trackdéchets

L'api TD reçoit 1 mutations et 2 queries privées.

### Api Gerico

Les requêtes sont authentifiées par un token renseigné en variable d'env

### Recette et développement

Il n'existe à ce jour qu'une seule instance de Gerico, aussi le webhook ne sera adressé que vers une seule instance de Trackdéchets. En recette, penser à utiliser des entreprises existantes en production, les entreprises fictives où non inscrites en production ne fonctionneront pas

 ### Synoptique

<img width="726" alt="Capture d’écran 2024-06-24 à 18 18 32" src="https://github.com/MTES-MCT/trackdechets/assets/878396/09572da7-efdc-423a-894a-399caf784dc5">

 


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14215)
