### PR TITLE
[TRA 15647 fix] Résolution de problème d'indexation de BSVHU

### DIFF
--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -185,7 +185,10 @@ describe("mutation.duplicateBsvhu", () => {
     });
 
     const searchResults = {
-      [emitter.company.siret!]: emitter.company
+      [emitter.company.siret!]: {
+        ...emitter.company,
+        isRegistered: true
+      }
     };
 
     (searchCompany as jest.Mock).mockImplementation((clue: string) => {

--- a/back/src/bsvhu/resolvers/mutations/create.ts
+++ b/back/src/bsvhu/resolvers/mutations/create.ts
@@ -33,12 +33,12 @@ export async function genericCreate({ isDraft, input, context }: CreateBsvhu) {
   await checkCanCreate(user, input);
 
   const zodBsvhu = graphQlInputToZodBsvhu(input);
-
   const { createdAt, ...parsedZodBsvhu } = await parseBsvhuAsync(
     { ...zodBsvhu, isDraft, createdAt: new Date() },
     {
       user,
-      currentSignatureType: !isDraft ? "EMISSION" : undefined
+      currentSignatureType: !isDraft ? "EMISSION" : undefined,
+      unsealed: true
     }
   );
 

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -816,6 +816,9 @@ export async function getSealedFields(
   bsvhu: ZodBsvhu,
   context: BsvhuValidationContext
 ): Promise<(keyof BsvhuEditionRules)[]> {
+  if (context.unsealed) {
+    return [];
+  }
   const currentSignatureType =
     context.currentSignatureType ?? getCurrentSignatureType(bsvhu);
   // Some signatures may be skipped, so always check all the hierarchy

--- a/back/src/bsvhu/validation/sirenify.ts
+++ b/back/src/bsvhu/validation/sirenify.ts
@@ -12,7 +12,7 @@ const sirenifyBsvhuAccessors = (
   {
     siret: bsvhu?.emitterCompanySiret,
     skip: sealedFields.includes("emitterCompanySiret") || bsvhu.emitterNoSiret,
-    setterIfNotFound: input => {
+    setterIfNotRegistered: input => {
       input.emitterNotOnTD = true;
     },
     setter: (input, companyInput) => {

--- a/back/src/bsvhu/validation/sirenify.ts
+++ b/back/src/bsvhu/validation/sirenify.ts
@@ -16,11 +16,14 @@ const sirenifyBsvhuAccessors = (
       input.emitterNotOnTD = true;
     },
     setter: (input, companyInput) => {
-      input.emitterCompanyName = companyInput.name;
-      input.emitterCompanyAddress = companyInput.address;
-      input.emitterCompanyCity = companyInput.city;
-      input.emitterCompanyPostalCode = companyInput.postalCode;
-      input.emitterCompanyStreet = companyInput.street;
+      input.emitterCompanyName = companyInput.name ?? input.emitterCompanyName;
+      input.emitterCompanyAddress =
+        companyInput.address ?? input.emitterCompanyAddress;
+      input.emitterCompanyCity = companyInput.city ?? input.emitterCompanyCity;
+      input.emitterCompanyPostalCode =
+        companyInput.postalCode ?? input.emitterCompanyPostalCode;
+      input.emitterCompanyStreet =
+        companyInput.street ?? input.emitterCompanyStreet;
     }
   },
   {

--- a/back/src/bsvhu/validation/types.ts
+++ b/back/src/bsvhu/validation/types.ts
@@ -14,7 +14,12 @@ export type BsvhuUserFunctions = {
 
 export type BsvhuValidationContext = {
   user?: User;
+  // the last signature applied on the BSVHU
+  // this is used to define which fields are required/sealed
   currentSignatureType?: SignatureTypeInput;
+  // override sealed fields, so all the validation can still happen
+  // for a certain level of signature, without blocking sirenify, recipify,...
+  unsealed?: boolean;
 };
 
 export type ZodBsvhuTransformer = (

--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -117,6 +117,7 @@ export default function buildSirenify<T>(
 export type NextCompanyInputAccessor<T> = {
   siret: string | null | undefined;
   skip: boolean;
+  // an optional function that will be run if the company is not found or not registered on trackdechet
   setterIfNotRegistered?: (input: T) => void;
   setter: (
     input: T,

--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -117,7 +117,7 @@ export default function buildSirenify<T>(
 export type NextCompanyInputAccessor<T> = {
   siret: string | null | undefined;
   skip: boolean;
-  setterIfNotFound?: (input: T) => void;
+  setterIfNotRegistered?: (input: T) => void;
   setter: (
     input: T,
     data: {
@@ -153,11 +153,17 @@ export function nextBuildSirenify<T>(
     const sirenifiedInput = { ...input };
 
     for (const [idx, companySearchResult] of companySearchResults.entries()) {
-      const { setter, setterIfNotFound } = accessors[idx];
-      if (!companySearchResult) {
-        if (setterIfNotFound) {
-          setterIfNotFound(sirenifiedInput);
+      const { siret, skip, setter, setterIfNotRegistered } = accessors[idx];
+      if (
+        siret &&
+        !skip &&
+        (!companySearchResult || !companySearchResult.isRegistered)
+      ) {
+        if (setterIfNotRegistered) {
+          setterIfNotRegistered(sirenifiedInput);
         }
+      }
+      if (!companySearchResult) {
         continue;
       }
       const company = companySearchResult as CompanySearchResult;


### PR DESCRIPTION

# Contexte

Le BSVHU ne remontait pas correctement dans les bordereaux à collecter du transporteur lorsque l'émetteur n'est pas inscrit sur TD. Celà arrivait uniquement si le bordereau était créé en brouillon puis publié.

Après investigation, le problème était double:
1er problème: la liste des champs scellés utilise currentSignatureType qui est à EMISSION à la publication, et qui bloque le sirenify sur l'emetteur. C'était passé inaperçu parce que ces champs scellés ne sont pas appliqués si l'émetteur est une entreprise de l'utilisateur, ce qui est souvent le cas lors de nos tests. Mais lorsque le bordereau est créé en brouillon, aucun champ n'est scellé, ce qui créait un comportement différent sur sirenify.

2e problème: la recherche d'entreprise faite dans sirenify trouve en fait les entreprises qui ne sont pas sur TD, donc setterIfNotFound n'était pas exécuté, l'entreprise était donc considérée comme trouvée, le flag emitterNotOnTD pas mis à true, donc la règle d'indexation n'était pas utilisée.

La résolution a donc consisté à:
- ajouter un flag "unsealed" dans le contexte de validation afin de ne pas sceller les champs lors de la création, tout en gardant les règles de validation (champs requis) correspondants à une signature émetteur, pour remonter les erreurs
- modifier la façon dont est traité le cas des entreprises non inscrites, pour exécuter setterIfNotFound (renommée en setterIfNotRegistered) uniquement lorsqu'on a fait une recherche d'entreprise (il y a un siret et pas skip) et qu'elle est soit non trouvée soit trouvée mais pas sur TD.

# Points de vigilance pour les intégrateurs

a priori aucun, pour être parfait il faudrait modifier quelques bordereaux en DB et les réindexer mais étant donné que le seul impact est en recette et n'est qu'une histoire d'affichage, ça ne me semble pas utile.

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB