### PR TITLE
[TRA-15014] ETQ utilisateur je peux signer la réception ET l'acceptation de l'entreposage provisoire en même temps

### DIFF
--- a/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
+++ b/front/src/Apps/Dashboard/Components/Validation/BSDD/SignReception.tsx
@@ -185,64 +185,73 @@ function SignReceptionModal({
       refusedWeight
     } = data;
 
+    let formStatus: FormStatus | undefined = form.status;
     if (isReception) {
-      isTempStorage && form.status === FormStatus.Sent
-        ? await markAsTempStored({
-            variables: {
-              id: form.id,
-              tempStoredInfos: {
-                quantityReceived: receivedWeight,
-                quantityType: quantityType,
-                receivedAt: signedAt,
-                receivedBy: signedBy,
-                signedAt: signedAt
-              }
+      if (isTempStorage && form.status === FormStatus.Sent) {
+        const res = await markAsTempStored({
+          variables: {
+            id: form.id,
+            tempStoredInfos: {
+              quantityReceived: receivedWeight,
+              quantityType: quantityType,
+              receivedAt: signedAt,
+              receivedBy: signedBy,
+              signedAt: signedAt
             }
-          })
-        : await markAsReceived({
-            variables: {
-              id: form.id,
-              receivedInfo: {
-                quantityReceived: receivedWeight,
-                receivedAt: signedAt,
-                receivedBy: signedBy,
-                signedAt: signedAt
-              }
+          }
+        });
+
+        formStatus = res.data?.markAsTempStored.status;
+      } else {
+        const res = await markAsReceived({
+          variables: {
+            id: form.id,
+            receivedInfo: {
+              quantityReceived: receivedWeight,
+              receivedAt: signedAt,
+              receivedBy: signedBy,
+              signedAt: signedAt
             }
-          });
+          }
+        });
+
+        formStatus = res.data?.markAsReceived.status;
+      }
     }
 
     if (
       ["ACCEPTED", "REFUSED", "PARTIALLY_REFUSED"].includes(acceptationStatus)
     ) {
-      isTempStorage && form.status === FormStatus.TempStored
-        ? await markAsTempStorerAccepted({
-            variables: {
-              id: form.id,
-              tempStorerAcceptedInfo: {
-                quantityReceived: receivedWeight,
-                quantityRefused: refusedWeight,
-                quantityType: quantityType,
-                signedAt: signedAt,
-                signedBy: signedBy,
-                wasteAcceptationStatus: wasteAcceptationStatus,
-                wasteRefusalReason: wasteRefusalReason
-              }
+      if (isTempStorage && formStatus === FormStatus.TempStored) {
+        await markAsTempStorerAccepted({
+          variables: {
+            id: form.id,
+            tempStorerAcceptedInfo: {
+              quantityReceived: receivedWeight,
+              quantityRefused: refusedWeight,
+              quantityType: quantityType,
+              signedAt: signedAt,
+              signedBy: signedBy,
+              wasteAcceptationStatus: wasteAcceptationStatus,
+              wasteRefusalReason: wasteRefusalReason
             }
-          })
-        : await markAsAccepted({
-            variables: {
-              id: form.id,
-              acceptedInfo: {
-                quantityReceived: receivedWeight,
-                quantityRefused: refusedWeight,
-                signedAt: signedAt,
-                signedBy: signedBy,
-                wasteAcceptationStatus: wasteAcceptationStatus,
-                wasteRefusalReason: wasteRefusalReason
-              }
+          }
+        });
+      } else {
+        await markAsAccepted({
+          variables: {
+            id: form.id,
+            acceptedInfo: {
+              quantityReceived: receivedWeight,
+              quantityRefused: refusedWeight,
+              signedAt: signedAt,
+              signedBy: signedBy,
+              wasteAcceptationStatus: wasteAcceptationStatus,
+              wasteRefusalReason: wasteRefusalReason
             }
-          });
+          }
+        });
+      }
     }
 
     onCancel();


### PR DESCRIPTION
# Contexte

On a un petit bug front qui fait qu'on ne peut pas signer la réceptation et l'acceptation en même temps pour de l'entreposage provisoire. C'est dû au code front qui regarde le statut du BSD une première fois pour la réception, mais qui regarde à nouveau de même statut (inchangé) pour l'acceptation (alors qu'il a été réceptionné entre temps). Il faut donc bien prendre le nouveau statut en compte.

# Ticket Favro

[Je devrai être en mesure de signer la réception ET l'acceptation de l'entreposage provisoire en même temps](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15014)


