### PR TITLE
[TRA 15033] Visibilité du bouton Signer en cas d'entreprise de travaux

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.test.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.test.ts
@@ -1003,10 +1003,7 @@ describe("dashboardServices", () => {
         }
       },
       worker: {
-        isDisabled: true,
-        company: {
-          siret: "currentSiret"
-        }
+        isDisabled: true
       }
     } as BsdDisplay;
 
@@ -1047,9 +1044,56 @@ describe("dashboardServices", () => {
       expect(result).toEqual(SIGNER);
     });
 
-    it("should return SIGNER when currentSiret is same as transporter, bsd type is bsda, and bsd workflow type is gathering", () => {
+    it("should return SIGNER when currentSiret is same as transporter, bsd type is bsda, there is no worker and bsd workflow type is gathering", () => {
       const permissions: UserPermission[] = [
         UserPermission.BsdCanSignTransport
+      ];
+      const result = getSignByProducerBtnLabel(
+        "currentSiret",
+        {
+          ...bsd,
+          type: BsdType.Bsda,
+          bsdWorkflowType: BsdaType.Gathering,
+          transporter: {
+            company: { siret: "currentSiret", orgId: "currentSiret" }
+          }
+        },
+        permissions,
+        "actTab"
+      );
+      expect(result).toEqual(SIGNER);
+    });
+
+    it("should return SIGNER when currentSiret is same as worker, bsd type is bsda, and bsd workflow type is gathering", () => {
+      const permissions: UserPermission[] = [UserPermission.BsdCanSignWork];
+      const result = getSignByProducerBtnLabel(
+        "currentSiret",
+        {
+          ...bsd,
+          type: BsdType.Bsda,
+          bsdWorkflowType: BsdaType.Gathering,
+          transporter: {
+            company: { siret: "otherSiret", orgId: "otherSiret" }
+          },
+
+          worker: {
+            ...bsd.worker,
+            isDisabled: false,
+            company: {
+              siret: "currentSiret"
+            }
+          }
+        },
+        permissions,
+        "actTab"
+      );
+      expect(result).toEqual(SIGNER);
+    });
+
+    it("should return SIGNER when currentSiret is same as worker and transporter, bsd type is bsda, and bsd workflow type is gathering", () => {
+      const permissions: UserPermission[] = [
+        UserPermission.BsdCanSignTransport,
+        UserPermission.BsdCanSignWork
       ];
       const result = getSignByProducerBtnLabel(
         "currentSiret",
@@ -1063,7 +1107,36 @@ describe("dashboardServices", () => {
 
           worker: {
             ...bsd.worker,
-            isDisabled: true,
+            isDisabled: false,
+            company: {
+              siret: "currentSiret"
+            }
+          }
+        },
+        permissions,
+        "actTab"
+      );
+      expect(result).toEqual(SIGNER);
+    });
+
+    it("should return an empty string when currentSiret is same as transporter, bsd type is bsda, there is a worker, and bsd workflow type is gathering", () => {
+      const permissions: UserPermission[] = [
+        UserPermission.BsdCanSignTransport,
+        UserPermission.BsdCanSignWork
+      ];
+      const result = getSignByProducerBtnLabel(
+        "currentSiret",
+        {
+          ...bsd,
+          type: BsdType.Bsda,
+          bsdWorkflowType: BsdaType.Gathering,
+          transporter: {
+            company: { siret: "currentSiret", orgId: "currentSiret" }
+          },
+
+          worker: {
+            ...bsd.worker,
+            isDisabled: false,
             company: {
               siret: "otherSiret"
             }
@@ -1072,7 +1145,7 @@ describe("dashboardServices", () => {
         permissions,
         "actTab"
       );
-      expect(result).toEqual(SIGNER);
+      expect(result).toEqual("");
     });
 
     it("should return SIGNER when bsd type is bsvhu", () => {
@@ -1112,7 +1185,17 @@ describe("dashboardServices", () => {
       const permissions: UserPermission[] = [UserPermission.BsdCanSignWork];
       const result = getSignByProducerBtnLabel(
         "currentSiret",
-        bsd,
+        {
+          ...bsd,
+          type: BsdType.Bsda,
+          worker: {
+            ...bsd.worker,
+            isDisabled: false,
+            company: {
+              siret: "currentSiret"
+            }
+          }
+        },
         permissions,
         "toCollectTab"
       );

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -297,7 +297,7 @@ const hasTemporaryStorage = (currentSiret: string, bsd: BsdDisplay): boolean =>
   ].includes(currentSiret);
 
 const hasWorker = (bsd: BsdDisplay): boolean =>
-  isBsda(bsd.type) && !!bsd.worker?.company?.siret;
+  isBsda(bsd.type) && !bsd.worker?.isDisabled && !!bsd.worker?.company?.siret;
 
 const isSameSiretTemporaryStorageTransporter = (
   currentSiret: string,

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -806,7 +806,6 @@ export const getSignByProducerBtnLabel = (
           isOtherCollection(bsd.bsdWorkflowType?.toString()) ||
           bsd.worker?.isDisabled) &&
         ((!hasWorker(bsd) &&
-          currentSiret === bsd.transporter?.company?.orgId &&
           permissions.includes(UserPermission.BsdCanSignTransport)) ||
           (hasWorker(bsd) &&
             currentSiret === bsd.worker?.company?.siret &&
@@ -826,10 +825,8 @@ export const getSignByProducerBtnLabel = (
     }
 
     if (
-      (currentSiret === bsd.worker?.company?.siret &&
-        permissions.includes(UserPermission.BsdCanSignWork)) ||
-      (currentSiret === bsd.transporter?.company?.orgId &&
-        permissions.includes(UserPermission.BsdCanSignTransport))
+      currentSiret === bsd.worker?.company?.siret &&
+      permissions.includes(UserPermission.BsdCanSignWork)
     ) {
       return SIGNER;
     }

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -296,6 +296,9 @@ const hasTemporaryStorage = (currentSiret: string, bsd: BsdDisplay): boolean =>
     bsd.temporaryStorageDetail?.transporter?.company?.orgId
   ].includes(currentSiret);
 
+const hasWorker = (bsd: BsdDisplay): boolean =>
+  isBsda(bsd.type) && !!bsd.worker?.company?.siret;
+
 const isSameSiretTemporaryStorageTransporter = (
   currentSiret: string,
   bsd: BsdDisplay
@@ -802,8 +805,12 @@ export const getSignByProducerBtnLabel = (
           isReshipment(bsd.bsdWorkflowType?.toString()) ||
           isOtherCollection(bsd.bsdWorkflowType?.toString()) ||
           bsd.worker?.isDisabled) &&
-        (permissions.includes(UserPermission.BsdCanSignTransport) ||
-          permissions.includes(UserPermission.BsdCanSignWork))) ||
+        ((!hasWorker(bsd) &&
+          currentSiret === bsd.transporter?.company?.orgId &&
+          permissions.includes(UserPermission.BsdCanSignTransport)) ||
+          (hasWorker(bsd) &&
+            currentSiret === bsd.worker?.company?.siret &&
+            permissions.includes(UserPermission.BsdCanSignWork)))) ||
       isBsvhu(bsd.type)
     ) {
       return SIGNER;


### PR DESCRIPTION
Les checks pour afficher le bouton Signer sur un BSDA ne prenaient pas en compte la présence ou non d'une entreprise de travaux, et rendaient donc possible pour le transporteur de signer le bordereau alors que c'était à l'entreprise de travaux de le faire (le bouton était affiché mais la backend rejetait la signature du transporteur, donc problème frontend uniquement).

Ce fix rajoute une vérification de la présence d'une entreprise de travaux dans le cas où l'entreprise connectée est le transporteur :
- si il y en a une, seule l'entreprise de travaux peut signer (et si l'entreprise de travaux est aussi transporteur, le bouton s'affiche)
- si il n'y en a pas, le transporteur peut signer

Le cas où c'est l'entreprise de travaux qui est connectée et qu'elle n'est pas aussi transporteur était géré (cas classique), mais il y avait une condition supplémentaire inutile que j'ai retiré (dans le else de "si transporteur", donc pas transporteur, pas la peine de checker si l'entreprise est transporteur).

J'ai aussi mis à jour les tests et rajouté des tests pour valider ces différents comportements.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15033)
