### PR TITLE
Corrige les updates et signature du paoh depuis l'ui

### DIFF
--- a/front/src/Apps/common/queries/bspaoh/queries.ts
+++ b/front/src/Apps/common/queries/bspaoh/queries.ts
@@ -4,7 +4,7 @@ import { fullBspaohFragment } from "../fragments";
 export const UPDATE_BSPAOH = gql`
   mutation UpdateBspaoh($id: ID!, $input: BspaohInput!) {
     updateBspaoh(id: $id, input: $input) {
-      ...FullBspaoh
+      ...BspaohFragment
     }
   }
   ${fullBspaohFragment}


### PR DESCRIPTION
Une erreur sur la déstructuration de fragment cassait toute mise à jour et signature du paoh

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15463)
