### PR TITLE
[TRA 15687] Ajout d'éco-organismes, filtrage des éco-organismes en front

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
 
+- Ajout d'éco-organismes, filtrage des éco-organismes en front [PR 3916](https://github.com/MTES-MCT/trackdechets/pull/3916)
+
 # [2025.01.1] 14/01/2025
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/companies/resolvers/queries/ecoOrganismes.ts
+++ b/back/src/companies/resolvers/queries/ecoOrganismes.ts
@@ -1,8 +1,20 @@
 import { prisma } from "@td/prisma";
 import type { QueryResolvers } from "@td/codegen-back";
 
-const ecoOrganismeResolver: QueryResolvers["ecoOrganismes"] = () => {
-  return prisma.ecoOrganisme.findMany();
+const ecoOrganismeResolver: QueryResolvers["ecoOrganismes"] = async (
+  _,
+  args
+) => {
+  const { handleBsdd, handleBsda, handleBsdasri, handleBsvhu } = args;
+
+  return prisma.ecoOrganisme.findMany({
+    where: {
+      handleBsdd: handleBsdd ?? undefined,
+      handleBsda: handleBsda ?? undefined,
+      handleBsdasri: handleBsdasri ?? undefined,
+      handleBsvhu: handleBsvhu ?? undefined
+    }
+  });
 };
 
 export default ecoOrganismeResolver;

--- a/back/src/companies/typeDefs/company.objects.graphql
+++ b/back/src/companies/typeDefs/company.objects.graphql
@@ -503,7 +503,7 @@ type EcoOrganisme {
 
   "Adresse de l'éco-organisme"
   address: String!
-
+  handleBsdd: Boolean
   handleBsdasri: Boolean
   handleBsda: Boolean
   handleBsvhu: Boolean

--- a/back/src/companies/typeDefs/company.queries.graphql
+++ b/back/src/companies/typeDefs/company.queries.graphql
@@ -41,6 +41,14 @@ type Query {
 
   """
   Renvoie la liste des éco-organismes
+  Peut être utilisé sans filtres, auquel cas tous les éco-organismes sont renvoyés
+  Sinon passer true sur l'un ou plusieurs des filtres renvoit les éco-organismes pouvant
+  être associés aux bordereaux correspondants
   """
-  ecoOrganismes: [EcoOrganisme!]!
+  ecoOrganismes(
+    handleBsdd: Boolean
+    handleBsda: Boolean
+    handleBsdasri: Boolean
+    handleBsvhu: Boolean
+  ): [EcoOrganisme!]!
 }

--- a/front/src/form/bsda/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsda/components/eco-organismes/EcoOrganismes.tsx
@@ -7,7 +7,7 @@ import TdSwitch from "../../../../common/components/Switch";
 
 const GET_ECO_ORGANISMES = gql`
   {
-    ecoOrganismes {
+    ecoOrganismes(handleBsda: true) {
       id
       name
       siret

--- a/front/src/form/bsda/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsda/components/eco-organismes/EcoOrganismes.tsx
@@ -72,12 +72,10 @@ export default function BsdaEcoOrganismes(props: EcoOrganismesProps) {
                     orgId: eo.orgId
                   })
                 }
-                results={data.ecoOrganismes
-                  .filter(eo => !!eo.handleBsda)
-                  .map(eo => ({
-                    ...eo,
-                    orgId: eo.siret
-                  }))}
+                results={data.ecoOrganismes.map(eo => ({
+                  ...eo,
+                  orgId: eo.siret
+                }))}
                 selectedItem={
                   data.ecoOrganismes
                     .map(eo => ({

--- a/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
@@ -88,12 +88,10 @@ export default function BsdasriEcoOrganismes(props: EcoOrganismesProps) {
                       orgId: eo.orgId
                     })
                   }
-                  results={data.ecoOrganismes
-                    .filter(eo => !!eo.handleBsdasri)
-                    .map(eo => ({
-                      ...eo,
-                      orgId: eo.siret
-                    }))}
+                  results={data.ecoOrganismes.map(eo => ({
+                    ...eo,
+                    orgId: eo.siret
+                  }))}
                   selectedItem={
                     data.ecoOrganismes
                       .map(eo => ({

--- a/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsdasri/components/eco-organismes/EcoOrganismes.tsx
@@ -13,7 +13,7 @@ import TdSwitch from "../../../../common/components/Switch";
 
 const GET_ECO_ORGANISMES = gql`
   {
-    ecoOrganismes {
+    ecoOrganismes(handleBsdasri: true) {
       id
       name
       siret

--- a/front/src/form/bsdd/components/eco-organismes/EcoOrganismes.tsx
+++ b/front/src/form/bsdd/components/eco-organismes/EcoOrganismes.tsx
@@ -10,7 +10,7 @@ import { getInitialEcoOrganisme } from "../../utils/initial-state";
 
 const GET_ECO_ORGANISMES = gql`
   {
-    ecoOrganismes {
+    ecoOrganismes(handleBsdd: true) {
       id
       name
       siret

--- a/libs/back/object-creator/src/main.ts
+++ b/libs/back/object-creator/src/main.ts
@@ -18,7 +18,7 @@ function getDbUrlWithSchema(rawDatabaseUrl: string) {
     dbUrl.searchParams.set("schema", "default$default");
 
     return unescape(dbUrl.href); // unescape needed because of the `$`
-  } catch (err) {
+  } catch (_) {
     return "";
   }
 }

--- a/libs/back/object-creator/src/objects.ts
+++ b/libs/back/object-creator/src/objects.ts
@@ -11,11 +11,220 @@ type CreationObject<M extends keyof PrismaClient> = {
 };
 const objects = [
   {
+    // prisma "path" (used like this : prisma[newObj.type].create)
     type: "ecoOrganisme",
     object: {
-      siret: "00000000000013",
-      name: "Mon éco-organisme",
-      address: "12 RUE DES PINSONS 75012 PARIS",
+      siret: "45368997800030",
+      name: "AKSOR",
+      address:
+        "ACRELEC GROUP, ZAC DE L'ESPLANADE 3 RUE LOUIS DE BROGLIE 77400 SAINT-THIBAULT-DES-VIGNES",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "81761178300033",
+      name: "PYREO",
+      address: "22 RUE DE MADRID, 75008 PARIS 8",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "89201535500019",
+      name: "ALCOME",
+      address: "88 AV DES TERNES, 75017 PARIS",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "90272217200035",
+      name: "VALOBAT",
+      address: "77 ESP DU GENERAL DE GAULLE 92800 PUTEAUX",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: true,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "90377711800022",
+      name: "CYCLEVIA",
+      address:
+        "IMMEUBLE CONCORDE, 4 RUE JACQUES DAGUERRE, 92500 RUEIL-MALMAISON",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "91187025100012",
+      name: "ECOMINERO",
+      address: "16 B BD JEAN JAURES 92110 CLICHY",
+      handleBsdd: true,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: false
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "95450607700120",
+      name: "RENAULT TRUCKS",
+      address: "99 ROUTE DE LYON, 69800 SAINT-PRIEST",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "52433526200431",
+      name: "TESLA FRANCE",
+      address: "150 BOULEVARD VICTOR HUGO, 93400 SAINT-OUEN-SUR-SEINE",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "33006637400043",
+      name: "SUZUKI FRANCE",
+      address: "ZA TRAPPES, 8 AVENUE DES FRERES LUMIERE, 78190 TRAPPES",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "41968381800027",
+      name: "IVECO FRANCE",
+      address: "PORTE E, 1 RUE DES COMBATS DU 24 AOUT 44, 69200 VENISSIEUX",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "71203404000154",
+      name: "TOYOTA FRANCE",
+      address: "N°20 A 30, 20 BOULEVARD DE LA REPUBLIQUE, 92420 VAUCRESSON",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "88857389600022",
+      name: "SAIC MOTOR FRANCE",
+      address: "25 QUAI DU PRESIDENT PAUL DOUMER, 92400 COURBEVOIE",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "78012998704037",
+      name: "RENAULT SAS",
+      address:
+        "122-122, 122 B AVENUE DU GENERAL LECLERC, 92100 BOULOGNE-BILLANCOURT",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "69980917400179",
+      name: "NISSAN WEST EUROPE",
+      address: "8 RUE JEAN-PIERRE TIMBAUD, 78180 MONTIGNY-LE-BRETONNEUX",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "50901680400049",
+      name: "JAGUAR LAND ROVER FRANCE",
+      address: "TOUR DEFENSE, 23 RUE DELARIVIERE LEFOULLON, 92800 PUTEAUX",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "54206547900926",
+      name: "STELLANTIS AUTO SAS",
+      address: "2-10, 2 BOULEVARD DE L’EUROPE, 78300 POISSY",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "83227737000017",
+      name: "VOLKSWAGEN GROUP FRANCE",
+      address: "11 AVENUE DE BOURSONNE, 02600 VILLERS-COTTERETS",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "50924356400010",
+      name: "HONDA MOTOR EUROPE LTD - SUCCURSALE FRANCE",
+      address: "CAIN ROAD BRACKNELL BERKHIRE,  ENGLAND RG 12 1HL ROYAUME-UNI",
+      handleBsdd: false,
       handleBsdasri: false,
       handleBsda: false,
       handleBsvhu: true

--- a/libs/back/prisma/src/migrations/20250116003327_add_handle_bsdd_ecoorganisme/migration.sql
+++ b/libs/back/prisma/src/migrations/20250116003327_add_handle_bsdd_ecoorganisme/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EcoOrganisme" ADD COLUMN     "handleBsdd" BOOLEAN NOT NULL DEFAULT false;

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -404,6 +404,7 @@ model EcoOrganisme {
   siret         String  @unique(map: "EcoOrganisme.siret._UNIQUE")
   name          String
   address       String
+  handleBsdd    Boolean @default(false)
   handleBsdasri Boolean @default(false)
   handleBsda    Boolean @default(false)
   handleBsvhu   Boolean @default(false)


### PR DESCRIPTION
# Contexte

Il fallait:
- Revoir la liste des éco-organismes en recette/sandbox/prod (certains sont manquants, pas à jour, ...)
- Ajouter des éco-organismes VHU ([Pour ce ticket](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15633))
- Faire en sorte que les éco-organismes qui s'affichent dans les listes de création de bordereau ne soient que ceux pouvant prendre en charge ce type de bordereau

J'ai donc ajouté les éco-organismes manquants au script d'ajout d'objet, à faire tourner dans une one-off (`npx nx run object-creator:run`). J'ai aussi ajouté un flag handleBsdd aux éco-organismes, et ajouté la possibilité de filtrer la query EcoOrganismes par ces flags, et ajouté ces filtres dans les composant de choix d'éco-organisme en front.
J'ai modif à la main les éco-organismes pas à jour mais déjà présents en DB (à faire en sandbox et prod une fois validé en recette)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/50e7b723-2616-43c7-a71f-667166eb2286



# Ticket Favro

[Revoir la liste des éco-organismes sur les bordereaux (BSDD, BSDA, DASRI et VHU)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15687)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB