### PR TITLE
TRA-15666 - Impossible de charger la liste des BSD à regrouper lors de la création/modification d'un BSDD

### DIFF
--- a/back/src/forms/resolvers/queries/appendixForms.ts
+++ b/back/src/forms/resolvers/queries/appendixForms.ts
@@ -28,6 +28,7 @@ const appendixFormsResolver: QueryResolvers["appendixForms"] = async (
       isDeleted: false,
       readableId: { not: { endsWith: "-suite" } }
     },
+    orderBy: { processedAt: "desc" },
     include: expandableFormIncludes
   });
 

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Form,
   InitialForm,
@@ -18,6 +18,8 @@ import Alert from "@codegouvfr/react-dsfr/Alert";
 import Decimal from "decimal.js";
 import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import NonScrollableInput from "../../../../Apps/common/Components/NonScrollableInput/NonScrollableInput";
+import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import Button from "@codegouvfr/react-dsfr/Button";
 
 type Appendix2MultiSelectProps = {
   // Résultat de la query `appendixForms` executé
@@ -36,6 +38,22 @@ type Appendix2MultiSelectProps = {
     }[]
   ) => void;
 };
+
+// Limite le nombre de bordereaux que l'on peut afficher dans le tableau
+// pour des raisons de performance (tra-15666)
+// Passé cette limite :
+// - on n'affiche que les derniers 500 bordereaux candidats au regroupement
+// - on affiche un message d'alerte pour informer l'utilisateur l'invitant à utiliser
+// le filtre par numéro de bordereau pour sélectionner les bordereaux individuellement
+// - on affiche un accordéon permettant d'afficher la liste des bordereaux regroupés
+const MAX_APPENDIX_2_COUNT_TABLE_DISPLAY = 500;
+
+// Le calcul en temps réel de la quantité totale et des contenants
+// via un `useEffect` pose des problèmes de performance lorsque la quantité
+// de données à afficher dans le tableau est importante. Passé une certaine limite
+// on désactive le useEffect et on affiche un bouton pour calculer manuellement
+// la quantité totale et les contenants
+const MAX_APPENDIX_2_COUNT_USE_EFFECT = 100;
 
 export default function Appendix2MultiSelect({
   appendixForms,
@@ -59,16 +77,21 @@ export default function Appendix2MultiSelect({
     [meta.initialValue]
   );
 
-  const initiallyAnnexedFormIds = initiallyAnnexedForms.map(
-    ({ form }) => form.id
+  const initiallyAnnexedFormIds = useMemo(
+    () => initiallyAnnexedForms.map(({ form }) => form.id),
+    [initiallyAnnexedForms]
   );
 
   // Liste les bordereaux en attente de regroupement qui ne sont pas
   // déjà annexés au bordereau de groupement au moment de l'ouverture du
   // formulaire
-  const canBeAnnexedForms = (appendixForms ?? [])
-    .filter(f => !initiallyAnnexedFormIds.includes(f.id))
-    .map(form => ({ form, quantity: 0 }));
+  const canBeAnnexedForms = useMemo(
+    () =>
+      (appendixForms ?? [])
+        .filter(f => !initiallyAnnexedFormIds.includes(f.id))
+        .map(form => ({ form, quantity: 0 })),
+    [appendixForms, initiallyAnnexedFormIds]
+  );
 
   // Liste tous les bordereaux candidats au regroupement, en commençant
   // par les bordereaux déjà annexés au moment de l'ouverture du formulaire
@@ -77,33 +100,38 @@ export default function Appendix2MultiSelect({
     [initiallyAnnexedForms, canBeAnnexedForms]
   );
 
-  const filteredForms = useMemo(
+  const filteredForms = useMemo(() => {
+    return forms.filter(({ form }) => {
+      if (
+        readableIdFilter.length > 0 &&
+        !form.readableId.includes(readableIdFilter)
+      ) {
+        return false;
+      }
+
+      if (
+        wasteCodeFilter.length > 0 &&
+        !form.wasteDetails?.code?.includes(wasteCodeFilter)
+      ) {
+        return false;
+      }
+
+      if (
+        emitterSiretFilter.length > 0 &&
+        !form.emitter?.company?.orgId?.includes(emitterSiretFilter)
+      ) {
+        return false;
+      }
+      return true;
+    });
+  }, [forms, readableIdFilter, wasteCodeFilter, emitterSiretFilter]);
+
+  const slicedForms = useMemo(
     () =>
-      forms.filter(({ form }) => {
-        if (
-          readableIdFilter.length > 0 &&
-          !form.readableId.includes(readableIdFilter)
-        ) {
-          return false;
-        }
-
-        if (
-          wasteCodeFilter.length > 0 &&
-          !form.wasteDetails?.code?.includes(wasteCodeFilter)
-        ) {
-          return false;
-        }
-
-        if (
-          emitterSiretFilter.length > 0 &&
-          !form.emitter?.company?.orgId?.includes(emitterSiretFilter)
-        ) {
-          return false;
-        }
-
-        return true;
-      }),
-    [forms, readableIdFilter, wasteCodeFilter, emitterSiretFilter]
+      filteredForms.length > MAX_APPENDIX_2_COUNT_TABLE_DISPLAY
+        ? filteredForms.slice(0, MAX_APPENDIX_2_COUNT_TABLE_DISPLAY)
+        : filteredForms,
+    [filteredForms]
   );
 
   // Liste les bordereaux annexés au bordereau de groupement présentement
@@ -111,13 +139,18 @@ export default function Appendix2MultiSelect({
     () => values.grouping ?? [],
     [values.grouping]
   );
-  const currentlyAnnexedFormIds = currentlyAnnexedForms.map(
-    ({ form }) => form.id
+  const currentlyAnnexedFormIds = useMemo(
+    () => currentlyAnnexedForms.map(({ form }) => form.id),
+    [currentlyAnnexedForms]
   );
-  const quantitiesGrouped: { [key: string]: number | string } =
-    currentlyAnnexedForms.reduce((acc, { form, quantity }) => {
-      return { ...acc, [form.id]: quantity };
-    }, {});
+
+  const quantitiesGrouped: { [key: string]: number | string } = useMemo(
+    () =>
+      currentlyAnnexedForms.reduce((acc, { form, quantity }) => {
+        return { ...acc, [form.id]: quantity };
+      }, {}),
+    [currentlyAnnexedForms]
+  );
 
   function getQuantityLeft({
     form,
@@ -143,160 +176,178 @@ export default function Appendix2MultiSelect({
     return quantityLeft.toDecimalPlaces(6);
   }
 
-  useEffect(() => {
-    if (isDirty) {
-      // Auto-complète la quantité totale à partir des annexes 2 sélectionnées
-      const totalQuantity = currentlyAnnexedForms
-        .reduce((q, { quantity }) => {
-          if (!quantity || quantity < 0) {
-            return q;
+  const calculateTotalQuantityAndPackagings = useCallback(() => {
+    const totalQuantity = currentlyAnnexedForms
+      .reduce((q, { quantity }) => {
+        if (!quantity || quantity < 0) {
+          return q;
+        }
+        return q.plus(quantity);
+      }, new Decimal(0))
+      .toNumber();
+
+    // Auto-complète les contenants à partir des annexes 2 sélectionnés
+    const totalPackagings = (() => {
+      const quantityByType = currentlyAnnexedForms.reduce(
+        (acc1, { form, quantity }) => {
+          if (!form.wasteDetails?.packagingInfos || !quantity) {
+            return acc1;
           }
-          return q.plus(quantity);
-        }, new Decimal(0))
-        .toNumber();
 
-      // Auto-complète les contenants à partir des annexes 2 sélectionnés
-      const totalPackagings = (() => {
-        const quantityByType = currentlyAnnexedForms.reduce(
-          (acc1, { form, quantity }) => {
-            if (!form.wasteDetails?.packagingInfos || !quantity) {
-              return acc1;
-            }
-
-            return form.wasteDetails.packagingInfos.reduce(
-              (acc2, packagingInfo) => {
-                if (!acc2[packagingInfo.type]) {
-                  return {
-                    ...acc2,
-                    [packagingInfo.type]: packagingInfo.quantity
-                  };
-                }
+          return form.wasteDetails.packagingInfos.reduce(
+            (acc2, packagingInfo) => {
+              if (!acc2[packagingInfo.type]) {
                 return {
                   ...acc2,
-                  [packagingInfo.type]: [
-                    Packagings.Benne,
-                    Packagings.Citerne
-                  ].includes(packagingInfo.type)
-                    ? Math.min(
-                        packagingInfo.quantity + acc2[packagingInfo.type],
-                        2
-                      )
-                    : packagingInfo.quantity + acc2[packagingInfo.type]
+                  [packagingInfo.type]: packagingInfo.quantity
                 };
-              },
-              acc1
-            );
-          },
-          {}
-        );
-        return Object.keys(quantityByType).map(type => ({
-          type,
-          other: "",
-          quantity: quantityByType[type]
-        }));
-      })();
+              }
+              return {
+                ...acc2,
+                [packagingInfo.type]: [
+                  Packagings.Benne,
+                  Packagings.Citerne
+                ].includes(packagingInfo.type)
+                  ? Math.min(
+                      packagingInfo.quantity + acc2[packagingInfo.type],
+                      2
+                    )
+                  : packagingInfo.quantity + acc2[packagingInfo.type]
+              };
+            },
+            acc1
+          );
+        },
+        {}
+      );
+      return Object.keys(quantityByType).map(type => ({
+        type,
+        other: "",
+        quantity: quantityByType[type]
+      }));
+    })();
 
-      updateTotalQuantity(totalQuantity);
-      updatePackagings(totalPackagings);
+    updateTotalQuantity(totalQuantity);
+    updatePackagings(totalPackagings);
+  }, [currentlyAnnexedForms, updateTotalQuantity, updatePackagings]);
+
+  // Auto-complète la quantité totale à partir des annexes 2 sélectionnées
+  useEffect(() => {
+    if (isDirty && appendixForms.length <= MAX_APPENDIX_2_COUNT_USE_EFFECT) {
+      calculateTotalQuantityAndPackagings();
     }
-  }, [currentlyAnnexedForms, isDirty, updateTotalQuantity, updatePackagings]);
+  }, [isDirty, appendixForms, calculateTotalQuantityAndPackagings]);
+
+  const rowsData = useMemo(
+    () =>
+      slicedForms.map(({ form, quantity }) => {
+        const checked = currentlyAnnexedFormIds.includes(form.id);
+        const quantityAccepted = new Decimal(
+          form.quantityAccepted ?? form.quantityReceived!
+        );
+        const quantityLeft = getQuantityLeft({ form, quantity });
+        const quantityGrouped = checked
+          ? // si le bordereau est sélectionné, `quantityGrouped`
+            // est contrôlé par le state Formik
+            quantitiesGrouped[form.id]
+          : // sinon l'input est disabled et sa valeur par défaut
+            // est égale à la quantité restante à regrouper
+            quantityLeft;
+        return {
+          form,
+          quantity,
+          checked,
+          quantityAccepted,
+          quantityLeft,
+          quantityGrouped
+        };
+      }),
+    [slicedForms, currentlyAnnexedFormIds, quantitiesGrouped]
+  );
 
   const renderTable: SharedRenderProps<FieldArrayRenderProps>["render"] = ({
     push,
     remove,
     replace
   }) => {
-    const rows = filteredForms.map(({ form, quantity }) => {
-      const checked = currentlyAnnexedFormIds.includes(form.id);
-      const quantityAccepted = new Decimal(
-        form.quantityAccepted ?? form.quantityReceived!
-      );
-
-      const quantityLeft = getQuantityLeft({ form, quantity });
-
-      const quantityGrouped = checked
-        ? // si le bordereau est sélectionné, `quantityGrouped`
-          // est contrôlé par le state Formik
-          quantitiesGrouped[form.id]
-        : // sinon l'input est disabled et sa valeur par défaut
-          // est égale à la quantité restante à regrouper
-          quantityLeft;
-
-      return [
-        <Checkbox
-          options={[
-            {
-              label: "",
-              nativeInputProps: {
-                checked,
-                onChange: e => {
-                  setIsDirty(true);
-                  if (e.target.checked) {
-                    push({
-                      form,
-                      quantity: quantityGrouped
-                    });
-                  } else {
-                    const idx = currentlyAnnexedFormIds.indexOf(form.id);
-                    remove(idx);
+    const rows = rowsData.map(
+      ({ form, checked, quantityAccepted, quantityLeft, quantityGrouped }) => {
+        return [
+          <Checkbox
+            options={[
+              {
+                label: "",
+                nativeInputProps: {
+                  checked,
+                  onChange: e => {
+                    setIsDirty(true);
+                    if (e.target.checked) {
+                      push({
+                        form,
+                        quantity: quantityGrouped
+                      });
+                    } else {
+                      const idx = currentlyAnnexedFormIds.indexOf(form.id);
+                      remove(idx);
+                    }
                   }
                 }
               }
+            ]}
+          />,
+          <div style={{ wordBreak: "break-word", wordWrap: "break-word" }}>
+            {form.readableId}
+          </div>,
+          form.wasteDetails?.code,
+          `${form.emitter?.company?.name} (${form.emitter?.company?.orgId})`,
+          form.signedAt && formatDate(form.signedAt),
+          form.processingOperationDone,
+          quantityAccepted.toNumber(),
+          quantityLeft.toNumber(),
+          <NonScrollableInput
+            label=""
+            disabled={!checked}
+            state={
+              Number(quantityGrouped) < 0 ||
+              quantityLeft.lessThan(Number(quantityGrouped))
+                ? "error"
+                : "default"
             }
-          ]}
-        />,
-        <div style={{ wordBreak: "break-word", wordWrap: "break-word" }}>
-          {form.readableId}
-        </div>,
-        form.wasteDetails?.code,
-        `${form.emitter?.company?.name} (${form.emitter?.company?.orgId})`,
-        form.signedAt && formatDate(form.signedAt),
-        form.processingOperationDone,
-        quantityAccepted.toNumber(),
-        quantityLeft.toNumber(),
-        <NonScrollableInput
-          label=""
-          disabled={!checked}
-          state={
-            Number(quantityGrouped) < 0 ||
-            quantityLeft.lessThan(Number(quantityGrouped))
-              ? "error"
-              : "default"
-          }
-          stateRelatedMessage={
-            Number(quantityGrouped) < 0
-              ? "La quantité doit être un nombre supérieur à 0"
-              : "Vous ne pouvez pas regrouper une" +
-                " quantité supérieure à la quantité restante"
-          }
-          style={{ minWidth: "120px" }}
-          nativeInputProps={{
-            type: "number",
-            min: 0,
-            max: quantityLeft.toNumber(),
-            inputMode: "decimal",
-            step: 0.000001, // increment kg
-            value: String(quantityGrouped),
-            onChange: e => {
-              setIsDirty(true);
-              const idx = currentlyAnnexedFormIds.indexOf(form.id);
-              const value = e.target.value;
-              replace(idx, {
-                form,
-                quantity: value === "" ? "" : Number(value)
-              });
+            stateRelatedMessage={
+              Number(quantityGrouped) < 0
+                ? "La quantité doit être un nombre supérieur à 0"
+                : "Vous ne pouvez pas regrouper une" +
+                  " quantité supérieure à la quantité restante"
             }
-          }}
-        />
-      ];
-    });
+            style={{ minWidth: "120px" }}
+            nativeInputProps={{
+              type: "number",
+              min: 0,
+              max: quantityLeft.toNumber(),
+              inputMode: "decimal",
+              step: 0.000001, // increment kg
+              value: String(quantityGrouped),
+              onChange: e => {
+                setIsDirty(true);
+                const idx = currentlyAnnexedFormIds.indexOf(form.id);
+                const value = e.target.value;
+                replace(idx, {
+                  form,
+                  quantity: value === "" ? "" : Number(value)
+                });
+              }
+            }}
+          />
+        ];
+      }
+    );
 
     // Callback executé lorsque l'on clique sur la checkbox de l'en-tête
     // permettant de sélectionner / dé-sélectionner en masse
     function onSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
       setIsDirty(true);
       if (e.target.checked) {
-        for (const { form, quantity } of filteredForms) {
+        for (const { form, quantity } of slicedForms) {
           if (!currentlyAnnexedFormIds.includes(form.id)) {
             push({
               form,
@@ -316,9 +367,10 @@ export default function Appendix2MultiSelect({
           {
             label: "",
             nativeInputProps: {
-              checked:
-                filteredForms.length > 0 &&
-                currentlyAnnexedForms.length >= filteredForms.length,
+              checked: slicedForms.every(({ form }) =>
+                currentlyAnnexedFormIds.includes(form.id)
+              ),
+
               onChange: onSelectAll
             }
           }
@@ -376,7 +428,47 @@ export default function Appendix2MultiSelect({
             />
           </div>
         </div>
+        {appendixForms.length > MAX_APPENDIX_2_COUNT_TABLE_DISPLAY && (
+          <>
+            <Alert
+              severity="warning"
+              small
+              description={
+                <div>
+                  Pour des raisons de performance, le tableau ci-dessous
+                  n'affiche que les {MAX_APPENDIX_2_COUNT_TABLE_DISPLAY}{" "}
+                  derniers bordereaux en attente de regroupement sur un total de{" "}
+                  {appendixForms.length} bordereaux. Vous pouvez sélectionner
+                  des bordereaux individuellement en utilisant le filtre par
+                  numéro de bordereau.
+                </div>
+              }
+            />
+            {currentlyAnnexedForms.length > 0 && (
+              <Accordion label="Afficher la liste des bordereaux annexés">
+                {currentlyAnnexedForms.map(({ form, quantity }) => (
+                  <div>
+                    {form.readableId}
+                    {quantity ? ` - ${quantity.toFixed(6)} T` : ""}
+                  </div>
+                ))}
+              </Accordion>
+            )}
+          </>
+        )}
         <FieldArray name="grouping" render={renderTable} />
+        {appendixForms.length > MAX_APPENDIX_2_COUNT_USE_EFFECT && (
+          <Button
+            priority="tertiary"
+            onClick={e => {
+              e.preventDefault();
+              calculateTotalQuantityAndPackagings();
+            }}
+          >
+            Calculer la quantité totale et le conditionnement à partir de la
+            liste des annexes 2
+          </Button>
+        )}
       </>
     );
   }


### PR DESCRIPTION
# Contexte

L'affichage du tableau des annexes 2 patinent quand il y a un grand nombre de bordereaux en attente de regroupement.

Cette PR limite le nombre de bordereaux que l'on peut afficher dans le tableau de sélection des annexes à 500 pour des raisons de performance 

Passé cette limite :
- on n'affiche que les derniers 500 bordereaux candidats au regroupement.
- on affiche un message d'alerte pour informer l'utilisateur l'invitant à utiliser le filtre par numéro de bordereau pour sélectionner les bordereaux individuellement.
- on affiche un accordéon permettant d'afficher la liste des bordereaux regroupés.

Par ailleurs dès que l'on a plus de 100 bordereaux candidats : 
- on désactive la mise à jour automatique de la quantité totale et du conditionnement.
- on affiche un bouton permettant de calculer manuellement la quantité totale et le conditionnement.

La bonne solution à terme serait d'introduire une pagination côté serveur.

J'ai également wrap toutes les variables qui servent à stocker des listes de bordereaux dans `useMemo`

# Démo



https://github.com/user-attachments/assets/5fc5a4ef-477a-4a7f-bdeb-3d044a20aeb9





# Ticket Favro

[Impossible de charger la liste des BSD à regrouper lors de la création/modification d'un BSDD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15666)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB