### PR TITLE
[TRA_15736] Permettre d'Enregistrer un VHU en brouillon lorsque le Type de conditionnement n'est pas sélectionné et afficher un message d'erreur à la publication si celui-ci est manquant

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Exports registres V2 : Modale d'export et petites améliorations d'UX [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3953)
 - Rendre optionnel les agréments à la publication d'un VHU [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3984)
+- Rendre optionnel le type de conditionnement du Bsvhu en brouillon [PR 3996](https://github.com/MTES-MCT/trackdechets/pull/3996)
 
 # [2025.02.1] 11/02/2025
 

--- a/back/src/bsvhu/resolvers/mutations/__tests__/createDraftBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/createDraftBsvhu.integration.ts
@@ -347,7 +347,7 @@ describe("Mutation.Vhu.createDraft", () => {
     expect(data.createDraftBsvhu.id).toBeTruthy();
   });
 
-  it("should fail when packaging is UNITE and identificationType is null", async () => {
+  it("should succeed when packaging is UNITE and identificationType is null", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const destinationCompany = await companyFactory({
       companyTypes: ["WASTE_VEHICLES"],
@@ -392,7 +392,7 @@ describe("Mutation.Vhu.createDraft", () => {
       }
     };
     const { mutate } = makeClient(user);
-    const { errors } = await mutate<Pick<Mutation, "createDraftBsvhu">>(
+    const { data, errors } = await mutate<Pick<Mutation, "createDraftBsvhu">>(
       CREATE_VHU_FORM,
       {
         variables: {
@@ -401,15 +401,8 @@ describe("Mutation.Vhu.createDraft", () => {
       }
     );
 
-    expect(errors).toEqual([
-      expect.objectContaining({
-        message:
-          "identificationType : Le type d'identification est obligatoire quand le conditionnement est en unité",
-        extensions: expect.objectContaining({
-          code: ErrorCode.BAD_USER_INPUT
-        })
-      })
-    ]);
+    expect(errors).toBeUndefined();
+    expect(data.createDraftBsvhu.id).toBeTruthy();
   });
 
   it.each([

--- a/back/src/bsvhu/resolvers/mutations/__tests__/publishBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/publishBsvhu.integration.ts
@@ -115,4 +115,36 @@ describe("Mutation.Vhu.publish", () => {
       })
     ]);
   });
+
+  it("should fail when packaging is UNITE and identificationType is nullshould pass the form as non draft", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const form = await bsvhuFactory({
+      userId: user.id,
+      opt: {
+        emitterCompanySiret: company.siret,
+        isDraft: true,
+        packaging: "UNITE",
+        identificationType: null
+      }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<Pick<Mutation, "publishBsvhu">>(
+      PUBLISH_VHU_FORM,
+      {
+        variables: { id: form.id }
+      }
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        message:
+          "identificationType : Le type d'identification est obligatoire quand le conditionnement est en unité\n" +
+          "Le type de numéro d'identification est un champ requis.",
+        extensions: expect.objectContaining({
+          code: ErrorCode.BAD_USER_INPUT
+        })
+      })
+    ]);
+  });
 });

--- a/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
+++ b/back/src/bsvhu/resolvers/mutations/__tests__/updateBsvhu.integration.ts
@@ -749,12 +749,12 @@ describe("Mutation.Vhu.update", () => {
     expect(data.updateBsvhu.identification?.type).toEqual(null);
   });
 
-  it("should fail when packaging is UNITE and identificationType is null", async () => {
+  it("should fail when packaging is UNITE and identificationType is null on a published bsvhu", async () => {
     const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
     const bsvhu = await bsvhuFactory({
       userId: user.id,
       opt: {
-        isDraft: true,
+        isDraft: false,
         status: "INITIAL",
         emitterCompanySiret: company.siret
       }
@@ -784,6 +784,34 @@ describe("Mutation.Vhu.update", () => {
         })
       })
     ]);
+  });
+
+  it("should succeed when packaging is UNITE and identificationType is null on a draft bsvhu", async () => {
+    const { company, user } = await userWithCompanyFactory(UserRole.ADMIN);
+    const bsvhu = await bsvhuFactory({
+      userId: user.id,
+      opt: {
+        isDraft: true,
+        status: "INITIAL",
+        emitterCompanySiret: company.siret
+      }
+    });
+    const { mutate } = makeClient(user);
+    const input = {
+      packaging: "UNITE",
+      identification: {
+        numbers: ["123", "456"],
+        type: null
+      }
+    };
+    const { errors } = await mutate<Pick<Mutation, "updateBsvhu">>(
+      UPDATE_VHU_FORM,
+      {
+        variables: { id: bsvhu.id, input }
+      }
+    );
+
+    expect(errors).toBeUndefined();
   });
 
   it("should succeed when packaging is UNITE and identificationType is null on a bsvhu created before release date", async () => {

--- a/back/src/bsvhu/validation/refinements.ts
+++ b/back/src/bsvhu/validation/refinements.ts
@@ -209,8 +209,12 @@ export const checkPackagingAndIdentificationType: Refinement<ParsedZodBsvhu> = (
         "identificationType : Le type d'identification doit être null quand le conditionnement est en lot"
     });
   }
-
-  if (bsvhu.packaging === "UNITE" && !bsvhu.identificationType) {
+  // Must not apply on draft bsvhus
+  if (
+    !bsvhu.isDraft &&
+    bsvhu.packaging === "UNITE" &&
+    !bsvhu.identificationType
+  ) {
     addIssue({
       code: z.ZodIssueCode.custom,
       path: ["identification", "type"],


### PR DESCRIPTION
# Contexte

Permettre d'Enregistrer un VHU en brouillon lorsque le Type de conditionnement n'est pas sélectionné (ce champ doit être rendu requis à la publication et non à l'enregistrement en brouillon

# Points de vigilance pour les intégrateurs
 
Nope

# Démo

 ](https://github.com/user-attachments/assets/3b24ba43-3f60-4fb3-ac96-00b9bb0e3062)

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15736

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB