### PR TITLE
[TRA-15172] HOTFIX - Impossible de publier/modifier un BSFF de regroupement dont les BSFF initiaux ont un "Volume du contenant en L" à 0

### DIFF
--- a/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
+++ b/back/src/bsffs/validation/bsff/__tests__/validation.integration.ts
@@ -348,6 +348,50 @@ describe("validation > parseBsff", () => {
       }
     );
 
+    it.each([null, undefined])(
+      "should parse correctly if packaging volume is %p" +
+        " and bsff is created after MEP 2024.09.1 (in case of reexpedition)",
+      v => {
+        const zodBsff: ZodBsff = {
+          type: "REEXPEDITION",
+          isDraft: false,
+          createdAt: new Date("2024-09-24T08:00:00"),
+          packagings: [
+            {
+              weight: 1,
+              volume: v,
+              numero: "1",
+              emissionNumero: "1",
+              type: "BOUTEILLE"
+            }
+          ]
+        };
+        expect(parseBsff(zodBsff)).toBeDefined();
+      }
+    );
+
+    it.each([null, undefined])(
+      "should parse correctly if packaging volume is %p" +
+        " and bsff is created after MEP 2024.09.1 (in case of groupement)",
+      v => {
+        const zodBsff: ZodBsff = {
+          type: "GROUPEMENT",
+          isDraft: false,
+          createdAt: new Date("2024-09-24T08:00:00"),
+          packagings: [
+            {
+              weight: 1,
+              volume: v,
+              numero: "1",
+              emissionNumero: "1",
+              type: "BOUTEILLE"
+            }
+          ]
+        };
+        expect(parseBsff(zodBsff)).toBeDefined();
+      }
+    );
+
     it("should throw if weight value is negative", () => {
       const zodBsff: ZodBsff = {
         weightValue: -1

--- a/back/src/bsffs/validation/bsff/refinements.ts
+++ b/back/src/bsffs/validation/bsff/refinements.ts
@@ -88,10 +88,14 @@ export const checkPackagings: Refinement<ParsedZodBsff> = (
     if (
       (packaging.volume === null || packaging.volume === undefined) &&
       !bsff.isDraft &&
+      ![BsffType.REEXPEDITION, BsffType.GROUPEMENT].includes(bsff.type) &&
       isCreatedAfterV2024091
     ) {
       // TRA-14567 Le volume est rendu obligatoire sur les contenants BSFF
-      // à partir de la v2024091
+      // à partir de la v2024091. L'obligation ne concerne pas les bordereaux
+      // de groupement ou réexpedition pour ne pas bloquer des utilisateurs
+      // regroupant des BSFF crées avant 2024091 ayant un volume null (les contenants
+      // étant calculés automatiquement à partir des contenants réexpédiés / regroupés).
       addIssue({
         code: z.ZodIssueCode.custom,
         message: "Conditionnements : le volume est requis"

--- a/front/src/form/bsff/components/packagings/Packagings.tsx
+++ b/front/src/form/bsff/components/packagings/Packagings.tsx
@@ -45,14 +45,6 @@ export default function BsffPackagings({
             {value.map((p, idx) => {
               const fieldName = `${name}.${idx}`;
 
-              const volumeIsDisabled =
-                disabled ||
-                ([BsffType.Reexpedition, BsffType.Groupement].includes(type) &&
-                  // Cas spécial pour le volume qui est rendu obligatoire à partir de la
-                  // 2024.09.1 : on permet d'éditer le volume sur un bordereau de groupement ou réexpédition
-                  // qui aurait un bordereau initial dont le packaging a un volume `null` ou `undefined`.
-                  !!p.volume);
-
               return (
                 <div
                   key={idx}
@@ -114,7 +106,7 @@ export default function BsffPackagings({
                             component={NumberInput}
                             className="td-input td-input--small"
                             name={`${fieldName}.volume`}
-                            disabled={volumeIsDisabled}
+                            disabled={fieldIsDisabled}
                           />
                         </label>
                       </div>


### PR DESCRIPTION
Effet de bord de [Rendre obligatoire le volume du contenant à la publication sur le BSFF](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14567).

Se produit quand on tente de réexpédier / regrouper des contenants qui ont été crées avec un volume `null`.

J'avais rendu le champ `volume` éditable dans l'UI pour gérer ce cas mais je n'avais pas pensé que les données de packagings n'étaient même pas envoyées à l'API en cas de groupement / réexpédition puisque c'est calculé côté back. Pour contourner le problème, je rend le volume non requis en cas de réexpédition / regroupement.


- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15172)
