### PR TITLE
[tra-15650]fix recette vhu situation irréguliere vider le champ agrement + fix afficher le  message d'erreur sur conditionnement en unité quand la valeur n'est pas sélectionée

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Emitter.tsx
@@ -153,6 +153,10 @@ const EmitterBsvhu = ({ errors }) => {
                   );
                   if (!e.currentTarget.checked) {
                     setValue("emitter.noSiret", false);
+                  } else {
+                    if (emitter.agrementNumber) {
+                      setValue("emitter.agrementNumber", "");
+                    }
                   }
                 }
               }

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -54,6 +54,12 @@ const WasteBsvhu = ({
         formState.errors?.identification?.numbers?.length,
         setError
       );
+      setFieldError(
+        errors,
+        "identification.type",
+        formState.errors?.identification?.type,
+        setError
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [errors]);
@@ -140,6 +146,10 @@ const WasteBsvhu = ({
           disabled={sealedFields.includes("identification.type")}
           className="fr-col-sm-10 fr-ml-3w"
           options={identificationTypeOptions}
+          state={formState.errors?.identification?.type && "error"}
+          stateRelatedMessage={
+            formState.errors?.identification?.type?.["message"]
+          }
         />
       )}
       <fieldset className="fr-fieldset">


### PR DESCRIPTION

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Fix de recette vhu situation irrégulière => vider le champ agrément démolisseur quand on coche la checkbox

Plus, en voulant fixer ce retour j'ai vu un bug d'affichage sur l'onglet "Dechet" : quand on ne sélectionne pas de condionnement et qu'on veux "enregistrer en brouillon" on a l'onglet déchet en erreur mais pas le message correspondant au champ en erreur
# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[tra-15650](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15650)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB