### PR TITLE
Recette multi-modal BSFF

### DIFF
--- a/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/bsdCard.test.tsx
@@ -398,6 +398,21 @@ describe("Bsd card primary action label", () => {
         customInfo: null,
         __typename: "BsffTransporter"
       },
+      transporters: [
+        {
+          company: {
+            siret: "13001045700013",
+            name: "DIRECTION REGIONALE DE L'ENVIRONNEMENT DE L'AMENAGEMENT ET DU LOGEMENT NOUVELLE-AQUITAINE",
+            __typename: "FormCompany"
+          },
+          transport: {
+            plates: [],
+            __typename: "BsffTransport"
+          },
+          customInfo: null,
+          __typename: "BsffTransporter"
+        }
+      ],
       bsffDestination: {
         company: {
           siret: "13001045700013",

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1242,11 +1242,13 @@ const canDuplicateBsdd = bsd =>
 
 export const canDuplicateBsff = (bsd, siret) => {
   const emitterSiret = bsd.emitter?.company?.siret;
-  const transporterSiret = bsd.transporter?.company?.siret;
+  const transporterOrgsIds = bsd.transporters?.map(t => t.company?.orgId);
   const destinationSiret = bsd.destination?.company?.siret;
   return (
     bsd.type === BsdType.Bsff &&
-    [emitterSiret, transporterSiret, destinationSiret].includes(siret)
+    [emitterSiret, destinationSiret, ...transporterOrgsIds]
+      .filter(Boolean)
+      .includes(siret)
   );
 };
 

--- a/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/WorkflowAction/SignTransport.tsx
@@ -121,7 +121,7 @@ function SignTransportForm({
             les informations ci-dessus sont correctes. En signant ce document,
             je déclare prendre en charge le déchet.
           </p>
-          <TransporterRecepisseWrapper transporter={bsff.transporter!} />
+          <TransporterRecepisseWrapper transporter={signingTransporter} />
 
           {!signingTransporter.transport?.mode ||
             (signingTransporter.transport?.mode === TransportMode.Road && (


### PR DESCRIPTION
- La modale de signature transport affichait le récépissé du transporteur N°1 pour les transporteurs N+1
- Les boutons Modifier et Dupliquer n'apparaissaient pas pour les transporteurs N>1

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14403)
