### PR TITLE
[TRA-15101] Erreur serveur lors de la lecture d'un BSDA suite à sa création par API - Le champ GraphQL BsdaPackagingType.type est rendu obligatoire

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Ajout d'éco-organismes, filtrage des éco-organismes en front [PR 3916](https://github.com/MTES-MCT/trackdechets/pull/3916)
 
+#### :boom: Breaking changes
+
+- Le champ GraphQL `BsdaPackagingInput.type` est rendu obligatoire [PR 3930](https://github.com/MTES-MCT/trackdechets/pull/3930).
+
 # [2025.01.1] 14/01/2025
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -204,7 +204,7 @@ input BsdaWasteInput {
 
 input BsdaPackagingInput {
   "Type de conditionnement"
-  type: BsdaPackagingType
+  type: BsdaPackagingType!
   "Description du conditionnement dans le cas où le type de conditionnement est `AUTRE`"
   other: String
   "Nombre de colis associés à ce conditionnement"


### PR DESCRIPTION
# Contexte

Surement une petite typo dans l'implémentation initiale qui nous cause des erreurs serveurs du type "Cannot return null for non-nullable field BsdaPackaging.type.".

# Points de vigilance pour les intégrateurs

:boom: `BsdaPackagingInput.type` devient obligatoire pour se conformer au type de sortie  `BsdaPackaging.type` :boom:

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Erreur serveur lors de la lecture d'un BSDA suite à sa création par API - Le champ GraphQL BsdaPackagingType.type est rendu obligatoire](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15101)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB