### PR TITLE
Fix partial dump script

### DIFF
--- a/libs/back/partial-backup/src/main.ts
+++ b/libs/back/partial-backup/src/main.ts
@@ -194,16 +194,18 @@ const run = async () => {
         continue;
       }
       const objects = await getter?.(item.foreignKey, root.obj[item.localKey]);
-      const filteredObjects = objects?.filter(obj => {
-        if (alreadyFetched[obj.id]) {
-          return false;
-        }
-        alreadyFetched[obj.id] = {
-          type: item.type,
-          obj
-        };
-        return true;
-      });
+      const filteredObjects = objects
+        ? objects?.filter(obj => {
+            if (alreadyFetched[obj.id]) {
+              return false;
+            }
+            alreadyFetched[obj.id] = {
+              type: item.type,
+              obj
+            };
+            return true;
+          })
+        : null;
       if (filteredObjects?.length) {
         const subRoots: structItem[] = filteredObjects.map(obj => ({
           type: item.type,

--- a/libs/back/partial-backup/src/pipelines.ts
+++ b/libs/back/partial-backup/src/pipelines.ts
@@ -23,6 +23,7 @@ import {
   BsffTransporter,
   Bspaoh,
   BspaohTransporter,
+  Bsvhu,
   Company,
   CompanyAssociation,
   EcoOrganisme,
@@ -124,6 +125,12 @@ const getPipelines = (
             Prisma.JsonNull
         }
       })
+  },
+  Bsvhu: {
+    getter: async (key: string, value?: string) =>
+      value && prismaRemote.bsvhu.findMany({ where: { [key]: value } }),
+    setter: async (bsvhu?: Bsvhu) =>
+      bsvhu && prismaLocal.bsvhu.create({ data: bsvhu })
   },
   Company: {
     getter: async (key: string, value?: string) =>

--- a/libs/back/partial-backup/src/traversals.ts
+++ b/libs/back/partial-backup/src/traversals.ts
@@ -455,21 +455,21 @@ const traversals = {
       localKey: "id",
       foreignKey: "companyId"
     },
-    {
-      type: "MembershipRequest",
-      localKey: "id",
-      foreignKey: "companyId"
-    },
-    {
-      type: "SignatureAutomation",
-      localKey: "id",
-      foreignKey: "fromId"
-    },
-    {
-      type: "SignatureAutomation",
-      localKey: "id",
-      foreignKey: "toId"
-    },
+    // {
+    //   type: "MembershipRequest",
+    //   localKey: "id",
+    //   foreignKey: "companyId"
+    // },
+    // {
+    //   type: "SignatureAutomation",
+    //   localKey: "id",
+    //   foreignKey: "fromId"
+    // },
+    // {
+    //   type: "SignatureAutomation",
+    //   localKey: "id",
+    //   foreignKey: "toId"
+    // },
     {
       type: "WebhookSetting",
       localKey: "orgId",
@@ -495,11 +495,11 @@ const traversals = {
       localKey: "governmentAccountId",
       foreignKey: "id"
     },
-    {
-      type: "AccessToken",
-      localKey: "id",
-      foreignKey: "userId"
-    },
+    // {
+    //   type: "AccessToken",
+    //   localKey: "id",
+    //   foreignKey: "userId"
+    // },
     {
       type: "Application",
       localKey: "id",
@@ -515,11 +515,11 @@ const traversals = {
       localKey: "id",
       foreignKey: "userId"
     },
-    {
-      type: "Grant",
-      localKey: "id",
-      foreignKey: "userId"
-    },
+    // {
+    //   type: "Grant",
+    //   localKey: "id",
+    //   foreignKey: "userId"
+    // },
     // {
     //   type: "MembershipRequest",
     //   localKey: "id",
@@ -657,17 +657,17 @@ const traversals = {
       type: "User",
       localKey: "adminId",
       foreignKey: "id"
-    },
-    {
-      type: "AccessToken",
-      localKey: "id",
-      foreignKey: "applicationId"
-    },
-    {
-      type: "Grant",
-      localKey: "id",
-      foreignKey: "applicationId"
     }
+    // {
+    //   type: "AccessToken",
+    //   localKey: "id",
+    //   foreignKey: "applicationId"
+    // },
+    // {
+    //   type: "Grant",
+    //   localKey: "id",
+    //   foreignKey: "applicationId"
+    // }
   ],
   FeatureFlag: [],
   Grant: [

--- a/libs/back/partial-backup/src/traversals.ts
+++ b/libs/back/partial-backup/src/traversals.ts
@@ -399,6 +399,21 @@ const traversals = {
       foreignKey: "orgId"
     },
     {
+      type: "Company",
+      localKey: "traderCompanySiret",
+      foreignKey: "orgId"
+    },
+    {
+      type: "EcoOrganisme",
+      localKey: "ecoOrganismeSiret",
+      foreignKey: "orgId"
+    },
+    {
+      type: "Company",
+      localKey: "brokerCompanySiret",
+      foreignKey: "orgId"
+    },
+    {
       type: "AnonymousCompany",
       localKey: "emitterCompanySiret",
       foreignKey: "orgId"


### PR DESCRIPTION
J'avais oublié de gérer les Bsvhu dans le script de dump partiel. J'ai aussi ajouté une petite sécu pour le cas où une proporiété est vide ("") au lieu de null, et enlevé certains traversals pour éviter de perdre trop de temps sur des objets pas nécessaires pour 99% des debugs. Ils sont commentés donc peuvent être remis en cas de besoin précis.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
