### PR TITLE
[TRA 15661] Rewords TransporterDisplay displayed information

### DIFF
--- a/front/src/Apps/Forms/Components/TransporterDisplay/TransporterDisplay.tsx
+++ b/front/src/Apps/Forms/Components/TransporterDisplay/TransporterDisplay.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { formatDate } from "../../../../common/datetime";
 import "./TransporterDisplay.scss";
 import { BsdTransporterInput } from "../../types";
+import { TransportMode } from "@td/codegen-ui";
+import { transportModeLabels } from "../../../../dashboard/constants";
 
 type TransporterFieldProps = {
   label: string;
@@ -73,37 +75,50 @@ export default function TransporterDisplay({ transporter }: TransporterProps) {
           <TransporterField label="E-mail" value={transporter.company?.mail} />
         </div>
       </div>
+      {(!transporter.recepisse?.isExempted ||
+        transporter.company?.vatNumber ||
+        !transporter.transport?.mode?.includes(TransportMode.Road)) && (
+        <div className="fr-grid-row fr-grid-row--gutters ">
+          <div className="fr-col-12 fr-col-md-4">
+            <TransporterField
+              label="Récépissé n°"
+              value={transporter.recepisse?.number}
+            />
+          </div>
+          <div className="fr-col-12 fr-col-md-4">
+            <TransporterField
+              label="Récépissé département"
+              value={transporter.recepisse?.department}
+            />
+          </div>
+          <div className="fr-col-12 fr-col-md-4">
+            <TransporterField
+              label="Récépissé valide jusqu'au"
+              value={
+                transporter.recepisse?.validityLimit
+                  ? formatDate(transporter.recepisse?.validityLimit)
+                  : ""
+              }
+            />
+          </div>
+        </div>
+      )}
+      {transporter.recepisse?.isExempted && (
+        <div className="fr-grid-row fr-grid-row--gutters ">
+          <div className="fr-col-12 fr-col-md-4">
+            <TransporterField label="Exemption de récépissé" value="Oui" />
+          </div>
+        </div>
+      )}
       <div className="fr-grid-row fr-grid-row--gutters ">
-        <div className="fr-col-12 fr-col-md-4">
-          <TransporterField
-            label="Récépissé n°"
-            value={transporter.recepisse?.number}
-          />
-        </div>
-        <div className="fr-col-12 fr-col-md-4">
-          <TransporterField
-            label="Récépissé département"
-            value={transporter.recepisse?.department}
-          />
-        </div>
-        <div className="fr-col-12 fr-col-md-4">
-          <TransporterField
-            label="Récépissé valide jusqu'au"
-            value={
-              transporter.recepisse?.validityLimit
-                ? formatDate(transporter.recepisse?.validityLimit)
-                : ""
-            }
-          />
-        </div>
-      </div>
-      <div className="fr-grid-row fr-grid-row--gutters ">
-        <div className="fr-col-12 fr-col-md-4">
-          <TransporterField
-            label="Mode de transport"
-            value={transporter?.transport?.mode}
-          />
-        </div>
+        {transporter?.transport?.mode && (
+          <div className="fr-col-12 fr-col-md-4">
+            <TransporterField
+              label="Mode de transport"
+              value={transportModeLabels[transporter.transport.mode]}
+            />
+          </div>
+        )}
         <div className="fr-col-12 fr-col-md-4">
           <TransporterField
             label="Immatriculation"


### PR DESCRIPTION
# Contexte

Revoir les informations transporteurs scellées en cas de multimodal (récépissé, exemption de récépissé et mode de transport pour transporteur étranger)

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->
[Screencast From 2025-01-27 16-09-36.webm](https://github.com/user-attachments/assets/44b14551-3314-44c1-9ad7-7369ca4b47d2)


# Ticket Favro

[Revoir les informations transporteurs scellées en cas de multimodal (récépissé, exemption de récépissé et mode de transport pour transporteur étranger)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15661)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB