### PR TITLE
Supprime le feature flag d'accès à la fiche établissements

### DIFF
--- a/back/src/companydigest/developper_doc.md
+++ b/back/src/companydigest/developper_doc.md
@@ -29,7 +29,7 @@ Chaque établissement est autorisé par un featureFlag.
 ### Base de données
 
 Le modèle CompanyDigest centralise les données persistés necessaires à cette fonctionalité.
-L'accès à la fcontionalité est ouvert à tous les établissementts depuis le 22/10/2024.
+L'accès à la fonctionnalité est ouvert à tous les établissementts depuis le 22/10/2024.
 CompanyDigest comporte user pour suivre l'utilisateur à l'origine de la demande
 
 ### Webhook

--- a/back/src/companydigest/developper_doc.md
+++ b/back/src/companydigest/developper_doc.md
@@ -29,7 +29,7 @@ Chaque établissement est autorisé par un featureFlag.
 ### Base de données
 
 Le modèle CompanyDigest centralise les données persistés necessaires à cette fonctionalité.
-Le modèle Company reçoit une nouvelle colonne featureFlags (string[]) dans lequel la présence de la chaine `COMPANY_DIGEST` détermine l'accès à la fonctionalité.
+L'accès à la fcontionalité est ouvert à tous les établissementts depuis le 22/10/2024.
 CompanyDigest comporte user pour suivre l'utilisateur à l'origine de la demande
 
 ### Webhook

--- a/back/src/companydigest/resolvers/mutations/__tests__/companyDigestCreate.integration.ts
+++ b/back/src/companydigest/resolvers/mutations/__tests__/companyDigestCreate.integration.ts
@@ -70,34 +70,8 @@ describe("Mutation.createCompanyDigest", () => {
     ]);
   });
 
-  it("should raise an error if company has no relevant featureFlag", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER");
-
-    const { mutate } = makeClient(user);
-    const { errors } = await mutate<Pick<Mutation, "createCompanyDigest">>(
-      CREATE_COMPANY_DIGEST,
-      {
-        variables: {
-          input: { orgId: company.siret, year: new Date().getFullYear() }
-        }
-      }
-    );
-
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "Vous nêtes pas autorisé à utiliser cette fonctionalité sur cet établissement.",
-        extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
-        })
-      })
-    ]);
-  });
-
   it("should raise an error if year is too old", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER", {
-      featureFlags: ["COMPANY_DIGEST"]
-    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
 
     const { mutate } = makeClient(user);
     const year = new Date().getFullYear() - 2;
@@ -122,9 +96,7 @@ describe("Mutation.createCompanyDigest", () => {
   });
 
   it("should create a companyDigest for current year", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER", {
-      featureFlags: ["COMPANY_DIGEST"]
-    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const year = new Date().getFullYear();
 
     const { mutate } = makeClient(user);
@@ -142,9 +114,7 @@ describe("Mutation.createCompanyDigest", () => {
   });
 
   it("should create a companyDigest for last year", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER", {
-      featureFlags: ["COMPANY_DIGEST"]
-    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
     const year = new Date().getFullYear() - 1;
 
     const { mutate } = makeClient(user);

--- a/back/src/companydigest/resolvers/mutations/create.ts
+++ b/back/src/companydigest/resolvers/mutations/create.ts
@@ -11,7 +11,6 @@ import { prisma } from "@td/prisma";
 import { sendGericoApiRequest } from "../../../queue/producers/gerico";
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { CompanyDigestStatus } from "@prisma/client";
-const COMPANY_DIGEST_FLAG = "COMPANY_DIGEST";
 
 const createCompanyDigestResolver = async (
   _: ResolversParentTypes["Mutation"],
@@ -54,16 +53,6 @@ const createCompanyDigestResolver = async (
     );
   }
 
-  const companyHasFeatureFlag = await prisma.company.findFirst({
-    where: { orgId, featureFlags: { has: COMPANY_DIGEST_FLAG } },
-    select: { id: true }
-  });
-
-  if (!companyHasFeatureFlag) {
-    throw new UserInputError(
-      "Vous nêtes pas autorisé à utiliser cette fonctionalité sur cet établissement."
-    );
-  }
   const companyDigest = await prisma.companyDigest.create({
     data: {
       orgId,

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=d57418c1"
+      href="/dsfr/utility/icons/icons.min.css?hash=4eaade81"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta

--- a/front/src/Apps/Companies/CompanyDetails.tsx
+++ b/front/src/Apps/Companies/CompanyDetails.tsx
@@ -27,8 +27,6 @@ export type TabContentProps = {
   company: CompanyPrivate;
 };
 
-const COMPANY_DIGEST_FLAG = "COMPANY_DIGEST";
-
 const buildTabs = (
   company: CompanyPrivate
 ): {
@@ -36,10 +34,7 @@ const buildTabs = (
   tabsContent: Record<string, React.FC<TabContentProps>>;
 } => {
   const isAdmin = company.userRole === UserRole.Admin;
-  const isMember = company.userRole === UserRole.Member;
-  // Admin and member can access the gerico tab
-  const canViewCompanyDigestTab =
-    company.featureFlags.includes(COMPANY_DIGEST_FLAG) && (isAdmin || isMember);
+
   const iconId = "fr-icon-checkbox-line" as FrIconClassName;
   const tabs = [
     {
@@ -61,22 +56,21 @@ const buildTabs = (
       tabId: "tab4",
       label: "Contact",
       iconId
+    },
+    {
+      tabId: "tab5",
+      label: "Fiche",
+      iconId
     }
   ];
   const tabsContent = {
     tab1: CompanyInfo,
     tab2: CompanySignature,
     tab3: CompanyMembers,
-    tab4: CompanyContactForm
+    tab4: CompanyContactForm,
+    tab5: CompanyDigestSheetForm
   };
-  if (canViewCompanyDigestTab) {
-    tabs.push({
-      tabId: "tab5",
-      label: "Fiche",
-      iconId
-    });
-    tabsContent["tab5"] = CompanyDigestSheetForm;
-  }
+
   if (isAdmin) {
     tabs.push({
       tabId: "tab6",


### PR DESCRIPTION
L'accès à la fiche étab était conditionné par le featureFlag "COMPANY_DIGEST". Tous les établissements en étant désormais nantis, le check de ce champ est superfétatoire.

- [x] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15215)
