### PR TITLE
[TRA-14702] Correction du poids d'une annexe 1 après la révision du poids d'un BSD enfant

### DIFF
--- a/back/src/common/helpers.ts
+++ b/back/src/common/helpers.ts
@@ -19,3 +19,11 @@ export const dateToXMonthAtHHMM = (date: Date = new Date()): string => {
 export const isDefined = (obj: any) => {
   return obj !== null && obj !== undefined;
 };
+
+/**
+ * Tests if a list of objects are ALL defined. 0 will be considered as defined
+ */
+export const areDefined = (...obj: any[]) => {
+  if (obj.some(o => !isDefined(o))) return false;
+  return true;
+};

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -26,6 +26,8 @@ import { distinct } from "../../../common/arrays";
 import { ForbiddenError } from "../../../common/errors";
 import { isFinalOperationCode } from "../../../common/operationCodes";
 import { operationHook } from "../../operationHook";
+import { isDefined } from "../../../common/helpers";
+import Decimal from "decimal.js";
 
 export type AcceptRevisionRequestApprovalFn = (
   revisionRequestApprovalId: string,
@@ -176,6 +178,7 @@ async function getUpdateFromFormRevisionRequest(
     ...(revisionRequest.wasteDetailsPop !== null && {
       wasteDetailsPop: revisionRequest.wasteDetailsPop
     }),
+    wasteDetailsQuantity: revisionRequest.wasteDetailsQuantity,
     ...(revisionRequest.wasteDetailsPackagingInfos && {
       wasteDetailsPackagingInfos: revisionRequest.wasteDetailsPackagingInfos
     }),
@@ -359,6 +362,42 @@ export async function approveAndApplyRevisionRequest(
     } else if (!updatedOperationIsFinal && beforeRevisionOperationIsFinal) {
       await prisma.bsddFinalOperation.deleteMany({
         where: { finalFormId: updatedBsdd.id }
+      });
+    }
+  }
+
+  // Revision targeted an ANNEXE_1 (child). We need to update its parent
+  if (updatedBsdd.emitterType === EmitterType.APPENDIX1_PRODUCER) {
+    // Quantity changed. We need to fix parent's quantity as well
+    if (isDefined(revisionRequest.wasteDetailsQuantity)) {
+      // Calculate revision diff
+      const diff =
+        bsddBeforeRevision.wasteDetailsQuantity
+          ?.minus(revisionRequest.wasteDetailsQuantity ?? 0)
+          .toDecimalPlaces(6) ?? new Decimal(0);
+      const { nextForm: parent } = await prisma.formGroupement.findFirstOrThrow(
+        {
+          where: { initialFormId: bsddBeforeRevision.id },
+          include: {
+            nextForm: true
+          }
+        }
+      );
+
+      // Calculate parent new quantity using diff
+      const parentNewQuantity = parent.wasteDetailsQuantity
+        ?.minus(diff)
+        .toDecimalPlaces(6);
+
+      // Update & re-index parent
+      await prisma.form.update({
+        where: { id: parent.id },
+        data: {
+          wasteDetailsQuantity: parentNewQuantity
+        }
+      });
+      prisma.addAfterCommitCallback?.(() => {
+        enqueueUpdatedBsdToIndex(parent.readableId);
       });
     }
   }

--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -240,7 +240,7 @@ export const mapRevision = (
       },
       {
         dataName: DataNameEnum.SAMPLE_NUMBER,
-        dataOldValue: review?.[bsdName]?.content?.wasteDetails?.sampleNumber,
+        dataOldValue: review?.[bsdName]?.wasteDetails?.sampleNumber,
         dataNewValue: review?.content?.wasteDetails?.sampleNumber
       },
       {

--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -235,7 +235,7 @@ export const mapRevision = (
       },
       {
         dataName: DataNameEnum.QTY_ESTIMATED,
-        dataOldValue: review?.[bsdName]?.content?.wasteDetails?.quantity,
+        dataOldValue: review?.[bsdName].wasteDetails.quantity,
         dataNewValue: review?.content?.wasteDetails?.quantity
       },
       {


### PR DESCRIPTION
# Contexte

Lorsqu'on révise le poids d'un BSD enfant d'une annexe 1, le poids sur le BSD parent n'est pas mis à jour. Côté back, le poids n'est pas pris en compte.

Tant que j'étais debout j'ai aussi fix le `sampleNumber` qui n'était pas révisé.

# Ticket Favro

[Mettre à jour le poids sur l'aperçu et le PDF d'une Annexe 1 après révision ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/2e73607ee11a34a3e0deb539?card=tra-14702)
