### PR TITLE
[TRA-14522] Ajout d'un switch dans le fomulaire de création de BSDD pour spécifier si le déchet est soumis à l'ADR ou non

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -109,6 +109,10 @@ function flattenWasteDetailsInput(input: {
 }) {
   return {
     wasteDetailsCode: chain(input.wasteDetails, w => w.code),
+    wasteDetailsIsSubjectToADR: chain(
+      input.wasteDetails,
+      w => w.isSubjectToADR
+    ),
     wasteDetailsOnuCode: chain(input.wasteDetails, w => w.onuCode),
     wasteDetailsPackagingInfos: prismaJsonNoNull(
       chain(input.wasteDetails, w => getProcessedPackagingInfos(w))

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -2192,6 +2192,41 @@ describe("Mutation.createForm", () => {
     ]);
   });
 
+  it.each(["", "     "])(
+    "should convert empty onuCode to null",
+    async onuCode => {
+      // Given
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors, data } = await mutate<
+        Pick<Mutation, "createForm">,
+        MutationCreateFormArgs
+      >(CREATE_FORM, {
+        variables: {
+          createFormInput: {
+            emitter: {
+              company: { siret: company.siret }
+            },
+            wasteDetails: {
+              onuCode
+            }
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+
+      const form = await prisma.form.findFirstOrThrow({
+        where: { id: data.createForm.id }
+      });
+
+      expect(form.wasteDetailsOnuCode).toBeNull();
+    }
+  );
+
   describe("Annexe 1", () => {
     it("should create an APPENDIX1_PRODUCER form", async () => {
       const { user, company } = await userWithCompanyFactory("MEMBER");

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -619,6 +619,9 @@ input WasteDetailsInput {
   "Dénomination usuelle. Obligatoire"
   name: String
 
+  "Si le déchet est soumis à l'ADR"
+  isSubjectToADR: Boolean
+
   "Code ONU. Obligatoire pour les déchets dangereux. Merci d'indiquer 'non soumis' si nécessaire."
   onuCode: String
 

--- a/libs/back/prisma/src/migrations/20241028161030_add_waste_details_is_subject_to_adr_field_form/migration.sql
+++ b/libs/back/prisma/src/migrations/20241028161030_add_waste_details_is_subject_to_adr_field_form/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "wasteDetailsIsSubjectToADR" BOOLEAN;

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -479,6 +479,7 @@ model Form {
   recipientIsTempStorage                Boolean?                   @default(false)
   wasteDetailsCode                      String?
   wasteDetailsName                      String?
+  wasteDetailsIsSubjectToADR            Boolean?
   wasteDetailsOnuCode                   String?
   wasteDetailsQuantity                  Decimal?                   @db.Decimal(65, 30)
   wasteDetailsQuantityType              QuantityType?


### PR DESCRIPTION
# Contexte

# Démo

# Ticket Favro

[ÉTAPE 2 - Permettre au créateur du BSDD de déclarer que son déchet est Soumis à l'ADR Oui / Non, et rendre la mention ADR obligatoire si Oui](https://favro.com/widget/ab14a4f0460a99a9d64d4945/76e5e3cb6cf95d7444ba2c0c?card=tra-14522)