### PR TITLE
Bsds - status check

### DIFF
--- a/back/src/bsda/repository/bsda/update.ts
+++ b/back/src/bsda/repository/bsda/update.ts
@@ -98,7 +98,7 @@ export function buildUpdateBsda(deps: RepositoryFnDeps): UpdateBsdaFn {
     if (data.transporters) {
       // recompute transporterOrgIds
       await prisma.bsda.update({
-        where,
+        where: { id: updatedBsda.id },
         data: {
           transportersOrgIds: getTransportersSync(updatedBsda)
             .flatMap(t => [

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -342,7 +342,10 @@ async function updateBsda(
 ) {
   return runInTransaction(async transaction => {
     const bsdaRepository = getBsdaRepository(user, transaction);
-    const signBsda = await bsdaRepository.update({ id: bsda.id }, updateInput);
+    const signBsda = await bsdaRepository.update(
+      { id: bsda.id, status: bsda.status },
+      updateInput
+    );
     await postSignatureHook(signBsda, bsdaRepository);
     return signBsda;
   });

--- a/back/src/bsdasris/repository/bsdasri/update.ts
+++ b/back/src/bsdasris/repository/bsdasri/update.ts
@@ -44,7 +44,7 @@ export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
       ].filter(Boolean);
 
       await prisma.bsdasri.update({
-        where,
+        where: { id: bsdasri.id },
         data: { synthesisEmitterSirets }
       });
     }
@@ -55,7 +55,7 @@ export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
         ...new Set(bsdasri.grouping.map(grouped => grouped.emitterCompanySiret))
       ].filter(Boolean);
       await prisma.bsdasri.update({
-        where,
+        where: { id: bsdasri.id },
         data: { groupingEmitterSirets }
       });
     }

--- a/back/src/bsdasris/repository/bsdasri/update.ts
+++ b/back/src/bsdasris/repository/bsdasri/update.ts
@@ -19,7 +19,7 @@ export type UpdateBsdasriFn = (
 export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
-    const previousBsdasri = await prisma.bsdasri.findUnique({
+    const previousBsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where,
       include: {
         synthesizing: true,

--- a/back/src/bsdasris/resolvers/mutations/signBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/signBsdasri.ts
@@ -324,7 +324,7 @@ async function updateBsdasri(
   return runInTransaction(async transaction => {
     const bsdasriRepository = getBsdasriRepository(user, transaction);
     const signedBsdasri = await bsdasriRepository.update(
-      { id: bsdasri.id },
+      { id: bsdasri.id, status: bsdasri.status },
       updateInput
     );
     await postSignatureHook(signedBsdasri, bsdasriRepository);

--- a/back/src/bsffs/resolvers/mutations/signBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/signBsff.ts
@@ -158,7 +158,7 @@ async function signEmission(
   const { updateBsff } = getBsffRepository(user);
 
   return updateBsff({
-    where: { id: bsff.id },
+    where: { id: bsff.id, status: bsff.status },
     data: {
       status: BsffStatus.SIGNED_BY_EMITTER,
       emitterEmissionSignatureDate: input.date,

--- a/back/src/bspaoh/repository/bspaoh/update.ts
+++ b/back/src/bspaoh/repository/bspaoh/update.ts
@@ -18,7 +18,7 @@ export type UpdateBspaohFn = (
 export function buildUpdateBspaoh(deps: RepositoryFnDeps): UpdateBspaohFn {
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
-    const previousPaoh = await prisma.bspaoh.findUnique({
+    const previousPaoh = await prisma.bspaoh.findUniqueOrThrow({
       where,
       include: {
         transporters: true

--- a/back/src/bspaoh/resolvers/mutations/sign.ts
+++ b/back/src/bspaoh/resolvers/mutations/sign.ts
@@ -315,5 +315,8 @@ async function updateBspaoh(
   updateInput: Prisma.BspaohUpdateInput
 ) {
   const bspaohRepository = getBspaohRepository(user);
-  return bspaohRepository.update({ id: bspaoh.id }, { ...updateInput });
+  return bspaohRepository.update(
+    { id: bspaoh.id, status: bspaoh.status },
+    { ...updateInput }
+  );
 }

--- a/back/src/bsvhu/repository/bsvhu/update.ts
+++ b/back/src/bsvhu/repository/bsvhu/update.ts
@@ -17,7 +17,7 @@ export function buildUpdateBsvhu(deps: RepositoryFnDeps): UpdateBsvhuFn {
   return async (where, data, logMetadata?) => {
     const { prisma, user } = deps;
 
-    const previousBsvhu = await prisma.bsvhu.findUnique({ where });
+    const previousBsvhu = await prisma.bsvhu.findUniqueOrThrow({ where });
     const bsvhu = await prisma.bsvhu.update({ where, data });
 
     const { updatedAt, ...updateDiff } = objectDiff(previousBsvhu, bsvhu);

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -213,7 +213,7 @@ async function updateBsvhu(
   return runInTransaction(async transaction => {
     const bsvhuRepository = getBsvhuRepository(user, transaction);
     const signBsda = await bsvhuRepository.update(
-      { id: bsvhu.id },
+      { id: bsvhu.id, status: bsvhu.status },
       updateInput
     );
     return signBsda;

--- a/back/src/forms/repository/form/update.ts
+++ b/back/src/forms/repository/form/update.ts
@@ -119,8 +119,9 @@ const buildUpdateForm: (deps: RepositoryFnDeps) => UpdateFormFn =
 
         canAccessDraftSirets.push(...ownerOrgIdsInForm);
       }
+
       await prisma.form.update({
-        where,
+        where: { id: updatedForm.id },
         data: { ...denormalizedSirets, canAccessDraftSirets }
       });
     }

--- a/back/src/forms/resolvers/mutations/importPaperForm.ts
+++ b/back/src/forms/resolvers/mutations/importPaperForm.ts
@@ -115,7 +115,7 @@ async function updateForm(
   };
 
   return getFormRepository(user).update(
-    { id: form.id },
+    { id: form.id, status: form.status },
     {
       status: transitionForm(form, {
         type: EventType.ImportPaperForm,

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -53,7 +53,7 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
     );
 
     const acceptedForm = await update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsAccepted,

--- a/back/src/forms/resolvers/mutations/markAsProcessed.ts
+++ b/back/src/forms/resolvers/mutations/markAsProcessed.ts
@@ -111,7 +111,7 @@ const markAsProcessedResolver: MutationResolvers["markAsProcessed"] = async (
       getFormRepository(user, transaction);
 
     const processedForm = await update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsProcessed,

--- a/back/src/forms/resolvers/mutations/markAsReceived.ts
+++ b/back/src/forms/resolvers/mutations/markAsReceived.ts
@@ -89,7 +89,7 @@ const markAsReceivedResolver: MutationResolvers["markAsReceived"] = async (
     } = getFormRepository(user, transaction);
 
     const receivedForm = await update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsReceived,

--- a/back/src/forms/resolvers/mutations/markAsResealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsResealed.ts
@@ -157,7 +157,7 @@ const markAsResealed: MutationResolvers["markAsResealed"] = async (
     resealedForm = await formRepository.update({ id }, formUpdateInput);
   } else {
     resealedForm = await formRepository.update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsResealed,

--- a/back/src/forms/resolvers/mutations/markAsResent.ts
+++ b/back/src/forms/resolvers/mutations/markAsResent.ts
@@ -72,7 +72,7 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
   };
 
   const resentForm = await getFormRepository(user).update(
-    { id: form.id },
+    { id: form.id, status: form.status },
     {
       status: transitionForm(form, {
         type: EventType.MarkAsResent,

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -65,7 +65,7 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   const resultingForm = await runInTransaction(async transaction => {
     const formRepository = getFormRepository(user, transaction);
     const sealedForm = await formRepository.update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsSealed
@@ -97,7 +97,7 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
         sealedForm.emitterIsPrivateIndividual === true)
     ) {
       return formRepository.update(
-        { id: sealedForm.id },
+        { id: sealedForm.id, status: sealedForm.status },
         {
           status: transitionForm(sealedForm, {
             type: EventType.SignedByProducer,

--- a/back/src/forms/resolvers/mutations/markAsTempStored.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStored.ts
@@ -66,7 +66,7 @@ const markAsTempStoredResolver: MutationResolvers["markAsTempStored"] = async (
   const tempStoredForm = await runInTransaction(async transaction => {
     const formRepository = getFormRepository(user, transaction);
     const tempStoredForm = await formRepository.update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.MarkAsTempStored,

--- a/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsTempStorerAccepted.ts
@@ -44,7 +44,7 @@ const markAsTempStorerAcceptedResolver: MutationResolvers["markAsTempStorerAccep
     const tempStoredForm = await runInTransaction(async transaction => {
       const formRepository = getFormRepository(user, transaction);
       const tempStoredForm = await formRepository.update(
-        { id: form.id },
+        { id: form.id, status: form.status },
         {
           status: transitionForm(form, {
             type: EventType.MarkAsTempStorerAccepted,

--- a/back/src/forms/resolvers/mutations/signEmissionForm.ts
+++ b/back/src/forms/resolvers/mutations/signEmissionForm.ts
@@ -103,7 +103,7 @@ const signatures: Partial<
     await validateBeforeEmission(futureForm as Form);
 
     const updatedForm = await getFormRepository(user).update(
-      { id: existingForm.id },
+      { id: existingForm.id, status: existingForm.status },
       {
         status: transitionForm(existingForm, {
           type: EventType.SignedByProducer,
@@ -179,7 +179,7 @@ const signatures: Partial<
     await validateBeforeEmission(futureFullForm.forwardedIn as Form);
 
     const updatedForm = await getFormRepository(user).update(
-      { id: existingForm.id },
+      { id: existingForm.id, status: existingForm.status },
       {
         status: transitionForm(existingForm, {
           type: EventType.SignedByTempStorer,

--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -171,7 +171,7 @@ const signTransportFn = async (
       getFormRepository(user, transaction);
 
     const updatedForm = await update(
-      { id: existingForm.id },
+      { id: existingForm.id, status: existingForm.status },
       {
         status: transitionForm(existingForm, {
           type: EventType.SignedByTransporter,
@@ -359,7 +359,7 @@ const signatures: Partial<
     };
 
     const updatedForm = await getFormRepository(user).update(
-      { id: existingFullForm.id },
+      { id: existingFullForm.id, status: existingFullForm.status },
       {
         status: transitionForm(existingFullForm, {
           type: EventType.MarkAsResent,

--- a/back/src/forms/resolvers/mutations/signedByTransporter.ts
+++ b/back/src/forms/resolvers/mutations/signedByTransporter.ts
@@ -149,7 +149,7 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
       };
 
       const resentForm = await formRepository.update(
-        { id: form.id },
+        { id: form.id, status: form.status },
         {
           status: transitionForm(form, {
             type: EventType.SignedByTransporter,
@@ -206,7 +206,7 @@ const signedByTransporterResolver: MutationResolvers["signedByTransporter"] =
     };
 
     const sentForm = await formRepository.update(
-      { id: form.id },
+      { id: form.id, status: form.status },
       {
         status: transitionForm(form, {
           type: EventType.SignedByTransporter,


### PR DESCRIPTION
Quand on a plusieurs requêtes de signatures qui se suivent on ne veut pas que 2 changements de statuts soient joués à la suite et que l'un écrase l'autre.

Pour éviter ca on check à l'update que le statut qu'on a lu est bien le même que celui en DB quand on écrit.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
