### PR TITLE
[tra-14363] Champs obligatoires sur le BSDA

### DIFF
--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -142,6 +142,19 @@ const sealedFromEmissionExceptAddOrRemoveNextDestination: GetBsdaSignatureTypeFn
   return isEmitter ? "WORK" : "EMISSION";
 };
 
+/**
+ * Régle de verrouillage des champs définie à partir d'une fonction.
+ * Un champ appliquant cette règle est verrouillé à partir de la
+ * signature émetteur s'il n'y a pas d'entreprise de travaux sur le BSDA.
+ * Sinon, le champ est vérouillé à partir de la signature de l'entreprise de
+ * travaux..
+ */
+const sealedFromWorkOrEmissionWhenThereIsNoWorker: GetBsdaSignatureTypeFn<
+  ZodBsda
+> = ({ workerCompanySiret }, _) => {
+  return workerCompanySiret ? "WORK" : "EMISSION";
+};
+
 function transporterSignature(
   transporter: ZodBsdaTransporter
 ): AllBsdaSignatureType {
@@ -727,17 +740,17 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   wasteAdr: { readableFieldName: "la mention ADR", sealed: { from: "WORK" } },
   wasteFamilyCode: {
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" },
     readableFieldName: "le code famille"
   },
   wasteMaterialName: {
     readableFieldName: "le nom de matériau",
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" }
   },
   wasteConsistence: {
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" },
     readableFieldName: "la consistance"
   },
@@ -747,11 +760,11 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   wastePop: {
     readableFieldName: "le champ sur les polluants organiques persistants",
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" }
   },
   packagings: {
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: {
       from: "WORK"
     },
@@ -759,12 +772,12 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   weightIsEstimate: {
     readableFieldName: "le champ pour indiquer sile poids est estimé",
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" }
   },
   weightValue: {
     readableFieldName: "le poids",
-    sealed: { from: "WORK" },
+    sealed: { from: sealedFromWorkOrEmissionWhenThereIsNoWorker },
     required: { from: "WORK" }
   },
   grouping: { sealed: { from: "EMISSION" } },


### PR DESCRIPTION
Rendre obligatoire les informations liées au déchet à la signature émetteur si aucune entreprise de travaux n'a été visée pour éviter un blocage BSDA à la signature transporteur 

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14363)
