### PR TITLE
Hotfix/bsvhu signature

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=d622bf53"
+      href="/dsfr/utility/icons/icons.min.css?hash=d57418c1"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignTransport.tsx
@@ -9,7 +9,8 @@ import {
   Mutation,
   MutationSignBsvhuArgs,
   MutationUpdateBsvhuArgs,
-  SignatureTypeInput
+  SignatureTypeInput,
+  Bsvhu
 } from "@td/codegen-ui";
 import React from "react";
 import { generatePath, Link, useLocation } from "react-router-dom";
@@ -59,14 +60,14 @@ export function SignTransport({
       onModalCloseFromParent={onModalCloseFromParent}
       displayActionButton={displayActionButton}
     >
-      {({ bsvhu, onClose }) => {
+      {({ bsvhu, onClose }: { bsvhu: Bsvhu; onClose: Function }) => {
         const TODAY = new Date();
 
         return (bsvhu.metadata?.errors ?? []).some(
           error =>
             error.requiredFor === SignatureTypeInput.Transport &&
             // Transporter Receipt will be auto-completed by the transporter
-            !error.path.startsWith("transporter.recepisse")
+            !error.path.join(".").startsWith("transporter.recepisse")
         ) ? (
           <>
             <p className="tw-mt-2 tw-text-red-700">


### PR DESCRIPTION
Le passage de BsvhuError.path: String! à [String!]! plante Le SIgnTransport.tsx du vhu à cause d'un error.path?.startswith("transporter.recepisse"). Correctif en incluant un join('.').

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15171)
