### PR TITLE
[TRA-14578] - Rendre les chemins d'erreur Zod BSVHU/BSPAOH plus explicite en les subdivisant

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Ajouter deux sous-profils pour l'installation de traitement VHU [PR 3480](https://github.com/MTES-MCT/trackdechets/pull/3480)
+- Rendre les chemins d'erreur Zod BSVHU/BSPAOH plus explicite en les subdivisant [PR 3547](https://github.com/MTES-MCT/trackdechets/pull/3547)
 
 # [2024.8.1] 27/08/2024
 

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -53,7 +53,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
           errors.issues?.map((e: ZodIssue) => {
             return {
               message: e.message,
-              path: `${e.path[0]}`, // e.path is an array, first element should be the path name
+              path: `${e.path.join(".")}`, // e.path is an array, first element should be the path name
               requiredFor
             };
           }) ?? []

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -4,7 +4,8 @@ import { ParsedZodBsvhu, ZodBsvhu } from "./schema";
 import {
   bsvhuEditionRules,
   BsvhuEditableFields,
-  isBsvhuFieldRequired
+  isBsvhuFieldRequired,
+  EditionRulePath
 } from "./rules";
 import { getSignatureAncestors } from "./helpers";
 import { isArray } from "../../common/dataTypes";
@@ -133,6 +134,7 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
   field: string;
   rule: EditionRule<T>;
   readableFieldName?: string;
+  path?: EditionRulePath;
   ctx: RefinementCtx;
   errorMsg?: (fieldDescription: string) => string;
 };
@@ -140,7 +142,8 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
 function checkFieldIsDefined<T extends ZodBsvhu>(
   args: CheckFieldIsDefinedArgs<T>
 ) {
-  const { resource, field, rule, ctx, readableFieldName, errorMsg } = args;
+  const { resource, field, rule, ctx, readableFieldName, path, errorMsg } =
+    args;
   const value = resource[field];
   if (value == null || (isArray(value) && (value as any[]).length === 0)) {
     const fieldDescription = readableFieldName
@@ -149,7 +152,7 @@ function checkFieldIsDefined<T extends ZodBsvhu>(
 
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      path: [field],
+      path: path ?? [field],
       message: [
         errorMsg
           ? errorMsg(fieldDescription)
@@ -172,7 +175,7 @@ export const checkRequiredFields: (
 
   return (bsvhu, zodContext) => {
     for (const bsvhuField of Object.keys(bsvhuEditionRules)) {
-      const { required, readableFieldName } =
+      const { required, readableFieldName, path } =
         bsvhuEditionRules[bsvhuField as keyof BsvhuEditableFields];
 
       if (required) {
@@ -186,6 +189,7 @@ export const checkRequiredFields: (
             resource: bsvhu,
             field: bsvhuField,
             rule: required,
+            path,
             readableFieldName,
             ctx: zodContext
           });

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -1,6 +1,6 @@
 import { ZodBsvhu } from "./schema";
 import { BsvhuUserFunctions, BsvhuValidationContext } from "./types";
-import { SignatureTypeInput } from "../../generated/graphql/types";
+import { BsvhuInput, SignatureTypeInput } from "../../generated/graphql/types";
 import { WasteAcceptationStatus } from "@prisma/client";
 import { isForeignVat } from "@td/constants";
 import {
@@ -11,6 +11,7 @@ import {
 } from "./helpers";
 import { capitalize } from "../../common/strings";
 import { SealedFieldError } from "../../common/errors";
+import { Leaves } from "../../types";
 
 // Liste des champs éditables sur l'objet Bsvhu
 export type BsvhuEditableFields = Required<
@@ -47,6 +48,8 @@ type GetBsvhuSignatureTypeFn<T extends ZodBsvhu> = (
   ruleContext?: RuleContext<T>
 ) => SignatureTypeInput | undefined;
 
+export type EditionRulePath = Leaves<BsvhuInput, 5>;
+
 // Règle d'édition qui permet de définir à partir de quelle signature
 // un champ est verrouillé / requis avec une config contenant un paramètre
 // optionnel `when`
@@ -66,6 +69,7 @@ export type EditionRules<T extends ZodBsvhu, E extends BsvhuEditableFields> = {
     // At what signature the field is required, and under which circumstances. If absent, field is never required
     required?: EditionRule<T>;
     readableFieldName?: string; // A custom field name for errors
+    path?: EditionRulePath;
   };
 };
 
@@ -91,25 +95,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
   },
   emitterAgrementNumber: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le N° d'agrément de l'émetteur"
+    readableFieldName: "Le N° d'agrément de l'émetteur",
+    path: ["emitter", "agrementNumber"]
   },
   emitterIrregularSituation: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La situation (irrégulière ou non) de l'émetteur"
+    readableFieldName: "La situation (irrégulière ou non) de l'émetteur",
+    path: ["emitter", "irregularSituation"]
   },
   emitterNoSiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur"
+    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur",
+    path: ["emitter", "noSiret"]
   },
   emitterCompanyName: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale de l'émetteur"
+    readableFieldName: "La raison sociale de l'émetteur",
+    path: ["emitter", "company", "name"]
   },
   emitterCompanySiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterNoSiret },
-    readableFieldName: "Le N° SIRET de l'émetteur"
+    readableFieldName: "Le N° SIRET de l'émetteur",
+    path: ["emitter", "company", "siret"]
   },
   emitterCompanyAddress: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -120,22 +129,26 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
         !bsvhu.emitterCompanyCity ||
         !bsvhu.emitterCompanyPostalCode
     },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "address"]
   },
   emitterCompanyStreet: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "street"]
   },
   emitterCompanyCity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "city"]
   },
   emitterCompanyPostalCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "postalCode"]
   },
   emitterCompanyContact: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -143,7 +156,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterNoSiret
     },
-    readableFieldName: "La personne à contacter chez l'émetteur"
+    readableFieldName: "La personne à contacter chez l'émetteur",
+    path: ["emitter", "company", "contact"]
   },
   emitterCompanyPhone: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -151,7 +165,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "Le N° de téléphone de l'émetteur"
+    readableFieldName: "Le N° de téléphone de l'émetteur",
+    path: ["emitter", "company", "phone"]
   },
   emitterCompanyMail: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -159,72 +174,86 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "L'adresse e-mail de l'émetteur"
+    readableFieldName: "L'adresse e-mail de l'émetteur",
+    path: ["emitter", "company", "mail"]
   },
   destinationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de destination"
+    readableFieldName: "Le type de destination",
+    path: ["destination", "type"]
   },
   destinationPlannedOperationCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "L'opération prévue"
+    readableFieldName: "L'opération prévue",
+    path: ["destination", "plannedOperationCode"]
   },
   destinationAgrementNumber: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° d'agrément du destinataire"
+    readableFieldName: "Le N° d'agrément du destinataire",
+    path: ["destination", "agrementNumber"]
   },
   destinationCompanyName: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale du destinataire"
+    readableFieldName: "La raison sociale du destinataire",
+    path: ["destination", "company", "name"]
   },
   destinationCompanySiret: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° SIRET du destinataire"
+    readableFieldName: "Le N° SIRET du destinataire",
+    path: ["destination", "company", "siret"]
   },
   destinationCompanyAddress: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse du destinataire"
+    readableFieldName: "L'adresse du destinataire",
+    path: ["destination", "company", "address"]
   },
   destinationCompanyContact: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La personne à contacter chez le destinataire"
+    readableFieldName: "La personne à contacter chez le destinataire",
+    path: ["destination", "company", "contact"]
   },
   destinationCompanyPhone: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° de téléphone du destinataire"
+    readableFieldName: "Le N° de téléphone du destinataire",
+    path: ["destination", "company", "phone"]
   },
   destinationCompanyMail: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse e-mail du destinataire"
+    readableFieldName: "L'adresse e-mail du destinataire",
+    path: ["destination", "company", "mail"]
   },
   destinationReceptionAcceptationStatus: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le statut d'acceptation du destinataire"
+    readableFieldName: "Le statut d'acceptation du destinataire",
+    path: ["destination", "reception", "acceptationStatus"]
   },
   destinationReceptionRefusalReason: {
     sealed: { from: "OPERATION" },
     readableFieldName: "La raison du refus par le destinataire",
-    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused }
+    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused },
+    path: ["destination", "reception", "refusalReason"]
   },
   destinationReceptionIdentificationNumbers: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Les numéros d'identification à la réception par le destinataire"
+      "Les numéros d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "numbers"]
   },
   destinationReceptionIdentificationType: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Le type de numéro d'identification à la réception par le destinataire"
+      "Le type de numéro d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "type"]
   },
   destinationOperationCode: {
     sealed: { from: "OPERATION" },
@@ -232,7 +261,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "OPERATION",
       when: isNotRefused
     },
-    readableFieldName: "L'opération réalisée par le destinataire"
+    readableFieldName: "L'opération réalisée par le destinataire",
+    path: ["destination", "operation", "code"]
   },
   destinationOperationMode: {
     sealed: { from: "OPERATION" },
@@ -240,20 +270,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     //   from: "OPERATION",
     //   when: isNotRefused // more precise check in checkOperationMode refinement
     // },
-    readableFieldName: "Le mode de traitement"
+    readableFieldName: "Le mode de traitement",
+    path: ["destination", "operation", "mode"]
   },
   destinationOperationDate: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION", when: isNotRefused },
-    readableFieldName: "la date de l'opération"
+    readableFieldName: "la date de l'opération",
+    path: ["destination", "operation", "date"]
   },
   destinationOperationNextDestinationCompanySiret: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° SIRET de l'exutoire"
+    readableFieldName: "Le N° SIRET de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "siret"]
   },
   destinationOperationNextDestinationCompanyVatNumber: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° de TVA de l'exutoire"
+    readableFieldName: "Le N° de TVA de l'exutoire",
+    path: [
+      "destination",
+      "operation",
+      "nextDestination",
+      "company",
+      "vatNumber"
+    ]
   },
   destinationOperationNextDestinationCompanyName: {
     sealed: { from: "OPERATION" },
@@ -262,7 +302,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La raison sociale de l'exutoire"
+    readableFieldName: "La raison sociale de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "name"]
   },
   destinationOperationNextDestinationCompanyAddress: {
     sealed: { from: "OPERATION" },
@@ -271,7 +312,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse de l'exutoire"
+    readableFieldName: "L'adresse de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "address"]
   },
   destinationOperationNextDestinationCompanyContact: {
     sealed: { from: "OPERATION" },
@@ -280,7 +322,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La personne à contacter chez l'exutoire"
+    readableFieldName: "La personne à contacter chez l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "contact"]
   },
   destinationOperationNextDestinationCompanyPhone: {
     sealed: { from: "OPERATION" },
@@ -289,7 +332,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "Le N° de téléphone de l'exutoire"
+    readableFieldName: "Le N° de téléphone de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "phone"]
   },
   destinationOperationNextDestinationCompanyMail: {
     sealed: { from: "OPERATION" },
@@ -298,20 +342,24 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse e-mail de l'exutoire"
+    readableFieldName: "L'adresse e-mail de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "mail"]
   },
   destinationReceptionQuantity: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "La quantité de VHUs reçue"
+    readableFieldName: "La quantité de VHUs reçue",
+    path: ["destination", "reception", "quantity"]
   },
   destinationReceptionWeight: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le poids réel reçu"
+    readableFieldName: "Le poids réel reçu",
+    path: ["destination", "reception", "weight"]
   },
   destinationReceptionDate: {
     readableFieldName: "la date de réception",
-    sealed: { from: "OPERATION" }
+    sealed: { from: "OPERATION" },
+    path: ["destination", "reception", "date"]
     // required: { from: "OPERATION" }
   },
   wasteCode: {
@@ -319,37 +367,44 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le code déchet"
+    readableFieldName: "Le code déchet",
+    path: ["wasteCode"]
   },
   packaging: {
     sealed: {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type d'empaquetage"
+    readableFieldName: "Le type d'empaquetage",
+    path: ["packaging"]
   },
   identificationNumbers: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Les numéros d'identification"
+    readableFieldName: "Les numéros d'identification",
+    path: ["identification", "numbers"]
   },
   identificationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de numéro d'identification"
+    readableFieldName: "Le type de numéro d'identification",
+    path: ["identification", "type"]
   },
   quantity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La quantité"
+    readableFieldName: "La quantité",
+    path: ["quantity"]
   },
   weightValue: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le poids"
+    readableFieldName: "Le poids",
+    path: ["weight", "value"]
   },
   weightIsEstimate: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le champ pour indiquer si le poids est estimé"
+    readableFieldName: "Le champ pour indiquer si le poids est estimé",
+    path: ["weight", "isEstimate"]
   },
   transporterCompanySiret: {
     readableFieldName: "le N° SIRET du transporteur",
@@ -357,7 +412,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanyVatNumber
-    }
+    },
+    path: ["transporter", "company", "siret"]
   },
   transporterCompanyVatNumber: {
     readableFieldName: "Le N° de TVA du transporteur",
@@ -365,42 +421,48 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanySiret
-    }
+    },
+    path: ["transporter", "company", "vatNumber"]
   },
   transporterCompanyName: {
     readableFieldName: "Le nom du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "name"]
   },
   transporterCompanyAddress: {
     readableFieldName: "L'adresse du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "address"]
   },
   transporterCompanyContact: {
     readableFieldName: "Le nom de contact du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "contact"]
   },
   transporterCompanyPhone: {
     readableFieldName: "Le téléphone du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "phone"]
   },
   transporterCompanyMail: {
     readableFieldName: "L'email du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "mail"]
   },
   transporterRecepisseNumber: {
     readableFieldName: "le numéro de récépissé du transporteur",
@@ -410,7 +472,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "number"]
   },
   transporterRecepisseDepartment: {
     readableFieldName: "le département de récépissé du transporteur",
@@ -420,7 +483,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "department"]
   },
   transporterRecepisseValidityLimit: {
     readableFieldName: "la date de validité du récépissé du transporteur",
@@ -430,15 +494,18 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "validityLimit"]
   },
   transporterTransportTakenOverAt: {
     readableFieldName: "la date d'enlèvement du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "transport", "takenOverAt"]
   },
   transporterRecepisseIsExempted: {
     readableFieldName: "l'exemption de récépissé du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "recepisse", "isExempted"]
     // required: {
     //   from: "TRANSPORT"
     // }

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,7 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+// utility types used by Paths and Leaves
 type Cons<H, T> = T extends readonly any[]
   ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
     ? R
@@ -55,7 +56,20 @@ type Prev = [
   20,
   ...0[]
 ];
-
+/*
+Creates a type with all possible paths in an other object type, recursively,
+including all possible subpaths.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["aa"] | ["a", "ab"] | ["ab"]
+*/
 export type Paths<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object
@@ -70,6 +84,19 @@ export type Paths<T, D extends number = 3> = [D] extends [never]
     }[keyof T]
   : [];
 
+/*
+Creates a type with all possible paths in an other object type, recursively.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["a", "ab"]
+*/
 export type Leaves<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,57 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+type Cons<H, T> = T extends readonly any[]
+  ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
+    ? R
+    : never
+  : never;
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+];
+
+export type Paths<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?:
+        | [K]
+        | (Paths<T[K], Prev[D]> extends infer P
+            ? P extends []
+              ? never
+              : Cons<K, P>
+            : never);
+    }[keyof T]
+  : [];
+
+export type Leaves<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? { [K in keyof T]-?: Cons<K, Leaves<T[K], Prev[D]>> }[keyof T]
+  : [];
+
 declare module "express-session" {
   interface SessionData {
     warningMessage?: string;

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -66,7 +66,7 @@ export function SignTransport({
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter
-            !error.path.startsWith("transporterRecepisse")
+            !error.path.startsWith("transporter.recepisse")
         ) ? (
           <>
             <p className="tw-mt-2 tw-text-red-700">


### PR DESCRIPTION
# Objectif

Modifier la façon dont les erreurs de validation (champs requis) émises par Zod renvoient leur path sur les BSVHU et BSPAOH. Pour l'instant, c'était simplement le nom backend du champ (ex: "transporterRecepisseValidityLimit"). De façon à rendre cette info plus exploitable par la front, le path est splité de façon à correspondre aux chemins des objets GraphQL, qui correspondent globalement aux chemins des champs en front (ex: ["transporter", "recepisse", "validityLimit"]).

## Tech

Pour renvoyer ces chemins, je les ai défini pour chaque règle de validation BSVHU/BSPAOH. Afin d'éviter les erreurs et assurer la continuité, j'ai défini le type de ce chemin à partir des objets GraphQL eux même.  De cette façon si les interface GraphQL évoluent, typescript mettra des erreurs pour forcer à mettre à jour ces paths.
Pour définir ces types, j'ai utilisé une fonction utilitaire Typescript (Leaves). J'ai ajouté cette fonction dans les parties communes, ainsi que Paths (qui ajoute les sous-chemins au type, voir les commentaires dans le code). A noter qu'un paramètre additionnel de ces méthodes permet de limiter la profondeur d'exploration des types, comme sécurité si le type est récursif (fait référence à lui même) ou très profond.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14578)
