### PR TITLE
[TRA-14470] : Permettre de faire une demande de révision BSDD lorsque le l'émetteur est un particulier ou un navire étranger

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :rocket: Nouvelles fonctionnalités
 
 - Ajout de l'export v2 des registres SSD [PR 3755](https://github.com/MTES-MCT/trackdechets/pull/3755)
+- Permettre de faire une demande de révision BSDD lorsque le l'émetteur est un particulier ou un navire étranger [PR 3785](https://github.com/MTES-MCT/trackdechets/pull/3785)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -205,11 +205,6 @@ async function checkIfUserCanRequestRevisionOnBsdd(
 ): Promise<void> {
   await checkCanRequestRevision(user, bsdd);
 
-  if (bsdd.emitterIsPrivateIndividual || bsdd.emitterIsForeignShip) {
-    throw new ForbiddenError(
-      "Impossible de créer une révision sur ce bordereau car l'émetteur est un particulier ou un navire étranger."
-    );
-  }
   if (Status.DRAFT === bsdd.status || Status.SEALED === bsdd.status) {
     throw new ForbiddenError(
       "Impossible de créer une révision sur ce bordereau. Vous pouvez le modifier directement, aucune signature bloquante n'a encore été apposée."

--- a/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
@@ -83,6 +83,10 @@ const reviewFragment = gql`
           processingOperation
         }
       }
+      ecoOrganisme {
+        siret
+        name
+      }
     }
     authoringCompany {
       siret


### PR DESCRIPTION
## Avant 

<img width="1291" alt="Capture d’écran 2024-05-31 à 12 41 50" src="https://github.com/user-attachments/assets/867e18bb-1fa6-4728-9191-605e5f966ba9">



## Après - Approbation automatique lorsqu'il n'y a pas d'éco-organisme


https://github.com/user-attachments/assets/c8bcbe1a-4b52-4e39-8bfd-4890b93d59e5


## Après - Demande de révision à l'éco-organisme s'il est présent


https://github.com/user-attachments/assets/43f028e0-95d4-47c6-a8c7-3efb0e4237f8




----

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14470)
