### PR TITLE
HOTFIX - les poids et volumes ne peuvent être 0 dès la création

### DIFF
--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -175,11 +175,13 @@ export function expandBsffFromDB(
       })
     }),
     packagings: [], // will be resolved in Bsff resolver
-    waste: nullIfNoValues<GraphQL.BsffWaste>({
-      code: prismaBsff.wasteCode,
-      description: prismaBsff.wasteDescription,
-      adr: prismaBsff.wasteAdr
-    }),
+    waste: prismaBsff.wasteCode
+      ? nullIfNoValues<GraphQL.BsffWaste>({
+          code: prismaBsff.wasteCode,
+          description: prismaBsff.wasteDescription,
+          adr: prismaBsff.wasteAdr
+        })
+      : null,
     weight: prismaBsff.weightValue
       ? {
           value: processDecimal(prismaBsff.weightValue).toNumber(),

--- a/back/src/bsffs/database.ts
+++ b/back/src/bsffs/database.ts
@@ -229,7 +229,7 @@ export async function createBsff(
 
   const { packagings, transporters, createdAt, ...parsedZodBsff } =
     await parseBsffAsync(
-      { ...zodBsff, isDraft },
+      { ...zodBsff, isDraft, createdAt: new Date() },
       {
         user,
         currentSignatureType: !isDraft ? "EMISSION" : undefined


### PR DESCRIPTION
En bonus correction d'une erreur qui remonte dans Sentry :
https://sentry.incubateur.net/organizations/betagouv/issues/55625/?project=19&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=8