### PR TITLE
Rebuild de l'index des registres V2: petites améliorations

### DIFF
--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -27,7 +27,11 @@ import {
 import { getFirstTransporterSync, getTransportersSync } from "./database";
 import { splitAddress } from "../common/addresses";
 import { getBsffSubType } from "../common/subTypes";
-import { deleteRegistryLookup, generateDateInfos } from "@td/registry";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "@td/registry";
 import { Nullable } from "../types";
 import { isFinalOperation } from "./constants";
 
@@ -1116,21 +1120,32 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("BSFF");
   await prisma.registryLookup.deleteMany({
     where: {
       bsffId: { not: null }
     }
   });
+  logger.logDelete();
+
+  const total = await prisma.bsff.count({
+    where: {
+      isDeleted: false,
+      isDraft: false
+    }
+  });
+
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.bsff.findMany({
       where: {
         isDeleted: false,
         isDraft: false
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -1144,14 +1159,18 @@ export const rebuildRegistryLookup = async () => {
       createArray = createArray.concat(createInputs);
     }
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -23,7 +23,11 @@ import { formToBsddV2, BsddV2 } from "./compat";
 import { getBsddSubType } from "../common/subTypes";
 import { splitAddress } from "../common/addresses";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
-import { deleteRegistryLookup, generateDateInfos } from "@td/registry";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "@td/registry";
 import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
 import { getTransporterCompanyOrgId } from "@td/constants";
@@ -1374,15 +1378,27 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("BSDD");
   await prisma.registryLookup.deleteMany({
     where: {
       bsddId: { not: null }
     }
   });
+  logger.logDelete();
+
+  const total = await prisma.form.count({
+    where: {
+      isDeleted: false,
+      NOT: {
+        status: "DRAFT"
+      }
+    }
+  });
 
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.form.findMany({
       where: {
@@ -1391,7 +1407,7 @@ export const rebuildRegistryLookup = async () => {
           status: "DRAFT"
         }
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -1405,14 +1421,18 @@ export const rebuildRegistryLookup = async () => {
       createArray = createArray.concat(createInputs);
     }
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/back/src/scripts/bin/rebuildRegistryLookup.ts
+++ b/back/src/scripts/bin/rebuildRegistryLookup.ts
@@ -168,6 +168,10 @@ const runIntegrityTest = async () => {
   const bsdOrRegistryTypesToIndex = bsdOrRegistryTypes.filter(t =>
     args.map(a => a.toUpperCase()).includes(t)
   );
+  const pageSize = args.includes("--page-size")
+    ? parseInt(args[args.indexOf("--page-size") + 1])
+    : 500;
+  console.log("pageSize", pageSize);
   try {
     if (integrityTest) {
       await runIntegrityTest();
@@ -177,92 +181,79 @@ const runIntegrityTest = async () => {
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("SSD")
     ) {
-      console.info("Rebuilding SSD registry lookup");
-      await ssdLookupUtils.rebuildLookup();
+      await ssdLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_WASTE")
     ) {
-      console.info("Rebuilding incoming waste registry lookup");
-      await incomingWasteLookupUtils.rebuildLookup();
+      await incomingWasteLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_TEXS")
     ) {
-      console.info("Rebuilding incoming texs registry lookup");
-      await incomingTexsLookupUtils.rebuildLookup();
+      await incomingTexsLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("OUTGOING_WASTE")
     ) {
-      console.info("Rebuilding outgoing waste registry lookup");
-      await outgoingWasteLookupUtils.rebuildLookup();
+      await outgoingWasteLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("OUTGOING_TEXS")
     ) {
-      console.info("Rebuilding outgoing texs registry lookup");
-      await outgoingTexsLookupUtils.rebuildLookup();
+      await outgoingTexsLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("TRANSPORTED")
     ) {
-      console.info("Rebuilding transported registry lookup");
-      await transportedLookupUtils.rebuildLookup();
+      await transportedLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("MANAGED")
     ) {
-      console.info("Rebuilding managed registry lookup");
-      await managedLookupUtils.rebuildLookup();
+      await managedLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDD")
     ) {
-      console.info("Rebuilding BSDD lookup");
-      await bsddLookupUtils.rebuildLookup();
+      await bsddLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDA")
     ) {
-      console.info("Rebuilding BSDA lookup");
-      await bsdaLookupUtils.rebuildLookup();
+      await bsdaLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDASRI")
     ) {
-      console.info("Rebuilding BSDASRI lookup");
-      await bsdasriLookupUtils.rebuildLookup();
+      await bsdasriLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSFF")
     ) {
-      console.info("Rebuilding BSFF lookup");
-      await bsffLookupUtils.rebuildLookup();
+      await bsffLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSPAOH")
     ) {
-      console.info("Rebuilding BSPAOH lookup");
-      await bspaohLookupUtils.rebuildLookup();
+      await bspaohLookupUtils.rebuildLookup(pageSize);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSVHU")
     ) {
-      console.info("Rebuilding BSVHU lookup");
-      await bsvhuLookupUtils.rebuildLookup();
+      await bsvhuLookupUtils.rebuildLookup(pageSize);
     }
   } catch (error) {
     console.error("Error in rebuildRegistryLookup script, exiting", error);

--- a/libs/back/registry/src/incomingTexs/registry.ts
+++ b/libs/back/registry/src/incomingTexs/registry.ts
@@ -7,7 +7,11 @@ import {
   RegistryIncomingTexs
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { deleteRegistryLookup, generateDateInfos } from "../lookup/utils";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "../lookup/utils";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { IncomingWasteV2 } from "@td/codegen-back";
 
@@ -260,22 +264,31 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("INCOMING_TEXS");
   await prisma.registryLookup.deleteMany({
     where: {
       registryIncomingTexsId: { not: null }
     }
   });
-  // reindex registrySSD
+  logger.logDelete();
+
+  const total = await prisma.registryIncomingTexs.count({
+    where: {
+      isCancelled: false,
+      isLatest: true
+    }
+  });
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.registryIncomingTexs.findMany({
       where: {
         isCancelled: false,
         isLatest: true
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -288,14 +301,18 @@ export const rebuildRegistryLookup = async () => {
         registryToLookupCreateInput(registryIncomingTexs)
     );
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/libs/back/registry/src/incomingWaste/registry.ts
+++ b/libs/back/registry/src/incomingWaste/registry.ts
@@ -7,7 +7,11 @@ import {
   RegistryIncomingWaste
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { deleteRegistryLookup, generateDateInfos } from "../lookup/utils";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "../lookup/utils";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { IncomingWasteV2 } from "@td/codegen-back";
 
@@ -265,22 +269,31 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("INCOMING_WASTE");
   await prisma.registryLookup.deleteMany({
     where: {
       registryIncomingWasteId: { not: null }
     }
   });
-  // reindex registrySSD
+  logger.logDelete();
+
+  const total = await prisma.registryIncomingWaste.count({
+    where: {
+      isCancelled: false,
+      isLatest: true
+    }
+  });
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.registryIncomingWaste.findMany({
       where: {
         isCancelled: false,
         isLatest: true
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -293,14 +306,18 @@ export const rebuildRegistryLookup = async () => {
         registryToLookupCreateInput(registryIncomingWaste)
     );
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/libs/back/registry/src/index.ts
+++ b/libs/back/registry/src/index.ts
@@ -13,7 +13,11 @@ export * from "./changeAggregates";
 
 export { SSD_HEADERS } from "./ssd/constants";
 
-export { generateDateInfos, deleteRegistryLookup } from "./lookup/utils";
+export {
+  generateDateInfos,
+  deleteRegistryLookup,
+  createRegistryLogger
+} from "./lookup/utils";
 
 export { lookupUtils as ssdLookupUtils } from "./ssd/registry";
 

--- a/libs/back/registry/src/outgoingTexs/registry.ts
+++ b/libs/back/registry/src/outgoingTexs/registry.ts
@@ -7,7 +7,11 @@ import {
   RegistryOutgoingTexs
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { deleteRegistryLookup, generateDateInfos } from "../lookup/utils";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "../lookup/utils";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { OutgoingWasteV2 } from "@td/codegen-back";
 
@@ -288,22 +292,31 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("OUTGOING_TEXS");
   await prisma.registryLookup.deleteMany({
     where: {
       registryOutgoingTexsId: { not: null }
     }
   });
-  // reindex registrySSD
+  logger.logDelete();
+
+  const total = await prisma.registryOutgoingTexs.count({
+    where: {
+      isCancelled: false,
+      isLatest: true
+    }
+  });
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.registryOutgoingTexs.findMany({
       where: {
         isCancelled: false,
         isLatest: true
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -316,14 +329,18 @@ export const rebuildRegistryLookup = async () => {
         registryToLookupCreateInput(registryOutgoingTexs)
     );
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/libs/back/registry/src/outgoingWaste/registry.ts
+++ b/libs/back/registry/src/outgoingWaste/registry.ts
@@ -7,7 +7,11 @@ import {
   RegistryOutgoingWaste
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { deleteRegistryLookup, generateDateInfos } from "../lookup/utils";
+import {
+  createRegistryLogger,
+  deleteRegistryLookup,
+  generateDateInfos
+} from "../lookup/utils";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { OutgoingWasteV2 } from "@td/codegen-back";
 
@@ -294,22 +298,31 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("OUTGOING_WASTE");
   await prisma.registryLookup.deleteMany({
     where: {
       registryOutgoingWasteId: { not: null }
     }
   });
-  // reindex registrySSD
+  logger.logDelete();
+
+  const total = await prisma.registryOutgoingWaste.count({
+    where: {
+      isCancelled: false,
+      isLatest: true
+    }
+  });
   let done = false;
   let cursorId: string | null = null;
+  let processedCount = 0;
   while (!done) {
     const items = await prisma.registryOutgoingWaste.findMany({
       where: {
         isCancelled: false,
         isLatest: true
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -322,14 +335,18 @@ export const rebuildRegistryLookup = async () => {
         registryToLookupCreateInput(registryOutgoingWaste)
     );
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+    if (items.length < pageSize) {
       done = true;
-      return;
+      break;
     }
     cursorId = items[items.length - 1].id;
   }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {

--- a/libs/back/registry/src/ssd/registry.ts
+++ b/libs/back/registry/src/ssd/registry.ts
@@ -9,8 +9,11 @@ import {
 import type { SsdWasteV2 } from "@td/codegen-back";
 import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { prisma } from "@td/prisma";
-import { deleteRegistryLookup, generateDateInfos } from "../lookup/utils";
-import { performance } from "perf_hooks";
+import {
+  deleteRegistryLookup,
+  generateDateInfos,
+  createRegistryLogger
+} from "../lookup/utils";
 
 export const toSsdWaste = (ssd: RegistrySsd): SsdWasteV2 => {
   return {
@@ -129,30 +132,35 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async () => {
-  const deleteStart = performance.now();
+export const rebuildRegistryLookup = async (pageSize = 100) => {
+  const logger = createRegistryLogger("SSD");
+
   await prisma.registryLookup.deleteMany({
     where: {
       registrySsdId: { not: null }
     }
   });
-  const deleteEnd = performance.now();
-  console.log(`global delete: ${deleteEnd - deleteStart}ms`);
+  logger.logDelete();
 
-  // reindex registrySSD
+  // First, get total count for progress calculation
+  const total = await prisma.registrySsd.count({
+    where: {
+      isCancelled: false,
+      isLatest: true
+    }
+  });
+
   let done = false;
   let cursorId: string | null = null;
-  let accuFetch = 0;
-  let accuUpdate = 0;
-  let iters = 0;
+  let processedCount = 0;
+
   while (!done) {
-    const fetchStart = performance.now();
     const items = await prisma.registrySsd.findMany({
       where: {
         isCancelled: false,
         isLatest: true
       },
-      take: 100,
+      take: pageSize,
       skip: cursorId ? 1 : 0,
       cursor: cursorId ? { id: cursorId } : undefined,
       orderBy: {
@@ -160,33 +168,26 @@ export const rebuildRegistryLookup = async () => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const fetchEnd = performance.now();
 
-    const updateStart = performance.now();
     const createArray = items.map((registrySsd: MinimalRegistryForLookup) =>
       registryToLookupCreateInput(registrySsd)
     );
     await prisma.registryLookup.createMany({
-      data: createArray
+      data: createArray,
+      skipDuplicates: true
     });
 
-    const updateEnd = performance.now();
-    if (items.length < 100) {
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+
+    if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
-    accuFetch += fetchEnd - fetchStart;
-    accuUpdate += updateEnd - updateStart;
-    iters += 1;
   }
 
-  if (iters > 0) {
-    const meanFetch = accuFetch / iters;
-    const meanUpdate = accuUpdate / iters;
-    console.log(`mean fetch (100 rows): ${meanFetch}ms`);
-    console.log(`mean update (100 rows): ${meanUpdate}ms`);
-  }
+  logger.logCompletion(processedCount);
 };
 
 export const lookupUtils = {


### PR DESCRIPTION
# Contexte

- Ajout de logs précis pour le process de reindex, utiles lorsque c'est long (sandbox/prod)

<img width="774" alt="Capture d’écran 2025-03-12 à 01 33 37" src="https://github.com/user-attachments/assets/4d0d94cd-29cf-4e19-9a86-9f26f3b2bfc9" />

- Ajout d'un paramètre page size commun pour optimiser la taille des pages et accélérer le process

- Ajout de la config skipDuplicates dans les createMany de façon à éviter de potentiels conflits (si un BSD est signé pendant le rebuild par exemple, le lookup va être créé, et lorsque le rebuild arrive dessus il y aura un duplicate key. skipDuplicate fait que dans ce cas on ne réécrit pas le lookup. Puisqu'il a été créé lors du dernier update du BSD, il est de toute façon valable.)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB