### PR TITLE
[TRA-15665] Cas particuliers pour le mail sur le changement de CAP: ajout ou suppression de la nextDestination

### DIFF
--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -2268,6 +2268,10 @@ describe("Mutation.updateBsda", () => {
       destinationOperationNextDestinationCap: "A"
     } as Bsda;
 
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
     describe("producerShouldBeNotifiedOfDestinationCapModification", () => {
       it.each([
         // Status pas bon
@@ -2488,6 +2492,376 @@ describe("Mutation.updateBsda", () => {
           })
         );
       });
+    });
+
+    it("[bug prod] if user updates the BSDA by adding a nextDestination - should not send mail", async () => {
+      // Given
+      const emitter = await companyFactory();
+      const worker = await companyFactory();
+      const destination = await companyFactory();
+      const ttr = await companyFactory();
+      const transporter = await companyFactory();
+
+      const user = await userInCompany(
+        "MEMBER",
+        emitter.id,
+        {
+          email: "emitter@mail.com",
+          name: "Emitter"
+        },
+        {
+          notificationIsActiveBsdaFinalDestinationUpdate: true
+        }
+      );
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          destinationCap: "DESTINATION-CAP",
+          // Companies
+          emitterCompanySiret: emitter.siret,
+          emitterCompanyName: emitter.name,
+          workerCompanySiret: worker.siret,
+          workerCompanyName: worker.name,
+          destinationCompanySiret: destination.siret,
+          destinationCompanyName: destination.name
+          // No next destination
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterCompanyName: transporter.name
+        }
+      });
+
+      // No mails
+      const { sendMail } = require("../../../../mailer/mailing");
+      jest.mock("../../../../mailer/mailing");
+      (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "updateBsda">,
+        MutationUpdateBsdaArgs
+      >(UPDATE_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            destination: {
+              cap: "TTR-CAP",
+              company: {
+                siret: ttr.siret
+              },
+              operation: {
+                // User adds a next destination!
+                nextDestination: {
+                  cap: "DESTINATION-CAP",
+                  company: {
+                    siret: destination.siret
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+      expect(sendMail as jest.Mock).toHaveBeenCalledTimes(0);
+    });
+
+    it("[bug prod] if user updates the BSDA by adding a nextDestination, and modifies the destination CAP - should not send mail", async () => {
+      // Given
+      const emitter = await companyFactory();
+      const worker = await companyFactory();
+      const destination = await companyFactory();
+      const ttr = await companyFactory();
+      const transporter = await companyFactory();
+
+      const user = await userInCompany(
+        "MEMBER",
+        emitter.id,
+        {
+          email: "emitter@mail.com",
+          name: "Emitter"
+        },
+        {
+          notificationIsActiveBsdaFinalDestinationUpdate: true
+        }
+      );
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          destinationCap: "DESTINATION-CAP",
+          // Companies
+          emitterCompanySiret: emitter.siret,
+          emitterCompanyName: emitter.name,
+          workerCompanySiret: worker.siret,
+          workerCompanyName: worker.name,
+          destinationCompanySiret: destination.siret,
+          destinationCompanyName: destination.name
+          // No next destination
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterCompanyName: transporter.name
+        }
+      });
+
+      // No mails
+      const { sendMail } = require("../../../../mailer/mailing");
+      jest.mock("../../../../mailer/mailing");
+      (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "updateBsda">,
+        MutationUpdateBsdaArgs
+      >(UPDATE_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            destination: {
+              cap: "TTR-CAP",
+              company: {
+                siret: ttr.siret,
+                name: ttr.name
+              },
+              operation: {
+                // User adds a next destination AND modifies the CAP!
+                nextDestination: {
+                  cap: "NEW-DESTINATION-CAP",
+                  company: {
+                    siret: destination.siret,
+                    name: destination.name
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Then
+      const updatedBsda = await prisma.bsda.findFirstOrThrow({
+        where: { id: bsda.id }
+      });
+      expect(errors).toBeUndefined();
+      expect(sendMail as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(sendMail as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: `<p>
+  Trackdéchets vous informe qu'une modification a été apportée sur le bordereau
+  amiante n° ${updatedBsda.id} que vous avez signé.
+</p>
+<br />
+<p>
+  Le champ CAP initialement DESTINATION-CAP est désormais remplacé par
+  NEW-DESTINATION-CAP.
+</p>
+<br />
+<p>
+  En cas de désaccord ou de question, il convient de vous rapprocher de
+  l'entreprise de travaux amiante ${updatedBsda.workerCompanyName}
+  ${updatedBsda.workerCompanySiret} mandatée et visée sur ce même bordereau, ou de
+  l'établissement de destination finale ${updatedBsda.destinationOperationNextDestinationCompanyName}
+  ${updatedBsda.destinationOperationNextDestinationCompanySiret}.
+</p>
+`,
+          messageVersions: [
+            { to: [{ email: "emitter@mail.com", name: "Emitter" }] }
+          ],
+          subject: `CAP du bordereau amiante n° ${updatedBsda.id} mis à jour par NEW-DESTINATION-CAP`
+        })
+      );
+    });
+
+    it("[bug prod] if user updates the BSDA by removing a nextDestination - should not send mail", async () => {
+      // Given
+      const emitter = await companyFactory();
+      const worker = await companyFactory();
+      const destination = await companyFactory();
+      const ttr = await companyFactory();
+      const transporter = await companyFactory();
+
+      const user = await userInCompany(
+        "MEMBER",
+        emitter.id,
+        {
+          email: "emitter@mail.com",
+          name: "Emitter"
+        },
+        {
+          notificationIsActiveBsdaFinalDestinationUpdate: true
+        }
+      );
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          // Companies
+          emitterCompanySiret: emitter.siret,
+          emitterCompanyName: emitter.name,
+          workerCompanySiret: worker.siret,
+          workerCompanyName: worker.name,
+          destinationCompanySiret: ttr.siret,
+          destinationCompanyName: ttr.name,
+          destinationCap: "TTR-CAP",
+          destinationOperationNextDestinationCompanySiret: destination.siret,
+          destinationOperationNextDestinationCompanyName: destination.name,
+          destinationOperationNextDestinationCap: "DESTINATION-CAP"
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterCompanyName: transporter.name
+        }
+      });
+
+      // No mails
+      const { sendMail } = require("../../../../mailer/mailing");
+      jest.mock("../../../../mailer/mailing");
+      (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "updateBsda">,
+        MutationUpdateBsdaArgs
+      >(UPDATE_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            destination: {
+              cap: "DESTINATION-CAP",
+              company: {
+                siret: destination.siret,
+                name: destination.name
+              },
+              operation: {
+                // User removes the next destination
+                nextDestination: {
+                  cap: null,
+                  company: null
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+      expect(sendMail as jest.Mock).toHaveBeenCalledTimes(0);
+    });
+
+    it("[bug prod] if user updates the BSDA by removing the nextDestination, and modifies the destination CAP - should not send mail", async () => {
+      // Given
+      const emitter = await companyFactory();
+      const worker = await companyFactory();
+      const destination = await companyFactory();
+      const ttr = await companyFactory();
+      const transporter = await companyFactory();
+
+      const user = await userInCompany(
+        "MEMBER",
+        emitter.id,
+        {
+          email: "emitter@mail.com",
+          name: "Emitter"
+        },
+        {
+          notificationIsActiveBsdaFinalDestinationUpdate: true
+        }
+      );
+
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "SIGNED_BY_PRODUCER",
+          // Companies
+          emitterCompanySiret: emitter.siret,
+          emitterCompanyName: emitter.name,
+          workerCompanySiret: worker.siret,
+          workerCompanyName: worker.name,
+          destinationCompanySiret: ttr.siret,
+          destinationCompanyName: ttr.name,
+          destinationCap: "TTR-CAP",
+          destinationOperationNextDestinationCompanySiret: destination.siret,
+          destinationOperationNextDestinationCompanyName: destination.name,
+          destinationOperationNextDestinationCap: "DESTINATION-CAP"
+        },
+        transporterOpt: {
+          transporterCompanySiret: transporter.siret,
+          transporterCompanyName: transporter.name
+        }
+      });
+
+      // No mails
+      const { sendMail } = require("../../../../mailer/mailing");
+      jest.mock("../../../../mailer/mailing");
+      (sendMail as jest.Mock).mockImplementation(() => Promise.resolve());
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "updateBsda">,
+        MutationUpdateBsdaArgs
+      >(UPDATE_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            destination: {
+              cap: "NEW-DESTINATION-CAP",
+              company: {
+                siret: destination.siret,
+                name: destination.name
+              },
+              operation: {
+                // User removes the next destination
+                nextDestination: {
+                  cap: null,
+                  company: null
+                }
+              }
+            }
+          }
+        }
+      });
+
+      // Then
+      const updatedBsda = await prisma.bsda.findFirstOrThrow({
+        where: { id: bsda.id }
+      });
+      expect(errors).toBeUndefined();
+      expect(sendMail as jest.Mock).toHaveBeenCalledTimes(1);
+      expect(sendMail as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: `<p>
+  Trackdéchets vous informe qu'une modification a été apportée sur le bordereau
+  amiante n° ${updatedBsda.id} que vous avez signé.
+</p>
+<br />
+<p>
+  Le champ CAP initialement DESTINATION-CAP est désormais remplacé par
+  NEW-DESTINATION-CAP.
+</p>
+<br />
+<p>
+  En cas de désaccord ou de question, il convient de vous rapprocher de
+  l'entreprise de travaux amiante ${updatedBsda.workerCompanyName}
+  ${updatedBsda.workerCompanySiret} mandatée et visée sur ce même bordereau, ou de
+  l'établissement de destination finale ${updatedBsda.destinationCompanyName}
+  ${updatedBsda.destinationCompanySiret}.
+</p>
+`,
+          messageVersions: [
+            { to: [{ email: "emitter@mail.com", name: "Emitter" }] }
+          ],
+          subject: `CAP du bordereau amiante n° ${updatedBsda.id} mis à jour par NEW-DESTINATION-CAP`
+        })
+      );
     });
   });
 });

--- a/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/update.integration.ts
@@ -2494,7 +2494,7 @@ describe("Mutation.updateBsda", () => {
       });
     });
 
-    it("[bug prod] if user updates the BSDA by adding a nextDestination - should not send mail", async () => {
+    it("[bug prod] if user updates the BSDA by adding a nextDestination but does not modify the CAP - should not send mail", async () => {
       // Given
       const emitter = await companyFactory();
       const worker = await companyFactory();
@@ -2571,7 +2571,7 @@ describe("Mutation.updateBsda", () => {
       expect(sendMail as jest.Mock).toHaveBeenCalledTimes(0);
     });
 
-    it("[bug prod] if user updates the BSDA by adding a nextDestination, and modifies the destination CAP - should not send mail", async () => {
+    it("[bug prod] if user updates the BSDA by adding a nextDestination, and modifies the destination CAP - should send mail", async () => {
       // Given
       const emitter = await companyFactory();
       const worker = await companyFactory();
@@ -2679,7 +2679,7 @@ describe("Mutation.updateBsda", () => {
       );
     });
 
-    it("[bug prod] if user updates the BSDA by removing a nextDestination - should not send mail", async () => {
+    it("[bug prod] if user updates the BSDA by removing a nextDestination, but does not change the CAP - should not send mail", async () => {
       // Given
       const emitter = await companyFactory();
       const worker = await companyFactory();
@@ -2757,7 +2757,7 @@ describe("Mutation.updateBsda", () => {
       expect(sendMail as jest.Mock).toHaveBeenCalledTimes(0);
     });
 
-    it("[bug prod] if user updates the BSDA by removing the nextDestination, and modifies the destination CAP - should not send mail", async () => {
+    it("[bug prod] if user updates the BSDA by removing the nextDestination, and modifies the destination CAP - should send mail", async () => {
       // Given
       const emitter = await companyFactory();
       const worker = await companyFactory();

--- a/back/src/bsda/resolvers/mutations/update.ts
+++ b/back/src/bsda/resolvers/mutations/update.ts
@@ -142,6 +142,28 @@ export const producerShouldBeNotifiedOfDestinationCapModification = (
     return false;
   }
 
+  // User is adding a nextDestination. Careful, compare correct fields
+  if (
+    !previousBsda.destinationOperationNextDestinationCompanySiret &&
+    updatedBsda.destinationOperationNextDestinationCompanySiret
+  ) {
+    return (
+      previousBsda.destinationCap !==
+      updatedBsda.destinationOperationNextDestinationCap
+    );
+  }
+
+  // User is removing the nextDestination. Careful, compare correct fields
+  if (
+    previousBsda.destinationOperationNextDestinationCompanySiret &&
+    !updatedBsda.destinationOperationNextDestinationCompanySiret
+  ) {
+    return (
+      previousBsda.destinationOperationNextDestinationCap !==
+      updatedBsda.destinationCap
+    );
+  }
+
   // Pas de TTR
   if (!updatedBsda.destinationOperationNextDestinationCompanySiret) {
     return previousBsda.destinationCap !== updatedBsda.destinationCap;


### PR DESCRIPTION
# Contexte

(bug remonté en prod)

Cette PR vient apporter un correctif à [celle-ci](https://github.com/MTES-MCT/trackdechets/pull/3780).

J'avais oublié de traiter 2 cas particuliers dans la mutation d'update:
- Si l'utilisateur **ajoute** une nextDestination
- Si l'utilisateur **supprime** la nextDestination

Dans les deux cas:
- S'il ne modifie pas le CAP de l'exutoire, pas de mail
- S'il modifie **aussi** le CAP de l'exutoire, on envoie un mail

# Démo

### Exemple: l'utilisateur ajoute un entreposage provisoire ET change le CAP

[Screencast from 2024-12-20 16-37-45.webm](https://github.com/user-attachments/assets/90961078-0fdb-43dd-9c7f-cf2aa76ba9e8)

# Ticket Favro

[Ne pas alerter le producteur que le CAP du TTR a été modifié (uniquement celui de l'exutoire)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15665)
