### PR TITLE
[TRA-15628] Seul l'émetteur peut supprimer un BSVHU s'il l'a signé (SIGNED_BY_PRODUCER)

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1345,10 +1345,11 @@ const canDeleteBsdasri = (bsd, siret) =>
     (isSameSiretEmitter(siret, bsd) &&
       bsd.status === BsdStatusCode.SignedByProducer));
 
-const canDeleteBsvhu = bsd =>
+const canDeleteBsvhu = (bsd, siret) =>
   bsd.type === BsdType.Bsvhu &&
   (bsd.status === BsdStatusCode.Initial ||
-    bsd.status === BsdStatusCode.SignedByProducer);
+    (isSameSiretEmitter(siret, bsd) &&
+      bsd.status === BsdStatusCode.SignedByProducer));
 
 const canDeleteBspaoh = bsd =>
   bsd.type === BsdType.Bspaoh && bsd.status === BsdStatusCode.Initial;
@@ -1403,7 +1404,7 @@ export const canDeleteBsd = (bsd, siret) =>
   canDeleteBsdasri(bsd, siret) ||
   canDeleteBsff(bsd, siret) ||
   canDeleteBspaoh(bsd) ||
-  canDeleteBsvhu(bsd);
+  canDeleteBsvhu(bsd, siret);
 
 const canUpdateBsff = (bsd, siret) =>
   bsd.type === BsdType.Bsff &&


### PR DESCRIPTION
# Contexte

Si l'émetteur a signé le VHU, il doit être le seul à pouvoir le supprimer (on retire cette option pour le transporteur et le destinataire).

# Démo

[Screencast from 2024-12-17 09-42-25.webm](https://github.com/user-attachments/assets/20ddd5f8-58ef-4257-8458-b20bdc28b323)

# Ticket Favro

[Retirer le bouton d'action Supprimer sur un VHU lorsque le statut du bordereau est Signé par l'émetteur pour le transporteur et la destination](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-15628)
