### PR TITLE
[TRA-15423] Un intermédiaire peut créer un BSDA

### DIFF
--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -170,6 +170,10 @@ async function creators(input: BsdaInput) {
       }
     ];
   }
+
+  const intermediariesOrgIds =
+    input.intermediaries?.map(i => i.siret).filter(Boolean) ?? [];
+
   return [
     input.emitter?.company?.siret,
     input.ecoOrganisme?.siret,
@@ -177,6 +181,7 @@ async function creators(input: BsdaInput) {
       t.transporterCompanySiret,
       t.transporterCompanyVatNumber
     ]),
+    ...intermediariesOrgIds,
     input.destination?.company?.siret,
     input.worker?.company?.siret,
     input.broker?.company?.siret,

--- a/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/create.integration.ts
@@ -1652,4 +1652,64 @@ describe("Mutation.Bsda.create", () => {
     expect(errors).toBeUndefined();
     expect(data.createBsda.status).toBe("INITIAL");
   });
+
+  it("should allow broker to create a bsda", async () => {
+    // Given
+    const { company: broker, user } = await userWithCompanyFactory("MEMBER");
+
+    const input: BsdaInput = {
+      type: "OTHER_COLLECTIONS",
+      broker: {
+        company: {
+          siret: broker.siret
+        }
+      }
+    };
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsda">>(CREATE_BSDA, {
+      variables: {
+        input
+      }
+    });
+
+    // Then
+    expect(
+      errors.some(
+        error =>
+          error.message ===
+          "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
+      )
+    ).toBeFalsy();
+  });
+
+  it("should allow intermediary to create a bsda", async () => {
+    // Given
+    const { company: intermediary, user } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const input: BsdaInput = {
+      type: "OTHER_COLLECTIONS",
+      intermediaries: [{ siret: intermediary.siret }]
+    };
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createBsda">>(CREATE_BSDA, {
+      variables: {
+        input
+      }
+    });
+
+    // Then
+    expect(
+      errors.some(
+        error =>
+          error.message ===
+          "Vous ne pouvez pas créer un bordereau sur lequel votre entreprise n'apparait pas"
+      )
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# Contexte

Petit trou dans la raquette: un intermédiaire ne pouvait pas créer de BSDA (un courtier oui, mais pas un intermédiaire).

# Ticket Favro

[ETQ intermédiaire, je ne peux pas créer un BSDA. Erreur :  Vous ne pouvez pas créer un bordereau sur lequel votre établissement n'apparaît pas. ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15423)