### PR TITLE
Correction de la documentation sur le champ quantityReceived

### DIFF
--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -103,7 +103,7 @@ input AcceptedFormInput {
   """
   Quantité réelle présentée en tonnes (case 10).
 
-  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  Doit être inférieure à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 
@@ -751,7 +751,7 @@ input TempStorerAcceptedFormInput {
   """
   Quantité réelle présentée en tonnes (case 13)
 
-  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  Doit être inférieure à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 
@@ -788,7 +788,7 @@ input TempStoredFormInput {
   """
   Quantité réelle présentée en tonnes (case 13)
 
-  Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
+  Doit être inférieure à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
 

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -103,9 +103,6 @@ input AcceptedFormInput {
   """
   Quantité réelle présentée en tonnes (case 10).
 
-  Doit être supérieure à 0 lorsque le déchet est accepté.
-  Doit être égale à 0 lorsque le déchet est refusé.
-
   Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
@@ -149,9 +146,6 @@ input ReceivedFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 10).
-
-  Doit être supérieure à 0 lorsque le déchet est accepté.
-  Doit être égale à 0 lorsque le déchet est refusé.
 
   Doit être inférieure à 40T en cas de transport routier et inférieure à 50 000 T tout type de transport confondu.
 
@@ -757,9 +751,6 @@ input TempStorerAcceptedFormInput {
   """
   Quantité réelle présentée en tonnes (case 13)
 
-  Doit être supérieure à 0 lorsque le déchet est accepté.
-  Doit être égale à 0 lorsque le déchet est refusé.
-
   Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """
   quantityReceived: Float!
@@ -796,9 +787,6 @@ input TempStoredFormInput {
 
   """
   Quantité réelle présentée en tonnes (case 13)
-
-  Doit être supérieure à 0 lorsque le déchet est accepté.
-  Doit être égale à 0 lorsque le déchet est refusé.
 
   Doit être inférieur à 40T en cas de transport routier et inférieur à 50 000 T tout type de transport confondu.
   """

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1483,15 +1483,10 @@ export const canReviewBsdd = (bsd, siret) => {
 };
 
 const canReviewBsddAppendix1 = (bsd, siret) => {
-  const transporterHasSigned = ![
-    BsdStatusCode.Draft,
-    BsdStatusCode.Sealed
-  ].includes(bsd.status);
-
   return (
     bsd.type === BsdType.Bsdd &&
     isAppendix1Producer(bsd) &&
-    transporterHasSigned &&
+    BsdStatusCode.Sent === bsd.status &&
     isSameSiretTransporter(siret, bsd)
   );
 };

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1483,10 +1483,15 @@ export const canReviewBsdd = (bsd, siret) => {
 };
 
 const canReviewBsddAppendix1 = (bsd, siret) => {
+  const transporterHasSigned = ![
+    BsdStatusCode.Draft,
+    BsdStatusCode.Sealed
+  ].includes(bsd.status);
+
   return (
     bsd.type === BsdType.Bsdd &&
     isAppendix1Producer(bsd) &&
-    BsdStatusCode.Sent === bsd.status &&
+    transporterHasSigned &&
     isSameSiretTransporter(siret, bsd)
   );
 };


### PR DESCRIPTION
# Contexte

On a eu un [post sur le forum](https://forum.trackdechets.beta.gouv.fr/t/bsd-dangereux-et-quantityrefused/1686) qui pointe qu'effectivement notre documentation n'est pas à jour.

J'enlève les explications legacy sur le `quantityReceived`.
