### PR TITLE
[TRA_14492] Supprimer le type de profil Crémation et ne conserver que le sous-type de l'Installation de traitement 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :boom: Breaking changes
 
+- Le profil crématorium est déprécié au profit du sous-type crémation [PR 3468](https://github.com/MTES-MCT/trackdechets/pull/3468)
+
 #### :nail_care: Améliorations
 
 - Amélioration du message d'erreur à l'ajout d'un Crématorium non inscrit / n'ayant pas le bon profil [PR 3401](https://github.com/MTES-MCT/trackdechets/pull/3401)

--- a/back/src/__tests__/factories.integration.ts
+++ b/back/src/__tests__/factories.integration.ts
@@ -57,8 +57,7 @@ describe("Test Factories", () => {
       "TRANSPORTER",
       "WASTEPROCESSOR",
       "WORKER",
-      "WASTE_VEHICLES",
-      "CREMATORIUM"
+      "WASTE_VEHICLES"
     ]);
     expect(companyAssociations[0].company.siret).toBe(company.siret);
   });

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -77,8 +77,7 @@ export const companyFactory = async (
           "TRANSPORTER",
           "WASTEPROCESSOR",
           "WORKER",
-          "WASTE_VEHICLES",
-          "CREMATORIUM"
+          "WASTE_VEHICLES"
         ]
       },
       name: `company_${companyIndex}`,
@@ -372,7 +371,7 @@ export const upsertBaseSiret = async siret => {
           orgId: siret,
           siret,
           companyTypes: {
-            set: ["TRANSPORTER", "WASTEPROCESSOR", "WORKER", "CREMATORIUM"]
+            set: ["TRANSPORTER", "WASTEPROCESSOR", "WORKER"]
           },
           name: `company_${siret}`,
           securityCode: 1234,

--- a/back/src/__tests__/oidc.integration.ts
+++ b/back/src/__tests__/oidc.integration.ts
@@ -583,8 +583,7 @@ describe("/oidc/token - id/secret auth", () => {
           "TRANSPORTER",
           "WASTEPROCESSOR",
           "WORKER",
-          "WASTE_VEHICLES",
-          "CREMATORIUM"
+          "WASTE_VEHICLES"
         ],
         verified: false
       }
@@ -1086,8 +1085,7 @@ describe("/oidc/token - basic auth", () => {
           "TRANSPORTER",
           "WASTEPROCESSOR",
           "WORKER",
-          "WASTE_VEHICLES",
-          "CREMATORIUM"
+          "WASTE_VEHICLES"
         ],
         verified: true
       }

--- a/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -782,7 +782,7 @@ describe("Mutation.submitBsdasriRevisionRequestApproval", () => {
       }
     });
 
-    const res = await mutate<
+    await mutate<
       Pick<Mutation, "submitBsdasriRevisionRequestApproval">,
       MutationSubmitBsdasriRevisionRequestApprovalArgs
     >(SUBMIT_BSDASRI_REVISION_REQUEST_APPROVAL, {
@@ -791,7 +791,7 @@ describe("Mutation.submitBsdasriRevisionRequestApproval", () => {
         isApproved: true
       }
     });
-    console.log(res);
+
     const updatedBsdasri = await prisma.bsdasri.findUniqueOrThrow({
       where: { id: bsdasri.id }
     });

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
@@ -92,7 +92,10 @@ describe("Query.bsds.bspaohs base workflow", () => {
     await transporterReceiptFactory({ company: transporter.company });
     destination = await userWithCompanyFactory(UserRole.ADMIN, {
       companyTypes: {
-        set: ["CREMATORIUM"]
+        set: ["WASTEPROCESSOR"]
+      },
+      wasteProcessorTypes: {
+        set: ["CREMATION"]
       }
     });
   });

--- a/back/src/bspaoh/__tests__/factories.integration.ts
+++ b/back/src/bspaoh/__tests__/factories.integration.ts
@@ -1,5 +1,5 @@
 import { resetDatabase } from "../../../integration-tests/helper";
-import { bspaohFactory } from "./factories";
+import { bspaohFactory, crematoriumFactory } from "./factories";
 
 describe("Test Factories", () => {
   afterEach(resetDatabase);
@@ -16,5 +16,12 @@ describe("Test Factories", () => {
     expect(paoh.transportersSirets).toEqual([
       paoh.transporters[0].transporterCompanySiret
     ]);
+  });
+
+  test("should create a crematorium", async () => {
+    const crematorium = await crematoriumFactory();
+    expect(crematorium.id).toBeTruthy();
+    expect(crematorium.companyTypes).toEqual(["WASTEPROCESSOR"]);
+    expect(crematorium.wasteProcessorTypes).toEqual(["CREMATION"]);
   });
 });

--- a/back/src/bspaoh/__tests__/factories.ts
+++ b/back/src/bspaoh/__tests__/factories.ts
@@ -1,7 +1,11 @@
 import { prisma } from "@td/prisma";
 import { BspaohStatus, Prisma } from "@prisma/client";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
-import { siretify, upsertBaseSiret } from "../../__tests__/factories";
+import {
+  siretify,
+  upsertBaseSiret,
+  companyFactory
+} from "../../__tests__/factories";
 
 const getBspaohTransporter = (
   transporterCompanySiret
@@ -84,6 +88,11 @@ export const bspaohFactory = async ({
   await upsertBaseSiret(emitterCompanySiret);
   await upsertBaseSiret(destinationCompanySiret);
   await upsertBaseSiret(transporterCompanySiret);
+
+  await prisma.company.update({
+    where: { siret: destinationCompanySiret },
+    data: { wasteProcessorTypes: ["CREMATION"] }
+  });
   const bspaohObject = getBspaohObject(
     emitterCompanySiret,
     destinationCompanySiret,
@@ -120,5 +129,16 @@ export const bspaohFactory = async ({
       transportersSirets
     },
     include: { transporters: true }
+  });
+};
+
+export const crematoriumFactory = async (
+  companyOpts: Partial<Prisma.CompanyCreateInput> = {}
+) => {
+  const opts = companyOpts || {};
+  return companyFactory({
+    companyTypes: { set: ["WASTEPROCESSOR"] },
+    wasteProcessorTypes: { set: ["CREMATION"] },
+    ...opts
   });
 };

--- a/back/src/bspaoh/examples/workflows/acheminementDirect.ts
+++ b/back/src/bspaoh/examples/workflows/acheminementDirect.ts
@@ -10,11 +10,14 @@ import { updateTransport } from "../steps/updateTransport";
 
 export default {
   title: `Acheminement direct du producteur des déchets vers le crématorium`,
-  description: "plop",
   companies: [
     { name: "emetteur", companyTypes: ["PRODUCER"] },
     { name: "transporteur", companyTypes: ["TRANSPORTER"] },
-    { name: "crematorium", companyTypes: ["CREMATORIUM"] }
+    {
+      name: "crematorium",
+      companyTypes: ["WASTEPROCESSOR"],
+      opt: { wasteProcessorTypes: ["CREMATION"] }
+    }
   ],
   steps: [
     createBspaoh("emetteur"),

--- a/back/src/bspaoh/examples/workflows/acheminementDirectAvecDepot.ts
+++ b/back/src/bspaoh/examples/workflows/acheminementDirectAvecDepot.ts
@@ -15,7 +15,11 @@ export default {
   companies: [
     { name: "emetteur", companyTypes: ["PRODUCER"] },
     { name: "transporteur", companyTypes: ["TRANSPORTER"] },
-    { name: "crematorium", companyTypes: ["CREMATORIUM"] }
+    {
+      name: "crematorium",
+      companyTypes: ["WASTEPROCESSOR"],
+      opt: { wasteProcessorTypes: ["CREMATION"] }
+    }
   ],
   steps: [
     createBspaoh("emetteur"),

--- a/back/src/bspaoh/examples/workflows/acheminementDirectDepuisBrouillon.ts
+++ b/back/src/bspaoh/examples/workflows/acheminementDirectDepuisBrouillon.ts
@@ -13,7 +13,11 @@ export default {
   companies: [
     { name: "emetteur", companyTypes: ["PRODUCER"] },
     { name: "transporteur", companyTypes: ["TRANSPORTER"] },
-    { name: "crematorium", companyTypes: ["CREMATORIUM"] }
+    {
+      name: "crematorium",
+      companyTypes: ["WASTEPROCESSOR"],
+      opt: { wasteProcessorTypes: ["CREMATION"] }
+    }
   ],
   steps: [
     createDraftBspaoh("emetteur"),

--- a/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
@@ -12,6 +12,7 @@ import makeClient from "../../../../__tests__/testClient";
 import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
 import { sirenify as sirenifyBspaohInput } from "../../../validation/sirenify";
+import { crematoriumFactory } from "../../../__tests__/factories";
 
 jest.mock("../../../validation/sirenify");
 (sirenifyBspaohInput as jest.Mock).mockImplementation(input =>
@@ -86,7 +87,7 @@ describe("Mutation.Bspaoh.create", () => {
     "should allow bspaoh creation",
     async bspaohType => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
-      const destinationCompany = await companyFactory();
+      const destinationCompany = await crematoriumFactory();
 
       const input: BspaohInput = {
         waste: {
@@ -171,10 +172,7 @@ describe("Mutation.Bspaoh.create", () => {
   it("should allow bspaoh creation for CREMATION companies", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
 
-    const destinationCompany = await companyFactory({
-      companyTypes: ["WASTEPROCESSOR"],
-      wasteProcessorTypes: ["CREMATION"]
-    });
+    const destinationCompany = await crematoriumFactory();
 
     const input: BspaohInput = {
       waste: {
@@ -257,7 +255,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it("should allow bspaoh creation for transporters", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
     const emitterCompany = await companyFactory();
 
     const input: BspaohInput = {
@@ -338,7 +336,8 @@ describe("Mutation.Bspaoh.create", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
 
     const { company: destinationCompany } = await userWithCompanyFactory(
-      "MEMBER"
+      "MEMBER",
+      { wasteProcessorTypes: { set: ["CREMATION"] } }
     );
 
     const transporterCompany = await companyFactory({
@@ -418,7 +417,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it("should forbid waste codes other than 18 01 02", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
 
     const input: BspaohInput = {
       waste: {
@@ -495,7 +494,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it("should forbid liquid consitence for FOETUS bspaoh", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
 
     const input: BspaohInput = {
       waste: {
@@ -571,7 +570,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it("should require transporter siret for creation", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
 
     const input: BspaohInput = {
       waste: {
@@ -636,10 +635,11 @@ describe("Mutation.Bspaoh.create", () => {
     ]);
   });
 
-  it("should forbid companies which are neither CREMATORIUM nor CREMATION for destination company", async () => {
+  it("should forbid companies which don't have wasteprocessorType.CREMATION for destination company", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const destinationCompany = await companyFactory({
-      companyTypes: ["WASTEPROCESSOR"]
+      companyTypes: ["WASTEPROCESSOR"],
+      wasteProcessorTypes: []
     });
 
     const input: BspaohInput = {
@@ -795,7 +795,9 @@ describe("Mutation.Bspaoh.create", () => {
 
   it("should forbid incomplete packagings", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await companyFactory({
+      wasteProcessorTypes: { set: ["CREMATION"] }
+    });
 
     const input: BspaohInput = {
       waste: {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/createDraftBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createDraftBspaoh.integration.ts
@@ -4,7 +4,6 @@ import {
   userFactory,
   userWithCompanyFactory,
   companyAssociatedToExistingUserFactory,
-  companyFactory,
   siretify
 } from "../../../../__tests__/factories";
 import { UserRole } from "@prisma/client";
@@ -14,6 +13,7 @@ import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
 import { prisma } from "@td/prisma";
 import { sirenify as sirenifyBspaohInput } from "../../../validation/sirenify";
+import { crematoriumFactory } from "../../../__tests__/factories";
 
 jest.mock("../../../validation/sirenify");
 (sirenifyBspaohInput as jest.Mock).mockImplementation(input =>
@@ -86,7 +86,7 @@ describe("Mutation.createDraftBspaoh", () => {
 
   it("create a draft bspaoh with an emitter and a destination", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destination = await companyFactory();
+    const destination = await crematoriumFactory();
 
     const input = {
       emitter: {
@@ -124,7 +124,7 @@ describe("Mutation.createDraftBspaoh", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     // user has a second company, not on the paoh, not expected in `canAccessDraftSirets`
     await companyAssociatedToExistingUserFactory(user, UserRole.MEMBER);
-    const destination = await companyFactory();
+    const destination = await crematoriumFactory();
 
     const input = {
       emitter: {
@@ -170,7 +170,11 @@ describe("Mutation.createDraftBspaoh", () => {
 
     const destination = await companyAssociatedToExistingUserFactory(
       user,
-      UserRole.MEMBER
+      UserRole.MEMBER,
+      {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      }
     );
 
     const input = {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
@@ -15,6 +15,7 @@ import {
 import { searchCompany } from "../../../../companies/search";
 import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
+import { crematoriumFactory } from "../../../__tests__/factories";
 
 jest.mock("../../../../companies/search");
 
@@ -142,7 +143,7 @@ describe("Mutation.duplicateBspaoh", () => {
       await prisma.transporterReceipt.findUniqueOrThrow({
         where: { id: transporterCompany.transporterReceiptId! }
       });
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
     const bspaoh = await bspaohFactory({
       opt: {
         emitterCompanySiret: emitter.company.siret,
@@ -343,7 +344,7 @@ describe("Mutation.duplicateBspaoh", () => {
       await prisma.transporterReceipt.findUniqueOrThrow({
         where: { id: transporterCompany.transporterReceiptId! }
       });
-    const destinationCompany = await companyFactory();
+    const destinationCompany = await crematoriumFactory();
 
     const bspaoh = await bspaohFactory({
       opt: {

--- a/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohOperation.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohOperation.integration.ts
@@ -30,7 +30,10 @@ describe("Mutation.Bspaoh.sign", () => {
 
   describe("OPERATION", () => {
     it("should allow destination to sign operation", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -99,7 +102,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should disallow destination to sign operation if reception is not signed", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company

--- a/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohReception.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/signBspaohReception.integration.ts
@@ -34,7 +34,10 @@ describe("Mutation.Bspaoh.sign", () => {
 
   describe("RECEPTION", () => {
     it("should allow destination to sign reception (RECEIVED)", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -103,7 +106,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should allow destination to sign reception (RECEIVED) if no weight, but quantity is provided", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -172,7 +178,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should allow destination to sign reception (REFUSED)", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -309,7 +318,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should disallow destination to sign reception if transporter did not sign", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -379,7 +391,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should disallow destination to sign reception (REFUSED) if refusal reason is missing", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -447,7 +462,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should deny destination to sign reception if all packagins are accepted (PARTIALLY_REFUSED)", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -514,8 +532,12 @@ describe("Mutation.Bspaoh.sign", () => {
         })
       ]);
     });
+
     it("should allow destination to sign reception (PARTIALLY_REFUSED)", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -585,7 +607,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should disallow destination to sign reception if received waste fields are incomplete", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -658,7 +683,10 @@ describe("Mutation.Bspaoh.sign", () => {
     });
 
     it("should deny reception signature if all packagings reception info is missing", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -729,7 +757,10 @@ describe("Mutation.Bspaoh.sign", () => {
       expect(persisted?.status).toEqual(BspaohStatus.SENT);
     });
     it("should deny reception signature if some packagings reception info is missing", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company
@@ -803,7 +834,10 @@ describe("Mutation.Bspaoh.sign", () => {
       expect(persisted?.status).toEqual(BspaohStatus.SENT);
     });
     it("should deny reception signature if all packagings are not accepted", async () => {
-      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN, {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      });
       const transporter = await userWithCompanyFactory(UserRole.ADMIN);
       const transporterReceipt = await transporterReceiptFactory({
         company: transporter.company

--- a/back/src/bspaoh/resolvers/mutations/__tests__/updateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/updateBspaoh.integration.ts
@@ -17,6 +17,7 @@ import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
 import { prisma } from "@td/prisma";
 import { sirenify as sirenifyBspaohInput } from "../../../validation/sirenify";
+import { crematoriumFactory } from "../../../__tests__/factories";
 
 jest.mock("../../../validation/sirenify");
 (sirenifyBspaohInput as jest.Mock).mockImplementation(input =>
@@ -175,7 +176,11 @@ describe("Mutation.updateBspaoh", () => {
     const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
     const destination = await companyAssociatedToExistingUserFactory(
       user,
-      UserRole.MEMBER
+      UserRole.MEMBER,
+      {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      }
     );
     const bspaoh = await bspaohFactory({
       opt: {
@@ -360,7 +365,10 @@ describe("Mutation.updateBspaoh", () => {
   });
 
   it("should not update emitter if they signed already", async () => {
-    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN, {
+      companyTypes: { set: ["WASTEPROCESSOR"] },
+      wasteProcessorTypes: { set: ["CREMATION"] }
+    });
     const bspaoh = await bspaohFactory({
       opt: {
         status: "SIGNED_BY_PRODUCER",
@@ -397,9 +405,12 @@ describe("Mutation.updateBspaoh", () => {
   });
 
   it("should allow emitter to update destination when he is the only one to have signed", async () => {
-    const { company: emitter, user } = await userWithCompanyFactory("ADMIN");
-    const destination = await companyFactory();
-    const destination2 = await companyFactory();
+    const { company: emitter, user } = await userWithCompanyFactory("ADMIN", {
+      companyTypes: { set: ["WASTEPROCESSOR"] },
+      wasteProcessorTypes: { set: ["CREMATION"] }
+    });
+    const destination = await crematoriumFactory();
+    const destination2 = await crematoriumFactory();
 
     const bspaoh = await bspaohFactory({
       opt: {
@@ -433,9 +444,12 @@ describe("Mutation.updateBspaoh", () => {
   });
 
   it("should not allow emitter to update destination if the transporter has signed", async () => {
-    const { company: emitter, user } = await userWithCompanyFactory("ADMIN");
-    const destination = await companyFactory();
-    const destination2 = await companyFactory();
+    const { company: emitter, user } = await userWithCompanyFactory("ADMIN", {
+      companyTypes: { set: ["WASTEPROCESSOR"] },
+      wasteProcessorTypes: { set: ["CREMATION"] }
+    });
+    const destination = await crematoriumFactory();
+    const destination2 = await crematoriumFactory();
     const transporter = await companyFactory();
 
     const bspaoh = await bspaohFactory({

--- a/back/src/bspaoh/validation/__tests__/validation.integration.ts
+++ b/back/src/bspaoh/validation/__tests__/validation.integration.ts
@@ -347,7 +347,10 @@ describe("BSPAOH validation", () => {
     });
 
     test("when destination is registered with wrong profile", async () => {
-      const company = await companyFactory({ companyTypes: ["PRODUCER"] });
+      const company = await companyFactory({
+        companyTypes: ["PRODUCER"],
+        wasteProcessorTypes: []
+      });
       const bspaoh = await bspaohFactory({});
       const data = {
         ...bspaoh,
@@ -467,7 +470,13 @@ describe("BSPAOH validation", () => {
   it("should be possible to update any fields when bspaoh status is SIGNED_BY_PRODUCER", async () => {
     const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
 
-    const { company: destinationCompany } = await userWithCompanyFactory();
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "ADMIN",
+      {
+        companyTypes: { set: ["WASTEPROCESSOR"] },
+        wasteProcessorTypes: { set: ["CREMATION"] }
+      }
+    );
     const bspaoh = await bspaohFactory({
       opt: {
         transporters: {

--- a/back/src/bspaoh/validation/dynamicRefinements.ts
+++ b/back/src/bspaoh/validation/dynamicRefinements.ts
@@ -5,7 +5,7 @@ import { BspaohValidationContext } from "./index";
 import { ZodBspaoh, ZodFullBspaoh } from "./schema";
 import { distinct } from "../../common/arrays";
 import { CompanyVerificationStatus } from "@prisma/client";
-import { hasCremationProfile, isCrematorium } from "../../companies/validation";
+import { hasCremationProfile } from "../../companies/validation";
 import {
   isTransporterRefinement,
   refineSiretAndGetCompany
@@ -186,7 +186,7 @@ function validateWeightFields(
 }
 export async function isCrematoriumRefinement(siret: string, ctx) {
   const company = await refineSiretAndGetCompany(siret, ctx);
-  if (company && !isCrematorium(company) && !hasCremationProfile(company)) {
+  if (company && !hasCremationProfile(company)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       message:

--- a/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
@@ -90,6 +90,29 @@ describe("mutation updateCompany", () => {
     expect(updatedCompany).toMatchObject(variables);
   });
 
+  it("should fail to update a company with crematorium companyType", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const variables = {
+      id: company.id,
+      companyTypes: ["CREMATORIUM"]
+    };
+    const { errors } = await mutate<Pick<Mutation, "updateCompany">>(
+      UPDATE_COMPANY,
+      {
+        variables
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le type CREMATORIUM est déprécié, utiliser WasteProcessorTypes.CREMATION."
+      })
+    ]);
+  });
+
   it("should update a french company information with name and adresse from Sirene index", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN", {
       codeNaf: "0112Z"

--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -117,6 +117,12 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
     throw new UserInputError(CLOSED_COMPANY_ERROR);
   }
 
+  if (companyTypes.includes("CREMATORIUM")) {
+    throw new UserInputError(
+      "Le type CREMATORIUM est déprécié, utiliser WasteProcessorTypes.CREMATION."
+    );
+  }
+
   if (companyTypes.includes("ECO_ORGANISME") && siret) {
     const ecoOrganismeExists = await prisma.ecoOrganisme.findUnique({
       where: { siret }
@@ -285,7 +291,6 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
   ) {
     await sendFirstOnboardingEmail(companyInput, user);
   }
-
   return convertUrls(company);
 };
 

--- a/back/src/companies/resolvers/mutations/updateCompany.ts
+++ b/back/src/companies/resolvers/mutations/updateCompany.ts
@@ -82,6 +82,11 @@ const updateCompanyResolver: MutationResolvers["updateCompany"] = async (
   const { companyTypes, collectorTypes, wasteProcessorTypes } =
     await validateCompanyTypes(company, args);
 
+  if (companyTypes.includes("CREMATORIUM")) {
+    throw new UserInputError(
+      "Le type CREMATORIUM est déprécié, utiliser WasteProcessorTypes.CREMATION."
+    );
+  }
   const { ecoOrganismeAgreements } = args;
   // update to anything else than ony a TRANSPORTER
   const updateOtherThanTransporter = args.companyTypes?.some(

--- a/back/src/companies/resolvers/queries/__tests__/companyPrivateInfos.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyPrivateInfos.integration.ts
@@ -480,8 +480,6 @@ describe("query { companyPrivateInfos(clue: <SIRET>) }", () => {
       gqlquery
     );
 
-    console.log(response);
-
     expect(response.data.companyPrivateInfos.users).toEqual([
       { email: companyMember.email }
     ]);

--- a/back/src/companies/typeDefs/company.enums.graphql
+++ b/back/src/companies/typeDefs/company.enums.graphql
@@ -32,6 +32,7 @@ enum CompanyType {
 
   "Crématorium"
   CREMATORIUM
+    @deprecated(reason: "Déprécié - Utiliser WasteprocessorType.CREMATION")
 
   "Intermédiaire : établissement qui peut être ajouté à une traçabilité, sans responsabilité réglementaire (y compris entreprises de travaux hors amiante)"
   INTERMEDIARY

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -57,9 +57,7 @@ export function isForeignTransporter({
 export function isWorker(company: Company) {
   return company.companyTypes.includes(CompanyType.WORKER);
 }
-export function isCrematorium(company: Company) {
-  return company.companyTypes.includes(CompanyType.CREMATORIUM);
-}
+
 export function hasCremationProfile(company: Company) {
   return company.wasteProcessorTypes.includes(WasteProcessorType.CREMATION);
 }

--- a/e2e/src/plans/companies.spec.ts
+++ b/e2e/src/plans/companies.spec.ts
@@ -290,7 +290,22 @@ test.describe
       });
     });
 
-    await test.step("#013 - Producteur + Transporteur avec signature DASRI", async () => {
+    await test.step("#013 - Crématorium", async () => {
+      await createWasteManagingCompany(page, {
+        company: {
+          name: "013 - Crématorium",
+          roles: ["Installation de traitement"],
+          subRoles: ["Crématorium (et cimetières pour la Guyane)"]
+        },
+        contact: {
+          name: "Crématorium 013",
+          phone: "+33 4 75 84 85 78",
+          email: "crematorium@installation.com"
+        }
+      });
+    });
+
+    await test.step("#014 - Producteur + Transporteur avec signature DASRI", async () => {
       await createWasteManagingCompany(page, {
         company: {
           name: "014 - Producteur + Transporteur",

--- a/e2e/src/plans/companies.spec.ts
+++ b/e2e/src/plans/companies.spec.ts
@@ -269,20 +269,6 @@ test.describe
       });
     });
 
-    await test.step("#013 - Crématorium", async () => {
-      await createWasteManagingCompany(page, {
-        company: {
-          name: "013 - Crématorium",
-          roles: ["Crématorium"]
-        },
-        contact: {
-          name: "Crématorium 013",
-          phone: "+33 4 75 84 85 78",
-          email: "crematorium@installation.com"
-        }
-      });
-    });
-
     await test.step("Établissement à supprimer", async () => {
       let producerSiret;
 
@@ -304,7 +290,7 @@ test.describe
       });
     });
 
-    await test.step("#014 - Producteur + Transporteur avec signature DASRI", async () => {
+    await test.step("#013 - Producteur + Transporteur avec signature DASRI", async () => {
       await createWasteManagingCompany(page, {
         company: {
           name: "014 - Producteur + Transporteur",
@@ -323,7 +309,7 @@ test.describe
       });
     });
 
-    await test.step("#015 - Entreprise de travaux amiante + Transporteur", async () => {
+    await test.step("#014 - Entreprise de travaux amiante + Transporteur", async () => {
       await createWasteManagingCompany(page, {
         company: {
           name: "015 - Entreprise de travaux amiante + transporteur",

--- a/e2e/src/utils/company.ts
+++ b/e2e/src/utils/company.ts
@@ -11,7 +11,6 @@ type CompanyRole =
   | "Installation de traitement"
   | "Négociant"
   | "Courtier"
-  | "Crématorium"
   | "Entreprise de travaux amiante"
   | "Intermédiaire : établissement qui peut être ajouté à une traçabilité, sans responsabilité réglementaire (y compris entreprises de travaux hors amiante)"
   | "Installation de valorisation de T&S"
@@ -71,7 +70,6 @@ export const getCreateButtonName = (roles: CompanyRole[]) => {
         "Installation de traitement",
         "Négociant",
         "Courtier",
-        "Crématorium",
         "Entreprise de travaux amiante"
       ].includes(role)
     ) {

--- a/e2e/src/utils/company.ts
+++ b/e2e/src/utils/company.ts
@@ -16,9 +16,12 @@ type CompanyRole =
   | "Installation de valorisation de T&S"
   | "Installation dans laquelle les déchets perdent leur statut de déchet";
 
+type CompanySubRole = "Crématorium (et cimetières pour la Guyane)";
+
 interface Company {
   name: string;
   roles: CompanyRole[];
+  subRoles?: CompanySubRole[];
   producesDASRI?: boolean;
 }
 
@@ -224,6 +227,11 @@ export const fillInGenericCompanyInfo = async (
   // Select the role
   for (const role of company.roles)
     await page.getByText(role, { exact: true }).click();
+
+  // Select the subRole
+  company.subRoles?.forEach(
+    async subRole => await page.getByText(subRole, { exact: true }).click()
+  );
 };
 
 /**
@@ -342,6 +350,9 @@ export const submitAndVerifyGenericInfo = async (
   for (const role of company.roles) {
     await expect(rolesDiv.getByText(role)).toBeVisible();
   }
+  company.subRoles?.forEach(async subRole => {
+    await expect(rolesDiv.getByText(subRole)).toBeVisible();
+  });
   await expect(companyDiv.getByText(`Nom Usuel${company.name}`)).toBeVisible();
   await expect(companyDiv.getByText("AdresseAdresse test")).toBeVisible();
   await expect(companyDiv.getByText("Code NAFXXXXX -")).toBeVisible();

--- a/front/src/Apps/Companies/common/utils.ts
+++ b/front/src/Apps/Companies/common/utils.ts
@@ -82,12 +82,6 @@ export const COMPANY_CONSTANTS = [
     label:
       "Installation dans laquelle les déchets perdent leur statut de déchet",
     helpText: ""
-  },
-  {
-    value: CompanyType.Crematorium,
-    label: "Crématorium",
-    helpText:
-      "Un crématorium autorisé prend en charge l'incinération des pièces anatomiques d'origine humaine"
   }
 ];
 
@@ -125,7 +119,7 @@ export const WASTE_PROCESSOR_OPTIONS = [
     value: WasteProcessorType.NonDangerousWastesIncineration
   },
   {
-    label: "Crémation",
+    label: "Crématorium (et cimetières pour la Guyane)",
     value: WasteProcessorType.Cremation
   },
   {

--- a/front/src/form/bspaoh/steps/Destination.tsx
+++ b/front/src/form/bspaoh/steps/Destination.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useEffect, useContext } from "react";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import {
   FavoriteType,
-  CompanyType,
   CompanySearchResult,
   WasteProcessorType
 } from "@td/codegen-ui";
@@ -45,7 +44,6 @@ export function Destination() {
       if (!company.isRegistered) {
         return "Cet établissement n'est pas inscrit sur Trackdéchets, il ne peut pas être ajouté sur le bordereau.";
       } else if (
-        !company.companyTypes?.includes(CompanyType.Crematorium) &&
         !company.wasteProcessorTypes?.includes(WasteProcessorType.Cremation)
       ) {
         return "Cet établissement n'a pas le profil Crématorium (et cimetières pour la Guyane).";

--- a/libs/back/scripts/src/scripts/20240717071507541_crematoriums-to-subtype-cremation.ts
+++ b/libs/back/scripts/src/scripts/20240717071507541_crematoriums-to-subtype-cremation.ts
@@ -1,0 +1,34 @@
+import { Prisma } from "@prisma/client";
+import { CompanyType, WasteProcessorType } from "@prisma/client";
+
+/**
+ *
+ *  Select CREMATORIUM companies
+ *  Add CREMATION to wasteProcessorTypes
+ *  Add WASTEPROCESSOR to companyTypes if needed
+ *  Remove CREMATORIUM from companyTypes
+ */
+export async function run(tx: Prisma.TransactionClient) {
+  const crematoriums = await tx.company.findMany({
+    where: {
+      companyTypes: { has: CompanyType.CREMATORIUM }
+    }
+  });
+  // prisma does not provide array item removing, we have to update the few relevant companies one by one to update companyTypes
+  for (const crematorium of crematoriums) {
+    await tx.company.update({
+      where: { id: crematorium.id },
+      data: {
+        wasteProcessorTypes: { push: WasteProcessorType.CREMATION },
+        companyTypes: [
+          ...new Set([
+            ...crematorium.companyTypes.filter(
+              type => type !== CompanyType.CREMATORIUM
+            ),
+            CompanyType.WASTEPROCESSOR
+          ])
+        ]
+      }
+    });
+  }
+}


### PR DESCRIPTION
Breaking change annoncé dans la NL du 01/07

 Le companyType CREMATORIUM est déprécié au profit de wasteProcessorTypes.CREMATION.

- L' enum en Db est conservé 
- Un script met à jour les companies
- CREMATORIUM est déprécié dans les types gql
- Une validation est effectuée sur les mutations de companies
- L'import en masse n'est pas traité, le validateur https://validateur.trackdechets.beta.gouv.fr/ bloque les types CREMATORIUM
- mise à jour de l'UI: creation et modification d'établissement (cf Screenshots)
- le companySelector de destination du PAOH affiche le m^me message d'erreur si l'établissement n'a pas le sous-type wasteProcessorTypes CREMATION

<img width="1009" alt="Capture d’écran 2024-07-18 à 09 28 58" src="https://github.com/user-attachments/assets/c21369ec-45cf-4d47-8450-a7da804b2c42">

<img width="1233" alt="Capture d’écran 2024-07-18 à 09 28 26" src="https://github.com/user-attachments/assets/13a5a4c7-049c-4e0e-8649-87aa3eb97e79">


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14492)
