### PR TITLE
Fix BSVHU DSFR form

### DIFF
--- a/front/src/Apps/Dashboard/Creation/FormStepsContent.tsx
+++ b/front/src/Apps/Dashboard/Creation/FormStepsContent.tsx
@@ -5,7 +5,9 @@ import FormStepsTabs from "../../Forms/Components/FormStepsTabs/FormStepsTabs";
 import { Loader } from "../../common/Components";
 import { SealedFieldsContext } from "./context";
 import {
-  TabsName,
+  NormalizedError,
+  SupportedBsdTypes,
+  TabId,
   getNextTab,
   getPrevTab,
   getTabs,
@@ -13,7 +15,7 @@ import {
 } from "./utils";
 
 interface FormStepsContentProps {
-  isCrematorium?: boolean;
+  bsdType: SupportedBsdTypes;
   sealedFields?: string[];
   isLoading: boolean;
   useformMethods: UseFormReturn<any>;
@@ -26,11 +28,11 @@ interface FormStepsContentProps {
     transporter: React.JSX.Element;
     destination: React.JSX.Element;
   };
-  setPublishErrors: Function;
-  errorTabIds?: string[] | (TabsName | undefined)[];
+  setPublishErrors: (normalizedErrors: NormalizedError[]) => void;
+  errorTabIds?: TabId[];
 }
 const FormStepsContent = ({
-  isCrematorium = false,
+  bsdType,
   tabsContent,
   sealedFields = [],
   isLoading,
@@ -41,9 +43,9 @@ const FormStepsContent = ({
   setPublishErrors,
   errorTabIds
 }: FormStepsContentProps) => {
-  const [selectedTabId, setSelectedTabId] = useState<TabsName>("waste");
+  const [selectedTabId, setSelectedTabId] = useState<TabId>(TabId.waste);
   const navigate = useNavigate();
-  const tabList = getTabs(isCrematorium, errorTabIds);
+  const tabList = getTabs(bsdType, errorTabIds);
   const tabIds = tabList.map(tab => tab.tabId);
   const lastTabId = tabIds[tabIds.length - 1];
   const firstTabId = tabIds[0];

--- a/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bspaoh/FormSteps.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  BsdType,
   BspaohInput,
   Mutation,
   MutationCreateBspaohArgs,
@@ -34,8 +35,7 @@ import { Destination } from "./steps/Destination";
 import {
   getErrorTabIds,
   getPublishErrorMessages,
-  getPublishErrorTabIds,
-  getTabs
+  getPublishErrorTabIds
 } from "../utils";
 
 const paohToInput = (paoh: BspaohInput): BspaohInput => {
@@ -139,17 +139,23 @@ export function ControlledTabs(props: Readonly<Props>) {
     }
   }
 
-  const tabIds = getTabs().map(tab => tab.tabId);
   const errorsFromPublishApi =
     publishErrors || props?.publishErrorsFromRedirect;
   const publishErrorTabIds = getPublishErrorTabIds(
-    errorsFromPublishApi,
-    tabIds
+    BsdType.Bspaoh,
+    errorsFromPublishApi
   );
   const formStateErrorsKeys = Object.keys(methods?.formState?.errors);
-  const errorTabIds = getErrorTabIds(publishErrorTabIds, formStateErrorsKeys);
+  const errorTabIds = getErrorTabIds(
+    BsdType.Bspaoh,
+    publishErrorTabIds,
+    formStateErrorsKeys
+  );
 
-  const publishErrorMessages = getPublishErrorMessages(errorsFromPublishApi);
+  const publishErrorMessages = getPublishErrorMessages(
+    BsdType.Bspaoh,
+    errorsFromPublishApi
+  );
 
   const tabsContent = {
     waste: <Waste />,
@@ -179,13 +185,13 @@ export function ControlledTabs(props: Readonly<Props>) {
   return (
     <>
       <FormStepsContent
+        bsdType={BsdType.Bspaoh}
         draftCtaLabel={draftCtaLabel}
         isLoading={loading}
         mainCtaLabel={mainCtaLabel}
         saveForm={saveForm}
         sealedFields={sealedFields}
         useformMethods={methods}
-        isCrematorium={true}
         tabsContent={tabsContent}
         setPublishErrors={setPublishErrors}
         errorTabIds={errorTabIds}

--- a/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+  BsdType,
   BsvhuInput,
   Mutation,
   MutationCreateBsvhuArgs,
@@ -32,7 +33,7 @@ import {
   getErrorTabIds,
   getPublishErrorMessages,
   getPublishErrorTabIds,
-  getTabs
+  TabId
 } from "../utils";
 
 const vhuToInput = (paoh: BsvhuInput): BsvhuInput => {
@@ -134,49 +135,61 @@ const BsvhuFormSteps = ({
     }
   };
 
-  const tabIds = getTabs().map(tab => tab.tabId);
   const errorsFromPublishApi = publishErrors || publishErrorsFromRedirect;
   const publishErrorTabIds = getPublishErrorTabIds(
-    errorsFromPublishApi,
-    tabIds
+    BsdType.Bsvhu,
+    errorsFromPublishApi
   );
   const formStateErrorsKeys = Object.keys(methods?.formState?.errors);
-  const errorTabIds = getErrorTabIds(publishErrorTabIds, formStateErrorsKeys);
+  const errorTabIds = getErrorTabIds(
+    BsdType.Bsvhu,
+    publishErrorTabIds,
+    formStateErrorsKeys
+  );
 
-  const publishErrorMessages = getPublishErrorMessages(errorsFromPublishApi);
+  const publishErrorMessages = useMemo(
+    () => getPublishErrorMessages(BsdType.Bsvhu, errorsFromPublishApi),
+    [errorsFromPublishApi]
+  );
 
-  const tabsContent = {
-    waste: (
-      <WasteBsvhu
-        errors={publishErrorMessages?.filter(error => error.tabId === "waste")}
-      />
-    ),
-    emitter: (
-      <EmitterBsvhu
-        errors={publishErrorMessages?.filter(
-          error => error.tabId === "emitter"
-        )}
-      />
-    ),
-    transporter: (
-      <TransporterBsvhu
-        errors={publishErrorMessages?.filter(
-          error => error.tabId === "transporter"
-        )}
-      />
-    ),
-    destination: (
-      <DestinationBsvhu
-        errors={publishErrorMessages?.filter(
-          error => error.tabId === "destination"
-        )}
-      />
-    )
-  };
+  const tabsContent = useMemo(
+    () => ({
+      waste: (
+        <WasteBsvhu
+          errors={publishErrorMessages.filter(
+            error => error.tabId === TabId.waste
+          )}
+        />
+      ),
+      emitter: (
+        <EmitterBsvhu
+          errors={publishErrorMessages.filter(
+            error => error.tabId === TabId.emitter
+          )}
+        />
+      ),
+      transporter: (
+        <TransporterBsvhu
+          errors={publishErrorMessages.filter(
+            error => error.tabId === TabId.transporter
+          )}
+        />
+      ),
+      destination: (
+        <DestinationBsvhu
+          errors={publishErrorMessages.filter(
+            error => error.tabId === TabId.destination
+          )}
+        />
+      )
+    }),
+    [publishErrorMessages]
+  );
 
   return (
     <>
       <FormStepsContent
+        bsdType={BsdType.Bsvhu}
         draftCtaLabel={draftCtaLabel}
         isLoading={loading}
         mainCtaLabel={mainCtaLabel}

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
@@ -126,29 +126,34 @@ const TransporterBsvhu = ({ errors }) => {
           selectedCompanyError={selectedCompanyError}
           onCompanySelected={company => {
             if (company) {
+              if (company.siret !== transporter?.company?.siret) {
+                setValue(`${actor}.company.contact`, company.contact);
+                setValue(`${actor}.company.phone`, company.contactPhone);
+                setValue(`${actor}.company.mail`, company.contactEmail);
+                if (errors?.length) {
+                  // server errors
+                  clearCompanyError(transporter, actor, clearErrors);
+                }
+              } else {
+                setValue(
+                  `${actor}.company.contact`,
+                  transporter?.company?.contact || company.contact
+                );
+                setValue(
+                  `${actor}.company.phone`,
+                  transporter?.company?.phone || company.contactPhone
+                );
+
+                setValue(
+                  `${actor}.company.mail`,
+                  transporter?.company?.mail || company.contactEmail
+                );
+              }
               setValue(`${actor}.company.orgId`, company.orgId);
               setValue(`${actor}.company.siret`, company.siret);
               setValue(`${actor}.company.name`, company.name);
               setValue(`${actor}.company.vatNumber`, company.vatNumber);
               setValue(`${actor}.company.address`, company.address);
-              setValue(
-                `${actor}.company.contact`,
-                transporter?.company?.contact || company.contact
-              );
-              setValue(
-                `${actor}.company.phone`,
-                transporter?.company?.phone || company.contactPhone
-              );
-
-              setValue(
-                `${actor}.company.mail`,
-                transporter?.company?.mail || company.contactEmail
-              );
-
-              if (errors?.length) {
-                // server errors
-                clearCompanyError(transporter, actor, clearErrors);
-              }
             }
           }}
         />

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -43,17 +43,6 @@ const WasteBsvhu = ({ errors }: { errors: TabError[] }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errors]);
 
-  useEffect(() => {
-    if (errors?.length) {
-      if (weight) {
-        clearErrors("weight.value");
-      }
-      if (identificationNumbers?.length) {
-        clearErrors("identification.numbers");
-      }
-    }
-  }, [clearErrors, errors?.length, identificationNumbers?.length, weight]);
-
   return (
     <>
       {!!sealedFields.length && <DisabledParagraphStep />}

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -7,10 +7,10 @@ import WasteRadioGroup from "../../../../Forms/Components/WasteRadioGoup/WasteRa
 import DisabledParagraphStep from "../../DisabledParagraphStep";
 import { ZodBsvhu } from "../schema";
 import { SealedFieldsContext } from "../../../../Dashboard/Creation/context";
-import { setFieldError } from "../../utils";
+import { setFieldError, TabError } from "../../utils";
 
-const WasteBsvhu = ({ errors }) => {
-  const { register, watch, setValue, formState, setError, clearErrors } =
+const WasteBsvhu = ({ errors }: { errors: TabError[] }) => {
+  const { register, watch, setValue, formState, setError } =
     useFormContext<ZodBsvhu>(); // retrieve all hook methods
 
   const weight = watch("weight.value");
@@ -27,33 +27,21 @@ const WasteBsvhu = ({ errors }) => {
 
   useEffect(() => {
     if (errors?.length) {
-      if (!weight) {
-        setFieldError(
-          errors,
-          "weight.value",
-          formState.errors?.weight?.value,
-          setError
-        );
-      }
-
-      if (!identificationNumbers?.length) {
-        setFieldError(
-          errors,
-          "identification.numbers",
-          formState.errors?.identification?.numbers,
-          setError
-        );
-      }
+      setFieldError(
+        errors,
+        "weight.value",
+        formState.errors?.weight?.value,
+        setError
+      );
+      setFieldError(
+        errors,
+        "identification.numbers",
+        formState.errors?.identification?.numbers?.length,
+        setError
+      );
     }
-  }, [
-    errors,
-    errors?.length,
-    formState.errors,
-    formState.errors?.weight?.value,
-    identificationNumbers?.length,
-    setError,
-    weight
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [errors]);
 
   useEffect(() => {
     if (errors?.length) {
@@ -140,6 +128,7 @@ const WasteBsvhu = ({ errors }) => {
           disabled={sealedFields.includes("identification.numbers")}
           name="identification.numbers"
           defaultValue={identificationNumbersDefaultValue}
+          error={formState.errors.identification?.numbers}
         />
         {formState.errors.identification?.numbers?.message && (
           <p className="fr-text fr-error-text">

--- a/front/src/Apps/Dashboard/Creation/utils.ts
+++ b/front/src/Apps/Dashboard/Creation/utils.ts
@@ -1,8 +1,10 @@
 import { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
 import { getTabClassName } from "../../Forms/Components/FormStepsTabs/utils";
 import { toastApolloError } from "./toaster";
+import { BsdType } from "@td/codegen-ui";
+import { ApolloError } from "@apollo/client";
 
-export const getNextTab = (tabIds, currentTabId) => {
+export const getNextTab = (tabIds: TabId[], currentTabId: TabId) => {
   const idx = tabIds.indexOf(currentTabId);
   if (idx === -1 || idx === tabIds.length) {
     return currentTabId;
@@ -10,7 +12,7 @@ export const getNextTab = (tabIds, currentTabId) => {
   return tabIds[idx + 1];
 };
 
-export const getPrevTab = (tabIds, currentTabId) => {
+export const getPrevTab = (tabIds: TabId[], currentTabId: TabId) => {
   const idx = tabIds.indexOf(currentTabId);
   if (idx === -1 || idx === 0) {
     return currentTabId;
@@ -18,7 +20,27 @@ export const getPrevTab = (tabIds, currentTabId) => {
   return tabIds[idx - 1];
 };
 
-export type TabsName = "waste" | "emitter" | "transporter" | "destination";
+export enum TabId {
+  waste = "waste",
+  emitter = "emitter",
+  transporter = "transporter",
+  destination = "destination"
+}
+
+export type NormalizedError = {
+  code: string;
+  path: string[];
+  message: string;
+};
+
+export type SupportedBsdTypes = BsdType.Bsvhu | BsdType.Bspaoh;
+
+export type TabError = {
+  tabId: TabId;
+  name: string;
+  message: string;
+};
+
 export type IconIdName =
   | "fr-icon-arrow-right-line"
   | "tabError fr-icon-warning-line fr-icon-arrow-right-line"
@@ -26,85 +48,127 @@ export type IconIdName =
   | RiIconClassName;
 
 export const getTabs = (
-  isCrematorium?: boolean,
-  errorTabIds?: string[] | (TabsName | undefined)[]
+  bsdType: SupportedBsdTypes,
+  errorTabIds?: TabId[]
 ): {
-  tabId: TabsName;
+  tabId: TabId;
   label: string;
   iconId: IconIdName;
 }[] => [
   {
-    tabId: "waste",
+    tabId: TabId.waste,
     label: "Déchet",
     iconId: getTabClassName(errorTabIds, "waste")
   },
   {
-    tabId: "emitter",
+    tabId: TabId.emitter,
     label: "Producteur",
     iconId: getTabClassName(errorTabIds, "emitter")
   },
   {
-    tabId: "transporter",
+    tabId: TabId.transporter,
     label: "Transporteur",
     iconId: getTabClassName(errorTabIds, "transporter")
   },
   {
-    tabId: "destination",
-    label: isCrematorium ? "Crématorium" : "Destination finale",
+    tabId: TabId.destination,
+    label: bsdType === BsdType.Bspaoh ? "Crématorium" : "Destination finale",
     iconId: getTabClassName(errorTabIds, "destination")
   }
 ];
 
-export const getPublishErrorTabIds = (apiErrors, tabIds) => {
+const pathPrefixToTab = {
+  [BsdType.Bsvhu]: (pathPrefix: string): TabId | null => {
+    if (
+      pathPrefix === "weight" ||
+      pathPrefix === "quantity" ||
+      pathPrefix === "wasteCode" ||
+      pathPrefix === "identification"
+    ) {
+      return TabId.waste;
+    }
+    if (Object.values(TabId).includes(pathPrefix as TabId)) {
+      return TabId[pathPrefix];
+    }
+    return null;
+  },
+  [BsdType.Bspaoh]: (pathPrefix: string): TabId | null => {
+    if (Object.values(TabId).includes(pathPrefix as TabId)) {
+      return TabId[pathPrefix];
+    }
+    return null;
+  }
+};
+
+export const getPublishErrorTabIds = (
+  bsdType: SupportedBsdTypes,
+  apiErrors?: NormalizedError[]
+): TabId[] => {
   // search for presence of tabId return in zod path api errors then return tab ids in error
   const publishErrorTabIds = [
     ...new Set(
       apiErrors?.map(apiError => {
-        if (["weight", "identification"].includes(apiError.path[0])) {
-          return tabIds.find(key => key === "waste");
+        if (apiError.path?.[0] && typeof apiError.path[0] === "string") {
+          return pathPrefixToTab[bsdType](apiError.path[0]);
         }
-        return tabIds.find(key => apiError.path[0]?.includes(key));
+        return null;
       })
     )
-  ];
+  ].filter((tabId): tabId is TabId => !!tabId);
 
-  return publishErrorTabIds as string[] | (TabsName | undefined)[];
+  return publishErrorTabIds;
 };
 
-export const getPublishErrorMessages = apiErrors => {
+export const getPublishErrorMessages = (
+  bsdType: SupportedBsdTypes,
+  apiErrors?: NormalizedError[]
+): TabError[] => {
   // return an array of messages with tabId, name (path) and the related message
-  const publishErrorMessages = apiErrors?.map(apiError => {
-    const errorPath = apiError?.path;
-    const pathPrefix = errorPath?.[0];
-    const tabId = ["weight", "identification"].includes(pathPrefix)
-      ? "waste"
-      : pathPrefix;
-    const name = errorPath.join(".");
-    const message = apiError.message;
-    return { tabId, name, message };
-  });
+  const publishErrorMessages =
+    apiErrors
+      ?.map(apiError => {
+        const errorPath = apiError?.path;
+        const pathPrefix = errorPath?.[0];
+        const tabId = pathPrefixToTab[bsdType](pathPrefix);
+        const name = errorPath.join(".");
+        const message = apiError.message;
+        return { tabId, name, message };
+      })
+      .filter(
+        (
+          err
+        ): err is {
+          tabId: TabId;
+          name: string;
+          message: string;
+        } => !!err.tabId
+      ) ?? [];
 
   return publishErrorMessages;
 };
 
-export const getErrorTabIds = (apiErrorTabIds, formStateErrorsKeys) => {
+export const getErrorTabIds = (
+  bsdType: BsdType,
+  apiErrorTabIds: TabId[],
+  formStateErrorsKeys: string[]
+): TabId[] => {
   // get tab id in error in order to display icon tab error (either api or front validation we need to display the right icon)
   const errorTabIds = apiErrorTabIds?.length
     ? apiErrorTabIds
     : formStateErrorsKeys?.length > 0
-    ? formStateErrorsKeys
+    ? formStateErrorsKeys.map(errKey => pathPrefixToTab[bsdType](errKey))
     : [];
 
   return errorTabIds;
 };
 
-export const handleGraphQlError = (err, setPublishErrors) => {
-  if (err?.graphQLErrors?.length) {
-    const issues = err.graphQLErrors[0]?.extensions?.issues as {
-      code: string;
-      path: string[];
-      message: string;
-    }[];
+export const handleGraphQlError = (
+  err: ApolloError,
+  setPublishErrors: (normalizedErrors: NormalizedError[]) => void
+) => {
+  if (err.graphQLErrors?.length) {
+    const issues = err.graphQLErrors[0]?.extensions
+      ?.issues as NormalizedError[];
     if (issues?.length) {
       const errorsWithEmptyPath = issues.filter(f => !f.path.length);
       if (errorsWithEmptyPath.length) {
@@ -113,13 +177,7 @@ export const handleGraphQlError = (err, setPublishErrors) => {
       const errorDetailList = issues?.map(error => {
         return error;
       });
-      setPublishErrors(
-        errorDetailList as {
-          code: string;
-          path: string[];
-          message: string;
-        }[]
-      );
+      setPublishErrors(errorDetailList as NormalizedError[]);
     } else {
       toastApolloError(err); // other case like forbidden, we need to display an error anyway ...
     }

--- a/front/src/Apps/Dashboard/Creation/utils.ts
+++ b/front/src/Apps/Dashboard/Creation/utils.ts
@@ -198,12 +198,8 @@ export const setFieldError = (errors, errorPath, stateError, setError) => {
 };
 
 export const clearCompanyError = (actor, actorName, clearErrors) => {
-  if (actor?.["company"]?.siret || actor?.noSiret) {
-    clearErrors([`${actorName}.company.siret`]);
-  }
-  if (actor?.["company"]?.orgId || actor?.noSiret) {
-    clearErrors([`${actorName}.company.orgId`]);
-  }
+  clearErrors([`${actorName}.company.siret`]);
+  clearErrors([`${actorName}.company.orgId`]);
   if (actor?.["company"]?.name) {
     clearErrors([`${actorName}.company.name`]);
   }

--- a/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
+++ b/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
@@ -1,6 +1,7 @@
 import Tag from "@codegouvfr/react-dsfr/Tag";
 import React, { useEffect, useReducer, useRef } from "react";
 import { useFormContext } from "react-hook-form";
+import classNames from "classnames";
 import TdTooltip from "../../../../common/components/Tooltip";
 import "./identificationNumber.scss";
 interface IdentificationNumberProps {
@@ -96,14 +97,17 @@ const IdentificationNumber = ({
 
   return (
     <>
-      <p className={`multiTags-title${error ? " error" : ""}`}>
+      <p className={classNames("multiTags-title", { error: !!error })}>
         {title}
         <TdTooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
       </p>
       <div
-        className={`fr-grid-row fr-grid-row--bottom multiTags${
-          error ? " error" : ""
-        }`}
+        className={classNames(
+          "fr-grid-row",
+          "fr-grid-row--bottom",
+          "multiTags",
+          { error: !!error }
+        )}
       >
         {state?.codes?.map((code, idx) => (
           <Tag
@@ -149,7 +153,12 @@ const IdentificationNumber = ({
         )}
       </div>
       {type && (
-        <p className={`${error ? "fr-error-text" : "fr-info-text"} fr-mt-5v`}>
+        <p
+          className={classNames(
+            "fr-mt-5v",
+            error ? "fr-error-text" : "fr-info-text"
+          )}
+        >
           Vous avez {state.codes.length} {type} pour ce contenant
         </p>
       )}

--- a/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
+++ b/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
@@ -19,7 +19,7 @@ const IdentificationNumber = ({
   type,
   defaultValue
 }: IdentificationNumberProps) => {
-  const { setValue, getValues } = useFormContext();
+  const { setValue, getValues, clearErrors } = useFormContext();
 
   const SET_INPUT_CODE = "set_input_code";
   const ADD_CODE = "add_code";
@@ -85,7 +85,8 @@ const IdentificationNumber = ({
 
   useEffect(() => {
     setValue(name, state.codes);
-  }, [state, name, setValue]);
+    clearErrors(name);
+  }, [state, name, setValue, clearErrors]);
 
   useEffect(() => {
     if (defaultValue) {
@@ -95,11 +96,15 @@ const IdentificationNumber = ({
 
   return (
     <>
-      <p>
+      <p className={`multiTags-title${error ? " error" : ""}`}>
         {title}
         <TdTooltip msg="Saisissez les identifications une par une. Appuyez sur la touche <Entrée> pour valider chacune" />
       </p>
-      <div className="fr-grid-row fr-grid-row--bottom multiTags">
+      <div
+        className={`fr-grid-row fr-grid-row--bottom multiTags${
+          error ? " error" : ""
+        }`}
+      >
         {state?.codes?.map((code, idx) => (
           <Tag
             dismissible

--- a/front/src/Apps/Forms/Components/IdentificationNumbers/identificationNumber.scss
+++ b/front/src/Apps/Forms/Components/IdentificationNumbers/identificationNumber.scss
@@ -5,6 +5,7 @@
   font-size: 1rem;
   line-height: 1.2rem;
   padding: 0.5rem 1rem 0.5rem 1rem;
+  margin-top: 0.5em;
   color: var(--text-default-grey);
   background-color: rgb(238, 238, 238);
   --idle: transparent;
@@ -12,6 +13,9 @@
   --active: var(--background-contrast-grey-active);
   box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);
   row-gap: 10px;
+  &.error {
+    box-shadow: inset 0 -2px 0 0 var(--border-plain-error);
+  }
 }
 
 .multiTagsInput {
@@ -19,4 +23,10 @@
   background-color: transparent;
   padding: 0 0.4rem;
   width: 100%;
+}
+
+.multiTags-title {
+  &.error {
+    color: var(--text-default-error);
+  }
 }


### PR DESCRIPTION
# Objectif

Résoudre ce problème remonté en recette:

> lorsque je suis sur le formulaire de création du BSVHU, et que je souhaite directement publier le bordereau alors que les numéros d'identification n'ont pas été renseignés, aucun message d'erreur n'apparaît m'indiquant que ce champ est obligatoire ou qu'il y a une erreur sur le bordereau.

## Modifications

Au final en voulant résoudre ce problème je suis tombé sur d'autres problèmes, etc, donc j'ai touché à plusieurs trucs:
- J'ai typé et ajouté une enum pour les tab ids, de façon à éviter les erreurs
- j'ai normalisé la façon dont sont dispatchés les erreurs entre les onglets en fonction de leur path, et adapté les formulaires BSVHU et BSPAOH
- J'ai amélioré la façon dont le champ "identifications" affiche les erreurs (pour que ça corresponde aux inputs texte, càd le label en rouge et le bas de l'input en rouge)
- J'ai modifié et simplifié la façon dont la tab Waste BSVHU gère l'update des erreurs du form pour éviter une boucle infini

<img width="817" alt="Capture d’écran 2024-10-16 à 18 18 34" src="https://github.com/user-attachments/assets/a0dd26ca-f0a6-4d47-9209-ebd8ad055fc2">


- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14815)
