### PR TITLE
[TRA-15847] Adds wastes codes to BSDD appendix 1

### DIFF
--- a/libs/shared/constants/src/WASTES.ts
+++ b/libs/shared/constants/src/WASTES.ts
@@ -5617,6 +5617,10 @@ export const BSDD_APPENDIX1_WASTE_CODES = [
     const prefixes = ["13 02", "13 05", "16 02", "16 07", "20 01"];
     return prefixes.some(prefix => waste.code.startsWith(prefix));
   }).map(waste => waste.code),
+  "13 01 10*",
+  "13 01 11*",
+  "13 01 12*",
+  "13 01 13*",
   "15 01 10*",
   "15 02 02*",
   "16 06 01*",


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Pouvoir sélectionner un code déchet 13 01 XX * (13 01 10* ; 13 01 11* ; 13 01 12* ; 13 01 13*) sur un bordereau de tournée dédiée 

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

[Screencast From 2025-02-20 10-01-28.webm](https://github.com/user-attachments/assets/9d9e5776-1c9f-418b-a02d-02e3b06b05f2)


# Ticket Favro

[Pouvoir sélectionner un code déchet 13 01 XX * (13 01 10* ; 13 01 11* ; 13 01 12* ; 13 01 13*) sur un bordereau de tournée dédiée ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15847)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB