### PR TITLE
[hotfix] Correction du passage des erreurs BSVHU à la signature

### DIFF
--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -49,7 +49,6 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
         });
         return [];
       } catch (errors) {
-        console.log(JSON.stringify(errors, null, 2));
         return (
           errors.issues?.map((e: ZodIssue) => {
             return {

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -1,4 +1,3 @@
-import { ValidationError } from "yup";
 import { getTransporterReceipt } from "../../companies/recipify";
 import {
   BsvhuMetadata,
@@ -9,6 +8,7 @@ import { getBsvhuOrNotFound } from "../database";
 import { parseBsvhu } from "../validation";
 import { prismaToZodBsvhu } from "../validation/helpers";
 import { SignatureTypeInput } from "../../generated/graphql/types";
+import { ZodIssue } from "zod";
 
 const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
   errors: async (
@@ -49,13 +49,16 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
         });
         return [];
       } catch (errors) {
-        return errors.inner?.map((e: ValidationError) => {
-          return {
-            message: e.message,
-            path: e.path ?? "",
-            requiredFor
-          };
-        });
+        console.log(JSON.stringify(errors, null, 2));
+        return (
+          errors.issues?.map((e: ZodIssue) => {
+            return {
+              message: e.message,
+              path: `${e.path[0]}`, // e.path is an array, first element should be the path name
+              requiredFor
+            };
+          }) ?? []
+        );
       }
     }
   }

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignEmission.tsx
@@ -52,7 +52,7 @@ export function SignEmission({
       displayActionButton={displayActionButton}
     >
       {({ bsvhu, onClose }) =>
-        bsvhu.metadata?.errors.some(
+        bsvhu.metadata?.errors?.some(
           error => error.requiredFor === SignatureTypeInput.Emission
         ) ? (
           <>


### PR DESCRIPTION
Ce ticket fix 2 problèmes qui se sont additionnés:
- crash de la front en cas d'objet bsvhu.metadata.error === null alors que le GraphQL permet ce cas
- passage d'erreurs de signature BSVHU pas mise à jour au passage à Zod

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
