### PR TITLE
Ne pas permettre d'accéder aux brouillons des autres acteurs sur le BSFF

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Permettre au transporteur étranger d'avoir les mêmes droits qu'un transporteur FR concernant la révision sur une Annexe 1 [PR 3770](https://github.com/MTES-MCT/trackdechets/pull/3770)
 - Remonter le VHU en situation irrégulière (sans émetteur TD) dans l'onglet À collecter du transporteur [PR 3792](https://github.com/MTES-MCT/trackdechets/pull/3792)
 - Mise à jour des règles de validations pour le conditionnement et l'identifications des bsvhus [PR 3807](https://github.com/MTES-MCT/trackdechets/pull/3807)
+- Rendre les BSFFs en brouillon inaccessibles aux entreprises dont l'auteur ne fait pas partie [PR 3793](https://github.com/MTES-MCT/trackdechets/pull/3793)
 
 #### :rocket: Nouvelles fonctionnalités
 

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -488,6 +488,7 @@ export const cloneBsff = async (user: Express.User, id: string) => {
     wasteCode: bsff.wasteCode,
     wasteDescription: bsff.wasteDescription,
     weightIsEstimate: bsff.weightIsEstimate,
+    canAccessDraftOrgIds: [], // filled in repository
     weightValue: bsff.weightValue
   };
 

--- a/back/src/bsffs/__tests__/bsff.factories.integration.ts
+++ b/back/src/bsffs/__tests__/bsff.factories.integration.ts
@@ -1,0 +1,54 @@
+import { resetDatabase } from "./../../../integration-tests/helper";
+import {
+  userWithCompanyFactory,
+  companyAssociatedToExistingUserFactory
+} from "../../__tests__/factories";
+import { UserRole } from "@prisma/client";
+import { createBsff } from "./factories";
+
+describe("Bsff factories", () => {
+  afterEach(resetDatabase);
+
+  it("should denormalize all user sirets on draft bsff", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await companyAssociatedToExistingUserFactory(
+      emitter.user,
+      UserRole.ADMIN
+    );
+    const transporter = await companyAssociatedToExistingUserFactory(
+      emitter.user,
+      UserRole.ADMIN
+    );
+    const bsff = await createBsff(
+      {
+        emitter,
+        destination: { company: destination, user: emitter.user },
+        transporter: { company: transporter, user: emitter.user }
+      },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+
+    expect(bsff.canAccessDraftOrgIds).toEqual([
+      emitter.company.siret,
+      destination.siret,
+      transporter.siret
+    ]);
+  });
+
+  it("should only denormalize user sirets on draft bsff", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsff = await createBsff(
+      {
+        emitter,
+        destination,
+        transporter
+      },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+
+    expect(bsff.canAccessDraftOrgIds).toEqual([emitter.company.siret]);
+  });
+});

--- a/back/src/bsffs/__tests__/factories.ts
+++ b/back/src/bsffs/__tests__/factories.ts
@@ -14,6 +14,7 @@ import { prisma } from "@td/prisma";
 import { UserWithCompany } from "../../__tests__/factories";
 import { OPERATION } from "../constants";
 import { BSFF_WASTE_CODES } from "@td/constants";
+import { getCanAccessDraftOrgIds } from "../utils";
 
 interface BsffFactoryCompanies {
   emitter?: UserWithCompany;
@@ -22,6 +23,7 @@ interface BsffFactoryCompanies {
 }
 
 interface BsffFactoryOpts {
+  userId?: string;
   data?: Partial<Prisma.BsffCreateInput>;
   transporterData?: Partial<Prisma.BsffTransporterCreateInput>;
   packagingData?: Partial<Prisma.BsffPackagingCreateInput>;
@@ -45,7 +47,8 @@ export async function createBsff(
     data,
     transporterData,
     packagingData,
-    previousPackagings
+    previousPackagings,
+    userId
   }: BsffFactoryOpts = {}
 ) {
   let input: Prisma.BsffCreateInput = {
@@ -124,15 +127,32 @@ export async function createBsff(
       destinationCompanyMail: destination.company.contactEmail
     };
   }
+  const include = {
+    packagings: { include: { previousPackagings: true } },
+    transporters: true,
+    ficheInterventions: true
+  };
 
-  return prisma.bsff.create({
+  const created = await prisma.bsff.create({
     data: input,
-    include: {
-      packagings: { include: { previousPackagings: true } },
-      transporters: true,
-      ficheInterventions: true
-    }
+    include
   });
+
+  if (created.isDraft) {
+    if (!userId) {
+      throw Error("Missing: userId is required for draft bsff factory");
+    }
+    const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(created, userId);
+
+    return prisma.bsff.update({
+      where: { id: created.id },
+      data: {
+        ...(canAccessDraftOrgIds.length ? { canAccessDraftOrgIds } : {})
+      },
+      include
+    });
+  }
+  return created;
 }
 
 export function createBsffBeforeEmission(

--- a/back/src/bsffs/permissions.ts
+++ b/back/src/bsffs/permissions.ts
@@ -20,15 +20,17 @@ import { prisma } from "@td/prisma";
  * Retrieves organisations allowed to read a BSFF
  */
 export function readers(bsff: BsffWithTransporters) {
-  return [
-    bsff.emitterCompanySiret,
-    ...bsff.transporters.flatMap(t => [
-      t.transporterCompanySiret,
-      t.transporterCompanyVatNumber
-    ]),
-    bsff.destinationCompanySiret,
-    ...bsff.detenteurCompanySirets
-  ].filter(Boolean);
+  return bsff.isDraft
+    ? [...bsff.canAccessDraftOrgIds]
+    : [
+        bsff.emitterCompanySiret,
+        ...bsff.transporters.flatMap(t => [
+          t.transporterCompanySiret,
+          t.transporterCompanyVatNumber
+        ]),
+        bsff.destinationCompanySiret,
+        ...bsff.detenteurCompanySirets
+      ].filter(Boolean);
 }
 
 /**
@@ -60,7 +62,7 @@ async function contributors(bsff: BsffWithTransporters, input?: BsffInput) {
       : bsff.destinationCompanySiret;
 
   if (input?.transporters) {
-    // on prend en compte la nouvelle liste de tranporteurs fournit
+    // on prend en compte la nouvelle liste de tranporteurs fournis
     transporters = await prisma.bsffTransporter.findMany({
       where: { id: { in: input.transporters } }
     });
@@ -99,11 +101,19 @@ async function contributors(bsff: BsffWithTransporters, input?: BsffInput) {
     .flatMap(t => [t.transporterCompanySiret, t.transporterCompanyVatNumber])
     .filter(Boolean);
 
-  return [
+  const bsffContributors = [
     emitterCompanySiret,
     destinationCompanySiret,
     ...transportersOrgIds
   ].filter(Boolean);
+
+  if (bsff.isDraft) {
+    return bsffContributors.filter(cb =>
+      bsff.canAccessDraftOrgIds.includes(cb)
+    );
+  }
+
+  return bsffContributors;
 }
 
 /**

--- a/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/createBsff.integration.ts
@@ -125,6 +125,9 @@ describe("Mutation.createBsff", () => {
     expect(createdBsff.wasteCode).toEqual(BSFF_WASTE_CODES[0]);
     expect(createdBsff.wasteAdr).toEqual("Mention ADR");
     expect(createdBsff.wasteDescription).toEqual("R410");
+
+    // check canAccessDraftOrgIds
+    expect(createdBsff.canAccessDraftOrgIds).toEqual([]);
   });
 
   it("should create a bsff with a fiche d'intervention", async () => {

--- a/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/deleteBsff.integration.ts
@@ -240,7 +240,8 @@ describe("Mutation.deleteBsff", () => {
             weight: p.acceptationWeight!,
             previousPackagings: { connect: { id: p.id } }
           }))
-        }
+        },
+        canAccessDraftOrgIds: [ttr.company.siret!]
       },
       include: { packagings: true }
     });
@@ -310,7 +311,8 @@ describe("Mutation.deleteBsff", () => {
               connect: initialBsff.packagings.map(p => ({ id: p.id }))
             }
           }
-        }
+        },
+        canAccessDraftOrgIds: [ttr.company.siret!]
       },
       include: { packagings: true }
     });
@@ -380,7 +382,8 @@ describe("Mutation.deleteBsff", () => {
               connect: { id: initialBsff.packagings[0].id }
             }
           }
-        }
+        },
+        canAccessDraftOrgIds: [ttr.company.siret!]
       },
       include: { packagings: true }
     });

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsff.integration.ts
@@ -23,6 +23,7 @@ import {
   userWithCompanyFactory,
   transporterReceiptFactory
 } from "../../../../__tests__/factories";
+import { associateUserToCompany } from "../../../../users/database";
 import makeClient from "../../../../__tests__/testClient";
 import { OPERATION } from "../../../constants";
 import { fullBsff } from "../../../fragments";
@@ -67,7 +68,10 @@ describe("Mutation.updateBsff", () => {
 
   it("should allow user to update a bsff", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { data: { isDraft: true } });
+    const bsff = await createBsff(
+      { emitter },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
 
     const { mutate } = makeClient(emitter.user);
     const { data, errors } = await mutate<
@@ -90,11 +94,52 @@ describe("Mutation.updateBsff", () => {
     expect(data.updateBsff.id).toBeTruthy();
   });
 
+  it("should update allowed companies on a draft bsff", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const anotherCompany = await companyFactory();
+    await associateUserToCompany(
+      emitter.user.id,
+      anotherCompany.orgId,
+      UserRole.ADMIN,
+      { notificationIsActiveMembershipRequest: false }
+    );
+    const bsff = await createBsff(
+      { emitter },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+
+    expect(bsff.canAccessDraftOrgIds).toEqual([emitter.company.siret]);
+    const { mutate } = makeClient(emitter.user);
+    const { data, errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {
+          destination: { company: { siret: anotherCompany.siret } }
+        }
+      }
+    });
+
+    expect(errors).toBeUndefined();
+    expect(data.updateBsff.id).toBeTruthy();
+
+    const updatedBsff = await prisma.bsff.findUniqueOrThrow({
+      where: { id: bsff.id }
+    });
+
+    expect(updatedBsff.canAccessDraftOrgIds).toEqual([
+      emitter.company.siret,
+      anotherCompany.siret
+    ]);
+  });
+
   it("should update a bsff transporter recepisse with data pulled from db", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     const bsff = await createBsff(
       { emitter, transporter: emitter },
-      { data: { isDraft: true } }
+      { data: { isDraft: true }, userId: emitter.user.id }
     );
 
     const transporter = await companyFactory({
@@ -138,6 +183,7 @@ describe("Mutation.updateBsff", () => {
       { emitter, transporter: emitter },
       {
         data: { isDraft: true },
+        userId: emitter.user.id,
         transporterData: {
           transporterRecepisseNumber: "abc",
           transporterRecepisseDepartment: "13",
@@ -181,6 +227,7 @@ describe("Mutation.updateBsff", () => {
       { emitter, transporter: emitter },
       {
         data: { isDraft: true },
+        userId: emitter.user.id,
         transporterData: {
           transporterRecepisseNumber: "abc",
           transporterRecepisseDepartment: "13",
@@ -224,6 +271,7 @@ describe("Mutation.updateBsff", () => {
       { emitter, transporter: emitter },
       {
         data: { isDraft: true },
+        userId: emitter.user.id,
         transporterData: {
           transporterRecepisseIsExempted: true
         }
@@ -263,6 +311,7 @@ describe("Mutation.updateBsff", () => {
       { emitter },
       {
         data: { isDraft: true },
+        userId: emitter.user.id,
         packagingData: {
           type: BsffPackagingType.BOUTEILLE,
           weight: 1,
@@ -560,7 +609,8 @@ describe("Mutation.updateBsff", () => {
           type: "COLLECTE_PETITES_QUANTITES",
           ficheInterventions: { connect: { id: ficheIntervention1.id } },
           isDraft: true
-        }
+        },
+        userId: operateur.user.id
       }
     );
 
@@ -769,6 +819,35 @@ describe("Mutation.updateBsff", () => {
     ]);
   });
 
+  it("should disallow user that is not the draft bsff creator", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    const transporter = await userWithCompanyFactory(UserRole.ADMIN);
+
+    const bsff = await createBsff(
+      { emitter, transporter, destination },
+      { data: { isDraft: true }, userId: destination.user.id }
+    );
+
+    const { mutate } = makeClient(emitter.user);
+    const { errors } = await mutate<
+      Pick<Mutation, "updateBsff">,
+      MutationUpdateBsffArgs
+    >(UPDATE_BSFF, {
+      variables: {
+        id: bsff.id,
+        input: {}
+      }
+    });
+    // despite being the emitter, they re not allowed to update the bsff creatd by destination
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Vous ne pouvez pas éditer un bordereau sur lequel le SIRET de votre entreprise n'apparaît pas."
+      })
+    ]);
+  });
+
   it("should throw an error if the bsff being updated doesn't exist", async () => {
     const { user } = await userWithCompanyFactory(UserRole.ADMIN);
 
@@ -820,7 +899,10 @@ describe("Mutation.updateBsff", () => {
 
   it("prevent user from removing their own company from the bsff", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
-    const bsff = await createBsff({ emitter }, { data: { isDraft: true } });
+    const bsff = await createBsff(
+      { emitter },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
 
     const { mutate } = makeClient(emitter.user);
     const { errors } = await mutate<
@@ -2086,6 +2168,7 @@ describe("Mutation.updateBsff", () => {
           data: {
             status: BsffStatus.INTERMEDIATELY_PROCESSED
           },
+          userId: emitter.user.id,
           packagingData: { operationCode: OPERATION.R12.code }
         }
       )
@@ -2100,7 +2183,8 @@ describe("Mutation.updateBsff", () => {
         data: {
           type: BsffType.GROUPEMENT,
           isDraft: true
-        }
+        },
+        userId: emitter.user.id
       }
     );
 
@@ -2150,7 +2234,8 @@ describe("Mutation.updateBsff", () => {
         data: {
           type: BsffType.REEXPEDITION,
           isDraft: true
-        }
+        },
+        userId: ttr.user.id
       }
     );
 
@@ -2198,6 +2283,7 @@ describe("Mutation.updateBsff", () => {
           type: BsffType.RECONDITIONNEMENT,
           isDraft: true
         },
+        userId: ttr.user.id,
         previousPackagings: repackagingBsff.packagings
       }
     );
@@ -2247,7 +2333,8 @@ describe("Mutation.updateBsff", () => {
           ficheInterventions: {
             connect: ficheInterventions.map(({ id }) => ({ id }))
           }
-        }
+        },
+        userId: emitter.user.id
       }
     );
 
@@ -2292,7 +2379,8 @@ describe("Mutation.updateBsff", () => {
         data: {
           type: BsffType.GROUPEMENT,
           isDraft: true
-        }
+        },
+        userId: emitter.user.id
       }
     );
     const { mutate } = makeClient(emitter.user);

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffPackagings.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffPackagings.integration.ts
@@ -143,7 +143,7 @@ describe("Query.bsffPackagings", () => {
         transporter,
         destination
       },
-      { data: { isDraft: true } }
+      { data: { isDraft: true }, userId: emitter.user.id }
     );
 
     const { query } = makeClient(emitter.user);

--- a/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
+++ b/back/src/bsffs/resolvers/queries/__tests__/bsffs.integration.ts
@@ -80,6 +80,65 @@ describe("Query.bsffs", () => {
     expect(data.bsffs.edges.map(edge => edge.node.id)).toEqual([bsff.id]);
   });
 
+  it("should return draft bsffs for the user's company", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    await createBsff(
+      { emitter },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+
+    const { query } = makeClient(emitter.user);
+    const { data } = await query<Pick<Query, "bsffs">, QueryBsffsArgs>(
+      GET_BSFFS
+    );
+
+    expect(data.bsffs.edges.length).toBe(1);
+  });
+
+  it("should not return draft bsffs for the user's company when created by somebody else", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+    // draft bsd created by emitter
+    await createBsff(
+      { emitter, destination },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+    // requested by destination
+    const { query } = makeClient(destination.user);
+    const { data } = await query<Pick<Query, "bsffs">, QueryBsffsArgs>(
+      GET_BSFFS
+    );
+    // not available
+    expect(data.bsffs.edges.length).toBe(0);
+  });
+
+  it("should return draft bsffs created by somebody else when belonging to the same companies", async () => {
+    const emitter = await userWithCompanyFactory(UserRole.ADMIN);
+    const destination = await userWithCompanyFactory(UserRole.ADMIN);
+
+    // associate destination user to emittter company
+    await prisma.companyAssociation.create({
+      data: {
+        company: { connect: { id: emitter.company.id } },
+        user: { connect: { id: destination.user.id } },
+        role: UserRole.ADMIN
+      }
+    });
+    // draft bsff created by emitter
+    await createBsff(
+      { emitter, destination },
+      { data: { isDraft: true }, userId: emitter.user.id }
+    );
+    for (const client of [emitter.user, destination.user]) {
+      const { query } = makeClient(client);
+      const { data } = await query<Pick<Query, "bsffs">, QueryBsffsArgs>(
+        GET_BSFFS
+      );
+
+      expect(data.bsffs.edges.length).toBe(1);
+    }
+  });
+
   it("should filter out bsffs where the user's company doesn't appear", async () => {
     const emitter = await userWithCompanyFactory(UserRole.ADMIN);
     await createBsff({ emitter });

--- a/back/src/bsffs/resolvers/queries/bsffs.ts
+++ b/back/src/bsffs/resolvers/queries/bsffs.ts
@@ -20,12 +20,26 @@ const bsffs: QueryResolvers["bsffs"] = async (
     can(roles[orgId], Permission.BsdCanList)
   );
 
-  const mask: Prisma.Enumerable<Prisma.BsffWhereInput> = {
+  const orgMask = {
     OR: [
       { emitterCompanySiret: { in: orgIdsWithListPermission } },
       { transportersOrgIds: { hasSome: orgIdsWithListPermission } },
       { destinationCompanySiret: { in: orgIdsWithListPermission } },
       { detenteurCompanySirets: { hasSome: orgIdsWithListPermission } }
+    ]
+  };
+
+  const mask: Prisma.Enumerable<Prisma.BsffWhereInput> = {
+    OR: [
+      {
+        isDraft: false,
+        ...orgMask
+      },
+      {
+        isDraft: true,
+        canAccessDraftOrgIds: { hasSome: orgIdsWithListPermission },
+        ...orgMask
+      }
     ]
   };
 

--- a/back/src/bsffs/utils.ts
+++ b/back/src/bsffs/utils.ts
@@ -1,0 +1,34 @@
+import { getUserCompanies } from "../users/database";
+import { BsffWithTransporters } from "./types";
+
+export const getCanAccessDraftOrgIds = async (
+  bsff: BsffWithTransporters,
+  userId: string
+): Promise<string[]> => {
+  const canAccessDraftOrgIds: string[] = [];
+
+  if (bsff.isDraft) {
+    const userCompanies = await getUserCompanies(userId);
+    const trsOrgIds = bsff.transporters.reduce(
+      (acc, trs) => [
+        ...acc,
+        trs.transporterCompanySiret,
+        trs.transporterCompanyVatNumber
+      ],
+      []
+    );
+    const userOrgIds = userCompanies.map(company => company.orgId);
+    // we skip detenteurs as they do not belong to the bsff itself
+    const bsffOrgIds = [
+      bsff.emitterCompanySiret,
+      bsff.destinationCompanySiret,
+      ...trsOrgIds
+    ].filter(Boolean);
+    const userOrgIdsInBsd = userOrgIds.filter(orgId =>
+      bsffOrgIds.includes(orgId)
+    );
+    canAccessDraftOrgIds.push(...userOrgIdsInBsd);
+  }
+
+  return canAccessDraftOrgIds;
+};

--- a/libs/back/prisma/src/migrations/20241130085509_add_bsff_can_access_draft_orgid/migration.sql
+++ b/libs/back/prisma/src/migrations/20241130085509_add_bsff_can_access_draft_orgid/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Bsff" ADD COLUMN     "canAccessDraftOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "_BsffCanAccessDraftOrgIdsIdx" ON "Bsff" USING GIN ("canAccessDraftOrgIds");

--- a/libs/back/prisma/src/schema.prisma
+++ b/libs/back/prisma/src/schema.prisma
@@ -1445,6 +1445,8 @@ model Bsff {
   // Denormalized transporter sirets to speed up query `bsffs`
   transportersOrgIds     String[] @default([])
 
+  canAccessDraftOrgIds String[] @default([])
+
   // partial _BsffIsDeletedIdx, _BsffIsDraftIdx index see migration82_missing_indices.sql
   @@index([emitterCompanySiret], map: "_BsffEmitterCompanySiretIdx")
   @@index([destinationCompanySiret], map: "_BsffDestinationCompanySiretIdx")
@@ -1454,6 +1456,7 @@ model Bsff {
   @@index([emitterEmissionSignatureDate], map: "_BsffEmitterEmissionSignatureDateIdx")
   @@index([transporterTransportSignatureDate], map: "_BsffTransporterTransportSignatureDateIdx")
   @@index([detenteurCompanySirets], map: "_BsffDetenteurSiretsIdx", type: Gin)
+  @@index([canAccessDraftOrgIds], map: "_BsffCanAccessDraftOrgIdsIdx", type: Gin)
 }
 
 model BsffTransporter {

--- a/libs/back/scripts/src/scripts/20241130173645420_bsff_draft_restrictions.ts
+++ b/libs/back/scripts/src/scripts/20241130173645420_bsff_draft_restrictions.ts
@@ -1,0 +1,188 @@
+import { MongoClient } from "mongodb";
+import Queue, { JobOptions } from "bull";
+import { Company, Event, Prisma, User } from "@prisma/client";
+import { prisma } from "@td/prisma";
+import { logger } from "@td/logger";
+
+type EventLike = Omit<Event, "metadata" | "data"> & {
+  data: any;
+  metadata: any;
+};
+
+type EventCollection = { _id: string } & Omit<EventLike, "id">;
+
+const { MONGO_URL, REDIS_URL, NODE_ENV } = process.env;
+const EVENTS_COLLECTION = "events";
+const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+
+const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
+  }
+});
+
+async function enqueueUpdatedBsdToIndex(
+  bsdId: string,
+  options?: JobOptions
+): Promise<void> {
+  logger.info(`Enqueuing BSD ${bsdId} for indexation`);
+  await indexQueue.add("index_updated", bsdId, options);
+}
+
+async function getUserCompanies(userId: string): Promise<Company[]> {
+  const companyAssociations = await prisma.companyAssociation.findMany({
+    where: { userId },
+    include: { company: true }
+  });
+  return companyAssociations.map(association => association.company);
+}
+
+const BATCH_SIZE = 10;
+export async function run() {
+  logger.info("starting BSSF draft restriction script");
+  const mongodbClient = new MongoClient(MONGO_URL!);
+
+  const database = mongodbClient.db();
+  const eventsCollection =
+    database.collection<EventCollection>(EVENTS_COLLECTION);
+  let finished = false;
+  let lastId: string | null = null;
+
+  while (!finished) {
+    let bsffs: Prisma.BsffGetPayload<{
+      include: {
+        transporters: true;
+      };
+    }>[] = [];
+    try {
+      bsffs = await prisma.bsff.findMany({
+        take: BATCH_SIZE,
+        skip: 1, // Skip the cursor
+        ...(lastId
+          ? {
+              cursor: {
+                id: lastId
+              }
+            }
+          : {}),
+        where: {
+          AND: [
+            {
+              isDraft: true
+            },
+            {
+              NOT: {
+                isDeleted: true
+              }
+            }
+          ]
+        },
+        include: {
+          transporters: true
+        },
+        orderBy: {
+          id: "asc"
+        }
+      });
+    } catch (error) {
+      logger.error(`failed to fetch bsffs from cursor ${lastId}`);
+      logger.error(error);
+      break;
+    }
+    logger.info(`got BSFFs ${bsffs.map(bsff => bsff.id).join(", ")}`);
+    if (bsffs.length < BATCH_SIZE) {
+      finished = true;
+    }
+    if (bsffs.length === 0) {
+      break;
+    }
+    lastId = bsffs[bsffs.length - 1].id;
+    let events: EventCollection[];
+    try {
+      events = await eventsCollection
+        .find({
+          streamId: { $in: bsffs.map(bsff => bsff.id) },
+          type: "BsffCreated"
+        })
+        .toArray();
+      logger.info(
+        `got events ${events.map(event => event.streamId).join(", ")}`
+      );
+    } catch (error) {
+      logger.error(
+        `failed to fetch events for bsffs ${bsffs
+          .map(bsff => bsff.id)
+          .join(", ")}`
+      );
+      logger.error(error);
+      break;
+    }
+
+    for (const bsff of bsffs) {
+      logger.info(`handling ${bsff.id}`);
+      const correspondingEvent = events.find(
+        event => event.streamId === bsff.id
+      );
+      let user: User | null = null;
+      if (correspondingEvent?.actor) {
+        logger.info("found creation event");
+        try {
+          user = await prisma.user.findFirst({
+            where: {
+              id: correspondingEvent.actor
+            }
+          });
+        } catch (_) {
+          logger.error(`failed to fetch user ${correspondingEvent.actor}`);
+        }
+      }
+      let canAccessDraftOrgIds: string[] = [];
+      const trsOrgIds = bsff.transporters.reduce(
+        (acc, trs) => [
+          ...acc,
+          trs.transporterCompanySiret,
+          trs.transporterCompanyVatNumber
+        ],
+        []
+      );
+      const bsffOrgIds = [
+        bsff.emitterCompanySiret,
+        bsff.destinationCompanySiret,
+        ...trsOrgIds
+      ].filter(Boolean);
+
+      if (user) {
+        logger.info("treating with user");
+        let userCompanies: Company[] = [];
+        try {
+          userCompanies = await getUserCompanies(user.id as string);
+        } catch (_) {
+          logger.error(`failed to fetch companies of user ${user.id}`);
+        }
+        const userOrgIds = userCompanies.map(company => company.orgId);
+        const userOrgIdsInForm = userOrgIds.filter(orgId =>
+          bsffOrgIds.includes(orgId)
+        );
+        canAccessDraftOrgIds.push(...userOrgIdsInForm);
+      } else {
+        logger.info("treating without user");
+        canAccessDraftOrgIds = bsffOrgIds.filter(Boolean) as string[];
+      }
+      logger.info(`updating ${bsff.id}`);
+      await prisma.bsff.update({
+        where: { id: bsff.id },
+        data: {
+          canAccessDraftOrgIds
+        },
+        select: {
+          id: true
+        }
+      });
+      enqueueUpdatedBsdToIndex(bsff.id);
+      logger.info(`updated ${bsff.id}`);
+    }
+  }
+}


### PR DESCRIPTION
Équivalent à ce qui a déjà été fait sur d'autres bsds. Un script de mise à jour est à lancer (c'est lui qui cause le warning sonarcloud)

﻿﻿**Vidéo à venir**

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [x] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14420)
