### PR TITLE
TRA-15240 La présence d'une quantité reçue est requise pour passer du statut SENT à ACCEPTED via la mutation markAsReceived

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :boom: Breaking changes
 
 - Le champ "Numéro de notification" est obligatoire lorsque la destination ultérieure renseignée est étrangère [PR 3719](https://github.com/MTES-MCT/trackdechets/pull/3719)
+- La présence d'une quantité reçue est requise pour passer du statut SENT à ACCEPTED via la mutation markAsReceived [PR 3720](https://github.com/MTES-MCT/trackdechets/pull/3720)
 
 # [2024.10.1] 22/10/2024
 

--- a/back/src/common/validation.ts
+++ b/back/src/common/validation.ts
@@ -84,9 +84,13 @@ export const weightConditions: WeightConditions = {
         WasteAcceptationStatus.PARTIALLY_REFUSED
       ].includes(status)
     ) {
-      return weight.positive(
-        "${path} : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
-      );
+      return weight
+        .required(
+          "${path} : le poids est requis lorsque le déchet est accepté ou accepté partiellement."
+        )
+        .positive(
+          "${path} : le poids doit être supérieur à 0 lorsque le déchet est accepté ou accepté partiellement"
+        );
     }
     return weight;
   },

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -154,6 +154,8 @@ input ReceivedFormInput {
   Doit être égale à 0 lorsque le déchet est refusé.
 
   Doit être inférieure à 40T en cas de transport routier et inférieure à 50 000 T tout type de transport confondu.
+
+  Le champ est requis pour passer du statut `SENT` à `ACCEPTED` via `markAsReceived`.
   """
   quantityReceived: Float
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "scalingo-postbuild": "bash scripts/build/scalingo.sh",
     "nx": "nx",
     "dev": "npx nx run-many -t serve --parallel=7 --projects=front,api,tag:backend:background",
-    "bg:integration": "npx nx run-many -t serve --configuration=integration --projects=tag:backend:queues --parallel=5",
+    "bg:integration": "npx nx run-many -t serve --configuration=integration --projects=tag:backend:queues --parallel=6",
     "afterpull": "npm i ; npx prisma migrate dev ; npx nx run back:codegen --skip-nx-cache ; npx nx run @td/codegen-ui:build --skip-nx-cache"
   },
   "engines": {


### PR DESCRIPTION
La présence d'une quantité reçue est requise pour passer du statut SENT à ACCEPTED via la mutation markAsReceived (pour pouvoir remonter les bordereaux au statut En attente d'un bordereau suite dans le tableau des bordereaux initiaux à regrouper dans le BSD annexe 2.)

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15240)
