### PR TITLE
[TRA-14517] Le mode de transport est désormais obligatoire à la signature transporteur

### DIFF
--- a/back/src/forms/resolvers/mutations/signTransportForm.ts
+++ b/back/src/forms/resolvers/mutations/signTransportForm.ts
@@ -102,8 +102,9 @@ const signTransportFn = async (
   const receiptFields = await getFormReceiptField(signingTransporter!);
 
   const transportersForValidation = [...transporters];
-  // Prend en compte la plaque d'immatriculation envoyée dans l'input de signature
-  // pour la validation des données
+  // Prend en compte la plaque d'immatriculation et le mode
+  // de transport envoyés dans l'input de signature pour
+  // la validation des données
   transportersForValidation[signingTransporterIdx] = {
     ...transportersForValidation[signingTransporterIdx],
     ...(receiptFields as any) // FIXME fix typing of getFormReceiptField
@@ -111,6 +112,10 @@ const signTransportFn = async (
   if (args.input?.transporterNumberPlate) {
     transportersForValidation[signingTransporterIdx].transporterNumberPlate =
       args.input?.transporterNumberPlate;
+  }
+  if (args.input?.transporterTransportMode !== undefined) {
+    transportersForValidation[signingTransporterIdx].transporterTransportMode =
+      args.input?.transporterTransportMode;
   }
 
   await validateBeforeTransport(
@@ -140,6 +145,11 @@ const signTransportFn = async (
     ...(args.input.transporterNumberPlate
       ? {
           transporterNumberPlate: args.input.transporterNumberPlate
+        }
+      : {}),
+    ...(args.input.transporterTransportMode
+      ? {
+          transporterTransportMode: args.input.transporterTransportMode
         }
       : {}),
     ...receiptFields

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -34,6 +34,9 @@ input SignTransportFormInput {
 
   "Numéro de la plaque d'immatriculation transporteur"
   transporterNumberPlate: String
+
+  "Le mode de transport utilisé par le transporteur"
+  transporterTransportMode: TransportMode
 }
 
 "Payload de signature d'un BSD par un transporteur"

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1118,7 +1118,25 @@ export const transporterSchemaFn: FactorySchemaOf<
             )
         }
       ),
-    transporterTransportMode: yup.mixed<TransportMode>()
+    transporterTransportMode: yup
+      .mixed<TransportMode>()
+      .nullable()
+      .test((transporterTransportMode, ctx) => {
+        const { transporterCompanySiret, transporterCompanyVatNumber } =
+          ctx.parent;
+
+        if (
+          context.signingTransporterOrgId &&
+          [transporterCompanySiret, transporterCompanyVatNumber].includes(
+            context.signingTransporterOrgId
+          ) &&
+          !transporterTransportMode
+        ) {
+          return new yup.ValidationError("Le mode de transport est requis");
+        }
+
+        return true;
+      })
   });
 
 export const traderSchemaFn: FactorySchemaOf<FormValidationContext, Trader> = ({


### PR DESCRIPTION
# Contexte

# Démo

# Ticket Favro

[Rendre obligatoire le mode de transport à la signature Transporteur pour tous les BSD + via l'UI par défaut si aucun mode de transport n'a été renseigné on ajoute Route et on permet de le modifier](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14517)
