### PR TITLE
Hotfix multiple revision management

### DIFF
--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -276,7 +276,7 @@ export function computeLatestRevision(
   return revisionRequests.reduce((latestRevision, currentRevision) => {
     if (
       !latestRevision ||
-      currentRevision.updatedAt > latestRevision.updatedAt
+      currentRevision.createdAt > latestRevision.createdAt
     ) {
       return currentRevision;
     }

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -251,7 +251,7 @@ export function computeLatestRevision(
   return revisionRequests.reduce((latestRevision, currentRevision) => {
     if (
       !latestRevision ||
-      currentRevision.updatedAt > latestRevision.updatedAt
+      currentRevision.createdAt > latestRevision.createdAt
     ) {
       return currentRevision;
     }

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -892,7 +892,7 @@ export function expandFormFromElastic(form: FormForElastic): GraphQLForm {
               (latestRevision, currentRevision) => {
                 if (
                   !latestRevision ||
-                  currentRevision.updatedAt > latestRevision.updatedAt
+                  currentRevision.createdAt > latestRevision.createdAt
                 ) {
                   return currentRevision;
                 }

--- a/front/index.html
+++ b/front/index.html
@@ -24,7 +24,7 @@
 
     <link
       rel="stylesheet"
-      href="/dsfr/utility/icons/icons.min.css?hash=4f3e3c25"
+      href="/dsfr/utility/icons/icons.min.css?hash=c38967d1"
     />
     <link rel="stylesheet" href="/dsfr/dsfr.min.css?v=1.12.1" />
     <meta


### PR DESCRIPTION
Des utilisateurs se sont plaints de ne pouvoir approuver des révisions, le dashboard affichant "consulter" au lieu de "gérer".
Lorsque plusieurs révisions sont rattachées à un bsd, une fonction calcule la dernière pour la renvoyer dans les metadata et permettre au dashbaord de savoir si c'est une révision en attente ou traitée, en les triant par l'updatedAt. Le pb existe sur BSDD, BSDA, BSDASRI (ça copie sans vergogne dans cette équipe)

Des scripts de mises à jour ont modifié certaines révisions, perturbant le tri sur les updatedAt qui ont été mis à jour.

Cette PR modifie le tri en se basant sur les createdAt, sachant qu'une révision ne peut de toutes façons pas être créée sur  un bsd si il en existe une en attente.

### Bug

<img width="772" alt="Capture d’écran 2024-10-09 à 15 39 37" src="https://github.com/user-attachments/assets/4f27e83b-6602-4a4d-987b-a3370e913189">

### Api

<img width="439" alt="Capture d’écran 2024-10-09 à 15 40 32" src="https://github.com/user-attachments/assets/f0c5c811-f4f6-4776-89c3-e1581e79f346">

### Fix
<img width="679" alt="Capture d’écran 2024-10-09 à 15 41 35" src="https://github.com/user-attachments/assets/7ca1c5f5-890e-41fe-91d7-ae343444a562">




- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15208)
