### PR TITLE
Correction du path retourné en cas d'erreur de validation sur les plaques

### DIFF
--- a/back/src/common/validation/zod/refinement.ts
+++ b/back/src/common/validation/zod/refinement.ts
@@ -368,10 +368,16 @@ export const onlyWhiteSpace = (str: string) => !str.trim().length; // check whit
 
 export const validateTransporterPlates = (
   transporter,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
+  transporterIndex?: number
 ) => {
   const { transporterTransportPlates: plates } = transporter;
   const bsdCreatedAt = transporter.createdAt || new Date();
+
+  const path =
+    transporterIndex !== undefined
+      ? ["transporters", transporterIndex, "transporter", "transport", "plates"]
+      : ["transporter", "transport", "plates"];
 
   const createdAfterV20250201 = bsdCreatedAt.getTime() > v20250201.getTime();
 
@@ -381,7 +387,8 @@ export const validateTransporterPlates = (
   if (plates.some(plate => plate.length > 12 || plate.length < 4)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH
+      message: ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH,
+      path
     });
     return;
   }
@@ -389,7 +396,8 @@ export const validateTransporterPlates = (
   if (plates.some(plate => onlyWhiteSpace(plate))) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
+      message: ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT,
+      path
     });
   }
 };
@@ -403,7 +411,7 @@ export const validateMultiTransporterPlates = (bsd, ctx: z.RefinementCtx) => {
     return;
   }
 
-  for (const transporter of bsd.transporters ?? []) {
-    validateTransporterPlates(transporter, ctx);
+  for (const [index, transporter] of (bsd.transporters ?? []).entries()) {
+    validateTransporterPlates(transporter, ctx, index);
   }
 };


### PR DESCRIPTION
# Contexte

Le path n'était pas retourné par les refinements zod sur les plaques d'immat et cassait l'affichage en surbrillance des onglets d'édition (vhu)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

## Cassé



https://github.com/user-attachments/assets/817972fa-84ab-49de-96a0-458ce6313a1e


## Plus cassé
 

https://github.com/user-attachments/assets/f2ad6859-7eab-449c-8001-0ac0e2bb516a



# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15149

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB