### PR TITLE
Correctifs sur les DASRI pour le nouveau mode de transport obligatoire

### DIFF
--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
@@ -1,11 +1,13 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import {
+  companyFactory,
   transporterReceiptFactory,
   userWithCompanyFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import {
   BsdasriStatus,
+  BsdasriType,
   TransportMode,
   WasteAcceptationStatus
 } from "@prisma/client";
@@ -32,7 +34,7 @@ const UPDATE_DASRI = gql`
 `;
 
 describe("Mutation.signBsdasri transport", () => {
-  afterEach(resetDatabase);
+  afterAll(resetDatabase);
 
   it("should put transport signature on a SIGNED_BY_PRODUCER dasri", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
@@ -219,14 +221,19 @@ describe("Mutation.signBsdasri transport", () => {
       // Update ?
       const { mutate } = makeClient(transporter);
       if (updateOpt) {
-        await mutate<Pick<Mutation, "updateBsdasri">>(UPDATE_DASRI, {
-          variables: {
-            id: dasri.id,
-            input: {
-              ...updateOpt
+        const { errors } = await mutate<Pick<Mutation, "updateBsdasri">>(
+          UPDATE_DASRI,
+          {
+            variables: {
+              id: dasri.id,
+              input: {
+                ...updateOpt
+              }
             }
           }
-        });
+        );
+
+        expect(errors).toBeUndefined();
       }
 
       // Sign transport
@@ -303,6 +310,51 @@ describe("Mutation.signBsdasri transport", () => {
       // Then
       expect(errors).not.toBeUndefined();
       expect(errors[0].message).toBe("Le mode de transport est obligatoire.");
+    });
+
+    it("transport mode is not required for synthesis DASRI", async () => {
+      // Given
+      const { company: initialCompany } = await userWithCompanyFactory(
+        "MEMBER"
+      );
+      const { user: transporter, company: transporterCompany } =
+        await userWithCompanyFactory("MEMBER");
+      await transporterReceiptFactory({ company: transporterCompany });
+      const { company: destinationCompany } = await userWithCompanyFactory(
+        "MEMBER"
+      );
+      const mainCompany = await companyFactory();
+      const initialBsdasri = await bsdasriFactory({
+        opt: {
+          ...initialData(initialCompany)
+        }
+      });
+      const synthesisBsdasri = await bsdasriFactory({
+        opt: {
+          type: BsdasriType.SYNTHESIS,
+          ...initialData(mainCompany),
+          ...readyToPublishData(destinationCompany),
+          ...readyToTakeOverData(transporterCompany),
+          status: BsdasriStatus.SIGNED_BY_PRODUCER,
+          synthesizing: { connect: [{ id: initialBsdasri.id }] },
+          transporterTransportMode: null
+        }
+      });
+
+      // When
+      const { mutate } = makeClient(transporter);
+      const { errors } = await mutate<Pick<Mutation, "signBsdasri">>(
+        SIGN_DASRI,
+        {
+          variables: {
+            id: synthesisBsdasri.id,
+            input: { type: "TRANSPORT", author: "Jimmy" }
+          }
+        }
+      );
+
+      // Then
+      expect(errors).toBeUndefined();
     });
   });
 });

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -34,6 +34,7 @@ import {
   transporterRecepisseSchema
 } from "../common/validation";
 import { destinationOperationModeValidation } from "../common/validation/operationMode";
+import { isDefined } from "../common/helpers";
 
 const wasteCodes = DASRI_WASTE_CODES.map(el => el.code);
 
@@ -481,9 +482,20 @@ export const transportSchema: FactorySchemaOf<
     transporterTransportMode: yup
       .mixed<TransportMode>()
       .nullable()
-      .requiredIf(
-        context.transportSignature,
-        "Le mode de transport est obligatoire."
+      .test(
+        "transport-mode",
+        "Le mode de transport est obligatoire.",
+        function (value) {
+          // Required only at transport signature
+          if (!context.transportSignature) return true;
+
+          // Not required for synthesis DASRI
+          if (this.parent.type === BsdasriType.SYNTHESIS) {
+            return true;
+          }
+
+          return isDefined(value);
+        }
       )
   });
 

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -7,7 +7,8 @@ import {
   QueryBsdasriArgs,
   BsdasriSignatureType,
   MutationUpdateBsdasriArgs,
-  Bsdasri
+  Bsdasri,
+  TransportMode
 } from "@td/codegen-ui";
 import {
   NotificationError,
@@ -164,6 +165,13 @@ export function RouteSignBsdasri({
   const formState = prefillWasteDetails(
     getComputedState(getInitialState(), bsdasri)
   );
+
+  // DASRI can be created via API with a null transport mode.
+  // getComputedState() will not fix it because it doesn't override null values,
+  // so fix it here manually
+  if (!formState.transporter.transport.mode) {
+    formState.transporter.transport.mode = TransportMode.Road;
+  }
 
   const TODAY = new Date();
 

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -1,5 +1,5 @@
 import { Field, useFormikContext } from "formik";
-import React, { lazy } from "react";
+import React, { lazy, useEffect } from "react";
 import classNames from "classnames";
 import Tooltip from "../../../common/components/Tooltip";
 import WeightWidget from "../components/Weight";
@@ -7,7 +7,12 @@ import { FieldTransportModeSelect } from "../../../common/components";
 import Packagings from "../components/packagings/Packagings";
 import { getInitialWeightFn } from "../utils/initial-state";
 import DateInput from "../../common/components/custom-inputs/DateInput";
-import { BsdasriStatus, Bsdasri, BsdasriType } from "@td/codegen-ui";
+import {
+  BsdasriStatus,
+  Bsdasri,
+  BsdasriType,
+  TransportMode
+} from "@td/codegen-ui";
 import Acceptation from "../components/acceptation/Acceptation";
 import { customInfoToolTip } from "./Emitter";
 import { subMonths } from "date-fns";
@@ -23,6 +28,13 @@ export default function Transport({ status, editionDisabled = false }) {
     }
   }
   const { values, setFieldValue } = useFormikContext<Bsdasri>();
+
+  useEffect(() => {
+    // If no transport mode selected, default to ROAD
+    if (!values.transporter?.transport?.mode) {
+      setFieldValue("transporter.transport.mode", TransportMode.Road);
+    }
+  });
 
   const showTransportFields =
     [

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -1,5 +1,5 @@
 import { Field, useFormikContext } from "formik";
-import React, { lazy, useEffect } from "react";
+import React, { lazy } from "react";
 import classNames from "classnames";
 import Tooltip from "../../../common/components/Tooltip";
 import WeightWidget from "../components/Weight";
@@ -7,12 +7,7 @@ import { FieldTransportModeSelect } from "../../../common/components";
 import Packagings from "../components/packagings/Packagings";
 import { getInitialWeightFn } from "../utils/initial-state";
 import DateInput from "../../common/components/custom-inputs/DateInput";
-import {
-  BsdasriStatus,
-  Bsdasri,
-  BsdasriType,
-  TransportMode
-} from "@td/codegen-ui";
+import { BsdasriStatus, Bsdasri, BsdasriType } from "@td/codegen-ui";
 import Acceptation from "../components/acceptation/Acceptation";
 import { customInfoToolTip } from "./Emitter";
 import { subMonths } from "date-fns";

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -29,13 +29,6 @@ export default function Transport({ status, editionDisabled = false }) {
   }
   const { values, setFieldValue } = useFormikContext<Bsdasri>();
 
-  useEffect(() => {
-    // If no transport mode selected, default to ROAD
-    if (!values.transporter?.transport?.mode) {
-      setFieldValue("transporter.transport.mode", TransportMode.Road);
-    }
-  });
-
   const showTransportFields =
     [
       BsdasriStatus.SignedByProducer,


### PR DESCRIPTION
# Contexte

Bugfix pour les DASRI pour le nouveau mode de transport obligatoire:
- Pour un DASRI simple, le mode de transport n'était pas renseigné dans le formulaire malgré la selectList qui, en apparence, affiche ROAD
- Pour un DASRI de synthèse, le mode de transport ne doit pas être obligatoire

# Ticket Favro

[Rendre obligatoire le mode de transport à la signature Transporteur pour tous les BSD + via l'UI par défaut si aucun mode de transport n'a été renseigné on ajoute Route et on permet de le modifier](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14517)
