### PR TITLE
[TRA-15158 | Fix recette] Révision de la quantité refusée sur les BSDD avec entreposage provisoire

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -415,6 +415,11 @@ export function flattenBsddRevisionRequestInput(
         chain(t.temporaryStorer, s => s.quantityReceived)
       )
     ),
+    temporaryStorageTemporaryStorerQuantityRefused: chain(reviewContent, c =>
+      chain(c.temporaryStorageDetail, t =>
+        chain(t.temporaryStorer, s => s.quantityRefused)
+      )
+    ),
     temporaryStorageDestinationProcessingOperation: chain(reviewContent, c =>
       chain(c.temporaryStorageDetail, t =>
         chain(t.destination, d => d.processingOperation)
@@ -1069,7 +1074,9 @@ export function expandBsddRevisionRequestContent(
       nullIfNoValues<FormRevisionRequestTemporaryStorageDetail>({
         temporaryStorer: nullIfNoValues<FormRevisionRequestTemporaryStorer>({
           quantityReceived:
-            bsddRevisionRequest.temporaryStorageTemporaryStorerQuantityReceived
+            bsddRevisionRequest.temporaryStorageTemporaryStorerQuantityReceived,
+          quantityRefused:
+            bsddRevisionRequest.temporaryStorageTemporaryStorerQuantityRefused
         }),
         destination: nullIfNoValues<FormRevisionRequestDestination>({
           cap: bsddRevisionRequest.temporaryStorageDestinationCap,

--- a/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
+++ b/back/src/forms/repository/formRevisionRequest/acceptRevisionRequestApproval.ts
@@ -185,7 +185,9 @@ async function getUpdateFromFormRevisionRequest(
     ...(hasTempStorage
       ? {
           quantityReceived:
-            revisionRequest.temporaryStorageTemporaryStorerQuantityReceived
+            revisionRequest.temporaryStorageTemporaryStorerQuantityReceived,
+          quantityRefused:
+            revisionRequest.temporaryStorageTemporaryStorerQuantityRefused
         }
       : {
           quantityReceived: revisionRequest.quantityReceived,
@@ -223,6 +225,7 @@ async function getUpdateFromFormRevisionRequest(
         recipientProcessingOperation:
           revisionRequest.temporaryStorageDestinationProcessingOperation,
         quantityReceived: revisionRequest.quantityReceived,
+        quantityRefused: revisionRequest.quantityRefused,
         processingOperationDone: revisionRequest.processingOperationDone,
         processingOperationDescription:
           revisionRequest.processingOperationDescription,

--- a/back/src/forms/resolvers/FormRevisionRequest.ts
+++ b/back/src/forms/resolvers/FormRevisionRequest.ts
@@ -88,7 +88,9 @@ const formRevisionRequestResolvers: FormRevisionRequestResolvers = {
             processingOperationDone:
               parent.initialTemporaryStorageDestinationProcessingOperation,
             quantityReceived:
-              parent.initialTemporaryStorageTemporaryStorerQuantityReceived
+              parent.initialTemporaryStorageTemporaryStorerQuantityReceived,
+            quantityRefused:
+              parent.initialTemporaryStorageTemporaryStorerQuantityRefused
           }
         : null,
       ...historicForm

--- a/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createFormRevisionRequest.integration.ts
@@ -2672,6 +2672,70 @@ describe("Mutation.createFormRevisionRequest", () => {
                 quantityRefused: 3
               }
             },
+            quantityReceived: 13
+          }
+        );
+
+        // Then
+        expect(errors).toBeUndefined();
+
+        const revisionRequest =
+          await prisma.bsddRevisionRequest.findFirstOrThrow({
+            where: { bsddId: bsdd.id }
+          });
+
+        expect(
+          revisionRequest.temporaryStorageTemporaryStorerQuantityReceived
+        ).toEqual(16);
+        expect(
+          revisionRequest.temporaryStorageTemporaryStorerQuantityRefused
+        ).toEqual(3);
+
+        expect(revisionRequest.initialQuantityReceived?.toNumber()).toEqual(15);
+        expect(revisionRequest.initialQuantityRefused?.toNumber()).toEqual(5);
+
+        expect(revisionRequest.quantityReceived).toEqual(13);
+        expect(revisionRequest.quantityRefused).toEqual(null);
+
+        expect(
+          revisionRequest.initialTemporaryStorageTemporaryStorerQuantityReceived?.toNumber()
+        ).toEqual(10);
+        expect(
+          revisionRequest.initialTemporaryStorageTemporaryStorerQuantityRefused?.toNumber()
+        ).toEqual(0);
+      });
+
+      it("should be able to review quantities & wasteAcceptationStatus on both temp storage & destination (PARTIALLY_REFUSED then ACCEPTED + quantityRefused defined)", async () => {
+        // Given
+        const { emitter, bsdd, emitterCompany } =
+          await createUserAndTempStoredBSDD(
+            {
+              status: Status.ACCEPTED,
+              wasteAcceptationStatus: WasteAcceptationStatus.PARTIALLY_REFUSED,
+              quantityReceived: 15,
+              quantityRefused: 5,
+              wasteRefusalReason: "Pas bon"
+            },
+            {
+              receivedAt: new Date(),
+              wasteAcceptationStatus: WasteAcceptationStatus.ACCEPTED,
+              quantityReceived: 10,
+              quantityRefused: 0
+            }
+          );
+
+        // When
+        const { errors } = await createRevision(
+          emitter,
+          emitterCompany,
+          bsdd.id,
+          {
+            temporaryStorageDetail: {
+              temporaryStorer: {
+                quantityReceived: 16,
+                quantityRefused: 3
+              }
+            },
             quantityReceived: 13,
             quantityRefused: 0
           }
@@ -2704,6 +2768,70 @@ describe("Mutation.createFormRevisionRequest", () => {
         expect(
           revisionRequest.initialTemporaryStorageTemporaryStorerQuantityRefused?.toNumber()
         ).toEqual(0);
+      });
+
+      it("should be able to review quantities & wasteAcceptationStatus on both temp storage & destination (PARTIALLY_REFUSED then ACCEPTED + quantityRefused defined)", async () => {
+        // Given
+        const { emitter, bsdd, emitterCompany } =
+          await createUserAndTempStoredBSDD(
+            {
+              status: Status.ACCEPTED,
+              wasteAcceptationStatus: WasteAcceptationStatus.ACCEPTED,
+              quantityReceived: 15,
+              quantityRefused: 0
+            },
+            {
+              receivedAt: new Date(),
+              wasteAcceptationStatus: WasteAcceptationStatus.PARTIALLY_REFUSED,
+              quantityReceived: 7.8,
+              quantityRefused: 2.9,
+              wasteRefusalReason: "Pas bon"
+            }
+          );
+
+        // When
+        const { errors } = await createRevision(
+          emitter,
+          emitterCompany,
+          bsdd.id,
+          {
+            temporaryStorageDetail: {
+              temporaryStorer: {
+                quantityReceived: 14
+              }
+            },
+            quantityReceived: 18,
+            quantityRefused: 16
+          }
+        );
+
+        // Then
+        expect(errors).toBeUndefined();
+
+        const revisionRequest =
+          await prisma.bsddRevisionRequest.findFirstOrThrow({
+            where: { bsddId: bsdd.id }
+          });
+
+        expect(
+          revisionRequest.temporaryStorageTemporaryStorerQuantityReceived
+        ).toEqual(14);
+        expect(
+          revisionRequest.temporaryStorageTemporaryStorerQuantityRefused
+        ).toEqual(null);
+
+        expect(revisionRequest.initialQuantityReceived?.toNumber()).toEqual(15);
+        expect(revisionRequest.initialQuantityRefused?.toNumber()).toEqual(0);
+
+        expect(revisionRequest.quantityReceived).toEqual(18);
+        expect(revisionRequest.quantityRefused).toEqual(16);
+
+        expect(
+          revisionRequest.initialTemporaryStorageTemporaryStorerQuantityReceived?.toNumber()
+        ).toEqual(7.8);
+        expect(
+          revisionRequest.initialTemporaryStorageTemporaryStorerQuantityRefused?.toNumber()
+        ).toEqual(2.9);
       });
 
       it("should throw if temp storage reviewed quantites are bad but destination is ok", async () => {

--- a/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/submitFormRevisionRequestApproval.integration.ts
@@ -2219,5 +2219,72 @@ describe("Mutation.submitFormRevisionRequestApproval", () => {
       expect(updatedBsdd.quantityReceived?.toNumber()).toBe(10);
       expect(updatedBsdd.quantityRefused?.toNumber()).toBe(5);
     });
+
+    it("should update quantityReceived & quantityRefused on temp storage BSD", async () => {
+      // Given
+      const { company: companyOfSomeoneElse } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { user: emitter, company: emitterCompany } =
+        await userWithCompanyFactory("ADMIN");
+      const { user: ttr, company: ttrCompany } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+      const { company: exutoireCompany } = await userWithCompanyFactory(
+        "ADMIN"
+      );
+
+      const bsdd = await formWithTempStorageFactory({
+        ownerId: emitter.id,
+        opt: {
+          emitterCompanySiret: emitterCompany.siret,
+          recipientCompanySiret: ttrCompany.siret,
+          status: Status.ACCEPTED,
+          receivedAt: new Date(),
+          wasteAcceptationStatus: WasteAcceptationStatus.PARTIALLY_REFUSED,
+          quantityReceived: 10,
+          quantityRefused: 2
+        },
+        forwardedInOpts: {
+          recipientCompanySiret: exutoireCompany.siret
+        }
+      });
+
+      const revisionRequest = await prisma.bsddRevisionRequest.create({
+        data: {
+          bsddId: bsdd.id,
+          authoringCompanyId: companyOfSomeoneElse.id,
+          approvals: { create: { approverSiret: ttrCompany.siret! } },
+          temporaryStorageTemporaryStorerQuantityReceived: 12,
+          temporaryStorageTemporaryStorerQuantityRefused: 3,
+          comment: "Comment"
+        }
+      });
+
+      // When
+      const { mutate } = makeClient(ttr);
+      const { data, errors } = await mutate<
+        Pick<Mutation, "submitFormRevisionRequestApproval">
+      >(SUBMIT_BSDD_REVISION_REQUEST_APPROVAL, {
+        variables: {
+          id: revisionRequest.id,
+          isApproved: true
+        }
+      });
+
+      // Then
+      expect(errors).toBeUndefined();
+      expect(data.submitFormRevisionRequestApproval.status).toBe("ACCEPTED");
+
+      const updatedBsdd = await prisma.form.findFirstOrThrow({
+        where: { id: bsdd.id }
+      });
+
+      expect(updatedBsdd.wasteAcceptationStatus).toBe(
+        WasteAcceptationStatus.PARTIALLY_REFUSED
+      );
+      expect(updatedBsdd.quantityReceived?.toNumber()).toBe(12);
+      expect(updatedBsdd.quantityRefused?.toNumber()).toBe(3);
+    });
   });
 });

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -49,6 +49,7 @@ import {
 } from "../../../companies/companyProfilesRules";
 import { INVALID_DESTINATION_SUBPROFILE } from "../../errors";
 import { isDefined } from "../../../common/helpers";
+import { FormWithForwardedIn } from "../../types";
 
 // If you modify this, also modify it in the frontend
 export const CANCELLABLE_BSDD_STATUSES: Status[] = [
@@ -276,7 +277,7 @@ async function validateWAsteAccordingToDestination(bsdd: Form, flatContent) {
 }
 async function getFlatContent(
   content: FormRevisionRequestContentInput,
-  bsdd: Form & { transporters: BsddTransporter[] }
+  bsdd: FormWithForwardedIn & { transporters: BsddTransporter[] }
 ): Promise<RevisionRequestContent> {
   const flatContent = flattenBsddRevisionRequestInput(content);
 
@@ -408,7 +409,7 @@ async function getFlatContent(
 }
 
 const getContentToValidate = (
-  bsdd: Form & { transporters: BsddTransporter[] },
+  bsdd: FormWithForwardedIn & { transporters: BsddTransporter[] },
   flatContent: ReturnType<typeof flattenBsddRevisionRequestInput>
 ) => {
   // quantityReceived & quantityRefused sont liées pour la validation, il faut donc
@@ -423,11 +424,15 @@ const getContentToValidate = (
   if (isReviewingQuantities) {
     if (isDefined(flatContent.quantityReceived))
       quantityReceived = flatContent.quantityReceived;
+    else if (isDefined(bsdd.forwardedIn?.quantityReceived))
+      quantityReceived = Number(bsdd.forwardedIn?.quantityReceived);
     else if (isDefined(bsdd.quantityReceived))
       quantityReceived = Number(bsdd.quantityReceived);
 
     if (isDefined(flatContent.quantityRefused))
       quantityRefused = flatContent.quantityRefused;
+    else if (isDefined(bsdd.forwardedIn?.quantityRefused))
+      quantityReceived = Number(bsdd.forwardedIn?.quantityRefused);
     else if (isDefined(bsdd.quantityRefused))
       quantityRefused = Number(bsdd.quantityRefused);
   }

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -36,7 +36,8 @@ import { INVALID_PROCESSING_OPERATION, INVALID_WASTE_CODE } from "../../errors";
 import {
   brokerSchemaFn,
   packagingInfoFn,
-  quantityRefusedNotRequired,
+  revisionRequestQuantityRefused,
+  revisionRequestTempStorageQuantityRefused,
   traderSchemaFn
 } from "../../validation";
 import { ForbiddenError, UserInputError } from "../../../common/errors";
@@ -541,11 +542,10 @@ const bsddRevisionRequestWasteQuantitiesSchema = yup.object({
     .number()
     .min(0)
     .nullable(),
-  temporaryStorageTemporaryStorerQuantityRefused: quantityRefusedNotRequired(
-    "temporaryStorageTemporaryStorerQuantityReceived"
-  ),
+  temporaryStorageTemporaryStorerQuantityRefused:
+    revisionRequestTempStorageQuantityRefused,
   quantityReceived: yup.number().min(0).nullable(),
-  quantityRefused: quantityRefusedNotRequired()
+  quantityRefused: revisionRequestQuantityRefused
 });
 
 async function recipify(
@@ -712,6 +712,8 @@ function getBsddHistory(bsdd: Form & { forwardedIn: Form | null }) {
     initialTemporaryStorageDestinationProcessingOperation:
       bsdd.forwardedIn?.processingOperationDone,
     initialTemporaryStorageTemporaryStorerQuantityReceived:
-      bsdd.forwardedIn?.quantityReceived
+      bsdd.forwardedIn?.quantityReceived,
+    initialTemporaryStorageTemporaryStorerQuantityRefused:
+      bsdd.forwardedIn?.quantityRefused
   };
 }

--- a/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
+++ b/back/src/forms/resolvers/mutations/createFormRevisionRequest.ts
@@ -416,24 +416,53 @@ const getContentToValidate = (
     isDefined(flatContent.quantityReceived) ||
     isDefined(flatContent.quantityRefused);
 
-  if (!isReviewingQuantities) return flatContent;
-
   let quantityReceived: number | null = null;
-  if (isDefined(flatContent.quantityReceived))
-    quantityReceived = flatContent.quantityReceived;
-  else if (isDefined(bsdd.quantityReceived))
-    quantityReceived = Number(bsdd.quantityReceived);
-
   let quantityRefused: number | null = null;
-  if (isDefined(flatContent.quantityRefused))
-    quantityRefused = flatContent.quantityRefused;
-  else if (isDefined(bsdd.quantityRefused))
-    quantityRefused = Number(bsdd.quantityRefused);
+
+  if (isReviewingQuantities) {
+    if (isDefined(flatContent.quantityReceived))
+      quantityReceived = flatContent.quantityReceived;
+    else if (isDefined(bsdd.quantityReceived))
+      quantityReceived = Number(bsdd.quantityReceived);
+
+    if (isDefined(flatContent.quantityRefused))
+      quantityRefused = flatContent.quantityRefused;
+    else if (isDefined(bsdd.quantityRefused))
+      quantityRefused = Number(bsdd.quantityRefused);
+  }
+
+  // Idem for temp storage
+  const isReviewingTempStorageQuantities =
+    isDefined(flatContent.temporaryStorageTemporaryStorerQuantityReceived) ||
+    isDefined(flatContent.temporaryStorageTemporaryStorerQuantityRefused);
+
+  let temporaryStorageTemporaryStorerQuantityReceived: number | null = null;
+  let temporaryStorageTemporaryStorerQuantityRefused: number | null = null;
+
+  if (isReviewingTempStorageQuantities) {
+    if (isDefined(flatContent.temporaryStorageTemporaryStorerQuantityReceived))
+      temporaryStorageTemporaryStorerQuantityReceived =
+        flatContent.temporaryStorageTemporaryStorerQuantityReceived;
+    else if (isDefined(bsdd.quantityReceived))
+      temporaryStorageTemporaryStorerQuantityReceived = Number(
+        bsdd.quantityRefused
+      );
+
+    if (isDefined(flatContent.temporaryStorageTemporaryStorerQuantityRefused))
+      temporaryStorageTemporaryStorerQuantityRefused =
+        flatContent.temporaryStorageTemporaryStorerQuantityRefused;
+    else if (isDefined(bsdd.quantityRefused))
+      temporaryStorageTemporaryStorerQuantityRefused = Number(
+        bsdd.quantityRefused
+      );
+  }
 
   return {
     ...flatContent,
     quantityReceived,
-    quantityRefused
+    quantityRefused,
+    temporaryStorageTemporaryStorerQuantityReceived,
+    temporaryStorageTemporaryStorerQuantityRefused
   };
 };
 
@@ -508,8 +537,15 @@ const bsddRevisionRequestWasteQuantitiesSchema = yup.object({
   //             v => !v
   //           )
   //   ),
+  temporaryStorageTemporaryStorerQuantityReceived: yup
+    .number()
+    .min(0)
+    .nullable(),
+  temporaryStorageTemporaryStorerQuantityRefused: quantityRefusedNotRequired(
+    "temporaryStorageTemporaryStorerQuantityReceived"
+  ),
   quantityReceived: yup.number().min(0).nullable(),
-  quantityRefused: quantityRefusedNotRequired
+  quantityRefused: quantityRefusedNotRequired()
 });
 
 async function recipify(
@@ -606,10 +642,6 @@ const bsddRevisionRequestSchema: yup.SchemaOf<RevisionRequestContent> = yup
       ),
     processingOperationDescription: yup.string().nullable(),
     temporaryStorageDestinationCap: yup.string().nullable(),
-    temporaryStorageTemporaryStorerQuantityReceived: yup
-      .number()
-      .min(0)
-      .nullable(),
     temporaryStorageDestinationProcessingOperation: yup
       .string()
       .oneOf(

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -1060,6 +1060,9 @@ input FormRevisionRequestDestinationInput {
 input FormRevisionRequestTemporaryStorerInput {
   "Quantité reçue sur l'installation d'entreposage provisoire ou de reconditionnement (en tonnes)"
   quantityReceived: Float
+
+  "Quantité refusée sur l'installation d'entreposage provisoire ou de reconditionnement (en tonnes)"
+  quantityRefused: Float
 }
 
 input FormRevisionRequestWhere {

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -869,6 +869,9 @@ type FormRevisionRequestDestination {
 type FormRevisionRequestTemporaryStorer {
   "Quantité reçue sur l'installation d'entreposage provisoire ou de reconditionnement (en tonnes)"
   quantityReceived: Float
+
+  "Quantité refusée par l'installation d'entreposage provisoire ou de reconditionnement (en tonnes)"
+  quantityRefused: Float
 }
 
 type FormRevisionRequestConnection {

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -278,12 +278,12 @@ const getReceptionData = (context: any, isTempStorage = false) => {
     wasteAcceptationStatus:
       context?.forwardedIn?.wasteAcceptationStatus ??
       context?.wasteAcceptationStatus,
-    quantityReceived: isDefined(context?.forwardedIn?.quantityReceived)
-      ? context?.forwardedIn?.quantityReceived
-      : context.quantityReceived,
-    quantityRefused: isDefined(context?.forwardedIn?.quantityReceived)
-      ? context?.forwardedIn?.quantityRefused
-      : context.quantityRefused
+    quantityReceived: isDefined(context?.quantityReceived)
+      ? context?.quantityReceived
+      : context?.forwardedIn?.quantityReceived,
+    quantityRefused: isDefined(context?.quantityReceived)
+      ? context?.quantityRefused
+      : context?.forwardedIn?.quantityRefused
   };
 };
 

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -265,96 +265,107 @@ export const hasPipeline = (value: {
 }): boolean =>
   value.wasteDetailsPackagingInfos?.some(i => i.type === "PIPELINE");
 
-export const quantityRefusedNotRequired = weight(WeightUnits.Tonne)
-  .min(0)
-  .test(
-    "not-defined-if-no-quantity-received",
-    "La quantité refusée (quantityRefused) ne peut être définie si la quantité reçue (quantityReceived) ne l'est pas",
-    (value, context) => {
-      const { quantityReceived } = context.parent;
+export const quantityRefusedNotRequired = (
+  quantityReceivedFieldName:
+    | "temporaryStorageTemporaryStorerQuantityReceived"
+    | "quantityReceived" = "quantityReceived"
+) =>
+  weight(WeightUnits.Tonne)
+    .min(0)
+    .test(
+      "not-defined-if-no-quantity-received",
+      "La quantité refusée (quantityRefused) ne peut être définie si la quantité reçue (quantityReceived) ne l'est pas",
+      (value, context) => {
+        const quantityReceived = context.parent[quantityReceivedFieldName];
 
-      const quantityReceivedIsDefined = isDefined(quantityReceived);
-      const quantityRefusedIsDefined = isDefined(value);
+        const quantityReceivedIsDefined = isDefined(quantityReceived);
+        const quantityRefusedIsDefined = isDefined(value);
 
-      if (!quantityReceivedIsDefined && quantityRefusedIsDefined) return false;
-      return true;
-    }
-  )
-  .test(
-    "waste-is-accepted",
-    "La quantité refusée (quantityRefused) ne peut être supérieure à zéro si le déchet est accepté (ACCEPTED)",
+        if (!quantityReceivedIsDefined && quantityRefusedIsDefined)
+          return false;
+        return true;
+      }
+    )
+    .test(
+      "waste-is-accepted",
+      "La quantité refusée (quantityRefused) ne peut être supérieure à zéro si le déchet est accepté (ACCEPTED)",
+      (value, context) => {
+        const { wasteAcceptationStatus } = context.parent;
+
+        if (wasteAcceptationStatus !== WasteAcceptationStatus.ACCEPTED)
+          return true;
+
+        // Legacy
+        if (value === null || value === undefined) return true;
+
+        return value === 0;
+      }
+    )
+    .test(
+      "waste-is-refused",
+      "La quantité refusée (quantityRefused) doit être égale à la quantité reçue (quantityReceived) si le déchet est refusé (REFUSED)",
+      (value, context) => {
+        const { wasteAcceptationStatus } = context.parent;
+        const quantityReceived = context.parent[quantityReceivedFieldName];
+
+        if (wasteAcceptationStatus !== WasteAcceptationStatus.REFUSED)
+          return true;
+
+        // Legacy
+        if (value === null || value === undefined) return true;
+
+        return value === quantityReceived;
+      }
+    )
+    .test(
+      "waste-is-partially-refused",
+      "La quantité refusée (quantityRefused) doit être inférieure à la quantité reçue (quantityReceived) et supérieure à zéro si le déchet est partiellement refusé (PARTIALLY_REFUSED)",
+      (value, context) => {
+        const { wasteAcceptationStatus } = context.parent;
+        const quantityReceived = context.parent[quantityReceivedFieldName];
+
+        if (wasteAcceptationStatus !== WasteAcceptationStatus.PARTIALLY_REFUSED)
+          return true;
+
+        // Legacy
+        if (value === null || value === undefined) return true;
+
+        return value > 0 && value < quantityReceived;
+      }
+    )
+    .test(
+      "lower-than-quantity-received",
+      "La quantité refusée (quantityRefused) doit être inférieure ou égale à la quantité réceptionnée (quantityReceived)",
+      (value, context) => {
+        const quantityReceived = context.parent[quantityReceivedFieldName];
+
+        if (!isDefined(quantityReceived)) return true;
+
+        // Legacy
+        if (value === null || value === undefined) return true;
+
+        return value <= quantityReceived;
+      }
+    );
+
+export const quantityRefused = (
+  quantityReceivedFieldName = "quantityReceived"
+) =>
+  quantityRefusedNotRequired(quantityReceivedFieldName).test(
+    "quantity-is-required",
+    "La quantité refusée (quantityRefused) est requise",
     (value, context) => {
       const { wasteAcceptationStatus } = context.parent;
 
-      if (wasteAcceptationStatus !== WasteAcceptationStatus.ACCEPTED)
-        return true;
+      // La quantity refusée est obligatoire à l'étape d'acceptation,
+      // donc si wasteAcceptationStatus est renseigné
+      if (isDefined(wasteAcceptationStatus) && !isDefined(value)) {
+        return false;
+      }
 
-      // Legacy
-      if (value === null || value === undefined) return true;
-
-      return value === 0;
-    }
-  )
-  .test(
-    "waste-is-refused",
-    "La quantité refusée (quantityRefused) doit être égale à la quantité reçue (quantityReceived) si le déchet est refusé (REFUSED)",
-    (value, context) => {
-      const { wasteAcceptationStatus, quantityReceived } = context.parent;
-
-      if (wasteAcceptationStatus !== WasteAcceptationStatus.REFUSED)
-        return true;
-
-      // Legacy
-      if (value === null || value === undefined) return true;
-
-      return value === quantityReceived;
-    }
-  )
-  .test(
-    "waste-is-partially-refused",
-    "La quantité refusée (quantityRefused) doit être inférieure à la quantité reçue (quantityReceived) et supérieure à zéro si le déchet est partiellement refusé (PARTIALLY_REFUSED)",
-    (value, context) => {
-      const { wasteAcceptationStatus, quantityReceived } = context.parent;
-
-      if (wasteAcceptationStatus !== WasteAcceptationStatus.PARTIALLY_REFUSED)
-        return true;
-
-      // Legacy
-      if (value === null || value === undefined) return true;
-
-      return value > 0 && value < quantityReceived;
-    }
-  )
-  .test(
-    "lower-than-quantity-received",
-    "La quantité refusée (quantityRefused) doit être inférieure ou égale à la quantité réceptionnée (quantityReceived)",
-    (value, context) => {
-      const { quantityReceived } = context.parent;
-
-      if (!isDefined(quantityReceived)) return true;
-
-      // Legacy
-      if (value === null || value === undefined) return true;
-
-      return value <= quantityReceived;
+      return true;
     }
   );
-
-export const quantityRefused = quantityRefusedNotRequired.test(
-  "quantity-is-required",
-  "La quantité refusée (quantityRefused) est requise",
-  (value, context) => {
-    const { wasteAcceptationStatus } = context.parent;
-
-    // La quantity refusée est obligatoire à l'étape d'acceptation,
-    // donc si wasteAcceptationStatus est renseigné
-    if (isDefined(wasteAcceptationStatus) && !isDefined(value)) {
-      return false;
-    }
-
-    return true;
-  }
-);
 
 // *************************************************************
 // DEFINES VALIDATION SCHEMA FOR INDIVIDUAL FRAMES IN BSD PAGE 1
@@ -1424,7 +1435,7 @@ export const receivedInfoSchema: yup.SchemaOf<ReceivedInfo> = yup.object({
     .label("Réception")
     .when("wasteAcceptationStatus", weightConditions.bsddWasteAcceptationStatus)
     .when("transporters", weightConditions.transporters(WeightUnits.Tonne)),
-  quantityRefused,
+  quantityRefused: quantityRefused(),
   wasteAcceptationStatus: yup
     .mixed<WasteAcceptationStatus>()
     .test(
@@ -1469,7 +1480,7 @@ export const acceptedInfoSchema: yup.SchemaOf<AcceptedInfo> = yup.object({
       "wasteAcceptationStatus",
       weightConditions.bsddWasteAcceptationStatus as any
     ),
-  quantityRefused,
+  quantityRefused: quantityRefused(),
   wasteAcceptationStatus: yup.mixed<WasteAcceptationStatus>().required(),
   wasteRefusalReason: yup
     .string()

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -349,7 +349,9 @@ export const quantityRefusedNotRequired = (
     );
 
 export const quantityRefused = (
-  quantityReceivedFieldName = "quantityReceived"
+  quantityReceivedFieldName:
+    | "temporaryStorageTemporaryStorerQuantityReceived"
+    | "quantityReceived" = "quantityReceived"
 ) =>
   quantityRefusedNotRequired(quantityReceivedFieldName).test(
     "quantity-is-required",

--- a/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
+++ b/front/src/Apps/Dashboard/Components/Revision/revisionMapper.ts
@@ -52,6 +52,7 @@ export enum DataNameEnum {
   QTY_PROCESSED = "Quantité traitée (en tonnes)",
   QTY_PROCESSED_KG = "Quantité traitée (en kg)",
   QTY_RECEIVED_TEMP_STORAGE = "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)",
+  QTY_REFUSED_TEMP_STORAGE = "Quantité refusée par l'installation d'entreposage provisoire ou reconditionnement (tonnes)",
   OPERATION_CODE = "Code d'opération réalisée",
   OPERATION_DONE = "Opération réalisée",
   OPERATION_DONE_DESC = "Description de l'opération réalisée",
@@ -305,6 +306,15 @@ export const mapRevision = (
         dataNewValue:
           review?.content?.temporaryStorageDetail?.temporaryStorer
             ?.quantityReceived
+      },
+      {
+        dataName: DataNameEnum.QTY_REFUSED_TEMP_STORAGE,
+        dataOldValue:
+          review?.[bsdName]?.temporaryStorageDetail?.temporaryStorer
+            ?.quantityRefused,
+        dataNewValue:
+          review?.content?.temporaryStorageDetail?.temporaryStorer
+            ?.quantityRefused
       },
       {
         dataName: DataNameEnum.OPERATION_CODE,

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
@@ -34,6 +34,7 @@ import NonScrollableInput from "../../../../../common/Components/NonScrollableIn
 import RhfBroker from "../../../../../Forms/Components/Broker/RhfBroker";
 import RhfTrader from "../../../../../Forms/Components/Trader/RhfTrader";
 import RhfPackagingList from "../../../../../Forms/Components/PackagingList/RhfPackagingList";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 
 type Props = {
   bsdd: Bsdd;
@@ -119,8 +120,13 @@ export function BsddRequestRevision({ bsdd }: Props) {
   const wasteDetailsCodeInput = register("wasteDetails.code");
 
   const hasBeenReceived = isDefined(bsdd.receivedAt);
+  const hasBeenAccepted = isDefined(bsdd.wasteAcceptationStatus);
+
   const hasBeenTempStoredReceived = isDefined(
     bsdd.temporaryStorageDetail?.temporaryStorer?.receivedAt
+  );
+  const hasBeenTempStoredAccepted = isDefined(
+    bsdd.temporaryStorageDetail?.temporaryStorer?.wasteAcceptationStatus
   );
   const hasBeenProcessed = isDefined(bsdd.processedAt);
 
@@ -222,41 +228,53 @@ export function BsddRequestRevision({ bsdd }: Props) {
                 </RhfReviewableField>
 
                 {hasBeenReceived && (
-                  <>
-                    <RhfReviewableField
-                      title={
-                        !isTempStorage
-                          ? "Quantité reçue"
-                          : "Quantité reçue sur l'installation de destination"
-                      }
-                      path="quantityReceived"
-                      value={bsdd.quantityReceived}
-                      defaultValue={initialBsddReview?.quantityReceived}
-                    >
-                      <NonScrollableInput
-                        label="Poids en tonnes"
-                        className="fr-col-2"
-                        state={errors.quantityReceived && "error"}
-                        stateRelatedMessage={
-                          errors.quantityReceived?.message ?? ""
-                        }
-                        nativeInputProps={{
-                          ...register("quantityReceived", {
-                            valueAsNumber: true
-                          }),
-                          type: "number",
-                          inputMode: "decimal",
-                          step: "0.000001",
-                          min: 0
-                        }}
+                  <RhfReviewableField
+                    title={
+                      !isTempStorage
+                        ? "Quantité reçue"
+                        : "Quantité reçue sur l'installation de destination"
+                    }
+                    path="quantityReceived"
+                    value={bsdd.quantityReceived}
+                    defaultValue={initialBsddReview?.quantityReceived}
+                  >
+                    {bsdd.wasteAcceptationStatus ===
+                      WasteAcceptationStatus.PartiallyRefused && (
+                      <Alert
+                        className="fr-my-2w"
+                        small
+                        description="En cas de refus partiel, la quantité reçue et refusée peuvent être révisées, impactant la quantité traitée: quantité acceptée = quantité reçue - quantité refusée."
+                        severity="info"
                       />
-                      {isDefined(formValues?.quantityReceived) && (
-                        <p className="fr-info-text">
-                          Soit {Number(formValues.quantityReceived) * 1000} kg
-                        </p>
-                      )}
-                    </RhfReviewableField>
+                    )}
+                    <NonScrollableInput
+                      label="Poids en tonnes"
+                      className="fr-col-2"
+                      state={errors.quantityReceived && "error"}
+                      stateRelatedMessage={
+                        errors.quantityReceived?.message ?? ""
+                      }
+                      nativeInputProps={{
+                        ...register("quantityReceived", {
+                          valueAsNumber: true
+                        }),
+                        type: "number",
+                        inputMode: "decimal",
+                        step: "0.000001",
+                        min: 0
+                      }}
+                    />
+                    {isDefined(formValues?.quantityReceived) && (
+                      <p className="fr-info-text">
+                        Soit {Number(formValues.quantityReceived) * 1000} kg
+                      </p>
+                    )}
+                  </RhfReviewableField>
+                )}
 
+                {hasBeenAccepted &&
+                  bsdd.wasteAcceptationStatus ===
+                    WasteAcceptationStatus.PartiallyRefused && (
                     <RhfReviewableField
                       title={
                         !isTempStorage
@@ -265,10 +283,6 @@ export function BsddRequestRevision({ bsdd }: Props) {
                       }
                       path="quantityRefused"
                       value={bsdd.quantityRefused}
-                      disabled={
-                        bsdd.wasteAcceptationStatus ===
-                        WasteAcceptationStatus.Accepted
-                      }
                       defaultValue={initialBsddReview?.quantityRefused}
                     >
                       <NonScrollableInput
@@ -294,61 +308,76 @@ export function BsddRequestRevision({ bsdd }: Props) {
                         </p>
                       )}
                     </RhfReviewableField>
-                  </>
+                  )}
+
+                {isTempStorage && hasBeenTempStoredReceived && (
+                  <RhfReviewableField
+                    title={
+                      "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
+                    }
+                    path="quantityReceived"
+                    value={
+                      bsdd.temporaryStorageDetail?.temporaryStorer
+                        ?.quantityReceived
+                    }
+                    defaultValue={
+                      initialBsddReview.temporaryStorageDetail?.temporaryStorer
+                        ?.quantityReceived
+                    }
+                  >
+                    {bsdd.temporaryStorageDetail?.temporaryStorer
+                      ?.wasteAcceptationStatus ===
+                      WasteAcceptationStatus.PartiallyRefused && (
+                      <Alert
+                        className="fr-my-2w"
+                        small
+                        description="En cas de refus partiel, la quantité reçue et refusée peuvent être révisées, impactant la quantité traitée: quantité acceptée = quantité reçue - quantité refusée."
+                        severity="info"
+                      />
+                    )}
+                    <NonScrollableInput
+                      label="Poids en tonnes"
+                      className="fr-col-2"
+                      state={
+                        errors.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived && "error"
+                      }
+                      stateRelatedMessage={
+                        errors.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived?.message ?? ""
+                      }
+                      nativeInputProps={{
+                        ...register(
+                          "temporaryStorageDetail.temporaryStorer.quantityReceived",
+                          { valueAsNumber: true }
+                        ),
+                        type: "number",
+                        inputMode: "decimal",
+                        step: "0.000001",
+                        min: 0
+                      }}
+                    />
+                    {isDefined(
+                      formValues?.temporaryStorageDetail?.temporaryStorer
+                        ?.quantityReceived
+                    ) && (
+                      <p className="fr-info-text">
+                        Soit{" "}
+                        {Number(
+                          formValues.temporaryStorageDetail.temporaryStorer
+                            .quantityReceived
+                        ) * 1000}{" "}
+                        kg
+                      </p>
+                    )}
+                  </RhfReviewableField>
                 )}
 
-                {isTempStorage && hasBeenTempStoredReceived ? (
-                  <>
-                    <RhfReviewableField
-                      title={
-                        "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
-                      }
-                      path="quantityReceived"
-                      value={
-                        bsdd.temporaryStorageDetail?.temporaryStorer
-                          ?.quantityReceived
-                      }
-                      defaultValue={
-                        initialBsddReview.temporaryStorageDetail
-                          ?.temporaryStorer?.quantityReceived
-                      }
-                    >
-                      <NonScrollableInput
-                        label="Poids en tonnes"
-                        className="fr-col-2"
-                        state={
-                          errors.temporaryStorageDetail?.temporaryStorer
-                            ?.quantityReceived && "error"
-                        }
-                        stateRelatedMessage={
-                          errors.temporaryStorageDetail?.temporaryStorer
-                            ?.quantityReceived?.message ?? ""
-                        }
-                        nativeInputProps={{
-                          ...register(
-                            "temporaryStorageDetail.temporaryStorer.quantityReceived",
-                            { valueAsNumber: true }
-                          ),
-                          type: "number",
-                          inputMode: "decimal",
-                          step: "0.000001",
-                          min: 0
-                        }}
-                      />
-                      {isDefined(
-                        formValues?.temporaryStorageDetail?.temporaryStorer
-                          ?.quantityReceived
-                      ) && (
-                        <p className="fr-info-text">
-                          Soit{" "}
-                          {Number(
-                            formValues.temporaryStorageDetail.temporaryStorer
-                              .quantityReceived
-                          ) * 1000}{" "}
-                          kg
-                        </p>
-                      )}
-                    </RhfReviewableField>
+                {isTempStorage &&
+                  hasBeenTempStoredAccepted &&
+                  bsdd.temporaryStorageDetail?.temporaryStorer
+                    ?.wasteAcceptationStatus ===
+                    WasteAcceptationStatus.PartiallyRefused && (
                     <RhfReviewableField
                       title={
                         "Quantité refusée sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
@@ -358,11 +387,6 @@ export function BsddRequestRevision({ bsdd }: Props) {
                         bsdd.temporaryStorageDetail?.temporaryStorer
                           ?.quantityRefused
                       }
-                      disabled={
-                        bsdd.temporaryStorageDetail?.temporaryStorer
-                          ?.wasteAcceptationStatus ===
-                        WasteAcceptationStatus.Accepted
-                      }
                       defaultValue={
                         initialBsddReview.temporaryStorageDetail
                           ?.temporaryStorer?.quantityRefused
@@ -371,11 +395,6 @@ export function BsddRequestRevision({ bsdd }: Props) {
                       <NonScrollableInput
                         label="Poids en tonnes"
                         className="fr-col-2"
-                        disabled={
-                          bsdd.temporaryStorageDetail?.temporaryStorer
-                            ?.wasteAcceptationStatus ===
-                          WasteAcceptationStatus.Accepted
-                        }
                         state={
                           errors.temporaryStorageDetail?.temporaryStorer
                             ?.quantityRefused && "error"
@@ -409,8 +428,7 @@ export function BsddRequestRevision({ bsdd }: Props) {
                         </p>
                       )}
                     </RhfReviewableField>
-                  </>
-                ) : null}
+                  )}
 
                 {hasBeenProcessed && (
                   <>

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/request/BsddRequestRevision.tsx
@@ -3,7 +3,8 @@ import {
   Form as Bsdd,
   BsdType,
   Mutation,
-  MutationCreateFormRevisionRequestArgs
+  MutationCreateFormRevisionRequestArgs,
+  WasteAcceptationStatus
 } from "@td/codegen-ui";
 import { PROCESSING_AND_REUSE_OPERATIONS } from "@td/constants";
 import React from "react";
@@ -118,6 +119,9 @@ export function BsddRequestRevision({ bsdd }: Props) {
   const wasteDetailsCodeInput = register("wasteDetails.code");
 
   const hasBeenReceived = isDefined(bsdd.receivedAt);
+  const hasBeenTempStoredReceived = isDefined(
+    bsdd.temporaryStorageDetail?.temporaryStorer?.receivedAt
+  );
   const hasBeenProcessed = isDefined(bsdd.processedAt);
 
   return (
@@ -242,10 +246,11 @@ export function BsddRequestRevision({ bsdd }: Props) {
                           }),
                           type: "number",
                           inputMode: "decimal",
-                          step: "0.000001"
+                          step: "0.000001",
+                          min: 0
                         }}
                       />
-                      {formValues?.quantityReceived && (
+                      {isDefined(formValues?.quantityReceived) && (
                         <p className="fr-info-text">
                           Soit {Number(formValues.quantityReceived) * 1000} kg
                         </p>
@@ -260,6 +265,10 @@ export function BsddRequestRevision({ bsdd }: Props) {
                       }
                       path="quantityRefused"
                       value={bsdd.quantityRefused}
+                      disabled={
+                        bsdd.wasteAcceptationStatus ===
+                        WasteAcceptationStatus.Accepted
+                      }
                       defaultValue={initialBsddReview?.quantityRefused}
                     >
                       <NonScrollableInput
@@ -275,10 +284,11 @@ export function BsddRequestRevision({ bsdd }: Props) {
                           }),
                           type: "number",
                           inputMode: "decimal",
-                          step: "0.000001"
+                          step: "0.000001",
+                          min: 0
                         }}
                       />
-                      {formValues?.quantityRefused && (
+                      {isDefined(formValues?.quantityRefused) && (
                         <p className="fr-info-text">
                           Soit {Number(formValues.quantityRefused) * 1000} kg
                         </p>
@@ -287,54 +297,119 @@ export function BsddRequestRevision({ bsdd }: Props) {
                   </>
                 )}
 
-                {isTempStorage && hasBeenReceived ? (
-                  <RhfReviewableField
-                    title={
-                      "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
-                    }
-                    path="quantityReceived"
-                    value={
-                      bsdd.temporaryStorageDetail?.temporaryStorer
-                        ?.quantityReceived
-                    }
-                    defaultValue={
-                      initialBsddReview.temporaryStorageDetail?.temporaryStorer
-                        ?.quantityReceived
-                    }
-                  >
-                    <NonScrollableInput
-                      label="Poids en tonnes"
-                      className="fr-col-2"
-                      state={
-                        errors.temporaryStorageDetail?.temporaryStorer
-                          ?.quantityReceived && "error"
+                {isTempStorage && hasBeenTempStoredReceived ? (
+                  <>
+                    <RhfReviewableField
+                      title={
+                        "Quantité reçue sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
                       }
-                      stateRelatedMessage={
-                        errors.temporaryStorageDetail?.temporaryStorer
-                          ?.quantityReceived?.message ?? ""
+                      path="quantityReceived"
+                      value={
+                        bsdd.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived
                       }
-                      nativeInputProps={{
-                        ...register(
-                          "temporaryStorageDetail.temporaryStorer.quantityReceived",
-                          { valueAsNumber: true }
-                        ),
-                        type: "number",
-                        inputMode: "decimal",
-                        step: "0.000001"
-                      }}
-                    />
-                    {formValues?.temporaryStorageDetail?.temporaryStorer
-                      ?.quantityReceived && (
-                      <p className="fr-info-text">
-                        Soit{" "}
-                        {Number(
-                          formValues.temporaryStorageDetail.temporaryStorer
-                            .quantityReceived
-                        ) * 1000}{" "}
-                        kg
-                      </p>
-                    )}
-                  </RhfReviewableField>
+                      defaultValue={
+                        initialBsddReview.temporaryStorageDetail
+                          ?.temporaryStorer?.quantityReceived
+                      }
+                    >
+                      <NonScrollableInput
+                        label="Poids en tonnes"
+                        className="fr-col-2"
+                        state={
+                          errors.temporaryStorageDetail?.temporaryStorer
+                            ?.quantityReceived && "error"
+                        }
+                        stateRelatedMessage={
+                          errors.temporaryStorageDetail?.temporaryStorer
+                            ?.quantityReceived?.message ?? ""
+                        }
+                        nativeInputProps={{
+                          ...register(
+                            "temporaryStorageDetail.temporaryStorer.quantityReceived",
+                            { valueAsNumber: true }
+                          ),
+                          type: "number",
+                          inputMode: "decimal",
+                          step: "0.000001",
+                          min: 0
+                        }}
+                      />
+                      {isDefined(
+                        formValues?.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityReceived
+                      ) && (
+                        <p className="fr-info-text">
+                          Soit{" "}
+                          {Number(
+                            formValues.temporaryStorageDetail.temporaryStorer
+                              .quantityReceived
+                          ) * 1000}{" "}
+                          kg
+                        </p>
+                      )}
+                    </RhfReviewableField>
+                    <RhfReviewableField
+                      title={
+                        "Quantité refusée sur l'installation d'entreposage provisoire ou reconditionnement (tonnes)"
+                      }
+                      path="quantityRefused"
+                      value={
+                        bsdd.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityRefused
+                      }
+                      disabled={
+                        bsdd.temporaryStorageDetail?.temporaryStorer
+                          ?.wasteAcceptationStatus ===
+                        WasteAcceptationStatus.Accepted
+                      }
+                      defaultValue={
+                        initialBsddReview.temporaryStorageDetail
+                          ?.temporaryStorer?.quantityRefused
+                      }
+                    >
+                      <NonScrollableInput
+                        label="Poids en tonnes"
+                        className="fr-col-2"
+                        disabled={
+                          bsdd.temporaryStorageDetail?.temporaryStorer
+                            ?.wasteAcceptationStatus ===
+                          WasteAcceptationStatus.Accepted
+                        }
+                        state={
+                          errors.temporaryStorageDetail?.temporaryStorer
+                            ?.quantityRefused && "error"
+                        }
+                        stateRelatedMessage={
+                          errors.temporaryStorageDetail?.temporaryStorer
+                            ?.quantityRefused?.message ?? ""
+                        }
+                        nativeInputProps={{
+                          ...register(
+                            "temporaryStorageDetail.temporaryStorer.quantityRefused",
+                            { valueAsNumber: true }
+                          ),
+                          type: "number",
+                          inputMode: "decimal",
+                          step: "0.000001",
+                          min: 0
+                        }}
+                      />
+                      {isDefined(
+                        formValues?.temporaryStorageDetail?.temporaryStorer
+                          ?.quantityRefused
+                      ) && (
+                        <p className="fr-info-text">
+                          Soit{" "}
+                          {Number(
+                            formValues.temporaryStorageDetail.temporaryStorer
+                              .quantityRefused
+                          ) * 1000}{" "}
+                          kg
+                        </p>
+                      )}
+                    </RhfReviewableField>
+                  </>
                 ) : null}
 
                 {hasBeenProcessed && (

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/schema.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/utils/schema.ts
@@ -141,7 +141,8 @@ export const initialBsddReview: BsddRevisionRequestValidationSchema = {
   processingOperationDescription: "",
   temporaryStorageDetail: {
     temporaryStorer: {
-      quantityReceived: null
+      quantityReceived: null,
+      quantityRefused: null
     },
     destination: {
       cap: "",
@@ -229,14 +230,15 @@ export const validationBsddSchema = z.object({
   recipient: z.object({
     cap: z.string().nullish()
   }),
-  quantityReceived: z.number().nullish(),
-  quantityRefused: z.number().nullish(),
+  quantityReceived: z.number().min(0).nullish(),
+  quantityRefused: z.number().min(0).nullish(),
   processingOperationDone: z.string().nullish(),
   destinationOperationMode: z.string().nullish(),
   processingOperationDescription: z.string().nullish(),
   temporaryStorageDetail: z.object({
     temporaryStorer: z.object({
-      quantityReceived: z.number().nullish()
+      quantityReceived: z.number().min(0).nullish(),
+      quantityRefused: z.number().min(0).nullish()
     }),
     destination: z.object({
       cap: z.string().nullish(),

--- a/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
+++ b/front/src/Apps/common/queries/reviews/BsddReviewsQuery.ts
@@ -80,6 +80,7 @@ const reviewFragment = gql`
       temporaryStorageDetail {
         temporaryStorer {
           quantityReceived
+          quantityRefused
         }
         destination {
           cap
@@ -142,6 +143,7 @@ const reviewFragment = gql`
       temporaryStorageDetail {
         temporaryStorer {
           quantityReceived
+          quantityRefused
         }
         destination {
           cap

--- a/libs/back/prisma/src/migrations/20250228093927_add_revision_temp_storage_quantity_refused/migration.sql
+++ b/libs/back/prisma/src/migrations/20250228093927_add_revision_temp_storage_quantity_refused/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BsddRevisionRequest" ADD COLUMN     "temporaryStorageTemporaryStorerQuantityRefused" DOUBLE PRECISION;

--- a/libs/back/prisma/src/migrations/20250228093927_add_revision_temp_storage_quantity_refused/migration.sql
+++ b/libs/back/prisma/src/migrations/20250228093927_add_revision_temp_storage_quantity_refused/migration.sql
@@ -1,2 +1,3 @@
 -- AlterTable
 ALTER TABLE "BsddRevisionRequest" ADD COLUMN     "temporaryStorageTemporaryStorerQuantityRefused" DOUBLE PRECISION;
+ALTER TABLE "BsddRevisionRequest" ADD COLUMN     "initialTemporaryStorageTemporaryStorerQuantityRefused" DECIMAL(65,30);

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -683,6 +683,7 @@ model BsddRevisionRequest {
   temporaryStorageDestinationCap                  String?
   temporaryStorageDestinationProcessingOperation  String?
   temporaryStorageTemporaryStorerQuantityReceived Float?
+  temporaryStorageTemporaryStorerQuantityRefused  Float?
 
   initialRecipientCap                                    String?
   initialWasteDetailsCode                                String?

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -720,6 +720,7 @@ model BsddRevisionRequest {
   initialTemporaryStorageDestinationCap                  String?
   initialTemporaryStorageDestinationProcessingOperation  String?
   initialTemporaryStorageTemporaryStorerQuantityReceived Decimal?
+  initialTemporaryStorageTemporaryStorerQuantityRefused  Decimal?
 
   @@index([authoringCompanyId], map: "_BsddRevisionRequestAuthoringCompanyIdIdx")
   @@index([bsddId], map: "_BsddRevisionRequestBsddIdIdx")


### PR DESCRIPTION
# Contexte

J'avais complètement zappé l'entreposage provisoire pour les révisions de la quantité refusée, et c'est fort dommage parce que c'est bien du plaisir!

Du coup la révision permet de modifier les quantités reçues & refusées sur l'entreposage provisoire ET la destination. 

Les champs concernés ne s'affichent que lorsque c'est pertinent, et on ajoute aussi un petit message informatif.

# Démo

![image](https://github.com/user-attachments/assets/284255e4-29a2-4731-a923-ae3d747f5ca5)

# Ticket Favro

[BSDD - Permettre de réviser la quantité refusée lors d'un refus partiel à partir du moment où l'acceptation a été signée](https://favro.com/widget/ab14a4f0460a99a9d64d4945/ca60ff23d07a2274c78317e5?card=tra-15158)