### PR TITLE
[TRA-15738] Les codes de traitement D6 & D7 ne sont plus autorisés sur le BSDD

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -3300,4 +3300,98 @@ describe("Mutation.createForm", () => {
       expect(updatedAppendix2_3.quantityGrouped).toEqual(10);
     });
   });
+
+  it.each(["D 6", "D 7"])(
+    "should not allow recipientProcessingOperation %p",
+    async code => {
+      // Given
+      const { user, company: emitter } = await userWithCompanyFactory("MEMBER");
+      const transporter = await companyFactory();
+
+      // recipient needs appropriate profiles and subprofiles
+      const destination = await companyFactory({
+        companyTypes: [CompanyType.WASTEPROCESSOR],
+        wasteProcessorTypes: [WasteProcessorType.DANGEROUS_WASTES_INCINERATION]
+      });
+
+      // When
+      const { mutate } = makeClient(user);
+      const { errors } = await mutate<
+        Pick<Mutation, "createForm">,
+        MutationCreateFormArgs
+      >(CREATE_FORM, {
+        variables: {
+          createFormInput: {
+            emitter: {
+              type: "PRODUCER",
+              company: {
+                siret: emitter.siret
+              }
+            },
+            recipient: {
+              processingOperation: code,
+              company: {
+                siret: destination.siret
+              }
+            },
+            transporter: {
+              company: {
+                siret: transporter.siret
+              }
+            }
+          }
+        }
+      });
+
+      // Then
+      expect(errors).not.toBeUndefined();
+      expect(errors[0].message).toBe(
+        "Destination : Cette opération d’élimination / valorisation n'existe pas."
+      );
+    }
+  );
+
+  it("should allow recipientProcessingOperation D 8", async () => {
+    // Given
+    const { user, company: emitter } = await userWithCompanyFactory("MEMBER");
+    const transporter = await companyFactory();
+
+    // recipient needs appropriate profiles and subprofiles
+    const destination = await companyFactory({
+      companyTypes: [CompanyType.WASTEPROCESSOR],
+      wasteProcessorTypes: [WasteProcessorType.DANGEROUS_WASTES_INCINERATION]
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createForm">,
+      MutationCreateFormArgs
+    >(CREATE_FORM, {
+      variables: {
+        createFormInput: {
+          emitter: {
+            type: "PRODUCER",
+            company: {
+              siret: emitter.siret
+            }
+          },
+          recipient: {
+            processingOperation: "D 8",
+            company: {
+              siret: destination.siret
+            }
+          },
+          transporter: {
+            company: {
+              siret: transporter.siret
+            }
+          }
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toBeUndefined();
+  });
 });

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -2293,4 +2293,71 @@ describe("mutation.markAsProcessed", () => {
       })
     ]);
   });
+
+  it.each(["D 6", "D 7"])("should not allow operation code %p", async code => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "ACCEPTED",
+        quantityReceived: 10,
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: code,
+          destinationOperationMode: OperationMode.ELIMINATION,
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z"
+        }
+      }
+    });
+
+    // Then
+    expect(errors).not.toBeUndefined();
+    expect(errors[0].message).toBe(
+      "Cette opération d’élimination / valorisation n'existe pas."
+    );
+  });
+
+  it("should allow operation code D 8", async () => {
+    // Given
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    const form = await formFactory({
+      ownerId: user.id,
+      opt: {
+        status: "ACCEPTED",
+        quantityReceived: 10,
+        recipientCompanyName: company.name,
+        recipientCompanySiret: company.siret
+      }
+    });
+
+    // When
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate(MARK_AS_PROCESSED, {
+      variables: {
+        id: form.id,
+        processedInfo: {
+          processingOperationDescription: "Une description",
+          processingOperationDone: "D 8",
+          destinationOperationMode: OperationMode.ELIMINATION,
+          processedBy: "A simple bot",
+          processedAt: "2018-12-11T00:00:00.000Z"
+        }
+      }
+    });
+
+    // Then
+    expect(errors).toBeUndefined();
+  });
 });

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -25,8 +25,9 @@ import {
   BSDD_WASTE_CODES,
   isDangerous,
   PROCESSING_AND_REUSE_OPERATIONS_CODES,
-  PROCESSING_OPERATIONS_CODES,
-  PROCESSING_OPERATIONS_GROUPEMENT_CODES
+  PROCESSING_OPERATIONS_GROUPEMENT_CODES,
+  BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES,
+  BSDD_PROCESSING_OPERATIONS_CODES
 } from "@td/constants";
 import {
   foreignVatNumber,
@@ -607,14 +608,14 @@ export const recipientSchemaFn: FactorySchemaOf<
         const oneOf =
           value === EmitterType.APPENDIX2
             ? [
-                ...PROCESSING_AND_REUSE_OPERATIONS_CODES,
-                ...PROCESSING_AND_REUSE_OPERATIONS_CODES.map(c =>
+                ...BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES,
+                ...BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES.map(c =>
                   c.replace(" ", "")
                 )
               ]
             : [
-                ...PROCESSING_OPERATIONS_CODES,
-                ...PROCESSING_OPERATIONS_CODES.map(c => c.replace(" ", ""))
+                ...BSDD_PROCESSING_OPERATIONS_CODES,
+                ...BSDD_PROCESSING_OPERATIONS_CODES.map(c => c.replace(" ", ""))
               ];
 
         return schema.oneOf(
@@ -1588,7 +1589,7 @@ const withNextDestination = (required: boolean) =>
         .string()
         .required(`Destination ultérieure : ${MISSING_PROCESSING_OPERATION}`)
         .oneOf(
-          PROCESSING_AND_REUSE_OPERATIONS_CODES,
+          BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES,
           `Destination ultérieure : ${INVALID_PROCESSING_OPERATION}`
         ),
       nextDestinationCompanyName: yup
@@ -1834,7 +1835,7 @@ const processedInfoSchemaFn: (
     processingOperationDone: yup
       .string()
       .oneOf(
-        PROCESSING_AND_REUSE_OPERATIONS_CODES,
+        BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES,
         INVALID_PROCESSING_OPERATION
       ),
     destinationOperationMode: yup

--- a/libs/shared/constants/src/PROCESSING_AND_REUSE_OPERATIONS.ts
+++ b/libs/shared/constants/src/PROCESSING_AND_REUSE_OPERATIONS.ts
@@ -14,3 +14,9 @@ export const PROCESSING_AND_REUSE_OPERATIONS = [
 
 export const PROCESSING_AND_REUSE_OPERATIONS_CODES: string[] =
   PROCESSING_AND_REUSE_OPERATIONS.map(operation => operation.code);
+
+// TRA-15738: D 6 and D 7 are not allowed for BSDs
+export const BSDD_PROCESSING_AND_REUSE_OPERATIONS_CODES: string[] =
+  PROCESSING_AND_REUSE_OPERATIONS_CODES.filter(
+    code => code !== "D 6" && code !== "D 7"
+  );

--- a/libs/shared/constants/src/PROCESSING_OPERATIONS.ts
+++ b/libs/shared/constants/src/PROCESSING_OPERATIONS.ts
@@ -170,6 +170,10 @@ export const PROCESSING_OPERATIONS_CODES = PROCESSING_OPERATIONS.map(
   operation => operation.code
 );
 
+// TRA-15738: D 6 and D 7 are not allowed for BSDs
+export const BSDD_PROCESSING_OPERATIONS_CODES =
+  PROCESSING_OPERATIONS_CODES.filter(code => code !== "D 6" && code !== "D 7");
+
 type OperationCode = (typeof PROCESSING_OPERATIONS_CODES)[number];
 export type TdOperationCode = OperationCode | "R 0";
 export type TdOperationCodeEnum = Readonly<


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Retirer D6 et D7 comme code d'opération BSDD - BACK
](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ca60ff23d07a2274c78317e5?card=tra-15738)
