### PR TITLE
Corrige le nom d'un index

### DIFF
--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1120,7 +1120,7 @@ model Bsvhu {
   @@index([canAccessDraftOrgIds], map: "_BsvhuCanAccessDraftOrgIdsIdx", type: Gin)
   @@index([status], map: "_BsvhuStatusIdx")
   @@index([updatedAt], map: "_BsvhuUpdatedAtIdx")
-  @@index([customId], map: "_Bsvhumigrations/CustomIdIdx")
+  @@index([customId], map: "_BsvhuCustomIdIdx")
 }
 
 model RegistryDelegation {


### PR DESCRIPTION
Nom d'index renommé par erreur dans le schema prisma, la migration est bonne, l'index est ok en recette



<img width="591" alt="Capture d’écran 2024-11-14 à 11 22 35" src="https://github.com/user-attachments/assets/a3451acd-8677-45c2-9498-ff794630b7b5">


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
