### PR TITLE
[TRA-15342] Le champ destinationCap du BSDA est scellé à partir de l'étape de transport (ou émission si pas d'entreprise de travaux)

### DIFF
--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -142,6 +142,18 @@ const sealedFromEmissionExceptAddOrRemoveNextDestination: GetBsdaSignatureTypeFn
   return isEmitter ? "WORK" : "EMISSION";
 };
 
+const sealedFromEmissionExceptIfWorker: GetBsdaSignatureTypeFn<ZodBsda> = (
+  _,
+  context
+) => {
+  // Si entreprise de travaux: on peut modifier jusqu'à l'étape de transport
+  // Sinon, scellé dès la signature émetteur
+  const persisted = context!.persisted;
+  const hasWorker = persisted?.workerCompanySiret;
+
+  return hasWorker ? "TRANSPORT" : "EMISSION";
+};
+
 /**
  * Renvoie la signature émetteur s'il n'y a pas d'entreprise de travaux sur le BSDA.
  * Sinon, renvoie la signature de l'entreprise de travaux.
@@ -434,7 +446,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationCap: {
     readableFieldName: "le CAP du destinataire",
-    sealed: { from: sealedFromEmissionExceptAddOrRemoveNextDestination },
+    sealed: { from: sealedFromEmissionExceptIfWorker },
     required: {
       from: "EMISSION",
       when: bsda =>

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -143,13 +143,12 @@ const sealedFromEmissionExceptAddOrRemoveNextDestination: GetBsdaSignatureTypeFn
 };
 
 const sealedFromEmissionExceptIfWorker: GetBsdaSignatureTypeFn<ZodBsda> = (
-  _,
-  context
+  bsda,
+  _
 ) => {
   // Si entreprise de travaux: on peut modifier jusqu'à l'étape de transport
   // Sinon, scellé dès la signature émetteur
-  const persisted = context!.persisted;
-  const hasWorker = persisted?.workerCompanySiret;
+  const hasWorker = bsda?.workerCompanySiret;
 
   return hasWorker ? "TRANSPORT" : "EMISSION";
 };


### PR DESCRIPTION
# Contexte

Modification des règles pour le champ `destinationCap` d'un BSDA:
- Si le BSDA a une entreprise de travaux, le champ est scellé à partir de la signature transporteur
- Sinon, il est scellé à partir de la signature émetteur

# Démo

### Avec entreprise de travaux

[avec_entreprise_travaux.webm](https://github.com/user-attachments/assets/e57ce945-2a07-4cbe-92c8-0ee1cc2f9396)


### Sans entreprise de travaux

[sans_entreprise_de_travaux.webm](https://github.com/user-attachments/assets/2e8bc0f0-471f-4b70-81c8-58e3ca9e1700)

# Ticket Favro

[Sceller le champ destinationCap à la signature de l'entreprise de travaux (au lieu de celle du producteur) Suites atelier amiante](https://favro.com/widget/ab14a4f0460a99a9d64d4945/bef298d9246ef5b38dd16e14?card=tra-15342)
