### PR TITLE
[TRA-15404] Correction du formulaire de sélection de type d'entreprise

### DIFF
--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeCheckbox.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeCheckbox.tsx
@@ -12,12 +12,17 @@ import {
 
 type CompanyTypeCheckboxProps = {
   label: string;
+  parentValue?: AllCompanyType | undefined;
   value: AllCompanyType;
   helpText?: string;
   subTypeOptions?: CompanySubTypeOption[];
   // Représente un formulaire récépissé, agrément, etc
   certificationForm?: ReactNode;
-  handleToggle: (value: AllCompanyType, checked: boolean) => void;
+  handleToggle: (
+    parentValue: AllCompanyType | undefined,
+    value: AllCompanyType,
+    checked: boolean
+  ) => void;
   inputProps?: CompanyTypeInputProps;
   inputErrors?: CompanyTypeInputErrors;
   inputValues: CompanyTypeInputValues;
@@ -25,6 +30,7 @@ type CompanyTypeCheckboxProps = {
 
 const CompanyTypeCheckbox = ({
   label,
+  parentValue,
   value,
   helpText,
   handleToggle,
@@ -33,10 +39,11 @@ const CompanyTypeCheckbox = ({
   inputProps,
   inputErrors
 }: CompanyTypeCheckboxProps): React.JSX.Element => {
-  const companyTypeChecked = React.useMemo(
-    () => inputValues.companyTypes.includes(value),
-    [value, inputValues.companyTypes]
-  );
+  const companyTypeChecked = React.useMemo(() => {
+    const fullValue = parentValue ? `${parentValue}.${value}` : value;
+    return inputValues.companyTypes.includes(fullValue);
+  }, [parentValue, value, inputValues.companyTypes]);
+
   const showSubTypes = React.useMemo(
     () => companyTypeChecked && Boolean(subTypeOptions),
     [companyTypeChecked, subTypeOptions]
@@ -61,6 +68,7 @@ const CompanyTypeCheckbox = ({
                   checked: companyTypeChecked,
                   onChange: e =>
                     handleToggle(
+                      parentValue,
                       e.currentTarget.value as AllCompanyType,
                       e.currentTarget.checked
                     )
@@ -84,6 +92,7 @@ const CompanyTypeCheckbox = ({
             return (
               <CompanyTypeCheckbox
                 key={subTypeOption.value}
+                parentValue={value}
                 value={subTypeOption.value}
                 label={subTypeOption.label}
                 inputValues={inputValues}

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/CompanyTypeForm.tsx
@@ -10,7 +10,7 @@ import { SelectProps } from "@codegouvfr/react-dsfr/SelectNext";
 import "./CompanyTypeForm.scss";
 
 export type CompanyTypeInputValues = {
-  companyTypes: AllCompanyType[];
+  companyTypes: string[];
   workerCertification: {
     hasSubSectionThree: boolean;
   };
@@ -99,7 +99,11 @@ type CompanyTypeFormProps = {
   inputErrors?: CompanyTypeInputErrors;
   // Gère les événements de sélection ou dé-selection d'une checkbox représentant
   // ou type ou sous-type d'établissement.
-  handleToggle: (value: AllCompanyType, checked: boolean) => void;
+  handleToggle: (
+    parentValue: AllCompanyType | undefined,
+    value: AllCompanyType,
+    checked: boolean
+  ) => void;
 };
 
 /**

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/FormikCompanyTypeForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/FormikCompanyTypeForm.tsx
@@ -63,12 +63,18 @@ const FormikCompanyTypeForm = ({
 
   const isSubmitted = submitCount > 0;
 
-  // La couche d'affichage des données au niveau de <CompanyTypeForm /> ne fait
-  // pas de différence entre type et sous-type d'établissement. La correspondance
-  // est gérée ici pour mettre à jour l'un des champs suivants :
-  // `companyType`, `wasteProcessTypes`, `collectorTypes` ou `wasteVehiclesTypes`,
-  const handleToggle = (value: AllCompanyType, checked: boolean) => {
-    if (COMPANY_TYPE_VALUES.includes(value as CompanyType)) {
+  // Reçoit le type ou sous-type d'établissement qui a été sélectionné, pour mettre
+  // à jour l'un des champs suivants : `companyType`, `wasteProcessTypes`, `collectorTypes`
+  // ou `wasteVehiclesTypes`.
+  //
+  // Ex pour un type: { parentValue: undefined, value: "PRODUCER"}
+  // Ex pour un sous-type: { parentValue: "COLLECTOR", value: "OTHER_NON_DANGEROUS_WASTES"}
+  const handleToggle = (
+    parentValue: AllCompanyType | undefined,
+    value: AllCompanyType,
+    checked: boolean
+  ) => {
+    if (!parentValue && COMPANY_TYPE_VALUES.includes(value as CompanyType)) {
       if (checked) {
         setFieldValue("companyTypes", [...companyTypes, value as CompanyType]);
       } else {
@@ -79,7 +85,10 @@ const FormikCompanyTypeForm = ({
       }
     }
 
-    if (COLLECTOR_TYPE_VALUES.includes(value as CollectorType)) {
+    if (
+      parentValue === "COLLECTOR" &&
+      COLLECTOR_TYPE_VALUES.includes(value as CollectorType)
+    ) {
       if (checked) {
         setFieldValue("collectorTypes", [
           ...collectorTypes,
@@ -93,7 +102,10 @@ const FormikCompanyTypeForm = ({
       }
     }
 
-    if (WASTE_PROCESSOR_TYPE_VALUES.includes(value as WasteProcessorType)) {
+    if (
+      parentValue === "WASTEPROCESSOR" &&
+      WASTE_PROCESSOR_TYPE_VALUES.includes(value as WasteProcessorType)
+    ) {
       if (checked) {
         setFieldValue("wasteProcessorTypes", [
           ...wasteProcessorTypes,
@@ -107,7 +119,10 @@ const FormikCompanyTypeForm = ({
       }
     }
 
-    if (WASTE_VEHICLES_TYPE_VALUES.includes(value as WasteVehiclesType)) {
+    if (
+      parentValue === "WASTE_VEHICLES" &&
+      WASTE_VEHICLES_TYPE_VALUES.includes(value as WasteVehiclesType)
+    ) {
       if (checked) {
         setFieldValue("wasteVehiclesTypes", [
           ...wasteVehiclesTypes,
@@ -130,11 +145,11 @@ const FormikCompanyTypeForm = ({
     }
   };
 
-  const allCompanyTypes = [
+  const allcompanyTypes = [
     ...companyTypes,
-    ...collectorTypes,
-    ...wasteProcessorTypes,
-    ...wasteVehiclesTypes
+    ...collectorTypes.map(type => `COLLECTOR.${type}`),
+    ...wasteProcessorTypes.map(type => `WASTEPROCESSOR.${type}`),
+    ...wasteVehiclesTypes.map(type => `WASTE_VEHICLES.${type}`)
   ];
 
   function fieldProps(name: string, index?: number) {
@@ -157,7 +172,7 @@ const FormikCompanyTypeForm = ({
   return (
     <CompanyTypeForm
       inputValues={{
-        companyTypes: allCompanyTypes,
+        companyTypes: allcompanyTypes,
         workerCertification: {
           hasSubSectionThree:
             values.workerCertification?.hasSubSectionThree ?? false

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/RhfCompanyTypeForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/RhfCompanyTypeForm.tsx
@@ -58,12 +58,18 @@ const RhfCompanyTypeForm = ({
   const wasteVehiclesTypes = watch("wasteVehiclesTypes");
   const ecoOrganismeAgreements = watch("ecoOrganismeAgreements");
 
-  // La couche d'affichage des données au niveau de <CompanyTypeForm /> ne fait
-  // pas de différence entre type et sous-type d'établissement. La correspondance
-  // est gérée ici pour mettre à jour l'un des champs suivants :
-  // `companyType`, `wasteProcessTypes`, `collectorTypes` ou `wasteVehiclesTypes`,
-  const handleToggle = (value: AllCompanyType, checked: boolean) => {
-    if (COMPANY_TYPE_VALUES.includes(value as CompanyType)) {
+  // Reçoit le type ou sous-type d'établissement qui a été sélectionné, pour mettre
+  // à jour l'un des champs suivants : `companyType`, `wasteProcessTypes`, `collectorTypes`
+  // ou `wasteVehiclesTypes`.
+  //
+  // Ex pour un type: { parentValue: undefined, value: "PRODUCER"}
+  // Ex pour un sous-type: { parentValue: "COLLECTOR", value: "OTHER_NON_DANGEROUS_WASTES"}
+  const handleToggle = (
+    parentValue: AllCompanyType | undefined,
+    value: AllCompanyType,
+    checked: boolean
+  ) => {
+    if (!parentValue && COMPANY_TYPE_VALUES.includes(value as CompanyType)) {
       if (checked) {
         setValue("companyTypes", [...companyTypes, value as CompanyType], {
           shouldDirty: true,
@@ -81,7 +87,10 @@ const RhfCompanyTypeForm = ({
       }
     }
 
-    if (COLLECTOR_TYPE_VALUES.includes(value as CollectorType)) {
+    if (
+      parentValue === "COLLECTOR" &&
+      COLLECTOR_TYPE_VALUES.includes(value as CollectorType)
+    ) {
       if (checked) {
         setValue(
           "collectorTypes",
@@ -101,7 +110,10 @@ const RhfCompanyTypeForm = ({
       }
     }
 
-    if (WASTE_PROCESSOR_TYPE_VALUES.includes(value as WasteProcessorType)) {
+    if (
+      parentValue === "WASTEPROCESSOR" &&
+      WASTE_PROCESSOR_TYPE_VALUES.includes(value as WasteProcessorType)
+    ) {
       if (checked) {
         setValue(
           "wasteProcessorTypes",
@@ -121,7 +133,10 @@ const RhfCompanyTypeForm = ({
       }
     }
 
-    if (WASTE_VEHICLES_TYPE_VALUES.includes(value as WasteVehiclesType)) {
+    if (
+      parentValue === "WASTE_VEHICLES" &&
+      WASTE_VEHICLES_TYPE_VALUES.includes(value as WasteVehiclesType)
+    ) {
       if (checked) {
         setValue(
           "wasteVehiclesTypes",
@@ -154,9 +169,9 @@ const RhfCompanyTypeForm = ({
 
   const allCompanyTypes = [
     ...companyTypes,
-    ...collectorTypes,
-    ...wasteProcessorTypes,
-    ...wasteVehiclesTypes
+    ...collectorTypes.map(type => `COLLECTOR.${type}`),
+    ...wasteProcessorTypes.map(type => `WASTEPROCESSOR.${type}`),
+    ...wasteVehiclesTypes.map(type => `WASTE_VEHICLES.${type}`)
   ];
 
   const hasSubSectionThree = watch("workerCertification.hasSubSectionThree");


### PR DESCRIPTION
# Contexte

Lorsque l'on sélectionne le profil installation de traitement "Autres traitements de déchets non dangereux (Rubriques 2791, 2781, 2782, 2780)", cela coche automatiquement le profil TTR "Autre cas de déchets non dangereux (Rubrique 2731). 

https://github.com/user-attachments/assets/dbfcc01a-06ba-43be-8c67-cfa33316b608

Cela est dû au fait que le formulaire de gestion des types & sous-types d'entreprises gère indifféremment les types & sous-types, pensant qu'ils sont tous uniques. 

Or ce n'est pas le cas:
- pour l'installation de traitement, "Autres cas déchets non dangereux (Rubrique 2731)" a pour valeur `OTHER_NON_DANGEROUS_WASTES`
- pour le TTR, "Autres traitements de déchets non dangereux (Rubriques 2791, 2781, 2782, 2780)" a aussi pour valeur `OTHER_NON_DANGEROUS_WASTES`

C'est pour cela que si l'on coche l'un, l'autre se coche automatiquement.

J'ai pensé à deux correctifs possibles:
- On corrige les enums pour avoir 2 valeurs différentes et on ne change rien au code. Mais je préfère éviter d'avoir à faire une migration difficile et dangereuse
- On corrige le code pour que le formulaire gère les types & sous-types différemment. Cela permettrait à l'avenir d'avoir d'autres enums de sous-types avec des valeurs égales.

J'ai opté pour la 2nde option. ça se rapproche du travail que j'avais fait pour le filtre avancé sur les types & sous-types de bordereaux. Le code s'en trouve un poil complexifié mais plus 'logique' dans le sens où tout est bien précisé et on n'imagine pas des conditions potentiellement fausses (comme l'unicité sur les enums).

# Ticket Favro

[Le profil "Autres traitements de déchets non dangereux (Rubriques 2791, 2781, 2782, 2780)"se coche automatiquement lorsqu'on sélectionne le profil TTR "Autre cas de déchets non dangereux (Rubrique 2731) et inversement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15404)




