### PR TITLE
[TRA-15272] Correctifs pour le formulaire ADR + PDF

### DIFF
--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -734,13 +734,11 @@ export function BsddPdf({
             </p>
             <p>
               {isDefined(form.emptyReturnADR) ? (
-                <>
-                  {getEmptyReturnADRLabel(form.emptyReturnADR)?.toUpperCase()}:{" "}
-                  {getFormWasteDetailsADRMention(form.wasteDetails)}
-                </>
-              ) : (
-                <>{getFormWasteDetailsADRMention(form.wasteDetails)}</>
-              )}
+                <p>
+                  {getEmptyReturnADRLabel(form.emptyReturnADR)?.toUpperCase()}{" "}
+                </p>
+              ) : null}
+              <>{getFormWasteDetailsADRMention(form.wasteDetails)}</>
             </p>
           </div>
         </div>

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -55,28 +55,12 @@ export default connect<{ disabled }, Values>(function WasteInfo({
 }) {
   const { values, setFieldValue } = formik;
 
-  // Hacky hack
-  // If the user selects a dangerous waste code, we want the ADR mention to switch to true
-  // However, we don't want this behaviour every time the user opens this form (ie for modification),
-  // only when the waste code actually changes. But because we don't have any control over the
-  // <WasteCodeSelect /> component, we use 'useRef' to detect actual value change
-  const prevWasteDetailsCode = useRef(values.wasteDetails.code);
-
   if (!values.wasteDetails.packagings) {
     values.wasteDetails.packagings = [];
   }
   useEffect(() => {
     if (isDangerous(values.wasteDetails.code)) {
       setFieldValue("wasteDetails.isDangerous", true);
-    }
-
-    // Waste code value has actually changed. Update the ADR switch accordingly
-    if (values.wasteDetails.code !== prevWasteDetailsCode.current) {
-      prevWasteDetailsCode.current = values.wasteDetails.code;
-
-      if (isDangerous(values.wasteDetails.code)) {
-        setFieldValue("wasteDetails.isSubjectToADR", true);
-      }
     }
   }, [values.wasteDetails.code, setFieldValue]);
 
@@ -95,6 +79,11 @@ export default connect<{ disabled }, Values>(function WasteInfo({
           component={WasteCodeSelect}
           validate={bsddWasteCodeValidator}
           disabled={disabled}
+          onSelect={code => {
+            if (isDangerous(code)) {
+              setFieldValue("wasteDetails.isSubjectToADR", true);
+            }
+          }}
         />
       </div>
 

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -8,7 +8,7 @@ import {
   isDangerous,
   PROCESSING_OPERATIONS_GROUPEMENT_CODES
 } from "@td/constants";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import Appendix2MultiSelect from "./components/appendix/Appendix2MultiSelect";
 import Packagings from "./components/packagings/Packagings";
 import { ParcelNumbersSelector } from "./components/parcel-number/ParcelNumber";
@@ -55,13 +55,28 @@ export default connect<{ disabled }, Values>(function WasteInfo({
 }) {
   const { values, setFieldValue } = formik;
 
+  // Hacky hack
+  // If the user selects a dangerous waste code, we want the ADR mention to switch to true
+  // However, we don't want this behaviour every time the user opens this form (ie for modification),
+  // only when the waste code actually changes. But because we don't have any control over the
+  // <WasteCodeSelect /> component, we use 'useRef' to detect actual value change
+  const prevWasteDetailsCode = useRef(values.wasteDetails.code);
+
   if (!values.wasteDetails.packagings) {
     values.wasteDetails.packagings = [];
   }
   useEffect(() => {
     if (isDangerous(values.wasteDetails.code)) {
       setFieldValue("wasteDetails.isDangerous", true);
-      setFieldValue("wasteDetails.isSubjectToADR", true);
+    }
+
+    // Waste code value has actually changed. Update the ADR switch accordingly
+    if (values.wasteDetails.code !== prevWasteDetailsCode.current) {
+      prevWasteDetailsCode.current = values.wasteDetails.code;
+
+      if (isDangerous(values.wasteDetails.code)) {
+        setFieldValue("wasteDetails.isSubjectToADR", true);
+      }
     }
   }, [values.wasteDetails.code, setFieldValue]);
 

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -8,7 +8,7 @@ import {
   isDangerous,
   PROCESSING_OPERATIONS_GROUPEMENT_CODES
 } from "@td/constants";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import Appendix2MultiSelect from "./components/appendix/Appendix2MultiSelect";
 import Packagings from "./components/packagings/Packagings";
 import { ParcelNumbersSelector } from "./components/parcel-number/ParcelNumber";

--- a/front/src/form/bsdd/components/waste-code/WasteCode.tsx
+++ b/front/src/form/bsdd/components/waste-code/WasteCode.tsx
@@ -30,8 +30,9 @@ function formatWasteCode(wasteCode: string) {
 export function WasteCodeSelect({
   field,
   form,
-  disabled
-}: FieldProps & { disabled: boolean }) {
+  disabled,
+  onSelect
+}: FieldProps & { disabled: boolean; onSelect?: (code) => void }) {
   const [openModal, setOpenModal] = useState(false);
 
   const waste = BSDD_WASTES.find(waste => waste.code === field.value);
@@ -53,6 +54,7 @@ export function WasteCodeSelect({
               onClose={() => setOpenModal(false)}
               onSelect={codes => {
                 form.setFieldValue(field.name, codes[0]);
+                if (onSelect) onSelect(codes[0]);
               }}
             />
           </li>

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -182,7 +182,7 @@ export function getInitialState(f?: Form | null): FormFormikValues {
     wasteDetails: {
       code: f?.wasteDetails?.code ?? "",
       name: f?.wasteDetails?.name ?? "",
-      isSubjectToADR: f?.wasteDetails?.isSubjectToADR ?? true,
+      isSubjectToADR: f?.wasteDetails?.isSubjectToADR ?? false,
       onuCode: f?.wasteDetails?.onuCode ?? "",
       nonRoadRegulationMention:
         f?.wasteDetails?.nonRoadRegulationMention ?? null,


### PR DESCRIPTION
# Contexte

2 correctifs:
- De la mise en forme dans le PDF pour la section 6.1 (ajout d'un retour à la ligne)
- Dans le formulaire de création de BSDD, ajout d'un fix pour que le comportement du switch de la mention ADR soit cohérent avec le choix de l'utilisateur

# Ticket Favro

[Retirer l'option "Vide, non nettoyé", ajouter 2 nouvelles mentions pour les conteneurs et ajouter "Mention ADR saisie sur le bordereau :" lorsque l'utilisateur a complété la mention ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/76e5e3cb6cf95d7444ba2c0c?card=tra-15272)
