### PR TITLE
Query pour la recherche Bsds dédiée à la fiche établissement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Suppression du champ isRegistreNational [PR 3652](https://github.com/MTES-MCT/trackdechets/pull/3652)
 - ETQ utilisateur je peux cloner un BSD [PR 3637](https://github.com/MTES-MCT/trackdechets/pull/3637)
 - ETQ utilisateur je peux créer, révoquer et consulter mes demandes de délégation RNDTS [PR 3561](https://github.com/MTES-MCT/trackdechets/pull/3561) [PR 3588](https://github.com/MTES-MCT/trackdechets/pull/3588)
+- Ajout de la query controlBsds dédiée à la fiche établissment [PR 3694](https://github.com/MTES-MCT/trackdechets/pull/3694)
 
 # [2024.9.1] 24/09/2024
 

--- a/back/src/bsds/resolvers/index.ts
+++ b/back/src/bsds/resolvers/index.ts
@@ -2,10 +2,12 @@ import { QueryResolvers } from "../../generated/graphql/types";
 import bsds from "./queries/bsds";
 import { bsdResolver } from "./queries/bsd";
 import { Mutation } from "./Mutation";
+import controlBsdsResolver from "./queries/controlBsds";
 
 const Query: QueryResolvers = {
   bsds,
-  bsd: bsdResolver
+  bsd: bsdResolver,
+  controlBsds: controlBsdsResolver
 };
 
 export default { Query, Mutation };

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.integration.ts
@@ -16,7 +16,7 @@ import { getFormForElastic, indexForm } from "../../../../forms/elastic";
 
 import { faker } from "@faker-js/faker";
 
-describe("query bsds: governement accoutns permissions", () => {
+describe("query bsds: governement accounts permissions", () => {
   afterEach(resetDatabase);
 
   it("should allow user authenticated with a token when tied to a government account with relevant perms", async () => {
@@ -103,8 +103,7 @@ describe("query bsds: governement accoutns permissions", () => {
     expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
   });
 
-  it("should forbid user authenticated with a token if no gov government is associated", async () => {
-    // the company and owner to build a registry
+  it("should forbid user authenticated with a token if no government account is associated", async () => {
     const { user: owner, company: someCompany } = await userWithCompanyFactory(
       "MEMBER"
     );

--- a/back/src/bsds/resolvers/queries/__tests__/controlbsds.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/controlbsds.integration.ts
@@ -1,0 +1,695 @@
+import { GovernmentPermission } from "@prisma/client";
+import {
+  refreshElasticSearch,
+  resetDatabase
+} from "../../../../../integration-tests/helper";
+import supertest from "supertest";
+
+import { app } from "../../../../server";
+import {
+  formFactory,
+  userWithCompanyFactory,
+  userWithAccessTokenFactory,
+  companyFactory,
+  siretify,
+  bsddTransporterData
+} from "../../../../__tests__/factories";
+import { Status, WasteAcceptationStatus } from "@prisma/client";
+import { getFormForElastic, indexForm } from "../../../../forms/elastic";
+
+import { faker } from "@faker-js/faker";
+
+describe("query controlbsds: governement accounts permissions", () => {
+  afterEach(resetDatabase);
+
+  it("should allow user authenticated with a token when tied to a government account with relevant perms", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+
+    const transporter = await companyFactory();
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date(),
+        transporters: {
+          create: {
+            ...bsddTransporterData,
+            number: 1,
+            transporterCompanySiret: transporter.siret
+          }
+        }
+      }
+    });
+
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${transporter.siret}" }) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.controlBsds.pageInfo).toEqual(1);
+  });
+
+  it("should forbid user authenticated with a token when tied to a government account without relevant perms", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.REGISTRY_CAN_READ_ALL], // wrong permission
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${someCompany.siret}" }) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+
+  it("should forbid user authenticated with a token if no government account is associated", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory();
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: Status.SENT,
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${someCompany.siret}" }) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+
+  it("should forbid user authenticated with a token tied to a government account when IPs do not match", async () => {
+    const { user: owner, company: someCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    const userIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP] // not user ip
+        }
+      }
+    });
+    const form = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        emitterCompanySiret: someCompany.siret,
+        status: "SENT",
+        sentAt: new Date(),
+        receivedAt: new Date()
+      }
+    });
+    await indexForm(await getFormForElastic(form));
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${someCompany.siret}" }) {pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", userIP); // IPs do not match
+    const { errors, data } = res.body;
+    expect(data).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toEqual(`Vous n'êtes pas connecté.`);
+  });
+
+  it("should filter by siret", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const siret1 = siretify(1);
+    const testInput_1 = {
+      transporterCompanySiret: siret1,
+      number: 1,
+      takenOverAt: new Date()
+    };
+    const testInput_2 = {
+      transporterCompanySiret: siretify(2),
+      number: 1,
+      takenOverAt: new Date()
+    };
+    // the siret we'll search after
+    const form1 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: { create: testInput_1 }
+      }
+    });
+    // another siret
+    const form2 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: { create: testInput_2 }
+      }
+    });
+
+    await indexForm(await getFormForElastic(form1));
+    await indexForm(await getFormForElastic(form2));
+
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${siret1}" }) {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.controlBsds.pageInfo).toEqual(1);
+    // the form matches the siret
+    expect(data.controlBsds.edges[0].node.id).toEqual(form1.id);
+  });
+
+  it("should only return isCollectedFor and isReturnFor", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const siret1 = siretify(1);
+    const trsInput = {
+      transporterCompanySiret: siret1,
+      number: 1
+    };
+
+    const formSent = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SENT,
+        sentAt: new Date(),
+        transporters: { create: { ...trsInput, takenOverAt: new Date() } }
+      }
+    });
+
+    const formReceived = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.RECEIVED,
+        wasteAcceptationStatus: WasteAcceptationStatus.ACCEPTED,
+
+        transporters: { create: trsInput },
+        receivedAt: new Date()
+      }
+    });
+
+    const formSealed = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SEALED,
+
+        transporters: { create: trsInput }
+      }
+    });
+
+    const formRefused = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.REFUSED,
+        receivedAt: new Date(),
+        wasteAcceptationStatus: WasteAcceptationStatus.REFUSED,
+        transporters: { create: trsInput }
+      }
+    });
+
+    await indexForm(await getFormForElastic(formSent));
+    await indexForm(await getFormForElastic(formRefused));
+
+    await indexForm(await getFormForElastic(formReceived));
+    await indexForm(await getFormForElastic(formSealed));
+
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${siret1}" }) {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.controlBsds.pageInfo).toEqual(2);
+    // the form matches the siret
+    expect(data.controlBsds.edges.map(e => e.node.id).sort()).toEqual([
+      formSent.id,
+
+      formRefused.id
+    ]);
+  });
+
+  it("should filter by siret and plate", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const siret1 = siretify(1);
+    const trsInput = {
+      transporterCompanySiret: siret1,
+      number: 1
+    };
+
+    const form1 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            ...trsInput,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "AZ 23 99"
+          }
+        }
+      }
+    });
+
+    const form2 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            ...trsInput,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "AZ 23 99"
+          }
+        }
+      }
+    });
+
+    const form3 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            ...trsInput,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "QS 23 99"
+          }
+        }
+      }
+    });
+
+    await indexForm(await getFormForElastic(form1));
+    await indexForm(await getFormForElastic(form2));
+    await indexForm(await getFormForElastic(form3));
+
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${siret1}" , plate: "AZ 23 99"}) {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.controlBsds.pageInfo).toEqual(2);
+    // the form matches the plate
+    expect(data.controlBsds.edges.map(e => e.node.id).sort()).toEqual([
+      form1.id,
+      form2.id
+    ]);
+  });
+
+  it("should filter by plate", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const siret1 = siretify(1);
+    const siret2 = siretify(2);
+    const siret3 = siretify(3);
+    const siret4 = siretify(3);
+
+    const form1 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            transporterCompanySiret: siret1,
+            number: 1,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "AZ 23 99"
+          }
+        }
+      }
+    });
+
+    const form2 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            transporterCompanySiret: siret2,
+            number: 1,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "AZ 23 99"
+          }
+        }
+      }
+    });
+
+    const form3 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "SENT",
+        sentAt: new Date(),
+        transporters: {
+          create: {
+            transporterCompanySiret: siret3,
+            number: 1,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "QS 23 99"
+          }
+        }
+      }
+    });
+
+    const form4 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.REFUSED,
+        receivedAt: new Date(),
+        wasteAcceptationStatus: WasteAcceptationStatus.REFUSED,
+        transporters: {
+          create: {
+            transporterCompanySiret: siret4,
+            number: 1,
+            takenOverAt: new Date(),
+            transporterNumberPlate: "AZ 23 99"
+          }
+        }
+      }
+    });
+
+    await indexForm(await getFormForElastic(form1));
+    await indexForm(await getFormForElastic(form2));
+    await indexForm(await getFormForElastic(form3));
+    await indexForm(await getFormForElastic(form4));
+
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {plate: "AZ 23 99"}) {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+    expect(data.controlBsds.pageInfo).toEqual(3);
+    // the form matches the
+    expect(data.controlBsds.edges.map(e => e.node.id).sort()).toEqual([
+      form1.id,
+      form2.id,
+      form4.id
+    ]);
+  });
+
+  it("should paginate controlbsds query", async () => {
+    const { user: owner } = await userWithCompanyFactory("MEMBER");
+    const request = supertest(app);
+
+    const allowedIP = faker.internet.ipv4();
+    // the gov account running the query
+    const { accessToken } = await userWithAccessTokenFactory({
+      governmentAccount: {
+        create: {
+          name: "GERICO",
+          permissions: [GovernmentPermission.BSDS_CAN_READ_ALL],
+          authorizedOrgIds: ["ALL"],
+          authorizedIPs: [allowedIP]
+        }
+      }
+    });
+    const siret1 = siretify(1);
+    const trsInput = {
+      transporterCompanySiret: siret1,
+      number: 1
+    };
+
+    const form1 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SENT,
+        sentAt: new Date(),
+        transporters: { create: { ...trsInput, takenOverAt: new Date() } }
+      }
+    });
+
+    const form2 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SENT,
+        sentAt: new Date(),
+        transporters: { create: { ...trsInput, takenOverAt: new Date() } }
+      }
+    });
+
+    const form3 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SENT,
+        sentAt: new Date(),
+        transporters: { create: { ...trsInput, takenOverAt: new Date() } }
+      }
+    });
+
+    const form4 = await formFactory({
+      ownerId: owner.id,
+      opt: {
+        status: Status.SENT,
+        sentAt: new Date(),
+        transporters: { create: { ...trsInput, takenOverAt: new Date() } }
+      }
+    });
+
+    await indexForm(await getFormForElastic(form1));
+    await indexForm(await getFormForElastic(form2));
+    await indexForm(await getFormForElastic(form3));
+    await indexForm(await getFormForElastic(form4));
+
+    await refreshElasticSearch();
+    const res = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${siret1}" }, first: 2) {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors, data } = res.body;
+
+    expect(errors).toBeUndefined();
+
+    expect(data.controlBsds.pageInfo).toEqual(4);
+    // the form matches the siret
+    expect(data.controlBsds.edges.map(e => e.node.id).sort()).toEqual([
+      form1.id,
+      form2.id
+    ]);
+
+    // second page
+
+    const res2 = await request
+      .post("/")
+      .send({
+        query: `{ controlBsds(where: {siret: "${siret1}" }, first: 2, after:"${form2.id}") {  
+      edges {
+        node {
+          ... on Form {
+            id
+          }
+        }
+      }
+        pageInfo: totalCount}}`
+      })
+      .set("Authorization", `Bearer ${accessToken}`)
+      .set("X-Forwarded-For", allowedIP);
+    const { errors: errors2, data: data2 } = res2.body;
+
+    expect(errors2).toBeUndefined();
+
+    expect(data2.controlBsds.pageInfo).toEqual(4);
+    // the form matches the siret
+    expect(data2.controlBsds.edges.map(e => e.node.id).sort()).toEqual([
+      form3.id,
+      form4.id
+    ]);
+  });
+});

--- a/back/src/bsds/resolvers/queries/controlBsds.ts
+++ b/back/src/bsds/resolvers/queries/controlBsds.ts
@@ -1,0 +1,144 @@
+import {
+  QueryResolvers,
+  QueryControlBsdsArgs
+} from "../../../generated/graphql/types";
+
+import { checkIsAuthenticated } from "../../../common/permissions";
+
+import { hasGovernmentReadAllBsdsPermOrThrow } from "../../../permissions";
+import { buildResponse } from "./helpers";
+import { controlBsdSearchSchema } from "../../validation";
+
+/**
+ *
+ * @param where
+ * plate
+ * readableId
+ * siret
+ * @returns
+ */
+function buildQuery({ where }: QueryControlBsdsArgs) {
+  const must: any[] = [];
+  const should: any[] = [];
+
+  if (where?.siret) {
+    must.push({
+      bool: {
+        should: [
+          {
+            terms: {
+              isCollectedFor: [where.siret]
+            }
+          },
+          {
+            terms: {
+              isReturnFor: [where.siret]
+            }
+          }
+        ]
+      }
+    });
+  } else {
+    must.push({
+      bool: {
+        should: [
+          {
+            bool: {
+              must: {
+                exists: {
+                  field: "isReturnFor"
+                }
+              }
+            }
+          },
+          {
+            bool: {
+              must: {
+                exists: {
+                  field: "isCollectedFor"
+                }
+              }
+            }
+          }
+        ]
+      }
+    });
+  }
+  if (where?.plate) {
+    must.push({
+      match: {
+        "transporterTransportPlates.ngram": {
+          query:
+            where.plate
+              .replace(/-/g, "")
+              .match(/.{1,5}/g)
+              ?.join(" ") ?? "",
+          operator: "and"
+        }
+      }
+    });
+  }
+
+  if (where?.readableId) {
+    must.push({
+      match: {
+        "readableId.ngram": {
+          query: where.readableId.match(/.{1,5}/g)?.join(" "),
+          operator: "and"
+        }
+      }
+    });
+  }
+  const query = {
+    bool: {
+      must,
+      filter: [
+        {
+          bool: {
+            should
+          }
+        }
+      ]
+    }
+  };
+
+  return query;
+}
+
+/**
+ * Recherche des bds indexés dans ES pour l'api destinée à la fiche d'inspection
+ * Version simplifiée et modifiée de la query bsds.
+ *
+ * Query limitée aux users associés à un government account disposant des permissions adéquates (BSDS_CAN_READ_ALL)
+ *
+ * Les bsds retournés figurent obligatoirement dans l'onglet collectés ou retour
+ * Recherche possible par siret (transporteur), plaque d'immatriculation ou numéro de bsd.
+ *
+ */
+const controlBsdsResolver: QueryResolvers["controlBsds"] = async (
+  _,
+  args,
+  context
+) => {
+  // This query is dedicated to government accounts (gerico)
+
+  const user = checkIsAuthenticated(context);
+
+  await hasGovernmentReadAllBsdsPermOrThrow(user);
+
+  const MIN_SIZE = 0;
+  const MAX_SIZE = 300;
+  const { first = MAX_SIZE } = args;
+  const size = Math.max(Math.min(first!, MAX_SIZE), MIN_SIZE);
+
+  controlBsdSearchSchema.parse(args.where);
+
+  const query = buildQuery(args);
+
+  const sort = { id: "ASC" };
+  const search_after = args?.after ? [args.after] : undefined;
+
+  return buildResponse({ query, size, sort, search_after });
+};
+
+export default controlBsdsResolver;

--- a/back/src/bsds/resolvers/queries/helpers.ts
+++ b/back/src/bsds/resolvers/queries/helpers.ts
@@ -1,0 +1,190 @@
+import { PrismaBsdMap } from "./types";
+import { FormForElastic } from "../../../forms/elastic";
+import { BsdasriForElastic } from "../../../bsdasris/elastic";
+import { BsvhuForElastic } from "../../../bsvhu/elastic";
+import { BsdaForElastic } from "../../../bsda/elastic";
+import { BsffForElastic } from "../../../bsffs/elastic";
+import { BspaohForElastic } from "../../../bspaoh/elastic";
+import { Bsd, BsdType } from "../../../generated/graphql/types";
+import { distinct } from "../../../common/arrays";
+import { prisma } from "@td/prisma";
+import { SearchResponse } from "./types";
+import {
+  client,
+  BsdElastic,
+  index,
+  groupByBsdType
+} from "../../../common/elastic";
+
+import { expandFormFromElastic } from "../../../forms/converter";
+
+import { expandVhuFormFromDb } from "../../../bsvhu/converter";
+import { expandBsdaFromElastic } from "../../../bsda/converter";
+import { expandBsffFromElastic } from "../../../bsffs/converter";
+import { expandBspaohFromElastic } from "../../../bspaoh/converter";
+
+import { ApiResponse } from "@elastic/elasticsearch";
+/**
+ * Convert a list of BsdElastic to a mapping of prisma-like Bsds by retrieving rawBsd elastic field
+ */
+export async function toRawBsds(
+  bsdsElastic: BsdElastic[]
+): Promise<PrismaBsdMap> {
+  const { BSDD, BSDA, BSDASRI, BSFF, BSVHU, BSPAOH } =
+    groupByBsdType(bsdsElastic);
+
+  return {
+    bsdds: BSDD.map(bsdElastic => bsdElastic.rawBsd as FormForElastic),
+    bsdasris: BSDASRI.map(
+      bsdsElastic => bsdsElastic.rawBsd as BsdasriForElastic
+    ),
+    bsvhus: BSVHU.map(bsdElastic => bsdElastic.rawBsd as BsvhuForElastic),
+    bsdas: BSDA.map(bsdElastic => bsdElastic.rawBsd as BsdaForElastic),
+    bsffs: BSFF.map(bsdsElastic => bsdsElastic.rawBsd as BsffForElastic),
+    bspaohs: BSPAOH.map(bsdsElastic => bsdsElastic.rawBsd as BspaohForElastic)
+  };
+}
+import { expandBsdasriFromElastic } from "../../../bsdasris/converter";
+
+/**
+ * Returns the keyword field matching the given fieldName.
+ *
+ * e.g passing "readableId" returns "readableId.keyword",
+ *     because "redableId" is a "text" with a sub field "readableId.keyword" which is a keyword.
+ *
+ * e.g passing "id" returns "id", because it's already a keyword.
+ *
+ * This is useful for context where we are given a property but need to use its keyword counterpart.
+ * For example when sorting, where it's not possible to sort on text fields.
+ */
+export function getKeywordFieldNameFromName(
+  fieldName: keyof BsdElastic
+): string {
+  const property = index.mappings.properties[fieldName];
+
+  if (property.type === "keyword") {
+    // this property is of type "keyword" itself, it can be used as such
+    return fieldName;
+  }
+
+  // look for a sub field with the type "keyword"
+  const [subFieldName] =
+    Object.entries(property.fields || {}).find(
+      ([_, property]) => property.type === "keyword"
+    ) ?? [];
+
+  if (subFieldName == null) {
+    throw new Error(
+      `The field "${fieldName}" is not of type "keyword" and has no sub fields of that type.`
+    );
+  }
+
+  return `${fieldName}.${subFieldName}`;
+}
+
+/**
+ * This function takes an array of dasris and, expand them and add `allowDirectTakeOver` boolean field by
+ * requesting emittercompany to know wether direct takeover is allowed
+ */
+export async function buildDasris(dasris: BsdasriForElastic[]) {
+  // build a list of emitter siret from dasris, non-INITIAL bsds are ignored
+  const emitterSirets = dasris
+    .filter(bsd => !!bsd.emitterCompanySiret && bsd.status === "INITIAL")
+    .map(bsd => bsd.emitterCompanySiret)
+    .filter(Boolean);
+
+  const uniqueSirets = distinct(emitterSirets);
+
+  // build an array of sirets allowing direct takeover
+  const allows = (
+    await prisma.company.findMany({
+      where: {
+        siret: { in: uniqueSirets },
+        allowBsdasriTakeOverWithoutSignature: true
+      },
+      select: {
+        siret: true
+      }
+    })
+  ).map(comp => comp.siret);
+
+  // expand dasris and insert `allowDirectTakeOver`
+  return dasris.map(bsd => ({
+    ...expandBsdasriFromElastic(bsd),
+    allowDirectTakeOver: allows.includes(bsd.emitterCompanySiret)
+  }));
+}
+
+export const buildResponse = async ({ query, size, sort, search_after }) => {
+  const { body }: ApiResponse<SearchResponse<BsdElastic>> = await client.search(
+    {
+      index: index.alias,
+      body: {
+        size:
+          size +
+          // Take one more result to know if there's a next page
+          // it's removed from the actual results though
+          1,
+        query,
+
+        sort,
+        search_after
+      }
+    }
+  );
+
+  const hits = body.hits.hits.slice(0, size);
+
+  const {
+    bsdds: concreteBsdds,
+    bsdasris: concreteBsdasris,
+    bsvhus: concreteBsvhus,
+    bsdas: concreteBsdas,
+    bsffs: concreteBsffs,
+    bspaohs: concreteBspaohs
+  } = await toRawBsds(hits.map(hit => hit._source));
+
+  const bsds: Record<BsdType, Bsd[]> = {
+    BSDD: concreteBsdds.map(expandFormFromElastic),
+    BSDASRI: await buildDasris(concreteBsdasris),
+    BSVHU: concreteBsvhus.map(expandVhuFormFromDb),
+    BSDA: concreteBsdas.map(expandBsdaFromElastic),
+    BSFF: concreteBsffs.map(expandBsffFromElastic),
+    BSPAOH: concreteBspaohs.map(expandBspaohFromElastic)
+  };
+
+  const edges = hits
+    .reduce<Array<Bsd>>((acc, { _source: { type, id } }) => {
+      const bsd = bsds[type].find(bsd => bsd.id === id);
+
+      if (bsd) {
+        // filter out null values in case Elastic Search
+        // is desynchronized with the actual database
+        return acc.concat(bsd);
+      }
+
+      return acc;
+    }, [])
+    .map(node => ({
+      cursor: node.id,
+      node
+    }));
+
+  const pageInfo = {
+    // startCursor and endCursor are null if the list is empty
+    // this is not 100% spec compliant but there are discussions to change that:
+    // https://github.com/facebook/relay/issues/1852
+    // https://github.com/facebook/relay/pull/2655
+    startCursor: edges[0]?.cursor || null,
+    endCursor: edges[edges.length - 1]?.cursor || null,
+
+    hasNextPage: body.hits.hits.length > size,
+    hasPreviousPage: false
+  };
+
+  return {
+    edges,
+    pageInfo,
+    totalCount: body.hits.total.value
+  };
+};

--- a/back/src/bsds/resolvers/queries/types.ts
+++ b/back/src/bsds/resolvers/queries/types.ts
@@ -1,0 +1,31 @@
+import { FormForElastic } from "../../../forms/elastic";
+import { BsdasriForElastic } from "../../../bsdasris/elastic";
+import { BsvhuForElastic } from "../../../bsvhu/elastic";
+import { BsdaForElastic } from "../../../bsda/elastic";
+import { BsffForElastic } from "../../../bsffs/elastic";
+import { BspaohForElastic } from "../../../bspaoh/elastic";
+// complete Typescript example:
+// https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/_a_complete_example.html
+export interface SearchResponse<T> {
+  hits: {
+    total: {
+      value: number;
+    };
+    hits: Array<{
+      _source: T;
+    }>;
+  };
+}
+
+export interface GetResponse<T> {
+  _source: T;
+}
+
+export type PrismaBsdMap = {
+  bsdds: FormForElastic[];
+  bsdasris: BsdasriForElastic[];
+  bsvhus: BsvhuForElastic[];
+  bsdas: BsdaForElastic[];
+  bsffs: BsffForElastic[];
+  bspaohs: BspaohForElastic[];
+};

--- a/back/src/bsds/typeDefs/private/bsd.inputs.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.inputs.graphql
@@ -165,3 +165,22 @@ input BsdSubTypeFilter {
   _eq: BsdSubType
   _in: [BsdSubType!]
 }
+
+"""
+Payload de recherche d'un établissment pour la fiche établissement
+
+Recherche par:
+
+- readableId
+- siret (transporteur)
+- plates
+- siret et plate
+"""
+input ControlBsdWhere {
+  # le siret d'un transporteur: 14 à 18 caractères
+  siret: String
+  # plaque d'immatriculation: 6 à 12 caractères
+  plate: String
+  # identifiant lisible du bsd: 20 à 25 caractères
+  readableId: String
+}

--- a/back/src/bsds/typeDefs/private/bsd.queries.graphql
+++ b/back/src/bsds/typeDefs/private/bsd.queries.graphql
@@ -27,4 +27,10 @@ type Query {
   ): BsdConnection!
 
   bsd(id: String!): Bsd!
+
+  """
+  Query bsds simplifiée et adaptée pour la fiche établissement.
+  Accessible uniquement aux comptes gouvernementaux disposant de la permission BSDS_CAN_READ_ALL.
+  """
+  controlBsds(where: ControlBsdWhere, after: String, first: Int): BsdConnection!
 }


### PR DESCRIPTION
La fiche établissement exploite la query bsds pour effectuer des recherches par siret (transporteur), plaque ou readableId sur l'ensemble des bsds.

L'introduction de l'onglet retour nécessitait soit de modifier cette query avec des filtres qui s'intégraient mal avec l'existant (le bsd doit porter la plaque xyz et être dans un onglet collecté ou retour, le siret n'étant pas fourni en paramètre).

Il a été jugé plus pertinent d'écrire une query spécialisée et simplifiée: controlBsds, réservée aux users rattachés à un compte gouvernemental disposant des perms adéquates.

Lors d'un prochain sprint le bypass de permissions ajouté sur bsds pour ouvrir son accès à l'api sera supprimé


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14965)
