### PR TITLE
[TRA 14578 + TRA 15020] split chemins d'erreur Zod BSVHU/BSPAOH + champs scellés dans metadata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Ajouter deux sous-profils pour l'installation de traitement VHU [PR 3480](https://github.com/MTES-MCT/trackdechets/pull/3480)
+- Rendre les chemins d'erreur Zod BSVHU/BSPAOH plus explicite en les subdivisant [PR 3547](https://github.com/MTES-MCT/trackdechets/pull/3547)
 
 #### :boom: Breaking changes
 

--- a/back/src/bspaoh/dataloader.ts
+++ b/back/src/bspaoh/dataloader.ts
@@ -1,0 +1,22 @@
+import DataLoader from "dataloader";
+import { prisma } from "@td/prisma";
+import { PrismaBspaohWithTransporters } from "./types";
+
+export function createBspaohDataLoaders() {
+  return {
+    bspaohs: new DataLoader((bspaohIds: string[]) => getBspaohs(bspaohIds))
+  };
+}
+
+async function getBspaohs(bspaohIds: string[]) {
+  const bspaohs = await prisma.bspaoh.findMany({
+    where: { id: { in: bspaohIds } },
+    include: { transporters: true }
+  });
+
+  const dict = Object.fromEntries(
+    bspaohs.map((bspaoh: PrismaBspaohWithTransporters) => [bspaoh.id, bspaoh])
+  );
+
+  return bspaohIds.map(bsdaId => dict[bsdaId]);
+}

--- a/back/src/bspaoh/dataloader.ts
+++ b/back/src/bspaoh/dataloader.ts
@@ -18,5 +18,5 @@ async function getBspaohs(bspaohIds: string[]) {
     bspaohs.map((bspaoh: PrismaBspaohWithTransporters) => [bspaoh.id, bspaoh])
   );
 
-  return bspaohIds.map(bsdaId => dict[bsdaId]);
+  return bspaohIds.map(bspaohId => dict[bspaohId]);
 }

--- a/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
@@ -13,6 +13,7 @@ import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
 import { sirenify as sirenifyBspaohInput } from "../../../validation/sirenify";
 import { crematoriumFactory } from "../../../__tests__/factories";
+import { BspaohType } from "@prisma/client";
 
 jest.mock("../../../validation/sirenify");
 (sirenifyBspaohInput as jest.Mock).mockImplementation(input =>
@@ -85,7 +86,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it.each(["FOETUS", "PAOH"])(
     "should allow bspaoh creation",
-    async bspaohType => {
+    async (bspaohType: BspaohType) => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
       const destinationCompany = await crematoriumFactory();
 
@@ -629,7 +630,12 @@ describe("Mutation.Bspaoh.create", () => {
       expect.objectContaining({
         message: "Le SIRET du transporteur est obligatoire.",
         extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
+          code: ErrorCode.BAD_USER_INPUT,
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              path: ["transporter", "company", "siret"]
+            })
+          ])
         })
       })
     ]);

--- a/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
@@ -44,15 +44,13 @@ type BspaohMetadata {
 }
 
 type BspaohMetadataFields {
-  "liste des champs qui seront requis pour la prochaine signature"
-  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [String!]!
+  sealed: [[String!]!]!
 }
 
 type BspaohError {
   message: String!
-  path: String!
+  path: [String!]!
   requiredFor: BspaohSignatureType!
 }
 

--- a/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
@@ -38,18 +38,16 @@ type BspaohReceptionWasteDetail {
 }
 
 type BspaohMetadata {
-  errors: [BspaohError]
+  errors: [BspaohError!]!
   "Informations sur les champs"
-  fields: BspaohMetadataFields
+  fields: BspaohMetadataFields!
 }
 
 type BspaohMetadataFields {
+  "liste des champs qui seront requis pour la prochaine signature"
+  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [BspaohMetadataField]
-}
-
-type BspaohMetadataField {
-  name: String!
+  sealed: [String!]!
 }
 
 type BspaohError {

--- a/back/src/bspaoh/validation/rules.ts
+++ b/back/src/bspaoh/validation/rules.ts
@@ -612,51 +612,30 @@ export function checkSealedAndRequiredFields(
 export const getRequiredAndSealedFieldPaths = async (
   bspaoh: BspaohForParsing,
   currentSignatures: BspaohSignatureType[],
-  nextSignature: BspaohSignatureType | undefined,
   user: User | undefined
 ): Promise<{
-  requiredForNextSignature: string[];
-  sealed: string[];
+  sealed: string[][];
 }> => {
-  const nextSignatures = nextSignature
-    ? currentSignatures.concat([nextSignature])
-    : currentSignatures;
-  const requiredFields: string[] = [];
-  const sealedFields: string[] = [];
+  const sealedFields: string[][] = [];
   const userFunctions = await getUserFunctions(user, bspaoh);
   for (const bspaohField of Object.keys(editionRules)) {
-    const { required, sealed, path } =
+    const { sealed, path } =
       editionRules[bspaohField as keyof BspaohRulesEntries];
     // Apply default values to rules
     const sealedRule = {
       from: sealed?.from,
       when: sealed?.when ?? (() => true) // Default to true
     };
-    const requiredRule = {
-      from: required?.from ?? "NO_CHECK_RULE",
-      when: required?.when ?? (() => true) // Default to true
-    };
-    if (path) {
-      if (required) {
-        const isRequired =
-          nextSignatures.includes(requiredRule.from) &&
-          requiredRule.when(bspaoh, bspaoh, userFunctions);
-        if (isRequired) {
-          requiredFields.push(path.join("."));
-        }
-      }
-      if (sealed) {
-        const isSealed =
-          currentSignatures.includes(sealedRule.from) &&
-          sealedRule.when(bspaoh, bspaoh, userFunctions);
-        if (isSealed) {
-          sealedFields.push(path.join("."));
-        }
+    if (path && sealed) {
+      const isSealed =
+        currentSignatures.includes(sealedRule.from) &&
+        sealedRule.when(bspaoh, bspaoh, userFunctions);
+      if (isSealed) {
+        sealedFields.push(path);
       }
     }
   }
   return {
-    requiredForNextSignature: requiredFields,
     sealed: sealedFields
   };
 };

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -1,0 +1,21 @@
+import DataLoader from "dataloader";
+import { prisma } from "@td/prisma";
+import { Bsvhu } from "@prisma/client";
+
+export function createBsvhuDataLoaders() {
+  return {
+    bsvhus: new DataLoader((bsvhuIds: string[]) => getBsvhus(bsvhuIds))
+  };
+}
+
+async function getBsvhus(bsvhuIds: string[]) {
+  const bsvhus = await prisma.bsvhu.findMany({
+    where: { id: { in: bsvhuIds } }
+  });
+
+  const dict = Object.fromEntries(
+    bsvhus.map((bsvhu: Bsvhu) => [bsvhu.id, bsvhu])
+  );
+
+  return bsvhuIds.map(bsdaId => dict[bsdaId]);
+}

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -17,5 +17,5 @@ async function getBsvhus(bsvhuIds: string[]) {
     bsvhus.map((bsvhu: Bsvhu) => [bsvhu.id, bsvhu])
   );
 
-  return bsvhuIds.map(bsdaId => dict[bsdaId]);
+  return bsvhuIds.map(bsvhuId => dict[bsvhuId]);
 }

--- a/back/src/bsvhu/resolvers/Bsvhu.ts
+++ b/back/src/bsvhu/resolvers/Bsvhu.ts
@@ -3,8 +3,7 @@ import { BsvhuResolvers } from "../../generated/graphql/types";
 const bsvhuResolvers: BsvhuResolvers = {
   metadata: bsvhu => {
     return {
-      id: bsvhu.id,
-      status: bsvhu.status
+      id: bsvhu.id
     } as any;
   }
 };

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -53,7 +53,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
           errors.issues?.map((e: ZodIssue) => {
             return {
               message: e.message,
-              path: `${e.path[0]}`, // e.path is an array, first element should be the path name
+              path: `${e.path.join(".")}`, // e.path is an array, first element should be the path name
               requiredFor
             };
           }) ?? []

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -41,7 +41,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
         errors.issues?.map((e: ZodIssue) => {
           return {
             message: e.message,
-            path: `${e.path.join(".")}`, // e.path is an array, first element should be the path name
+            path: e.path,
             requiredFor: nextSignature
           };
         }) ?? []
@@ -62,12 +62,10 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
       ...transporterReceipt
     });
     const currentSignature = getCurrentSignatureType(zodBsvhu);
-    const nextSignature = getNextSignatureType(currentSignature);
     const currentSignatureAncestors = getSignatureAncestors(currentSignature);
     return getRequiredAndSealedFieldPaths(
       zodBsvhu,
       currentSignatureAncestors,
-      nextSignature,
       context.user ?? undefined
     );
   }

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -1,7 +1,7 @@
 import { getTransporterReceipt } from "../../companies/recipify";
 import {
   BsvhuError,
-  BsvhuFieldsMetadata,
+  BsvhuMetadataFields,
   BsvhuMetadata,
   BsvhuMetadataResolvers
 } from "../../generated/graphql/types";
@@ -32,10 +32,6 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
     const nextSignature = getNextSignatureType(currentSignature);
 
     try {
-      console.log(currentSignature);
-
-      console.log(nextSignature);
-
       parseBsvhu(zodBsvhu, {
         currentSignatureType: nextSignature
       });
@@ -56,7 +52,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
     metadata: BsvhuMetadata & { id: string },
     _,
     context
-  ): Promise<BsvhuFieldsMetadata> => {
+  ): Promise<BsvhuMetadataFields> => {
     const bsvhu = await context.dataloaders.bsvhus.load(metadata.id);
 
     // import transporterReceipt that will be completed after transporter signature

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
@@ -362,6 +362,10 @@ describe("Mutation.Vhu.create", () => {
     expect(errors[0].message).toBe(
       "Le N° d'agrément du destinataire est un champ requis."
     );
+    expect(errors[0].extensions!.issues![0].path).toStrictEqual([
+      "destination",
+      "agrementNumber"
+    ]);
   });
 
   it("should create a bsvhu with split address input and get a composite address output", async () => {

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -1,0 +1,155 @@
+import { UserRole, BsvhuStatus } from "@prisma/client";
+import { gql } from "graphql-tag";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+import { bsvhuFactory } from "../../../__tests__/factories.vhu";
+
+const GET_BSVHU = gql`
+  query GetBsvhu($id: ID!) {
+    bsvhu(id: $id) {
+      id
+      status
+      metadata {
+        fields {
+          sealed
+          requiredForNextSignature
+        }
+      }
+    }
+  }
+`;
+
+describe("Query.Bsvhu", () => {
+  afterEach(resetDatabase);
+
+  it("should return INITIAL bsvhu sealed fields", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.INITIAL,
+        emitterCompanySiret: emitterCompany.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(0);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      20
+    );
+  });
+
+  it("should return EMISSION signed bsvhu sealed fields", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SIGNED_BY_PRODUCER,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(0);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      29
+    );
+  });
+
+  it("should return EMISSION signed bsvhu sealed fields with emitter fields sealed", async () => {
+    const emitterCompany = await companyFactory();
+    const { user, company: transporterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SIGNED_BY_PRODUCER,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date(),
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(21);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      29
+    );
+  });
+
+  it("should return TRANSPORTER signed bsvhu sealed fields", async () => {
+    const { user, company: transporterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const emitterCompany = await companyFactory();
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SENT,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date(),
+        transporterCompanySiret: transporterCompany.siret,
+        transporterTransportSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(33);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      33
+    );
+  });
+
+  it("should return OPERATION signed bsvhu sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.PROCESSED,
+        emitterCompanySiret: company.siret,
+        emitterEmissionSignatureDate: new Date(),
+        destinationOperationSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(57);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      33
+    );
+  });
+});

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -10,10 +10,8 @@ type BsvhuEdge {
 }
 
 type BsvhuMetadataFields {
-  "liste des champs qui seront requis pour la prochaine signature"
-  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [String!]!
+  sealed: [[String!]!]!
 }
 
 type BsvhuMetadata {
@@ -24,7 +22,7 @@ type BsvhuMetadata {
 
 type BsvhuError {
   message: String!
-  path: String!
+  path: [String!]!
   requiredFor: SignatureTypeInput!
 }
 

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -9,8 +9,14 @@ type BsvhuEdge {
   node: Bsvhu!
 }
 
+type BsvhuFieldsMetadata {
+  requiredForNextSignature: [String!]!
+  sealed: [String!]!
+}
+
 type BsvhuMetadata {
-  errors: [BsvhuError!]
+  errors: [BsvhuError!]!
+  fields: BsvhuFieldsMetadata!
 }
 
 type BsvhuError {

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -9,14 +9,17 @@ type BsvhuEdge {
   node: Bsvhu!
 }
 
-type BsvhuFieldsMetadata {
+type BsvhuMetadataFields {
+  "liste des champs qui seront requis pour la prochaine signature"
   requiredForNextSignature: [String!]!
+  "Liste des champs scellés"
   sealed: [String!]!
 }
 
 type BsvhuMetadata {
   errors: [BsvhuError!]!
-  fields: BsvhuFieldsMetadata!
+  "Informations sur les champs"
+  fields: BsvhuMetadataFields!
 }
 
 type BsvhuError {

--- a/back/src/bsvhu/validation/helpers.ts
+++ b/back/src/bsvhu/validation/helpers.ts
@@ -73,24 +73,6 @@ export function getUpdatedFields<T extends ZodBsvhu>(
   return Object.keys(diff);
 }
 
-/**
- * Gets all the signatures prior to the target signature in the signature hierarchy.
- */
-export function getSignatureAncestors(
-  targetSignature: SignatureTypeInput | undefined | null
-): SignatureTypeInput[] {
-  if (!targetSignature) return [];
-
-  const parent = Object.entries(BSVHU_SIGNATURES_HIERARCHY).find(
-    ([_, details]) => details.next === targetSignature
-  )?.[0];
-
-  return [
-    targetSignature,
-    ...getSignatureAncestors(parent as SignatureTypeInput)
-  ];
-}
-
 export async function getBsvhuUserFunctions(
   user: User | undefined,
   bsvhu: ZodBsvhu
@@ -110,6 +92,37 @@ export async function getBsvhuUserFunctions(
       (bsvhu.transporterCompanyVatNumber != null &&
         orgIds.includes(bsvhu.transporterCompanyVatNumber))
   };
+}
+
+/**
+ * Gets all the signatures prior to the target signature in the signature hierarchy.
+ */
+export function getSignatureAncestors(
+  targetSignature: SignatureTypeInput | undefined | null
+): SignatureTypeInput[] {
+  if (!targetSignature) return [];
+
+  const parent = Object.entries(BSVHU_SIGNATURES_HIERARCHY).find(
+    ([_, details]) => details.next === targetSignature
+  )?.[0];
+
+  return [
+    targetSignature,
+    ...getSignatureAncestors(parent as SignatureTypeInput)
+  ];
+}
+
+export function getNextSignatureType(
+  currentSignature: SignatureTypeInput | undefined | null
+): SignatureTypeInput | undefined {
+  if (!currentSignature) {
+    return "EMISSION";
+  }
+  const signature = BSVHU_SIGNATURES_HIERARCHY[currentSignature];
+  if (signature.next) {
+    return signature.next;
+  }
+  return undefined;
 }
 
 /**

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -4,7 +4,8 @@ import { ParsedZodBsvhu, ZodBsvhu } from "./schema";
 import {
   bsvhuEditionRules,
   BsvhuEditableFields,
-  isBsvhuFieldRequired
+  isBsvhuFieldRequired,
+  EditionRulePath
 } from "./rules";
 import { getSignatureAncestors } from "./helpers";
 import { isArray } from "../../common/dataTypes";
@@ -133,6 +134,7 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
   field: string;
   rule: EditionRule<T>;
   readableFieldName?: string;
+  path?: EditionRulePath;
   ctx: RefinementCtx;
   errorMsg?: (fieldDescription: string) => string;
 };
@@ -140,7 +142,8 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
 function checkFieldIsDefined<T extends ZodBsvhu>(
   args: CheckFieldIsDefinedArgs<T>
 ) {
-  const { resource, field, rule, ctx, readableFieldName, errorMsg } = args;
+  const { resource, field, rule, ctx, readableFieldName, path, errorMsg } =
+    args;
   const value = resource[field];
   if (value == null || (isArray(value) && (value as any[]).length === 0)) {
     const fieldDescription = readableFieldName
@@ -149,7 +152,7 @@ function checkFieldIsDefined<T extends ZodBsvhu>(
 
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      path: [field],
+      path: path ?? [field],
       message: [
         errorMsg
           ? errorMsg(fieldDescription)
@@ -172,7 +175,7 @@ export const checkRequiredFields: (
 
   return (bsvhu, zodContext) => {
     for (const bsvhuField of Object.keys(bsvhuEditionRules)) {
-      const { required, readableFieldName } =
+      const { required, readableFieldName, path } =
         bsvhuEditionRules[bsvhuField as keyof BsvhuEditableFields];
 
       if (required) {
@@ -186,6 +189,7 @@ export const checkRequiredFields: (
             resource: bsvhu,
             field: bsvhuField,
             rule: required,
+            path,
             readableFieldName,
             ctx: zodContext
           });

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -1,6 +1,6 @@
 import { ZodBsvhu } from "./schema";
 import { BsvhuUserFunctions, BsvhuValidationContext } from "./types";
-import { SignatureTypeInput } from "../../generated/graphql/types";
+import { BsvhuInput, SignatureTypeInput } from "../../generated/graphql/types";
 import { WasteAcceptationStatus } from "@prisma/client";
 import { isForeignVat } from "@td/constants";
 import {
@@ -11,6 +11,7 @@ import {
 } from "./helpers";
 import { capitalize } from "../../common/strings";
 import { SealedFieldError } from "../../common/errors";
+import { Leaves } from "../../types";
 
 // Liste des champs éditables sur l'objet Bsvhu
 export type BsvhuEditableFields = Required<
@@ -47,6 +48,8 @@ type GetBsvhuSignatureTypeFn<T extends ZodBsvhu> = (
   ruleContext?: RuleContext<T>
 ) => SignatureTypeInput | undefined;
 
+export type EditionRulePath = Leaves<BsvhuInput, 5>;
+
 // Règle d'édition qui permet de définir à partir de quelle signature
 // un champ est verrouillé / requis avec une config contenant un paramètre
 // optionnel `when`
@@ -66,6 +69,7 @@ export type EditionRules<T extends ZodBsvhu, E extends BsvhuEditableFields> = {
     // At what signature the field is required, and under which circumstances. If absent, field is never required
     required?: EditionRule<T>;
     readableFieldName?: string; // A custom field name for errors
+    path?: EditionRulePath;
   };
 };
 
@@ -91,25 +95,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
   },
   emitterAgrementNumber: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le N° d'agrément de l'émetteur"
+    readableFieldName: "Le N° d'agrément de l'émetteur",
+    path: ["emitter", "agrementNumber"]
   },
   emitterIrregularSituation: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La situation (irrégulière ou non) de l'émetteur"
+    readableFieldName: "La situation (irrégulière ou non) de l'émetteur",
+    path: ["emitter", "irregularSituation"]
   },
   emitterNoSiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur"
+    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur",
+    path: ["emitter", "noSiret"]
   },
   emitterCompanyName: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale de l'émetteur"
+    readableFieldName: "La raison sociale de l'émetteur",
+    path: ["emitter", "company", "name"]
   },
   emitterCompanySiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterNoSiret },
-    readableFieldName: "Le N° SIRET de l'émetteur"
+    readableFieldName: "Le N° SIRET de l'émetteur",
+    path: ["emitter", "company", "siret"]
   },
   emitterCompanyAddress: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -120,22 +129,26 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
         !bsvhu.emitterCompanyCity ||
         !bsvhu.emitterCompanyPostalCode
     },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "address"]
   },
   emitterCompanyStreet: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "street"]
   },
   emitterCompanyCity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "city"]
   },
   emitterCompanyPostalCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "postalCode"]
   },
   emitterCompanyContact: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -143,7 +156,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterNoSiret
     },
-    readableFieldName: "La personne à contacter chez l'émetteur"
+    readableFieldName: "La personne à contacter chez l'émetteur",
+    path: ["emitter", "company", "contact"]
   },
   emitterCompanyPhone: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -151,7 +165,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "Le N° de téléphone de l'émetteur"
+    readableFieldName: "Le N° de téléphone de l'émetteur",
+    path: ["emitter", "company", "phone"]
   },
   emitterCompanyMail: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -159,72 +174,86 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "L'adresse e-mail de l'émetteur"
+    readableFieldName: "L'adresse e-mail de l'émetteur",
+    path: ["emitter", "company", "mail"]
   },
   destinationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de destination"
+    readableFieldName: "Le type de destination",
+    path: ["destination", "type"]
   },
   destinationPlannedOperationCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "L'opération prévue"
+    readableFieldName: "L'opération prévue",
+    path: ["destination", "plannedOperationCode"]
   },
   destinationAgrementNumber: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° d'agrément du destinataire"
+    readableFieldName: "Le N° d'agrément du destinataire",
+    path: ["destination", "agrementNumber"]
   },
   destinationCompanyName: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale du destinataire"
+    readableFieldName: "La raison sociale du destinataire",
+    path: ["destination", "company", "name"]
   },
   destinationCompanySiret: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° SIRET du destinataire"
+    readableFieldName: "Le N° SIRET du destinataire",
+    path: ["destination", "company", "siret"]
   },
   destinationCompanyAddress: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse du destinataire"
+    readableFieldName: "L'adresse du destinataire",
+    path: ["destination", "company", "address"]
   },
   destinationCompanyContact: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La personne à contacter chez le destinataire"
+    readableFieldName: "La personne à contacter chez le destinataire",
+    path: ["destination", "company", "contact"]
   },
   destinationCompanyPhone: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° de téléphone du destinataire"
+    readableFieldName: "Le N° de téléphone du destinataire",
+    path: ["destination", "company", "phone"]
   },
   destinationCompanyMail: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse e-mail du destinataire"
+    readableFieldName: "L'adresse e-mail du destinataire",
+    path: ["destination", "company", "mail"]
   },
   destinationReceptionAcceptationStatus: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le statut d'acceptation du destinataire"
+    readableFieldName: "Le statut d'acceptation du destinataire",
+    path: ["destination", "reception", "acceptationStatus"]
   },
   destinationReceptionRefusalReason: {
     sealed: { from: "OPERATION" },
     readableFieldName: "La raison du refus par le destinataire",
-    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused }
+    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused },
+    path: ["destination", "reception", "refusalReason"]
   },
   destinationReceptionIdentificationNumbers: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Les numéros d'identification à la réception par le destinataire"
+      "Les numéros d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "numbers"]
   },
   destinationReceptionIdentificationType: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Le type de numéro d'identification à la réception par le destinataire"
+      "Le type de numéro d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "type"]
   },
   destinationOperationCode: {
     sealed: { from: "OPERATION" },
@@ -232,7 +261,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "OPERATION",
       when: isNotRefused
     },
-    readableFieldName: "L'opération réalisée par le destinataire"
+    readableFieldName: "L'opération réalisée par le destinataire",
+    path: ["destination", "operation", "code"]
   },
   destinationOperationMode: {
     sealed: { from: "OPERATION" },
@@ -240,20 +270,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     //   from: "OPERATION",
     //   when: isNotRefused // more precise check in checkOperationMode refinement
     // },
-    readableFieldName: "Le mode de traitement"
+    readableFieldName: "Le mode de traitement",
+    path: ["destination", "operation", "mode"]
   },
   destinationOperationDate: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION", when: isNotRefused },
-    readableFieldName: "la date de l'opération"
+    readableFieldName: "la date de l'opération",
+    path: ["destination", "operation", "date"]
   },
   destinationOperationNextDestinationCompanySiret: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° SIRET de l'exutoire"
+    readableFieldName: "Le N° SIRET de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "siret"]
   },
   destinationOperationNextDestinationCompanyVatNumber: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° de TVA de l'exutoire"
+    readableFieldName: "Le N° de TVA de l'exutoire",
+    path: [
+      "destination",
+      "operation",
+      "nextDestination",
+      "company",
+      "vatNumber"
+    ]
   },
   destinationOperationNextDestinationCompanyName: {
     sealed: { from: "OPERATION" },
@@ -262,7 +302,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La raison sociale de l'exutoire"
+    readableFieldName: "La raison sociale de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "name"]
   },
   destinationOperationNextDestinationCompanyAddress: {
     sealed: { from: "OPERATION" },
@@ -271,7 +312,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse de l'exutoire"
+    readableFieldName: "L'adresse de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "address"]
   },
   destinationOperationNextDestinationCompanyContact: {
     sealed: { from: "OPERATION" },
@@ -280,7 +322,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La personne à contacter chez l'exutoire"
+    readableFieldName: "La personne à contacter chez l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "contact"]
   },
   destinationOperationNextDestinationCompanyPhone: {
     sealed: { from: "OPERATION" },
@@ -289,7 +332,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "Le N° de téléphone de l'exutoire"
+    readableFieldName: "Le N° de téléphone de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "phone"]
   },
   destinationOperationNextDestinationCompanyMail: {
     sealed: { from: "OPERATION" },
@@ -298,20 +342,24 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse e-mail de l'exutoire"
+    readableFieldName: "L'adresse e-mail de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "mail"]
   },
   destinationReceptionQuantity: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "La quantité de VHUs reçue"
+    readableFieldName: "La quantité de VHUs reçue",
+    path: ["destination", "reception", "quantity"]
   },
   destinationReceptionWeight: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le poids réel reçu"
+    readableFieldName: "Le poids réel reçu",
+    path: ["destination", "reception", "weight"]
   },
   destinationReceptionDate: {
     readableFieldName: "la date de réception",
-    sealed: { from: "OPERATION" }
+    sealed: { from: "OPERATION" },
+    path: ["destination", "reception", "date"]
     // required: { from: "OPERATION" }
   },
   wasteCode: {
@@ -319,37 +367,44 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le code déchet"
+    readableFieldName: "Le code déchet",
+    path: ["wasteCode"]
   },
   packaging: {
     sealed: {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type d'empaquetage"
+    readableFieldName: "Le type d'empaquetage",
+    path: ["packaging"]
   },
   identificationNumbers: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Les numéros d'identification"
+    readableFieldName: "Les numéros d'identification",
+    path: ["identification", "numbers"]
   },
   identificationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de numéro d'identification"
+    readableFieldName: "Le type de numéro d'identification",
+    path: ["identification", "type"]
   },
   quantity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La quantité"
+    readableFieldName: "La quantité",
+    path: ["quantity"]
   },
   weightValue: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le poids"
+    readableFieldName: "Le poids",
+    path: ["weight", "value"]
   },
   weightIsEstimate: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le champ pour indiquer si le poids est estimé"
+    readableFieldName: "Le champ pour indiquer si le poids est estimé",
+    path: ["weight", "isEstimate"]
   },
   transporterCompanySiret: {
     readableFieldName: "le N° SIRET du transporteur",
@@ -357,7 +412,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanyVatNumber
-    }
+    },
+    path: ["transporter", "company", "siret"]
   },
   transporterCompanyVatNumber: {
     readableFieldName: "Le N° de TVA du transporteur",
@@ -365,42 +421,48 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanySiret
-    }
+    },
+    path: ["transporter", "company", "vatNumber"]
   },
   transporterCompanyName: {
     readableFieldName: "Le nom du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "name"]
   },
   transporterCompanyAddress: {
     readableFieldName: "L'adresse du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "address"]
   },
   transporterCompanyContact: {
     readableFieldName: "Le nom de contact du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "contact"]
   },
   transporterCompanyPhone: {
     readableFieldName: "Le téléphone du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "phone"]
   },
   transporterCompanyMail: {
     readableFieldName: "L'email du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "mail"]
   },
   transporterRecepisseNumber: {
     readableFieldName: "le numéro de récépissé du transporteur",
@@ -410,7 +472,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "number"]
   },
   transporterRecepisseDepartment: {
     readableFieldName: "le département de récépissé du transporteur",
@@ -420,7 +483,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "department"]
   },
   transporterRecepisseValidityLimit: {
     readableFieldName: "la date de validité du récépissé du transporteur",
@@ -430,15 +494,18 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "validityLimit"]
   },
   transporterTransportTakenOverAt: {
     readableFieldName: "la date d'enlèvement du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "transport", "takenOverAt"]
   },
   transporterRecepisseIsExempted: {
     readableFieldName: "l'exemption de récépissé du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "recepisse", "isExempted"]
     // required: {
     //   from: "TRANSPORT"
     // }

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -515,45 +515,26 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
 export const getRequiredAndSealedFieldPaths = async (
   bsvhu: ZodBsvhu,
   currentSignatures: SignatureTypeInput[],
-  nextSignature: SignatureTypeInput | undefined,
   user: User | undefined
 ): Promise<{
-  requiredForNextSignature: string[];
-  sealed: string[];
+  sealed: string[][];
 }> => {
-  const nextSignatures = nextSignature
-    ? currentSignatures.concat([nextSignature])
-    : currentSignatures;
-  const requiredFields: string[] = [];
-  const sealedFields: string[] = [];
+  const sealedFields: string[][] = [];
   const userFunctions = await getBsvhuUserFunctions(user, bsvhu);
   for (const bsvhuField of Object.keys(bsvhuEditionRules)) {
-    const { required, sealed, path } =
+    const { sealed, path } =
       bsvhuEditionRules[bsvhuField as keyof BsvhuEditableFields];
-    if (path) {
-      if (required) {
-        const isRequired = isBsvhuFieldRequired(
-          required,
-          bsvhu,
-          nextSignatures
-        );
-        if (isRequired) {
-          requiredFields.push(path.join("."));
-        }
-      }
-      if (sealed) {
-        const isSealed = isBsvhuFieldSealed(sealed, bsvhu, currentSignatures, {
-          persisted: bsvhu,
-          userFunctions
-        });
-        if (isSealed) {
-          sealedFields.push(path.join("."));
-        }
+    if (path && sealed) {
+      const isSealed = isBsvhuFieldSealed(sealed, bsvhu, currentSignatures, {
+        persisted: bsvhu,
+        userFunctions
+      });
+      if (isSealed) {
+        sealedFields.push(path);
       }
     }
   }
   return {
-    requiredForNextSignature: requiredFields,
     sealed: sealedFields
   };
 };

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -20,6 +20,7 @@ import { ZodError } from "zod";
 import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { passportBearerMiddleware } from "./auth";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
+import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
 import { captchaGen, captchaSound } from "./captcha/captchaGen";
 import { ErrorCode, UserInputError } from "./common/errors";
 import errorHandler from "./common/middlewares/errorHandler";
@@ -369,6 +370,7 @@ export const getServerDataloaders = () => ({
   ...createCompanyDataLoaders(),
   ...createFormDataLoaders(),
   ...createBsdaDataLoaders(),
+  ...createBsvhuDataLoaders(),
   ...createEventsDataLoaders()
 });
 

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -21,6 +21,7 @@ import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { passportBearerMiddleware } from "./auth";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
+import { createBspaohDataLoaders } from "./bspaoh/dataloader";
 import { captchaGen, captchaSound } from "./captcha/captchaGen";
 import { ErrorCode, UserInputError } from "./common/errors";
 import errorHandler from "./common/middlewares/errorHandler";
@@ -371,6 +372,7 @@ export const getServerDataloaders = () => ({
   ...createFormDataLoaders(),
   ...createBsdaDataLoaders(),
   ...createBsvhuDataLoaders(),
+  ...createBspaohDataLoaders(),
   ...createEventsDataLoaders()
 });
 

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,7 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+// utility types used by Paths and Leaves
 type Cons<H, T> = T extends readonly any[]
   ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
     ? R
@@ -55,7 +56,20 @@ type Prev = [
   20,
   ...0[]
 ];
-
+/*
+Creates a type with all possible paths in an other object type, recursively,
+including all possible subpaths.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["aa"] | ["a", "ab"] | ["ab"]
+*/
 export type Paths<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object
@@ -70,6 +84,19 @@ export type Paths<T, D extends number = 3> = [D] extends [never]
     }[keyof T]
   : [];
 
+/*
+Creates a type with all possible paths in an other object type, recursively.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["a", "ab"]
+*/
 export type Leaves<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -5,6 +5,7 @@ import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
+import { createBspaohDataLoaders } from "./bspaoh/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 import "express-session";
 
@@ -13,6 +14,7 @@ export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createFormDataLoaders> &
   ReturnType<typeof createBsdaDataLoaders> &
   ReturnType<typeof createBsvhuDataLoaders> &
+  ReturnType<typeof createBspaohDataLoaders> &
   ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = {
@@ -74,7 +76,7 @@ Paths<obj>
 */
 export type Paths<T, D extends number = 3> = [D] extends [never]
   ? never
-  : T extends object
+  : T extends Record<string, unknown>
   ? {
       [K in keyof T]-?:
         | [K]
@@ -101,7 +103,7 @@ Paths<obj>
 */
 export type Leaves<T, D extends number = 3> = [D] extends [never]
   ? never
-  : T extends object
+  : T extends Record<string, unknown>
   ? { [K in keyof T]-?: Cons<K, Leaves<T[K], Prev[D]>> }[keyof T]
   : [];
 

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,57 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+type Cons<H, T> = T extends readonly any[]
+  ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
+    ? R
+    : never
+  : never;
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+];
+
+export type Paths<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?:
+        | [K]
+        | (Paths<T[K], Prev[D]> extends infer P
+            ? P extends []
+              ? never
+              : Cons<K, P>
+            : never);
+    }[keyof T]
+  : [];
+
+export type Leaves<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? { [K in keyof T]-?: Cons<K, Leaves<T[K], Prev[D]>> }[keyof T]
+  : [];
+
 declare module "express-session" {
   interface SessionData {
     warningMessage?: string;

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -4,6 +4,7 @@ import { GqlInfo } from "./common/plugins/gqlInfosPlugin";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
+import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 import "express-session";
 
@@ -11,6 +12,7 @@ export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createCompanyDataLoaders> &
   ReturnType<typeof createFormDataLoaders> &
   ReturnType<typeof createBsdaDataLoaders> &
+  ReturnType<typeof createBsvhuDataLoaders> &
   ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = {

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=d5199fe9"
+      href="/dsfr/utility/icons/icons.min.css?hash=ea40c0cf"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=ea40c0cf"
+      href="/dsfr/utility/icons/icons.min.css?hash=fe60f3b9"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
@@ -65,9 +65,9 @@ export function ControlledTabs(props: Readonly<Props>) {
 
   const sealedFields = useMemo(
     () =>
-      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])
-        ?.map(f => f?.name!)
-        .filter(Boolean),
+      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])?.filter(
+        Boolean
+      ),
     [formQuery.data]
   );
 

--- a/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
@@ -65,9 +65,9 @@ export function ControlledTabs(props: Readonly<Props>) {
 
   const sealedFields = useMemo(
     () =>
-      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])?.filter(
-        Boolean
-      ),
+      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])
+        ?.filter(Boolean)
+        .map(sealedField => sealedField.join(".")),
     [formQuery.data]
   );
 

--- a/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
@@ -12,7 +12,6 @@ export const GET_VHU_FORM = gql`
           requiredFor
         }
         fields {
-          requiredForNextSignature
           sealed
         }
       }

--- a/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
@@ -11,6 +11,10 @@ export const GET_VHU_FORM = gql`
           path
           requiredFor
         }
+        fields {
+          requiredForNextSignature
+          sealed
+        }
       }
     }
   }

--- a/front/src/Apps/common/queries/fragments/bspaoh.ts
+++ b/front/src/Apps/common/queries/fragments/bspaoh.ts
@@ -77,9 +77,7 @@ const metadataFragment = gql`
         requiredFor
       }
       fields {
-        sealed {
-          name
-        }
+        sealed
       }
     }
   }

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -66,7 +66,7 @@ export function SignTransport({
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter
-            !error.path.startsWith("transporterRecepisse")
+            !error.path.startsWith("transporter.recepisse")
         ) ? (
           <>
             <p className="tw-mt-2 tw-text-red-700">


### PR DESCRIPTION
# Objectif

## TRA 14578 - renvoit des paths complets dans les erreurs de validation Zod VHU/PAOH

Modifier la façon dont les erreurs de validation (champs requis) émises par Zod renvoient leur path sur les BSVHU et BSPAOH. Pour l'instant, c'était simplement le nom backend du champ (ex: "transporterRecepisseValidityLimit"). De façon à rendre cette info plus exploitable par la front, le path est splité de façon à correspondre aux chemins des objets GraphQL, qui correspondent globalement aux chemins des champs en front (ex: ["transporter", "recepisse", "validityLimit"]).

<img width="810" alt="Capture d’écran 2024-08-31 à 02 11 56" src="https://github.com/user-attachments/assets/4c17111a-c281-48a6-812e-c35b92348fa2">


## TRA 15020 - ajout d'une liste de champs scellés dans les Metadata VHU

Renvoyer à la front l'info des champs scellés sur un BSVHU, et standardiser le format renvoyé par metadata.errors.path et metadata.fields.sealed

<img width="764" alt="Capture d’écran 2024-09-04 à 00 25 41" src="https://github.com/user-attachments/assets/bb889c02-1e71-4192-9934-922e71998f5a">


## Bonus : harmonisation PAOH/VHU

Le champ fields.sealed a déjà été ajouté sur les BSPAOH, donc quelque soit le choix d'implémentation, il faut qu'elle soit uniforme entre les 2 afin de faciliter le maintien du code et la compréhension des utilisateurs.

### Remarque

Dans l'implémentation existante de fields.sealed pour BSPAOH, les champs sont représentés sous la forme "transporter.recepisse.validityLimit".
Dans les erreurs de validation Zod (qui remontent via les erreurs GraphQL), le chemin est sous la forme ["transporter", "recepisse", "validityLimit"].
La raison pour cette incohérence est que Zod impose que le path renvoyé dans les erreurs soit une Array.
Après discussion, il a été choisi d'uniformiser le format des chemins entre:
- erreurs Zod
- errors.path
- fields.sealed
sous la forme d'array (["transporter", "recepisse", "validityLimit"]).

# Tech

Pour renvoyer ces chemins dans les erreurs Zod et les metadata, je les ai défini pour chaque règle de validation BSVHU/BSPAOH. Afin d'éviter les erreurs de dev et assurer la continuité, j'ai défini le type de ce chemin à partir des objets GraphQL eux même. De cette façon si les interface GraphQL évoluent, typescript mettra des erreurs pour forcer à mettre à jour ces paths.
Pour définir ces types, j'ai utilisé une fonction utilitaire Typescript (Leaves). J'ai ajouté cette fonction dans les parties communes, ainsi que Paths (qui ajoute les sous-chemins au type, voir les commentaires dans le code). A noter qu'un paramètre additionnel de ces méthodes permet de limiter la profondeur d'exploration des types, comme sécurité si le type est récursif (fait référence à lui même) ou très profond.

## TRA 14578 - renvoit des paths complets dans les erreurs de validation Zod VHU/PAOH

J'ai harmonisé la gestion de metadata.errors BSVHU/BSPAOH avec la façon dont c'est géré dans BsdaMetadata, par cohérence, et parce que sur le BSVHU c'était un hybride entre l'ancienne validation et la nouvelle (utilisation des status pour déterminer la signature suivante, boucle inutile, ...). J'ai ajouté un dataloader BSVHU pour éviter les requêtes inutiles (car le VHU est chargé dans errors et dans fields). J'ai aussi refacto le fonctionnement PAOH pour harmoniser et utiliser les paths définis dans les rules, ainsi qu'ajouté un dataloader utilisé dans le resolver de metadata.

## TRA 15020 - ajout d'une liste de champs scellés dans les Metadata VHU

Là aussi j'ai harmonisé la récupération de ces champs scellés/requis entre PAOH et VHU, par cohérence et parce que la méthode de récupération des champs scellés dans le PAOH ne prenait pas en compte les conditions définies dans les rules (par exemple certains champs ne sont pas scellés pour l'émetteur tant que le transporteur n'a pas signé).

J'ai aussi mis à jour les tests bspaohMetadata.integration, et créé un équivalent bsvhuMetadata.integration.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro TRA 14578](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14578)
- [Ticket Favro TRA 15020](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15020)
