### PR TITLE
[tra-15635]Lorsque je coche L'installation n'a pas de numéro SIRET après avoir renseigné un SIRET, l'établissement sélectionné (Company Selector) ainsi que ses informations de contact devraient se vider

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -127,6 +127,13 @@ const EmitterBsvhu = ({ errors }) => {
     return null;
   };
 
+  const onNoSiretClick = () => {
+    if (!!emitter.company) {
+      setValue("emitter.company", {});
+      setValue("emitter.agrementNumber", null);
+    }
+  };
+
   return (
     <>
       {!!sealedFields.length && <DisabledParagraphStep />}
@@ -228,7 +235,8 @@ const EmitterBsvhu = ({ errors }) => {
                 {
                   label: "L'installation n'a pas de numéro SIRET",
                   nativeInputProps: {
-                    ...register("emitter.noSiret")
+                    ...register("emitter.noSiret"),
+                    onClick: onNoSiretClick
                   }
                 }
               ]}
@@ -239,9 +247,9 @@ const EmitterBsvhu = ({ errors }) => {
               <>
                 <DsfrfWorkSiteAddress
                   designation="du site d'enlèvement"
-                  address={emitter.company.address}
-                  postalCode={emitter.company.postalCode}
-                  city={emitter.company.city}
+                  address={emitter.company?.address}
+                  postalCode={emitter.company?.postalCode}
+                  city={emitter.company?.city}
                   placeholder="Rechercher"
                   onAddressSelection={details => {
                     // `address` is passed as `name` because of adresse api return fields


### PR DESCRIPTION
# Contexte

Lorsque je coche L'installation n'a pas de numéro SIRET après avoir renseigné un SIRET, l'établissement sélectionné (Company Selector) ainsi que ses informations de contact devraient se vider

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/d1673a69-8067-46f7-9b5c-55dea768fb33



# Ticket Favro

[tra-15635](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15635)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB