### PR TITLE
[TRA-15262] Rendre optionnel les agréments  à la publication d'un VHU

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Exports registres V2 : Modale d'export et petites améliorations d'UX [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3953)
+- Rendre optionnel les agréments à la publication d'un VHU [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3984)
 
 # [2025.02.1] 11/02/2025
 

--- a/back/src/bsvhu/validation/__tests__/validation.integration.ts
+++ b/back/src/bsvhu/validation/__tests__/validation.integration.ts
@@ -332,6 +332,20 @@ describe("BSVHU validation", () => {
       });
       expect(parsed).toBeDefined();
     });
+
+    test("when destination agrement number is missing", async () => {
+      const data: ZodBsvhu = {
+        ...bsvhu,
+        destinationAgrementNumber: null
+      };
+
+      const parsed = parseBsvhu(data, {
+        ...context,
+        currentSignatureType: "EMISSION"
+      });
+
+      expect(parsed).toBeDefined();
+    });
   });
 
   describe("BSVHU should not be valid", () => {
@@ -639,26 +653,6 @@ describe("BSVHU validation", () => {
           expect.objectContaining({
             message:
               "La date de validité du récépissé du transporteur est un champ requis. L'établissement doit renseigner son récépissé dans Trackdéchets"
-          })
-        ]);
-      }
-    });
-
-    test("when destination agrement number is missing", async () => {
-      const data: ZodBsvhu = {
-        ...bsvhu,
-        destinationAgrementNumber: null
-      };
-      expect.assertions(1);
-      try {
-        parseBsvhu(data, {
-          ...context,
-          currentSignatureType: "EMISSION"
-        });
-      } catch (err) {
-        expect((err as ZodError).issues).toEqual([
-          expect.objectContaining({
-            message: "Le N° d'agrément du destinataire est un champ requis."
           })
         ]);
       }

--- a/back/src/bsvhu/validation/rules.ts
+++ b/back/src/bsvhu/validation/rules.ts
@@ -231,7 +231,6 @@ export const bsvhuEditionRules: BsvhuEditionRules = {
   },
   destinationAgrementNumber: {
     sealed: { from: "OPERATION" },
-    required: { from: "EMISSION" },
     readableFieldName: "Le N° d'agrément du destinataire",
     path: ["destination", "agrementNumber"]
   },


### PR DESCRIPTION
# Contexte

En tant que, acteur visé sur un BSVHU,

Je souhaite, que la vérification sur la présence d'un numéro d'agrément à la publication d'un BSVHU soit retirée, 

Afin de, respecter la règlementation qui ne les rend plus obligatoires depuis le 1er janvier 2025. 

La partie front relative à l’édition d’établissement est déjà gérée par (https://github.com/MTES-MCT/trackdechets/pull/3972). Ici on lève simplement le required de la rule correspondante.

# Points de vigilance pour les intégrateurs

Aucune

# Démo

### Avant

<img width="669" alt="Capture d’écran 2025-02-19 à 09 29 07" src="https://github.com/user-attachments/assets/d40f7433-ad8b-42b9-8f4a-9076664b0b7e" />

### Après

https://github.com/user-attachments/assets/c7669aa0-982d-4173-af3e-7607599d407a


# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15262

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB