### PR TITLE
[tra-14930]fix focus trap issue on radio and check box inputs

### DIFF
--- a/front/src/Apps/common/Components/Modal/Modal.tsx
+++ b/front/src/Apps/common/Components/Modal/Modal.tsx
@@ -1,11 +1,7 @@
 import React from "react";
-import {
-  FocusScope,
-  Overlay,
-  useModalOverlay,
-  useOverlayTrigger
-} from "react-aria";
+import { Overlay, useModalOverlay, useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState, OverlayTriggerState } from "react-stately";
+import FocusTrap from "focus-trap-react";
 import "./modal.scss";
 
 const ModalSizesClass = {
@@ -50,7 +46,7 @@ export function Modal({
             {...modalProps}
             ref={ref}
           >
-            <FocusScope contain restoreFocus autoFocus>
+            <FocusTrap active>
               <div className="fr-grid-row fr-grid-row--center">
                 <div className={ModalSizesClass[size]}>
                   <div className="fr-modal__body">
@@ -73,7 +69,7 @@ export function Modal({
                   </div>
                 </div>
               </div>
-            </FocusScope>
+            </FocusTrap>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14930)

Bug
---

https://github.com/user-attachments/assets/6f2000ab-58eb-4aa2-8634-dd22055e63c2


FocusScope de react-aria pose probleme lorsqu'on clique sur le label au lieu de l'input
Pour fixer il faut override tous les inputs avec les hooks fournis cf https://github.com/adobe/react-spectrum/issues/4288
https://codesandbox.io/p/sandbox/funny-pateu-bi7k8f?file=%2Fsrc%2FRadio.js%3A2%2C10-2%2C33


j'ai préféré reprendre la lib react-focus-trap que l'on utilise déja et ne pose pas de soucis.

Demo
---


https://github.com/user-attachments/assets/ea021b3e-c9f5-4628-a57a-5c2bd9e85a06

