### PR TITLE
[TRA-15711] Fixes DSFR links CSS

### DIFF
--- a/front/src/Pages/Company/Company.tsx
+++ b/front/src/Pages/Company/Company.tsx
@@ -165,7 +165,10 @@ export default function CompanyInfo() {
                     <p>
                       Il s'agit de votre établissement ? Mettez à jour vos
                       informations en{" "}
-                      <a className="fr-link" href={routes.signup.index}>
+                      <a
+                        className="fr-link force-underline-link"
+                        href={routes.signup.index}
+                      >
                         vous inscrivant
                       </a>
                       .
@@ -222,7 +225,7 @@ export default function CompanyInfo() {
                                 href={agreement}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="fr-link"
+                                className="fr-link force-underline-link force-external-link-content"
                               >
                                 {agreement}
                               </a>
@@ -237,15 +240,16 @@ export default function CompanyInfo() {
                   <div className="fr-container">
                     <p>
                       <span className="fr-notice__title">
-                        Une information vous semble erronée,
+                        Une information vous semble erronée ? Faites-le nous
+                        savoir via
                       </span>
                       <a
                         href="https://faq.trackdechets.fr/pour-aller-plus-loin/assistance"
                         target="_blank"
                         rel="noopener noreferrer external"
-                        className="fr-notice__link"
+                        className="fr-notice__link force-external-link-content force-underline-link"
                       >
-                        faites nous le savoir
+                        le formulaire d'assistance Trackdéchets
                       </a>
                       .
                     </p>

--- a/front/src/scss/index.scss
+++ b/front/src/scss/index.scss
@@ -77,3 +77,15 @@ address {
   white-space: nowrap !important;
   border: 0 !important;
 }
+
+// Cette classe permet de forcer l'affichage du lien externe. L'utilisation de raw-link pour raison de compatibilités avec Tailwind rentrant en conflit avec le DSFR
+.force-external-link-content {
+  &::after {
+    content: "" !important;
+  }
+}
+
+// Cette classe permet de forcer le sous-lignage des liens. L'utilisation de raw-link pour raison de compatibilités avec Tailwind rentrant en conflit avec le DSFR
+.force-underline-link {
+  --underline-img: linear-gradient(0deg, currentColor, currentColor) !important;
+}


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Ajout de deux classes CSS permettant de corriger le conflit entre TW et DSFR au niveau des liens dus à l'utilisation de fr-raw-link. On perd parfois le sous-lignage et l'icône d'ouverture de lien externe. Ces deux classes permettent de corriger ça.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Mettre au DSFR la page Informations sur l'établissement](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15711)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB