### PR TITLE
[TRA-15230] Les BSDA sont désormais inclus dans les transferts de bordereaux d'un SIRET mis en sommeil vers un autre SIRET

### DIFF
--- a/back/src/queue/jobs/__tests__/administrativeTransfer.integration.ts
+++ b/back/src/queue/jobs/__tests__/administrativeTransfer.integration.ts
@@ -1,0 +1,113 @@
+import { prisma } from "@td/prisma";
+import { companyFactory } from "../../../__tests__/factories";
+import { bsdaFactory } from "../../../bsda/__tests__/factories";
+import {
+  AdministrativeTransferArgs,
+  processAdministrativeTransferJob
+} from "../administrativeTransfer";
+import { Job } from "bull";
+import { BsdaStatus } from "@prisma/client";
+import { resetDatabase } from "../../../../integration-tests/helper";
+
+describe("processAdministrativeTransferJob", () => {
+  afterEach(resetDatabase);
+
+  it("should transfer BSDAs with status AWAITING_CHILD", async () => {
+    // Given
+    const fromCompany = await companyFactory();
+    const toCompany = await companyFactory();
+
+    const bsda = await bsdaFactory({
+      opt: {
+        status: "AWAITING_CHILD",
+        destinationCompanySiret: fromCompany.siret
+      }
+    });
+
+    // When
+    const job = {
+      data: {
+        fromOrgId: fromCompany.siret,
+        toOrgId: toCompany.siret
+      }
+    } as Job<AdministrativeTransferArgs>;
+    await processAdministrativeTransferJob(job);
+
+    // Then
+    const updatedBsda = await prisma.bsda.findFirstOrThrow({
+      where: {
+        id: bsda.id
+      }
+    });
+    expect(updatedBsda.destinationCompanySiret).toBe(toCompany.siret);
+  });
+
+  it.each([
+    BsdaStatus.CANCELED,
+    BsdaStatus.INITIAL,
+    BsdaStatus.PROCESSED,
+    BsdaStatus.REFUSED,
+    BsdaStatus.SENT,
+    BsdaStatus.SIGNED_BY_PRODUCER,
+    BsdaStatus.SIGNED_BY_WORKER
+  ])("should not transfer BSDAs with status %p", async status => {
+    // Given
+    const fromCompany = await companyFactory();
+    const toCompany = await companyFactory();
+
+    const bsda = await bsdaFactory({
+      opt: {
+        status,
+        destinationCompanySiret: fromCompany.siret
+      }
+    });
+
+    // When
+    const job = {
+      data: {
+        fromOrgId: fromCompany.siret,
+        toOrgId: toCompany.siret
+      }
+    } as Job<AdministrativeTransferArgs>;
+    await processAdministrativeTransferJob(job);
+
+    // Then
+    const updatedBsda = await prisma.bsda.findFirstOrThrow({
+      where: {
+        id: bsda.id
+      }
+    });
+    expect(updatedBsda.destinationCompanySiret).toBe(fromCompany.siret);
+  });
+
+  it("should not transfer BSDA that has nothing to do with companies", async () => {
+    // Given
+    const fromCompany = await companyFactory();
+    const toCompany = await companyFactory();
+    const otherCompany = await companyFactory();
+
+    const bsda = await bsdaFactory({
+      opt: {
+        status: "AWAITING_CHILD",
+        destinationCompanySiret: otherCompany.siret
+      }
+    });
+
+    // When
+    const job = {
+      data: {
+        fromOrgId: fromCompany.siret,
+        toOrgId: toCompany.siret
+      }
+    } as Job<AdministrativeTransferArgs>;
+    await processAdministrativeTransferJob(job);
+
+    // Then
+    const updatedBsda = await prisma.bsda.findFirstOrThrow({
+      where: {
+        id: bsda.id
+      }
+    });
+    expect(updatedBsda.destinationCompanySiret).toBe(otherCompany.siret);
+  });
+});

--- a/back/src/queue/jobs/administrativeTransfer.ts
+++ b/back/src/queue/jobs/administrativeTransfer.ts
@@ -50,16 +50,6 @@ export async function processAdministrativeTransferJob(
   );
 
   // BSDAs
-  const bsdasToTransfer = await prisma.bsda.findMany({
-    where: {
-      destinationCompanySiret: fromOrgId,
-      status: {
-        in: ["AWAITING_CHILD"]
-      }
-    },
-    select: { id: true }
-  });
-
   const bsdaRepository = getBsdaRepository({
     auth: AuthType.Bearer,
     id: "JOB_ADMINISTRATIVE_TRANSFER",
@@ -67,7 +57,10 @@ export async function processAdministrativeTransferJob(
   } as Express.User);
 
   await bsdaRepository.updateMany(
-    { id: { in: bsdasToTransfer.map(bsda => bsda.id) } },
+    {
+      destinationCompanySiret: fromOrgId,
+      status: "AWAITING_CHILD"
+    },
     {
       destinationCompanySiret: toCompany.orgId,
       destinationCompanyName: toCompany.name,

--- a/back/src/queue/jobs/administrativeTransfer.ts
+++ b/back/src/queue/jobs/administrativeTransfer.ts
@@ -3,6 +3,7 @@ import { prisma } from "@td/prisma";
 import { Job } from "bull";
 import { getFormRepository } from "../../forms/repository";
 import { AuthType } from "../../auth";
+import { getBsdaRepository } from "../../bsda/repository";
 
 export type AdministrativeTransferArgs = { fromOrgId: string; toOrgId: string };
 
@@ -45,6 +46,35 @@ export async function processAdministrativeTransferJob(
       recipientCompanyContact: toCompany.contact,
       recipientCompanyMail: toCompany.contactEmail,
       recipientCompanyPhone: toCompany.contactPhone
+    }
+  );
+
+  // BSDAs
+  const bsdasToTransfer = await prisma.bsda.findMany({
+    where: {
+      destinationCompanySiret: fromOrgId,
+      status: {
+        in: ["AWAITING_CHILD"]
+      }
+    },
+    select: { id: true }
+  });
+
+  const bsdaRepository = getBsdaRepository({
+    auth: AuthType.Bearer,
+    id: "JOB_ADMINISTRATIVE_TRANSFER",
+    name: "JOB_ADMINISTRATIVE_TRANSFER"
+  } as Express.User);
+
+  await bsdaRepository.updateMany(
+    { id: { in: bsdasToTransfer.map(bsda => bsda.id) } },
+    {
+      destinationCompanySiret: toCompany.orgId,
+      destinationCompanyName: toCompany.name,
+      destinationCompanyAddress: toCompany.address,
+      destinationCompanyContact: toCompany.contact,
+      destinationCompanyMail: toCompany.contactEmail,
+      destinationCompanyPhone: toCompany.contactPhone
     }
   );
 

--- a/front/src/Apps/Companies/CompanyAdvanced/RequestAdministrativeTransfer.tsx
+++ b/front/src/Apps/Companies/CompanyAdvanced/RequestAdministrativeTransfer.tsx
@@ -158,9 +158,9 @@ export function RequestAdministrativeTranfer({ company }: Props) {
               l'onglet "avancé de son établissement
             </li>
             <li>
-              L'ensemble des bordereaux (BSDD) au statut "awaiting-group" (En
-              attente de regroupement) sera transféré. (pas de sélection
-              possible)
+              L'ensemble des bordereaux (BSDD au statut "awaiting-group" et BSDA
+              au statut "awaiting-child" soit En attente de regroupement) sera
+              transféré (pas de sélection possible).
             </li>
             <li>L'opération est irréversible.</li>
           </ul>


### PR DESCRIPTION
# Contexte

Lors de la mise en sommeil d'un établissement, on veut transférer les BSDA au statut AWAITING_CHILD en plus du reste

# Démo

[Screencast from 2024-11-26 10-34-52.webm](https://github.com/user-attachments/assets/bedd9271-9607-4476-a0ac-7c0099b220b3)


# Ticket Favro

[Inclure les BSDA dans les transferts de bordereaux d'un SIRET mis en sommeil vers un autre SIRET](https://favro.com/widget/ab14a4f0460a99a9d64d4945/bef298d9246ef5b38dd16e14?card=tra-15230)
