### PR TITLE
Fix erreur 404 à la suppression de label

### DIFF
--- a/.github/workflows/add-ready-to-merge-label.yml
+++ b/.github/workflows/add-ready-to-merge-label.yml
@@ -40,4 +40,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: "ready to merge"
+            }).catch(function(error) {
+              if (error.status === 404) {
+                return;
+              } else {
+                throw error;
+              }
             })


### PR DESCRIPTION
L'action comporte une étape qui retire le label "ready to merge" si il y a moins de 2 approvals ou des requêtes de changement. Ca sert dans les cas où une review est supprimée ou un autre reviewer demande des changements.

