### PR TITLE
[TRA-15663] Lors de la duplication d'un VHU, on ne duplique pas la date & signature de réception

### DIFF
--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -148,6 +148,8 @@ describe("mutation.duplicateBsvhu", () => {
         emitterEmissionSignatureAuthor: "John",
         transporterTransportSignatureDate: new Date(),
         transporterTransportSignatureAuthor: "John",
+        destinationReceptionSignatureDate: new Date(),
+        destinationReceptionSignatureAuthor: "John",
         destinationOperationSignatureDate: new Date(),
         destinationOperationSignatureAuthor: "John",
         intermediaries: {
@@ -315,7 +317,6 @@ describe("mutation.duplicateBsvhu", () => {
       "destinationOperationMode",
       "destinationOperationSignatureAuthor",
       "destinationOperationSignatureDate",
-
       "intermediaries",
       "intermediariesOrgIds",
       "canAccessDraftOrgIds"
@@ -416,6 +417,8 @@ describe("mutation.duplicateBsvhu", () => {
     expect(duplicatedBsvhu.destinationOperationSignatureAuthor).toBeNull();
     expect(duplicatedBsvhu.transporterTransportSignatureDate).toBeNull();
     expect(duplicatedBsvhu.transporterTransportSignatureAuthor).toBeNull();
+    expect(duplicatedBsvhu.destinationReceptionSignatureAuthor).toBeNull();
+    expect(duplicatedBsvhu.destinationReceptionSignatureDate).toBeNull();
   });
 
   it("should duplicate without the transporter receipt when it was emptied", async () => {

--- a/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/duplicateBsvhu.integration.ts
@@ -150,6 +150,7 @@ describe("mutation.duplicateBsvhu", () => {
         transporterTransportSignatureAuthor: "John",
         destinationReceptionSignatureDate: new Date(),
         destinationReceptionSignatureAuthor: "John",
+        destinationReceptionDate: new Date(),
         destinationOperationSignatureDate: new Date(),
         destinationOperationSignatureAuthor: "John",
         intermediaries: {
@@ -419,6 +420,7 @@ describe("mutation.duplicateBsvhu", () => {
     expect(duplicatedBsvhu.transporterTransportSignatureAuthor).toBeNull();
     expect(duplicatedBsvhu.destinationReceptionSignatureAuthor).toBeNull();
     expect(duplicatedBsvhu.destinationReceptionSignatureDate).toBeNull();
+    expect(duplicatedBsvhu.destinationReceptionDate).toBeNull();
   });
 
   it("should duplicate without the transporter receipt when it was emptied", async () => {

--- a/back/src/bsvhu/resolvers/mutations/duplicate.ts
+++ b/back/src/bsvhu/resolvers/mutations/duplicate.ts
@@ -86,6 +86,8 @@ async function getDuplicateData(
     destinationOperationMode,
     destinationOperationSignatureAuthor,
     destinationOperationSignatureDate,
+    destinationReceptionSignatureAuthor,
+    destinationReceptionSignatureDate,
     intermediariesOrgIds,
     ...zodBsvhu
   } = prismaToZodBsvhu(bsvhu);


### PR DESCRIPTION
# Contexte

Petit oubli de ma part. J'ai introduit l'étape de réception sur les VHU, mais j'ai laissé les dates & signature de réception dans la duplication, ce qui bloque les VHU dupliqué (les champs sont sealed).

# Ticket Favro

[Ajouter la possibilité d'effectuer la signature du traitement en deux temps (réception puis opération) et créer les champs liés à la signature de la réception](https://favro.com/widget/ab14a4f0460a99a9d64d4945/428fc483d313d26a7c9bbd3f?card=tra-15663)
