### PR TITLE
[TRA-15149] Appliquer des restrictions sur le format de l'immatriculation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Révision BSDD - Vérifier le type de profil du courtier et/ou négociant lors d'une révision et retirer les champs liés aux récépissés [PR 3914](https://github.com/MTES-MCT/trackdechets/pull/3914).
 - Bordereau BSDA - Vérifier le type de profil du courtier lors de l'ajout sur un bordereau et retirer les champs liés aux récépissés [PR 3914](https://github.com/MTES-MCT/trackdechets/pull/3914).
 - Révision BSDA - Vérifier le type de profil du courtier lors d'une révision et retirer les champs liés aux récépissés [PR 3914](https://github.com/MTES-MCT/trackdechets/pull/3914).
+- Restrictions sur le format des plaques d'immatriculations sur le BSDA, BSDASRI, BSFF, BSPAOH, BSDD [PR 3935](https://github.com/MTES-MCT/trackdechets/pull/3935).
 
 # [2025.01.1] 14/01/2025
 

--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -268,7 +268,7 @@ export const bsddTransporterData: Omit<
   transporterDepartment: "86",
   transporterIsExemptedOfReceipt: false,
   transporterTransportMode: TransportMode.ROAD,
-  transporterNumberPlate: "aa22",
+  transporterNumberPlate: "AA-22", // valid plate
   transporterReceipt: "33AA",
   transporterValidityLimit: "2019-11-27T00:00:00.000Z",
   readyToTakeOver: true

--- a/back/src/bsda/__tests__/registry.integration.ts
+++ b/back/src/bsda/__tests__/registry.integration.ts
@@ -76,31 +76,31 @@ const createBsdaWith5Transporters = async () => {
           data: [
             {
               transporterCompanySiret: transporter.company.siret,
-              transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+              transporterTransportPlates: ["TR-01-AA"],
               transporterCompanyAddress: transporter.company.address,
               number: 1
             },
             {
               transporterCompanySiret: transporter2.company.siret,
-              transporterTransportPlates: ["TRANSPORTER2-NBR-PLATES"],
+              transporterTransportPlates: ["TR-02-AA"],
               transporterCompanyAddress: transporter2.company.address,
               number: 2
             },
             {
               transporterCompanySiret: transporter3.company.siret,
-              transporterTransportPlates: ["TRANSPORTER3-NBR-PLATES"],
+              transporterTransportPlates: ["TR-03-AA"],
               transporterCompanyAddress: transporter3.company.address,
               number: 3
             },
             {
               transporterCompanySiret: transporter4.company.siret,
-              transporterTransportPlates: ["TRANSPORTER4-NBR-PLATES"],
+              transporterTransportPlates: ["TR-04-AA"],
               transporterCompanyAddress: transporter4.company.address,
               number: 4
             },
             {
               transporterCompanyVatNumber: transporter5.company.vatNumber,
-              transporterTransportPlates: ["TRANSPORTER5-NBR-PLATES"],
+              transporterTransportPlates: ["TR-05-AA"],
               transporterCompanyAddress: transporter5.company.address,
               number: 5
             }
@@ -658,29 +658,19 @@ describe("toTransportedWaste", () => {
 
     // Then
     expect(waste.transporterCompanySiret).toBe(data.transporter1.siret);
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(data.transporter2.siret);
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(data.transporter3.siret);
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(data.transporter4.siret);
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     expect(waste.transporter5CompanySiret).toBe(data.transporter5.vatNumber);
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 });
 
@@ -1018,29 +1008,19 @@ describe("toAllWaste", () => {
 
     // Then
     expect(waste.transporterCompanySiret).toBe(data.transporter1.siret);
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(data.transporter2.siret);
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(data.transporter3.siret);
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(data.transporter4.siret);
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     expect(waste.transporter5CompanySiret).toBe(data.transporter5.vatNumber);
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 
   it("if forwarding BSD, should contain the info of the initial emitter", async () => {

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -367,7 +367,7 @@ input BsdaBrokerRecepisseInput {
 input BsdaTransportInput {
   "Mode de transport"
   mode: TransportMode
-  "Plaque(s) d'immatriculation - maximum 2"
+  "Plaque(s) d'immatriculation - maximum 2 - 4 à 12 caractères."
   plates: [String!]
   "Date de prise en charge"
   takenOverAt: DateTime

--- a/back/src/bsda/validation/__tests__/validation.integration.ts
+++ b/back/src/bsda/validation/__tests__/validation.integration.ts
@@ -124,6 +124,24 @@ describe("BSDA parsing", () => {
       expect(parsed).toBeDefined();
     });
 
+    test("when transporter plate is not present and transport mode is not ROAD before TRANSPORT signature", () => {
+      const data: ZodBsda = {
+        ...bsda,
+        transporters: [
+          {
+            ...bsda.transporters![0],
+            transporterTransportPlates: [],
+            transporterTransportMode: "ROAD" as TransportMode
+          }
+        ]
+      };
+      const parsed = parseBsda(data, {
+        ...context,
+        currentSignatureType: "EMISSION"
+      });
+      expect(parsed).toBeDefined();
+    });
+
     test("when transporter plate is not present and transport mode is not ROAD", () => {
       const data: ZodBsda = {
         ...bsda,
@@ -149,7 +167,7 @@ describe("BSDA parsing", () => {
           {
             ...bsda.transporters![0],
             transporterTransportMode: "ROAD" as TransportMode,
-            transporterTransportPlates: ["TRANSPORTER-PLATES"]
+            transporterTransportPlates: ["AZ-12-BA"]
           }
         ]
       };
@@ -448,8 +466,8 @@ describe("BSDA parsing", () => {
       }
     });
 
-    test.each([undefined, [], [""]])(
-      "when transporter plate is %p invalid and transporter mode is ROAD",
+    test.each([undefined, []])(
+      "when transporter plate is %p and transporter mode is ROAD",
       async invalidValue => {
         const data: ZodBsda = {
           ...bsda,
@@ -461,7 +479,7 @@ describe("BSDA parsing", () => {
             }
           ]
         };
-
+        expect.assertions(1);
         try {
           parseBsda(data, {
             ...context,
@@ -474,6 +492,137 @@ describe("BSDA parsing", () => {
             })
           ]);
         }
+      }
+    );
+
+    test("when transporter plate is an empty string and transporter mode is ROAD", async () => {
+      const data: ZodBsda = {
+        ...bsda,
+        transporters: [
+          {
+            ...bsda.transporters![0],
+            transporterTransportMode: "ROAD" as TransportMode,
+            transporterTransportPlates: [""]
+          }
+        ]
+      };
+      expect.assertions(1);
+      try {
+        parseBsda(data, {
+          ...context,
+          currentSignatureType: "TRANSPORT"
+        });
+      } catch (err) {
+        expect((err as ZodError).issues).toEqual([
+          expect.objectContaining({
+            message:
+              "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+          })
+        ]);
+      }
+    });
+
+    test("when transporter plate is too short and transporter mode is ROAD", async () => {
+      const data: ZodBsda = {
+        ...bsda,
+        transporters: [
+          {
+            ...bsda.transporters![0],
+            transporterTransportMode: "ROAD" as TransportMode,
+            transporterTransportPlates: ["x"]
+          }
+        ]
+      };
+      expect.assertions(1);
+      try {
+        parseBsda(data, {
+          ...context,
+          currentSignatureType: "TRANSPORT"
+        });
+      } catch (err) {
+        expect((err as ZodError).issues).toEqual([
+          expect.objectContaining({
+            message:
+              "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+          })
+        ]);
+      }
+    });
+
+    test("when transporter plate is too long and transporter mode is ROAD", async () => {
+      const data: ZodBsda = {
+        ...bsda,
+        transporters: [
+          {
+            ...bsda.transporters![0],
+            transporterTransportMode: "ROAD" as TransportMode,
+            transporterTransportPlates: ["AZ-12-ER-98-AA-12"]
+          }
+        ]
+      };
+      expect.assertions(1);
+      try {
+        parseBsda(data, {
+          ...context,
+          currentSignatureType: "TRANSPORT"
+        });
+      } catch (err) {
+        expect((err as ZodError).issues).toEqual([
+          expect.objectContaining({
+            message:
+              "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+          })
+        ]);
+      }
+    });
+
+    test("when transporter plate only contains whitespace and transporter mode is ROAD", async () => {
+      const data: ZodBsda = {
+        ...bsda,
+        transporters: [
+          {
+            ...bsda.transporters![0],
+            transporterTransportMode: "ROAD" as TransportMode,
+            transporterTransportPlates: ["      "]
+          }
+        ]
+      };
+      expect.assertions(1);
+      try {
+        parseBsda(data, {
+          ...context,
+          currentSignatureType: "TRANSPORT"
+        });
+      } catch (err) {
+        expect((err as ZodError).issues).toEqual([
+          expect.objectContaining({
+            message: "Le numéro de plaque fourni est incorrect"
+          })
+        ]);
+      }
+    });
+
+    test.each(["XX", "AZ-ER-TY-UI-09-LP-87", "     "])(
+      "when plate is incorrect (%p) on a bsda created before V20250201",
+      async plate => {
+        const data: ZodBsda = {
+          ...bsda,
+          createdAt: new Date("2025-01-10T00:00:00Z"),
+          transporters: [
+            {
+              ...bsda.transporters![0],
+              transporterTransportMode: "ROAD" as TransportMode,
+              transporterTransportPlates: [plate] // should throw, but bsda was created before V20250201
+            }
+          ]
+        };
+
+        const parsed = parseBsda(data, {
+          ...context,
+          currentSignatureType: "TRANSPORT"
+        });
+
+        expect(parsed).toBeDefined();
       }
     );
 
@@ -528,7 +677,7 @@ describe("BSDA parsing", () => {
           }
         ]
       };
-
+      expect.assertions(1);
       try {
         await parseBsdaAsync(data, {
           ...context,

--- a/back/src/bsda/validation/schema.ts
+++ b/back/src/bsda/validation/schema.ts
@@ -42,6 +42,7 @@ import {
   rawTransporterSchema,
   siretSchema
 } from "../../common/validation/zod/schema";
+import { validateMultiTransporterPlates } from "../../common/validation/zod/refinement";
 
 const ZodBsdaPackagingEnum = z.enum([
   "BIG_BAG",
@@ -265,7 +266,8 @@ export const refinedSchema = rawBsdaSchema
   .superRefine(checkNoTransporterWhenCollection2710)
   .superRefine(checkNoWorkerWhenCollection2710)
   .superRefine(checkNoBothGroupingAndForwarding)
-  .superRefine(checkTransporters);
+  .superRefine(checkTransporters)
+  .superRefine(validateMultiTransporterPlates);
 
 // Transformations synchrones qui sont toujours
 // joués même si `enableCompletionTransformers=false`

--- a/back/src/bsdasris/__tests__/factories.ts
+++ b/back/src/bsdasris/__tests__/factories.ts
@@ -122,7 +122,7 @@ export const readyToTakeOverData = company => ({
   transporterRecepisseNumber: "xyz",
   transporterRecepisseDepartment: "83",
   transporterRecepisseValidityLimit: new Date(),
-  transporterTransportPlates: ["TRANSPORTER-PLATE"],
+  transporterTransportPlates: ["AB-65-ML"],
   transporterTransportMode: TransportMode.ROAD,
   transporterWastePackagings: [
     { type: "BOITE_CARTON", volume: 22, quantity: 3 }

--- a/back/src/bsdasris/__tests__/registry.integration.ts
+++ b/back/src/bsdasris/__tests__/registry.integration.ts
@@ -148,7 +148,7 @@ describe("toIncomingWaste", () => {
       opt: {
         destinationCompanyMail: "destination@mail.com",
         transporterCompanySiret: transporter.siret,
-        transporterTransportPlates: ["TRANSPORTER-NBR-PLATES"]
+        transporterTransportPlates: ["TR-12-AA"]
       }
     });
 
@@ -364,7 +364,7 @@ describe("toOutgoingWaste", () => {
       opt: {
         destinationCompanyMail: "destination@mail.com",
         transporterCompanySiret: transporter.siret,
-        transporterTransportPlates: ["TRANSPORTER-NBR-PLATES"]
+        transporterTransportPlates: ["TR-12-AA"]
       }
     });
 
@@ -447,7 +447,7 @@ describe("toTransportedWaste", () => {
       opt: {
         destinationCompanyMail: "destination@mail.com",
         transporterCompanySiret: transporter.siret,
-        transporterTransportPlates: ["TRANSPORTER-NBR-PLATES"]
+        transporterTransportPlates: ["TR-12-AA"]
       }
     });
 
@@ -462,9 +462,7 @@ describe("toTransportedWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       dasriForRegistry.transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-12-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();
@@ -514,7 +512,7 @@ describe("toManagedWaste", () => {
       opt: {
         destinationCompanyMail: "destination@mail.com",
         transporterCompanySiret: transporter.siret,
-        transporterTransportPlates: ["TRANSPORTER-NBR-PLATES"]
+        transporterTransportPlates: ["TR-12-AA"]
       }
     });
 
@@ -686,7 +684,7 @@ describe("toAllWaste", () => {
       opt: {
         destinationCompanyMail: "destination@mail.com",
         transporterCompanySiret: transporter.siret,
-        transporterTransportPlates: ["TRANSPORTER-NBR-PLATES"]
+        transporterTransportPlates: ["TR-12-AA"]
       }
     });
 
@@ -701,9 +699,7 @@ describe("toAllWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       dasriForRegistry.transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-12-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriReception.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriReception.integration.ts
@@ -64,7 +64,56 @@ describe("Mutation.signBsdasri reception", () => {
     );
   });
 
-  it("should put reception signature on a dasri and preserver handedOverToRecipientAt", async () => {
+  it("should put reception signature on a dasri even if plates are invalid and bsd was created before V2025020", async () => {
+    // When a reception is signed, handedOverToRecipientAt is filled with destinationReceptionDate field
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { company: transporterCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+    const { user: recipient, company: destinationCompany } =
+      await userWithCompanyFactory("MEMBER");
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        ...readyToReceiveData(),
+        transporterTransportPlates: ["XY"], // too short
+        destinationReceptionDate: new Date("2020-12-15T11:00:00.000Z"),
+        createdAt: new Date("2025-01-04T00:00:00.000Z"), // created before V2025020
+
+        status: BsdasriStatus.SENT
+      }
+    });
+    expect(dasri.handedOverToRecipientAt).toBeNull(); // sanity check
+
+    const { mutate } = makeClient(recipient); // recipient
+
+    await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "RECEPTION", author: "Monique" }
+      }
+    });
+
+    const receivedDasri = await prisma.bsdasri.findUniqueOrThrow({
+      where: { id: dasri.id }
+    });
+    expect(receivedDasri.status).toEqual("RECEIVED");
+    expect(receivedDasri.destinationReceptionSignatureAuthor).toEqual(
+      "Monique"
+    );
+    expect(receivedDasri.destinationReceptionSignatureDate).toBeTruthy();
+    expect(receivedDasri.receptionSignatoryId).toEqual(recipient.id);
+    expect(receivedDasri.handedOverToRecipientAt).not.toBeNull();
+
+    expect(receivedDasri.handedOverToRecipientAt).toEqual(
+      new Date("2020-12-15T11:00:00.000Z")
+    );
+  });
+
+  it("should put reception signature on a dasri and preserve handedOverToRecipientAt", async () => {
     // When a reception is signed, handedOverToRecipientAt must be kept if already filled
 
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signBsdasriTransport.integration.ts
@@ -113,6 +113,76 @@ describe("Mutation.signBsdasri transport", () => {
     expect(readyTotakeOverDasri.transportSignatoryId).toEqual(transporter.id);
   });
 
+  it("should forbid transport signature on a SIGNED_BY_PRODUCER dasri if plates are invalid", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { user: transporter, company: transporterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        emitterEmissionSignatureDate: new Date(),
+        transporterRecepisseIsExempted: true,
+        emitterEmissionSignatureAuthor: "Producteur",
+        transporterTransportPlates: ["XY"], // too short
+        status: BsdasriStatus.SIGNED_BY_PRODUCER
+      }
+    });
+    const { mutate } = makeClient(transporter); // transporter
+
+    const { errors } = await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "TRANSPORT", author: "Jimmy" }
+      }
+    });
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+      })
+    ]);
+  });
+
+  it("should put transport signature on a SIGNED_BY_PRODUCER dasri wihth invalid plates", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { user: transporter, company: transporterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        emitterEmissionSignatureDate: new Date(),
+        transporterRecepisseIsExempted: true,
+        emitterEmissionSignatureAuthor: "Producteur",
+        transporterTransportPlates: ["XY"], // too short
+        status: BsdasriStatus.SIGNED_BY_PRODUCER,
+        createdAt: new Date("2025-01-04T00:00:00.000Z") // created before V2025020
+      }
+    });
+    const { mutate } = makeClient(transporter); // transporter
+
+    const { errors } = await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "TRANSPORT", author: "Jimmy" }
+      }
+    });
+
+    expect(errors).toBeUndefined();
+  });
+
   it("should not allow the transport signature when recepisse is absent", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
     const { user: transporter, company: transporterCompany } =

--- a/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/signSynthesisBsdasri.integration.ts
@@ -74,6 +74,7 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
       })
     ]);
   });
+
   it("should put transport signature on an INITIAL synthesis dasri and cascade on associated bsds", async () => {
     const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
     const { user: transporter, company: transporterCompany } =
@@ -137,6 +138,54 @@ describe("Mutation.signBsdasri on synthesis bsd", () => {
     expect(updatedSynthesizeBsdasri.transportSignatoryId).toEqual(
       transporter.id
     );
+  });
+
+  it("should forbid transport signature on an INITIAL synthesis dasri if plates are invalid", async () => {
+    const { company: emitterCompany } = await userWithCompanyFactory("MEMBER");
+    const { user: transporter, company: transporterCompany } =
+      await userWithCompanyFactory("MEMBER");
+    await transporterReceiptFactory({ company: transporterCompany });
+    const { company: destinationCompany } = await userWithCompanyFactory(
+      "MEMBER"
+    );
+
+    // this dasri will be grouped by the synthesis dasris
+    const synthesizeBsdasri = await bsdasriFactory({
+      opt: {
+        ...initialData(emitterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        status: BsdasriStatus.SENT
+      }
+    });
+
+    // synthesis dasris
+    const dasri = await bsdasriFactory({
+      opt: {
+        ...initialData(transporterCompany),
+        ...readyToPublishData(destinationCompany),
+        ...readyToTakeOverData(transporterCompany),
+        transporterTransportPlates: ["XY"], // too short
+        status: BsdasriStatus.INITIAL,
+        type: BsdasriType.SYNTHESIS,
+
+        synthesizing: { connect: [{ id: synthesizeBsdasri.id }] }
+      }
+    });
+    const { mutate } = makeClient(transporter); // transporter
+
+    const { errors } = await mutate<Pick<Mutation, "signBsdasri">>(SIGN_DASRI, {
+      variables: {
+        id: dasri.id,
+        input: { type: "TRANSPORT", author: "Jimmy" }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+      })
+    ]);
   });
 
   it.each([

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -2,7 +2,8 @@ import { resetDatabase } from "../../../../../integration-tests/helper";
 import { ErrorCode } from "../../../../common/errors";
 import {
   bsdasriFactory,
-  readyToPublishData
+  readyToPublishData,
+  readyToTakeOverData
 } from "../../../__tests__/factories";
 import {
   userWithCompanyFactory,
@@ -203,6 +204,72 @@ describe("Mutation.updateBsdasri", () => {
       expect(sirenify).toHaveBeenCalledTimes(1);
     }
   );
+
+  it("should forbid invalid transporter plates", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const dasri = await bsdasriFactory({
+      opt: {
+        status: BsdasriStatus.SIGNED_BY_PRODUCER,
+        isDraft: false,
+        emitterCompanySiret: company.siret,
+        ...readyToPublishData(await companyFactory()),
+        ...readyToTakeOverData(company)
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const input = {
+      transporter: { transport: { plates: "AA" } }
+    };
+
+    const { errors } = await mutate<Pick<Mutation, "updateBsdasri">>(
+      UPDATE_DASRI,
+      {
+        variables: {
+          id: dasri.id,
+          input
+        }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+      })
+    ]);
+  });
+
+  it("should forbid invalid transporter plates if bsd was create before V2025020", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const dasri = await bsdasriFactory({
+      opt: {
+        status: BsdasriStatus.SIGNED_BY_PRODUCER,
+        isDraft: false,
+        emitterCompanySiret: company.siret,
+        ...readyToPublishData(await companyFactory()),
+        ...readyToTakeOverData(company),
+        createdAt: new Date("2025-01-04T00:00:00.000Z") // created before V2025020
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const input = {
+      transporter: { transport: { plates: "AA" } }
+    };
+
+    const { errors } = await mutate<Pick<Mutation, "updateBsdasri">>(
+      UPDATE_DASRI,
+      {
+        variables: {
+          id: dasri.id,
+          input
+        }
+      }
+    );
+
+    expect(errors).toBeUndefined();
+  });
 
   it("should update transporter recepisse with data pulled from db", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -73,6 +73,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     transporterWasteWeightValue,
     transporterWasteWeightIsEstimate,
     transporterWasteVolume,
+    transporterTransportPlates,
     handedOverToRecipientAt,
     transportSignatoryId,
     transporterTransportSignatureDate,

--- a/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
+++ b/back/src/bsdasris/typeDefs/bsdasri.inputs.graphql
@@ -191,7 +191,7 @@ input BsdasriTransportInput {
   "Mode de transport"
   acceptation: BsdasriAcceptationInput
   mode: TransportMode
-  "Plaque(s) d'immatriculation - maximum 2"
+  "Plaque(s) d'immatriculation - maximum 2 - 4 à 12 caractères."
   plates: [String!]
 }
 

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -33,8 +33,15 @@ import {
   WeightUnits,
   transporterRecepisseSchema
 } from "../common/validation";
+import { onlyWhiteSpace } from "../common/validation/zod/refinement";
+import {
+  ERROR_TRANSPORTER_PLATES_TOO_MANY,
+  ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH,
+  ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
+} from "../common/validation/messages";
 import { destinationOperationModeValidation } from "../common/validation/operationMode";
 import { isDefined } from "../common/helpers";
+import { v20250201 } from "../common/validation";
 
 const wasteCodes = DASRI_WASTE_CODES.map(el => el.code);
 
@@ -310,18 +317,41 @@ export const transporterSchema: FactorySchemaOf<
     transporterTransportPlates: yup
       .array()
       .of(yup.string())
-      .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
+      .max(2, ERROR_TRANSPORTER_PLATES_TOO_MANY)
       .test((transporterTransportPlates, ctx) => {
-        const { transporterTransportMode } = ctx.parent;
+        const { transporterTransportMode, createdAt = new Date() } = ctx.parent;
+        const createdAfterV20250201 = createdAt.getTime() > v20250201.getTime();
 
+        if (context.transportSignature) {
+          if (
+            transporterTransportMode === "ROAD" &&
+            (!transporterTransportPlates ||
+              !transporterTransportPlates?.filter(p => Boolean(p)).length)
+          ) {
+            return new yup.ValidationError(
+              "La plaque d'immatriculation est requise"
+            );
+          }
+        }
         if (
-          context.transportSignature &&
-          transporterTransportMode === "ROAD" &&
-          (!transporterTransportPlates ||
-            !transporterTransportPlates?.filter(p => Boolean(p)).length)
+          createdAfterV20250201 &&
+          transporterTransportPlates &&
+          transporterTransportPlates.some(
+            plate => (plate ?? "").length > 12 || (plate ?? "").length < 4
+          )
         ) {
           return new yup.ValidationError(
-            "La plaque d'immatriculation est requise"
+            ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH
+          );
+        }
+
+        if (
+          createdAfterV20250201 &&
+          transporterTransportPlates &&
+          transporterTransportPlates.some(plate => onlyWhiteSpace(plate ?? ""))
+        ) {
+          return new yup.ValidationError(
+            ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
           );
         }
 
@@ -481,7 +511,7 @@ export const transportSchema: FactorySchemaOf<
     transporterTransportPlates: yup
       .array()
       .of(yup.string())
-      .max(2, "Un maximum de 2 plaques d'immatriculation est accepté") as any,
+      .max(2, ERROR_TRANSPORTER_PLATES_TOO_MANY) as any,
     transporterTransportMode: yup
       .mixed<TransportMode>()
       .nullable()

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -154,7 +154,7 @@ describe("Query.bsds.dasris base workflow", () => {
                 takenOverAt: new Date().toISOString() as any,
 
                 weight: { value: 99, isEstimate: false },
-                plates: ["TRANSPORTER-PLATE"],
+                plates: ["AB-65-ML"],
                 packagings: [{ type: "FUT", quantity: 44, volume: 123 }],
 
                 acceptation: { status: WasteAcceptationStatus.ACCEPTED }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
@@ -170,7 +170,7 @@ describe("Query.bsds.bspaohs base workflow", () => {
               transport: {
                 takenOverAt: new Date().toISOString() as any,
                 mode: "ROAD",
-                plates: ["TRANSPORTER-PLATE"]
+                plates: ["AB-12-TY"]
               }
             },
             destination: {

--- a/back/src/bsffs/__tests__/factories.ts
+++ b/back/src/bsffs/__tests__/factories.ts
@@ -198,7 +198,7 @@ export function createBsffBeforeTransport(
     ...opts,
     transporterData: {
       transporterTransportMode: TransportMode.ROAD,
-      transporterTransportPlates: ["TRANSPORTER-PLATE"],
+      transporterTransportPlates: ["AB-12-YZ"],
       transporterTransportTakenOverAt: new Date(),
       ...opts.transporterData
     }

--- a/back/src/bsffs/__tests__/registry.integration.ts
+++ b/back/src/bsffs/__tests__/registry.integration.ts
@@ -66,7 +66,7 @@ const createBsffWith5Transporters = async () => {
       data: { destinationCompanyMail: "destination@mail.com" },
       transporterData: {
         transporterCompanySiret: transporter1.company.siret,
-        transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+        transporterTransportPlates: ["TR-01-AA"],
         transporterCompanyAddress: transporter1.company.address
       }
     }
@@ -75,22 +75,22 @@ const createBsffWith5Transporters = async () => {
   await addBsffTransporter({
     bsffId: bsff.id,
     transporter: transporter2,
-    opt: { transporterTransportPlates: ["TRANSPORTER2-NBR-PLATES"] }
+    opt: { transporterTransportPlates: ["TR-02-AA"] }
   });
   await addBsffTransporter({
     bsffId: bsff.id,
     transporter: transporter3,
-    opt: { transporterTransportPlates: ["TRANSPORTER3-NBR-PLATES"] }
+    opt: { transporterTransportPlates: ["TR-03-AA"] }
   });
   await addBsffTransporter({
     bsffId: bsff.id,
     transporter: transporter4,
-    opt: { transporterTransportPlates: ["TRANSPORTER4-NBR-PLATES"] }
+    opt: { transporterTransportPlates: ["TR-04-AA"] }
   });
   await addBsffTransporter({
     bsffId: bsff.id,
     transporter: transporter5,
-    opt: { transporterTransportPlates: ["TRANSPORTER5-NBR-PLATES"] }
+    opt: { transporterTransportPlates: ["TR-05-AA"] }
   });
 
   return {
@@ -559,37 +559,27 @@ describe("toTransportedWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       bsffForRegistry.transporters[0].transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(
       bsffForRegistry.transporters[1].transporterCompanySiret
     );
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(
       bsffForRegistry.transporters[2].transporterCompanySiret
     );
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(
       bsffForRegistry.transporters[3].transporterCompanySiret
     );
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     expect(waste.transporter5CompanySiret).toBe(
       bsffForRegistry.transporters[4].transporterCompanyVatNumber
     );
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 });
 
@@ -843,37 +833,27 @@ describe("toAllWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       bsffForRegistry.transporters[0].transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(
       bsffForRegistry.transporters[1].transporterCompanySiret
     );
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(
       bsffForRegistry.transporters[2].transporterCompanySiret
     );
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(
       bsffForRegistry.transporters[3].transporterCompanySiret
     );
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     expect(waste.transporter5CompanySiret).toBe(
       bsffForRegistry.transporters[4].transporterCompanyVatNumber
     );
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 });
 

--- a/back/src/bsffs/typeDefs/bsff.inputs.graphql
+++ b/back/src/bsffs/typeDefs/bsff.inputs.graphql
@@ -312,7 +312,7 @@ input BsffTransporterTransportInput {
   "Date de prise en charge"
   takenOverAt: DateTime
   mode: TransportMode
-  "Plaque(s) d'immatriculation - maximum 2"
+  "Plaque(s) d'immatriculation - maximum 2 - 4 à 12 caractères."
   plates: [String!]
 }
 

--- a/back/src/bsffs/validation/bsff/schema.ts
+++ b/back/src/bsffs/validation/bsff/schema.ts
@@ -25,6 +25,7 @@ import {
   rawTransporterSchema,
   siretSchema
 } from "../../../common/validation/zod/schema";
+import { validateMultiTransporterPlates } from "../../../common/validation/zod/refinement";
 
 export const ZodWasteCodeEnum = z
   .enum(BSFF_WASTE_CODES, {
@@ -174,7 +175,8 @@ export type ParsedZodBsff = z.output<typeof rawBsffSchema>;
 
 const refinedBsffSchema = rawBsffSchema
   .superRefine(checkPackagings)
-  .superRefine(checkWeights);
+  .superRefine(checkWeights)
+  .superRefine(validateMultiTransporterPlates);
 
 /**
  * Modification du schéma Zod pour appliquer des tranformations et

--- a/back/src/bspaoh/__tests__/registry.integration.ts
+++ b/back/src/bspaoh/__tests__/registry.integration.ts
@@ -157,7 +157,7 @@ describe("toIncomingWaste", () => {
         transporters: {
           create: {
             transporterCompanySiret: transporter.siret,
-            transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+            transporterTransportPlates: ["TR-01-AA"],
             number: 1
           }
         }
@@ -247,7 +247,7 @@ describe("toOutgoingWaste", () => {
         transporters: {
           create: {
             transporterCompanySiret: transporter.siret,
-            transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+            transporterTransportPlates: ["TR-01-AA"],
             number: 1
           }
         }
@@ -335,7 +335,7 @@ describe("toTransportedWaste", () => {
         transporters: {
           create: {
             transporterCompanySiret: transporter.siret,
-            transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+            transporterTransportPlates: ["TR-01-AA"],
             number: 1
           }
         }
@@ -353,9 +353,7 @@ describe("toTransportedWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       paohForRegistry.transporters[0].transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();
@@ -383,7 +381,7 @@ describe("toManagedWaste", () => {
         transporters: {
           create: {
             transporterCompanySiret: transporter.siret,
-            transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+            transporterTransportPlates: ["TR-01-AA"],
             number: 1
           }
         }
@@ -453,7 +451,7 @@ describe("toAllWaste", () => {
         transporters: {
           create: {
             transporterCompanySiret: transporter.siret,
-            transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"],
+            transporterTransportPlates: ["TR-01-AA"],
             number: 1
           }
         }
@@ -471,9 +469,7 @@ describe("toAllWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       paohForRegistry.transporters[0].transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();

--- a/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
+++ b/back/src/bspaoh/resolvers/mutations/__tests__/duplicateBspaoh.integration.ts
@@ -486,4 +486,56 @@ describe("Mutation.duplicateBspaoh", () => {
       }
     ]);
   });
+
+  it("should not duplicate tranporter plates", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const transporterCompany = await companyFactory({
+      transporterReceipt: {
+        create: {
+          receiptNumber: "TRANSPORTER-RECEIPT-NUMBER",
+          validityLimit: TODAY.toISOString(),
+          department: "83T"
+        }
+      }
+    });
+    const bspaoh = await bspaohFactory({
+      opt: {
+        emitterCompanySiret: company.siret,
+
+        transporters: {
+          create: {
+            number: 1,
+            transporterCompanySiret: transporterCompany.siret,
+            transporterCompanyName: transporterCompany.name,
+            transporterCompanyAddress: transporterCompany.address,
+            transporterCompanyContact: transporterCompany.contact,
+            transporterCompanyMail: transporterCompany.contactEmail,
+            transporterCompanyPhone: transporterCompany.contactPhone,
+            transporterTransportPlates: ["AZ-77-PO"]
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(user); // emitter
+
+    const { data } = await mutate<Pick<Mutation, "duplicateBspaoh">>(
+      DUPLICATE_BSPAOH,
+      {
+        variables: {
+          id: bspaoh.id
+        }
+      }
+    );
+
+    expect(data.duplicateBspaoh.status).toBe("INITIAL");
+    expect(data.duplicateBspaoh.isDraft).toBe(true);
+
+    const duplicated = await prisma.bspaoh.findUnique({
+      where: { id: data.duplicateBspaoh.id },
+      include: { transporters: true }
+    });
+
+    expect(duplicated?.transporters[0].transporterTransportPlates).toEqual([]);
+  });
 });

--- a/back/src/bspaoh/resolvers/mutations/duplicate.ts
+++ b/back/src/bspaoh/resolvers/mutations/duplicate.ts
@@ -161,6 +161,7 @@ async function duplicateBspaoh(
     bspaohId,
     createdAt: trsCreatedAt,
     updatedAt: trsUpdatedAt,
+    transporterTransportPlates,
 
     ...trsFieldsToCopy
   } = bspaohTransporter;

--- a/back/src/bspaoh/typeDefs/bspaoh.inputs.graphql
+++ b/back/src/bspaoh/typeDefs/bspaoh.inputs.graphql
@@ -167,7 +167,7 @@ input BspaohRecepisseInput {
 input BspaohTransportInput {
   "Mode de transport"
   mode: TransportMode
-  "Plaque(s) d'immatriculation - maximum 2"
+  "Plaque(s) d'immatriculation - maximum 2 - 4 à 12 caractères."
   plates: [String!]
   "Date de prise en charge"
   takenOverAt: DateTime

--- a/back/src/bspaoh/validation/schema.ts
+++ b/back/src/bspaoh/validation/schema.ts
@@ -1,14 +1,17 @@
 import { z } from "zod";
-import { WasteAcceptationStatus, TransportMode } from "@prisma/client";
+import { WasteAcceptationStatus } from "@prisma/client";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { isCrematoriumRefinement } from "./dynamicRefinements";
 import { BSPAOH_WASTE_CODES, BSPAOH_WASTE_TYPES } from "@td/constants";
 import {
   CompanyRole,
-  foreignVatNumberSchema,
-  siretSchema
+  siretSchema,
+  rawTransporterSchema
 } from "../../common/validation/zod/schema";
-import { isRegisteredVatNumberRefinement } from "../../common/validation/zod/refinement";
+import {
+  isRegisteredVatNumberRefinement,
+  validateTransporterPlates
+} from "../../common/validation/zod/refinement";
 
 export const BSPAOH_OPERATIONS = ["R 1", "D 10"] as const;
 
@@ -125,41 +128,16 @@ const rawBspaohSchema = z.object({
 
 export type ZodBspaoh = z.infer<typeof rawBspaohSchema>;
 
-const rawBspaohTransporterSchema = z.object({
-  transporterCompanyName: z.string().nullish(),
-  transporterCompanySiret: siretSchema(CompanyRole.Transporter).nullish(), // Further verifications done here under in superRefine
-  transporterCompanyAddress: z.string().nullish(),
-  transporterCompanyContact: z.string().nullish(),
-  transporterCompanyPhone: z.string().nullish(),
-  transporterCompanyMail: z.string().nullish(),
-  transporterCompanyVatNumber: foreignVatNumberSchema(CompanyRole.Transporter)
-    .nullish()
-    .superRefine(isRegisteredVatNumberRefinement),
-  transporterCustomInfo: z.string().nullish(),
-  transporterRecepisseIsExempted: z
-    .boolean()
-    .nullish()
-    .transform(v => Boolean(v)),
-  transporterRecepisseNumber: z.string().nullish(),
-  transporterRecepisseDepartment: z.string().nullish(),
-  transporterRecepisseValidityLimit: z.coerce.date().nullish(),
-  transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
-  transporterTakenOverAt: z.coerce.date().nullish(),
-  transporterTransportPlates: z
-    .array(z.string())
-    .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
-    .default([]),
-  transporterTransportTakenOverAt: z.coerce.date().nullish(),
-  transporterTransportSignatureAuthor: z.string().nullish(),
-  transporterTransportSignatureDate: z.coerce.date().nullish()
-});
+const rawBspaohTransporterSchema = rawTransporterSchema
+  .omit({ id: true, number: true })
+  .merge(z.object({ transporterTakenOverAt: z.coerce.date().nullish() }));
 
 export type ZodBspaohTransporter = z.infer<typeof rawBspaohTransporterSchema>;
 
 const rawFullBspaohSchema = rawBspaohSchema.merge(rawBspaohTransporterSchema);
 
 export const fullBspaohSchema = rawFullBspaohSchema
-  .superRefine((val, ctx) => {
+  .superRefine(async (val, ctx) => {
     // refine date order
     if (
       val.destinationReceptionDate &&
@@ -181,7 +159,11 @@ export const fullBspaohSchema = rawFullBspaohSchema
         message: `La consistance ne peut être liquide pour ce type de déchet`
       });
     }
+    // refine transporter vat
+    await isRegisteredVatNumberRefinement(val.transporterCompanyVatNumber, ctx);
   })
+
+  .superRefine(validateTransporterPlates)
   .transform(val => {
     return val;
   });

--- a/back/src/bsvhu/__tests__/registry.integration.ts
+++ b/back/src/bsvhu/__tests__/registry.integration.ts
@@ -290,7 +290,7 @@ describe("toTransportedWaste", () => {
     const bsvhu = await bsvhuFactory({
       opt: {
         destinationCompanyMail: "destination@mail.com",
-        transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"]
+        transporterTransportPlates: ["TR-01-AA"]
       }
     });
 
@@ -305,9 +305,7 @@ describe("toTransportedWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       bsvhuForRegistry.transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();
@@ -475,7 +473,7 @@ describe("toAllWaste", () => {
     const bsvhu = await bsvhuFactory({
       opt: {
         destinationCompanyMail: "destination@mail.com",
-        transporterTransportPlates: ["TRANSPORTER1-NBR-PLATES"]
+        transporterTransportPlates: ["TR-01-AA"]
       }
     });
 
@@ -490,9 +488,7 @@ describe("toAllWaste", () => {
     expect(waste.transporterCompanySiret).toBe(
       bsvhuForRegistry.transporterCompanySiret
     );
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBeNull();
     expect(waste.transporter2NumberPlates).toBeNull();

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -310,42 +310,6 @@ export const checkTransportModeAndReceptionWeight: Refinement<
   );
 };
 
-const onlyWhiteSpace = (str: string) => !str.trim().length; // check whitespaces, tabs, newlines and invisible chars
-
-export const checkTransportPlates: Refinement<ParsedZodBsvhu> = (
-  bsvhu,
-  ctx
-) => {
-  const { transporterTransportPlates } = bsvhu;
-  const path = ["transporter", "transport", "plates"];
-  if (transporterTransportPlates.length > 2) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path,
-      message: "Un maximum de 2 plaques d'immatriculation est accepté"
-    });
-  }
-
-  if (
-    transporterTransportPlates.some(plate => plate.length > 12) ||
-    transporterTransportPlates.some(plate => plate.length < 4)
-  ) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path,
-      message: "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
-    });
-  }
-
-  if (transporterTransportPlates.some(plate => onlyWhiteSpace(plate))) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path,
-      message: "Le numéro de plaque fourni est incorrect"
-    });
-  }
-};
-
 export const checkRequiredFields: (
   validationContext: BsvhuValidationContext
 ) => Refinement<ParsedZodBsvhu> = validationContext => {

--- a/back/src/common/validation/messages.ts
+++ b/back/src/common/validation/messages.ts
@@ -1,0 +1,7 @@
+export const ERROR_TRANSPORTER_PLATES_TOO_MANY =
+  "Un maximum de 2 plaques d'immatriculation est accepté";
+export const ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH =
+  "Le numéro d'immatriculation doit faire entre 4 et 12 caractères";
+
+export const ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT =
+  "Le numéro de plaque fourni est incorrect";

--- a/back/src/common/validation/zod/refinement.ts
+++ b/back/src/common/validation/zod/refinement.ts
@@ -14,6 +14,12 @@ import { prisma } from "@td/prisma";
 import { BsdType, Company, CompanyVerificationStatus } from "@prisma/client";
 import { getOperationModesFromOperationCode } from "../../operationModes";
 import { CompanyRole, pathFromCompanyRole } from "./schema";
+import { v20250201 } from "../../validation";
+
+import {
+  ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH,
+  ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
+} from "../messages";
 
 const { VERIFY_COMPANY } = process.env;
 
@@ -357,3 +363,47 @@ export async function isTraderRefinement(
     });
   }
 }
+
+export const onlyWhiteSpace = (str: string) => !str.trim().length; // check whitespaces, tabs, newlines and invisible chars
+
+export const validateTransporterPlates = (
+  transporter,
+  ctx: z.RefinementCtx
+) => {
+  const { transporterTransportPlates: plates } = transporter;
+  const bsdCreatedAt = transporter.createdAt || new Date();
+
+  const createdAfterV20250201 = bsdCreatedAt.getTime() > v20250201.getTime();
+
+  if (!createdAfterV20250201 || !plates) {
+    return;
+  }
+  if (plates.some(plate => plate.length > 12 || plate.length < 4)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH
+    });
+    return;
+  }
+
+  if (plates.some(plate => onlyWhiteSpace(plate))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
+    });
+  }
+};
+
+export const validateMultiTransporterPlates = (bsd, ctx: z.RefinementCtx) => {
+  const bsdCreatedAt = bsd.createdAt || new Date();
+
+  const createdAfterV20250201 = bsdCreatedAt.getTime() > v20250201.getTime();
+
+  if (!createdAfterV20250201) {
+    return;
+  }
+
+  for (const transporter of bsd.transporters ?? []) {
+    validateTransporterPlates(transporter, ctx);
+  }
+};

--- a/back/src/common/validation/zod/schema.ts
+++ b/back/src/common/validation/zod/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { TransportMode } from "@prisma/client";
 import { isForeignVat, isSiret, isVat } from "@td/constants";
+import { ERROR_TRANSPORTER_PLATES_TOO_MANY } from "../messages";
 
 export enum CompanyRole {
   Emitter = "Émetteur",
@@ -118,7 +119,7 @@ export const rawTransporterSchema = z.object({
   transporterTransportMode: z.nativeEnum(TransportMode).nullish(),
   transporterTransportPlates: z
     .array(z.string())
-    .max(2, "Un maximum de 2 plaques d'immatriculation est accepté")
+    .max(2, ERROR_TRANSPORTER_PLATES_TOO_MANY)
     .default([]),
   transporterTransportTakenOverAt: z.coerce.date().nullish(),
   transporterTransportSignatureAuthor: z.string().nullish(),

--- a/back/src/forms/__tests__/registry.integration.ts
+++ b/back/src/forms/__tests__/registry.integration.ts
@@ -89,35 +89,35 @@ const createBsddWith5Transporters = async () => {
           data: [
             {
               transporterCompanySiret: transporter.company.siret,
-              transporterNumberPlate: "TRANSPORTER1-NBR-PLATES",
+              transporterNumberPlate: "TR-01-AA",
               transporterCompanyAddress: transporter.company.address,
               takenOverAt: new Date(),
               number: 1
             },
             {
               transporterCompanySiret: transporter2.company.siret,
-              transporterNumberPlate: "TRANSPORTER2-NBR-PLATES",
+              transporterNumberPlate: "TR-02-AA",
               transporterCompanyAddress: transporter2.company.address,
               takenOverAt: new Date(),
               number: 2
             },
             {
               transporterCompanySiret: transporter3.company.siret,
-              transporterNumberPlate: "TRANSPORTER3-NBR-PLATES",
+              transporterNumberPlate: "TR-03-AA",
               transporterCompanyAddress: transporter3.company.address,
               takenOverAt: new Date(),
               number: 3
             },
             {
               transporterCompanySiret: transporter4.company.siret,
-              transporterNumberPlate: "TRANSPORTER4-NBR-PLATES",
+              transporterNumberPlate: "TR-04-AA",
               transporterCompanyAddress: transporter4.company.address,
               takenOverAt: new Date(),
               number: 4
             },
             {
               transporterCompanyVatNumber: transporter5.company.vatNumber,
-              transporterNumberPlate: "TRANSPORTER5-NBR-PLATES",
+              transporterNumberPlate: "TR-05-AA",
               transporterCompanyAddress: transporter5.company.address,
               takenOverAt: new Date(),
               number: 5
@@ -717,29 +717,19 @@ describe("toTransportedWaste", () => {
 
     // Then
     expect(waste.transporterCompanySiret).toBe(data.transporter1.siret);
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(data.transporter2.siret);
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(data.transporter3.siret);
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(data.transporter4.siret);
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     expect(waste.transporter5CompanySiret).toBe(data.transporter5.vatNumber);
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 });
 
@@ -1228,30 +1218,20 @@ describe("toAllWaste", () => {
 
     // Then
     expect(waste.transporterCompanySiret).toBe(data.transporter1.siret);
-    expect(waste.transporterNumberPlates).toStrictEqual([
-      "TRANSPORTER1-NBR-PLATES"
-    ]);
+    expect(waste.transporterNumberPlates).toStrictEqual(["TR-01-AA"]);
 
     expect(waste.transporter2CompanySiret).toBe(data.transporter2.siret);
-    expect(waste.transporter2NumberPlates).toStrictEqual([
-      "TRANSPORTER2-NBR-PLATES"
-    ]);
+    expect(waste.transporter2NumberPlates).toStrictEqual(["TR-02-AA"]);
 
     expect(waste.transporter3CompanySiret).toBe(data.transporter3.siret);
-    expect(waste.transporter3NumberPlates).toStrictEqual([
-      "TRANSPORTER3-NBR-PLATES"
-    ]);
+    expect(waste.transporter3NumberPlates).toStrictEqual(["TR-03-AA"]);
 
     expect(waste.transporter4CompanySiret).toBe(data.transporter4.siret);
-    expect(waste.transporter4NumberPlates).toStrictEqual([
-      "TRANSPORTER4-NBR-PLATES"
-    ]);
+    expect(waste.transporter4NumberPlates).toStrictEqual(["TR-04-AA"]);
 
     // Foreign transporter
     expect(waste.transporter5CompanySiret).toBe(data.transporter5.vatNumber);
-    expect(waste.transporter5NumberPlates).toStrictEqual([
-      "TRANSPORTER5-NBR-PLATES"
-    ]);
+    expect(waste.transporter5NumberPlates).toStrictEqual(["TR-05-AA"]);
   });
 
   it("if forwarding BSD, should contain the info of the initial emitter", async () => {

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -735,14 +735,18 @@ describe("beforeTransportSchema", () => {
     transporters: Partial<BsddTransporter>[];
   };
 
+  let transporterCompany;
+
   afterAll(resetDatabase);
   beforeAll(async () => {
     const emitterCompany = await companyFactory({
       companyTypes: ["PRODUCER"]
     });
-    const transporterCompany = await companyFactory({
+
+    transporterCompany = await companyFactory({
       companyTypes: ["TRANSPORTER"]
     });
+
     const destinationCompany = await companyFactory({
       companyTypes: ["WASTEPROCESSOR"]
     });
@@ -921,6 +925,124 @@ describe("beforeTransportSchema", () => {
     );
   });
 
+  it("transporter plate is required if transporter mode is ROAD - too short", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      transporters: [
+        {
+          ...transporterData,
+          transporterTransportMode: "ROAD",
+          transporterNumberPlate: "ab"
+        }
+      ]
+    };
+    const validateFn = () =>
+      beforeTransportSchemaFn({
+        signingTransporterOrgId: transporterData.transporterCompanySiret
+      }).validate(testForm);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+    );
+  });
+
+  it("transporter plate is required if transporter mode is ROAD - too long", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      transporters: [
+        {
+          ...transporterData,
+          transporterTransportMode: "ROAD",
+          transporterNumberPlate: "abcdefghijklm"
+        }
+      ]
+    };
+    const validateFn = () =>
+      beforeTransportSchemaFn({
+        signingTransporterOrgId: transporterData.transporterCompanySiret
+      }).validate(testForm);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+    );
+  });
+
+  it("transporter plate is required if transporter mode is ROAD - 2 plates provided", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      transporters: [
+        {
+          ...transporterData,
+          transporterCompanySiret: transporterCompany.siret,
+          transporterTransportMode: "ROAD",
+          transporterNumberPlate: "AZ-12-TY, TY-LK-34"
+        }
+      ]
+    };
+    const validateFn = () =>
+      beforeTransportSchemaFn({
+        signingTransporterOrgId: transporterData.transporterCompanySiret
+      }).validate(testForm);
+
+    const isValid = await validateFn();
+
+    expect(isValid).toBeTruthy();
+  });
+
+  it("transporter plate is required if transporter mode is ROAD - too many plates", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      transporters: [
+        {
+          ...transporterData,
+          transporterCompanySiret: transporterCompany.siret,
+          transporterTransportMode: "ROAD",
+          transporterNumberPlate: "AZ-12-TY, TY-LK-34, QS-23-TY"
+        }
+      ]
+    };
+    const validateFn = () =>
+      beforeTransportSchemaFn({
+        signingTransporterOrgId: transporterData.transporterCompanySiret
+      }).validate(testForm);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Un maximum de 2 plaques d'immatriculation est accepté"
+    );
+  });
+
+  it("transporter plate is required if transporter mode is ROAD - only whitespace", async () => {
+    const testForm: Partial<Form> & {
+      transporters: Partial<BsddTransporter>[];
+    } = {
+      ...beforeTransportForm,
+      createdAt: new Date("2025-01-10T00:00:00Z"),
+      transporters: [
+        {
+          ...transporterData,
+          transporterTransportMode: "ROAD",
+          transporterNumberPlate: "      "
+        }
+      ]
+    };
+    const validateFn = () =>
+      beforeTransportSchemaFn({
+        signingTransporterOrgId: transporterData.transporterCompanySiret
+      }).validate(testForm);
+
+    await expect(validateFn()).rejects.toThrow(
+      "Le numéro de plaque fourni est incorrect"
+    );
+  });
+
   it("transporter plate is not required if transport mode is not ROAD", async () => {
     const testForm: Partial<Form> & {
       transporters: Partial<BsddTransporter>[];
@@ -972,7 +1094,7 @@ describe("beforeTransportSchema", () => {
         {
           ...transporterData,
           transporterTransportMode: "ROAD",
-          transporterNumberPlate: "TRANSPORTER-PLATES"
+          transporterNumberPlate: "AZ-45-TR"
         }
       ]
     };

--- a/back/src/forms/resolvers/mutations/__tests__/createFormTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormTransporter.integration.ts
@@ -74,6 +74,47 @@ describe("Mutation.createFormTransporter", () => {
     ]);
   });
 
+  it("should throw error if plates are invalid", async () => {
+    const user = await userFactory();
+    const { mutate } = makeClient(user);
+    const transporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"],
+      transporterReceipt: {
+        create: {
+          department: "13",
+          receiptNumber: "MON-RECEPISSE",
+          validityLimit: new Date("2024-01-01")
+        }
+      }
+    });
+    const { errors } = await mutate<
+      Pick<Mutation, "createFormTransporter">,
+      MutationCreateFormTransporterArgs
+    >(CREATE_FORM_TRANSPORTER, {
+      variables: {
+        input: {
+          company: {
+            siret: transporter.siret,
+            name: transporter.name,
+            address: transporter.address,
+            contact: transporter.contact
+          },
+          mode: "ROAD",
+          receipt: "receipt", // should be ignored
+          department: "07", // should be ignored
+          numberPlate: "AB",
+          validityLimit: new Date().toISOString() as any // should be ignored
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+      })
+    ]);
+  });
+
   it("should create a form transporter", async () => {
     const user = await userFactory();
     const { mutate } = makeClient(user);

--- a/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsAccepted.integration.ts
@@ -160,6 +160,68 @@ describe("Test Form reception", () => {
     expect(logs[0].status).toBe("ACCEPTED");
   });
 
+  it("ensure an older RECEIVED bsdd with invalid plates can still be accepted", async () => {
+    const emitter = await userWithCompanyFactory("ADMIN");
+    const transporter = await userWithCompanyFactory("ADMIN");
+    const recipient = await userWithCompanyFactory("ADMIN");
+    const initialForm = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "RECEIVED",
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        signedByTransporter: null,
+        sentAt: null,
+        sentBy: null,
+
+        emittedBy: emitter.user.name,
+
+        recipientCompanySiret: recipient.company.siret,
+        recipientsSirets: [recipient.company.siret!],
+        receivedBy: "Bill",
+        receivedAt: new Date("2019-01-17T10:22:00+0100"),
+        transporters: {
+          create: {
+            transporterCompanySiret: transporter.company.siret,
+            transporterCompanyName: transporter.company.name,
+            transporterNumberPlate: "XY", // invalid plate number
+            number: 1
+          }
+        }
+      }
+    });
+
+    const { mutate } = makeClient(recipient.user);
+
+    await mutate(MARK_AS_ACCEPTED, {
+      variables: {
+        id: initialForm.id,
+        acceptedInfo: {
+          signedAt: "2019-01-17T10:22:00+0100",
+          signedBy: "Bill",
+          wasteAcceptationStatus: "ACCEPTED",
+          quantityReceived: 11
+        }
+      }
+    });
+
+    const acceptedForm = await prisma.form.findUniqueOrThrow({
+      where: { id: initialForm.id }
+    });
+
+    expect(acceptedForm.status).toBe("ACCEPTED");
+    expect(acceptedForm.wasteAcceptationStatus).toBe("ACCEPTED");
+    expect(acceptedForm.signedBy).toBe("Bill");
+    expect(acceptedForm.quantityReceived?.toNumber()).toBe(11);
+
+    // A StatusLog object is created
+    const logs = await prisma.statusLog.findMany({
+      where: { form: { id: acceptedForm.id }, user: { id: recipient.id } }
+    });
+    expect(logs.length).toBe(1);
+    expect(logs[0].status).toBe("ACCEPTED");
+  });
+
   it("should not accept negative values", async () => {
     const { emitterCompany, recipient, recipientCompany, form } =
       await prepareDB();

--- a/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsReceived.integration.ts
@@ -102,6 +102,70 @@ describe("Test Form reception", () => {
     expect(logs[0].status).toBe("RECEIVED");
   });
 
+  it("ensure an older SENT bsdd with invalid plates can still be accepted", async () => {
+    const emitter = await userWithCompanyFactory("ADMIN");
+    const transporter = await userWithCompanyFactory("ADMIN");
+    const recipient = await userWithCompanyFactory("ADMIN");
+    const initialForm = await formFactory({
+      ownerId: emitter.user.id,
+      opt: {
+        status: "SENT",
+        emitterCompanySiret: emitter.company.siret,
+        emitterCompanyName: emitter.company.name,
+        signedByTransporter: null,
+        sentAt: null,
+        sentBy: null,
+
+        emittedBy: emitter.user.name,
+
+        recipientCompanySiret: recipient.company.siret,
+        recipientsSirets: [recipient.company.siret!],
+        transporters: {
+          create: {
+            transporterCompanySiret: transporter.company.siret,
+            transporterCompanyName: transporter.company.name,
+            transporterNumberPlate: "XY", // invalid plate number
+            number: 1
+          }
+        }
+      }
+    });
+
+    const form = await prisma.form.update({
+      where: { id: initialForm.id },
+      data: { currentTransporterOrgId: siretify(3) }
+    });
+
+    const { mutate } = makeClient(recipient.user);
+
+    await mutate(MARK_AS_RECEIVED, {
+      variables: {
+        id: form.id,
+        receivedInfo: {
+          receivedBy: "Bill",
+          receivedAt: "2019-01-17T10:22:00+0100"
+        }
+      }
+    });
+
+    const frm = await prisma.form.findUniqueOrThrow({ where: { id: form.id } });
+
+    expect(frm.status).toBe("RECEIVED");
+    expect(frm.wasteAcceptationStatus).toBe(null);
+    expect(frm.receivedBy).toBe("Bill");
+    expect(frm.quantityReceived).toBe(null);
+
+    // when form is received, we clean up currentTransporterOrgId
+    expect(frm.currentTransporterOrgId).toEqual("");
+
+    // A StatusLog object is created
+    const logs = await prisma.statusLog.findMany({
+      where: { form: { id: frm.id }, user: { id: recipient.id } }
+    });
+    expect(logs.length).toBe(1);
+    expect(logs[0].status).toBe("RECEIVED");
+  });
+
   it("should be possible to specify a quantityReceived=0 when acceptation status is not specified", async () => {
     const {
       emitterCompany,

--- a/back/src/forms/resolvers/mutations/__tests__/updateFormTransporter.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateFormTransporter.integration.ts
@@ -165,6 +165,40 @@ describe("Mutation.updateFormTransporter", () => {
     ]);
   });
 
+  it("should throw error if plates are invalid", async () => {
+    const user = await userFactory();
+    const { mutate } = makeClient(user);
+    const transporter = await companyFactory({
+      companyTypes: ["TRANSPORTER"]
+    });
+    const bsddTransporter = await prisma.bsddTransporter.create({
+      data: {
+        number: 0,
+        readyToTakeOver: true,
+        transporterCompanySiret: transporter.siret,
+        transporterCompanyName: transporter.name,
+        transporterTransportMode: "ROAD"
+      }
+    });
+    const { errors } = await mutate<
+      Pick<Mutation, "updateFormTransporter">,
+      MutationUpdateFormTransporterArgs
+    >(UPDATE_FORM_TRANSPORTER, {
+      variables: {
+        id: bsddTransporter.id,
+        input: {
+          numberPlate: "AZ"
+        }
+      }
+    });
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Le numéro d'immatriculation doit faire entre 4 et 12 caractères"
+      })
+    ]);
+  });
+
   it("should not be possible to update a transporter that has already signed", async () => {
     const emitter = await userWithCompanyFactory("MEMBER");
     const transporter = await companyFactory({ companyTypes: ["TRANSPORTER"] });

--- a/back/src/forms/resolvers/mutations/updateTransporterFields.ts
+++ b/back/src/forms/resolvers/mutations/updateTransporterFields.ts
@@ -6,6 +6,7 @@ import { checkCanUpdateTransporterFields } from "../../permissions";
 import { getAndExpandFormFromDb } from "../../converter";
 import { getFormRepository } from "../../repository";
 import { ForbiddenError } from "../../../common/errors";
+import { transporterPlatesSchema } from "../../validation";
 
 const updateTransporterFieldsResolver: MutationResolvers["updateTransporterFields"] =
   async (
@@ -24,6 +25,8 @@ const updateTransporterFieldsResolver: MutationResolvers["updateTransporterField
     }
 
     await checkCanUpdateTransporterFields(user, form);
+
+    await transporterPlatesSchema.validate({ transporterNumberPlate });
 
     const updatedForm = await getFormRepository(user).update(
       { id },

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -15,7 +15,11 @@ input SignEmissionFormInput {
   "Mention au titre des règlements RID, ADNR, IMDG (optionnel)"
   nonRoadRegulationMention: String
 
-  "Numéro de la plaque d'immatriculation transporteur"
+  """
+  Numéro de la plaque d'immatriculation transporteur.
+  Jusqu'à 2 plaques séparées par une virgule ex: AZ-12-TR, AQ-34-JK
+  Format de chaque plaque: 4 à 12 caractères
+  """
   transporterNumberPlate: String
 
   "Date de signature de l'émetteur"
@@ -35,7 +39,11 @@ input SignTransportFormInput {
   "Nom de la personne signant pour le transporteur"
   takenOverBy: String!
 
-  "Numéro de la plaque d'immatriculation transporteur"
+  """
+  Numéro de la plaque d'immatriculation transporteur.
+  Jusqu'à 2 plaques séparées par une virgule ex: AZ-12-TR, AQ-34-JK
+  Format de chaque plaque: 4 à 12 caractères
+  """
   transporterNumberPlate: String
 
   "Le mode de transport utilisé par le transporteur"
@@ -548,7 +556,11 @@ input TransporterInput {
       reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par l'entreprise de transport "
     )
 
-  "Numéro de plaque d'immatriculation"
+  """
+  Numéro de la plaque d'immatriculation transporteur.
+  Jusqu'à 2 plaques séparées par une virgule ex: AZ-12-TR, AQ-34-JK
+  Format de chaque plaque: 4 à 12 caractères
+  """
   numberPlate: String
 
   "Information libre, destinée aux transporteurs"

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -72,7 +72,11 @@ export default function Transport({ status, editionDisabled = false }) {
             Immatriculations
             <Tooltip msg={customInfoToolTip} />
           </label>
-          <TagsInput name="transporter.transport.plates" disabled={disabled} />
+          <TagsInput
+            name="transporter.transport.plates"
+            disabled={disabled}
+            limit={2}
+          />
         </div>
       )}
       {showTransportFields && (


### PR DESCRIPTION
# Contexte

Harmonisation avec ce qui a été fait sur le vhu
- Ne doit pas être uniquement des espaces
- Doit avoir a minima 4 caractères et au maximum 12 caractères
- max 2 plaques

Les validations étant gérées via zod et yup, la logique est dupliquée sur les 2 libs en attendant de pouvoir tout migrer vers zod.
Le code de validation du vhu  qui checkait déjà le format des plaques a été harmonisé pour utiliser le même fonctionnement que les autres bsds zod (superrefine)

On se retrouve avec une logique dupliquée en yup/zod qui sera migrée au fur et à mesure de l’harmonisation de la validation.

La validation est ignorée pour les bsd créés avant la date de mep.

Pas modif sur le front si ce n'est la limitation à 2 plaques sur le composant plaques du dasri

# Points de vigilance pour les intégrateurs

💥 BR Annoncé dans la NL tech du 16 décembre pour le 11 février 

# Démo

Signature transporter BSDD

https://github.com/user-attachments/assets/1c1c9584-0d23-4860-9f1b-dc3a96c5304d

Signature transporter BSFF

https://github.com/user-attachments/assets/773c1aa6-9767-4b08-aebe-24e6ef88ec29

Signature transporter BSDA

https://github.com/user-attachments/assets/8b5cc022-4509-4062-9ede-7598d8025138

Mise à jour des plaques depuis le dashboard

https://github.com/user-attachments/assets/ffd787cb-63f4-45a5-a071-7be63ad18074


 

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15149

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB