### PR TITLE
[TRA-14634] Correctifs sur les quantités refusées

### DIFF
--- a/back/src/companies/resolvers/queries/searchCompanies.ts
+++ b/back/src/companies/resolvers/queries/searchCompanies.ts
@@ -8,7 +8,6 @@ const searchCompaniesResolver: QueryResolvers["searchCompanies"] = async (
   context
 ) => {
   checkIsAuthenticated(context);
-  console.log(">> searchCompanies");
   return searchCompanies(clue, department, allowForeignCompanies);
 };
 

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -936,8 +936,6 @@ export function expandInitialFormFromDb(
     quantityRefused
   });
 
-  console.log("wasteQuantities", wasteQuantities);
-
   return {
     id,
     readableId,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -618,6 +618,12 @@ export function expandFormFromDb(
     quantityRefused: form.quantityRefused
   });
 
+  const forwardedInWasteQuantities = bsddWasteQuantities({
+    wasteAcceptationStatus: form.forwardedIn?.wasteAcceptationStatus,
+    quantityReceived: form.forwardedIn?.quantityReceived,
+    quantityRefused: form.forwardedIn?.quantityRefused
+  });
+
   return {
     id: form.id,
     readableId: form.readableId,
@@ -740,7 +746,11 @@ export function expandFormFromDb(
     quantityReceived: forwardedIn
       ? processDecimal(forwardedIn.quantityReceived)?.toNumber()
       : processDecimal(form.quantityReceived)?.toNumber(),
-    quantityRefused: processDecimal(form.quantityRefused)?.toNumber(),
+    quantityRefused: forwardedIn
+      ? processDecimal(forwardedIn.quantityRefused)?.toNumber()
+      : processDecimal(form.quantityRefused)?.toNumber(),
+    quantityAccepted:
+      forwardedInWasteQuantities?.quantityAccepted?.toNumber() ?? null,
     quantityGrouped: form.quantityGrouped,
     processingOperationDone: forwardedIn
       ? forwardedIn.processingOperationDone
@@ -924,6 +934,8 @@ export function expandInitialFormFromDb(
     quantityReceived,
     quantityRefused
   });
+
+  console.log("wasteQuantities", wasteQuantities);
 
   return {
     id,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -619,9 +619,9 @@ export function expandFormFromDb(
   });
 
   const forwardedInWasteQuantities = bsddWasteQuantities({
-    wasteAcceptationStatus: form.forwardedIn?.wasteAcceptationStatus,
-    quantityReceived: form.forwardedIn?.quantityReceived,
-    quantityRefused: form.forwardedIn?.quantityRefused
+    wasteAcceptationStatus: forwardedIn?.wasteAcceptationStatus,
+    quantityReceived: forwardedIn?.quantityReceived,
+    quantityRefused: forwardedIn?.quantityRefused
   });
 
   return {
@@ -749,8 +749,9 @@ export function expandFormFromDb(
     quantityRefused: forwardedIn
       ? processDecimal(forwardedIn.quantityRefused)?.toNumber()
       : processDecimal(form.quantityRefused)?.toNumber(),
-    quantityAccepted:
-      forwardedInWasteQuantities?.quantityAccepted?.toNumber() ?? null,
+    quantityAccepted: forwardedIn
+      ? forwardedInWasteQuantities?.quantityAccepted?.toNumber()
+      : wasteQuantities?.quantityAccepted?.toNumber(),
     quantityGrouped: form.quantityGrouped,
     processingOperationDone: forwardedIn
       ? forwardedIn.processingOperationDone

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -79,7 +79,6 @@ export async function renderFormRefusedEmail(
   ].map(admin => ({ email: admin.email, name: admin.name ?? "" }));
 
   // Get formNotAccepted or formPartiallyRefused mail function according to wasteAcceptationStatus value
-  console.log("wasteAcceptationStatus", wasteAcceptationStatus);
   const mailTemplate = {
     REFUSED: formNotAccepted,
     PARTIALLY_REFUSED: formPartiallyRefused

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -90,7 +90,9 @@ export async function renderFormRefusedEmail(
     forwardedInTransporter = await getFirstTransporter(forwardedIn);
   }
 
-  const wasteQuantities = bsddWasteQuantities(form);
+  const wasteQuantities = isFinalDestinationRefusal
+    ? bsddWasteQuantities(forwardedIn)
+    : bsddWasteQuantities(form);
 
   return renderMail(mailTemplate, {
     to,

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -79,6 +79,7 @@ export async function renderFormRefusedEmail(
   ].map(admin => ({ email: admin.email, name: admin.name ?? "" }));
 
   // Get formNotAccepted or formPartiallyRefused mail function according to wasteAcceptationStatus value
+  console.log("wasteAcceptationStatus", wasteAcceptationStatus);
   const mailTemplate = {
     REFUSED: formNotAccepted,
     PARTIALLY_REFUSED: formPartiallyRefused

--- a/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
@@ -27,6 +27,7 @@ import { getFirstTransporter } from "../../../database";
 jest.mock("../../../../mailer/mailing");
 (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
 
+// No PDFs
 jest.mock("../../../pdf/generateBsddPdf");
 (generateBsddPdfToBase64 as jest.Mock).mockResolvedValue("");
 
@@ -42,6 +43,17 @@ const MARK_AS_RECEIVED = `
 describe("Test Form reception", () => {
   afterEach(async () => {
     await resetDatabase();
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    // No mails
+    jest.mock("../../../../mailer/mailing");
+    (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+    // No PDFs
+    jest.mock("../../../pdf/generateBsddPdf");
+    (generateBsddPdfToBase64 as jest.Mock).mockResolvedValue("");
   });
 
   it("should mark a sent form as received", async () => {

--- a/back/src/forms/resolvers/mutations/markAsResealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsResealed.ts
@@ -24,6 +24,7 @@ import {
 import { getFormRepository } from "../../repository";
 import { sirenifyResealedFormInput } from "../../sirenify";
 import { prismaJsonNoNull } from "../../../common/converter";
+import { bsddWasteQuantities } from "../../helpers/bsddWasteQuantities";
 
 const markAsResealed: MutationResolvers["markAsResealed"] = async (
   parent,
@@ -54,6 +55,12 @@ const markAsResealed: MutationResolvers["markAsResealed"] = async (
     wasteDetails
   } = await sirenifyResealedFormInput(resealedInfos, user);
 
+  const wasteQuantities = bsddWasteQuantities({
+    wasteAcceptationStatus: form.wasteAcceptationStatus,
+    quantityReceived: form.quantityReceived,
+    quantityRefused: form.quantityRefused
+  });
+
   // copy basic info from initial BSD and overwrite it with resealedInfos
   const updateInput = {
     emitterType: EmitterType.PRODUCER,
@@ -71,7 +78,8 @@ const markAsResealed: MutationResolvers["markAsResealed"] = async (
     wasteDetailsOnuCode: form.wasteDetailsOnuCode,
     wasteDetailsPop: form.wasteDetailsPop,
     wasteDetailsQuantityType: QuantityType.REAL,
-    wasteDetailsQuantity: form.quantityReceived,
+    wasteDetailsQuantity:
+      wasteQuantities?.quantityAccepted ?? form.quantityReceived,
     wasteDetailsPackagingInfos: prismaJsonNoNull(
       form.wasteDetailsPackagingInfos
     ),

--- a/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
@@ -193,7 +193,7 @@ function SignReceptionModal({
     } = data;
 
     if (isReception) {
-      isTempStorage
+      (isTempStorage && !isFinalDestination)
         ? await markAsTempStored({
             variables: {
               id: form.id,
@@ -222,7 +222,7 @@ function SignReceptionModal({
     if (
       ["ACCEPTED", "REFUSED", "PARTIALLY_REFUSED"].includes(acceptationStatus)
     ) {
-      isTempStorage
+      (isTempStorage && !isFinalDestination)
         ? await markAsTempStorerAccepted({
             variables: {
               id: form.id,

--- a/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
@@ -193,7 +193,7 @@ function SignReceptionModal({
     } = data;
 
     if (isReception) {
-      (isTempStorage && !isFinalDestination)
+      isTempStorage && !isFinalDestination
         ? await markAsTempStored({
             variables: {
               id: form.id,
@@ -222,7 +222,7 @@ function SignReceptionModal({
     if (
       ["ACCEPTED", "REFUSED", "PARTIALLY_REFUSED"].includes(acceptationStatus)
     ) {
-      (isTempStorage && !isFinalDestination)
+      isTempStorage && !isFinalDestination
         ? await markAsTempStorerAccepted({
             variables: {
               id: form.id,


### PR DESCRIPTION
# Correctifs

- Fix du front qui n'utilisait pas la bonne requête lors de la réception post-entreposage provisoire
- Fix du back qui crashait lors de la réception post-entreposage provisoire (bug qui existe déjà en production)
- Mise à jour du `stateSummary` pour prendre en compte les quantités acceptées
- Fix du mail de refus qui prenait les données de l'entreposage provisoire plutôt que de la destination finale, lors du refus par la destination finale

# Ticket Favro

[Retours sur la quantité refusée](https://favro.com/widget/ab14a4f0460a99a9d64d4945/d1d68fa2bf29329712112449?card=tra-14634)
