### PR TITLE
Ajouter la possibilité de Réviser l'Annexe 1 pour le transporteur lorsqu'il vient de signer l'enlèvement 

### DIFF
--- a/back/src/forms/permissions.ts
+++ b/back/src/forms/permissions.ts
@@ -561,11 +561,17 @@ export async function checkCanImportForm(
 
 export async function checkCanRequestRevision(user: User, form: Form) {
   const fullForm = await getFullForm(form);
+
+  const transporterIsAuthorized =
+    fullForm.emitterType === EmitterType.APPENDIX1_PRODUCER &&
+    fullForm.takenOverAt;
+
   const authorizedOrgIds = [
     fullForm.emitterCompanySiret,
     fullForm.recipientCompanySiret,
     fullForm.ecoOrganismeSiret,
-    fullForm.forwardedIn?.recipientCompanySiret
+    fullForm.forwardedIn?.recipientCompanySiret,
+    ...(transporterIsAuthorized ? form.transportersSirets : [])
   ].filter(Boolean);
 
   return checkUserPermissions(

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -145,14 +145,18 @@ async function getAuthoringCompany(
     bsdd.id
   );
 
-  if (
-    ![
-      bsdd.emitterCompanySiret,
-      bsdd.recipientCompanySiret,
-      bsdd.ecoOrganismeSiret,
-      forwardedIn?.recipientCompanySiret
-    ].includes(authoringCompanySiret)
-  ) {
+  const transporterCanBeAuthor =
+    bsdd.emitterType === EmitterType.APPENDIX1_PRODUCER && bsdd.takenOverAt;
+
+  const canBeAuthorCompany = [
+    bsdd.emitterCompanySiret,
+    bsdd.recipientCompanySiret,
+    bsdd.ecoOrganismeSiret,
+    forwardedIn?.recipientCompanySiret,
+    ...(transporterCanBeAuthor ? bsdd.transportersSirets : [])
+  ].filter(Boolean);
+
+  if (!canBeAuthorCompany.includes(authoringCompanySiret)) {
     throw new UserInputError(
       `Le SIRET "${authoringCompanySiret}" ne peut pas être auteur de la révision.`
     );


### PR DESCRIPTION


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14695)
