### PR TITLE
[TRA-14910] Traduction des intitulés des packagings des DASRI dans le PDF

### DIFF
--- a/back/src/bsdasris/pdf/components/PackagingInfosTable.tsx
+++ b/back/src/bsdasris/pdf/components/PackagingInfosTable.tsx
@@ -1,4 +1,14 @@
 import React from "react";
+
+const PACKAGINGS_NAMES = {
+  BOITE_CARTON: "Caisse en carton avec sac en plastique",
+  FUT: "Fûts ou jerrican à usage unique",
+  BOITE_PERFORANTS: "Boîtes et Mini-collecteurs pour déchets perforants",
+  GRAND_EMBALLAGE: "Grand emballage",
+  GRV: "Grand récipient pour vrac",
+  AUTRE: "Autre"
+};
+
 export function PackagingInfosTable({ packagingInfos }) {
   return (
     <table>
@@ -14,7 +24,7 @@ export function PackagingInfosTable({ packagingInfos }) {
         {packagingInfos.map((row, index) => (
           <tr key={index}>
             <td>{row.quantity}</td>
-            <td>{row.type}</td>
+            <td>{PACKAGINGS_NAMES[row.type]}</td>
             <td>{row.volume}</td>
             <td>{row.quantity * row.volume}</td>
           </tr>


### PR DESCRIPTION
# Contexte

Dans le PDF des DASRI, les intitulés des packagings ne sont pas traduits, on affiche directement l'enum.

# Démo

### Avant

![image](https://github.com/user-attachments/assets/59a861dd-1d55-449a-b49b-f7627ce85eb9)

### Après

![image](https://github.com/user-attachments/assets/e51dfed1-c0cc-428b-bb16-e00639679c70)

# Ticket Favro

[PDF DASRI indiquent en emballage la dénomination API « boite_carton » et non « caisse en carton avec sac en plastique » ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-14910)
