### PR TITLE
Corrections des erreurs en recette

### DIFF
--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -224,7 +224,13 @@ describe("expandFormFromDb", () => {
         onuCode: forwardedIn!.wasteDetailsOnuCode,
         nonRoadRegulationMention:
           forwardedIn!.wasteDetailsNonRoadRegulationMention,
-        packagingInfos: forwardedIn!.wasteDetailsPackagingInfos,
+        packagingInfos: (
+          form.wasteDetailsPackagingInfos as PackagingInfo[]
+        ).map(p => ({
+          ...p,
+          identificationNumbers: [],
+          volume: null
+        })),
         packagings: ["CITERNE"],
         otherPackaging: undefined,
         numberOfPackages: 1,

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -686,13 +686,12 @@ export function expandFormFromDb(
       isSubjectToADR: form.wasteDetailsIsSubjectToADR,
       onuCode: form.wasteDetailsOnuCode,
       nonRoadRegulationMention: form.wasteDetailsNonRoadRegulationMention,
-      packagingInfos: (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(
-        p => ({
+      packagingInfos:
+        (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(p => ({
           ...p,
           volume: p.volume ?? null,
           identificationNumbers: p.identificationNumbers ?? []
-        })
-      ),
+        })) ?? [],
       // DEPRECATED - To remove with old packaging fields
       ...getDeprecatedPackagingApiFields(
         form.wasteDetailsPackagingInfos as PackagingInfo[]
@@ -874,7 +873,13 @@ export function expandFormFromDb(
             nonRoadRegulationMention:
               forwardedIn.wasteDetailsNonRoadRegulationMention,
             packagingInfos:
-              forwardedIn.wasteDetailsPackagingInfos as PackagingInfo[],
+              (forwardedIn.wasteDetailsPackagingInfos as PackagingInfo[])?.map(
+                p => ({
+                  ...p,
+                  volume: p.volume ?? null,
+                  identificationNumbers: p.identificationNumbers ?? []
+                })
+              ) ?? [],
             // DEPRECATED - To remove with old packaging fields
             ...getDeprecatedPackagingApiFields(
               forwardedIn.wasteDetailsPackagingInfos as PackagingInfo[]

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -686,7 +686,7 @@ export function expandFormFromDb(
       isSubjectToADR: form.wasteDetailsIsSubjectToADR,
       onuCode: form.wasteDetailsOnuCode,
       nonRoadRegulationMention: form.wasteDetailsNonRoadRegulationMention,
-      packagingInfos: (form.wasteDetailsPackagingInfos as PackagingInfo[]).map(
+      packagingInfos: (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(
         p => ({
           ...p,
           volume: p.volume ?? null,

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -524,7 +524,7 @@ type PackagingInfo {
   volume: Float
 
   "Numéros des contenants"
-  identificationNumbers: [String!]
+  identificationNumbers: [String!]!
 }
 
 "Détails du déchet (case 3, 4, 5, 6)"

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -524,7 +524,7 @@ type PackagingInfo {
   volume: Float
 
   "Numéros des contenants"
-  identificationNumbers: [String!]!
+  identificationNumbers: [String!]
 }
 
 "Détails du déchet (case 3, 4, 5, 6)"


### PR DESCRIPTION
# Contexte

Les erreurs sont dues à cette PR: [[TRA 15675 | 15396 | 15767 | 15698 | 15700] Permettre l'ajout d'un volume et de numéros d'identifications sur les contenants d'un BSDD #3936](https://github.com/MTES-MCT/trackdechets/pull/3936)

Les identificationNumbers sont requis dans l'API alors qu'ils peuvent être vides (pour tous les BSDs legacy par exemple).

# Démo

![image](https://github.com/user-attachments/assets/0dc51ea6-4c0c-4ebe-8769-d1d72ad88a92)


![image](https://github.com/user-attachments/assets/366a2de6-6a00-4a03-9e1c-c5d77e177b4b)