### PR TITLE
[TRA-15009] Retrait du bouton de revision dans l'UI sur les DASRI regroupés

### DIFF
--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -309,6 +309,7 @@ export const mapBsdasri = (bsdasri: Bsdasri): BsdDisplay => {
     emittedByEcoOrganisme: bsdasri.ecoOrganisme?.emittedByEcoOrganisme,
     bsdWorkflowType: bsdasri?.type,
     grouping: bsdasri?.grouping,
+    groupedIn: bsdasri.groupedIn,
     synthesizing: bsdasri?.synthesizing,
     allowDirectTakeOver: bsdasri?.allowDirectTakeOver,
     transporterCustomInfo: truncateTransporterInfo(

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1311,9 +1311,10 @@ const canReviewBsdasri = (bsd, siret) => {
     return false;
   }
 
-  if (bsd.groupedInId || bsd.synthesizedInId) {
+  if (bsd.groupedIn || bsd.synthesizedIn) {
     return false;
   }
+
   const isDestination = isSameSiretDestination(siret, bsd);
   const isProducer = isSameSiretEmitter(siret, bsd);
   const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);

--- a/front/src/Apps/common/queries/fragments/bsdasri.ts
+++ b/front/src/Apps/common/queries/fragments/bsdasri.ts
@@ -134,10 +134,16 @@ export const dashboardDasriFragment = gql`
         }
       }
     }
+    groupedIn {
+      id
+    }
     # Attention, pour des raisons de performance, seul
     # l'identifiant est exposé ici. Requêter d'autres champs sur
     # grouping ne fonctionnera pas
     grouping {
+      id
+    }
+    synthesizedIn {
       id
     }
     # Attention, pour des raisons de performance, seul

--- a/front/src/Apps/common/queries/fragments/bsdasri.ts
+++ b/front/src/Apps/common/queries/fragments/bsdasri.ts
@@ -143,9 +143,6 @@ export const dashboardDasriFragment = gql`
     grouping {
       id
     }
-    synthesizedIn {
-      id
-    }
     # Attention, pour des raisons de performance, seul
     # l'identifiant est exposé ici. Requêter d'autres champs sur
     # synthesizing ne fonctionnera pas

--- a/front/src/Apps/common/types/bsdTypes.ts
+++ b/front/src/Apps/common/types/bsdTypes.ts
@@ -127,7 +127,7 @@ export interface BsdDisplay {
     | Maybe<Array<InitialBsdasri>>
     | Array<BsffPackaging>
     | Maybe<Array<InitialBsda>>;
-  groupedIn?: Maybe<Bsda>;
+  groupedIn?: Maybe<Bsda> | Maybe<Bsdasri>;
   forwardedIn?: Maybe<Bsda>;
   synthesizing?: Maybe<Array<InitialBsdasri>>;
   temporaryStorageDetail?: Maybe<TemporaryStorageDetail>;


### PR DESCRIPTION
# Contexte

On ne peut déjà pas réviser un DASRI regroupé (synthèse ou groupement), l'API l'interdit. Cette PR cache juste le bouton pour éviter à l'utilisateur de perdre son temps.

# Démo

![image](https://github.com/user-attachments/assets/85630d66-a6da-471e-927a-f1accd60b171)

# Ticket Favro

[Retirer la possibilité de réviser un DASRI initial à partir du moment où celui-ci a été regroupé dans un DASRI de synthèse ou groupement](https://favro.com/widget/ab14a4f0460a99a9d64d4945/2e73607ee11a34a3e0deb539?card=tra-15009)
