### PR TITLE
[tra-15333]Permettre au créateur d'Effacer le composant transporteur lorsqu'il n'y a qu'un seul transporteur de visé

### DIFF
--- a/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.test.tsx
@@ -23,6 +23,7 @@ describe("TransporterAccordion", () => {
       onTransporterShiftUp={onTransporterShiftUp}
       onTransporterShiftDown={onTransporterShiftDown}
       onExpanded={onExpanded}
+      deleteLabel="Supprimer"
     >
       {foldableContent}
     </TransporterAccordion>

--- a/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
+++ b/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
@@ -82,11 +82,11 @@ export function TransporterAccordion({
             priority="tertiary"
             iconPosition="right"
             iconId="ri-delete-bin-line"
-            title="Supprimer"
+            title={disableUp && disableDown ? "Effacer" : "Supprimer"}
             onClick={onTransporterDelete}
             disabled={disableDelete}
           >
-            Supprimer
+            {disableUp && disableDown ? "Effacer" : "Supprimer"}
           </Button>
           <Button
             type="button"

--- a/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
+++ b/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
@@ -87,6 +87,9 @@ export function TransporterAccordion({
             title={deleteLabel}
             onClick={onTransporterDelete}
             disabled={disableDelete}
+            nativeButtonProps={{
+              "data-testid": collapseElementId
+            }}
           >
             {deleteLabel}
           </Button>

--- a/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
+++ b/front/src/Apps/Forms/Components/TransporterAccordion/TransporterAccordion.tsx
@@ -16,6 +16,7 @@ export type TransporterAccordionProps = {
   disableDown?: boolean;
   expanded?: boolean;
   children: NonNullable<React.ReactNode>;
+  deleteLabel: string;
 };
 
 /**
@@ -38,7 +39,8 @@ export function TransporterAccordion({
   disableDelete = false,
   disableUp = false,
   disableDown = false,
-  children
+  children,
+  deleteLabel
 }: TransporterAccordionProps) {
   const collapseElementId = `transporter__${numero}__form`;
 
@@ -82,11 +84,11 @@ export function TransporterAccordion({
             priority="tertiary"
             iconPosition="right"
             iconId="ri-delete-bin-line"
-            title={disableUp && disableDown ? "Effacer" : "Supprimer"}
+            title={deleteLabel}
             onClick={onTransporterDelete}
             disabled={disableDelete}
           >
-            {disableUp && disableDown ? "Effacer" : "Supprimer"}
+            {deleteLabel}
           </Button>
           <Button
             type="button"

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
@@ -97,7 +97,7 @@ describe("<TransporterList />", () => {
     "delete button is disabled when there is only one transporter and bsdType is %p",
     bsdType => {
       render(component([getInitialTransporter(bsdType)], bsdType));
-      const addButton = screen.getByTitle("Supprimer");
+      const addButton = screen.getByTestId("transporter__1__form");
       expect(addButton).toBeDisabled();
     }
   );
@@ -159,8 +159,9 @@ describe("<TransporterList />", () => {
       );
       expect(await screen.findByText("1 - Transporteur")).toBeInTheDocument();
       expect(await screen.findByText("2 - Transporteur")).toBeInTheDocument();
-      const deleteButtons = screen.getAllByTitle("Supprimer");
-      fireEvent.click(deleteButtons[1]);
+      const deleteButtonTransporteur2 =
+        screen.getByTestId(`transporter__2__form`);
+      fireEvent.click(deleteButtonTransporteur2);
       expect(await screen.findByText("1 - Transporteur")).toBeInTheDocument();
       await expect(() =>
         screen.findByText("2 - Transporteur")
@@ -316,8 +317,9 @@ describe("<TransporterList />", () => {
       ).toBeInTheDocument();
 
       expect(screen.getByText("Date de prise en charge")).toBeInTheDocument();
-      const deleteButtons = screen.getAllByTitle("Supprimer");
-      expect(deleteButtons[0]).toBeDisabled();
+      const deleteButton1 = screen.getByTestId("transporter__1__form");
+
+      expect(deleteButton1).toBeDisabled();
       const upButtons = screen.getAllByTitle("Remonter");
       expect(upButtons[0]).toBeDisabled();
       // on ne peut pas permuter un transporteur qui a déjà signé

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
@@ -99,7 +99,10 @@ export function TransporterList<TransporterInput extends AnyTransporterInput>({
               // Désactive la possibilité de supprimer le transporteur
               // s'il est le seul dans la liste ou s'il a déjà pris en charge le déchet
               const disableDelete =
-                hasTakenOver || (transporters.length === 1 && hasTakenOver);
+                hasTakenOver || (transporters.length === 1 && !t.company?.name);
+
+              const deleteLabel =
+                transporters.length === 1 ? "Effacer" : "Supprimer";
 
               // Désactive le bouton permettant de remonter le transporteur dans
               // la liste s'il est le seul ou le premier, ou s'il a déjà pris en
@@ -160,6 +163,7 @@ export function TransporterList<TransporterInput extends AnyTransporterInput>({
                   disableUp={disableUp}
                   disableDown={disableDown}
                   expanded={idx === expandedIdx}
+                  deleteLabel={deleteLabel}
                 >
                   {t.takenOverAt ? (
                     <TransporterDisplay transporter={t} />

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
@@ -67,12 +67,20 @@ export function TransporterList<TransporterInput extends AnyTransporterInput>({
                   // Supprime le transporteur en base et dans le state Formik
                   return deleteFormTransporter({
                     variables: { id: t.id },
-                    onCompleted: () => arrayHelpers.remove(idx)
+                    onCompleted: () => {
+                      arrayHelpers.remove(idx);
+                      if (transporters.length === 1) {
+                        arrayHelpers.insert(0, initialTransporterData);
+                      }
+                    }
                   });
                 } else {
                   // Supprime le transporteur uniquement dans le state Formik
                   // puisqu'il n'existe pas encore en base
                   arrayHelpers.remove(idx);
+                  if (transporters.length === 1) {
+                    arrayHelpers.insert(0, initialTransporterData);
+                  }
                 }
               };
 
@@ -90,7 +98,8 @@ export function TransporterList<TransporterInput extends AnyTransporterInput>({
 
               // Désactive la possibilité de supprimer le transporteur
               // s'il est le seul dans la liste ou s'il a déjà pris en charge le déchet
-              const disableDelete = hasTakenOver || transporters.length === 1;
+              const disableDelete =
+                hasTakenOver || (transporters.length === 1 && hasTakenOver);
 
               // Désactive le bouton permettant de remonter le transporteur dans
               // la liste s'il est le seul ou le premier, ou s'il a déjà pris en


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Permettre au créateur d'Effacer le composant transporteur lorsqu'il n'y a qu'un seul transporteur de visé
# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/26d2ade8-cb62-4ebd-94e1-bcf7a377d6e1


# Ticket Favro

[tra-15333](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15333)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB