### PR TITLE
[TRA-15504] Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif sur le besoin de confirmer, selon le type de BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2025.02.1] 11/02/2025
+
+#### :nail_care: Améliorations
+
+BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
+
 # [2025.01.1] 14/01/2025
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsda/converter.ts
+++ b/back/src/bsda/converter.ts
@@ -62,6 +62,7 @@ export function expandBsdaFromDb(bsda: BsdaWithTransporters): GraphqlBsda {
     isDraft: bsda.isDraft,
     status: bsda.status,
     type: bsda.type,
+    isDuplicateOf: bsda.isDuplicateOf,
     emitter: nullIfNoValues<BsdaEmitter>({
       isPrivateIndividual: bsda.emitterIsPrivateIndividual,
       company: nullIfNoValues<FormCompany>({

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -19,6 +19,7 @@ export const DUPLICATE_BSDA = gql`
   mutation DuplicateBsda($id: ID!) {
     duplicateBsda(id: $id) {
       id
+      isDuplicateOf
     }
   }
 `;
@@ -152,6 +153,7 @@ describe("Mutation.Bsda.duplicate", () => {
 
     // Then
     expect(errors).toBeUndefined();
+    expect(data.duplicateBsda.isDuplicateOf).toEqual(bsda.id);
     const duplicatedBsda = await prisma.bsda.findUniqueOrThrow({
       where: { id: data.duplicateBsda.id },
       include: { transporters: true }
@@ -251,6 +253,7 @@ describe("Mutation.Bsda.duplicate", () => {
       "isDraft",
       "isDeleted",
       "status",
+      "isDuplicateOf",
       "emitterEmissionSignatureAuthor",
       "emitterEmissionSignatureDate",
       "emitterCustomInfo",
@@ -299,6 +302,7 @@ describe("Mutation.Bsda.duplicate", () => {
 
     expect(duplicatedBsda).toMatchObject({
       type,
+      isDuplicateOf: bsda.id,
       emitterIsPrivateIndividual,
       emitterCompanyName,
       emitterCompanySiret,

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -114,6 +114,7 @@ export default async function duplicate(
     id: getReadableId(ReadableIdPrefix.BSDA),
     status: BsdaStatus.INITIAL,
     isDraft: true,
+    isDuplicateOf: prismaBsda.id,
     // Emitter company info
     emitterCompanyMail: emitter?.contactEmail ?? bsda.emitterCompanyMail,
     emitterCompanyPhone: emitter?.contactPhone ?? bsda.emitterCompanyPhone,

--- a/back/src/bsda/typeDefs/bsda.objects.graphql
+++ b/back/src/bsda/typeDefs/bsda.objects.graphql
@@ -18,8 +18,14 @@ type Bsda {
   updatedAt: DateTime!
   "Indique si le bordereau est à l'état de brouillon"
   isDraft: Boolean!
-  "Statur du bordereau"
+  "Statut du bordereau"
   status: BsdaStatus!
+
+  """
+  Identifiant du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
 
   """
   Type de bordereau

--- a/back/src/bsdasris/converter.ts
+++ b/back/src/bsdasris/converter.ts
@@ -57,7 +57,7 @@ export function expandBsdasriFromDB(bsdasri: Bsdasri): GqlBsdasri {
     id: bsdasri.id,
     isDraft: Boolean(bsdasri.isDraft),
     type: bsdasri.type,
-
+    isDuplicateOf: bsdasri.isDuplicateOf,
     waste: nullIfNoValues<BsdasriWaste>({
       code: bsdasri.wasteCode,
       adr: bsdasri.wasteAdr

--- a/back/src/bsdasris/edition.ts
+++ b/back/src/bsdasris/edition.ts
@@ -16,6 +16,7 @@ type EditableBsdasriFields = Required<
     | "rowNumber"
     | "isDraft"
     | "isDeleted"
+    | "isDuplicateOf"
     | "status"
     | "type"
     | "groupedIn"

--- a/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/duplicateBsdasri.integration.ts
@@ -23,6 +23,7 @@ mutation DuplicateDasri($id: ID!){
     id
     status
     isDraft
+    isDuplicateOf
   }
 }
 `;
@@ -144,6 +145,7 @@ describe("Mutation.duplicateBsdasri", () => {
 
     expect(data.duplicateBsdasri.status).toBe("INITIAL");
     expect(data.duplicateBsdasri.isDraft).toBe(true);
+    expect(data.duplicateBsdasri.isDuplicateOf).toBe(dasri.id);
   });
 
   test("duplicated BSDASRI should have the updated data when company info changes", async () => {

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -51,6 +51,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     createdAt,
     updatedAt,
     rowNumber,
+    isDuplicateOf,
 
     emissionSignatoryId,
     emitterEmissionSignatureDate,
@@ -115,6 +116,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     id: getReadableId(ReadableIdPrefix.DASRI),
     status: BsdasriStatus.INITIAL,
     isDraft: true,
+    isDuplicateOf: bsdasri.id,
     // Emitter company info
     emitterCompanyAddress: emitter?.address ?? bsdasri.emitterCompanyAddress,
     emitterCompanyMail: emitter?.contactEmail ?? bsdasri.emitterCompanyMail,

--- a/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.objects.graphql
@@ -187,6 +187,12 @@ type Bsdasri {
   updatedAt: DateTime
   isDraft: Boolean!
 
+  """
+  Identifiant du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
+
   waste: BsdasriWaste
 
   emitter: BsdasriEmitter

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -61,6 +61,7 @@ export const cloneBsda = async (user: Express.User, id: string) => {
     | "registryLookups"
   > = {
     id: getReadableId(ReadableIdPrefix.BSDA),
+    isDuplicateOf: null,
     brokerCompanyAddress: bsda.brokerCompanyAddress,
     brokerCompanyContact: bsda.brokerCompanyContact,
     brokerCompanyMail: bsda.brokerCompanyMail,
@@ -250,6 +251,7 @@ export const cloneBsdasri = async (user: Express.User, id: string) => {
   > = {
     id: getReadableId(ReadableIdPrefix.DASRI),
     createdAt: bsdasri.createdAt,
+    isDuplicateOf: null,
     destinationCompanyAddress: bsdasri.destinationCompanyAddress,
     destinationCompanyContact: bsdasri.destinationCompanyContact,
     destinationCompanyMail: bsdasri.destinationCompanyMail,
@@ -459,6 +461,7 @@ export const cloneBsff = async (user: Express.User, id: string) => {
       : {},
     isDeleted: bsff.isDeleted,
     isDraft: bsff.isDraft,
+    isDuplicateOf: null,
     packagings: bsff.packagings.length
       ? {
           createMany: {
@@ -550,6 +553,7 @@ export const cloneBsvhu = async (user: Express.User, id: string) => {
     id: getReadableId(ReadableIdPrefix.VHU),
     createdAt: bsvhu.createdAt,
     customId: null,
+    isDuplicateOf: null,
     destinationAgrementNumber: bsvhu.destinationAgrementNumber,
     destinationCompanyAddress: bsvhu.destinationCompanyAddress,
     destinationCompanyContact: bsvhu.destinationCompanyContact,
@@ -696,6 +700,7 @@ export const cloneBspaoh = async (user: Express.User, id: string) => {
     id: getReadableId(ReadableIdPrefix.PAOH),
     canAccessDraftSirets: bspaoh.canAccessDraftSirets,
     createdAt: bspaoh.createdAt,
+    isDuplicateOf: null,
     currentTransporterOrgId: bspaoh.currentTransporterOrgId,
     destinationCap: bspaoh.destinationCap,
     destinationCompanyAddress: bspaoh.destinationCompanyAddress,
@@ -834,6 +839,7 @@ export const cloneBsdd = async (
       }
     },
     readableId: getReadableId(),
+    isDuplicateOf: null,
     brokerCompanyAddress: bsdd.brokerCompanyAddress,
     brokerCompanyContact: bsdd.brokerCompanyContact,
     brokerCompanyMail: bsdd.brokerCompanyMail,

--- a/back/src/bsffs/converter.ts
+++ b/back/src/bsffs/converter.ts
@@ -157,6 +157,7 @@ export function expandBsffFromDB(
     isDraft: prismaBsff.isDraft,
     type: prismaBsff.type,
     status: prismaBsff.status,
+    isDuplicateOf: prismaBsff.isDuplicateOf,
     emitter: nullIfNoValues<GraphQL.BsffEmitter>({
       company: nullIfNoValues<GraphQL.FormCompany>({
         name: prismaBsff.emitterCompanyName,

--- a/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/duplicateBsff.integration.ts
@@ -30,6 +30,7 @@ const DUPLICATE_BSFF = gql`
     duplicateBsff(id: $id) {
       id
       status
+      isDuplicateOf
     }
   }
 `;
@@ -52,6 +53,7 @@ describe("Mutation.duplicateBsff", () => {
     });
 
     expect(data.duplicateBsff.status).toEqual("INITIAL");
+    expect(data.duplicateBsff.isDuplicateOf).toEqual(bsff.id);
   });
 
   it("should disallow unauthenticated user from duplicating a bsff", async () => {

--- a/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
+++ b/back/src/bsffs/resolvers/mutations/duplicateBsff.ts
@@ -34,6 +34,7 @@ const duplicateBsff: MutationResolvers["duplicateBsff"] = async (
     isDraft: true,
     type: existingBsff.type,
     status: BsffStatus.INITIAL,
+    isDuplicateOf: existingBsff.id,
     emitterCompanyName: emitter?.name ?? existingBsff.emitterCompanyName,
     emitterCompanySiret: emitter?.siret ?? existingBsff.emitterCompanySiret,
     emitterCompanyAddress:

--- a/back/src/bsffs/typeDefs/bsff.objects.graphql
+++ b/back/src/bsffs/typeDefs/bsff.objects.graphql
@@ -22,6 +22,12 @@ type Bsff {
   isDraft: Boolean!
 
   """
+  Identifiant du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
+
+  """
   Type de BSFF, voir l'enum pour plus de détails.
   """
   type: BsffType!

--- a/back/src/bspaoh/converter.ts
+++ b/back/src/bspaoh/converter.ts
@@ -105,6 +105,7 @@ export function expandBspaohFromDb(
       bspaoh.status === BspaohStatus.DRAFT
         ? BspaohStatus.INITIAL
         : bspaoh.status,
+    isDuplicateOf: bspaoh.isDuplicateOf,
     waste: nullIfNoValues<BspaohWaste>({
       code: bspaoh.wasteCode,
       adr: bspaoh.wasteAdr,

--- a/back/src/bspaoh/fragments.ts
+++ b/back/src/bspaoh/fragments.ts
@@ -7,6 +7,7 @@ export const fullBspaoh = gql`
     isDraft
     createdAt
     updatedAt
+    isDuplicateOf
     waste {
       code
       adr

--- a/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
@@ -112,6 +112,7 @@ describe("Mutation.duplicateBspaoh", () => {
 
     expect(data.duplicateBspaoh.status).toBe("INITIAL");
     expect(data.duplicateBspaoh.isDraft).toBe(true);
+    expect(data.duplicateBspaoh.isDuplicateOf).toBe(bspaoh.id);
 
     const duplicated = await prisma.bspaoh.findUnique({
       where: { id: data.duplicateBspaoh.id },

--- a/back/src/bspaoh/resolvers/mutations/duplicate.ts
+++ b/back/src/bspaoh/resolvers/mutations/duplicate.ts
@@ -123,6 +123,7 @@ async function duplicateBspaoh(
     id,
     createdAt,
     updatedAt,
+    isDuplicateOf,
 
     emitterEmissionSignatureDate,
     emitterEmissionSignatureAuthor,
@@ -173,6 +174,7 @@ async function duplicateBspaoh(
     wastePackagings: cleanPackagings(wastePackagings),
     id: getReadableId(ReadableIdPrefix.PAOH),
     status: BspaohStatus.DRAFT,
+    isDuplicateOf: bspaoh.id,
 
     // Emitter company info
 

--- a/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.objects.graphql
@@ -180,6 +180,12 @@ type BspaohTransporter {
 type Bspaoh {
   "Bordereau n°"
   id: ID!
+
+  """
+  Identifiant du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
   "Date de création"
   createdAt: DateTime!
   "Date de dernière modification"

--- a/back/src/bspaoh/validation/rules.ts
+++ b/back/src/bspaoh/validation/rules.ts
@@ -30,6 +30,7 @@ type EditableBspaohFields = Required<
     | "updatedAt"
     | "rowNumber"
     | "isDeleted"
+    | "isDuplicateOf"
     | "status"
     | "emitterEmissionSignatureDate"
     | "emitterEmissionSignatureAuthor"

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -51,154 +51,155 @@ export const getAddress = ({
   return address ?? null;
 };
 
-export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
+export function expandVhuFormFromDb(bsvhu: PrismaVhuForm): GraphqlVhuForm {
   return {
-    id: form.id,
-    customId: form.customId,
-    createdAt: processDate(form.createdAt),
-    updatedAt: processDate(form.updatedAt),
-    isDraft: form.isDraft,
-    status: form.status,
+    id: bsvhu.id,
+    customId: bsvhu.customId,
+    createdAt: processDate(bsvhu.createdAt),
+    updatedAt: processDate(bsvhu.updatedAt),
+    isDraft: bsvhu.isDraft,
+    status: bsvhu.status,
+    isDuplicateOf: bsvhu.isDuplicateOf,
     emitter: nullIfNoValues<BsvhuEmitter>({
-      agrementNumber: form.emitterAgrementNumber,
-      irregularSituation: form.emitterIrregularSituation ?? false,
-      noSiret: form.emitterNoSiret ?? false,
+      agrementNumber: bsvhu.emitterAgrementNumber,
+      irregularSituation: bsvhu.emitterIrregularSituation ?? false,
+      noSiret: bsvhu.emitterNoSiret ?? false,
       company: nullIfNoValues<FormCompany>({
-        name: form.emitterCompanyName,
-        siret: form.emitterCompanySiret,
+        name: bsvhu.emitterCompanyName,
+        siret: bsvhu.emitterCompanySiret,
         address: getAddress({
-          address: form.emitterCompanyAddress,
-          street: form.emitterCompanyStreet,
-          city: form.emitterCompanyCity,
-          postalCode: form.emitterCompanyPostalCode
+          address: bsvhu.emitterCompanyAddress,
+          street: bsvhu.emitterCompanyStreet,
+          city: bsvhu.emitterCompanyCity,
+          postalCode: bsvhu.emitterCompanyPostalCode
         }),
-        contact: form.emitterCompanyContact,
-        phone: form.emitterCompanyPhone,
-        mail: form.emitterCompanyMail
+        contact: bsvhu.emitterCompanyContact,
+        phone: bsvhu.emitterCompanyPhone,
+        mail: bsvhu.emitterCompanyMail
       }),
       emission: nullIfNoValues<BsvhuEmission>({
         signature: nullIfNoValues<Signature>({
-          author: form.emitterEmissionSignatureAuthor,
-          date: processDate(form.emitterEmissionSignatureDate)
+          author: bsvhu.emitterEmissionSignatureAuthor,
+          date: processDate(bsvhu.emitterEmissionSignatureDate)
         })
       })
     }),
-    packaging: form.packaging,
-    wasteCode: form.wasteCode,
+    packaging: bsvhu.packaging,
+    wasteCode: bsvhu.wasteCode,
     identification: nullIfNoValues<BsvhuIdentification>({
-      numbers: form.identificationNumbers,
-      type: form.identificationType
+      numbers: bsvhu.identificationNumbers,
+      type: bsvhu.identificationType
     }),
-    quantity: form.quantity,
+    quantity: bsvhu.quantity,
     weight: nullIfNoValues<BsvhuWeight>({
-      value: form.weightValue ? form.weightValue / 1000 : form.weightValue,
-      isEstimate: form.weightIsEstimate
+      value: bsvhu.weightValue ? bsvhu.weightValue / 1000 : bsvhu.weightValue,
+      isEstimate: bsvhu.weightIsEstimate
     }),
     destination: nullIfNoValues<BsvhuDestination>({
-      type: form.destinationType,
-      agrementNumber: form.destinationAgrementNumber,
+      type: bsvhu.destinationType,
+      agrementNumber: bsvhu.destinationAgrementNumber,
       company: nullIfNoValues<FormCompany>({
-        name: form.destinationCompanyName,
-        siret: form.destinationCompanySiret,
-        address: form.destinationCompanyAddress,
-        contact: form.destinationCompanyContact,
-        phone: form.destinationCompanyPhone,
-        mail: form.destinationCompanyMail
+        name: bsvhu.destinationCompanyName,
+        siret: bsvhu.destinationCompanySiret,
+        address: bsvhu.destinationCompanyAddress,
+        contact: bsvhu.destinationCompanyContact,
+        phone: bsvhu.destinationCompanyPhone,
+        mail: bsvhu.destinationCompanyMail
       }),
-      plannedOperationCode: form.destinationPlannedOperationCode,
+      plannedOperationCode: bsvhu.destinationPlannedOperationCode,
       reception: nullIfNoValues<BsvhuReception>({
-        acceptationStatus: form.destinationReceptionAcceptationStatus,
-        date: processDate(form.destinationReceptionDate),
+        acceptationStatus: bsvhu.destinationReceptionAcceptationStatus,
+        date: processDate(bsvhu.destinationReceptionDate),
         identification: nullIfNoValues<BsvhuIdentification>({
-          numbers: form.destinationReceptionIdentificationNumbers,
-          type: form.destinationReceptionIdentificationType
+          numbers: bsvhu.destinationReceptionIdentificationNumbers,
+          type: bsvhu.destinationReceptionIdentificationType
         }),
-        weight: form.destinationReceptionWeight
-          ? form.destinationReceptionWeight / 1000
-          : form.destinationReceptionWeight,
-        refusalReason: form.destinationReceptionRefusalReason
+        weight: bsvhu.destinationReceptionWeight
+          ? bsvhu.destinationReceptionWeight / 1000
+          : bsvhu.destinationReceptionWeight,
+        refusalReason: bsvhu.destinationReceptionRefusalReason
       }),
       operation: nullIfNoValues<BsvhuOperation>({
-        code: form.destinationOperationCode,
-        mode: form.destinationOperationMode,
-        date: processDate(form.destinationOperationDate),
+        code: bsvhu.destinationOperationCode,
+        mode: bsvhu.destinationOperationMode,
+        date: processDate(bsvhu.destinationOperationDate),
         nextDestination: nullIfNoValues<BsvhuNextDestination>({
           company: nullIfNoValues<FormCompany>({
-            name: form.destinationOperationNextDestinationCompanyName,
-            siret: form.destinationOperationNextDestinationCompanySiret,
-            address: form.destinationOperationNextDestinationCompanyAddress,
-            contact: form.destinationOperationNextDestinationCompanyContact,
-            phone: form.destinationOperationNextDestinationCompanyPhone,
-            mail: form.destinationOperationNextDestinationCompanyMail
+            name: bsvhu.destinationOperationNextDestinationCompanyName,
+            siret: bsvhu.destinationOperationNextDestinationCompanySiret,
+            address: bsvhu.destinationOperationNextDestinationCompanyAddress,
+            contact: bsvhu.destinationOperationNextDestinationCompanyContact,
+            phone: bsvhu.destinationOperationNextDestinationCompanyPhone,
+            mail: bsvhu.destinationOperationNextDestinationCompanyMail
           })
         }),
 
         signature: nullIfNoValues<Signature>({
-          author: form.destinationOperationSignatureAuthor,
-          date: processDate(form.destinationOperationSignatureDate)
+          author: bsvhu.destinationOperationSignatureAuthor,
+          date: processDate(bsvhu.destinationOperationSignatureDate)
         })
       })
     }),
     transporter: nullIfNoValues<BsvhuTransporter>({
       company: nullIfNoValues<FormCompany>({
-        name: form.transporterCompanyName,
-        orgId: getTransporterCompanyOrgId(form),
-        siret: form.transporterCompanySiret,
-        address: form.transporterCompanyAddress,
-        contact: form.transporterCompanyContact,
-        phone: form.transporterCompanyPhone,
-        mail: form.transporterCompanyMail,
-        vatNumber: form.transporterCompanyVatNumber
+        name: bsvhu.transporterCompanyName,
+        orgId: getTransporterCompanyOrgId(bsvhu),
+        siret: bsvhu.transporterCompanySiret,
+        address: bsvhu.transporterCompanyAddress,
+        contact: bsvhu.transporterCompanyContact,
+        phone: bsvhu.transporterCompanyPhone,
+        mail: bsvhu.transporterCompanyMail,
+        vatNumber: bsvhu.transporterCompanyVatNumber
       }),
       customInfo: form.transporterCustomInfo,
       recepisse: nullIfNoValues<BsvhuRecepisse>({
-        number: form.transporterRecepisseNumber,
-        department: form.transporterRecepisseDepartment,
-        validityLimit: processDate(form.transporterRecepisseValidityLimit),
-        isExempted: form.transporterRecepisseIsExempted
+        number: bsvhu.transporterRecepisseNumber,
+        department: bsvhu.transporterRecepisseDepartment,
+        validityLimit: processDate(bsvhu.transporterRecepisseValidityLimit),
+        isExempted: bsvhu.transporterRecepisseIsExempted
       }),
       transport: nullIfNoValues<BsvhuTransport>({
-        mode: form.transporterTransportMode,
-        plates: form.transporterTransportPlates,
+        mode: bsvhu.transporterTransportMode,
+        plates: bsvhu.transporterTransportPlates,
         signature: nullIfNoValues<Signature>({
-          author: form.transporterTransportSignatureAuthor,
-          date: processDate(form.transporterTransportSignatureDate)
+          author: bsvhu.transporterTransportSignatureAuthor,
+          date: processDate(bsvhu.transporterTransportSignatureDate)
         }),
-        takenOverAt: processDate(form.transporterTransportTakenOverAt)
+        takenOverAt: processDate(bsvhu.transporterTransportTakenOverAt)
       })
     }),
     ecoOrganisme: nullIfNoValues<BsvhuEcoOrganisme>({
-      name: form.ecoOrganismeName,
-      siret: form.ecoOrganismeSiret
+      name: bsvhu.ecoOrganismeName,
+      siret: bsvhu.ecoOrganismeSiret
     }),
     broker: nullIfNoValues<BsvhuBroker>({
       company: nullIfNoValues<FormCompany>({
-        name: form.brokerCompanyName,
-        siret: form.brokerCompanySiret,
-        address: form.brokerCompanyAddress,
-        contact: form.brokerCompanyContact,
-        phone: form.brokerCompanyPhone,
-        mail: form.brokerCompanyMail
+        name: bsvhu.brokerCompanyName,
+        siret: bsvhu.brokerCompanySiret,
+        address: bsvhu.brokerCompanyAddress,
+        contact: bsvhu.brokerCompanyContact,
+        phone: bsvhu.brokerCompanyPhone,
+        mail: bsvhu.brokerCompanyMail
       }),
       recepisse: nullIfNoValues<BsvhuRecepisse>({
-        department: form.brokerRecepisseDepartment,
-        number: form.brokerRecepisseNumber,
-        validityLimit: processDate(form.brokerRecepisseValidityLimit)
+        department: bsvhu.brokerRecepisseDepartment,
+        number: bsvhu.brokerRecepisseNumber,
+        validityLimit: processDate(bsvhu.brokerRecepisseValidityLimit)
       })
     }),
     trader: nullIfNoValues<BsvhuTrader>({
       company: nullIfNoValues<FormCompany>({
-        name: form.traderCompanyName,
-        siret: form.traderCompanySiret,
-        address: form.traderCompanyAddress,
-        contact: form.traderCompanyContact,
-        phone: form.traderCompanyPhone,
-        mail: form.traderCompanyMail
+        name: bsvhu.traderCompanyName,
+        siret: bsvhu.traderCompanySiret,
+        address: bsvhu.traderCompanyAddress,
+        contact: bsvhu.traderCompanyContact,
+        phone: bsvhu.traderCompanyPhone,
+        mail: bsvhu.traderCompanyMail
       }),
       recepisse: nullIfNoValues<BsvhuRecepisse>({
-        department: form.traderRecepisseDepartment,
-        number: form.traderRecepisseNumber,
-        validityLimit: processDate(form.traderRecepisseValidityLimit)
+        department: bsvhu.traderRecepisseDepartment,
+        number: bsvhu.traderRecepisseNumber,
+        validityLimit: processDate(bsvhu.traderRecepisseValidityLimit)
       })
     }),
     metadata: null as any

--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -151,7 +151,7 @@ export function expandVhuFormFromDb(bsvhu: PrismaVhuForm): GraphqlVhuForm {
         mail: bsvhu.transporterCompanyMail,
         vatNumber: bsvhu.transporterCompanyVatNumber
       }),
-      customInfo: form.transporterCustomInfo,
+      customInfo: bsvhu.transporterCustomInfo,
       recepisse: nullIfNoValues<BsvhuRecepisse>({
         number: bsvhu.transporterRecepisseNumber,
         department: bsvhu.transporterRecepisseDepartment,

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -24,6 +24,7 @@ const DUPLICATE_BVHU = gql`
     duplicateBsvhu(id: $id) {
       id
       status
+      isDuplicateOf
     }
   }
 `;
@@ -294,7 +295,7 @@ describe("mutation.duplicateBsvhu", () => {
       "isDraft",
       "isDeleted",
       "status",
-
+      "isDuplicateOf",
       "emitterEmissionSignatureAuthor",
       "emitterEmissionSignatureDate",
       "transporterTransportSignatureAuthor",
@@ -320,6 +321,7 @@ describe("mutation.duplicateBsvhu", () => {
 
     expect(duplicatedBsvhu.status).toEqual("INITIAL");
     expect(duplicatedBsvhu.isDraft).toBe(true);
+    expect(duplicatedBsvhu.isDuplicateOf).toBe(bsvhu.id);
 
     expect(duplicatedBsvhu).toMatchObject({
       emitterIrregularSituation,

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -102,6 +102,7 @@ async function getDuplicateData(
     id: getReadableId(ReadableIdPrefix.VHU),
     status: BsvhuStatus.INITIAL,
     isDraft: true,
+    isDuplicateOf: bsvhu.id,
     createdAt: new Date(),
     emitterCompanyContact:
       emitter?.contact ?? parsedBsvhu.emitterCompanyContact,

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -43,6 +43,12 @@ type Bsvhu {
   "Status du bordereau"
   status: BsvhuStatus!
 
+  """
+  Identifiant du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
+
   "Émetteur du bordereau"
   emitter: BsvhuEmitter
 

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -38,6 +38,7 @@ describe("expandFormFromDb", () => {
       metadata: undefined,
       citerneNotWashedOutReason: null,
       hasCiterneBeenWashedOut: null,
+      isDuplicateOf: null,
       emitter: {
         type: form.emitterType,
         workSite: null,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -637,6 +637,7 @@ export function expandFormFromDb(
     readableId: form.readableId,
     customId: form.customId,
     isImportedFromPaper: form.isImportedFromPaper,
+    isDuplicateOf: form.isDuplicateOf,
     emitter: nullIfNoValues<Emitter>({
       type: form.emitterType,
       workSite: nullIfNoValues<WorkSite>({

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -21,6 +21,7 @@ type EditableBsddFields = Required<
     | "updatedAt"
     | "rowNumber"
     | "readableId"
+    | "isDuplicateOf"
     | "status"
     | "emittedBy"
     | "emittedAt"

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -1,10 +1,5 @@
 import { EmitterType, Prisma, Status, UserRole } from "@prisma/client";
 import { resetDatabase } from "../../../../../integration-tests/helper";
-import {
-  CompanySearchResult,
-  Mutation,
-  MutationCreateFormArgs
-} from "../../../../generated/graphql/types";
 import { prisma } from "@td/prisma";
 import {
   companyFactory,
@@ -22,6 +17,11 @@ import {
 } from "../../../database";
 import { searchCompany } from "../../../../companies/search";
 import getReadableId from "../../../readableId";
+import {
+  CompanySearchResult,
+  Mutation,
+  MutationCreateFormArgs
+} from "@td/codegen-back";
 
 jest.mock("../../../../companies/search");
 
@@ -37,6 +37,7 @@ const DUPLICATE_FORM = `
   mutation DuplicateForm($id: ID!) {
     duplicateForm(id: $id) {
       id
+      isDuplicateOf
       intermediaries {
         siret
         name
@@ -255,6 +256,7 @@ describe("Mutation.duplicateForm", () => {
       "rowNumber",
       "readableId",
       "status",
+      "isDuplicateOf",
       "emittedBy",
       "emittedAt",
       "emittedByEcoOrganisme",
@@ -342,6 +344,8 @@ describe("Mutation.duplicateForm", () => {
       }
     );
 
+    expect(data.duplicateForm.isDuplicateOf).toEqual(form.readableId);
+
     const duplicatedForm = await prisma.form.findUnique({
       where: { id: data.duplicateForm.id },
       include: { transporters: true }
@@ -350,6 +354,7 @@ describe("Mutation.duplicateForm", () => {
     const duplicatedTransporter = await getFirstTransporter(duplicatedForm!);
 
     expect(duplicatedForm).toMatchObject({
+      isDuplicateOf: form.readableId,
       emitterType,
       emitterPickupSite,
       emitterIsPrivateIndividual,
@@ -546,6 +551,7 @@ describe("Mutation.duplicateForm", () => {
       "rowNumber",
       "readableId",
       "status",
+      "isDuplicateOf",
       "recipientIsTempStorage",
       "emitterCompanyOmiNumber",
       "emitterIsForeignShip",

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -118,7 +118,9 @@ async function getDuplicateFormInput(
     recipientCompanyMail: recipient?.contactEmail ?? form.recipientCompanyMail,
     recipientIsTempStorage: form.recipientIsTempStorage,
     wasteDetailsCode: form.wasteDetailsCode,
-    wasteDetailsPackagingInfos: Prisma.JsonNull,
+    wasteDetailsPackagingInfos: prismaJsonNoNull(
+      form.wasteDetailsPackagingInfos
+    ),
     wasteDetailsQuantity: 0,
     wasteDetailsQuantityType: form.wasteDetailsQuantityType,
     wasteDetailsPop: form.wasteDetailsPop,
@@ -129,9 +131,11 @@ async function getDuplicateFormInput(
     wasteDetailsName: form.wasteDetailsName,
     wasteDetailsConsistence: form.wasteDetailsConsistence,
     wasteDetailsSampleNumber: form.wasteDetailsSampleNumber,
-    wasteDetailsIsSubjectToADR: form.wasteDetailsIsDangerous
-      ? true
-      : form.wasteDetailsIsSubjectToADR,
+    wasteDetailsIsSubjectToADR:
+      form.wasteDetailsIsDangerous || form.wasteDetailsPop
+        ? true
+        : form.wasteDetailsIsSubjectToADR,
+    wasteDetailsOnuCode: form.wasteDetailsOnuCode,
     traderCompanyName: trader?.name ?? form.traderCompanyName,
     traderCompanySiret: form.traderCompanySiret,
     traderCompanyAddress: trader?.address ?? form.traderCompanyAddress,

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -88,6 +88,7 @@ async function getDuplicateFormInput(
 
   return {
     readableId: getReadableId(),
+    isDuplicateOf: form.readableId,
     status: Status.DRAFT,
     owner: { connect: { id: user.id } },
     emitterType: form.emitterType,

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -22,6 +22,12 @@ type Form {
   customId: String
 
   """
+  Identifiant lisible du bordereau à partir duquel ce celui-ci a été dupliqué.
+  Est égal à `null` si le bordereau n'est pas issue d'une duplication.
+  """
+  isDuplicateOf: String
+
+  """
   Permet de savoir si les données du BSD ont été importées depuis un
   bordereau signé papier via la mutation `importPaperForm`
   """

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -161,6 +161,7 @@ export const staticFieldsFragment = gql`
     customId
     createdAt
     status
+    isDuplicateOf
     stateSummary {
       packagingInfos {
         type

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -170,6 +170,7 @@ export default function StepsList(props: Props) {
       ecoOrganisme,
       grouping,
       transporters,
+      isDuplicateOf,
       ...rest
     } = values;
 

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -130,7 +130,7 @@ export type CreateOrUpdateTransporterInput = TransporterInput & {
 
 export type FormFormikValues = Omit<FormInput, "transporters"> & {
   transporters: CreateOrUpdateTransporterInput[];
-} & { id?: string | null };
+} & { id?: string | null; isDuplicateOf?: string | null };
 
 /**
  * Computes initial values of Formik's form by merging
@@ -146,6 +146,7 @@ export function getInitialState(f?: Form | null): FormFormikValues {
   return {
     id: f?.id ?? null,
     customId: f?.customId ?? "",
+    isDuplicateOf: f?.isDuplicateOf,
     emitter: {
       pickupSite: null, // deprecated
       type: f?.emitter?.type ?? EmitterType.Producer,

--- a/libs/back/prisma/src/migrations/20250107141838_add_is_duplicate_of/migration.sql
+++ b/libs/back/prisma/src/migrations/20250107141838_add_is_duplicate_of/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "Bsda" ADD COLUMN     "isDuplicateOf" TEXT;
+
+-- AlterTable
+ALTER TABLE "Bsdasri" ADD COLUMN     "isDuplicateOf" TEXT;
+
+-- AlterTable
+ALTER TABLE "Bsff" ADD COLUMN     "isDuplicateOf" TEXT;
+
+-- AlterTable
+ALTER TABLE "Bspaoh" ADD COLUMN     "isDuplicateOf" TEXT;
+
+-- AlterTable
+ALTER TABLE "Bsvhu" ADD COLUMN     "isDuplicateOf" TEXT;
+
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "isDuplicateOf" TEXT;

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -336,17 +336,17 @@ model Company {
 // Cette table permet également de stocker de "faux établissements" pouvant être visés lors
 // du rattachement d'établissements de test sur l'environnement sandbox
 model AnonymousCompany {
-  id                String  @id @default(cuid())
+  id                String    @id @default(cuid())
   createdAt         DateTime? @default(now())
-  orgId             String  @unique(map: "AnonymousCompany.orgId_unique")
-  siret             String? @unique(map: "AnonymousCompany.siret_unique")
-  vatNumber         String? @unique(map: "AnonymousCompany.vatnumber_unique")
+  orgId             String    @unique(map: "AnonymousCompany.orgId_unique")
+  siret             String?   @unique(map: "AnonymousCompany.siret_unique")
+  vatNumber         String?   @unique(map: "AnonymousCompany.vatnumber_unique")
   name              String
   address           String
   codeNaf           String
   libelleNaf        String
   codeCommune       String
-  etatAdministratif String  @default("A")
+  etatAdministratif String    @default("A")
 
   @@index([vatNumber], map: "_AnonymousCompanyVatNumberIdx")
 }
@@ -443,6 +443,7 @@ model Form {
   updatedAt                             DateTime                   @updatedAt @db.Timestamptz(6)
   readableId                            String                     @unique(map: "Form.readableId._UNIQUE")
   customId                              String?
+  isDuplicateOf                         String?
   isDeleted                             Boolean?                   @default(false)
   status                                Status                     @default(DRAFT)
   emitterType                           EmitterType?
@@ -1016,7 +1017,8 @@ model Bsvhu {
   isDeleted Boolean  @default(false)
   customId  String?
 
-  status BsvhuStatus @default(INITIAL)
+  status        BsvhuStatus @default(INITIAL)
+  isDuplicateOf String?
 
   emitterIrregularSituation                           Boolean?                 @default(false)
   emitterNoSiret                                      Boolean?                 @default(false)
@@ -1086,8 +1088,8 @@ model Bsvhu {
   transporterTransportTakenOverAt                     DateTime?                @db.Timestamptz(6)
   transporterCustomInfo                               String?
   transporterTransportMode                            TransportMode?           @default(ROAD)
-  transporterTransportPlates     String[]
-  transporterRecepisseIsExempted Boolean?
+  transporterTransportPlates                          String[]
+  transporterRecepisseIsExempted                      Boolean?
 
   ecoOrganismeName  String?
   ecoOrganismeSiret String?
@@ -1181,14 +1183,15 @@ model IntermediaryBsvhuAssociation {
 }
 
 model Bsdasri {
-  id        String        @id
-  type      BsdasriType   @default(SIMPLE)
-  status    BsdasriStatus @default(INITIAL)
-  rowNumber Int           @unique(map: "Bsdasri_rowNumber_ukey") @default(autoincrement())
-  createdAt DateTime      @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime      @updatedAt @db.Timestamptz(6)
-  isDeleted Boolean?      @default(false)
-  isDraft   Boolean?      @default(false)
+  id            String        @id
+  type          BsdasriType   @default(SIMPLE)
+  status        BsdasriStatus @default(INITIAL)
+  rowNumber     Int           @unique(map: "Bsdasri_rowNumber_ukey") @default(autoincrement())
+  createdAt     DateTime      @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime      @updatedAt @db.Timestamptz(6)
+  isDeleted     Boolean?      @default(false)
+  isDraft       Boolean?      @default(false)
+  isDuplicateOf String?
 
   emitterCompanyName                          String?
   emitterCompanySiret                         String?
@@ -1400,14 +1403,15 @@ model BsdasriRevisionRequestApproval {
 // end dasri revisions
 
 model Bsff {
-  id        String     @id
-  rowNumber Int        @unique(map: "Bsff_rowNumber_ukey") @default(autoincrement())
-  createdAt DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime   @updatedAt @db.Timestamptz(6)
-  status    BsffStatus @default(INITIAL)
-  isDraft   Boolean    @default(false)
-  type      BsffType   @default(TRACER_FLUIDE)
-  isDeleted Boolean    @default(false)
+  id            String     @id
+  rowNumber     Int        @unique(map: "Bsff_rowNumber_ukey") @default(autoincrement())
+  createdAt     DateTime   @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime   @updatedAt @db.Timestamptz(6)
+  status        BsffStatus @default(INITIAL)
+  isDraft       Boolean    @default(false)
+  type          BsffType   @default(TRACER_FLUIDE)
+  isDeleted     Boolean    @default(false)
+  isDuplicateOf String?
 
   emitterCompanyName             String?
   emitterCompanySiret            String?
@@ -1607,14 +1611,15 @@ model BsffPackaging {
 }
 
 model Bsda {
-  id        String     @id
-  rowNumber Int        @unique(map: "Bsda_rowNumber_ukey") @default(autoincrement())
-  createdAt DateTime   @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime   @updatedAt @db.Timestamptz(6)
-  isDraft   Boolean    @default(false)
-  isDeleted Boolean    @default(false)
-  status    BsdaStatus @default(INITIAL)
-  type      BsdaType   @default(OTHER_COLLECTIONS)
+  id            String     @id
+  rowNumber     Int        @unique(map: "Bsda_rowNumber_ukey") @default(autoincrement())
+  createdAt     DateTime   @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime   @updatedAt @db.Timestamptz(6)
+  isDraft       Boolean    @default(false)
+  isDeleted     Boolean    @default(false)
+  status        BsdaStatus @default(INITIAL)
+  type          BsdaType   @default(OTHER_COLLECTIONS)
+  isDuplicateOf String?
 
   emitterIsPrivateIndividual     Boolean?
   emitterCompanyName             String?
@@ -1909,12 +1914,13 @@ model Event {
 }
 
 model Bspaoh {
-  id        String       @id
-  rowNumber Int          @unique(map: "Bspaoh_rowNumber_ukey") @default(autoincrement())
-  createdAt DateTime     @default(now()) @db.Timestamptz(6)
-  updatedAt DateTime     @updatedAt @db.Timestamptz(6)
-  isDeleted Boolean      @default(false)
-  status    BspaohStatus @default(INITIAL)
+  id            String       @id
+  rowNumber     Int          @unique(map: "Bspaoh_rowNumber_ukey") @default(autoincrement())
+  createdAt     DateTime     @default(now()) @db.Timestamptz(6)
+  updatedAt     DateTime     @updatedAt @db.Timestamptz(6)
+  isDeleted     Boolean      @default(false)
+  status        BspaohStatus @default(INITIAL)
+  isDuplicateOf String?
 
   wasteCode       String?
   wasteAdr        String?


### PR DESCRIPTION
# Contexte

En tant que, utilisateur de la plateforme Trackdéchets, 

Je souhaite, lorsque je duplique un BSDD que les types de conditionnements ainsi que l'ADR soient dupliqués, 

Afin de, gagner du temps lorsque je crée l'ensemble de mes bordereaux. 

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

- On crée un BSDD avec un conditionnement et une mention ADR.
- On le duplique et on constate que le conditionnement et la mention ADR ont bien été dupliqués.
- On modifie le BSDD dupliqué et on constate qu'on a un message d'avertissement.
- On va jusqu'à la signature transporteur et on constate que le message d'avertissement n'est plus visible quand les champs sont scellés.


https://github.com/user-attachments/assets/57e67f65-9b53-44c8-8d4a-4dc955242e76



# Ticket Favro

[Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif sur le besoin de confirmer, selon le type de BSDD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15504)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB