### PR TITLE
Amélioration du message d'erreur sur la longueur des numéros de plaques sur le bsvhu

### DIFF
--- a/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.inputs.graphql
@@ -305,7 +305,7 @@ input BsvhuTraderInput {
 input BsvhuTransportInput {
   "Mode de transport"
   mode: TransportMode
-  "Plaque(s) d'immatriculation - maximum 2"
+  "Plaque(s) d'immatriculation - maximum 2 - 4 à 12 caractères"
   plates: [String!]
   "Date de prise en charge"
   takenOverAt: DateTime

--- a/back/src/bsvhu/validation/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/validation/__tests__/validation.integration.ts
@@ -760,7 +760,7 @@ describe("BSVHU validation", () => {
         expect((err as ZodError).issues).toEqual([
           expect.objectContaining({
             message:
-              "Un numéro d'immatriculation doit faire 4 caractères au minimum"
+              "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
           })
         ]);
       }
@@ -786,7 +786,7 @@ describe("BSVHU validation", () => {
         expect((err as ZodError).issues).toEqual([
           expect.objectContaining({
             message:
-              "Un numéro d'immatriculation doit faire 12 caractères au maximum"
+              "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
           })
         ]);
       }

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -325,21 +325,17 @@ export const checkTransportPlates: Refinement<ParsedZodBsvhu> = (
     });
   }
 
-  if (transporterTransportPlates.some(plate => plate.length > 12)) {
+  if (
+    transporterTransportPlates.some(plate => plate.length > 12) ||
+    transporterTransportPlates.some(plate => plate.length < 4)
+  ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path,
-      message: "Un numéro d'immatriculation doit faire 12 caractères au maximum"
+      message: "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
     });
   }
 
-  if (transporterTransportPlates.some(plate => plate.length < 4)) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path,
-      message: "Un numéro d'immatriculation doit faire 4 caractères au minimum"
-    });
-  }
   if (transporterTransportPlates.some(plate => onlyWhiteSpace(plate))) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,


### PR DESCRIPTION
# Contexte

On remplace 2 messages d'erreurs distcint (pour moins de 4 et plus de 12 caractères) par un seul :"Le numéro d'immatriculation doit faire entre 4 et 12 caractères"

# Points de vigilance pour les intégrateurs

nope

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14967

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB