### PR TITLE
[hotfix][tra-14922]Révision BSDA : impossible de saisir un numéro de scellé déjà renseigné sur le bordereau

### DIFF
--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -133,7 +133,7 @@ export function BsdaRequestRevision({ bsda }: Props) {
   };
 
   const handleAddSealNumbers = value => {
-    if (value && !bsda.waste?.sealNumbers?.includes(value)) {
+    if (value && ![...sealNumbersTags]?.includes(value)) {
       setSealNumbersTags([...sealNumbersTags, value]);
       setValue("waste.sealNumbers", [...sealNumbersTags, value]);
     }


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14922)


https://github.com/user-attachments/assets/96548e95-870f-4c03-b44f-b775ef469c39


