### PR TITLE
TRA-14007 Il ne devrait pas être possible de valider la réception d'un BSDA avec un poids à 0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,8 +11,8 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - BSDD - Dupliquer le(s) conditionnement(s) et la mention ADR et afficher un message informatif en cas de BSDD provenant d'une duplication [PR 3881](https://github.com/MTES-MCT/trackdechets/pull/3881)
 - BSVHU - Ajout d'un nouveau type de conditionnement "Identification par numéro de fiche VHU DROMCOM" [PR 3019](https://github.com/MTES-MCT/trackdechets/pull/3919)
-
 - Ajout d'éco-organismes, filtrage des éco-organismes en front [PR 3916](https://github.com/MTES-MCT/trackdechets/pull/3916)
+- Il ne devrait pas être possible de valider la réception d'un BSDA avec un poids à 0 [PR 3934](https://github.com/MTES-MCT/trackdechets/pull/3934)
 
 # [2025.01.1] 14/01/2025
 

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -243,6 +243,9 @@ input BsdaReceptionInput {
   """
   Quantité présentée en tonnes
 
+  Doit être renseigné pour la signature OPERATION.
+  Doit être strictement supérieur à 0 lorsque le déchet est accepté ou partielement refusé.
+
   Doit être inférieure à 40T en cas de transport routier et inférieure à 50 000 T tout type de transport confondu.
   """
   weight: Float

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -244,7 +244,7 @@ input BsdaReceptionInput {
   Quantité présentée en tonnes
 
   Doit être renseigné pour la signature OPERATION.
-  Doit être strictement supérieur à 0 lorsque le déchet est accepté ou partielement refusé.
+  Doit être strictement supérieur à 0 lorsque le déchet est accepté ou partiellement refusé.
 
   Doit être inférieure à 40T en cas de transport routier et inférieure à 50 000 T tout type de transport confondu.
   """

--- a/back/src/bsda/validation/refinements.ts
+++ b/back/src/bsda/validation/refinements.ts
@@ -618,9 +618,6 @@ export const validateDestinationReceptionWeight: (
 ) => Refinement<ParsedZodBsda> = validationContext => {
   const currentSignatureType = validationContext.currentSignatureType;
   return async (bsda, { addIssue }) => {
-    // Destination is freely editable until EMISSION signature.
-    // Once transported, destination is not editable for anyone.
-    // This is enforced by the sealing rules
     if (currentSignatureType !== "OPERATION") {
       return;
     }

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -26,7 +26,8 @@ import {
   checkTransporters,
   checkWorkerSubSectionThree,
   validateDestination,
-  validatePreviousBsdas
+  validatePreviousBsdas,
+  validateDestinationReceptionWeight
 } from "./refinements";
 import {
   fillIntermediariesOrgIds,
@@ -303,6 +304,7 @@ export const contextualSchemaAsync = (context: BsdaValidationContext) => {
       checkCompanies(bsda, zodContext, context)
     )
     .superRefine(validateDestination(context))
+    .superRefine(validateDestinationReceptionWeight(context))
     .superRefine(
       // run le check sur les champs requis après les transformations
       // au cas où une des transformations auto-complète certains champs


### PR DESCRIPTION
# Contexte

À la réception des déchets, il devrait être obligatoire de compléter la quantité reçue par l'installation de destination.

# Points de vigilance pour les intégrateurs

 Nope


# Démo
https://github.com/user-attachments/assets/5daaf434-03c7-4a0a-b3d6-f1e64e2751ea


# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14007

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB