### PR TITLE
[TRA 16017] - ajout de quantité sur exports BSDD & fix date sur paramètre d'activation BSD DND

### DIFF
--- a/back/src/forms/__tests__/compat.integration.ts
+++ b/back/src/forms/__tests__/compat.integration.ts
@@ -9,6 +9,7 @@ import { prisma } from "@td/prisma";
 import { RegistryFormInclude } from "../../registry/elastic";
 import { formToBsdd } from "../compat";
 import { Decimal } from "@prisma/client/runtime/library";
+import { PackagingInfo } from "@td/codegen-back";
 
 describe("simpleFormToBsdd", () => {
   it("should convert a Form to a Bsdd", async () => {
@@ -103,7 +104,12 @@ describe("simpleFormToBsdd", () => {
       emitterPickupSiteInfos: form.emitterWorkSiteInfos,
       emitterEmissionSignatureAuthor: form.sentBy,
       emitterEmissionSignatureDate: form.sentAt,
-      packagings: form.wasteDetailsPackagingInfos,
+      packagings:
+        (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(p => ({
+          ...p,
+          volume: p.volume ?? null,
+          identificationNumbers: p.identificationNumbers ?? []
+        })) ?? [],
       weightValue: form.wasteDetailsQuantity?.toNumber(),
       wasteAdr: form.wasteDetailsOnuCode,
       nonRoadRegulationMention: form.wasteDetailsNonRoadRegulationMention,
@@ -498,7 +504,14 @@ describe("simpleFormToBsdd", () => {
       emitterPickupSiteInfos: fullForwardedInForm.emitterWorkSiteInfos,
       emitterEmissionSignatureAuthor: fullForwardedInForm.sentBy,
       emitterEmissionSignatureDate: fullForwardedInForm.sentAt,
-      packagings: fullForwardedInForm.wasteDetailsPackagingInfos,
+      packagings:
+        (
+          fullForwardedInForm.wasteDetailsPackagingInfos as PackagingInfo[]
+        )?.map(p => ({
+          ...p,
+          volume: p.volume ?? null,
+          identificationNumbers: p.identificationNumbers ?? []
+        })) ?? [],
       weightValue: fullForwardedInForm.wasteDetailsQuantity?.toNumber(),
       wasteAdr: fullForwardedInForm.wasteDetailsOnuCode,
       nonRoadRegulationMention:
@@ -696,7 +709,12 @@ describe("simpleFormToBsdd", () => {
         emitterPickupSiteInfos: form.emitterWorkSiteInfos,
         emitterEmissionSignatureAuthor: form.sentBy,
         emitterEmissionSignatureDate: form.sentAt,
-        packagings: form.wasteDetailsPackagingInfos,
+        packagings:
+          (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(p => ({
+            ...p,
+            volume: p.volume ?? null,
+            identificationNumbers: p.identificationNumbers ?? []
+          })) ?? [],
         weightValue: form.wasteDetailsQuantity?.toNumber(),
         wasteAdr: form.wasteDetailsOnuCode,
         nonRoadRegulationMention: form.wasteDetailsNonRoadRegulationMention,

--- a/back/src/forms/compat.ts
+++ b/back/src/forms/compat.ts
@@ -6,6 +6,7 @@ import {
 import type {
   AppendixFormInput,
   InitialFormFractionInput,
+  PackagingInfo,
   ParcelNumber
 } from "@td/codegen-back";
 import { Bsdd } from "./types";
@@ -90,7 +91,12 @@ export function simpleFormToBsdd(
     emitterPickupSiteInfos: form.emitterWorkSiteInfos,
     emitterEmissionSignatureAuthor: form.sentBy,
     emitterEmissionSignatureDate: form.sentAt,
-    packagings: form.wasteDetailsPackagingInfos,
+    packagings:
+      (form.wasteDetailsPackagingInfos as PackagingInfo[])?.map(p => ({
+        ...p,
+        volume: p.volume ?? null,
+        identificationNumbers: p.identificationNumbers ?? []
+      })) ?? [],
     weightValue: form.wasteDetailsQuantity
       ? form.wasteDetailsQuantity.toNumber()
       : null,

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -2,6 +2,7 @@ import {
   IncomingWasteV2,
   ManagedWasteV2,
   OutgoingWasteV2,
+  PackagingInfo,
   TransportedWasteV2
 } from "@td/codegen-back";
 import {
@@ -116,6 +117,16 @@ const getFinalOperationsData = (bsdd: BsddV2) => {
   };
 };
 
+const getQuantity = (packagings: PackagingInfo[]) => {
+  if (!packagings) {
+    return null;
+  }
+  return packagings.reduce(
+    (totalQuantity, p) => totalQuantity + (p.quantity ?? 0),
+    0
+  );
+};
+
 export const toIncomingWasteV2 = (
   form: RegistryV2Bsdd
 ): Omit<Required<IncomingWasteV2>, "__typename"> => {
@@ -214,7 +225,7 @@ export const toIncomingWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: null,
+    quantity: getQuantity(bsdd.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     initialEmitterCompanyName,
@@ -490,7 +501,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: null,
+    quantity: getQuantity(bsdd.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     weightIsEstimate: bsdd.weightIsEstimate,
@@ -779,7 +790,7 @@ export const toTransportedWasteV2 = (
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
     weight: bsdd.weightValue,
-    quantity: null,
+    quantity: getQuantity(bsdd.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: bsdd.weightIsEstimate,
     volume: null,
@@ -1045,7 +1056,7 @@ export const toManagedWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsdd.pop,
     wasteIsDangerous: bsdd.wasteIsDangerous,
-    quantity: null,
+    quantity: getQuantity(bsdd.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsdd.weightValue,
     weightIsEstimate: bsdd.weightIsEstimate,

--- a/back/src/forms/types.ts
+++ b/back/src/forms/types.ts
@@ -8,7 +8,11 @@ import {
   OperationMode,
   EmitterType
 } from "@prisma/client";
-import type { CiterneNotWashedOutReason, FormStatus } from "@td/codegen-back";
+import type {
+  CiterneNotWashedOutReason,
+  FormStatus,
+  PackagingInfo
+} from "@td/codegen-back";
 
 export const FormWithTransportersInclude =
   Prisma.validator<Prisma.FormInclude>()({
@@ -171,7 +175,7 @@ export type Bsdd = {
   emitterPickupSiteInfos: string | null;
   emitterEmissionSignatureAuthor: string | null;
   emitterEmissionSignatureDate: Date | null;
-  packagings: Prisma.JsonValue;
+  packagings: PackagingInfo[];
   wasteCode: string | null;
   wasteDescription: string | null;
   wasteDetailsLandIdentifiers: string[] | null;

--- a/back/src/registryV2/columns.ts
+++ b/back/src/registryV2/columns.ts
@@ -47,6 +47,7 @@ const formatEmitterType = (emitterType: EmitterType | null) => {
 };
 const formatNumber = (n: number) =>
   isDefined(n) ? parseFloat(n.toFixed(3)) : null; // return as a number to allow xls cells formulas
+const formatInteger = (n: number) => (isDefined(n) ? Math.round(n) : null);
 const formatArray = (arr: any[], opts = { separator: "," }) =>
   Array.isArray(arr) ? arr.join(opts.separator) : "";
 const formatArrayWithMissingElements = (arr: any[]) => {
@@ -229,7 +230,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)" },
+    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -522,7 +523,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)" },
+    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -882,7 +883,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)" },
+    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean
@@ -1131,7 +1132,7 @@ export const EXPORT_COLUMNS: {
     wasteCodeBale: { label: "Code déchet Bâle" },
     wastePop: { label: "POP", format: formatBoolean },
     wasteIsDangerous: { label: "Dangereux", format: formatBoolean },
-    quantity: { label: "Nombre d'unité(s)" },
+    quantity: { label: "Nombre d'unité(s)", format: formatInteger },
     wasteContainsElectricOrHybridVehicles: {
       label: "VHU électrique ou hybride",
       format: formatBoolean

--- a/front/src/Apps/Companies/CompanyRegistry/CompanyRegistryDndFromBsd.tsx
+++ b/front/src/Apps/Companies/CompanyRegistry/CompanyRegistryDndFromBsd.tsx
@@ -17,7 +17,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import { CompanyDetailsfragment } from "../common/fragments";
 import { useMutation } from "@apollo/client";
 import Alert from "@codegouvfr/react-dsfr/Alert";
-import { format, isFuture } from "date-fns";
+import { format, isFuture, subDays } from "date-fns";
 import { fr } from "date-fns/locale";
 
 interface Props {
@@ -124,7 +124,10 @@ export const CompanyRegistryDndFromBsd = ({ company }: Props) => {
             {`L'activation de la traçabilité est irréversible et ${
               isFutureDate
                 ? `prendra effet à 23h59 (heure de Paris) le ${format(
-                    new Date(company.hasEnabledRegistryDndFromBsdSince),
+                    subDays(
+                      new Date(company.hasEnabledRegistryDndFromBsdSince),
+                      1
+                    ),
                     "d MMMM yyyy",
                     { locale: fr }
                   )}`


### PR DESCRIPTION
# Contexte

- ajout de la quantité sur les exports registre V2 BSDD en faisant la somme des quantité des packagings. J'ai modifié les tests après avoir contrôlé que ce qui dépendait de formToBsdd n'utilisait pas packagings avant, donc pas d'impact)
- fix de la date d'activation sur BSD DND (en back on met la date à 00:00 du lendemain, donc il faut soustraire un jour quand on affiche le jour de l'activation, pour que ce soit cohérent)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB