### PR TITLE
[TRA-14348] Corrections de recette: wording & règles de révision sur le DASRI de sythèse

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -19,7 +19,8 @@ import {
   RevisionRequestStatus,
   UserPermission,
   Transporter,
-  BsdaTransporter
+  BsdaTransporter,
+  BsdasriStatus
 } from "@td/codegen-ui";
 import {
   ACCEPTE,
@@ -1271,6 +1272,11 @@ const canReviewBsda = (bsd, siret) => {
 };
 
 const canReviewBsdasri = (bsd, siret) => {
+  // You can't review a SYNTHESIS dasri with RECEIVED status
+  if (bsd.synthesizing && bsd.status === BsdasriStatus.Received) {
+    return false;
+  }
+
   // these types are not implemented yet
   if ([BsdasriType.Synthesis, BsdasriType.Grouping].includes(bsd.type)) {
     return false;

--- a/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.tsx
+++ b/front/src/dashboard/components/RevisionRequestList/bsdasri/request/BsdasriRequestRevision.tsx
@@ -346,7 +346,7 @@ export function BsdasriRequestRevision({ bsdasri }: Props) {
           )}
 
           <RhfReviewableField
-            title="Quantité reçue"
+            title="Quantité traitée"
             suffix="kg"
             path="destination.operation.weight"
             value={bsdasri?.destination?.operation?.weight?.value}
@@ -378,7 +378,7 @@ export function BsdasriRequestRevision({ bsdasri }: Props) {
             </p>
           </RhfReviewableField>
           <RhfReviewableField
-            title="Code de l’opération D/R"
+            title="Code de l’opération réalisée"
             path="destination.operation.code"
             value={bsdasri?.destination?.operation?.code}
             defaultValue={initialReview?.destination?.operation?.code}


### PR DESCRIPTION
# Contexte

Petits fix de recette sur la révision des DASRI de synthèse:
- Changement de wording dans la modale
- Plus possible de réviser un DASRI de synthèse au statut RECEIVED

# Démo

![demo_wording_dasri_revision](https://github.com/MTES-MCT/trackdechets/assets/45355989/2fe18792-9768-4b53-9b03-306b9dd7d42b)

# Ticket Favro

[Permettre la révision d'un DASRI de synthèse](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14348)
