### PR TITLE
Résoudre problème de permissions à la suppression BSDA en status initial

### DIFF
--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -290,11 +290,13 @@ export async function checkCanUpdateBsdaTransporter(
 }
 
 export async function checkCanDelete(user: User, bsda: BsdaWithTransporters) {
-  const authorizedOrgIds = bsda.isDraft
-    ? await contributors(bsda)
-    : bsda.status === BsdaStatus.SIGNED_BY_PRODUCER && bsda.emitterCompanySiret
-    ? [bsda.emitterCompanySiret]
-    : [];
+  const authorizedOrgIds =
+    bsda.status === BsdaStatus.INITIAL
+      ? await contributors(bsda)
+      : bsda.status === BsdaStatus.SIGNED_BY_PRODUCER &&
+        bsda.emitterCompanySiret
+      ? [bsda.emitterCompanySiret]
+      : [];
 
   const errorMsg = bsda.isDraft
     ? "Vous n'êtes pas autorisé à supprimer ce bordereau."


### PR DESCRIPTION
Problème introduit par https://github.com/MTES-MCT/trackdechets/pull/3503 qui empêche la suppression en status initial mais pas draft (donc publié).

La fonction contributors() différencie déjà entre draft (avec utilisation de la liste de SIRET canAccessDraftOrgIds) et publié.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
