### PR TITLE
[TRA 15005] - Ajoute la possibilité de réviser la quantité du destinataire si entreposage provisoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Rendre BSDAs en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
+- Ajout de la possibilité de réviser la quantité du destinataire d'un BSDD si un entreposage provisoire est présent [PR 3527](https://github.com/MTES-MCT/trackdechets/pull/3527)
 
 # [2024.7.2] 30/07/2024
 

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
@@ -154,19 +154,6 @@ export function BsddRequestRevision({ bsdd }: Props) {
     setBrokerOrTraderReceipt(company?.traderReceipt, field);
   };
 
-  const quantityReceivedFormValue = !isTempStorage
-    ? formValues?.quantityReceived || undefined
-    : formValues?.temporaryStorageDetail?.temporaryStorer?.quantityReceived ||
-      undefined;
-
-  const quantityReceivedDefaultValue = !isTempStorage
-    ? initialBsddReview?.quantityReceived
-    : initialBsddReview.temporaryStorageDetail?.temporaryStorer
-        ?.quantityReceived;
-  const quantityReceivedValue = !isTempStorage
-    ? bsdd.quantityReceived
-    : bsdd.temporaryStorageDetail?.temporaryStorer?.quantityReceived;
-
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>
@@ -274,47 +261,80 @@ export function BsddRequestRevision({ bsdd }: Props) {
                   title={
                     !isTempStorage
                       ? "Quantité reçue"
-                      : "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
+                      : "Quantité reçue sur l'installation de destination"
                   }
                   path="quantityReceived"
-                  value={quantityReceivedValue}
-                  defaultValue={quantityReceivedDefaultValue}
+                  value={bsdd.quantityReceived}
+                  defaultValue={initialBsddReview?.quantityReceived}
                 >
                   <Input
                     label="Poids en tonnes"
                     className="fr-col-2"
-                    state={
-                      !isTempStorage
-                        ? errors.quantityReceived && "error"
-                        : errors.temporaryStorageDetail?.temporaryStorer
-                            ?.quantityReceived && "error"
-                    }
-                    stateRelatedMessage={
-                      !isTempStorage
-                        ? errors.quantityReceived?.message ?? ""
-                        : errors.temporaryStorageDetail?.temporaryStorer
-                            ?.quantityReceived?.message ?? ""
-                    }
+                    state={errors.quantityReceived && "error"}
+                    stateRelatedMessage={errors.quantityReceived?.message ?? ""}
                     nativeInputProps={{
-                      ...register(
-                        `${
-                          !isTempStorage
-                            ? "quantityReceived"
-                            : "temporaryStorageDetail.temporaryStorer.quantityReceived"
-                        }`,
-                        { valueAsNumber: true }
-                      ),
+                      ...register("quantityReceived", { valueAsNumber: true }),
                       type: "number",
                       inputMode: "decimal",
                       step: "0.000001"
                     }}
                   />
-                  {quantityReceivedFormValue && (
+                  {formValues?.quantityReceived && (
                     <p className="fr-info-text">
-                      Soit {Number(quantityReceivedFormValue) * 1000} kg
+                      Soit {Number(formValues.quantityReceived) * 1000} kg
                     </p>
                   )}
                 </RhfReviewableField>
+
+                {isTempStorage ? (
+                  <RhfReviewableField
+                    title={
+                      "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
+                    }
+                    path="quantityReceived"
+                    value={
+                      bsdd.temporaryStorageDetail?.temporaryStorer
+                        ?.quantityReceived
+                    }
+                    defaultValue={
+                      initialBsddReview.temporaryStorageDetail?.temporaryStorer
+                        ?.quantityReceived
+                    }
+                  >
+                    <Input
+                      label="Poids en tonnes"
+                      className="fr-col-2"
+                      state={
+                        errors.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived && "error"
+                      }
+                      stateRelatedMessage={
+                        errors.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived?.message ?? ""
+                      }
+                      nativeInputProps={{
+                        ...register(
+                          "temporaryStorageDetail.temporaryStorer.quantityReceived",
+                          { valueAsNumber: true }
+                        ),
+                        type: "number",
+                        inputMode: "decimal",
+                        step: "0.000001"
+                      }}
+                    />
+                    {formValues?.temporaryStorageDetail?.temporaryStorer
+                      ?.quantityReceived && (
+                      <p className="fr-info-text">
+                        Soit{" "}
+                        {Number(
+                          formValues.temporaryStorageDetail.temporaryStorer
+                            .quantityReceived
+                        ) * 1000}{" "}
+                        kg
+                      </p>
+                    )}
+                  </RhfReviewableField>
+                ) : null}
 
                 <RhfReviewableField
                   title="Code de l'opération D/R"


### PR DESCRIPTION
La présence d'un entreposage provisoire cachait la révision de la quantité destinataire dans la modale de révision BSDD (c'était l'un ou l'autre). J'ai donc modifié pour rendre possible de modifier la quantité de destination même en cas d'entreposage provisoire.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15005)
