### PR TITLE
[TRA-14961] La mention ADR d'un BSDD n'est plus dupliquée

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -185,7 +185,6 @@ describe("Mutation.duplicateForm", () => {
       recipientCompanyMail,
       recipientIsTempStorage,
       wasteDetailsCode,
-      wasteDetailsOnuCode,
       wasteDetailsPackagingInfos,
       wasteDetailsQuantity,
       wasteDetailsQuantityType,
@@ -295,7 +294,8 @@ describe("Mutation.duplicateForm", () => {
       "quantityGrouped",
       "citerneNotWashedOutReason",
       "hasCiterneBeenWashedOut",
-      "emptyReturnADR"
+      "emptyReturnADR",
+      "wasteDetailsOnuCode"
     ];
 
     const expectedSkippedTransporter = [
@@ -364,7 +364,6 @@ describe("Mutation.duplicateForm", () => {
       recipientCompanyMail,
       recipientIsTempStorage,
       wasteDetailsCode,
-      wasteDetailsOnuCode,
       wasteDetailsQuantityType,
       wasteDetailsPop,
       wasteDetailsIsDangerous,
@@ -457,7 +456,6 @@ describe("Mutation.duplicateForm", () => {
       recipientCompanyMail,
       wasteDetailsCode,
       wasteDetailsPackagingInfos,
-      wasteDetailsOnuCode,
       wasteDetailsPop,
       wasteDetailsIsDangerous,
       wasteDetailsName,
@@ -514,7 +512,6 @@ describe("Mutation.duplicateForm", () => {
       recipientCompanyMail,
       wasteDetailsCode,
       wasteDetailsPackagingInfos,
-      wasteDetailsOnuCode,
       wasteDetailsPop,
       wasteDetailsIsDangerous,
       wasteDetailsName,
@@ -622,7 +619,8 @@ describe("Mutation.duplicateForm", () => {
       "quantityGrouped",
       "citerneNotWashedOutReason",
       "hasCiterneBeenWashedOut",
-      "emptyReturnADR"
+      "emptyReturnADR",
+      "wasteDetailsOnuCode"
     ];
 
     // make sure this test breaks when a new field is added to the Form model

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -116,7 +116,6 @@ async function getDuplicateFormInput(
     recipientCompanyMail: recipient?.contactEmail ?? form.recipientCompanyMail,
     recipientIsTempStorage: form.recipientIsTempStorage,
     wasteDetailsCode: form.wasteDetailsCode,
-    wasteDetailsOnuCode: form.wasteDetailsOnuCode,
     wasteDetailsPackagingInfos: Prisma.JsonNull,
     wasteDetailsQuantity: 0,
     wasteDetailsQuantityType: form.wasteDetailsQuantityType,
@@ -235,7 +234,6 @@ async function getDuplicateFormForwardedInInput(
     wasteDetailsPackagingInfos: prismaJsonNoNull(
       form.wasteDetailsPackagingInfos
     ),
-    wasteDetailsOnuCode: forwardedIn.wasteDetailsOnuCode,
     wasteDetailsPop: forwardedIn.wasteDetailsPop,
     wasteDetailsIsDangerous: forwardedIn.wasteDetailsIsDangerous,
     wasteDetailsName: forwardedIn.wasteDetailsName,


### PR DESCRIPTION
# Contexte

Lorsqu'on duplique un BSDD, on ne veut pas dupliquer la mention ADR (`wasteDetailsOnuCode`).

# Démo

![Screenshot from 2024-10-21 17-38-24](https://github.com/user-attachments/assets/c03552cb-d4ed-43f6-9d04-05875ee9bda9)

# Ticket Favro

[Ne pas dupliquer la mention ADR d'un BSDD à la duplication](https://favro.com/widget/ab14a4f0460a99a9d64d4945/76e5e3cb6cf95d7444ba2c0c?card=tra-14961)
