### PR TITLE
[TRA-15342][Fix recette] Nouvelles règles pour les champs destinationCap & destinationOperationNextDestinationCap

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -2272,12 +2272,6 @@ describe("Mutation.updateBsda", () => {
       it.each([
         // Status pas bon
         [previousBsda, { ...updatedBsda, status: BsdaStatus.INITIAL }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.AWAITING_CHILD }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.CANCELED }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.PROCESSED }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.REFUSED }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.SIGNED_BY_WORKER }],
-        [previousBsda, { ...updatedBsda, status: BsdaStatus.SENT }],
         // Pas d'entreprise de travaux
         [previousBsda, { ...updatedBsda, workerCompanySiret: undefined }],
         // Pas d'émetteur
@@ -2355,39 +2349,6 @@ describe("Mutation.updateBsda", () => {
             notificationIsActiveBsdaFinalDestinationUpdate: true
           }
         );
-        await userInCompany(
-          "MEMBER",
-          worker.id,
-          {
-            email: "worker@mail.com",
-            name: "Worker"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          destination.id,
-          {
-            email: "destination@mail.com",
-            name: "Destination"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          transporter.id,
-          {
-            email: "transporter@mail.com",
-            name: "Transporter"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
 
         const bsda = await bsdaFactory({
           opt: {
@@ -2439,10 +2400,6 @@ describe("Mutation.updateBsda", () => {
   ${bsda.destinationCompanySiret}.
 </p>
 `,
-            cc: [
-              { email: "worker@mail.com", name: "Worker" },
-              { email: "destination@mail.com", name: "Destination" }
-            ],
             messageVersions: [
               { to: [{ email: "emitter@mail.com", name: "Emitter" }] }
             ],
@@ -2465,50 +2422,6 @@ describe("Mutation.updateBsda", () => {
           {
             email: "emitter@mail.com",
             name: "Emitter"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          worker.id,
-          {
-            email: "worker@mail.com",
-            name: "Worker"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          destination.id,
-          {
-            email: "destination@mail.com",
-            name: "Destination"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          nextDestination.id,
-          {
-            email: "next.destination@mail.com",
-            name: "Next Destination"
-          },
-          {
-            notificationIsActiveBsdaFinalDestinationUpdate: true
-          }
-        );
-        await userInCompany(
-          "MEMBER",
-          transporter.id,
-          {
-            email: "transporter@mail.com",
-            name: "Transporter"
           },
           {
             notificationIsActiveBsdaFinalDestinationUpdate: true
@@ -2568,10 +2481,6 @@ describe("Mutation.updateBsda", () => {
   ${bsda.destinationOperationNextDestinationCompanySiret}.
 </p>
 `,
-            cc: [
-              { email: "worker@mail.com", name: "Worker" },
-              { email: "next.destination@mail.com", name: "Next Destination" }
-            ],
             messageVersions: [
               { to: [{ email: "emitter@mail.com", name: "Emitter" }] }
             ],

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -128,7 +128,7 @@ export const producerShouldBeNotifiedOfDestinationCapModification = (
   previousBsda: Bsda,
   updatedBsda: Bsda
 ) => {
-  if (![BsdaStatus.INITIAL].includes(updatedBsda.status)) {
+  if ([BsdaStatus.INITIAL].includes(updatedBsda.status)) {
     return false;
   }
 

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -128,13 +128,7 @@ export const producerShouldBeNotifiedOfDestinationCapModification = (
   previousBsda: Bsda,
   updatedBsda: Bsda
 ) => {
-  // On ne notifie que si le bordereau est signé par le producteur
-  // et pas encore pris en charge par le transporteur
-  if (
-    ![BsdaStatus.SIGNED_BY_PRODUCER, BsdaStatus.SIGNED_BY_WORKER].includes(
-      updatedBsda.status
-    )
-  ) {
+  if (![BsdaStatus.INITIAL].includes(updatedBsda.status)) {
     return false;
   }
 
@@ -166,16 +160,12 @@ export const sendDestinationCapModificationMail = async (
   updatedBsda: Bsda
 ) => {
   const emitterSiret = updatedBsda.emitterCompanySiret;
-  const workerSiret = updatedBsda.workerCompanySiret;
-  const destinationSiret =
-    updatedBsda.destinationOperationNextDestinationCompanySiret ??
-    updatedBsda.destinationCompanySiret;
 
-  const companies = await prisma.company.findMany({
+  if (!emitterSiret) return;
+
+  const emitterCompany = await prisma.company.findFirstOrThrow({
     where: {
-      orgId: {
-        in: [emitterSiret, workerSiret, destinationSiret].filter(Boolean)
-      }
+      orgId: emitterSiret
     },
     select: {
       id: true,
@@ -183,13 +173,9 @@ export const sendDestinationCapModificationMail = async (
     }
   });
 
-  const emitterCompany = companies.find(
-    company => company.orgId === emitterSiret
-  );
-
   const companyAssociations = await prisma.companyAssociation.findMany({
     where: {
-      companyId: { in: companies.map(company => company.id) },
+      companyId: emitterCompany.id,
       notificationIsActiveBsdaFinalDestinationUpdate: true
     },
     include: {
@@ -224,13 +210,7 @@ export const sendDestinationCapModificationMail = async (
         updatedBsda.destinationOperationNextDestinationCompanySiret ??
         updatedBsda.destinationCompanySiret
     },
-    messageVersions: [messageVersion],
-    cc: companyAssociations
-      .filter(association => association.companyId !== emitterCompany?.id)
-      .map(association => ({
-        name: association.user.name,
-        email: association.user.email
-      }))
+    messageVersions: [messageVersion]
   });
 
   await sendMail(payload);

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -560,7 +560,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationOperationNextDestinationCap: {
     readableFieldName: "le CAP de l'exutoire",
-    sealed: { from: "OPERATION" },
+    sealed: { from: sealedFromEmissionExceptIfWorker },
     required: {
       from: "EMISSION",
       when: bsda =>

--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -142,17 +142,6 @@ const sealedFromEmissionExceptAddOrRemoveNextDestination: GetBsdaSignatureTypeFn
   return isEmitter ? "WORK" : "EMISSION";
 };
 
-const sealedFromEmissionExceptIfWorker: GetBsdaSignatureTypeFn<ZodBsda> = (
-  bsda,
-  _
-) => {
-  // Si entreprise de travaux: on peut modifier jusqu'à l'étape de transport
-  // Sinon, scellé dès la signature émetteur
-  const hasWorker = bsda?.workerCompanySiret;
-
-  return hasWorker ? "TRANSPORT" : "EMISSION";
-};
-
 /**
  * Renvoie la signature émetteur s'il n'y a pas d'entreprise de travaux sur le BSDA.
  * Sinon, renvoie la signature de l'entreprise de travaux.
@@ -445,7 +434,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationCap: {
     readableFieldName: "le CAP du destinataire",
-    sealed: { from: sealedFromEmissionExceptIfWorker },
+    sealed: { from: "OPERATION" },
     required: {
       from: "EMISSION",
       when: bsda =>
@@ -560,7 +549,7 @@ export const bsdaEditionRules: BsdaEditionRules = {
   },
   destinationOperationNextDestinationCap: {
     readableFieldName: "le CAP de l'exutoire",
-    sealed: { from: sealedFromEmissionExceptIfWorker },
+    sealed: { from: "OPERATION" },
     required: {
       from: "EMISSION",
       when: bsda =>

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -21,9 +21,7 @@ const DestinationCAPModificationAlert = () => (
 const showCAPModificationAlert = bsdaContext => {
   return (
     bsdaContext?.status &&
-    [BsdaStatus.SignedByProducer, BsdaStatus.SignedByWorker].includes(
-      bsdaContext?.status
-    ) &&
+    ![BsdaStatus.Initial].includes(bsdaContext?.status) &&
     Boolean(bsdaContext?.worker?.company?.siret) &&
     Boolean(bsdaContext?.emitter?.company?.siret)
   );

--- a/front/src/form/bsda/stepper/steps/Destination.tsx
+++ b/front/src/form/bsda/stepper/steps/Destination.tsx
@@ -20,8 +20,7 @@ const DestinationCAPModificationAlert = () => (
 
 const showCAPModificationAlert = bsdaContext => {
   return (
-    bsdaContext?.status &&
-    ![BsdaStatus.Initial].includes(bsdaContext?.status) &&
+    bsdaContext?.status !== BsdaStatus.Initial &&
     Boolean(bsdaContext?.worker?.company?.siret) &&
     Boolean(bsdaContext?.emitter?.company?.siret)
   );


### PR DESCRIPTION
# Contexte

Après de nouvelles discussions avec Emmanuel & AS, a été décidé ce qui suit:
- Les champs `destinationCap` & `destinationOperationNextDestinationCap` sont scellés **à partir de la réception par l'exutoire** (on est plus permissif, donc non breaking)
- On envoie un mail en cas de modification **uniquement au producteur** (on ne met plus l'entreprise de travaux ni l'exutoire en copie)

# Ticket Favro

[Sceller le champ destinationCap à la signature émetteur, sauf si présence d'une entreprise de travaux auquel cas il sera scellé à la signature transporteur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15342)
