### PR TITLE
[tra-15576] - Impossible de changer de destination finale sur un BSDD avec entreposage provisoire si la destination finale initialement renseignée a été mise en sommeil

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ne pas doubler les quantités restantes à regrouper lorsqu'on modifie un bordereau de groupement [PR 3760](https://github.com/MTES-MCT/trackdechets/pull/3760)
 - Retirer la possibilité de réviser une Annexe 1 avant la signature de l'enlèvement pour tous les acteurs [PR 3784](https://github.com/MTES-MCT/trackdechets/pull/3784)
 - Retirer les accès à la révision pour les profils Négociant, Courtier et Autre intermédiaire [PR 3784](https://github.com/MTES-MCT/trackdechets/pull/3784)
+- Impossible de changer de destination finale sur un BSDD avec entreposage provisoire si la destination finale initialement renseignée a été mise en sommeil [PR 3804](https://github.com/MTES-MCT/trackdechets/pull/3804)
 
 # [2024.11.1] 19/11/2024
 

--- a/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsResealed.integration.ts
@@ -857,4 +857,51 @@ describe("Mutation markAsResealed", () => {
     });
     expect(resealedForm.wasteDetailsQuantity?.toNumber()).toEqual(3.3);
   });
+
+  test("tra-15576 - it should work when updating destination (previous destination is dormant and new one is not)", async () => {
+    const owner = await userFactory();
+    const { user, company: collector } = await userWithCompanyFactory(
+      "MEMBER",
+      {
+        companyTypes: { set: [CompanyType.COLLECTOR] }
+      }
+    );
+    const dormantDestination = await destinationFactory({
+      isDormantSince: new Date()
+    });
+    const { mutate } = makeClient(user);
+    const form = await formWithTempStorageFactory({
+      ownerId: owner.id,
+      opt: {
+        status: "TEMP_STORER_ACCEPTED",
+        recipientCompanySiret: collector.siret,
+        wasteAcceptationStatus: "PARTIALLY_REFUSED",
+        quantityReceived: 10.5,
+        quantityRefused: 7.2
+      },
+      forwardedInOpts: { recipientCompanySiret: dormantDestination.siret }
+    });
+
+    const newDestination = await destinationFactory();
+
+    const { errors } = await mutate<
+      Pick<Mutation, "markAsResealed">,
+      MutationMarkAsResealedArgs
+    >(MARK_AS_RESEALED, {
+      variables: {
+        id: form.id,
+        resealedInfos: {
+          destination: { company: { siret: newDestination.siret } }
+        }
+      }
+    });
+
+    expect(errors).toBeUndefined();
+
+    const resealedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: form.forwardedInId! }
+    });
+
+    expect(resealedForm.recipientCompanySiret).toEqual(newDestination.siret);
+  });
 });

--- a/back/src/forms/resolvers/mutations/markAsResent.ts
+++ b/back/src/forms/resolvers/mutations/markAsResent.ts
@@ -12,6 +12,7 @@ import { EventType } from "../../workflow/types";
 import { getFormRepository } from "../../repository";
 import { EmitterType, Prisma, Status } from "@prisma/client";
 import { UserInputError } from "../../../common/errors";
+import { FormWithForwardedInWithTransportersInclude } from "../../types";
 
 const markAsResentResolver: MutationResolvers["markAsResent"] = async (
   parent,
@@ -22,7 +23,10 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
 
   const { id, resentInfos } = args;
 
-  const form = await getFormOrFormNotFound({ id });
+  const form = await getFormOrFormNotFound(
+    { id },
+    FormWithForwardedInWithTransportersInclude
+  );
 
   const formRepository = getFormRepository(user);
 
@@ -40,7 +44,7 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
   const { destination, wasteDetails } = resentInfos;
 
   // copy basic info from initial BSD and overwrite it with resealedInfos
-  const updateInput: Prisma.FormUpdateInput = {
+  const updateInput = {
     emitterType: EmitterType.PRODUCER,
     emitterCompanySiret: form.recipientCompanySiret,
     emitterCompanyName: form.recipientCompanyName,
@@ -59,17 +63,30 @@ const markAsResentResolver: MutationResolvers["markAsResent"] = async (
     ...flattenFormInput({ wasteDetails, recipient: destination })
   };
 
-  // validate input
-  await sealedFormSchema.validate({
+  const bsdSuiteForValidation = {
     ...forwardedIn,
     ...updateInput
+  };
+
+  // validate input
+  await sealedFormSchema.validate(bsdSuiteForValidation);
+
+  // La validation doit s'appliquer sur les données de validation
+  // (fusion de l'existant et de ce qui est contenu dans l'input)
+  await validateForwardedInCompanies({
+    destinationCompanySiret: bsdSuiteForValidation.recipientCompanySiret,
+    transporterCompanySiret: null,
+    transporterCompanyVatNumber: null
   });
 
-  await validateForwardedInCompanies(form);
+  const forwardedInUpdateInput: Prisma.FormUpdateWithoutForwardingInput = {
+    ...updateInput,
+    status: Status.SEALED
+  };
 
   const formUpdateInput: Prisma.FormUpdateInput = {
     forwardedIn: {
-      update: { ...updateInput, status: Status.SENT }
+      update: forwardedInUpdateInput
     }
   };
 

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -7,7 +7,11 @@ import { runInTransaction } from "../../../common/repository/helper";
 import { MutationResolvers } from "../../../generated/graphql/types";
 import { sendMail } from "../../../mailer/mailing";
 import { getAndExpandFormFromDb } from "../../converter";
-import { getFirstTransporter, getFormOrFormNotFound } from "../../database";
+import {
+  getFirstTransporter,
+  getFirstTransporterSync,
+  getFormOrFormNotFound
+} from "../../database";
 import { checkCanMarkAsSealed } from "../../permissions";
 import { FormRepository, getFormRepository } from "../../repository";
 import {
@@ -18,6 +22,7 @@ import {
 import transitionForm from "../../workflow/transitionForm";
 import { EventType } from "../../workflow/types";
 import { enqueueUpdateAppendix2Job } from "../../../queue/producers/updateAppendix2";
+import { FormWithForwardedInWithTransportersInclude } from "../../types";
 
 const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   parent,
@@ -25,14 +30,27 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
   context
 ) => {
   const user = checkIsAuthenticated(context);
-  const form = await getFormOrFormNotFound({ id });
+  const form = await getFormOrFormNotFound(
+    { id },
+    FormWithForwardedInWithTransportersInclude
+  );
   await checkCanMarkAsSealed(user, form);
 
   const transporter = await getFirstTransporter(form);
   // validate form data
   await checkCanBeSealed({ ...form, ...transporter });
 
-  await validateForwardedInCompanies(form);
+  const transporterAfterTempStorage = form.forwardedIn
+    ? getFirstTransporterSync(form.forwardedIn)
+    : null;
+  await validateForwardedInCompanies({
+    destinationCompanySiret: form?.forwardedIn?.recipientCompanySiret,
+    transporterCompanySiret:
+      transporterAfterTempStorage?.transporterCompanySiret,
+    transporterCompanyVatNumber:
+      transporterAfterTempStorage?.transporterCompanyVatNumber
+  });
+
   let formUpdateInput;
 
   if (


### PR DESCRIPTION
La fonction `validateForwardedInCompanies` est utilisée pour valider que les établissements du bordereau suite (destination finale et transporteur) sont bien valides (inscrit, bon profil, pas en sommeil, etc). 

La vérification était effectuée à deux endroits : 
- Lors de la publication du bordereau - mutation `markAsSealed`.
- Lors de la préparation du bordereau suite par le TTR (qui permet de modifier la destination finale et l'établissement de transport après entreposage provisoire) - mutation `markAsResealed` et `markAsResent` (déprécié). 

Le problème est que cette fonction s’appliquait aux données stockées en base et ne prenait pas en compte la modification des données apportées par le payload de `markAsResealed` ou `markAsResent` (déprécié). Pas de soucis sur `markAsSealed` en revanche car cette mutation ne permet pas de modifier les données.

Le fix de cette PR propose de changer la signature de `validateForwardedInCompanies` pour lui passer explicitement les n°SIRET ou n°TVA des établissements du bordereau suite ce qui permet de prendre en compte les données de l'input. 


## Avant 

L'établissement de destination finale initialement sélectionné a été mis en sommeil, j'essaye de changer d'établissement, en vain.

https://github.com/user-attachments/assets/3eaa54e3-21c0-459d-b820-11d3c4992da3

## Après

Magique ça marche

https://github.com/user-attachments/assets/44315c2c-31df-4992-a75d-0f70c62ec78b




- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] S'assurer que la numérotation des nouvelles migrations est bien cohérente
- [ ] Informer le data engineer de tout changement de schéma DB
---

- [Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15576)
