### PR TITLE
[TRA-14974] - Fix registre entrant qui ne se télécharge pas

### DIFF
--- a/back/src/bsda/registry.ts
+++ b/back/src/bsda/registry.ts
@@ -145,8 +145,8 @@ export const getTransportersData = (
     city: transporterCompanyCity,
     country: transporterCompanyCountry
   } = splitAddress(
-    transporter.transporterCompanyAddress,
-    transporter.transporterCompanyVatNumber
+    transporter?.transporterCompanyAddress,
+    transporter?.transporterCompanyVatNumber
   );
 
   const {


### PR DESCRIPTION
Résolution d'un bug qui empêchait le téléchargement du registre dans le cas où un BSDA n'avait pas de transporteur.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-14974)
