### PR TITLE
[TRA-tra-8351] Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2024.12.1] 17/12/2024
+
+#### :bug: Corrections de bugs
+
+- Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement [PR 3760](https://github.com/MTES-MCT/trackdechets/pull/3760)
+
 # [2024.11.1] 19/11/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -259,6 +259,7 @@ const mutableFieldsFragment = gql`
         }
         signedAt
         quantityReceived
+        quantityAccepted
         quantityGrouped
         processingOperationDone
       }

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -194,10 +194,15 @@ export default function StepsList(props: Props) {
       ...(ecoOrganisme?.siret ? { ecoOrganisme } : { ecoOrganisme: null }),
       ...(grouping?.length
         ? {
-            grouping: grouping.map(({ form, quantity }) => ({
-              form: { id: form.id },
-              quantity
-            }))
+            grouping: grouping
+              .map(({ form, quantity }) => ({
+                form: { id: form.id },
+                // quantity peut être égal à "" dans le
+                // cas où l'input est laissé vide dans le sélecteur
+                // d'annexes 2
+                quantity: Number(quantity)
+              }))
+              .filter(g => g.quantity > 0)
           }
         : {}),
       transporters: transporterIds

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -9,7 +9,6 @@ import {
   PROCESSING_OPERATIONS_GROUPEMENT_CODES
 } from "@td/constants";
 import React, { useEffect } from "react";
-import Appendix2MultiSelect from "./components/appendix/Appendix2MultiSelect";
 import Packagings from "./components/packagings/Packagings";
 import { ParcelNumbersSelector } from "./components/parcel-number/ParcelNumber";
 import {
@@ -19,6 +18,7 @@ import {
 import "./WasteInfo.scss";
 import EstimatedQuantityTooltip from "../../common/components/EstimatedQuantityTooltip";
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
+import Appendix2MultiSelectWrapper from "./components/appendix/Appendix2MultiSelectWrapper";
 
 type Values = {
   wasteDetails: {
@@ -185,7 +185,9 @@ export default connect<{ disabled }, Values>(function WasteInfo({
             traitement de type{" "}
             {PROCESSING_OPERATIONS_GROUPEMENT_CODES.join(", ")}.
           </p>
-          <Appendix2MultiSelect />
+          <Appendix2MultiSelectWrapper
+            emitterCompanySiret={values.emitter?.company?.siret}
+          />
         </>
       )}
 

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.test.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.test.tsx
@@ -1,0 +1,371 @@
+import React from "react";
+
+import { InitialFormFraction, Form } from "@td/codegen-ui";
+import { Formik } from "formik";
+import Appendix2MultiSelect from "./Appendix2MultiSelect";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Exemple de retour de la query `appendixForms`
+const appendixForms = [
+  {
+    __typename: "Form",
+    id: "cm3h52nk70002ftxsnedbcz1l",
+    readableId: "BSD-20241114-FBB5364K6",
+    emitter: {
+      __typename: "Emitter",
+      company: {
+        __typename: "FormCompany",
+        name: "CODE EN STOCK",
+        orgId: "85001946400021"
+      }
+    },
+    wasteDetails: {
+      __typename: "WasteDetails",
+      code: "07 01 01*",
+      name: "eaux de lavage",
+      quantity: 1,
+      packagingInfos: [
+        {
+          __typename: "PackagingInfo",
+          type: "BENNE",
+          other: "",
+          quantity: 1
+        }
+      ]
+    },
+    signedAt: "2024-11-14T00:00:00.000Z",
+    quantityReceived: 1,
+    quantityAccepted: 1,
+    quantityRefused: 0,
+    quantityGrouped: 0.6,
+    processingOperationDone: "D 13",
+    recipient: {
+      __typename: "Recipient",
+      cap: "cap"
+    }
+  },
+  {
+    __typename: "Form",
+    id: "cm3hhbmrw000ora3ei689lqd2",
+    readableId: "BSD-20241114-41RTX259Q",
+    emitter: {
+      __typename: "Emitter",
+      company: {
+        __typename: "FormCompany",
+        name: "CODE EN STOCK",
+        orgId: "85001946400021"
+      }
+    },
+    wasteDetails: {
+      __typename: "WasteDetails",
+      code: "07 01 01*",
+      name: "eaux de lavage",
+      quantity: 1,
+      packagingInfos: [
+        {
+          __typename: "PackagingInfo",
+          type: "GRV",
+          other: "",
+          quantity: 1
+        }
+      ]
+    },
+    signedAt: "2024-11-14T00:00:00.000Z",
+    quantityReceived: 1,
+    quantityAccepted: 1,
+    quantityRefused: 0,
+    quantityGrouped: 0,
+    processingOperationDone: "D 13",
+    recipient: {
+      __typename: "Recipient",
+      cap: "cap"
+    }
+  }
+];
+
+// Exemple de valeur initiale pour `grouping`
+const grouping = [
+  {
+    __typename: "InitialFormFraction",
+    quantity: 0.2,
+    form: {
+      __typename: "InitialForm",
+      id: "cm3hh2m7y000ara3ez9bc0qjd",
+      readableId: "BSD-20241114-2Z6F1PQ20",
+      status: "AWAITING_GROUP",
+      wasteDetails: {
+        __typename: "WasteDetails",
+        code: "07 01 01*",
+        name: "eaux de lavage",
+        quantity: 1,
+        packagingInfos: [
+          {
+            __typename: "PackagingInfo",
+            type: "BENNE",
+            other: "",
+            quantity: 1
+          }
+        ]
+      },
+      emitter: {
+        __typename: "Emitter",
+        company: {
+          __typename: "FormCompany",
+          name: "CODE EN STOCK",
+          orgId: "85001946400021"
+        },
+        isPrivateIndividual: false
+      },
+      transporter: {
+        __typename: "Transporter",
+        company: {
+          __typename: "FormCompany",
+          orgId: "33902484600034",
+          siret: "33902484600034"
+        }
+      },
+      recipient: {
+        __typename: "Recipient",
+        company: {
+          __typename: "FormCompany",
+          siret: "49383186100049",
+          orgId: "49383186100049"
+        }
+      },
+      signedAt: "2024-11-14T00:00:00.000Z",
+      quantityReceived: 1.2,
+      quantityAccepted: 1,
+      quantityGrouped: 0.2,
+      processingOperationDone: "D 13"
+    }
+  }
+];
+
+describe("<Appendix2MultiSelect />", () => {
+  const updateTotalQuantity = jest.fn();
+  const updatePackagings = jest.fn();
+
+  const component = (
+    // Bordereaux candidats au regroupement obtenu à partir
+    // de la query `appendixForms`
+    appendixForms: Form[],
+    // Bordereaux déja regroupés au sein du bordereau de groupement
+    grouping: InitialFormFraction[]
+  ) => (
+    <Formik initialValues={{ grouping }} onSubmit={jest.fn()}>
+      <Appendix2MultiSelect
+        appendixForms={appendixForms}
+        updateTotalQuantity={updateTotalQuantity}
+        updatePackagings={updatePackagings}
+      />
+    </Formik>
+  );
+
+  it("should render a warning message if there is no annexe 2 candidate", () => {
+    render(component([], []));
+    const warningMessage = screen.getByText(
+      "Aucun bordereau éligible au regroupement"
+    );
+    expect(warningMessage).toBeInTheDocument();
+  });
+
+  it("should render correctly with data from `grouping` and `appendixForms`", async () => {
+    render(
+      component(appendixForms as Form[], grouping as InitialFormFraction[])
+    );
+    // Vérifie la présence des headers
+    const headers = screen.getAllByRole("columnheader");
+    const headerCheckbox = within(headers[0]).getByRole("checkbox");
+    // Par défaut aucun bordereau n'est sélectionné
+    expect(headerCheckbox).not.toBeChecked();
+    expect(headers[1]).toHaveTextContent("Numéro");
+    expect(headers[2]).toHaveTextContent("Code déchet");
+    expect(headers[3]).toHaveTextContent("Émetteur initial");
+    expect(headers[4]).toHaveTextContent("Date de l'acceptation");
+    expect(headers[5]).toHaveTextContent("Opération réalisée");
+    expect(headers[6]).toHaveTextContent("Qté acceptée");
+    expect(headers[7]).toHaveTextContent("Qté restante");
+    expect(headers[8]).toHaveTextContent("Qté à regrouper");
+
+    const rows = screen.getAllByRole("row");
+
+    await waitFor(() =>
+      // Sur le premier render les données provenant de state initiale Formik
+      // ne sont pas affichées, ce waitFor permet d'attendre que ça le soit
+      expect(screen.getByText(grouping[0].form.readableId)).toBeInTheDocument()
+    );
+
+    // La première ligne correspondent aux bordereaux déjà annexés
+    // à l'ouverture du formulaire (paramètre `grouping`)
+
+    const row1 = within(rows[1]).getAllByRole("cell");
+    const checkbox1 = within(row1[0]).getByRole("checkbox");
+    // La checkbox est coché par défaut puisque ce bordereau est déjà annexé
+    expect(checkbox1).toBeChecked();
+    expect(row1[1]).toHaveTextContent(grouping[0].form.readableId);
+    expect(row1[2]).toHaveTextContent(grouping[0].form.wasteDetails?.code);
+    expect(row1[3]).toHaveTextContent(grouping[0].form.emitter?.company?.name);
+    expect(row1[3]).toHaveTextContent(grouping[0].form.emitter?.company?.orgId);
+    expect(row1[4]).toHaveTextContent("14/11/2024");
+    expect(row1[5]).toHaveTextContent(grouping[0].form.processingOperationDone);
+    expect(row1[6]).toHaveTextContent("1");
+    // La quantité déjà regroupée reste disponible puisque c'est groupé
+    // sur le bordereau de groupement qui fait l'objet de ce formulaire
+    expect(row1[7]).toHaveTextContent("1");
+    const input1 = within(row1[8]).getByDisplayValue(
+      String(grouping[0].quantity)
+    );
+    expect(input1).toBeInTheDocument();
+    expect(input1).toBeEnabled();
+
+    // Les lignes suivantes correspondent aux bordereaux "candidats"
+    // qui ne sont pas encore annexés (paramètre `appendixForms`)
+
+    const row2 = within(rows[2]).getAllByRole("cell");
+    const checkbox2 = within(row2[0]).getByRole("checkbox");
+    expect(checkbox2).not.toBeChecked();
+    expect(row2[1]).toHaveTextContent(appendixForms[0].readableId);
+    expect(row2[2]).toHaveTextContent(appendixForms[0].wasteDetails?.code);
+    expect(row2[3]).toHaveTextContent(appendixForms[0].emitter?.company?.name);
+    expect(row2[3]).toHaveTextContent(appendixForms[0].emitter?.company?.orgId);
+    expect(row2[4]).toHaveTextContent("14/11/2024");
+    expect(row2[5]).toHaveTextContent(appendixForms[0].processingOperationDone);
+    expect(row2[6]).toHaveTextContent("1");
+    // La quantité restante est de 1 - 0.6
+    expect(row2[7]).toHaveTextContent("0.4");
+    // La valeur de l'input correspond par défaut à la quantité restante
+    const input2 = within(row2[8]).getByDisplayValue("0.4");
+    expect(input2).toBeInTheDocument();
+    // L'input est disabled tant que le bordereau n'est pas sélectionné
+    expect(input2).toBeDisabled();
+
+    const row3 = within(rows[3]).getAllByRole("cell");
+    const checkbox3 = within(row3[0]).getByRole("checkbox");
+    expect(checkbox3).not.toBeChecked();
+    expect(row3[1]).toHaveTextContent(appendixForms[1].readableId);
+    expect(row3[2]).toHaveTextContent(appendixForms[1].wasteDetails?.code);
+    expect(row3[3]).toHaveTextContent(appendixForms[1].emitter?.company?.name);
+    expect(row3[3]).toHaveTextContent(appendixForms[1].emitter?.company?.orgId);
+    expect(row3[4]).toHaveTextContent("14/11/2024");
+    expect(row3[5]).toHaveTextContent(appendixForms[1].processingOperationDone);
+    expect(row3[6]).toHaveTextContent("1");
+    expect(row3[7]).toHaveTextContent("1");
+    const input3 = within(row3[8]).getByDisplayValue("1");
+    expect(input3).toBeInTheDocument();
+    expect(input3).toBeDisabled();
+
+    fireEvent.click(checkbox2);
+    await waitFor(() => expect(checkbox2).toBeChecked());
+    expect(input2).not.toBeDisabled();
+    expect(updateTotalQuantity).toHaveBeenCalledWith(0.6);
+    expect(updatePackagings).toHaveBeenCalledWith([
+      {
+        other: "",
+        quantity: 2,
+        type: "BENNE"
+      }
+    ]);
+
+    fireEvent.click(checkbox3);
+    await waitFor(() => expect(checkbox3).toBeChecked());
+    expect(updateTotalQuantity).toHaveBeenCalledWith(1.6);
+    expect(updatePackagings).toHaveBeenCalledWith([
+      {
+        other: "",
+        quantity: 2,
+        type: "BENNE"
+      },
+      {
+        other: "",
+        quantity: 1,
+        type: "GRV"
+      }
+    ]);
+    expect(input3).not.toBeDisabled();
+
+    expect(headerCheckbox).toBeChecked();
+
+    const user = userEvent.setup();
+    user.type(input2, "1");
+
+    await waitFor(() => expect(input2).toHaveValue(0.41));
+
+    user.clear(input2);
+    await waitFor(() => expect(input2).toHaveValue(null));
+
+    user.type(input2, "2");
+    await waitFor(() => expect(input2).toHaveValue(2));
+    expect(
+      within(row2[8]).getByText(
+        "Vous ne pouvez pas regrouper une quantité supérieure à la quantité restante"
+      )
+    ).toBeInTheDocument();
+
+    user.clear(input2);
+    user.type(input2, "-1");
+    await waitFor(() => expect(input2).toHaveValue(-1));
+    expect(
+      within(row2[8]).getByText("La quantité doit être un nombre supérieur à 0")
+    ).toBeInTheDocument();
+
+    // La checkbox du header permet de tout déselectionner
+    fireEvent.click(headerCheckbox);
+    await waitFor(() => {
+      expect(checkbox1).not.toBeChecked();
+      expect(checkbox2).not.toBeChecked();
+      expect(checkbox3).not.toBeChecked();
+    });
+
+    expect(updateTotalQuantity).toHaveBeenCalledWith(0);
+    expect(updatePackagings).toHaveBeenCalledWith([]);
+
+    // Les inputs sont tous disabled et leurs valeurs est reset à
+    // la quantité restante disponible
+    expect(input1).toBeDisabled();
+    expect(input1).toHaveValue(1);
+
+    expect(input2).toBeDisabled();
+    expect(input2).toHaveValue(0.4);
+
+    expect(input3).toBeDisabled();
+    expect(input3).toHaveValue(1);
+
+    // Si l'on clique à nouveau sur la checkbox du header, tous les
+    // bordereaux sont sélectionnés
+    fireEvent.click(headerCheckbox);
+    await waitFor(() => {
+      expect(checkbox1).toBeChecked();
+      expect(checkbox2).toBeChecked();
+      expect(checkbox3).toBeChecked();
+    });
+    expect(updateTotalQuantity).toHaveBeenCalledWith(2.4);
+    expect(updatePackagings).toHaveBeenCalledWith([
+      {
+        other: "",
+        quantity: 2,
+        type: "BENNE"
+      },
+      {
+        other: "",
+        quantity: 1,
+        type: "GRV"
+      }
+    ]);
+
+    const readableIfFilter = screen.getByLabelText("Numéro de bordereau");
+    expect(readableIfFilter).toBeInTheDocument();
+
+    user.type(readableIfFilter, appendixForms[0].readableId);
+    await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(2));
+
+    user.clear(readableIfFilter);
+    await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(4));
+  });
+});

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -79,24 +79,28 @@ export default function Appendix2MultiSelect({
   const filteredForms = useMemo(
     () =>
       forms.filter(({ form }) => {
-        let r = true;
-
-        if (readableIdFilter.length > 0) {
-          r = r && form.readableId.includes(readableIdFilter);
-          if (r === false) return r;
+        if (
+          readableIdFilter.length > 0 &&
+          !form.readableId.includes(readableIdFilter)
+        ) {
+          return false;
         }
 
-        if (wasteCodeFilter.length > 0) {
-          r = r && !!form.wasteDetails?.code?.includes(wasteCodeFilter);
-          if (r === false) return r;
+        if (
+          wasteCodeFilter.length > 0 &&
+          !form.wasteDetails?.code?.includes(wasteCodeFilter)
+        ) {
+          return false;
         }
 
-        if (emitterSiretFilter.length > 0) {
-          r = r && !!form.emitter?.company?.orgId?.includes(emitterSiretFilter);
-          if (r === false) return r;
+        if (
+          emitterSiretFilter.length > 0 &&
+          !form.emitter?.company?.orgId?.includes(emitterSiretFilter)
+        ) {
+          return false;
         }
 
-        return r;
+        return true;
       }),
     [forms, readableIdFilter, wasteCodeFilter, emitterSiretFilter]
   );
@@ -135,7 +139,7 @@ export default function Appendix2MultiSelect({
         .plus(initialQuantity);
     }
 
-    return quantityLeft;
+    return quantityLeft.toDecimalPlaces(6);
   }
 
   useEffect(() => {

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -240,7 +240,9 @@ export default function Appendix2MultiSelect({
             }
           ]}
         />,
-        form.readableId,
+        <div style={{ wordBreak: "break-word", wordWrap: "break-word" }}>
+          {form.readableId}
+        </div>,
         form.wasteDetails?.code,
         `${form.emitter?.company?.name} (${form.emitter?.company?.orgId})`,
         form.signedAt && formatDate(form.signedAt),
@@ -324,7 +326,14 @@ export default function Appendix2MultiSelect({
       "Qté à regrouper"
     ];
 
-    return <Table headers={headers} data={rows} />;
+    return (
+      <Table
+        caption="Sélection des bordereaux à ajouter en annexe 2" // accessibilité
+        noCaption
+        headers={headers}
+        data={rows}
+      />
+    );
   };
 
   if (forms.length > 0) {

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback } from "react";
+import gql from "graphql-tag";
+import { useQuery } from "@apollo/client";
+import { Form, Query, QueryAppendixFormsArgs } from "@td/codegen-ui";
+import { Loader } from "../../../../Apps/common/Components";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import Appendix2MultiSelect from "./Appendix2MultiSelect";
+import { useFormikContext } from "formik";
+
+const APPENDIX2_FORMS = gql`
+  query AppendixForms($siret: String!, $wasteCode: String) {
+    appendixForms(siret: $siret, wasteCode: $wasteCode) {
+      id
+      readableId
+      emitter {
+        company {
+          name
+          orgId
+        }
+      }
+      wasteDetails {
+        code
+        name
+        quantity
+        packagingInfos {
+          type
+          other
+          quantity
+        }
+      }
+      signedAt
+      quantityReceived
+      quantityAccepted
+      quantityRefused
+      quantityGrouped
+      processingOperationDone
+      recipient {
+        cap
+      }
+    }
+  }
+`;
+
+type Appendix2MultiSelectWrapperProps = {
+  emitterCompanySiret?: string | null;
+};
+
+function Appendix2MultiSelectWrapper({
+  emitterCompanySiret
+}: Appendix2MultiSelectWrapperProps) {
+  const { setFieldValue } = useFormikContext<Form>();
+
+  const { loading, error, data } = useQuery<
+    Pick<Query, "appendixForms">,
+    QueryAppendixFormsArgs
+  >(APPENDIX2_FORMS, {
+    variables: {
+      siret: emitterCompanySiret ?? ""
+    },
+    skip: !emitterCompanySiret,
+    fetchPolicy: "network-only"
+  });
+
+  // Cette fonction est ensuite utilisée dans un useEffect
+  // On la wrap dans un `useCallaback` pour éviter un render infinie
+  const updateTotalQuantity = useCallback(
+    (totalQuantity: number) =>
+      setFieldValue("wasteDetails.quantity", totalQuantity),
+    [setFieldValue]
+  );
+
+  // Cette fonction est ensuite utilisée dans un useEffect
+  // On la wrap dans un `useCallaback` pour éviter un render infinie
+  const updatePackagings = useCallback(
+    (
+      packagings: {
+        type: string;
+        other: string;
+        quantity: any;
+      }[]
+    ) => setFieldValue("wasteDetails.packagingInfos", packagings),
+    [setFieldValue]
+  );
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return (
+      <Alert
+        severity="error"
+        description={error.message}
+        title="Erreur"
+        small
+      />
+    );
+  }
+
+  if (data) {
+    return (
+      <Appendix2MultiSelect
+        appendixForms={data.appendixForms}
+        updateTotalQuantity={updateTotalQuantity}
+        updatePackagings={updatePackagings}
+      />
+    );
+  }
+}
+
+export default Appendix2MultiSelectWrapper;

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
@@ -62,7 +62,7 @@ function Appendix2MultiSelectWrapper({
   });
 
   // Cette fonction est ensuite utilisée dans un useEffect
-  // On la wrap dans un `useCallaback` pour éviter un render infinie
+  // On la wrap dans un `useCallback` pour éviter un render infini
   const updateTotalQuantity = useCallback(
     (totalQuantity: number) =>
       setFieldValue("wasteDetails.quantity", totalQuantity),


### PR DESCRIPTION
### Avant (bug les quantités restantes sont doublées)


https://github.com/user-attachments/assets/b3ee5308-20d5-494f-a76b-c42188336c1a

### Après (passage au DSFR + refacto avec correction du bug)


https://github.com/user-attachments/assets/81935e4f-c2f3-4434-ac7c-5925f15d2a8f

### Refacto 

J'ai profité du passage au DSFR pour réécrire ce composant, le simplifier et ajouter un test. La simplification principale est que l'on utilise le state Formik comme source des données pour l'affichage plutôt que d'avoir un state dans le composant qui se synchronise avec les données Formik à chaque changement. 

---

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB

---

- [Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-8351)
