### PR TITLE
[TRA-15625] Affiche sur le PDF les informations du courtier ET du négociant lorsque ces deux acteurs sont renseignés sur un BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,11 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Exports registres V2 : Modale d'export et petites améliorations d'UX [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3953)
 
+#### :bug: Corrections de bugs
+
+- BSDD : Affiche sur le PDF les informations du courtier ET du négociant lorsque ces deux acteurs sont renseignés [PR 3979](https://github.com/MTES-MCT/trackdechets/pull/3979).
+- BSVHU : Le courtier apparaît deux fois sur le récépissé PDF lorsqu'aucun négociant n'est sélectionné [PR 3979](https://github.com/MTES-MCT/trackdechets/pull/3979).
+
 # [2025.02.1] 11/02/2025
 
 #### :rocket: Nouvelles fonctionnalités

--- a/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
+++ b/back/src/bsvhu/pdf/components/BsvhuPdf.tsx
@@ -312,73 +312,44 @@ export function BsvhuPdf({ bsvhu, qrCode, renderEmpty }: Props) {
           <div></div>
         </div>
         {/* End Emitter signature */}
-        {/* Trader informations or broker information if no trader */}
-        <div className="BoxRow">
-          <div className="BoxCol">
-            <p>
-              <strong>
-                8.{bsvhu.trader && bsvhu.broker ? "1" : ""}{" "}
-                <input
-                  type="checkbox"
-                  checked={Boolean(bsvhu.trader)}
-                  readOnly
-                />{" "}
-                Négociant{" "}
-                <input
-                  type="checkbox"
-                  checked={!bsvhu.trader && Boolean(bsvhu.broker)}
-                  readOnly
-                />{" "}
-                Courtier
-              </strong>
-            </p>
-            <div className="Row">
-              <div className="Col">
-                <FormCompanyFields
-                  company={
-                    bsvhu.trader ? bsvhu.trader.company : bsvhu.broker?.company
-                  }
-                />
-              </div>
-              <div className="Col">
-                <Recepisse
-                  recepisse={{
-                    ...(bsvhu.trader?.recepisse ??
-                      bsvhu.broker?.recepisse ??
-                      {})
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* End Broker/Trader informations */}
-        {/* Broker information */}
-        {bsvhu.broker ? (
+        {/* Trader informations */}
+        {bsvhu.trader && (
           <div className="BoxRow">
             <div className="BoxCol">
               <p>
-                <strong>
-                  8.{bsvhu.trader ? "2" : ""}{" "}
-                  <input type="checkbox" checked={false} readOnly /> Négociant{" "}
-                  <input type="checkbox" checked={true} readOnly /> Courtier
-                </strong>
+                <strong>8.{bsvhu.broker ? "1" : ""} Négociant</strong>
               </p>
               <div className="Row">
                 <div className="Col">
-                  <FormCompanyFields company={bsvhu.broker?.company} />
+                  <FormCompanyFields company={bsvhu.trader.company} />
                 </div>
                 <div className="Col">
-                  <Recepisse
-                    recepisse={{
-                      ...(bsvhu.broker?.recepisse ?? {})
-                    }}
-                  />
+                  <Recepisse recepisse={bsvhu.trader.recepisse} />
                 </div>
               </div>
             </div>
           </div>
-        ) : null}
+        )}
+
+        {/* End Trader informations */}
+        {/* Broker informations */}
+        {bsvhu.broker && (
+          <div className="BoxRow">
+            <div className="BoxCol">
+              <p>
+                <strong>8.{bsvhu.trader ? "2" : ""} Courtier</strong>
+              </p>
+              <div className="Row">
+                <div className="Col">
+                  <FormCompanyFields company={bsvhu.broker.company} />
+                </div>
+                <div className="Col">
+                  <Recepisse recepisse={bsvhu.broker.recepisse} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
         {/* End Broker informations */}
         {/* Transporter */}
         <div className="BoxRow">

--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -755,43 +755,54 @@ export function BsddPdf({
           </div>
         </div>
 
-        <div className="BoxRow">
-          <div className="BoxCol">
-            <p>
-              <strong>
-                7.{" "}
-                <input
-                  type="checkbox"
-                  checked={Boolean(form.trader) && renderCheckboxState}
-                  readOnly
-                />{" "}
-                Négociant{" "}
-                <input
-                  type="checkbox"
-                  checked={Boolean(form.broker) && renderCheckboxState}
-                  readOnly
-                />{" "}
-                Courtier
-              </strong>
-            </p>
-            {form.emitter?.type === EmitterType.APPENDIX1_PRODUCER ? (
-              appendix1ProducerPlaceholder
-            ) : (
-              <>
-                <div className="Row">
-                  <div className="Col">
-                    <FormCompanyFields
-                      company={form.trader?.company ?? form.broker?.company}
-                    />
+        {form.trader && (
+          <div className="BoxRow">
+            <div className="BoxCol">
+              <p>
+                <strong>7.{form.broker ? "1" : ""} Négociant</strong>
+              </p>
+              {form.emitter?.type === EmitterType.APPENDIX1_PRODUCER ? (
+                appendix1ProducerPlaceholder
+              ) : (
+                <>
+                  <div className="Row">
+                    <div className="Col">
+                      <FormCompanyFields company={form.trader.company} />
+                    </div>
+                    <div className="Col">
+                      <ReceiptFields {...form.trader} />
+                    </div>
                   </div>
-                  <div className="Col">
-                    <ReceiptFields {...(form.trader ?? form.broker ?? {})} />
-                  </div>
-                </div>
-              </>
-            )}
+                </>
+              )}
+            </div>
           </div>
-        </div>
+        )}
+
+        {form.broker && (
+          <div className="BoxRow">
+            <div className="BoxCol">
+              <p>
+                <strong>7.{form.trader ? "2" : ""} Courtier</strong>
+              </p>
+              {form.emitter?.type === EmitterType.APPENDIX1_PRODUCER ? (
+                appendix1ProducerPlaceholder
+              ) : (
+                <>
+                  <div className="Row">
+                    <div className="Col">
+                      <FormCompanyFields company={form.broker.company} />
+                    </div>
+                    <div className="Col">
+                      <ReceiptFields {...form.broker} />
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
         {form.intermediaries?.length ? (
           <div className="BoxRow">
             <div className="BoxCol">


### PR DESCRIPTION
# Contexte

Depuis [Bordereau BSDD - Vérifier le type de profil du courtier et/ou négociant lors de l'ajout sur un bordereau et retirer les champs liés aux récépissés](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15623) on autorise sur l'UI l'ajout d'un courtier et d'un négociant mais l'affichage ne fonctionne pas côté PDF.

J'ai corrigé au passage un bug constaté en regardant le fonctionnement du PDF sur le BSVHU [Le courtier apparaît deux fois sur le récépissé PDF du BSVHU lorsqu'aucun négociant n'est sélectionné](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-15931)

# Démo

![Capture d’écran 2025-02-13 à 16 33 00](https://github.com/user-attachments/assets/c1c0d4ec-7096-4d90-a1a7-8a46142ca836)


# Ticket Favro

 [Bordereau BSDD - Vérifier le type de profil du courtier et/ou négociant lors de l'ajout sur un bordereau et retirer les champs liés aux récépissés](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15623)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB