### PR TITLE
Correction d'une erreur dans le fichier de définition GraphQL

### DIFF
--- a/back/src/registry/typeDefs/registry.objects.graphql
+++ b/back/src/registry/typeDefs/registry.objects.graphql
@@ -1928,7 +1928,7 @@ type AllWaste {
 
 type AllWasteEdge {
   cursor: String!
-  node: ManagedWaste!
+  node: AllWaste!
 }
 
 type AllWasteConnection {


### PR DESCRIPTION
J'ai détecté cette erreur en parcourant la doc développeur : `ManagedWaste`était présent à la place de `AllWaste`.
`AllWaste` étant une "sur-définition" de tous les autres types, ce n'est pas sensé causer de breaking change.

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro]()
