### PR TITLE
Corrige la checkbox et la date du template bsda 

### DIFF
--- a/back/src/bsda/pdf/components/BsdaPdf.tsx
+++ b/back/src/bsda/pdf/components/BsdaPdf.tsx
@@ -25,9 +25,19 @@ const PACKAGINGS_NAMES = {
   OTHER: "Autre - "
 };
 
-type Props = { bsda: Bsda; qrCode: string; previousBsdas: Bsda[] };
+type Props = {
+  bsda: Bsda;
+  qrCode: string;
+  previousBsdas: Bsda[];
+  renderEmpty?: boolean;
+};
 
-export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
+export function BsdaPdf({
+  bsda,
+  qrCode,
+  previousBsdas,
+  renderEmpty = false
+}: Props) {
   return (
     <Document title={bsda.id}>
       <div className="Page">
@@ -49,7 +59,7 @@ export function BsdaPdf({ bsda, qrCode, previousBsdas }: Props) {
               dangerouslySetInnerHTML={{ __html: qrCode }}
             />
             <div>
-              <b>Document édité le {dateToXMonthAtHHMM()}</b>
+              <b>Document édité le {renderEmpty ? "" : dateToXMonthAtHHMM()}</b>
             </div>
           </div>
         </div>

--- a/back/src/bsda/pdf/components/WasteDetails.tsx
+++ b/back/src/bsda/pdf/components/WasteDetails.tsx
@@ -23,7 +23,13 @@ export function WasteDetails({ waste, weight }: Props) {
         Consistance : {waste?.consistence ? CONSISTANCE[waste.consistence] : ""}
         <br />
         Quantité en tonnes : {weight?.value} <br />
-        <input type="checkbox" checked={!weight?.isEstimate} readOnly /> Réelle
+        {/* intentional strict equality for empy templates */}
+        <input
+          type="checkbox"
+          checked={weight?.isEstimate === false}
+          readOnly
+        />{" "}
+        Réelle
         <br />
         <input
           type="checkbox"

--- a/back/src/bsda/pdf/generator.tsx
+++ b/back/src/bsda/pdf/generator.tsx
@@ -34,6 +34,7 @@ export async function buildPdf(bsda: BsdaForPDF, renderEmptyPdf?: boolean) {
       bsda={expandedBsda}
       qrCode={qrCode}
       previousBsdas={previousBsdas}
+      renderEmpty={renderEmptyPdf}
     />
   );
   return generatePdf(html);

--- a/back/src/scripts/bin/bsdTemplates/generateBsdTemplates.ts
+++ b/back/src/scripts/bin/bsdTemplates/generateBsdTemplates.ts
@@ -90,16 +90,18 @@ const getBsds = async () => {
       S3_BSD_TEMPLATES_BUCKET
     ].some(el => !el)
   ) {
-    console.log("no templates");
+    // Script not run when env variables are missing
+    console.log("Skip empty templates generation");
     process.exit(0);
   }
+
   const folder = "bsds/";
   const client = new S3Client({
-    endpoint: S3_ENDPOINT,
-    region: S3_REGION,
+    endpoint: S3_ENDPOINT ?? "",
+    region: S3_REGION ?? "",
     credentials: {
-      accessKeyId: S3_BSD_TEMPLATES_ACCESS_KEY_ID,
-      secretAccessKey: S3_BSD_TEMPLATES_SECRET_ACCESS_KEY
+      accessKeyId: S3_BSD_TEMPLATES_ACCESS_KEY_ID ?? "",
+      secretAccessKey: S3_BSD_TEMPLATES_SECRET_ACCESS_KEY ?? ""
     }
   });
 


### PR DESCRIPTION
- Une checkbox du bdsa était cochée et la daté d'édition renseignée
- Le script de postdeploy est skippé si les variables d'envs S3_BSD_TEMPLATES_* sont absentes. Log plus explicite et fix du typage

Modèle corrigé déployé sur https://td-bsds-templates.s3-website.fr-par.scw.cloud/

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
