### PR TITLE
Affichage de l'erreur renvoyée par le serveur dans la page admin d'impersonation

### DIFF
--- a/front/src/admin/user/impersonate.tsx
+++ b/front/src/admin/user/impersonate.tsx
@@ -5,6 +5,7 @@ import { Table } from "@codegouvfr/react-dsfr/Table";
 import { Query } from "@td/codegen-ui";
 import React from "react";
 import { SIRET_STORAGE_KEY } from "../../Apps/common/Components/CompanySwitcher/CompanySwitcher";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 
 const COMPANY_PRIVATE_INFOS = gql`
   query CompanyPrivateInfos($clue: String!) {
@@ -56,6 +57,8 @@ export function Impersonate() {
       </form>
     ]) ?? [];
 
+  console.log("error", error);
+
   return (
     <div>
       <div>
@@ -85,7 +88,7 @@ export function Impersonate() {
             search({ variables: { clue: formData.get("clue") } });
           }}
         >
-          <div className="fr-grid-row fr-grid-row--bottom">
+          <div className="fr-grid-row fr-grid-row--bottom fr-mb-4v">
             <div className="fr-col-8">
               <Input
                 label="SIRET ou Numéro TVA"
@@ -99,10 +102,20 @@ export function Impersonate() {
               <Button size="medium">Rechercher</Button>
             </div>
           </div>
+
+          <div className="fr-grid-row">
+            {loading && <div>Chargement...</div>}
+            {error && (
+              <Alert
+                className="fr-mb-3w"
+                small
+                description={error.message}
+                severity="error"
+              />
+            )}
+          </div>
         </form>
       </div>
-      {loading && <div>Chargement...</div>}
-      {error && <div>Erreur</div>}
       {data && (
         <div>
           <Table data={tableData} headers={tableHeaders} />

--- a/front/src/admin/user/impersonate.tsx
+++ b/front/src/admin/user/impersonate.tsx
@@ -57,8 +57,6 @@ export function Impersonate() {
       </form>
     ]) ?? [];
 
-  console.log("error", error);
-
   return (
     <div>
       <div>


### PR DESCRIPTION
# Contexte

Ce petit coquin d'Orion, dans sa hâte, affichait le mot "Erreur" hardcodé. Du coup au support c'est pas évident de comprendre ce qui se passe!

# Démo

Par exemple ici avec un SIRET fermé, l'API renvoie une erreur claire, ce serait dommage de pas en profiter:

![image](https://github.com/user-attachments/assets/ba7a96f0-8573-4c62-b857-256feb17d7ef)
