### PR TITLE
[Fix] Fixes blurry modals

### DIFF
--- a/front/src/Apps/common/Components/Modal/modal.scss
+++ b/front/src/Apps/common/Components/Modal/modal.scss
@@ -11,13 +11,14 @@
   background: rgba(0, 0, 0, 0.5);
   overflow: auto;
   height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .tdModalInner {
   position: relative;
-  top: 50%;
-  right: 50%;
-  transform: translate(50%, -50%);
+  flex: auto;
 }
 
 .fr-modal__header.close-btn-override {


### PR DESCRIPTION
`Webkit treats 3d transformed elements as textures instead of vectors in order to provide hardware 3d acceleration. The only solution to this would be to increase the size of the text and downscaling the element, in essence creating a higher res texture.`

On retire le positionnement de la modale par transform et on le gère en flex pour corriger les fonts floues.

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
