### PR TITLE
[TRA-14910] Traduction des types de contenants pour les DASRI de synthèse

### DIFF
--- a/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdasri/BsdasriDetailContent.tsx
@@ -510,7 +510,7 @@ const Dasripackaging = ({
   );
 };
 
-const verbosePackagings = {
+export const verbosePackagings = {
   BOITE_CARTON: "Caisse en carton avec sac en plastique",
   FUT: "Fûts ou jerrican à usage unique",
   BOITE_PERFORANTS: "Boîtes et Mini-collecteurs pour déchets perforants",

--- a/front/src/form/bsdasri/components/grouping/BsdasriTableSynthesis.tsx
+++ b/front/src/form/bsdasri/components/grouping/BsdasriTableSynthesis.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../../common/components";
 import { RefreshButton } from "./Common";
 import { aggregatePackagings } from "./utils";
+import { verbosePackagings } from "../../../../dashboard/detail/bsdasri/BsdasriDetailContent";
 
 const GET_ELIGIBLE_BSDASRIS = gql`
   query Bsdasris($where: BsdasriWhere) {
@@ -80,7 +81,7 @@ const SelectedBsdasrisDigest = ({ selectedItems }) => {
               <TableCell>{""}</TableCell>
               <TableCell>{row.quantity}</TableCell>
               <TableCell>
-                {row.type} {!!row.other && `: ${row.other}`}
+                {verbosePackagings[row.type]} {!!row.other && `: ${row.other}`}
               </TableCell>
 
               <TableCell>{row.volume}</TableCell>


### PR DESCRIPTION
# Contexte

[Cette PR](https://github.com/MTES-MCT/trackdechets/pull/3833) corrigeait les PDF, mais il reste un souci de traduction dans le formulaire de création côté front.

# Démo

[Screencast from 2025-01-09 09-51-07.webm](https://github.com/user-attachments/assets/55ab6ebb-96c7-4b25-b980-f480f74d7b59)

# Ticket Favro

[PDF DASRI indiquent en emballage la dénomination API « boite_carton » et non « caisse en carton avec sac en plastique » ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-14910)
