### PR TITLE
[TRA-15876] Ajout d'espaces et de texte en gras dans l'email sur la création d'une délégation registre

### DIFF
--- a/back/src/registryDelegation/resolvers/mutations/__tests__/createRegistryDelegation.integration.ts
+++ b/back/src/registryDelegation/resolvers/mutations/__tests__/createRegistryDelegation.integration.ts
@@ -315,8 +315,9 @@ describe("mutation createRegistryDelegation", () => {
     );
     expect(sendMail as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.stringContaining(`effective à partir du ${formattedStartDate}
-  <span>pour une durée illimitée.</span>`),
+        body: expect.stringContaining(`effective
+  <b
+    >à partir du ${formattedStartDate}     <span>pour une durée illimitée.</span>`),
         subject: `Émission d'une demande de délégation de l'établissement ${delegator.name} (${delegator.siret})`
       })
     );
@@ -353,8 +354,10 @@ describe("mutation createRegistryDelegation", () => {
     const formattedEndDate = toddMMYYYY(endDate).replace(/\//g, "&#x2F;");
     expect(sendMail as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.stringContaining(`effective à partir du ${formattedStartDate}
-  <span>et jusqu'au ${formattedEndDate}.</span>`),
+        body: expect.stringContaining(`effective
+  <b
+    >à partir du ${formattedStartDate} 
+    <span>et jusqu'au ${formattedEndDate}.</span>`),
         subject: `Émission d'une demande de délégation de l'établissement ${delegator.name} (${delegator.siret})`
       })
     );

--- a/libs/back/mail/src/templates/mustache/registry-delegation-creation.html
+++ b/libs/back/mail/src/templates/mustache/registry-delegation-creation.html
@@ -1,16 +1,20 @@
 <p>
-  La plateforme Trackdéchets vous informe qu'une délégation a été accordée par
-  l'établissement {{delegator.name}} ({{delegator.siret}}) à l'établissement
-  {{delegate.name}} ({{delegate.siret}}), effective à partir du {{startDate}}
-  {{#endDate}}
-  <span>et jusqu'au {{endDate}}.</span>
-  {{/endDate}} {{^endDate}}
-  <span>pour une durée illimitée.</span>
-  {{/endDate}} Cette délégation permet à l'établissement {{delegate.name}}
+  La plateforme Trackdéchets vous informe qu'une
+  <b>délégation a été accordée par l'établissement {{delegator.name}}</b>
+  ({{delegator.siret}})
+  <b>à l'établissement {{delegate.name}}</b> ({{delegate.siret}}), effective
+  <b
+    >à partir du {{startDate}} {{#endDate}}
+    <span>et jusqu'au {{endDate}}.</span>
+    {{/endDate}} {{^endDate}}
+    <span>pour une durée illimitée.</span>
+    {{/endDate}}</b
+  >
+  Cette délégation permet à l'établissement {{delegate.name}}
   ({{delegate.siret}}) de déclarer des registres de déchets règlementaires au
   nom de l'établissement {{delegator.name}} ({{delegator.siret}}).
 </p>
-
+<br />
 <p>
   Pour en savoir plus sur vos obligations en matière de déclarations, nous vous
   invitons à consulter cet
@@ -19,7 +23,7 @@
     >article</a
   >.
 </p>
-
+<br />
 <p>
   Si vous avez des questions, n'hésitez pas à consulter notre
   <a href="https://faq.trackdechets.fr">Foire aux Questions</a>.


### PR DESCRIPTION
# Contexte

Petite repasse de formattage de l'email de création de délégation pour le rendre plus lisible.

# Démo

![image](https://github.com/user-attachments/assets/4ed80e1d-2e83-47f5-954a-cf3442af609f)

# Ticket Favro

[Ajouter de l'espace entre les paragraphes des e-mails de délégation](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ca60ff23d07a2274c78317e5?card=tra-15876)
