### PR TITLE
[tra-15660]Garder les infos de contact saisies par l'utilisateur même quand c'est une donnée vide

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Destination.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Destination.tsx
@@ -216,17 +216,11 @@ const DestinationBsvhu = ({ errors }) => {
               } else {
                 setValue(
                   `${actor}.company.contact`,
-                  destination?.company?.contact || company.contact
+                  destination?.company?.contact
                 );
-                setValue(
-                  `${actor}.company.phone`,
-                  destination?.company?.phone || company.contactPhone
-                );
+                setValue(`${actor}.company.phone`, destination?.company?.phone);
 
-                setValue(
-                  `${actor}.company.mail`,
-                  destination?.company?.mail || company.contactEmail
-                );
+                setValue(`${actor}.company.mail`, destination?.company?.mail);
               }
               setValue(`${actor}.company.orgId`, company.orgId);
               setValue(`${actor}.company.siret`, company.siret);

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -184,17 +184,13 @@ const EmitterBsvhu = ({ errors }) => {
                   name: (emitter?.company?.name || company.name) as string,
                   address: (emitter?.company?.address ||
                     company.address) as string,
-                  contact: (emitter?.company?.contact ||
-                    company.contact) as string,
-                  phone: (emitter?.company?.phone ||
-                    company.contactPhone) as string,
-                  mail: (emitter?.company?.mail ||
-                    company.contactEmail) as string,
+                  contact: emitter?.company?.contact,
+                  phone: emitter?.company?.phone,
+                  mail: emitter?.company?.mail,
                   country: company.codePaysEtrangerEtablissement
                 };
 
-                agrementNumber = (emitter?.agrementNumber ||
-                  company?.vhuAgrementDemolisseur?.agrementNumber) as string;
+                agrementNumber = emitter?.agrementNumber;
               }
 
               setValue("emitter", {

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
@@ -136,17 +136,11 @@ const TransporterBsvhu = ({ errors }) => {
               } else {
                 setValue(
                   `${actor}.company.contact`,
-                  transporter?.company?.contact || company.contact
+                  transporter?.company?.contact
                 );
-                setValue(
-                  `${actor}.company.phone`,
-                  transporter?.company?.phone || company.contactPhone
-                );
+                setValue(`${actor}.company.phone`, transporter?.company?.phone);
 
-                setValue(
-                  `${actor}.company.mail`,
-                  transporter?.company?.mail || company.contactEmail
-                );
+                setValue(`${actor}.company.mail`, transporter?.company?.mail);
               }
               setValue(`${actor}.company.orgId`, company.orgId);
               setValue(`${actor}.company.siret`, company.siret);


### PR DESCRIPTION

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Ne pas écraser les informations de contact avec ceux du profil de l'établissement dès que je reviens sur un onglet du VHU
# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/cd5ab471-6ad1-4403-a9de-f934a948a239


# Ticket Favro

[tra-15660](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15660)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB