### PR TITLE
[TRA-15655] Correction de la mise à jour des numéros d'identification sur le bsvhu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Pour le Bsvhu lors d'un transport routier, la plaque d'immatriculation est désormais obligatoire et les poids de déchets sont limités à 40 T (50 kT pour les autres modes) [PR 3719](https://github.com/MTES-MCT/trackdechets/pull/3719)
 
+#### :bug: Corrections de bugs
+
+- Correction de la mise à jour des numéros d'identification sur le bsvhu [PR 3876](https://github.com/MTES-MCT/trackdechets/pull/3876)
+
 # [2024.12.1] 17/12/2024
 
 #### :rocket: Nouvelles fonctionnalités

--- a/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
+++ b/front/src/Apps/Forms/Components/IdentificationNumbers/IdentificationNumber.tsx
@@ -29,22 +29,27 @@ const IdentificationNumber = ({
   function identificationNumberReducer(state, action) {
     switch (action.type) {
       case SET_INPUT_CODE:
-        return { ...state, inputCode: action.payload };
+        return { ...state, inputCode: action.payload, touched: true };
+
       case ADD_CODE: {
-        if (!state.codes.length && defaultValue?.length) {
+        if (!state.codes.length && defaultValue?.length && !state.touched) {
+          // initial
           return {
             ...state,
             codes: [...state.codes, ...defaultValue],
-            inputCode: ""
+            inputCode: "",
+            touched: true
           };
         }
         if (!state.inputCode || state.codes.includes(state.inputCode)) {
           return state;
         }
+
         return {
           ...state,
           codes: [...state.codes, state.inputCode],
-          inputCode: ""
+          inputCode: "",
+          touched: true
         };
       }
       case REMOVE_CODE: {
@@ -53,7 +58,7 @@ const IdentificationNumber = ({
 
         return {
           ...state,
-          codes
+          codes: [...codes]
         };
       }
     }
@@ -81,7 +86,8 @@ const IdentificationNumber = ({
 
   const [state, dispatch] = useReducer(identificationNumberReducer, {
     codes: getValues(name),
-    inputCode: ""
+    inputCode: "",
+    touched: false
   });
 
   useEffect(() => {
@@ -116,8 +122,11 @@ const IdentificationNumber = ({
             className="fr-mr-2v"
             nativeButtonProps={{
               type: "button",
-              onClick: () =>
-                !disabled && dispatch({ type: REMOVE_CODE, payload: idx }),
+              onClick: () => {
+                return (
+                  !disabled && dispatch({ type: REMOVE_CODE, payload: idx })
+                );
+              },
               ...{ "data-testid": "tagInputIdentificationNumber" }
             }}
           >


### PR DESCRIPTION
# Contexte

L'UI ne permet pas la lise à jour des numéros d'identification des vhus.

# Points de vigilance pour les intégrateurs



# Démo
 

https://github.com/user-attachments/assets/fb354e53-5538-414e-9a55-8a4076bc10e7

 

# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15655

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB