### PR TITLE
Corrige le champ de recherche d'adresse chantier

### DIFF
--- a/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
+++ b/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
@@ -4,6 +4,7 @@ import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import SearchInput from "../../../../Apps/common/Components/search/DsfrSearchInput";
 import styles from "./WorkSiteAddress.module.scss";
 import { Input } from "@codegouvfr/react-dsfr/Input";
+import { API_MIN_CHARS } from "../../constants";
 
 function init({ address, city, postalCode }) {
   const selectedAdress = [address, postalCode, city].filter(Boolean).join(" ");
@@ -20,9 +21,9 @@ function init({ address, city, postalCode }) {
 function reducer(state, action) {
   switch (action.type) {
     case "search_input":
-      return { ...state, searchInput: action.payload };
+      return { ...state, searchInput: action.payload ?? [] };
     case "search_done":
-      return { ...state, searchResults: action.payload };
+      return { ...state, searchResults: action.payload ?? [] };
     case "set_fields":
       return {
         ...state,
@@ -55,7 +56,11 @@ export default function DsfrfWorkSiteAddress({
 
   useEffect(() => {
     const handler = setTimeout(() => {
-      if (!state.searchInput || state.searchInput === state.selectedAdress) {
+      if (
+        !state.searchInput ||
+        state.searchInput === state.selectedAdress ||
+        state.searchInput.length < API_MIN_CHARS
+      ) {
         dispatch({ type: "search_done", payload: [] });
         return;
       }

--- a/front/src/form/common/components/work-site/WorkSiteAddress.tsx
+++ b/front/src/form/common/components/work-site/WorkSiteAddress.tsx
@@ -4,6 +4,7 @@ import TdSwitch from "../../../../common/components/Switch";
 
 import SearchInput from "../../../../common/components/SearchInput";
 import styles from "./WorkSiteAddress.module.scss";
+import { API_MIN_CHARS } from "../../constants";
 
 function init({ address, city, postalCode }) {
   const selectedAdress = [address, postalCode, city].filter(Boolean).join(" ");
@@ -20,9 +21,9 @@ function init({ address, city, postalCode }) {
 function reducer(state, action) {
   switch (action.type) {
     case "search_input":
-      return { ...state, searchInput: action.payload };
+      return { ...state, searchInput: action.payload ?? [] };
     case "search_done":
-      return { ...state, searchResults: action.payload };
+      return { ...state, searchResults: action.payload ?? [] };
     case "set_fields":
       return {
         ...state,
@@ -55,7 +56,11 @@ export default function WorkSiteAddress({
 
   useEffect(() => {
     const handler = setTimeout(() => {
-      if (!state.searchInput || state.searchInput === state.selectedAdress) {
+      if (
+        !state.searchInput ||
+        state.searchInput === state.selectedAdress ||
+        state.searchInput.length < API_MIN_CHARS
+      ) {
         dispatch({ type: "search_done", payload: [] });
         return;
       }

--- a/front/src/form/common/constants.ts
+++ b/front/src/form/common/constants.ts
@@ -1,0 +1,1 @@
+export const API_MIN_CHARS = 3;


### PR DESCRIPTION
Le composant d'affichage plantait lorsque la recherche faisait moins de 3 caractères à cause d'un undefined.map. On n'envoie plus de requêtes en dessous du nb minimal fixé par l'api (3) et on s'assure d'avoir un array vide au lieu d'undefined dans les searchResults


### bug

https://github.com/user-attachments/assets/94f39791-6414-434e-9736-faa7f7989860

#### fix

https://github.com/user-attachments/assets/1f9a01d5-e3b7-41da-8a03-ca10d0891733



- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15226)
