### PR TITLE
TRA-15652 - BSVHU : Ajoute un nouveau type de conditionnement En unités > Identification par numéro de fiche VHU DROMCOM

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 #### :nail_care: Améliorations
 
-BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
+- BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
+- BSVHU - Ajout d'un nouveau type de conditionnement "Identification par numéro de fiche VHU DROMCOM" [PR 3019](https://github.com/MTES-MCT/trackdechets/pull/3919)
 
 # [2025.01.1] 14/01/2025
 

--- a/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
+++ b/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
@@ -14,7 +14,8 @@ import { Recepisse } from "../../../common/pdf/components/Recepisse";
 const UNITE_IDENTIFICATION_TYPES_LABELS = {
   NUMERO_ORDRE_REGISTRE_POLICE:
     "identification par n° d'ordre tels qu'ils figurent dans le registre de police",
-  NUMERO_IMMATRICULATION: "identification par numéro d’immatriculation"
+  NUMERO_IMMATRICULATION: "identification par numéro d’immatriculation",
+  NUMERO_FICHE_DROMCOM: "identification par numéro de fiche VHU DROMCOM"
 };
 
 const getIdentificationTypeLabel = (bsvhu: Bsvhu) => {

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createBsvhu.integration.ts
@@ -113,67 +113,74 @@ describe("Mutation.Vhu.create", () => {
     ]);
   });
 
-  it("should allow creating a valid form for the producer signature", async () => {
-    const { user, company } = await userWithCompanyFactory("MEMBER");
-    const destinationCompany = await companyFactory({
-      companyTypes: ["WASTE_VEHICLES"],
-      wasteVehiclesTypes: ["BROYEUR", "DEMOLISSEUR"]
-    });
+  it.each([
+    "NUMERO_ORDRE_REGISTRE_POLICE",
+    "NUMERO_IMMATRICULATION",
+    "NUMERO_FICHE_DROMCOM"
+  ])(
+    "should allow creating a valid form for the producer signature with %p identification type",
+    async identificationType => {
+      const { user, company } = await userWithCompanyFactory("MEMBER");
+      const destinationCompany = await companyFactory({
+        companyTypes: ["WASTE_VEHICLES"],
+        wasteVehiclesTypes: ["BROYEUR", "DEMOLISSEUR"]
+      });
 
-    const input = {
-      emitter: {
-        company: {
-          siret: company.siret,
-          name: "The crusher",
-          address: "Rue de la carcasse",
-          contact: "Un centre VHU",
-          phone: "0101010101",
-          mail: "emitter@mail.com"
+      const input = {
+        emitter: {
+          company: {
+            siret: company.siret,
+            name: "The crusher",
+            address: "Rue de la carcasse",
+            contact: "Un centre VHU",
+            phone: "0101010101",
+            mail: "emitter@mail.com"
+          },
+          agrementNumber: "1234"
         },
-        agrementNumber: "1234"
-      },
-      wasteCode: "16 01 06",
-      packaging: "UNITE",
-      identification: {
-        numbers: ["123", "456"],
-        type: "NUMERO_ORDRE_REGISTRE_POLICE"
-      },
-      quantity: 2,
-      weight: {
-        isEstimate: false,
-        value: 1.3
-      },
-      destination: {
-        type: "BROYEUR",
-        plannedOperationCode: "R 12",
-        company: {
-          siret: destinationCompany.siret,
-          name: "destination",
-          address: "address",
-          contact: "contactEmail",
-          phone: "contactPhone",
-          mail: "contactEmail@mail.com"
+        wasteCode: "16 01 06",
+        packaging: "UNITE",
+        identification: {
+          numbers: ["123", "456"],
+          type: identificationType
         },
-        agrementNumber: "9876"
-      }
-    };
-    const { mutate } = makeClient(user);
-    const { data } = await mutate<Pick<Mutation, "createBsvhu">>(
-      CREATE_VHU_FORM,
-      {
-        variables: {
-          input
+        quantity: 2,
+        weight: {
+          isEstimate: false,
+          value: 1.3
+        },
+        destination: {
+          type: "BROYEUR",
+          plannedOperationCode: "R 12",
+          company: {
+            siret: destinationCompany.siret,
+            name: "destination",
+            address: "address",
+            contact: "contactEmail",
+            phone: "contactPhone",
+            mail: "contactEmail@mail.com"
+          },
+          agrementNumber: "9876"
         }
-      }
-    );
+      };
+      const { mutate } = makeClient(user);
+      const { data } = await mutate<Pick<Mutation, "createBsvhu">>(
+        CREATE_VHU_FORM,
+        {
+          variables: {
+            input
+          }
+        }
+      );
 
-    expect(data.createBsvhu.id).toMatch(
-      new RegExp(`^VHU-[0-9]{8}-[A-Z0-9]{9}$`)
-    );
-    expect(data.createBsvhu.destination!.company!.siret).toBe(
-      input.destination.company.siret
-    );
-  });
+      expect(data.createBsvhu.id).toMatch(
+        new RegExp(`^VHU-[0-9]{8}-[A-Z0-9]{9}$`)
+      );
+      expect(data.createBsvhu.destination!.company!.siret).toBe(
+        input.destination.company.siret
+      );
+    }
+  );
 
   it("should create a valid form with customid", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
@@ -229,7 +236,6 @@ describe("Mutation.Vhu.create", () => {
         }
       }
     );
-
     expect(data.createBsvhu.customId).toBe("my custom id");
   });
 

--- a/back/src/bsvhu/typeDefs/bsvhu.enums.graphql
+++ b/back/src/bsvhu/typeDefs/bsvhu.enums.graphql
@@ -7,13 +7,19 @@ enum BsvhuStatus {
 }
 
 enum BsvhuPackaging {
+  "En unités"
   UNITE
+  "En lots (identification par numéro de lot)"
   LOT
 }
 
 enum BsvhuIdentificationType {
+  "Identification par n° d'ordre tels qu'ils figurent dans le registre de police"
   NUMERO_ORDRE_REGISTRE_POLICE
+  "Identification par numéro d'immatriculation"
   NUMERO_IMMATRICULATION
+  "Identification par numéro de fiche VHU DROMCOM"
+  NUMERO_FICHE_DROMCOM
   "Déprécié, plus accepté sur les bsvhus créés après le 17/12/2024"
   NUMERO_ORDRE_LOTS_SORTANTS
 }

--- a/back/src/bsvhu/validation/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/validation/__tests__/validation.integration.ts
@@ -1053,7 +1053,8 @@ describe("BSVHU validation", () => {
 
     test.each([
       BsvhuIdentificationType.NUMERO_ORDRE_REGISTRE_POLICE,
-      BsvhuIdentificationType.NUMERO_IMMATRICULATION
+      BsvhuIdentificationType.NUMERO_IMMATRICULATION,
+      BsvhuIdentificationType.NUMERO_FICHE_DROMCOM
     ])(
       "when packaging is UNITE and identificationType is %p",
       async identificationType => {

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -177,7 +177,8 @@ export const v20250101 = new Date(
 
 const BsvhuIdentificationTypesAfterV20241201 = [
   BsvhuIdentificationType.NUMERO_ORDRE_REGISTRE_POLICE,
-  BsvhuIdentificationType.NUMERO_IMMATRICULATION
+  BsvhuIdentificationType.NUMERO_IMMATRICULATION,
+  BsvhuIdentificationType.NUMERO_FICHE_DROMCOM
 ];
 
 export const checkPackagingAndIdentificationType: Refinement<ParsedZodBsvhu> = (

--- a/front/src/Apps/Dashboard/Creation/bsvhu/schema.ts
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/schema.ts
@@ -88,6 +88,7 @@ const zodDestination = z.object({
             .enum([
               "NUMERO_ORDRE_LOTS_SORTANTS",
               "NUMERO_IMMATRICULATION",
+              "NUMERO_FICHE_DROMCOM",
               "NUMERO_ORDRE_REGISTRE_POLICE"
             ])
             .nullish()
@@ -115,6 +116,7 @@ export const rawBsvhuSchema = z
         .enum([
           "NUMERO_ORDRE_LOTS_SORTANTS",
           "NUMERO_ORDRE_REGISTRE_POLICE",
+          "NUMERO_FICHE_DROMCOM",
           "NUMERO_IMMATRICULATION"
         ])
         .nullish()

--- a/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
+++ b/front/src/Apps/Dashboard/Creation/bsvhu/steps/Waste.tsx
@@ -79,6 +79,13 @@ const WasteBsvhu = ({
         ...register("identification.type"),
         value: "NUMERO_IMMATRICULATION"
       }
+    },
+    {
+      label: "Identification par numéro de fiche VHU DROMCOM",
+      nativeInputProps: {
+        ...register("identification.type"),
+        value: "NUMERO_FICHE_DROMCOM"
+      }
     }
   ];
   // deprecated, kept for bsvhu created before release

--- a/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
+++ b/front/src/dashboard/detail/bsvhu/BsvhuDetailContent.tsx
@@ -281,6 +281,7 @@ const UNITE_IDENTIFICATION_TYPES_LABELS = {
   NUMERO_ORDRE_REGISTRE_POLICE:
     "identification par n° d'ordre tels qu'ils figurent dans le registre de police",
   NUMERO_IMMATRICULATION: "identification par numéro d’immatriculation",
+  NUMERO_FICHE_DROMCOM: "Identification par numéro de fiche VHU DROMCOM",
   NUMERO_ORDRE_LOTS_SORTANTS:
     "identification par numéro d'ordre des lots sortants"
 };

--- a/libs/back/prisma/src/migrations/20250123083809_vh_identification_type_dromcom/migration.sql
+++ b/libs/back/prisma/src/migrations/20250123083809_vh_identification_type_dromcom/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "BsvhuIdentificationType" ADD VALUE 'NUMERO_FICHE_DROMCOM';

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -2127,6 +2127,7 @@ enum BsvhuPackaging {
 enum BsvhuIdentificationType {
   NUMERO_ORDRE_REGISTRE_POLICE
   NUMERO_IMMATRICULATION
+  NUMERO_FICHE_DROMCOM
   NUMERO_ORDRE_LOTS_SORTANTS // deprecated
 }
 


### PR DESCRIPTION
# Contexte

Ajout d'une valeur d'enum pour l'identificationType du Bsvhu NUMERO_FICHE_DROMCOM/Identification par numéro de fiche VHU DROMCOM

Impacts sur:
- api
- formulaire vhu
- aperçu
- pdf

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

 
<img width="1193" alt="Capture d’écran 2025-01-23 à 11 44 11" src="https://github.com/user-attachments/assets/ef340b80-504c-4b09-9097-853ceba948b5" />


# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB