### PR TITLE
[TRA 15687 - 2] Ajout d'une validation de l'éco-organisme sur BSDD + update Changelog + ajout d'eco-org BSVHU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
 - BSVHU - Ajout d'un nouveau type de conditionnement "Identification par numéro de fiche VHU DROMCOM" [PR 3019](https://github.com/MTES-MCT/trackdechets/pull/3919)
-- Ajout d'éco-organismes, filtrage des éco-organismes en front [PR 3916](https://github.com/MTES-MCT/trackdechets/pull/3916)
+- Ajout d'éco-organismes, filtrage des éco-organismes en front. Mise à jour des SIRET de certains éco-organismes en base de donnée [PR 3916](https://github.com/MTES-MCT/trackdechets/pull/3916)
 - Il ne devrait pas être possible de valider la réception d'un BSDA avec un poids à 0 [PR 3934](https://github.com/MTES-MCT/trackdechets/pull/3934)
 
 #### :boom: Breaking changes

--- a/back/prisma/seed.model.ts
+++ b/back/prisma/seed.model.ts
@@ -126,7 +126,8 @@ export default async () => {
     data: {
       address: "34 RUE DU DECHETS 13001 MARSEILLE",
       name: "ECOORG",
-      siret: siretify(5)
+      siret: siretify(5),
+      handleBsdd: true
     }
   });
 };

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -621,19 +621,21 @@ export const ecoOrganismeFactory = async ({
 }: {
   siret?: string;
   handle?: {
+    handleBsdd?: boolean;
     handleBsdasri?: boolean;
     handleBsda?: boolean;
     handleBsvhu?: boolean;
   };
   createAssociatedCompany?: boolean;
 }) => {
-  const { handleBsdasri, handleBsda, handleBsvhu } = handle ?? {};
+  const { handleBsdd, handleBsdasri, handleBsda, handleBsvhu } = handle ?? {};
   const ecoOrganismeIndex = (await prisma.ecoOrganisme.count()) + 1;
   const ecoOrganisme = await prisma.ecoOrganisme.create({
     data: {
       address: "",
       name: `Eco-Organisme ${ecoOrganismeIndex}`,
       siret: siret ?? siretify(),
+      handleBsdd,
       handleBsdasri,
       handleBsda,
       handleBsvhu

--- a/back/src/__tests__/testWorkflow.ts
+++ b/back/src/__tests__/testWorkflow.ts
@@ -23,7 +23,12 @@ async function testWorkflow(workflow: Workflow) {
       // create ecoOrganisme to allow its user to perform api calls
       await ecoOrganismeFactory({
         siret: company.siret!,
-        handle: { handleBsdasri: true }
+        handle: {
+          handleBsdd: true,
+          handleBsdasri: true,
+          handleBsda: true,
+          handleBsvhu: true
+        }
       });
     }
     if (

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmission.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmission.integration.ts
@@ -2,7 +2,8 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 
 import {
   userWithCompanyFactory,
-  companyFactory
+  companyFactory,
+  ecoOrganismeFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { BsdasriStatus } from "@prisma/client";
@@ -21,13 +22,9 @@ describe("Mutation.signBsdasri emission", () => {
   it("should put emission signature on a dasri signed by eco-organisme", async () => {
     const { company: ecoOrganismeCompany, user: ecoOrganismeUser } =
       await userWithCompanyFactory("MEMBER");
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: "Eco-Organisme",
-        siret: ecoOrganismeCompany.siret!,
-        handleBsdasri: true
-      }
+    await ecoOrganismeFactory({
+      siret: ecoOrganismeCompany.siret!,
+      handle: { handleBsdasri: true }
     });
     const emitterCompany = await companyFactory();
     const destinationCompany = await companyFactory();

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmissionWithSecretCode.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriEcoorganismeEmissionWithSecretCode.integration.ts
@@ -2,7 +2,8 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import {
   userWithCompanyFactory,
-  companyFactory
+  companyFactory,
+  ecoOrganismeFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { BsdasriStatus } from "@prisma/client";
@@ -23,14 +24,9 @@ describe("Mutation.signBsdasri emission with secret code", () => {
       "MEMBER",
       { securityCode: 7777 }
     );
-
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: "Eco-Organisme",
-        siret: ecoOrganismeCompany.siret!,
-        handleBsdasri: true
-      }
+    await ecoOrganismeFactory({
+      siret: ecoOrganismeCompany.siret!,
+      handle: { handleBsdasri: true }
     });
     const emitterCompany = await companyFactory();
     const { user: transporter, company: transporterCompany } =
@@ -80,13 +76,9 @@ describe("Mutation.signBsdasri emission with secret code", () => {
       { securityCode: 7777 }
     );
     const destination = await companyFactory();
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: "Eco-Organisme",
-        siret: ecoOrganismeCompany.siret!,
-        handleBsdasri: true
-      }
+    await ecoOrganismeFactory({
+      siret: ecoOrganismeCompany.siret!,
+      handle: { handleBsdasri: true }
     });
     const emitterCompany = await companyFactory();
     const { user: transporter, company: transporterCompany } =

--- a/back/src/companies/resolvers/queries/__tests__/ecoOrganismes.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/ecoOrganismes.integration.ts
@@ -1,7 +1,6 @@
 import { resetDatabase } from "../../../../../integration-tests/helper";
 import type { Query } from "@td/codegen-back";
-import { prisma } from "@td/prisma";
-import { siretify } from "../../../../__tests__/factories";
+import { ecoOrganismeFactory, siretify } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 
 const ECO_ORGANISMES = `query { ecoOrganismes { siret } }`;
@@ -12,8 +11,8 @@ describe("query ecoOrgansime", () => {
   it("should return list of registered ecoOrganismes", async () => {
     const { query } = makeClient();
     const siret = siretify(1);
-    await prisma.ecoOrganisme.create({
-      data: { siret, name: "", address: "" }
+    await ecoOrganismeFactory({
+      siret
     });
     const { data } = await query<Pick<Query, "ecoOrganismes">>(ECO_ORGANISMES);
     expect(data.ecoOrganismes.map(c => c.siret)).toEqual([siret]);

--- a/back/src/forms/__tests__/permissions.integration.ts
+++ b/back/src/forms/__tests__/permissions.integration.ts
@@ -4,6 +4,7 @@ import { resetDatabase } from "../../../integration-tests/helper";
 import { ErrorCode } from "../../common/errors";
 import {
   companyFactory,
+  ecoOrganismeFactory,
   formFactory,
   formWithTempStorageFactory,
   userFactory,
@@ -89,12 +90,9 @@ async function checkEcoOrganismePermission(
 ) {
   const owner = await userFactory();
   const { user, company } = await userWithCompanyFactory("MEMBER");
-  const ecoOrganisme = await prisma.ecoOrganisme.create({
-    data: {
-      siret: company.siret!,
-      name: "EO",
-      address: ""
-    }
+  const ecoOrganisme = await ecoOrganismeFactory({
+    siret: company.siret!,
+    handle: { handleBsdd: true }
   });
   const form = await formFactory({
     ownerId: owner.id,

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1703,7 +1703,10 @@ describe("draftFormSchema", () => {
   });
 
   it("should not be valid when passing eco-organisme as emitter", async () => {
-    const ecoOrganisme = await ecoOrganismeFactory({ siret: siretify() });
+    const ecoOrganisme = await ecoOrganismeFactory({
+      siret: siretify(),
+      handle: { handleBsdd: true }
+    });
 
     const partialForm: Partial<Form> = {
       emitterCompanySiret: ecoOrganisme.siret

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -930,14 +930,10 @@ describe("Mutation.createForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        siret: eo.siret!,
-        name: eo.name
-      }
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
-
     const { mutate } = makeClient(user);
     const { data } = await mutate<Pick<Mutation, "createForm">>(CREATE_FORM, {
       variables: {

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -980,6 +980,38 @@ describe("Mutation.createForm", () => {
     ]);
   });
 
+  it("should return an error when trying to create a form with an ecoorganisme not allowed to handle BSDDs", async () => {
+    const ecoOrg = await ecoOrganismeFactory({});
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+
+    const createFormInput = {
+      emitter: {
+        company: {
+          siret: company.siret
+        }
+      },
+      ecoOrganisme: {
+        name: ecoOrg.name,
+        siret: ecoOrg.siret
+      }
+    };
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "createForm">>(CREATE_FORM, {
+      variables: {
+        createFormInput
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message: `L'éco-organisme avec le siret "${createFormInput.ecoOrganisme.siret}" n'est pas reconnu.`,
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
+
   it("should create a form with a pickup site", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
 

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -16,7 +16,8 @@ import {
   siretify,
   userFactory,
   userWithCompanyFactory,
-  companyFactory
+  companyFactory,
+  ecoOrganismeFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import { resetDatabase } from "../../../../../integration-tests/helper";
@@ -207,12 +208,8 @@ describe("mutation / importPaperForm", () => {
         companyTypes: [CompanyType.WASTEPROCESSOR],
         wasteProcessorTypes: [WasteProcessorType.DANGEROUS_WASTES_INCINERATION]
       });
-      const ecoOrganisme = await prisma.ecoOrganisme.create({
-        data: {
-          name: "EO",
-          siret: siretify(3),
-          address: "Somewhere"
-        }
+      const ecoOrganisme = await ecoOrganismeFactory({
+        handle: { handleBsdd: true }
       });
 
       const { mutate } = makeClient(user);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -11,6 +11,7 @@ import { prisma } from "@td/prisma";
 import {
   companyFactory,
   destinationFactory,
+  ecoOrganismeFactory,
   formFactory,
   formWithTempStorageFactory,
   siretify,
@@ -200,12 +201,9 @@ describe("Mutation.markAsSealed", () => {
       "MEMBER"
     );
 
-    const eo = await prisma.ecoOrganisme.create({
-      data: {
-        name: "An EO",
-        siret: ecoOrganismeCompany.siret!,
-        address: "An address"
-      }
+    const eo = await ecoOrganismeFactory({
+      siret: ecoOrganismeCompany.siret!,
+      handle: { handleBsdd: true }
     });
 
     let form = await formFactory({
@@ -239,12 +237,9 @@ describe("Mutation.markAsSealed", () => {
     const emitterCompany = await companyFactory();
     const recipientCompany = await destinationFactory();
     const { user, company: eo } = await userWithCompanyFactory("MEMBER");
-    await prisma.ecoOrganisme.create({
-      data: {
-        name: eo.name,
-        siret: eo.siret!,
-        address: "An address"
-      }
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
 
     let form = await formFactory({
@@ -278,12 +273,9 @@ describe("Mutation.markAsSealed", () => {
     const emitterCompany = await companyFactory();
     const recipientCompany = await destinationFactory();
     const { user, company: eo } = await userWithCompanyFactory("MEMBER");
-    await prisma.ecoOrganisme.create({
-      data: {
-        name: eo.name,
-        siret: eo.siret!,
-        address: "An address"
-      }
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
 
     let form = await formFactory({
@@ -318,12 +310,9 @@ describe("Mutation.markAsSealed", () => {
     const emitterCompany = await companyFactory();
     const recipientCompany = await destinationFactory();
     const { user, company: eo } = await userWithCompanyFactory("MEMBER");
-    await prisma.ecoOrganisme.create({
-      data: {
-        name: eo.name,
-        siret: eo.siret!,
-        address: "An address"
-      }
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
 
     const groupedForm1 = await formFactory({

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -17,7 +17,8 @@ import {
   toIntermediaryCompany,
   userFactory,
   userWithCompanyFactory,
-  transporterReceiptFactory
+  transporterReceiptFactory,
+  ecoOrganismeFactory
 } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import type {
@@ -1648,12 +1649,9 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: eo.name,
-        siret: eo.siret!
-      }
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
 
     // recipient needs appropriate profiles and subprofiles
@@ -1764,13 +1762,11 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: originalEO.name,
-        siret: originalEO.siret!
-      }
+    await ecoOrganismeFactory({
+      siret: originalEO.siret!,
+      handle: { handleBsdd: true }
     });
+
     const form = await formFactory({
       ownerId: user.id,
       opt: {
@@ -1786,12 +1782,9 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: newEO.name,
-        siret: newEO.siret!
-      }
+    await ecoOrganismeFactory({
+      siret: newEO.siret!,
+      handle: { handleBsdd: true }
     });
 
     const { mutate } = makeClient(user);
@@ -1820,12 +1813,10 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: eo.name,
-        siret: eo.siret!
-      }
+
+    await ecoOrganismeFactory({
+      siret: eo.siret!,
+      handle: { handleBsdd: true }
     });
     // recipient needs appropriate profiles and subprofiles
     const destination = await companyFactory({
@@ -3965,12 +3956,9 @@ describe("Mutation.updateForm", () => {
         set: ["ECO_ORGANISME"]
       }
     });
-    await prisma.ecoOrganisme.create({
-      data: {
-        address: "",
-        name: ecoOrganisme.company.name,
-        siret: ecoOrganisme.company.siret!
-      }
+    await ecoOrganismeFactory({
+      siret: ecoOrganisme.company.siret!,
+      handle: { handleBsdd: true }
     });
 
     const { mutate } = makeClient(user);

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -561,7 +561,7 @@ export const ecoOrganismeSchema = yup.object().shape({
         ecoOrganismeSiret
           ? prisma.ecoOrganisme
               .findFirst({
-                where: { siret: ecoOrganismeSiret }
+                where: { siret: ecoOrganismeSiret, handleBsdd: true }
               })
               .then(el => el != null)
           : true

--- a/libs/back/object-creator/src/objects.ts
+++ b/libs/back/object-creator/src/objects.ts
@@ -229,6 +229,43 @@ const objects = [
       handleBsda: false,
       handleBsvhu: true
     }
+  } as CreationObject<"ecoOrganisme">,
+
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "42512736200043",
+      name: "FMC AUTOMOBILES",
+      address: "IMMEUBLE AXE SEINE, 1 RUE DU 1ER MAI, 92000 NANTERRE",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "43445596000022",
+      name: "MAZDA AUTOMOBILES FRANCE",
+      address: "34 RUE DE LA CROIX DE FER, 78100 SAINT-GERMAIN-EN-LAYE",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
+  } as CreationObject<"ecoOrganisme">,
+  {
+    type: "ecoOrganisme",
+    object: {
+      siret: "41139489300043",
+      name: "HYUNDAI MOTOR FRANCE",
+      address: "TOUR NOVA, 71 BOULEVARD NATIONAL, 92250 LA GARENNE-COLOMBES",
+      handleBsdd: false,
+      handleBsdasri: false,
+      handleBsda: false,
+      handleBsvhu: true
+    }
   } as CreationObject<"ecoOrganisme">
 ];
 


### PR DESCRIPTION
# Contexte

Ceci est un petit follow-up de cette PR https://github.com/MTES-MCT/trackdechets/pull/3916
Je me suis rendu compte qu'il manquait une validation du type d'éco-organisme sur BSDD (présente sur les autres types de bordereaux acceptant un éco-organisme).
J'ai aussi rendu plus explicite que cette MEP allait inclure quelques changements de SIRET d'éco-organismes afin d'informer de potentiels intégrateurs ayant mis en dur ces valeurs.
Enfin 3 éco-organismes VHU sont ajoutés, en plus de ceux ajoutés dans la PR précédente

# Points de vigilance pour les intégrateurs

Cela n'est pas visible dans le code lui même, mais cette mise en prod inclue des changements de certains SIRET d'éco-organismes :
- REFASHION (50929280100024 -> 50929280100032)
- SOREN (80054749900023 -> 80054749900031)
- LEKO (82330882000021 -> 82330882000039)

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Revoir la liste des éco-organismes sur les bordereaux (BSDD, BSDA, DASRI et VHU)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15687)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB