### PR TITLE
[TRA-15516] Permettre aux éco-organismes de réviser un BSDA

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 # [2024.12.1] 17/12/2024
 
+#### :rocket: Nouvelles fonctionnalités
+
+- Permettre aux éco-organismes de réviser un BSDA [PR 3790](https://github.com/MTES-MCT/trackdechets/pull/3790)
+
 #### :nail_care: Améliorations
 
 - Permettre au transporteur étranger d'avoir les mêmes droits qu'un transporteur FR concernant la révision sur une Annexe 1 [PR 3770](https://github.com/MTES-MCT/trackdechets/pull/3770)

--- a/back/src/bsda/permissions.ts
+++ b/back/src/bsda/permissions.ts
@@ -336,7 +336,8 @@ export async function checkCanRequestRevision(user: User, bsda: Bsda) {
   const authorizedOrgIds = [
     bsda.emitterCompanySiret,
     bsda.workerCompanySiret,
-    bsda.destinationCompanySiret
+    bsda.destinationCompanySiret,
+    bsda.ecoOrganismeSiret
   ].filter(Boolean);
 
   return checkUserPermissions(

--- a/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/__tests__/submitRevisionRequestApproval.integration.ts
@@ -273,6 +273,94 @@ describe("Mutation.submitBsdaRevisionRequestApproval", () => {
     expect(data.submitBsdaRevisionRequestApproval.status).toBe("REFUSED");
   });
 
+  it("should approve both emitter and ecoOrganisme request when ecoOrganisme approves", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("ADMIN");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { user, company: ecoOrganisme } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { mutate } = makeClient(user);
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        destinationCompanySiret: destinationCompany.siret,
+        ecoOrganismeSiret: ecoOrganisme.siret
+      }
+    });
+
+    const revisionRequest = await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda.id,
+        authoringCompanyId: destinationCompany.id,
+        approvals: {
+          create: [
+            { approverSiret: ecoOrganisme.siret! },
+            { approverSiret: emitterCompany.siret! }
+          ]
+        },
+        comment: "comment"
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdaRevisionRequestApproval">
+    >(SUBMIT_BSDA_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(data.submitBsdaRevisionRequestApproval.status).toBe("ACCEPTED");
+  });
+
+  it("should approve both emitter and ecoOrganisme request when emitter approves", async () => {
+    const { user, company: emitterCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "ADMIN"
+    );
+    const { company: ecoOrganisme } = await userWithCompanyFactory("ADMIN");
+    const { mutate } = makeClient(user);
+
+    const bsda = await bsdaFactory({
+      opt: {
+        emitterCompanySiret: emitterCompany.siret,
+        destinationCompanySiret: destinationCompany.siret,
+        ecoOrganismeSiret: ecoOrganisme.siret
+      }
+    });
+
+    const revisionRequest = await prisma.bsdaRevisionRequest.create({
+      data: {
+        bsdaId: bsda.id,
+        authoringCompanyId: destinationCompany.id,
+        approvals: {
+          create: [
+            { approverSiret: ecoOrganisme.siret! },
+            { approverSiret: emitterCompany.siret! }
+          ]
+        },
+        comment: "comment"
+      }
+    });
+
+    const { data } = await mutate<
+      Pick<Mutation, "submitBsdaRevisionRequestApproval">
+    >(SUBMIT_BSDA_REVISION_REQUEST_APPROVAL, {
+      variables: {
+        id: revisionRequest.id,
+        isApproved: true
+      }
+    });
+
+    expect(data.submitBsdaRevisionRequestApproval.status).toBe("ACCEPTED");
+  });
+
   it("should edit bsda accordingly when accepted", async () => {
     const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
       "ADMIN"

--- a/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
+++ b/back/src/bsda/resolvers/mutations/revisionRequest/createRevisionRequest.ts
@@ -41,7 +41,8 @@ export const NON_CANCELLABLE_BSDA_STATUSES: BsdaStatus[] = Object.values(
 const BSDA_REVISION_REQUESTER_FIELDS = [
   "emitterCompanySiret",
   "destinationCompanySiret",
-  "workerCompanySiret"
+  "workerCompanySiret",
+  "ecoOrganismeSiret"
 ];
 
 export type RevisionRequestContent = Pick<

--- a/front/src/Apps/Dashboard/Components/Revision/revisionServices.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionServices.ts
@@ -9,7 +9,13 @@ export const getActorName = (bsd: Form | Bsda, orgId: string): string => {
       company: bsdFormatted?.emitter?.company
     },
     { company: bsdFormatted?.destination?.company },
-    { company: bsdFormatted?.transporter?.company }
+    { company: bsdFormatted?.transporter?.company },
+    {
+      company: {
+        orgId: bsdFormatted?.ecoOrganisme?.siret,
+        name: bsdFormatted?.ecoOrganisme?.name
+      }
+    }
   ];
 
   const actor = actors.find(actor => actor?.company?.orgId === orgId);

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1422,8 +1422,7 @@ export const canReviewBsda = (bsd: BsdDisplay, siret: string) => {
   const isDestination = isSameSiretDestination(siret, bsd);
   const isEmitter = isSameSiretEmitter(siret, bsd);
   const isWorker = isSameSiretWorker(siret, bsd);
-  // TODO [tra-15516] gérer l'implémentation back
-  //const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
+  const isEcoOrganisme = isSameSiretEcorganisme(siret, bsd);
 
   return (
     (isEmitter &&
@@ -1432,9 +1431,8 @@ export const canReviewBsda = (bsd: BsdDisplay, siret: string) => {
       // modifier le BSDA
       bsd.status !== BsdStatusCode.SignedByProducer) ||
     isDestination ||
-    isWorker
-    // TODO [tra-15516] gérer l'implémentation back
-    // || isEcoOrganisme
+    isWorker ||
+    isEcoOrganisme
   );
 };
 

--- a/front/src/Apps/common/queries/reviews/BsdaReviewQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsdaReviewQuery.ts
@@ -24,6 +24,10 @@ const reviewFragment = gql`
           infos
         }
       }
+      ecoOrganisme {
+        siret
+        name
+      }
       waste {
         code
         materialName
@@ -74,6 +78,7 @@ const reviewFragment = gql`
     }
     authoringCompany {
       siret
+      orgId
       name
     }
     approvals {

--- a/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
@@ -34,6 +34,10 @@ const reviewFragment = gql`
           orgId
         }
       }
+      ecoOrganisme {
+        siret
+        name
+      }
       wasteDetails {
         code
         name


### PR DESCRIPTION
## L'éco-organisme peut faire une demande de révision 


https://github.com/user-attachments/assets/4535d827-42b5-4ca7-acc5-aae52d9aeaae



## L'éco-organisme peut approuver une demande de révision (ce qui approuve la demande de l'émetteur automatiquement)


https://github.com/user-attachments/assets/536d7807-fb63-4651-9953-655222afa56d




- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15516)
