### PR TITLE
[Recette/tra-15501] Permettre la modification des informations d'un contenant à la signature de son opération et après son traitement pendant 60 jours

### DIFF
--- a/back/src/bsffs/__tests__/factories.ts
+++ b/back/src/bsffs/__tests__/factories.ts
@@ -311,6 +311,21 @@ export function createBsffAfterAcceptation(
   });
 }
 
+export function createBsffAfterRefusal(
+  companies: Required<BsffFactoryCompanies>,
+  opts: BsffFactoryOpts = {}
+) {
+  return createBsffBeforeRefusal(companies, {
+    ...opts,
+    data: { status: BsffStatus.REFUSED, ...opts.data },
+    packagingData: {
+      acceptationSignatureAuthor: "Juste Leblanc",
+      acceptationSignatureDate: new Date().toISOString(),
+      ...opts.packagingData
+    }
+  });
+}
+
 export function createBsffBeforeOperation(
   companies: Required<BsffFactoryCompanies>,
   opts: BsffFactoryOpts = {}

--- a/back/src/bsffs/__tests__/registry.integration.ts
+++ b/back/src/bsffs/__tests__/registry.integration.ts
@@ -208,6 +208,39 @@ describe("toGenericWaste", () => {
     expect(waste.emitterCompanyCity).toBe("Nantes");
     expect(waste.emitterCompanyCountry).toBe("FR");
   });
+
+  it(
+    "it should return accepted wasteCode and wasteDescription when there is" +
+      " only one packaging",
+    async () => {
+      const emitter = await userWithCompanyFactory();
+      const transporter = await userWithCompanyFactory();
+      const destination = await userWithCompanyFactory();
+
+      const bsff = await createBsffAfterAcceptation(
+        { emitter, transporter, destination },
+        {
+          data: {
+            wasteCode: "14 06 01*",
+            wasteDescription: "HFC"
+          },
+          packagingData: {
+            acceptationWasteCode: "14 06 02*",
+            acceptationWasteDescription: "HFC 2"
+          }
+        }
+      );
+
+      const bsffForRegistry = await prisma.bsff.findUniqueOrThrow({
+        where: { id: bsff.id },
+        include: RegistryBsffInclude
+      });
+      const waste = toGenericWaste(bsffForRegistry);
+
+      expect(waste.wasteCode).toEqual("14 06 02*");
+      expect(waste.wasteDescription).toEqual("HFC 2");
+    }
+  );
 });
 
 describe("toIncomingWaste", () => {

--- a/back/src/bsffs/pdf/BsffPdf.tsx
+++ b/back/src/bsffs/pdf/BsffPdf.tsx
@@ -315,6 +315,7 @@ function BsffQuantity({
   renderEmpty
 }: Pick<Props, "bsff" | "renderEmpty">) {
   const renderCheckboxState = !renderEmpty;
+
   return (
     <div className="BoxCol">
       <p>
@@ -340,7 +341,11 @@ function BsffQuantity({
               />{" "}
               Estimée
               <br />
-              "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2" de l'ADR 2023
+              {bsff.weight?.isEstimate && (
+                <div>
+                  "QUANTITÉE ESTIMÉE CONFORMÉMENT AU 5.4.1.1.3.2 de l'ADR"
+                </div>
+              )}
             </span>
           </div>
           <div>Kilogramme(s) : {bsff.weight.value}</div>

--- a/back/src/bsffs/pdf/generator.tsx
+++ b/back/src/bsffs/pdf/generator.tsx
@@ -82,7 +82,7 @@ export async function buildPdf(bsff: BsffForBuildPdf, renderEmpty?: boolean) {
     bsffForPdf = emptyValues(bsffForPdf);
   }
   const html = ReactDOMServer.renderToStaticMarkup(
-    <BsffPdf bsff={bsffForPdf} qrCode={qrCode} renderEmpty={true} />
+    <BsffPdf bsff={bsffForPdf} qrCode={qrCode} renderEmpty={renderEmpty} />
   );
   return generatePdf(html);
 }

--- a/back/src/bsffs/registry.ts
+++ b/back/src/bsffs/registry.ts
@@ -313,9 +313,22 @@ export function toGenericWaste(bsff: RegistryBsff): GenericWaste {
     country: emitterCompanyCountry
   } = splitAddress(bsff.emitterCompanyAddress);
 
+  let wasteCode = bsff.wasteCode;
+  let wasteDescription = bsff.wasteDescription;
+
+  if (
+    bsff.packagings.length === 1 &&
+    bsff.packagings[0].acceptationSignatureDate
+  ) {
+    const packaging = bsff.packagings[0];
+    wasteCode = packaging.acceptationWasteCode ?? wasteCode;
+    wasteDescription =
+      packaging.acceptationWasteDescription ?? wasteDescription;
+  }
+
   return {
-    wasteDescription: bsff.wasteDescription,
-    wasteCode: bsff.wasteCode,
+    wasteDescription,
+    wasteCode,
     wasteIsDangerous: true,
     pop: false,
     id: bsff.id,

--- a/back/src/bsffs/repository/bsffPackaging/update.ts
+++ b/back/src/bsffs/repository/bsffPackaging/update.ts
@@ -39,12 +39,18 @@ export function buildUpdateBsffPackaging(
       }
     });
 
-    if (bsffPackaging.operationSignatureDate && args.data.operationCode) {
+    if (
       // Il s'agit d'un changement sur le code de traitement du contenant
       // qui est effectuée suite à la signature de l'opération via une correction.
       // Nous devons donc recalculer le statut du BSFF au cas où l'on ait un
       // changement Processed -> IntermediatelyProcessed
       // ou IntermediatelyProcessed -> Processed
+      (bsffPackaging.operationSignatureDate && args.data.operationCode) ||
+      // Il s'agit d'une correction du statut d'acceptation qui est effectuée suite
+      // à la signature du refus. Nous devons donc recalculer le statut du BSFF au
+      // cas où il y ait un changement Refused => Accepted, Refused => PartiallyRefused
+      (bsffPackaging.acceptationSignatureDate && args.data.acceptationStatus)
+    ) {
       const bsff = await prisma.bsff.findUniqueOrThrow({
         where: { id: bsffPackaging.bsffId },
         include: { packagings: true }

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
@@ -564,11 +564,10 @@ function SignBsffPackagingForm({
         )}
         {isAccepted && (
           <div className="fr-grid-row fr-grid-row--gutters">
-            <div className="fr-col-12 fr-col-md-4">
+            <div className="fr-col-12 fr-col-md-6">
               <NonScrollableInput
                 label="Quantité de fluide présentée en kg"
                 hintText="pour les installations d'entreposage ou de reconditionnement, la quantité peut être estimée"
-                disabled={isRefused}
                 nativeInputProps={{
                   ...register("acceptation.weight", {
                     valueAsNumber: true
@@ -589,7 +588,6 @@ function SignBsffPackagingForm({
             </div>
           </div>
         )}
-
         {
           // signature du traitement ou correction
           showOperation && (

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
@@ -45,35 +45,47 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 
 type SignBsffPackagingFormProps = {
-  packaging: BsffPackaging & { bsff?: Bsff };
+  packaging: BsffPackaging & { bsff: Bsff };
   onCancel: () => void;
   onSuccess: () => void;
 };
 
 type FormValues = UpdateBsffPackagingInput & { signature: BsffSignatureInput };
 
+function getDefaultWeight(packaging: BsffPackaging & { bsff?: Bsff }) {
+  if (packaging.bsff.packagings.length === 1 && packaging.bsff.weight?.value) {
+    // Lorsqu'un seul contenant est présent sur le BSFF
+    // on prend la valeur du poids total renseigné sur le BSFF lors de l'émission
+    // comme valeur par défaut pour le contenant
+    return packaging.bsff.weight.value;
+  }
+  return 0;
+}
+
 function getDefaultFormValues(
   packaging: BsffPackaging & { bsff?: Bsff }
 ): FormValues {
+  const today = new Date();
+
   return {
     acceptation: {
-      weight: packaging?.acceptation?.weight ?? 0,
+      weight: packaging?.acceptation?.weight ?? getDefaultWeight(packaging),
       status: packaging?.acceptation?.status ?? WasteAcceptationStatus.Accepted,
       date: packaging?.acceptation?.date
         ? datetimeToYYYYMMDD(new Date(packaging.acceptation.date))
-        : "",
+        : datetimeToYYYYMMDD(today),
       wasteCode:
         packaging?.acceptation?.wasteCode ?? packaging.bsff?.waste?.code ?? "",
       wasteDescription:
         packaging?.acceptation?.wasteDescription ??
         packaging.bsff?.waste?.description ??
         "",
-      refusalReason: null
+      refusalReason: packaging?.acceptation?.refusalReason ?? null
     },
     operation: {
       date: packaging?.operation?.date
         ? datetimeToYYYYMMDD(new Date(packaging.operation.date))
-        : "",
+        : datetimeToYYYYMMDD(today),
       code: packaging?.operation?.code ?? BsffOperationCode.R1,
       mode: packaging?.operation?.mode ?? OperationMode.Elimination,
       description: packaging?.operation?.description ?? "",
@@ -221,27 +233,38 @@ const signatureSchema = z.object({
   })
 });
 
-function getSchema(signatureType: BsffSignatureType | null) {
-  if (signatureType === BsffSignatureType.Operation) {
-    return acceptationSchema
-      .merge(operationSchema)
-      .merge(signatureSchema)
-      .superRefine(acceptationRefinement);
-  } else if (signatureType === null) {
-    // cas de la correction
+function getSchema(packaging: BsffPackaging) {
+  if (packaging?.operation?.signature?.date) {
+    // Correction post traitement
     return acceptationSchema
       .merge(operationSchema)
       .superRefine(acceptationRefinement);
   }
 
-  // cas de l'acceptation
+  if (packaging?.acceptation?.signature?.date) {
+    if (packaging?.acceptation?.status === WasteAcceptationStatus.Refused) {
+      // Correction d'un refus
+      return acceptationSchema.superRefine(acceptationRefinement);
+    } else {
+      // Signature de l'opération
+      return acceptationSchema
+        .merge(operationSchema)
+        .merge(signatureSchema)
+        .superRefine(acceptationRefinement);
+    }
+  }
+
+  // Signature de l'acceptation
   return acceptationSchema
     .merge(signatureSchema)
     .superRefine(acceptationRefinement);
 }
 
 function getSignatureType(packaging: BsffPackaging): BsffSignatureType | null {
-  if (packaging?.operation?.signature?.date) {
+  if (
+    packaging?.operation?.signature?.date ||
+    packaging?.acceptation?.status === WasteAcceptationStatus.Refused
+  ) {
     return null;
   }
   if (packaging?.acceptation?.signature?.date) {
@@ -310,7 +333,7 @@ function SignBsffPackagingForm({
     }
   }, [signatureType, loading]);
 
-  const schema = useMemo(() => getSchema(signatureType), [signatureType]);
+  const schema = useMemo(() => getSchema(packaging), [packaging]);
 
   const methods = useForm<FormValues>({
     defaultValues,
@@ -462,7 +485,10 @@ function SignBsffPackagingForm({
           </div>
         </div>
 
-        {signatureType === BsffSignatureType.Acceptation && (
+        {(signatureType === BsffSignatureType.Acceptation ||
+          (signatureType === null &&
+            packaging.acceptation?.status ===
+              WasteAcceptationStatus.Refused)) && (
           <>
             <div className="fr-grid-row fr-grid-row--gutters">
               <div className="fr-col-12">
@@ -482,13 +508,31 @@ function SignBsffPackagingForm({
                         field.onChange(status);
                         if (!checked) {
                           setValue("acceptation.refusalReason", null);
-                          unregister("acceptation.refusalReason");
+                          setValue(
+                            "acceptation.weight",
+                            getDefaultWeight(packaging)
+                          );
                         } else {
                           setValue("acceptation.weight", 0);
                         }
                       }}
                     />
                   )}
+                />
+              </div>
+            </div>
+            <div className="fr-grid-row fr-grid-row--gutters">
+              <div className="fr-col-12 fr-col-md-4">
+                <Input
+                  label={acceptationDateLabel}
+                  nativeInputProps={{
+                    max: maxDate,
+                    min: minDate,
+                    type: "date",
+                    ...register("acceptation.date")
+                  }}
+                  state={errors.acceptation?.date ? "error" : "default"}
+                  stateRelatedMessage={errors.acceptation?.date?.message}
                 />
               </div>
             </div>
@@ -511,55 +555,43 @@ function SignBsffPackagingForm({
                 </div>
               </div>
             )}
-            <div className="fr-grid-row fr-grid-row--gutters">
-              <div className="fr-col-12 fr-col-md-4">
-                <Input
-                  label={acceptationDateLabel}
-                  nativeInputProps={{
-                    max: maxDate,
-                    min: minDate,
-                    type: "date",
-                    ...register("acceptation.date")
-                  }}
-                  state={errors.acceptation?.date ? "error" : "default"}
-                  stateRelatedMessage={errors.acceptation?.date?.message}
-                />
-              </div>
-            </div>
           </>
         )}
-
-        <div className="fr-grid-row fr-grid-row--gutters">
-          <div className="fr-col-12 fr-col-md-4">
-            <NonScrollableInput
-              label="Quantité de fluide présentée en kg"
-              hintText="pour les installations d'entreposage ou de reconditionnement, la quantité peut être estimée"
-              disabled={isRefused}
-              nativeInputProps={{
-                ...register("acceptation.weight", {
-                  valueAsNumber: true
-                }),
-                type: "number",
-                inputMode: "decimal",
-                step: "1"
-              }}
-              state={errors.acceptation?.weight ? "error" : "default"}
-              stateRelatedMessage={errors.acceptation?.weight?.message}
-            />
-            {acceptationWeight > 0 && (
-              <p className="fr-info-text fr-mt-5v">
-                Soit {new Decimal(acceptationWeight).dividedBy(1000).toFixed(4)}{" "}
-                t
-              </p>
-            )}
+        {isAccepted && (
+          <div className="fr-grid-row fr-grid-row--gutters">
+            <div className="fr-col-12 fr-col-md-4">
+              <NonScrollableInput
+                label="Quantité de fluide présentée en kg"
+                hintText="pour les installations d'entreposage ou de reconditionnement, la quantité peut être estimée"
+                disabled={isRefused}
+                nativeInputProps={{
+                  ...register("acceptation.weight", {
+                    valueAsNumber: true
+                  }),
+                  type: "number",
+                  inputMode: "decimal",
+                  step: "0.001" // grammes
+                }}
+                state={errors.acceptation?.weight ? "error" : "default"}
+                stateRelatedMessage={errors.acceptation?.weight?.message}
+              />
+              {acceptationWeight > 0 && (
+                <p className="fr-info-text fr-mt-5v">
+                  Soit{" "}
+                  {new Decimal(acceptationWeight).dividedBy(1000).toFixed(4)} t
+                </p>
+              )}
+            </div>
           </div>
-        </div>
+        )}
 
         {
           // signature traitement
           (signatureType === BsffSignatureType.Operation ||
-            // ou correction
-            signatureType === null) && (
+            // ou correction (sauf refus)
+            (signatureType === null &&
+              packaging.acceptation?.status ===
+                WasteAcceptationStatus.Accepted)) && (
             <>
               <h6 className="fr-h6">Traitement</h6>
               <div className="fr-grid-row fr-grid-row--gutters">

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingModal.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingModal.tsx
@@ -7,7 +7,12 @@ import {
   Modal
 } from "../../../../common/components";
 import { useQuery } from "@apollo/client";
-import { BsffPackaging, Query, QueryBsffPackagingArgs } from "@td/codegen-ui";
+import {
+  BsffPackaging,
+  Query,
+  QueryBsffPackagingArgs,
+  WasteAcceptationStatus
+} from "@td/codegen-ui";
 import { GET_BSFF_PACKAGING } from "./queries";
 import { Loader } from "../../../common/Components";
 import Alert from "@codegouvfr/react-dsfr/Alert";
@@ -19,10 +24,14 @@ type SignBsffPackagingModalProps = {
 };
 
 function getModalTitle(packaging: BsffPackaging) {
-  if (packaging.operation?.signature) {
+  if (
+    packaging.operation?.signature?.date ||
+    (packaging.acceptation?.signature?.date &&
+      packaging.acceptation?.status === WasteAcceptationStatus.Refused)
+  ) {
     return `Corriger le contenant ${packaging.numero}`;
   }
-  if (packaging?.acceptation?.signature) {
+  if (packaging?.acceptation?.signature?.date) {
     return `Signer le traitement du contenant ${packaging.numero}`;
   }
   return `Signer l'acceptation du contenant ${packaging.numero}`;

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
@@ -270,6 +270,7 @@ export function SignBsffPackagingsModal({
           noCaption
           headers={headers}
           data={tableData}
+          fixed={true}
         ></Table>
         <div>{packagingsRecap}</div>
       </Modal>

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
@@ -31,19 +31,27 @@ interface SignPackagingsModalProps {
 }
 
 function getSignBtnLabel(packaging: BsffPackaging): string | null {
-  if (!!packaging.operation?.signature?.date) {
-    // Calcule le nombre de jours depuis la signature du traitement
-    const daysOld = differenceInDays(
-      new Date(),
-      new Date(packaging.operation.signature.date)
-    );
+  if (
+    !!packaging.operation?.signature?.date ||
+    (!!packaging.acceptation?.signature?.date &&
+      packaging.acceptation?.status === WasteAcceptationStatus.Refused)
+  ) {
+    const signatureDate =
+      packaging.operation?.signature?.date ??
+      packaging.acceptation?.signature?.date;
 
-    if (daysOld <= 60 && !packaging.nextBsff) {
-      // La correction est autorisée pendant un maximum de 60 jours
-      // après la signature de traitement du contenant et tant que le
-      // contenant n'a pas été groupé / réexpédié / reconditionné
-      return "Corriger";
+    if (signatureDate) {
+      // Calcule le nombre de jours depuis la signature du traitement ou du refus
+      const daysOld = differenceInDays(new Date(), new Date(signatureDate));
+
+      if (daysOld <= 60 && !packaging.nextBsff) {
+        // La correction est autorisée pendant un maximum de 60 jours
+        // après la signature de traitement du contenant et tant que le
+        // contenant n'a pas été groupé / réexpédié / reconditionné
+        return "Corriger";
+      }
     }
+
     return null;
   }
   if (packaging.acceptation?.signature?.date) {

--- a/front/src/Apps/Dashboard/Signature/bsff/queries.ts
+++ b/front/src/Apps/Dashboard/Signature/bsff/queries.ts
@@ -45,6 +45,9 @@ const bsffPackagingFragment = gql`
       weight {
         value
       }
+      destination {
+        plannedOperationCode
+      }
       packagings {
         id
       }

--- a/front/src/Apps/Dashboard/Signature/bsff/queries.ts
+++ b/front/src/Apps/Dashboard/Signature/bsff/queries.ts
@@ -13,6 +13,7 @@ const bsffPackagingFragment = gql`
       weight
       wasteCode
       wasteDescription
+      refusalReason
       signature {
         date
       }
@@ -40,6 +41,12 @@ const bsffPackagingFragment = gql`
       waste {
         code
         description
+      }
+      weight {
+        value
+      }
+      packagings {
+        id
       }
     }
     nextBsff {
@@ -81,7 +88,6 @@ export const GET_BSFF_PACKAGING = gql`
 export const UPDATE_BSFF_PACKAGING = gql`
   mutation UpdateBsffPackaging($id: ID!, $input: UpdateBsffPackagingInput!) {
     updateBsffPackaging(id: $id, input: $input) {
-      id
       ...BsffPackagingFragment
     }
   }

--- a/front/src/Apps/Dashboard/Validation/workflow/Act/ActBsffValidation.tsx
+++ b/front/src/Apps/Dashboard/Validation/workflow/Act/ActBsffValidation.tsx
@@ -72,6 +72,7 @@ const ActBsffValidation = ({
       {[
         BsffStatus.Received,
         BsffStatus.Accepted,
+        BsffStatus.Refused,
         BsffStatus.PartiallyRefused,
         BsffStatus.Processed,
         BsffStatus.IntermediatelyProcessed
@@ -79,7 +80,7 @@ const ActBsffValidation = ({
         // La modale de signature et de correction par contenant est la même
         // à partir de la réception du BSFF. L'affichage des différents
         // champs du formulaire en fonction du statut est géré directement
-        // au sein des modales <SignBsffPackagingModal /> (1 seul contenant)ou
+        // au sein des modales <SignBsffPackagingModal /> (1 seul contenant) ou
         // <SignPackagings /> (plusieurs contenants).
         renderReceivedModal()}
     </>

--- a/front/src/Apps/Dashboard/dashboardServices.test.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.test.ts
@@ -1582,6 +1582,22 @@ describe("dashboardServices", () => {
       expect(result).toBe(true);
     });
 
+    it("should return true if bsd type is BSFF, status is Refused, and within 60 days of refusal", () => {
+      const result = canMakeCorrection(
+        {
+          ...bsd,
+          status: BsdStatusCode.Refused,
+          packagings: [
+            {
+              acceptation: { signature: { date: new Date().toISOString() } }
+            } as BsffPackaging
+          ]
+        },
+        currentSiret
+      );
+      expect(result).toBe(true);
+    });
+
     it("should return false if bsd type is not BSFF", () => {
       const result = canMakeCorrection(
         { ...bsd, type: BsdType.Bsda },

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1593,9 +1593,11 @@ export const canUpdateBsd = (bsd, siret) =>
 export const canGeneratePdf = bsd => bsd.type === BsdType.Bsff || !bsd.isDraft;
 
 export const canMakeCorrection = (bsd: BsdDisplay, siret: string) => {
-  const lastOperationSignatureDate = () =>
+  const lastSignatureDate = () =>
     (bsd.packagings ?? []).reduce((lastDate, packaging) => {
-      const signatureDate = packaging?.operation?.signature?.date;
+      const signatureDate =
+        packaging?.operation?.signature?.date ??
+        packaging?.acceptation?.signature?.date;
       if (signatureDate) {
         const date = new Date(signatureDate);
         if (lastDate) {
@@ -1615,11 +1617,12 @@ export const canMakeCorrection = (bsd: BsdDisplay, siret: string) => {
     bsd.type === BsdType.Bsff &&
     isSameSiretDestination(siret, bsd) &&
     (bsd.status === BsdStatusCode.Processed ||
+      bsd.status === BsdStatusCode.Refused ||
       (bsd.status === BsdStatusCode.IntermediatelyProcessed &&
         !haveNextBsff())) &&
     // On autorise la correction d'un BSFF pendant 60 jours après
     // la dernière signature de l'opération sur les contenants
-    differenceInDays(new Date(), lastOperationSignatureDate()) <= 60
+    differenceInDays(new Date(), lastSignatureDate()) <= 60
   );
 };
 

--- a/front/src/Apps/common/Components/NonScrollableInput/NonScrollableInput.tsx
+++ b/front/src/Apps/common/Components/NonScrollableInput/NonScrollableInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
-import Input from "@codegouvfr/react-dsfr/Input";
+import Input, { InputProps } from "@codegouvfr/react-dsfr/Input";
 
-export default function NonScrollableInput(props) {
+export default function NonScrollableInput(props: InputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {

--- a/front/src/Apps/common/queries/fragments/bsff.ts
+++ b/front/src/Apps/common/queries/fragments/bsff.ts
@@ -71,6 +71,9 @@ export const dashboardBsffFragment = gql`
         wasteCode
         wasteDescription
         weight
+        signature {
+          date
+        }
       }
       operation {
         code


### PR DESCRIPTION
- [x] pré-compléter les dates d'acceptation et de traitement avec la date du jour.
- [x] pré-compléter le poids avec le poids renseigné sur le BSFF lorqu'il n'y a qu'un seul contenant.  
- [x] pouvoir ajouter un poids avec des décimales lors de l'acceptation.
- [x] pré-compléter le code opération avec le code opération prévu. 
- [x] PDF : manque la coche quantité réelle ou estimée
- [x] Afficher le code déchet et la description du contenant à l'acceptation dans le registre lorsqu'il n'y a qu'un seul contenant. 
- [x] [UX] Élargir le champ "Quantité de fluide présentée en kg".
- [x] [UX] Masquer le champ "Quantité de fluide présentée en kg" en cas de refus plutôt que de le désactiver. 
- [x] [UX] Adapter la largeur du tableau de gestion des contenants à la taille de la modale. 

[Ticket Favro](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15501)