### PR TITLE
Registry - Stats

### DIFF
--- a/back/src/registryV2/resolvers/Query.ts
+++ b/back/src/registryV2/resolvers/Query.ts
@@ -6,6 +6,7 @@ import { registryUploadSignedUrl } from "./queries/registryUploadSignedUrl";
 import { registryDownloadSignedUrl } from "./queries/registryDownloadSignedUrl";
 import { registryImports } from "./queries/registryImports";
 import { registryImport } from "./queries/registryImport";
+import { registryChangeAggregates } from "./queries/registryChangeAggregates";
 
 export const Query: QueryResolvers = {
   registryUploadSignedUrl,
@@ -14,5 +15,6 @@ export const Query: QueryResolvers = {
   registryImport: registryImport as any,
   registryV2ExportDownloadSignedUrl,
   registryV2Exports: registryV2Exports as any,
-  registryV2Export: registryV2Export as any
+  registryV2Export: registryV2Export as any,
+  registryChangeAggregates: registryChangeAggregates as any
 };

--- a/back/src/registryV2/resolvers/mutations/addToIncomingTexsRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToIncomingTexsRegistry.ts
@@ -1,4 +1,3 @@
-import { importOptions } from "@td/registry";
 import { MutationAddToIncomingWasteRegistryArgs } from "@td/codegen-back";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
@@ -8,5 +7,5 @@ export async function addToIncomingTexsRegistry(
   { lines }: MutationAddToIncomingWasteRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.INCOMING_TEXS, lines, context);
+  return genericAddToRegistry("INCOMING_TEXS", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToIncomingWasteRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToIncomingWasteRegistry.ts
@@ -1,4 +1,3 @@
-import { importOptions } from "@td/registry";
 import { MutationAddToIncomingWasteRegistryArgs } from "@td/codegen-back";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
@@ -8,5 +7,5 @@ export async function addToIncomingWasteRegistry(
   { lines }: MutationAddToIncomingWasteRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.INCOMING_WASTE, lines, context);
+  return genericAddToRegistry("INCOMING_WASTE", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToManagedRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToManagedRegistry.ts
@@ -1,5 +1,4 @@
 import type { MutationAddToManagedRegistryArgs } from "@td/codegen-back";
-import { importOptions } from "@td/registry";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
 
@@ -8,5 +7,5 @@ export async function addToManagedRegistry(
   { lines }: MutationAddToManagedRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.MANAGED, lines, context);
+  return genericAddToRegistry("MANAGED", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToOutgoingTexsRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToOutgoingTexsRegistry.ts
@@ -1,5 +1,4 @@
 import type { MutationAddToOutgoingTexsRegistryArgs } from "@td/codegen-back";
-import { importOptions } from "@td/registry";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
 
@@ -8,5 +7,5 @@ export async function addToOutgoingTexsRegistry(
   { lines }: MutationAddToOutgoingTexsRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.OUTGOING_TEXS, lines, context);
+  return genericAddToRegistry("OUTGOING_TEXS", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToOutgoingWasteRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToOutgoingWasteRegistry.ts
@@ -1,5 +1,4 @@
 import type { MutationAddToOutgoingWasteRegistryArgs } from "@td/codegen-back";
-import { importOptions } from "@td/registry";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
 
@@ -8,5 +7,5 @@ export async function addToOutgoingWasteRegistry(
   { lines }: MutationAddToOutgoingWasteRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.OUTGOING_WASTE, lines, context);
+  return genericAddToRegistry("OUTGOING_WASTE", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToSsdRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToSsdRegistry.ts
@@ -1,5 +1,4 @@
 import type { MutationAddToSsdRegistryArgs } from "@td/codegen-back";
-import { importOptions } from "@td/registry";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
 
@@ -8,5 +7,5 @@ export async function addToSsdRegistry(
   { lines }: MutationAddToSsdRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.SSD, lines, context);
+  return genericAddToRegistry("SSD", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/addToTransportedRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/addToTransportedRegistry.ts
@@ -1,5 +1,4 @@
 import type { MutationAddToTransportedRegistryArgs } from "@td/codegen-back";
-import { importOptions } from "@td/registry";
 import { GraphQLContext } from "../../../types";
 import { genericAddToRegistry } from "./genericAddToRegistry";
 
@@ -8,5 +7,5 @@ export async function addToTransportedRegistry(
   { lines }: MutationAddToTransportedRegistryArgs,
   context: GraphQLContext
 ) {
-  return genericAddToRegistry(importOptions.TRANSPORTED, lines, context);
+  return genericAddToRegistry("TRANSPORTED", lines, context);
 }

--- a/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
@@ -1,13 +1,13 @@
 import { pluralize } from "@td/constants";
 import { prisma } from "@td/prisma";
 import {
-  UNAUTHORIZED_ERROR,
-  isAuthorized,
-  RegistryChanges,
-  incrementLocalChangesForCompany,
-  saveCompaniesChanges,
   ImportType,
-  importOptions
+  RegistryChanges,
+  UNAUTHORIZED_ERROR,
+  importOptions,
+  incrementLocalChangesForCompany,
+  isAuthorized,
+  saveCompaniesChanges
 } from "@td/registry";
 import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
@@ -68,7 +68,10 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
 
   const { safeParseAsync, saveLine } = options;
   const errors = new Map<string, string>();
-  const changesByCompany = new Map<string, RegistryChanges>();
+  const changesByCompany = new Map<
+    string,
+    { [reportAsSiret: string]: RegistryChanges }
+  >();
 
   for (const line of lines) {
     const result = await safeParseAsync(line);
@@ -90,7 +93,9 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
 
       incrementLocalChangesForCompany(changesByCompany, {
         reason: result.data.reason,
-        reportForCompanySiret: result.data.reportForCompanySiret
+        reportForCompanySiret: result.data.reportForCompanySiret,
+        reportAsCompanySiret:
+          result.data.reportAsCompanySiret ?? result.data.reportForCompanySiret
       });
 
       await saveLine({

--- a/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
@@ -2,8 +2,12 @@ import { pluralize } from "@td/constants";
 import { prisma } from "@td/prisma";
 import {
   UNAUTHORIZED_ERROR,
-  type ImportOptions,
-  isAuthorized
+  isAuthorized,
+  RegistryChanges,
+  incrementLocalChangesForCompany,
+  saveCompaniesChanges,
+  ImportType,
+  importOptions
 } from "@td/registry";
 import { UserInputError } from "../../../common/errors";
 import { checkIsAuthenticated } from "../../../common/permissions";
@@ -21,10 +25,12 @@ type UnparsedLine = {
 };
 
 export async function genericAddToRegistry<T extends UnparsedLine>(
-  importOptions: ImportOptions,
+  importType: ImportType,
   lines: T[],
   context: GraphQLContext
 ) {
+  const options = importOptions[importType];
+
   const user = checkIsAuthenticated(context);
   const userCompanies = await getUserCompanies(user.id);
   await checkUserPermissions(
@@ -60,8 +66,9 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
     return map;
   }, new Map<string, string[]>());
 
-  const { safeParseAsync, saveLine } = importOptions;
+  const { safeParseAsync, saveLine } = options;
   const errors = new Map<string, string>();
+  const changesByCompany = new Map<string, RegistryChanges>();
 
   for (const line of lines) {
     const result = await safeParseAsync(line);
@@ -81,6 +88,11 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
         continue;
       }
 
+      incrementLocalChangesForCompany(changesByCompany, {
+        reason: result.data.reason,
+        reportForCompanySiret: result.data.reportForCompanySiret
+      });
+
       await saveLine({
         line: { ...result.data, createdById: user.id },
         importId: null
@@ -94,6 +106,12 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
       );
     }
   }
+
+  await saveCompaniesChanges(changesByCompany, {
+    type: importType,
+    source: "API",
+    createdById: user.id
+  });
 
   if (errors.size > 0) {
     throw new UserInputError(

--- a/back/src/registryV2/resolvers/queries/registryChangeAggregates.ts
+++ b/back/src/registryV2/resolvers/queries/registryChangeAggregates.ts
@@ -1,0 +1,83 @@
+import { prisma } from "@td/prisma";
+import { UserInputError } from "../../../common/errors";
+import { checkIsAuthenticated } from "../../../common/permissions";
+import type { QueryRegistryChangeAggregatesArgs } from "@td/codegen-back";
+import { Permission, checkUserPermissions } from "../../../permissions";
+import { GraphQLContext } from "../../../types";
+import { getUserCompanies } from "../../../users/database";
+import { sub } from "date-fns";
+
+export async function registryChangeAggregates(
+  _,
+  { siret, window, source }: QueryRegistryChangeAggregatesArgs,
+  context: GraphQLContext
+) {
+  const user = checkIsAuthenticated(context);
+
+  const filteredOnCompany = await prisma.company.findUnique({
+    where: { siret }
+  });
+  if (!filteredOnCompany) {
+    throw new UserInputError("Impossible de filtrer sur ce SIRET");
+  }
+
+  if (window > 30) {
+    throw new UserInputError(
+      "La fenêtre de temps ne peut pas dépasser 30 jours"
+    );
+  }
+
+  const userCompanies = await getUserCompanies(user.id);
+  const userCompanyIds = userCompanies.map(c => c.id);
+
+  const siretsThatCanAccessAggregates = [siret];
+  const reportAsIdsFilter: string[] = [];
+
+  if (!userCompanyIds.includes(filteredOnCompany.id)) {
+    const delegations = await prisma.registryDelegation.findMany({
+      where: {
+        delegatorId: filteredOnCompany.id,
+        revokedBy: null,
+        cancelledBy: null,
+        startDate: { lte: new Date() },
+        OR: [{ endDate: null }, { endDate: { gt: new Date() } }]
+      },
+      include: { delegate: { select: { orgId: true } } }
+    });
+
+    const siretsThatHaveDelegationOnTarget = delegations.map(
+      delegation => delegation.delegate.orgId
+    );
+    siretsThatCanAccessAggregates.push(...siretsThatHaveDelegationOnTarget);
+
+    const companyIdsThatHaveDelegationOnTarget = delegations.map(
+      delegation => delegation.delegateId
+    );
+    reportAsIdsFilter.push(...companyIdsThatHaveDelegationOnTarget);
+  }
+
+  await checkUserPermissions(
+    user,
+    siretsThatCanAccessAggregates,
+    Permission.RegistryCanRead,
+    `Vous n'êtes pas autorisé à lire les informations pour ce siret`
+  );
+
+  return prisma.registryChangeAggregate.findMany({
+    where: {
+      reportForId: filteredOnCompany.id,
+      ...(reportAsIdsFilter.length > 0 && {
+        reportAsId: { in: reportAsIdsFilter }
+      }),
+      source,
+      createdAt: {
+        gte: sub(new Date(), { days: window })
+      }
+    },
+    orderBy: { createdAt: "desc" },
+    include: {
+      createdBy: { select: { name: true } },
+      reportAs: { select: { name: true, siret: true } }
+    }
+  });
+}

--- a/back/src/registryV2/resolvers/queries/registryImport.ts
+++ b/back/src/registryV2/resolvers/queries/registryImport.ts
@@ -16,8 +16,8 @@ export async function registryImport(
   await checkUserPermissions(
     user,
     userCompanies.map(company => company.orgId),
-    Permission.RegistryCanImport,
-    `Vous n'êtes pas autorisé à importer des données dans le registre`
+    Permission.RegistryCanRead,
+    `Vous n'êtes pas autorisé à lire les données de cet import`
   );
 
   const registryImport = await prisma.registryImport.findUnique({

--- a/back/src/registryV2/typeDefs/private/registryV2.enums.graphql
+++ b/back/src/registryV2/typeDefs/private/registryV2.enums.graphql
@@ -1,0 +1,4 @@
+enum RegistryImportSource {
+  API
+  FILE
+}

--- a/back/src/registryV2/typeDefs/private/registryV2.objects.graphql
+++ b/back/src/registryV2/typeDefs/private/registryV2.objects.graphql
@@ -1,0 +1,24 @@
+type ChangeAggregate {
+  id: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  type: RegistryImportType!
+  source: RegistryImportSource!
+  createdBy: ChangeAggregateCratedBy!
+  reportAs: ChangeAggregateReportAs!
+  numberOfAggregates: Int!
+  numberOfErrors: Int!
+  numberOfInsertions: Int!
+  numberOfEdits: Int!
+  numberOfCancellations: Int!
+  numberOfSkipped: Int!
+}
+
+type ChangeAggregateCratedBy {
+  name: String!
+}
+
+type ChangeAggregateReportAs {
+  name: String!
+  siret: String
+}

--- a/back/src/registryV2/typeDefs/private/registryV2.queries.graphql
+++ b/back/src/registryV2/typeDefs/private/registryV2.queries.graphql
@@ -1,0 +1,7 @@
+type Query {
+  registryChangeAggregates(
+    siret: String!
+    window: Int!
+    source: RegistryImportSource!
+  ): [ChangeAggregate!]
+}

--- a/front/src/dashboard/registry/CompanyImports.tsx
+++ b/front/src/dashboard/registry/CompanyImports.tsx
@@ -1,170 +1,37 @@
-import { useLazyQuery, useQuery } from "@apollo/client";
-import Button from "@codegouvfr/react-dsfr/Button";
-import { Download } from "@codegouvfr/react-dsfr/Download";
-import Table from "@codegouvfr/react-dsfr/Table";
-import {
-  Query,
-  QueryRegistryDownloadSignedUrlArgs,
-  RegistryDownloadTarget
-} from "@td/codegen-ui";
 import React, { useState } from "react";
+import Tabs from "@codegouvfr/react-dsfr/Tabs";
 
-import Alert from "@codegouvfr/react-dsfr/Alert";
-import { format } from "date-fns";
-import { InlineLoader } from "../../Apps/common/Components/Loader/Loaders";
+import { StatsTab } from "./companyImport/StatsTab";
 import { RegistryCompanySwitcher } from "./RegistryCompanySwitcher";
-import {
-  badges,
-  downloadFromSignedUrl,
-  GET_REGISTRY_IMPORTS,
-  REGISTRY_DOWNLOAD_SIGNED_URL,
-  TYPES
-} from "./shared";
-import { pluralize } from "@td/constants";
-
-const HEADERS = [
-  "Date",
-  "Import",
-  "Déclaration",
-  "Déclaré par",
-  "Fichier importé",
-  "Rapport d'erreur"
-];
 
 export function CompanyImports() {
   const [siret, setSiret] = useState<string | undefined>();
-
-  const { loading, error, data } = useQuery<Pick<Query, "registryImports">>(
-    GET_REGISTRY_IMPORTS,
-    { variables: { siret, first: 25 }, skip: !siret }
-  );
-
-  const [getDownloadLink] = useLazyQuery<
-    Pick<Query, "registryDownloadSignedUrl">,
-    Partial<QueryRegistryDownloadSignedUrlArgs>
-  >(REGISTRY_DOWNLOAD_SIGNED_URL);
-
-  async function downloadErrorFile(importId: string) {
-    const link = await getDownloadLink({
-      variables: { importId, target: RegistryDownloadTarget.ErrorFile }
-    });
-    downloadFromSignedUrl(link.data?.registryDownloadSignedUrl.signedUrl);
-  }
-  async function downloadImportFile(importId: string) {
-    const link = await getDownloadLink({
-      variables: { importId, target: RegistryDownloadTarget.ImportFile }
-    });
-    downloadFromSignedUrl(link.data?.registryDownloadSignedUrl.signedUrl);
-  }
-
-  const tableData =
-    data?.registryImports.edges.map(importData => [
-      format(new Date(importData.node.createdAt), "dd/MM/yyyy HH'h'mm"),
-      <div>
-        {badges[importData.node.status]("import")}
-        <div>{TYPES[importData.node.type]}</div>
-      </div>,
-      <ul>
-        {importData.node.numberOfErrors > 0 && (
-          <li>
-            <strong>{importData.node.numberOfErrors} en erreur</strong>
-          </li>
-        )}
-        {importData.node.numberOfInsertions > 0 && (
-          <li>
-            {importData.node.numberOfInsertions}{" "}
-            {pluralize(
-              "ajoutée",
-              importData.node.numberOfInsertions,
-              "ajoutées"
-            )}
-          </li>
-        )}
-        {importData.node.numberOfEdits > 0 && (
-          <li>
-            {importData.node.numberOfEdits}{" "}
-            {pluralize("modifiée", importData.node.numberOfEdits, "modifiées")}
-          </li>
-        )}
-        {importData.node.numberOfCancellations > 0 && (
-          <li>
-            {importData.node.numberOfCancellations}{" "}
-            {pluralize(
-              "annulée",
-              importData.node.numberOfCancellations,
-              "annulées"
-            )}
-          </li>
-        )}
-        {importData.node.numberOfSkipped > 0 && (
-          <li>
-            {importData.node.numberOfSkipped}{" "}
-            {pluralize("ignorée", importData.node.numberOfSkipped, "ignorées")}
-          </li>
-        )}
-      </ul>,
-      importData.node.createdBy.name,
-      <div className="tw-flex">
-        <Download
-          details={(
-            importData.node.originalFileName.split(".").pop() ?? ""
-          ).toUpperCase()}
-          label={importData.node.originalFileName
-            .split(".")
-            .slice(0, -1)
-            .join(".")}
-          linkProps={{
-            href: "#",
-            onClick: e => {
-              e.preventDefault();
-              downloadImportFile(importData.node.id);
-            }
-          }}
-        />
-      </div>,
-      <div className="tw-flex tw-justify-center">
-        {importData.node.numberOfErrors > 0 && (
-          <Button
-            title="Voir le rapport d'erreur"
-            priority="secondary"
-            iconId="fr-icon-download-line"
-            onClick={() => downloadErrorFile(importData.node.id)}
-            size="small"
-          />
-        )}
-      </div>
-    ]) ?? [];
+  const [selectedTabId, setSelectedTabId] = useState("API");
 
   return (
     <div className="tw-p-6">
       <div>
         <RegistryCompanySwitcher onCompanySelect={v => setSiret(v)} />
       </div>
-      {loading && <InlineLoader />}
-      {error && (
-        <Alert
-          closable
-          description={error.message}
-          severity="error"
-          title="Erreur lors du chargement"
-        />
-      )}
-      {data && tableData.length === 0 && (
-        <p className="tw-mt-24 tw-text-xl tw-mb-4 tw-text-center">
-          Aucun import n'a encore été réalisé pour cet établissement
-        </p>
-      )}
-      {data && tableData.length > 0 && (
-        <div>
-          <Table
-            bordered
-            fixed
-            caption="Historique des imports par entreprise"
-            data={tableData}
-            headers={HEADERS}
-          />
-        </div>
-      )}
+
+      <div className="fr-mt-4w">
+        <Tabs
+          selectedTabId={selectedTabId}
+          tabs={[
+            {
+              tabId: "API",
+              label: "Déclaration par API"
+            },
+            {
+              tabId: "FILE",
+              label: "Déclaration par fichiers"
+            }
+          ]}
+          onTabChange={setSelectedTabId}
+        >
+          <StatsTab source={selectedTabId as "API" | "FILE"} siret={siret} />
+        </Tabs>
+      </div>
     </div>
   );
 }

--- a/front/src/dashboard/registry/MyImports.tsx
+++ b/front/src/dashboard/registry/MyImports.tsx
@@ -19,11 +19,11 @@ import { ImportModal } from "./ImportModal";
 import {
   badges,
   downloadFromSignedUrl,
+  formatStats,
   GET_REGISTRY_IMPORTS,
   REGISTRY_DOWNLOAD_SIGNED_URL,
   TYPES
 } from "./shared";
-import { pluralize } from "@td/constants";
 
 const HEADERS = [
   "Importé le",
@@ -92,57 +92,9 @@ export function MyImports() {
         0 &&
       ![RegistryImportStatus.Pending, RegistryImportStatus.Started].includes(
         importData.node.status
-      ) ? (
-        "Fichier d'import vide"
-      ) : (
-        <ul>
-          {importData.node.numberOfErrors > 0 && (
-            <li>
-              <strong>{importData.node.numberOfErrors} en erreur</strong>
-            </li>
-          )}
-          {importData.node.numberOfInsertions > 0 && (
-            <li>
-              {importData.node.numberOfInsertions}{" "}
-              {pluralize(
-                "ajoutée",
-                importData.node.numberOfInsertions,
-                "ajoutées"
-              )}
-            </li>
-          )}
-          {importData.node.numberOfEdits > 0 && (
-            <li>
-              {importData.node.numberOfEdits}{" "}
-              {pluralize(
-                "modifiée",
-                importData.node.numberOfEdits,
-                "modifiées"
-              )}
-            </li>
-          )}
-          {importData.node.numberOfCancellations > 0 && (
-            <li>
-              {importData.node.numberOfCancellations}{" "}
-              {pluralize(
-                "annulée",
-                importData.node.numberOfCancellations,
-                "annulées"
-              )}
-            </li>
-          )}
-          {importData.node.numberOfSkipped > 0 && (
-            <li>
-              {importData.node.numberOfSkipped}{" "}
-              {pluralize(
-                "ignorée",
-                importData.node.numberOfSkipped,
-                "ignorées"
-              )}
-            </li>
-          )}
-        </ul>
-      ),
+      )
+        ? "Fichier d'import vide"
+        : formatStats(importData.node),
       importData.node.associations
         .map(
           association =>

--- a/front/src/dashboard/registry/companyImport/ChangeAggregatesTable.tsx
+++ b/front/src/dashboard/registry/companyImport/ChangeAggregatesTable.tsx
@@ -2,7 +2,7 @@ import { Table } from "@codegouvfr/react-dsfr/Table";
 import { ChangeAggregate } from "@td/codegen-ui";
 import { format } from "date-fns";
 import React from "react";
-import { TYPES, formatStats } from "../shared";
+import { TYPES, badges, formatStats, getStatusFromStats } from "../shared";
 
 type Props = { aggregates: ChangeAggregate[]; siret: string };
 
@@ -14,7 +14,10 @@ export function ChangeAggregatesTable({ aggregates, siret }: Props) {
   }
 
   const tableData = aggregates.map(aggregate => [
-    format(new Date(aggregate.createdAt), "dd/MM/yyyy HH'h'mm"),
+    <div>
+      <div>{format(new Date(aggregate.createdAt), "dd/MM/yyyy HH'h'mm")}</div>
+      {badges[getStatusFromStats(aggregate)]("import")}
+    </div>,
     TYPES[aggregate.type],
     formatStats(aggregate),
     <div>

--- a/front/src/dashboard/registry/companyImport/ChangeAggregatesTable.tsx
+++ b/front/src/dashboard/registry/companyImport/ChangeAggregatesTable.tsx
@@ -1,0 +1,41 @@
+import { Table } from "@codegouvfr/react-dsfr/Table";
+import { ChangeAggregate } from "@td/codegen-ui";
+import { format } from "date-fns";
+import React from "react";
+import { TYPES, formatStats } from "../shared";
+
+type Props = { aggregates: ChangeAggregate[]; siret: string };
+
+const HEADERS = ["Date", "Import", "Déclarations", "Déclaré par"];
+
+export function ChangeAggregatesTable({ aggregates, siret }: Props) {
+  if (!aggregates.length) {
+    return null;
+  }
+
+  const tableData = aggregates.map(aggregate => [
+    format(new Date(aggregate.createdAt), "dd/MM/yyyy HH'h'mm"),
+    TYPES[aggregate.type],
+    formatStats(aggregate),
+    <div>
+      <p>{aggregate.createdBy.name}</p>
+      {siret !== aggregate.reportAs.siret && (
+        <p>
+          {aggregate.reportAs.name} {aggregate.reportAs.siret}
+        </p>
+      )}
+    </div>
+  ]);
+
+  return (
+    <div>
+      <Table
+        bordered
+        fixed
+        caption="Déclarations par API"
+        data={tableData}
+        headers={HEADERS}
+      />
+    </div>
+  );
+}

--- a/front/src/dashboard/registry/companyImport/FileImportsTable.tsx
+++ b/front/src/dashboard/registry/companyImport/FileImportsTable.tsx
@@ -1,0 +1,164 @@
+import { useLazyQuery, useQuery } from "@apollo/client";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Download from "@codegouvfr/react-dsfr/Download";
+import Table from "@codegouvfr/react-dsfr/Table";
+import {
+  Query,
+  QueryRegistryDownloadSignedUrlArgs,
+  RegistryDownloadTarget
+} from "@td/codegen-ui";
+import { pluralize } from "@td/constants";
+import { format } from "date-fns";
+import React from "react";
+import { InlineLoader } from "../../../Apps/common/Components/Loader/Loaders";
+import {
+  GET_REGISTRY_IMPORTS,
+  REGISTRY_DOWNLOAD_SIGNED_URL,
+  TYPES,
+  badges,
+  downloadFromSignedUrl
+} from "../shared";
+
+type Props = { siret: string };
+
+const HEADERS = [
+  "Date",
+  "Import",
+  "Déclaration",
+  "Déclaré par",
+  "Fichier importé",
+  "Rapport d'erreur"
+];
+
+export function FileImportsTable({ siret }: Props) {
+  const { loading, error, data } = useQuery<Pick<Query, "registryImports">>(
+    GET_REGISTRY_IMPORTS,
+    { variables: { siret, first: 25 }, skip: !siret }
+  );
+
+  const [getDownloadLink] = useLazyQuery<
+    Pick<Query, "registryDownloadSignedUrl">,
+    Partial<QueryRegistryDownloadSignedUrlArgs>
+  >(REGISTRY_DOWNLOAD_SIGNED_URL);
+
+  async function downloadErrorFile(importId: string) {
+    const link = await getDownloadLink({
+      variables: { importId, target: RegistryDownloadTarget.ErrorFile }
+    });
+    downloadFromSignedUrl(link.data?.registryDownloadSignedUrl.signedUrl);
+  }
+  async function downloadImportFile(importId: string) {
+    const link = await getDownloadLink({
+      variables: { importId, target: RegistryDownloadTarget.ImportFile }
+    });
+    downloadFromSignedUrl(link.data?.registryDownloadSignedUrl.signedUrl);
+  }
+
+  const tableData =
+    data?.registryImports.edges.map(importData => [
+      format(new Date(importData.node.createdAt), "dd/MM/yyyy HH'h'mm"),
+      <div>
+        {badges[importData.node.status]("import")}
+        <div>{TYPES[importData.node.type]}</div>
+      </div>,
+      <ul>
+        {importData.node.numberOfErrors > 0 && (
+          <li>
+            <strong>{importData.node.numberOfErrors} en erreur</strong>
+          </li>
+        )}
+        {importData.node.numberOfInsertions > 0 && (
+          <li>
+            {importData.node.numberOfInsertions}{" "}
+            {pluralize(
+              "ajoutée",
+              importData.node.numberOfInsertions,
+              "ajoutées"
+            )}
+          </li>
+        )}
+        {importData.node.numberOfEdits > 0 && (
+          <li>
+            {importData.node.numberOfEdits}{" "}
+            {pluralize("modifiée", importData.node.numberOfEdits, "modifiées")}
+          </li>
+        )}
+        {importData.node.numberOfCancellations > 0 && (
+          <li>
+            {importData.node.numberOfCancellations}{" "}
+            {pluralize(
+              "annulée",
+              importData.node.numberOfCancellations,
+              "annulées"
+            )}
+          </li>
+        )}
+        {importData.node.numberOfSkipped > 0 && (
+          <li>
+            {importData.node.numberOfSkipped}{" "}
+            {pluralize("ignorée", importData.node.numberOfSkipped, "ignorées")}
+          </li>
+        )}
+      </ul>,
+      importData.node.createdBy.name,
+      <div className="tw-flex">
+        <Download
+          details={(
+            importData.node.originalFileName.split(".").pop() ?? ""
+          ).toUpperCase()}
+          label={importData.node.originalFileName
+            .split(".")
+            .slice(0, -1)
+            .join(".")}
+          linkProps={{
+            href: "#",
+            onClick: e => {
+              e.preventDefault();
+              downloadImportFile(importData.node.id);
+            }
+          }}
+        />
+      </div>,
+      <div className="tw-flex tw-justify-center">
+        {importData.node.numberOfErrors > 0 && (
+          <Button
+            title="Voir le rapport d'erreur"
+            priority="secondary"
+            iconId="fr-icon-download-line"
+            onClick={() => downloadErrorFile(importData.node.id)}
+            size="small"
+          />
+        )}
+      </div>
+    ]) ?? [];
+  return (
+    <div>
+      {loading && <InlineLoader />}
+      {error && (
+        <Alert
+          closable
+          description={error.message}
+          severity="error"
+          title="Erreur lors du chargement"
+        />
+      )}
+      {data && tableData.length === 0 && (
+        <p className="tw-mt-24 tw-text-xl tw-mb-4 tw-text-center">
+          Aucun import n'a encore été réalisé pour cet établissement
+        </p>
+      )}
+      {data && tableData.length > 0 && (
+        <div>
+          <Table
+            bordered
+            fixed
+            caption="Déclarations par fichiers"
+            data={tableData}
+            headers={HEADERS}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/dashboard/registry/companyImport/Stat.tsx
+++ b/front/src/dashboard/registry/companyImport/Stat.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+type Props = { value: number | undefined; label: string };
+
+export function Stat({ value, label }: Props) {
+  return (
+    <div className="tw-flex tw-flex-col fr-m-2w">
+      <span className="tw-text-4xl tw-font-bold">{value ?? 0}</span>
+      <span className="fr-mt-1w fr-text--md">{label}</span>
+    </div>
+  );
+}

--- a/front/src/dashboard/registry/companyImport/StatsTab.tsx
+++ b/front/src/dashboard/registry/companyImport/StatsTab.tsx
@@ -49,6 +49,14 @@ export function StatsTab({ source, siret }: Props) {
           aggregate.type === RegistryImportType.OutgoingTexs
             ? sum.outgoingTexs + aggregate.numberOfInsertions
             : sum.outgoingTexs,
+        transported:
+          aggregate.type === RegistryImportType.Transported
+            ? sum.transported + aggregate.numberOfInsertions
+            : sum.transported,
+        managed:
+          aggregate.type === RegistryImportType.Managed
+            ? sum.managed + aggregate.numberOfInsertions
+            : sum.managed,
         inserted: sum.inserted + aggregate.numberOfInsertions,
         edited: sum.edited + aggregate.numberOfEdits,
         cancelled: sum.cancelled + aggregate.numberOfCancellations
@@ -62,7 +70,9 @@ export function StatsTab({ source, siret }: Props) {
       incomingWaste: 0,
       outgoingWaste: 0,
       incomingTexs: 0,
-      outgoingTexs: 0
+      outgoingTexs: 0,
+      transported: 0,
+      managed: 0
     }
   );
 
@@ -123,6 +133,8 @@ export function StatsTab({ source, siret }: Props) {
             <Stat value={stats?.outgoingWaste} label="D(N)D sortants" />
             <Stat value={stats?.incomingTexs} label="TEXS entrants" />
             <Stat value={stats?.outgoingTexs} label="TEXS sortants" />
+            <Stat value={stats?.transported} label="Transportés" />
+            <Stat value={stats?.managed} label="Managés" />
           </div>
         </div>
       </CallOut>

--- a/front/src/dashboard/registry/companyImport/StatsTab.tsx
+++ b/front/src/dashboard/registry/companyImport/StatsTab.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from "@apollo/client";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import { CallOut } from "@codegouvfr/react-dsfr/CallOut";
+import { SegmentedControl } from "@codegouvfr/react-dsfr/SegmentedControl";
+import { Query, RegistryImportType } from "@td/codegen-ui";
+import { format, subDays } from "date-fns";
+import React, { useState } from "react";
+import { InlineLoader } from "../../../Apps/common/Components/Loader/Loaders";
+import { GET_CHANGE_AGGREGATES } from "../shared";
+import { Stat } from "./Stat";
+import { FileImportsTable } from "./FileImportsTable";
+import { ChangeAggregatesTable } from "./ChangeAggregatesTable";
+
+type Props = { source: "API" | "FILE"; siret: string | undefined };
+
+export function StatsTab({ source, siret }: Props) {
+  const [window, setWindow] = useState(1);
+
+  const { loading, error, data } = useQuery<
+    Pick<Query, "registryChangeAggregates">
+  >(GET_CHANGE_AGGREGATES, {
+    variables: {
+      siret,
+      window,
+      source
+    }
+  });
+
+  const stats = data?.registryChangeAggregates?.reduce(
+    (sum, aggregate) => {
+      return {
+        ssd:
+          aggregate.type === RegistryImportType.Ssd
+            ? sum.ssd + aggregate.numberOfInsertions
+            : sum.ssd,
+        incomingWaste:
+          aggregate.type === RegistryImportType.IncomingWaste
+            ? sum.incomingWaste + aggregate.numberOfInsertions
+            : sum.incomingWaste,
+        outgoingWaste:
+          aggregate.type === RegistryImportType.OutgoingWaste
+            ? sum.outgoingWaste + aggregate.numberOfInsertions
+            : sum.outgoingWaste,
+        incomingTexs:
+          aggregate.type === RegistryImportType.IncomingTexs
+            ? sum.incomingTexs + aggregate.numberOfInsertions
+            : sum.incomingTexs,
+        outgoingTexs:
+          aggregate.type === RegistryImportType.OutgoingTexs
+            ? sum.outgoingTexs + aggregate.numberOfInsertions
+            : sum.outgoingTexs,
+        inserted: sum.inserted + aggregate.numberOfInsertions,
+        edited: sum.edited + aggregate.numberOfEdits,
+        cancelled: sum.cancelled + aggregate.numberOfCancellations
+      };
+    },
+    {
+      inserted: 0,
+      edited: 0,
+      cancelled: 0,
+      ssd: 0,
+      incomingWaste: 0,
+      outgoingWaste: 0,
+      incomingTexs: 0,
+      outgoingTexs: 0
+    }
+  );
+
+  return (
+    <div>
+      <CallOut title="">
+        <SegmentedControl
+          legend="Statistiques des déclarations par API"
+          hintText={generatePeriodText(window)}
+          segments={[
+            {
+              label: "24 heures",
+              iconId: "fr-icon-calendar-event-line",
+              nativeInputProps: {
+                defaultChecked: true,
+                value: 1,
+                onChange: v => setWindow(parseInt(v.currentTarget.value, 10))
+              }
+            },
+            {
+              label: "7 jours",
+              iconId: "fr-icon-calendar-event-line",
+              nativeInputProps: {
+                value: 7,
+                onChange: v => setWindow(parseInt(v.currentTarget.value, 10))
+              }
+            },
+            {
+              label: "30 jours",
+              iconId: "fr-icon-calendar-event-line",
+              nativeInputProps: {
+                value: 30,
+                onChange: v => setWindow(parseInt(v.currentTarget.value, 10))
+              }
+            }
+          ]}
+        />
+
+        <div className="fr-mt-3w">
+          {loading && <InlineLoader />}
+          {error && (
+            <Alert
+              closable
+              description={error.message}
+              severity="error"
+              title="Erreur lors du chargement"
+            />
+          )}
+
+          <div className="tw-flex">
+            <Stat value={stats?.inserted} label="Nouvelles" />
+            <Stat value={stats?.edited} label="Corrigées" />
+            <Stat value={stats?.cancelled} label="Annulées" />
+          </div>
+          <div className="tw-flex">
+            <Stat value={stats?.ssd} label="SSD" />
+            <Stat value={stats?.incomingWaste} label="D(N)D entrants" />
+            <Stat value={stats?.outgoingWaste} label="D(N)D sortants" />
+            <Stat value={stats?.incomingTexs} label="TEXS entrants" />
+            <Stat value={stats?.outgoingTexs} label="TEXS sortants" />
+          </div>
+        </div>
+      </CallOut>
+
+      {siret && source === "FILE" && <FileImportsTable siret={siret} />}
+
+      {siret && data?.registryChangeAggregates && source === "API" && (
+        <ChangeAggregatesTable
+          aggregates={data.registryChangeAggregates}
+          siret={siret}
+        />
+      )}
+    </div>
+  );
+}
+
+function generatePeriodText(window: number) {
+  const now = new Date();
+  const startDate = subDays(now, window);
+
+  const formattedStartDate = format(startDate, "dd/MM/yyyy HH:mm");
+  const formattedEndDate = format(now, "dd/MM/yyyy HH:mm");
+
+  return `Période : du ${formattedStartDate} au ${formattedEndDate}`;
+}

--- a/front/src/dashboard/registry/shared.tsx
+++ b/front/src/dashboard/registry/shared.tsx
@@ -1,5 +1,6 @@
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import { RegistryImportType } from "@td/codegen-ui";
+import { pluralize } from "@td/constants";
 import gql from "graphql-tag";
 import React from "react";
 
@@ -209,3 +210,78 @@ export const GET_MY_COMPANIES_WITH_DELEGATORS = gql`
     }
   }
 `;
+
+export const GET_CHANGE_AGGREGATES = gql`
+  query RegistryChangeAggregates(
+    $siret: String!
+    $window: Int!
+    $source: RegistryImportSource!
+  ) {
+    registryChangeAggregates(siret: $siret, window: $window, source: $source) {
+      id
+      createdAt
+      updatedAt
+      type
+      source
+      createdBy {
+        name
+      }
+      reportAs {
+        name
+        siret
+      }
+      numberOfAggregates
+      numberOfErrors
+      numberOfInsertions
+      numberOfEdits
+      numberOfCancellations
+      numberOfSkipped
+    }
+  }
+`;
+
+export function formatStats({
+  numberOfErrors,
+  numberOfInsertions,
+  numberOfEdits,
+  numberOfCancellations,
+  numberOfSkipped
+}: {
+  numberOfErrors: number;
+  numberOfInsertions: number;
+  numberOfEdits: number;
+  numberOfCancellations: number;
+  numberOfSkipped: number;
+}) {
+  return (
+    <ul>
+      {numberOfErrors > 0 && (
+        <li>
+          <strong>{numberOfErrors} en erreur</strong>
+        </li>
+      )}
+      {numberOfInsertions > 0 && (
+        <li>
+          {numberOfInsertions}{" "}
+          {pluralize("ajoutée", numberOfInsertions, "ajoutées")}
+        </li>
+      )}
+      {numberOfEdits > 0 && (
+        <li>
+          {numberOfEdits} {pluralize("modifiée", numberOfEdits, "modifiées")}
+        </li>
+      )}
+      {numberOfCancellations > 0 && (
+        <li>
+          {numberOfCancellations}{" "}
+          {pluralize("annulée", numberOfCancellations, "annulées")}
+        </li>
+      )}
+      {numberOfSkipped > 0 && (
+        <li>
+          {numberOfSkipped} {pluralize("ignorée", numberOfSkipped, "ignorées")}
+        </li>
+      )}
+    </ul>
+  );
+}

--- a/front/src/dashboard/registry/shared.tsx
+++ b/front/src/dashboard/registry/shared.tsx
@@ -1,5 +1,5 @@
 import Badge from "@codegouvfr/react-dsfr/Badge";
-import { RegistryImportType } from "@td/codegen-ui";
+import { RegistryImportStatus, RegistryImportType } from "@td/codegen-ui";
 import { pluralize } from "@td/constants";
 import gql from "graphql-tag";
 import React from "react";
@@ -262,8 +262,10 @@ export function formatStats({
       )}
       {numberOfInsertions > 0 && (
         <li>
-          {numberOfInsertions}{" "}
-          {pluralize("ajoutée", numberOfInsertions, "ajoutées")}
+          <strong>
+            {numberOfInsertions}{" "}
+            {pluralize("ajoutée", numberOfInsertions, "ajoutées")}
+          </strong>
         </li>
       )}
       {numberOfEdits > 0 && (
@@ -284,4 +286,35 @@ export function formatStats({
       )}
     </ul>
   );
+}
+
+export function getStatusFromStats({
+  numberOfErrors,
+  numberOfInsertions,
+  numberOfEdits,
+  numberOfCancellations,
+  numberOfSkipped
+}: {
+  numberOfErrors: number;
+  numberOfInsertions: number;
+  numberOfEdits: number;
+  numberOfCancellations: number;
+  numberOfSkipped: number;
+}): RegistryImportStatus {
+  if (
+    numberOfCancellations +
+      numberOfEdits +
+      numberOfInsertions +
+      numberOfSkipped ===
+    0
+  ) {
+    // No data was processed. Mark the import as failed
+    return RegistryImportStatus.Failed;
+  }
+
+  if (numberOfErrors) {
+    return RegistryImportStatus.PartiallySuccessful;
+  }
+
+  return RegistryImportStatus.Successful;
 }

--- a/libs/back/prisma/src/migrations/20250225142741_registry_add_change_aggregates/migration.sql
+++ b/libs/back/prisma/src/migrations/20250225142741_registry_add_change_aggregates/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "RegistrySource" AS ENUM ('FILE', 'API');
+
+-- CreateTable
+CREATE TABLE "RegistryChangeAggregate" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(6) NOT NULL,
+    "type" "RegistryImportType" NOT NULL,
+    "source" "RegistrySource" NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "reportForId" TEXT NOT NULL,
+    "reportAsId" TEXT,
+    "numberOfAggregates" INTEGER NOT NULL DEFAULT 1,
+    "numberOfErrors" INTEGER NOT NULL DEFAULT 0,
+    "numberOfInsertions" INTEGER NOT NULL DEFAULT 0,
+    "numberOfEdits" INTEGER NOT NULL DEFAULT 0,
+    "numberOfCancellations" INTEGER NOT NULL DEFAULT 0,
+    "numberOfSkipped" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "RegistryChangeAggregate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "_RRegistryChangeAggregateReportForIdIdx" ON "RegistryChangeAggregate"("reportForId");
+
+-- CreateIndex
+CREATE INDEX "_RRegistryChangeAggregateUpdatedAtIdx" ON "RegistryChangeAggregate"("updatedAt");
+
+-- AddForeignKey
+ALTER TABLE "RegistryChangeAggregate" ADD CONSTRAINT "RegistryChangeAggregate_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RegistryChangeAggregate" ADD CONSTRAINT "RegistryChangeAggregate_reportForId_fkey" FOREIGN KEY ("reportForId") REFERENCES "Company"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RegistryChangeAggregate" ADD CONSTRAINT "RegistryChangeAggregate_reportAsId_fkey" FOREIGN KEY ("reportAsId") REFERENCES "Company"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/libs/back/prisma/src/schema/registry.prisma
+++ b/libs/back/prisma/src/schema/registry.prisma
@@ -948,3 +948,30 @@ model RegistryLookup {
     @@index([wasteType], map: "_RegistryLookupWasteTypeIdx")
     @@index([wasteCode], map: "_RegistryLookupWasteCodeIdx")
 }
+
+enum RegistrySource {
+  FILE
+  API
+}
+
+model RegistryChangeAggregate {
+    id        String             @id @default(cuid())
+    createdAt DateTime           @default(now()) @db.Timestamptz(6)
+    updatedAt DateTime           @updatedAt @db.Timestamptz(6)
+    type      RegistryImportType
+    source    RegistrySource
+
+    createdById String
+    createdBy   User   @relation(fields: [createdById], references: [id])
+
+    companyId String
+    company   Company @relation(fields: [companyId], references: [id])
+
+    numberOfAggregates Int @default(1)
+
+    numberOfErrors        Int @default(0)
+    numberOfInsertions    Int @default(0)
+    numberOfEdits         Int @default(0)
+    numberOfCancellations Int @default(0)
+    numberOfSkipped       Int @default(0)
+}

--- a/libs/back/prisma/src/schema/registry.prisma
+++ b/libs/back/prisma/src/schema/registry.prisma
@@ -950,8 +950,8 @@ model RegistryLookup {
 }
 
 enum RegistrySource {
-  FILE
-  API
+    FILE
+    API
 }
 
 model RegistryChangeAggregate {
@@ -964,8 +964,11 @@ model RegistryChangeAggregate {
     createdById String
     createdBy   User   @relation(fields: [createdById], references: [id])
 
-    companyId String
-    company   Company @relation(fields: [companyId], references: [id])
+    reportForId String
+    reportFor   Company @relation("RegistryChangeAggregatesReportedFor", fields: [reportForId], references: [id])
+
+    reportAsId String?
+    reportAs   Company? @relation("RegistryChangeAggregatesReportedAs", fields: [reportAsId], references: [id])
 
     numberOfAggregates Int @default(1)
 
@@ -974,4 +977,7 @@ model RegistryChangeAggregate {
     numberOfEdits         Int @default(0)
     numberOfCancellations Int @default(0)
     numberOfSkipped       Int @default(0)
+
+    @@index([reportForId], map: "_RRegistryChangeAggregateReportForIdIdx")
+    @@index([updatedAt], map: "_RRegistryChangeAggregateUpdatedAtIdx")
 }

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -316,6 +316,8 @@ model Company {
 
   delegatorRegistryDelegations RegistryDelegation[] @relation("RegistryDelegationDelegator")
   delegateRegistryDelegations  RegistryDelegation[] @relation("RegistryDelegationDelegate")
+  
+  registryChangeAggregates RegistryChangeAggregate[]
 
   @@index([name], map: "_CompanyNameIdx")
   @@index([givenName], map: "_CompanyGivenNameIdx")
@@ -937,6 +939,7 @@ model User {
   registryTransported        RegistryTransported[]
   registryManaged            RegistryManaged[]
   registryExports            RegistryExport[]
+  registryChangeAggregates   RegistryChangeAggregate[]
 }
 
 enum GovernmentPermission {

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -317,7 +317,8 @@ model Company {
   delegatorRegistryDelegations RegistryDelegation[] @relation("RegistryDelegationDelegator")
   delegateRegistryDelegations  RegistryDelegation[] @relation("RegistryDelegationDelegate")
   
-  registryChangeAggregates RegistryChangeAggregate[]
+  registryReportedForChangeAggregates RegistryChangeAggregate[] @relation("RegistryChangeAggregatesReportedFor")
+  registryReportedAsChangeAggregates  RegistryChangeAggregate[] @relation("RegistryChangeAggregatesReportedAs")
 
   @@index([name], map: "_CompanyNameIdx")
   @@index([givenName], map: "_CompanyGivenNameIdx")

--- a/libs/back/registry/src/changeAggregates.ts
+++ b/libs/back/registry/src/changeAggregates.ts
@@ -1,0 +1,173 @@
+import { RegistryImportType, RegistrySource } from "@prisma/client";
+import { prisma } from "@td/prisma";
+import { getCachedCompany } from "./shared/helpers";
+
+export type RegistryChanges = {
+  errors: number;
+  insertions: number;
+  edits: number;
+  cancellations: number;
+  skipped: number;
+};
+
+export type RegistryChangesByCompany = Map<string, RegistryChanges>;
+
+const AGGREGATE_WINDOW = 3 * 60 * 1000;
+
+export function getEmptyChanges(): RegistryChanges {
+  return {
+    errors: 0,
+    insertions: 0,
+    edits: 0,
+    cancellations: 0,
+    skipped: 0
+  };
+}
+
+export function getSumOfChanges(
+  changesByCompany: RegistryChangesByCompany,
+  globalErrorNumber = 0
+) {
+  const globalChanges = getEmptyChanges();
+
+  for (const changes of changesByCompany.values()) {
+    globalChanges.insertions += changes.insertions;
+    globalChanges.edits += changes.edits;
+    globalChanges.cancellations += changes.cancellations;
+    globalChanges.skipped += changes.skipped;
+  }
+
+  globalChanges.errors += globalErrorNumber;
+
+  return globalChanges;
+}
+
+export function incrementLocalChangesForCompany(
+  changesByCompany: RegistryChangesByCompany,
+  {
+    reason,
+    reportForCompanySiret
+  }: {
+    reason: "MODIFIER" | "ANNULER" | "IGNORER" | null | undefined;
+    reportForCompanySiret: string;
+  }
+) {
+  if (!changesByCompany.has(reportForCompanySiret)) {
+    changesByCompany.set(reportForCompanySiret, getEmptyChanges());
+  }
+
+  const companyStats = changesByCompany.get(
+    reportForCompanySiret
+  ) as RegistryChanges;
+
+  switch (reason) {
+    case "MODIFIER":
+      companyStats.edits++;
+      break;
+    case "ANNULER":
+      companyStats.cancellations++;
+      break;
+    case "IGNORER":
+      companyStats.skipped++;
+      break;
+    default:
+      companyStats.insertions++;
+      break;
+  }
+}
+
+export async function saveCompaniesChanges(
+  changesByCompany: RegistryChangesByCompany,
+  {
+    createdById,
+    type,
+    source
+  }: { type: RegistryImportType; source: RegistrySource; createdById: string }
+) {
+  const promises = Array.from(changesByCompany.entries()).map(
+    async ([siret, changes]) => {
+      const company = await getCachedCompany(siret);
+
+      if (!company) {
+        return;
+      }
+
+      await saveRegistryChanges(changes, {
+        createdById,
+        companyId: company.id,
+        type,
+        source
+      });
+    }
+  );
+
+  await Promise.all(promises);
+}
+
+export async function saveRegistryChanges(
+  registryChanges: RegistryChanges,
+  {
+    createdById,
+    companyId,
+    type,
+    source
+  }: {
+    createdById: string;
+    companyId: string;
+    type: RegistryImportType;
+    source: RegistrySource;
+  }
+) {
+  const existingChangeAggregate =
+    await prisma.registryChangeAggregate.findFirst({
+      where: {
+        createdById,
+        companyId,
+        type,
+        source,
+        updatedAt: {
+          gte: new Date(Date.now() - AGGREGATE_WINDOW)
+        }
+      }
+    });
+
+  if (existingChangeAggregate) {
+    return prisma.registryChangeAggregate.update({
+      where: { id: existingChangeAggregate.id },
+      data: {
+        numberOfAggregates: {
+          increment: 1
+        },
+        numberOfErrors: {
+          increment: registryChanges.errors
+        },
+        numberOfInsertions: {
+          increment: registryChanges.insertions
+        },
+        numberOfEdits: {
+          increment: registryChanges.edits
+        },
+        numberOfCancellations: {
+          increment: registryChanges.cancellations
+        },
+        numberOfSkipped: {
+          increment: registryChanges.skipped
+        }
+      }
+    });
+  }
+
+  return prisma.registryChangeAggregate.create({
+    data: {
+      createdById,
+      companyId,
+      type,
+      source,
+      numberOfErrors: registryChanges.errors,
+      numberOfInsertions: registryChanges.insertions,
+      numberOfEdits: registryChanges.edits,
+      numberOfCancellations: registryChanges.cancellations,
+      numberOfSkipped: registryChanges.skipped
+    }
+  });
+}

--- a/libs/back/registry/src/database.ts
+++ b/libs/back/registry/src/database.ts
@@ -1,12 +1,5 @@
 import { prisma } from "@td/prisma";
-
-type ImportStats = {
-  errors: number;
-  insertions: number;
-  edits: number;
-  cancellations: number;
-  skipped: number;
-};
+import type { RegistryChanges } from "./changeAggregates";
 
 export async function startImport(importId: string) {
   const registryImport = await prisma.registryImport.update({
@@ -23,8 +16,8 @@ export async function endImport({
   sirets
 }: {
   importId: string;
-  stats: ImportStats;
   sirets: { for: string; as: string }[];
+  stats: RegistryChanges;
 }) {
   const status = getStatus(stats);
 
@@ -56,7 +49,7 @@ export function updateImportStats({
   stats
 }: {
   importId: string;
-  stats: ImportStats;
+  stats: RegistryChanges;
 }) {
   return prisma.registryImport.update({
     where: { id: importId },
@@ -70,7 +63,7 @@ export function updateImportStats({
   });
 }
 
-function getStatus(stats: ImportStats) {
+function getStatus(stats: RegistryChanges) {
   if (
     stats.cancellations + stats.edits + stats.insertions + stats.skipped ===
     0

--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -42,7 +42,10 @@ export async function processStream({
     { importId, importType, inputStream, fileType }
   );
   const options = importOptions[importType];
-  const changesByCompany = new Map<string, RegistryChanges>();
+  const changesByCompany = new Map<
+    string,
+    { [reportAsSiret: string]: RegistryChanges }
+  >();
   let globalErrorNumber = 0;
 
   const errorStream =
@@ -119,7 +122,8 @@ export async function processStream({
 
       incrementLocalChangesForCompany(changesByCompany, {
         reason,
-        reportForCompanySiret
+        reportForCompanySiret,
+        reportAsCompanySiret: reportAsCompanySiret ?? reportForCompanySiret
       });
 
       const line = { ...result.data, createdById };

--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -164,6 +164,9 @@ export async function processStream({
       sirets
     });
   }
+
+  const stats = getSumOfChanges(changesByCompany, globalErrorNumber);
+  return stats;
 }
 
 function formatErrorMessage(message: string) {

--- a/libs/back/registry/src/index.ts
+++ b/libs/back/registry/src/index.ts
@@ -9,6 +9,7 @@ export {
   exportOptions
 } from "./options";
 export * from "./s3";
+export * from "./changeAggregates";
 
 export { SSD_HEADERS } from "./ssd/constants";
 


### PR DESCRIPTION
# Contexte

Introduction d'un nouvel objet "ChangeAggregate".
L'idée est que ces objets aggrègent le nombre de changements effectués par un utilisateur, sur une compagnie, dans une durée de temps de 5min maximum.

Si des modifications sont faites à la suite, via plusieurs calls API par exemple, et espacés de moins d'1 min, toutes les statistiques des ces appels seront aggrégées dans un unique objet.
Si les appels sont faits avec plus d'1min d'écart entre eux, ou plus de 5min d'écart avec l'appel initial, alors un nouvel objet ChangeAggregate sera créé.

C'est ces nouveaux objets qui sont affichés sur la page statistiques API, et ce sont eux qui nous permettent également de calculer la somme des changements effectués sur un SIRET, par type d'import et source (API / File).

# Démo

![image](https://github.com/user-attachments/assets/5854c514-ba3f-45da-a1c5-a565e80dc0fb)

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB