### PR TITLE
[TRA-15459] Fixes VHU date mobile width

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuEmission.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuEmission.tsx
@@ -147,7 +147,7 @@ const SignVhuEmission = ({ bsvhuId, onClose }) => {
               onClose();
             })}
           >
-            <div className="fr-col-4 fr-mb-2w">
+            <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
               <Input
                 label="Date de prise en charge"
                 nativeInputProps={{

--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuOperation.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuOperation.tsx
@@ -281,7 +281,7 @@ const SignVhuOperation = ({ bsvhuId, onClose }) => {
             de déchets renseignée.
           </p>
 
-          <div className="fr-col-4 fr-mb-2w">
+          <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
             <Input
               label="Date de traitement"
               nativeInputProps={{

--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuReception.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuReception.tsx
@@ -313,7 +313,7 @@ const SignVhuReception = ({ bsvhuId, onClose }) => {
               également une copie.
             </p>
 
-            <div className="fr-col-4 fr-mb-2w">
+            <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
               <Input
                 label="Date de prise en charge"
                 nativeInputProps={{

--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuTransport.tsx
@@ -213,7 +213,7 @@ const SignVhuTransport = ({ bsvhuId, onClose }) => {
                 que les informations ci-dessus sont correctes. En signant ce
                 document, je déclare prendre en charge le déchet.
               </p>
-              <div className="fr-col-4 fr-mb-2w">
+              <div className="fr-col-8 fr-col-sm-4 fr-mb-2w">
                 <Input
                   label="Date de prise en charge"
                   nativeInputProps={{


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Correction de la largeur du champ date des modales de signature VHU en mobile.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

![image](https://github.com/user-attachments/assets/2a8d1da3-6367-4ca1-8eca-bab415aee91b)

# Ticket Favro

[Largeur champ date signature VHU](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15459)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB