### PR TITLE
Display plate format hint

### DIFF
--- a/front/src/Apps/Forms/Components/TransportPlates/TransportPlates.tsx
+++ b/front/src/Apps/Forms/Components/TransportPlates/TransportPlates.tsx
@@ -17,7 +17,11 @@ const TransportPlates = ({
     return (
       <Field name={fieldName}>
         {({ field }) => (
-          <Input label="Immatriculation" nativeInputProps={field} />
+          <Input
+            label="Immatriculation"
+            nativeInputProps={field}
+            hintText="Max 2 plaques, séparées par une virgule"
+          />
         )}
       </Field>
     );

--- a/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
+++ b/front/src/Apps/Forms/Components/TransporterForm/TransporterForm.tsx
@@ -127,7 +127,7 @@ export function TransporterForm<T extends AnyTransporterInput>({
           />
         )}
 
-      <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--top">
+      <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-mt-1w">
         <div className="fr-col-12 fr-col-md-3">
           <Field name={transportModeFieldName}>
             {({ field }) => (
@@ -141,7 +141,7 @@ export function TransporterForm<T extends AnyTransporterInput>({
             )}
           </Field>
         </div>
-        <div className="fr-col-12 fr-col-md-3">
+        <div className="fr-col-12 fr-col-md-4">
           <TransportPlates
             bsdType={bsdType}
             fieldName={transportPlatesFieldName}

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteTransportSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteTransportSummary.tsx
@@ -57,6 +57,7 @@ const EDITABLE_FIELDS: Record<FormKeys, () => JSX.Element> = {
     <div className="form__row">
       <label>
         Plaque d'immatriculation{" "}
+        <span>(Max 2 plaques, séparées par une virgule)</span>{" "}
         <Field name="transporterNumberPlate" className="td-input" />
       </label>
       <RedErrorMessage name="transporterNumberPlate" />


### PR DESCRIPTION
# Contexte

Au support des utilisateurs habitués à saisis des plaques séparées par autre chose qu'une virgule sont surpris par la validation.

Cette PR affiche un texte spécifiant comment saisir 2 plaques sur le bsdd sur le formulaire d'édition et les modales de signature

La doc api le spécifie déjà.


<img width="681" alt="Capture d’écran 2025-02-12 à 17 37 36" src="https://github.com/user-attachments/assets/456d33ad-8801-4e5d-a73f-ecde12101281" />


<img width="768" alt="Capture d’écran 2025-02-12 à 17 48 18" src="https://github.com/user-attachments/assets/54a16bce-1dad-4cd6-ab3b-cd4ed65988ca" />



# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB