### PR TITLE
[TRA 14421] brouillons BSVHU non accessibles si pas auteur

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Changer la référence du cerfa lors de l'ajout d'une fiche d'intervention [PR 3616](https://github.com/MTES-MCT/trackdechets/pull/3616)
 - ETQ membre d'un établissement, je peux gérer mes préférences de notifications (demandes de rattachement, demandes de révisions, renouvellement code signature, etc) en lien avec cet établissement [PR 3634](https://github.com/MTES-MCT/trackdechets/pull/3634)
 - Amélioration du contenu de l'e-mail transactionnel envoyé au contact d'un établissement visé sur un bordereau en tant qu'émetteur [PR 3635](https://github.com/MTES-MCT/trackdechets/pull/3635)
+- Rendre les brouillons BSVHU non accessibles aux entreprises mentionnées sur le bordereau mais qui n'en sont pas les auteurs [PR 3677](https://github.com/MTES-MCT/trackdechets/pull/3677)
 
 #### :boom: Breaking changes
 

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -298,9 +298,10 @@ export async function checkCanDelete(user: User, bsda: BsdaWithTransporters) {
       ? [bsda.emitterCompanySiret]
       : [];
 
-  const errorMsg = bsda.isDraft
-    ? "Vous n'êtes pas autorisé à supprimer ce bordereau."
-    : "Seuls les bordereaux en brouillon ou n'ayant pas encore été signés peuvent être supprimés";
+  const errorMsg =
+    bsda.status === BsdaStatus.INITIAL
+      ? "Vous n'êtes pas autorisé à supprimer ce bordereau."
+      : "Seuls les bordereaux en brouillon ou n'ayant pas encore été signés peuvent être supprimés";
   return checkUserPermissions(
     user,
     authorizedOrgIds,

--- a/back/src/bsda/repository/bsda/create.ts
+++ b/back/src/bsda/repository/bsda/create.ts
@@ -6,7 +6,7 @@ import {
 import { enqueueCreatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdaEventTypes } from "./eventTypes";
 import { BsdaWithTransporters } from "../../types";
-import { getUserCompanies } from "../../../users/database";
+import { getCanAccessDraftOrgIds } from "../../utils";
 
 export type CreateBsdaFn = (
   data: Prisma.BsdaCreateInput,
@@ -52,11 +52,7 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
         )
       );
     }
-    const intermediariesOrgIds: string[] = bsda.intermediaries
-      ? bsda.intermediaries
-          .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
-          .filter(Boolean)
-      : [];
+
     const transportersOrgIds: string[] = bsda.transporters
       ? bsda.transporters
           .flatMap(t => [
@@ -66,25 +62,7 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
           .filter(Boolean)
       : [];
     // For drafts, only the owner's sirets that appear on the bsd have access
-    const canAccessDraftOrgIds: string[] = [];
-    if (bsda.isDraft) {
-      const userCompanies = await getUserCompanies(user.id);
-      const userOrgIds = userCompanies.map(company => company.orgId);
-      const bsdaOrgIds = [
-        ...intermediariesOrgIds,
-        ...transportersOrgIds,
-        bsda.emitterCompanySiret,
-        bsda.ecoOrganismeSiret,
-        bsda.destinationCompanySiret,
-        bsda.destinationOperationNextDestinationCompanySiret,
-        bsda.workerCompanySiret,
-        bsda.brokerCompanySiret
-      ].filter(Boolean);
-      const userOrgIdsInForm = userOrgIds.filter(orgId =>
-        bsdaOrgIds.includes(orgId)
-      );
-      canAccessDraftOrgIds.push(...userOrgIdsInForm);
-    }
+    const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(bsda, user.id);
 
     const updatedBsda = await prisma.bsda.update({
       where: { id: bsda.id },

--- a/back/src/bsda/repository/bsda/create.ts
+++ b/back/src/bsda/repository/bsda/create.ts
@@ -90,8 +90,7 @@ export function buildCreateBsda(deps: RepositoryFnDeps): CreateBsdaFn {
       where: { id: bsda.id },
       data: {
         ...(canAccessDraftOrgIds.length ? { canAccessDraftOrgIds } : {}),
-        ...(transportersOrgIds.length ? { transportersOrgIds } : {}),
-        transportersOrgIds
+        ...(transportersOrgIds.length ? { transportersOrgIds } : {})
       },
       include: {
         grouping: { select: { id: true } },

--- a/back/src/bsda/utils.ts
+++ b/back/src/bsda/utils.ts
@@ -1,0 +1,42 @@
+import { getUserCompanies } from "../users/database";
+import { BsdaWithIntermediaries, BsdaWithTransporters } from "./types";
+
+export const getCanAccessDraftOrgIds = async (
+  bsda: BsdaWithIntermediaries & BsdaWithTransporters,
+  userId: string
+): Promise<string[]> => {
+  const intermediariesOrgIds: string[] = bsda.intermediaries
+    ? bsda.intermediaries
+        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+        .filter(Boolean)
+    : [];
+  const transportersOrgIds: string[] = bsda.transporters
+    ? bsda.transporters
+        .flatMap(t => [
+          t.transporterCompanySiret,
+          t.transporterCompanyVatNumber
+        ])
+        .filter(Boolean)
+    : [];
+  // For drafts, only the owner's sirets that appear on the bsd have access
+  const canAccessDraftOrgIds: string[] = [];
+  if (bsda.isDraft) {
+    const userCompanies = await getUserCompanies(userId);
+    const userOrgIds = userCompanies.map(company => company.orgId);
+    const bsdaOrgIds = [
+      ...intermediariesOrgIds,
+      ...transportersOrgIds,
+      bsda.emitterCompanySiret,
+      bsda.ecoOrganismeSiret,
+      bsda.destinationCompanySiret,
+      bsda.destinationOperationNextDestinationCompanySiret,
+      bsda.workerCompanySiret,
+      bsda.brokerCompanySiret
+    ].filter(Boolean);
+    const userOrgIdsInForm = userOrgIds.filter(orgId =>
+      bsdaOrgIds.includes(orgId)
+    );
+    canAccessDraftOrgIds.push(...userOrgIdsInForm);
+  }
+  return canAccessDraftOrgIds;
+};

--- a/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
+++ b/back/src/bsds/indexation/__tests__/bulkIndexBsds.integration.ts
@@ -255,10 +255,11 @@ describe("indexAllBsdTypeSync", () => {
   });
 
   it("should index BSVHUs synchronously", async () => {
+    const user = await userFactory();
     const bsvhus = await Promise.all([
-      bsvhuFactory({}),
-      bsvhuFactory({}),
-      bsvhuFactory({})
+      bsvhuFactory({ userId: user.id }),
+      bsvhuFactory({ userId: user.id }),
+      bsvhuFactory({ userId: user.id })
     ]);
     await indexAllBsdTypeSync({
       bsdName: "bsvhu",
@@ -407,10 +408,11 @@ describe("indexAllBsdTypeConcurrently", () => {
   });
 
   it("should index BSVHUs using the index queue", async () => {
+    const user = await userFactory();
     const bsvhus = await Promise.all([
-      bsvhuFactory({}),
-      bsvhuFactory({}),
-      bsvhuFactory({})
+      bsvhuFactory({ userId: user.id }),
+      bsvhuFactory({ userId: user.id }),
+      bsvhuFactory({ userId: user.id })
     ]);
     const jobs = await indexAllBsdTypeConcurrentJobs({
       bsdName: "bsvhu",

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -600,7 +600,7 @@ export const cloneBsvhu = async (user: Express.User, id: string) => {
         }
       : {},
     intermediariesOrgIds: bsvhu.intermediariesOrgIds,
-	canAccessDraftOrgIds: bsvhu.canAccessDraftOrgIds,
+    canAccessDraftOrgIds: bsvhu.canAccessDraftOrgIds,
     isDeleted: bsvhu.isDeleted,
     isDraft: bsvhu.isDraft,
     packaging: bsvhu.packaging,

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -600,6 +600,7 @@ export const cloneBsvhu = async (user: Express.User, id: string) => {
         }
       : {},
     intermediariesOrgIds: bsvhu.intermediariesOrgIds,
+	canAccessDraftOrgIds: bsvhu.canAccessDraftOrgIds,
     isDeleted: bsvhu.isDeleted,
     isDraft: bsvhu.isDraft,
     packaging: bsvhu.packaging,

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsvhu.integration.ts
@@ -203,7 +203,7 @@ describe("Query.bsds.vhus base workflow", () => {
         expect.objectContaining({ node: { id: vhuId } })
       ]);
     });
-    it("draft vhu should be isDraftFor transporter", async () => {
+    it("draft vhu should not be isDraftFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -216,11 +216,9 @@ describe("Query.bsds.vhus base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: vhuId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
-    it("draft vhu should be isDraftFor destination", async () => {
+    it("draft vhu should not be isDraftFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -233,9 +231,7 @@ describe("Query.bsds.vhus base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: vhuId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
   });
 

--- a/back/src/bsvhu/__tests__/factories.vhu.ts
+++ b/back/src/bsvhu/__tests__/factories.vhu.ts
@@ -9,13 +9,17 @@ import { prisma } from "@td/prisma";
 import {
   companyFactory,
   ecoOrganismeFactory,
-  siretify
+  siretify,
+  userWithCompanyFactory
 } from "../../__tests__/factories";
 import { BsvhuForElastic, BsvhuForElasticInclude } from "../elastic";
+import { getUserCompanies } from "../../users/database";
 
 export const bsvhuFactory = async ({
+  userId,
   opt = {}
 }: {
+  userId?: string;
   opt?: Partial<Prisma.BsvhuCreateInput>;
 }): Promise<BsvhuForElastic> => {
   const transporterCompany = await companyFactory({
@@ -39,9 +43,20 @@ export const bsvhuFactory = async ({
     handle: { handleBsvhu: true },
     createAssociatedCompany: true
   });
+  const bsvhuObject = getVhuFormdata();
+  const userAndCompany = userId
+    ? null
+    : await userWithCompanyFactory("ADMIN", {
+        siret: bsvhuObject.emitterCompanySiret,
+        name: bsvhuObject.emitterCompanyName ?? undefined,
+        address: bsvhuObject.emitterCompanyAddress ?? undefined,
+        contact: bsvhuObject.emitterCompanyContact ?? undefined,
+        contactPhone: bsvhuObject.emitterCompanyPhone ?? undefined,
+        contactEmail: bsvhuObject.emitterCompanyMail ?? undefined
+      });
   const created = await prisma.bsvhu.create({
     data: {
-      ...getVhuFormdata(),
+      ...bsvhuObject,
       transporterCompanySiret: transporterCompany.siret,
       destinationCompanySiret: destinationCompany.siret,
       destinationOperationNextDestinationCompanySiret:
@@ -60,9 +75,35 @@ export const bsvhuFactory = async ({
         .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
         .filter(Boolean)
     : [];
+
+  // For drafts, only the owner's sirets that appear on the bsd have access
+  const canAccessDraftOrgIds: string[] = [];
+  if (created.isDraft) {
+    const userCompanies = await getUserCompanies(
+      (userId || userAndCompany?.user?.id) as string
+    );
+    const userOrgIds = userCompanies.map(company => company.orgId);
+    const bsvhuOrgIds = [
+      ...intermediariesOrgIds,
+      created.emitterCompanySiret,
+      ...[
+        created.transporterCompanySiret,
+        created.transporterCompanyVatNumber
+      ].filter(Boolean),
+      created.ecoOrganismeSiret,
+      created.destinationCompanySiret,
+      created.traderCompanySiret,
+      created.brokerCompanySiret
+    ].filter(Boolean);
+    const userOrgIdsInForm = userOrgIds.filter(orgId =>
+      bsvhuOrgIds.includes(orgId)
+    );
+    canAccessDraftOrgIds.push(...userOrgIdsInForm);
+  }
   return prisma.bsvhu.update({
     where: { id: created.id },
     data: {
+      ...(canAccessDraftOrgIds.length ? { canAccessDraftOrgIds } : {}),
       ...(intermediariesOrgIds.length ? { intermediariesOrgIds } : {})
     },
     include: BsvhuForElasticInclude

--- a/back/src/bsvhu/__tests__/factories.vhu.ts
+++ b/back/src/bsvhu/__tests__/factories.vhu.ts
@@ -13,7 +13,7 @@ import {
   userWithCompanyFactory
 } from "../../__tests__/factories";
 import { BsvhuForElastic, BsvhuForElasticInclude } from "../elastic";
-import { getUserCompanies } from "../../users/database";
+import { getCanAccessDraftOrgIds } from "../utils";
 
 export const bsvhuFactory = async ({
   userId,
@@ -77,29 +77,11 @@ export const bsvhuFactory = async ({
     : [];
 
   // For drafts, only the owner's sirets that appear on the bsd have access
-  const canAccessDraftOrgIds: string[] = [];
-  if (created.isDraft) {
-    const userCompanies = await getUserCompanies(
-      (userId || userAndCompany?.user?.id) as string
-    );
-    const userOrgIds = userCompanies.map(company => company.orgId);
-    const bsvhuOrgIds = [
-      ...intermediariesOrgIds,
-      created.emitterCompanySiret,
-      ...[
-        created.transporterCompanySiret,
-        created.transporterCompanyVatNumber
-      ].filter(Boolean),
-      created.ecoOrganismeSiret,
-      created.destinationCompanySiret,
-      created.traderCompanySiret,
-      created.brokerCompanySiret
-    ].filter(Boolean);
-    const userOrgIdsInForm = userOrgIds.filter(orgId =>
-      bsvhuOrgIds.includes(orgId)
-    );
-    canAccessDraftOrgIds.push(...userOrgIdsInForm);
-  }
+  const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(
+    created,
+    (userId || userAndCompany?.user?.id) as string
+  );
+
   return prisma.bsvhu.update({
     where: { id: created.id },
     data: {

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -71,6 +71,14 @@ const getBsvhuSirets = (bsvhu: BsvhuForElastic): ElasticSirets => {
     ...intermediarySirets
   };
 
+  // Drafts only appear in the dashboard for companies the bsvhu owner belongs to
+  if (bsvhu.isDraft) {
+    const draftFormSiretsEntries = Object.entries(bsvhuSirets).filter(
+      ([, siret]) => siret && bsvhu.canAccessDraftOrgIds.includes(siret)
+    );
+    return Object.fromEntries(draftFormSiretsEntries) as ElasticSirets;
+  }
+
   return bsvhuSirets;
 };
 

--- a/back/src/bsvhu/permissions.ts
+++ b/back/src/bsvhu/permissions.ts
@@ -6,16 +6,18 @@ import { Permission, checkUserPermissions } from "../permissions";
  * Retrieves organisations allowed to read a BSVHU
  */
 function readers(bsvhu: Bsvhu): string[] {
-  return [
-    bsvhu.emitterCompanySiret,
-    bsvhu.destinationCompanySiret,
-    bsvhu.transporterCompanySiret,
-    bsvhu.transporterCompanyVatNumber,
-    bsvhu.ecoOrganismeSiret,
-    bsvhu.brokerCompanySiret,
-    bsvhu.traderCompanySiret,
-    ...bsvhu.intermediariesOrgIds
-  ].filter(Boolean);
+  return bsvhu.isDraft
+    ? [...bsvhu.canAccessDraftOrgIds]
+    : [
+        bsvhu.emitterCompanySiret,
+        bsvhu.destinationCompanySiret,
+        bsvhu.transporterCompanySiret,
+        bsvhu.transporterCompanyVatNumber,
+        bsvhu.ecoOrganismeSiret,
+        bsvhu.brokerCompanySiret,
+        bsvhu.traderCompanySiret,
+        ...bsvhu.intermediariesOrgIds
+      ].filter(Boolean);
 }
 
 /**
@@ -25,6 +27,9 @@ function readers(bsvhu: Bsvhu): string[] {
  * a user is not removing his own company from the BSVHU
  */
 function contributors(bsvhu: Bsvhu, input?: BsvhuInput): string[] {
+  if (bsvhu.isDraft) {
+    return [...bsvhu.canAccessDraftOrgIds];
+  }
   const updateEmitterCompanySiret = input?.emitter?.company?.siret;
   const updateDestinationCompanySiret = input?.destination?.company?.siret;
   const updateTransporterCompanySiret = input?.transporter?.company?.siret;

--- a/back/src/bsvhu/repository/bsvhu/create.ts
+++ b/back/src/bsvhu/repository/bsvhu/create.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../common/repository/types";
 import { enqueueCreatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsvhuEventTypes } from "./eventTypes";
+import { getUserCompanies } from "../../../users/database";
 export type CreateBsvhuFn = (
   data: Prisma.BsvhuCreateInput,
   logMetadata?: LogMetadata
@@ -14,7 +15,12 @@ export function buildCreateBsvhu(deps: RepositoryFnDeps): CreateBsvhuFn {
   return async (data, logMetadata?) => {
     const { prisma, user } = deps;
 
-    const bsvhu = await prisma.bsvhu.create({ data });
+    const bsvhu = await prisma.bsvhu.create({
+      data,
+      include: {
+        intermediaries: true
+      }
+    });
 
     await prisma.event.create({
       data: {
@@ -26,8 +32,49 @@ export function buildCreateBsvhu(deps: RepositoryFnDeps): CreateBsvhuFn {
       }
     });
 
-    prisma.addAfterCommitCallback(() => enqueueCreatedBsdToIndex(bsvhu.id));
+    const intermediariesOrgIds: string[] = bsvhu.intermediaries
+      ? bsvhu.intermediaries
+          .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+          .filter(Boolean)
+      : [];
 
-    return bsvhu;
+    // For drafts, only the owner's sirets that appear on the bsd have access
+    const canAccessDraftOrgIds: string[] = [];
+    if (bsvhu.isDraft) {
+      const userCompanies = await getUserCompanies(user.id);
+      const userOrgIds = userCompanies.map(company => company.orgId);
+      const bsvhuOrgIds = [
+        ...intermediariesOrgIds,
+        bsvhu.emitterCompanySiret,
+        ...[
+          bsvhu.transporterCompanySiret,
+          bsvhu.transporterCompanyVatNumber
+        ].filter(Boolean),
+        bsvhu.ecoOrganismeSiret,
+        bsvhu.destinationCompanySiret,
+        bsvhu.traderCompanySiret,
+        bsvhu.brokerCompanySiret
+      ].filter(Boolean);
+      const userOrgIdsInForm = userOrgIds.filter(orgId =>
+        bsvhuOrgIds.includes(orgId)
+      );
+      canAccessDraftOrgIds.push(...userOrgIdsInForm);
+    }
+
+    const updatedBsvhu = await prisma.bsvhu.update({
+      where: { id: bsvhu.id },
+      data: {
+        ...(canAccessDraftOrgIds.length ? { canAccessDraftOrgIds } : {})
+      },
+      include: {
+        intermediaries: true
+      }
+    });
+
+    prisma.addAfterCommitCallback(() =>
+      enqueueCreatedBsdToIndex(updatedBsvhu.id)
+    );
+
+    return updatedBsvhu;
   };
 }

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -119,6 +119,7 @@ describe("mutaion.duplicateBsvhu", () => {
     });
 
     const bsvhu = await bsvhuFactory({
+      userId: emitter.user.id,
       opt: {
         emitterIrregularSituation: false,
         emitterNoSiret: false,
@@ -301,7 +302,8 @@ describe("mutaion.duplicateBsvhu", () => {
       "destinationOperationSignatureDate",
 
       "intermediaries",
-      "intermediariesOrgIds"
+      "intermediariesOrgIds",
+      "canAccessDraftOrgIds"
     ];
 
     expect(duplicatedBsvhu.status).toEqual("INITIAL");

--- a/back/src/bsvhu/utils.ts
+++ b/back/src/bsvhu/utils.ts
@@ -1,3 +1,6 @@
+import { getUserCompanies } from "../users/database";
+import { BsvhuWithIntermediaries } from "./types";
+
 export function getWasteDescription(wasteCode: string | null) {
   return wasteCode === "16 01 06"
     ? "Véhicules hors d'usage ne contenant ni liquides ni autres composants dangereux"
@@ -5,3 +8,37 @@ export function getWasteDescription(wasteCode: string | null) {
     ? "Véhicules hors d’usage non dépollués par un centre agréé"
     : "";
 }
+
+export const getCanAccessDraftOrgIds = async (
+  bsvhu: BsvhuWithIntermediaries,
+  userId: string
+): Promise<string[]> => {
+  const intermediariesOrgIds: string[] = bsvhu.intermediaries
+    ? bsvhu.intermediaries
+        .flatMap(intermediary => [intermediary.siret, intermediary.vatNumber])
+        .filter(Boolean)
+    : [];
+
+  const canAccessDraftOrgIds: string[] = [];
+  if (bsvhu.isDraft) {
+    const userCompanies = await getUserCompanies(userId);
+    const userOrgIds = userCompanies.map(company => company.orgId);
+    const bsvhuOrgIds = [
+      ...intermediariesOrgIds,
+      bsvhu.emitterCompanySiret,
+      ...[
+        bsvhu.transporterCompanySiret,
+        bsvhu.transporterCompanyVatNumber
+      ].filter(Boolean),
+      bsvhu.ecoOrganismeSiret,
+      bsvhu.destinationCompanySiret,
+      bsvhu.traderCompanySiret,
+      bsvhu.brokerCompanySiret
+    ].filter(Boolean);
+    const userOrgIdsInForm = userOrgIds.filter(orgId =>
+      bsvhuOrgIds.includes(orgId)
+    );
+    canAccessDraftOrgIds.push(...userOrgIdsInForm);
+  }
+  return canAccessDraftOrgIds;
+};

--- a/back/src/registry/__tests__/streams.integration.ts
+++ b/back/src/registry/__tests__/streams.integration.ts
@@ -111,6 +111,7 @@ describe("wastesReader", () => {
         .fill(1)
         .map(() =>
           bsvhuFactory({
+            userId: destination.user.id,
             opt: {
               destinationCompanySiret: destination.company.siret,
               destinationReceptionDate: new Date(),

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Destination.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Destination.tsx
@@ -324,18 +324,6 @@ const DestinationBsvhu = ({ errors }) => {
                   destination?.operation?.nextDestinationcompany
                     ?.contactEmail || company.contactEmail
                 );
-
-                const agrementNumber =
-                  company?.vhuAgrementBroyeur?.agrementNumber;
-
-                if (agrementNumber) {
-                  setValue(
-                    "destination.agrementNumber",
-                    company?.vhuAgrementBroyeur?.agrementNumber
-                  );
-                } else {
-                  setValue("destination.agrementNumber", "");
-                }
               }
             }}
           />

--- a/libs/back/prisma/src/migrations/20241009180028_bsvhu_draft_access/migration.sql
+++ b/libs/back/prisma/src/migrations/20241009180028_bsvhu_draft_access/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Bsvhu" ADD COLUMN     "canAccessDraftOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "_BsvhuCanAccessDraftOrgIdsIdx" ON "Bsvhu" USING GIN ("canAccessDraftOrgIds");

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1111,6 +1111,7 @@ model Bsvhu {
 
   // Denormalized fields, storing sirets to speed up queries and avoid expensive joins
   intermediariesOrgIds String[] @default([])
+  canAccessDraftOrgIds String[] @default([])
 
   // partial indices _BsvhuIsDeletedIdx,_BsvhuIsDraftIdx  see migration82_missing_indices.sql
 
@@ -1122,6 +1123,7 @@ model Bsvhu {
   @@index([brokerCompanySiret], map: "_BsvhuBrokerCompanySiretIdx")
   @@index([traderCompanySiret], map: "_BsvhuTraderCompanySiretIdx")
   @@index([intermediariesOrgIds], map: "_BsvhuIntermediariesOrgIdsIdx", type: Gin)
+  @@index([canAccessDraftOrgIds], map: "_BsvhuCanAccessDraftOrgIdsIdx", type: Gin)
   @@index([status], map: "_BsvhuStatusIdx")
   @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
 }

--- a/libs/back/scripts/src/scripts/20241009174516425_bsvhu_draft_restriction.ts
+++ b/libs/back/scripts/src/scripts/20241009174516425_bsvhu_draft_restriction.ts
@@ -1,0 +1,196 @@
+import { MongoClient } from "mongodb";
+import Queue, { JobOptions } from "bull";
+import { Company, Event, Prisma, User } from "@prisma/client";
+import { prisma } from "@td/prisma";
+import { logger } from "@td/logger";
+
+type EventLike = Omit<Event, "metadata" | "data"> & {
+  data: any;
+  metadata: any;
+};
+
+type EventCollection = { _id: string } & Omit<EventLike, "id">;
+
+const { MONGO_URL, REDIS_URL, NODE_ENV } = process.env;
+const EVENTS_COLLECTION = "events";
+const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+
+const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
+  }
+});
+
+async function enqueueUpdatedBsdToIndex(
+  bsdId: string,
+  options?: JobOptions
+): Promise<void> {
+  logger.info(`Enqueuing BSD ${bsdId} for indexation`);
+  await indexQueue.add("index_updated", bsdId, options);
+}
+
+async function getUserCompanies(userId: string): Promise<Company[]> {
+  const companyAssociations = await prisma.companyAssociation.findMany({
+    where: { userId },
+    include: { company: true }
+  });
+  return companyAssociations.map(association => association.company);
+}
+
+export async function run() {
+  logger.info("starting BSVHU draft restriction script");
+  const mongodbClient = new MongoClient(MONGO_URL!);
+
+  const database = mongodbClient.db();
+  const eventsCollection =
+    database.collection<EventCollection>(EVENTS_COLLECTION);
+  let finished = false;
+  let lastId: string | null = null;
+  while (!finished) {
+    let bsvhus: Prisma.BsvhuGetPayload<{
+      include: {
+        intermediaries: true;
+      };
+    }>[] = [];
+    try {
+      bsvhus = await prisma.bsvhu.findMany({
+        take: 10,
+        skip: 1, // Skip the cursor
+        ...(lastId
+          ? {
+              cursor: {
+                id: lastId
+              }
+            }
+          : {}),
+        where: {
+          AND: [
+            {
+              isDraft: true
+            },
+            {
+              NOT: {
+                isDeleted: true
+              }
+            }
+          ]
+        },
+        include: {
+          intermediaries: true
+        },
+        orderBy: {
+          id: "asc"
+        }
+      });
+    } catch (error) {
+      logger.error(`failed to fetch bsvhus from cursor ${lastId}`);
+      logger.error(error);
+      break;
+    }
+    logger.info(`got BSVHUs ${bsvhus.map(bsvhu => bsvhu.id).join(", ")}`);
+    if (bsvhus.length < 10) {
+      finished = true;
+    }
+    if (bsvhus.length === 0) {
+      break;
+    }
+    lastId = bsvhus[bsvhus.length - 1].id;
+    let events: EventCollection[];
+    try {
+      events = await eventsCollection
+        .find({
+          streamId: { $in: bsvhus.map(bsda => bsda.id) },
+          type: "BsvhuCreated"
+        })
+        .toArray();
+      logger.info(
+        `got events ${events.map(event => event.streamId).join(", ")}`
+      );
+    } catch (error) {
+      logger.error(
+        `failed to fetch events for bsvhus ${bsvhus
+          .map(bsvhu => bsvhu.id)
+          .join(", ")}`
+      );
+      logger.error(error);
+      break;
+    }
+
+    for (const bsvhu of bsvhus) {
+      logger.info(`handling ${bsvhu.id}`);
+      const correspondingEvent = events.find(
+        event => event.streamId === bsvhu.id
+      );
+      let user: User | null = null;
+      if (correspondingEvent?.actor) {
+        logger.info("found creation event");
+        try {
+          user = await prisma.user.findFirst({
+            where: {
+              id: correspondingEvent.actor
+            }
+          });
+        } catch (error) {
+          logger.error(`failed to fetch user ${correspondingEvent.actor}`);
+        }
+      }
+      const intermediariesOrgIds: string[] = bsvhu.intermediaries
+        ? (bsvhu.intermediaries
+            .flatMap(intermediary => [
+              intermediary.siret,
+              intermediary.vatNumber
+            ])
+            .filter(Boolean) as string[])
+        : [];
+      let canAccessDraftOrgIds: string[] = [];
+      const bsvhuOrgIds = [
+        ...intermediariesOrgIds,
+        bsvhu.emitterCompanySiret,
+        bsvhu.ecoOrganismeSiret,
+        ...[
+          bsvhu.transporterCompanySiret,
+          bsvhu.transporterCompanyVatNumber
+        ].filter(Boolean),
+        bsvhu.destinationCompanySiret,
+        bsvhu.destinationOperationNextDestinationCompanySiret,
+        bsvhu.brokerCompanySiret,
+        bsvhu.traderCompanySiret
+      ].filter(Boolean);
+      if (user) {
+        logger.info("treating with user");
+        let userCompanies: Company[] = [];
+        try {
+          userCompanies = await getUserCompanies(user.id as string);
+        } catch (error) {
+          logger.error(`failed to fetch companies of user ${user.id}`);
+        }
+        const userOrgIds = userCompanies.map(company => company.orgId);
+        const userOrgIdsInForm = userOrgIds.filter(orgId =>
+          bsvhuOrgIds.includes(orgId)
+        );
+        canAccessDraftOrgIds.push(...userOrgIdsInForm);
+      } else {
+        logger.info("treating without user");
+        canAccessDraftOrgIds = bsvhuOrgIds.filter(Boolean) as string[];
+      }
+      logger.info(`updating ${bsvhu.id}`);
+      await prisma.bsvhu.update({
+        where: { id: bsvhu.id },
+        data: {
+          canAccessDraftOrgIds
+        },
+        select: {
+          id: true
+        }
+      });
+      enqueueUpdatedBsdToIndex(bsvhu.id);
+      logger.info(`updated ${bsvhu.id}`);
+    }
+  }
+  logger.info("exiting");
+  await mongodbClient.close();
+  logger.info("mongo connection closed");
+}


### PR DESCRIPTION
# Objectif

Faire en sorte que seuls les membres des entreprises auxquelles appartient le créateur du bordereau puisse voir le bordereau.

## Au merge

Faire tourner le script pour modifier la visibilité des anciens BSVHU en brouillon

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14421)
