### PR TITLE
[TRA-15098] - Permettre au transporteur étranger d'avoir les mêmes droits qu'un transporteur FR concernant la révision sur une Annexe 1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2024.12.1] 17/12/2024
+
+#### :nail_care: Améliorations
+
+- Permettre au transporteur étranger d'avoir les mêmes droits qu'un transporteur FR concernant la révision sur une Annexe 1 [PR 3770](https://github.com/MTES-MCT/trackdechets/pull/3770)
+
 # [2024.11.1] 19/11/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 # [2024.12.1] 17/12/2024
 
-
 #### :nail_care: Améliorations
 
 - Permettre au transporteur étranger d'avoir les mêmes droits qu'un transporteur FR concernant la révision sur une Annexe 1 [PR 3770](https://github.com/MTES-MCT/trackdechets/pull/3770)
@@ -15,7 +14,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement [PR 3760](https://github.com/MTES-MCT/trackdechets/pull/3760)
-
 
 # [2024.11.1] 19/11/2024
 

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -137,7 +137,6 @@ const buildAcceptRevisionRequestApproval: (
         status: RevisionRequestApprovalStatus.PENDING
       }
     });
-
     if (remainingApprovals !== 0) return;
 
     await approveAndApplyRevisionRequest(updatedApproval.revisionRequestId, {

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -137,6 +137,7 @@ const buildAcceptRevisionRequestApproval: (
         status: RevisionRequestApprovalStatus.PENDING
       }
     });
+
     if (remainingApprovals !== 0) return;
 
     await approveAndApplyRevisionRequest(updatedApproval.revisionRequestId, {

--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -680,7 +680,7 @@ describe("Mutation.createFormRevisionRequest", () => {
     }
   );
 
-  it.only(
+  it(
     "should create a revisionRequest and identifying current user" +
       " as the requester (foreign transporter when emitterType=APPENDIX_PRODUCER) ",
     async () => {

--- a/back/src/forms/resolvers/mutations/submitFormRevisionRequestApproval.ts
+++ b/back/src/forms/resolvers/mutations/submitFormRevisionRequestApproval.ts
@@ -43,17 +43,18 @@ export default async function submitFormRevisionRequestApproval(
     );
   }
 
-  const currentApproverSiret = await getCurrentApproverSiret(
+  const currentApproverOrgId = await getCurrentApproverOrgId(
     user,
     revisionRequest
   );
+
   const approval = revisionRequest.approvals.find(
-    approval => approval.approverSiret === currentApproverSiret
+    approval => approval.approverSiret === currentApproverOrgId
   );
 
   if (!approval) {
     throw new Error(
-      `No approval found for current approver siret ${currentApproverSiret}`
+      `No approval found for current approver siret ${currentApproverOrgId}`
     );
   }
 
@@ -91,7 +92,7 @@ export default async function submitFormRevisionRequestApproval(
   return formRepository.getRevisionRequestById(id);
 }
 
-async function getCurrentApproverSiret(
+async function getCurrentApproverOrgId(
   user: User,
   revisionRequest: BsddRevisionRequestWithApprovals
 ) {
@@ -101,7 +102,7 @@ async function getCurrentApproverSiret(
 
   const userCompanies = await getUserCompanies(user.id);
   const approvingCompaniesCandidates = userCompanies.filter(
-    company => company.siret && remainingApproverSirets.includes(company.siret)
+    company => company.orgId && remainingApproverSirets.includes(company.orgId)
   );
 
   if (approvingCompaniesCandidates.length === 0) {
@@ -110,5 +111,5 @@ async function getCurrentApproverSiret(
     );
   }
 
-  return approvingCompaniesCandidates[0].siret;
+  return approvingCompaniesCandidates[0].orgId;
 }

--- a/back/src/forms/resolvers/queries/formRevisionRequests.ts
+++ b/back/src/forms/resolvers/queries/formRevisionRequests.ts
@@ -17,18 +17,18 @@ const MAX_SIZE = 50;
 
 const formRevisionRequestResolver: QueryResolvers["formRevisionRequests"] =
   async (_, args, context) => {
-    const { siret, where, first = MAX_SIZE, after } = args;
+    const { siret: orgId, where, first = MAX_SIZE, after } = args;
 
     const user = checkIsAuthenticated(context);
 
     await checkUserPermissions(
       user,
-      siret,
+      orgId,
       Permission.BsdCanList,
-      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${siret}`
+      `Vous n'avez pas la permission de lister les demandes de révision de l'établissement ${orgId}`
     );
-    // TODO support orgId instead of siret for foreign companies
-    const company = await getCompanyOrCompanyNotFound({ siret });
+
+    const company = await getCompanyOrCompanyNotFound({ orgId });
 
     const pageSize = Math.max(Math.min(first ?? 0, MAX_SIZE), MIN_SIZE);
 

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -927,7 +927,10 @@ input ImportPaperFormInput {
 input CreateFormRevisionRequestInput {
   "Identifiant du bordereau à réviser"
   formId: ID!
-  "Numéro SIRET du demandeur"
+  """
+  Numéro SIRET du demandeur (ou numéro de TVA intracommunautaire dans le cas d'un transporteur
+  étranger faisant une demande de révision sur un bordereau d'annexe 1)
+  """
   authoringCompanySiret: String!
   "Contenu de la révision"
   content: FormRevisionRequestContentInput!

--- a/back/src/forms/typeDefs/bsdd.queries.graphql
+++ b/back/src/forms/typeDefs/bsdd.queries.graphql
@@ -248,7 +248,10 @@ type Query {
   Renvoie les demandes de révisions BSDD associées à un SIRET (demandes soumises et approbations requises)
   """
   formRevisionRequests(
-    "SIRET d'un établissement dont je suis membre"
+    """
+    SIRET d'un établissement dont je suis membre
+    (ou numéro de TVA intracommunautaire pour les transporteurs étrangers)
+    """
     siret: String!
     "(Optionnel) Filtres"
     where: FormRevisionRequestWhere

--- a/front/src/Apps/Dashboard/Components/Revision/ActorStatus/ActorSatus.tsx
+++ b/front/src/Apps/Dashboard/Components/Revision/ActorStatus/ActorSatus.tsx
@@ -36,7 +36,7 @@ const ActorStatus = ({ review }: { review: ReviewInterface }) => {
           &nbsp;Demandeur
         </p>
         <p className="actor-name">
-          {`${review.authoringCompany?.name} - ${review.authoringCompany?.siret}`}
+          {`${review.authoringCompany?.name} - ${review.authoringCompany?.orgId}`}
         </p>
       </div>
       {Object.entries(approvalsGroupedByStatus).map(([status, approvals]) => (

--- a/front/src/Apps/Dashboard/Components/Revision/revisionServices.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionServices.ts
@@ -1,7 +1,7 @@
 import { Bsda, Form } from "@td/codegen-ui";
 import { formatBsd } from "../../../Dashboard/bsdMapper";
 
-export const getActorName = (bsd: Form | Bsda, siret: string): string => {
+export const getActorName = (bsd: Form | Bsda, orgId: string): string => {
   const bsdFormatted = formatBsd(bsd);
 
   const actors = [
@@ -12,7 +12,7 @@ export const getActorName = (bsd: Form | Bsda, siret: string): string => {
     { company: bsdFormatted?.transporter?.company }
   ];
 
-  const actor = actors.find(actor => actor?.company?.siret === siret);
+  const actor = actors.find(actor => actor?.company?.orgId === orgId);
 
-  return [actor?.company?.name, siret].filter(Boolean).join(" - ");
+  return [actor?.company?.name, orgId].filter(Boolean).join(" - ");
 };

--- a/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
@@ -82,6 +82,7 @@ const reviewFragment = gql`
     }
     authoringCompany {
       siret
+      orgId
       name
     }
     approvals {


### PR DESCRIPTION
## Reproduction du bug

Impossible pour le transporteur étranger de demander une demande de révision et impossible pour le transporteur étranger de consulter une demande de révision demandé par l'émetteur.

https://github.com/user-attachments/assets/27a95c1d-0a96-4dc3-933c-94dd79b6796c


## Correction du bug

Demande de révision par le transporteur étranger puis approbation par l'émetteur puis demande de révision par l'émetteur et approbation par le transporteur étranger.

https://github.com/user-attachments/assets/3c65035f-6121-46f7-b67a-609f427577b8



<!--
  Décrivez brièvement l'objectif de votre pull request.
  La liste ci-dessous comporte des éléments importants à garder en tête pour chaque PR.
  Pensez à ajouter le lien du ticket Favro correspondant.
-->

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15098)
