### PR TITLE
Revert TRA-13421 : Le numéro de notification n'est plus requis

### DIFF
--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1856,7 +1856,8 @@ describe("processedInfoSchema", () => {
     }
   ];
 
-  it.each(testMatrix)(
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  it.skip.each(testMatrix)(
     "should throw when `nextDestinationNotificationNumber` is missing %o",
     async ({
       noTraceability,
@@ -1895,7 +1896,8 @@ describe("processedInfoSchema", () => {
     }
   );
 
-  it("should also throw when `nextDestinationNotificationNumber` is null", async () => {
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  it.skip("should also throw when `nextDestinationNotificationNumber` is null", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),
@@ -1926,7 +1928,7 @@ describe("processedInfoSchema", () => {
   });
 
   it.each(testMatrix)(
-    "should pas when `nextDestinationNotificationNumber` is provided %o",
+    "should pass when `nextDestinationNotificationNumber` is provided %o",
     async ({
       wasteDetailsCode,
       wasteDetailsPop,

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -208,7 +208,8 @@ describe("mutation.markAsProcessed", () => {
     expect(updatedForm.status).toEqual("AWAITING_GROUP");
   });
 
-  it("should fail to mark a form with temporary storage as FOLLOWED_WITH_PNTTD if notification number is missing", async () => {
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  it.skip("should fail to mark a form with temporary storage as FOLLOWED_WITH_PNTTD if notification number is missing", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formWithTempStorageFactory({
       ownerId: user.id,
@@ -551,7 +552,8 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  it.each([
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  it.skip.each([
     {
       wasteDetailsCode: "05 01 12*",
       wasteDetailsPop: false,
@@ -1564,7 +1566,8 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  test("nextDestinationNotificationNumber should be mandatory when noTraceability is true and wasteCode is dangerous", async () => {
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  test.skip("nextDestinationNotificationNumber should be mandatory when noTraceability is true and wasteCode is dangerous", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -1607,7 +1610,8 @@ describe("mutation.markAsProcessed", () => {
     ]);
   });
 
-  it.each([
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  it.skip.each([
     {
       wasteDetailsCode: "07 07 07*",
       wasteDetailsPop: false,
@@ -1716,7 +1720,7 @@ describe("mutation.markAsProcessed", () => {
     ]);
   });
 
-  test("nextDestinationNotificationNumber should not be mandatory when wasteCode is not conisdered as dangerous", async () => {
+  test("nextDestinationNotificationNumber should not be mandatory when wasteCode is not considered as dangerous", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -1757,7 +1761,8 @@ describe("mutation.markAsProcessed", () => {
     expect(errors).toBeUndefined();
   });
 
-  test("nextDestinationNotificationNumber should not be mandatory when nextDestination.company is foreign when noTraceability is false", async () => {
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  test.skip("nextDestinationNotificationNumber should be mandatory when nextDestination.company is foreign when noTraceability is false", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -1929,7 +1934,8 @@ describe("mutation.markAsProcessed", () => {
     ]);
   });
 
-  test("nextDestination.company and notificationNumber should be mandatory when company is extra-EU and when noTraceability is false", async () => {
+  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+  test.skip("nextDestination.company and notificationNumber should be mandatory when company is extra-EU and when noTraceability is false", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1497,9 +1497,11 @@ const withNextDestination = (required: boolean) =>
                   "Destination ultérieure : Le numéro de notification (format PPAAAADDDRRR) ou le numéro de déclaration Annexe 7 (format A7E AAAA DDDRRR) renseigné ne correspond pas au format attendu."
                 )
                 .nullable()
-                .required(
-                  "Destination ultérieure : le numéro de notification est obligatoire"
-                ),
+                .notRequired(),
+            // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
+            // .required(
+            //   "Destination ultérieure : le numéro de notification est obligatoire"
+            // ),
             otherwise: schema =>
               schema
                 .max(


### PR DESCRIPTION
Revert de https://github.com/MTES-MCT/trackdechets/pull/3332/ car des clients API n'ont pas eu le temps d'intégrer ce breaking changes et se retrouvent bloqués. 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

