### PR TITLE
[TRA-15064] Ajout d'un encart réglementaire pour éviter un usage abusif de l'absence d'entreprise de travaux BSDA

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Amélioration de la page Mes applications avec le passage au DSFR [PR 3562](https://github.com/MTES-MCT/trackdechets/pull/3562)
 - ETQ destinataire, je peux indiquer que mon véhicule est rincé ou non pour son retour à vide [PR 3576](https://github.com/MTES-MCT/trackdechets/pull/3576)
 - ETQ destinataire, je peux indiquer que la citerne est rincée pour son retour à vide [PR 3573](https://github.com/MTES-MCT/trackdechets/pull/3573)
+- Ajout d'un encart réglementaire pour éviter un usage abusif de l'absence d'entreprise de travaux BSDA [PR 3609](https://github.com/MTES-MCT/trackdechets/pull/3609)
 
 #### :boom: Breaking changes
 

--- a/front/src/form/bsda/components/NoWorkerAlert.tsx
+++ b/front/src/form/bsda/components/NoWorkerAlert.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+
+// Dispositions permettant de cochant la case d'absence d'entreprise de travaux
+
+const title =
+  "Attention, vous devez mentionner l'entreprise qui a effectué" +
+  " les travaux sur des matériaux ou produits contenant de l'amiante (MPCA)";
+
+const faqLink =
+  "https://faq.trackdechets.fr/amiante/informations-generales/" +
+  "questions-frequentes#dans-quel-cas-je-peux-cocher-il-ny-a-pas-dentreprise-de-travaux";
+
+const description = (
+  <div>
+    En effet, conformément aux dispositions du code du travail, vous êtes tenus,
+    lorsque vous faites appel à une entreprise SS3 pour des travaux de retrait
+    ou d’encapsulage de MPCA ou à une entreprise SS4 pour une intervention
+    susceptible d’émettre des fibres d’amiante, de mentionner cette entreprise
+    sur la traçabilité. Un particulier (ou un agriculteur réalisant des travaux
+    dans ses propres locaux d’habitation) à l’origine d’une opération du BTP ne
+    peut prendre en charge personnellement le conditionnement de MPCA déposés à
+    cette occasion que si aucun professionnel n’a participé d’une quelconque
+    façon à la réalisation de ce chantier. Cas décrits en{" "}
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fr-link"
+      href={faqLink}
+    >
+      FAQ
+    </a>
+  </div>
+);
+
+export function NoWorkerAlert() {
+  return <Alert severity="warning" title={title} description={description} />;
+}

--- a/front/src/form/bsda/stepper/steps/Worker.tsx
+++ b/front/src/form/bsda/stepper/steps/Worker.tsx
@@ -10,6 +10,7 @@ import {
 } from "@td/codegen-ui";
 import React, { useCallback, useState } from "react";
 import { getInitialState } from "../initial-state";
+import { NoWorkerAlert } from "../../components/NoWorkerAlert";
 
 export function Worker({ disabled }) {
   const initialState = getInitialState();
@@ -101,6 +102,12 @@ export function Worker({ disabled }) {
           Il n'y a pas d'entreprise de travaux
         </label>
       </div>
+
+      {values?.worker?.isDisabled === true && (
+        <div style={{ marginTop: 25 }}>
+          <NoWorkerAlert />
+        </div>
+      )}
 
       {!Boolean(values?.worker?.isDisabled) && (
         <>


### PR DESCRIPTION


![Capture d’écran 2024-09-24 à 10 10 56](https://github.com/user-attachments/assets/2f1214ec-2989-4c71-8f8b-677c03e19299)


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](tra-15064)
