### PR TITLE
HOTFIX - Config open telemetry

### DIFF
--- a/otel/collector-config.sec-fr1.yaml
+++ b/otel/collector-config.sec-fr1.yaml
@@ -15,9 +15,14 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 15
       
-  batch/datadog:
-    send_batch_max_size: ${env:OTEL_DD_BATCH_MAX_SIZE:-100}
+  batch/datadog_metrics:
+    send_batch_max_size: 100
     send_batch_size: 10
+    timeout: 10s
+    
+  batch/datadog_generic:
+    send_batch_max_size: ${env:OTEL_DD_BATCH_MAX_SIZE:-1000}
+    send_batch_size: ${env:OTEL_DD_BATCH_SIZE:-100}
     timeout: 10s
 
 connectors:
@@ -33,13 +38,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, batch/datadog_generic]
       exporters: [datadog/connector, datadog/exporter]
     metrics:
       receivers: [datadog/connector, otlp, postgresql/prod, postgresql/sandbox]
-      processors: [memory_limiter, batch/datadog]
+      processors: [memory_limiter, batch/datadog_metrics]
       exporters: [datadog/exporter]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, batch/datadog_generic]
       exporters: [datadog/exporter]

--- a/otel/collector-config.sec-fr1.yaml
+++ b/otel/collector-config.sec-fr1.yaml
@@ -10,8 +10,13 @@ receivers:
     password: ${env:SANDBOX_DB_PWD}
 
 processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 15
+      
   batch/datadog:
-    send_batch_max_size: 100
+    send_batch_max_size: ${env:OTEL_DD_BATCH_MAX_SIZE:-100}
     send_batch_size: 10
     timeout: 10s
 
@@ -28,13 +33,13 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch, memory_limiter]
+      processors: [memory_limiter, batch]
       exporters: [datadog/connector, datadog/exporter]
     metrics:
       receivers: [datadog/connector, otlp, postgresql/prod, postgresql/sandbox]
-      processors: [batch/datadog, memory_limiter]
+      processors: [memory_limiter, batch/datadog]
       exporters: [datadog/exporter]
     logs:
       receivers: [otlp]
-      processors: [batch, memory_limiter]
+      processors: [memory_limiter, batch]
       exporters: [datadog/exporter]

--- a/otel/collector-config.sec-fr1.yaml
+++ b/otel/collector-config.sec-fr1.yaml
@@ -14,12 +14,12 @@ processors:
     check_interval: 1s
     limit_percentage: 80
     spike_limit_percentage: 15
-      
+
   batch/datadog_metrics:
     send_batch_max_size: 100
     send_batch_size: 10
     timeout: 10s
-    
+
   batch/datadog_generic:
     send_batch_max_size: ${env:OTEL_DD_BATCH_MAX_SIZE:-1000}
     send_batch_size: ${env:OTEL_DD_BATCH_SIZE:-100}


### PR DESCRIPTION
Fix de config open telemetry.
On a des problèmes de mémoire depuis le 03/03 15h30. On impose des limites plus précises et configurables pour essayer de baisser la charge. On a en plus énormément de batchs qui ne passent pas en raison de 413 request entity too large. Donc il faut varier la taille de nos batchs.