### PR TITLE
[TRA-15418] ETQ Transporteur je peux réviser une annexe 1 même après réception

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1483,10 +1483,15 @@ export const canReviewBsdd = (bsd, siret) => {
 };
 
 const canReviewBsddAppendix1 = (bsd, siret) => {
+  const transporterHasSigned = ![
+    BsdStatusCode.Draft,
+    BsdStatusCode.Sealed
+  ].includes(bsd.status);
+
   return (
     bsd.type === BsdType.Bsdd &&
     isAppendix1Producer(bsd) &&
-    BsdStatusCode.Sent === bsd.status &&
+    transporterHasSigned &&
     isSameSiretTransporter(siret, bsd)
   );
 };


### PR DESCRIPTION
# Contexte

Un transporteur ne peut réviser une annexe 1 qu'au statut `SENT`. Il doit pouvoir le faire même après.

# Ticket Favro

[Annexe 1 : le transporteur n'a plus accès à la révision - aucun bouton d'action](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15418)
