### PR TITLE
[tra-16089]Ne pas permettre d'accéder au PDF dans le menu d'action d'un BSFF lorsque celui-ci est au statut Brouillons

### DIFF
--- a/front/src/Apps/Dashboard/dashboardServices.ts
+++ b/front/src/Apps/Dashboard/dashboardServices.ts
@@ -1594,7 +1594,7 @@ export const canUpdateBsd = (bsd, siret) =>
   canUpdateBsvhu(bsd) ||
   canUpdateBspaoh(bsd);
 
-export const canGeneratePdf = bsd => bsd.type === BsdType.Bsff || !bsd.isDraft;
+export const canGeneratePdf = bsd => !bsd.isDraft;
 
 export const canMakeCorrection = (bsd: BsdDisplay, siret: string) => {
   // On ne permet pas la correction des contenants qui sont


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->
<img width="1209" alt="Screenshot 2025-03-13 at 18 22 31" src="https://github.com/user-attachments/assets/4cd6fa57-4cbd-4a1a-b445-163685a88ed8" />

# Ticket Favro

[tra-16089](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16089)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB