### PR TITLE
[TRA 14360] Rendre BSDA en brouillon inaccessibles pour les autres entreprises

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Modification des permissions pour la query Bsds et toutes les queries Pdf [PR 3519](https://github.com/MTES-MCT/trackdechets/pull/3519)
 
+#### :nail_care: Améliorations
+
+- Rendre BSDA en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
+
 # [2024.7.2] 30/07/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,7 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
-- Rendre BSDA en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
+- Rendre BSDAs en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
 
 # [2024.7.2] 30/07/2024
 

--- a/back/src/activity-events/bsda/reducer.ts
+++ b/back/src/activity-events/bsda/reducer.ts
@@ -14,6 +14,7 @@ export function bsdaReducer(
         intermediaries,
         wasteSealNumbers,
         intermediariesOrgIds,
+        canAccessDraftOrgIds,
         transporters,
         ...bsda
       } = event.data;
@@ -31,6 +32,7 @@ export function bsdaReducer(
         grouping,
         intermediaries,
         intermediariesOrgIds,
+        canAccessDraftOrgIds,
         transporters,
         forwarding,
         ...bsda

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -103,7 +103,7 @@ const getBsdaSirets = (
   };
 
   // Drafts only appear in the dashboard for companies the bsda owner belongs to
-  if (bsda.status === BsdaStatus.INITIAL) {
+  if (bsda.isDraft) {
     const draftFormSiretsEntries = Object.entries(bsdaSirets).filter(
       ([, siret]) => siret && bsda.canAccessDraftOrgIds.includes(siret)
     );

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -54,6 +54,65 @@ function transporterCompanyOrgIdKey(transporter: BsdaTransporter) {
   return `transporter${transporter.number}CompanyOrgId`;
 }
 
+const getBsdaSirets = (
+  bsda: BsdaForElastic
+): Partial<
+  Record<keyof Bsda | "transporterCompanySiret", string | null | undefined>
+> => {
+  const intermediarySirets = bsda.intermediaries.reduce(
+    (sirets, intermediary) => {
+      if (intermediary.siret) {
+        const nbOfKeys = Object.keys(sirets).length;
+        return {
+          ...sirets,
+          [`intermediarySiret${nbOfKeys + 1}`]: intermediary.siret
+        };
+      }
+      return sirets;
+    },
+    {}
+  );
+
+  // build a mapping that looks like
+  // { transporter1CompanyOrgId: "SIRET1", transporter2CompanyOrgId: "SIRET2"}
+  const transporterOrgIds = (bsda.transporters ?? []).reduce(
+    (acc, transporter) => {
+      const orgId = getTransporterCompanyOrgId(transporter);
+      if (orgId) {
+        return {
+          ...acc,
+          [transporterCompanyOrgIdKey(transporter)]: orgId
+        };
+      }
+      return acc;
+    },
+    {}
+  );
+  const bsdaSirets: Partial<
+    Record<keyof Bsda | "transporterCompanySiret", string | null | undefined>
+  > = {
+    emitterCompanySiret: bsda.emitterCompanySiret,
+    ecoOrganismeSiret: bsda.ecoOrganismeSiret,
+    workerCompanySiret: bsda.workerCompanySiret,
+    destinationCompanySiret: bsda.destinationCompanySiret,
+    brokerCompanySiret: bsda.brokerCompanySiret,
+    destinationOperationNextDestinationCompanySiret:
+      bsda.destinationOperationNextDestinationCompanySiret,
+    ...intermediarySirets,
+    ...transporterOrgIds
+  };
+
+  // Drafts only appear in the dashboard for companies the bsda owner belongs to
+  if (bsda.status === BsdaStatus.INITIAL) {
+    const draftFormSiretsEntries = Object.entries(bsdaSirets).filter(
+      ([, siret]) => siret && bsda.canAccessDraftOrgIds.includes(siret)
+    );
+    return Object.fromEntries(draftFormSiretsEntries);
+  }
+
+  return bsdaSirets;
+};
+
 type WhereKeys =
   | "isDraftFor"
   | "isForActionFor"
@@ -81,51 +140,9 @@ function getWhere(bsda: BsdaForElastic): Pick<BsdElastic, WhereKeys> {
     isCollectedFor: []
   };
 
-  const intermediarySirets = bsda.intermediaries.reduce(
-    (sirets, intermediary) => {
-      if (intermediary.siret) {
-        const nbOfKeys = Object.keys(sirets).length;
-        return {
-          ...sirets,
-          [`intermediarySiret${nbOfKeys + 1}`]: intermediary.siret
-        };
-      }
-      return sirets;
-    },
-    {}
-  );
-
   const firstTransporter = getFirstTransporterSync(bsda);
 
-  // build a mapping that looks like
-  // { transporter1CompanyOrgId: "SIRET1", transporter2CompanyOrgId: "SIRET2"}
-  const transporterOrgIds = (bsda.transporters ?? []).reduce(
-    (acc, transporter) => {
-      const orgId = getTransporterCompanyOrgId(transporter);
-      if (orgId) {
-        return {
-          ...acc,
-          [transporterCompanyOrgIdKey(transporter)]: orgId
-        };
-      }
-      return acc;
-    },
-    {}
-  );
-
-  const bsdaSirets: Partial<
-    Record<keyof Bsda | "transporterCompanySiret", string | null | undefined>
-  > = {
-    emitterCompanySiret: bsda.emitterCompanySiret,
-    ecoOrganismeSiret: bsda.ecoOrganismeSiret,
-    workerCompanySiret: bsda.workerCompanySiret,
-    destinationCompanySiret: bsda.destinationCompanySiret,
-    brokerCompanySiret: bsda.brokerCompanySiret,
-    destinationOperationNextDestinationCompanySiret:
-      bsda.destinationOperationNextDestinationCompanySiret,
-    ...intermediarySirets,
-    ...transporterOrgIds
-  };
+  const bsdaSirets = getBsdaSirets(bsda);
 
   const siretsFilters = new Map<string, keyof typeof where>(
     Object.entries(bsdaSirets)

--- a/back/src/bsda/resolvers/mutations/__tests__/delete.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/delete.integration.ts
@@ -23,7 +23,9 @@ describe("Mutation.deleteBsda", () => {
   it("should allow user to delete a bsda", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const bsda = await bsdaFactory({
+      userId: user.id,
       opt: {
+        isDraft: true,
         emitterCompanySiret: company.siret
       }
     });
@@ -65,7 +67,11 @@ describe("Mutation.deleteBsda", () => {
     const { user } = await userWithCompanyFactory(UserRole.ADMIN);
     const { mutate } = makeClient(user);
 
-    const bsda = await bsdaFactory({ opt: {} });
+    const bsda = await bsdaFactory({
+      opt: {
+        isDraft: true
+      }
+    });
     const { errors } = await mutate<
       Pick<Mutation, "deleteBsda">,
       MutationDeleteBsdaArgs
@@ -157,12 +163,16 @@ describe("Mutation.deleteBsda", () => {
   it("should remove forwardedIn link in deleted BSDA", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const forwardedBsda = await bsdaFactory({
+      userId: user.id,
       opt: {
+        isDraft: true,
         destinationCompanySiret: company.siret
       }
     });
     const forwardingBsda = await bsdaFactory({
+      userId: user.id,
       opt: {
+        isDraft: true,
         forwarding: { connect: { id: forwardedBsda.id } },
         emitterCompanySiret: company.siret
       }
@@ -223,6 +233,8 @@ describe("Mutation.deleteBsda", () => {
         status: BsdaStatus.SIGNED_BY_PRODUCER
       }
     });
+    console.log(bsda);
+
     const { errors } = await mutate<
       Pick<Mutation, "deleteBsda">,
       MutationDeleteBsdaArgs

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -71,6 +71,7 @@ async function createBsda(opt: Partial<Prisma.BsdaCreateInput> = {}) {
   const destination = await userWithCompanyFactory();
 
   const bsda = await bsdaFactory({
+    userId: emitter.user.id,
     opt: {
       emitterCompanySiret: emitter.company.siret,
       emitterCompanyName: emitter.company.name,
@@ -278,6 +279,7 @@ describe("Mutation.Bsda.duplicate", () => {
       "groupedInId",
       "intermediaries",
       "intermediariesOrgIds",
+      "canAccessDraftOrgIds",
       "transporters"
     ];
 

--- a/back/src/bsda/resolvers/mutations/__tests__/publish.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/publish.integration.ts
@@ -63,6 +63,7 @@ describe("Mutation.Bsda.publish", () => {
   it("should pass the form as non draft", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const form = await bsdaFactory({
+      userId: user.id,
       opt: {
         emitterCompanySiret: company.siret,
         isDraft: true

--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -96,6 +96,7 @@ describe("Mutation.updateBsda", () => {
   it("should allow user to update a draft BSDA", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const bsda = await bsdaFactory({
+      userId: user.id,
       opt: {
         isDraft: true,
         status: "INITIAL",

--- a/back/src/bsda/resolvers/mutations/create.ts
+++ b/back/src/bsda/resolvers/mutations/create.ts
@@ -29,7 +29,6 @@ export default async function create(
 
 export async function genericCreate({ isDraft, input, context }: CreateBsda) {
   const user = checkIsAuthenticated(context);
-
   await checkCanCreate(user, input);
   const companies = await getUserCompanies(user.id);
   const destinationCompany = companies.find(
@@ -100,6 +99,5 @@ export async function genericCreate({ isDraft, input, context }: CreateBsda) {
     intermediaries,
     transporters
   });
-
   return expandBsdaFromDb(newBsda);
 }

--- a/back/src/bsda/resolvers/queries/bsdas.ts
+++ b/back/src/bsda/resolvers/queries/bsdas.ts
@@ -7,7 +7,7 @@ import { applyMask } from "../../../common/where";
 import { getConnection } from "../../../common/pagination";
 import { getBsdaRepository } from "../../repository";
 import { Permission, can, getUserRoles } from "../../../permissions";
-import { BsdaStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 export default async function bsdas(
   _,
@@ -40,11 +40,11 @@ export default async function bsdas(
   const draftMask: Prisma.BsdaWhereInput = {
     OR: [
       {
-        status: { not: BsdaStatus.INITIAL },
+        isDraft: false,
         ...mask
       },
       {
-        status: BsdaStatus.INITIAL,
+        isDraft: true,
         canAccessDraftOrgIds: { hasSome: orgIdsWithListPermission },
         ...mask
       }

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -170,10 +170,11 @@ describe("indexAllBsdTypeSync", () => {
   });
 
   it("should index BSDAs synchronously", async () => {
+    const user = await userFactory();
     const bsdas = await Promise.all([
-      bsdaFactory({}),
-      bsdaFactory({}),
-      bsdaFactory({})
+      bsdaFactory({ userId: user.id }),
+      bsdaFactory({ userId: user.id }),
+      bsdaFactory({ userId: user.id })
     ]);
 
     await indexAllBsdTypeSync({
@@ -316,12 +317,12 @@ describe("indexAllBsdTypeConcurrently", () => {
   });
 
   it("should index BSDAs using the index queue", async () => {
+    const user = await userFactory();
     const bsdas = await Promise.all([
-      bsdaFactory({}),
-      bsdaFactory({}),
-      bsdaFactory({})
+      bsdaFactory({ userId: user.id }),
+      bsdaFactory({ userId: user.id }),
+      bsdaFactory({ userId: user.id })
     ]);
-
     const jobs = await indexAllBsdTypeConcurrentJobs({
       bsdName: "bsda",
       index: index.alias,

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsda.integration.ts
@@ -250,7 +250,7 @@ describe("Query.bsds.bsda base workflow", () => {
         expect.objectContaining({ node: { id: bsdaId } })
       ]);
     });
-    it("draft bsda should be isDraftFor worker", async () => {
+    it("draft bsda should not be isDraftFor worker (not author)", async () => {
       const { query } = makeClient(worker.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -263,11 +263,9 @@ describe("Query.bsds.bsda base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bsdaId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
-    it("draft bsda should be isDraftFor transporter", async () => {
+    it("draft bsda should not be isDraftFor transporter (not author)", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -280,11 +278,9 @@ describe("Query.bsds.bsda base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bsdaId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
-    it("draft bsda should be isDraftFor destination", async () => {
+    it("draft bsda should not be isDraftFor destination (not author)", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -297,9 +293,7 @@ describe("Query.bsds.bsda base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bsdaId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
   });
 
@@ -1477,7 +1471,9 @@ describe("Query.bsds.bsdas mutations", () => {
     });
 
     const bsda = await bsdaFactory({
+      userId: emitter.user.id,
       opt: {
+        isDraft: true,
         emitterCompanySiret: emitter.company.siret
       }
     });

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -68,6 +68,7 @@ describe("wastesReader", () => {
         .fill(1)
         .map(() =>
           bsdaFactory({
+            userId: destination.user.id,
             opt: {
               destinationCompanySiret: destination.company.siret,
               destinationReceptionDate: new Date(),

--- a/libs/back/prisma/src/migrations/20240730143503_add_draft_access_bsda/migration.sql
+++ b/libs/back/prisma/src/migrations/20240730143503_add_draft_access_bsda/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Bsda" ADD COLUMN     "canAccessDraftOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "_BsdaCanAccessDraftOrgIdsIdx" ON "Bsda" USING GIN ("canAccessDraftOrgIds");

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1545,6 +1545,7 @@ model Bsda {
   // Denormalized fields, storing sirets to speed up queries and avoid expensive joins
   intermediariesOrgIds String[] @default([])
   transportersOrgIds   String[] @default([])
+  canAccessDraftOrgIds String[] @default([])
 
   // Relation vers les infos de traçabilité finales
   // Même si aujourd'hui il ne peut y avoir qu'une opération finale, on anticipe le fait 
@@ -1563,6 +1564,7 @@ model Bsda {
   @@index([updatedAt], map: "_BsdaUpdatedAtIdx")
   @@index([intermediariesOrgIds], map: "_BsdaIntermediariesOrgIdsIdx", type: Gin)
   @@index([transportersOrgIds], map: "_BsdaTransportersOrgIdsIdx", type: Gin)
+  @@index([canAccessDraftOrgIds], map: "_BsdaCanAccessDraftOrgIdsIdx", type: Gin)
 }
 
 model BsdaFinalOperation {

--- a/libs/back/scripts/src/scripts/20240802142645389_bsda_draft_restriction.ts
+++ b/libs/back/scripts/src/scripts/20240802142645389_bsda_draft_restriction.ts
@@ -1,0 +1,178 @@
+import { MongoClient } from "mongodb";
+import { Company, Event, Prisma, User } from "@prisma/client";
+import { prisma } from "@td/prisma";
+import { logger } from "@td/logger";
+
+type EventLike = Omit<Event, "metadata" | "data"> & {
+  data: any;
+  metadata: any;
+};
+
+type EventCollection = { _id: string } & Omit<EventLike, "id">;
+
+const { MONGO_URL } = process.env;
+logger.info(MONGO_URL);
+const EVENTS_COLLECTION = "events";
+
+async function getUserCompanies(userId: string): Promise<Company[]> {
+  const companyAssociations = await prisma.companyAssociation.findMany({
+    where: { userId },
+    include: { company: true }
+  });
+  return companyAssociations.map(association => association.company);
+}
+
+export async function run() {
+  logger.info("starting BSDA draft restriction script");
+  const mongodbClient = new MongoClient(MONGO_URL!);
+
+  const database = mongodbClient.db();
+  const eventsCollection =
+    database.collection<EventCollection>(EVENTS_COLLECTION);
+  let finished = false;
+  let lastId: string | null = null;
+  while (!finished) {
+    let bsdas: Prisma.BsdaGetPayload<{
+      include: {
+        intermediaries: true;
+        transporters: true;
+      };
+    }>[] = [];
+    try {
+      bsdas = await prisma.bsda.findMany({
+        take: 10,
+        skip: 1, // Skip the cursor
+        ...(lastId
+          ? {
+              cursor: {
+                id: lastId
+              }
+            }
+          : {}),
+        where: {
+          isDraft: true
+          // canAccessDraftOrgIds: {
+          //   isEmpty: true
+          // }
+        },
+        include: {
+          intermediaries: true,
+          transporters: true
+        },
+        orderBy: {
+          id: "asc"
+        }
+      });
+    } catch (error) {
+      logger.error(`failed to fetch bsdas from cursor ${lastId}`);
+      logger.error(error);
+      break;
+    }
+    logger.info(`got BSDAs ${bsdas.map(bsda => bsda.id).join(", ")}`);
+    if (bsdas.length < 10) {
+      finished = true;
+    }
+    if (bsdas.length === 0) {
+      break;
+    }
+    lastId = bsdas[bsdas.length - 1].id;
+    let events: EventCollection[];
+    try {
+      events = await eventsCollection
+        .find({
+          streamId: { $in: bsdas.map(bsda => bsda.id) },
+          type: "BsdaCreated"
+        })
+        .toArray();
+      logger.info(
+        `got events ${events.map(event => event.streamId).join(", ")}`
+      );
+    } catch (error) {
+      logger.error(
+        `failed to fetch events for BSDAS ${bsdas
+          .map(bsda => bsda.id)
+          .join(", ")}`
+      );
+      logger.error(error);
+      break;
+    }
+
+    for (const bsda of bsdas) {
+      logger.info(`handling ${bsda.id}`);
+      const correspondingEvent = events.find(
+        event => event.streamId === bsda.id
+      );
+      let user: User | null = null;
+      if (correspondingEvent?.actor) {
+        logger.info("found creation event");
+        try {
+          user = await prisma.user.findFirst({
+            where: {
+              id: correspondingEvent.actor
+            }
+          });
+        } catch (error) {
+          logger.error(`failed to fetch user ${correspondingEvent.actor}`);
+        }
+      }
+      const intermediariesOrgIds: string[] = bsda.intermediaries
+        ? (bsda.intermediaries
+            .flatMap(intermediary => [
+              intermediary.siret,
+              intermediary.vatNumber
+            ])
+            .filter(Boolean) as string[])
+        : [];
+      const transportersOrgIds: string[] = bsda.transporters
+        ? (bsda.transporters
+            .flatMap(t => [
+              t.transporterCompanySiret,
+              t.transporterCompanyVatNumber
+            ])
+            .filter(Boolean) as string[])
+        : [];
+      let canAccessDraftOrgIds: string[] = [];
+      const bsdaOrgIds = [
+        ...intermediariesOrgIds,
+        ...transportersOrgIds,
+        bsda.emitterCompanySiret,
+        bsda.ecoOrganismeSiret,
+        bsda.destinationCompanySiret,
+        bsda.destinationOperationNextDestinationCompanySiret,
+        bsda.workerCompanySiret,
+        bsda.brokerCompanySiret
+      ].filter(Boolean);
+      if (user) {
+        logger.info("treating with user");
+        let userCompanies: Company[] = [];
+        try {
+          userCompanies = await getUserCompanies(user.id as string);
+        } catch (error) {
+          logger.error(`failed to fetch companies of user ${user.id}`);
+        }
+        const userOrgIds = userCompanies.map(company => company.orgId);
+        const userOrgIdsInForm = userOrgIds.filter(orgId =>
+          bsdaOrgIds.includes(orgId)
+        );
+        canAccessDraftOrgIds.push(...userOrgIdsInForm);
+      } else {
+        logger.info("treating without user");
+        canAccessDraftOrgIds = bsdaOrgIds.filter(Boolean) as string[];
+      }
+      logger.info(`updating ${bsda.id}`);
+      await prisma.bsda.update({
+        where: { id: bsda.id },
+        data: {
+          canAccessDraftOrgIds
+        },
+        select: {
+          id: true
+        }
+      });
+      logger.info(`updated ${bsda.id}`);
+    }
+  }
+  logger.info("exiting");
+  await mongodbClient.close();
+  logger.info("mongo connection closed");
+}

--- a/libs/back/scripts/src/scripts/20240802142645389_bsda_draft_restriction.ts
+++ b/libs/back/scripts/src/scripts/20240802142645389_bsda_draft_restriction.ts
@@ -11,7 +11,6 @@ type EventLike = Omit<Event, "metadata" | "data"> & {
 type EventCollection = { _id: string } & Omit<EventLike, "id">;
 
 const { MONGO_URL } = process.env;
-logger.info(MONGO_URL);
 const EVENTS_COLLECTION = "events";
 
 async function getUserCompanies(userId: string): Promise<Company[]> {
@@ -51,9 +50,6 @@ export async function run() {
           : {}),
         where: {
           isDraft: true
-          // canAccessDraftOrgIds: {
-          //   isEmpty: true
-          // }
         },
         include: {
           intermediaries: true,


### PR DESCRIPTION
## Objectif

Faire en sorte que seules les entreprises liées à l'utilisateur ayant créé le BSDA puissent le voir lorsqu'il est en brouillon.

## Tech

- Ajout d'une array canAccessDraftOrgIds sur le modèle BSDA
- Remplissage de canAccessDraftOrgIds lors de la création de BSDA en Draft (dans le repository, comme ça c'est aussi utilisé à la duplication par exemple)
- Ajout d'un filtre sur les SIRETs ayant accès au BSD à l'indexation Elastic
- Adaptation de tests
- Ajout d'un script de migration pour remplir canAccessDraftOrgIds en utilisant les events mongo pour trouver l'utilisateur ayant créé le BSDA, pour connaître les entreprises y ayant accès

## Demo


https://github.com/user-attachments/assets/c839a330-7619-4de4-b95a-654b5152b7fc



- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14360)
