### PR TITLE
HOTFIX - Pagination infinie sur l'export des établissements lorsque plus de 100 établissements

### DIFF
--- a/back/src/users/resolvers/queries/myCompaniesCsv.ts
+++ b/back/src/users/resolvers/queries/myCompaniesCsv.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@td/prisma";
 import { getFileDownload } from "../../../common/fileDownload";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { QueryResolvers } from "../../../generated/graphql/types";
@@ -11,9 +12,15 @@ export type MyCompaniesCsvArgs = { userId: string };
 export const myCompaniesCsvDownloadHandler: DownloadHandler<MyCompaniesCsvArgs> =
   {
     name: "myCompaniesCsv",
-    handler: (_, res, args) => {
+    handler: async (_, res, { userId }) => {
+      // Liste tous les établissements auxquels appartient l'utilisateur
+      const associations = await prisma.companyAssociation.findMany({
+        where: { userId },
+        select: { companyId: true }
+      });
+      const companyIds = associations.map(a => a.companyId);
       const reader = myCompaniesReader({
-        userId: args.userId,
+        companyIds,
         chunk: 100
       });
       const filename = getCompaniesExportFileName();

--- a/back/src/users/resolvers/queries/myCompaniesXls.ts
+++ b/back/src/users/resolvers/queries/myCompaniesXls.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@td/prisma";
 import { getFileDownload } from "../../../common/fileDownload";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { QueryResolvers } from "../../../generated/graphql/types";
@@ -12,9 +13,15 @@ export type MyCompaniesXlsArgs = { userId: string };
 export const myCompaniesXlsDownloadHandler: DownloadHandler<MyCompaniesXlsArgs> =
   {
     name: "myCompaniesXls",
-    handler: (_, res, args) => {
+    handler: async (_, res, { userId }) => {
+      // Liste tous les établissements auxquels appartient l'utilisateur
+      const associations = await prisma.companyAssociation.findMany({
+        where: { userId },
+        select: { companyId: true }
+      });
+      const companyIds = associations.map(a => a.companyId);
       const reader = myCompaniesReader({
-        userId: args.userId,
+        companyIds,
         chunk: 100
       });
 


### PR DESCRIPTION
 - Oubli du paramètre `after`.
 - Au passage calcul des identifiants à paginer un cran au dessus pour éviter de faire plusieurs fois la requête. 

![Capture d’écran 2024-07-04 à 12 08 32](https://github.com/MTES-MCT/trackdechets/assets/2269165/54c37389-c987-4f01-b09b-4d6264275a75)

---

- [Impossible de télécharger l'export des établissements et membres](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14542)
