### PR TITLE
[TRA 15626 fix] Ne pas supprimer l'intermédiaire inopinément

### DIFF
--- a/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/BsvhuFormSteps.tsx
@@ -62,7 +62,8 @@ const vhuToInput = (vhu: ZodBsvhu): BsvhuInput => {
     "hasIntermediaries",
     ...addressCleanup
   ]);
-  if (!vhu.hasIntermediaries) {
+  // clear the intermediaries array if it only contains the default value
+  if (vhu.intermediaries?.length === 1 && !vhu.intermediaries[0].siret) {
     omitted.intermediaries = [];
   }
   return omitted;


### PR DESCRIPTION
# Contexte

Dans ma PR précédente pour ce ticket, j'avais fait un fix qui permettait de supprimer un intermédiaire en décochant le toggle correspondant, et de ne pas envoyer d'intermédiaire vide (ne pas envoyer l'entreprise vide qui sert d'initialisation au formulaire). Le fix consistait simplement à ne pas envoyer d'intermédiaire si le toggle "présence d'intermédiaire" était décochée. Le problème est que l'état du toggle n'est initialisé que lors de la visite de l'onglet "autres acteurs", donc lors d'une modification du bordereau sans passer par et onglet le toggle restait à false, et l'intermédiaire était supprimé.
Afin de régler le problème tout en gardant le comportement souhaité, j'ai plutôt utilisé le contenu de l'array d'intermédiaire, pour détecter qu'elle ne contient que l'entreprise vide par défaut, et seulement dans ce cas renvoyer une array d'intermédiaires vide.

# Points de vigilance pour les intégrateurs

aucun

# Démo

pas de changement de comportement

# Ticket Favro

[TRA 15626 - Permettre d'ajouter un intermédiaire sur le VHU jusqu'au traitement du bordereau](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15626)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB