### PR TITLE
[TRA-14633] Ajout d'un outil de visualisation des données entreprise pour les admins

### DIFF
--- a/back/src/companies/resolvers/Query.ts
+++ b/back/src/companies/resolvers/Query.ts
@@ -5,6 +5,7 @@ import searchCompanies from "./queries/searchCompanies";
 import favorites from "./queries/favorites";
 import ecoOrganismes from "./queries/ecoOrganismes";
 import companiesForVerification from "./queries/companiesForVerification";
+import companyExhaustive from "./queries/companyExhaustive";
 
 const Query: QueryResolvers = {
   companyInfos,
@@ -12,7 +13,8 @@ const Query: QueryResolvers = {
   searchCompanies,
   favorites,
   ecoOrganismes,
-  companiesForVerification
+  companiesForVerification,
+  companyExhaustive
 };
 
 export default Query;

--- a/back/src/companies/resolvers/queries/companyExhaustive.ts
+++ b/back/src/companies/resolvers/queries/companyExhaustive.ts
@@ -1,0 +1,124 @@
+import { QueryResolvers } from "../../../generated/graphql/types";
+
+import { checkIsAdmin } from "../../../common/permissions";
+import { applyAuthStrategies, AuthType } from "../../../auth";
+import { prisma } from "@td/prisma";
+import { searchCompanyTD } from "../../sirene/trackdechets/client";
+import { searchCompanySirene } from "../../sirene/insee/client";
+import { AnonymousCompany, Company } from "@prisma/client";
+import { SireneSearchResult } from "../../sirene/types";
+import { isSiret } from "@td/constants";
+import { UserInputError } from "../../../common/errors";
+
+const formatEtatAdministratif = etat => {
+  if (etat === "A") return "A (Active)";
+  if (etat === "F") return "F (Fermé)";
+  if (etat === "C") return "C (Cessée)";
+  return null;
+};
+
+const formatStatutDiffusion = status => {
+  if (status === "O") return "O (Diffusible)";
+  if (status === "P") return "P (Diffusion Partielle)";
+  return null;
+};
+
+const formatAnonymousCompany = (company?: AnonymousCompany | null) => {
+  return {
+    siret: company?.siret,
+    name: company?.name,
+    contact: null,
+    address: company?.address,
+    createdAt: null,
+    etatAdministratif: null,
+    statutDiffusion: null,
+    codeNaf: company?.codeNaf
+  };
+};
+
+const formatDBCompany = (company?: Company | null) => {
+  return {
+    name: company?.name,
+    siret: company?.siret,
+    contact: company?.contact,
+    address: company?.address,
+    createdAt: company?.createdAt,
+    etatAdministratif: null,
+    statutDiffusion: null,
+    codeNaf: company?.codeNaf
+  };
+};
+
+const formatESCompany = (company?: SireneSearchResult | null) => {
+  return {
+    name: company?.name,
+    siret: company?.siret,
+    contact: null,
+    address: company?.address,
+    createdAt: null,
+    etatAdministratif: formatEtatAdministratif(company?.etatAdministratif),
+    statutDiffusion: formatStatutDiffusion(
+      company?.statutDiffusionEtablissement
+    ),
+    codeNaf: company?.naf
+  };
+};
+
+const formatSireneCompany = (company?: SireneSearchResult) => {
+  return {
+    name: company?.name,
+    siret: company?.siret,
+    contact: null,
+    address: company?.address,
+    createdAt: null,
+    etatAdministratif: formatEtatAdministratif(company?.etatAdministratif),
+    statutDiffusion: formatStatutDiffusion(
+      company?.statutDiffusionEtablissement
+    ),
+    codeNaf: company?.naf
+  };
+};
+
+const companyExhaustiveResolvers: QueryResolvers["companyExhaustive"] = async (
+  _,
+  { siret },
+  context
+) => {
+  applyAuthStrategies(context, [AuthType.Session]);
+  checkIsAdmin(context);
+
+  if (!isSiret(siret)) {
+    throw new UserInputError("Le siret renseigné n'est pas valide");
+  }
+
+  const anonymousCompany = await prisma.anonymousCompany.findFirst({
+    where: { siret }
+  });
+
+  const dbCompany = await prisma.company.findFirst({
+    where: { siret }
+  });
+
+  let esCompany;
+  try {
+    esCompany = await searchCompanyTD(siret);
+  } catch (e) {
+    //
+  }
+
+  let sireneCompany;
+  try {
+    sireneCompany = await searchCompanySirene(siret);
+  } catch (e) {
+    //
+  }
+
+  return {
+    anonymousCompany: formatAnonymousCompany(anonymousCompany),
+    dbCompany: formatDBCompany(dbCompany),
+    esCompany: formatESCompany(esCompany),
+    sireneCompany: formatSireneCompany(sireneCompany)
+  };
+};
+
+export default companyExhaustiveResolvers;

--- a/back/src/companies/resolvers/queries/companyExhaustive.ts
+++ b/back/src/companies/resolvers/queries/companyExhaustive.ts
@@ -12,8 +12,8 @@ import { UserInputError } from "../../../common/errors";
 
 const formatEtatAdministratif = etat => {
   if (etat === "A") return "A (Active)";
-  if (etat === "F") return "F (Fermé)";
-  if (etat === "C") return "C (Cessée)";
+  if (etat === "F") return "F (Etablissement fermé)";
+  if (etat === "C") return "C (Unité légale cessée)";
   return null;
 };
 

--- a/back/src/companies/sirene/insee/client.ts
+++ b/back/src/companies/sirene/insee/client.ts
@@ -16,7 +16,7 @@ import {
   StatutDiffusionEtablissement
 } from "../../../generated/graphql/types";
 
-const SIRENE_API_BASE_URL = "https://api.insee.fr/entreprises/sirene/V3";
+const SIRENE_API_BASE_URL = "https://api.insee.fr/entreprises/sirene/V3.11";
 export const SEARCH_COMPANIES_MAX_SIZE = 20;
 
 /**
@@ -81,6 +81,12 @@ function searchResponseToCompany({
   return company;
 }
 
+export const searchCompanySirene = async siret => {
+  const searchUrl = `${SIRENE_API_BASE_URL}/siret/${siret}`;
+  const response = await authorizedAxiosGet<SearchResponseInsee>(searchUrl);
+  return searchResponseToCompany(response.data);
+};
+
 /**
  * Search a company by SIRET
  * @param siret
@@ -89,11 +95,8 @@ export async function searchCompany(
   siret: string,
   _source_includes?: string[] // ignored
 ): Promise<SireneSearchResult> {
-  const searchUrl = `${SIRENE_API_BASE_URL}/siret/${siret}`;
-
   try {
-    const response = await authorizedAxiosGet<SearchResponseInsee>(searchUrl);
-    const company = searchResponseToCompany(response.data);
+    const company = await searchCompanySirene(siret);
 
     if (company.etatAdministratif === ("F" as EtatAdministratif)) {
       throw new ClosedCompanyError();

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -31,7 +31,7 @@ const index = process.env.TD_COMPANY_ELASTICSEARCH_INDEX;
  * Build a company object from a search response
  * @param data etablissement response object
  */
-const searchResponseToCompany = (
+export const searchResponseToCompany = (
   etablissement: SearchStockEtablissement
 ): SireneSearchResult => {
   const addressVoie = buildAddress([
@@ -72,6 +72,28 @@ const searchResponseToCompany = (
   return company;
 };
 
+export const searchCompanyTD = async (siret: string) => {
+  const response = await client.search<SearchResponse>({
+    index,
+    body: {
+      query: {
+        term: {
+          siret: {
+            value: siret
+          }
+        }
+      }
+    }
+  });
+
+  if (!response.body.hits.hits || !response.body.hits.hits[0]?._source) {
+    throw new SiretNotFoundError();
+  }
+  const company = searchResponseToCompany(response.body.hits.hits[0]._source);
+
+  return company;
+};
+
 /**
  * Search a company by SIRET
  * @param siret
@@ -80,22 +102,7 @@ export const searchCompany = async (
   siret: string
 ): Promise<SireneSearchResult> => {
   try {
-    const response = await client.search<SearchResponse>({
-      index,
-      body: {
-        query: {
-          term: {
-            siret: {
-              value: siret
-            }
-          }
-        }
-      }
-    });
-    if (!response.body.hits.hits || !response.body.hits.hits[0]?._source) {
-      throw new SiretNotFoundError();
-    }
-    const company = searchResponseToCompany(response.body.hits.hits[0]._source);
+    const company = await searchCompanyTD(siret);
 
     if (company.etatAdministratif === ("F" as EtatAdministratif)) {
       throw new ClosedCompanyError();

--- a/back/src/companies/sirene/trackdechets/client.ts
+++ b/back/src/companies/sirene/trackdechets/client.ts
@@ -89,9 +89,8 @@ export const searchCompanyTD = async (siret: string) => {
   if (!response.body.hits.hits || !response.body.hits.hits[0]?._source) {
     throw new SiretNotFoundError();
   }
-  const company = searchResponseToCompany(response.body.hits.hits[0]._source);
 
-  return company;
+  return searchResponseToCompany(response.body.hits.hits[0]._source);
 };
 
 /**

--- a/back/src/companies/typeDefs/private/company.objects.graphql
+++ b/back/src/companies/typeDefs/private/company.objects.graphql
@@ -173,3 +173,21 @@ type CompanySearchPrivate implements CompanySearchPrivateCommon {
   """
   workerCertification: WorkerCertification
 }
+
+type CompanyExhaustiveInfo {
+  siret: String
+  name: String
+  contact: String
+  address: String
+  createdAt: DateTime
+  etatAdministratif: String
+  statutDiffusion: String
+  codeNaf: String
+}
+
+type CompanyExhaustive {
+  anonymousCompany: CompanyExhaustiveInfo!
+  dbCompany: CompanyExhaustiveInfo!
+  esCompany: CompanyExhaustiveInfo!
+  sireneCompany: CompanyExhaustiveInfo!
+}

--- a/back/src/companies/typeDefs/private/company.queries.graphql
+++ b/back/src/companies/typeDefs/private/company.queries.graphql
@@ -37,4 +37,6 @@ type Query {
     """
     clue: String!
   ): CompanySearchPrivate!
+
+  companyExhaustive(siret: String!): CompanyExhaustive!
 }

--- a/front/src/Apps/routes.ts
+++ b/front/src/Apps/routes.ts
@@ -2,6 +2,7 @@ const routes = {
   admin: {
     index: "/admin",
     verification: "/admin/verification",
+    companies: "/admin/companies",
     anonymousCompany: "/admin/anonymous-company",
     reindex: "/admin/reindex",
     user: "/admin/user",

--- a/front/src/admin/Admin.tsx
+++ b/front/src/admin/Admin.tsx
@@ -11,6 +11,7 @@ import "../Apps/Dashboard/dashboard.scss";
 import { Impersonate } from "./user/impersonate";
 import { Registry } from "./registry/Registry";
 import { MembersAdmin } from "./company/MembersAdmin";
+import { CompaniesDashboard } from "./companies/CompaniesDashboard";
 
 const toRelative = route => {
   return getRelativeRoute(routes.admin.index, route);
@@ -35,6 +36,18 @@ export default function Admin() {
                 }
               >
                 Vérification
+              </NavLink>
+            </li>
+            <li className="tw-mb-1">
+              <NavLink
+                to={routes.admin.companies}
+                className={({ isActive }) =>
+                  isActive
+                    ? "sidebarv2__item sidebarv2__item--indented sidebarv2__item--active"
+                    : "sidebarv2__item sidebarv2__item--indented"
+                }
+              >
+                Entreprises
               </NavLink>
             </li>
             <li className="tw-mb-1">
@@ -118,6 +131,11 @@ export default function Admin() {
           <Route
             path={toRelative(routes.admin.verification)}
             element={<CompaniesVerification />}
+          />
+
+          <Route
+            path={toRelative(routes.admin.companies)}
+            element={<CompaniesDashboard />}
           />
 
           <Route

--- a/front/src/admin/companies/CompaniesDashboard.tsx
+++ b/front/src/admin/companies/CompaniesDashboard.tsx
@@ -71,7 +71,7 @@ export const CompaniesDashboard = () => {
   > = async data => {
     const { siret } = data;
 
-    companiesExhaustive({ variables: { siret: "AAA" } });
+    companiesExhaustive({ variables: { siret } });
   };
 
   const { handleSubmit, reset, formState, register } = useForm<

--- a/front/src/admin/companies/CompaniesDashboard.tsx
+++ b/front/src/admin/companies/CompaniesDashboard.tsx
@@ -74,7 +74,7 @@ export const CompaniesDashboard = () => {
     companiesExhaustive({ variables: { siret } });
   };
 
-  const { handleSubmit, reset, formState, register } = useForm<
+  const { handleSubmit, formState, register } = useForm<
     z.infer<typeof validationSchema>
   >({ resolver: zodResolver(validationSchema) });
 
@@ -106,9 +106,7 @@ export const CompaniesDashboard = () => {
       {error && <DsfrNotificationError apolloError={error} />}
 
       {!loading && Boolean(data?.companyExhaustive) && !Boolean(error) && (
-        <>
-          <CompaniesTable data={data?.companyExhaustive} />
-        </>
+        <CompaniesTable data={data?.companyExhaustive} />
       )}
     </div>
   );

--- a/front/src/admin/companies/CompaniesDashboard.tsx
+++ b/front/src/admin/companies/CompaniesDashboard.tsx
@@ -9,7 +9,7 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { Loader } from "../../Apps/common/Components";
 import { DsfrNotificationError } from "../../Apps/common/Components/Error/Error";
-import CompaniesTable from "./CompanyTable";
+import CompanyTable from "./CompanyTable";
 
 export const companyExhaustiveInfoFragment = gql`
   fragment CompanyExhaustiveInfoFragment on CompanyExhaustiveInfo {
@@ -78,6 +78,12 @@ export const CompaniesDashboard = () => {
     z.infer<typeof validationSchema>
   >({ resolver: zodResolver(validationSchema) });
 
+  const showTable =
+    !loading &&
+    Boolean(data) &&
+    Boolean(data?.companyExhaustive) &&
+    !Boolean(error);
+
   return (
     <div>
       <h3 className="fr-h3 fr-mt-2w">Entreprises</h3>
@@ -105,9 +111,7 @@ export const CompaniesDashboard = () => {
 
       {error && <DsfrNotificationError apolloError={error} />}
 
-      {!loading && Boolean(data?.companyExhaustive) && !Boolean(error) && (
-        <CompaniesTable data={data?.companyExhaustive} />
-      )}
+      {showTable && <CompanyTable data={data?.companyExhaustive!} />}
     </div>
   );
 };

--- a/front/src/admin/companies/CompaniesDashboard.tsx
+++ b/front/src/admin/companies/CompaniesDashboard.tsx
@@ -1,0 +1,115 @@
+import { useLazyQuery } from "@apollo/client";
+import gql from "graphql-tag";
+import React from "react";
+import { Query } from "@td/codegen-ui";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, SubmitHandler } from "react-hook-form";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { Loader } from "../../Apps/common/Components";
+import { DsfrNotificationError } from "../../Apps/common/Components/Error/Error";
+import CompaniesTable from "./CompanyTable";
+
+export const companyExhaustiveInfoFragment = gql`
+  fragment CompanyExhaustiveInfoFragment on CompanyExhaustiveInfo {
+    siret
+    name
+    contact
+    address
+    createdAt
+    etatAdministratif
+    statutDiffusion
+    codeNaf
+  }
+`;
+
+const COMPANIES_EXHAUSTIVE = gql`
+  ${companyExhaustiveInfoFragment}
+
+  query companyExhaustive($siret: String!) {
+    companyExhaustive(siret: $siret) {
+      anonymousCompany {
+        ...CompanyExhaustiveInfoFragment
+      }
+      dbCompany {
+        ...CompanyExhaustiveInfoFragment
+      }
+      esCompany {
+        ...CompanyExhaustiveInfoFragment
+      }
+      sireneCompany {
+        ...CompanyExhaustiveInfoFragment
+      }
+    }
+  }
+`;
+
+const validationSchema = z.object({
+  siret: z
+    .string({
+      required_error: "Le siret est requis"
+    })
+    .transform(value => value.replace(/\s+/g, ""))
+    .pipe(
+      z
+        .string()
+        .min(14, { message: "Le siret doit faire 14 caractères" })
+        .max(14, { message: "Le siret doit faire 14 caractères" })
+    )
+});
+
+export const CompaniesDashboard = () => {
+  const [companiesExhaustive, { data, error, loading }] = useLazyQuery<
+    Pick<Query, "companyExhaustive">
+  >(COMPANIES_EXHAUSTIVE, {
+    fetchPolicy: "network-only"
+  });
+
+  const onSubmit: SubmitHandler<
+    z.infer<typeof validationSchema>
+  > = async data => {
+    const { siret } = data;
+
+    companiesExhaustive({ variables: { siret: "AAA" } });
+  };
+
+  const { handleSubmit, reset, formState, register } = useForm<
+    z.infer<typeof validationSchema>
+  >({ resolver: zodResolver(validationSchema) });
+
+  return (
+    <div>
+      <h3 className="fr-h3 fr-mt-2w">Entreprises</h3>
+
+      <div className="fr-mb-4v">
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Input
+            label="Siret"
+            className="fr-col-3 fr-mb-5v"
+            hintText="Format: 14 chiffres 123 456 789 00099"
+            state={formState.errors.siret ? "error" : "default"}
+            nativeInputProps={{
+              ...register("siret", { required: true })
+            }}
+            stateRelatedMessage={
+              (formState?.errors?.siret?.message as string) ?? ""
+            }
+          />
+
+          <Button disabled={loading}>Rechercher</Button>
+        </form>
+      </div>
+
+      {loading && <Loader />}
+
+      {error && <DsfrNotificationError apolloError={error} />}
+
+      {!loading && Boolean(data?.companyExhaustive) && !Boolean(error) && (
+        <>
+          <CompaniesTable data={data?.companyExhaustive} />
+        </>
+      )}
+    </div>
+  );
+};

--- a/front/src/admin/companies/CompanyTable.tsx
+++ b/front/src/admin/companies/CompanyTable.tsx
@@ -1,0 +1,84 @@
+import { CompanyExhaustive } from "@td/codegen-ui";
+import React, { useMemo } from "react";
+import { useTable } from "react-table";
+import { Table } from "@codegouvfr/react-dsfr/Table";
+
+const rearrangeData = (data: CompanyExhaustive) => {
+  const keys = new Set([
+    ...Object.keys(data.anonymousCompany),
+    ...Object.keys(data.dbCompany),
+    ...Object.keys(data.esCompany),
+    ...Object.keys(data.sireneCompany)
+  ]);
+
+  const keysSorted = Array.from(keys)
+    .filter(key => key !== "__typename")
+    .sort((a, b) => a.localeCompare(b));
+
+  return keysSorted.map(key => ({
+    field: key,
+    anonymous: data?.anonymousCompany[key] ?? "",
+    db: data?.dbCompany[key] ?? "",
+    es: data?.esCompany[key] ?? "",
+    sirene: data?.sireneCompany[key] ?? ""
+  }));
+};
+
+type Props = {
+  data?: CompanyExhaustive;
+};
+
+export default function CompaniesTable({ data }: Props) {
+  if (!data) return null;
+
+  // Swap lines & columns for clarity
+  const rearrangedData = rearrangeData(data);
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: "",
+        accessor: "field" as const
+      },
+      {
+        Header: "Anonymous",
+        accessor: "anonymous" as const
+      },
+      {
+        Header: "Base de données",
+        accessor: "db" as const
+      },
+      {
+        Header: "Elastic Search",
+        accessor: "es" as const
+      },
+      {
+        Header: "SIRENE",
+        accessor: "sirene" as const
+      }
+    ],
+    []
+  );
+
+  const tableInstance = useTable({
+    columns,
+    data: rearrangedData
+  });
+
+  const { rows, prepareRow, headerGroups } = tableInstance;
+
+  const tableHeaders = [
+    ...headerGroups[0].headers.map(column => column.render("Header"))
+  ].map(c => <div className="textCenter fr-text--lg">{c}</div>);
+
+  const tableData = rows.map(row => {
+    prepareRow(row);
+    return [...row.cells.map(cell => cell.render("Cell"))];
+  });
+
+  return (
+    <>
+      <Table headers={tableHeaders} data={tableData} fixed />
+    </>
+  );
+}

--- a/front/src/admin/companies/CompanyTable.tsx
+++ b/front/src/admin/companies/CompanyTable.tsx
@@ -1,5 +1,5 @@
 import { CompanyExhaustive } from "@td/codegen-ui";
-import React, { useMemo } from "react";
+import React from "react";
 import { useTable } from "react-table";
 import { Table } from "@codegouvfr/react-dsfr/Table";
 
@@ -25,40 +25,35 @@ const rearrangeData = (data: CompanyExhaustive) => {
 };
 
 type Props = {
-  data?: CompanyExhaustive;
+  data: CompanyExhaustive;
 };
 
-export default function CompaniesTable({ data }: Props) {
-  if (!data) return null;
-
+export default function CompanyTable({ data }: Props) {
   // Swap lines & columns for clarity
   const rearrangedData = rearrangeData(data);
 
-  const columns = useMemo(
-    () => [
-      {
-        Header: "",
-        accessor: "field" as const
-      },
-      {
-        Header: "Anonymous",
-        accessor: "anonymous" as const
-      },
-      {
-        Header: "Base de données",
-        accessor: "db" as const
-      },
-      {
-        Header: "Elastic Search",
-        accessor: "es" as const
-      },
-      {
-        Header: "SIRENE",
-        accessor: "sirene" as const
-      }
-    ],
-    []
-  );
+  const columns = [
+    {
+      Header: "",
+      accessor: "field" as const
+    },
+    {
+      Header: "Anonymous",
+      accessor: "anonymous" as const
+    },
+    {
+      Header: "Base de données",
+      accessor: "db" as const
+    },
+    {
+      Header: "Elastic Search",
+      accessor: "es" as const
+    },
+    {
+      Header: "SIRENE",
+      accessor: "sirene" as const
+    }
+  ];
 
   const tableInstance = useTable({
     columns,


### PR DESCRIPTION
# Contexte

Pour y voir plus clair dans les problèmes de désynchro entre l'API SIRENE et nos propres données, j'ai créé une page admin pour avoir les données côte-à-côte.

# Démo

![demo_admin_companies](https://github.com/MTES-MCT/trackdechets/assets/45355989/cd92a0b7-8464-4264-9aa5-d98cee76bff0)

# Ticket Favro

[Ajout d'un outil de visualisation des données entreprise pour les admins](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ea7309cf84d697a867bc92ea?card=tra-14633)