### PR TITLE
[TRA-15970] Enlever la limite des 60 jours pour permettre une correction du "code opération réalisé" par contenant

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Exports registres V2 : Modale d'export et petites améliorations d'UX [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3953)
 - Rendre optionnel les agréments à la publication d'un VHU [PR 3953](https://github.com/MTES-MCT/trackdechets/pull/3984)
+- BSFF : Suppression temporaire de la limite de 60 jours au delà de laquelle il n'était pas possible de corriger les infos d'acceptation et de traitement des contenants BSFF [PR 4001](https://github.com/MTES-MCT/trackdechets/pull/4001)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
@@ -312,7 +312,7 @@ describe("Mutation.updateBsffPackaging", () => {
     }
   );
 
-  test(
+  test.skip(
     "more than 60 days after refusal > " +
       " it should not be possible to update acceptation status",
     async () => {
@@ -505,7 +505,7 @@ describe("Mutation.updateBsffPackaging", () => {
     }
   );
 
-  test(
+  test.skip(
     "more than 60 days after operation >" +
       " it should not be possible to update acceptation and operation fields",
     async () => {

--- a/back/src/bsffs/validation/bsffPackaging/rules.ts
+++ b/back/src/bsffs/validation/bsffPackaging/rules.ts
@@ -9,7 +9,6 @@ import {
   BsffPackagingSignatureType,
   BsffPackagingValidationContext
 } from "./types";
-import { differenceInDays } from "date-fns";
 
 // Specs métier
 // https://docs.google.com/spreadsheets/d/1Uvd04DsmTNiMr4wzpfmS2uLd84i6IzJsgXssxzy_2ns/edit#gid=0
@@ -62,10 +61,7 @@ function isBsffPackagingFieldSealed(bsffPackaging: ZodBsffPackaging) {
     !!lastSignatureDate &&
     // cas particulier : on ne permet pas de modifier un contenant qui est
     // déjà réexpédié, regroupé ou reconditionné
-    !bsffPackaging.nextPackagingId &&
-    // tra-15501 Le destinataire peut modifier les informations du contenant
-    // (acceptation et opération) jusqu'à 60 jours après l'opération ou le refus
-    differenceInDays(new Date(), lastSignatureDate) <= 60
+    !bsffPackaging.nextPackagingId
   ) {
     return false;
   }

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingForm.tsx
@@ -443,9 +443,14 @@ function SignBsffPackagingForm({
       ? "Date de l'acceptation"
       : "Date du refus";
 
-  const today = new Date();
-  const maxDate = datetimeToYYYYMMDD(today);
-  const minDate = datetimeToYYYYMMDD(subMonths(today, 2));
+  const signatureDate = packaging?.operation?.signature?.date
+    ? // Dans le cas d'une correction, on prend la date de signature
+      // de l'opération comme date de référence
+      new Date(packaging.operation.signature.date)
+    : // sinon on prend la date du jour
+      new Date();
+  const maxDate = datetimeToYYYYMMDD(signatureDate);
+  const minDate = datetimeToYYYYMMDD(subMonths(signatureDate, 2));
 
   return (
     <FormProvider {...methods}>

--- a/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
+++ b/front/src/Apps/Dashboard/Signature/bsff/SignBsffPackagingsModal.tsx
@@ -23,7 +23,6 @@ import { BsdStatusCode, TBsdStatusCode } from "../../../common/types/bsdTypes";
 import SignBsffPackagingButton from "./SignBsffPackagingButton";
 import { GET_BSFF } from "./queries";
 import { pluralize } from "@td/constants";
-import { differenceInDays } from "date-fns";
 
 interface SignPackagingsModalProps {
   bsffId: string;
@@ -40,16 +39,10 @@ function getSignBtnLabel(packaging: BsffPackaging): string | null {
       packaging.operation?.signature?.date ??
       packaging.acceptation?.signature?.date;
 
-    if (signatureDate) {
-      // Calcule le nombre de jours depuis la signature du traitement ou du refus
-      const daysOld = differenceInDays(new Date(), new Date(signatureDate));
-
-      if (daysOld <= 60 && !packaging.nextBsff) {
-        // La correction est autorisée pendant un maximum de 60 jours
-        // après la signature de traitement du contenant et tant que le
-        // contenant n'a pas été groupé / réexpédié / reconditionné
-        return "Corriger";
-      }
+    if (signatureDate && !packaging.nextBsff) {
+      // La correction est autorisée tant que le
+      // contenant n'a pas été groupé / réexpédié / reconditionné
+      return "Corriger";
     }
 
     return null;

--- a/front/src/Apps/Dashboard/dashboardServices.test.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.test.ts
@@ -1622,7 +1622,7 @@ describe("dashboardServices", () => {
       expect(result).toBe(false);
     });
 
-    it("should return false if more than 60 days have passed since the last operation", () => {
+    it.skip("should return false if more than 60 days have passed since the last operation", () => {
       const oldDate = new Date();
       oldDate.setDate(oldDate.getDate() - 61);
       const result = canMakeCorrection(

--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -66,7 +66,7 @@ import {
   completer_bsd_suite
 } from "../common/wordings/dashboard/wordingsDashboard";
 import { BsdCurrentTab } from "../common/types/commonTypes";
-import { sub, differenceInDays } from "date-fns";
+import { sub } from "date-fns";
 
 export const getBsdView = (bsd): BsdDisplay | null => {
   const bsdView = formatBsd(bsd);
@@ -1597,21 +1597,6 @@ export const canUpdateBsd = (bsd, siret) =>
 export const canGeneratePdf = bsd => bsd.type === BsdType.Bsff || !bsd.isDraft;
 
 export const canMakeCorrection = (bsd: BsdDisplay, siret: string) => {
-  const lastSignatureDate = () =>
-    (bsd.packagings ?? []).reduce((lastDate, packaging) => {
-      const signatureDate =
-        packaging?.operation?.signature?.date ??
-        packaging?.acceptation?.signature?.date;
-      if (signatureDate) {
-        const date = new Date(signatureDate);
-        if (lastDate) {
-          return date > lastDate ? date : lastDate;
-        }
-        return date;
-      }
-      return lastDate;
-    }, new Date(0));
-
   // On ne permet pas la correction des contenants qui sont
   // déjà inclut dans un bordereau suite
   const haveNextBsff = () =>
@@ -1622,11 +1607,7 @@ export const canMakeCorrection = (bsd: BsdDisplay, siret: string) => {
     isSameSiretDestination(siret, bsd) &&
     (bsd.status === BsdStatusCode.Processed ||
       bsd.status === BsdStatusCode.Refused ||
-      (bsd.status === BsdStatusCode.IntermediatelyProcessed &&
-        !haveNextBsff())) &&
-    // On autorise la correction d'un BSFF pendant 60 jours après
-    // la dernière signature de l'opération sur les contenants
-    differenceInDays(new Date(), lastSignatureDate()) <= 60
+      (bsd.status === BsdStatusCode.IntermediatelyProcessed && !haveNextBsff()))
   );
 };
 


### PR DESCRIPTION
# Contexte


# Démo

#### BSFF avec un seul contenant 

https://github.com/user-attachments/assets/8e49a855-cb63-47e0-8e5f-5f770a594c25

#### BSFF avec plusieurs contenants 

https://github.com/user-attachments/assets/507fa7bf-2faf-4a92-aba0-01a9e42352f4


# Ticket Favro

[ Enlever la limite des 60 jours pour permettre une correction du "code opération réalisé" par contenant](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15970)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB