### PR TITLE
[TRA-14634] Correctifs de recette sur les quantités refusées

### DIFF
--- a/back/src/bsda/mails/__tests__/refused.integration.ts
+++ b/back/src/bsda/mails/__tests__/refused.integration.ts
@@ -58,8 +58,8 @@ describe("renderBsdaRefusedEmail", () => {
       ?.dividedBy(1000)
       .toDecimalPlaces(6)
       .toNumber()} tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${bsda.destinationReceptionRefusalReason}</span>`);
@@ -168,8 +168,8 @@ describe("renderBsdaRefusedEmail", () => {
       ?.dividedBy(1000)
       .toDecimalPlaces(6)
       .toNumber()} tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${bsda.destinationReceptionRefusalReason}</span>`);

--- a/back/src/bsda/mails/__tests__/refused.integration.ts
+++ b/back/src/bsda/mails/__tests__/refused.integration.ts
@@ -54,12 +54,12 @@ describe("renderBsdaRefusedEmail", () => {
     <li>Numéro du BSD: ${bsda.id}</li>
     <li>Appellation du déchet : ${bsda.wasteMaterialName}</li>
     <li>Code déchet : ${bsda.wasteCode}</li>
-    <li>Quantité réelle présentée nette: ${bsda.destinationReceptionWeight
+    <li>Quantité réelle présentée nette : ${bsda.destinationReceptionWeight
       ?.dividedBy(1000)
       .toDecimalPlaces(6)
       .toNumber()} tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${bsda.destinationReceptionRefusalReason}</span>`);
@@ -164,12 +164,12 @@ describe("renderBsdaRefusedEmail", () => {
     <li>Numéro du BSD : ${bsda.id}</li>
     <li>Appellation du déchet : ${bsda.wasteMaterialName}</li>
     <li>Code déchet : ${bsda.wasteCode}</li>
-    <li>Quantité réelle présentée nette: ${bsda.destinationReceptionWeight
+    <li>Quantité réelle présentée nette : ${bsda.destinationReceptionWeight
       ?.dividedBy(1000)
       .toDecimalPlaces(6)
       .toNumber()} tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${bsda.destinationReceptionRefusalReason}</span>`);

--- a/back/src/bspaoh/mails/__tests__/refused.integration.ts
+++ b/back/src/bspaoh/mails/__tests__/refused.integration.ts
@@ -56,9 +56,9 @@ describe("renderBspaohRefusedEmail", () => {
     <li>Numéro du BSD: ${bspaoh.id}</li>
     <li>Appellation du déchet : Pièce anatomique d&#39;origine humaine</li>
     <li>Code déchet : ${bspaoh.wasteCode}</li>
-    <li>Quantité réelle présentée nette: 0.01 tonnes</li>
-    <li>Quantité refusée nette: 0.01 tonnes</li>
-    <li>Quantité acceptée nette: 0 tonnes</li>
+    <li>Quantité réelle présentée nette : 0.01 tonnes</li>
+    <li>Quantité refusée nette : 0.01 tonnes</li>
+    <li>Quantité acceptée nette : 0 tonnes</li>
     <li>
       Motif de refus :
       <span>${bspaoh.destinationReceptionWasteRefusalReason}</span>`);
@@ -110,9 +110,9 @@ describe("renderBspaohRefusedEmail", () => {
     <li>Numéro du BSD : ${bspaoh.id}</li>
     <li>Appellation du déchet : Pièce anatomique d&#39;origine humaine</li>
     <li>Code déchet : ${bspaoh.wasteCode}</li>
-    <li>Quantité réelle présentée nette: 0.05 tonnes</li>
-    <li>Quantité refusée: 0.03 tonnes</li>
-    <li>Quantité acceptée: 0.02 tonnes</li>
+    <li>Quantité réelle présentée nette : 0.05 tonnes</li>
+    <li>Quantité refusée : 0.03 tonnes</li>
+    <li>Quantité acceptée : 0.02 tonnes</li>
     <li>
       Motif de refus :
       <span>${bspaoh.destinationReceptionWasteRefusalReason}</span>`);

--- a/back/src/bspaoh/mails/__tests__/refused.integration.ts
+++ b/back/src/bspaoh/mails/__tests__/refused.integration.ts
@@ -57,8 +57,8 @@ describe("renderBspaohRefusedEmail", () => {
     <li>Appellation du déchet : Pièce anatomique d&#39;origine humaine</li>
     <li>Code déchet : ${bspaoh.wasteCode}</li>
     <li>Quantité réelle présentée nette: 0.01 tonnes</li>
-    <li>Quantité refusée: 0.01 tonnes</li>
-    <li>Quantité acceptée: 0 tonnes</li>
+    <li>Quantité refusée nette: 0.01 tonnes</li>
+    <li>Quantité acceptée nette: 0 tonnes</li>
     <li>
       Motif de refus :
       <span>${bspaoh.destinationReceptionWasteRefusalReason}</span>`);

--- a/back/src/bspaoh/mails/__tests__/refused.integration.ts
+++ b/back/src/bspaoh/mails/__tests__/refused.integration.ts
@@ -111,8 +111,8 @@ describe("renderBspaohRefusedEmail", () => {
     <li>Appellation du déchet : Pièce anatomique d&#39;origine humaine</li>
     <li>Code déchet : ${bspaoh.wasteCode}</li>
     <li>Quantité réelle présentée nette : 0.05 tonnes</li>
-    <li>Quantité refusée : 0.03 tonnes</li>
-    <li>Quantité acceptée : 0.02 tonnes</li>
+    <li>Quantité refusée nette : 0.03 tonnes</li>
+    <li>Quantité acceptée nette : 0.02 tonnes</li>
     <li>
       Motif de refus :
       <span>${bspaoh.destinationReceptionWasteRefusalReason}</span>`);

--- a/back/src/bspaoh/mails/refused.ts
+++ b/back/src/bspaoh/mails/refused.ts
@@ -13,7 +13,11 @@ import { buildPdfAsBase64 } from "../pdf/generator";
 
 const getValueDividedBy1000 = (quantity: number | null) => {
   if (quantity !== null) {
-    return new Decimal(quantity).dividedBy(1000).toNumber().toString(); // mustache doesn't differenciate 0 and null, so return a string
+    return new Decimal(quantity)
+      .dividedBy(1000)
+      .toDecimalPlaces(6)
+      .toNumber()
+      .toString(); // mustache doesn't differenciate 0 and null, so return a string
   }
 
   return null;

--- a/back/src/common/helpers.ts
+++ b/back/src/common/helpers.ts
@@ -12,3 +12,10 @@ export const dateToXMonthAtHHMM = (date: Date = new Date()): string => {
 
   return date.toLocaleDateString("fr-FR", options);
 };
+
+/**
+ * Tests if an object is defined. 0 will be considered as defined.
+ */
+export const isDefined = (obj: any) => {
+  return obj !== null && obj !== undefined;
+};

--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -852,6 +852,32 @@ describe("simpleFormToBsdd", () => {
     expect(bsdd.destinationReceptionRefusedWeight).toEqual(3);
   });
 
+  it("should return destinationReceptionAcceptedWeight = 0", async () => {
+    // Given
+    const { user } = await userWithCompanyFactory("MEMBER");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        wasteAcceptationStatus: "REFUSED",
+        quantityReceived: new Decimal(10),
+        quantityRefused: new Decimal(10)
+      }
+    });
+
+    // When
+    const fullForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.id },
+      include: RegistryFormInclude
+    });
+
+    const bsdd = formToBsdd(fullForm);
+
+    // Then
+    expect(bsdd.destinationReceptionWeight).toEqual(10);
+    expect(bsdd.destinationReceptionAcceptedWeight).toEqual(0);
+    expect(bsdd.destinationReceptionRefusedWeight).toEqual(10);
+  });
+
   it("[legacy] should return quantityReceived (destinationReceptionWeight)", async () => {
     // Given
     const { user } = await userWithCompanyFactory("MEMBER");

--- a/back/src/forms/__tests__/registry.integration.ts
+++ b/back/src/forms/__tests__/registry.integration.ts
@@ -296,6 +296,33 @@ describe("toIncomingWaste", () => {
     expect(wasteRegistry.destinationReceptionRefusedWeight).toBe(8.6);
   });
 
+  it("should contain acceptedWeight = 0 in case of refusal", async () => {
+    // Given
+    const user = await userFactory();
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: {
+        wasteDetailsQuantity: 10.5,
+        wasteAcceptationStatus: "REFUSED",
+        quantityReceived: 11.7,
+        quantityRefused: 11.7
+      }
+    });
+
+    // When
+    const formForRegistry = await prisma.form.findUniqueOrThrow({
+      where: { id: bsdd.id },
+      include: RegistryFormInclude
+    });
+    const wasteRegistry = toIncomingWaste(formToBsdd(formForRegistry));
+
+    // Then
+    expect(wasteRegistry.weight).toBe(10.5);
+    expect(wasteRegistry.destinationReceptionWeight).toBe(11.7);
+    expect(wasteRegistry.destinationReceptionAcceptedWeight).toBe(0);
+    expect(wasteRegistry.destinationReceptionRefusedWeight).toBe(11.7);
+  });
+
   it("should contain nextDestination operation code & notification number", async () => {
     // Given
     const user = await userFactory();

--- a/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
+++ b/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
@@ -204,6 +204,45 @@ describe("renderFormRefusedEmail", () => {
       <span>${form.wasteRefusalReason}</span>`);
   });
 
+  test("when the form is partially refused by the recipient (with quantityRefused) > testing decimals", async () => {
+    // Given
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const form = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        emitterCompanyAddress: emitter.company.address,
+        recipientCompanySiret: destination.company.siret,
+        recipientCompanyName: destination.company.name,
+        recipientCompanyAddress: destination.company.address,
+        sentAt: new Date("2022-01-01"),
+        signedAt: new Date("2022-01-02"),
+        status: Status.ACCEPTED,
+        wasteAcceptationStatus: WasteAcceptationStatus.PARTIALLY_REFUSED,
+        quantityReceived: 8.7,
+        quantityRefused: 4.5,
+        wasteRefusalReason: "Parce que !!"
+      }
+    });
+
+    // When
+    const email = await renderFormRefusedEmail(form);
+
+    // Then
+    expect(email!.body).toContain(
+      `<li>Quantité réelle présentée nette: 8.7 tonnes</li>`
+    );
+    expect(email!.body).toContain(
+      `<li>Quantité refusée nette: 4.5 tonnes</li>`
+    );
+    expect(email!.body).toContain(
+      `<li>Quantité acceptée nette: 4.2 tonnes</li>`
+    );
+  });
+
   test("when the form is refused by the temp storer", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const ttr = await userWithCompanyFactory(UserRole.ADMIN);

--- a/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
+++ b/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
@@ -59,9 +59,9 @@ describe("renderFormRefusedEmail", () => {
     <li>Numéro du BSD: ${form.readableId}</li>
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
-    <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité réelle présentée nette : ${form.quantityReceived} tonnes</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -143,9 +143,9 @@ describe("renderFormRefusedEmail", () => {
     <li>Numéro du BSD : ${form.readableId}</li>
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
-    <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité réelle présentée nette : ${form.quantityReceived} tonnes</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -196,9 +196,9 @@ describe("renderFormRefusedEmail", () => {
     <li>Numéro du BSD : ${form.readableId}</li>
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
-    <li>Quantité réelle présentée nette: 7.5 tonnes</li>
-    <li>Quantité refusée nette: 7.5 tonnes</li>
-    <li>Quantité acceptée nette: 0 tonnes</li>
+    <li>Quantité réelle présentée nette : 7.5 tonnes</li>
+    <li>Quantité refusée nette : 7.5 tonnes</li>
+    <li>Quantité acceptée nette : 0 tonnes</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -233,13 +233,13 @@ describe("renderFormRefusedEmail", () => {
 
     // Then
     expect(email!.body).toContain(
-      `<li>Quantité réelle présentée nette: 8.7 tonnes</li>`
+      `<li>Quantité réelle présentée nette : 8.7 tonnes</li>`
     );
     expect(email!.body).toContain(
-      `<li>Quantité refusée nette: 4.5 tonnes</li>`
+      `<li>Quantité refusée nette : 4.5 tonnes</li>`
     );
     expect(email!.body).toContain(
-      `<li>Quantité acceptée nette: 4.2 tonnes</li>`
+      `<li>Quantité acceptée nette : 4.2 tonnes</li>`
     );
   });
 
@@ -295,9 +295,9 @@ describe("renderFormRefusedEmail", () => {
     <li>Numéro du BSD: ${form.readableId}</li>
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
-    <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité réelle présentée nette : ${form.quantityReceived} tonnes</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -364,11 +364,11 @@ describe("renderFormRefusedEmail", () => {
     <li>Numéro du BSD: ${form.readableId}</li>
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
-    <li>Quantité réelle présentée nette: ${
+    <li>Quantité réelle présentée nette : ${
       forwardedIn?.quantityReceived
     } tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     <li>
       Motif de refus :
       <span>${forwardedIn!.wasteRefusalReason}</span>`);

--- a/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
+++ b/back/src/forms/mail/__tests__/renderFormRefusedEmail.integration.ts
@@ -60,8 +60,8 @@ describe("renderFormRefusedEmail", () => {
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
     <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -144,8 +144,8 @@ describe("renderFormRefusedEmail", () => {
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
     <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -197,8 +197,8 @@ describe("renderFormRefusedEmail", () => {
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
     <li>Quantité réelle présentée nette: 7.5 tonnes</li>
-    <li>Quantité refusée: 7.5 tonnes</li>
-    <li>Quantité acceptée: 0 tonnes</li>
+    <li>Quantité refusée nette: 7.5 tonnes</li>
+    <li>Quantité acceptée nette: 0 tonnes</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -257,8 +257,8 @@ describe("renderFormRefusedEmail", () => {
     <li>Appellation du déchet : ${form.wasteDetailsName}</li>
     <li>Code déchet : ${form.wasteDetailsCode}</li>
     <li>Quantité réelle présentée nette: ${form.quantityReceived} tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${form.wasteRefusalReason}</span>`);
@@ -328,8 +328,8 @@ describe("renderFormRefusedEmail", () => {
     <li>Quantité réelle présentée nette: ${
       forwardedIn?.quantityReceived
     } tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     <li>
       Motif de refus :
       <span>${forwardedIn!.wasteRefusalReason}</span>`);

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -120,7 +120,7 @@ export async function renderFormRefusedEmail(
               ),
               transporterReceipt: forwardedInTransporter?.transporterReceipt,
               sentBy: forwardedIn.sentBy,
-              quantityReceived: forwardedIn.quantityReceived
+              quantityReceived: forwardedIn.quantityReceived?.toDecimalPlaces(6)
             }
           : {
               signedAt: form.signedAt,
@@ -133,7 +133,7 @@ export async function renderFormRefusedEmail(
               transporterCompanySiret: getTransporterCompanyOrgId(transporter),
               transporterReceipt: transporter?.transporterReceipt,
               sentBy: form.sentBy,
-              quantityReceived: form.quantityReceived
+              quantityReceived: form.quantityReceived?.toDecimalPlaces(6)
             })
       }
     },

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -136,10 +136,10 @@ function AcceptationFields({
       />{" "}
       partiellement
       <br />
-      Quantité refusée :{" "}
+      Quantité refusée nette :{" "}
       {displayWasteQuantity(wasteQuantities?.quantityRefused)}
       <br />
-      Quantité acceptée :{" "}
+      Quantité acceptée nette :{" "}
       {displayWasteQuantity(wasteQuantities?.quantityAccepted)}
       <br />
       Motif de refus (même partiel) :<br />

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
@@ -845,9 +845,9 @@ describe("{ mutation { markAsTempStored } }", () => {
     expect(sendMail as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({
         subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
-        body: expect.stringContaining(`<li>Quantité réelle présentée nette: 10 tonnes</li>
-    <li>Quantité refusée nette: 7 tonnes</li>
-    <li>Quantité acceptée nette: 3 tonnes</li>`)
+        body: expect.stringContaining(`<li>Quantité réelle présentée nette : 10 tonnes</li>
+    <li>Quantité refusée nette : 7 tonnes</li>
+    <li>Quantité acceptée nette : 3 tonnes</li>`)
       })
     );
   });
@@ -921,9 +921,9 @@ describe("{ mutation { markAsTempStored } }", () => {
     expect(sendMail as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({
         subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
-        body: expect.stringContaining(`<li>Quantité réelle présentée nette: 10 tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>`)
+        body: expect.stringContaining(`<li>Quantité réelle présentée nette : 10 tonnes</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>`)
       })
     );
   });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStored.integration.ts
@@ -846,8 +846,8 @@ describe("{ mutation { markAsTempStored } }", () => {
       expect.objectContaining({
         subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
         body: expect.stringContaining(`<li>Quantité réelle présentée nette: 10 tonnes</li>
-    <li>Quantité refusée: 7 tonnes</li>
-    <li>Quantité acceptée: 3 tonnes</li>`)
+    <li>Quantité refusée nette: 7 tonnes</li>
+    <li>Quantité acceptée nette: 3 tonnes</li>`)
       })
     );
   });
@@ -922,8 +922,8 @@ describe("{ mutation { markAsTempStored } }", () => {
       expect.objectContaining({
         subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
         body: expect.stringContaining(`<li>Quantité réelle présentée nette: 10 tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>`)
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>`)
       })
     );
   });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
@@ -635,8 +635,8 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
     expect.objectContaining({
       subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
       body: expect.stringContaining(`<li>Quantité réelle présentée nette: 2.4 tonnes</li>
-  <li>Quantité refusée: 1.1 tonnes</li>
-  <li>Quantité acceptée: 1.3 tonnes</li>`)
+  <li>Quantité refusée nette: 1.1 tonnes</li>
+  <li>Quantité acceptée nette: 1.3 tonnes</li>`)
     });
   });
 
@@ -707,8 +707,8 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
     expect.objectContaining({
       subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
       body: expect.stringContaining(`<li>Quantité réelle présentée nette: 2.4 tonnes</li>
-    <li>Quantité refusée: Non renseignée</li>
-    <li>Quantité acceptée: Non renseignée</li>`)
+    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>`)
     });
   });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsTempStorerAccepted.integration.ts
@@ -634,9 +634,9 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
     // Mail
     expect.objectContaining({
       subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
-      body: expect.stringContaining(`<li>Quantité réelle présentée nette: 2.4 tonnes</li>
-  <li>Quantité refusée nette: 1.1 tonnes</li>
-  <li>Quantité acceptée nette: 1.3 tonnes</li>`)
+      body: expect.stringContaining(`<li>Quantité réelle présentée nette : 2.4 tonnes</li>
+  <li>Quantité refusée nette : 1.1 tonnes</li>
+  <li>Quantité acceptée nette : 1.3 tonnes</li>`)
     });
   });
 
@@ -706,9 +706,9 @@ describe("{ mutation { markAsTempStorerAccepted } }", () => {
     // Mail
     expect.objectContaining({
       subject: `Le déchet de l’entreprise ${form.emitterCompanyName} a été partiellement refusé à réception`,
-      body: expect.stringContaining(`<li>Quantité réelle présentée nette: 2.4 tonnes</li>
-    <li>Quantité refusée nette: Non renseignée</li>
-    <li>Quantité acceptée nette: Non renseignée</li>`)
+      body: expect.stringContaining(`<li>Quantité réelle présentée nette : 2.4 tonnes</li>
+    <li>Quantité refusée nette : Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>`)
     });
   });
 });

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -105,7 +105,7 @@ input AcceptedFormInput {
   quantityReceived: Float!
 
   """
-  Quantité refusée (optionnelle)
+  Quantité refusée nette (optionnelle)
 
   Si définie:
   - doit être supérieure à 0 et inférieure ou égale à quantityReceived si le déchet est partiellement refusé.
@@ -143,7 +143,7 @@ input ReceivedFormInput {
   quantityReceived: Float
 
   """
-  Quantité refusée (optionnelle)
+  Quantité refusée nette (optionnelle)
 
   Si définie:
   - doit être supérieure à 0 et inférieure ou égale à quantityReceived si le déchet est partiellement refusé.
@@ -729,7 +729,7 @@ input TempStorerAcceptedFormInput {
   quantityReceived: Float!
 
   """
-  Quantité refusée (optionnelle)
+  Quantité refusée nette (optionnelle)
 
   Si définie:
   - doit être supérieure à 0 et inférieure ou égale à quantityReceived si le déchet est partiellement refusé.
@@ -769,7 +769,7 @@ input TempStoredFormInput {
   quantityReceived: Float!
 
   """
-  Quantité refusée (optionnelle)
+  Quantité refusée nette (optionnelle)
 
   Si définie:
   - doit être supérieure à 0 et inférieure ou égale à quantityReceived si le déchet est partiellement refusé.
@@ -934,7 +934,7 @@ input FormRevisionRequestContentInput {
   "Quantité reçue sur l'installation de destination, en tonnes"
   quantityReceived: Float
 
-  "Quantité refusée, en tonnes"
+  "Quantité refusée nette, en tonnes"
   quantityRefused: Float
 
   "Traitement réalisé (code D/R)"

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -103,10 +103,10 @@ type Form {
   "Quantité réelle présentée en tonnes (case 10)"
   quantityReceived: Float
 
-  "Quantité acceptée"
+  "Quantité acceptée nette"
   quantityAccepted: Float
 
-  "Quantité refusée"
+  "Quantité refusée nette"
   quantityRefused: Float
 
   "Traitement réalisé (code D/R)"
@@ -219,10 +219,10 @@ type InitialForm {
   """
   quantityReceived: Float
 
-  "Quantité acceptée"
+  "Quantité acceptée nette"
   quantityAccepted: Float
 
-  "Quantité refusée"
+  "Quantité refusée nette"
   quantityRefused: Float
 
   """
@@ -336,9 +336,9 @@ type TemporaryStorer {
   quantityType: QuantityType
   "Quantité reçue en tonnes"
   quantityReceived: Float
-  "Quantité refusée en tonnes"
+  "Quantité refusée nette en tonnes"
   quantityRefused: Float
-  "Quantité acceptée en tonnes"
+  "Quantité acceptée nette en tonnes"
   quantityAccepted: Float
   wasteAcceptationStatus: WasteAcceptationStatus
   wasteRefusalReason: String

--- a/back/src/registry/__tests__/columns.test.ts
+++ b/back/src/registry/__tests__/columns.test.ts
@@ -168,6 +168,23 @@ describe("formatRow", () => {
       Object.keys(waste).length + CUSTOM_WASTE_COLUMNS.length
     );
   });
+
+  it("should contain received, refused & accepted quantities", () => {
+    const waste: AllWaste = {
+      destinationReceptionWeight: 11.7,
+      destinationReceptionRefusedWeight: 11.7,
+      destinationReceptionAcceptedWeight: 0
+    };
+
+    const formattedWithLabels = formatRow(waste, true);
+    expect(formattedWithLabels).toEqual(
+      expect.objectContaining({
+        "Quantité réceptionnée nette (tonnes)": 11.7,
+        "Quantité refusée nette (tonnes)": 11.7,
+        "Quantité acceptée / traitée nette (tonnes)": 0
+      })
+    );
+  });
 });
 
 describe("formatSubType", () => {

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -12,6 +12,7 @@ import { formatStatusLabel } from "@td/constants";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { TransportMode } from "@prisma/client";
+import { isDefined } from "../common/helpers";
 
 // Type for custom fields that might not be in the DB
 // But that we still want to display (ie for user convenience)
@@ -46,7 +47,8 @@ const formatBoolean = (b: boolean | null) => {
   }
   return b ? "O" : "N";
 };
-const formatNumber = (n: number) => (!!n ? parseFloat(n.toFixed(3)) : null); // return as a number to allow xls cells formulas
+const formatNumber = (n: number) =>
+  isDefined(n) ? parseFloat(n.toFixed(3)) : null; // return as a number to allow xls cells formulas
 const formatArray = (arr: any[], sep = ",") =>
   Array.isArray(arr) ? arr.join(sep) : "";
 const formatArrayWithMissingElements = (arr: any[]) => {
@@ -335,12 +337,12 @@ export const columns: Column[] = [
   },
   {
     field: "destinationReceptionRefusedWeight",
-    label: "Quantité refusée (tonnes)",
+    label: "Quantité refusée nette (tonnes)",
     format: formatNumber
   },
   {
     field: "destinationReceptionAcceptedWeight",
-    label: "Quantité acceptée / traitée (tonnes)",
+    label: "Quantité acceptée / traitée nette (tonnes)",
     format: formatNumber
   },
   {

--- a/back/src/registry/utils.ts
+++ b/back/src/registry/utils.ts
@@ -1,7 +1,8 @@
 import Decimal from "decimal.js";
+import { isDefined } from "../common/helpers";
 
 export const displayWasteQuantity = (quantity, units = "tonne(s)") => {
-  if (quantity !== null && quantity !== undefined) {
+  if (isDefined(quantity)) {
     return `${new Decimal(quantity).toDecimalPlaces(6).toNumber()} ${units}`;
   }
 

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -78,11 +78,7 @@ import { mapBsdd } from "../../../Apps/Dashboard/bsdMapper";
 import { canAddAppendix1 } from "../../../Apps/Dashboard/dashboardServices";
 import { usePermissions } from "../../../common/contexts/PermissionsContext";
 import { isDefined } from "../../../common/helper";
-import TdTooltip from "../../../common/components/Tooltip";
-import {
-  BSD_DETAILS_QTY_TOOLTIP,
-  NON_RENSEIGNE
-} from "../../../Apps/common/wordings/dashboard/wordingsDashboard";
+import { BSD_DETAILS_QTY_TOOLTIP } from "../../../Apps/common/wordings/dashboard/wordingsDashboard";
 
 type CompanyProps = {
   company?: FormCompany | null;

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -146,20 +146,20 @@ const TempStorage = ({ form }) => {
 
           <PackagingRow packagingInfos={form.stateSummary?.packagingInfos} />
 
-          <DetailRow
+          <QuantityRow
             value={temporaryStorageDetail?.temporaryStorer?.quantityReceived}
-            label="Quantité reçue"
+            label="Quantité reçue nette"
             showEmpty={hasBeenReceived}
           />
           <QuantityRow
             value={temporaryStorageDetail?.temporaryStorer?.quantityRefused}
-            label="Quantité refusée"
+            label="Quantité refusée nette"
             tooltip={BSD_DETAILS_QTY_TOOLTIP}
             showEmpty={hasBeenReceived}
           />
           <QuantityRow
             value={temporaryStorageDetail?.temporaryStorer?.quantityAccepted}
-            label="Quantité traitée"
+            label="Quantité traitée nette"
             tooltip={BSD_DETAILS_QTY_TOOLTIP}
             showEmpty={hasBeenReceived}
           />
@@ -405,14 +405,14 @@ const Recipient = ({
           value={getVerboseAcceptationStatus(form?.wasteAcceptationStatus)}
           label="Lot accepté"
         />
-        <DetailRow
-          value={form?.quantityReceived && `${form?.quantityReceived} tonnes`}
-          label="Quantité reçue"
+        <QuantityRow
+          value={form?.quantityReceived}
+          label="Quantité reçue nette"
           showEmpty={hasBeenReceived}
         />
         <QuantityRow
           value={form?.quantityRefused}
-          label="Quantité refusée"
+          label="Quantité refusée nette"
           tooltip={BSD_DETAILS_QTY_TOOLTIP}
           showEmpty={hasBeenReceived}
         />
@@ -421,21 +421,9 @@ const Recipient = ({
       <div className={styles.detailGrid}>
         <QuantityRow
           value={form?.quantityAccepted}
-          label="Quantité traitée"
+          label="Quantité traitée nette"
           tooltip={BSD_DETAILS_QTY_TOOLTIP}
           showEmpty={hasBeenReceived}
-        />
-        <DetailRow
-          value={
-            form?.quantityAccepted ? (
-              `${form?.quantityAccepted} tonnes`
-            ) : (
-              <>
-                {NON_RENSEIGNE} <TdTooltip msg={BSD_DETAILS_QTY_TOOLTIP} />
-              </>
-            )
-          }
-          label="Quantité traitée"
         />
         <DetailRow
           value={recipient?.processingOperation}

--- a/front/src/dashboard/detail/common/Components.tsx
+++ b/front/src/dashboard/detail/common/Components.tsx
@@ -198,7 +198,7 @@ export const QuantityRow = ({
 }: {
   value: string | number | ReactNode | undefined | null;
   label: string;
-  tooltip: string | undefined | null;
+  tooltip?: string | undefined | null;
   showEmpty: boolean;
 }) => {
   const hasValue = isDefined(value);

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -94,9 +94,6 @@ export const formPartiallyRefused: MailTemplate<{
         transporterCompanyName: cleanupSpecialChars(
           form.transporterCompanyName
         ),
-        quantityPartiallyRefused: form.wasteDetailsQuantity
-          ?.minus(form.quantityReceived!)
-          .toNumber(),
         signedAt: form.signedAt
           ? toFrFormat(new Date(form.signedAt))
           : form.signedAt,

--- a/libs/back/mail/src/templates/mustache/refus-partiel-dechet.html
+++ b/libs/back/mail/src/templates/mustache/refus-partiel-dechet.html
@@ -14,15 +14,15 @@
     <li>Numéro du BSD : {{form.readableId}}</li>
     <li>Appellation du déchet : {{form.wasteDetailsName}}</li>
     <li>Code déchet : {{form.wasteDetailsCode}}</li>
-    <li>Quantité réelle présentée nette: {{form.quantityReceived}} tonnes</li>
+    <li>Quantité réelle présentée nette : {{form.quantityReceived}} tonnes</li>
     {{#form.quantityRefused}}
-    <li>Quantité refusée nette: {{form.quantityRefused}} tonnes</li>
+    <li>Quantité refusée nette : {{form.quantityRefused}} tonnes</li>
     {{/form.quantityRefused}} {{^form.quantityRefused}}
-    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité refusée nette : Non renseignée</li>
     {{/form.quantityRefused}} {{#form.quantityAccepted}}
-    <li>Quantité acceptée nette: {{form.quantityAccepted}} tonnes</li>
+    <li>Quantité acceptée nette : {{form.quantityAccepted}} tonnes</li>
     {{/form.quantityAccepted}} {{^form.quantityAccepted}}
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     {{/form.quantityAccepted}}
     <li>
       Motif de refus :

--- a/libs/back/mail/src/templates/mustache/refus-partiel-dechet.html
+++ b/libs/back/mail/src/templates/mustache/refus-partiel-dechet.html
@@ -16,13 +16,13 @@
     <li>Code déchet : {{form.wasteDetailsCode}}</li>
     <li>Quantité réelle présentée nette: {{form.quantityReceived}} tonnes</li>
     {{#form.quantityRefused}}
-    <li>Quantité refusée: {{form.quantityRefused}} tonnes</li>
+    <li>Quantité refusée nette: {{form.quantityRefused}} tonnes</li>
     {{/form.quantityRefused}} {{^form.quantityRefused}}
-    <li>Quantité refusée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
     {{/form.quantityRefused}} {{#form.quantityAccepted}}
-    <li>Quantité acceptée: {{form.quantityAccepted}} tonnes</li>
+    <li>Quantité acceptée nette: {{form.quantityAccepted}} tonnes</li>
     {{/form.quantityAccepted}} {{^form.quantityAccepted}}
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     {{/form.quantityAccepted}}
     <li>
       Motif de refus :

--- a/libs/back/mail/src/templates/mustache/refus-total-dechet.html
+++ b/libs/back/mail/src/templates/mustache/refus-total-dechet.html
@@ -14,15 +14,15 @@
     <li>Numéro du BSD: {{form.readableId}}</li>
     <li>Appellation du déchet : {{form.wasteDetailsName}}</li>
     <li>Code déchet : {{form.wasteDetailsCode}}</li>
-    <li>Quantité réelle présentée nette: {{form.quantityReceived}} tonnes</li>
+    <li>Quantité réelle présentée nette : {{form.quantityReceived}} tonnes</li>
     {{#form.quantityRefused}}
-    <li>Quantité refusée nette: {{form.quantityRefused}} tonnes</li>
+    <li>Quantité refusée nette : {{form.quantityRefused}} tonnes</li>
     {{/form.quantityRefused}} {{^form.quantityRefused}}
-    <li>Quantité refusée nette: Non renseignée</li>
+    <li>Quantité refusée nette : Non renseignée</li>
     {{/form.quantityRefused}} {{#form.quantityAccepted}}
-    <li>Quantité acceptée nette: {{form.quantityAccepted}} tonnes</li>
+    <li>Quantité acceptée nette : {{form.quantityAccepted}} tonnes</li>
     {{/form.quantityAccepted}} {{^form.quantityAccepted}}
-    <li>Quantité acceptée nette: Non renseignée</li>
+    <li>Quantité acceptée nette : Non renseignée</li>
     {{/form.quantityAccepted}}
     <li>
       Motif de refus :

--- a/libs/back/mail/src/templates/mustache/refus-total-dechet.html
+++ b/libs/back/mail/src/templates/mustache/refus-total-dechet.html
@@ -16,13 +16,13 @@
     <li>Code déchet : {{form.wasteDetailsCode}}</li>
     <li>Quantité réelle présentée nette: {{form.quantityReceived}} tonnes</li>
     {{#form.quantityRefused}}
-    <li>Quantité refusée: {{form.quantityRefused}} tonnes</li>
+    <li>Quantité refusée nette: {{form.quantityRefused}} tonnes</li>
     {{/form.quantityRefused}} {{^form.quantityRefused}}
-    <li>Quantité refusée: Non renseignée</li>
+    <li>Quantité refusée nette: Non renseignée</li>
     {{/form.quantityRefused}} {{#form.quantityAccepted}}
-    <li>Quantité acceptée: {{form.quantityAccepted}} tonnes</li>
+    <li>Quantité acceptée nette: {{form.quantityAccepted}} tonnes</li>
     {{/form.quantityAccepted}} {{^form.quantityAccepted}}
-    <li>Quantité acceptée: Non renseignée</li>
+    <li>Quantité acceptée nette: Non renseignée</li>
     {{/form.quantityAccepted}}
     <li>
       Motif de refus :


### PR DESCRIPTION
# Correctifs

- La quantité acceptée s'affiche dans le registre même si elle vaut zéro
- La quantité reçue dans les mails de refus n'affiche plus 12 décimales après la virgule
- Changement de wording: ajoute de "nette" après "quantité acceptée" et "quantité refusée"
- La quantité traitée n'est plus affichée en double dans l'Aperçu
- Ajout d'espaces avant les `:` dans les mails de refus

# Ticket Favro

[Retours sur la quantité refusée](https://favro.com/widget/ab14a4f0460a99a9d64d4945/d1d68fa2bf29329712112449?card=tra-14634)
