### PR TITLE
Correctifs CSS sur le filtre avancé par types / sous-types de bordereaux

### DIFF
--- a/front/src/Apps/common/Components/Filters/AdvancedFilters.stories.tsx
+++ b/front/src/Apps/common/Components/Filters/AdvancedFilters.stories.tsx
@@ -30,7 +30,7 @@ export const Primary: Story = {
             },
             {
               value: "bsdasri",
-              label: "Déchets d'Activités de Soins à Risque Infectieux"
+              label: "Déchets d'Activités de Soins à Risques Infectieux"
             }
           ]
         },

--- a/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
+++ b/front/src/Apps/common/Components/SelectWithSubOptions/SelectWithSubOptions.tsx
@@ -50,10 +50,10 @@ const SelectWithSubOptions = ({
         );
 
         return (
-          <div key={optionPath}>
+          <div className="fr-grid-row--gutters" key={optionPath}>
             <div>
               <Checkbox
-                className={`optionCheckbox fr-ml-${ml * 4}v`}
+                className={`optionCheckbox fr-ml-${ml * 8}v`}
                 options={[
                   {
                     label: option.label,

--- a/front/src/Apps/common/Components/SelectWithSubOptions/selectWithSubOptions.scss
+++ b/front/src/Apps/common/Components/SelectWithSubOptions/selectWithSubOptions.scss
@@ -19,7 +19,7 @@
 }
 
 .dropDownWrapper {
-  padding: 12px 8px;
+  padding: 30px 20px 0 20px;
   background: #ffffff;
   box-shadow: 0px 2px 6px 0px #00001229;
   position: absolute;
@@ -29,7 +29,6 @@
 }
 
 .optionCheckbox {
-  height: 24px;
   margin: 0;
   padding: 0;
   margin-bottom: 16px;

--- a/front/src/Apps/common/wordings/dashboard/wordingsDashboard.ts
+++ b/front/src/Apps/common/wordings/dashboard/wordingsDashboard.ts
@@ -119,7 +119,7 @@ export const bsd_type_option_bsvhu = "Véhicules Hors d'Usage";
 export const bsd_type_option_bsff = "Déchets de Fluides Frigorigènes";
 export const bsd_type_option_bsda = "Déchets d'Amiante";
 export const bsd_type_option_bsdasri =
-  "Déchets d'Activités de Soins à Risque Infectieux";
+  "Déchets d'Activités de Soins à Risques Infectieux";
 export const bsd_type_option_bspaoh = "Pièces Anatomiques d'Origine Humaine";
 export const bsd_sub_type_option_initial = "Initial";
 export const bsd_sub_type_option_tournee = "Tournée dédiée";

--- a/front/src/dashboard/components/BSDList/BSDTypeFilter.tsx
+++ b/front/src/dashboard/components/BSDList/BSDTypeFilter.tsx
@@ -11,7 +11,7 @@ const OPTIONS = [
   },
   {
     value: BsdType.Bsdasri,
-    label: "Déchets d'Activités de Soins à Risque Infectieux"
+    label: "Déchets d'Activités de Soins à Risques Infectieux"
   },
   {
     value: BsdType.Bsvhu,


### PR DESCRIPTION
# Contexte

Correctifs CSS:

![demo_css](https://github.com/user-attachments/assets/0749f3a5-53f4-442d-a867-cac83e0163f1)

# Ticket Favro

[Permettre de filtrer par sous-type de bordereau](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6346492fbc222d1eaeb8961?card=tra-14399)
