### PR TITLE
[tra-15570] La vérification de l'avis de situation SIRENE ne fonctionne pas pour les établissements anonymes lorsque le SIRET du siège est différent du SIRET de l'établissement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Impossible de changer de destination finale sur un BSDD avec entreposage provisoire si la destination finale initialement renseignée a été mise en sommeil [PR 3804](https://github.com/MTES-MCT/trackdechets/pull/3804)
 - Les intermédiaires n'apparaissent pas sur le récépissé PDF du BSDA [PR 3796](https://github.com/MTES-MCT/trackdechets/pull/3796)
 - Corrige l'affichage des décimales sur le poids du PAOH [PR 3808](https://github.com/MTES-MCT/trackdechets/pull/3808)
+- La vérification de l'avis de situation SIRENE ne fonctionne pas pour les établissements anonymes lorsque le SIRET du siège est différent du SIRET de l'établissement [PR 3794](https://github.com/MTES-MCT/trackdechets/pull/3794)
 
 # [2024.11.1] 19/11/2024
 

--- a/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompanyFromPDF.helpers.test.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createAnonymousCompanyFromPDF.helpers.test.ts
@@ -52,7 +52,7 @@ export const EXTRACTED_STRINGS = (date?: Date) => {
     `À la date du ${nowAsddMMYYYY}`,
     `Description de l'entrepriseEntreprise active depuis le ${nowAsddMMYYYY}`,
     "Identifiant SIREN982 549 826",
-    "Identifiant SIRET du siège982 549 826 00013",
+    "Identifiant SIRET du siège982 549 826 00021",
     "DénominationACME CORP",
     "Catégorie juridique5499 - Société à responsabilité limitée (sans autre ",
     "indication)",
@@ -63,6 +63,8 @@ export const EXTRACTED_STRINGS = (date?: Date) => {
     "Appartenance au champ des ",
     "sociétés à mission",
     `Description de l'établissementEtablissement actif depuis le ${nowAsddMMYYYY}`,
+    // tra-15570 cela doit fonctionner si le SIRET de
+    // l'établissement est différent du SIRET du siège
     "Identifiant SIRET982 549 826 00013",
     "Adresse4 BD PASTEUR",
     "44100 NANTES",

--- a/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.helpers.ts
+++ b/back/src/companies/resolvers/mutations/createAnonymousCompanyFromPDF.helpers.ts
@@ -166,10 +166,12 @@ export const extractEmittedAt = (texts: string[]) => {
 };
 
 export const extractSiret = (texts: string[]) => {
-  const siret = extractLine(texts, "Identifiant SIRET du siège")?.replace(
-    / /g,
-    ""
-  );
+  const siret = extractLine(
+    // On exclue la ligne correspondant au SIRET du siège
+    // pour éviter qu'elle match à tort dans `extractLine`
+    texts.filter(t => !t.includes("Identifiant SIRET du siège")),
+    "Identifiant SIRET"
+  )?.replace(/ /g, "");
 
   if (!siret || !siret.length || !isSiret(siret)) {
     throw new Error("Invalid siret");


### PR DESCRIPTION

![Capture d’écran 2024-12-06 à 08 56 45](https://github.com/user-attachments/assets/96835c45-e3be-4269-8163-4a54a5712aef)

La vérification de l'avis de situation SIRENE pour les établissements anonymes ne fonctionnait pas lorsque le n°SIRET de l'établissement est différent de celui du siège.


- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15570)
