### PR TITLE
[TRA-15451] Correction d'une typo dans le PDF du BSDD, dans les cadres 7, 10, 11 et 12 d'une annexe 1 

### DIFF
--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -371,7 +371,7 @@ export function BsddPdf({
     isDangerous(form.wasteDetails?.code) ||
     Boolean(form.wasteDetails?.pop);
 
-  const appendix1ProducerPlaceholder = `En cas de contrôle, les informations relatives à ce cadre sont celle du BSD de tournée dédié associé n° ${groupedIn.map(
+  const appendix1ProducerPlaceholder = `En cas de contrôle, les informations relatives à ce cadre sont celles du BSD de tournée dédié associé n° ${groupedIn.map(
     bsd => bsd.readableId
   )}`;
   const isRepackaging =


### PR DESCRIPTION
# Démo

On corrige simplement: 
En cas de contrôle, les informations relatives à ce cadre sont celle du BSD de tournée dédié associé n° XXX
En cas de contrôle, les informations relatives à ce cadre sont **celles** du BSD de tournée dédié associé n° XXX

# Démo

![image](https://github.com/user-attachments/assets/5564bcc7-434c-4507-9ed3-e70d9f7f7dc2)

# Ticket Favro

[Corriger le texte affiché dans les cadres 7, 10, 11 et 12 d'une annexe 1 ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15451)
