### PR TITLE
[TRA 14703] - Ajout de chemins d'erreurs sur les erreurs hors rules

### DIFF
--- a/back/src/bspaoh/validation/dynamicRefinements.ts
+++ b/back/src/bspaoh/validation/dynamicRefinements.ts
@@ -10,6 +10,10 @@ import {
   isTransporterRefinement,
   refineSiretAndGetCompany
 } from "../../common/validation/zod/refinement";
+import {
+  CompanyRole,
+  pathFromCompanyRole
+} from "../../common/validation/zod/schema";
 
 const { VERIFY_COMPANY } = process.env;
 
@@ -72,6 +76,7 @@ function validatePackagingsReception(
   if (!!receptionPackagingsIds.length && duplicateReceptionIds) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "packagings"],
       message: `Les informations d'acceptation de packagings comportent des identifiants en doublon`
     });
   }
@@ -83,6 +88,7 @@ function validatePackagingsReception(
   if (!!receptionPackagingsIds.length && !allReceptionPackagingsIdsExists) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "packagings"],
       message: `Les informations d'acceptation de packagings ne correspondent pas aux packagings`
     });
   }
@@ -97,6 +103,7 @@ function validatePackagingsReception(
   if (receptionPackagingsIds.length > packagingsIds.length) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "packagings"],
       message: `Les informations d'acceptation de packagings ne correspondent pas aux packagings`
     });
   }
@@ -110,6 +117,7 @@ function validatePackagingsReception(
   if (!allIdsPresents || remainingPending) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "status"],
       message: `Le statut d'acceptation de tous les packagings doit être précisé`
     });
     return;
@@ -125,6 +133,7 @@ function validatePackagingsReception(
   if (destinationReceptionAcceptationStatus === "ACCEPTED" && !allAccepted) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "status"],
       message: `Le bordereau ne peut être accepté que si tous les packagings sont acceptés`
     });
     return;
@@ -132,6 +141,7 @@ function validatePackagingsReception(
   if (destinationReceptionAcceptationStatus === "REFUSED" && !allRefused) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "status"],
       message: `Le bordereau ne peut être refusé si tous les packagings ne sont pas refusés`
     });
     return;
@@ -142,6 +152,7 @@ function validatePackagingsReception(
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "acceptation", "status"],
       message: `Le bordereau ne peut être partiellement refusé si tous les packagings sont refusés ou acceptés`
     });
   }
@@ -159,6 +170,7 @@ function validateWeightFields(
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "detail", "receivedWeight"],
       message: `Le poids reçu est requis pour renseigner le poid refusé`
     });
   }
@@ -169,6 +181,7 @@ function validateWeightFields(
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "detail", "refusedWeight"],
       message: `Le poids refusé ne eut être supérieur au poids accepté`
     });
   }
@@ -180,6 +193,7 @@ function validateWeightFields(
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["destination", "reception", "detail", "refusedWeight"],
       message: `Le poids refusé ne peut être renseigné si le PAOH est accepté`
     });
   }
@@ -189,6 +203,7 @@ export async function isCrematoriumRefinement(siret: string, ctx) {
   if (company && !hasCremationProfile(company)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: pathFromCompanyRole(CompanyRole.Destination),
       message:
         `L'entreprise avec le SIRET "${siret}" n'est pas inscrite` +
         ` sur Trackdéchets en tant que crématorium. Cette installation ne peut` +
@@ -203,6 +218,7 @@ export async function isCrematoriumRefinement(siret: string, ctx) {
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: pathFromCompanyRole(CompanyRole.Destination),
       message:
         `Le compte de l'installation du crématorium` +
         ` avec le SIRET ${siret} n'a pas encore été vérifié. Cette installation ne peut pas être visée sur le bordereau.`

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -67,6 +67,7 @@ export const checkWeights: Refinement<ParsedZodBsvhu> = (
     // On pourra à terme passer de .nonnegative à .positive directement dans le schéma zod.}
     addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["weight", "value"],
       message: "Le poids doit être supérieur à 0"
     });
   }
@@ -95,6 +96,7 @@ export const checkReceptionWeight: Refinement<ParsedZodBsvhu> = (
     ) {
       addIssue({
         code: z.ZodIssueCode.custom,
+        path: ["destination", "reception", "weight"],
         message:
           "destinationReceptionWeight : le poids doit être égal à 0 lorsque le déchet est refusé"
       });
@@ -108,6 +110,7 @@ export const checkReceptionWeight: Refinement<ParsedZodBsvhu> = (
     ) {
       addIssue({
         code: z.ZodIssueCode.custom,
+        path: ["destination", "reception", "weight"],
         message:
           "destinationReceptionWeight : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
       });
@@ -123,6 +126,7 @@ export const checkEmitterSituation: Refinement<ParsedZodBsvhu> = (
     // Le seul cas où l'émetteur peut ne pas avoir de SIRET est si il est en situation irrégulière
     addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["emitter", "irregularSituation"],
       message:
         "emitterIrregularSituation : L'émetteur doit obligatoirement avoir un numéro de SIRET si il n'est pas en situation irrégulière"
     });

--- a/back/src/common/validation/zod/schema.ts
+++ b/back/src/common/validation/zod/schema.ts
@@ -13,6 +13,29 @@ export enum CompanyRole {
   NextDestination = "Éxutoire"
 }
 
+export const pathFromCompanyRole = (companyRole?: CompanyRole): string[] => {
+  switch (companyRole) {
+    case CompanyRole.Emitter:
+      return ["emitter"];
+    case CompanyRole.Transporter:
+      return ["transporter"];
+    case CompanyRole.Destination:
+      return ["destination"];
+    case CompanyRole.EcoOrganisme:
+      return ["ecoOrganisme"];
+    case CompanyRole.Broker:
+      return ["broker"];
+    case CompanyRole.Worker:
+      return ["worker"];
+    case CompanyRole.Intermediary:
+      return ["intermediaries"];
+    case CompanyRole.NextDestination:
+      return ["nextDestination"];
+    default:
+      return [];
+  }
+};
+
 export const siretSchema = (expectedCompanyRole?: CompanyRole) =>
   z
     .string({
@@ -28,6 +51,7 @@ export const siretSchema = (expectedCompanyRole?: CompanyRole) =>
         return isSiret(value);
       },
       val => ({
+        path: pathFromCompanyRole(expectedCompanyRole),
         message: `${
           expectedCompanyRole ? `${expectedCompanyRole} : ` : ""
         }${val} n'est pas un numéro de SIRET valide`
@@ -43,10 +67,18 @@ export const vatNumberSchema = z.string().refine(
   val => ({ message: `${val} n'est pas un numéro de TVA valide` })
 );
 export const foreignVatNumberSchema = (expectedCompanyRole?: CompanyRole) =>
-  vatNumberSchema.refine(value => {
-    if (!value) return true;
-    return isForeignVat(value);
-  }, `${expectedCompanyRole ? `${expectedCompanyRole} : ` : ""}Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement`);
+  vatNumberSchema.refine(
+    value => {
+      if (!value) return true;
+      return isForeignVat(value);
+    },
+    {
+      path: pathFromCompanyRole(expectedCompanyRole),
+      message: `${
+        expectedCompanyRole ? `${expectedCompanyRole} : ` : ""
+      }Impossible d'utiliser le numéro de TVA pour un établissement français, veuillez renseigner son SIRET uniquement`
+    }
+  );
 
 export const rawTransporterSchema = z.object({
   id: z.string().nullish(),

--- a/back/src/common/validation/zod/schema.ts
+++ b/back/src/common/validation/zod/schema.ts
@@ -16,21 +16,21 @@ export enum CompanyRole {
 export const pathFromCompanyRole = (companyRole?: CompanyRole): string[] => {
   switch (companyRole) {
     case CompanyRole.Emitter:
-      return ["emitter"];
+      return ["emitter", "company", "siret"];
     case CompanyRole.Transporter:
-      return ["transporter"];
+      return ["transporter", "company", "siret"];
     case CompanyRole.Destination:
-      return ["destination"];
+      return ["destination", "company", "siret"];
     case CompanyRole.EcoOrganisme:
-      return ["ecoOrganisme"];
+      return ["ecoOrganisme", "company", "siret"];
     case CompanyRole.Broker:
-      return ["broker"];
+      return ["broker", "company", "siret"];
     case CompanyRole.Worker:
-      return ["worker"];
+      return ["worker", "company", "siret"];
     case CompanyRole.Intermediary:
-      return ["intermediaries"];
+      return ["intermediaries", "company", "siret"];
     case CompanyRole.NextDestination:
-      return ["nextDestination"];
+      return ["nextDestination", "company", "siret"];
     default:
       return [];
   }


### PR DESCRIPTION
Les erreurs venant de refinements n'avaient pas de chemin associé. Déjà cela faisait planter la front (Juliana a fix ça), mais aussi ça n'affichait pas les erreurs sur les onglets ni sur les champs associés comme les erreurs de rules. J'ai donc ajouté des chemins sur les erreurs renvoyées pas les refinements VHU/PAOH.

<img width="1100" alt="Capture d’écran 2024-09-20 à 18 34 31" src="https://github.com/user-attachments/assets/46787863-be5d-4f63-800a-88ab9189a993">


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
