### PR TITLE
[Hotfix] Dupliquer un VHU ou DASRI ne devrait pas dupliquer les destinationOperationCode & Mode

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -456,4 +456,36 @@ describe("Mutation.duplicateBsdasri", () => {
     expect(duplicatedDasri.emitterWasteVolume).toBeNull();
     expect(duplicatedDasri.emitterWastePackagings).toStrictEqual([]);
   });
+
+  it("should *not* duplicate destinationOperationCode & Mode", async () => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(company),
+        destinationOperationCode: "R1",
+        destinationOperationMode: "VALORISATION_ENERGETIQUE"
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data, errors } = await mutate<Pick<Mutation, "duplicateBsdasri">>(
+      DUPLICATE_DASRI,
+      {
+        variables: {
+          id: dasri.id
+        }
+      }
+    );
+    expect(errors).toBeUndefined();
+
+    // When
+    const duplicatedDasri = await prisma.bsdasri.findFirstOrThrow({
+      where: { id: data.duplicateBsdasri.id }
+    });
+
+    expect(duplicatedDasri.destinationOperationCode).toBeNull();
+    expect(duplicatedDasri.destinationOperationMode).toBeNull();
+  });
 });

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -90,6 +90,8 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     destinationReceptionSignatureAuthor,
 
     destinationOperationDate,
+    destinationOperationCode,
+    destinationOperationMode,
 
     operationSignatoryId,
     destinationOperationSignatureDate,

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -396,4 +396,33 @@ describe("mutaion.duplicateBsvhu", () => {
       "updated destination address"
     );
   });
+
+  it("should *not* duplicate destinationOperationCode & Mode", async () => {
+    // Given
+    const emitter = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: { emitterCompanySiret: emitter.company.siret,
+        destinationOperationCode: "R1",
+        destinationOperationMode: "VALORISATION_ENERGETIQUE"
+      }
+    });
+    const { mutate } = makeClient(emitter.user);
+
+    // When
+    const { data, errors } = await mutate<Pick<Mutation, "duplicateBsvhu">>(
+      DUPLICATE_BVHU,
+      {
+        variables: { id: bsvhu.id }
+      }
+    );
+    expect(errors).toBeUndefined();
+
+    // Then
+    const duplicatedVhu = await prisma.bsvhu.findFirstOrThrow({
+      where: { id: data.duplicateBsvhu.id }
+    });
+
+    expect(duplicatedVhu.destinationOperationCode).toBeNull();
+    expect(duplicatedVhu.destinationOperationMode).toBeNull();
+  });
 });

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -401,7 +401,8 @@ describe("mutaion.duplicateBsvhu", () => {
     // Given
     const emitter = await userWithCompanyFactory("MEMBER");
     const bsvhu = await bsvhuFactory({
-      opt: { emitterCompanySiret: emitter.company.siret,
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
         destinationOperationCode: "R1",
         destinationOperationMode: "VALORISATION_ENERGETIQUE"
       }

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -51,6 +51,7 @@ async function getDuplicateData(
     destinationReceptionDate,
     destinationOperationDate,
     destinationOperationCode,
+    destinationOperationMode,
     destinationOperationSignatureAuthor,
     destinationOperationSignatureDate,
     ...rest


### PR DESCRIPTION
# Contexte

Aujourd'hui quand on duplique un DASRI ou un VHU, on duplique le destinationOperationCode, mais pas le mode, ce qui cause des problèmes dans le workflow plus tard. 

On ne devrait dupliquer ni l'un, ni l'autre.

# Ticket Favro

[[BUG] Dupliquer un VHU ou un DASRI ne devrait pas dupliquer destinationOperationCode & Mode](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14609)
