### PR TITLE
[tra-15656]Retirer l'affichage du Conditionnement sur l'Aperçu d'un VHU pour ne pas faire doublon avec Critères d'identification

### DIFF
--- a/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
+++ b/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
@@ -300,7 +300,7 @@ const getIdentificationTypeLabel = (bsvhu: Bsvhu) => {
 };
 
 function Emitter({ form }: { form: Bsvhu }) {
-  const { emitter, quantity, packaging, identification, weight } = form;
+  const { emitter, quantity, identification, weight } = form;
   return (
     <div className={styles.detailColumns}>
       <div className={styles.detailGrid}>
@@ -319,11 +319,6 @@ function Emitter({ form }: { form: Bsvhu }) {
           value={identification?.numbers?.join(", ")}
           label="Identifications"
         />
-        <DetailRow
-          value={packaging ? PACKAGING_LABELS[packaging] : null}
-          label="Conditionnement"
-        />
-
         <DetailRow value={quantity} label="Quantité" />
         <DetailRow value={weight?.value} label="Poids" units="tonnes" />
       </div>


### PR DESCRIPTION
# Contexte

Retirer l'affichage du Conditionnement sur l'Aperçu d'un VHU pour ne pas faire doublon avec Critères d'identification

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<img width="1179" alt="Screenshot 2024-12-20 at 11 41 02" src="https://github.com/user-attachments/assets/d546aab8-c39e-4bec-9d5e-6e683969b360" />


# Ticket Favro

[tra-15656](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15656)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB