### PR TITLE
Registre - corrections et améliorations relatives aux informations de traitement final

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Ajout de la possibilité de gérer les rôles des membres d'une entreprise depuis la liste des membres [PR 3384](https://github.com/MTES-MCT/trackdechets/pull/3384)
 - Ajout d'une gestion des membres d'entreprises pour les admin Trackdéchets [PR 3384](https://github.com/MTES-MCT/trackdechets/pull/3384)
+- Ajout du N°SIRET de la destination finale sur les registres sortants et exhaustifs [PR 3447](https://github.com/MTES-MCT/trackdechets/pull/3447)
 
 #### :bug: Corrections de bugs
 
@@ -25,6 +26,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Le champ allowBsdasriTakeOverWithoutSignature est désormais retourné par la requête companyInfos même pour des entreprises non-diffusibles [PR 3399](https://github.com/MTES-MCT/trackdechets/pull/3399)
 - Le volume total d'un DASRI est désormais un Float, et déprécié [PR 3398](https://github.com/MTES-MCT/trackdechets/pull/3398)
 - Une déchetterie (WASTE_CENTER) non vérifiée peut désormais créer un BSDA COLLECTION_2710 [PR 3436](https://github.com/MTES-MCT/trackdechets/pull/3436)
+- Corriger les données remontées dans la colonne Quantité(s) liée(s) [PR 3447](https://github.com/MTES-MCT/trackdechets/pull/3447)
 
 #### :boom: Breaking changes
 

--- a/back/src/bsda/__tests__/registry.integration.ts
+++ b/back/src/bsda/__tests__/registry.integration.ts
@@ -168,23 +168,29 @@ describe("toOutgoingWaste", () => {
     "should compute destinationFinalOperationCodes" +
       " and destinationfinalOperationWeights",
     async () => {
-      const finalBsda1 = await bsdaFactory({});
-      const finalBsda2 = await bsdaFactory({});
+      const finalBsda1 = await bsdaFactory({
+        opt: { destinationOperationCode: "R 5", destinationReceptionWeight: 1 }
+      });
+      const finalBsda2 = await bsdaFactory({
+        opt: { destinationOperationCode: "D 5", destinationReceptionWeight: 2 }
+      });
 
-      const form = await bsdaFactory({
+      const bsda = await bsdaFactory({
         opt: {
+          destinationOperationCode: "D 13",
+          destinationOperationSignatureDate: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalBsdaId: finalBsda1.id,
-                  operationCode: "R 5",
-                  quantity: 1
+                  operationCode: finalBsda1.destinationOperationCode!,
+                  quantity: finalBsda1.destinationReceptionWeight!
                 },
                 {
                   finalBsdaId: finalBsda2.id,
-                  operationCode: "D 5",
-                  quantity: 2
+                  operationCode: finalBsda2.destinationOperationCode!,
+                  quantity: finalBsda2.destinationReceptionWeight!
                 }
               ]
             }
@@ -192,7 +198,7 @@ describe("toOutgoingWaste", () => {
         }
       });
       const bsdaForRegistry = await prisma.bsda.findUniqueOrThrow({
-        where: { id: form.id },
+        where: { id: bsda.id },
         include: RegistryBsdaInclude
       });
       const waste = toOutgoingWaste(bsdaForRegistry);
@@ -200,7 +206,52 @@ describe("toOutgoingWaste", () => {
         "R 5",
         "D 5"
       ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        0.001, 0.002
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalBsda1.destinationCompanySiret,
+        finalBsda2.destinationCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsda has a final operation",
+    async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          destinationOperationCode: "R 5",
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+
+      await prisma.bsda.update({
+        where: { id: bsda.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalBsdaId: bsda.id,
+                  operationCode: bsda.destinationOperationCode!,
+                  quantity: bsda.destinationReceptionWeight!
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const bsdaForRegistry = await prisma.bsda.findUniqueOrThrow({
+        where: { id: bsda.id },
+        include: RegistryBsdaInclude
+      });
+      const waste = toOutgoingWaste(bsdaForRegistry);
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 
@@ -346,23 +397,29 @@ describe("toAllWaste", () => {
     "should compute destinationFinalOperationCodes" +
       " and destinationfinalOperationWeights",
     async () => {
-      const finalBsda1 = await bsdaFactory({});
-      const finalBsda2 = await bsdaFactory({});
+      const finalBsda1 = await bsdaFactory({
+        opt: { destinationOperationCode: "R 5", destinationReceptionWeight: 1 }
+      });
+      const finalBsda2 = await bsdaFactory({
+        opt: { destinationOperationCode: "D 5", destinationReceptionWeight: 2 }
+      });
 
       const form = await bsdaFactory({
         opt: {
+          destinationOperationCode: "D 13",
+          destinationOperationSignatureDate: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalBsdaId: finalBsda1.id,
-                  operationCode: "R 5",
-                  quantity: 1
+                  operationCode: finalBsda1.destinationOperationCode!,
+                  quantity: finalBsda1.destinationReceptionWeight!
                 },
                 {
                   finalBsdaId: finalBsda2.id,
-                  operationCode: "D 5",
-                  quantity: 2
+                  operationCode: finalBsda2.destinationOperationCode!,
+                  quantity: finalBsda2.destinationReceptionWeight!
                 }
               ]
             }
@@ -378,7 +435,52 @@ describe("toAllWaste", () => {
         "R 5",
         "D 5"
       ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        0.001, 0.002
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalBsda1.destinationCompanySiret,
+        finalBsda2.destinationCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsda has a final operation",
+    async () => {
+      const bsda = await bsdaFactory({
+        opt: {
+          destinationOperationCode: "R 5",
+          destinationOperationSignatureDate: new Date()
+        }
+      });
+
+      await prisma.bsda.update({
+        where: { id: bsda.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalBsdaId: bsda.id,
+                  operationCode: bsda.destinationOperationCode!,
+                  quantity: bsda.destinationReceptionWeight!
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const bsdaForRegistry = await prisma.bsda.findUniqueOrThrow({
+        where: { id: bsda.id },
+        include: RegistryBsdaInclude
+      });
+      const waste = toAllWaste(bsdaForRegistry);
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -85,7 +85,7 @@ const getFinalOperationsData = (
       destinationFinalOperationCodes.push(ope.operationCode);
       destinationFinalOperationWeights.push(
         // conversion en tonnes
-        ope.quantity.dividedBy(1000).toNumber()
+        ope.quantity.dividedBy(1000).toDecimalPlaces(6).toNumber()
       );
       if (ope.finalBsda.destinationCompanySiret) {
         // cela devrait tout le temps être le cas
@@ -360,7 +360,7 @@ export function toOutgoingWaste(bsda: RegistryBsda): Required<OutgoingWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     weight: bsda.weightValue
-      ? bsda.weightValue.dividedBy(1000).toNumber()
+      ? bsda.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
     ...getOperationData(bsda),
     ...getFinalOperationsData(bsda),

--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -23,6 +23,7 @@ import { splitAddress } from "../utils";
 import { getFirstTransporterSync, getTransportersSync } from "./database";
 import { RegistryBsda } from "../registry/elastic";
 import { BsdaForElastic } from "./elastic";
+import { isFinalOperationCode } from "../common/operationCodes";
 
 const getPostTempStorageDestination = (bsda: RegistryBsda) => {
   if (!bsda.forwardedIn) return {};
@@ -57,18 +58,48 @@ const getIntermediariesData = (bsda: RegistryBsda) => ({
   intermediary3CompanySiret: bsda.intermediaries?.[2]?.siret ?? null
 });
 
-const getFinalOperationsData = (bsda: RegistryBsda) => {
+const getFinalOperationsData = (
+  bsda: RegistryBsda
+): Pick<
+  OutgoingWaste | AllWaste,
+  | "destinationFinalOperationCodes"
+  | "destinationFinalOperationWeights"
+  | "destinationFinalOperationCompanySirets"
+> => {
   const destinationFinalOperationCodes: string[] = [];
   const destinationFinalOperationWeights: number[] = [];
+  const destinationFinalOperationCompanySirets: string[] = [];
+
   // Check if finalOperations is defined and has elements
-  if (bsda.finalOperations && bsda.finalOperations.length > 0) {
+  if (
+    bsda.destinationOperationSignatureDate &&
+    bsda.destinationOperationCode &&
+    // Cf tra-14603 => si le code de traitement du bordereau initial est final,
+    // aucun code d'Opération(s) finale(s) réalisée(s) par la traçabilité suite
+    // ni de Quantité(s) liée(s) ne doit remonter dans les deux colonnes.
+    !isFinalOperationCode(bsda.destinationOperationCode) &&
+    bsda.finalOperations?.length
+  ) {
     // Iterate through each operation once and fill both arrays
     bsda.finalOperations.forEach(ope => {
       destinationFinalOperationCodes.push(ope.operationCode);
-      destinationFinalOperationWeights.push(ope.quantity.toNumber());
+      destinationFinalOperationWeights.push(
+        // conversion en tonnes
+        ope.quantity.dividedBy(1000).toNumber()
+      );
+      if (ope.finalBsda.destinationCompanySiret) {
+        // cela devrait tout le temps être le cas
+        destinationFinalOperationCompanySirets.push(
+          ope.finalBsda.destinationCompanySiret
+        );
+      }
     });
   }
-  return { destinationFinalOperationCodes, destinationFinalOperationWeights };
+  return {
+    destinationFinalOperationCodes,
+    destinationFinalOperationWeights,
+    destinationFinalOperationCompanySirets
+  };
 };
 
 const getTransportersData = (bsda: RegistryBsda, includePlates = false) => {

--- a/back/src/bsdasris/__tests__/registry.integration.ts
+++ b/back/src/bsdasris/__tests__/registry.integration.ts
@@ -13,6 +13,7 @@ import { bsdasriFactory } from "./factories";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { BsdasriType } from "@prisma/client";
 import { companyFactory } from "../../__tests__/factories";
+import { siretify } from "../../__tests__/factories";
 
 describe("toIncomingWaste", () => {
   afterAll(resetDatabase);
@@ -62,23 +63,39 @@ describe("toOutgoingWaste", () => {
     "should compute destinationFinalOperationCodes" +
       " and destinationfinalOperationWeights",
     async () => {
-      const finalBsdasri1 = await bsdasriFactory({});
-      const finalBsdasri2 = await bsdasriFactory({});
-
-      const form = await bsdasriFactory({
+      const finalBsdasri1 = await bsdasriFactory({
         opt: {
+          destinationOperationCode: "R 5",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 1,
+          destinationCompanySiret: siretify()
+        }
+      });
+      const finalBsdasri2 = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "D 5",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 2,
+          destinationCompanySiret: siretify()
+        }
+      });
+
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "D 13",
+          destinationOperationSignatureDate: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalBsdasriId: finalBsdasri1.id,
-                  operationCode: "R 5",
-                  quantity: 1
+                  operationCode: finalBsdasri1.destinationOperationCode!,
+                  quantity: finalBsdasri1.destinationReceptionWasteWeightValue!
                 },
                 {
                   finalBsdasriId: finalBsdasri2.id,
-                  operationCode: "D 5",
-                  quantity: 2
+                  operationCode: finalBsdasri2.destinationOperationCode!,
+                  quantity: finalBsdasri2.destinationReceptionWasteWeightValue!
                 }
               ]
             }
@@ -86,15 +103,66 @@ describe("toOutgoingWaste", () => {
         }
       });
       const bsdasriForRegistry = await prisma.bsdasri.findUniqueOrThrow({
-        where: { id: form.id },
+        where: { id: bsdasri.id },
         include: RegistryBsdasriInclude
       });
       const waste = toOutgoingWaste(bsdasriForRegistry);
       expect(waste.destinationFinalOperationCodes).toStrictEqual([
-        "R 5",
-        "D 5"
+        finalBsdasri1.destinationOperationCode,
+        finalBsdasri2.destinationOperationCode
       ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        finalBsdasri1.destinationReceptionWasteWeightValue
+          ?.dividedBy(1000)
+          .toNumber(),
+        finalBsdasri2.destinationReceptionWasteWeightValue
+          ?.dividedBy(1000)
+          .toNumber()
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalBsdasri1.destinationCompanySiret,
+        finalBsdasri2.destinationCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsdasri has a final operation",
+    async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "R 1",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 1
+        }
+      });
+
+      await prisma.bsdasri.update({
+        where: { id: bsdasri.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalBsdasriId: bsdasri.id,
+                  operationCode: bsdasri.destinationOperationCode!,
+                  quantity: bsdasri.destinationReceptionWasteWeightValue!
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const bsdasriForRegistry = await prisma.bsdasri.findUniqueOrThrow({
+        where: { id: bsdasri.id },
+        include: RegistryBsdasriInclude
+      });
+      const waste = toOutgoingWaste(bsdasriForRegistry);
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 
@@ -227,23 +295,39 @@ describe("toAllWaste", () => {
     "should compute destinationFinalOperationCodes" +
       " and destinationfinalOperationWeights",
     async () => {
-      const finalBsdasri1 = await bsdasriFactory({});
-      const finalBsdasri2 = await bsdasriFactory({});
+      const finalBsdasri1 = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "R 5",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 1,
+          destinationCompanySiret: siretify()
+        }
+      });
+      const finalBsdasri2 = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "D 5",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 2,
+          destinationCompanySiret: siretify()
+        }
+      });
 
       const form = await bsdasriFactory({
         opt: {
+          destinationOperationCode: "D 13",
+          destinationOperationSignatureDate: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalBsdasriId: finalBsdasri1.id,
-                  operationCode: "R 5",
-                  quantity: 1
+                  operationCode: finalBsdasri1.destinationOperationCode!,
+                  quantity: finalBsdasri1.destinationReceptionWasteWeightValue!
                 },
                 {
                   finalBsdasriId: finalBsdasri2.id,
-                  operationCode: "D 5",
-                  quantity: 2
+                  operationCode: finalBsdasri2.destinationOperationCode!,
+                  quantity: finalBsdasri2.destinationReceptionWasteWeightValue!
                 }
               ]
             }
@@ -256,10 +340,61 @@ describe("toAllWaste", () => {
       });
       const waste = toAllWaste(bsdasriForRegistry);
       expect(waste.destinationFinalOperationCodes).toStrictEqual([
-        "R 5",
-        "D 5"
+        finalBsdasri1.destinationOperationCode,
+        finalBsdasri2.destinationOperationCode
       ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        finalBsdasri1.destinationReceptionWasteWeightValue
+          ?.dividedBy(1000)
+          .toNumber(),
+        finalBsdasri2.destinationReceptionWasteWeightValue
+          ?.dividedBy(1000)
+          .toNumber()
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalBsdasri1.destinationCompanySiret,
+        finalBsdasri2.destinationCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsdasri has a final operation",
+    async () => {
+      const bsdasri = await bsdasriFactory({
+        opt: {
+          destinationOperationCode: "R 1",
+          destinationOperationSignatureDate: new Date(),
+          destinationReceptionWasteWeightValue: 1
+        }
+      });
+
+      await prisma.bsdasri.update({
+        where: { id: bsdasri.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalBsdasriId: bsdasri.id,
+                  operationCode: bsdasri.destinationOperationCode!,
+                  quantity: bsdasri.destinationReceptionWasteWeightValue!
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const bsdasriForRegistry = await prisma.bsdasri.findUniqueOrThrow({
+        where: { id: bsdasri.id },
+        include: RegistryBsdasriInclude
+      });
+      const waste = toAllWaste(bsdasriForRegistry);
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 

--- a/back/src/bsdasris/registry.ts
+++ b/back/src/bsdasris/registry.ts
@@ -56,7 +56,7 @@ const getFinalOperationsData = (
       destinationFinalOperationCodes.push(ope.operationCode);
       destinationFinalOperationWeights.push(
         // conversion en tonnes
-        ope.quantity.dividedBy(1000).toNumber()
+        ope.quantity.dividedBy(1000).toDecimalPlaces(6).toNumber()
       );
       if (ope.finalBsdasri.destinationCompanySiret) {
         // cela devrait tout le temps être le cas
@@ -250,7 +250,10 @@ export function toOutgoingWaste(
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     weight: bsdasri.emitterWasteWeightValue
-      ? bsdasri.emitterWasteWeightValue.dividedBy(1000).toNumber()
+      ? bsdasri.emitterWasteWeightValue
+          .dividedBy(1000)
+          .toDecimalPlaces(6)
+          .toNumber()
       : null,
     ...getOperationData(bsdasri),
     ...getFinalOperationsData(bsdasri)
@@ -269,7 +272,10 @@ export function toTransportedWaste(
     ...getTransporterData(bsdasri, true),
     destinationReceptionDate: bsdasri.destinationReceptionDate,
     weight: bsdasri.emitterWasteWeightValue
-      ? bsdasri.emitterWasteWeightValue.dividedBy(1000).toNumber()
+      ? bsdasri.emitterWasteWeightValue
+          .dividedBy(1000)
+          .toDecimalPlaces(6)
+          .toNumber()
       : null,
     emitterCompanyAddress: bsdasri.emitterCompanyAddress,
     emitterCompanyName: bsdasri.emitterCompanyName,

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -22,6 +22,7 @@ import { toBsffDestination } from "./compat";
 import { RegistryBsff } from "../registry/elastic";
 import { getFirstTransporterSync, getTransportersSync } from "./database";
 import { BsffWithTransporters } from "./types";
+import { isFinalOperation } from "./constants";
 
 const getOperationData = (bsff: RegistryBsff) => {
   const bsffDestination = toBsffDestination(bsff.packagings);
@@ -33,21 +34,53 @@ const getOperationData = (bsff: RegistryBsff) => {
   };
 };
 
-const getFinalOperationsData = (bsff: RegistryBsff) => {
+const getFinalOperationsData = (
+  bsff: RegistryBsff
+): Pick<
+  OutgoingWaste | AllWaste,
+  | "destinationFinalOperationCodes"
+  | "destinationFinalOperationWeights"
+  | "destinationFinalOperationCompanySirets"
+> => {
   const destinationFinalOperationCodes: string[] = [];
   const destinationFinalOperationWeights: number[] = [];
+  const destinationFinalOperationCompanySirets: string[] = [];
   // Check if finalOperations is defined and has elements
   for (const packaging of bsff.packagings) {
-    if (packaging.finalOperations && packaging.finalOperations.length > 0) {
+    if (
+      packaging.operationSignatureDate &&
+      packaging.operationCode &&
+      // Cf tra-14603 => si le code de traitement du bordereau initial est final,
+      // aucun code d'Opération(s) finale(s) réalisée(s) par la traçabilité suite
+      // ni de Quantité(s) liée(s) ne doit remonter dans les deux colonnes.
+      !isFinalOperation(
+        packaging.operationCode,
+        packaging.operationNoTraceability
+      ) &&
+      packaging.finalOperations?.length
+    ) {
       // Iterate through each operation once and fill both arrays
       packaging.finalOperations.forEach(ope => {
         destinationFinalOperationCodes.push(ope.operationCode);
-        destinationFinalOperationWeights.push(ope.quantity.toNumber());
+        // conversion en tonnes
+        destinationFinalOperationWeights.push(
+          ope.quantity.dividedBy(1000).toNumber()
+        );
+        if (ope.finalBsffPackaging.bsff.destinationCompanySiret) {
+          // cela devrait tout le temps être le cas
+          destinationFinalOperationCompanySirets.push(
+            ope.finalBsffPackaging.bsff.destinationCompanySiret
+          );
+        }
       });
     }
   }
 
-  return { destinationFinalOperationCodes, destinationFinalOperationWeights };
+  return {
+    destinationFinalOperationCodes,
+    destinationFinalOperationWeights,
+    destinationFinalOperationCompanySirets
+  };
 };
 
 const getTransportersData = (bsff: RegistryBsff, includePlates = false) => {

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -64,7 +64,7 @@ const getFinalOperationsData = (
         destinationFinalOperationCodes.push(ope.operationCode);
         // conversion en tonnes
         destinationFinalOperationWeights.push(
-          ope.quantity.dividedBy(1000).toNumber()
+          ope.quantity.dividedBy(1000).toDecimalPlaces(6).toNumber()
         );
         if (ope.finalBsffPackaging.bsff.destinationCompanySiret) {
           // cela devrait tout le temps être le cas
@@ -317,7 +317,7 @@ export function toOutgoingWaste(bsff: RegistryBsff): Required<OutgoingWaste> {
     traderCompanySiret: null,
     traderRecepisseNumber: null,
     weight: bsff.weightValue
-      ? bsff.weightValue.dividedBy(1000).toNumber()
+      ? bsff.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
     ...getOperationData(bsff),
     ...getFinalOperationsData(bsff),
@@ -337,7 +337,7 @@ export function toTransportedWaste(
     ...genericWaste,
     destinationReceptionDate: bsff.destinationReceptionDate,
     weight: bsff.weightValue
-      ? bsff.weightValue.dividedBy(1000).toNumber()
+      ? bsff.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
     emitterCompanyAddress: bsff.emitterCompanyAddress,
     emitterCompanyName: bsff.emitterCompanyName,
@@ -411,7 +411,7 @@ export function toAllWaste(bsff: RegistryBsff): Required<AllWaste> {
     initialEmitterCompanyName: null,
     initialEmitterCompanySiret: null,
     weight: bsff.weightValue
-      ? bsff.weightValue.dividedBy(1000).toNumber()
+      ? bsff.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
     traderCompanyName: null,
     traderCompanySiret: null,

--- a/back/src/forms/__tests__/registry.integration.ts
+++ b/back/src/forms/__tests__/registry.integration.ts
@@ -292,33 +292,44 @@ describe("toOutgoingWaste", () => {
       " and destinationfinalOperationWeights",
     async () => {
       const user = await userFactory();
-      const finalForm1 = await formFactory({ ownerId: user.id });
-      const finalForm2 = await formFactory({ ownerId: user.id });
-      const finalForm3 = await formFactory({ ownerId: user.id });
+      const finalForm1 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "R 1", quantityReceived: 1 }
+      });
+      const finalForm2 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "R 2", quantityReceived: 2 }
+      });
+      const finalForm3 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "D 13", quantityReceived: 3 }
+      });
 
       const form = await formFactory({
         ownerId: user.id,
         opt: {
+          processingOperationDone: "D 13",
+          processedAt: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalFormId: finalForm1.id,
-                  operationCode: "R 1",
+                  operationCode: finalForm1.processingOperationDone!,
                   noTraceability: false,
-                  quantity: 1
+                  quantity: finalForm1.quantityReceived!
                 },
                 {
                   finalFormId: finalForm2.id,
-                  operationCode: "R 2",
+                  operationCode: finalForm2.processingOperationDone!,
                   noTraceability: false,
-                  quantity: 2
+                  quantity: finalForm2.quantityReceived!
                 },
                 {
                   finalFormId: finalForm3.id,
-                  operationCode: "D 13",
+                  operationCode: finalForm3.processingOperationDone!,
                   noTraceability: true,
-                  quantity: 3
+                  quantity: finalForm3.quantityReceived!
                 }
               ]
             }
@@ -331,11 +342,61 @@ describe("toOutgoingWaste", () => {
       });
       const waste = toOutgoingWaste(formToBsdd(formForRegistry));
       expect(waste.destinationFinalOperationCodes).toStrictEqual([
-        "R 1",
-        "R 2",
-        "D 13"
+        finalForm1.processingOperationDone,
+        finalForm2.processingOperationDone,
+        finalForm3.processingOperationDone
       ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2, 3]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        finalForm1.quantityReceived?.toNumber(),
+        finalForm2.quantityReceived?.toNumber(),
+        finalForm3.quantityReceived?.toNumber()
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalForm1.recipientCompanySiret,
+        finalForm2.recipientCompanySiret,
+        finalForm3.recipientCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsdd has a final operation",
+    async () => {
+      const user = await userFactory();
+      const form = await formFactory({
+        ownerId: user.id,
+        opt: {
+          processingOperationDone: "R 1",
+          processedAt: new Date(),
+          quantityReceived: 1
+        }
+      });
+      await prisma.form.update({
+        where: { id: form.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalFormId: form.id,
+                  operationCode: form.recipientProcessingOperation!,
+                  noTraceability: false,
+                  quantity: form.quantityReceived!
+                }
+              ]
+            }
+          }
+        }
+      });
+      const formForRegistry = await prisma.form.findUniqueOrThrow({
+        where: { id: form.id },
+        include: RegistryFormInclude
+      });
+      const waste = toOutgoingWaste(formToBsdd(formForRegistry));
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 
@@ -471,33 +532,99 @@ describe("toAllWaste", () => {
       " and destinationfinalOperationWeights",
     async () => {
       const user = await userFactory();
-      const finalForm1 = await formFactory({ ownerId: user.id });
-      const finalForm2 = await formFactory({ ownerId: user.id });
-      const finalForm3 = await formFactory({ ownerId: user.id });
+
+      const finalForm1 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "R 1", quantityReceived: 1 }
+      });
+      const finalForm2 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "R 2", quantityReceived: 2 }
+      });
+      const finalForm3 = await formFactory({
+        ownerId: user.id,
+        opt: { processingOperationDone: "D 13", quantityReceived: 3 }
+      });
 
       const form = await formFactory({
         ownerId: user.id,
         opt: {
+          processingOperationDone: "D 13",
+          processedAt: new Date(),
           finalOperations: {
             createMany: {
               data: [
                 {
                   finalFormId: finalForm1.id,
-                  operationCode: "R 1",
+                  operationCode: finalForm1.processingOperationDone!,
                   noTraceability: false,
-                  quantity: 1
+                  quantity: finalForm1.quantityReceived!
                 },
                 {
                   finalFormId: finalForm2.id,
-                  operationCode: "R 2",
+                  operationCode: finalForm2.processingOperationDone!,
                   noTraceability: false,
-                  quantity: 2
+                  quantity: finalForm2.quantityReceived!
                 },
                 {
                   finalFormId: finalForm3.id,
-                  operationCode: "D 13",
+                  operationCode: finalForm3.processingOperationDone!,
                   noTraceability: true,
-                  quantity: 3
+                  quantity: finalForm3.quantityReceived!
+                }
+              ]
+            }
+          }
+        }
+      });
+
+      const formForRegistry = await prisma.form.findUniqueOrThrow({
+        where: { id: form.id },
+        include: RegistryFormInclude
+      });
+      const waste = toAllWaste(formToBsdd(formForRegistry));
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([
+        finalForm1.processingOperationDone,
+        finalForm2.processingOperationDone,
+        finalForm3.processingOperationDone
+      ]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([
+        finalForm1.quantityReceived?.toNumber(),
+        finalForm2.quantityReceived?.toNumber(),
+        finalForm3.quantityReceived?.toNumber()
+      ]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([
+        finalForm1.recipientCompanySiret,
+        finalForm2.recipientCompanySiret,
+        finalForm3.recipientCompanySiret
+      ]);
+    }
+  );
+
+  test(
+    "destinationFinalOperationCodes and destinationfinalOperationWeights should be empty" +
+      " when bsdd has a final operation",
+    async () => {
+      const user = await userFactory();
+      const form = await formFactory({
+        ownerId: user.id,
+        opt: {
+          processingOperationDone: "R 1",
+          processedAt: new Date(),
+          quantityReceived: 1
+        }
+      });
+      await prisma.form.update({
+        where: { id: form.id },
+        data: {
+          finalOperations: {
+            createMany: {
+              data: [
+                {
+                  finalFormId: form.id,
+                  operationCode: form.recipientProcessingOperation!,
+                  noTraceability: false,
+                  quantity: form.quantityReceived!
                 }
               ]
             }
@@ -509,12 +636,9 @@ describe("toAllWaste", () => {
         include: RegistryFormInclude
       });
       const waste = toAllWaste(formToBsdd(formForRegistry));
-      expect(waste.destinationFinalOperationCodes).toStrictEqual([
-        "R 1",
-        "R 2",
-        "D 13"
-      ]);
-      expect(waste.destinationFinalOperationWeights).toStrictEqual([1, 2, 3]);
+      expect(waste.destinationFinalOperationCodes).toStrictEqual([]);
+      expect(waste.destinationFinalOperationWeights).toStrictEqual([]);
+      expect(waste.destinationFinalOperationCompanySirets).toStrictEqual([]);
     }
   );
 

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -1,5 +1,4 @@
 import {
-  BsddFinalOperation,
   IntermediaryFormAssociation,
   QuantityType,
   Status
@@ -258,11 +257,9 @@ export function formToBsdd(form: RegistryForm): Bsdd & {
   forwardedIn: (Bsdd & { grouping: Bsdd[] }) | null;
 } & {
   forwarding: (Bsdd & { grouping: Bsdd[] }) | null;
-} & {
-  finalOperations: BsddFinalOperation[];
-} & {
-  intermediaries: IntermediaryFormAssociation[] | null;
-} {
+} & Pick<RegistryForm, "finalOperations"> & {
+    intermediaries: IntermediaryFormAssociation[] | null;
+  } {
   let grouping: Bsdd[] = [];
 
   if (form.grouping) {

--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -82,9 +82,9 @@ describe("formatRow", () => {
       destinationReceptionDate: "2021-01-01",
       destinationReceptionWeight: 1.2,
       destinationPlannedOperationCode: "R10",
-      destinationFinalOperationCodes: "R1 R2",
-      destinationFinalOperationWeights: "1,24 2,78",
-      destinationFinalOperationCompanySirets: "85001946400021 88792840600024"
+      destinationFinalOperationCodes: "R1,R2",
+      destinationFinalOperationWeights: "1,24 - 2,78",
+      destinationFinalOperationCompanySirets: "85001946400021,88792840600024"
     });
     const formattedWithLabels = formatRow(waste, true);
     expect(formattedWithLabels).toEqual({
@@ -121,9 +121,9 @@ describe("formatRow", () => {
       "Mode de traitement réalisé": "RECYCLAGE",
       "Date de réception": "2021-01-01",
       "Quantité de déchet entrant (tonnes)": 1.2,
-      "Opération(s) finale(s) réalisée(s) par la traçabilité suite": "R1 R2",
-      "Quantité(s) liée(s) (tonnes)": "1,24 2,78",
-      "SIRET(s) de la destination finale": "85001946400021 88792840600024"
+      "Code opération finale réalisée": "R1,R2",
+      "Quantité finale (tonnes)": "1,24 - 2,78",
+      "SIRET de la destination finale": "85001946400021,88792840600024"
     });
     expect(Object.keys(formattedWithLabels).length).toEqual(
       Object.keys(waste).length + CUSTOM_WASTE_COLUMNS.length

--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -1,9 +1,9 @@
-import { BsdSubType, IncomingWaste } from "../../generated/graphql/types";
+import { BsdSubType, AllWaste } from "../../generated/graphql/types";
 import { CUSTOM_WASTE_COLUMNS, formatRow, formatSubType } from "../columns";
 
 describe("formatRow", () => {
   it("should format waste", () => {
-    const waste: IncomingWaste = {
+    const waste: AllWaste = {
       bsdType: "BSDA",
       brokerCompanyName: "broker",
       brokerCompanySiret: "broker_siret",
@@ -35,7 +35,13 @@ describe("formatRow", () => {
       transporterTransportMode: "ROAD",
       wasteCode: "01 01 01*",
       wasteDescription: "déchets dangereux",
-      destinationPlannedOperationCode: "R10"
+      destinationPlannedOperationCode: "R10",
+      destinationFinalOperationCodes: ["R1", "R2"],
+      destinationFinalOperationWeights: [1.24, 2.78],
+      destinationFinalOperationCompanySirets: [
+        "85001946400021",
+        "88792840600024"
+      ]
     };
     const formatted = formatRow(waste);
     // Fields in the waste object + custom fields added for user convenience
@@ -75,7 +81,10 @@ describe("formatRow", () => {
       destinationOperationMode: "RECYCLAGE",
       destinationReceptionDate: "2021-01-01",
       destinationReceptionWeight: 1.2,
-      destinationPlannedOperationCode: "R10"
+      destinationPlannedOperationCode: "R10",
+      destinationFinalOperationCodes: "R1 R2",
+      destinationFinalOperationWeights: "1,24 2,78",
+      destinationFinalOperationCompanySirets: "85001946400021 88792840600024"
     });
     const formattedWithLabels = formatRow(waste, true);
     expect(formattedWithLabels).toEqual({
@@ -111,7 +120,10 @@ describe("formatRow", () => {
       "Code opération prévu": "R10",
       "Mode de traitement réalisé": "RECYCLAGE",
       "Date de réception": "2021-01-01",
-      "Quantité de déchet entrant (t)": 1.2
+      "Quantité de déchet entrant (tonnes)": 1.2,
+      "Opération(s) finale(s) réalisée(s) par la traçabilité suite": "R1 R2",
+      "Quantité(s) liée(s) (tonnes)": "1,24 2,78",
+      "SIRET(s) de la destination finale": "85001946400021 88792840600024"
     });
     expect(Object.keys(formattedWithLabels).length).toEqual(
       Object.keys(waste).length + CUSTOM_WASTE_COLUMNS.length

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -76,13 +76,7 @@ const formatTransportMode = (mode?: TransportMode): string => {
       return "";
   }
 };
-/**
- * Clean Final Operation lists
- */
-const formatFinalOperations = (val?: string[]) =>
-  val ? val.map(quant => quant.replace(/ /g, "")).join(" ") : ""; // be consistent and remove all white spaces
-const formatFinalOperationWeights = (val?: number[]) =>
-  val ? val.map(quant => quant.toLocaleString("fr")).join(" ") : "";
+
 export const formatSubType = (subType?: BsdSubType) => {
   if (!subType) return "";
 
@@ -317,19 +311,24 @@ export const columns: Column[] = [
     format: formatBoolean
   },
   {
+    field: "destinationFinalOperationCompanySirets",
+    label: "SIRET de la destination finale",
+    format: (v: string[]) => formatArray(v)
+  },
+  {
     field: "destinationFinalOperationCodes",
-    label: "Opération(s) finale(s) réalisée(s) par la traçabilité suite",
-    format: formatFinalOperations
+    label: "Code opération finale réalisée",
+    format: (codes: string[]) =>
+      formatArray(codes.map(c => formatOperationCode(c)))
   },
   {
     field: "destinationFinalOperationWeights",
-    label: "Quantité(s) liée(s) (tonnes)",
-    format: formatFinalOperationWeights
-  },
-  {
-    field: "destinationFinalOperationCompanySirets",
-    label: "SIRET(s) de la destination finale",
-    format: (v: string[]) => formatArray(v, " ")
+    label: "Quantité finale (tonnes)",
+    format: (quantities: number[]) =>
+      formatArray(
+        quantities.map(q => q.toLocaleString("fr")),
+        " - "
+      )
   },
   {
     field: "nextDestinationNotificationNumber",

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -45,7 +45,8 @@ const formatBoolean = (b: boolean | null) => {
   return b ? "O" : "N";
 };
 const formatNumber = (n: number) => (!!n ? parseFloat(n.toFixed(3)) : null); // return as a number to allow xls cells formulas
-const formatArray = (arr: any[]) => (Array.isArray(arr) ? arr.join(",") : "");
+const formatArray = (arr: any[], sep = ",") =>
+  Array.isArray(arr) ? arr.join(sep) : "";
 const formatArrayWithMissingElements = (arr: any[]) => {
   if (!Array.isArray(arr)) {
     return "";
@@ -79,9 +80,9 @@ const formatTransportMode = (mode?: TransportMode): string => {
  * Clean Final Operation lists
  */
 const formatFinalOperations = (val?: string[]) =>
-  val ? val.map(quant => quant.replace(/ /g, "")).join("; ") : ""; // be consistent and remove all white spaces
+  val ? val.map(quant => quant.replace(/ /g, "")).join(" ") : ""; // be consistent and remove all white spaces
 const formatFinalOperationWeights = (val?: number[]) =>
-  val ? val.map(quant => quant.toFixed(2)).join("; ") : "";
+  val ? val.map(quant => quant.toLocaleString("fr")).join(" ") : "";
 export const formatSubType = (subType?: BsdSubType) => {
   if (!subType) return "";
 
@@ -181,12 +182,12 @@ export const columns: Column[] = [
   {
     field: "parcelCities",
     label: "Parcelle commune",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "parcelPostalCodes",
     label: "Parcelle code postal",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "parcelNumbers",
@@ -242,7 +243,7 @@ export const columns: Column[] = [
   {
     field: "transporterNumberPlates",
     label: "Transporteur immatriculation",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "transporterTransportMode",
@@ -293,7 +294,7 @@ export const columns: Column[] = [
   },
   {
     field: "destinationReceptionWeight",
-    label: "Quantité de déchet entrant (t)",
+    label: "Quantité de déchet entrant (tonnes)",
     format: formatNumber
   },
   {
@@ -322,8 +323,13 @@ export const columns: Column[] = [
   },
   {
     field: "destinationFinalOperationWeights",
-    label: "Quantité(s) liée(s)",
+    label: "Quantité(s) liée(s) (tonnes)",
     format: formatFinalOperationWeights
+  },
+  {
+    field: "destinationFinalOperationCompanySirets",
+    label: "SIRET(s) de la destination finale",
+    format: (v: string[]) => formatArray(v, " ")
   },
   {
     field: "nextDestinationNotificationNumber",
@@ -352,7 +358,7 @@ export const columns: Column[] = [
   {
     field: "transporter2NumberPlates",
     label: "Transporteur n°2 immatriculation",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "transporter2TransportMode",
@@ -383,7 +389,7 @@ export const columns: Column[] = [
   {
     field: "transporter3NumberPlates",
     label: "Transporteur n°3 immatriculation",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "transporter3TransportMode",
@@ -414,7 +420,7 @@ export const columns: Column[] = [
   {
     field: "transporter4NumberPlates",
     label: "Transporteur n°4 immatriculation",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "transporter4TransportMode",
@@ -445,7 +451,7 @@ export const columns: Column[] = [
   {
     field: "transporter5NumberPlates",
     label: "Transporteur n°5 immatriculation",
-    format: formatArray
+    format: (v: string[]) => formatArray(v)
   },
   {
     field: "transporter5TransportMode",

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -84,7 +84,9 @@ export const RegistryFormInclude = Prisma.validator<Prisma.FormInclude>()({
   forwarding: { include: { transporters: true } },
   intermediaries: true,
   forwardedIn: { include: { transporters: true } },
-  finalOperations: true,
+  finalOperations: {
+    include: { finalForm: { select: { recipientCompanySiret: true } } }
+  },
   grouping: { include: { initialForm: { include: { transporters: true } } } },
   transporters: true
 });
@@ -99,14 +101,23 @@ export const RegistryBsdaInclude = Prisma.validator<Prisma.BsdaInclude>()({
   intermediaries: true,
   forwardedIn: true,
   transporters: true,
-  finalOperations: true
+  finalOperations: {
+    include: { finalBsda: { select: { destinationCompanySiret: true } } }
+  }
 });
 
 export type RegistryBsda = Prisma.BsdaGetPayload<{
   include: typeof RegistryBsdaInclude;
 }>;
 
-export const RegistryBsdasriInclude = { grouping: true, finalOperations: true };
+export const RegistryBsdasriInclude = Prisma.validator<Prisma.BsdasriInclude>()(
+  {
+    grouping: true,
+    finalOperations: {
+      include: { finalBsdasri: { select: { destinationCompanySiret: true } } }
+    }
+  }
+);
 
 export type RegistryBsdasri = Prisma.BsdasriGetPayload<{
   include: typeof RegistryBsdasriInclude;
@@ -124,7 +135,13 @@ export const RegistryBsffInclude = Prisma.validator<Prisma.BsffInclude>()({
   transporters: true,
   packagings: {
     include: {
-      finalOperations: true,
+      finalOperations: {
+        include: {
+          finalBsffPackaging: {
+            include: { bsff: { select: { destinationCompanySiret: true } } }
+          }
+        }
+      },
       previousPackagings: {
         include: { bsff: true }
       }

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -529,6 +529,9 @@ type OutgoingWaste {
   "Extra - Quantité(s) correspondante(s) au traitement réalisé par le ou les exutoires finaux"
   destinationFinalOperationWeights: [Float!]
 
+  "Extra - Installation(s) de traitement dans le ou lesquelles le traitement final a été réalisé"
+  destinationFinalOperationCompanySirets: [String!]
+
   "Extra - Adresse email de contact du transporteur"
   transporterCompanyMail: String
 
@@ -1421,6 +1424,9 @@ type AllWaste {
 
   "Extra - Quantité(s) correspondante(s) au traitement réalisé par le ou les exutoires finaux"
   destinationFinalOperationWeights: [Float!]
+
+  "Extra - Installation(s) de traitement dans le ou lesquelles le traitement final a été réalisé"
+  destinationFinalOperationCompanySirets: [String!]
 
   "Extra - Adresse email de contact de l'expéditeur du déchet"
   emitterCompanyMail: String

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -227,6 +227,7 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   workerCompanyAddress: null,
   destinationFinalOperationCodes: [],
   destinationFinalOperationWeights: [],
+  destinationFinalOperationCompanySirets: [],
   nextDestinationNotificationNumber: null,
   nextDestinationProcessingOperation: null,
   postTempStorageDestinationAddress: null,
@@ -416,9 +417,6 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   parcelPostalCodes: null,
   parcelNumbers: null,
   parcelCoordinates: null,
-  // En attente des correctifs recette sur TRA-12745
-  // finalOperationCodes: null,
-  // finalReceptionWeights: null
   brokerCompanyMail: null,
   traderCompanyMail: null
 };
@@ -520,6 +518,7 @@ export const emptyAllWaste: Required<AllWaste> = {
   workerCompanyAddress: null,
   destinationFinalOperationCodes: [],
   destinationFinalOperationWeights: [],
+  destinationFinalOperationCompanySirets: [],
   nextDestinationNotificationNumber: null,
   nextDestinationProcessingOperation: null,
   intermediary1CompanyName: null,


### PR DESCRIPTION
## Demo 

Sur le démo on voit : 
- un BSDD qui a été regroupé avec ventilation des quantités dans deux bordereaux vers des destinations différentes. Sur le registre, on constate bien que les SIRETs des deux destinations finales apparaissent.
- Un BSFF qui a été réexpédié. Sur le registre on constate bien que le SIRET de la destination finale apparait et que la quantité a été convertie en tonnes (et non plus en kg comme c'était le cas avant). 

https://github.com/MTES-MCT/trackdechets/assets/2269165/3747170e-d854-40ed-acfd-e08b2ae08309


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Corriger les données remontées dans la colonne Quantité(s) liée(s) ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14603)
- [Ajouter le SIRET de la Destination finale sur les registres sortants et exhaustifs](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14459)
