### PR TITLE
tra-14553  Bsdasri suppression du champ volume de BsdasriReceptionInput

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Résolution d'un problème de resolver BsdaRevisionRequest qui empêchait l'ouverture de la modale de révision [PR 3513](https://github.com/MTES-MCT/trackdechets/pull/3513)
 
+#### :boom: Breaking changes
+
+- Le champ volume de BsdasriReceptionInput est supprimé, BsdasriReception/volume étant calculé à partir des packagings [PR #3509](https://github.com/MTES-MCT/trackdechets/pull/3509)
+
 # [2024.7.2] 30/07/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsdasris/__tests__/factories.integration.ts
+++ b/back/src/bsdasris/__tests__/factories.integration.ts
@@ -18,6 +18,20 @@ describe("Test Factories", () => {
     expect(dasri.isDraft).toEqual(false);
   });
 
+  test("should compute total volume", async () => {
+    const dasri = await bsdasriFactory({
+      opt: {
+        emitterCompanyName: "somecompany",
+        destinationWastePackagings: [
+          { type: "BOITE_CARTON", quantity: 2, volume: 3 },
+          { type: "FUT", quantity: 3, volume: 7 }
+        ]
+      }
+    });
+
+    expect(dasri.destinationReceptionWasteVolume).toEqual(27);
+  });
+
   test("should denormalize synthesis bsdasri", async () => {
     const { company: initialCompany } = await userWithCompanyFactory("MEMBER");
 

--- a/back/src/bsdasris/__tests__/factories.ts
+++ b/back/src/bsdasris/__tests__/factories.ts
@@ -6,9 +6,10 @@ import {
   BsdasriType,
   OperationMode
 } from "@prisma/client";
+import { BsdasriPackagingsInput } from "../../generated/graphql/types";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { distinct } from "../../common/arrays";
-
+import { computeTotalVolume } from "../converter";
 const dasriData = () => ({
   status: "INITIAL" as BsdasriStatus,
   id: getReadableId(ReadableIdPrefix.DASRI),
@@ -20,7 +21,18 @@ export const bsdasriFactory = async ({
 }: {
   opt?: Partial<Prisma.BsdasriCreateInput>;
 }) => {
-  const dasriParams = { ...dasriData(), ...opt };
+  const dasriParams = {
+    ...dasriData(),
+    ...opt,
+    ...(opt.destinationWastePackagings
+      ? {
+          destinationReceptionWasteVolume: computeTotalVolume(
+            opt.destinationWastePackagings as BsdasriPackagingsInput[]
+          )
+        }
+      : {})
+  };
+
   const created = await prisma.bsdasri.create({
     data: {
       ...dasriParams
@@ -103,7 +115,6 @@ export const readyToReceiveData = () => ({
   destinationWastePackagings: [
     { type: "BOITE_CARTON", volume: 22, quantity: 3 }
   ],
-  destinationReceptionWasteVolume: 66,
   destinationReceptionAcceptationStatus: WasteAcceptationStatus.ACCEPTED,
   destinationReceptionDate: new Date()
 });

--- a/back/src/bsdasris/examples/fixtures.ts
+++ b/back/src/bsdasris/examples/fixtures.ts
@@ -94,7 +94,6 @@ function destinationInput(siret: string) {
 const receptionInput = {
   acceptation: { status: "ACCEPTED" },
 
-  volume: 1,
   packagings: [{ type: "BOITE_CARTON", quantity: 1, volume: 1 }],
 
   date: "2021-04-27"

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -240,12 +240,6 @@ input BsdasriDestinationInput {
 }
 
 input BsdasriReceptionInput {
-  "Volume total de tous les contenants"
-  volume: Float
-    @deprecated(
-      reason: "Ignoré - Calculé par Trackdéchets en faisant la somme des volumes des contenants"
-    )
-
   packagings: [BsdasriPackagingsInput!]
   date: DateTime
   acceptation: BsdasriAcceptationInput

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -141,7 +141,7 @@ type BsdasriEmission {
 
 "Informations relatives à la réception du Bsdasri"
 type BsdasriReception {
-  "Volume reçu"
+  "Volume reçu calculé en effectuant la somme des volumes de packagings"
   volume: Float
   "Conditionnement"
   packagings: [BsdasriPackaging!]

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1077,6 +1077,7 @@ model Bsdasri {
   destinationReceptionWasteRefusalReason      String?
   destinationReceptionWasteRefusedWeightValue Decimal?                @db.Decimal(65, 30)
   destinationReceptionWasteWeightValue        Decimal?                @db.Decimal(65, 30)
+  // cached value to avoid computing it each time the dasri is accessed
   destinationReceptionWasteVolume             Float?
   destinationReceptionDate                    DateTime?               @db.Timestamptz(6)
   destinationOperationCode                    String?


### PR DESCRIPTION
Le champ BsdasriReceptionInput.volume est ignoré, le volume total étant calculé en fonction de BsdasriReceptionInput.packagings. Le champ est supprimé (breaking change annoncé)

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14553)
