### PR TITLE
Correction validation des plaques sur le bsdd multimodal

### DIFF
--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -170,7 +170,7 @@ export const v20241201 = new Date(
   process.env.OVERRIDE_V20241201 || "2024-12-18T00:00:00.000"
 );
 
-// Date de la MAJ 2025.01.1 qui modifie les règles de validation du mode de transport, des palques d'immatriculations et la quantité transportée
+// Date de la MAJ 2025.01.1 qui modifie les règles de validation du mode de transport, des plaques d'immatriculations et la quantité transportée
 export const v20250101 = new Date(
   process.env.OVERRIDE_V20250101 || "2025-01-15T00:00:00.000"
 );

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -1061,7 +1061,8 @@ export const transporterSchemaFn: FactorySchemaOf<
         const {
           transporterTransportMode,
           transporterCompanySiret,
-          transporterCompanyVatNumber
+          transporterCompanyVatNumber,
+          takenOverAt
         } = ctx.parent;
 
         if (
@@ -1081,6 +1082,10 @@ export const transporterSchemaFn: FactorySchemaOf<
           return true;
         }
 
+        // Skip if already takenOver, useful for the multimodal because validation may be re-applied on already taken over transporters
+        if (takenOverAt) {
+          return true;
+        }
         return validatePlates(transporterNumberPlate);
       }),
     transporterCompanyName: yup


### PR DESCRIPTION
# Contexte

Sur le multimodal bsdd, la validation des transporteurs est rejouée sur ceux ayant déjà signé l'emport, bloquant potentiellement un bsd dont le 1er transporteur, signé avant la mep,  comporte une plaque invalide.
Cette PR skippe la validation des plaques dès que l'emport a été validé.

# Points de vigilance pour les intégrateurs

Aucun

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

 https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15939

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB