### PR TITLE
Rendre obligatoire le volume du contenant à la publication sur le BSFF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,7 +34,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Rendre BSDAs en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
 - Ajout de la possibilité de réviser la quantité du destinataire d'un BSDD si un entreposage provisoire est présent [PR 3527](https://github.com/MTES-MCT/trackdechets/pull/3527)
-- Rendre obligatoire le volume du contenant à la publication sur le BSFF
 
 #### :boom: Breaking changes
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Ajouter deux sous-profils pour l'installation de traitement VHU [PR 3480](https://github.com/MTES-MCT/trackdechets/pull/3480)
 
+#### :boom: Breaking changes
+
+- Rendre obligatoire le volume du contenant à la publication sur le BSFF [PR 3555](https://github.com/MTES-MCT/trackdechets/pull/3555)
+
 # [2024.8.1] 27/08/2024
 
 #### :rocket: Nouvelles fonctionnalités
@@ -30,6 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Rendre BSDAs en brouillon inaccessibles pour les entreprises dont l'auteur ne fait pas partie [PR 3503](https://github.com/MTES-MCT/trackdechets/pull/3503)
 - Ajout de la possibilité de réviser la quantité du destinataire d'un BSDD si un entreposage provisoire est présent [PR 3527](https://github.com/MTES-MCT/trackdechets/pull/3527)
+- Rendre obligatoire le volume du contenant à la publication sur le BSFF
 
 #### :boom: Breaking changes
 

--- a/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
+++ b/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
@@ -297,6 +297,57 @@ describe("validation > parseBsff", () => {
       }
     );
 
+    it.each([null, undefined])(
+      "should parse correctly if packaging volume is %p" +
+        " and bsff is created before MEP 2024.09.1",
+      v => {
+        const zodBsff: ZodBsff = {
+          isDraft: false,
+          createdAt: new Date("2024-09-23"),
+          packagings: [
+            {
+              weight: 1,
+              volume: v,
+              numero: "1",
+              emissionNumero: "1",
+              type: "BOUTEILLE"
+            }
+          ]
+        };
+        expect(parseBsff(zodBsff)).toBeDefined();
+      }
+    );
+
+    it.each([null, undefined])(
+      "should throw if packaging volume is %p " +
+        "and bsff is created after MEP 2024.09.1",
+      v => {
+        const zodBsff: ZodBsff = {
+          createdAt: new Date("2024-09-24T08:00:00"),
+          isDraft: false,
+          packagings: [
+            {
+              weight: 1,
+              volume: v,
+              numero: "1",
+              emissionNumero: "1",
+              type: "BOUTEILLE"
+            }
+          ]
+        };
+        expect.assertions(1);
+        try {
+          parseBsff(zodBsff);
+        } catch (e) {
+          expect(e.errors).toEqual([
+            expect.objectContaining({
+              message: "Conditionnements : le volume est requis"
+            })
+          ]);
+        }
+      }
+    );
+
     it("should throw if weight value is negative", () => {
       const zodBsff: ZodBsff = {
         weightValue: -1

--- a/back/src/bsffs/validation/bsff/refinements.ts
+++ b/back/src/bsffs/validation/bsff/refinements.ts
@@ -42,6 +42,11 @@ import { MAX_WEIGHT_BY_ROAD_TONNES } from "../../../common/validation";
 // désormais être strictement > 0
 const v2024071 = new Date("2024-07-03");
 
+// Date de la MAJ 2024.9.1 qui rend obligatoire
+// le volume sur les contenants
+//const v2024091 = new Date("2024-09-24");
+const v2024091 = new Date("2024-09-01");
+
 /**
  * Ce refinement permet de vérifier que les établissements présents sur le
  * BSFF sont bien inscrits sur Trackdéchets avec le bon profil
@@ -75,6 +80,22 @@ export const checkPackagings: Refinement<ParsedZodBsff> = (
   for (const packaging of bsff.packagings ?? []) {
     const isCreatedAfterV2024071 =
       bsff.createdAt && bsff.createdAt.getTime() - v2024071.getTime() > 0;
+
+    const isCreatedAfterV2024091 =
+      bsff.createdAt && bsff.createdAt.getTime() - v2024091.getTime() > 0;
+
+    if (
+      (packaging.volume === null || packaging.volume === undefined) &&
+      !bsff.isDraft &&
+      isCreatedAfterV2024091
+    ) {
+      // TRA-14567 Le volume est rendu obligatoire sur les contenants BSFF
+      // à partir de la v2024091
+      addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Conditionnements : le volume est requis"
+      });
+    }
 
     if (packaging.volume === 0 && isCreatedAfterV2024071) {
       // Changement de règle de validation dans la MAJ 2024.07.1. Il était possible

--- a/back/src/bsffs/validation/bsff/refinements.ts
+++ b/back/src/bsffs/validation/bsff/refinements.ts
@@ -44,8 +44,7 @@ const v2024071 = new Date("2024-07-03");
 
 // Date de la MAJ 2024.9.1 qui rend obligatoire
 // le volume sur les contenants
-//const v2024091 = new Date("2024-09-24");
-const v2024091 = new Date("2024-09-01");
+const v2024091 = new Date("2024-09-24");
 
 /**
  * Ce refinement permet de vérifier que les établissements présents sur le

--- a/front/src/form/bsff/components/packagings/Packagings.tsx
+++ b/front/src/form/bsff/components/packagings/Packagings.tsx
@@ -31,8 +31,8 @@ export default function BsffPackagings({
 
   const { setFieldValue } = useFormikContext<BsffPackagingInput>();
 
-  const canEdit =
-    !disabled && ![BsffType.Reexpedition, BsffType.Groupement].includes(type);
+  const fieldIsDisabled =
+    disabled || [BsffType.Reexpedition, BsffType.Groupement].includes(type);
 
   const maxPackagings = type === BsffType.Reconditionnement ? 1 : Infinity;
 
@@ -44,6 +44,14 @@ export default function BsffPackagings({
           <div>
             {value.map((p, idx) => {
               const fieldName = `${name}.${idx}`;
+
+              const volumeIsDisabled =
+                disabled ||
+                ([BsffType.Reexpedition, BsffType.Groupement].includes(type) &&
+                  // Cas spécial pour le volume qui est rendu obligatoire à partir de la
+                  // 2024.09.1 : on permet d'éditer le volume sur un bordereau de groupement ou réexpédition
+                  // qui aurait un bordereau initial dont le packaging a un volume `null` ou `undefined`.
+                  !!p.volume);
 
               return (
                 <div
@@ -59,7 +67,7 @@ export default function BsffPackagings({
                             as="select"
                             className="td-select"
                             name={`${fieldName}.type`}
-                            disabled={!canEdit}
+                            disabled={fieldIsDisabled}
                             onChange={(v: ChangeEvent<HTMLInputElement>) => {
                               setFieldValue(
                                 `${fieldName}.type`,
@@ -83,7 +91,7 @@ export default function BsffPackagings({
                           <Field
                             className="td-input"
                             name={`${fieldName}.other`}
-                            disabled={!canEdit || p.type !== "AUTRE"}
+                            disabled={fieldIsDisabled || p.type !== "AUTRE"}
                           />
                         </label>
                       </div>
@@ -94,7 +102,7 @@ export default function BsffPackagings({
                           <Field
                             className="td-input"
                             name={`${fieldName}.numero`}
-                            disabled={!canEdit}
+                            disabled={fieldIsDisabled}
                           />
                         </label>
                       </div>
@@ -106,7 +114,7 @@ export default function BsffPackagings({
                             component={NumberInput}
                             className="td-input td-input--small"
                             name={`${fieldName}.volume`}
-                            disabled={!canEdit}
+                            disabled={volumeIsDisabled}
                           />
                         </label>
                       </div>
@@ -118,12 +126,12 @@ export default function BsffPackagings({
                             component={NumberInput}
                             className="td-input td-input--small"
                             name={`${fieldName}.weight`}
-                            disabled={!canEdit}
+                            disabled={fieldIsDisabled}
                           />
                         </label>
                       </div>
                     </div>
-                    {canEdit && (
+                    {!fieldIsDisabled && (
                       <div
                         className="tw-px-2"
                         onClick={() => arrayHelpers.remove(idx)}
@@ -149,7 +157,7 @@ export default function BsffPackagings({
                 </div>
               );
             })}
-            {canEdit && value.length < maxPackagings && (
+            {!fieldIsDisabled && value.length < maxPackagings && (
               <button
                 type="button"
                 className="btn btn--outline-primary"

--- a/front/src/form/bsff/components/packagings/Packagings.tsx
+++ b/front/src/form/bsff/components/packagings/Packagings.tsx
@@ -101,7 +101,7 @@ export default function BsffPackagings({
 
                       <div className="tw-px-2 tw-flex-shrink">
                         <label>
-                          Volume du contenant en L (optionnel)
+                          Volume du contenant en L
                           <Field
                             component={NumberInput}
                             className="td-input td-input--small"


### PR DESCRIPTION


https://github.com/user-attachments/assets/0b7281d2-a696-4ef1-b486-1b3a896524d7





---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14567)
