### PR TITLE
Correctif pour empêcher les entreprises en sommeil de créer ou recevoir des demandes de délégation

### DIFF
--- a/back/src/registryDelegation/resolvers/mutations/__tests__/createRegistryDelegation.integration.ts
+++ b/back/src/registryDelegation/resolvers/mutations/__tests__/createRegistryDelegation.integration.ts
@@ -415,6 +415,45 @@ describe("mutation createRegistryDelegation", () => {
         "L'entreprise 40081510600010 visée comme délégante n'existe pas dans Trackdéchets"
       );
     });
+
+    it("delegator company must not be dormant", async () => {
+      // Given
+      const { user, company: delegator } = await userWithCompanyFactory(
+        "ADMIN",
+        { isDormantSince: new Date() }
+      );
+      const delegate = await companyFactory();
+
+      // When
+      const { errors } = await createDelegation(user, {
+        delegateOrgId: delegate.orgId,
+        delegatorOrgId: delegator.orgId
+      });
+
+      // Then
+      expect(errors).not.toBeUndefined();
+      expect(errors[0].message).toBe(
+        `L'entreprise ${delegator.siret} visée comme délégante est en sommeil`
+      );
+    });
+
+    it("delegate company must not be dormant", async () => {
+      // Given
+      const { user, company: delegator } = await userWithCompanyFactory();
+      const delegate = await companyFactory({ isDormantSince: new Date() });
+
+      // When
+      const { errors } = await createDelegation(user, {
+        delegateOrgId: delegate.orgId,
+        delegatorOrgId: delegator.orgId
+      });
+
+      // Then
+      expect(errors).not.toBeUndefined();
+      expect(errors[0].message).toBe(
+        `L'entreprise ${delegate.siret} visée comme délégataire est en sommeil`
+      );
+    });
   });
 
   describe("prevent simultaneous valid delegations", () => {

--- a/back/src/registryDelegation/resolvers/utils.ts
+++ b/back/src/registryDelegation/resolvers/utils.ts
@@ -23,9 +23,21 @@ export const findDelegateAndDelegatorOrThrow = async (
     );
   }
 
+  if (delegator.isDormantSince) {
+    throw new UserInputError(
+      `L'entreprise ${delegatorOrgId} visée comme délégante est en sommeil`
+    );
+  }
+
   if (!delegate) {
     throw new UserInputError(
       `L'entreprise ${delegateOrgId} visée comme délégataire n'existe pas dans Trackdéchets`
+    );
+  }
+
+  if (delegate.isDormantSince) {
+    throw new UserInputError(
+      `L'entreprise ${delegateOrgId} visée comme délégataire est en sommeil`
     );
   }
 


### PR DESCRIPTION
# Ticket Favro

[Permettre à un établissement de déléguer ses déclarations - BACK](https://favro.com/widget/ab14a4f0460a99a9d64d4945/2e73607ee11a34a3e0deb539?card=tra-14824)
