### PR TITLE
FIX: résout problème de champ undefined sur BSVHU emitter

### DIFF
--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -57,8 +57,8 @@ export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
     status: form.status,
     emitter: nullIfNoValues<BsvhuEmitter>({
       agrementNumber: form.emitterAgrementNumber,
-      irregularSituation: form.emitterIrregularSituation,
-      noSiret: form.emitterNoSiret,
+      irregularSituation: form.emitterIrregularSituation ?? false,
+      noSiret: form.emitterNoSiret ?? false,
       company: nullIfNoValues<FormCompany>({
         name: form.emitterCompanyName,
         siret: form.emitterCompanySiret,

--- a/libs/back/prisma/src/migrations/20241003231226_set_bsvhu_emitter_defaults/migration.sql
+++ b/libs/back/prisma/src/migrations/20241003231226_set_bsvhu_emitter_defaults/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Bsvhu" ALTER COLUMN "emitterIrregularSituation" SET DEFAULT false,
+ALTER COLUMN "emitterNoSiret" SET DEFAULT false;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -995,8 +995,8 @@ model Bsvhu {
 
   status BsvhuStatus @default(INITIAL)
 
-  emitterIrregularSituation                           Boolean?
-  emitterNoSiret                                      Boolean?
+  emitterIrregularSituation                           Boolean?                 @default(false)
+  emitterNoSiret                                      Boolean?                 @default(false)
   emitterAgrementNumber                               String?                  @db.VarChar(100)
   emitterCompanyName                                  String?
   emitterCompanySiret                                 String?                  @db.VarChar(17)


### PR DESCRIPTION
les champs emitter `emitterIrregularSituation` et `emitterNoSiret` sont requis dans le modèle d'objet GraphQL mais n'existent pas sur les anciens BSVHU.
J'ai donc ajouté un défaut dans le converter, et ajouté un défaut sur Prisma pour éviter l'ambiguité sur les bordereaux futurs.

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
