### PR TITLE
[TRA 14647] ajout d'intermédiaires sur BSVHU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 # [2024.9.1] 24/09/2024
 
+#### :rocket: Nouvelles fonctionnalités
+
+- Ajout d'intermédiaires sur les BSVHU [PR 3560](https://github.com/MTES-MCT/trackdechets/pull/3560)
+
 #### :nail_care: Améliorations
 
 - Ajouter deux sous-profils pour l'installation de traitement VHU [PR 3480](https://github.com/MTES-MCT/trackdechets/pull/3480)

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Ajouter deux sous-profils pour l'installation de traitement VHU [PR 3480](https://github.com/MTES-MCT/trackdechets/pull/3480)
+- Rendre les chemins d'erreur Zod BSVHU/BSPAOH plus explicite en les subdivisant [PR 3547](https://github.com/MTES-MCT/trackdechets/pull/3547)
 
 # [2024.8.1] 27/08/2024
 

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -25,7 +25,10 @@ import {
   FormForElasticInclude,
   toBsdElastic as formToBsdElastic
 } from "../../forms/elastic";
-import { toBsdElastic as bsvhuToBsdElastic } from "../../bsvhu/elastic";
+import {
+  BsvhuForElasticInclude,
+  toBsdElastic as bsvhuToBsdElastic
+} from "../../bsvhu/elastic";
 import { toBsdElastic as bspaohToBsdElastic } from "../../bspaoh/elastic";
 import { bulkIndexQueue } from "../../queue/producers/elastic";
 import { IndexAllFnSignature, FindManyAndIndexBsdsFnSignature } from "./types";
@@ -64,7 +67,9 @@ const prismaFindManyOptions = {
   bsff: {
     include: BsffForElasticInclude
   },
-  bsvhu: {},
+  bsvhu: {
+    include: BsvhuForElasticInclude
+  },
   bsda: {
     include: BsdaForElasticInclude
   },

--- a/back/src/bsds/indexation/reindexBsdHelpers.ts
+++ b/back/src/bsds/indexation/reindexBsdHelpers.ts
@@ -2,7 +2,7 @@ import { prisma } from "@td/prisma";
 import { BsdaForElasticInclude, indexBsda } from "../../bsda/elastic";
 import { BsdasriForElasticInclude, indexBsdasri } from "../../bsdasris/elastic";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { indexBspaoh } from "../../bspaoh/elastic";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { deleteBsd } from "../../common/elastic";
@@ -62,7 +62,7 @@ export async function reindex(bsdId, exitFn) {
     });
 
     if (!!bsvhu && !bsvhu.isDeleted) {
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
     } else {
       await deleteBsd({ id: bsdId });
     }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -21,7 +21,11 @@ import {
 } from "../../../../../integration-tests/helper";
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { BsvhuForElasticInclude, indexBsvhu } from "../../../../bsvhu/elastic";
+import {
+  BsvhuForElasticInclude,
+  getBsvhuForElastic,
+  indexBsvhu
+} from "../../../../bsvhu/elastic";
 import {
   transporterReceiptFactory,
   userWithCompanyFactory
@@ -541,7 +545,9 @@ describe("Query.bsds.vhus base workflow", () => {
           ...BsvhuForElasticInclude
         }
       });
-      await indexBsvhu(refusedVhu);
+      const bsvhuForElastic = await getBsvhuForElastic(refusedVhu);
+      await indexBsvhu(bsvhuForElastic);
+
       await refreshElasticSearch();
     });
 
@@ -617,7 +623,8 @@ describe("Query.bsds.vhus mutations", () => {
       }
     });
 
-    await indexBsvhu(vhu);
+    const bsvhuForElastic = await getBsvhuForElastic(vhu);
+    await indexBsvhu(bsvhuForElastic);
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);
@@ -666,7 +673,8 @@ describe("Query.bsds.vhus mutations", () => {
         emitterCompanySiret: emitter.company.siret
       }
     });
-    await indexBsvhu(vhu);
+    const bsvhuForElastic = await getBsvhuForElastic(vhu);
+    await indexBsvhu(bsvhuForElastic);
 
     //duplicate vhu
     const { mutate } = makeClient(emitter.user);
@@ -692,7 +700,7 @@ describe("Query.bsds.vhus mutations", () => {
       }
     });
 
-    await indexBsvhu(vhu);
+    await indexBsvhu(bsvhuForElastic);
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -21,7 +21,7 @@ import {
 } from "../../../../../integration-tests/helper";
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { BsvhuForElasticInclude, indexBsvhu } from "../../../../bsvhu/elastic";
 import {
   transporterReceiptFactory,
   userWithCompanyFactory
@@ -536,7 +536,10 @@ describe("Query.bsds.vhus base workflow", () => {
     beforeAll(async () => {
       const refusedVhu = await prisma.bsvhu.update({
         where: { id: vhuId },
-        data: { status: "REFUSED" }
+        data: { status: "REFUSED" },
+        include: {
+          ...BsvhuForElasticInclude
+        }
       });
       await indexBsvhu(refusedVhu);
       await refreshElasticSearch();

--- a/back/src/bspaoh/dataloader.ts
+++ b/back/src/bspaoh/dataloader.ts
@@ -1,0 +1,22 @@
+import DataLoader from "dataloader";
+import { prisma } from "@td/prisma";
+import { PrismaBspaohWithTransporters } from "./types";
+
+export function createBspaohDataLoaders() {
+  return {
+    bspaohs: new DataLoader((bspaohIds: string[]) => getBspaohs(bspaohIds))
+  };
+}
+
+async function getBspaohs(bspaohIds: string[]) {
+  const bspaohs = await prisma.bspaoh.findMany({
+    where: { id: { in: bspaohIds } },
+    include: { transporters: true }
+  });
+
+  const dict = Object.fromEntries(
+    bspaohs.map((bspaoh: PrismaBspaohWithTransporters) => [bspaoh.id, bspaoh])
+  );
+
+  return bspaohIds.map(bsdaId => dict[bsdaId]);
+}

--- a/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/createBspaoh.integration.ts
@@ -13,6 +13,7 @@ import { fullBspaoh } from "../../../fragments";
 import { gql } from "graphql-tag";
 import { sirenify as sirenifyBspaohInput } from "../../../validation/sirenify";
 import { crematoriumFactory } from "../../../__tests__/factories";
+import { BspaohType } from "@prisma/client";
 
 jest.mock("../../../validation/sirenify");
 (sirenifyBspaohInput as jest.Mock).mockImplementation(input =>
@@ -85,7 +86,7 @@ describe("Mutation.Bspaoh.create", () => {
 
   it.each(["FOETUS", "PAOH"])(
     "should allow bspaoh creation",
-    async bspaohType => {
+    async (bspaohType: BspaohType) => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
       const destinationCompany = await crematoriumFactory();
 
@@ -629,7 +630,12 @@ describe("Mutation.Bspaoh.create", () => {
       expect.objectContaining({
         message: "Le SIRET du transporteur est obligatoire.",
         extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
+          code: ErrorCode.BAD_USER_INPUT,
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              path: ["transporter", "company", "siret"]
+            })
+          ])
         })
       })
     ]);

--- a/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
@@ -44,15 +44,13 @@ type BspaohMetadata {
 }
 
 type BspaohMetadataFields {
-  "liste des champs qui seront requis pour la prochaine signature"
-  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [String!]!
+  sealed: [[String!]!]!
 }
 
 type BspaohError {
   message: String!
-  path: String!
+  path: [String!]!
   requiredFor: BspaohSignatureType!
 }
 

--- a/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
@@ -38,18 +38,16 @@ type BspaohReceptionWasteDetail {
 }
 
 type BspaohMetadata {
-  errors: [BspaohError]
+  errors: [BspaohError!]!
   "Informations sur les champs"
-  fields: BspaohMetadataFields
+  fields: BspaohMetadataFields!
 }
 
 type BspaohMetadataFields {
+  "liste des champs qui seront requis pour la prochaine signature"
+  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [BspaohMetadataField]
-}
-
-type BspaohMetadataField {
-  name: String!
+  sealed: [String!]!
 }
 
 type BspaohError {

--- a/back/src/bspaoh/validation/rules.ts
+++ b/back/src/bspaoh/validation/rules.ts
@@ -612,51 +612,30 @@ export function checkSealedAndRequiredFields(
 export const getRequiredAndSealedFieldPaths = async (
   bspaoh: BspaohForParsing,
   currentSignatures: BspaohSignatureType[],
-  nextSignature: BspaohSignatureType | undefined,
   user: User | undefined
 ): Promise<{
-  requiredForNextSignature: string[];
-  sealed: string[];
+  sealed: string[][];
 }> => {
-  const nextSignatures = nextSignature
-    ? currentSignatures.concat([nextSignature])
-    : currentSignatures;
-  const requiredFields: string[] = [];
-  const sealedFields: string[] = [];
+  const sealedFields: string[][] = [];
   const userFunctions = await getUserFunctions(user, bspaoh);
   for (const bspaohField of Object.keys(editionRules)) {
-    const { required, sealed, path } =
+    const { sealed, path } =
       editionRules[bspaohField as keyof BspaohRulesEntries];
     // Apply default values to rules
     const sealedRule = {
       from: sealed?.from,
       when: sealed?.when ?? (() => true) // Default to true
     };
-    const requiredRule = {
-      from: required?.from ?? "NO_CHECK_RULE",
-      when: required?.when ?? (() => true) // Default to true
-    };
-    if (path) {
-      if (required) {
-        const isRequired =
-          nextSignatures.includes(requiredRule.from) &&
-          requiredRule.when(bspaoh, bspaoh, userFunctions);
-        if (isRequired) {
-          requiredFields.push(path.join("."));
-        }
-      }
-      if (sealed) {
-        const isSealed =
-          currentSignatures.includes(sealedRule.from) &&
-          sealedRule.when(bspaoh, bspaoh, userFunctions);
-        if (isSealed) {
-          sealedFields.push(path.join("."));
-        }
+    if (path && sealed) {
+      const isSealed =
+        currentSignatures.includes(sealedRule.from) &&
+        sealedRule.when(bspaoh, bspaoh, userFunctions);
+      if (isSealed) {
+        sealedFields.push(path);
       }
     }
   }
   return {
-    requiredForNextSignature: requiredFields,
     sealed: sealedFields
   };
 };

--- a/back/src/bsvhu/__tests__/bsvhuFactories.integration.ts
+++ b/back/src/bsvhu/__tests__/bsvhuFactories.integration.ts
@@ -1,0 +1,25 @@
+import { resetDatabase } from "./../../../integration-tests/helper";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../__tests__/factories";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
+
+describe("Bsvhu factories", () => {
+  afterEach(resetDatabase);
+
+  it("should denormalize intermediaries sirets", async () => {
+    const otherCompany = await companyFactory();
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: otherCompany.siret,
+        intermediaries: {
+          create: [toIntermediaryCompany(company)]
+        }
+      }
+    });
+
+    expect(bsvhu.intermediariesOrgIds).toEqual([company.siret]);
+  });
+});

--- a/back/src/bsvhu/__tests__/elastic.integration.ts
+++ b/back/src/bsvhu/__tests__/elastic.integration.ts
@@ -3,7 +3,7 @@ import { resetDatabase } from "../../../integration-tests/helper";
 import { companyFactory } from "../../__tests__/factories";
 import { BsdElastic } from "../../common/elastic";
 import { getWhere, toBsdElastic } from "../elastic";
-import { bsvhuFactory } from "./factories.vhu";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
 
 describe("getWhere", () => {
   test("if emitter publishes VHU > transporter should see it in 'follow' tab", async () => {
@@ -28,6 +28,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
   let destination: Company;
   let bsvhu: any;
   let elasticBsvhu: BsdElastic;
+  let intermediary1: Company;
+  let intermediary2: Company;
 
   beforeAll(async () => {
     // Given
@@ -39,6 +41,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     destination = await companyFactory({
       name: "Destination"
     });
+    intermediary1 = await companyFactory({ name: "Intermediaire 1" });
+    intermediary2 = await companyFactory({ name: "Intermediaire 2" });
 
     bsvhu = await bsvhuFactory({
       opt: {
@@ -48,7 +52,15 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
         transporterCompanySiret: transporter.siret,
         transporterCompanyVatNumber: transporter.vatNumber,
         destinationCompanyName: destination.name,
-        destinationCompanySiret: destination.siret
+        destinationCompanySiret: destination.siret,
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2)
+            ]
+          }
+        }
       }
     });
 
@@ -61,6 +73,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     expect(elasticBsvhu.companyNames).toContain(emitter.name);
     expect(elasticBsvhu.companyNames).toContain(transporter.name);
     expect(elasticBsvhu.companyNames).toContain(destination.name);
+    expect(elasticBsvhu.companyNames).toContain(intermediary1.name);
+    expect(elasticBsvhu.companyNames).toContain(intermediary2.name);
   });
 
   test("companyOrgIds > should contain the orgIds of ALL BSVHU companies", async () => {
@@ -68,5 +82,7 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     expect(elasticBsvhu.companyOrgIds).toContain(emitter.siret);
     expect(elasticBsvhu.companyOrgIds).toContain(transporter.vatNumber);
     expect(elasticBsvhu.companyOrgIds).toContain(destination.siret);
+    expect(elasticBsvhu.companyOrgIds).toContain(intermediary1.siret);
+    expect(elasticBsvhu.companyOrgIds).toContain(intermediary2.siret);
   });
 });

--- a/back/src/bsvhu/__tests__/factories.vhu.ts
+++ b/back/src/bsvhu/__tests__/factories.vhu.ts
@@ -7,12 +7,13 @@ import {
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { prisma } from "@td/prisma";
 import { companyFactory, siretify } from "../../__tests__/factories";
+import { BsvhuForElastic, BsvhuForElasticInclude } from "../elastic";
 
 export const bsvhuFactory = async ({
   opt = {}
 }: {
   opt?: Partial<Prisma.BsvhuCreateInput>;
-}) => {
+}): Promise<BsvhuForElastic> => {
   const transporterCompany = await companyFactory({
     companyTypes: ["TRANSPORTER"]
   });
@@ -40,9 +41,7 @@ export const bsvhuFactory = async ({
     data: {
       ...(intermediariesOrgIds.length ? { intermediariesOrgIds } : {})
     },
-    include: {
-      intermediaries: true
-    }
+    include: BsvhuForElasticInclude
   });
 };
 

--- a/back/src/bsvhu/__tests__/registry.integration.ts
+++ b/back/src/bsvhu/__tests__/registry.integration.ts
@@ -7,9 +7,10 @@ import {
   toOutgoingWaste,
   toTransportedWaste
 } from "../registry";
-import { bsvhuFactory } from "./factories.vhu";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { companyFactory } from "../../__tests__/factories";
+import { RegistryBsvhuInclude } from "../../registry/elastic";
 
 describe("toGenericWaste", () => {
   afterAll(resetDatabase);
@@ -22,7 +23,8 @@ describe("toGenericWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toGenericWaste(bsvhuForRegistry);
 
@@ -48,7 +50,8 @@ describe("toGenericWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
 
     const waste = toGenericWaste(bsvhuForRegistry);
@@ -76,7 +79,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toIncomingWaste(bsvhuForRegistry);
 
@@ -95,7 +99,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toIncomingWaste(bsvhuForRegistry);
 
@@ -124,7 +129,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toIncomingWaste(bsvhuForRegistry);
 
@@ -153,7 +159,8 @@ describe("toOutgoingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toOutgoingWaste(bsvhuForRegistry);
 
@@ -170,7 +177,8 @@ describe("toOutgoingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toOutgoingWaste(bsvhuForRegistry);
 
@@ -199,7 +207,8 @@ describe("toTransportedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toTransportedWaste(bsvhuForRegistry);
 
@@ -219,7 +228,8 @@ describe("toTransportedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toTransportedWaste(bsvhuForRegistry);
 
@@ -260,7 +270,8 @@ describe("toManagedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toManagedWaste(bsvhuForRegistry);
 
@@ -279,7 +290,8 @@ describe("toManagedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toManagedWaste(bsvhuForRegistry);
 
@@ -312,7 +324,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toAllWaste(bsvhuForRegistry);
 
@@ -337,7 +350,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toAllWaste(bsvhuForRegistry);
 
@@ -359,7 +373,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toAllWaste(bsvhuForRegistry);
 
@@ -400,9 +415,10 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
-    const waste = toGenericWaste(bsvhuForRegistry);
+    const waste = toAllWaste(bsvhuForRegistry);
 
     // Then
     expect(waste.destinationCompanyAddress).toBe("4 Boulevard Pasteur");
@@ -430,9 +446,10 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
-    const waste = toGenericWaste(bsvhuForRegistry);
+    const waste = toAllWaste(bsvhuForRegistry);
 
     // Then
     expect(waste.emitterCompanyName).toBe(emitter.name);
@@ -441,6 +458,106 @@ describe("toAllWaste", () => {
     expect(waste.emitterCompanyPostalCode).toBe("44100");
     expect(waste.emitterCompanyCity).toBe("Nantes");
     expect(waste.emitterCompanyCountry).toBe("FR");
+  });
+  it("should contain all 3 intermediaries", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+    const intermediary2 = await companyFactory({});
+    const intermediary3 = await companyFactory({});
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2),
+              toIntermediaryCompany(intermediary3)
+            ]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(intermediary2.name);
+    expect(waste.intermediary2CompanySiret).toBe(intermediary2.siret);
+    expect(waste.intermediary3CompanyName).toBe(intermediary3.name);
+    expect(waste.intermediary3CompanySiret).toBe(intermediary3.siret);
+  });
+  it("should work with 1 intermediary", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [toIntermediaryCompany(intermediary1)]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(null);
+    expect(waste.intermediary2CompanySiret).toBe(null);
+    expect(waste.intermediary3CompanyName).toBe(null);
+    expect(waste.intermediary3CompanySiret).toBe(null);
+  });
+  it("should work with 2 intermediaries", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+    const intermediary2 = await companyFactory({});
+
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2)
+            ]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(intermediary2.name);
+    expect(waste.intermediary2CompanySiret).toBe(intermediary2.siret);
+    expect(waste.intermediary3CompanyName).toBe(null);
+    expect(waste.intermediary3CompanySiret).toBe(null);
   });
 });
 
@@ -458,7 +575,8 @@ describe("getTransportersData", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toTransportedWaste(bsvhuForRegistry);
 

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -21,9 +21,14 @@ import {
   BsvhuOperation,
   BsvhuNextDestination,
   BsvhuTransport,
-  BsvhuTransportInput
+  BsvhuTransportInput,
+  CompanyInput
 } from "../generated/graphql/types";
-import { Bsvhu as PrismaVhuForm, WasteAcceptationStatus } from "@prisma/client";
+import {
+  Prisma,
+  Bsvhu as PrismaVhuForm,
+  WasteAcceptationStatus
+} from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 
 export const getAddress = ({
@@ -168,7 +173,8 @@ export function flattenVhuInput(formInput: BsvhuInput) {
     wasteCode: chain(formInput, f => f.wasteCode),
     quantity: chain(formInput, f => f.quantity),
     ...flattenVhuIdentificationInput(formInput),
-    ...flattenVhuWeightInput(formInput)
+    ...flattenVhuWeightInput(formInput),
+    intermediaries: formInput.intermediaries
   });
 }
 
@@ -369,4 +375,22 @@ function flattenVhuWeightInput({ weight }: Pick<BsvhuInput, "weight">) {
     weightValue: chain(weight, q => (q.value ? q.value * 1000 : q.value)),
     weightIsEstimate: chain(weight, q => q.isEstimate)
   };
+}
+
+export function companyToIntermediaryInput(
+  companies: CompanyInput[]
+): Prisma.IntermediaryBsvhuAssociationCreateManyBsvhuInput[] {
+  if (!companies) return [];
+
+  return companies.map(company => {
+    return {
+      name: company.name!,
+      siret: company.siret!,
+      vatNumber: company.vatNumber,
+      address: company.address,
+      contact: company.contact!,
+      phone: company.phone,
+      mail: company.mail
+    };
+  });
 }

--- a/back/src/bsvhu/database.ts
+++ b/back/src/bsvhu/database.ts
@@ -1,8 +1,11 @@
+import { Prisma } from "@prisma/client";
 import { FormNotFound } from "../forms/errors";
 import { getReadonlyBsvhuRepository } from "./repository";
 
-export async function getBsvhuOrNotFound(id: string) {
-  const bsvhu = await getReadonlyBsvhuRepository().findUnique({ id });
+export async function getBsvhuOrNotFound<
+  Args extends Omit<Prisma.BsvhuDefaultArgs, "where">
+>(id: string, args?: Args): Promise<Prisma.BsvhuGetPayload<Args>> {
+  const bsvhu = await getReadonlyBsvhuRepository().findUnique({ id }, args);
   if (bsvhu == null || !!bsvhu.isDeleted) {
     throw new FormNotFound(id.toString());
   }

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -10,7 +10,10 @@ export function createBsvhuDataLoaders() {
 
 async function getBsvhus(bsvhuIds: string[]) {
   const bsvhus = await prisma.bsvhu.findMany({
-    where: { id: { in: bsvhuIds } }
+    where: { id: { in: bsvhuIds } },
+    include: {
+      intermediaries: true
+    }
   });
 
   const dict = Object.fromEntries(

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -1,23 +1,28 @@
 import DataLoader from "dataloader";
 import { prisma } from "@td/prisma";
-import { Bsvhu } from "@prisma/client";
+import {
+  BsvhuWithIntermediaries,
+  BsvhuWithIntermediariesInclude
+} from "./types";
 
 export function createBsvhuDataLoaders() {
   return {
-    bsvhus: new DataLoader((bsvhuIds: string[]) => getBsvhus(bsvhuIds))
+    bsvhus: new DataLoader<string, BsvhuWithIntermediaries>(
+      (bsvhuIds: string[]) => getBsvhus(bsvhuIds)
+    )
   };
 }
 
-async function getBsvhus(bsvhuIds: string[]) {
+async function getBsvhus(
+  bsvhuIds: string[]
+): Promise<BsvhuWithIntermediaries[]> {
   const bsvhus = await prisma.bsvhu.findMany({
     where: { id: { in: bsvhuIds } },
-    include: {
-      intermediaries: true
-    }
+    include: BsvhuWithIntermediariesInclude
   });
 
   const dict = Object.fromEntries(
-    bsvhus.map((bsvhu: Bsvhu) => [bsvhu.id, bsvhu])
+    bsvhus.map((bsvhu: BsvhuWithIntermediaries) => [bsvhu.id, bsvhu])
   );
 
   return bsvhuIds.map(bsdaId => dict[bsdaId]);

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -1,0 +1,21 @@
+import DataLoader from "dataloader";
+import { prisma } from "@td/prisma";
+import { Bsvhu } from "@prisma/client";
+
+export function createBsvhuDataLoaders() {
+  return {
+    bsvhus: new DataLoader((bsvhuIds: string[]) => getBsvhus(bsvhuIds))
+  };
+}
+
+async function getBsvhus(bsvhuIds: string[]) {
+  const bsvhus = await prisma.bsvhu.findMany({
+    where: { id: { in: bsvhuIds } }
+  });
+
+  const dict = Object.fromEntries(
+    bsvhus.map((bsvhu: Bsvhu) => [bsvhu.id, bsvhu])
+  );
+
+  return bsvhuIds.map(bsdaId => dict[bsdaId]);
+}

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,9 +1,47 @@
 import { BsvhuStatus, Bsvhu, BsdType } from "@prisma/client";
-import { getTransporterCompanyOrgId } from "@td/constants";
+import {
+  getIntermediaryCompanyOrgId,
+  getTransporterCompanyOrgId
+} from "@td/constants";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 import { getAddress } from "./converter";
+import { BsvhuWithIntermediaries } from "./types";
+
+type ElasticSirets = {
+  emitterCompanySiret: string | null | undefined;
+  destinationCompanySiret: string | null | undefined;
+  transporterCompanySiret: string | null | undefined;
+  intermediarySiret1?: string | null | undefined;
+  intermediarySiret2?: string | null | undefined;
+  intermediarySiret3?: string | null | undefined;
+};
+const getBsvhuSirets = (bsvhu: BsvhuForElastic): ElasticSirets => {
+  const intermediarySirets = bsvhu.intermediaries.reduce(
+    (sirets, intermediary) => {
+      const orgId = getIntermediaryCompanyOrgId(intermediary);
+      if (orgId) {
+        const nbOfKeys = Object.keys(sirets).length;
+        return {
+          ...sirets,
+          [`intermediarySiret${nbOfKeys + 1}`]: orgId
+        };
+      }
+      return sirets;
+    },
+    {}
+  );
+
+  const bsvhuSirets: ElasticSirets = {
+    emitterCompanySiret: bsvhu.emitterCompanySiret,
+    destinationCompanySiret: bsvhu.destinationCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsvhu),
+    ...intermediarySirets
+  };
+
+  return bsvhuSirets;
+};
 
 type WhereKeys =
   | "isDraftFor"
@@ -13,16 +51,16 @@ type WhereKeys =
   | "isToCollectFor"
   | "isCollectedFor";
 
-// | state              | emitter | transporter | destination |
-// |--------------------|---------|-------------|-------------|
-// | initial (draft)    | draft   | draft       | draft       |
-// | initial            | action  | follow      | follow      |
-// | signed_by_producer | follow  | to collect  | follow      |
-// | sent               | follow  | collected   | action      |
-// | processed          | archive | archive     | archive     |
-// | refused            | archive | archive     | archive     |
+// | state              | emitter | transporter | destination | intermediary |
+// |--------------------|---------|-------------|-------------|--------------|
+// | initial (draft)    | draft   | draft       | draft       | follow       |
+// | initial            | action  | follow      | follow      | follow       |
+// | signed_by_producer | follow  | to collect  | follow      | follow       |
+// | sent               | follow  | collected   | action      | follow       |
+// | processed          | archive | archive     | archive     | archive      |
+// | refused            | archive | archive     | archive     | archive      |
 
-export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
+export function getWhere(bsvhu: BsvhuForElastic): Pick<BsdElastic, WhereKeys> {
   const where: Record<WhereKeys, string[]> = {
     isDraftFor: [],
     isForActionFor: [],
@@ -32,11 +70,7 @@ export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
     isCollectedFor: []
   };
 
-  const formSirets: Partial<Record<keyof Bsvhu, string | null | undefined>> = {
-    emitterCompanySiret: bsvhu.emitterCompanySiret,
-    destinationCompanySiret: bsvhu.destinationCompanySiret,
-    transporterCompanySiret: getTransporterCompanyOrgId(bsvhu)
-  };
+  const formSirets = getBsvhuSirets(bsvhu);
 
   const siretsFilters = new Map<string, keyof typeof where>(
     Object.entries(formSirets)
@@ -96,7 +130,7 @@ export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
   return where;
 }
 
-export type BsvhuForElastic = Bsvhu;
+export type BsvhuForElastic = Bsvhu & BsvhuWithIntermediaries;
 
 /**
  * Convert a bsvhu from the bsvhu table to Elastic Search's BSD model.
@@ -187,12 +221,14 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
     ...getRegistryFields(bsvhu),
     rawBsd: bsvhu,
     revisionRequests: [],
+    intermediaries: bsvhu.intermediaries,
 
     // ALL actors from the BSVHU, for quick search
     companyNames: [
       bsvhu.emitterCompanyName,
       bsvhu.transporterCompanyName,
-      bsvhu.destinationCompanyName
+      bsvhu.destinationCompanyName,
+      ...bsvhu.intermediaries.map(intermediary => intermediary.name)
     ]
       .filter(Boolean)
       .join(" "),
@@ -200,11 +236,13 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
       bsvhu.emitterCompanySiret,
       bsvhu.transporterCompanySiret,
       bsvhu.transporterCompanyVatNumber,
-      bsvhu.destinationCompanySiret
+      bsvhu.destinationCompanySiret,
+      ...bsvhu.intermediaries.map(intermediary => intermediary.siret),
+      ...bsvhu.intermediaries.map(intermediary => intermediary.vatNumber)
     ].filter(Boolean)
   };
 }
 
-export function indexBsvhu(bsvhu: Bsvhu, ctx?: GraphQLContext) {
+export function indexBsvhu(bsvhu: BsvhuForElastic, ctx?: GraphQLContext) {
   return indexBsd(toBsdElastic(bsvhu), ctx);
 }

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,4 +1,5 @@
 import { BsvhuStatus, Bsvhu, BsdType } from "@prisma/client";
+import { prisma } from "@td/prisma";
 import {
   getIntermediaryCompanyOrgId,
   getTransporterCompanyOrgId
@@ -7,7 +8,23 @@ import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 import { getAddress } from "./converter";
-import { BsvhuWithIntermediaries } from "./types";
+import {
+  BsvhuWithIntermediaries,
+  BsvhuWithIntermediariesInclude
+} from "./types";
+
+export const BsvhuForElasticInclude = {
+  ...BsvhuWithIntermediariesInclude
+};
+
+export async function getBsvhuForElastic(
+  bsda: Pick<Bsvhu, "id">
+): Promise<BsvhuForElastic> {
+  return prisma.bsvhu.findUniqueOrThrow({
+    where: { id: bsda.id },
+    include: BsvhuForElasticInclude
+  });
+}
 
 type ElasticSirets = {
   emitterCompanySiret: string | null | undefined;

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -84,11 +84,11 @@ const getIntermediariesData = (bsda: RegistryBsvhu) => ({
     : null,
   intermediary2CompanyName: bsda.intermediaries?.[1]?.name ?? null,
   intermediary2CompanySiret: bsda.intermediaries?.[1]
-    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[1])
     : null,
   intermediary3CompanyName: bsda.intermediaries?.[2]?.name ?? null,
   intermediary3CompanySiret: bsda.intermediaries?.[2]
-    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[2])
     : null
 });
 

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -19,6 +19,9 @@ import {
 import { getWasteDescription } from "./utils";
 import { splitAddress } from "../common/addresses";
 import Decimal from "decimal.js";
+import { RegistryBsvhu } from "../registry/elastic";
+import { getIntermediaryCompanyOrgId } from "@td/constants";
+import { BsvhuForElastic } from "./elastic";
 
 const getOperationData = (bsvhu: Bsvhu) => ({
   destinationPlannedOperationCode: bsvhu.destinationPlannedOperationCode,
@@ -74,8 +77,23 @@ export const getTransporterData = (bsvhu: Bsvhu, includePlates = false) => {
   return data;
 };
 
+const getIntermediariesData = (bsda: RegistryBsvhu) => ({
+  intermediary1CompanyName: bsda.intermediaries?.[0]?.name ?? null,
+  intermediary1CompanySiret: bsda.intermediaries?.[0]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    : null,
+  intermediary2CompanyName: bsda.intermediaries?.[1]?.name ?? null,
+  intermediary2CompanySiret: bsda.intermediaries?.[1]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    : null,
+  intermediary3CompanyName: bsda.intermediaries?.[2]?.name ?? null,
+  intermediary3CompanySiret: bsda.intermediaries?.[2]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    : null
+});
+
 export function getRegistryFields(
-  bsvhu: Bsvhu
+  bsvhu: BsvhuForElastic
 ): Pick<BsdElastic, RegistryFields> {
   const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
@@ -100,6 +118,15 @@ export function getRegistryFields(
       registryFields.isTransportedWasteFor.push(bsvhu.transporterCompanySiret);
       registryFields.isAllWasteFor.push(bsvhu.transporterCompanySiret);
     }
+    if (bsvhu.intermediaries?.length) {
+      for (const intermediary of bsvhu.intermediaries) {
+        const intermediaryOrgId = getIntermediaryCompanyOrgId(intermediary);
+        if (intermediaryOrgId) {
+          registryFields.isManagedWasteFor.push(intermediaryOrgId);
+          registryFields.isAllWasteFor.push(intermediaryOrgId);
+        }
+      }
+    }
   }
 
   if (
@@ -112,7 +139,7 @@ export function getRegistryFields(
   return registryFields;
 }
 
-export function toGenericWaste(bsvhu: Bsvhu): GenericWaste {
+export function toGenericWaste(bsvhu: RegistryBsvhu): GenericWaste {
   const {
     street: destinationCompanyAddress,
     postalCode: destinationCompanyPostalCode,
@@ -197,7 +224,7 @@ export function toGenericWaste(bsvhu: Bsvhu): GenericWaste {
   };
 }
 
-export function toIncomingWaste(bsvhu: Bsvhu): Required<IncomingWaste> {
+export function toIncomingWaste(bsvhu: RegistryBsvhu): Required<IncomingWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -218,7 +245,7 @@ export function toIncomingWaste(bsvhu: Bsvhu): Required<IncomingWaste> {
   };
 }
 
-export function toOutgoingWaste(bsvhu: Bsvhu): Required<OutgoingWaste> {
+export function toOutgoingWaste(bsvhu: RegistryBsvhu): Required<OutgoingWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -240,7 +267,9 @@ export function toOutgoingWaste(bsvhu: Bsvhu): Required<OutgoingWaste> {
   };
 }
 
-export function toTransportedWaste(bsvhu: Bsvhu): Required<TransportedWaste> {
+export function toTransportedWaste(
+  bsvhu: RegistryBsvhu
+): Required<TransportedWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -264,7 +293,7 @@ export function toTransportedWaste(bsvhu: Bsvhu): Required<TransportedWaste> {
  * BSVHU has no trader or broker so this function should not
  * be called. We implement it anyway in case it is added later on
  */
-export function toManagedWaste(bsvhu: Bsvhu): Required<ManagedWaste> {
+export function toManagedWaste(bsvhu: RegistryBsvhu): Required<ManagedWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -281,7 +310,7 @@ export function toManagedWaste(bsvhu: Bsvhu): Required<ManagedWaste> {
   };
 }
 
-export function toAllWaste(bsvhu: Bsvhu): Required<AllWaste> {
+export function toAllWaste(bsvhu: RegistryBsvhu): Required<AllWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -301,6 +330,7 @@ export function toAllWaste(bsvhu: Bsvhu): Required<AllWaste> {
     emitterCompanyMail: bsvhu.emitterCompanyMail,
     ...getOperationData(bsvhu),
     ...getTransporterData(bsvhu, true),
-    ...getInitialEmitterData()
+    ...getInitialEmitterData(),
+    ...getIntermediariesData(bsvhu)
   };
 }

--- a/back/src/bsvhu/repository/bsvhu/findRelatedEntity.ts
+++ b/back/src/bsvhu/repository/bsvhu/findRelatedEntity.ts
@@ -1,0 +1,19 @@
+import { Bsvhu, Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+type ChainableBsvhu = Pick<
+  Prisma.Prisma__BsvhuClient<Bsvhu | null, null>,
+  "intermediaries"
+>;
+
+export type FindRelatedEntityFn = (
+  where: Prisma.BsvhuWhereUniqueInput
+) => ChainableBsvhu;
+
+export function buildFindRelatedBsvhuEntity({
+  prisma
+}: ReadRepositoryFnDeps): FindRelatedEntityFn {
+  return where => {
+    return prisma.bsvhu.findUnique({ where });
+  };
+}

--- a/back/src/bsvhu/repository/index.ts
+++ b/back/src/bsvhu/repository/index.ts
@@ -3,6 +3,7 @@ import { transactionWrapper } from "../../common/repository/helper";
 import { BsvhuActions } from "./types";
 import { buildFindUniqueBsvhu } from "./bsvhu/findUnique";
 import { buildFindManyBsvhu } from "./bsvhu/findMany";
+import { buildFindRelatedBsvhuEntity } from "./bsvhu/findRelatedEntity";
 import { buildCountBsvhus } from "./bsvhu/count";
 
 import { buildCreateBsvhu } from "./bsvhu/create";
@@ -19,7 +20,8 @@ export function getReadonlyBsvhuRepository() {
   return {
     count: buildCountBsvhus({ prisma }),
     findUnique: buildFindUniqueBsvhu({ prisma }),
-    findMany: buildFindManyBsvhu({ prisma })
+    findMany: buildFindManyBsvhu({ prisma }),
+    findRelatedEntity: buildFindRelatedBsvhuEntity({ prisma })
   };
 }
 

--- a/back/src/bsvhu/repository/types.ts
+++ b/back/src/bsvhu/repository/types.ts
@@ -2,6 +2,7 @@ import { CountBsvhusFn } from "./bsvhu/count";
 import { CreateBsvhuFn } from "./bsvhu/create";
 import { DeleteBsvhuFn } from "./bsvhu/delete";
 import { FindManyBsvhuFn } from "./bsvhu/findMany";
+import { FindRelatedEntityFn } from "./bsvhu/findRelatedEntity";
 
 import { FindUniqueBsvhuFn } from "./bsvhu/findUnique";
 import { UpdateBsvhuFn } from "./bsvhu/update";
@@ -10,6 +11,7 @@ import { UpdateManyBsvhuFn } from "./bsvhu/updateMany";
 export type BsvhuActions = {
   findUnique: FindUniqueBsvhuFn;
   findMany: FindManyBsvhuFn;
+  findRelatedEntity: FindRelatedEntityFn;
   create: CreateBsvhuFn;
   update: UpdateBsvhuFn;
   updateMany: UpdateManyBsvhuFn;

--- a/back/src/bsvhu/resolvers/Bsvhu.ts
+++ b/back/src/bsvhu/resolvers/Bsvhu.ts
@@ -3,8 +3,7 @@ import { BsvhuResolvers } from "../../generated/graphql/types";
 const bsvhuResolvers: BsvhuResolvers = {
   metadata: bsvhu => {
     return {
-      id: bsvhu.id,
-      status: bsvhu.status
+      id: bsvhu.id
     } as any;
   }
 };

--- a/back/src/bsvhu/resolvers/Bsvhu.ts
+++ b/back/src/bsvhu/resolvers/Bsvhu.ts
@@ -1,6 +1,14 @@
 import { BsvhuResolvers } from "../../generated/graphql/types";
+import { getReadonlyBsvhuRepository } from "../repository";
 
 const bsvhuResolvers: BsvhuResolvers = {
+  intermediaries: async bsvhu => {
+    const intermediaries = await getReadonlyBsvhuRepository()
+      .findRelatedEntity({ id: bsvhu.id })
+      .intermediaries();
+
+    return intermediaries ?? null;
+  },
   metadata: bsvhu => {
     return {
       id: bsvhu.id

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -53,7 +53,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
           errors.issues?.map((e: ZodIssue) => {
             return {
               message: e.message,
-              path: `${e.path[0]}`, // e.path is an array, first element should be the path name
+              path: `${e.path.join(".")}`, // e.path is an array, first element should be the path name
               requiredFor
             };
           }) ?? []

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -41,7 +41,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
         errors.issues?.map((e: ZodIssue) => {
           return {
             message: e.message,
-            path: `${e.path.join(".")}`, // e.path is an array, first element should be the path name
+            path: e.path,
             requiredFor: nextSignature
           };
         }) ?? []
@@ -62,12 +62,10 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
       ...transporterReceipt
     });
     const currentSignature = getCurrentSignatureType(zodBsvhu);
-    const nextSignature = getNextSignatureType(currentSignature);
     const currentSignatureAncestors = getSignatureAncestors(currentSignature);
     return getRequiredAndSealedFieldPaths(
       zodBsvhu,
       currentSignatureAncestors,
-      nextSignature,
       context.user ?? undefined
     );
   }

--- a/back/src/bsvhu/resolvers/BsvhuMetadata.ts
+++ b/back/src/bsvhu/resolvers/BsvhuMetadata.ts
@@ -1,7 +1,7 @@
 import { getTransporterReceipt } from "../../companies/recipify";
 import {
   BsvhuError,
-  BsvhuFieldsMetadata,
+  BsvhuMetadataFields,
   BsvhuMetadata,
   BsvhuMetadataResolvers
 } from "../../generated/graphql/types";
@@ -32,10 +32,6 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
     const nextSignature = getNextSignatureType(currentSignature);
 
     try {
-      console.log(currentSignature);
-
-      console.log(nextSignature);
-
       parseBsvhu(zodBsvhu, {
         currentSignatureType: nextSignature
       });
@@ -56,7 +52,7 @@ const bsvhuMetadataResolvers: BsvhuMetadataResolvers = {
     metadata: BsvhuMetadata & { id: string },
     _,
     context
-  ): Promise<BsvhuFieldsMetadata> => {
+  ): Promise<BsvhuMetadataFields> => {
     const bsvhu = await context.dataloaders.bsvhus.load(metadata.id);
 
     // import transporterReceipt that will be completed after transporter signature

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
@@ -362,6 +362,10 @@ describe("Mutation.Vhu.create", () => {
     expect(errors[0].message).toBe(
       "Le N° d'agrément du destinataire est un champ requis."
     );
+    expect(errors[0].extensions!.issues![0].path).toStrictEqual([
+      "destination",
+      "agrementNumber"
+    ]);
   });
 
   it("should create a bsvhu with split address input and get a composite address output", async () => {

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -48,9 +48,7 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
   const intermediaries =
     parsedZodBsvhu.intermediaries && parsedZodBsvhu.intermediaries.length > 0
       ? {
-          createMany: {
-            data: companyToIntermediaryInput(parsedZodBsvhu.intermediaries)
-          }
+          create: companyToIntermediaryInput(parsedZodBsvhu.intermediaries)
         }
       : undefined;
 

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -6,7 +6,10 @@ import {
 } from "../../../generated/graphql/types";
 
 import { GraphQLContext } from "../../../types";
-import { expandVhuFormFromDb } from "../../converter";
+import {
+  companyToIntermediaryInput,
+  expandVhuFormFromDb
+} from "../../converter";
 import { parseBsvhuAsync } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
 
@@ -42,12 +45,22 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
     }
   );
 
+  const intermediaries =
+    parsedZodBsvhu.intermediaries && parsedZodBsvhu.intermediaries.length > 0
+      ? {
+          createMany: {
+            data: companyToIntermediaryInput(parsedZodBsvhu.intermediaries)
+          }
+        }
+      : undefined;
+
   const bsvhuRepository = getBsvhuRepository(user);
 
   const newForm = await bsvhuRepository.create({
     ...parsedZodBsvhu,
     id: getReadableId(ReadableIdPrefix.VHU),
-    isDraft
+    isDraft,
+    intermediaries
   });
 
   return expandVhuFormFromDb(newForm);

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -67,7 +67,7 @@ async function getDuplicateData(
 
   const { emitter, transporter, destination } = await getBsvhuCompanies(bsvhu);
 
-  return {
+  let data: Prisma.BsvhuCreateInput = {
     ...parsedBsvhu,
     id: getReadableId(ReadableIdPrefix.VHU),
     status: BsvhuStatus.INITIAL,
@@ -92,6 +92,26 @@ async function getDuplicateData(
       transporter?.contactEmail ?? parsedBsvhu.transporterCompanyMail,
     transporterCompanyVatNumber: parsedBsvhu.transporterCompanyVatNumber
   };
+  if (intermediaries) {
+    data = {
+      ...data,
+      intermediaries: {
+        createMany: {
+          data: intermediaries.map(intermediary => ({
+            siret: intermediary.siret!,
+            address: intermediary.address,
+            vatNumber: intermediary.vatNumber,
+            name: intermediary.name!,
+            contact: intermediary.contact!,
+            phone: intermediary.phone,
+            mail: intermediary.mail
+          }))
+        }
+      },
+      intermediariesOrgIds
+    };
+  }
+  return data;
 }
 
 async function getBsvhuCompanies(bsvhu: PrismaBsvhuForParsing) {

--- a/back/src/bsvhu/resolvers/mutations/publish.ts
+++ b/back/src/bsvhu/resolvers/mutations/publish.ts
@@ -8,6 +8,7 @@ import { getBsvhuRepository } from "../../repository";
 import { checkCanUpdate } from "../../permissions";
 import { ForbiddenError } from "../../../common/errors";
 import { prismaToZodBsvhu } from "../../validation/helpers";
+import { BsvhuForParsingInclude } from "../../validation/types";
 
 export default async function publish(
   _,
@@ -16,7 +17,9 @@ export default async function publish(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const existingBsvhu = await getBsvhuOrNotFound(id);
+  const existingBsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
 
   await checkCanUpdate(user, existingBsvhu);
 

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../companies/recipify";
 import { prismaToZodBsvhu } from "../../validation/helpers";
 import { prisma } from "@td/prisma";
+import { BsvhuForParsingInclude } from "../../validation/types";
 
 export default async function sign(
   _,
@@ -29,7 +30,9 @@ export default async function sign(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const bsvhu = await getBsvhuOrNotFound(id);
+  const bsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
   const authorizedOrgIds = getAuthorizedOrgIds(bsvhu, input.type);
 
   // To sign a form for a company, you must either:

--- a/back/src/bsvhu/resolvers/mutations/update.ts
+++ b/back/src/bsvhu/resolvers/mutations/update.ts
@@ -40,9 +40,7 @@ export default async function edit(
     ? {
         deleteMany: {},
         ...(parsedBsvhu.intermediaries.length > 0 && {
-          createMany: {
-            data: companyToIntermediaryInput(parsedBsvhu.intermediaries)
-          }
+          create: companyToIntermediaryInput(parsedBsvhu.intermediaries)
         })
       }
     : undefined;

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -139,7 +139,7 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(33);
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(34);
   });
 
   it("should return OPERATION signed bsvhu sealed fields", async () => {
@@ -161,6 +161,6 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(57);
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(58);
   });
 });

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -1,0 +1,155 @@
+import { UserRole, BsvhuStatus } from "@prisma/client";
+import { gql } from "graphql-tag";
+import { resetDatabase } from "../../../../../integration-tests/helper";
+import { Query } from "../../../../generated/graphql/types";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../../../__tests__/factories";
+import makeClient from "../../../../__tests__/testClient";
+
+import { bsvhuFactory } from "../../../__tests__/factories.vhu";
+
+const GET_BSVHU = gql`
+  query GetBsvhu($id: ID!) {
+    bsvhu(id: $id) {
+      id
+      status
+      metadata {
+        fields {
+          sealed
+          requiredForNextSignature
+        }
+      }
+    }
+  }
+`;
+
+describe("Query.Bsvhu", () => {
+  afterEach(resetDatabase);
+
+  it("should return INITIAL bsvhu sealed fields", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.INITIAL,
+        emitterCompanySiret: emitterCompany.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(0);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      20
+    );
+  });
+
+  it("should return EMISSION signed bsvhu sealed fields", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SIGNED_BY_PRODUCER,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(0);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      29
+    );
+  });
+
+  it("should return EMISSION signed bsvhu sealed fields with emitter fields sealed", async () => {
+    const emitterCompany = await companyFactory();
+    const { user, company: transporterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SIGNED_BY_PRODUCER,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date(),
+        transporterCompanySiret: transporterCompany.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(21);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      29
+    );
+  });
+
+  it("should return TRANSPORTER signed bsvhu sealed fields", async () => {
+    const { user, company: transporterCompany } = await userWithCompanyFactory(
+      UserRole.ADMIN
+    );
+    const emitterCompany = await companyFactory();
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.SENT,
+        emitterCompanySiret: emitterCompany.siret,
+        emitterEmissionSignatureDate: new Date(),
+        transporterCompanySiret: transporterCompany.siret,
+        transporterTransportSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(33);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      33
+    );
+  });
+
+  it("should return OPERATION signed bsvhu sealed fields", async () => {
+    const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsd = await bsvhuFactory({
+      opt: {
+        status: BsvhuStatus.PROCESSED,
+        emitterCompanySiret: company.siret,
+        emitterEmissionSignatureDate: new Date(),
+        destinationOperationSignatureDate: new Date(),
+        transporterTransportSignatureDate: new Date()
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhu">>(GET_BSVHU, {
+      variables: { id: bsd.id }
+    });
+
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(57);
+    expect(data.bsvhu.metadata?.fields?.requiredForNextSignature?.length).toBe(
+      33
+    );
+  });
+});

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhupdf.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhupdf.integration.ts
@@ -1,11 +1,15 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import {
   userWithCompanyFactory,
-  userWithAccessTokenFactory
+  userWithAccessTokenFactory,
+  companyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { bsvhuFactory } from "../../../__tests__/factories.vhu";
+import {
+  bsvhuFactory,
+  toIntermediaryCompany
+} from "../../../__tests__/factories.vhu";
 
 import { Query } from "../../../../generated/graphql/types";
 import { GovernmentPermission } from "@prisma/client";
@@ -69,6 +73,27 @@ describe("Query.BsvhuPdf", () => {
     const bsvhu = await bsvhuFactory({
       opt: {
         emitterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhuPdf">>(BSVHU_PDF, {
+      variables: { id: bsvhu.id }
+    });
+
+    expect(data.bsvhuPdf.token).toBeTruthy();
+  });
+
+  it("should return a token for requested id if current user is an intermediary", async () => {
+    const otherCompany = await companyFactory();
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: otherCompany.siret,
+        intermediaries: {
+          create: [toIntermediaryCompany(company)]
+        }
       }
     });
 

--- a/back/src/bsvhu/resolvers/queries/bsvhus.ts
+++ b/back/src/bsvhu/resolvers/queries/bsvhus.ts
@@ -26,7 +26,8 @@ export default async function bsvhus(
       { emitterCompanySiret: { in: orgIdsWithListPermission } },
       { transporterCompanySiret: { in: orgIdsWithListPermission } },
       { transporterCompanyVatNumber: { in: orgIdsWithListPermission } },
-      { destinationCompanySiret: { in: orgIdsWithListPermission } }
+      { destinationCompanySiret: { in: orgIdsWithListPermission } },
+      { intermediariesOrgIds: { hasSome: orgIdsWithListPermission } }
     ]
   };
 

--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -89,6 +89,13 @@ input BsvhuInput {
   destination: BsvhuDestinationInput
   "Détails sur le transporteur"
   transporter: BsvhuTransporterInput
+  """
+  Liste d'entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,
+  mais pas à la responsabilité de la traçabilité. Il pourra lire ce bordereau, sans étape de signature.
+
+  Le nombre maximal d'intermédiaires sur un bordereau est de 3.
+  """
+  intermediaries: [CompanyInput!]
 }
 
 input BsvhuEmitterInput {

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -10,10 +10,8 @@ type BsvhuEdge {
 }
 
 type BsvhuMetadataFields {
-  "liste des champs qui seront requis pour la prochaine signature"
-  requiredForNextSignature: [String!]!
   "Liste des champs scellés"
-  sealed: [String!]!
+  sealed: [[String!]!]!
 }
 
 type BsvhuMetadata {
@@ -24,7 +22,7 @@ type BsvhuMetadata {
 
 type BsvhuError {
   message: String!
-  path: String!
+  path: [String!]!
   requiredFor: SignatureTypeInput!
 }
 

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -56,6 +56,11 @@ type Bsvhu {
   destination: BsvhuDestination
   "Transporteur"
   transporter: BsvhuTransporter
+  """
+  Liste d'entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,
+  mais pas à la responsabilité de la traçabilité. Il pourra lire ce bordereau, sans étape de signature.
+  """
+  intermediaries: [FormCompany!]
 
   metadata: BsvhuMetadata!
 }

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -9,8 +9,14 @@ type BsvhuEdge {
   node: Bsvhu!
 }
 
+type BsvhuFieldsMetadata {
+  requiredForNextSignature: [String!]!
+  sealed: [String!]!
+}
+
 type BsvhuMetadata {
-  errors: [BsvhuError!]
+  errors: [BsvhuError!]!
+  fields: BsvhuFieldsMetadata!
 }
 
 type BsvhuError {

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -9,14 +9,17 @@ type BsvhuEdge {
   node: Bsvhu!
 }
 
-type BsvhuFieldsMetadata {
+type BsvhuMetadataFields {
+  "liste des champs qui seront requis pour la prochaine signature"
   requiredForNextSignature: [String!]!
+  "Liste des champs scellés"
   sealed: [String!]!
 }
 
 type BsvhuMetadata {
   errors: [BsvhuError!]!
-  fields: BsvhuFieldsMetadata!
+  "Informations sur les champs"
+  fields: BsvhuMetadataFields!
 }
 
 type BsvhuError {

--- a/back/src/bsvhu/types.ts
+++ b/back/src/bsvhu/types.ts
@@ -1,0 +1,10 @@
+import { Prisma } from "@prisma/client";
+
+export const BsvhuWithIntermediariesInclude =
+  Prisma.validator<Prisma.BsvhuInclude>()({
+    intermediaries: true
+  });
+
+export type BsvhuWithIntermediaries = Prisma.BsvhuGetPayload<{
+  include: typeof BsvhuWithIntermediariesInclude;
+}>;

--- a/back/src/bsvhu/validation/helpers.ts
+++ b/back/src/bsvhu/validation/helpers.ts
@@ -1,8 +1,8 @@
-import { Bsvhu, User } from "@prisma/client";
+import { User } from "@prisma/client";
 import { BsvhuInput, SignatureTypeInput } from "../../generated/graphql/types";
 import { BSVHU_SIGNATURES_HIERARCHY } from "./constants";
 import { ZodBsvhu, ZodOperationEnum, ZodWasteCodeEnum } from "./schema";
-import { BsvhuUserFunctions } from "./types";
+import { BsvhuUserFunctions, PrismaBsvhuForParsing } from "./types";
 import { getUserCompanies } from "../../users/database";
 import { flattenVhuInput } from "../converter";
 import { safeInput } from "../../common/converter";
@@ -21,6 +21,7 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
     wasteCode,
     destinationPlannedOperationCode,
     destinationOperationCode,
+    intermediaries,
     ...flatBsvhuInput
   } = flattenVhuInput(bsvhuInput);
 
@@ -29,7 +30,24 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
     destinationPlannedOperationCode:
       destinationPlannedOperationCode as ZodOperationEnum,
     destinationOperationCode: destinationOperationCode as ZodOperationEnum,
-    wasteCode: wasteCode as ZodWasteCodeEnum
+    wasteCode: wasteCode as ZodWasteCodeEnum,
+    intermediaries: intermediaries?.map(i =>
+      safeInput({
+        // FIXME : Les règles d'édition (fichier rules.ts) ne permettent
+        // pas à ce jour de définir les règles de champ requis pour les intermédiaire.
+        // Le schéma zod des intermédiaires enforce donc des champs requis dès le début
+        // (contrairement aux autres champs du BSVHU), ce qui est incohérent avec le typage
+        // côté input GraphQL. On force donc le typage ici, quitte à lever des erreurs
+        // de validation Zod dans le process de parsing.
+        siret: i.siret!,
+        vatNumber: i.vatNumber,
+        address: i.address!,
+        name: i.name!,
+        contact: i.contact!,
+        phone: i.phone,
+        mail: i.mail
+      })
+    )
   });
 }
 
@@ -39,11 +57,12 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
  * typés en string côté Prisma mais en enum côté Zod ce qui nous oblige
  * à faire un casting de type.
  */
-export function prismaToZodBsvhu(bsvhu: Bsvhu): ZodBsvhu {
+export function prismaToZodBsvhu(bsvhu: PrismaBsvhuForParsing): ZodBsvhu {
   const {
     wasteCode,
     destinationPlannedOperationCode,
     destinationOperationCode,
+    intermediaries,
     ...data
   } = bsvhu;
 
@@ -52,7 +71,11 @@ export function prismaToZodBsvhu(bsvhu: Bsvhu): ZodBsvhu {
     wasteCode: wasteCode as ZodWasteCodeEnum,
     destinationPlannedOperationCode:
       destinationPlannedOperationCode as ZodOperationEnum,
-    destinationOperationCode: destinationOperationCode as ZodOperationEnum
+    destinationOperationCode: destinationOperationCode as ZodOperationEnum,
+    intermediaries: intermediaries.map(i => {
+      const { bsvhuId, id, createdAt, ...intermediaryData } = i;
+      return { ...intermediaryData, address: intermediaryData.address! };
+    })
   };
 }
 

--- a/back/src/bsvhu/validation/helpers.ts
+++ b/back/src/bsvhu/validation/helpers.ts
@@ -73,24 +73,6 @@ export function getUpdatedFields<T extends ZodBsvhu>(
   return Object.keys(diff);
 }
 
-/**
- * Gets all the signatures prior to the target signature in the signature hierarchy.
- */
-export function getSignatureAncestors(
-  targetSignature: SignatureTypeInput | undefined | null
-): SignatureTypeInput[] {
-  if (!targetSignature) return [];
-
-  const parent = Object.entries(BSVHU_SIGNATURES_HIERARCHY).find(
-    ([_, details]) => details.next === targetSignature
-  )?.[0];
-
-  return [
-    targetSignature,
-    ...getSignatureAncestors(parent as SignatureTypeInput)
-  ];
-}
-
 export async function getBsvhuUserFunctions(
   user: User | undefined,
   bsvhu: ZodBsvhu
@@ -110,6 +92,37 @@ export async function getBsvhuUserFunctions(
       (bsvhu.transporterCompanyVatNumber != null &&
         orgIds.includes(bsvhu.transporterCompanyVatNumber))
   };
+}
+
+/**
+ * Gets all the signatures prior to the target signature in the signature hierarchy.
+ */
+export function getSignatureAncestors(
+  targetSignature: SignatureTypeInput | undefined | null
+): SignatureTypeInput[] {
+  if (!targetSignature) return [];
+
+  const parent = Object.entries(BSVHU_SIGNATURES_HIERARCHY).find(
+    ([_, details]) => details.next === targetSignature
+  )?.[0];
+
+  return [
+    targetSignature,
+    ...getSignatureAncestors(parent as SignatureTypeInput)
+  ];
+}
+
+export function getNextSignatureType(
+  currentSignature: SignatureTypeInput | undefined | null
+): SignatureTypeInput | undefined {
+  if (!currentSignature) {
+    return "EMISSION";
+  }
+  const signature = BSVHU_SIGNATURES_HIERARCHY[currentSignature];
+  if (signature.next) {
+    return signature.next;
+  }
+  return undefined;
 }
 
 /**

--- a/back/src/bsvhu/validation/index.ts
+++ b/back/src/bsvhu/validation/index.ts
@@ -1,4 +1,3 @@
-import { Bsvhu } from "@prisma/client";
 import { BsvhuInput } from "../../generated/graphql/types";
 import {
   getCurrentSignatureType,
@@ -7,11 +6,12 @@ import {
 } from "./helpers";
 import { checkBsvhuSealedFields } from "./rules";
 import {
+  ParsedZodBsvhu,
   ZodBsvhu,
   contextualBsvhuSchema,
   contextualBsvhuSchemaAsync
 } from "./schema";
-import { BsvhuValidationContext } from "./types";
+import { BsvhuValidationContext, PrismaBsvhuForParsing } from "./types";
 
 /**
  * Wrapper autour de `parseBsvhuAsync` qui peut être appelé
@@ -22,7 +22,7 @@ import { BsvhuValidationContext } from "./types";
  */
 export async function mergeInputAndParseBsvhuAsync(
   // BSFF déjà stockée en base de données.
-  persisted: Bsvhu,
+  persisted: PrismaBsvhuForParsing,
   // Données entrantes provenant de la couche GraphQL.
   input: BsvhuInput,
   context: BsvhuValidationContext
@@ -66,7 +66,7 @@ export async function mergeInputAndParseBsvhuAsync(
 export async function parseBsvhuAsync(
   bsvhu: ZodBsvhu,
   context: BsvhuValidationContext = {}
-) {
+): Promise<ParsedZodBsvhu> {
   const schema = contextualBsvhuSchemaAsync(context);
   return schema.parseAsync(bsvhu);
 }
@@ -78,7 +78,7 @@ export async function parseBsvhuAsync(
 export function parseBsvhu(
   bsvhu: ZodBsvhu,
   context: BsvhuValidationContext = {}
-) {
+): ParsedZodBsvhu {
   const schema = contextualBsvhuSchema(context);
   return schema.parse(bsvhu);
 }

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -4,7 +4,8 @@ import { ParsedZodBsvhu, ZodBsvhu } from "./schema";
 import {
   bsvhuEditionRules,
   BsvhuEditableFields,
-  isBsvhuFieldRequired
+  isBsvhuFieldRequired,
+  EditionRulePath
 } from "./rules";
 import { getSignatureAncestors } from "./helpers";
 import { isArray } from "../../common/dataTypes";
@@ -133,6 +134,7 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
   field: string;
   rule: EditionRule<T>;
   readableFieldName?: string;
+  path?: EditionRulePath;
   ctx: RefinementCtx;
   errorMsg?: (fieldDescription: string) => string;
 };
@@ -140,7 +142,8 @@ type CheckFieldIsDefinedArgs<T extends ZodBsvhu> = {
 function checkFieldIsDefined<T extends ZodBsvhu>(
   args: CheckFieldIsDefinedArgs<T>
 ) {
-  const { resource, field, rule, ctx, readableFieldName, errorMsg } = args;
+  const { resource, field, rule, ctx, readableFieldName, path, errorMsg } =
+    args;
   const value = resource[field];
   if (value == null || (isArray(value) && (value as any[]).length === 0)) {
     const fieldDescription = readableFieldName
@@ -149,7 +152,7 @@ function checkFieldIsDefined<T extends ZodBsvhu>(
 
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      path: [field],
+      path: path ?? [field],
       message: [
         errorMsg
           ? errorMsg(fieldDescription)
@@ -172,7 +175,7 @@ export const checkRequiredFields: (
 
   return (bsvhu, zodContext) => {
     for (const bsvhuField of Object.keys(bsvhuEditionRules)) {
-      const { required, readableFieldName } =
+      const { required, readableFieldName, path } =
         bsvhuEditionRules[bsvhuField as keyof BsvhuEditableFields];
 
       if (required) {
@@ -186,6 +189,7 @@ export const checkRequiredFields: (
             resource: bsvhu,
             field: bsvhuField,
             rule: required,
+            path,
             readableFieldName,
             ctx: zodContext
           });

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -1,6 +1,6 @@
 import { ZodBsvhu } from "./schema";
 import { BsvhuUserFunctions, BsvhuValidationContext } from "./types";
-import { SignatureTypeInput } from "../../generated/graphql/types";
+import { BsvhuInput, SignatureTypeInput } from "../../generated/graphql/types";
 import { WasteAcceptationStatus } from "@prisma/client";
 import { isForeignVat } from "@td/constants";
 import {
@@ -11,6 +11,7 @@ import {
 } from "./helpers";
 import { capitalize } from "../../common/strings";
 import { SealedFieldError } from "../../common/errors";
+import { Leaves } from "../../types";
 
 // Liste des champs éditables sur l'objet Bsvhu
 export type BsvhuEditableFields = Required<
@@ -47,6 +48,8 @@ type GetBsvhuSignatureTypeFn<T extends ZodBsvhu> = (
   ruleContext?: RuleContext<T>
 ) => SignatureTypeInput | undefined;
 
+export type EditionRulePath = Leaves<BsvhuInput, 5>;
+
 // Règle d'édition qui permet de définir à partir de quelle signature
 // un champ est verrouillé / requis avec une config contenant un paramètre
 // optionnel `when`
@@ -66,6 +69,7 @@ export type EditionRules<T extends ZodBsvhu, E extends BsvhuEditableFields> = {
     // At what signature the field is required, and under which circumstances. If absent, field is never required
     required?: EditionRule<T>;
     readableFieldName?: string; // A custom field name for errors
+    path?: EditionRulePath;
   };
 };
 
@@ -91,25 +95,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
   },
   emitterAgrementNumber: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le N° d'agrément de l'émetteur"
+    readableFieldName: "Le N° d'agrément de l'émetteur",
+    path: ["emitter", "agrementNumber"]
   },
   emitterIrregularSituation: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La situation (irrégulière ou non) de l'émetteur"
+    readableFieldName: "La situation (irrégulière ou non) de l'émetteur",
+    path: ["emitter", "irregularSituation"]
   },
   emitterNoSiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur"
+    readableFieldName: "La présence ou absence de N° SIRET de l'émetteur",
+    path: ["emitter", "noSiret"]
   },
   emitterCompanyName: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale de l'émetteur"
+    readableFieldName: "La raison sociale de l'émetteur",
+    path: ["emitter", "company", "name"]
   },
   emitterCompanySiret: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterNoSiret },
-    readableFieldName: "Le N° SIRET de l'émetteur"
+    readableFieldName: "Le N° SIRET de l'émetteur",
+    path: ["emitter", "company", "siret"]
   },
   emitterCompanyAddress: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -120,22 +129,26 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
         !bsvhu.emitterCompanyCity ||
         !bsvhu.emitterCompanyPostalCode
     },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "address"]
   },
   emitterCompanyStreet: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "street"]
   },
   emitterCompanyCity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "city"]
   },
   emitterCompanyPostalCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION", when: bsvhu => !bsvhu.emitterCompanyAddress },
-    readableFieldName: "L'adresse de l'émetteur"
+    readableFieldName: "L'adresse de l'émetteur",
+    path: ["emitter", "company", "postalCode"]
   },
   emitterCompanyContact: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -143,7 +156,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterNoSiret
     },
-    readableFieldName: "La personne à contacter chez l'émetteur"
+    readableFieldName: "La personne à contacter chez l'émetteur",
+    path: ["emitter", "company", "contact"]
   },
   emitterCompanyPhone: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -151,7 +165,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "Le N° de téléphone de l'émetteur"
+    readableFieldName: "Le N° de téléphone de l'émetteur",
+    path: ["emitter", "company", "phone"]
   },
   emitterCompanyMail: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
@@ -159,72 +174,86 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "EMISSION",
       when: bsvhu => !bsvhu.emitterIrregularSituation
     },
-    readableFieldName: "L'adresse e-mail de l'émetteur"
+    readableFieldName: "L'adresse e-mail de l'émetteur",
+    path: ["emitter", "company", "mail"]
   },
   destinationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de destination"
+    readableFieldName: "Le type de destination",
+    path: ["destination", "type"]
   },
   destinationPlannedOperationCode: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "L'opération prévue"
+    readableFieldName: "L'opération prévue",
+    path: ["destination", "plannedOperationCode"]
   },
   destinationAgrementNumber: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° d'agrément du destinataire"
+    readableFieldName: "Le N° d'agrément du destinataire",
+    path: ["destination", "agrementNumber"]
   },
   destinationCompanyName: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La raison sociale du destinataire"
+    readableFieldName: "La raison sociale du destinataire",
+    path: ["destination", "company", "name"]
   },
   destinationCompanySiret: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° SIRET du destinataire"
+    readableFieldName: "Le N° SIRET du destinataire",
+    path: ["destination", "company", "siret"]
   },
   destinationCompanyAddress: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse du destinataire"
+    readableFieldName: "L'adresse du destinataire",
+    path: ["destination", "company", "address"]
   },
   destinationCompanyContact: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "La personne à contacter chez le destinataire"
+    readableFieldName: "La personne à contacter chez le destinataire",
+    path: ["destination", "company", "contact"]
   },
   destinationCompanyPhone: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "Le N° de téléphone du destinataire"
+    readableFieldName: "Le N° de téléphone du destinataire",
+    path: ["destination", "company", "phone"]
   },
   destinationCompanyMail: {
     sealed: { from: "OPERATION" },
     required: { from: "EMISSION" },
-    readableFieldName: "L'adresse e-mail du destinataire"
+    readableFieldName: "L'adresse e-mail du destinataire",
+    path: ["destination", "company", "mail"]
   },
   destinationReceptionAcceptationStatus: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le statut d'acceptation du destinataire"
+    readableFieldName: "Le statut d'acceptation du destinataire",
+    path: ["destination", "reception", "acceptationStatus"]
   },
   destinationReceptionRefusalReason: {
     sealed: { from: "OPERATION" },
     readableFieldName: "La raison du refus par le destinataire",
-    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused }
+    required: { from: "OPERATION", when: isRefusedOrPartiallyRefused },
+    path: ["destination", "reception", "refusalReason"]
   },
   destinationReceptionIdentificationNumbers: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Les numéros d'identification à la réception par le destinataire"
+      "Les numéros d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "numbers"]
   },
   destinationReceptionIdentificationType: {
     sealed: { from: "OPERATION" },
     readableFieldName:
-      "Le type de numéro d'identification à la réception par le destinataire"
+      "Le type de numéro d'identification à la réception par le destinataire",
+    path: ["destination", "reception", "identification", "type"]
   },
   destinationOperationCode: {
     sealed: { from: "OPERATION" },
@@ -232,7 +261,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: "OPERATION",
       when: isNotRefused
     },
-    readableFieldName: "L'opération réalisée par le destinataire"
+    readableFieldName: "L'opération réalisée par le destinataire",
+    path: ["destination", "operation", "code"]
   },
   destinationOperationMode: {
     sealed: { from: "OPERATION" },
@@ -240,20 +270,30 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     //   from: "OPERATION",
     //   when: isNotRefused // more precise check in checkOperationMode refinement
     // },
-    readableFieldName: "Le mode de traitement"
+    readableFieldName: "Le mode de traitement",
+    path: ["destination", "operation", "mode"]
   },
   destinationOperationDate: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION", when: isNotRefused },
-    readableFieldName: "la date de l'opération"
+    readableFieldName: "la date de l'opération",
+    path: ["destination", "operation", "date"]
   },
   destinationOperationNextDestinationCompanySiret: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° SIRET de l'exutoire"
+    readableFieldName: "Le N° SIRET de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "siret"]
   },
   destinationOperationNextDestinationCompanyVatNumber: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "Le N° de TVA de l'exutoire"
+    readableFieldName: "Le N° de TVA de l'exutoire",
+    path: [
+      "destination",
+      "operation",
+      "nextDestination",
+      "company",
+      "vatNumber"
+    ]
   },
   destinationOperationNextDestinationCompanyName: {
     sealed: { from: "OPERATION" },
@@ -262,7 +302,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La raison sociale de l'exutoire"
+    readableFieldName: "La raison sociale de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "name"]
   },
   destinationOperationNextDestinationCompanyAddress: {
     sealed: { from: "OPERATION" },
@@ -271,7 +312,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse de l'exutoire"
+    readableFieldName: "L'adresse de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "address"]
   },
   destinationOperationNextDestinationCompanyContact: {
     sealed: { from: "OPERATION" },
@@ -280,7 +322,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "La personne à contacter chez l'exutoire"
+    readableFieldName: "La personne à contacter chez l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "contact"]
   },
   destinationOperationNextDestinationCompanyPhone: {
     sealed: { from: "OPERATION" },
@@ -289,7 +332,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "Le N° de téléphone de l'exutoire"
+    readableFieldName: "Le N° de téléphone de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "phone"]
   },
   destinationOperationNextDestinationCompanyMail: {
     sealed: { from: "OPERATION" },
@@ -298,20 +342,24 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: bsvhu =>
         Boolean(bsvhu.destinationOperationNextDestinationCompanySiret)
     },
-    readableFieldName: "L'adresse e-mail de l'exutoire"
+    readableFieldName: "L'adresse e-mail de l'exutoire",
+    path: ["destination", "operation", "nextDestination", "company", "mail"]
   },
   destinationReceptionQuantity: {
     sealed: { from: "OPERATION" },
-    readableFieldName: "La quantité de VHUs reçue"
+    readableFieldName: "La quantité de VHUs reçue",
+    path: ["destination", "reception", "quantity"]
   },
   destinationReceptionWeight: {
     sealed: { from: "OPERATION" },
     required: { from: "OPERATION" },
-    readableFieldName: "Le poids réel reçu"
+    readableFieldName: "Le poids réel reçu",
+    path: ["destination", "reception", "weight"]
   },
   destinationReceptionDate: {
     readableFieldName: "la date de réception",
-    sealed: { from: "OPERATION" }
+    sealed: { from: "OPERATION" },
+    path: ["destination", "reception", "date"]
     // required: { from: "OPERATION" }
   },
   wasteCode: {
@@ -319,37 +367,44 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le code déchet"
+    readableFieldName: "Le code déchet",
+    path: ["wasteCode"]
   },
   packaging: {
     sealed: {
       from: sealedFromEmissionExceptForEmitter
     },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type d'empaquetage"
+    readableFieldName: "Le type d'empaquetage",
+    path: ["packaging"]
   },
   identificationNumbers: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Les numéros d'identification"
+    readableFieldName: "Les numéros d'identification",
+    path: ["identification", "numbers"]
   },
   identificationType: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le type de numéro d'identification"
+    readableFieldName: "Le type de numéro d'identification",
+    path: ["identification", "type"]
   },
   quantity: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "La quantité"
+    readableFieldName: "La quantité",
+    path: ["quantity"]
   },
   weightValue: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
     required: { from: "EMISSION" },
-    readableFieldName: "Le poids"
+    readableFieldName: "Le poids",
+    path: ["weight", "value"]
   },
   weightIsEstimate: {
     sealed: { from: sealedFromEmissionExceptForEmitter },
-    readableFieldName: "Le champ pour indiquer si le poids est estimé"
+    readableFieldName: "Le champ pour indiquer si le poids est estimé",
+    path: ["weight", "isEstimate"]
   },
   transporterCompanySiret: {
     readableFieldName: "le N° SIRET du transporteur",
@@ -357,7 +412,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanyVatNumber
-    }
+    },
+    path: ["transporter", "company", "siret"]
   },
   transporterCompanyVatNumber: {
     readableFieldName: "Le N° de TVA du transporteur",
@@ -365,42 +421,48 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     required: {
       from: "TRANSPORT",
       when: bsvhu => !bsvhu.transporterCompanySiret
-    }
+    },
+    path: ["transporter", "company", "vatNumber"]
   },
   transporterCompanyName: {
     readableFieldName: "Le nom du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "name"]
   },
   transporterCompanyAddress: {
     readableFieldName: "L'adresse du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "address"]
   },
   transporterCompanyContact: {
     readableFieldName: "Le nom de contact du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "contact"]
   },
   transporterCompanyPhone: {
     readableFieldName: "Le téléphone du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "phone"]
   },
   transporterCompanyMail: {
     readableFieldName: "L'email du transporteur",
     sealed: {
       from: "TRANSPORT"
     },
-    required: { from: "TRANSPORT" }
+    required: { from: "TRANSPORT" },
+    path: ["transporter", "company", "mail"]
   },
   transporterRecepisseNumber: {
     readableFieldName: "le numéro de récépissé du transporteur",
@@ -410,7 +472,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "number"]
   },
   transporterRecepisseDepartment: {
     readableFieldName: "le département de récépissé du transporteur",
@@ -420,7 +483,8 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "department"]
   },
   transporterRecepisseValidityLimit: {
     readableFieldName: "la date de validité du récépissé du transporteur",
@@ -430,15 +494,18 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
       when: requireTransporterRecepisse,
       customErrorMessage:
         "L'établissement doit renseigner son récépissé dans Trackdéchets"
-    }
+    },
+    path: ["transporter", "recepisse", "validityLimit"]
   },
   transporterTransportTakenOverAt: {
     readableFieldName: "la date d'enlèvement du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "transport", "takenOverAt"]
   },
   transporterRecepisseIsExempted: {
     readableFieldName: "l'exemption de récépissé du transporteur",
-    sealed: { from: "TRANSPORT" }
+    sealed: { from: "TRANSPORT" },
+    path: ["transporter", "recepisse", "isExempted"]
     // required: {
     //   from: "TRANSPORT"
     // }

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -30,6 +30,7 @@ export type BsvhuEditableFields = Required<
     | "transporterTransportSignatureAuthor"
     | "destinationOperationSignatureDate"
     | "destinationOperationSignatureAuthor"
+    | "intermediariesOrgIds"
   >
 >;
 
@@ -509,6 +510,11 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     // required: {
     //   from: "TRANSPORT"
     // }
+  },
+  intermediaries: {
+    readableFieldName: "les intermédiaires",
+    sealed: { from: "TRANSPORT" },
+    path: ["intermediaries"]
   }
 };
 

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -515,45 +515,26 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
 export const getRequiredAndSealedFieldPaths = async (
   bsvhu: ZodBsvhu,
   currentSignatures: SignatureTypeInput[],
-  nextSignature: SignatureTypeInput | undefined,
   user: User | undefined
 ): Promise<{
-  requiredForNextSignature: string[];
-  sealed: string[];
+  sealed: string[][];
 }> => {
-  const nextSignatures = nextSignature
-    ? currentSignatures.concat([nextSignature])
-    : currentSignatures;
-  const requiredFields: string[] = [];
-  const sealedFields: string[] = [];
+  const sealedFields: string[][] = [];
   const userFunctions = await getBsvhuUserFunctions(user, bsvhu);
   for (const bsvhuField of Object.keys(bsvhuEditionRules)) {
-    const { required, sealed, path } =
+    const { sealed, path } =
       bsvhuEditionRules[bsvhuField as keyof BsvhuEditableFields];
-    if (path) {
-      if (required) {
-        const isRequired = isBsvhuFieldRequired(
-          required,
-          bsvhu,
-          nextSignatures
-        );
-        if (isRequired) {
-          requiredFields.push(path.join("."));
-        }
-      }
-      if (sealed) {
-        const isSealed = isBsvhuFieldSealed(sealed, bsvhu, currentSignatures, {
-          persisted: bsvhu,
-          userFunctions
-        });
-        if (isSealed) {
-          sealedFields.push(path.join("."));
-        }
+    if (path && sealed) {
+      const isSealed = isBsvhuFieldSealed(sealed, bsvhu, currentSignatures, {
+        persisted: bsvhu,
+        userFunctions
+      });
+      if (isSealed) {
+        sealedFields.push(path);
       }
     }
   }
   return {
-    requiredForNextSignature: requiredFields,
     sealed: sealedFields
   };
 };

--- a/back/src/bsvhu/validation/sirenify.ts
+++ b/back/src/bsvhu/validation/sirenify.ts
@@ -48,7 +48,23 @@ const sirenifyBsvhuAccessors = (
       input.transporterCompanyName = companyInput.name;
       input.transporterCompanyAddress = companyInput.address;
     }
-  }
+  },
+  ...(bsvhu.intermediaries ?? []).map(
+    (_, idx) =>
+      ({
+        siret: bsvhu.intermediaries![idx].siret,
+        skip: sealedFields.includes("intermediaries"),
+        setter: (input, companyInput) => {
+          const intermediary = input.intermediaries![idx];
+          if (companyInput.name) {
+            intermediary!.name = companyInput.name;
+          }
+          if (companyInput.address) {
+            intermediary!.address = companyInput.address;
+          }
+        }
+      } as NextCompanyInputAccessor<ParsedZodBsvhu>)
+  )
 ];
 
 export const sirenifyBsvhu: (

--- a/back/src/bsvhu/validation/transformers.ts
+++ b/back/src/bsvhu/validation/transformers.ts
@@ -1,0 +1,11 @@
+import { ZodBsvhuTransformer } from "./types";
+
+export const fillIntermediariesOrgIds: ZodBsvhuTransformer = bsvhu => {
+  bsvhu.intermediariesOrgIds = bsvhu.intermediaries
+    ? bsvhu.intermediaries
+        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+        .filter(Boolean)
+    : undefined;
+
+  return bsvhu;
+};

--- a/back/src/bsvhu/validation/types.ts
+++ b/back/src/bsvhu/validation/types.ts
@@ -1,4 +1,4 @@
-import { User } from "@prisma/client";
+import { Prisma, User } from "@prisma/client";
 import { ParsedZodBsvhu } from "./schema";
 import { RefinementCtx } from "zod";
 import { SignatureTypeInput } from "../../generated/graphql/types";
@@ -18,3 +18,11 @@ export type ZodBsvhuTransformer = (
   bsff: ParsedZodBsvhu,
   ctx: RefinementCtx
 ) => ParsedZodBsvhu | Promise<ParsedZodBsvhu>;
+
+export const BsvhuForParsingInclude = Prisma.validator<Prisma.BsvhuInclude>()({
+  intermediaries: true
+});
+
+export type PrismaBsvhuForParsing = Prisma.BsvhuGetPayload<{
+  include: typeof BsvhuForParsingInclude;
+}>;

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -4,14 +4,17 @@ import {
   toBsdElastic as toBsddElastic
 } from "../../forms/elastic";
 import {
-  BsdaForElasticInclude,
+  getBsdaForElastic,
   toBsdElastic as toBsdaElastic
 } from "../../bsda/elastic";
 import {
   BsdasriForElasticInclude,
   toBsdElastic as toBsdasriElastic
 } from "../../bsdasris/elastic";
-import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
+import {
+  getBsvhuForElastic,
+  toBsdElastic as toBsvhuElastic
+} from "../../bsvhu/elastic";
 import {
   BsffForElasticInclude,
   toBsdElastic as toBsffElastic
@@ -30,10 +33,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   await deleteBsd({ id: bsdId });
 
   if (bsdId.startsWith("BSDA-")) {
-    const bsda = await prisma.bsda.findUniqueOrThrow({
-      where: { id: bsdId },
-      include: BsdaForElasticInclude
-    });
+    const bsda = await getBsdaForElastic({ id: bsdId });
 
     return toBsdaElastic(bsda);
   }
@@ -48,9 +48,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsdId }
-    });
+    const bsvhu = await getBsvhuForElastic({ id: bsdId });
 
     return toBsvhuElastic(bsvhu);
   }

--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -7,7 +7,10 @@ import {
   toBsdElastic as toBsdasriElastic,
   getBsdasriForElastic
 } from "../../bsdasris/elastic";
-import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
+import {
+  getBsvhuForElastic,
+  toBsdElastic as toBsvhuElastic
+} from "../../bsvhu/elastic";
 import { toBsdElastic as toBsffElastic } from "../../bsffs/elastic";
 import { toBsdElastic as toBspaohElastic } from "../../bspaoh/elastic";
 import { BsdElastic, indexBsd, getElasticBsdById } from "../../common/elastic";
@@ -49,9 +52,7 @@ export async function indexBsdJob(
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsdId }
-    });
+    const bsvhu = await getBsvhuForElastic({ id: bsdId });
 
     const elasticBsvhu = toBsvhuElastic(bsvhu);
     await indexBsd(elasticBsvhu);

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -29,7 +29,7 @@ import {
   createBsffBeforeEmission,
   createFicheIntervention
 } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
 import {
@@ -325,7 +325,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -337,7 +337,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
       expect(bsds).toEqual([]);
@@ -614,7 +614,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -627,7 +627,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
       expect(bsds).toEqual([]);
@@ -931,7 +931,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("TRANSPORTED", [
         transporter.company.siret!
@@ -946,7 +946,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("TRANSPORTED", [
         transporter.company.siret!
@@ -1453,7 +1453,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
 
       // When
@@ -1472,7 +1472,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
 
       // When
@@ -1489,7 +1489,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [emitter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -1502,7 +1502,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [transporter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -1516,7 +1516,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [destination.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -12,7 +12,7 @@ import { createBsffAfterReception } from "../../bsffs/__tests__/factories";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { getBsdaForElastic, indexBsda } from "../../bsda/elastic";
 import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 
 describe("wastesReader", () => {
@@ -120,7 +120,11 @@ describe("wastesReader", () => {
         )
     );
 
-    await Promise.all(bsvhus.map(bsvhu => indexBsvhu(bsvhu)));
+    const bsvhusForElastic = await Promise.all(
+      bsvhus.map(bsff => getBsvhuForElastic(bsff))
+    );
+
+    await Promise.all(bsvhusForElastic.map(bsvhu => indexBsvhu(bsvhu)));
 
     // create 5 incoming BSFFs
     const bsffs = await Promise.all(

--- a/back/src/registry/__tests__/where.dates.integration.ts
+++ b/back/src/registry/__tests__/where.dates.integration.ts
@@ -267,8 +267,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -703,8 +703,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -1186,8 +1186,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.dates.integration.ts
+++ b/back/src/registry/__tests__/where.dates.integration.ts
@@ -9,7 +9,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
@@ -268,7 +268,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -704,7 +704,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -1187,7 +1187,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.destination.integration.ts
+++ b/back/src/registry/__tests__/where.destination.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -142,7 +142,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -368,7 +368,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -547,7 +547,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.destination.integration.ts
+++ b/back/src/registry/__tests__/where.destination.integration.ts
@@ -141,8 +141,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -367,8 +367,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -546,8 +546,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.emitter.integration.ts
+++ b/back/src/registry/__tests__/where.emitter.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -181,7 +181,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -370,7 +370,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -548,7 +548,7 @@ describe("toElasticFilter", () => {
 
     await Promise.all(
       [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
-        return indexBsvhu(bsvhu);
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.emitter.integration.ts
+++ b/back/src/registry/__tests__/where.emitter.integration.ts
@@ -180,8 +180,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -369,8 +369,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();
@@ -547,8 +547,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(bsvhu);
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.integration.ts
+++ b/back/src/registry/__tests__/where.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -38,7 +38,7 @@ describe("toElasticFilter", () => {
       BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
       BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-      BSVHU: await bsvhuFactory({}),
+      BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
       BSFF: await getBsffForElastic(await createBsff()),
       BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
     };
@@ -85,7 +85,7 @@ describe("toElasticFilter", () => {
         BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
         BSDA: await getBsdaForElastic(await bsdaFactory({})),
         BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-        BSVHU: await bsvhuFactory({}),
+        BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
         BSFF: await getBsffForElastic(await createBsff()),
         BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
       };
@@ -116,7 +116,7 @@ describe("toElasticFilter", () => {
       BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
       BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-      BSVHU: await bsvhuFactory({}),
+      BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
       BSFF: await getBsffForElastic(await createBsff()),
       BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
     };

--- a/back/src/registry/__tests__/where.transporter.integration.ts
+++ b/back/src/registry/__tests__/where.transporter.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -205,8 +205,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -424,8 +424,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -637,8 +637,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.weight.integration.ts
+++ b/back/src/registry/__tests__/where.weight.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -199,8 +199,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -445,8 +445,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -685,8 +685,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -6,7 +6,7 @@ import {
   WasteRegistryWhere
 } from "../generated/graphql/types";
 import { toElasticFilter } from "./where";
-import { Bsvhu, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@td/prisma";
 
 export function buildQuery(
@@ -153,7 +153,13 @@ export type RegistryBsff = Prisma.BsffGetPayload<{
   include: typeof RegistryBsffInclude;
 }>;
 
-type RegistryBsvhu = Bsvhu;
+export const RegistryBsvhuInclude = Prisma.validator<Prisma.BsvhuInclude>()({
+  intermediaries: true
+});
+
+export type RegistryBsvhu = Prisma.BsvhuGetPayload<{
+  include: typeof RegistryBsvhuInclude;
+}>;
 
 export type RegistryBsdMap = {
   bsdds: RegistryForm[];
@@ -197,7 +203,8 @@ export async function toPrismaBsds(
         id: {
           in: BSVHU.map(bsvhu => bsvhu.id)
         }
-      }
+      },
+      include: RegistryBsvhuInclude
     }),
     prisma.bsda.findMany({
       where: {

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -28,7 +28,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
@@ -211,7 +211,7 @@ describe("All wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -5,7 +5,6 @@ import {
   BsdaStatus,
   BsdasriStatus,
   Bsff,
-  Bsvhu,
   Bspaoh,
   BspaohStatus,
   BsvhuStatus,
@@ -13,7 +12,8 @@ import {
   Status,
   User,
   UserRole,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -29,7 +29,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
@@ -215,7 +215,7 @@ describe("Incoming wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -5,7 +5,6 @@ import {
   BsdaStatus,
   BsdasriStatus,
   Bsff,
-  Bsvhu,
   BsvhuStatus,
   Bspaoh,
   BspaohStatus,
@@ -13,7 +12,8 @@ import {
   Status,
   User,
   UserRole,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -30,7 +30,7 @@ import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../../../bspaoh/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
@@ -210,7 +210,7 @@ describe("Outgoing wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -4,7 +4,6 @@ import {
   Bsdasri,
   BsdaStatus,
   Bsff,
-  Bsvhu,
   BsvhuStatus,
   Bspaoh,
   BspaohStatus,
@@ -13,7 +12,8 @@ import {
   User,
   UserRole,
   BsdasriStatus,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -29,7 +29,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
@@ -209,7 +209,7 @@ describe("Transported wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -20,6 +20,7 @@ import { ZodError } from "zod";
 import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { passportBearerMiddleware } from "./auth";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
+import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
 import { captchaGen, captchaSound } from "./captcha/captchaGen";
 import { ErrorCode, UserInputError } from "./common/errors";
 import errorHandler from "./common/middlewares/errorHandler";
@@ -369,6 +370,7 @@ export const getServerDataloaders = () => ({
   ...createCompanyDataLoaders(),
   ...createFormDataLoaders(),
   ...createBsdaDataLoaders(),
+  ...createBsvhuDataLoaders(),
   ...createEventsDataLoaders()
 });
 

--- a/back/src/server.ts
+++ b/back/src/server.ts
@@ -21,6 +21,7 @@ import { createEventsDataLoaders } from "./activity-events/dataloader";
 import { passportBearerMiddleware } from "./auth";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
+import { createBspaohDataLoaders } from "./bspaoh/dataloader";
 import { captchaGen, captchaSound } from "./captcha/captchaGen";
 import { ErrorCode, UserInputError } from "./common/errors";
 import errorHandler from "./common/middlewares/errorHandler";
@@ -371,6 +372,7 @@ export const getServerDataloaders = () => ({
   ...createFormDataLoaders(),
   ...createBsdaDataLoaders(),
   ...createBsvhuDataLoaders(),
+  ...createBspaohDataLoaders(),
   ...createEventsDataLoaders()
 });
 

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,7 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+// utility types used by Paths and Leaves
 type Cons<H, T> = T extends readonly any[]
   ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
     ? R
@@ -55,7 +56,20 @@ type Prev = [
   20,
   ...0[]
 ];
-
+/*
+Creates a type with all possible paths in an other object type, recursively,
+including all possible subpaths.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["aa"] | ["a", "ab"] | ["ab"]
+*/
 export type Paths<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object
@@ -70,6 +84,19 @@ export type Paths<T, D extends number = 3> = [D] extends [never]
     }[keyof T]
   : [];
 
+/*
+Creates a type with all possible paths in an other object type, recursively.
+For example:
+type obj = {
+  a: {
+    aa: number,
+    ab: string
+  },
+  c: number
+}
+Paths<obj>
+-> ["a"] | ["b"] | ["c"] | ["a", "aa"] | ["a", "ab"]
+*/
 export type Leaves<T, D extends number = 3> = [D] extends [never]
   ? never
   : T extends object

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -5,6 +5,7 @@ import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
 import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
+import { createBspaohDataLoaders } from "./bspaoh/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 import "express-session";
 
@@ -13,6 +14,7 @@ export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createFormDataLoaders> &
   ReturnType<typeof createBsdaDataLoaders> &
   ReturnType<typeof createBsvhuDataLoaders> &
+  ReturnType<typeof createBspaohDataLoaders> &
   ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = {
@@ -74,7 +76,7 @@ Paths<obj>
 */
 export type Paths<T, D extends number = 3> = [D] extends [never]
   ? never
-  : T extends object
+  : T extends Record<string, unknown>
   ? {
       [K in keyof T]-?:
         | [K]
@@ -101,7 +103,7 @@ Paths<obj>
 */
 export type Leaves<T, D extends number = 3> = [D] extends [never]
   ? never
-  : T extends object
+  : T extends Record<string, unknown>
   ? { [K in keyof T]-?: Cons<K, Leaves<T[K], Prev[D]>> }[keyof T]
   : [];
 

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -25,6 +25,57 @@ export type Nullable<T> = {
   [P in keyof T]: T[P] | null;
 };
 
+type Cons<H, T> = T extends readonly any[]
+  ? ((h: H, ...t: T) => void) extends (...r: infer R) => void
+    ? R
+    : never
+  : never;
+type Prev = [
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
+];
+
+export type Paths<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? {
+      [K in keyof T]-?:
+        | [K]
+        | (Paths<T[K], Prev[D]> extends infer P
+            ? P extends []
+              ? never
+              : Cons<K, P>
+            : never);
+    }[keyof T]
+  : [];
+
+export type Leaves<T, D extends number = 3> = [D] extends [never]
+  ? never
+  : T extends object
+  ? { [K in keyof T]-?: Cons<K, Leaves<T[K], Prev[D]>> }[keyof T]
+  : [];
+
 declare module "express-session" {
   interface SessionData {
     warningMessage?: string;

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -4,6 +4,7 @@ import { GqlInfo } from "./common/plugins/gqlInfosPlugin";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
 import { createBsdaDataLoaders } from "./bsda/dataloader";
+import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
 import "express-session";
 
@@ -11,6 +12,7 @@ export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createCompanyDataLoaders> &
   ReturnType<typeof createFormDataLoaders> &
   ReturnType<typeof createBsdaDataLoaders> &
+  ReturnType<typeof createBsvhuDataLoaders> &
   ReturnType<typeof createEventsDataLoaders>;
 
 export type GraphQLContext = {

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=d5199fe9"
+      href="/dsfr/utility/icons/icons.min.css?hash=ea40c0cf"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=fe60f3b9"
+      href="/dsfr/utility/icons/icons.min.css?hash=618ed71d"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=ea40c0cf"
+      href="/dsfr/utility/icons/icons.min.css?hash=fe60f3b9"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
@@ -65,9 +65,9 @@ export function ControlledTabs(props: Readonly<Props>) {
 
   const sealedFields = useMemo(
     () =>
-      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])
-        ?.map(f => f?.name!)
-        .filter(Boolean),
+      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])?.filter(
+        Boolean
+      ),
     [formQuery.data]
   );
 

--- a/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
@@ -65,9 +65,9 @@ export function ControlledTabs(props: Readonly<Props>) {
 
   const sealedFields = useMemo(
     () =>
-      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])?.filter(
-        Boolean
-      ),
+      (formQuery?.data?.bspaoh?.metadata?.fields?.sealed ?? [])
+        ?.filter(Boolean)
+        .map(sealedField => sealedField.join(".")),
     [formQuery.data]
   );
 

--- a/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
@@ -12,7 +12,6 @@ export const GET_VHU_FORM = gql`
           requiredFor
         }
         fields {
-          requiredForNextSignature
           sealed
         }
       }

--- a/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/utils/queries.ts
@@ -11,6 +11,10 @@ export const GET_VHU_FORM = gql`
           path
           requiredFor
         }
+        fields {
+          requiredForNextSignature
+          sealed
+        }
       }
     }
   }

--- a/front/src/Apps/common/queries/fragments/bspaoh.ts
+++ b/front/src/Apps/common/queries/fragments/bspaoh.ts
@@ -77,9 +77,7 @@ const metadataFragment = gql`
         requiredFor
       }
       fields {
-        sealed {
-          name
-        }
+        sealed
       }
     }
   }

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -66,7 +66,7 @@ export function SignTransport({
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter
-            !error.path.startsWith("transporterRecepisse")
+            !error.path.startsWith("transporter.recepisse")
         ) ? (
           <>
             <p className="tw-mt-2 tw-text-red-700">

--- a/libs/back/prisma/src/migrations/20240903225951_add_bsvhu_intermediaries/migration.sql
+++ b/libs/back/prisma/src/migrations/20240903225951_add_bsvhu_intermediaries/migration.sql
@@ -1,0 +1,33 @@
+-- AlterTable
+ALTER TABLE "Bsvhu" ADD COLUMN     "intermediariesOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "IntermediaryBsvhuAssociation" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "siret" TEXT NOT NULL,
+    "contact" TEXT NOT NULL,
+    "vatNumber" TEXT,
+    "address" TEXT,
+    "phone" TEXT,
+    "mail" TEXT,
+    "bsvhuId" TEXT NOT NULL,
+
+    CONSTRAINT "IntermediaryBsvhuAssociation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_IntermediaryBsvhuAssociationBsvhuIdIdx" ON "IntermediaryBsvhuAssociation"("bsvhuId");
+
+-- CreateIndex
+CREATE INDEX "IntermediaryBsvhuAssociationSiretIdx" ON "IntermediaryBsvhuAssociation"("siret");
+
+-- CreateIndex
+CREATE INDEX "IntermediaryBsvhuAssociationVatNumberIdx" ON "IntermediaryBsvhuAssociation"("vatNumber");
+
+-- CreateIndex
+CREATE INDEX "_BsvhuIntermediariesOrgIdsIdx" ON "Bsvhu" USING GIN ("intermediariesOrgIds");
+
+-- AddForeignKey
+ALTER TABLE "IntermediaryBsvhuAssociation" ADD CONSTRAINT "IntermediaryBsvhuAssociation_bsvhuId_fkey" FOREIGN KEY ("bsvhuId") REFERENCES "Bsvhu"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1022,14 +1022,38 @@ model Bsvhu {
   transporterTransportPlates                          String[]
   transporterRecepisseIsExempted                      Boolean?
 
+  intermediaries IntermediaryBsvhuAssociation[]
+
+  // Denormalized fields, storing sirets to speed up queries and avoid expensive joins
+  intermediariesOrgIds String[] @default([])
+
   // partial indices _BsvhuIsDeletedIdx,_BsvhuIsDraftIdx  see migration82_missing_indices.sql
 
   @@index([emitterCompanySiret], map: "_BvhuEmitterCompanySirettIdx")
   @@index([destinationCompanySiret], map: "_BsvhuDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsvhuTransporterCompanySiretIdx")
   @@index([transporterCompanyVatNumber], map: "_BsvhuTransporterCompanyVatNumberIdx")
+  @@index([intermediariesOrgIds], map: "_BsvhuIntermediariesOrgIdsIdx", type: Gin)
   @@index([status], map: "_BsvhuStatusIdx")
   @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
+}
+
+model IntermediaryBsvhuAssociation {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  siret     String
+  contact   String
+  vatNumber String?
+  address   String?
+  phone     String?
+  mail      String?
+  bsvhuId   String
+  bsvhu     Bsvhu    @relation(fields: [bsvhuId], references: [id])
+
+  @@index([bsvhuId], map: "_IntermediaryBsvhuAssociationBsvhuIdIdx")
+  @@index([siret], map: "IntermediaryBsvhuAssociationSiretIdx")
+  @@index([vatNumber], map: "IntermediaryBsvhuAssociationVatNumberIdx")
 }
 
 model Bsdasri {

--- a/libs/shared/constants/src/companySearchHelpers.ts
+++ b/libs/shared/constants/src/companySearchHelpers.ts
@@ -199,6 +199,20 @@ export const getTransporterCompanyOrgId = (
     : form.transporterCompanyVatNumber;
 };
 
+export type PartialIntermediaryCompany = {
+  siret: string | null;
+  vatNumber: string | null;
+};
+
+export const getIntermediaryCompanyOrgId = (
+  intermediary: PartialIntermediaryCompany | null
+): string | null => {
+  if (!intermediary) return null;
+  return intermediary.siret?.length
+    ? intermediary.siret
+    : intermediary.vatNumber;
+};
+
 /**
  * Check for etatAdministratif
  */


### PR DESCRIPTION
# Objectif

Ajouter 3 intermédiares au BSVHU. Voilà c'est tout.

# Tech

C'est la même architecture backend et la même spec que pour les intermédiaires BSDA, donc j'ai largement repris l'implémentation. Rien de particluier à signaler a priori.

## ⚠️ Dépendance
Vu que ça touche aux même fichiers que la PR https://github.com/MTES-MCT/trackdechets/pull/3549, la branche est pour l'instant à la suite de l'autre, donc il faut merger l'autre PR avant que celle-ci soit reviewable/mergeable. Ainsi cette PR bénéficiera des chemins d'erreurs sur les intermédiaires.

- [x] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14647)
