### PR TITLE
[tra-15460]fix css mobile modale aperçu

### DIFF
--- a/front/src/Apps/common/Components/Modal/modal.scss
+++ b/front/src/Apps/common/Components/Modal/modal.scss
@@ -10,7 +10,7 @@
   right: 0;
   background: rgba(0, 0, 0, 0.5);
   overflow: auto;
-  height: 100%;
+  height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Lorsque je consulte l'Aperçu d'un bordereau sur mobile, j'ai du mal à cliquer sur Fermer car le CTA est caché par la barre de navigation + je scrolle dans la page derrière
# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

![image](https://github.com/user-attachments/assets/e178c129-5f98-4a18-b23a-9216dc616ad9)


# Ticket Favro

[tra-15460](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15460)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB