### PR TITLE
Hotfix bsvhu sign errors

### DIFF
--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -60,7 +60,7 @@ export function SignTransport({
       {({ bsvhu, onClose }) => {
         const TODAY = new Date();
 
-        return bsvhu.metadata?.errors.some(
+        return (bsvhu.metadata?.errors ?? []).some(
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter


### PR DESCRIPTION
Hotfix après une remontée de crash d'un utilisateur. L'erreur était "Cannot read properties of null (reading 'some')" donc si metadata.errors est null/undefined le .some posait problème. J'ai repris la même syntaxe que dans le SignTransport Bsda.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---
