### PR TITLE
HOTFIX : problème d'affichage d'une révision portant sur le conditionnement

### DIFF
--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -1042,8 +1042,14 @@ export function expandBsddRevisionRequestContent(
       code: bsddRevisionRequest.wasteDetailsCode,
       name: bsddRevisionRequest.wasteDetailsName,
       pop: bsddRevisionRequest.wasteDetailsPop,
-      packagingInfos:
-        bsddRevisionRequest.wasteDetailsPackagingInfos as PackagingInfo[],
+      packagingInfos: (
+        (bsddRevisionRequest.wasteDetailsPackagingInfos ??
+          []) as PackagingInfo[]
+      ).map(p => ({
+        ...p,
+        volume: p.volume ?? null,
+        identificationNumbers: p.identificationNumbers ?? []
+      })),
       sampleNumber: bsddRevisionRequest.wasteDetailsSampleNumber,
       quantity: bsddRevisionRequest.wasteDetailsQuantity
         ? processDecimal(bsddRevisionRequest.wasteDetailsQuantity).toNumber()


### PR DESCRIPTION
Erreur Sentry `Cannot return null for non-nullable field PackagingInfo.identificationNumbers.`au moment de l'affichage des demandes de révision. 

https://sentry.incubateur.net/organizations/betagouv/issues/152513/?query=is%3Aunresolved&referrer=issue-stream&stream_index=0