### PR TITLE
[TRA-15638]- Supprimer l'annexe 2 d'un BSDD de regroupement lorsque celle-ci a bien été retirée

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-# [2025.01.1] 14/01/2024
+
+# [2025.01.1] 14/01/2025
+
+#### :bug: Corrections de bugs
+
+- Supprimer l'annexe 2 d'un BSDD de regroupement lorsque celle-ci a bien été retirée [PR 3874](https://github.com/MTES-MCT/trackdechets/pull/3874).
 
 #### :boom: Breaking changes
 

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -193,7 +193,7 @@ export default function StepsList(props: Props) {
         : { temporaryStorageDetail: null }),
       // discard ecoOrganisme if not selected
       ...(ecoOrganisme?.siret ? { ecoOrganisme } : { ecoOrganisme: null }),
-      ...(grouping?.length
+      ...(grouping
         ? {
             grouping: grouping
               .map(({ form, quantity }) => ({


### PR DESCRIPTION

# Démo

### Reproduction du bug 

On dé-sélectionne toutes les annexes 2 puis on enregistre et on constate que les bordereaux sont toujours annexés.


https://github.com/user-attachments/assets/136c0554-ec02-48c3-9fad-e9339b092402

### Bug résolu 

https://github.com/user-attachments/assets/84248dbd-7525-410d-99fb-851a39e49c7d



# Ticket Favro

[Supprimer l'annexe 2 d'un BSDD de regroupement lorsque celle-ci a bien été retirée](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15638)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB