### PR TITLE
Nettoie les données de certificats amiante quand la sous section 3 est supprimée

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/updateWorkerCertification.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateWorkerCertification.integration.ts
@@ -57,4 +57,100 @@ describe("{ mutation { updateworkerCertification } }", () => {
       });
     expect(updated.certificationNumber).toEqual(update.certificationNumber);
   });
+
+  it("should reset Worker certification when subsection 3 is false", async () => {
+    const certification = {
+      hasSubSectionFour: true,
+      hasSubSectionThree: true,
+      certificationNumber: "AAA",
+      validityLimit: new Date().toISOString(),
+      organisation: "AFNOR Certification"
+    };
+
+    const createdCertification = await prisma.workerCertification.create({
+      data: certification
+    });
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await prisma.company.update({
+      data: {
+        workerCertification: { connect: { id: createdCertification.id } }
+      },
+      where: { id: company.id }
+    });
+
+    const update = {
+      hasSubSectionThree: false
+    };
+
+    const mutation = `
+      mutation {
+        updateWorkerCertification(
+          input: {
+            id: "${createdCertification.id}"
+            hasSubSectionThree:false
+          }
+          ) { hasSubSectionThree }
+        }`;
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    const { data } = await mutate<Pick<Mutation, "updateWorkerCertification">>(
+      mutation
+    );
+
+    // check returned value
+    expect(data.updateWorkerCertification).toEqual(update);
+
+    // check record was modified in db
+    const { id, ...updated } =
+      await prisma.workerCertification.findUniqueOrThrow({
+        where: { id: createdCertification.id }
+      });
+    expect(updated.hasSubSectionThree).toEqual(false);
+    expect(updated.certificationNumber).toEqual("");
+    expect(updated.organisation).toEqual("");
+    expect(updated.validityLimit).toEqual(null);
+  });
+
+  it("should not reset Worker certification when input does not contain subsection 3 field", async () => {
+    const certification = {
+      hasSubSectionFour: true,
+      hasSubSectionThree: true,
+      certificationNumber: "AAA",
+      validityLimit: new Date().toISOString(),
+      organisation: "AFNOR Certification"
+    };
+
+    const createdCertification = await prisma.workerCertification.create({
+      data: certification
+    });
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await prisma.company.update({
+      data: {
+        workerCertification: { connect: { id: createdCertification.id } }
+      },
+      where: { id: company.id }
+    });
+
+    const mutation = `
+      mutation {
+        updateWorkerCertification(
+          input: {
+            id: "${createdCertification.id}"
+             organisation:   "QUALIBAT"
+          }
+          ) { hasSubSectionThree }
+        }`;
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+
+    await mutate<Pick<Mutation, "updateWorkerCertification">>(mutation);
+
+    // check record was modified in db
+    const { id, ...updated } =
+      await prisma.workerCertification.findUniqueOrThrow({
+        where: { id: createdCertification.id }
+      });
+    expect(updated.hasSubSectionThree).toEqual(true);
+    expect(updated.certificationNumber).toEqual("AAA");
+    expect(updated.organisation).toEqual("QUALIBAT");
+  });
 });

--- a/back/src/companies/resolvers/mutations/updateWorkerCertification.ts
+++ b/back/src/companies/resolvers/mutations/updateWorkerCertification.ts
@@ -1,12 +1,26 @@
 import { applyAuthStrategies, AuthType } from "../../../auth";
 import { removeEmptyKeys } from "../../../common/converter";
 import { checkIsAuthenticated } from "../../../common/permissions";
-import { MutationUpdateWorkerCertificationArgs } from "../../../generated/graphql/types";
+import {
+  MutationUpdateWorkerCertificationArgs,
+  UpdateWorkerCertificationInput
+} from "../../../generated/graphql/types";
 import { prisma } from "@td/prisma";
 import { GraphQLContext } from "../../../types";
 import { getWorkerCertificationOrNotFound } from "../../database";
 import { checkCanReadUpdateDeleteWorkerCertification } from "../../permissions";
 import { workerCertificationSchema } from "./createWorkerCertification";
+
+const cleanupCertificate = (
+  input: Omit<UpdateWorkerCertificationInput, "id">
+) => {
+  return {
+    ...removeEmptyKeys(input),
+    certificationNumber: "",
+    organisation: "",
+    validityLimit: null
+  };
+};
 
 export async function updateWorkerCertification(
   _,
@@ -16,13 +30,15 @@ export async function updateWorkerCertification(
   applyAuthStrategies(context, [AuthType.Session]);
   const user = checkIsAuthenticated(context);
   const { id, ...data } = input;
-
+  const hasNoSubSectionThree = input.hasSubSectionThree === false;
   const certification = await getWorkerCertificationOrNotFound({ id });
   await checkCanReadUpdateDeleteWorkerCertification(user, certification);
   await workerCertificationSchema.validate(input);
 
   return prisma.workerCertification.update({
-    data: removeEmptyKeys(data),
+    data: hasNoSubSectionThree
+      ? cleanupCertificate(data)
+      : removeEmptyKeys(data),
     where: { id: certification.id }
   });
 }


### PR DESCRIPTION
La refonte de la validation bsda renforce les contrôle au niveau de la sous section 3 (cf checkWorkerSubSectionThree).

Des utilisateurs se sont retrouvés bloqués aprce que la case ss3 était décichée, mais les donnes de certificat (numero, date, organisme) étaient encore en db.
cette PR supprime lesdites données quand on décoche la ss3.


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15177)
