### PR TITLE
Script compatibility with bash 3.2

### DIFF
--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -48,7 +48,6 @@ default_user="trackdechets"
 echo "${bold}? Postgres User${reset} [$default_user]: "
 read psqlUser
 psqlUser="${psqlUser:-$default_user}"
-# read -rp $'${bold}? Postgres User:${reset} ' -i "trackdechets" -e psqlUser
 
 echo "Copying backup file to postgres"
 docker cp "$backupPath" "$psql_container_id":/tmp/dump.sql

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -6,13 +6,13 @@
 BASEDIR=$(realpath "$0" | sed 's|\(.*\)/.*|\1|')
 psql_container_id=$(docker ps -qf name=^/trackdechets.postgres)
 
-read -erp $'\e[1m! Before running this script, make sure you closed all open connections to the DB (app, queue, notifier, SQL soft...)\e[m'
+printf "\e[1m! Before running this script, make sure you closed all open connections to the DB (app, queue, notifier, SQL soft...)\e[m\n"
 
 read -erp $'\e[1m? Do you wish to download the latest backup of your chosen database \e[m (Y/n) ' -e downloadBackup
 downloadBackup=${downloadBackup:-Y}
 
 if [ "$downloadBackup" != "${downloadBackup#[Yy]}" ]; then
-    echo -e "\e[90m"
+    printf "\e[90m"
 
     backupName="db_backup.pgsql"
     backupPath="$BASEDIR/$backupName"
@@ -26,38 +26,42 @@ if [ "$downloadBackup" != "${downloadBackup#[Yy]}" ]; then
       mv "$name" $backupName
     done
     rm $backupTarName
-    echo -e "\e[m"
+    printf "\e[m"
 else
     while read -erp $'\e[1m? Enter local backup path (pgsql file):\e[m ' backupPath; do
         if [ -f "$backupPath" ]; then
             break
         else
-            echo -e "\e[91m$backupPath is not a valid path.\e[m"
-        fi 
+            printf "\e[91m$backupPath is not a valid path.\e[m\n"
+        fi
     done
-fi 
+fi
 
-echo -e "\e[1m→ Using backup file \e[36m$backupPath\e[m"
+printf "\e[1m→ Using backup file \e[36m$backupPath\e[m\n"
 
-read -rp $'\e[1m? Postgres User:\e[m ' -i "trackdechets" -e psqlUser
+default_user="trackdechets"
+printf "\e[1m? Postgres User\e[m [$default_user]: "
+read psqlUser
+psqlUser="${psqlUser:-$default_user}"
+# read -rp $'\e[1m? Postgres User:\e[m ' -i "trackdechets" -e psqlUser
 
 echo "Copying backup file to postgres"
 docker cp "$backupPath" "$psql_container_id":/tmp/dump.sql
 
-echo -e "\e[1m→ Recreating DB \e[36mprisma\e[m"
+printf "\e[1m→ Recreating DB \e[36mprisma\e[m\n"
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -c \"DROP DATABASE IF EXISTS prisma;\"";
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -c \"CREATE DATABASE prisma;\"";
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -d prisma -c 'CREATE SCHEMA default\$default;'";
 
-echo -e "\e[1m→ Restoring dump"
+printf "\e[1m→ Restoring dump\n"
 docker exec -t "$psql_container_id" bash -c "pg_restore -U $psqlUser -d prisma --clean /tmp/dump.sql 2>/dev/null";
 
 PWD=$(pwd)
 if [ "$BASEDIR"  == "$PWD" ]; then
   APP_DIR=$(dirname "$PWD")
-  echo -e "\e[1m→ Changing directory to $APP_DIR, as migrate needs to access envs\e[m"
+  printf "\e[1m→ Changing directory to $APP_DIR, as migrate needs to access envs\e[m\n"
   cd "$APP_DIR" || exit
 fi
 
-echo -e "\e[1m→ Running SQL migrations"
+printf "\e[1m→ Running SQL migrations\n"
 npx prisma migrate dev

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -3,16 +3,21 @@
 # Helper to restore a DB backup locally
 # -------------------------------------
 
+bold=$(tput bold)
+reset=$(tput sgr0)
+green=$(tput setaf 2)
+red=$(tput setaf 9)
+
 BASEDIR=$(realpath "$0" | sed 's|\(.*\)/.*|\1|')
 psql_container_id=$(docker ps -qf name=^/trackdechets.postgres)
 
-printf "\e[1m! Before running this script, make sure you closed all open connections to the DB (app, queue, notifier, SQL soft...)\e[m\n"
+echo "${bold}! Before running this script, make sure you closed all open connections to the DB (app, queue, notifier, SQL soft...)${reset}"
 
-read -erp $'\e[1m? Do you wish to download the latest backup of your chosen database \e[m (Y/n) ' -e downloadBackup
+read -erp "${bold}? Do you wish to download the latest backup of your chosen database ${reset} (Y/n) " -e downloadBackup
 downloadBackup=${downloadBackup:-Y}
 
 if [ "$downloadBackup" != "${downloadBackup#[Yy]}" ]; then
-    printf "\e[90m"
+    echo "${reset}"
 
     backupName="db_backup.pgsql"
     backupPath="$BASEDIR/$backupName"
@@ -26,42 +31,42 @@ if [ "$downloadBackup" != "${downloadBackup#[Yy]}" ]; then
       mv "$name" $backupName
     done
     rm $backupTarName
-    printf "\e[m"
+    echo "${reset}"
 else
-    while read -erp $'\e[1m? Enter local backup path (pgsql file):\e[m ' backupPath; do
+    while read -erp "${bold}? Enter local backup path (pgsql file):${reset} " backupPath; do
         if [ -f "$backupPath" ]; then
             break
         else
-            printf "\e[91m$backupPath is not a valid path.\e[m\n"
+            echo "${red}$backupPath is not a valid path.${reset}"
         fi
     done
 fi
 
-printf "\e[1m→ Using backup file \e[36m$backupPath\e[m\n"
+echo "${bold}→ Using backup file ${green}$backupPath${reset}"
 
 default_user="trackdechets"
-printf "\e[1m? Postgres User\e[m [$default_user]: "
+echo "${bold}? Postgres User${reset} [$default_user]: "
 read psqlUser
 psqlUser="${psqlUser:-$default_user}"
-# read -rp $'\e[1m? Postgres User:\e[m ' -i "trackdechets" -e psqlUser
+# read -rp $'${bold}? Postgres User:${reset} ' -i "trackdechets" -e psqlUser
 
 echo "Copying backup file to postgres"
 docker cp "$backupPath" "$psql_container_id":/tmp/dump.sql
 
-printf "\e[1m→ Recreating DB \e[36mprisma\e[m\n"
+echo "${bold}→ Recreating DB ${green}prisma${reset}"
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -c \"DROP DATABASE IF EXISTS prisma;\"";
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -c \"CREATE DATABASE prisma;\"";
 docker exec -t "$psql_container_id" bash -c "psql -U $psqlUser -d prisma -c 'CREATE SCHEMA default\$default;'";
 
-printf "\e[1m→ Restoring dump\n"
+echo "${bold}→ Restoring dump"
 docker exec -t "$psql_container_id" bash -c "pg_restore -U $psqlUser -d prisma --clean /tmp/dump.sql 2>/dev/null";
 
 PWD=$(pwd)
 if [ "$BASEDIR"  == "$PWD" ]; then
   APP_DIR=$(dirname "$PWD")
-  printf "\e[1m→ Changing directory to $APP_DIR, as migrate needs to access envs\e[m\n"
+  echo "${bold}→ Changing directory to $APP_DIR, as migrate needs to access envs${reset}"
   cd "$APP_DIR" || exit
 fi
 
-printf "\e[1m→ Running SQL migrations\n"
+echo "${bold}→ Running SQL migrations"
 npx prisma migrate dev

--- a/scripts/run-import.sh
+++ b/scripts/run-import.sh
@@ -31,7 +31,7 @@ echo "${bold}→ Spawning XSLX2CSV CLI...${reset}"
 echo "${bold}→ Please use the 'Export csv' action${reset}"
 echo "${blue}-------------------------------------------------------${reset}"
 cd "$TD_XSLX2CSV_PATH" || exit
-pipenv run python src/xlsx2csv.py "$cleanedPath"
+pipenv run python xlsx2csv.py "$cleanedPath"
 echo "${blue}-------------------------------------------------------${reset}"
 
 cd "$CURRENT_DIR" || exit

--- a/scripts/run-import.sh
+++ b/scripts/run-import.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+bold=$(tput bold)
+reset=$(tput sgr0)
+green=$(tput setaf 2)
+red=$(tput setaf 9)
+blue=$(tput setaf 4)
+
 if [ -f .env ]
 then
   export "$(<.env xargs)"
@@ -8,32 +14,33 @@ fi
 CURRENT_DIR=$(pwd)
 if [ -z "$TD_XSLX2CSV_PATH" ];
 then
-    echo -e "\e[91mPlease set \$TD_XSLX2CSV_PATH either as ENV or in .env file (ex: home/you/trackdechets-xslx2csv/src)\e[m"
+    echo "${red}Please set \$TD_XSLX2CSV_PATH either as ENV or in .env file (ex: home/you/trackdechets-xslx2csv/src)${reset}"
     exit
 fi
 
-while read -erp $'\e[1m? Enter local XLS path :\e[m ' xlsPath; do
-    if [ -f "$xlsPath" ]; then
+while read -erp "${bold}? Enter local XLS path :${reset} " xlsPath; do
+    cleanedPath=$(echo "$xlsPath" | sed -e 's/\\ / /g')
+    if [ -f "$cleanedPath" ]; then
         break
     else
-        echo -e "\e[91m$xlsPath is not a valid path.\e[m"
+        echo "${red}$cleanedPath is not a valid path.${reset}"
     fi 
 done
 
-echo -e "\e[1m→ Spawning XSLX2CSV CLI...\e[m"
-echo -e "\e[1m→ Please use the 'Export csv' action\e[m"
-echo -e "\e[94m-------------------------------------------------------\e[m"
+echo "${bold}→ Spawning XSLX2CSV CLI...${reset}"
+echo "${bold}→ Please use the 'Export csv' action${reset}"
+echo "${blue}-------------------------------------------------------${reset}"
 cd "$TD_XSLX2CSV_PATH" || exit
-pipenv run python xlsx2csv.py "$xlsPath"
-echo -e "\e[94m-------------------------------------------------------\e[m"
+pipenv run python src/xlsx2csv.py "$cleanedPath"
+echo "${blue}-------------------------------------------------------${reset}"
 
 cd "$CURRENT_DIR" || exit
 OUTPUT_DIR="$TD_XSLX2CSV_PATH/csv"
 
-echo -e "\e[1m→ Listing extracted files\e[m"
+echo "${bold}→ Listing extracted files${reset}"
 ls "$OUTPUT_DIR"
 
-read -erp $'\e[1m? Proceed with import \e[m (Y/n) ' -n 1 PROCEED
+read -erp "${bold}? Proceed with import ${reset} (Y/n) " -n 1 PROCEED
 PROCEED=${PROCEED:-Y}
 
 if [[ ! $PROCEED =~ ^[Yy]$ ]]


### PR DESCRIPTION
Je suis entrain de passer sur un MBP, et je constate que la version de bash par défaut est la 3.2. Du coup le script de restauration de la DB ne marchait pas.
Je l'ai adapté pour que ça soit le cas. En gros:
- utilisation de tput pour les couleurs au lieu des ansi codes et des `echo -e` qui posaient problème
- pas de `read -i` pour les valeurs dispos, donc on fait un read et on fallback séparemment sur une valeur
Idem pour le script d'import de fichiers.

Vous autres utilisateurs de mac, vous ne l'utilisiez pas jusqu'à présent ? ou alors vous aviez maj votre bash par défaut ?