### PR TITLE
[TRA-14434] Permet aux comptes gouvernementaux d'effectuer des queries Bds et *Pdf sur l'ensemble des établissements.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Résolution d'un problème de resolver BsdaRevisionRequest qui empêchait l'ouverture de la modale de révision [PR 3513](https://github.com/MTES-MCT/trackdechets/pull/3513)
 
+#### :house: Interne
+
+- Modification des permissions pour la query Bsds et toutes les queries Pdf [PR 3519](https://github.com/MTES-MCT/trackdechets/pull/3519)
+
 # [2024.7.2] 30/07/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsdasris/resolvers/queries/bsdasriPdf.ts
+++ b/back/src/bsdasris/resolvers/queries/bsdasriPdf.ts
@@ -9,6 +9,7 @@ import { buildPdf } from "../../pdf/generator";
 import { createPDFResponse } from "../../../common/pdf";
 import { DownloadHandler } from "../../../routers/downloadRouter";
 import { checkCanRead } from "../../permissions";
+import { hasGovernmentReadAllBsdsPermOrThrow } from "../../../permissions";
 
 export const bsdasriPdfDownloadHandler: DownloadHandler<QueryBsdasriPdfArgs> = {
   name: "bsdasriPdf",
@@ -27,7 +28,12 @@ const bsdasriPdfResolver: QueryResolvers["bsdasriPdf"] = async (
   const user = checkIsAuthenticated(context);
   const dasri = await getBsdasriOrNotFound({ id });
 
-  await checkCanRead(user, dasri);
+  if (!user.isAdmin && !user.governmentAccountId) {
+    await checkCanRead(user, dasri);
+  }
+  if (user.governmentAccountId) {
+    await hasGovernmentReadAllBsdsPermOrThrow(user);
+  }
 
   return getFileDownload({
     handler: bsdasriPdfDownloadHandler.name,

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
@@ -1,0 +1,182 @@
+import { GovernmentPermission } from "@prisma/client";
+import {
+  refreshElasticSearch,
+  resetDatabase
+} from "../../../../../integration-tests/helper";
+import supertest from "supertest";
+
+import { app } from "../../../../server";
+import {
+  formFactory,
+  userWithCompanyFactory,
+  userWithAccessTokenFactory
+} from "../../../../__tests__/factories";
+
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
+
+import { faker } from "@faker-js/faker";
+
+describe("query bsds: governement accoutns permissions", () => {
+  afterEach(resetDatabase);
+
+  it("should allow user authenticated with a token when tied to a government account with relevant perms", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ bsds(where: {isFollowFor: ["${someCompany.siret}"]}) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.bsds.pageInfo).toEqual(1);
+  });
+
+  it("should forbid user authenticated with a token when tied to a government account without relevant perms", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL], // wrong permission
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ bsds(where: {isFollowFor: ["${someCompany.siret}"]}) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+
+  it("should forbid user authenticated with a token if no gov government is associated", async () => {
+    // the company and owner to build a registry
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory();
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ bsds(where: {isFollowFor: ["${someCompany.siret}"]}) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+
+  it("should forbid user authenticated with a token tied to a government account when IPs do not match", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    const userIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP] // not user ip
+        }
+      }
+    });
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ bsds(where: {isFollowFor: ["${someCompany.siret}"]}) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", userIP); // IPs do not match
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+});

--- a/back/src/bsds/resolvers/queries/bsds.ts
+++ b/back/src/bsds/resolvers/queries/bsds.ts
@@ -338,14 +338,11 @@ const bsdsResolver: QueryResolvers["bsds"] = async (_, args, context) => {
 
   // if user is authenticated with Bearer and has a gov account id, check their perms
   if (!context.user && contextUser?.governmentAccountId) {
-    try {
-      await hasGovernmentReadAllBsdsPermOrThrow(contextUser);
-      // if permission matches, set context.user back
-      context.user = contextUser;
-      bypassOrgIdsWithListPermission = true;
-    } catch (_) {
-      bypassOrgIdsWithListPermission = false;
-    }
+    // throw NotLoggedIn if perms do not match
+    await hasGovernmentReadAllBsdsPermOrThrow(contextUser);
+    // if permission matches, set context.user back
+    context.user = contextUser;
+    bypassOrgIdsWithListPermission = true;
   }
 
   const user = checkIsAuthenticated(context);

--- a/back/src/bspaoh/resolvers/queries/bspaohPdf.ts
+++ b/back/src/bspaoh/resolvers/queries/bspaohPdf.ts
@@ -5,8 +5,8 @@ import { createPDFResponse } from "../../../common/pdf";
 import { getBspaohOrNotFound } from "../../database";
 import { buildPdf } from "../../pdf/generator";
 import { DownloadHandler } from "../../../routers/downloadRouter";
-
 import { checkCanReadPdf } from "../../permissions";
+import { hasGovernmentReadAllBsdsPermOrThrow } from "../../../permissions";
 
 export const bspaohPdfDownloadHandler: DownloadHandler<QueryBspaohPdfArgs> = {
   name: "bspaohPdf",
@@ -25,7 +25,12 @@ export default async function bspaohPdf(
   const user = checkIsAuthenticated(context);
   const bspaoh = await getBspaohOrNotFound({ id });
 
-  await checkCanReadPdf(user, bspaoh);
+  if (!user.isAdmin && !user.governmentAccountId) {
+    await checkCanReadPdf(user, bspaoh);
+  }
+  if (user.governmentAccountId) {
+    await hasGovernmentReadAllBsdsPermOrThrow(user);
+  }
 
   return getFileDownload({
     handler: bspaohPdfDownloadHandler.name,

--- a/back/src/bsvhu/resolvers/queries/bsvhuPdf.ts
+++ b/back/src/bsvhu/resolvers/queries/bsvhuPdf.ts
@@ -7,6 +7,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { getBsvhuOrNotFound } from "../../database";
 import { createPDFResponse } from "../../../common/pdf";
 import { buildPdf } from "../../pdf/generator";
+import { hasGovernmentReadAllBsdsPermOrThrow } from "../../../permissions";
 
 import { DownloadHandler } from "../../../routers/downloadRouter";
 import { checkCanRead } from "../../permissions";
@@ -28,7 +29,12 @@ const formPdfResolver: QueryResolvers["bsvhuPdf"] = async (
   const user = checkIsAuthenticated(context);
   const bsvhu = await getBsvhuOrNotFound(id);
 
-  await checkCanRead(user, bsvhu);
+  if (!user.isAdmin && !user.governmentAccountId) {
+    await checkCanRead(user, bsvhu);
+  }
+  if (user.governmentAccountId) {
+    await hasGovernmentReadAllBsdsPermOrThrow(user);
+  }
 
   return getFileDownload({
     handler: bsvhuPdfDownloadHandler.name,

--- a/back/src/common/redis/users.ts
+++ b/back/src/common/redis/users.ts
@@ -1,5 +1,5 @@
 import { redisClient, generateKey } from "./redis";
-import { USER_ROLES_CACHE_KEY } from "../../permissions";
+import { USER_ROLES_CACHE_KEY } from "../../permissions/permissions";
 
 const CACHED_COMPANY_EXPIRATION = 10 * 60; // 10 minutes
 

--- a/back/src/forms/resolvers/queries/__tests__/formPdf.integration.ts
+++ b/back/src/forms/resolvers/queries/__tests__/formPdf.integration.ts
@@ -1,38 +1,42 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import {
-  companyFactory,
   userWithCompanyFactory,
-  userWithAccessTokenFactory
+  userWithAccessTokenFactory,
+  formFactory
 } from "../../../../__tests__/factories";
+import { GovernmentPermission } from "@prisma/client";
+
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { bsdaFactory } from "../../../__tests__/factories";
+
 import { Query } from "../../../../generated/graphql/types";
-import { GovernmentPermission } from "@prisma/client";
 import supertest from "supertest";
 import { faker } from "@faker-js/faker";
 import { app } from "../../../../server";
+
 import { gql } from "graphql-tag";
 
-const BSDA_PDF = gql`
-  query BsdaPdf($id: ID!) {
-    bsdaPdf(id: $id) {
+const FORM_PDF = gql`
+  query FormPdf($id: ID!) {
+    formPdf(id: $id) {
       token
     }
   }
 `;
 
-describe("Query.BsdaPdf", () => {
+describe("Query.FormPdf", () => {
   afterEach(resetDatabase);
 
   it("should disallow unauthenticated user", async () => {
     const { query } = makeClient();
-    const bsda = await bsdaFactory({
-      opt: {}
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
 
-    const { errors } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
-      variables: { id: bsda.id }
+    const { errors } = await query<Pick<Query, "formPdf">>(FORM_PDF, {
+      variables: { id: bsdd.id }
     });
     expect(errors).toEqual([
       expect.objectContaining({
@@ -44,20 +48,21 @@ describe("Query.BsdaPdf", () => {
     ]);
   });
 
-  it("should forbid access to user not on the bsd (simple bsda)", async () => {
-    const bsda = await bsdaFactory({
-      opt: {}
+  it("should forbid access to user not on the bsdd", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
-    const { user } = await userWithCompanyFactory("MEMBER");
+    const { user: otherUser } = await userWithCompanyFactory("MEMBER");
 
-    const { query } = makeClient(user);
-    const { errors } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
-      variables: { id: bsda.id }
+    const { query } = makeClient(otherUser);
+    const { errors } = await query<Pick<Query, "formPdf">>(FORM_PDF, {
+      variables: { id: bsdd.id }
     });
     expect(errors).toEqual([
       expect.objectContaining({
-        message:
-          "Vous n'êtes pas autorisé à accéder au récépissé PDF de ce BSDA.",
+        message: "Vous n'êtes pas autorisé à accéder à ce bordereau",
         extensions: expect.objectContaining({
           code: ErrorCode.FORBIDDEN
         })
@@ -67,73 +72,25 @@ describe("Query.BsdaPdf", () => {
 
   it("should return a token for requested id", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: company.siret
-      }
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
 
     const { query } = makeClient(user);
 
-    const { data } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
-      variables: { id: bsda.id }
+    const { data } = await query<Pick<Query, "formPdf">>(FORM_PDF, {
+      variables: { id: bsdd.id }
     });
 
-    expect(data.bsdaPdf.token).toBeTruthy();
-  });
-
-  it("should return a token for requested id if current user is not on the bsda but on a parent bsda", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER");
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: company.siret
-      }
-    });
-
-    const forwardingBsda = await bsdaFactory({
-      opt: {
-        forwarding: { connect: { id: bsda.id } }
-      }
-    });
-
-    const { query } = makeClient(user);
-
-    const { data } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
-      variables: { id: forwardingBsda.id }
-    });
-
-    expect(data.bsdaPdf.token).toBeTruthy();
-  });
-
-  it("should return a token for requested id if current user is an intermediary", async () => {
-    const otherCompany = await companyFactory();
-    const { user, company } = await userWithCompanyFactory("MEMBER");
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: otherCompany.siret,
-        intermediaries: {
-          create: [
-            { siret: company.siret!, name: company.name, contact: "joe" }
-          ]
-        }
-      }
-    });
-
-    const { query } = makeClient(user);
-
-    const { data } = await query<Pick<Query, "bsdaPdf">>(BSDA_PDF, {
-      variables: { id: bsda.id }
-    });
-
-    expect(data.bsdaPdf.token).toBeTruthy();
+    expect(data.formPdf.token).toBeTruthy();
   });
 
   it("should allow pdf access to user authenticated with a token when tied to a government account with relevant perms", async () => {
-    const { company } = await userWithCompanyFactory("MEMBER");
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: company.siret
-      }
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
 
     const allowedIP = faker.internet.ipv4();
@@ -154,22 +111,23 @@ describe("Query.BsdaPdf", () => {
     const res = await request
       .post("/")
       .send({
-        query: `{bsdaPdf(id: "${bsda.id}") {token}}`
+        query: `{formPdf(id: "${bsdd.id}") {token}}`
       })
       .set("Authorization", `Bearer ${accessToken}`)
       .set("X-Forwarded-For", allowedIP);
     const { errors, data } = res.body;
 
     expect(errors).toBeUndefined();
-    expect(data.bsdaPdf.token).toBeTruthy();
+    expect(data.formPdf.token).toBeTruthy();
   });
+
   it("should forbid pdf access to user authenticated with a token when tied to a government account without relevant perms", async () => {
-    const { company } = await userWithCompanyFactory("MEMBER");
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: company.siret
-      }
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
+
     const allowedIP = faker.internet.ipv4();
 
     const { accessToken } = await userWithAccessTokenFactory({
@@ -188,7 +146,7 @@ describe("Query.BsdaPdf", () => {
     const res = await request
       .post("/")
       .send({
-        query: `{bsdaPdf(id: "${bsda.id}") {token}}`
+        query: `{formPdf(id: "${bsdd.id}") {token}}`
       })
       .set("Authorization", `Bearer ${accessToken}`)
       .set("X-Forwarded-For", allowedIP);
@@ -200,7 +158,7 @@ describe("Query.BsdaPdf", () => {
   });
 
   it("should forbid user authenticated with a token tied to a government account when IPs do not match", async () => {
-    const { company } = await userWithCompanyFactory("MEMBER");
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const request = supertest(app);
 
     const allowedIP = faker.internet.ipv4();
@@ -216,16 +174,15 @@ describe("Query.BsdaPdf", () => {
         }
       }
     });
-    const bsda = await bsdaFactory({
-      opt: {
-        emitterCompanySiret: company.siret
-      }
+    const bsdd = await formFactory({
+      ownerId: user.id,
+      opt: { emitterCompanySiret: company.siret }
     });
 
     const res = await request
       .post("/")
       .send({
-        query: `{bsdaPdf(id: "${bsda.id}") {token}}`
+        query: `{formPdf(id: "${bsdd.id}") {token}}`
       })
       .set("Authorization", `Bearer ${accessToken}`)
       .set("X-Forwarded-For", userIP); // IPs do not match

--- a/back/src/forms/resolvers/queries/formPdf.ts
+++ b/back/src/forms/resolvers/queries/formPdf.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../generated/graphql/types";
 import { getFileDownload } from "../../../common/fileDownload";
 import { checkIsAuthenticated } from "../../../common/permissions";
+import { hasGovernmentReadAllBsdsPermOrThrow } from "../../../permissions";
 import { getFormOrFormNotFound } from "../../database";
 import { checkCanRead } from "../../permissions";
 import { generateBsddPdf } from "../../pdf";
@@ -39,10 +40,13 @@ const formPdfResolver: QueryResolvers["formPdf"] = async (
   );
 
   // The admin dashboard shows BSD cards & must allow PDF downloads
-  if (!user.isAdmin) {
+  if (!user.isAdmin && !user.governmentAccountId) {
     await checkCanRead(user, form);
   }
 
+  if (user.governmentAccountId) {
+    await hasGovernmentReadAllBsdsPermOrThrow(user);
+  }
   return getFileDownload({
     handler: formPdfDownloadHandler.name,
     params: { id }

--- a/back/src/permissions/governmentPermissions.ts
+++ b/back/src/permissions/governmentPermissions.ts
@@ -1,14 +1,11 @@
 import { prisma } from "@td/prisma";
 import { GovernmentPermission } from "@prisma/client";
+import { NotLoggedIn } from "../common/errors";
 
-/**
- * Les utilisateurs liés à un compte gouvernemental
- * (ex: GEREP, RNDTS) sont susceptibles d'avoir un accès
- * étendu au registre
- */
-export async function hasGovernmentRegistryPerm(
+export async function hasGovernmentPerm(
   user: Express.User,
-  sirets: string[]
+  sirets: string[],
+  requiredPermission: GovernmentPermission
 ): Promise<boolean> {
   if (!user.governmentAccountId || !user.ip) {
     return false;
@@ -26,7 +23,7 @@ export async function hasGovernmentRegistryPerm(
 
   const { permissions, authorizedIPs, authorizedOrgIds } = governmentAccount;
 
-  if (permissions.includes(GovernmentPermission.REGISTRY_CAN_READ_ALL)) {
+  if (permissions.includes(requiredPermission)) {
     const authorizedIP = (authorizedIPs ?? []).find(ip => ip === user.ip);
     if (!authorizedIP) {
       // la requête ne provient pas d'une IP autorisée
@@ -43,4 +40,37 @@ export async function hasGovernmentRegistryPerm(
   }
 
   return false;
+}
+
+/**
+ * Les utilisateurs liés à un compte gouvernemental
+ * (ex: GEREP, RNDTS) sont susceptibles d'avoir un accès
+ * étendu au registre
+ */
+export async function hasGovernmentRegistryPerm(
+  user: Express.User,
+  sirets: string[]
+): Promise<boolean> {
+  return hasGovernmentPerm(
+    user,
+    sirets,
+    GovernmentPermission.REGISTRY_CAN_READ_ALL
+  );
+}
+
+/**
+ * La fiche établissement/gerico necessit des permissions spéicifique via un compte gouvernemental
+ */
+export async function hasGovernmentReadAllBsdsPermOrThrow(
+  user: Express.User
+): Promise<void> {
+  const hasPerm = await hasGovernmentPerm(
+    user,
+    [],
+    GovernmentPermission.BSDS_CAN_READ_ALL
+  );
+
+  if (!hasPerm) {
+    throw new NotLoggedIn();
+  }
 }

--- a/back/src/permissions/governmentPermissions.ts
+++ b/back/src/permissions/governmentPermissions.ts
@@ -59,7 +59,7 @@ export async function hasGovernmentRegistryPerm(
 }
 
 /**
- * La fiche établissement/gerico necessit des permissions spéicifique via un compte gouvernemental
+ * La fiche établissement/gerico necessite des permissions spécifiques via un compte gouvernemental
  */
 export async function hasGovernmentReadAllBsdsPermOrThrow(
   user: Express.User

--- a/back/src/permissions/index.ts
+++ b/back/src/permissions/index.ts
@@ -1,0 +1,2 @@
+export * from "./permissions";
+export * from "./governmentPermissions";

--- a/back/src/permissions/permissions.ts
+++ b/back/src/permissions/permissions.ts
@@ -1,5 +1,5 @@
 import { User, UserRole } from "@prisma/client";
-import { cachedGet } from "./common/redis";
+import { cachedGet } from "../common/redis";
 import { prisma } from "@td/prisma";
 import {
   BsdaSignatureType,
@@ -8,10 +8,10 @@ import {
   SignatureTypeInput,
   UserPermission,
   BspaohSignatureType
-} from "./generated/graphql/types";
-import { checkSecurityCode } from "./common/permissions";
-import { ForbiddenError } from "./common/errors";
-import { MultiModalSignatureType } from "./common/types";
+} from "../generated/graphql/types";
+import { checkSecurityCode } from "../common/permissions";
+import { ForbiddenError } from "../common/errors";
+import { MultiModalSignatureType } from "../common/types";
 
 // List of all the permissions
 export enum Permission {

--- a/back/src/registry/resolvers/queries/incomingWastes.ts
+++ b/back/src/registry/resolvers/queries/incomingWastes.ts
@@ -1,8 +1,12 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { hasGovernmentRegistryPerm } from "../../permissions";
-import { Permission, checkUserPermissions } from "../../../permissions";
+
+import {
+  Permission,
+  checkUserPermissions,
+  hasGovernmentRegistryPerm
+} from "../../../permissions";
 
 const incomingWastesResolver: QueryResolvers["incomingWastes"] = async (
   _,

--- a/back/src/registry/resolvers/queries/managedWastes.ts
+++ b/back/src/registry/resolvers/queries/managedWastes.ts
@@ -1,8 +1,12 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { hasGovernmentRegistryPerm } from "../../permissions";
-import { Permission, checkUserPermissions } from "../../../permissions";
+
+import {
+  Permission,
+  checkUserPermissions,
+  hasGovernmentRegistryPerm
+} from "../../../permissions";
 
 const managedWastesResolver: QueryResolvers["managedWastes"] = async (
   _,

--- a/back/src/registry/resolvers/queries/outgoingWastes.ts
+++ b/back/src/registry/resolvers/queries/outgoingWastes.ts
@@ -1,8 +1,12 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { hasGovernmentRegistryPerm } from "../../permissions";
-import { Permission, checkUserPermissions } from "../../../permissions";
+
+import {
+  Permission,
+  checkUserPermissions,
+  hasGovernmentRegistryPerm
+} from "../../../permissions";
 
 const outgoingWastesResolver: QueryResolvers["outgoingWastes"] = async (
   _,

--- a/back/src/registry/resolvers/queries/transportedWastes.ts
+++ b/back/src/registry/resolvers/queries/transportedWastes.ts
@@ -1,8 +1,12 @@
 import { QueryResolvers } from "../../../generated/graphql/types";
 import getWasteConnection from "../../wastes";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { hasGovernmentRegistryPerm } from "../../permissions";
-import { Permission, checkUserPermissions } from "../../../permissions";
+
+import {
+  Permission,
+  checkUserPermissions,
+  hasGovernmentRegistryPerm
+} from "../../../permissions";
 
 const transportedWastesResolver: QueryResolvers["transportedWastes"] = async (
   _,

--- a/back/src/registry/resolvers/queries/wasteRegistryBase.ts
+++ b/back/src/registry/resolvers/queries/wasteRegistryBase.ts
@@ -2,10 +2,13 @@ import { QueryWastesRegistryXlsArgs } from "../../../generated/graphql/types";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { searchBsds } from "../../elastic";
 import { GraphQLContext } from "../../../types";
-import { Permission, syncCheckUserPermissions } from "../../../permissions";
+import {
+  Permission,
+  syncCheckUserPermissions,
+  hasGovernmentRegistryPerm
+} from "../../../permissions";
 import { UserInputError } from "../../../common/errors";
 import { TotalHits } from "@elastic/elasticsearch/api/types";
-import { hasGovernmentRegistryPerm } from "../../permissions";
 
 export async function checkWastesRegistryDownloadPermissions(
   args: QueryWastesRegistryXlsArgs,

--- a/libs/back/prisma/src/migrations/20240807123846_ctt_government_permissions/migration.sql
+++ b/libs/back/prisma/src/migrations/20240807123846_ctt_government_permissions/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "GovernmentPermission" ADD VALUE 'BSDS_CAN_READ_ALL';
+ALTER TYPE "GovernmentPermission" ADD VALUE 'BSDS_PDF_CAN_DOWNLOAD_ALL';

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -864,6 +864,10 @@ model User {
 enum GovernmentPermission {
   // Accès en lecture au registre de tous les établissements
   REGISTRY_CAN_READ_ALL
+  // Accès en lecture à la recherche multi bsds (query bsds)
+  BSDS_CAN_READ_ALL
+  // Accès au téléchargement de tout bsd au format pdf
+  BSDS_PDF_CAN_DOWNLOAD_ALL
 }
 
 model GovernmentAccount {


### PR DESCRIPTION
Modifie les permissions sur les queries suivantes afin de permettre l'accès api de gerico quand le compte est lié à un GovernementAccount disposant de la nouvelle permission BSDS_CAN_READ_ALL, que authorizedOrgIds vaut ALL et que les IPs matchent:
- query bsds: accès api si GovernementAccount (bearer, précedemment réservées au sessions)
- formPdf, bsdaPdf, bsdasriPdf, bspaohPdf, PsvhuPdf, BsffPdf: accès à tous les bsds

Ajout des tests pour les queries pdfs qui n'en avaient pas

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14334)
