### PR TITLE
[TRA-15007] - Accepter une demande de rattachement lorsque l'utilisateur ayant fait la demande est invité dans l'entreprise

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Résolution d'un problème de resolver BsdaRevisionRequest qui empêchait l'ouverture de la modale de révision [PR 3513](https://github.com/MTES-MCT/trackdechets/pull/3513)
+- Une demande de rattachement est automatiquement acceptée si l'utilisateur est invité dans un établissement [PR 3526](https://github.com/MTES-MCT/trackdechets/pull/3526)
 
 # [2024.7.2] 30/07/2024
 

--- a/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/inviteUserToCompany.integration.ts
@@ -107,7 +107,7 @@ describe("mutation inviteUserToCompany", () => {
       vars: {
         API_URL: "http://api.trackdechets.local",
         UI_URL: "http://trackdechets.local",
-        companyName: "company_2",
+        companyName: company.name,
         companyOrgId: company.siret,
         hash: encodeURIComponent(hashValue)
       }

--- a/back/src/users/resolvers/mutations/inviteUserToCompany.ts
+++ b/back/src/users/resolvers/mutations/inviteUserToCompany.ts
@@ -21,7 +21,7 @@ const inviteUserToCompanyResolver: MutationResolvers["inviteUserToCompany"] =
       Permission.CompanyCanManageMembers,
       NotCompanyAdminErrorMsg(company.orgId)
     );
-    return inviteUserToCompanyFn(args);
+    return inviteUserToCompanyFn(user, args);
   };
 
 export default inviteUserToCompanyResolver;


### PR DESCRIPTION
## Situation rencontrée

L'utilisateur a fait une demande de rattachement à une entreprise. Un admin de l'entreprise, au lieu d'accepter sa demande (qu'il n'a pas reçu à cause d'un Hard bounce de sa boîte mail) l'a invité sur l'entreprise en tant qu'admin. La demande de rattachement n'ayant pas été acceptée, des emails de relance ont été envoyés, même à l'utilisateur invité qui est devenu admin entre temps.

## Comportement attendu

Que la demande de rattachement soit considérée comme acceptée si l'utilisateur est directement invité sur l'entreprise.
/!\ J'ai supposé que le comportement attendu était celui-là. N'hésitez pas à me dire si vous pensez que ça devrait être fait autrement.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15007)
