### PR TITLE
[TRA-13845] Correction de la dénomination du code de traitement non final D12 par D13

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :boom: Breaking changes
 
 - Le profil crématorium est déprécié au profit du sous-type crémation [PR 3468](https://github.com/MTES-MCT/trackdechets/pull/3468)
+- Correction de la dénomination du code de traitement non final D12 par D13 [PR 3457](https://github.com/MTES-MCT/trackdechets/pull/3457)
 
 #### :nail_care: Améliorations
 

--- a/back/src/bsdasris/__tests__/validation.integration.ts
+++ b/back/src/bsdasris/__tests__/validation.integration.ts
@@ -519,7 +519,7 @@ describe("Mutation.signBsdasri emission", () => {
       ["D9", undefined],
       ["D10", "ELIMINATION"],
       ["R1", "VALORISATION_ENERGETIQUE"],
-      ["D12", "ELIMINATION"],
+      ["D13", undefined],
       ["R12", undefined]
     ])(
       "should work if operation code & mode are compatible (code: %p, mode: %p)",
@@ -558,7 +558,7 @@ describe("Mutation.signBsdasri emission", () => {
       ["D9", "VALORISATION_ENERGETIQUE"], // No mode is expected
       ["D10", "VALORISATION_ENERGETIQUE"], // Correct mode is ELIMINATION
       ["R1", "ELIMINATION"], //  Correct mode is VALORISATION_ENERGETIQUE
-      ["D12", "VALORISATION_ENERGETIQUE"], //  Correct mode is ELIMINATION
+      ["D13", "VALORISATION_ENERGETIQUE"], //  No mode is expected
       ["R12", "VALORISATION_ENERGETIQUE"] // R12 has no associated mode
     ])(
       "should not be valid if operation mode is not compatible with operation code (mode: %p, code: %p)",
@@ -584,7 +584,7 @@ describe("Mutation.signBsdasri emission", () => {
       }
     );
 
-    test.each(["D10", "R1", "D12"])(
+    test.each(["D10", "R1"])(
       "should not be valid if operation code has associated operation modes but none is specified (code: %p)",
       async code => {
         const data = {
@@ -595,12 +595,11 @@ describe("Mutation.signBsdasri emission", () => {
           destinationReceptionWasteWeightValue: 10
         };
 
-        expect.assertions(2);
-
         try {
           await validateBsdasri(data as any, { operationSignature: true });
         } catch (err) {
           expect(err.errors.length).toBeTruthy();
+
           expect(err.errors[0]).toBe(
             "Vous devez préciser un mode de traitement"
           );

--- a/back/src/bsdasris/examples/fixtures.ts
+++ b/back/src/bsdasris/examples/fixtures.ts
@@ -113,8 +113,7 @@ const operationForGroupingInput = {
   weight: {
     value: 1
   },
-  code: "D12",
-  mode: "ELIMINATION",
+  code: "D13",
   date: "2020-04-28"
 };
 

--- a/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
+++ b/back/src/bsdasris/pdf/components/BsdasriPdf.tsx
@@ -463,10 +463,10 @@ export function BsdasriPdf({ bsdasri, qrCode, associatedBsdasris }: Props) {
             <p>
               <input
                 type="checkbox"
-                checked={bsdasri?.destination?.operation?.code === "D12"}
+                checked={bsdasri?.destination?.operation?.code === "D13"}
                 readOnly
               />{" "}
-              Groupement avant D9 ou D10 (D12) sur site relevant de la 2718
+              Groupement avant D9 ou D10 (D13) sur site relevant de la 2718
             </p>
             <p>
               <input

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriGrouping.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createBsdasriGrouping.integration.ts
@@ -164,7 +164,7 @@ describe("Mutation.createDasri", () => {
         status: BsdasriStatus.AWAITING_GROUP,
         emitterCompanySiret: siretify(1),
         destinationCompanySiret: company.siret,
-        destinationOperationCode: "D12"
+        destinationOperationCode: "D13"
       }
     });
 

--- a/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/createDraftBsdasri.integration.ts
@@ -110,11 +110,11 @@ describe("Mutation.createDraftBsdasri", () => {
 
   it.each([
     ["R12", undefined],
-    ["D12", "ELIMINATION"]
+    ["D13", undefined]
   ])(
-    "should disallow R12 & D12 for non waste processor destination ",
+    "should disallow R12 & D13 for non waste processor destination ",
     async (code, mode) => {
-      // both R12 & D12 operation codes require the destination to be a COLLECTOR
+      // both R12 & D13 operation codes require the destination to be a COLLECTOR
 
       const { user, company } = await userWithCompanyFactory("MEMBER");
 
@@ -151,7 +151,7 @@ describe("Mutation.createDraftBsdasri", () => {
       expect(errors).toEqual([
         expect.objectContaining({
           message:
-            "Les codes R12 et D12 sont réservés aux installations de tri transit regroupement",
+            "Les codes R12 et D13 sont réservés aux installations de tri transit regroupement",
           extensions: expect.objectContaining({
             code: ErrorCode.BAD_USER_INPUT
           })
@@ -161,9 +161,9 @@ describe("Mutation.createDraftBsdasri", () => {
   );
   it.each([
     ["R12", undefined],
-    ["D12", "ELIMINATION"]
-  ])("should allow R12 & D12 for waste processor ", async (code, mode) => {
-    // both R12 & D12 operation codes require the destination to be a COLLECTOR
+    ["D13", undefined]
+  ])("should allow R12 & D13 for waste processor ", async (code, mode) => {
+    // both R12 & D13 operation codes require the destination to be a COLLECTOR
 
     const { user, company } = await userWithCompanyFactory("MEMBER");
 

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriOperation.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriOperation.integration.ts
@@ -182,7 +182,8 @@ describe("Mutation.signBsdasri operation", () => {
         ...readyToTakeOverData(transporterCompany),
         ...readyToReceiveData(),
         ...readyToProcessData,
-        destinationOperationCode: "D12",
+        destinationOperationCode: "D13",
+        destinationOperationMode: null,
         status: BsdasriStatus.RECEIVED
       }
     });
@@ -272,7 +273,8 @@ describe("Mutation.signBsdasri operation", () => {
         ...readyToTakeOverData(transporterCompany),
         ...readyToReceiveData(),
         ...readyToProcessData,
-        destinationOperationCode: "D12",
+        destinationOperationCode: "D13",
+        destinationOperationMode: null,
         status: BsdasriStatus.RECEIVED
       }
     });

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasriSynthesis.integration.ts
@@ -378,7 +378,7 @@ describe("Mutation.updateBsdasri", () => {
 
   it.each([
     ["R12", undefined],
-    ["D12", "ELIMINATION"]
+    ["D13", undefined]
   ])(
     "should forbid %p operation code on synthesis dasri",
     async (operationCode, operationMode) => {
@@ -441,7 +441,7 @@ describe("Mutation.updateBsdasri", () => {
       expect(errors).toEqual([
         expect.objectContaining({
           message:
-            "Les codes R12 et D12 sont interdits sur un bordereau de synthèse",
+            "Les codes R12 et D13 sont interdits sur un bordereau de synthèse",
           extensions: expect.objectContaining({
             code: ErrorCode.BAD_USER_INPUT
           })

--- a/back/src/bsdasris/resolvers/mutations/utils.ts
+++ b/back/src/bsdasris/resolvers/mutations/utils.ts
@@ -97,7 +97,7 @@ export const checkDasrisAreGroupable = async (
   // retrieve dasris:
   // whose id is in regroupedBsdasrisIds array
   // which are in PROCESSED status
-  // whose destinationOperationCode is either D12 or  R12
+  // whose destinationOperationCode is either D13 or  R12
   // wich are of SIMPLE type
   // which are not already grouped, grouping, synthesized or synthesizing
   // whose recipient in current emitter

--- a/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.enums.graphql
@@ -57,7 +57,7 @@ enum BsdasriPackagingType {
 enum destinationOperationCodeTypes {
   D9
   D10
-  D12
+  D13
   R1
   R12
 }

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -260,7 +260,7 @@ input BsdasriOperationInput {
   weight: BsdasriRealWeightInput
   """
   Code de traitement
-  Les codes R12 et D12 ne sont autorisé que si le destinataire est une installation TTR (tri transit regroupement).
+  Les codes R12 et D13 ne sont autorisé que si le destinataire est une installation TTR (tri transit regroupement).
   """
   code: String
   "Qualification du traitement final"

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -155,7 +155,7 @@ type BsdasriReception {
 type BsdasriOperation {
   "Quantité traitée"
   weight: BsdasriOperationWeight
-  "Code de l'opération de traitement - Les codes R12 et D12 sont interdits pour les bsds de synthèse."
+  "Code de l'opération de traitement - Les codes R12 et D13 sont interdits pour les bsds de synthèse."
   code: String
   "Qualification du traitement final"
   mode: OperationMode

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -573,7 +573,7 @@ export const operationSchema: FactorySchemaOf<
   BsdasriValidationContext,
   Operation
 > = context => {
-  // a grouping dasri should not have a grouping operation code (D12, R12)
+  // a grouping dasri should not have a grouping operation code (D13, R12)
   const allowedOperations = context?.isGrouping
     ? DASRI_PROCESSING_OPERATIONS_CODES
     : DASRI_ALL_OPERATIONS_CODES;
@@ -585,7 +585,7 @@ export const operationSchema: FactorySchemaOf<
         "operation-quantity-required-if-final-processing-operation",
         "Le poids du déchet traité en kg est obligatoire si le code correspond à un traitement final",
         function (value) {
-          // We do not run this validator until processing signature because fields are not avilable in UI until then
+          // We do not run this validator until processing signature because fields are not available in UI until then
           if (!context.operationSignature) {
             return true;
           }
@@ -609,7 +609,7 @@ export const operationSchema: FactorySchemaOf<
       .requiredIf(context.operationSignature)
       .test(
         "recipientIsCollectorForGroupingCodes",
-        "Les codes R12 et D12 sont réservés aux installations de tri transit regroupement",
+        "Les codes R12 et D13 sont réservés aux installations de tri transit regroupement",
         async (value, ctx) => {
           const recipientSiret = ctx.parent.destinationCompanySiret;
 
@@ -631,7 +631,7 @@ export const operationSchema: FactorySchemaOf<
       )
       .test(
         "groupingCodesFordbiddenForSynthesis",
-        "Les codes R12 et D12 sont interdits sur un bordereau de synthèse",
+        "Les codes R12 et D13 sont interdits sur un bordereau de synthèse",
         async (value, ctx) => {
           const type = ctx.parent.type;
 

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -160,7 +160,7 @@ export const getBsdStatusLabel = (
       return SIGNER_PAR_ENTREPRISE_TRAVAUX;
     case BsdStatusCode.AwaitingGroup:
       if (bsdType === BsdType.Bsdasri) {
-        if (operationCode === "R12" || operationCode === "D12") {
+        if (operationCode === "R12" || operationCode === "D13") {
           return EN_ATTENTE_BSD_SUITE;
         }
         return ANNEXE_BORDEREAU_SUITE;

--- a/front/src/Apps/common/queries/company/query.ts
+++ b/front/src/Apps/common/queries/company/query.ts
@@ -27,7 +27,9 @@ trackdechetsId
 contact
 contactPhone
 contactEmail
-companyTypes
+companyTypes`;
+
+const commonCompanyTypesSearchString = `
 collectorTypes
 wasteProcessorTypes`;
 
@@ -76,6 +78,7 @@ workerCertification {
 const companySearchResultFragment = gql`
   fragment CompanySearchResultFragment on CompanySearchResult {
     ${commonCompanySearchString}
+    ${commonCompanyTypesSearchString}
     ${transporterReceiptCompanySearchString}
     ${traderReceiptCompanySearchString}
     ${brokerReceiptCompanySearchString}

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -253,8 +253,8 @@ export function OperationSignatureForm() {
           </option>
           {values.type !== BsdasriType.Synthesis ? (
             <>
-              <option value="D12">
-                D12 - Groupement avant désinfection en D9 ou incinération en D10
+              <option value="D13">
+                D13 - Groupement avant désinfection en D9 ou incinération en D10
                 sur un site relevant de la rubrique 2718
               </option>
               <option value="R12">

--- a/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTableGrouping.tsx
@@ -78,7 +78,7 @@ export default function BsdasriTableGrouping({
           operation: {
             code: {
               _in: [
-                DestinationOperationCodeTypes.D12,
+                DestinationOperationCodeTypes.D13,
                 DestinationOperationCodeTypes.R12
               ]
             }

--- a/front/src/form/bsdasri/steps/Operation.tsx
+++ b/front/src/form/bsdasri/steps/Operation.tsx
@@ -37,8 +37,8 @@ export default function Operation({ status, disabled = false }) {
 
           {values.type !== BsdasriType.Synthesis ? (
             <>
-              <option value="D12">
-                D12 - Groupement avant désinfection en D9 ou incinération en D10
+              <option value="D13">
+                D13 - Groupement avant désinfection en D9 ou incinération en D10
                 sur un site relevant de la rubrique 2718
               </option>
               <option value="R12">

--- a/libs/back/scripts/src/scripts/20240711141357215_dasri-D12-D13.ts
+++ b/libs/back/scripts/src/scripts/20240711141357215_dasri-D12-D13.ts
@@ -1,0 +1,8 @@
+import { Prisma } from "@prisma/client";
+
+export async function run(tx: Prisma.TransactionClient) {
+  await tx.bsdasri.updateMany({
+    where: { destinationOperationCode: "D12" },
+    data: { destinationOperationCode: "D13", destinationOperationMode: null }
+  });
+}

--- a/libs/shared/constants/src/DASRI_CONSTANTS.ts
+++ b/libs/shared/constants/src/DASRI_CONSTANTS.ts
@@ -42,7 +42,7 @@ export const DASRI_PROCESSING_OPERATIONS = [
 export const DASRI_GROUPING_OPERATIONS = [
   {
     type: DasriProcessingOperationType.RegroupementPrealableD9D10,
-    code: "D12",
+    code: "D13",
     description:
       "Groupement avant désinfection en D9 ou incinération en D10 sur un site relevant de la rubrique 2718"
   },


### PR DESCRIPTION
Breaking change annoncé dans la NL du 06/05

Sur le dasri, le code D12 est remplacé par D13 
- script de migration
- ce code n'a pas de mode de traitement correspondant
- les révisions ne sont pas impactées, seuls les codes "D9", "D10", "R1" sont acceptés à ce jour

https://github.com/user-attachments/assets/ba2bc6b2-e606-4c0e-9e6f-f18d33db1838



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13845)
