### PR TITLE
[TRA-14634] Correctifs pour les quantités refusées

### DIFF
--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -35,6 +35,7 @@ describe("expandFormFromDb", () => {
       readableId: form.readableId,
       customId: null,
       isImportedFromPaper: false,
+      metadata: undefined,
       emitter: {
         type: form.emitterType,
         workSite: null,
@@ -151,6 +152,9 @@ describe("expandFormFromDb", () => {
       receivedAt: null,
       signedAt: null,
       quantityReceived: undefined,
+      quantityRefused: undefined,
+      quantityReceivedType: null,
+      quantityAccepted: undefined,
       processingOperationDone: null,
       quantityGrouped: 0,
       processingOperationDescription: null,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -743,6 +743,9 @@ export function expandFormFromDb(
       forwardedIn ? forwardedIn.receivedAt : form.receivedAt
     ),
     signedAt: processDate(forwardedIn ? forwardedIn.signedAt : form.signedAt),
+    quantityReceivedType: forwardedIn
+      ? forwardedIn.quantityReceivedType
+      : form.quantityReceivedType,
     quantityReceived: forwardedIn
       ? processDecimal(forwardedIn.quantityReceived)?.toNumber()
       : processDecimal(form.quantityReceived)?.toNumber(),

--- a/back/src/forms/mail/renderFormRefusedEmail.ts
+++ b/back/src/forms/mail/renderFormRefusedEmail.ts
@@ -84,6 +84,8 @@ export async function renderFormRefusedEmail(
     PARTIALLY_REFUSED: formPartiallyRefused
   }[wasteAcceptationStatus];
 
+  if (!mailTemplate) return;
+
   const transporter = await getFirstTransporter(form);
   let forwardedInTransporter: BsddTransporter | null = null;
   if (forwardedIn) {

--- a/back/src/forms/resolvers/forms/stateSummary.ts
+++ b/back/src/forms/resolvers/forms/stateSummary.ts
@@ -1,4 +1,4 @@
-import { Status } from "@prisma/client";
+import { QuantityType, Status } from "@prisma/client";
 import {
   Form,
   FormResolvers,
@@ -59,9 +59,12 @@ export function getStateSummary(form: Form) {
     (form.status === Status.RESEALED ||
       !!form.temporaryStorageDetail?.emittedAt);
 
+  // Quantity & quantity type
   let quantity: number | undefined | null;
+  let quantityType: QuantityType | undefined | null = QuantityType.REAL;
   if (isDefined(form.quantityReceived)) {
     quantity = form.quantityAccepted ?? form.quantityReceived;
+    quantityType = form.quantityReceivedType ?? QuantityType.REAL;
   } else {
     if (
       [Status.TEMP_STORED, Status.TEMP_STORER_ACCEPTED].includes(
@@ -71,10 +74,17 @@ export function getStateSummary(form: Form) {
       quantity =
         form.temporaryStorageDetail?.temporaryStorer?.quantityAccepted ??
         form.temporaryStorageDetail?.temporaryStorer?.quantityReceived;
+      quantityType =
+        form.temporaryStorageDetail?.temporaryStorer?.quantityType ??
+        QuantityType.REAL;
     } else if (isResealed) {
       quantity = form.temporaryStorageDetail?.wasteDetails?.quantity;
+      quantityType =
+        form.temporaryStorageDetail?.wasteDetails?.quantityType ??
+        QuantityType.REAL;
     } else {
       quantity = form.wasteDetails?.quantity;
+      quantityType = form.wasteDetails?.quantityType ?? QuantityType.REAL;
     }
   }
 
@@ -109,6 +119,7 @@ export function getStateSummary(form: Form) {
 
   return {
     quantity,
+    quantityType,
     packagingInfos,
     packagings: packagingInfos.map(pi => pi.type),
     onuCode,

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -11,6 +11,7 @@ import { EventType } from "../../workflow/types";
 import { renderFormRefusedEmail } from "../../mail/renderFormRefusedEmail";
 import { sendMail } from "../../../mailer/mailing";
 import { runInTransaction } from "../../../common/repository/helper";
+import { isWasteRefused } from "./markAsReceived";
 
 const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
   _,
@@ -80,11 +81,7 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
     return acceptedForm;
   });
 
-  if (
-    acceptedForm.wasteAcceptationStatus === WasteAcceptationStatus.REFUSED ||
-    acceptedForm.wasteAcceptationStatus ===
-      WasteAcceptationStatus.PARTIALLY_REFUSED
-  ) {
+  if (isWasteRefused(acceptedForm)) {
     const refusedEmail = await renderFormRefusedEmail(acceptedForm);
     if (refusedEmail) {
       sendMail(refusedEmail);

--- a/back/src/forms/resolvers/mutations/markAsReceived.ts
+++ b/back/src/forms/resolvers/mutations/markAsReceived.ts
@@ -20,7 +20,7 @@ import { renderFormRefusedEmail } from "../../mail/renderFormRefusedEmail";
 import { sendMail } from "../../../mailer/mailing";
 import { runInTransaction } from "../../../common/repository/helper";
 
-const isWasteRefused = form => {
+export const isWasteRefused = form => {
   // Final destination
   if (form.forwardedIn && !!form.forwardedIn.sentAt) {
     return (

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -103,6 +103,9 @@ type Form {
   "Quantité réelle présentée en tonnes (case 10)"
   quantityReceived: Float
 
+  "Quantité réelle ou estimée"
+  quantityReceivedType: QuantityType
+
   "Quantité acceptée nette"
   quantityAccepted: Float
 
@@ -267,6 +270,9 @@ Cet objet `StateSummary` vise à simplifier ces questions. Il renverra toujours 
 type StateSummary {
   "Quantité la plus à jour (en tonnes)"
   quantity: Float
+
+  "Si la quantité est estimée ou pas"
+  quantityType: QuantityType
 
   "DEPRECATED Packaging le plus à jour"
   packagings: [Packagings!]! @deprecated(reason: "Utiliser packagingInfos")


### PR DESCRIPTION
# Contexte

Correctifs:
- Ajout de la `quantityType` au `stateSummary` pour faciliter la vie du front
- Correction de la requête `markAsAccepted` qui essayait d'envoyer un mail de refus à tort (bug qui existe en production pas lié à la fonctionnalité `quantityRefused`)

# Ticket Favro

[Retours sur la quantité refusée](https://favro.com/widget/ab14a4f0460a99a9d64d4945/d1d68fa2bf29329712112449?card=tra-14634)
