### PR TITLE
[TRA-14910] Traduction des types de contenants pour les DASRI (BsdasriWasteSummary)

### DIFF
--- a/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/Summary/BsdasriWasteSummary.tsx
@@ -6,6 +6,7 @@ import {
   DataListTerm,
   DataListDescription
 } from "../../../../../common/components";
+import { verbosePackagings } from "../../../../detail/bsdasri/BsdasriDetailContent";
 
 interface BsdasriWasteSummaryProps {
   bsdasri: Bsdasri;
@@ -50,7 +51,8 @@ export function BsdasriWasteSummary({ bsdasri }: BsdasriWasteSummaryProps) {
             <>
               {packagings.map((packaging, idx) => (
                 <div key={idx}>
-                  {packaging.quantity} {packaging.other} {packaging.type} (
+                  {packaging.quantity} {verbosePackagings[packaging.type]}
+                  {!!packaging.other && `: ${packaging.other}`} (
                   {packaging.volume} litre(s))
                 </div>
               ))}


### PR DESCRIPTION
# Contexte

Les noms de contenants n'étaient pas non plus traduits dans le "summary" des DASRI, qui apparaît dans toutes les modales du workflow.

# Démo

![image](https://github.com/user-attachments/assets/757af4a3-3ce1-43f8-a4ca-bc6b22900323)

# Ticket Favro

[PDF DASRI indiquent en emballage la dénomination API « boite_carton » et non « caisse en carton avec sac en plastique » ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/0fc0444ad4541f44e962ee0a?card=tra-14910)