### PR TITLE
[TRA-15738] Retrait de D6 et D7 comme codes d'opération

### DIFF
--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -317,7 +317,7 @@ const formdata: Partial<Prisma.FormCreateInput> = {
   recipientCompanyName: "WASTE COMPANY",
   recipientCompanyPhone: "06 18 76 02 99",
   recipientCompanySiret: siretify(2),
-  recipientProcessingOperation: "D 6",
+  recipientProcessingOperation: "D 8",
   sentAt: "2019-11-20T00:00:00.000Z",
   sentBy: "signe",
   signedByTransporter: true,

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -92,7 +92,7 @@ describe("ActivityEvent.Bsdd", () => {
           },
           recipient: {
             cap: "1234",
-            processingOperation: "D 6",
+            processingOperation: "D 8",
             company: {
               name: destinationCompany.name,
               siret: destinationCompany.siret,

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -47,7 +47,7 @@ const formData: Partial<Form> = {
   emitterCompanyAddress: "8 rue du Général de Gaulle",
   emitterCompanyMail: "e@e.fr",
   recipientCap: "1234",
-  recipientProcessingOperation: "D 6",
+  recipientProcessingOperation: "D 8",
   recipientCompanyName: "A company 3",
   recipientCompanySiret: siret2,
   recipientCompanyAddress: "8 rue du Général de Gaulle",

--- a/front/src/Apps/Dashboard/Validation/BSDD/SignOperation.tsx
+++ b/front/src/Apps/Dashboard/Validation/BSDD/SignOperation.tsx
@@ -9,7 +9,7 @@ import {
 } from "@td/codegen-ui";
 import {
   PROCESSING_OPERATIONS_GROUPEMENT_CODES,
-  PROCESSING_AND_REUSE_OPERATIONS_SIGNATURE,
+  PROCESSING_AND_REUSE_OPERATIONS,
   isDangerous
 } from "@td/constants";
 import { useMutation, gql } from "@apollo/client";
@@ -346,7 +346,7 @@ function SignOperationModal({
               stateRelatedMessage={errors.processingOperationDone?.message}
               className="fr-mb-2w"
             >
-              {PROCESSING_AND_REUSE_OPERATIONS_SIGNATURE.map(operation => (
+              {PROCESSING_AND_REUSE_OPERATIONS.map(operation => (
                 <option value={operation.code} key={operation.code}>
                   {operation.code} - {operation.description}
                 </option>
@@ -442,7 +442,7 @@ function SignOperationModal({
                     errors.nextDestination?.processingOperation?.message
                   }
                 >
-                  {PROCESSING_AND_REUSE_OPERATIONS_SIGNATURE.map(operation => (
+                  {PROCESSING_AND_REUSE_OPERATIONS.map(operation => (
                     <option value={operation.code} key={operation.code}>
                       {operation.code} - {operation.description}
                     </option>

--- a/libs/shared/constants/src/PROCESSING_AND_REUSE_OPERATIONS.ts
+++ b/libs/shared/constants/src/PROCESSING_AND_REUSE_OPERATIONS.ts
@@ -12,10 +12,5 @@ export const PROCESSING_AND_REUSE_OPERATIONS = [
   ...PROCESSING_OPERATIONS
 ] as const;
 
-export const PROCESSING_AND_REUSE_OPERATIONS_SIGNATURE =
-  PROCESSING_AND_REUSE_OPERATIONS.filter(op => op.code !== "D 6").filter(
-    op => op.code !== "D 7"
-  );
-
 export const PROCESSING_AND_REUSE_OPERATIONS_CODES: string[] =
   PROCESSING_AND_REUSE_OPERATIONS.map(operation => operation.code);

--- a/libs/shared/constants/src/PROCESSING_OPERATIONS.ts
+++ b/libs/shared/constants/src/PROCESSING_OPERATIONS.ts
@@ -107,16 +107,17 @@ export const PROCESSING_OPERATIONS = [
     description:
       "Mise en décharge spécialement aménagée (par exemple, placement dans des alvéoles étanches séparées, recouvertes et isolées les unes et les autres et de l’environnement, etc …)"
   },
-  {
-    type: ProcessingOperationType.Eliminiation,
-    code: "D 6",
-    description: "Rejet dans le milieu aquatique sauf l’immersion"
-  },
-  {
-    type: ProcessingOperationType.Eliminiation,
-    code: "D 7",
-    description: "Immersion, y compris enfouissement dans le sous-sol marin"
-  },
+  // TRA-15738: on retire ces codes de traitement car illégaux en France.
+  // {
+  //   type: ProcessingOperationType.Eliminiation,
+  //   code: "D 6",
+  //   description: "Rejet dans le milieu aquatique sauf l’immersion"
+  // },
+  // {
+  //   type: ProcessingOperationType.Eliminiation,
+  //   code: "D 7",
+  //   description: "Immersion, y compris enfouissement dans le sous-sol marin"
+  // },
   {
     type: ProcessingOperationType.Eliminiation,
     code: "D 8",
@@ -207,8 +208,9 @@ export const PROCESSING_OPERATIONS_CODES_ENUM: TdOperationCodeEnum = [
   "D 3",
   "D 4",
   "D 5",
-  "D 6",
-  "D 7",
+  // TRA-15738: on retire ces codes de traitement car illégaux en France.
+  // "D 6",
+  // "D 7",
   "D 8",
   "D 9",
   "D 9 F",


### PR DESCRIPTION
# Contexte

On retire les codes d'opération D6 & D7, qui sont illégaux en France, de tous les bordereaux. Le front a déjà été implémenté, c'est juste le back.

# Points de vigilance pour les intégrateurs

:boom: Les codes D6 & D7 seront désormais rejetés par l'API! :boom: 

# Ticket Favro

[Retirer D6 et D7 comme code d'opération BSDD - BACK](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ca60ff23d07a2274c78317e5?card=tra-15738)