### PR TITLE
[TRA-15331] Ajouter un lien "Gérer mes préférences e-mails" dans les e-mails transactionnels auquel l'utilisateur est en capacité de s'inscrire / désinscrire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Permettre l'ajout d'un numéro libre sur le Bsvhu [PR 3718](https://github.com/MTES-MCT/trackdechets/pull/3718)
 - Permettre à l'utilisateur de gérer les alertes de tous ses établissements [PR 3688](https://github.com/MTES-MCT/trackdechets/pull/3688)
 - Afficher le nombre d'inscrits par type d'alertes au sein d'un établissement [PR 3688](https://github.com/MTES-MCT/trackdechets/pull/3688)
+- Ajouter un lien "Gérer mes préférences e-mails" dans les e-mails transactionnels auquel l'utilisateur est en capacité de s'inscrire / désinscrire [PR 3738](https://github.com/MTES-MCT/trackdechets/pull/3738)
 
 #### :boom: Breaking changes
 

--- a/apps/cron/src/commands/__tests__/sendmails.integration.ts
+++ b/apps/cron/src/commands/__tests__/sendmails.integration.ts
@@ -371,9 +371,9 @@ describe("sendPendingMembershipRequestToAdminDetailsEmail", () => {
             ]
           }
         ],
-        params: {
+        params: expect.objectContaining({
           body: expect.any(String)
-        }
+        })
       },
       expect.anything()
     );
@@ -474,7 +474,7 @@ describe("sendPendingRevisionRequestToAdminDetailsEmail", () => {
       {
         subject: "Votre action est attendue sur une demande de révision",
         templateId: 9, // hardcoded console FIRST_ONBOARDING_TEMPLATE_ID template ID
-        params: { body: expect.any(String) },
+        params: expect.objectContaining({ body: expect.any(String) }),
         sender: {
           email: "us@td.test",
           name: "Wastetracker corp."

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -165,12 +165,7 @@ async function mailToNonExistentEmitter(
       }
     });
 
-    await sendMail({
-      ...mail,
-      // permet de cacher le message "Vous avez reçu cet e-mail car vous
-      // êtes inscrit sur la plateforme Trackdéchets" dans le template Brevo
-      params: { hideRegisteredUserInfo: true }
-    });
+    await sendMail(mail);
   }
 }
 

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -9,6 +9,11 @@ import { MailTemplate } from "../types";
 import { templateIds } from "./provider/templateIds";
 import { mustacheRenderer } from "./renderers";
 
+const { UI_HOST } = process.env;
+
+// URL permettant de gérer les préférences de notifications par e-mail
+const handlePreferencesUrl = `${UI_HOST}/account/notifications`;
+
 export const onSignup: MailTemplate<{ activationHash: string }> = {
   subject: "Activer votre compte sur Trackdéchets",
   body: mustacheRenderer("confirmation-de-compte.html"),
@@ -48,7 +53,10 @@ export const yourCompanyIsIdentifiedOnABsd: MailTemplate<{
   subject:
     "Votre établissement a été identifié sur un bordereau de suivi de déchets dangereux sur Trackdéchets",
   body: mustacheRenderer("your-company-is-identified-on-a-bsd.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  // permet de cacher le message "Vous avez reçu cet e-mail car vous
+  // êtes inscrit sur la plateforme Trackdéchets" dans le template Brevo
+  params: { hideRegisteredUserInfo: true }
 };
 
 export const onboardingFirstStep: MailTemplate = {
@@ -83,6 +91,10 @@ export const formNotAccepted: MailTemplate<{ form: Form & BsddTransporter }> = {
         sentBy: form.sentBy ?? ""
       }
     };
+  },
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
   }
 };
 
@@ -107,6 +119,10 @@ export const formPartiallyRefused: MailTemplate<{
         sentBy: form.sentBy ?? ""
       }
     };
+  },
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
   }
 };
 
@@ -129,7 +145,11 @@ export const membershipRequest: MailTemplate<{
 }> = {
   subject: "Un utilisateur souhaite rejoindre votre établissement",
   body: mustacheRenderer("membership-request.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
+  }
 };
 
 export const membershipRequestAccepted: MailTemplate<{
@@ -158,7 +178,11 @@ export const securityCodeRenewal: MailTemplate<{
   subject: ({ company }) =>
     `Renouvellement du code de signature de votre établissement "${company.name}" (${company.orgId})`,
   body: mustacheRenderer("notification-renouvellement-code-signature.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
+  }
 };
 
 export const verificationProcessInfo: MailTemplate<{
@@ -203,7 +227,11 @@ export const finalDestinationModified: MailTemplate<{
 }> = {
   subject: ({ id }) => `Alerte sur le bordereau ${id}`,
   body: mustacheRenderer("destination-finale-modifiee.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
+  }
 };
 
 export const membershipRequestDetailsEmail: MailTemplate = {
@@ -225,7 +253,11 @@ export const pendingMembershipRequestEmail: MailTemplate<{
 }> = {
   subject: "Un utilisateur est toujours en attente de réponse de votre part",
   body: mustacheRenderer("pending-membership-request.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
+  }
 };
 
 export const profesionalsSecondOnboardingEmail: MailTemplate = {
@@ -249,7 +281,11 @@ export const pendingRevisionRequestEmail: MailTemplate<{
 }> = {
   subject: "Votre action est attendue sur une demande de révision",
   body: mustacheRenderer("pending-revision-request-admin-details.html"),
-  templateId: templateIds.LAYOUT
+  templateId: templateIds.LAYOUT,
+  params: {
+    // permet d'afficher le lien "Gérer mes préférences e-mails"
+    handlePreferencesUrl
+  }
 };
 
 export const registryDelegationCreation: MailTemplate<{

--- a/libs/back/mail/src/templates/renderers.ts
+++ b/libs/back/mail/src/templates/renderers.ts
@@ -93,6 +93,7 @@ export function renderMail<V>(
     subject,
     templateId: mailTemplate.templateId,
     ...sanitizeMailProps(mailProps),
+    params: mailTemplate.params,
     vars // pass vars to mail provider
   };
 }

--- a/libs/back/mail/src/types.ts
+++ b/libs/back/mail/src/types.ts
@@ -45,4 +45,6 @@ export type MailTemplate<
   // optional body or body template to be used in conjunction with the LAYOUT templateId
   body?: string | ((values: V) => string);
   prepareVariables?: (variables: V) => any;
+  // paramètres transactionnels Brevo
+  params?: { [id: string]: any };
 };


### PR DESCRIPTION
### Modification du template Brevo

![Capture d’écran 2024-11-12 à 14 49 30](https://github.com/user-attachments/assets/e9c2eaba-d18b-4932-ade0-7908a773eb64)
![Capture d’écran 2024-11-12 à 14 51 48](https://github.com/user-attachments/assets/7bfa2e66-f460-47b0-a234-54a8b8deb367)


### Modification du code 

On passe la variable `handlePreferencesUrl` sur tous les templates d'e-mail pour lesquelles il est possible de s'abonner / se désabonner. 

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15331)
