### PR TITLE
[TRA-15074] Au chargement des quantités du tableau des Annexes 2, bien récupérer la quantité acceptée par l'installation de destination finale et non par l'entreposage provisoire (si BSDD-suite à regrouper) à la modification

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,12 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
-
 # [2025.01.1] 14/01/2025
 
 #### :bug: Corrections de bugs
 
 - Supprimer l'annexe 2 d'un BSDD de regroupement lorsque celle-ci a bien été retirée [PR 3874](https://github.com/MTES-MCT/trackdechets/pull/3874).
+- Au chargement des quantités du tableau des Annexes 2, bien récupérer la quantité acceptée par l'installation de destination finale et non par l'entreposage provisoire (si BSDD-suite à regrouper) à la modification [PR 3875](https://github.com/MTES-MCT/trackdechets/pull/3875)
 
 #### :boom: Breaking changes
 

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -935,9 +935,9 @@ export function expandInitialFormFromDb(
     transporter,
     takenOverAt,
     signedAt,
-    wasteAcceptationStatus,
     quantityReceived,
     quantityRefused,
+    quantityAccepted,
     processingOperationDone,
     quantityGrouped
   } = expandFormFromDb({
@@ -948,12 +948,6 @@ export function expandInitialFormFromDb(
 
   const hasPickupSite =
     emitter?.workSite?.postalCode && emitter.workSite.postalCode.length > 0;
-
-  const wasteQuantities = bsddWasteQuantities({
-    wasteAcceptationStatus,
-    quantityReceived,
-    quantityRefused
-  });
 
   return {
     id,
@@ -970,7 +964,7 @@ export function expandInitialFormFromDb(
     transporter,
     quantityReceived,
     quantityRefused,
-    quantityAccepted: wasteQuantities?.quantityAccepted?.toNumber() ?? null,
+    quantityAccepted,
     quantityGrouped,
     processingOperationDone
   };

--- a/back/src/forms/resolvers/queries/form.ts
+++ b/back/src/forms/resolvers/queries/form.ts
@@ -27,7 +27,16 @@ const formResolver: QueryResolvers["form"] = async (_, args, context) => {
   const form = await getFormOrFormNotFound(validArgs, {
     ...expandableFormIncludes,
     intermediaries: true,
-    grouping: { include: { initialForm: { include: { transporters: true } } } }
+    grouping: {
+      include: {
+        initialForm: {
+          include: {
+            transporters: true,
+            forwardedIn: true
+          }
+        }
+      }
+    }
   });
 
   await checkCanRead(user, form);


### PR DESCRIPTION

# Démo

### Reproduction du bug 

Lors de la modification, la quantité acceptée qui apparait est celle au niveau de l'entreposage provisoire.

https://github.com/user-attachments/assets/4b1a4699-f8a7-4421-a20c-298d325284ed

### Correction du bug 

La quantité acceptée est bien celle au niveau de la destination après entreposage provisoire (avant groupement)


https://github.com/user-attachments/assets/9f54d229-313a-4c12-865f-ad9f0eeafdc3



# Ticket Favro

[Au chargement des quantités du tableau des Annexes 2, bien récupérer la quantité acceptée par l'installation de destination finale et non par l'entreposage provisoire (si BSDD-suite à regrouper) à la modification](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15074)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB