### PR TITLE
[TRA-15422] A sa création, une annexe 1 reprend les informations ADR du bordereau chapeau

### DIFF
--- a/back/src/forms/repository/form/setAppendix1.ts
+++ b/back/src/forms/repository/form/setAppendix1.ts
@@ -139,6 +139,10 @@ async function setAppendix1AutomaticValues(
           wasteDetailsName: container.wasteDetailsName,
           wasteDetailsQuantityType: "ESTIMATED",
           wasteDetailsConsistence: container.wasteDetailsConsistence,
+          wasteDetailsOnuCode: container.wasteDetailsOnuCode,
+          wasteDetailsNonRoadRegulationMention:
+            container.wasteDetailsNonRoadRegulationMention,
+          wasteDetailsIsSubjectToADR: container.wasteDetailsIsSubjectToADR,
           recipientCompanySiret: container.recipientCompanySiret,
           recipientCompanyName: container.recipientCompanyName,
           recipientCompanyAddress: container.recipientCompanyAddress,


### PR DESCRIPTION
# Contexte

Lorsque je crée une annexe 1, je veux qu'elle hérite des informations ADR (& RID) du bordereau chapeau.

# Démo

[Screencast from 2024-11-18 09-45-22.webm](https://github.com/user-attachments/assets/73615c06-1a4e-43ca-9edc-f4d25edbe7fc)

# Ticket Favro

[Ajouter les mentions ADR et RID du bordereau de tournée dédiée sur ses Annexes 1](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15422)

