### PR TITLE
  [TRA-14919]  Correction du poids affiché sur le tableau de bord en cas de refus total pour les BSDD

### DIFF
--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -57,6 +57,7 @@ import { NON_RENSEIGNE } from "../../../common/wordings/dashboard/wordingsDashbo
 
 import "./bsdCard.scss";
 import { getCurrentTransporterInfos } from "../../bsdMapper";
+import { isDefined } from "../../../../common/helper";
 
 function BsdCard({
   bsd,
@@ -417,7 +418,7 @@ function BsdCard({
                   code={bsdDisplay.wasteDetails.code!}
                   name={bsdDisplay.wasteDetails.name!}
                   weight={
-                    Boolean(bsdDisplay.wasteDetails?.weight)
+                    isDefined(bsdDisplay.wasteDetails?.weight)
                       ? `${bsdDisplay.wasteDetails.weight} ${unitOfMeasure}`
                       : ""
                   }

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -223,7 +223,7 @@ export const mapBsdd = (bsdd: Form): BsdDisplay => {
     wasteDetails: {
       code: bsdd.wasteDetails?.code,
       name: bsdd.wasteDetails?.name,
-      weight: bsdd.stateSummary?.quantity || bsdd.wasteDetails?.quantity
+      weight: bsdd.stateSummary?.quantity ?? bsdd.wasteDetails?.quantity
     },
     isTempStorage: bsdd.recipient?.isTempStorage,
     emitter: bsdd.emitter,


### PR DESCRIPTION
# Contexte

Je ne sais pas ce qui s'est passé mais visiblement mes changements ont disparu après le merge. Je vais donc merger direct la PR, vu que c'est un copié-collé de [celle-là](https://github.com/MTES-MCT/trackdechets/pull/3536) qui a déjà été approuvée.

# Ticket Favro

[Mettre à jour le poids affiché sur le tableau de bord lorsque la réception se fait avec un refus total](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14919)
