### PR TITLE
Rendre obligatoire le champ "Numéro de notification" lorsque la destination ultérieure renseignée est étrangère 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2024.11.1] 19/11/2024
+
+#### :boom: Breaking changes
+
+- Le champ "Numéro de notification" est obligatoire lorsque la destination ultérieure renseignée est étrangère [PR 3719](https://github.com/MTES-MCT/trackdechets/pull/3719)
+
 # [2024.10.1] 22/10/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1859,8 +1859,7 @@ describe("processedInfoSchema", () => {
     }
   ];
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  it.skip.each(testMatrix)(
+  it.each(testMatrix)(
     "should throw when `nextDestinationNotificationNumber` is missing %o",
     async ({
       noTraceability,
@@ -1899,8 +1898,7 @@ describe("processedInfoSchema", () => {
     }
   );
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  it.skip("should also throw when `nextDestinationNotificationNumber` is null", async () => {
+  it("should also throw when `nextDestinationNotificationNumber` is null", async () => {
     const processedInfo = {
       processedBy: "John Snow",
       processedAt: new Date(),

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -210,8 +210,7 @@ describe("mutation.markAsProcessed", () => {
     expect(updatedForm.status).toEqual("AWAITING_GROUP");
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  it.skip("should fail to mark a form with temporary storage as FOLLOWED_WITH_PNTTD if notification number is missing", async () => {
+  it("should fail to mark a form with temporary storage as FOLLOWED_WITH_PNTTD if notification number is missing", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formWithTempStorageFactory({
       ownerId: user.id,
@@ -554,8 +553,7 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  it.skip.each([
+  it.each([
     {
       wasteDetailsCode: "05 01 12*",
       wasteDetailsPop: false,
@@ -1752,8 +1750,7 @@ describe("mutation.markAsProcessed", () => {
     expect(resultingForm.status).toBe("NO_TRACEABILITY");
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  test.skip("nextDestinationNotificationNumber should be mandatory when noTraceability is true and wasteCode is dangerous", async () => {
+  test("nextDestinationNotificationNumber should be mandatory when noTraceability is true and wasteCode is dangerous", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -1796,8 +1793,7 @@ describe("mutation.markAsProcessed", () => {
     ]);
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  it.skip.each([
+  it.each([
     {
       wasteDetailsCode: "07 07 07*",
       wasteDetailsPop: false,
@@ -1947,8 +1943,7 @@ describe("mutation.markAsProcessed", () => {
     expect(errors).toBeUndefined();
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  test.skip("nextDestinationNotificationNumber should be mandatory when nextDestination.company is foreign when noTraceability is false", async () => {
+  test("nextDestinationNotificationNumber should be mandatory when nextDestination.company is foreign when noTraceability is false", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,
@@ -2120,8 +2115,7 @@ describe("mutation.markAsProcessed", () => {
     ]);
   });
 
-  // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-  test.skip("nextDestination.company and notificationNumber should be mandatory when company is extra-EU and when noTraceability is false", async () => {
+  test("nextDestination.company and notificationNumber should be mandatory when company is extra-EU and when noTraceability is false", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
     const form = await formFactory({
       ownerId: user.id,

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1650,11 +1650,9 @@ const withNextDestination = (required: boolean) =>
                   "Destination ultérieure : Le numéro de notification (format PPAAAADDDRRR) ou le numéro de déclaration Annexe 7 (format A7E AAAA DDDRRR) renseigné ne correspond pas au format attendu."
                 )
                 .nullable()
-                .notRequired(),
-            // FIXME Revert de TRA-13421 suite à des clients API qui sont bloqués
-            // .required(
-            //   "Destination ultérieure : le numéro de notification est obligatoire"
-            // ),
+                .required(
+                  "Destination ultérieure : le numéro de notification est obligatoire"
+                ),
             otherwise: schema =>
               schema
                 .max(


### PR DESCRIPTION
Rollback du rollback d'une PR validée (cf. carte favro)

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15065)
