### PR TITLE
[TRA-15678] Permettre d'ajouter un 0 après la virgule dans la quantité à regrouper d'une Annexe 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Seul l'émetteur peut supprimer un BSVHU s'il l'a signé (SIGNED_BY_PRODUCER) [PR 3837](https://github.com/MTES-MCT/trackdechets/pull/3837)
 - Correction pour les cas particuliers pour le mail sur le changement de CAP: ajout ou suppression de la nextDestination [PR 3858](https://github.com/MTES-MCT/trackdechets/pull/3858)
 - Les numéros d'identification du bsvhus ne devraient pas être obligatoires pour les vhus créés avant l'ajout de la règle [PR 3877](https://github.com/MTES-MCT/trackdechets/pull/3877)
+- Permettre d'ajouter un 0 après la virgule dans la quantité à regrouper d'une Annexe 2 [PR 3903](https://github.com/MTES-MCT/trackdechets/pull/3903)
 
 #### :boom: Breaking changes
 

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -331,9 +331,10 @@ export default function Appendix2MultiSelect({
                 setIsDirty(true);
                 const idx = currentlyAnnexedFormIds.indexOf(form.id);
                 const value = e.target.value;
+
                 replace(idx, {
                   form,
-                  quantity: value === "" ? "" : Number(value)
+                  quantity: value === "" ? "" : value.replace(",", ".")
                 });
               }
             }}

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -334,7 +334,7 @@ export default function Appendix2MultiSelect({
 
                 replace(idx, {
                   form,
-                  quantity: value === "" ? "" : value.replace(",", ".")
+                  quantity: value
                 });
               }
             }}


### PR DESCRIPTION
# Contexte

Le formulaire des annexes2 n'acceptait pas les valeurs décimales commençant par un 0 (eg 2,01, 12,009 etc) à cause du cast par Number() qui transformer 1,0 en 1

# Points de vigilance pour les intégrateurs

Intégrateur, toujours vigilant tu seras.

# Démo

 Vidéo du bug: https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15678


https://github.com/user-attachments/assets/9b5fe229-0276-4da2-822e-f5190737cf25



 



# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15678

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB