### PR TITLE
Ajoute les sourcemaps pour Sentry

### DIFF
--- a/.github/workflows/deploy-recette.yml
+++ b/.github/workflows/deploy-recette.yml
@@ -34,6 +34,6 @@ jobs:
           SENTRY_URL: https://sentry.incubateur.net/
         with:
           environment: recette
-          sourcemaps: ./dist/back/back/src ./dist/front/assets
+          sourcemaps: ./dist/apps/api ./dist/front/assets
           projects: trackdechets-api trackdechets-front
           ignore_missing: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           SENTRY_URL: https://sentry.incubateur.net/
         with:
           environment: production
-          sourcemaps: ./dist/back/back/src ./dist/front/assets
+          sourcemaps: ./dist/apps/api ./dist/front/assets
           projects: trackdechets-api trackdechets-front
           ignore_missing: true
 

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -58,7 +58,7 @@
         },
         "production": {
           "esbuildOptions": {
-            "sourcemap": false,
+            "sourcemap": true,
             "outExtension": {
               ".js": ".js"
             }

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true
-    }
+    },
+    sourcemap: true
   },
   cacheDir: "../node_modules/.vite/front",
   plugins: [


### PR DESCRIPTION
Afin de simplifier le debug sur Sentry, activation de la génération des sourcemaps là où ce n'était pas le cas, et correction du chemin d'accès aux sourcemaps backend

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
