### PR TITLE
Ajoute quelques tests pour le security code des vhu

### DIFF
--- a/back/src/bsvhu/resolvers/mutations/__tests__/signBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/signBsvhu.integration.ts
@@ -7,7 +7,11 @@ import {
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { bsvhuFactory } from "../../../__tests__/factories.vhu";
-import { companyFactory } from "../../../../__tests__/factories";
+import {
+  companyFactory,
+  transporterReceiptFactory
+} from "../../../../__tests__/factories";
+import { prisma } from "@td/prisma";
 
 const SIGN_VHU_FORM = `
 mutation SignVhuForm($id: ID!, $input: BsvhuSignatureInput!) {
@@ -73,6 +77,226 @@ describe("Mutation.Vhu.sign", () => {
 
     expect(data.signBsvhu.emitter!.emission!.signature!.author).toBe(user.name);
     expect(data.signBsvhu.emitter!.emission!.signature!.date).not.toBeNull();
+  });
+  it("should forbid another company to sign EMISSION  when security code is not provided", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER", {
+      securityCode: 9421
+    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        destinationCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "signBsvhu">>(
+      SIGN_VHU_FORM,
+      {
+        variables: {
+          id: bsvhu.id,
+          input: { type: "EMISSION", author: user.name }
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous ne pouvez pas signer ce bordereau",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  it("should forbid another company to sign EMISSION when security code is wrong", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER", {
+      securityCode: 9421
+    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        destinationCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "signBsvhu">>(
+      SIGN_VHU_FORM,
+      {
+        variables: {
+          id: bsvhu.id,
+          input: { type: "EMISSION", author: user.name, securityCode: 5555 }
+        }
+      }
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le code de signature est invalide.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  it("should allow another company to sign EMISSION when security code is provided", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER", {
+      securityCode: 9421
+    });
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        destinationCompanySiret: company.siret
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { data } = await mutate<Pick<Mutation, "signBsvhu">>(SIGN_VHU_FORM, {
+      variables: {
+        id: bsvhu.id,
+        input: { type: "EMISSION", author: user.name, securityCode: 9421 }
+      }
+    });
+
+    expect(data.signBsvhu.emitter!.emission!.signature!.author).toBe(user.name);
+    expect(data.signBsvhu.emitter!.emission!.signature!.date).not.toBeNull();
+  });
+
+  it("should forbid another company to sign TRANSPORT when security code is not provided", async () => {
+    const { user: emitter, company: emitterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: transporterCompany } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: ["TRANSPORTER"],
+        securityCode: 9421
+      }
+    );
+
+    await transporterReceiptFactory({ company: transporterCompany });
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        transporterCompanySiret: transporterCompany.siret,
+        status: "SIGNED_BY_PRODUCER"
+      }
+    });
+
+    const { mutate } = makeClient(emitter);
+    const { errors } = await mutate<Pick<Mutation, "signBsvhu">>(
+      SIGN_VHU_FORM,
+      {
+        variables: {
+          id: bsvhu.id,
+          input: { type: "TRANSPORT", author: emitter.name }
+        }
+      }
+    );
+
+    const signedBsvhu = await prisma.bsvhu.findUnique({
+      where: { id: bsvhu.id }
+    });
+    expect(signedBsvhu?.status).toEqual("SIGNED_BY_PRODUCER");
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Vous ne pouvez pas signer ce bordereau",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  it("should forbid another company to sign TRANSPORT when security code is wrong", async () => {
+    const { user: emitter, company: emitterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: transporterCompany } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: ["TRANSPORTER"],
+        securityCode: 9421
+      }
+    );
+
+    await transporterReceiptFactory({ company: transporterCompany });
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        transporterCompanySiret: transporterCompany.siret,
+        status: "SIGNED_BY_PRODUCER"
+      }
+    });
+
+    const { mutate } = makeClient(emitter);
+    const { errors } = await mutate<Pick<Mutation, "signBsvhu">>(
+      SIGN_VHU_FORM,
+      {
+        variables: {
+          id: bsvhu.id,
+          input: { type: "TRANSPORT", author: emitter.name, securityCode: 3333 }
+        }
+      }
+    );
+
+    const signedBsvhu = await prisma.bsvhu.findUnique({
+      where: { id: bsvhu.id }
+    });
+    expect(signedBsvhu?.status).toEqual("SIGNED_BY_PRODUCER");
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: "Le code de signature est invalide.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.FORBIDDEN
+        })
+      })
+    ]);
+  });
+
+  it("should allow another company to sign TRANSPORT when security code is provided", async () => {
+    const { user: emitter, company: emitterCompany } =
+      await userWithCompanyFactory("MEMBER", {});
+    const { company: transporterCompany } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: ["TRANSPORTER"],
+        securityCode: 9421
+      }
+    );
+
+    await transporterReceiptFactory({ company: transporterCompany });
+    const bsvhu = await bsvhuFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        transporterCompanySiret: transporterCompany.siret,
+        status: "SIGNED_BY_PRODUCER"
+      }
+    });
+
+    const { mutate } = makeClient(emitter);
+    const { data } = await mutate<Pick<Mutation, "signBsvhu">>(SIGN_VHU_FORM, {
+      variables: {
+        id: bsvhu.id,
+        input: { type: "TRANSPORT", author: emitter.name, securityCode: 9421 }
+      }
+    });
+
+    const signedBsvhu = await prisma.bsvhu.findUnique({
+      where: { id: bsvhu.id }
+    });
+    expect(signedBsvhu?.status).toEqual("SENT");
+
+    expect(data.signBsvhu.transporter!.transport!.signature!.author).toBe(
+      emitter.name
+    );
+    expect(
+      data.signBsvhu.transporter!.transport!.signature!.date
+    ).not.toBeNull();
   });
 
   it("should use the provided date for the signature if  given", async () => {


### PR DESCRIPTION
Un utilisateur api a ouvert un ticket alléguant que le security code de la signature vhu n'était pas contrôlé, les tests ajoutés semblent le contredire (https://trackdechets.zammad.com/#ticket/zoom/42538)

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---


