### PR TITLE
[TRA-14836] Retirer limite de 1 contenant sur un reconditionnement BSFF

### DIFF
--- a/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
+++ b/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
@@ -297,23 +297,6 @@ describe("validation > parseBsff", () => {
       }
     );
 
-    it("should throw when repackaging more than 1 contenants", () => {
-      const zodBsff: ZodBsff = {
-        repackaging: ["contenant_1", "contenant_2"]
-      };
-      expect.assertions(1);
-      try {
-        parseBsff(zodBsff);
-      } catch (e) {
-        expect(e.errors).toEqual([
-          expect.objectContaining({
-            message:
-              "Vous ne pouvez saisir qu'un seul contenant lors d'une opération de reconditionnement"
-          })
-        ]);
-      }
-    });
-
     it("should throw if weight value is negative", () => {
       const zodBsff: ZodBsff = {
         weightValue: -1

--- a/back/src/bsffs/validation/bsff/schema.ts
+++ b/back/src/bsffs/validation/bsff/schema.ts
@@ -146,13 +146,7 @@ const rawBsffSchema = z.object({
   packagings: z.array(rawBsffPackagingSchema).nullish(),
   ficheInterventions: z.string().array().nullish(),
   forwarding: z.array(z.string()).nullish(),
-  repackaging: z
-    .array(z.string())
-    // .max(
-    //   1,
-    //   "Vous ne pouvez saisir qu'un seul contenant lors d'une opération de reconditionnement"
-    // )
-    .nullish(),
+  repackaging: z.array(z.string()).nullish(),
   grouping: z.array(z.string()).nullish()
 });
 

--- a/back/src/bsffs/validation/bsff/schema.ts
+++ b/back/src/bsffs/validation/bsff/schema.ts
@@ -148,10 +148,10 @@ const rawBsffSchema = z.object({
   forwarding: z.array(z.string()).nullish(),
   repackaging: z
     .array(z.string())
-    .max(
-      1,
-      "Vous ne pouvez saisir qu'un seul contenant lors d'une opération de reconditionnement"
-    )
+    // .max(
+    //   1,
+    //   "Vous ne pouvez saisir qu'un seul contenant lors d'une opération de reconditionnement"
+    // )
     .nullish(),
   grouping: z.array(z.string()).nullish()
 });


### PR DESCRIPTION
Hotfix :
Retire la limite à un contenant dans repackaging qui n'avait pas lieu d'être. Probablement un mélange entre repackaging et forwarding. la limite sur le forwarding sera ajoutée plus tard (puisqu'elle est breaking).

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14836)
