### PR TITLE
Corrige l'indexation des annexe1 orphelines supprimées par le cron

### DIFF
--- a/apps/cron/src/commands/appendix1.helpers.ts
+++ b/apps/cron/src/commands/appendix1.helpers.ts
@@ -88,10 +88,15 @@ async function cleanOrphanAppendix1() {
     });
 
     cursor = orphansChunk[orphansChunk.length - 1].id;
+    const orphansChunkIds = orphansChunk.map(form => form.id);
 
     await prisma.form.updateMany({
-      where: { id: { in: orphansChunk.map(form => form.id) } },
+      where: { id: { in: orphansChunkIds } },
       data: { isDeleted: true }
     });
+
+    for (const id of orphansChunkIds) {
+      await deleteBsd({ id }, { user: { auth: AuthType.BEARER } } as any);
+    }
   }
 }

--- a/back/package.json
+++ b/back/package.json
@@ -11,7 +11,8 @@
     "reindex-bsd": "tsx --tsconfig tsconfig.lib.json ./src/scripts/bin/reindexBsd.ts $bsdId",
     "purge-pdf-token": "tsx --tsconfig tsconfig.lib.json ./src/scripts/bin/purgePdfAccessToken.ts",
     "storeAllWebhookSettings.ts": "tsx --tsconfig tsconfig.lib.json ./src/webhooks/commands/storeAllWebhookSettings.ts",
-    "generate-bsds-templates": "tsx --tsconfig tsconfig.lib.json ./src/scripts/bin/bsdTemplates/generateBsdTemplates.ts"
+    "generate-bsds-templates": "tsx --tsconfig tsconfig.lib.json ./src/scripts/bin/bsdTemplates/generateBsdTemplates.ts",
+    "reindex-deleted-orphan-appendix1": "tsx --tsconfig tsconfig.lib.json ./src/scripts/bin/reindexDeletedOrphanAppendix1.ts"
   },
   "engines": {
     "node": "^20"

--- a/back/src/scripts/bin/reindexDeletedOrphanAppendix1.ts
+++ b/back/src/scripts/bin/reindexDeletedOrphanAppendix1.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@td/prisma";
+import { AuthType, EmitterType, Prisma } from "@prisma/client";
+import { logger } from "@td/logger";
+import { deleteBsd } from "../../common/elastic";
+import { closeQueues } from "../../queue/producers";
+
+async function exitScript() {
+  logger.info("Done reindexAllInBulk script, exiting");
+  await prisma.$disconnect();
+  await closeQueues();
+  process.exit(0);
+}
+
+// ensure deleted orphans appendix1 are removed from ES
+(async function () {
+  const CHUNK_SIZE = 200;
+
+  const where: Prisma.FormWhereInput = {
+    emitterType: EmitterType.APPENDIX1_PRODUCER,
+    isDeleted: true,
+    groupedIn: { none: {} }
+  };
+  const orphansCount = await prisma.form.count({ where });
+
+  let cursor: string | null = null;
+
+  for (let i = 0; i < orphansCount; i += CHUNK_SIZE) {
+    console.log(`Chunk ${i + 1}`);
+
+    const orphans = await prisma.form.findMany({
+      where,
+      orderBy: { id: "asc" },
+      take: CHUNK_SIZE,
+      select: { id: true },
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
+    });
+
+    cursor = orphans[orphans.length - 1].id;
+
+    const orphansIds = orphans.map(form => form.id);
+
+    for (const id of orphansIds) {
+      console.log(`Removing ${id}`);
+      await deleteBsd({ id }, { user: { auth: AuthType.BEARER } } as any);
+    }
+  }
+
+  await exitScript();
+})();


### PR DESCRIPTION
On a un cron qui fait le ménage dans les appendix1, notamment en supprimant ceux qui ont plus de 10jours et ne sont pas rattachés à un chapeau, mais l'indexation manquait, ce qui explique probablement qu'on ait quelques demandes au support.

Cette PR ajoute l'indexation manquante et un script à lancer une fois pour désindexer les bsds fantômes.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
