### PR TITLE
Hotfix: permettre de mettre à jour l'Emport direct de DASRI quand l'email de contact est une chaîne vide

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateCompany.integration.ts
@@ -67,6 +67,21 @@ const UPDATE_COMPANY = gql`
   }
 `;
 
+const UPDATE_COMPANY_BSDASRI_TAKEOVER = gql`
+  mutation UpdateCompany(
+    $id: String!
+    $allowBsdasriTakeOverWithoutSignature: Boolean
+  ) {
+    updateCompany(
+      id: $id
+
+      allowBsdasriTakeOverWithoutSignature: $allowBsdasriTakeOverWithoutSignature
+    ) {
+      id
+    }
+  }
+`;
+
 describe("mutation updateCompany", () => {
   afterEach(async () => {
     await resetDatabase();
@@ -89,6 +104,33 @@ describe("mutation updateCompany", () => {
     };
     const { data } = await mutate<Pick<Mutation, "updateCompany">>(
       UPDATE_COMPANY,
+      {
+        variables
+      }
+    );
+    expect(data.updateCompany.id).toEqual(company.id);
+
+    const updatedCompany = await prisma.company.findUnique({
+      where: { id: company.id }
+    });
+    expect(updatedCompany).toMatchObject(variables);
+  });
+
+  it("should update a company allowBsdasriTakeOverWithoutSignature when cotactEMail is an contactEmail string", async () => {
+    // bugfix: user were not able to update allowBsdasriTakeOverWithoutSignature when contactEmail was en empty string
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      contactEmail: ""
+    });
+
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const variables = {
+      id: company.id,
+
+      allowBsdasriTakeOverWithoutSignature: true
+    };
+    const { data } = await mutate<Pick<Mutation, "updateCompany">>(
+      UPDATE_COMPANY_BSDASRI_TAKEOVER,
       {
         variables
       }

--- a/back/src/companies/validation/schema.ts
+++ b/back/src/companies/validation/schema.ts
@@ -32,7 +32,7 @@ const rawCompanySchema = z.object({
   gerepId: z.string().nullish(),
   codeNaf: z.string().nullish(),
   givenName: z.string().nullish(),
-  contactEmail: z.string().email().nullish(),
+  contactEmail: z.string().email().nullish().or(z.literal("")), // accept empty strings
   contactPhone: z.string().nullish(),
   contact: z.string().nullish(),
   website: z

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=d57418c1"
+      href="/dsfr/utility/icons/icons.min.css?hash=4f3e3c25"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta


### PR DESCRIPTION
Le passage à zod (contactEmail: z.string().email().nullish()) a entraîné un effet de bord: pour un établissement dont contactEmail est une chaîne vide, la mise à jour de `allowBsdasriTakeOverWithoutSignature` lève une erreur


## Bug

https://github.com/user-attachments/assets/7a12185c-2d0e-4c7b-9787-7d8beaa2f24c

## Fix

https://github.com/user-attachments/assets/f5db3fbf-06a4-4a41-b720-b10e9d9ee6c7




- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
