### PR TITLE
[TRA-15300] Fixes favicon import

### DIFF
--- a/front/index.html
+++ b/front/index.html
@@ -16,11 +16,26 @@
       content="bsd, bsds, bsdr, dechet, dechet dangereux, cerfa, tracabilite"
     />
     <meta name="robots" content="noindex" />
-    <!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="/manifest.json" />
+    <link
+      rel="apple-touch-icon"
+      href="/dsfr/favicon/apple-touch-icon.png?v=1.13.8"
+    />
+    <link
+      rel="icon"
+      href="/dsfr/favicon/favicon.svg?v=1.13.8"
+      type="image/svg+xml"
+    />
+    <link
+      rel="shortcut icon"
+      href="/dsfr/favicon/favicon.ico?v=1.13.8"
+      type="image/x-icon"
+    />
+    <link
+      rel="manifest"
+      href="/dsfr/favicon/manifest.webmanifest?v=1.13.8"
+      crossorigin="use-credentials"
+    />
+
     <title>Trackdéchets | La traçabilité des déchets en toute sécurité</title>
   </head>
   <body>

--- a/front/project.json
+++ b/front/project.json
@@ -7,7 +7,7 @@
     "dsfr": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cd front && react-dsfr update-icons"
+        "command": "cd front && react-dsfr update-icons && react-dsfr copy-static-assets"
       }
     },
     "build": {

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -8,10 +8,6 @@ import "./setupPlausible";
 import * as React from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 
-import "@codegouvfr/react-dsfr/favicon/apple-touch-icon.png";
-import "@codegouvfr/react-dsfr/favicon/favicon.svg";
-import "@codegouvfr/react-dsfr/favicon/favicon.ico";
-import "@codegouvfr/react-dsfr/favicon/manifest.webmanifest";
 import "@codegouvfr/react-dsfr/main.css";
 import "./scss/index.scss";
 


### PR DESCRIPTION
On doit conserver le script d'import pour gérer les favicons mais la CSS est importée directement dans le javascript pour s'éviter le hash qui change.

<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15300)
