### PR TITLE
[tra-15659]Revoir le fonctionnement / les messages d'erreur affichés selon le type de transporteur sélectionné sur un VHU

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -122,6 +122,8 @@ const EmitterBsvhu = ({ errors }) => {
     if (company) {
       if (!company.isRegistered) {
         return "L'entreprise n'est pas inscrite sur Trackdéchets, la signature Producteur ne pourra pas se faire. Vous pouvez publier le bordereau, mais seul le transporteur pourra le signer.";
+      } else if (formState.errors?.emitter?.["company"]?.siret?.message) {
+        return formState.errors?.emitter?.["company"]?.siret?.message;
       }
     }
     return null;
@@ -208,19 +210,13 @@ const EmitterBsvhu = ({ errors }) => {
             }
           }}
         />
-        {formState.errors?.emitter?.["company"]?.orgId?.message && (
-          <p
-            id="text-input-error-desc-error"
-            className="fr-mb-4v fr-error-text"
-          >
-            {formState.errors?.emitter?.["company"]?.orgId?.message}
-          </p>
-        )}
-        {formState.errors?.emitter?.["company"]?.siret && (
-          <p className="fr-mb-4v fr-error-text">
-            {formState.errors?.emitter?.["company"]?.siret?.message}
-          </p>
-        )}
+        {!emitter?.company?.siret &&
+          formState.errors?.emitter?.["company"]?.siret && (
+            <p className="fr-text--sm fr-error-text fr-mb-4v">
+              {formState.errors?.emitter?.["company"]?.siret?.message}
+            </p>
+          )}
+
         {emitter.irregularSituation && (
           <>
             <Checkbox

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
@@ -106,7 +106,9 @@ const TransporterBsvhu = ({ errors }) => {
         !transporter?.recepisse?.isExempted &&
         !company.companyTypes?.includes(CompanyType.Transporter)
       ) {
-        return "Cet établissement n'a pas le profil Transporteur. Si vous transportez vos propres déchets, veuillez cocher la case d'exemption.";
+        return "Cet établissement n'a pas le profil Transporteur. Il ne pourra pas être visé comme tel sur le bordereau, il lui appartient de compléter cette information dans son profil. Si vous transportez vos propres déchets, veuillez cocher la case d'exemption.";
+      } else if (formState.errors?.transporter?.["company"]?.siret?.message) {
+        return formState.errors?.transporter?.["company"]?.siret?.message;
       }
     }
     return null;
@@ -156,19 +158,12 @@ const TransporterBsvhu = ({ errors }) => {
             }
           }}
         />
-        {formState.errors?.transporter?.["company"]?.orgId?.message && (
-          <p
-            id="text-input-error-desc-error"
-            className="fr-mb-4v fr-error-text"
-          >
-            {formState.errors?.transporter?.["company"]?.orgId?.message}
-          </p>
-        )}
-        {formState.errors?.transporter?.["company"]?.siret && (
-          <p className="fr-mb-4v fr-error-text">
-            {formState.errors?.transporter?.["company"]?.siret?.message}
-          </p>
-        )}
+        {!transporter?.company?.siret &&
+          formState.errors?.transporter?.["company"]?.siret && (
+            <p className="fr-text--sm fr-error-text fr-mb-4v">
+              {formState.errors?.transporter?.["company"]?.siret?.message}
+            </p>
+          )}
         <CompanyContactInfo
           fieldName={`${actor}.company`}
           errorObject={formState.errors?.transporter?.["company"]}


### PR DESCRIPTION
# Contexte

Revoir le fonctionnement / les messages d'erreur affichés selon le type de transporteur sélectionné sur un VHU


j'ai corrigé aussi sur la partie emitter ou il y avait le même systeme donc un double message.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->


https://github.com/user-attachments/assets/baf1a487-24b4-486b-96d2-76931d99b2cb



# Ticket Favro

[tra-15659](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15659)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB