### PR TITLE
[Hotfix] Modification de l'adresse mail de la DREAL 93 Pays Loire

### DIFF
--- a/libs/shared/constants/src/DREALS.ts
+++ b/libs/shared/constants/src/DREALS.ts
@@ -604,7 +604,7 @@ export const Dreals = [
     DrealRegion: "DREAL Pays Loire",
     name: "UD93 (Unité Départementale de Seine-Saint-Denis)",
     Dept: "93",
-    email: "ud93-driee.ud93.drieat-if@developpement-durable.gouv.fr"
+    email: "sric.ud93.drieat-if@developpement-durable.gouv.fr "
   },
   {
     DrealRegion: "DREAL Pays Loire",

--- a/libs/shared/constants/src/DREALS.ts
+++ b/libs/shared/constants/src/DREALS.ts
@@ -604,7 +604,7 @@ export const Dreals = [
     DrealRegion: "DREAL Pays Loire",
     name: "UD93 (Unité Départementale de Seine-Saint-Denis)",
     Dept: "93",
-    email: "sric.ud93.drieat-if@developpement-durable.gouv.fr "
+    email: "sric.ud93.drieat-if@developpement-durable.gouv.fr"
   },
   {
     DrealRegion: "DREAL Pays Loire",


### PR DESCRIPTION
# Contexte

La DREAL a contacté le support pour changer une adresse mail.

# Ticket Favro

[Modifier email information DREAL pour UD 93](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15840)
