### PR TITLE
[TRA-15674] Sortir Conditionné pour pipeline de la liste des conditionnements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Ajout de l'export du registre sortant V2 [PR 3976](https://github.com/MTES-MCT/trackdechets/pull/3976)
 - Ajout d'un paramètre pour les établissements souhaitant pousser automatiquement leurs BSDND dans leurs déclarations [PR3988](https://github.com/MTES-MCT/trackdechets/pull/3988)
 
+#### :nail_care: Breaking Change
+
+- BSDD - Le type de conditionnement PIPELINE est déprécié sur l'enum [Packagings](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/enums#packagings). Il est nécessaire de renseigner un nouveau champ booléen `isDirectSupply` sur [FormInput](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/inputObjects#forminput) pouvant correspondre à un acheminement par pipeline ou par convoyeur. Aucun conditionnement ne devra être renseigné en cas d'acheminement direct, c'est à dire que lorsque `isDirectSupply` est true, le champ packagingsInfos sur [FormInput](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/inputObjects#forminput) devra valoir null ou []. Les données existantes seront migrées de sorte qu'il vous faudra prendre en compte en lecture le nouveau champ `isDirectSupply` sur l'objet [Form](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/objects#form). Nous continuerons d'accepter la valeur `PIPELINE` comme type de packagings en écriture mais les données entrantes seront automatiquement converties pour s'adapter au nouveau format de données.
+
 #### :nail_care: Améliorations
 
 - Exports registres V2 : Modale d'export et petites améliorations d'UX [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3953)

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -974,7 +974,8 @@ export const cloneBsdd = async (
     wasteDetailsQuantity: bsdd.wasteDetailsQuantity,
     wasteDetailsQuantityType: bsdd.wasteDetailsQuantityType,
     wasteDetailsSampleNumber: bsdd.wasteDetailsSampleNumber,
-    wasteRefusalReason: bsdd.wasteRefusalReason
+    wasteRefusalReason: bsdd.wasteRefusalReason,
+    isDirectSupply: false
   };
 
   const newBsdd = await create(newBsddCreateInput);

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -975,7 +975,7 @@ export const cloneBsdd = async (
     wasteDetailsQuantityType: bsdd.wasteDetailsQuantityType,
     wasteDetailsSampleNumber: bsdd.wasteDetailsSampleNumber,
     wasteRefusalReason: bsdd.wasteRefusalReason,
-    isDirectSupply: false
+    isDirectSupply: bsdd.isDirectSupply
   };
 
   const newBsdd = await create(newBsddCreateInput);

--- a/back/src/common/typeDefs/common.enums.graphql
+++ b/back/src/common/typeDefs/common.enums.graphql
@@ -88,6 +88,9 @@ enum TransportMode {
   SEA
   "Autre (utilisé avec Packaging = PIPELINE par exemple)"
   OTHER
+    @deprecated(
+      reason: "Utiliser `isDirectSupply=true` sans transporteur en cas d'acheminement direct par pipeline ou convoyeur"
+    )
   "Non renseigné. Cas particulier pour des données importés"
   UNKNOWN
 }

--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -62,6 +62,7 @@ describe("simpleFormToBsdd", () => {
       isDeleted: form.isDeleted,
       isDraft: false,
       status: form.status,
+      isDirectSupply: false,
       wasteCode: form.wasteDetailsCode,
       wasteIsDangerous: true,
       wasteDetailsLandIdentifiers: form.wasteDetailsLandIdentifiers,
@@ -454,6 +455,7 @@ describe("simpleFormToBsdd", () => {
       nextDestinationNotificationNumber: null,
       nextDestinationProcessingOperation: null,
       status: fullForwardedInForm.status,
+      isDirectSupply: false,
       wasteCode: fullForwardedInForm.wasteDetailsCode,
       wasteIsDangerous: true,
       wasteDetailsLandIdentifiers:
@@ -653,6 +655,7 @@ describe("simpleFormToBsdd", () => {
         isDeleted: form.isDeleted,
         isDraft: form.status === "DRAFT",
         status: form.status,
+        isDirectSupply: false,
         wasteCode: form.wasteDetailsCode,
         wasteIsDangerous: true,
         wasteDetailsLandIdentifiers: form.wasteDetailsLandIdentifiers,

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -36,6 +36,7 @@ describe("expandFormFromDb", () => {
       readableId: form.readableId,
       customId: null,
       isImportedFromPaper: false,
+      isDirectSupply: false,
       metadata: undefined,
       citerneNotWashedOutReason: null,
       hasCiterneBeenWashedOut: null,

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1774,6 +1774,20 @@ describe("draftFormSchema", () => {
     );
   });
 
+  it("isDirectSupply=true cannot be set with a transporter", async () => {
+    const validateFn = () =>
+      draftFormSchema.validate({
+        wasteDetailsPackagingInfos: [
+          { type: "PIPELINE", numero: null, weight: null, volume: null }
+        ],
+        transporters: [{ transporterCompanySiret: siretify(1) }]
+      });
+
+    await expect(validateFn()).rejects.toThrow(
+      "Vous ne devez pas spécifier de transporteur dans le cas d'un transport par pipeline"
+    );
+  });
+
   it.each([-1, 0])(
     "should not validate when packaging volume is %p (not strictly positive)",
     async volume => {

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1770,7 +1770,7 @@ describe("draftFormSchema", () => {
       });
 
     await expect(validateFn()).rejects.toThrow(
-      "Vous ne devez pas spécifier de transporteur dans le cas d'un transport par pipeline"
+      "Vous ne devez pas spécifier de transporteur dans le cas d'un acheminement direct par pipeline ou convoyeur"
     );
   });
 
@@ -1784,7 +1784,7 @@ describe("draftFormSchema", () => {
       });
 
     await expect(validateFn()).rejects.toThrow(
-      "Vous ne devez pas spécifier de transporteur dans le cas d'un transport par pipeline"
+      "Vous ne devez pas spécifier de transporteur dans le cas d'un acheminement direct par pipeline ou convoyeur"
     );
   });
 

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -1739,39 +1739,35 @@ describe("draftFormSchema", () => {
     expect(isValid).toEqual(true);
   });
 
-  it("packaging PIPELINE can be set without any other details", async () => {
+  it("isDirectSupply=true can be set without any other details", async () => {
     const isValid = await draftFormSchema.isValid({
-      wasteDetailsPackagingInfos: [
-        { type: "PIPELINE", numero: null, weight: null, volume: null }
-      ]
+      isDirectSupply: true,
+      wasteDetailsPackagingInfos: []
     });
 
     expect(isValid).toEqual(true);
   });
 
-  it("packaging PIPELINE cannot be set with any other packaging", async () => {
-    const isValid = await draftFormSchema.isValid({
-      wasteDetailsPackagingInfos: [
-        { type: "PIPELINE", other: null, quantity: null },
-        { type: "FUT", other: null, quantity: 1 }
-      ]
-    });
-
-    expect(isValid).toEqual(false);
-  });
-
-  it("packaging PIPELINE cannot be set with a transporter", async () => {
+  it("packaging PIPELINE should not be valid", async () => {
     const validateFn = () =>
       draftFormSchema.validate({
         wasteDetailsPackagingInfos: [
           { type: "PIPELINE", numero: null, weight: null, volume: null }
-        ],
-        transporters: [{ transporterCompanySiret: siretify(1) }]
+        ]
       });
 
     await expect(validateFn()).rejects.toThrow(
-      "Vous ne devez pas spécifier de transporteur dans le cas d'un acheminement direct par pipeline ou convoyeur"
+      "Le type de conditionnement PIPELINE n'est pas valide"
     );
+  });
+
+  it("isDirectSupply=true cannot be set with any packaging", async () => {
+    const isValid = await draftFormSchema.isValid({
+      isDirectSupply: true,
+      wasteDetailsPackagingInfos: [{ type: "FUT", other: null, quantity: 1 }]
+    });
+
+    expect(isValid).toEqual(false);
   });
 
   it("isDirectSupply=true cannot be set with a transporter", async () => {

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -48,6 +48,7 @@ export function simpleFormToBsdd(
     isDeleted: Boolean(form.isDeleted),
     isDraft: form.status == Status.DRAFT,
     status: form.status,
+    isDirectSupply: form.isDirectSupply,
     forwardedInId: form.forwardedInId,
     wasteCode: form.wasteDetailsCode,
     wasteDescription: form.wasteDetailsName,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -63,6 +63,7 @@ import { getFirstTransporterSync } from "./database";
 import { FormForElastic } from "./elastic";
 import { extractPostalCode } from "../common/addresses";
 import { bsddWasteQuantities } from "./helpers/bsddWasteQuantities";
+import { isDefined } from "../common/helpers";
 
 function flattenDestinationInput(input: {
   destination?: DestinationInput | null;
@@ -440,8 +441,8 @@ export function flattenFormInput(
     customId: formInput.customId,
     // Si `isDirectSupply` est null ou undefined, on omet le champ
     // et on laisse le soin à la DB de mettre une valeur par défaut
-    ...(typeof formInput.isDirectSupply === "boolean"
-      ? { isDirectSupply: formInput.isDirectSupply }
+    ...(isDefined(formInput.isDirectSupply)
+      ? { isDirectSupply: formInput.isDirectSupply! }
       : {}),
     ...flattenEmitterInput(formInput),
     ...flattenRecipientInput(formInput),

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -438,7 +438,11 @@ export function flattenFormInput(
 ): Partial<Omit<Prisma.FormCreateInput, "temporaryStorageDetail">> {
   return safeInput({
     customId: formInput.customId,
-    isDirectSupply: formInput.isDirectSupply ?? false,
+    // Si `isDirectSupply` est null ou undefined, on omet le champ
+    // et on laisse le soin à la DB de mettre une valeur par défaut
+    ...(typeof formInput.isDirectSupply === "boolean"
+      ? { isDirectSupply: formInput.isDirectSupply }
+      : {}),
     ...flattenEmitterInput(formInput),
     ...flattenRecipientInput(formInput),
     ...flattenWasteDetailsInput(formInput),

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -427,6 +427,7 @@ export function flattenFormInput(
   formInput: Pick<
     FormInput,
     | "customId"
+    | "isDirectSupply"
     | "emitter"
     | "recipient"
     | "wasteDetails"
@@ -437,6 +438,7 @@ export function flattenFormInput(
 ): Partial<Omit<Prisma.FormCreateInput, "temporaryStorageDetail">> {
   return safeInput({
     customId: formInput.customId,
+    isDirectSupply: formInput.isDirectSupply ?? false,
     ...flattenEmitterInput(formInput),
     ...flattenRecipientInput(formInput),
     ...flattenWasteDetailsInput(formInput),

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -667,6 +667,7 @@ export function expandFormFromDb(
       .map(segment => expandTransportSegmentFromDb(segment)),
     transporter: transporter ? expandTransporterFromDb(transporter) : null,
     transporters: transporters.map(t => expandTransporterFromDb(t)!),
+    isDirectSupply: form.isDirectSupply,
     recipient: nullIfNoValues<Recipient>({
       cap: form.recipientCap,
       processingOperation: form.recipientProcessingOperation,

--- a/back/src/forms/edition.ts
+++ b/back/src/forms/edition.ts
@@ -120,6 +120,7 @@ export const editionRules: {
   wasteDetailsOnuCode: "EMISSION",
   wasteDetailsIsSubjectToADR: "EMISSION",
   wasteDetailsNonRoadRegulationMention: "EMISSION",
+  isDirectSupply: "EMISSION",
   wasteDetailsPackagingInfos: "EMISSION",
   wasteDetailsQuantity: "EMISSION",
   wasteDetailsQuantityType: "EMISSION",

--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -675,9 +675,13 @@ export function BsddPdf({
             <p>
               <strong>4. Conditionnement</strong>
             </p>
-            <PackagingInfosTable
-              packagingInfos={form.wasteDetails?.packagingInfos ?? []}
-            />
+            {form.isDirectSupply ? (
+              <p>Acheminement direct par pipeline ou convoyeur</p>
+            ) : (
+              <PackagingInfosTable
+                packagingInfos={form.wasteDetails?.packagingInfos ?? []}
+              />
+            )}
           </div>
 
           <div className="BoxCol">
@@ -792,7 +796,11 @@ export function BsddPdf({
             <p>
               <strong>8. Collecteur-Transporteur</strong>
             </p>
-            <TransporterFormCompanyFields {...form} />
+            {form.isDirectSupply ? (
+              <p>Acheminement direct par pipeline ou convoyeur</p>
+            ) : (
+              <TransporterFormCompanyFields {...form} />
+            )}
           </div>
         </div>
 

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -250,7 +250,7 @@ export const toIncomingWasteV2 = (
     brokerCompanySiret: bsdd.brokerCompanySiret,
     brokerCompanyMail: bsdd.brokerCompanyMail,
     brokerRecepisseNumber: bsdd.brokerRecepisseNumber,
-    isDirectSupply: false,
+    isDirectSupply: bsdd.isDirectSupply,
     transporter1CompanyName: bsdd.transporterCompanyName,
     transporter1CompanyGivenName: null,
     transporter1CompanySiret: bsdd.transporterCompanySiret?.length
@@ -526,7 +526,7 @@ export const toOutgoingWasteV2 = (
     traderCompanyName: bsdd.traderCompanyName,
     traderCompanyMail: bsdd.traderCompanyMail,
     traderRecepisseNumber: bsdd.traderRecepisseNumber,
-    isDirectSupply: false,
+    isDirectSupply: bsdd.isDirectSupply,
     transporter1CompanySiret: bsdd.transporterCompanySiret?.length
       ? bsdd.transporterCompanySiret
       : bsdd.transporterCompanyVatNumber,

--- a/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/duplicateForm.integration.ts
@@ -162,7 +162,7 @@ async function createForm(opt: Partial<Prisma.FormCreateInput> = {}) {
 describe("Mutation.duplicateForm", () => {
   afterEach(() => resetDatabase());
 
-  it("should duplicate a form %s", async () => {
+  it("should duplicate a form", async () => {
     const { form, emitter } = await createForm({
       ecoOrganismeName: "COREPILE",
       ecoOrganismeSiret: siretify(1)
@@ -229,6 +229,7 @@ describe("Mutation.duplicateForm", () => {
       ecoOrganismeName,
       ecoOrganismeSiret,
       wasteDetailsIsSubjectToADR,
+      isDirectSupply,
       ...rest
     } = form;
 
@@ -414,7 +415,8 @@ describe("Mutation.duplicateForm", () => {
       brokerValidityLimit,
       ecoOrganismeName,
       ecoOrganismeSiret,
-      wasteDetailsIsSubjectToADR
+      wasteDetailsIsSubjectToADR,
+      isDirectSupply
     });
 
     expect(duplicatedTransporter).toMatchObject({
@@ -645,7 +647,8 @@ describe("Mutation.duplicateForm", () => {
       "citerneNotWashedOutReason",
       "hasCiterneBeenWashedOut",
       "emptyReturnADR",
-      "wasteDetailsOnuCode"
+      "wasteDetailsOnuCode",
+      "isDirectSupply"
     ];
 
     // make sure this test breaks when a new field is added to the Form model

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -135,6 +135,8 @@ const createFormResolver = async (
       (form.wasteDetailsPackagingInfos ?? []) as PackagingInfo[]
     ).filter(p => p.type !== "PIPELINE");
     form.isDirectSupply = true;
+    transporters = {};
+    transportersForValidation = [];
   }
 
   const readableId = getReadableId();

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -1,4 +1,4 @@
-import { EmitterType, Prisma, TransportMode } from "@prisma/client";
+import { EmitterType, Prisma } from "@prisma/client";
 import { isDangerous } from "@td/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import type {
@@ -18,7 +18,7 @@ import { getFormRepository } from "../../repository";
 import {
   Transporter,
   draftFormSchema,
-  hasPipeline,
+  hasPipelinePackaging,
   validateGroupement,
   validateIntermediaries
 } from "../../validation";
@@ -118,25 +118,20 @@ const createFormResolver = async (
     };
   }
 
-  // Pipeline erases transporter EXCEPT for transporterTransportMode
-  // FIXME here we have a silent side effect. It would be be better to throw an
-  // exception is the transporter data sent by the user does not comply
-  if (hasPipeline(form)) {
-    // transporters = {
-    //   create: {
-    //     number: 1,
-    //     transporterTransportMode: TransportMode.OTHER
-    //   }
-    // };
-    transportersForValidation = [];
-  }
-
   // Do not take into account user sent transporter data in case of APPENDIX1_PRODUCER
   // Transporter data will be copied from the bordereau chapeau
   if (form.emitterType === "APPENDIX1_PRODUCER") {
     delete transporters.create;
     delete transporters.connect;
     transportersForValidation = [];
+  }
+
+  // Rétro-compatibilité avec l'utilisation d'un conditionnement "Pipeline"
+  // Cela permet de ne pas faire de breaking change lors de l'implémentation
+  // de tra-15674 - Sortir Conditionné pour pipeline de la liste des conditionnements
+  if (hasPipelinePackaging(form)) {
+    form.wasteDetailsPackagingInfos = [];
+    form.isDirectSupply = true;
   }
 
   const readableId = getReadableId();

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -3,6 +3,7 @@ import { isDangerous } from "@td/constants";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import type {
   MutationCreateFormArgs,
+  PackagingInfo,
   ResolversParentTypes
 } from "@td/codegen-back";
 import { GraphQLContext } from "../../../types";
@@ -130,7 +131,9 @@ const createFormResolver = async (
   // Cela permet de ne pas faire de breaking change lors de l'implémentation
   // de tra-15674 - Sortir Conditionné pour pipeline de la liste des conditionnements
   if (hasPipelinePackaging(form)) {
-    form.wasteDetailsPackagingInfos = [];
+    form.wasteDetailsPackagingInfos = (
+      (form.wasteDetailsPackagingInfos ?? []) as PackagingInfo[]
+    ).filter(p => p.type !== "PIPELINE");
     form.isDirectSupply = true;
   }
 

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -121,13 +121,13 @@ const createFormResolver = async (
   // Pipeline erases transporter EXCEPT for transporterTransportMode
   // FIXME here we have a silent side effect. It would be be better to throw an
   // exception is the transporter data sent by the user does not comply
-  if (hasPipeline(form as any)) {
-    transporters = {
-      create: {
-        number: 1,
-        transporterTransportMode: TransportMode.OTHER
-      }
-    };
+  if (hasPipeline(form)) {
+    // transporters = {
+    //   create: {
+    //     number: 1,
+    //     transporterTransportMode: TransportMode.OTHER
+    //   }
+    // };
     transportersForValidation = [];
   }
 

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -192,7 +192,8 @@ async function getDuplicateFormInput(
         number: 1,
         readyToTakeOver: true
       }
-    }
+    },
+    isDirectSupply: form.isDirectSupply
   };
 }
 

--- a/back/src/forms/resolvers/mutations/signEmissionForm.ts
+++ b/back/src/forms/resolvers/mutations/signEmissionForm.ts
@@ -110,7 +110,12 @@ const signatures: Partial<
       {
         status: transitionForm(existingForm, {
           type: EventType.SignedByProducer,
-          formUpdateInput
+          formUpdateInput: {
+            ...formUpdateInput,
+            // permet d'accéder à la variable `isDirectSupply` dans une
+            // condition du state machine pour passer directement au statut SENT
+            isDirectSupply: existingForm.isDirectSupply
+          }
         }),
         ...formUpdateInput
       }

--- a/back/src/forms/resolvers/mutations/updateForm.ts
+++ b/back/src/forms/resolvers/mutations/updateForm.ts
@@ -23,7 +23,7 @@ import { getFormRepository } from "../../repository";
 import {
   Transporter,
   draftFormSchema,
-  hasPipeline,
+  hasPipelinePackaging,
   sealedFormSchema,
   validateGroupement,
   validateIntermediaries
@@ -166,7 +166,7 @@ const updateFormResolver = async (
   // Pipeline erases transporter EXCEPT for transporterTransportMode
   // FIXME here we have a silent side effect. It would be be better to throw an
   // exception is the transporter data sent by the user does not comply
-  if (hasPipeline(form as any)) {
+  if (hasPipelinePackaging(form as any)) {
     transporters = {
       deleteMany: {},
       create: {

--- a/back/src/forms/typeDefs/bsdd.enums.graphql
+++ b/back/src/forms/typeDefs/bsdd.enums.graphql
@@ -111,7 +111,7 @@ enum Packagings {
   BENNE
 
   "Conditionné pour pipeline"
-  PIPELINE
+  PIPELINE @deprecated(reason: "Utiliser `FormInput.isDirectSupply`")
 
   "Autre"
   AUTRE

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -251,6 +251,13 @@ input CreateFormInput {
   """
   transporters: [ID!]
 
+  """
+  Le déchet est acheminé directement par pipeline ou convoyeur.
+  Lorsque `isDirectSupply` est `true`, aucun transporteur
+  ni conditionnement (`wasteDetails.packagingInfos`) ne doivent être spécifiés.
+  """
+  isDirectSupply: Boolean
+
   "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput
 
@@ -319,6 +326,13 @@ input UpdateFormInput {
   supprimés à l'aide des mutations createFormTransporter, updateFormTransporter, deleteFormTransporter.
   """
   transporters: [ID!]
+
+  """
+  Le déchet est acheminé directement par pipeline ou convoyeur.
+  Lorsque `isDirectSupply` est `true`, aucun transporteur
+  ni conditionnement (`wasteDetails.packagingInfos`) ne doivent être spécifiés.
+  """
+  isDirectSupply: Boolean
 
   "Détails du déchet (case 3 à 6)"
   wasteDetails: WasteDetailsInput

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -375,6 +375,13 @@ input FormInput {
   transporter: TransporterInput
 
   """
+  Le déchet est acheminé directement par pipeline ou convoyeur.
+  Lorsque `isDirectSupply` est `true`, aucun transporteur
+  ni conditionnement (`wasteDetails.packagingInfos`) ne doivent être spécifiés.
+  """
+  isDirectSupply: Boolean
+
+  """
   Liste des différents transporteurs, dans l'ordre de prise en charge du déchet.
   Contient un seul identifiant en cas d'achemninement direct. Peut contenir au maximum
   5 identifiants en cas de transport multi-modal. Les transporteurs peuvent être crées, modifiés,

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -43,6 +43,13 @@ type Form {
   transporter: Transporter
 
   """
+  Le déchet est acheminé directement par pipeline ou convoyeur.
+  Lorsque `isDirectSupply` est `true`, aucun transporteur
+  ni conditionnement (`wasteDetails.packagingInfos`) ne doivent être spécifiés.
+  """
+  isDirectSupply: Boolean!
+
+  """
   Liste des transporteurs du déchet. Contient 1 seul transporteur en cas d'achemniment direct.
   Peut contenir un maximum de 5 transporteurs différents en cas de transport multi-modal
   """

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -152,6 +152,7 @@ export type Bsdd = {
   isDraft: boolean;
   status: FormStatus;
   forwardedInId: string | null;
+  isDirectSupply: boolean;
   pop: boolean | null;
   emitterType: EmitterType | null;
   ecoOrganismeName: string | null;

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -258,7 +258,7 @@ type FormValidationContext = {
   signingTransporterOrgId?: string | null;
 };
 
-export const hasPipeline = (
+export const hasPipelinePackaging = (
   value: Pick<Form, "wasteDetailsPackagingInfos">
 ): boolean =>
   ((value.wasteDetailsPackagingInfos ?? []) as PackagingInfo[]).some(
@@ -1963,16 +1963,14 @@ const baseFormSchemaFn = (context: FormValidationContext) =>
           transporters: yup
             .array<Transporter>()
             .of(transporterSchema)
-            .when(
-              "wasteDetailsPackagingInfos",
-              (wasteDetailsPackagingInfos, schema) =>
-                hasPipeline({ wasteDetailsPackagingInfos })
-                  ? schema.length(
-                      0,
-                      "Vous ne devez pas spécifier de transporteur dans le cas d'un transport par pipeline"
-                    )
-                  : schema
-            )
+            .when("isDirectSupply", {
+              is: true,
+              then: schema =>
+                schema.length(
+                  0,
+                  "Vous ne devez pas spécifier de transporteur dans le cas d'un transport par pipeline"
+                )
+            })
             .max(5, "Vous ne pouvez pas ajouter plus de ${max} transporteurs")
         })
       );

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -671,6 +671,11 @@ export const packagingInfoFn = ({
   yup.object().shape({
     type: yup
       .mixed<Packagings>()
+      .test({
+        name: "is-not-pipeline",
+        test: value => value !== "PIPELINE",
+        message: "Le type de conditionnement PIPELINE n'est pas valide"
+      })
       .required("Le type de conditionnement doit être précisé."),
     other: yup
       .string()

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -258,12 +258,12 @@ type FormValidationContext = {
   signingTransporterOrgId?: string | null;
 };
 
-export const hasPipeline = (value: {
-  wasteDetailsPackagingInfos: Array<{
-    type: Packagings;
-  }>;
-}): boolean =>
-  value.wasteDetailsPackagingInfos?.some(i => i.type === "PIPELINE");
+export const hasPipeline = (
+  value: Pick<Form, "wasteDetailsPackagingInfos">
+): boolean =>
+  ((value.wasteDetailsPackagingInfos ?? []) as PackagingInfo[]).some(
+    i => i.type === "PIPELINE"
+  );
 
 export const quantityRefusedNotRequired = weight(WeightUnits.Tonne)
   .min(0)

--- a/back/src/forms/workflow/__tests__/machine.test.ts
+++ b/back/src/forms/workflow/__tests__/machine.test.ts
@@ -20,7 +20,7 @@ describe("Workflow machine", () => {
     const nextState = machine.transition(Status.SEALED, {
       type: EventType.SignedByProducer,
       formUpdateInput: {
-        wasteDetailsPackagingInfos: [{ type: "PIPELINE", quantity: 1 }]
+        isDirectSupply: true
       }
     });
     expect(nextState.value).toEqual(Status.SENT);

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -6,7 +6,7 @@ import {
   PROCESSING_OPERATIONS_GROUPEMENT_CODES
 } from "@td/constants";
 import { Event, EventType } from "./types";
-import { hasPipeline } from "../validation";
+import { hasPipelinePackaging } from "../validation";
 
 /**
  * Workflow state machine
@@ -306,10 +306,10 @@ const machine = Machine<any, Event>(
       },
       hasPipeline: (_, event) =>
         !!event.formUpdateInput?.wasteDetailsPackagingInfos &&
-        hasPipeline(event.formUpdateInput as any),
+        hasPipelinePackaging(event.formUpdateInput as any),
       notPipeline: (_, event) =>
         !event.formUpdateInput?.wasteDetailsPackagingInfos ||
-        !hasPipeline(event.formUpdateInput as any)
+        !hasPipelinePackaging(event.formUpdateInput as any)
     }
   }
 );

--- a/back/src/forms/workflow/machine.ts
+++ b/back/src/forms/workflow/machine.ts
@@ -6,7 +6,6 @@ import {
   PROCESSING_OPERATIONS_GROUPEMENT_CODES
 } from "@td/constants";
 import { Event, EventType } from "./types";
-import { hasPipelinePackaging } from "../validation";
 
 /**
  * Workflow state machine
@@ -39,12 +38,11 @@ const machine = Machine<any, Event>(
           ],
           [EventType.SignedByProducer]: [
             {
-              target: Status.SIGNED_BY_PRODUCER,
-              cond: "notPipeline"
+              target: Status.SENT,
+              cond: "isDirectSupply"
             },
             {
-              target: Status.SENT,
-              cond: "hasPipeline"
+              target: Status.SIGNED_BY_PRODUCER
             }
           ]
         }
@@ -304,12 +302,9 @@ const machine = Machine<any, Event>(
           guard(event.formUpdateInput?.forwardedIn?.update)
         );
       },
-      hasPipeline: (_, event) =>
-        !!event.formUpdateInput?.wasteDetailsPackagingInfos &&
-        hasPipelinePackaging(event.formUpdateInput as any),
-      notPipeline: (_, event) =>
-        !event.formUpdateInput?.wasteDetailsPackagingInfos ||
-        !hasPipelinePackaging(event.formUpdateInput as any)
+      isDirectSupply: (_, event) => {
+        return !!event.formUpdateInput?.isDirectSupply;
+      }
     }
   }
 );

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/Packagings/packagings.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/Packagings/packagings.ts
@@ -26,7 +26,6 @@ export const PACKAGINGS_BSD_NAMES = {
     [Packagings.Citerne]: "Citerne(s)",
     [Packagings.Fut]: "Fût(s)",
     [Packagings.Grv]: "GRV(s)",
-    [Packagings.Pipeline]: "Conditionné pour Pipeline",
     [Packagings.Autre]: "Autre(s)"
   },
   [BsdTypename.Bsda]: {

--- a/front/src/Apps/common/queries/fragments/bsdd.ts
+++ b/front/src/Apps/common/queries/fragments/bsdd.ts
@@ -199,6 +199,7 @@ const mutableFieldsFragment = gql`
   fragment MutableFieldsFragment on Form {
     id
     customId
+    isDirectSupply
     sentAt
     emittedAt
     emittedBy

--- a/front/src/Apps/common/utils/packagingsBsddSummary.ts
+++ b/front/src/Apps/common/utils/packagingsBsddSummary.ts
@@ -1,4 +1,4 @@
-import { FormInput, PackagingInfo, Packagings } from "@td/codegen-ui";
+import { PackagingInfo, Packagings } from "@td/codegen-ui";
 import { pluralize } from "@td/constants";
 import Decimal from "decimal.js";
 
@@ -7,7 +7,6 @@ export const PACKAGINGS_NAMES = {
   [Packagings.Citerne]: "Citerne",
   [Packagings.Fut]: "Fût",
   [Packagings.Grv]: "GRV",
-  [Packagings.Pipeline]: "Conditionné pour Pipeline",
   [Packagings.Autre]: "Autre"
 };
 
@@ -61,22 +60,5 @@ export function getPackagingInfosSummary(packagingInfos: PackagingInfo[]) {
     })
     .join(", ");
 
-  const isPipeline = formTransportIsPipeline({
-    wasteDetails: {
-      packagingInfos
-    }
-  });
-
-  if (isPipeline) {
-    return packages;
-  }
-
   return `${total} colis : ${packages}`;
 }
-
-export const formTransportIsPipeline = (
-  form: Pick<FormInput, "wasteDetails">
-): boolean =>
-  form.wasteDetails?.packagingInfos?.some(
-    pkg => pkg.type === Packagings.Pipeline
-  )!;

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormJourneySummary.tsx
@@ -6,7 +6,6 @@ import {
   JourneyStopDescription,
   JourneyStopName
 } from "../../../../../common/components";
-import { formTransportIsPipeline } from "../../../../../Apps/common/utils/packagingsBsddSummary";
 
 interface FormJourneySummaryProps {
   form: Form;
@@ -31,7 +30,10 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
       }
     : {
         isComplete: Boolean(form.receivedAt),
-        isActive: (form.transporters ?? []).every(t => Boolean(t.takenOverAt)),
+        isActive:
+          (form.isDirectSupply && form.emittedAt) ||
+          (!form.isDirectSupply &&
+            (form.transporters ?? []).every(t => Boolean(t.takenOverAt))),
         company: form.recipient?.company
       };
 
@@ -46,6 +48,16 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
           </JourneyStopDescription>
         )}
       </JourneyStop>
+      {!!form.isDirectSupply && (
+        <JourneyStop variant={form.emittedAt ? "complete" : "incomplete"}>
+          <JourneyStopName>Transport</JourneyStopName>
+          {form.emitter?.company && (
+            <JourneyStopDescription>
+              Acheminement direct par pipeline ou convoyeur
+            </JourneyStopDescription>
+          )}
+        </JourneyStop>
+      )}
       {form.transporters.map((transporter, idx) => {
         return (
           <JourneyStop
@@ -65,16 +77,11 @@ export function FormJourneySummary({ form }: FormJourneySummaryProps) {
             <JourneyStopName>
               Transporteur{form.transporters.length > 1 ? ` n° ${idx + 1}` : ""}
             </JourneyStopName>
-            {transporter.company && !formTransportIsPipeline(form) && (
+            {transporter.company && (
               <JourneyStopDescription>
                 {transporter.company.name} ({transporter.company.orgId})
                 <br />
                 {transporter.company.address}
-              </JourneyStopDescription>
-            )}
-            {formTransportIsPipeline(form) && (
-              <JourneyStopDescription>
-                Conditionné pour Pipeline
               </JourneyStopDescription>
             )}
           </JourneyStop>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteEmissionSummary.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/FormWasteEmissionSummary.tsx
@@ -104,31 +104,34 @@ export function FormWasteEmissionSummary({
             </button>
           </DataListDescription>
         </DataListItem>
-        <DataListItem>
-          <DataListTerm>Contenant(s)</DataListTerm>
-          <DataListDescription>
-            {values.packagingInfos
-              ?.map(packaging =>
-                packaging?.type
-                  ? `${packaging.quantity} ${packaging.type}(s)`
-                  : ""
-              )
-              .join(", ")}
+        {!form.isDirectSupply && (
+          <DataListItem>
+            <DataListTerm>Contenant(s)</DataListTerm>
+            <DataListDescription>
+              {values.packagingInfos
+                ?.map(packaging =>
+                  packaging?.type
+                    ? `${packaging.quantity} ${packaging.type}(s)`
+                    : ""
+                )
+                .join(", ")}
 
-            <button
-              type="button"
-              onClick={() => {
-                addField("packagingInfos");
-                if (!values.packagingInfos?.length) {
-                  setFieldValue("packagingInfos", [emptyPackaging]);
-                }
-              }}
-              className="tw-ml-2"
-            >
-              <IconPaperWrite color="blue" />
-            </button>
-          </DataListDescription>
-        </DataListItem>
+              <button
+                type="button"
+                onClick={() => {
+                  addField("packagingInfos");
+                  if (!values.packagingInfos?.length) {
+                    setFieldValue("packagingInfos", [emptyPackaging]);
+                  }
+                }}
+                className="tw-ml-2"
+              >
+                <IconPaperWrite color="blue" />
+              </button>
+            </DataListDescription>
+          </DataListItem>
+        )}
+
         {form.emitter?.type !== EmitterType.Appendix1Producer && (
           <DataListItem>
             <DataListTerm>Mention ADR</DataListTerm>

--- a/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionFormModalContent.tsx
+++ b/front/src/dashboard/components/BSDList/BSDD/WorkflowAction/SignEmissionFormModalContent.tsx
@@ -37,7 +37,7 @@ interface SignEmissionFormModalProps {
 const validationSchema = (form: Form) => {
   let packagingInfosSchema = yup.array().of(packagingInfo);
 
-  if (form.emitter?.type !== "APPENDIX1_PRODUCER") {
+  if (form.emitter?.type !== "APPENDIX1_PRODUCER" && !form.isDirectSupply) {
     packagingInfosSchema = packagingInfosSchema
       .required()
       .min(1, "Vous devez préciser le conditionnement");

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -75,7 +75,6 @@ import {
   COMPANY_RECEIVED_SIGNATURE_AUTOMATIONS,
   SEARCH_COMPANIES
 } from "../../../Apps/common/queries/company/query";
-import { formTransportIsPipeline } from "../../../Apps/common/utils/packagingsBsddSummary";
 import { getOperationModeLabel } from "../../../Apps/common/operationModes";
 import { mapBsdd } from "../../../Apps/Dashboard/bsdMapper";
 import { hasAppendix1Cta } from "../../../Apps/Dashboard/dashboardServices";
@@ -807,9 +806,16 @@ export default function BSDDetailContent({
               <DetailRow value={form.wasteDetails?.name} label="Nom usuel" />
               <dt>Quantité</dt>
               <dd>{form.stateSummary?.quantity ?? "?"} tonnes</dd>
-              <PackagingRow
-                packagingInfos={form.stateSummary?.packagingInfos}
-              />
+              {form.isDirectSupply ? (
+                <DetailRow
+                  label="Conditionnement"
+                  value="Acheminement direct par pipeline ou convoyeur"
+                />
+              ) : (
+                <PackagingRow
+                  packagingInfos={form.stateSummary?.packagingInfos}
+                />
+              )}
               <dt>Consistance</dt>{" "}
               <dd>{getVerboseConsistence(form.wasteDetails?.consistence)}</dd>
               <DetailRow
@@ -1013,7 +1019,7 @@ export default function BSDDetailContent({
               </TabPanel>
             )}
             {/* Transporter tab panel */}
-            {!formTransportIsPipeline(form) ? (
+            {!form.isDirectSupply ? (
               (form.transporters ?? []).map((transporter, idx) => (
                 <TabPanel className={styles.detailTabPanel}>
                   <div className={`${styles.detailGrid} `}>
@@ -1077,7 +1083,7 @@ export default function BSDDetailContent({
               <TabPanel className={styles.detailTabPanel}>
                 <div className={`${styles.detailGrid} `}>
                   <DetailRow
-                    value="Conditionné pour Pipeline"
+                    value="Acheminement direct par pipeline ou convoyeur"
                     label="Transport"
                   />
                 </div>

--- a/front/src/form/bsdd/Transporter.tsx
+++ b/front/src/form/bsdd/Transporter.tsx
@@ -1,6 +1,5 @@
 import { useFormikContext } from "formik";
 import React from "react";
-import { formTransportIsPipeline } from "../../Apps/common/utils/packagingsBsddSummary";
 import { TransporterList } from "../../Apps/Forms/Components/TransporterList/TransporterList";
 import { useParams } from "react-router-dom";
 import { FormFormikValues } from "./utils/initial-state";
@@ -15,8 +14,12 @@ export default function Transporter() {
   const { siret } = useParams<{ siret: string }>();
   const emitterType = values.emitter?.type;
 
-  if (formTransportIsPipeline(values)) {
-    return <h4 className="form__section-heading">Transport par pipeline</h4>;
+  if (values.isDirectSupply) {
+    return (
+      <h4 className="form__section-heading">
+        Acheminement direct par pipeline ou convoyeur
+      </h4>
+    );
   } else if (
     emitterType === EmitterType.Appendix1 ||
     emitterType === EmitterType.Appendix1Producer

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -186,7 +186,7 @@ export default function WasteInfo({ disabled }) {
       {values.emitter?.type !== "APPENDIX1" && (
         <div className="form__row" style={{ flexDirection: "row" }}>
           <Switch
-            label="Le déchet est conditionné pour pipeline"
+            label="Le déchet est acheminé directement par pipeline ou convoyeur"
             disabled={disabled}
             checked={isPipeline}
             onChange={checked => {

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -19,9 +19,11 @@ import EstimatedQuantityTooltip from "../../common/components/EstimatedQuantityT
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
 import Appendix2MultiSelectWrapper from "./components/appendix/Appendix2MultiSelectWrapper";
 import Alert from "@codegouvfr/react-dsfr/Alert";
-import { FormFormikValues } from "./utils/initial-state";
+import {
+  FormFormikValues,
+  initialFormTransporter
+} from "./utils/initial-state";
 import FormikPackagingList from "../../Apps/Forms/Components/PackagingList/FormikPackagingList";
-import { Packagings } from "@td/codegen-ui";
 import { emptyPackaging } from "../../Apps/Forms/Components/PackagingList/helpers";
 
 const SOIL_CODES = [
@@ -51,10 +53,6 @@ export default function WasteInfo({ disabled }) {
   }, [values.wasteDetails?.code, setFieldValue]);
 
   const showDuplicateWarning = !!values.isDuplicateOf && !disabled;
-
-  const isPipeline = (values.wasteDetails?.packagingInfos ?? []).some(
-    p => p.type === Packagings.Pipeline
-  );
 
   return (
     <>
@@ -188,22 +186,26 @@ export default function WasteInfo({ disabled }) {
           <Switch
             label="Le déchet est acheminé directement par pipeline ou convoyeur"
             disabled={disabled}
-            checked={isPipeline}
-            onChange={checked => {
-              const updatedPackagings = checked
-                ? [{ type: Packagings.Pipeline, quantity: 1 }]
-                : [emptyPackaging];
-              setFieldValue(
-                "wasteDetails.packagingInfos",
-                updatedPackagings,
-                false
-              );
+            checked={Boolean(values.isDirectSupply)}
+            onChange={(checked: boolean) => {
+              setFieldValue("isDirectSupply", checked);
+              if (checked) {
+                setFieldValue("wasteDetails.packagingInfos", []);
+                setFieldValue("transporters", []);
+              } else {
+                setFieldValue(
+                  "wasteDetails.packagingInfos",
+                  [emptyPackaging],
+                  false
+                );
+                setFieldValue("transporters", [initialFormTransporter], false);
+              }
             }}
           />
         </div>
       )}
 
-      {values.emitter?.type !== "APPENDIX1" && !isPipeline && (
+      {values.emitter?.type !== "APPENDIX1" && !values.isDirectSupply && (
         <>
           <h4 className="form__section-heading">Conditionnement</h4>
           <FormikPackagingList

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -139,14 +139,12 @@ export type FormFormikValues = Omit<FormInput, "transporters"> & {
  * @param f current BSD
  */
 export function getInitialState(f?: Form | null): FormFormikValues {
-  const initialTransporters =
-    f?.transporters && f?.transporters.length > 0
-      ? f.transporters
-      : [initialFormTransporter];
+  const initialTransporters = f?.id ? f.transporters : [initialFormTransporter];
 
   return {
     id: f?.id ?? null,
     customId: f?.customId ?? "",
+    isDirectSupply: f?.isDirectSupply ?? false,
     isDuplicateOf: f?.isDuplicateOf,
     emitter: {
       pickupSite: null, // deprecated

--- a/libs/back/prisma/src/migrations/20250213142801_add_form_is_direct_supply/migration.sql
+++ b/libs/back/prisma/src/migrations/20250213142801_add_form_is_direct_supply/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE
+  "Form"
+ADD
+  COLUMN "isDirectSupply" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE
+  "Form"
+SET
+  "isDirectSupply" = TRUE,
+  "wasteDetailsPackagingInfos" = '[]'
+WHERE
+  EXISTS (
+    SELECT
+      1
+    FROM
+      jsonb_array_elements("wasteDetailsPackagingInfos") AS conditionnement
+    WHERE
+      jsonb_typeof("wasteDetailsPackagingInfos") = 'array'
+      AND conditionnement ->> 'type' = 'PIPELINE'
+  );

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -556,6 +556,7 @@ model Form {
   hasCiterneBeenWashedOut               Boolean?
   citerneNotWashedOutReason             CiterneNotWashedOutReason?
   emptyReturnADR                        EmptyReturnADR?
+  isDirectSupply                        Boolean                    @default(false)
 
   transporters BsddTransporter[]
   groupedIn    FormGroupement[]  @relation("GroupedIn")


### PR DESCRIPTION
Migration testée sur les données de prod ~20 secondes

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

BSDD - Le type de conditionnement PIPELINE est déprécié sur l'enum  [Packagings](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/enums#packagings). Il est nécessaire de renseigner un nouveau  champ booléen `isDirectSupply` sur [FormInput](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/inputObjects#forminput) pouvant correspondre à un acheminement par pipeline ou par convoyeur. Aucun conditionnement ne devra être renseigné en cas d'acheminement direct, c'est à dire que lorsque `isDirectSupply` est true, le champ packagingsInfos sur   [FormInput](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/inputObjects#forminput) devra valoir null ou []. Les données existantes seront migrées de sorte qu'il vous faudra prendre en compte en lecture le nouveau champ `isDirectSupply` sur l'objet [Form](https://developers.trackdechets.beta.gouv.fr/reference/api-reference/bsdd/objects#form). Nous continuerons d'accepter la valeur `PIPELINE` comme type de packagings en écriture mais les données entrantes seront automatiquement converties pour s'adapter au nouveau format de données.

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/c5c7705a-71dc-4e7b-ba72-1aa54cf5cb02


![Capture d’écran 2025-02-26 à 15 49 42](https://github.com/user-attachments/assets/17da9616-6f2b-4e58-8bf7-d70d7f7efbf2)

![Capture d’écran 2025-02-26 à 15 50 13](https://github.com/user-attachments/assets/2f4329bd-1b36-4825-9668-543207481fd5)


# Ticket Favro

[Sortir Conditionné pour pipeline de la liste des conditionnements](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15674)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB