### PR TITLE
[TRA-15371] Affichage de l'icône d'immatriculation dans l'onglet "A Collecter"

### DIFF
--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -60,6 +60,28 @@ import { getCurrentTransporterInfos } from "../../bsdMapper";
 import { isDefined } from "../../../../common/helper";
 import { useCloneBsd } from "../Clone/useCloneBsd";
 
+const shouldDisplayTransporterNumberPlate = (
+  currentTransporterInfos,
+  isToCollectTab
+) => {
+  if (!currentTransporterInfos) return false;
+
+  const isRoad =
+    currentTransporterInfos.transporterMode === TransportMode.Road ||
+    // permet de gérer un trou dans la raquette en terme de validation des données
+    // qui ne rend pas le mode de transport obligatoire à la signature transporteur
+    // en attente de correction Cf ticket tra-14517
+    !currentTransporterInfos.transporterMode;
+
+  if (!isRoad) return false;
+
+  const platesAreDefined = Boolean(
+    currentTransporterInfos?.transporterNumberPlate?.length
+  );
+
+  return platesAreDefined || isToCollectTab;
+};
+
 function BsdCard({
   bsd,
   posInSet = 0,
@@ -206,16 +228,10 @@ function BsdCard({
       (isCollectedTab &&
         !!currentTransporterInfos?.transporterCustomInfo?.length));
 
-  // display the transporter's number plate if:
-  // - the mode of transport is ROAD
-  const displayTransporterNumberPlate =
-    !!currentTransporterInfos &&
-    (currentTransporterInfos.transporterMode === TransportMode.Road ||
-      // permet de gérer un trou dans la raquette en terme de validation des données
-      // qui ne rend pas le mode de transport obligatoire à la signature transporteur
-      // en attente de correction Cf ticket tra-14517
-      !currentTransporterInfos.transporterMode) &&
-    !!currentTransporterInfos?.transporterNumberPlate?.length;
+  const displayTransporterNumberPlate = shouldDisplayTransporterNumberPlate(
+    currentTransporterInfos,
+    isToCollectTab
+  );
 
   const handleValidationClick = (
     _: React.MouseEvent<HTMLButtonElement, MouseEvent>


### PR DESCRIPTION
# Contexte

L'icône qui permet de modifier l'immatriculation n'apparaît dans l'onglet "A Collecter" que si les plaques ont déjà été renseignées. Il faudrait qu'elle apparaîsse aussi (et surtout!) si elles ne sont pas définies.

# Démo

![image](https://github.com/user-attachments/assets/d26df02a-abd5-4d18-9094-88063645d5e9)

# Ticket Favro

[Depuis l'onglet à collecter, l'icône immatriculation n'est plus disponible](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15371)