### PR TITLE
[TRA-14958] Add empty return ADR to reception

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout d'un filtre par sous-type de bordereau [PR 3476](https://github.com/MTES-MCT/trackdechets/pull/3476)
 - Amélioration des pages de connexion oauth / oidc avec leur passage au DSFR [PR 3550](https://github.com/MTES-MCT/trackdechets/pull/3550)
 - Amélioration de la page Mes applications avec le passage au DSFR [PR 3562](https://github.com/MTES-MCT/trackdechets/pull/3562)
+- ETQ destinataire, je peux indiquer que mon véhicule est rincé ou non pour son retour à vide [PR 3576](https://github.com/MTES-MCT/trackdechets/pull/3576)
 
 #### :boom: Breaking changes
 

--- a/front/src/Apps/common/utils/adrBsddSummary.ts
+++ b/front/src/Apps/common/utils/adrBsddSummary.ts
@@ -1,0 +1,9 @@
+import { EmptyReturnAdr } from "@td/codegen-ui";
+
+export const EMPTY_RETURN_ADR_REASON = {
+  [EmptyReturnAdr.EmptyCiterne]:
+    "Véhicule-Citerne vide, dernière marchandise chargée",
+  [EmptyReturnAdr.EmptyNotWashed]: "Vide, non nettoyé",
+  [EmptyReturnAdr.EmptyReturnNotWashed]: "Retour à vide, non nettoyé",
+  [EmptyReturnAdr.EmptyVehicle]: "Véhicule vide, dernière marchandise chargée"
+};


### PR DESCRIPTION
Ajout de la notion de retour à vide ADR sur la modale de réception / acceptation.

![image](https://github.com/user-attachments/assets/ec9a2b32-c8c6-4d1c-9411-681029b83b15)

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14958)
