### PR TITLE
[TRA-15424] ETQ utilisateur je peux faire une révision sur un bordereau en attente de regroupement

### DIFF
--- a/back/src/bsdasris/zodSchema.ts
+++ b/back/src/bsdasris/zodSchema.ts
@@ -141,7 +141,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -155,7 +156,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -170,7 +172,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -184,7 +187,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -198,7 +202,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -214,7 +219,8 @@ const revisionRules: RevisionRules = {
       return [
         BsdasriStatus.SENT,
         BsdasriStatus.RECEIVED,
-        BsdasriStatus.PROCESSED
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
       ];
     }
   },
@@ -226,21 +232,25 @@ const revisionRules: RevisionRules = {
       if (type === BsdasriType.SYNTHESIS) {
         return [];
       }
-      return [BsdasriStatus.RECEIVED, BsdasriStatus.PROCESSED];
+      return [
+        BsdasriStatus.RECEIVED,
+        BsdasriStatus.PROCESSED,
+        BsdasriStatus.AWAITING_GROUP
+      ];
     }
   },
   destinationOperationCode: {
     readableFieldName: "le code de traitement",
 
-    revisableFor: () => [BsdasriStatus.PROCESSED]
+    revisableFor: () => [BsdasriStatus.PROCESSED, BsdasriStatus.AWAITING_GROUP]
   },
   destinationOperationMode: {
     readableFieldName: "le mode de traitement",
-    revisableFor: () => [BsdasriStatus.PROCESSED]
+    revisableFor: () => [BsdasriStatus.PROCESSED, BsdasriStatus.AWAITING_GROUP]
   },
   destinationReceptionWasteWeightValue: {
     readableFieldName: "le poids de déchet traité",
-    revisableFor: () => [BsdasriStatus.PROCESSED]
+    revisableFor: () => [BsdasriStatus.PROCESSED, BsdasriStatus.AWAITING_GROUP]
   }
 };
 

--- a/back/src/bsdasris/zodSchema.ts
+++ b/back/src/bsdasris/zodSchema.ts
@@ -178,7 +178,7 @@ const revisionRules: RevisionRules = {
     }
   },
   emitterPickupSitePostalCode: {
-    readableFieldName: "le doe postal du site d'enlèvement",
+    readableFieldName: "le code postal du site d'enlèvement",
 
     revisableFor: type => {
       if (type !== BsdasriType.SIMPLE) {

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/rules.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/rules.ts
@@ -10,7 +10,8 @@ export const revisionDasriRules = {
     revisable: [
       BsdasriStatus.Sent,
       BsdasriStatus.Received,
-      BsdasriStatus.Processed
+      BsdasriStatus.Processed,
+      BsdasriStatus.AwaitingGroup
     ]
   },
 
@@ -18,19 +19,24 @@ export const revisionDasriRules = {
     revisable: [
       BsdasriStatus.Sent,
       BsdasriStatus.Received,
-      BsdasriStatus.Processed
+      BsdasriStatus.Processed,
+      BsdasriStatus.AwaitingGroup
     ]
   },
 
   "destination.reception.packagings": {
-    revisable: [BsdasriStatus.Received, BsdasriStatus.Processed]
+    revisable: [
+      BsdasriStatus.Received,
+      BsdasriStatus.Processed,
+      BsdasriStatus.AwaitingGroup
+    ]
   },
   "destination.operation.code": {
-    revisable: [BsdasriStatus.Processed]
+    revisable: [BsdasriStatus.Processed, BsdasriStatus.AwaitingGroup]
   },
 
   "destination.operation.weight": {
-    revisable: [BsdasriStatus.Processed]
+    revisable: [BsdasriStatus.Processed, BsdasriStatus.AwaitingGroup]
   }
 };
 


### PR DESCRIPTION
# Contexte

L'utilisateur peut ouvrir la modal de révision mais tous les champs sont grisés. Il faut explicitement autoriser à modifier tous les champs pour un DASRI au statut `AWAITING_GROUP`.

# Ticket Favro

[Révision impossible d'un BSDASRI en attente d'un bordereau suite. ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15424)
