### PR TITLE
Corrige le message d'erreur des destinations non inscrites en crématorium

### DIFF
--- a/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
@@ -708,7 +708,7 @@ describe("Mutation.Bspaoh.create", () => {
       expect.objectContaining({
         message:
           `L'entreprise avec le SIRET "${destinationCompany.siret}" n'est pas inscrite sur ` +
-          `Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut donc pas être visée sur le bordereau. ` +
+          `Trackdéchets en tant que crématorium. Cette installation ne peut donc pas être visée sur le bordereau. ` +
           `Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`,
         extensions: expect.objectContaining({
           code: ErrorCode.BAD_USER_INPUT

--- a/back/src/bspaoh/validation/__tests__/validation.integration.ts
+++ b/back/src/bspaoh/validation/__tests__/validation.integration.ts
@@ -360,7 +360,7 @@ describe("BSPAOH validation", () => {
 
       expect(result.error.issues[0].message).toBe(
         `L'entreprise avec le SIRET "${company.siret}" n'est pas inscrite` +
-          ` sur Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut` +
+          ` sur Trackdéchets en tant que crématorium. Cette installation ne peut` +
           ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
           ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
       );

--- a/back/src/bspaoh/validation/dynamicRefinements.ts
+++ b/back/src/bspaoh/validation/dynamicRefinements.ts
@@ -191,7 +191,7 @@ export async function isCrematoriumRefinement(siret: string, ctx) {
       code: z.ZodIssueCode.custom,
       message:
         `L'entreprise avec le SIRET "${siret}" n'est pas inscrite` +
-        ` sur Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut` +
+        ` sur Trackdéchets en tant que crématorium. Cette installation ne peut` +
         ` donc pas être visée sur le bordereau. Veuillez vous rapprocher de l'administrateur de cette installation pour qu'il` +
         ` modifie le profil de l'établissement depuis l'interface Trackdéchets Mon Compte > Établissements`
     });

--- a/front/src/Apps/common/Components/Modal/DsfrModal.tsx
+++ b/front/src/Apps/common/Components/Modal/DsfrModal.tsx
@@ -24,7 +24,7 @@ export function DsfrModal({
   onClose,
   size = "M",
   closeLabel = "Fermer",
-  padding
+  padding = true
 }: Readonly<DsfrModalProps>) {
   // Handling react-dsfr modal is a bit hacky and tricky to customize, let's stick to a dsfr-ized custom modal component
   // Dsrf modal is vertically centered, it does not play nicely with tabs and varying children height, so we override the flex

--- a/front/src/form/bspaoh/FormContainer.tsx
+++ b/front/src/form/bspaoh/FormContainer.tsx
@@ -12,7 +12,6 @@ export default function FormContainer() {
       onClose={() => navigate(-1)}
       closeLabel="Annuler"
       size="BSD_FORM"
-      padding={true}
     >
       <ControlledTabs bsdId={id} />
     </DsfrModal>


### PR DESCRIPTION
Le message:

L'entreprise avec le xxx n'est pas inscrite sur Trackdéchets en tant que crématorium et ne dispose pas d'une capacité de crémation. Cette installation ne peut donc pas être visée sur le bordereau.

devient

L'entreprise avec le xxx n'est pas inscrite su Trackdéchets en tant que crématorium. Cette installation ne peut donc pas être visée sur le bordereau.

Au passage correction du padding des modales paoh.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14435)
