### PR TITLE
[TRA-14818] Correction de la "Mention au titre des règlements RID, ADNR, IMDG (optionnel)" dans le formulaire de création du BSDD

### DIFF
--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -184,6 +184,8 @@ export function getInitialState(f?: Form | null): FormFormikValues {
       name: f?.wasteDetails?.name ?? "",
       isSubjectToADR: f?.wasteDetails?.isSubjectToADR ?? true,
       onuCode: f?.wasteDetails?.onuCode ?? "",
+      nonRoadRegulationMention:
+        f?.wasteDetails?.nonRoadRegulationMention ?? null,
       packagingInfos: f?.wasteDetails?.packagingInfos ?? [],
       quantity: f?.wasteDetails?.quantity ?? null,
       quantityType: f?.wasteDetails?.quantityType ?? QuantityType.Estimated,


### PR DESCRIPTION
# Context

Correctif d'une petite erreur d'initialistion du state du formulaire de création du BSDD, où la mention "Mention au titre des règlements RID, ADNR, IMDG (optionnel)" était mal initialisée.

# Ticket Favro

[ÉTAPE 1 - Distinguer la mention ADR de la "Mention au titre des règlements RID, ADNR, IMDG (optionnel)" (créer un nouveau champ)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/76e5e3cb6cf95d7444ba2c0c?card=tra-14818)
