### PR TITLE
[TRA-15686] Renommage de "COLIS (totaux)" par "Total conditionnement" sur le PDF du BSDD 

### DIFF
--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -351,7 +351,7 @@ function PackagingInfosTable({ packagingInfos }: PackagingInfosTableProps) {
             </strong>
           </td>
           <td>
-            <strong>COLIS (totaux)</strong>
+            <strong>Total conditionnement</strong>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
# Contexte

Petit renommage dans le PDF du BSDD: "COLIS (totaux)" devient "Total conditionnement" 

# Démo

![image](https://github.com/user-attachments/assets/40193d52-54c9-4cef-a9a5-a231aa2cf920)

# Ticket Favro

[Renommer COLIS (totaux) par Total conditionnement sur le PDF du BSDD ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/428fc483d313d26a7c9bbd3f?card=tra-15686)
