### PR TITLE
Registres V2 : Optimisation de la table de lookup et de la réindexation

### DIFF
--- a/back/src/queue/jobs/processRegistryExport.ts
+++ b/back/src/queue/jobs/processRegistryExport.ts
@@ -193,11 +193,7 @@ export async function processRegistryExportJob(
       siret: {
         in: registryExport.sirets
       },
-      reportAsSirets: registryExport.delegateSiret
-        ? {
-            has: registryExport.delegateSiret
-          }
-        : undefined,
+      reportAsSiret: registryExport.delegateSiret ?? undefined,
       exportRegistryType: registryExport.registryType ?? undefined,
       wasteType: registryExport.wasteTypes?.length
         ? {

--- a/back/src/scripts/bin/rebuildRegistryLookup.ts
+++ b/back/src/scripts/bin/rebuildRegistryLookup.ts
@@ -3,7 +3,6 @@ import {
   incomingWasteLookupUtils,
   incomingTexsLookupUtils
 } from "@td/registry";
-import { logger } from "@td/logger";
 import { prisma } from "@td/prisma";
 import { lookupUtils as bsddLookupUtils } from "../../forms/registryV2";
 import { lookupUtils as bsdaLookupUtils } from "../../bsda/registryV2";
@@ -32,7 +31,7 @@ const bsdOrRegistryTypes: (BsdType | RegistryImportType)[] = [
 ];
 
 async function exitScript() {
-  logger.info("Done rebuildRegistryLookup script, exiting");
+  console.info("Done rebuildRegistryLookup script, exiting");
   await prisma.$disconnect();
   process.exit(0);
 }
@@ -167,67 +166,67 @@ const runIntegrityTest = async () => {
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("SSD")
     ) {
-      logger.info("Rebuilding SSD registry lookup");
+      console.info("Rebuilding SSD registry lookup");
       await ssdLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_WASTE")
     ) {
-      logger.info("Rebuilding incoming waste registry lookup");
+      console.info("Rebuilding incoming waste registry lookup");
       await incomingWasteLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_TEXS")
     ) {
-      logger.info("Rebuilding incoming texs registry lookup");
+      console.info("Rebuilding incoming texs registry lookup");
       await incomingTexsLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDD")
     ) {
-      logger.info("Rebuilding BSDD lookup");
+      console.info("Rebuilding BSDD lookup");
       await bsddLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDA")
     ) {
-      logger.info("Rebuilding BSDA lookup");
+      console.info("Rebuilding BSDA lookup");
       await bsdaLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDASRI")
     ) {
-      logger.info("Rebuilding BSDASRI lookup");
+      console.info("Rebuilding BSDASRI lookup");
       await bsdasriLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSFF")
     ) {
-      logger.info("Rebuilding BSFF lookup");
+      console.info("Rebuilding BSFF lookup");
       await bsffLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSPAOH")
     ) {
-      logger.info("Rebuilding BSPAOH lookup");
+      console.info("Rebuilding BSPAOH lookup");
       await bspaohLookupUtils.rebuildLookup();
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSVHU")
     ) {
-      logger.info("Rebuilding BSVHU lookup");
+      console.info("Rebuilding BSVHU lookup");
       await bsvhuLookupUtils.rebuildLookup();
     }
   } catch (error) {
-    logger.error("Error in rebuildRegistryLookup script, exiting", error);
+    console.error("Error in rebuildRegistryLookup script, exiting", error);
     throw new Error(`Error in rebuildRegistryLookup script : ${error}`);
   } finally {
     await exitScript();

--- a/docs/RegistryExportV2.md
+++ b/docs/RegistryExportV2.md
@@ -121,9 +121,9 @@ la colonne "id" de RegistryLookup n'est pas, contrairement à la plupart des aut
 
 La colonne readableId contient le publicId dans le cas des registres, et le readableId dans le cas des BSD. Cette colonne est surtout utile pour le debug/support, et rend plus "lisible" la table.
 
-- reportAsSirets
+- reportAsSiret
 
-Cette colonne contient les délégataires ayant ajouté/modifié la ligne de registre correspondant à l'objet RegistryLookup. Elle permet de retrouver les lignes de registre à exporter chez un délégataire. Il peut sembler étrange que cette colonne soit une array, alors que lors de l'ajout d'une ligne de registre, il n'y a qu'un seul délégataire qui fait l'import. Cependant, il est possible qu'un établissement ait plusieurs délégataires, et que l'un crée la ligne de registre, et qu'un autre la modifie. Or dans ce cas il faut que les 2 délégataires voient cette ligne dans leurs exports, ce qui justifie donc que tous les délégaitaires ayant touché à cette ligne soient ajoutés au RegistryLookup dans cette array.
+Cette colonne contient le délégataire identifié sur la ligne de registre correspondant à l'objet RegistryLookup. Elle permet de retrouver les lignes de registre à exporter chez un délégataire.
 
 - dateId
 

--- a/libs/back/prisma/src/migrations/20250131221330_modify_lookup_indexes/migration.sql
+++ b/libs/back/prisma/src/migrations/20250131221330_modify_lookup_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- DropIndex
+DROP INDEX "_RegistryLookupDateIdIdx";
+
+-- DropIndex
+DROP INDEX "_RegistryLookupReadableIdIdx";
+
+-- RenameIndex
+ALTER INDEX "RegistryLookup_dateId_key" RENAME TO "_RegistryLookupDateIdIdx";

--- a/libs/back/prisma/src/migrations/20250204153812_single_report_as_siret_lookup/migration.sql
+++ b/libs/back/prisma/src/migrations/20250204153812_single_report_as_siret_lookup/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `reportAsSirets` on the `RegistryLookup` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "_RegistryLookupReportAsSiretsIdx";
+
+-- AlterTable
+ALTER TABLE "RegistryLookup" DROP COLUMN "reportAsSirets",
+ADD COLUMN     "reportAsSiret" TEXT;
+
+-- CreateIndex
+CREATE INDEX "_RegistryLookupReportAsSiretIdx" ON "RegistryLookup"("reportAsSiret");

--- a/libs/back/prisma/src/schema/registry.prisma
+++ b/libs/back/prisma/src/schema/registry.prisma
@@ -120,7 +120,7 @@ model RegistryIncomingWaste {
     wasteCode                              String
     wastePop                               Boolean
     wasteIsDangerous                       Boolean?
-    receptionDate                          DateTime @db.Timestamptz(6)
+    receptionDate                          DateTime       @db.Timestamptz(6)
     weighingHour                           String?
     wasteDescription                       String
     wasteCodeBale                          String?
@@ -245,7 +245,7 @@ model RegistryIncomingTexs {
     wasteCode                              String?
     wastePop                               Boolean
     wasteIsDangerous                       Boolean?
-    receptionDate                          DateTime @db.Timestamptz(6)
+    receptionDate                          DateTime       @db.Timestamptz(6)
     wasteDescription                       String
     wasteCodeBale                          String?
     wasteDap                               String?
@@ -384,7 +384,7 @@ model RegistryOutgoingTexs {
     wasteCodeBale                          String?
     wastePop                               Boolean
     wasteIsDangerous                       Boolean?
-    dispatchDate                           DateTime? @db.Timestamptz(6)
+    dispatchDate                           DateTime?      @db.Timestamptz(6)
     wasteDap                               String?
     weightValue                            Float
     weightIsEstimate                       Boolean
@@ -514,7 +514,7 @@ model RegistryOutgoingWaste {
     wasteCodeBale                          String?
     wastePop                               Boolean
     wasteIsDangerous                       Boolean?
-    dispatchDate                           DateTime? @db.Timestamptz(6)
+    dispatchDate                           DateTime?      @db.Timestamptz(6)
     weightValue                            Float
     weightIsEstimate                       Boolean
     volume                                 Float?
@@ -687,7 +687,7 @@ model RegistryLookup {
     // should be a UUIDv7 using date as time source
     // to allow cursor based queries that required a unique key that should
     // also be the sort order
-    dateId             String                        @unique @db.Uuid
+    dateId             String                        @db.Uuid
 
     // foreign keys to registry models
     registrySsdId String?
@@ -716,14 +716,13 @@ model RegistryLookup {
     // the id itself is not unique, since a same BSD will appear in multiple export registries.
     // so the unique index is made of id + exportRegistryType + siret
     @@id([id, exportRegistryType, siret], name: "idExportTypeAndSiret")
-    // pseudo-random with only "=" lookups so hash index is appropriate
-    @@index([readableId], map: "_RegistryLookupReadableIdIdx", type: Hash)
+    // UUIDv7 unique index used for sorting/pagination on exports
+    @@unique([dateId(sort: Asc)], map: "_RegistryLookupDateIdIdx")
     // array of elements so gin index
     @@index([reportAsSirets], map: "_RegistryLookupReportAsSiretsIdx", type: Gin)
     // multi-column index because those columns are mandatory for any export
     @@index([date(sort: Asc), exportRegistryType, siret], map: "_RegistryLookupMainIdx")
     @@index([declarationType], map: "_RegistryLookupDeclarationTypeIdx")
-    @@index([dateId(sort: Asc)], map: "_RegistryLookupDateIdIdx")
     @@index([wasteType], map: "_RegistryLookupWasteTypeIdx")
     @@index([wasteCode], map: "_RegistryLookupWasteCodeIdx")
 }

--- a/libs/back/prisma/src/schema/registry.prisma
+++ b/libs/back/prisma/src/schema/registry.prisma
@@ -677,7 +677,7 @@ model RegistryLookup {
     // contains the publicId of the registry or the readableId of the BSD
     // for support/display
     readableId         String
-    reportAsSirets     String[]                      @default([])
+    reportAsSiret      String?
     siret              String
     exportRegistryType RegistryExportType
     declarationType    RegistryExportDeclarationType
@@ -719,7 +719,7 @@ model RegistryLookup {
     // UUIDv7 unique index used for sorting/pagination on exports
     @@unique([dateId(sort: Asc)], map: "_RegistryLookupDateIdIdx")
     // array of elements so gin index
-    @@index([reportAsSirets], map: "_RegistryLookupReportAsSiretsIdx", type: Gin)
+    @@index([reportAsSiret], map: "_RegistryLookupReportAsSiretIdx")
     // multi-column index because those columns are mandatory for any export
     @@index([date(sort: Asc), exportRegistryType, siret], map: "_RegistryLookupMainIdx")
     @@index([declarationType], map: "_RegistryLookupDeclarationTypeIdx")

--- a/libs/back/registry/src/lookup/utils.ts
+++ b/libs/back/registry/src/lookup/utils.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient, RegistryExportType } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 import { prisma } from "@td/prisma";
 import { v7 as uuidv7 } from "uuid";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
@@ -12,48 +12,6 @@ export const generateDateInfos = (date: Date) => ({
     msecs: date.getTime()
   })
 });
-
-export const updateRegistryDelegateSirets = async (
-  registryType: RegistryExportType,
-  registry: {
-    id: string;
-    reportForCompanySiret: string;
-    reportAsCompanySiret?: string | null;
-  },
-  registryLookup: Prisma.RegistryLookupGetPayload<{
-    select: { reportAsSirets: true };
-  }>,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-) => {
-  // if the registry entry comes from a delegation, we need to update the reportAsCompanySirets array.
-  // We only push the delegator's siret if it's not in it yet.
-  // this is done separately from the previous upsert because it's not possible
-  // to push to an array and check unicity with prisma.
-
-  // For cases where the siret can change during the update :
-  // the new registryLookup doesn't contain anything in reportAsCompanySirets
-  // this still makes sense because a change of siret would also mean that previous delegates
-  // don't necessarily apply to the new siret, so it makes sense to lose them.
-
-  if (
-    registry.reportAsCompanySiret &&
-    registry.reportAsCompanySiret !== registry.reportForCompanySiret &&
-    !registryLookup.reportAsSirets.includes(registry.reportAsCompanySiret)
-  ) {
-    await tx.registryLookup.updateMany({
-      where: {
-        id: registry.id,
-        exportRegistryType: registryType
-      },
-      data: {
-        reportAsSirets: [
-          ...registryLookup.reportAsSirets,
-          registry.reportAsCompanySiret
-        ]
-      }
-    });
-  }
-};
 
 // cleanup method for cases where the siret could change between updates
 


### PR DESCRIPTION
# Contexte

J'ai fait des tests de perf pour la réindexation sur la recette et me suis rendu compte que le traitement ligne par ligne était beaucoup trop lent. J'ai donc modifié les fonctions de réindexation pour faire des batch d'écriture, ce qui divise largement le temps d'exécution. La taille des batch pourra être variée par la suite (je ferai d'autres tests).

Après discussion, il a aussi été décidé que seul le délégataire courant d'une ligne de registre doit l'avoir dans son export, pour des raisons de cohérence. C'est à dire que si un délégataire crée une ligne puis un autre délégataire la modifie, ou l'entreprise visée la modifie, la ligne n'apparaîtra plus dans les exports du premier délégataire. Ce choix permet d'accélérer tout particulièrement l'indexation puisqu'il n'est plus nécessaire de repasser sur toutes les lignes pour vérifier qu'il y a un historique de délégation. Ce changement veut donc dire qu'il n'y a plus qu'un seul délégataire visé sur une ligne de lookup.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB