### PR TITLE
[tra-15459]le clavier virtuel ne doit pas cacher les champs de saisie

### DIFF
--- a/front/src/Apps/common/Components/Modal/Modal.tsx
+++ b/front/src/Apps/common/Components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Overlay, useModalOverlay, useOverlayTrigger } from "react-aria";
 import { useOverlayTriggerState, OverlayTriggerState } from "react-stately";
 import FocusTrap from "focus-trap-react";
@@ -36,9 +36,44 @@ export function Modal({
   const ref = React.useRef(null);
   const { modalProps, underlayProps } = useModalOverlay(props, state, ref);
 
+  const [keyboardOffset, setKeyboardOffset] = useState(0);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.visualViewport) {
+        const viewportHeight = window.visualViewport.height;
+        const screenHeight = window.innerHeight;
+
+        if (viewportHeight < screenHeight) {
+          // Le clavier est ouvert, calcul de l'espace perdu
+          setKeyboardOffset(screenHeight - viewportHeight);
+        } else {
+          // Clavier fermé
+          setKeyboardOffset(0);
+        }
+      }
+    };
+
+    window.visualViewport?.addEventListener("resize", handleResize);
+    window.visualViewport?.addEventListener("scroll", handleResize);
+
+    return () => {
+      window.visualViewport?.removeEventListener("resize", handleResize);
+      window.visualViewport?.removeEventListener("scroll", handleResize);
+    };
+  }, []);
+
   return (
     <Overlay>
-      <div className="tdModalOverlay" {...underlayProps}>
+      <div
+        style={{
+          height: `calc(100vh - ${keyboardOffset}px)`,
+          overflow: "auto",
+          transition: "height 0.05s ease-out"
+        }}
+        className="tdModalOverlay"
+        {...underlayProps}
+      >
         <div className="tdModalInner">
           <div
             className="fr-container fr-container--fluid fr-container-md"


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

- Utilisation de `visualViewport.height` pour détecter la vraie hauteur visible pour le clavier virtuel sur iOS et Android.
- Ajout automatique d'un offset pour compenser la place prise par le clavier :
      - Si le clavier est ouvert, on réduit dynamiquement la hauteur de l'écran.
      - Quand il se ferme, la hauteur redevient normale.

- Aucune modification des inputs nécessaire :
Ça marche peu importe quel input est sélectionné.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/1b4ed413-4163-40ff-8472-1200c6671c59


# Ticket Favro

[tra-15459](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15459)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB