### PR TITLE
[Bugfix] Correction de la tâche "npx nx dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "scalingo-postbuild": "bash scripts/build/scalingo.sh",
     "nx": "nx",
-    "dev": "npx nx run-many -t serve --parallel=6 --projects=front,api,tag:backend:background",
+    "dev": "npx nx run-many -t serve --parallel=7 --projects=front,api,tag:backend:background",
     "bg:integration": "npx nx run-many -t serve --configuration=integration --projects=tag:backend:queues --parallel=5",
     "afterpull": "npm i ; npx prisma migrate dev ; npx nx run back:codegen ; npx nx run @td/codegen-ui:build"
   },


### PR DESCRIPTION
# Contexte

Depuis que Laurent a ajouté Gerico à la liste des patentes qui se lancent avec `npx nx dev`, il faut ajouter un thread.
