### PR TITLE
[TRA-15875 - HOTFIX] Page d'erreur lors de la création d'un BSDD de regroupement

### DIFF
--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -450,7 +450,7 @@ export default function Appendix2MultiSelect({
                 {currentlyAnnexedForms.map(({ form, quantity }) => (
                   <div>
                     {form.readableId}
-                    {quantity ? ` - ${quantity.toFixed(6)} T` : ""}
+                    {quantity ? ` - ${new Decimal(quantity).toFixed(6)} T` : ""}
                   </div>
                 ))}
               </Accordion>


### PR DESCRIPTION
`quantity` peut être une `string` et on avait une erreur en appelant `toFixed`.


[Page d'erreur lors de la création d'un BSDD de regroupement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15875)