### PR TITLE
[TRA-14519][BACK] ETQ destinataire, je peux indiquer que mon véhicule est rincé ou non pour son retour à vide

### DIFF
--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -294,7 +294,8 @@ describe("simpleFormToBsdd", () => {
       parcelCities: null,
       parcelCoordinates: null,
       parcelNumbers: null,
-      parcelPostalCodes: null
+      parcelPostalCodes: null,
+      destinationHasCiterneBeenWashedOut: form.hasCiterneBeenWashedOut
     });
   });
 
@@ -627,6 +628,7 @@ describe("simpleFormToBsdd", () => {
       destinationOperationNextDestinationCompanyContact: null,
       destinationOperationNextDestinationCompanyPhone: null,
       destinationOperationNextDestinationCompanyMail: null,
+      destinationHasCiterneBeenWashedOut: form.hasCiterneBeenWashedOut,
       grouping: [],
       intermediaries: [],
       finalOperations: [],
@@ -821,7 +823,8 @@ describe("simpleFormToBsdd", () => {
         forwardedInId: fullForwardedInForm.id,
         nextDestinationNotificationNumber: null,
         nextDestinationProcessingOperation: null,
-        grouping: []
+        grouping: [],
+        destinationHasCiterneBeenWashedOut: form.hasCiterneBeenWashedOut
       }
     });
   });

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -36,6 +36,8 @@ describe("expandFormFromDb", () => {
       customId: null,
       isImportedFromPaper: false,
       metadata: undefined,
+      citerneNotWashedOutReason: null,
+      hasCiterneBeenWashedOut: null,
       emitter: {
         type: form.emitterType,
         workSite: null,

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -222,6 +222,7 @@ export function simpleFormToBsdd(
     destinationOperationSignatureDate: form.processedAt,
     destinationCap: form.recipientCap,
     destinationOperationNoTraceability: form.noTraceability,
+    destinationHasCiterneBeenWashedOut: form.hasCiterneBeenWashedOut,
     destinationOperationNextDestinationCompanyName:
       form.nextDestinationCompanyName,
     destinationOperationNextDestinationCompanySiret:

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -738,6 +738,8 @@ export function expandFormFromDb(
     wasteRefusalReason: forwardedIn
       ? forwardedIn.wasteRefusalReason
       : form.wasteRefusalReason,
+    hasCiterneBeenWashedOut: form.hasCiterneBeenWashedOut,
+    citerneNotWashedOutReason: form.citerneNotWashedOutReason,
     receivedBy: forwardedIn ? forwardedIn.receivedBy : form.receivedBy,
     receivedAt: processDate(
       forwardedIn ? forwardedIn.receivedAt : form.receivedAt

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -34,6 +34,8 @@ type EditableBsddFields = Required<
     | "quantityReceived"
     | "quantityRefused"
     | "quantityReceivedType"
+    | "hasCiterneBeenWashedOut"
+    | "citerneNotWashedOutReason"
     | "processingOperationDone"
     | "destinationOperationMode"
     | "isDeleted"

--- a/back/src/forms/helpers/citerneNotWashedOutReason.ts
+++ b/back/src/forms/helpers/citerneNotWashedOutReason.ts
@@ -1,0 +1,18 @@
+import { CiterneNotWashedOutReason } from "@prisma/client";
+
+const LABELS = {
+  EXEMPTED: "Exemptions de rinçage (citerne dédiée)",
+  INCOMPATIBLE: "Incompatibilité avec l'opération de rinçage à l'eau",
+  UNAVAILABLE: "Indisponibilité de l'installation de rinçage",
+  NOT_BY_DRIVER: "Rinçage non réalisé par le chauffeur"
+};
+
+export const getReasonLabel = (
+  reason: CiterneNotWashedOutReason | null | undefined
+) => {
+  if (!reason) {
+    return null;
+  }
+
+  return LABELS[reason];
+};

--- a/back/src/forms/pdf/generateBsddPdf.tsx
+++ b/back/src/forms/pdf/generateBsddPdf.tsx
@@ -7,7 +7,8 @@ import {
   WasteAcceptationStatus,
   EmitterType,
   Status,
-  OperationMode
+  OperationMode,
+  CiterneNotWashedOutReason
 } from "@prisma/client";
 import * as QRCode from "qrcode";
 import concatStream from "concat-stream";
@@ -37,7 +38,8 @@ import { FormCompanyDetails } from "../../common/pdf/components/FormCompanyDetai
 import { isFrenchCompany } from "../../companies/validation";
 import { bsddWasteQuantities } from "../helpers/bsddWasteQuantities";
 import { displayWasteQuantity } from "../../registry/utils";
-import { dateToXMonthAtHHMM } from "../../common/helpers";
+import { dateToXMonthAtHHMM, isDefined } from "../../common/helpers";
+import { getReasonLabel } from "../helpers/citerneNotWashedOutReason";
 
 type ReceiptFieldsProps = Partial<
   Pick<
@@ -104,8 +106,10 @@ function AcceptationFields({
   wasteRefusalReason,
   signedAt,
   quantityReceived,
-  quantityRefused
-}: AcceptationFieldsProps) {
+  quantityRefused,
+  hasCiterneBeenWashedOut,
+  citerneNotWashedOutReason
+}: AcceptationFieldsProps & CharteCiterneProps) {
   const wasteQuantities = bsddWasteQuantities({
     wasteAcceptationStatus,
     quantityReceived,
@@ -145,10 +149,45 @@ function AcceptationFields({
       Motif de refus (même partiel) :<br />
       {wasteRefusalReason}
       <br />
+      <CharteCiterne
+        hasCiterneBeenWashedOut={hasCiterneBeenWashedOut}
+        citerneNotWashedOutReason={citerneNotWashedOutReason}
+      />
       Date de signature : {formatDate(signedAt)}
       <br />
     </p>
   );
+}
+
+type CharteCiterneProps = {
+  hasCiterneBeenWashedOut?: boolean | null;
+  citerneNotWashedOutReason?: CiterneNotWashedOutReason | null;
+};
+
+function CharteCiterne({
+  hasCiterneBeenWashedOut,
+  citerneNotWashedOutReason
+}: CharteCiterneProps) {
+  if (!isDefined(hasCiterneBeenWashedOut)) return null;
+
+  if (hasCiterneBeenWashedOut) {
+    return (
+      <>
+        Charte "Rinçage des citernes": Rinçage effectué
+        <br />
+        <br />
+      </>
+    );
+  } else {
+    return (
+      <>
+        Charte "Rinçage des citernes":{" "}
+        {getReasonLabel(citerneNotWashedOutReason)}
+        <br />
+        <br />
+      </>
+    );
+  }
 }
 
 type RecipientFormCompanyFieldsProps = {

--- a/back/src/forms/registry.ts
+++ b/back/src/forms/registry.ts
@@ -406,7 +406,8 @@ export function toGenericWaste(
     emitterCompanyCity,
     emitterCompanyCountry,
     emitterCompanyName: bsdd.emitterCompanyName,
-    emitterCompanySiret: bsdd.emitterCompanySiret
+    emitterCompanySiret: bsdd.emitterCompanySiret,
+    destinationHasCiterneBeenWashedOut: bsdd.destinationHasCiterneBeenWashedOut
   };
 }
 

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -292,7 +292,9 @@ describe("Mutation.duplicateForm", () => {
       "canAccessDraftSirets",
       "forwardedIn",
       "destinationOperationMode",
-      "quantityGrouped"
+      "quantityGrouped",
+      "citerneNotWashedOutReason",
+      "hasCiterneBeenWashedOut"
     ];
 
     const expectedSkippedTransporter = [
@@ -616,7 +618,9 @@ describe("Mutation.duplicateForm", () => {
       "ecoOrganismeSiret",
       "transporters",
       "destinationOperationMode",
-      "quantityGrouped"
+      "quantityGrouped",
+      "citerneNotWashedOutReason",
+      "hasCiterneBeenWashedOut"
     ];
 
     // make sure this test breaks when a new field is added to the Form model

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -23,7 +23,10 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
   const form = await getFormOrFormNotFound({ id });
   await checkCanMarkAsAccepted(user, form);
 
-  await acceptedInfoSchema.validate(acceptedInfo);
+  await acceptedInfoSchema.validate({
+    wasteDetailsPackagingInfos: form.wasteDetailsPackagingInfos,
+    ...acceptedInfo
+  });
 
   const formUpdateInput = form.forwardedInId
     ? {

--- a/back/src/forms/resolvers/mutations/markAsAccepted.ts
+++ b/back/src/forms/resolvers/mutations/markAsAccepted.ts
@@ -25,6 +25,10 @@ const markAsAcceptedResolver: MutationResolvers["markAsAccepted"] = async (
 
   await acceptedInfoSchema.validate({
     wasteDetailsPackagingInfos: form.wasteDetailsPackagingInfos,
+    wasteDetailsIsDangerous: form.wasteDetailsIsDangerous,
+    wasteDetailsPop: form.wasteDetailsPop,
+    wasteDetailsCode: form.wasteDetailsCode,
+    // TODO: mode transport!!!
     ...acceptedInfo
   });
 

--- a/back/src/forms/typeDefs/bsdd.enums.graphql
+++ b/back/src/forms/typeDefs/bsdd.enums.graphql
@@ -205,3 +205,18 @@ enum CiterneNotWashedOutReason {
   "Rinçage non réalisé par le chauffeur"
   NOT_BY_DRIVER
 }
+
+"Retour à vide ADR"
+enum EmptyReturnADR {
+  "Vide, non nettoyé"
+  EMPTY_NOT_WASHED
+
+  "Retour à vide, non nettoyé"
+  EMPTY_RETURN_NOT_WASHED
+
+  "Véhicule vide, dernière marchandise chargée"
+  EMPTY_VEHICLE
+
+  "Véhicule-Citerne vide, dernière marchandise chargée"
+  EMPTY_CITERNE
+}

--- a/back/src/forms/typeDefs/bsdd.enums.graphql
+++ b/back/src/forms/typeDefs/bsdd.enums.graphql
@@ -190,3 +190,18 @@ enum FormsRegisterExportFormat {
   """
   XLSX
 }
+
+"Charte citerne - Raison pour laquelle la citerne n'a pas été rincée"
+enum CiterneNotWashedOutReason {
+  "Exemptions de rinçage (citerne dédiée)"
+  EXEMPTED
+
+  "Incompatibilité avec l'opération de rinçage à l'eau"
+  INCOMPATIBLE
+
+  "Indisponibilité de l'installation de rinçage"
+  UNAVAILABLE
+
+  "Rinçage non réalisé par le chauffeur"
+  NOT_BY_DRIVER
+}

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -119,6 +119,9 @@ input AcceptedFormInput {
 
   "Charte citerne - Raison pour laquelle la citerne n'a pas été rincée"
   citerneNotWashedOutReason: CiterneNotWashedOutReason
+
+  "Retour à vide ADR"
+  emptyReturnADR: EmptyReturnADR
 }
 
 "Payload de réception d'un BSD"

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -113,6 +113,12 @@ input AcceptedFormInput {
   - doit être égale à quantityReceived si le déchet est totalement refusé.
   """
   quantityRefused: Float
+
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  hasCiterneBeenWashedOut: Boolean
+
+  "Charte citerne - Raison pour laquelle la citerne n'a pas été rincée"
+  citerneNotWashedOutReason: CiterneNotWashedOutReason
 }
 
 "Payload de réception d'un BSD"

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -91,6 +91,12 @@ type Form {
   "Raison du refus (case 10)"
   wasteRefusalReason: String
 
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  hasCiterneBeenWashedOut: Boolean
+
+  "Charte citerne - Raison pour laquelle la citerne n'a pas été rincée"
+  citerneNotWashedOutReason: CiterneNotWashedOutReason
+
   "Nom de la personne en charge de la réception du déchet (case 10)"
   receivedBy: String
 

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -297,6 +297,7 @@ export type Bsdd = {
   destinationOperationNextDestinationCompanyContact: string | null;
   destinationOperationNextDestinationCompanyPhone: string | null;
   destinationOperationNextDestinationCompanyMail: string | null;
+  destinationHasCiterneBeenWashedOut: boolean | null;
   destinationOperationSignatureAuthor: string | null;
   destinationOperationDate: Date | null;
   destinationOperationSignatureDate: Date | null;

--- a/back/src/registry/columns.ts
+++ b/back/src/registry/columns.ts
@@ -112,6 +112,14 @@ export const formatSubType = (subType?: BsdSubType) => {
   }
 };
 
+const formatHasCiterneBeenWashedOut = (
+  hasCiterneBeenWashedOut: boolean | null | undefined
+) => {
+  if (!isDefined(hasCiterneBeenWashedOut)) return "";
+
+  return hasCiterneBeenWashedOut ? "Effectué" : "Non effectué";
+};
+
 export const columns: Column[] = [
   // Dénomination, nature et quantité :
   { field: "id", label: "N° de bordereau" },
@@ -363,6 +371,11 @@ export const columns: Column[] = [
     field: "destinationOperationCode",
     label: "Code opération réalisé",
     format: formatOperationCode
+  },
+  {
+    field: "destinationHasCiterneBeenWashedOut",
+    label: "Rinçage citerne",
+    format: formatHasCiterneBeenWashedOut
   },
   {
     field: "destinationOperationNoTraceability",

--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -235,6 +235,9 @@ type IncomingWaste {
   "La quantité de déchet entrant refusée exprimée en tonne"
   destinationReceptionRefusedWeight: Float
 
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  destinationHasCiterneBeenWashedOut: Boolean
+
   "N° de notification / déclaration"
   nextDestinationNotificationNumber: String
   "Code d'opération ultérieure prévue"
@@ -645,6 +648,9 @@ type OutgoingWaste {
   "Extra - La quantité de déchet entrant refusée exprimée en tonne"
   destinationReceptionRefusedWeight: Float
 
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  destinationHasCiterneBeenWashedOut: Boolean
+
   "N° de notification / déclaration"
   nextDestinationNotificationNumber: String
   "Code d'opération ultérieure prévue"
@@ -1008,6 +1014,9 @@ type TransportedWaste {
   "Extra - La quantité de déchet reçu sur l'installation de destination ou d'entreposage provisoire exprimée en tonne"
   destinationReceptionWeight: Float
 
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  destinationHasCiterneBeenWashedOut: Boolean
+
   ###########################################################
   # Champs additionnels non mentionnés dans l'arrêté registre
   ###########################################################
@@ -1347,6 +1356,9 @@ type ManagedWaste {
   destinationReceptionAcceptedWeight: Float
   "La quantité de déchet entrant refusée exprimée en tonne"
   destinationReceptionRefusedWeight: Float
+
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  destinationHasCiterneBeenWashedOut: Boolean
 
   "N° de notification / déclaration"
   nextDestinationNotificationNumber: String
@@ -1758,6 +1770,9 @@ type AllWaste {
   destinationPlannedOperationMode: OperationMode
   "Extra - Date de réalisation de l'opération"
   destinationOperationDate: DateTime
+
+  "Charte citerne - Est-ce que la citerne a été rincée ou non?"
+  destinationHasCiterneBeenWashedOut: Boolean
 
   "N° de notification / déclaration"
   nextDestinationNotificationNumber: String

--- a/back/src/registry/types.ts
+++ b/back/src/registry/types.ts
@@ -180,7 +180,8 @@ export const emptyIncomingWaste: Required<IncomingWaste> = {
   emitterPickupsitePostalCode: null,
   emitterCompanyCity: null,
   emitterCompanyCountry: null,
-  emitterCompanyPostalCode: null
+  emitterCompanyPostalCode: null,
+  destinationHasCiterneBeenWashedOut: null
 };
 
 export const emptyOutgoingWaste: Required<OutgoingWaste> = {
@@ -322,7 +323,8 @@ export const emptyOutgoingWaste: Required<OutgoingWaste> = {
   emitterPickupsitePostalCode: null,
   emitterCompanyCity: null,
   emitterCompanyCountry: null,
-  emitterCompanyPostalCode: null
+  emitterCompanyPostalCode: null,
+  destinationHasCiterneBeenWashedOut: null
 };
 
 export const emptyTransportedWaste: Required<TransportedWaste> = {
@@ -449,7 +451,8 @@ export const emptyTransportedWaste: Required<TransportedWaste> = {
   emitterPickupsitePostalCode: null,
   emitterCompanyCity: null,
   emitterCompanyCountry: null,
-  emitterCompanyPostalCode: null
+  emitterCompanyPostalCode: null,
+  destinationHasCiterneBeenWashedOut: null
 };
 
 export const emptyManagedWaste: Required<ManagedWaste> = {
@@ -572,7 +575,8 @@ export const emptyManagedWaste: Required<ManagedWaste> = {
   emitterCompanyPostalCode: null,
   destinationReceptionAcceptedWeight: null,
   destinationReceptionRefusedWeight: null,
-  weight: null
+  weight: null,
+  destinationHasCiterneBeenWashedOut: null
 };
 
 export const emptyAllWaste: Required<AllWaste> = {
@@ -732,5 +736,6 @@ export const emptyAllWaste: Required<AllWaste> = {
   emitterPickupsitePostalCode: null,
   emitterCompanyCity: null,
   emitterCompanyCountry: null,
-  emitterCompanyPostalCode: null
+  emitterCompanyPostalCode: null,
+  destinationHasCiterneBeenWashedOut: null
 };

--- a/libs/back/prisma/src/migrations/20240829090308_charte_citerne/migration.sql
+++ b/libs/back/prisma/src/migrations/20240829090308_charte_citerne/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "CiterneNotWashedOutReason" AS ENUM ('EXEMPTED', 'INCOMPATIBLE', 'UNAVAILABLE', 'NOT_BY_DRIVER');
+
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "citerneNotWashedOutReason" "CiterneNotWashedOutReason",
+ADD COLUMN     "hasCiterneBeenWashedOut" BOOLEAN;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -514,6 +514,8 @@ model Form {
   noTraceability                        Boolean?
   destinationOperationMode              OperationMode?
   currentTransporterOrgId               String?
+  hasCiterneBeenWashedOut               Boolean?
+  citerneNotWashedOutReason             CiterneNotWashedOutReason?
 
   transporters BsddTransporter[]
   groupedIn    FormGroupement[]  @relation("GroupedIn")
@@ -1998,4 +2000,11 @@ enum BspaohStatus {
 enum BspaohType {
   PAOH
   FOETUS
+}
+
+enum CiterneNotWashedOutReason {
+  EXEMPTED
+  INCOMPATIBLE
+  UNAVAILABLE
+  NOT_BY_DRIVER
 }

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -516,6 +516,7 @@ model Form {
   currentTransporterOrgId               String?
   hasCiterneBeenWashedOut               Boolean?
   citerneNotWashedOutReason             CiterneNotWashedOutReason?
+  emptyReturnADR                        EmptyReturnADR?
 
   transporters BsddTransporter[]
   groupedIn    FormGroupement[]  @relation("GroupedIn")
@@ -2007,4 +2008,11 @@ enum CiterneNotWashedOutReason {
   INCOMPATIBLE
   UNAVAILABLE
   NOT_BY_DRIVER
+}
+
+enum EmptyReturnADR {
+  EMPTY_NOT_WASHED
+  EMPTY_RETURN_NOT_WASHED
+  EMPTY_VEHICLE
+  EMPTY_CITERNE
 }


### PR DESCRIPTION
# Contexte

Ajout d'un champ au modèle Form et à la requête markAsAccepted:
```
emptyReturnADR                        EmptyReturnADR?
```

# Démo

# Ticket Favro

[ADR - ETQ destinataire, je peux indiquer que mon véhicule est rincé ou non pour son retour à vide - BACK](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14519)
