### PR TITLE
[tra-15096][tra-14783] - Refacto de la fonction `canReviewBsd`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement [PR 3760](https://github.com/MTES-MCT/trackdechets/pull/3760)
+- Retirer la possibilité de réviser une Annexe 1 avant la signature de l'enlèvement pour tous les acteurs [PR 3784](https://github.com/MTES-MCT/trackdechets/pull/3784)
+- Retirer les accès à la révision pour les profils Négociant, Courtier et Autre intermédiaire [PR 3784](https://github.com/MTES-MCT/trackdechets/pull/3784)
 
 # [2024.11.1] 19/11/2024
 

--- a/front/src/Apps/Dashboard/Components/BsdAdditionalActionsButton/bsdAdditionalActions.test.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdAdditionalActionsButton/bsdAdditionalActions.test.tsx
@@ -243,6 +243,7 @@ describe("BsdAdditionalActionsButton", () => {
     const permissions = [UserPermission.BsdCanRevise];
     const bsdReview = {
       ...bsd,
+      emitter: { company: { siret: currentSiret } },
       status: BsdStatusCode.Processed,
       type: BsdType.Bsdd
     } as BsdDisplay;

--- a/front/src/Apps/Dashboard/dashboardServices.test.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.test.ts
@@ -29,7 +29,9 @@ import {
   hasRoadControlButton,
   getPrimaryActionsLabelFromBsdStatus,
   isSiretActorForBsd,
-  ActorType
+  ActorType,
+  canReviewBsda,
+  canReviewBsdasri
 } from "./dashboardServices";
 import {
   BsdType,
@@ -1355,52 +1357,396 @@ describe("dashboardServices", () => {
   });
 
   describe("canReviewBsdd", () => {
-    it("should return true when Bsdd status is not Draft, Sealed, or Refused, and emitterType is not Appendix1Producer", () => {
-      const bsd = {
-        type: BsdType.Bsdd,
-        status: BsdStatusCode.Accepted,
-        emitterType: EmitterType.Producer
-      };
-
-      const result = canReviewBsdd(bsd, "1234");
-
-      expect(result).toBe(true);
-    });
-
-    it("should return false when bsd type is not Bsdd", () => {
-      const bsd = {
+    it("should return false if bsd is not BSDD", async () => {
+      const siret = "123";
+      const bsdd = {
         type: BsdType.Bsda,
-        status: BsdStatusCode.Accepted,
-        emitterType: EmitterType.Producer
+        status: BsdStatusCode.Processed,
+        emitter: { company: { siret } }
       };
-
-      const result = canReviewBsdd(bsd, "1234");
-
-      expect(result).toBe(false);
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
     });
 
-    it("should return false when bsd status is Draft, Sealed, or Refused", () => {
-      const bsd = {
+    it.each([BsdStatusCode.Draft, BsdStatusCode.Sealed, BsdStatusCode.Refused])(
+      "should not be possible to revise a BSDD when its status is %p",
+      status => {
+        const siret = "123";
+        const bsdd = {
+          type: BsdType.Bsdd,
+          emitter: { company: { siret } },
+          status
+        };
+        expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+      }
+    );
+
+    it.each([
+      EmitterType.Producer,
+      EmitterType.Other,
+      EmitterType.Appendix1,
+      EmitterType.Appendix2
+    ])(
+      "should be possible for emitter to revise a BSDD when emitter type is %p",
+      emitterType => {
+        const siret = "123";
+        const bsdd = {
+          type: BsdType.Bsdd,
+          emitterType,
+          status: BsdStatusCode.Processed,
+          emitter: { company: { siret } }
+        };
+        expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+      }
+    );
+
+    it.each([
+      EmitterType.Producer,
+      EmitterType.Other,
+      EmitterType.Appendix1,
+      EmitterType.Appendix2
+    ])(
+      "should be possible for destination to revise a BSDD when emitter type is %p",
+      emitterType => {
+        const siret = "123";
+        const bsdd = {
+          type: BsdType.Bsdd,
+          emitterType,
+          status: BsdStatusCode.Processed,
+          destination: { company: { siret } }
+        };
+        expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+      }
+    );
+
+    it.each([
+      EmitterType.Producer,
+      EmitterType.Other,
+      EmitterType.Appendix1,
+      EmitterType.Appendix2
+    ])(
+      "should be possible for eco-organisme to revise a BSDD when emitter type is %p",
+      emitterType => {
+        const siret = "123";
+        const bsdd = {
+          type: BsdType.Bsdd,
+          emitterType,
+          status: BsdStatusCode.Processed,
+          ecoOrganisme: { siret, name: "ÉCO-ORG" }
+        };
+        expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+      }
+    );
+
+    it.each([EmitterType.Producer, EmitterType.Other, EmitterType.Appendix2])(
+      "should be possible for final destination after temp storage to revise a BSDD when emitter type is %p",
+      emitterType => {
+        const siret = "123";
+        const bsdd = {
+          type: BsdType.Bsdd,
+          emitterType,
+          status: BsdStatusCode.Processed,
+          isTempStorage: true,
+          temporaryStorageDetail: { destination: { company: { siret } } }
+        };
+        expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+      }
+    );
+
+    it("should not be possible for a trader to revise a BSDD", async () => {
+      const siret = "123";
+      const bsdd = {
         type: BsdType.Bsdd,
-        status: BsdStatusCode.Draft,
-        emitterType: EmitterType.Producer
+        emitterType: EmitterType.Producer,
+        status: BsdStatusCode.Processed,
+        trader: { company: { siret } }
       };
-
-      const result = canReviewBsdd(bsd, "1234");
-
-      expect(result).toBe(false);
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
     });
 
-    it("should return true when emitterType is Appendix1Producer", () => {
-      const bsd = {
+    it("should not be possible for a broker to revise a BSDD", async () => {
+      const siret = "123";
+      const bsdd = {
         type: BsdType.Bsdd,
-        status: BsdStatusCode.Accepted,
-        emitterType: EmitterType.Appendix1Producer
+        emitterType: EmitterType.Producer,
+        status: BsdStatusCode.Processed,
+        broker: { company: { siret } }
       };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+    });
 
-      const result = canReviewBsdd(bsd, "1234");
+    it("should not be possible for an intermediary to revise a BSDD", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Producer,
+        status: BsdStatusCode.Processed,
+        intermediaries: [{ siret }]
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+    });
 
-      expect(result).toBe(true);
+    it("should be possible for destination to revise a BSDD when status is SIGNED_BY_PRODUCER", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Producer,
+        status: BsdStatusCode.SignedByProducer,
+        destination: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should not be possible for emitter to revise a BSDD when status is SIGNED_BY_PRODUCER", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Producer,
+        status: BsdStatusCode.SignedByProducer,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should be possible for emitter to review an APPENDIX_1_PRODUCER bsdd after transporter signature", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Appendix1Producer,
+        status: BsdStatusCode.Sent,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for transporter to review an APPENDIX_1_PRODUCER bsdd after transporter signature", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Appendix1Producer,
+        status: BsdStatusCode.Sent,
+        transporter: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for foreign transporter to review an APPENDIX_1_PRODUCER bsdd after transporter signature", async () => {
+      const vatNumber = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Appendix1Producer,
+        status: BsdStatusCode.Sent,
+        transporter: { company: { vatNumber } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, vatNumber)).toEqual(true);
+    });
+
+    it("should not be possible for emitter to review an APPENDIX_1_PRODUCER bsdd before transporter signature", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Appendix1Producer,
+        status: BsdStatusCode.SignedByProducer,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible for transporter to review an APPENDIX_1_PRODUCER bsdd before transporter signature", async () => {
+      const siret = "123";
+      const bsdd = {
+        type: BsdType.Bsdd,
+        emitterType: EmitterType.Appendix1Producer,
+        status: BsdStatusCode.SignedByProducer,
+        transporter: { company: { siret } }
+      };
+      expect(canReviewBsdd(bsdd as BsdDisplay, siret)).toEqual(false);
+    });
+  });
+
+  describe("canReviewBsda", () => {
+    it("should return false if bsd is not BSDA", async () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsdd,
+        status: BsdStatusCode.Processed,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible to revise a BSDA when its status is Initial", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Initial
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should be possible for worker to revise a BSDA", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        worker: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for destination to revise a BSDA", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        destination: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for emitter to revise a BSDA", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for worker to revise a BSDA before transporter's signature", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        worker: { company: { siret } },
+        status: BsdStatusCode.SignedByProducer
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for destination to revise a BSDA before transporter's signature", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        destination: { company: { siret } },
+        status: BsdStatusCode.SignedByProducer
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for emitter to revise a BSDA before transporter's signature", () => {
+      const siret = "123";
+      const bsda = {
+        type: BsdType.Bsda,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.SignedByProducer
+      };
+      expect(canReviewBsda(bsda as BsdDisplay, siret)).toEqual(false);
+    });
+  });
+
+  describe("canReviewBsdasri", () => {
+    it("should return false if bsd is not BSDASRI", async () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdd,
+        status: BsdStatusCode.Processed,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible to revise a BSDASRI when its status is Initial", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Initial
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible to revise a synthesis BSDASRI at status RECEIVED", () => {
+      const siret = "123";
+      const bsdasri = {
+        bsdWorkflowType: BsdasriType.Synthesis,
+        type: BsdType.Bsdasri,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Received
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible to revise a BSDASRI that is grouped in another one", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.AwaitingGroup,
+        groupedIn: { id: "" }
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should not be possible to revise a BSDASRI that is synthesized in another one", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Sent,
+        synthesizedIn: { id: "" }
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
+    });
+
+    it("should be possible for emitter to revise a BSDASRI", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        emitter: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for destination to revise a BSDASRI", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        destination: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for destination to revise a BSDASRI", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        destination: { company: { siret } },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should be possible for eco-organisme to revise a BSDASRI", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        ecoOrganisme: { siret },
+        status: BsdStatusCode.Processed
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(true);
+    });
+
+    it("should not be possible for emitter to revise a BSDASRI before transporter signature", () => {
+      const siret = "123";
+      const bsdasri = {
+        type: BsdType.Bsdasri,
+        status: BsdStatusCode.SignedByProducer,
+        emitter: { company: { siret } }
+      };
+      expect(canReviewBsdasri(bsdasri as BsdDisplay, siret)).toEqual(false);
     });
   });
 

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -20,7 +20,6 @@ import {
   UserPermission,
   Transporter,
   BsdaTransporter,
-  BsdasriStatus,
   BsffTransporter,
   BsvhuStatus
 } from "@td/codegen-ui";
@@ -289,6 +288,13 @@ const isSameSiretDestination = (
   bsd: BsdDisplay
 ): boolean => currentSiret === bsd.destination?.company?.siret;
 
+// destination finale après entreposage provisoire
+const isSameSiretFinalBsddDestination = (
+  currentSiret: string,
+  bsd: BsdDisplay
+): boolean =>
+  currentSiret === bsd.temporaryStorageDetail?.destination?.company?.siret;
+
 const isSameSiretWorker = (currentSiret: string, bsd: BsdDisplay): boolean =>
   currentSiret === bsd.worker?.company?.siret;
 
@@ -297,7 +303,7 @@ export const isSameSiretTransporter = (
   bsd: BsdDisplay | Form
 ): boolean =>
   currentSiret === bsd.transporter?.company?.siret ||
-  currentSiret === bsd.transporter?.company?.orgId;
+  currentSiret === bsd.transporter?.company?.vatNumber;
 
 // Renvoie le premier transporteur de la liste qui n'a pas encore
 // pris en charge le déchet.
@@ -1408,108 +1414,108 @@ const canUpdateBsff = (bsd, siret) =>
   ].includes(bsd.status) &&
   canDuplicateBsff(bsd, siret);
 
-const canReviewBsda = (bsd, siret) => {
-  const isTransporter = isSameSiretTransporter(siret, bsd);
+export const canReviewBsda = (bsd: BsdDisplay, siret: string) => {
+  if (bsd.type !== BsdType.Bsda || bsd.status === BsdStatusCode.Initial) {
+    return false;
+  }
+
   const isDestination = isSameSiretDestination(siret, bsd);
-  const isProducer = isSameSiretEmitter(siret, bsd);
+  const isEmitter = isSameSiretEmitter(siret, bsd);
   const isWorker = isSameSiretWorker(siret, bsd);
+  // TODO [tra-15516] gérer l'implémentation back
+  //const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
 
   return (
-    bsd.type === BsdType.Bsda &&
-    !canDeleteBsda(bsd, siret) &&
-    (isTransporter || isDestination || isProducer || isWorker)
+    (isEmitter &&
+      // On ne propose pas le bouton "Réviser" à l'émetteur
+      // lorsqu'il est le seul à avoir signé car il peut encore
+      // modifier le BSDA
+      bsd.status !== BsdStatusCode.SignedByProducer) ||
+    isDestination ||
+    isWorker
+    // TODO [tra-15516] gérer l'implémentation back
+    // || isEcoOrganisme
   );
 };
 
-const canReviewBsdasri = (bsd, siret) => {
-  // You can't review a SYNTHESIS dasri with RECEIVED status
+export const canReviewBsdasri = (bsd: BsdDisplay, siret: string) => {
+  if (bsd.type !== BsdType.Bsdasri || bsd.status === BsdStatusCode.Initial) {
+    return false;
+  }
+
+  // TRA-14348 tous les champs de révision sont grisés dans ce cas
+  // donc on enlève le bouton
   if (
-    [BsdasriType.Synthesis].includes(bsd.bsdWorkflowType?.toString()) &&
-    bsd.status === BsdasriStatus.Received
+    bsd.bsdWorkflowType === BsdasriType.Synthesis &&
+    bsd.status === BsdStatusCode.Received
   ) {
     return false;
   }
 
+  // TRA-15009 tous les champs de révision sont grisés dans ce cas
+  // donc on enlève le bouton
   if (bsd.groupedIn || bsd.synthesizedIn) {
     return false;
   }
 
   const isDestination = isSameSiretDestination(siret, bsd);
-  const isProducer = isSameSiretEmitter(siret, bsd);
+  const isEmitter = isSameSiretEmitter(siret, bsd);
   const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
 
   return (
-    bsd.type === BsdType.Bsdasri &&
-    !canDeleteBsdasri(bsd, siret) &&
-    (isDestination || isProducer || isEcoOrganisme)
+    (isEmitter &&
+      // On ne propose pas le bouton "Réviser" à l'émetteur
+      // lorsqu'il est le seul à avoir signé car il peut encore
+      // modifier le BSDASRI
+      bsd.status !== BsdStatusCode.SignedByProducer) ||
+    isDestination ||
+    isEcoOrganisme
   );
 };
 
-export const canReviewBsdd = (bsd, siret) => {
-  const isSentStatus = BsdStatusCode.Sent === bsd.status;
+export const canReviewBsdd = (bsd: BsdDisplay, siret: string) => {
+  if (
+    bsd.type !== BsdType.Bsdd ||
+    bsd.status === BsdStatusCode.Draft ||
+    bsd.status === BsdStatusCode.Sealed ||
+    bsd.status === BsdStatusCode.Refused
+  ) {
+    return false;
+  }
 
-  const isMultimodalTransporter =
-    !!bsd.transporters &&
-    bsd.transporters.length > 1 &&
-    (bsd.transporters as Transporter[]).some(t => t.company?.orgId === siret);
-
-  return (
-    bsd.type === BsdType.Bsdd &&
-    ![
-      BsdStatusCode.Draft,
-      BsdStatusCode.Sealed,
-      BsdStatusCode.Refused
-    ].includes(bsd.status) &&
-    !(
-      bsd.emitterType === EmitterType.Producer &&
-      !isSentStatus &&
-      isSameSiretEmitter(siret, bsd) &&
-      canUpdateBsd(bsd, siret)
-    ) &&
-    !(
-      bsd.emitterType === EmitterType.Appendix2 &&
-      !isSentStatus &&
-      isSameSiretDestination(siret, bsd) &&
-      canUpdateBsd(bsd, siret)
-    ) &&
-    !(
-      bsd.emitterType === EmitterType.Appendix2 &&
-      isSameSiretEmitter(siret, bsd) &&
-      canUpdateBsd(bsd, siret) &&
-      bsd.status === BsdStatusCode.SignedByProducer
-    ) &&
-    !isMultimodalTransporter
-  );
-};
-
-const canReviewBsddAppendix1 = (bsd, siret) => {
-  const transporterHasSigned = ![
-    BsdStatusCode.Draft,
-    BsdStatusCode.Sealed
-  ].includes(bsd.status);
-
-  return (
-    bsd.type === BsdType.Bsdd &&
-    isAppendix1Producer(bsd) &&
-    transporterHasSigned &&
-    isSameSiretTransporter(siret, bsd)
-  );
-};
-
-export const canReviewBsd = (bsd, siret) => {
-  const isTransporter = isSameSiretTransporter(siret, bsd);
+  const isEmitter = isSameSiretEmitter(siret, bsd);
   const isDestination = isSameSiretDestination(siret, bsd);
-  const isProducer = isSameSiretEmitter(siret, bsd);
-  const isWorker = isSameSiretWorker(siret, bsd);
-  const isTransporterOnly =
-    isTransporter && !isDestination && !isProducer && !isWorker;
+  const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
+  const isDestinationFinale = isSameSiretFinalBsddDestination(siret, bsd);
 
+  if (bsd.emitterType === EmitterType.Appendix1Producer) {
+    const isTransporter = isSameSiretTransporter(siret, bsd);
+    return (
+      // On n'autorise les révisions qu'à partir de la signature transporteur
+      bsd.status !== BsdStatusCode.SignedByProducer &&
+      (isEmitter || isTransporter)
+    );
+  } else {
+    // vérifier que ça s'applique aussi au bordereau de tournée dédié
+    return (
+      isDestination ||
+      isEcoOrganisme ||
+      isDestinationFinale ||
+      (isEmitter &&
+        // On ne propose pas le bouton "Réviser" à l'émetteur
+        // lorsqu'il est le seul à avoir signé car il peut encore
+        // modifier le BSDD
+        bsd.status !== BsdStatusCode.SignedByProducer)
+    );
+  }
+};
+
+// Specs révision https://docs.google.com/spreadsheets/d/1Mp2Q2Esn3jFa3RT1NtW7WAYq0vh9-iv-xoppEoW80Hk/edit?gid=0#gid=0
+export const canReviewBsd = (bsd: BsdDisplay, siret: string) => {
   return (
-    ((canReviewBsdd(bsd, siret) ||
-      canReviewBsda(bsd, siret) ||
-      canReviewBsdasri(bsd, siret)) &&
-      !isTransporterOnly) ||
-    canReviewBsddAppendix1(bsd, siret)
+    (bsd.type === BsdType.Bsdd && canReviewBsdd(bsd, siret)) ||
+    (bsd.type === BsdType.Bsda && canReviewBsda(bsd, siret)) ||
+    (bsd.type === BsdType.Bsdasri && canReviewBsdasri(bsd, siret))
   );
 };
 


### PR DESCRIPTION
Deux bugs corrigés ici par le refacto de la fonction `canReviewBsdd` : 
- [Retirer la possibilité de réviser une Annexe 1 avant la signature de l'enlèvement pour tous les acteurs](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15096)
- [Retirer les accès à la révision pour les profils Négociant, Courtier et Autre intermédiaire](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14783)

Les fonctions `canReviewBsdd`, `canReviewBsda` et `canReviewBsdasi` étaient devenus de vrais sacs de noeuds, je suis reparti des specs et j'ai ajouté des tests pour chaque use case 

https://docs.google.com/spreadsheets/d/1Mp2Q2Esn3jFa3RT1NtW7WAYq0vh9-iv-xoppEoW80Hk/edit?gid=2124745641#gid=2124745641


- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---
