### PR TITLE
[TRA-15597] Plus besoin de préciser de code d'opération prévue pour l'entreposage provisoire pour le BSDD

### DIFF
--- a/front/src/form/bsdd/Recipient.tsx
+++ b/front/src/form/bsdd/Recipient.tsx
@@ -135,7 +135,7 @@ export default function Recipient({ disabled }) {
         </div>
       )}
       {isTempStorage && (
-        <div className="notification tw-mt-2">
+        <div className="notification fr-mt-6v">
           Vous avez sélectionné "Entreposage provisoire ou reconditionnement".
           En cas de doute, et pour éviter une erreur qui serait bloquante pour
           le parcours du déchet, veuillez vérifier avec vos partenaires ce qu'il
@@ -168,15 +168,17 @@ export default function Recipient({ disabled }) {
         disabled={disabled}
       />
       <h4 className="form__section-heading">Informations complémentaires</h4>
-      <div className="form__row">
-        <Field
-          component={ProcessingOperation}
-          name="recipient.processingOperation"
-          enableReuse={isGrouping}
-          disabled={disabled}
-        />
-        <RedErrorMessage name="recipient.processingOperation" />
-      </div>
+      {!isTempStorage && (
+        <div className="form__row">
+          <Field
+            component={ProcessingOperation}
+            name="recipient.processingOperation"
+            enableReuse={isGrouping}
+            disabled={disabled}
+          />
+          <RedErrorMessage name="recipient.processingOperation" />
+        </div>
+      )}
       <div className="form__row">
         <label>
           Numéro de CAP


### PR DESCRIPTION
# Contexte

Lorsqu'on crée un BSDD, on peut préciser un code d'opération prévue pour l'entreposage provisoire, ce qui n'est pas logique. Je retire le champ

# Démo

[Screencast from 2024-12-17 16-31-04.webm](https://github.com/user-attachments/assets/123d0727-b932-47de-931f-c45ef3395f1e)

# Ticket Favro

[Retirer la possibilité de compléter un code de traitement prévu pour l'entreposage provisoire sur le BSDD](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-15597)
