### PR TITLE
[TRA 14647] ajout d'intermédiaires sur BSVHU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - ETQ destinataire, je peux spécifier le statut de rinçage de la citerne pour son retour à vide (back) [PR 3546](https://github.com/MTES-MCT/trackdechets/pull/3546)
 - ETQ destinataire, je peux indiquer que mon véhicule est rincé ou non pour son retour à vide (back) [PR 3548](https://github.com/MTES-MCT/trackdechets/pull/3548)
+- Ajout d'intermédiaires sur les BSVHU [PR 3560](https://github.com/MTES-MCT/trackdechets/pull/3560)
 
 #### :nail_care: Améliorations
 

--- a/back/src/bsds/indexation/bulkIndexBsds.ts
+++ b/back/src/bsds/indexation/bulkIndexBsds.ts
@@ -25,7 +25,10 @@ import {
   FormForElasticInclude,
   toBsdElastic as formToBsdElastic
 } from "../../forms/elastic";
-import { toBsdElastic as bsvhuToBsdElastic } from "../../bsvhu/elastic";
+import {
+  BsvhuForElasticInclude,
+  toBsdElastic as bsvhuToBsdElastic
+} from "../../bsvhu/elastic";
 import { toBsdElastic as bspaohToBsdElastic } from "../../bspaoh/elastic";
 import { bulkIndexQueue } from "../../queue/producers/elastic";
 import { IndexAllFnSignature, FindManyAndIndexBsdsFnSignature } from "./types";
@@ -64,7 +67,9 @@ const prismaFindManyOptions = {
   bsff: {
     include: BsffForElasticInclude
   },
-  bsvhu: {},
+  bsvhu: {
+    include: BsvhuForElasticInclude
+  },
   bsda: {
     include: BsdaForElasticInclude
   },

--- a/back/src/bsds/indexation/reindexBsdHelpers.ts
+++ b/back/src/bsds/indexation/reindexBsdHelpers.ts
@@ -2,7 +2,7 @@ import { prisma } from "@td/prisma";
 import { BsdaForElasticInclude, indexBsda } from "../../bsda/elastic";
 import { BsdasriForElasticInclude, indexBsdasri } from "../../bsdasris/elastic";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { indexBspaoh } from "../../bspaoh/elastic";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { deleteBsd } from "../../common/elastic";
@@ -62,7 +62,7 @@ export async function reindex(bsdId, exitFn) {
     });
 
     if (!!bsvhu && !bsvhu.isDeleted) {
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
     } else {
       await deleteBsd({ id: bsdId });
     }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -21,7 +21,11 @@ import {
 } from "../../../../../integration-tests/helper";
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import {
+  BsvhuForElasticInclude,
+  getBsvhuForElastic,
+  indexBsvhu
+} from "../../../../bsvhu/elastic";
 import {
   transporterReceiptFactory,
   userWithCompanyFactory
@@ -536,9 +540,14 @@ describe("Query.bsds.vhus base workflow", () => {
     beforeAll(async () => {
       const refusedVhu = await prisma.bsvhu.update({
         where: { id: vhuId },
-        data: { status: "REFUSED" }
+        data: { status: "REFUSED" },
+        include: {
+          ...BsvhuForElasticInclude
+        }
       });
-      await indexBsvhu(refusedVhu);
+      const bsvhuForElastic = await getBsvhuForElastic(refusedVhu);
+      await indexBsvhu(bsvhuForElastic);
+
       await refreshElasticSearch();
     });
 
@@ -614,7 +623,8 @@ describe("Query.bsds.vhus mutations", () => {
       }
     });
 
-    await indexBsvhu(vhu);
+    const bsvhuForElastic = await getBsvhuForElastic(vhu);
+    await indexBsvhu(bsvhuForElastic);
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);
@@ -663,7 +673,8 @@ describe("Query.bsds.vhus mutations", () => {
         emitterCompanySiret: emitter.company.siret
       }
     });
-    await indexBsvhu(vhu);
+    const bsvhuForElastic = await getBsvhuForElastic(vhu);
+    await indexBsvhu(bsvhuForElastic);
 
     //duplicate vhu
     const { mutate } = makeClient(emitter.user);
@@ -689,7 +700,7 @@ describe("Query.bsds.vhus mutations", () => {
       }
     });
 
-    await indexBsvhu(vhu);
+    await indexBsvhu(bsvhuForElastic);
     await refreshElasticSearch();
 
     const { query } = makeClient(emitter.user);

--- a/back/src/bsvhu/__tests__/bsvhuFactories.integration.ts
+++ b/back/src/bsvhu/__tests__/bsvhuFactories.integration.ts
@@ -1,0 +1,25 @@
+import { resetDatabase } from "./../../../integration-tests/helper";
+import {
+  companyFactory,
+  userWithCompanyFactory
+} from "../../__tests__/factories";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
+
+describe("Bsvhu factories", () => {
+  afterEach(resetDatabase);
+
+  it("should denormalize intermediaries sirets", async () => {
+    const otherCompany = await companyFactory();
+    const { company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: otherCompany.siret,
+        intermediaries: {
+          create: [toIntermediaryCompany(company)]
+        }
+      }
+    });
+
+    expect(bsvhu.intermediariesOrgIds).toEqual([company.siret]);
+  });
+});

--- a/back/src/bsvhu/__tests__/elastic.integration.ts
+++ b/back/src/bsvhu/__tests__/elastic.integration.ts
@@ -3,7 +3,7 @@ import { resetDatabase } from "../../../integration-tests/helper";
 import { companyFactory } from "../../__tests__/factories";
 import { BsdElastic } from "../../common/elastic";
 import { getWhere, toBsdElastic } from "../elastic";
-import { bsvhuFactory } from "./factories.vhu";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
 
 describe("getWhere", () => {
   test("if emitter publishes VHU > transporter should see it in 'follow' tab", async () => {
@@ -28,6 +28,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
   let destination: Company;
   let bsvhu: any;
   let elasticBsvhu: BsdElastic;
+  let intermediary1: Company;
+  let intermediary2: Company;
 
   beforeAll(async () => {
     // Given
@@ -39,6 +41,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     destination = await companyFactory({
       name: "Destination"
     });
+    intermediary1 = await companyFactory({ name: "Intermediaire 1" });
+    intermediary2 = await companyFactory({ name: "Intermediaire 2" });
 
     bsvhu = await bsvhuFactory({
       opt: {
@@ -48,7 +52,15 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
         transporterCompanySiret: transporter.siret,
         transporterCompanyVatNumber: transporter.vatNumber,
         destinationCompanyName: destination.name,
-        destinationCompanySiret: destination.siret
+        destinationCompanySiret: destination.siret,
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2)
+            ]
+          }
+        }
       }
     });
 
@@ -61,6 +73,8 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     expect(elasticBsvhu.companyNames).toContain(emitter.name);
     expect(elasticBsvhu.companyNames).toContain(transporter.name);
     expect(elasticBsvhu.companyNames).toContain(destination.name);
+    expect(elasticBsvhu.companyNames).toContain(intermediary1.name);
+    expect(elasticBsvhu.companyNames).toContain(intermediary2.name);
   });
 
   test("companyOrgIds > should contain the orgIds of ALL BSVHU companies", async () => {
@@ -68,5 +82,7 @@ describe("toBsdElastic > companies Names & OrgIds", () => {
     expect(elasticBsvhu.companyOrgIds).toContain(emitter.siret);
     expect(elasticBsvhu.companyOrgIds).toContain(transporter.vatNumber);
     expect(elasticBsvhu.companyOrgIds).toContain(destination.siret);
+    expect(elasticBsvhu.companyOrgIds).toContain(intermediary1.siret);
+    expect(elasticBsvhu.companyOrgIds).toContain(intermediary2.siret);
   });
 });

--- a/back/src/bsvhu/__tests__/registry.integration.ts
+++ b/back/src/bsvhu/__tests__/registry.integration.ts
@@ -7,9 +7,10 @@ import {
   toOutgoingWaste,
   toTransportedWaste
 } from "../registry";
-import { bsvhuFactory } from "./factories.vhu";
+import { bsvhuFactory, toIntermediaryCompany } from "./factories.vhu";
 import { resetDatabase } from "../../../integration-tests/helper";
 import { companyFactory } from "../../__tests__/factories";
+import { RegistryBsvhuInclude } from "../../registry/elastic";
 
 describe("toGenericWaste", () => {
   afterAll(resetDatabase);
@@ -22,7 +23,8 @@ describe("toGenericWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toGenericWaste(bsvhuForRegistry);
 
@@ -48,7 +50,8 @@ describe("toGenericWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
 
     const waste = toGenericWaste(bsvhuForRegistry);
@@ -76,7 +79,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toIncomingWaste(bsvhuForRegistry);
 
@@ -95,7 +99,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toIncomingWaste(bsvhuForRegistry);
 
@@ -124,7 +129,8 @@ describe("toIncomingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toIncomingWaste(bsvhuForRegistry);
 
@@ -153,7 +159,8 @@ describe("toOutgoingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toOutgoingWaste(bsvhuForRegistry);
 
@@ -170,7 +177,8 @@ describe("toOutgoingWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toOutgoingWaste(bsvhuForRegistry);
 
@@ -199,7 +207,8 @@ describe("toTransportedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toTransportedWaste(bsvhuForRegistry);
 
@@ -219,7 +228,8 @@ describe("toTransportedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toTransportedWaste(bsvhuForRegistry);
 
@@ -260,7 +270,8 @@ describe("toManagedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toManagedWaste(bsvhuForRegistry);
 
@@ -279,7 +290,8 @@ describe("toManagedWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toManagedWaste(bsvhuForRegistry);
 
@@ -312,7 +324,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toAllWaste(bsvhuForRegistry);
 
@@ -337,7 +350,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const wasteRegistry = toAllWaste(bsvhuForRegistry);
 
@@ -359,7 +373,8 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toAllWaste(bsvhuForRegistry);
 
@@ -400,9 +415,10 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
-    const waste = toGenericWaste(bsvhuForRegistry);
+    const waste = toAllWaste(bsvhuForRegistry);
 
     // Then
     expect(waste.destinationCompanyAddress).toBe("4 Boulevard Pasteur");
@@ -430,9 +446,10 @@ describe("toAllWaste", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
-    const waste = toGenericWaste(bsvhuForRegistry);
+    const waste = toAllWaste(bsvhuForRegistry);
 
     // Then
     expect(waste.emitterCompanyName).toBe(emitter.name);
@@ -441,6 +458,106 @@ describe("toAllWaste", () => {
     expect(waste.emitterCompanyPostalCode).toBe("44100");
     expect(waste.emitterCompanyCity).toBe("Nantes");
     expect(waste.emitterCompanyCountry).toBe("FR");
+  });
+  it("should contain all 3 intermediaries", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+    const intermediary2 = await companyFactory({});
+    const intermediary3 = await companyFactory({});
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2),
+              toIntermediaryCompany(intermediary3)
+            ]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(intermediary2.name);
+    expect(waste.intermediary2CompanySiret).toBe(intermediary2.siret);
+    expect(waste.intermediary3CompanyName).toBe(intermediary3.name);
+    expect(waste.intermediary3CompanySiret).toBe(intermediary3.siret);
+  });
+  it("should work with 1 intermediary", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [toIntermediaryCompany(intermediary1)]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(null);
+    expect(waste.intermediary2CompanySiret).toBe(null);
+    expect(waste.intermediary3CompanyName).toBe(null);
+    expect(waste.intermediary3CompanySiret).toBe(null);
+  });
+  it("should work with 2 intermediaries", async () => {
+    // Given
+    const intermediary1 = await companyFactory({});
+    const intermediary2 = await companyFactory({});
+
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        intermediaries: {
+          createMany: {
+            data: [
+              toIntermediaryCompany(intermediary1),
+              toIntermediaryCompany(intermediary2)
+            ]
+          }
+        }
+      }
+    });
+
+    // When
+    const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
+    });
+    const waste = toAllWaste(bsvhuForRegistry);
+
+    // Then
+    expect(waste).not.toBeUndefined();
+    expect(waste.intermediary1CompanyName).toBe(intermediary1.name);
+    expect(waste.intermediary1CompanySiret).toBe(intermediary1.siret);
+    expect(waste.intermediary2CompanyName).toBe(intermediary2.name);
+    expect(waste.intermediary2CompanySiret).toBe(intermediary2.siret);
+    expect(waste.intermediary3CompanyName).toBe(null);
+    expect(waste.intermediary3CompanySiret).toBe(null);
   });
 });
 
@@ -458,7 +575,8 @@ describe("getTransportersData", () => {
 
     // When
     const bsvhuForRegistry = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsvhu.id }
+      where: { id: bsvhu.id },
+      include: RegistryBsvhuInclude
     });
     const waste = toTransportedWaste(bsvhuForRegistry);
 

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -21,9 +21,14 @@ import {
   BsvhuOperation,
   BsvhuNextDestination,
   BsvhuTransport,
-  BsvhuTransportInput
+  BsvhuTransportInput,
+  CompanyInput
 } from "../generated/graphql/types";
-import { Bsvhu as PrismaVhuForm, WasteAcceptationStatus } from "@prisma/client";
+import {
+  Prisma,
+  Bsvhu as PrismaVhuForm,
+  WasteAcceptationStatus
+} from "@prisma/client";
 import { getTransporterCompanyOrgId } from "@td/constants";
 
 export const getAddress = ({
@@ -168,7 +173,8 @@ export function flattenVhuInput(formInput: BsvhuInput) {
     wasteCode: chain(formInput, f => f.wasteCode),
     quantity: chain(formInput, f => f.quantity),
     ...flattenVhuIdentificationInput(formInput),
-    ...flattenVhuWeightInput(formInput)
+    ...flattenVhuWeightInput(formInput),
+    intermediaries: formInput.intermediaries
   });
 }
 
@@ -369,4 +375,22 @@ function flattenVhuWeightInput({ weight }: Pick<BsvhuInput, "weight">) {
     weightValue: chain(weight, q => (q.value ? q.value * 1000 : q.value)),
     weightIsEstimate: chain(weight, q => q.isEstimate)
   };
+}
+
+export function companyToIntermediaryInput(
+  companies: CompanyInput[]
+): Prisma.IntermediaryBsvhuAssociationCreateManyBsvhuInput[] {
+  if (!companies) return [];
+
+  return companies.map(company => {
+    return {
+      name: company.name!,
+      siret: company.siret!,
+      vatNumber: company.vatNumber,
+      address: company.address,
+      contact: company.contact!,
+      phone: company.phone,
+      mail: company.mail
+    };
+  });
 }

--- a/back/src/bsvhu/database.ts
+++ b/back/src/bsvhu/database.ts
@@ -1,8 +1,11 @@
+import { Prisma } from "@prisma/client";
 import { FormNotFound } from "../forms/errors";
 import { getReadonlyBsvhuRepository } from "./repository";
 
-export async function getBsvhuOrNotFound(id: string) {
-  const bsvhu = await getReadonlyBsvhuRepository().findUnique({ id });
+export async function getBsvhuOrNotFound<
+  Args extends Omit<Prisma.BsvhuDefaultArgs, "where">
+>(id: string, args?: Args): Promise<Prisma.BsvhuGetPayload<Args>> {
+  const bsvhu = await getReadonlyBsvhuRepository().findUnique({ id }, args);
   if (bsvhu == null || !!bsvhu.isDeleted) {
     throw new FormNotFound(id.toString());
   }

--- a/back/src/bsvhu/dataloader.ts
+++ b/back/src/bsvhu/dataloader.ts
@@ -1,20 +1,28 @@
 import DataLoader from "dataloader";
 import { prisma } from "@td/prisma";
-import { Bsvhu } from "@prisma/client";
+import {
+  BsvhuWithIntermediaries,
+  BsvhuWithIntermediariesInclude
+} from "./types";
 
 export function createBsvhuDataLoaders() {
   return {
-    bsvhus: new DataLoader((bsvhuIds: string[]) => getBsvhus(bsvhuIds))
+    bsvhus: new DataLoader<string, BsvhuWithIntermediaries>(
+      (bsvhuIds: string[]) => getBsvhus(bsvhuIds)
+    )
   };
 }
 
-async function getBsvhus(bsvhuIds: string[]) {
+async function getBsvhus(
+  bsvhuIds: string[]
+): Promise<BsvhuWithIntermediaries[]> {
   const bsvhus = await prisma.bsvhu.findMany({
-    where: { id: { in: bsvhuIds } }
+    where: { id: { in: bsvhuIds } },
+    include: BsvhuWithIntermediariesInclude
   });
 
   const dict = Object.fromEntries(
-    bsvhus.map((bsvhu: Bsvhu) => [bsvhu.id, bsvhu])
+    bsvhus.map((bsvhu: BsvhuWithIntermediaries) => [bsvhu.id, bsvhu])
   );
 
   return bsvhuIds.map(bsvhuId => dict[bsvhuId]);

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -1,10 +1,65 @@
 import { BsvhuStatus, Bsvhu, BsdType } from "@prisma/client";
-import { getTransporterCompanyOrgId } from "@td/constants";
+import { prisma } from "@td/prisma";
+import {
+  getIntermediaryCompanyOrgId,
+  getTransporterCompanyOrgId
+} from "@td/constants";
 import { BsdElastic, indexBsd, transportPlateFilter } from "../common/elastic";
 import { GraphQLContext } from "../types";
 import { getRegistryFields } from "./registry";
 import { getBsvhuSubType } from "../common/subTypes";
 import { getAddress } from "./converter";
+import {
+  BsvhuWithIntermediaries,
+  BsvhuWithIntermediariesInclude
+} from "./types";
+
+export const BsvhuForElasticInclude = {
+  ...BsvhuWithIntermediariesInclude
+};
+
+export async function getBsvhuForElastic(
+  bsda: Pick<Bsvhu, "id">
+): Promise<BsvhuForElastic> {
+  return prisma.bsvhu.findUniqueOrThrow({
+    where: { id: bsda.id },
+    include: BsvhuForElasticInclude
+  });
+}
+
+type ElasticSirets = {
+  emitterCompanySiret: string | null | undefined;
+  destinationCompanySiret: string | null | undefined;
+  transporterCompanySiret: string | null | undefined;
+  intermediarySiret1?: string | null | undefined;
+  intermediarySiret2?: string | null | undefined;
+  intermediarySiret3?: string | null | undefined;
+};
+const getBsvhuSirets = (bsvhu: BsvhuForElastic): ElasticSirets => {
+  const intermediarySirets = bsvhu.intermediaries.reduce(
+    (sirets, intermediary) => {
+      const orgId = getIntermediaryCompanyOrgId(intermediary);
+      if (orgId) {
+        const nbOfKeys = Object.keys(sirets).length;
+        return {
+          ...sirets,
+          [`intermediarySiret${nbOfKeys + 1}`]: orgId
+        };
+      }
+      return sirets;
+    },
+    {}
+  );
+
+  const bsvhuSirets: ElasticSirets = {
+    emitterCompanySiret: bsvhu.emitterCompanySiret,
+    destinationCompanySiret: bsvhu.destinationCompanySiret,
+    transporterCompanySiret: getTransporterCompanyOrgId(bsvhu),
+    ...intermediarySirets
+  };
+
+  return bsvhuSirets;
+};
 
 type WhereKeys =
   | "isDraftFor"
@@ -14,16 +69,16 @@ type WhereKeys =
   | "isToCollectFor"
   | "isCollectedFor";
 
-// | state              | emitter | transporter | destination |
-// |--------------------|---------|-------------|-------------|
-// | initial (draft)    | draft   | draft       | draft       |
-// | initial            | action  | follow      | follow      |
-// | signed_by_producer | follow  | to collect  | follow      |
-// | sent               | follow  | collected   | action      |
-// | processed          | archive | archive     | archive     |
-// | refused            | archive | archive     | archive     |
+// | state              | emitter | transporter | destination | intermediary |
+// |--------------------|---------|-------------|-------------|--------------|
+// | initial (draft)    | draft   | draft       | draft       | follow       |
+// | initial            | action  | follow      | follow      | follow       |
+// | signed_by_producer | follow  | to collect  | follow      | follow       |
+// | sent               | follow  | collected   | action      | follow       |
+// | processed          | archive | archive     | archive     | archive      |
+// | refused            | archive | archive     | archive     | archive      |
 
-export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
+export function getWhere(bsvhu: BsvhuForElastic): Pick<BsdElastic, WhereKeys> {
   const where: Record<WhereKeys, string[]> = {
     isDraftFor: [],
     isForActionFor: [],
@@ -33,11 +88,7 @@ export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
     isCollectedFor: []
   };
 
-  const formSirets: Partial<Record<keyof Bsvhu, string | null | undefined>> = {
-    emitterCompanySiret: bsvhu.emitterCompanySiret,
-    destinationCompanySiret: bsvhu.destinationCompanySiret,
-    transporterCompanySiret: getTransporterCompanyOrgId(bsvhu)
-  };
+  const formSirets = getBsvhuSirets(bsvhu);
 
   const siretsFilters = new Map<string, keyof typeof where>(
     Object.entries(formSirets)
@@ -97,7 +148,7 @@ export function getWhere(bsvhu: Bsvhu): Pick<BsdElastic, WhereKeys> {
   return where;
 }
 
-export type BsvhuForElastic = Bsvhu;
+export type BsvhuForElastic = Bsvhu & BsvhuWithIntermediaries;
 
 /**
  * Convert a bsvhu from the bsvhu table to Elastic Search's BSD model.
@@ -189,12 +240,14 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
     ...getRegistryFields(bsvhu),
     rawBsd: bsvhu,
     revisionRequests: [],
+    intermediaries: bsvhu.intermediaries,
 
     // ALL actors from the BSVHU, for quick search
     companyNames: [
       bsvhu.emitterCompanyName,
       bsvhu.transporterCompanyName,
-      bsvhu.destinationCompanyName
+      bsvhu.destinationCompanyName,
+      ...bsvhu.intermediaries.map(intermediary => intermediary.name)
     ]
       .filter(Boolean)
       .join(" "),
@@ -202,11 +255,13 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
       bsvhu.emitterCompanySiret,
       bsvhu.transporterCompanySiret,
       bsvhu.transporterCompanyVatNumber,
-      bsvhu.destinationCompanySiret
+      bsvhu.destinationCompanySiret,
+      ...bsvhu.intermediaries.map(intermediary => intermediary.siret),
+      ...bsvhu.intermediaries.map(intermediary => intermediary.vatNumber)
     ].filter(Boolean)
   };
 }
 
-export function indexBsvhu(bsvhu: Bsvhu, ctx?: GraphQLContext) {
+export function indexBsvhu(bsvhu: BsvhuForElastic, ctx?: GraphQLContext) {
   return indexBsd(toBsdElastic(bsvhu), ctx);
 }

--- a/back/src/bsvhu/registry.ts
+++ b/back/src/bsvhu/registry.ts
@@ -20,6 +20,9 @@ import { getWasteDescription } from "./utils";
 import { getBsvhuSubType } from "../common/subTypes";
 import { splitAddress } from "../common/addresses";
 import Decimal from "decimal.js";
+import { RegistryBsvhu } from "../registry/elastic";
+import { getIntermediaryCompanyOrgId } from "@td/constants";
+import { BsvhuForElastic } from "./elastic";
 
 const getOperationData = (bsvhu: Bsvhu) => ({
   destinationPlannedOperationCode: bsvhu.destinationPlannedOperationCode,
@@ -75,8 +78,23 @@ export const getTransporterData = (bsvhu: Bsvhu, includePlates = false) => {
   return data;
 };
 
+const getIntermediariesData = (bsda: RegistryBsvhu) => ({
+  intermediary1CompanyName: bsda.intermediaries?.[0]?.name ?? null,
+  intermediary1CompanySiret: bsda.intermediaries?.[0]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[0])
+    : null,
+  intermediary2CompanyName: bsda.intermediaries?.[1]?.name ?? null,
+  intermediary2CompanySiret: bsda.intermediaries?.[1]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[1])
+    : null,
+  intermediary3CompanyName: bsda.intermediaries?.[2]?.name ?? null,
+  intermediary3CompanySiret: bsda.intermediaries?.[2]
+    ? getIntermediaryCompanyOrgId(bsda.intermediaries[2])
+    : null
+});
+
 export function getRegistryFields(
-  bsvhu: Bsvhu
+  bsvhu: BsvhuForElastic
 ): Pick<BsdElastic, RegistryFields> {
   const registryFields: Record<RegistryFields, string[]> = {
     isIncomingWasteFor: [],
@@ -101,6 +119,15 @@ export function getRegistryFields(
       registryFields.isTransportedWasteFor.push(bsvhu.transporterCompanySiret);
       registryFields.isAllWasteFor.push(bsvhu.transporterCompanySiret);
     }
+    if (bsvhu.intermediaries?.length) {
+      for (const intermediary of bsvhu.intermediaries) {
+        const intermediaryOrgId = getIntermediaryCompanyOrgId(intermediary);
+        if (intermediaryOrgId) {
+          registryFields.isManagedWasteFor.push(intermediaryOrgId);
+          registryFields.isAllWasteFor.push(intermediaryOrgId);
+        }
+      }
+    }
   }
 
   if (
@@ -113,7 +140,7 @@ export function getRegistryFields(
   return registryFields;
 }
 
-export function toGenericWaste(bsvhu: Bsvhu): GenericWaste {
+export function toGenericWaste(bsvhu: RegistryBsvhu): GenericWaste {
   const {
     street: destinationCompanyAddress,
     postalCode: destinationCompanyPostalCode,
@@ -198,7 +225,7 @@ export function toGenericWaste(bsvhu: Bsvhu): GenericWaste {
   };
 }
 
-export function toIncomingWaste(bsvhu: Bsvhu): Required<IncomingWaste> {
+export function toIncomingWaste(bsvhu: RegistryBsvhu): Required<IncomingWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -219,7 +246,7 @@ export function toIncomingWaste(bsvhu: Bsvhu): Required<IncomingWaste> {
   };
 }
 
-export function toOutgoingWaste(bsvhu: Bsvhu): Required<OutgoingWaste> {
+export function toOutgoingWaste(bsvhu: RegistryBsvhu): Required<OutgoingWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -241,7 +268,9 @@ export function toOutgoingWaste(bsvhu: Bsvhu): Required<OutgoingWaste> {
   };
 }
 
-export function toTransportedWaste(bsvhu: Bsvhu): Required<TransportedWaste> {
+export function toTransportedWaste(
+  bsvhu: RegistryBsvhu
+): Required<TransportedWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -265,7 +294,7 @@ export function toTransportedWaste(bsvhu: Bsvhu): Required<TransportedWaste> {
  * BSVHU has no trader or broker so this function should not
  * be called. We implement it anyway in case it is added later on
  */
-export function toManagedWaste(bsvhu: Bsvhu): Required<ManagedWaste> {
+export function toManagedWaste(bsvhu: RegistryBsvhu): Required<ManagedWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -282,7 +311,7 @@ export function toManagedWaste(bsvhu: Bsvhu): Required<ManagedWaste> {
   };
 }
 
-export function toAllWaste(bsvhu: Bsvhu): Required<AllWaste> {
+export function toAllWaste(bsvhu: RegistryBsvhu): Required<AllWaste> {
   const { __typename, ...genericWaste } = toGenericWaste(bsvhu);
 
   return {
@@ -302,6 +331,7 @@ export function toAllWaste(bsvhu: Bsvhu): Required<AllWaste> {
     emitterCompanyMail: bsvhu.emitterCompanyMail,
     ...getOperationData(bsvhu),
     ...getTransporterData(bsvhu, true),
-    ...getInitialEmitterData()
+    ...getInitialEmitterData(),
+    ...getIntermediariesData(bsvhu)
   };
 }

--- a/back/src/bsvhu/repository/bsvhu/findRelatedEntity.ts
+++ b/back/src/bsvhu/repository/bsvhu/findRelatedEntity.ts
@@ -1,0 +1,19 @@
+import { Bsvhu, Prisma } from "@prisma/client";
+import { ReadRepositoryFnDeps } from "../../../common/repository/types";
+
+type ChainableBsvhu = Pick<
+  Prisma.Prisma__BsvhuClient<Bsvhu | null, null>,
+  "intermediaries"
+>;
+
+export type FindRelatedEntityFn = (
+  where: Prisma.BsvhuWhereUniqueInput
+) => ChainableBsvhu;
+
+export function buildFindRelatedBsvhuEntity({
+  prisma
+}: ReadRepositoryFnDeps): FindRelatedEntityFn {
+  return where => {
+    return prisma.bsvhu.findUnique({ where });
+  };
+}

--- a/back/src/bsvhu/repository/index.ts
+++ b/back/src/bsvhu/repository/index.ts
@@ -3,6 +3,7 @@ import { transactionWrapper } from "../../common/repository/helper";
 import { BsvhuActions } from "./types";
 import { buildFindUniqueBsvhu } from "./bsvhu/findUnique";
 import { buildFindManyBsvhu } from "./bsvhu/findMany";
+import { buildFindRelatedBsvhuEntity } from "./bsvhu/findRelatedEntity";
 import { buildCountBsvhus } from "./bsvhu/count";
 
 import { buildCreateBsvhu } from "./bsvhu/create";
@@ -19,7 +20,8 @@ export function getReadonlyBsvhuRepository() {
   return {
     count: buildCountBsvhus({ prisma }),
     findUnique: buildFindUniqueBsvhu({ prisma }),
-    findMany: buildFindManyBsvhu({ prisma })
+    findMany: buildFindManyBsvhu({ prisma }),
+    findRelatedEntity: buildFindRelatedBsvhuEntity({ prisma })
   };
 }
 

--- a/back/src/bsvhu/repository/types.ts
+++ b/back/src/bsvhu/repository/types.ts
@@ -2,6 +2,7 @@ import { CountBsvhusFn } from "./bsvhu/count";
 import { CreateBsvhuFn } from "./bsvhu/create";
 import { DeleteBsvhuFn } from "./bsvhu/delete";
 import { FindManyBsvhuFn } from "./bsvhu/findMany";
+import { FindRelatedEntityFn } from "./bsvhu/findRelatedEntity";
 
 import { FindUniqueBsvhuFn } from "./bsvhu/findUnique";
 import { UpdateBsvhuFn } from "./bsvhu/update";
@@ -10,6 +11,7 @@ import { UpdateManyBsvhuFn } from "./bsvhu/updateMany";
 export type BsvhuActions = {
   findUnique: FindUniqueBsvhuFn;
   findMany: FindManyBsvhuFn;
+  findRelatedEntity: FindRelatedEntityFn;
   create: CreateBsvhuFn;
   update: UpdateBsvhuFn;
   updateMany: UpdateManyBsvhuFn;

--- a/back/src/bsvhu/resolvers/Bsvhu.ts
+++ b/back/src/bsvhu/resolvers/Bsvhu.ts
@@ -1,6 +1,14 @@
 import { BsvhuResolvers } from "../../generated/graphql/types";
+import { getReadonlyBsvhuRepository } from "../repository";
 
 const bsvhuResolvers: BsvhuResolvers = {
+  intermediaries: async bsvhu => {
+    const intermediaries = await getReadonlyBsvhuRepository()
+      .findRelatedEntity({ id: bsvhu.id })
+      .intermediaries();
+
+    return intermediaries ?? null;
+  },
   metadata: bsvhu => {
     return {
       id: bsvhu.id

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -6,7 +6,10 @@ import {
 } from "../../../generated/graphql/types";
 
 import { GraphQLContext } from "../../../types";
-import { expandVhuFormFromDb } from "../../converter";
+import {
+  companyToIntermediaryInput,
+  expandVhuFormFromDb
+} from "../../converter";
 import { parseBsvhuAsync } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
 
@@ -42,12 +45,20 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
     }
   );
 
+  const intermediaries =
+    parsedZodBsvhu.intermediaries && parsedZodBsvhu.intermediaries.length > 0
+      ? {
+          create: companyToIntermediaryInput(parsedZodBsvhu.intermediaries)
+        }
+      : undefined;
+
   const bsvhuRepository = getBsvhuRepository(user);
 
   const newForm = await bsvhuRepository.create({
     ...parsedZodBsvhu,
     id: getReadableId(ReadableIdPrefix.VHU),
-    isDraft
+    isDraft,
+    intermediaries
   });
 
   return expandVhuFormFromDb(newForm);

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -1,4 +1,4 @@
-import { Prisma, BsvhuStatus, Bsvhu, User } from "@prisma/client";
+import { Prisma, BsvhuStatus, User } from "@prisma/client";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
 import { MutationDuplicateBsvhuArgs } from "../../../generated/graphql/types";
@@ -9,6 +9,10 @@ import { checkCanDuplicate } from "../../permissions";
 import { prisma } from "@td/prisma";
 import { prismaToZodBsvhu } from "../../validation/helpers";
 import { parseBsvhuAsync } from "../../validation";
+import {
+  BsvhuForParsingInclude,
+  PrismaBsvhuForParsing
+} from "../../validation/types";
 
 export default async function duplicate(
   _,
@@ -17,7 +21,9 @@ export default async function duplicate(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const prismaBsvhu = await getBsvhuOrNotFound(id);
+  const prismaBsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
 
   await checkCanDuplicate(user, prismaBsvhu);
   const bsvhuRepository = getBsvhuRepository(user);
@@ -30,7 +36,7 @@ export default async function duplicate(
 }
 
 async function getDuplicateData(
-  bsvhu: Bsvhu,
+  bsvhu: PrismaBsvhuForParsing,
   user: User
 ): Promise<Prisma.BsvhuCreateInput> {
   const {
@@ -51,16 +57,17 @@ async function getDuplicateData(
     destinationOperationMode,
     destinationOperationSignatureAuthor,
     destinationOperationSignatureDate,
+    intermediariesOrgIds,
     ...zodBsvhu
   } = prismaToZodBsvhu(bsvhu);
 
-  const parsedBsvhu = await parseBsvhuAsync(zodBsvhu, {
+  const { intermediaries, ...parsedBsvhu } = await parseBsvhuAsync(zodBsvhu, {
     user
   });
 
   const { emitter, transporter, destination } = await getBsvhuCompanies(bsvhu);
 
-  return {
+  let data: Prisma.BsvhuCreateInput = {
     ...parsedBsvhu,
     id: getReadableId(ReadableIdPrefix.VHU),
     status: BsvhuStatus.INITIAL,
@@ -85,9 +92,29 @@ async function getDuplicateData(
       transporter?.contactEmail ?? parsedBsvhu.transporterCompanyMail,
     transporterCompanyVatNumber: parsedBsvhu.transporterCompanyVatNumber
   };
+  if (intermediaries) {
+    data = {
+      ...data,
+      intermediaries: {
+        createMany: {
+          data: intermediaries.map(intermediary => ({
+            siret: intermediary.siret!,
+            address: intermediary.address,
+            vatNumber: intermediary.vatNumber,
+            name: intermediary.name!,
+            contact: intermediary.contact!,
+            phone: intermediary.phone,
+            mail: intermediary.mail
+          }))
+        }
+      },
+      intermediariesOrgIds
+    };
+  }
+  return data;
 }
 
-async function getBsvhuCompanies(bsvhu: Bsvhu) {
+async function getBsvhuCompanies(bsvhu: PrismaBsvhuForParsing) {
   const companiesOrgIds = [
     bsvhu.emitterCompanySiret,
     bsvhu.transporterCompanySiret,

--- a/back/src/bsvhu/resolvers/mutations/publish.ts
+++ b/back/src/bsvhu/resolvers/mutations/publish.ts
@@ -8,6 +8,7 @@ import { getBsvhuRepository } from "../../repository";
 import { checkCanUpdate } from "../../permissions";
 import { ForbiddenError } from "../../../common/errors";
 import { prismaToZodBsvhu } from "../../validation/helpers";
+import { BsvhuForParsingInclude } from "../../validation/types";
 
 export default async function publish(
   _,
@@ -16,7 +17,9 @@ export default async function publish(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const existingBsvhu = await getBsvhuOrNotFound(id);
+  const existingBsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
 
   await checkCanUpdate(user, existingBsvhu);
 

--- a/back/src/bsvhu/resolvers/mutations/sign.ts
+++ b/back/src/bsvhu/resolvers/mutations/sign.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../companies/recipify";
 import { prismaToZodBsvhu } from "../../validation/helpers";
 import { prisma } from "@td/prisma";
+import { BsvhuForParsingInclude } from "../../validation/types";
 
 export default async function sign(
   _,
@@ -29,7 +30,9 @@ export default async function sign(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const bsvhu = await getBsvhuOrNotFound(id);
+  const bsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
   const authorizedOrgIds = getAuthorizedOrgIds(bsvhu, input.type);
 
   // To sign a form for a company, you must either:

--- a/back/src/bsvhu/resolvers/mutations/update.ts
+++ b/back/src/bsvhu/resolvers/mutations/update.ts
@@ -1,12 +1,15 @@
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { MutationUpdateBsvhuArgs } from "../../../generated/graphql/types";
 import { GraphQLContext } from "../../../types";
-import { expandVhuFormFromDb } from "../../converter";
+import {
+  companyToIntermediaryInput,
+  expandVhuFormFromDb
+} from "../../converter";
 import { getBsvhuOrNotFound } from "../../database";
 import { mergeInputAndParseBsvhuAsync } from "../../validation";
 import { getBsvhuRepository } from "../../repository";
 import { checkCanUpdate } from "../../permissions";
-import { Prisma } from "@prisma/client";
+import { BsvhuForParsingInclude } from "../../validation/types";
 
 export default async function edit(
   _,
@@ -15,7 +18,9 @@ export default async function edit(
 ) {
   const user = checkIsAuthenticated(context);
 
-  const existingBsvhu = await getBsvhuOrNotFound(id);
+  const existingBsvhu = await getBsvhuOrNotFound(id, {
+    include: BsvhuForParsingInclude
+  });
 
   await checkCanUpdate(user, existingBsvhu, input);
 
@@ -31,12 +36,25 @@ export default async function edit(
     return expandVhuFormFromDb(existingBsvhu);
   }
 
+  const intermediaries = parsedBsvhu.intermediaries
+    ? {
+        deleteMany: {},
+        ...(parsedBsvhu.intermediaries.length > 0 && {
+          create: companyToIntermediaryInput(parsedBsvhu.intermediaries)
+        })
+      }
+    : undefined;
+
   const { update } = getBsvhuRepository(user);
   const { createdAt, ...bsvhu } = parsedBsvhu;
 
-  const data: Prisma.BsvhuUpdateInput = { ...bsvhu };
-
-  const updatedBsvhu = await update({ id }, data);
+  const updatedBsvhu = await update(
+    { id },
+    {
+      ...bsvhu,
+      intermediaries
+    }
+  );
 
   return expandVhuFormFromDb(updatedBsvhu);
 }

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -139,7 +139,7 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(33);
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(34);
   });
 
   it("should return OPERATION signed bsvhu sealed fields", async () => {
@@ -161,6 +161,6 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(57);
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(58);
   });
 });

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhupdf.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhupdf.integration.ts
@@ -1,11 +1,15 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import {
   userWithCompanyFactory,
-  userWithAccessTokenFactory
+  userWithAccessTokenFactory,
+  companyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { ErrorCode } from "../../../../common/errors";
-import { bsvhuFactory } from "../../../__tests__/factories.vhu";
+import {
+  bsvhuFactory,
+  toIntermediaryCompany
+} from "../../../__tests__/factories.vhu";
 
 import { Query } from "../../../../generated/graphql/types";
 import { GovernmentPermission } from "@prisma/client";
@@ -69,6 +73,27 @@ describe("Query.BsvhuPdf", () => {
     const bsvhu = await bsvhuFactory({
       opt: {
         emitterCompanySiret: company.siret
+      }
+    });
+
+    const { query } = makeClient(user);
+
+    const { data } = await query<Pick<Query, "bsvhuPdf">>(BSVHU_PDF, {
+      variables: { id: bsvhu.id }
+    });
+
+    expect(data.bsvhuPdf.token).toBeTruthy();
+  });
+
+  it("should return a token for requested id if current user is an intermediary", async () => {
+    const otherCompany = await companyFactory();
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: otherCompany.siret,
+        intermediaries: {
+          create: [toIntermediaryCompany(company)]
+        }
       }
     });
 

--- a/back/src/bsvhu/resolvers/queries/bsvhus.ts
+++ b/back/src/bsvhu/resolvers/queries/bsvhus.ts
@@ -26,7 +26,8 @@ export default async function bsvhus(
       { emitterCompanySiret: { in: orgIdsWithListPermission } },
       { transporterCompanySiret: { in: orgIdsWithListPermission } },
       { transporterCompanyVatNumber: { in: orgIdsWithListPermission } },
-      { destinationCompanySiret: { in: orgIdsWithListPermission } }
+      { destinationCompanySiret: { in: orgIdsWithListPermission } },
+      { intermediariesOrgIds: { hasSome: orgIdsWithListPermission } }
     ]
   };
 

--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -89,6 +89,13 @@ input BsvhuInput {
   destination: BsvhuDestinationInput
   "Détails sur le transporteur"
   transporter: BsvhuTransporterInput
+  """
+  Liste d'entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,
+  mais pas à la responsabilité de la traçabilité. Il pourra lire ce bordereau, sans étape de signature.
+
+  Le nombre maximal d'intermédiaires sur un bordereau est de 3.
+  """
+  intermediaries: [CompanyInput!]
 }
 
 input BsvhuEmitterInput {

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -56,6 +56,11 @@ type Bsvhu {
   destination: BsvhuDestination
   "Transporteur"
   transporter: BsvhuTransporter
+  """
+  Liste d'entreprises intermédiaires. Un intermédiaire est une entreprise qui prend part à la gestion du déchet,
+  mais pas à la responsabilité de la traçabilité. Il pourra lire ce bordereau, sans étape de signature.
+  """
+  intermediaries: [FormCompany!]
 
   metadata: BsvhuMetadata!
 }

--- a/back/src/bsvhu/types.ts
+++ b/back/src/bsvhu/types.ts
@@ -1,0 +1,10 @@
+import { Prisma } from "@prisma/client";
+
+export const BsvhuWithIntermediariesInclude =
+  Prisma.validator<Prisma.BsvhuInclude>()({
+    intermediaries: true
+  });
+
+export type BsvhuWithIntermediaries = Prisma.BsvhuGetPayload<{
+  include: typeof BsvhuWithIntermediariesInclude;
+}>;

--- a/back/src/bsvhu/validation/helpers.ts
+++ b/back/src/bsvhu/validation/helpers.ts
@@ -1,8 +1,8 @@
-import { Bsvhu, User } from "@prisma/client";
+import { User } from "@prisma/client";
 import { BsvhuInput, SignatureTypeInput } from "../../generated/graphql/types";
 import { BSVHU_SIGNATURES_HIERARCHY } from "./constants";
 import { ZodBsvhu, ZodOperationEnum, ZodWasteCodeEnum } from "./schema";
-import { BsvhuUserFunctions } from "./types";
+import { BsvhuUserFunctions, PrismaBsvhuForParsing } from "./types";
 import { getUserCompanies } from "../../users/database";
 import { flattenVhuInput } from "../converter";
 import { safeInput } from "../../common/converter";
@@ -21,6 +21,7 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
     wasteCode,
     destinationPlannedOperationCode,
     destinationOperationCode,
+    intermediaries,
     ...flatBsvhuInput
   } = flattenVhuInput(bsvhuInput);
 
@@ -29,7 +30,24 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
     destinationPlannedOperationCode:
       destinationPlannedOperationCode as ZodOperationEnum,
     destinationOperationCode: destinationOperationCode as ZodOperationEnum,
-    wasteCode: wasteCode as ZodWasteCodeEnum
+    wasteCode: wasteCode as ZodWasteCodeEnum,
+    intermediaries: intermediaries?.map(i =>
+      safeInput({
+        // FIXME : Les règles d'édition (fichier rules.ts) ne permettent
+        // pas à ce jour de définir les règles de champ requis pour les intermédiaire.
+        // Le schéma zod des intermédiaires enforce donc des champs requis dès le début
+        // (contrairement aux autres champs du BSVHU), ce qui est incohérent avec le typage
+        // côté input GraphQL. On force donc le typage ici, quitte à lever des erreurs
+        // de validation Zod dans le process de parsing.
+        siret: i.siret!,
+        vatNumber: i.vatNumber,
+        address: i.address!,
+        name: i.name!,
+        contact: i.contact!,
+        phone: i.phone,
+        mail: i.mail
+      })
+    )
   });
 }
 
@@ -39,11 +57,12 @@ export function graphQlInputToZodBsvhu(input: BsvhuInput): ZodBsvhu {
  * typés en string côté Prisma mais en enum côté Zod ce qui nous oblige
  * à faire un casting de type.
  */
-export function prismaToZodBsvhu(bsvhu: Bsvhu): ZodBsvhu {
+export function prismaToZodBsvhu(bsvhu: PrismaBsvhuForParsing): ZodBsvhu {
   const {
     wasteCode,
     destinationPlannedOperationCode,
     destinationOperationCode,
+    intermediaries,
     ...data
   } = bsvhu;
 
@@ -52,7 +71,11 @@ export function prismaToZodBsvhu(bsvhu: Bsvhu): ZodBsvhu {
     wasteCode: wasteCode as ZodWasteCodeEnum,
     destinationPlannedOperationCode:
       destinationPlannedOperationCode as ZodOperationEnum,
-    destinationOperationCode: destinationOperationCode as ZodOperationEnum
+    destinationOperationCode: destinationOperationCode as ZodOperationEnum,
+    intermediaries: intermediaries.map(i => {
+      const { bsvhuId, id, createdAt, ...intermediaryData } = i;
+      return { ...intermediaryData, address: intermediaryData.address! };
+    })
   };
 }
 

--- a/back/src/bsvhu/validation/index.ts
+++ b/back/src/bsvhu/validation/index.ts
@@ -1,4 +1,3 @@
-import { Bsvhu } from "@prisma/client";
 import { BsvhuInput } from "../../generated/graphql/types";
 import {
   getCurrentSignatureType,
@@ -7,11 +6,12 @@ import {
 } from "./helpers";
 import { checkBsvhuSealedFields } from "./rules";
 import {
+  ParsedZodBsvhu,
   ZodBsvhu,
   contextualBsvhuSchema,
   contextualBsvhuSchemaAsync
 } from "./schema";
-import { BsvhuValidationContext } from "./types";
+import { BsvhuValidationContext, PrismaBsvhuForParsing } from "./types";
 
 /**
  * Wrapper autour de `parseBsvhuAsync` qui peut être appelé
@@ -22,7 +22,7 @@ import { BsvhuValidationContext } from "./types";
  */
 export async function mergeInputAndParseBsvhuAsync(
   // BSFF déjà stockée en base de données.
-  persisted: Bsvhu,
+  persisted: PrismaBsvhuForParsing,
   // Données entrantes provenant de la couche GraphQL.
   input: BsvhuInput,
   context: BsvhuValidationContext
@@ -66,7 +66,7 @@ export async function mergeInputAndParseBsvhuAsync(
 export async function parseBsvhuAsync(
   bsvhu: ZodBsvhu,
   context: BsvhuValidationContext = {}
-) {
+): Promise<ParsedZodBsvhu> {
   const schema = contextualBsvhuSchemaAsync(context);
   return schema.parseAsync(bsvhu);
 }
@@ -78,7 +78,7 @@ export async function parseBsvhuAsync(
 export function parseBsvhu(
   bsvhu: ZodBsvhu,
   context: BsvhuValidationContext = {}
-) {
+): ParsedZodBsvhu {
   const schema = contextualBsvhuSchema(context);
   return schema.parse(bsvhu);
 }

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -30,6 +30,7 @@ export type BsvhuEditableFields = Required<
     | "transporterTransportSignatureAuthor"
     | "destinationOperationSignatureDate"
     | "destinationOperationSignatureAuthor"
+    | "intermediariesOrgIds"
   >
 >;
 
@@ -509,6 +510,11 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
     // required: {
     //   from: "TRANSPORT"
     // }
+  },
+  intermediaries: {
+    readableFieldName: "les intermédiaires",
+    sealed: { from: "TRANSPORT" },
+    path: ["intermediaries"]
   }
 };
 

--- a/back/src/bsvhu/validation/sirenify.ts
+++ b/back/src/bsvhu/validation/sirenify.ts
@@ -48,7 +48,23 @@ const sirenifyBsvhuAccessors = (
       input.transporterCompanyName = companyInput.name;
       input.transporterCompanyAddress = companyInput.address;
     }
-  }
+  },
+  ...(bsvhu.intermediaries ?? []).map(
+    (_, idx) =>
+      ({
+        siret: bsvhu.intermediaries![idx].siret,
+        skip: sealedFields.includes("intermediaries"),
+        setter: (input, companyInput) => {
+          const intermediary = input.intermediaries![idx];
+          if (companyInput.name) {
+            intermediary!.name = companyInput.name;
+          }
+          if (companyInput.address) {
+            intermediary!.address = companyInput.address;
+          }
+        }
+      } as NextCompanyInputAccessor<ParsedZodBsvhu>)
+  )
 ];
 
 export const sirenifyBsvhu: (

--- a/back/src/bsvhu/validation/transformers.ts
+++ b/back/src/bsvhu/validation/transformers.ts
@@ -1,0 +1,11 @@
+import { ZodBsvhuTransformer } from "./types";
+
+export const fillIntermediariesOrgIds: ZodBsvhuTransformer = bsvhu => {
+  bsvhu.intermediariesOrgIds = bsvhu.intermediaries
+    ? bsvhu.intermediaries
+        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+        .filter(Boolean)
+    : undefined;
+
+  return bsvhu;
+};

--- a/back/src/bsvhu/validation/types.ts
+++ b/back/src/bsvhu/validation/types.ts
@@ -1,4 +1,4 @@
-import { User } from "@prisma/client";
+import { Prisma, User } from "@prisma/client";
 import { ParsedZodBsvhu } from "./schema";
 import { RefinementCtx } from "zod";
 import { SignatureTypeInput } from "../../generated/graphql/types";
@@ -18,3 +18,11 @@ export type ZodBsvhuTransformer = (
   bsff: ParsedZodBsvhu,
   ctx: RefinementCtx
 ) => ParsedZodBsvhu | Promise<ParsedZodBsvhu>;
+
+export const BsvhuForParsingInclude = Prisma.validator<Prisma.BsvhuInclude>()({
+  intermediaries: true
+});
+
+export type PrismaBsvhuForParsing = Prisma.BsvhuGetPayload<{
+  include: typeof BsvhuForParsingInclude;
+}>;

--- a/back/src/queue/jobs/deleteBsd.ts
+++ b/back/src/queue/jobs/deleteBsd.ts
@@ -4,14 +4,17 @@ import {
   toBsdElastic as toBsddElastic
 } from "../../forms/elastic";
 import {
-  BsdaForElasticInclude,
+  getBsdaForElastic,
   toBsdElastic as toBsdaElastic
 } from "../../bsda/elastic";
 import {
   BsdasriForElasticInclude,
   toBsdElastic as toBsdasriElastic
 } from "../../bsdasris/elastic";
-import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
+import {
+  getBsvhuForElastic,
+  toBsdElastic as toBsvhuElastic
+} from "../../bsvhu/elastic";
 import {
   BsffForElasticInclude,
   toBsdElastic as toBsffElastic
@@ -30,10 +33,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   await deleteBsd({ id: bsdId });
 
   if (bsdId.startsWith("BSDA-")) {
-    const bsda = await prisma.bsda.findUniqueOrThrow({
-      where: { id: bsdId },
-      include: BsdaForElasticInclude
-    });
+    const bsda = await getBsdaForElastic({ id: bsdId });
 
     return toBsdaElastic(bsda);
   }
@@ -48,9 +48,7 @@ export async function deleteBsdJob(job: Job<string>): Promise<BsdElastic> {
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsdId }
-    });
+    const bsvhu = await getBsvhuForElastic({ id: bsdId });
 
     return toBsvhuElastic(bsvhu);
   }

--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -7,7 +7,10 @@ import {
   toBsdElastic as toBsdasriElastic,
   getBsdasriForElastic
 } from "../../bsdasris/elastic";
-import { toBsdElastic as toBsvhuElastic } from "../../bsvhu/elastic";
+import {
+  getBsvhuForElastic,
+  toBsdElastic as toBsvhuElastic
+} from "../../bsvhu/elastic";
 import { toBsdElastic as toBsffElastic } from "../../bsffs/elastic";
 import { toBsdElastic as toBspaohElastic } from "../../bspaoh/elastic";
 import { BsdElastic, indexBsd, getElasticBsdById } from "../../common/elastic";
@@ -49,9 +52,7 @@ export async function indexBsdJob(
   }
 
   if (bsdId.startsWith("VHU-")) {
-    const bsvhu = await prisma.bsvhu.findUniqueOrThrow({
-      where: { id: bsdId }
-    });
+    const bsvhu = await getBsvhuForElastic({ id: bsdId });
 
     const elasticBsvhu = toBsvhuElastic(bsvhu);
     await indexBsd(elasticBsvhu);

--- a/back/src/registry/__tests__/elastic.integration.ts
+++ b/back/src/registry/__tests__/elastic.integration.ts
@@ -29,7 +29,7 @@ import {
   createBsffBeforeEmission,
   createFicheIntervention
 } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
 import {
@@ -325,7 +325,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -337,7 +337,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("INCOMING", [destination.company.siret!]);
       expect(bsds).toEqual([]);
@@ -614,7 +614,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -627,7 +627,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("OUTGOING", [emitter.company.siret!]);
       expect(bsds).toEqual([]);
@@ -931,7 +931,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("TRANSPORTED", [
         transporter.company.siret!
@@ -946,7 +946,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("TRANSPORTED", [
         transporter.company.siret!
@@ -1453,7 +1453,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
 
       // When
@@ -1472,7 +1472,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: null
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
 
       // When
@@ -1489,7 +1489,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [emitter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -1502,7 +1502,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           transporterTransportSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [transporter.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);
@@ -1516,7 +1516,7 @@ describe("Retrieval of bsds in ES based on waste registry type", () => {
           destinationOperationSignatureDate: new Date()
         }
       });
-      await indexBsvhu(bsvhu);
+      await indexBsvhu(await getBsvhuForElastic(bsvhu));
       await refreshElasticSearch();
       const bsds = await searchBsds("ALL", [destination.company.siret!]);
       expect(bsds.map(bsd => bsd.id)).toEqual([bsvhu.id]);

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -12,7 +12,7 @@ import { createBsffAfterReception } from "../../bsffs/__tests__/factories";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
 import { getBsdaForElastic, indexBsda } from "../../bsda/elastic";
 import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 
 describe("wastesReader", () => {
@@ -120,7 +120,11 @@ describe("wastesReader", () => {
         )
     );
 
-    await Promise.all(bsvhus.map(bsvhu => indexBsvhu(bsvhu)));
+    const bsvhusForElastic = await Promise.all(
+      bsvhus.map(bsff => getBsvhuForElastic(bsff))
+    );
+
+    await Promise.all(bsvhusForElastic.map(bsvhu => indexBsvhu(bsvhu)));
 
     // create 5 incoming BSFFs
     const bsffs = await Promise.all(

--- a/back/src/registry/__tests__/where.dates.integration.ts
+++ b/back/src/registry/__tests__/where.dates.integration.ts
@@ -9,7 +9,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { client, index } from "../../common/elastic";
 import { getFormForElastic, indexForm } from "../../forms/elastic";
@@ -267,8 +267,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -703,8 +703,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -1186,8 +1186,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.destination.integration.ts
+++ b/back/src/registry/__tests__/where.destination.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -141,8 +141,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -367,8 +367,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -546,8 +546,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.emitter.integration.ts
+++ b/back/src/registry/__tests__/where.emitter.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -180,8 +180,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -369,8 +369,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -547,8 +547,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.integration.ts
+++ b/back/src/registry/__tests__/where.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -38,7 +38,7 @@ describe("toElasticFilter", () => {
       BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
       BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-      BSVHU: await bsvhuFactory({}),
+      BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
       BSFF: await getBsffForElastic(await createBsff()),
       BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
     };
@@ -85,7 +85,7 @@ describe("toElasticFilter", () => {
         BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
         BSDA: await getBsdaForElastic(await bsdaFactory({})),
         BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-        BSVHU: await bsvhuFactory({}),
+        BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
         BSFF: await getBsffForElastic(await createBsff()),
         BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
       };
@@ -116,7 +116,7 @@ describe("toElasticFilter", () => {
       BSDD: await getFormForElastic(await formFactory({ ownerId: user.id })),
       BSDA: await getBsdaForElastic(await bsdaFactory({})),
       BSDASRI: await getBsdasriForElastic(await bsdasriFactory({})),
-      BSVHU: await bsvhuFactory({}),
+      BSVHU: await getBsvhuForElastic(await bsvhuFactory({})),
       BSFF: await getBsffForElastic(await createBsff()),
       BSPAOH: await getBspaohForElastic(await bspaohFactory({}))
     };

--- a/back/src/registry/__tests__/where.transporter.integration.ts
+++ b/back/src/registry/__tests__/where.transporter.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -205,8 +205,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -424,8 +424,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -637,8 +637,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/__tests__/where.weight.integration.ts
+++ b/back/src/registry/__tests__/where.weight.integration.ts
@@ -8,7 +8,7 @@ import { getBsdasriForElastic, indexBsdasri } from "../../bsdasris/elastic";
 import { bsdasriFactory } from "../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../bsffs/elastic";
 import { createBsff } from "../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../bsvhu/elastic";
 import { bsvhuFactory } from "../../bsvhu/__tests__/factories.vhu";
 import { bspaohFactory } from "../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../bspaoh/elastic";
@@ -199,8 +199,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -445,8 +445,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();
@@ -685,8 +685,8 @@ describe("toElasticFilter", () => {
     });
 
     await Promise.all(
-      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsda => {
-        return indexBsvhu(bsda);
+      [bsvhu1, bsvhu2, bsvhu3, bsvhu4].map(async bsvhu => {
+        return indexBsvhu(await getBsvhuForElastic(bsvhu));
       })
     );
     await refreshElasticSearch();

--- a/back/src/registry/elastic.ts
+++ b/back/src/registry/elastic.ts
@@ -6,7 +6,7 @@ import {
   WasteRegistryWhere
 } from "../generated/graphql/types";
 import { toElasticFilter } from "./where";
-import { Bsvhu, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@td/prisma";
 
 export function buildQuery(
@@ -153,7 +153,13 @@ export type RegistryBsff = Prisma.BsffGetPayload<{
   include: typeof RegistryBsffInclude;
 }>;
 
-type RegistryBsvhu = Bsvhu;
+export const RegistryBsvhuInclude = Prisma.validator<Prisma.BsvhuInclude>()({
+  intermediaries: true
+});
+
+export type RegistryBsvhu = Prisma.BsvhuGetPayload<{
+  include: typeof RegistryBsvhuInclude;
+}>;
 
 export type RegistryBsdMap = {
   bsdds: RegistryForm[];
@@ -197,7 +203,8 @@ export async function toPrismaBsds(
         id: {
           in: BSVHU.map(bsvhu => bsvhu.id)
         }
-      }
+      },
+      include: RegistryBsvhuInclude
     }),
     prisma.bsda.findMany({
       where: {

--- a/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/allWastes.integration.ts
@@ -28,7 +28,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
@@ -211,7 +211,7 @@ describe("All wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/incomingWastes.integration.ts
@@ -5,7 +5,6 @@ import {
   BsdaStatus,
   BsdasriStatus,
   Bsff,
-  Bsvhu,
   Bspaoh,
   BspaohStatus,
   BsvhuStatus,
@@ -13,7 +12,8 @@ import {
   Status,
   User,
   UserRole,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -29,7 +29,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
@@ -215,7 +215,7 @@ describe("Incoming wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/outgoingWastes.integration.ts
@@ -5,7 +5,6 @@ import {
   BsdaStatus,
   BsdasriStatus,
   Bsff,
-  Bsvhu,
   BsvhuStatus,
   Bspaoh,
   BspaohStatus,
@@ -13,7 +12,8 @@ import {
   Status,
   User,
   UserRole,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -30,7 +30,7 @@ import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
 import { getBspaohForElastic, indexBspaoh } from "../../../../bspaoh/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { Query } from "../../../../generated/graphql/types";
@@ -210,7 +210,7 @@ describe("Outgoing wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
+++ b/back/src/registry/resolvers/queries/__tests__/transportedWastes.integration.ts
@@ -4,7 +4,6 @@ import {
   Bsdasri,
   BsdaStatus,
   Bsff,
-  Bsvhu,
   BsvhuStatus,
   Bspaoh,
   BspaohStatus,
@@ -13,7 +12,8 @@ import {
   User,
   UserRole,
   BsdasriStatus,
-  GovernmentPermission
+  GovernmentPermission,
+  Bsvhu
 } from "@prisma/client";
 import {
   refreshElasticSearch,
@@ -29,7 +29,7 @@ import {
 import { bsdasriFactory } from "../../../../bsdasris/__tests__/factories";
 import { getBsffForElastic, indexBsff } from "../../../../bsffs/elastic";
 import { createBsffAfterOperation } from "../../../../bsffs/__tests__/factories";
-import { indexBsvhu } from "../../../../bsvhu/elastic";
+import { getBsvhuForElastic, indexBsvhu } from "../../../../bsvhu/elastic";
 import { bsvhuFactory } from "../../../../bsvhu/__tests__/factories.vhu";
 import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 import { bspaohFactory } from "../../../../bspaoh/__tests__/factories";
@@ -209,7 +209,7 @@ describe("Transported wastes registry", () => {
       indexForm(await getFormForElastic(bsd1)),
       indexBsda(await getBsdaForElastic(bsd2)),
       indexBsdasri(await getBsdasriForElastic(bsd3)),
-      indexBsvhu(bsd4),
+      indexBsvhu(await getBsvhuForElastic(bsd4)),
       indexBsff(await getBsffForElastic(bsd5)),
       indexBspaoh(await getBspaohForElastic(bsd6))
     ]);

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=c5bdfaab"
+      href="/dsfr/utility/icons/icons.min.css?hash=618ed71d"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/libs/back/prisma/src/migrations/20240903225951_add_bsvhu_intermediaries/migration.sql
+++ b/libs/back/prisma/src/migrations/20240903225951_add_bsvhu_intermediaries/migration.sql
@@ -1,0 +1,33 @@
+-- AlterTable
+ALTER TABLE "Bsvhu" ADD COLUMN     "intermediariesOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateTable
+CREATE TABLE "IntermediaryBsvhuAssociation" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "siret" TEXT NOT NULL,
+    "contact" TEXT NOT NULL,
+    "vatNumber" TEXT,
+    "address" TEXT,
+    "phone" TEXT,
+    "mail" TEXT,
+    "bsvhuId" TEXT NOT NULL,
+
+    CONSTRAINT "IntermediaryBsvhuAssociation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_IntermediaryBsvhuAssociationBsvhuIdIdx" ON "IntermediaryBsvhuAssociation"("bsvhuId");
+
+-- CreateIndex
+CREATE INDEX "IntermediaryBsvhuAssociationSiretIdx" ON "IntermediaryBsvhuAssociation"("siret");
+
+-- CreateIndex
+CREATE INDEX "IntermediaryBsvhuAssociationVatNumberIdx" ON "IntermediaryBsvhuAssociation"("vatNumber");
+
+-- CreateIndex
+CREATE INDEX "_BsvhuIntermediariesOrgIdsIdx" ON "Bsvhu" USING GIN ("intermediariesOrgIds");
+
+-- AddForeignKey
+ALTER TABLE "IntermediaryBsvhuAssociation" ADD CONSTRAINT "IntermediaryBsvhuAssociation_bsvhuId_fkey" FOREIGN KEY ("bsvhuId") REFERENCES "Bsvhu"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1064,14 +1064,38 @@ model Bsvhu {
   transporterTransportPlates                          String[]
   transporterRecepisseIsExempted                      Boolean?
 
+  intermediaries IntermediaryBsvhuAssociation[]
+
+  // Denormalized fields, storing sirets to speed up queries and avoid expensive joins
+  intermediariesOrgIds String[] @default([])
+
   // partial indices _BsvhuIsDeletedIdx,_BsvhuIsDraftIdx  see migration82_missing_indices.sql
 
   @@index([emitterCompanySiret], map: "_BvhuEmitterCompanySirettIdx")
   @@index([destinationCompanySiret], map: "_BsvhuDestinationCompanySiretIdx")
   @@index([transporterCompanySiret], map: "_BsvhuTransporterCompanySiretIdx")
   @@index([transporterCompanyVatNumber], map: "_BsvhuTransporterCompanyVatNumberIdx")
+  @@index([intermediariesOrgIds], map: "_BsvhuIntermediariesOrgIdsIdx", type: Gin)
   @@index([status], map: "_BsvhuStatusIdx")
   @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
+}
+
+model IntermediaryBsvhuAssociation {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  siret     String
+  contact   String
+  vatNumber String?
+  address   String?
+  phone     String?
+  mail      String?
+  bsvhuId   String
+  bsvhu     Bsvhu    @relation(fields: [bsvhuId], references: [id])
+
+  @@index([bsvhuId], map: "_IntermediaryBsvhuAssociationBsvhuIdIdx")
+  @@index([siret], map: "IntermediaryBsvhuAssociationSiretIdx")
+  @@index([vatNumber], map: "IntermediaryBsvhuAssociationVatNumberIdx")
 }
 
 model Bsdasri {

--- a/libs/shared/constants/src/companySearchHelpers.ts
+++ b/libs/shared/constants/src/companySearchHelpers.ts
@@ -199,6 +199,20 @@ export const getTransporterCompanyOrgId = (
     : form.transporterCompanyVatNumber;
 };
 
+export type PartialIntermediaryCompany = {
+  siret: string | null;
+  vatNumber: string | null;
+};
+
+export const getIntermediaryCompanyOrgId = (
+  intermediary: PartialIntermediaryCompany | null
+): string | null => {
+  if (!intermediary) return null;
+  return intermediary.siret?.length
+    ? intermediary.siret
+    : intermediary.vatNumber;
+};
+
 /**
  * Check for etatAdministratif
  */


### PR DESCRIPTION
# Objectif

Ajouter 3 intermédiares au BSVHU. Voilà c'est tout.

# Tech

C'est la même architecture backend et la même spec que pour les intermédiaires BSDA, donc j'ai largement repris l'implémentation. Rien de particluier à signaler a priori.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14647)
