### PR TITLE
Correctifs pour la fonction de clonage et les BSFF

### DIFF
--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -408,6 +408,12 @@ export const cloneBsff = async (user: Express.User, id: string) => {
     throw new UserInputError(`ID invalide ${id}`);
   }
 
+  if (bsff.packagings?.some(packaging => packaging.nextPackagingId)) {
+    throw new UserInputError(
+      "Impossible de cloner ce type de BSD pour le moment"
+    );
+  }
+
   const { create } = getBsffRepository(user);
 
   const newBsffCreateInput: Omit<
@@ -441,7 +447,12 @@ export const cloneBsff = async (user: Express.User, id: string) => {
     emitterEmissionSignatureAuthor: bsff.emitterEmissionSignatureAuthor,
     emitterEmissionSignatureDate: bsff.emitterEmissionSignatureDate,
     ficheInterventions: bsff.ficheInterventions.length
-      ? { create: bsff.ficheInterventions[0] }
+      ? {
+          create: {
+            ...bsff.ficheInterventions[0],
+            id: undefined
+          }
+        }
       : {},
     isDeleted: bsff.isDeleted,
     isDraft: bsff.isDraft,


### PR DESCRIPTION
# Contexte

Un bug survient sur les BSFF avec des fiches d'intervention. On essaie de cloner l'ID donc une erreur d'unicité ressort:
![image](https://github.com/user-attachments/assets/289c8d4b-63e2-4d5d-9912-062f86dd7102)

Aussi, j'en profite pour exclure les BSFF dont les packagings sont forwardés dans d'autres BSFF pour éviter les effets de bord indésirables.