### PR TITLE
[tra-15647]Ne pas afficher le bouton d'action Signer sur le tableau de bord du transporteur lorsque le VHU est au statut INITIAL, que l'émetteur est situation irrégulière  ET que le SIRET est inscrit sur Trackdéchets

### DIFF
--- a/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCard/BsdCard.tsx
@@ -45,7 +45,10 @@ import {
   useBsvhuDuplicate,
   useBspaohDuplicate
 } from "../Duplicate/useDuplicate";
-import { COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS } from "../../../common/queries/company/query";
+import {
+  COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS,
+  COMPANY_SELECTOR_PRIVATE_INFOS
+} from "../../../common/queries/company/query";
 import { Loader } from "../../../common/Components";
 import { BsdDisplay, BsdStatusCode } from "../../../common/types/bsdTypes";
 import DeleteModal from "../DeleteModal/DeleteModal";
@@ -186,6 +189,16 @@ function BsdCard({
     )?.length
   );
 
+  const { data: dataEmitterRegistered } = useQuery<
+    Pick<Query, "companyPrivateInfos">,
+    QueryCompanyPrivateInfosArgs
+  >(COMPANY_SELECTOR_PRIVATE_INFOS, {
+    variables: { clue: bsd.emitter?.company?.siret! }
+  });
+
+  const isEmitterRegistered =
+    dataEmitterRegistered?.companyPrivateInfos?.isRegistered;
+
   const actionsLabel = useMemo(
     () =>
       getPrimaryActionsLabelFromBsdStatus(
@@ -194,7 +207,8 @@ function BsdCard({
         permissions,
         bsdCurrentTab,
         hasAutomaticSignature,
-        emitterIsExutoireOrTtr
+        emitterIsExutoireOrTtr,
+        isEmitterRegistered
       ),
     [
       bsdCurrentTab,
@@ -202,7 +216,8 @@ function BsdCard({
       currentSiret,
       hasAutomaticSignature,
       permissions,
-      emitterIsExutoireOrTtr
+      emitterIsExutoireOrTtr,
+      isEmitterRegistered
     ]
   );
   const ctaPrimaryLabel = bsdDisplay?.type ? actionsLabel : "";


### PR DESCRIPTION

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Ne pas afficher le bouton d'action Signer sur le tableau de bord du transporteur lorsque le VHU est au statut INITIAL, que l'émetteur est situation irrégulière  ET que le SIRET est inscrit sur Trackdéchets
# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/12e0a318-78ba-4386-911d-9c9dd3f5c4c3


# Ticket Favro

[tra-15647](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15647)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB