### PR TITLE
[TRA-15078] Le champ "Modifié le" des BSDD dans le dashboard affiche la valeur du updatedAt, pas du lastActionOn

### DIFF
--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -234,7 +234,7 @@ export const mapBsdd = (bsdd: Form): BsdDisplay => {
     broker: bsdd.broker,
     trader: bsdd.trader,
     intermediaries: bsdd.intermediaries,
-    updatedAt: bsdd.stateSummary?.lastActionOn,
+    updatedAt: bsdd.updatedAt,
     emittedByEcoOrganisme: bsdd.emittedByEcoOrganisme,
     grouping: bsdd.grouping,
     temporaryStorageDetail: bsdd.temporaryStorageDetail,

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -411,6 +411,7 @@ export const dashboardFormFragment = gql`
     emittedBy
     emittedByEcoOrganisme
     takenOverAt
+    updatedAt
     status
     quantityReceived
     wasteDetails {


### PR DESCRIPTION
# Contexte

On n'affiche pas la bonne valeur dans le champ "Modifié le" des BsdCards pour les BSDD. On affiche `stateSummery.lastActionOn` au lieu de `updatedAt`.

# Démo

![image](https://github.com/user-attachments/assets/5f10d689-3e41-490f-aeba-ee62dc87c8c9)

# Ticket Favro

[Mettre à jour la date de dernière modification lorsque des informations de contact sont mises à jour sur un BSDD - pour affichage antéchronologique sur le tableau de bord](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-15078)
