### PR TITLE
Correctifs sur le filtre avancé par type / sous-type de bordereau

### DIFF
--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -91,30 +91,24 @@ const bsdTypeFilterSelectOptions = [
     ]
   },
   {
-    value: BsdType.Bsdasri,
-    label: bsd_type_option_bsdasri,
+    value: BsdType.Bsda,
+    label: bsd_type_option_bsda,
     options: [
       {
         value: BsdSubType.Initial,
         label: bsd_sub_type_option_initial
-      },
-      {
-        value: BsdSubType.Synthesis,
-        label: bsd_sub_type_option_synthesis
       },
       {
         value: BsdSubType.Gathering,
         label: bsd_sub_type_option_gathering
-      }
-    ]
-  },
-  {
-    value: BsdType.Bsvhu,
-    label: bsd_type_option_bsvhu,
-    options: [
+      },
       {
-        value: BsdSubType.Initial,
-        label: bsd_sub_type_option_initial
+        value: BsdSubType.Reshipment,
+        label: bsd_sub_type_option_reshipment
+      },
+      {
+        value: BsdSubType.Collection_2710,
+        label: bsd_sub_type_option_collection_2710
       }
     ]
   },
@@ -141,36 +135,30 @@ const bsdTypeFilterSelectOptions = [
     ]
   },
   {
-    value: BsdType.Bsda,
-    label: bsd_type_option_bsda,
+    value: BsdType.Bsvhu,
+    label: bsd_type_option_bsvhu
+  },
+  {
+    value: BsdType.Bsdasri,
+    label: bsd_type_option_bsdasri,
     options: [
       {
         value: BsdSubType.Initial,
         label: bsd_sub_type_option_initial
       },
       {
+        value: BsdSubType.Synthesis,
+        label: bsd_sub_type_option_synthesis
+      },
+      {
         value: BsdSubType.Gathering,
         label: bsd_sub_type_option_gathering
-      },
-      {
-        value: BsdSubType.Reshipment,
-        label: bsd_sub_type_option_reshipment
-      },
-      {
-        value: BsdSubType.Collection_2710,
-        label: bsd_sub_type_option_collection_2710
       }
     ]
   },
   {
     value: BsdType.Bspaoh,
-    label: bsd_type_option_bspaoh,
-    options: [
-      {
-        value: BsdSubType.Initial,
-        label: bsd_sub_type_option_initial
-      }
-    ]
+    label: bsd_type_option_bspaoh
   }
 ];
 

--- a/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
+++ b/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
@@ -77,6 +77,7 @@ const SelectWithSubOptions = ({
 
             {/* Option's potential sub-options */}
             {option.options &&
+              optionIsAlreadySelected &&
               mapOptions(
                 option.options,
                 [...parentPaths, option.value],


### PR DESCRIPTION
# Contexte

Petits correctifs pour le Filtre avancé sur les types & sous-types de bordereaux, à savoir:
- Modification de l'ordre des filtres
- On n'affiche plus les sous-types si le type n'a pas été sélectionné (pour plus de lisibilité)

# Démo

![demo_filtre_bsds](https://github.com/user-attachments/assets/78f74f8c-0d4c-4d0e-9150-dcc83e10d1ed)

# Ticket Favro

[Permettre de filtrer par sous-type de bordereau](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14399)
