### PR TITLE
Affichage des erreurs API dans l'interface d'admin pour la recherche par BSD

### DIFF
--- a/front/src/admin/bsd/BsdAdmin.tsx
+++ b/front/src/admin/bsd/BsdAdmin.tsx
@@ -26,6 +26,7 @@ import {
 import { Modal } from "../../common/components";
 import { PermissionsContext } from "../../common/contexts/PermissionsContext";
 import { BsdDetailContent } from "./BsdDetailContent";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 
 const BSD = gql`
   query Bsd($id: String!) {
@@ -187,10 +188,23 @@ export function BsdAdmin() {
             <Button size="medium">Rechercher</Button>
           </div>
         </div>
+
+        {loading && <div>Chargement...</div>}
+        {error && (
+          <div className="fr-grid-row">
+            {loading && <div>Chargement...</div>}
+            {error && (
+              <Alert
+                className="fr-mb-3w"
+                small
+                description={error.message}
+                severity="error"
+              />
+            )}
+          </div>
+        )}
       </form>
 
-      {loading && <div>Chargement...</div>}
-      {error && <div>Une erreur s'est produite...</div>}
       {data && (
         <div>
           <h4 className="fr-h4 fr-mt-4w">Carte comme dans le dashboard</h4>

--- a/front/src/admin/bsd/BsdAdmin.tsx
+++ b/front/src/admin/bsd/BsdAdmin.tsx
@@ -174,7 +174,7 @@ export function BsdAdmin() {
           bsd({ variables: { id: formData.get("id") } });
         }}
       >
-        <div className="fr-grid-row fr-grid-row--bottom">
+        <div className="fr-grid-row fr-grid-row--bottom fr-mb-4v">
           <div className="fr-col-8">
             <Input
               label="Identifiant du bordereau"


### PR DESCRIPTION
# Contexte

Dans l'interface d'admin c'est plus sympa de voir les erreurs retournées par l'API quand on essaie de visualiser un bordereau

# Démo

Bon en l'occurence dans ce cas particulier, l'API fait pas d'effort sur le message d'erreur, mais vous avez l'idée:

![image](https://github.com/user-attachments/assets/bdf9cacf-7666-46e0-a36b-41b21000f9a6)
