### PR TITLE
[TRA-14915] Recette - gestion des plaques et mode de transport

### DIFF
--- a/back/src/bsvhu/converter.ts
+++ b/back/src/bsvhu/converter.ts
@@ -150,6 +150,7 @@ export function expandVhuFormFromDb(form: PrismaVhuForm): GraphqlVhuForm {
         mail: form.transporterCompanyMail,
         vatNumber: form.transporterCompanyVatNumber
       }),
+      customInfo: form.transporterCustomInfo,
       recepisse: nullIfNoValues<BsvhuRecepisse>({
         number: form.transporterRecepisseNumber,
         department: form.transporterRecepisseDepartment,
@@ -370,6 +371,7 @@ function flattenVhuTransporterInput({
     transporterCompanyVatNumber: chain(transporter, t =>
       chain(t.company, c => c.vatNumber)
     ),
+    transporterCustomInfo: chain(transporter, t => t.customInfo),
     transporterRecepisseNumber: chain(transporter, t =>
       chain(t.recepisse, r => r.number)
     ),

--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -282,6 +282,8 @@ input BsvhuTransporterInput {
   company: CompanyInput
   "Récépissé transporteur"
   recepisse: BsvhuRecepisseInput
+  "Champ libre"
+  customInfo: String
   "Informations liés au transport"
   transport: BsvhuTransportInput
 }

--- a/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.objects.graphql
@@ -107,6 +107,8 @@ type BsvhuTransporter {
   company: FormCompany
   "Récépissé transporteur"
   recepisse: BsvhuRecepisse
+  "Champ libre"
+  customInfo: String
   "Informations liés au transport"
   transport: BsvhuTransport
 }

--- a/back/src/bsvhu/validation/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/validation/__tests__/validation.integration.ts
@@ -757,7 +757,6 @@ describe("BSVHU validation", () => {
           currentSignatureType: "TRANSPORT"
         });
       } catch (err) {
-        console.log(err);
         expect((err as ZodError).issues).toEqual([
           expect.objectContaining({
             message:
@@ -784,7 +783,6 @@ describe("BSVHU validation", () => {
           currentSignatureType: "TRANSPORT"
         });
       } catch (err) {
-        console.log(err);
         expect((err as ZodError).issues).toEqual([
           expect.objectContaining({
             message:
@@ -811,7 +809,6 @@ describe("BSVHU validation", () => {
           currentSignatureType: "TRANSPORT"
         });
       } catch (err) {
-        console.log(err);
         expect((err as ZodError).issues).toEqual([
           expect.objectContaining({
             message: "Le numéro de plaque fourni est incorrect"

--- a/back/src/bsvhu/validation/index.ts
+++ b/back/src/bsvhu/validation/index.ts
@@ -21,7 +21,7 @@ import { BsvhuValidationContext, PrismaBsvhuForParsing } from "./types";
  * par signature.
  */
 export async function mergeInputAndParseBsvhuAsync(
-  // BSFF déjà stockée en base de données.
+  // Bsvhu déjà stocké en base de données.
   persisted: PrismaBsvhuForParsing,
   // Données entrantes provenant de la couche GraphQL.
   input: BsvhuInput,
@@ -65,7 +65,7 @@ export async function mergeInputAndParseBsvhuAsync(
   }
 
   // Calcule la signature courante à partir des données si elle n'est
-  // pas fourni via le contexte
+  // pas fournie via le contexte
   const currentSignatureType =
     context.currentSignatureType ?? getCurrentSignatureType(zodPersisted);
 
@@ -75,7 +75,7 @@ export async function mergeInputAndParseBsvhuAsync(
   };
 
   // Vérifie que l'on n'est pas en train de modifier des données
-  // vérrouillées par signature.
+  // verrouillées par signature.
   const updatedFields = await checkBsvhuSealedFields(
     zodPersisted,
     bsvhu,

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -309,6 +309,46 @@ export const checkTransportModeAndReceptionWeight: Refinement<
   );
 };
 
+const onlyWhiteSpace = (str: string) => !str.trim().length; // check whitespaces, tabs, newlines and invisible chars
+
+export const checkTransportPlates: Refinement<ParsedZodBsvhu> = (
+  bsvhu,
+  ctx
+) => {
+  const { transporterTransportPlates } = bsvhu;
+  const path = ["transporter", "transport", "plates"];
+  if (transporterTransportPlates.length > 2) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: "Un maximum de 2 plaques d'immatriculation est accepté"
+    });
+  }
+
+  if (transporterTransportPlates.some(plate => plate.length > 12)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: "Un numéro d'immatriculation doit faire 12 caractères au maximum"
+    });
+  }
+
+  if (transporterTransportPlates.some(plate => plate.length < 4)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: "Un numéro d'immatriculation doit faire 4 caractères au minimum"
+    });
+  }
+  if (transporterTransportPlates.some(plate => onlyWhiteSpace(plate))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: "Le numéro de plaque fourni est incorrect"
+    });
+  }
+};
+
 export const checkRequiredFields: (
   validationContext: BsvhuValidationContext
 ) => Refinement<ParsedZodBsvhu> = validationContext => {

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -25,7 +25,6 @@ export type BsvhuEditableFields = Required<
     | "emitterCustomInfo"
     | "emitterNotOnTD"
     | "destinationCustomInfo"
-    | "transporterCustomInfo"
     | "emitterEmissionSignatureDate"
     | "emitterEmissionSignatureAuthor"
     | "transporterTransportSignatureDate"
@@ -547,6 +546,11 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
         );
       }
     }
+  },
+  transporterCustomInfo: {
+    readableFieldName:
+      "les champs d'informations complémentaires du transporteur",
+    sealed: { from: "TRANSPORT" }
   },
   ecoOrganismeName: {
     readableFieldName: "le nom de l'éco-organisme",

--- a/back/src/bsvhu/validation/schema.ts
+++ b/back/src/bsvhu/validation/schema.ts
@@ -10,7 +10,8 @@ import {
   checkEmitterSituation,
   checkPackagingAndIdentificationType,
   checkTransportModeAndWeight,
-  checkTransportModeAndReceptionWeight
+  checkTransportModeAndReceptionWeight,
+  checkTransportPlates
 } from "./refinements";
 import { BsvhuValidationContext } from "./types";
 import { weightSchema } from "../../common/validation/weight";
@@ -70,8 +71,6 @@ export const ZodOperationEnum = z
   .nullish();
 
 export type ZodOperationEnum = z.infer<typeof ZodOperationEnum>;
-
-const notOnlyWhiteSpace = (str: string) => str.trim(); // check whitespaces, tabs, newlines and invisible chars
 
 const rawBsvhuSchema = z.object({
   id: z.string().default(() => getReadableId(ReadableIdPrefix.VHU)),
@@ -192,24 +191,9 @@ const rawBsvhuSchema = z.object({
   transporterTransportTakenOverAt: z.coerce.date().nullish(),
   transporterCustomInfo: z.string().nullish(),
   transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
-  transporterTransportPlates: z
-    .array(
-      z
-        .string()
-        .min(4, {
-          message:
-            "Un numéro d'immatriculation doit faire 4 caractères au minimum"
-        })
-        .max(12, {
-          message:
-            "Un numéro d'immatriculation doit faire 12 caractères au maximum"
-        })
-        .refine(notOnlyWhiteSpace, {
-          message: "Le numéro de plaque fourni est incorrect"
-        })
-    )
-    .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
-    .default([]),
+
+  transporterTransportPlates: z.array(z.string()).default([]),
+
   ecoOrganismeName: z.string().nullish(),
   ecoOrganismeSiret: siretSchema(CompanyRole.EcoOrganisme).nullish(),
   brokerCompanyName: z.string().nullish(),
@@ -255,7 +239,8 @@ const refinedBsvhuSchema = rawBsvhuSchema
   .superRefine(checkEmitterSituation)
   .superRefine(checkPackagingAndIdentificationType)
   .superRefine(checkTransportModeAndWeight)
-  .superRefine(checkTransportModeAndReceptionWeight);
+  .superRefine(checkTransportModeAndReceptionWeight)
+  .superRefine(checkTransportPlates);
 
 // Transformations synchrones qui sont toujours
 // joués même si `enableCompletionTransformers=false`
@@ -284,7 +269,7 @@ export const contextualBsvhuSchemaAsync = (context: BsvhuValidationContext) => {
     .transform((bsvhu: ParsedZodBsvhu) => runTransformers(bsvhu, context))
     .superRefine(
       // run le check sur les champs requis après les transformations
-      // au cas où des transformations auto-complète certains champs
+      // au cas où des transformations auto-complètent certains champs
       checkRequiredFields(context)
     );
 };

--- a/back/src/bsvhu/validation/schema.ts
+++ b/back/src/bsvhu/validation/schema.ts
@@ -210,7 +210,6 @@ const rawBsvhuSchema = z.object({
     )
     .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
     .default([]),
-
   ecoOrganismeName: z.string().nullish(),
   ecoOrganismeSiret: siretSchema(CompanyRole.EcoOrganisme).nullish(),
   brokerCompanyName: z.string().nullish(),

--- a/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
+++ b/front/src/Apps/Dashboard/Components/BsdCardList/BsdCardList.tsx
@@ -461,6 +461,7 @@ function BsdCardList({
           const hasAutomaticSignature = siretsWithAutomaticSignature?.includes(
             node?.emitter?.company?.siret
           );
+
           return (
             <li className="bsd-card-list__item" key={key}>
               <BsdCard

--- a/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
+++ b/front/src/Apps/Dashboard/Components/TransporterInfoEditModal/TransporterInfoEditModal.tsx
@@ -7,7 +7,8 @@ import {
   MutationUpdateBsdasriArgs,
   MutationUpdateBsffArgs,
   MutationUpdateBspaohArgs,
-  MutationUpdateFormTransporterArgs
+  MutationUpdateFormTransporterArgs,
+  MutationUpdateBsvhuArgs
 } from "@td/codegen-ui";
 import TdModal from "../../../common/Components/Modal/Modal";
 import { NotificationError } from "../../../common/Components/Error/Error";
@@ -20,6 +21,7 @@ import { UPDATE_BSDD_TRANSPORTER } from "../../../common/queries/bsdd/queries";
 import { UPDATE_BSFF_FORM } from "../../../common/queries/bsff/queries";
 import { UPDATE_BSDASRI } from "../../../common/queries/bsdasri/queries";
 import { UPDATE_BSPAOH } from "../../../common/queries/bspaoh/queries";
+import { UPDATE_VHU_FORM } from "../../../common/queries/bsvhu/queries";
 import TransporterInfoEditForm from "./TransporterInfoEditForm";
 import { Loader } from "../../../common/Components";
 
@@ -71,6 +73,13 @@ const TransporterInfoEditModal = ({
     { error: errorBspaoh, loading: loadingBspaoh }
   ] = useMutation<Pick<Mutation, "updateBspaoh">, MutationUpdateBspaohArgs>(
     UPDATE_BSPAOH
+  );
+
+  const [
+    updateTransporterInfoBsvhu,
+    { error: errorBsvhu, loading: loadingBsvhu }
+  ] = useMutation<Pick<Mutation, "updateBsvhu">, MutationUpdateBsvhuArgs>(
+    UPDATE_VHU_FORM
   );
 
   const onSubmitForm = async data => {
@@ -140,17 +149,35 @@ const TransporterInfoEditModal = ({
           }
         }
       });
+    } else if (bsd.type === BsdType.Bsvhu) {
+      await updateTransporterInfoBsvhu({
+        variables: {
+          id: bsd.id,
+          input: {
+            transporter: {
+              customInfo: data.customInfo,
+              transport: { plates: formattedPlates }
+            }
+          }
+        }
+      });
     }
   };
 
   const error =
-    errorBsdd || errorBsda || errorBsdasri || errorBsff || errorBspaoh;
+    errorBsdd ||
+    errorBsda ||
+    errorBsdasri ||
+    errorBsff ||
+    errorBspaoh ||
+    errorBsvhu;
   const loading =
     loadingBsdd ||
     loadingBsda ||
     loadingBsdasri ||
     loadingBsff ||
-    loadingBspaoh;
+    loadingBspaoh ||
+    loadingBsvhu;
 
   return (
     <TdModal

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Transporter.tsx
@@ -92,6 +92,14 @@ const TransporterBsvhu = ({ errors }) => {
           setError
         );
       }
+      if (transporter?.transport?.plates) {
+        setFieldError(
+          errors,
+          `${actor}.transport.plates`,
+          formState.errors?.[actor]?.["transport"]?.plates,
+          setError
+        );
+      }
     }
   }, [
     errors,
@@ -104,7 +112,8 @@ const TransporterBsvhu = ({ errors }) => {
     transporter?.company?.mail,
     transporter?.company?.phone,
     transporter?.company?.siret,
-    transporter?.company?.vatNumber
+    transporter?.company?.vatNumber,
+    transporter?.transport?.plates
   ]);
 
   const orgId = useMemo(
@@ -220,11 +229,6 @@ const TransporterBsvhu = ({ errors }) => {
             fieldName={`transporter.transport.plates`}
             hintText="2 max : Véhicule, remorque"
           />
-          {formState.errors?.transporter?.["transport"]?.plates && (
-            <p className="fr-text--sm fr-error-text fr-mb-4v">
-              {formState.errors?.transporter?.["transport"]?.plates?.message}
-            </p>
-          )}
         </div>
       </div>
     </>

--- a/front/src/Apps/Dashboard/Creation/utils.ts
+++ b/front/src/Apps/Dashboard/Creation/utils.ts
@@ -110,6 +110,10 @@ const pathPrefixToTab = {
     if (pathPrefix === "ecoOrganisme") {
       return TabId.other;
     }
+    if (pathPrefix.startsWith("transporter")) {
+      // dirty solution to handle TransporterFooBar paths
+      return TabId.transporter;
+    }
     if (Object.values(TabId).includes(pathPrefix as TabId)) {
       return TabId[pathPrefix];
     }
@@ -147,6 +151,7 @@ export const getPublishErrorMessages = (
   apiErrors?: NormalizedError[]
 ): TabError[] => {
   // return an array of messages with tabId, name (path) and the related message
+
   const publishErrorMessages =
     apiErrors
       ?.map(apiError => {

--- a/front/src/Apps/Dashboard/Validation/BSPaoh/WorkflowAction/SignTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/BSPaoh/WorkflowAction/SignTransport.tsx
@@ -23,7 +23,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import { datetimeToYYYYMMDDHHSS } from "../paohUtils";
 import { SignatureTimestamp } from "./components/Signature";
 
-import { RhfTagsInputWrapper } from "../../../../../Apps/Forms/Components/TagsInput/TagsInputWrapper";
+import { RhfTagsInputWrapper } from "../../../../Forms/Components/TagsInput/TagsInputWrapper";
 
 // instanciate schema in component to have an up-to-date max datetime validaton
 const getSchema = () =>

--- a/front/src/Apps/Dashboard/bsdMapper.ts
+++ b/front/src/Apps/Dashboard/bsdMapper.ts
@@ -211,7 +211,7 @@ export const getBsvhuCurrentTransporterInfos = (
     transporterNumberPlate: currentTransporter?.transport?.plates?.filter(
       plate => plate.trim()
     ),
-    transporterCustomInfo: "",
+    transporterCustomInfo: currentTransporter?.customInfo,
     transporterMode: currentTransporter?.transport?.mode ?? undefined
   };
 };
@@ -350,6 +350,7 @@ const mapBsvhu = (bsvhu: Bsvhu): BsdDisplay => {
   const wasteCode = bsvhu?.wasteCode;
   const wasteName =
     wasteCode === "16 01 04*" ? "VHU non dépollués" : "VHU dépollués"; //16 01 06
+  const transporter = bsvhu.transporter || bsvhu["bsvhuTransporter"];
   const bsvhuFormatted: BsdDisplay = {
     id: bsvhu.id,
     readableid: bsvhu.id,
@@ -364,11 +365,13 @@ const mapBsvhu = (bsvhu: Bsvhu): BsdDisplay => {
     },
     emitter: bsvhu.emitter || bsvhu["bsvhuEmitter"],
     destination: bsvhu.destination || bsvhu["bsvhuDestination"],
-    transporter: bsvhu.transporter || bsvhu["bsvhuTransporter"],
-    transporterNumberPlate: "fff",
+    transporter: transporter,
+    transporterCustomInfo: transporter?.customInfo,
+    transporterNumberPlate: transporter?.transport?.plates,
     updatedAt: bsvhu["bsvhuUpdatedAt"],
     ecoOrganisme: bsvhu.ecoOrganisme
   };
+
   return bsvhuFormatted;
 };
 

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -70,6 +70,7 @@ import { sub, differenceInDays } from "date-fns";
 
 export const getBsdView = (bsd): BsdDisplay | null => {
   const bsdView = formatBsd(bsd);
+
   return bsdView;
 };
 

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
@@ -53,6 +53,7 @@ const TagsInput = ({
           },
           onKeyDown: e => {
             if (e.key === "Enter") {
+              e.preventDefault();
               saveTag();
             }
           }

--- a/front/src/Apps/common/queries/fragments/bsvhu.ts
+++ b/front/src/Apps/common/queries/fragments/bsvhu.ts
@@ -21,6 +21,7 @@ export const vhuFragment = gql`
         plates
         mode
       }
+      customInfo
       recepisse {
         number
       }
@@ -84,6 +85,7 @@ export const dashboardVhuFragment = gql`
         validityLimit
         isExempted
       }
+      customInfo
     }
     destination {
       type
@@ -184,6 +186,7 @@ export const FullBsvhuFragment = gql`
         validityLimit
         isExempted
       }
+      customInfo
       transport {
         plates
         mode

--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -206,6 +206,7 @@ const DashboardPage = () => {
   };
 
   const bsds = data?.bsds.edges;
+
   const bsdsTotalCount = data?.bsds.totalCount;
   const hasNextPage = data?.bsds.pageInfo.hasNextPage;
   const isLoadingBsds = loading;

--- a/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
+++ b/front/src/dashboard/components/BSDList/BSVhu/WorkflowAction/SignOperation.tsx
@@ -1,7 +1,10 @@
 import { useMutation } from "@apollo/client";
 import { RedErrorMessage } from "../../../../../common/components";
 import Operation from "../../../../../form/bsvhu/Operation";
-import { UPDATE_VHU_FORM } from "../../../../../Apps/common/queries/bsvhu/queries";
+import {
+  UPDATE_VHU_FORM,
+  SIGN_BSVHU
+} from "../../../../../Apps/common/queries/bsvhu/queries";
 import { getComputedState } from "../../../../../Apps/Dashboard/Creation/getComputedState";
 import { Field, Form, Formik } from "formik";
 import {
@@ -13,7 +16,6 @@ import {
 import React from "react";
 import * as yup from "yup";
 import { SignBsvhu } from "./SignBsvhu";
-import { SIGN_BSVHU } from "../../../../../Apps/common/queries/bsvhu/queries";
 import DateInput from "../../../../../form/common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
 import { getInitialCompany } from "../../../../../Apps/common/data/initialState";


### PR DESCRIPTION
# Contexte

Correctifs et évolutions de recette sur le bsvhu (gestions des plaques et mode de transport):

- permettre de renseigner mode de transports et plaques sur la modale de signature transporteur
- ajout d'une info libre pour les transporteurs
- permettre de renseigner les plaques et l'info libre depuis le dashboard
- affichage de l'info libre sur les cartes dashboards
- affichage des messages d’erreurs sur les différents formulaires (format de plaque notamment)
- correction du tags input qui ne soumet plus le formulaire sur appui d'enter
- affichage des erreurs liées aux plaques dans le froumaire d'édition

# Points de vigilance pour les intégrateurs

nope

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14915
https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15596
https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14967

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB