### PR TITLE
[TRA 15626 + TRA 15662] VHU: édition d'intermédiaires & émetteur inscrit sur TD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout de "2795" à la suite de Installation de traitement > Autres traitements de déchets non dangereux (Rubriques 2791, 2781, 2782, 2780) sur le type de profil Installation de traitement. [PR 3845](https://github.com/MTES-MCT/trackdechets/pull/3845)
 - BSFF - Mettre à jour les informations du contenant modifié (code déchet, description, poids) dans l'aperçu et dans le tableau de bord lorsque le BSFF a un seul contenant [PR 3853](https://github.com/MTES-MCT/trackdechets/pull/3853).
 - Permettre d'ajouter un intermédiaire sur le VHU jusqu'au traitement du bordereau [PR 3855](https://github.com/MTES-MCT/trackdechets/pull/3855)
-- Retirer la possibilité de publier un BSVHU si l'émetteur visé n'est pas inscrit sur Trackdéchets et qu'il n'est pas une situation irrégulière [PR 3855](https://github.com/MTES-MCT/trackdechets/pull/3855)
+- Retirer la possibilité de publier un BSVHU si l'émetteur visé n'est pas inscrit sur Trackdéchets et qu'il n'est pas en situation irrégulière [PR 3855](https://github.com/MTES-MCT/trackdechets/pull/3855)
 
 #### :bug: Corrections de bugs
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Ajout de "2795" à la suite de Installation de traitement > Autres traitements de déchets non dangereux (Rubriques 2791, 2781, 2782, 2780) sur le type de profil Installation de traitement. [PR 3845](https://github.com/MTES-MCT/trackdechets/pull/3845)
 - BSFF - Mettre à jour les informations du contenant modifié (code déchet, description, poids) dans l'aperçu et dans le tableau de bord lorsque le BSFF a un seul contenant [PR 3853](https://github.com/MTES-MCT/trackdechets/pull/3853).
+- Permettre d'ajouter un intermédiaire sur le VHU jusqu'au traitement du bordereau [PR 3855](https://github.com/MTES-MCT/trackdechets/pull/3855)
+- Retirer la possibilité de publier un BSVHU si l'émetteur visé n'est pas inscrit sur Trackdéchets et qu'il n'est pas une situation irrégulière [PR 3855](https://github.com/MTES-MCT/trackdechets/pull/3855)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsda/validation/refinements.ts
+++ b/back/src/bsda/validation/refinements.ts
@@ -28,7 +28,7 @@ import { isWorker } from "../../companies/validation";
 import {
   isDestinationRefinement,
   isEcoOrganismeRefinement,
-  isEmitterNotDormantRefinement,
+  isEmitterRefinement,
   isRegisteredVatNumberRefinement,
   isTransporterRefinement,
   refineSiretAndGetCompany
@@ -300,7 +300,7 @@ export const checkCompanies: Refinement<ParsedZodBsda> = async (
     );
   };
 
-  await isEmitterNotDormantRefinement(bsda.emitterCompanySiret, zodContext);
+  await isEmitterRefinement(bsda.emitterCompanySiret, BsdType.BSDA, zodContext);
   await isDestinationRefinement(
     bsda.destinationCompanySiret,
     zodContext,

--- a/back/src/bsffs/validation/bsff/refinements.ts
+++ b/back/src/bsffs/validation/bsff/refinements.ts
@@ -22,6 +22,7 @@ import { getSignatureAncestors } from "./helpers";
 import { isArray } from "../../../common/dataTypes";
 import { capitalize } from "../../../common/strings";
 import {
+  BsdType,
   BsffPackagingType,
   BsffType,
   Prisma,
@@ -32,7 +33,7 @@ import { OPERATION } from "../../constants";
 import type { BsffOperationCode } from "@td/codegen-back";
 import {
   isDestinationRefinement,
-  isEmitterNotDormantRefinement,
+  isEmitterRefinement,
   isRegisteredVatNumberRefinement,
   isTransporterRefinement
 } from "../../../common/validation/zod/refinement";
@@ -55,7 +56,7 @@ export const checkCompanies: Refinement<ParsedZodBsff> = async (
   bsff,
   zodContext
 ) => {
-  await isEmitterNotDormantRefinement(bsff.emitterCompanySiret, zodContext);
+  await isEmitterRefinement(bsff.emitterCompanySiret, BsdType.BSFF, zodContext);
   await isDestinationRefinement(bsff.destinationCompanySiret, zodContext);
 
   for (const transporter of bsff.transporters ?? []) {

--- a/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
@@ -506,7 +506,7 @@ describe("Mutation.Vhu.update", () => {
     const bsvhu = await bsvhuFactory({
       opt: {
         destinationCompanySiret: company.siret,
-        transporterTransportSignatureDate: new Date(),
+        destinationOperationSignatureDate: new Date(),
         intermediaries: {
           create: {
             siret: company.siret!,
@@ -520,8 +520,6 @@ describe("Mutation.Vhu.update", () => {
 
     const { mutate } = makeClient(user);
 
-    // We pass an update with the same value as before.
-    // Even if the field is locked, this should be ignored
     const input = {
       intermediaries: [
         {
@@ -750,7 +748,7 @@ describe("Mutation.Vhu.update", () => {
     ]);
   });
 
-  it("should succed when packaging is UNITE and identificationType is null on a bsvhu created before release date", async () => {
+  it("should succeed when packaging is UNITE and identificationType is null on a bsvhu created before release date", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const bsvhu = await bsvhuFactory({
       userId: user.id,
@@ -784,7 +782,7 @@ describe("Mutation.Vhu.update", () => {
     BsvhuIdentificationType.NUMERO_ORDRE_REGISTRE_POLICE,
     BsvhuIdentificationType.NUMERO_IMMATRICULATION
   ])(
-    "should succed when packaging is UNITE and identificationType is %p",
+    "should succeed when packaging is UNITE and identificationType is %p",
     async identificationType => {
       const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
       const bsvhu = await bsvhuFactory({
@@ -803,12 +801,13 @@ describe("Mutation.Vhu.update", () => {
           type: identificationType
         }
       };
-      const { data } = await mutate<Pick<Mutation, "updateBsvhu">>(
+      const { data, errors } = await mutate<Pick<Mutation, "updateBsvhu">>(
         UPDATE_VHU_FORM,
         {
           variables: { id: bsvhu.id, input }
         }
       );
+      console.log(errors);
 
       expect(data.updateBsvhu.packaging).toEqual("UNITE");
       expect(data.updateBsvhu.identification?.type).toEqual(identificationType);

--- a/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
@@ -801,13 +801,12 @@ describe("Mutation.Vhu.update", () => {
           type: identificationType
         }
       };
-      const { data, errors } = await mutate<Pick<Mutation, "updateBsvhu">>(
+      const { data } = await mutate<Pick<Mutation, "updateBsvhu">>(
         UPDATE_VHU_FORM,
         {
           variables: { id: bsvhu.id, input }
         }
       );
-      console.log(errors);
 
       expect(data.updateBsvhu.packaging).toEqual("UNITE");
       expect(data.updateBsvhu.identification?.type).toEqual(identificationType);

--- a/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
+++ b/back/src/bsvhu/resolvers/queries/__tests__/bsvhumetadata.integration.ts
@@ -139,7 +139,7 @@ describe("Query.Bsvhu", () => {
       variables: { id: bsd.id }
     });
 
-    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(39);
+    expect(data.bsvhu.metadata?.fields?.sealed?.length).toBe(38);
   });
 
   it("should return OPERATION signed bsvhu sealed fields", async () => {

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -86,7 +86,7 @@ type BsvhuEmitter {
   irregularSituation: Boolean!
   "Indique si l'émetteur est un particulier ou une entreprise sans SIRET"
   noSiret: Boolean!
-  "Coordonnées de l'entreprise émétrice"
+  "Coordonnées de l'entreprise émettrice"
   company: FormCompany
   "Déclaration générale de l'émetteur du bordereau"
   emission: BsvhuEmission

--- a/back/src/bsvhu/validation/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/validation/__tests__/validation.integration.ts
@@ -1224,7 +1224,8 @@ describe("BSVHU validation", () => {
         {
           ...bsvhu,
           emitterEmissionSignatureDate: new Date(),
-          transporterTransportSignatureDate: new Date()
+          transporterTransportSignatureDate: new Date(),
+          destinationOperationSignatureDate: new Date()
         },
         {
           ...context

--- a/back/src/bsvhu/validation/index.ts
+++ b/back/src/bsvhu/validation/index.ts
@@ -35,6 +35,35 @@ export async function mergeInputAndParseBsvhuAsync(
     ...zodInput
   };
 
+  // keep address fields coherent while we have both address and street/city/postalCode
+  // if the address changes, and the street/city/postalCode is not in input, clean it
+  // if street/city/postalCode changes, cleanup address field.
+  if (
+    zodInput.emitterCompanyAddress !== undefined &&
+    zodInput.emitterCompanyAddress !== zodPersisted.emitterCompanyAddress
+  ) {
+    if (!zodInput.emitterCompanyStreet) {
+      bsvhu.emitterCompanyStreet = null;
+    }
+    if (!zodInput.emitterCompanyCity) {
+      bsvhu.emitterCompanyCity = null;
+    }
+    if (!zodInput.emitterCompanyPostalCode) {
+      bsvhu.emitterCompanyPostalCode = null;
+    }
+  } else if (
+    ((zodInput.emitterCompanyStreet !== undefined &&
+      zodInput.emitterCompanyStreet !== zodPersisted.emitterCompanyStreet) ||
+      (zodInput.emitterCompanyCity !== undefined &&
+        zodInput.emitterCompanyCity !== zodPersisted.emitterCompanyCity) ||
+      (zodInput.emitterCompanyPostalCode !== undefined &&
+        zodInput.emitterCompanyPostalCode !==
+          zodPersisted.emitterCompanyPostalCode)) &&
+    !zodInput.emitterCompanyAddress
+  ) {
+    bsvhu.emitterCompanyAddress = null;
+  }
+
   // Calcule la signature courante à partir des données si elle n'est
   // pas fourni via le contexte
   const currentSignatureType =

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -21,7 +21,7 @@ import {
   isBrokerRefinement,
   isDestinationRefinement,
   isEcoOrganismeRefinement,
-  isEmitterNotDormantRefinement,
+  isEmitterRefinement,
   isRegisteredVatNumberRefinement,
   isTraderRefinement,
   isTransporterRefinement
@@ -43,7 +43,12 @@ export const checkCompanies: Refinement<ParsedZodBsvhu> = async (
   bsvhu,
   zodContext
 ) => {
-  await isEmitterNotDormantRefinement(bsvhu.emitterCompanySiret, zodContext);
+  await isEmitterRefinement(
+    bsvhu.emitterCompanySiret,
+    BsdType.BSVHU,
+    zodContext,
+    !!bsvhu.emitterIrregularSituation
+  );
   await isDestinationRefinement(
     bsvhu.destinationCompanySiret,
     zodContext,

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -701,7 +701,7 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
   },
   intermediaries: {
     readableFieldName: "les intermédiaires",
-    sealed: { from: "TRANSPORT" },
+    sealed: { from: "OPERATION" },
     path: ["intermediaries"]
   }
 };

--- a/back/src/common/validation/intermediaries.ts
+++ b/back/src/common/validation/intermediaries.ts
@@ -37,6 +37,7 @@ export function intermediariesRefinement(
   if (intermediaries.length > 3) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["intermediaries"],
       message: "Intermédiaires: impossible d'ajouter plus de 3 intermédiaires",
       fatal: true
     });
@@ -46,11 +47,20 @@ export function intermediariesRefinement(
   const intermediaryIdentifiers = intermediaries.map(
     c => c.siret || c.vatNumber
   );
+  if (intermediaryIdentifiers.some(orgId => !orgId)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["intermediaries"],
+      message: "Intermédiaires: Un SIRET ou numéro de TVA est obligatoire",
+      fatal: true
+    });
+  }
   const hasDuplicate =
     new Set(intermediaryIdentifiers).size !== intermediaryIdentifiers.length;
   if (hasDuplicate) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
+      path: ["intermediaries"],
       message:
         "Intermédiaires: impossible d'ajouter le même établissement en intermédiaire plusieurs fois",
       fatal: true

--- a/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
@@ -38,16 +38,34 @@ import {
 import OtherActors from "./steps/OtherActors";
 
 const vhuToInput = (vhu: ZodBsvhu): BsvhuInput => {
-  return omitDeep(vhu, [
+  const addressCleanup: string[] = [];
+  // the emitter company object (FormCompany) doesn't support street/city/postalCode
+  // so on updates, even if the address hasn't changed, those fields will be null.
+  // in order to avoid erasing the street/city/postalCode fields on updates, we remove them
+  // from the input.
+  if (vhu.emitter.company.address) {
+    if (!vhu.emitter.company.street) {
+      addressCleanup.push("emitter.company.street");
+    }
+    if (!vhu.emitter.company.city) {
+      addressCleanup.push("emitter.company.city");
+    }
+    if (!vhu.emitter.company.postalCode) {
+      addressCleanup.push("emitter.company.postalCode");
+    }
+  }
+  const omitted = omitDeep(vhu, [
     "isDraft",
     "ecoOrganisme.hasEcoOrganisme",
     "hasTrader",
-    ...(!vhu.hasTrader ? ["trader"] : []),
     "hasBroker",
-    ...(!vhu.hasBroker ? ["broker"] : []),
     "hasIntermediaries",
-    ...(!vhu.hasIntermediaries ? ["intermediaries"] : [])
+    ...addressCleanup
   ]);
+  if (!vhu.hasIntermediaries) {
+    omitted.intermediaries = [];
+  }
+  return omitted;
 };
 interface Props {
   bsdId?: string;

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -120,8 +120,8 @@ const EmitterBsvhu = ({ errors }) => {
   const selectedCompanyError = (company?: CompanySearchResult) => {
     // L'émetteur est en situation irrégulière mais il a un SIRET et n'est pas inscrit sur Trackdéchets
     if (company) {
-      if (!company.isRegistered) {
-        return "L'entreprise n'est pas inscrite sur Trackdéchets, la signature Producteur ne pourra pas se faire. Vous pouvez publier le bordereau, mais seul le transporteur pourra le signer.";
+      if (!emitter.irregularSituation && !company.isRegistered) {
+        return "Cet établissement n'est pas inscrit sur Trackdéchets. Il ne peut être visé comme émetteur sur ce bordereau, sauf s'il s'agit d'une installation en situation irrégulière. Dans ce cas, veuillez cocher la case correspondante ci-dessus.";
       } else if (formState.errors?.emitter?.["company"]?.siret?.message) {
         return formState.errors?.emitter?.["company"]?.siret?.message;
       }
@@ -245,7 +245,7 @@ const EmitterBsvhu = ({ errors }) => {
                   placeholder="Rechercher"
                   onAddressSelection={details => {
                     // `address` is passed as `name` because of adresse api return fields
-                    setValue(`emitter.company.address`, details.name);
+                    setValue(`emitter.company.address`, details.label);
                     setValue(`emitter.company.city`, details.city);
                     setValue(`emitter.company.street`, details.name);
                     setValue(`emitter.company.postalCode`, details.postcode);

--- a/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
+++ b/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
@@ -6,6 +6,58 @@ import styles from "./WorkSiteAddress.module.scss";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { API_MIN_CHARS } from "../../constants";
 
+export type GeoJsonProperties = {
+  label: string;
+  score: number;
+  housenumber: string;
+  id: string;
+  type: string;
+  name: string;
+  postcode: string;
+  citycode: string;
+  x: number;
+  y: number;
+  city: string;
+  context: string;
+  importance: number;
+  street: string;
+};
+
+type Feature = {
+  type: "Feature";
+  properties: GeoJsonProperties;
+};
+
+type State = {
+  selectedAdress: string;
+  searchInput: string;
+  searchResults: Array<Feature>;
+  address: string | null | undefined;
+  postalCode: string | null | undefined;
+  city: string | null | undefined;
+};
+
+type Action =
+  | {
+      type: "search_input";
+      payload: string;
+    }
+  | {
+      type: "search_done";
+      payload: Array<Feature>;
+    }
+  | {
+      type: "set_fields";
+      payload: {
+        address: string | null | undefined;
+        postalCode: string | null | undefined;
+        city: string | null | undefined;
+      };
+    }
+  | {
+      type: "select_address";
+      payload: string;
+    };
 function init({ address, city, postalCode }) {
   const selectedAdress = [address, postalCode, city].filter(Boolean).join(" ");
   return {
@@ -18,7 +70,7 @@ function init({ address, city, postalCode }) {
   };
 }
 
-function reducer(state, action) {
+function reducer(state: State, action: Action) {
   switch (action.type) {
     case "search_input":
       return { ...state, searchInput: action.payload ?? [] };
@@ -46,6 +98,19 @@ export default function DsfrfWorkSiteAddress({
   designation,
   disabled = false,
   placeholder = "Recherchez une adresse puis sélectionnez un des choix qui apparait..."
+}: {
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  designation?: string;
+  disabled?: boolean;
+  placeholder?: string;
+  onAddressSelection: (selectedAddress: {
+    name: string | null | undefined;
+    city: string | null | undefined;
+    postcode: string | null | undefined;
+    label: string;
+  }) => void;
 }) {
   const [state, dispatch] = useReducer(
     reducer,
@@ -85,7 +150,11 @@ export default function DsfrfWorkSiteAddress({
       payload: feature.properties.label
     });
   }
-  function setManualAddress(payload) {
+  function setManualAddress(payload: {
+    address: string | null | undefined;
+    city: string | null | undefined;
+    postalCode: string | null | undefined;
+  }) {
     const { city, address, postalCode } = payload;
 
     dispatch({
@@ -95,6 +164,9 @@ export default function DsfrfWorkSiteAddress({
 
     // beware postCode/postalCode & name/address (former fields returned by address api)
     onAddressSelection({
+      label: [address ?? "", postalCode ?? "", city ?? ""]
+        .filter(Boolean)
+        .join(" "),
       city: city,
       name: address,
       postcode: postalCode

--- a/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
+++ b/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
@@ -99,9 +99,9 @@ export default function DsfrfWorkSiteAddress({
   disabled = false,
   placeholder = "Recherchez une adresse puis sélectionnez un des choix qui apparait..."
 }: {
-  address?: string;
-  city?: string;
-  postalCode?: string;
+  address?: string | null;
+  city?: string | null;
+  postalCode?: string | null;
   designation?: string;
   disabled?: boolean;
   placeholder?: string;
@@ -204,7 +204,7 @@ export default function DsfrfWorkSiteAddress({
             <Input
               label="N° et libellé de voie ou lieu-dit"
               nativeInputProps={{
-                defaultValue: address,
+                defaultValue: address ?? undefined,
                 onChange: e =>
                   setManualAddress({
                     city: state.city,
@@ -219,7 +219,7 @@ export default function DsfrfWorkSiteAddress({
               <Input
                 label="Code postal"
                 nativeInputProps={{
-                  defaultValue: postalCode,
+                  defaultValue: postalCode ?? undefined,
                   onChange: e =>
                     setManualAddress({
                       address: state.address,
@@ -233,7 +233,7 @@ export default function DsfrfWorkSiteAddress({
               <Input
                 label="Ville"
                 nativeInputProps={{
-                  defaultValue: city,
+                  defaultValue: city ?? undefined,
                   onChange: e =>
                     setManualAddress({
                       address: state.address,


### PR DESCRIPTION
# Contexte

Cette PR couvre 2 tickets + une variété de bug fixes rencontrés sur le chemin.

## Permettre d'ajouter un intermédiaire sur le VHU jusqu'au traitement du bordereau

Les règles de validation empêchaient la mise à jour des intermédiaires après la signature transporteur, j'ai donc modifié la règle correspondante. Il s'agit de ce changement :

<img width="715" alt="Capture d’écran 2024-12-19 à 21 03 33" src="https://github.com/user-attachments/assets/2216f29b-9af8-4589-a6b9-51d625a936a8" />

Cependant, ce changement m'a amené à devoir régler plusieurs problèmes.

### Mismatch d'adresses à l'update

Lors de la mise à jour d'intermédiaire sur un bordereau dont l'émetteur est un particulier (dont on a rentré l'adresse manuellement dans la partie émetteur) l'update était rejeté au motif que l'adresse ne pouvait pas être modifié après la signature émetteur.

Le problème venait du fait que lors de la création du bordereau, le champ d'adresse envoyait une adresse sous cette forme:

```
emitterCompanyAddress: 82 rue des Mirabelles <-- là déjà il y a un soucis, ça devrait être l'adresse complète
emitterCompanyStreet: 82 rue des Mirabelles
emitterCompanyCity: Paris
emitterCompanyPostalCode: 75000
```

Par contre, lors d'un update, l'adresse envoyée était de la forme:
```
emitterCompanyAddress: 82 rue des Mirabelles
emitterCompanyStreet: null
emitterCompanyCity: null
emitterCompanyPostalCode: null
```

Cela est dû au fait que le bordereau envoyé par la back a un emitter de type FormCompany, qui ne contient pas street/city/postalCode, seulement le champ address. Puisque l'on ne repasse pas par le champ d'adresse, qui complète les champs street/city/postalCode, ces champs sont renvoyés vides à la back.
Il y a donc 2 problèmes:
- le champ address devraient contenir toute l'adresse en sortie du sélecteur d'adresse
- la front ne devrait pas renvoyer null dans les champs street/city/postalCode si il y a une adresse mais que ces champs sont vides

Le fix du champ addresse est celui là :
<img width="491" alt="Capture d’écran 2024-12-19 à 21 21 17" src="https://github.com/user-attachments/assets/8f9e7f02-cb78-4581-845f-0fa750da2f83" />

Le reste des changements dans le composant `DsfrfWorkSiteAddress` est de l'ajout de typage parce que ça m'a stressé de pas avoir de typage 😅

Le fix pour ne pas envoyer les champs vides est celui là :
<img width="473" alt="Capture d’écran 2024-12-19 à 21 32 26" src="https://github.com/user-attachments/assets/5fb04d9d-2b72-445b-a77c-5689206abe63" />

Ca m'a amené à me poser la question de la cohérence entre le champ address et street/city/postalCode. Les 2 doivent cohabiter pour des raison de compatibilité avec les sélecteurs d'entreprise, le modèle gql FormCompany, etc. Mais ils doivent normalement contenir la même info.

L'objectif d'ajouter les champs street/city/postalCode étant de s'éviter les problèmes de parsing d'un champ d'adresse, je ne vais pas rajouter un parsing de l'adresse pour vérifier que ça correspond aux champs. Donc techniquement il reste possible de ne pas envoyer les mêmes infos. Cependant, j'ai quand même rajouter en back un "filtre" qui fait que si on écrit une nouvelle adresse dans address, les autres champ sont supprimés, et si on écrit de nouvelles infos dans street/city/postalCode, on supprime le champ address.

Ce fix est fait dans mergeInputAndParseBsvhuAsync` (un peu long donc je ne le colle pas ici).

### Impossibilité de retirer un intermédiaire

En faisant les tests pour ajouter un intermédiaire après la signature transporteur, j'ai réalisé qu'il était impossible de supprimer un intermédiaire/broker/trader en décochant le toggle correspondant. Celà était dû au fait que si les toggle étaient décochés, les infos broker/trader/intermédaire étaient juste supprimées de l'input envoyé à la back, donc considérés comme non modifiés.

Le fix pour ça consiste simplement à ne plus ignorer les champs en cas de toggle décoché, mais de bien renvoyer une aray vide pour les intermédiaires plutôt qu'une array contenant un intermédiaire vide, ce qui n'a pas de sens (voir point suivant)
<img width="858" alt="Capture d’écran 2024-12-19 à 21 39 23" src="https://github.com/user-attachments/assets/2d622fa9-ba09-4932-b418-efae708c1942" />

### Ne pas accepter d'intermédiaires sans siret

Après discussion avec @Riron du problème précédent, il a été choisi de ne pas accepter un intermédiaire vide. J'ai donc ajouté une petite vérification dans un refinement :
<img width="537" alt="Capture d’écran 2024-12-19 à 21 47 34" src="https://github.com/user-attachments/assets/7857b052-5cac-494b-b59b-20bdf6d006d0" />


## Retirer la possibilité de publier un BSVHU si l'émetteur visé n'est pas inscrit sur Trackdéchets et qu'il n'est pas une situation irrégulière

Pour ça, j'ai simplement modifié la fonction de refinement d'emitter qui checkait si l'établissement est dormant, et rajouté pour le VHU une récupération de la Company qui fail si elle n'existe pas. J'ai choisi de reprendre le refinement existant et de l'étendre car il est évoqué le fait d'étendre le blocage d'émetteur non inscrits à d'autres bordereaux à l'avenir. De ce fait, il suffira d'ajouter le type de bordereau dans la condition et ce sera bon.
<img width="1056" alt="Capture d’écran 2024-12-19 à 21 44 01" src="https://github.com/user-attachments/assets/840630cf-0aa6-4152-b38e-2f00eca2a8c3" />

J'ai donc dû remplacer la fonction là où elle était utilisée (BSDA, BSFF).

J'ai aussi modifié l'erreur affichée selon la demande du ticket.


# Points de vigilance pour les intégrateurs

A priori aucun

# Démo

## Ajout d'intermédiaire
https://github.com/user-attachments/assets/d2525f33-1bd8-46c0-929e-7f789d3bd2e4

## Émetteur non inscrit
https://github.com/user-attachments/assets/521c34d5-a381-4bbc-a868-f02b89cafff5


# Ticket Favro

[TRA 15626 - Permettre d'ajouter un intermédiaire sur le VHU jusqu'au traitement du bordereau](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15626)

[TRA 15662 - Retirer la possibilité de publier un BSVHU si l'émetteur visé n'est pas inscrit sur Trackdéchets et qu'il n'est pas une situation irrégulière](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15662)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB