### PR TITLE
[TRA-16150] Impossibilité d'ajouter un transporteur via l'UI si la liste de transporteur est vide lors de l'édition d'un BSDD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Mettre à jour la doc "Utiliser le playground" de la documentation développeur [PR 4034](https://github.com/MTES-MCT/trackdechets/pull/4034)
 
+#### :bug: Corrections de bugs
+
+- Impossibilité d'ajouter un transporteur via l'UI si la liste de transporteur est vide lors de l'édition d'un BSDD [PR 4042](https://github.com/MTES-MCT/trackdechets/pull/4042)
+
 # [2025.03.1] 11/03/2025
 
 #### :rocket: Nouvelles fonctionnalités

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.test.tsx
@@ -346,4 +346,16 @@ describe("<TransporterList />", () => {
       expect(addButtons[1]).not.toBeDisabled();
     }
   );
+
+  test.each([BsdType.Bsdd, BsdType.Bsda, BsdType.Bsff])(
+    "Add button is available when transporters list is empty and bsdType is %p",
+    async bsdType => {
+      render(component([], bsdType));
+      const addButton = screen.getByTitle("Ajouter");
+      expect(addButton).toBeInTheDocument();
+      fireEvent.click(addButton);
+      const transporter1 = await screen.findByText("1 - Transporteur");
+      expect(transporter1).toBeInTheDocument();
+    }
+  );
 });

--- a/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
+++ b/front/src/Apps/Forms/Components/TransporterList/TransporterList.tsx
@@ -10,6 +10,7 @@ import { AnyTransporterInput } from "../../types";
 import { useTransporters } from "../../hooks/useTransporters";
 import { useDeleteTransporter } from "../../hooks/useDeleteTransporter";
 import { initialTransporter } from "../../../common/data/initialState";
+import Button from "@codegouvfr/react-dsfr/Button";
 
 type TransporterListProps = {
   // SIRET ou VAT de l'établissement courant
@@ -54,6 +55,25 @@ export function TransporterList<TransporterInput extends AnyTransporterInput>({
         name={fieldName}
         render={arrayHelpers => (
           <>
+            {transporters.length === 0 && (
+              // Ce cas peut se produire lors de la modification d'un BSDD
+              // crée par API avec une liste de transporteurs vide (contrairement
+              // au front TD qui initialise un premier transporteur à la création du BSDD).
+              <Button
+                type="button"
+                className="transporter__header__button"
+                priority="secondary"
+                iconPosition="right"
+                iconId="ri-add-line"
+                title="Ajouter"
+                onClick={() => {
+                  arrayHelpers.insert(0, initialTransporterData);
+                  setExpandedIdx(0);
+                }}
+              >
+                Ajouter
+              </Button>
+            )}
             {transporters.map((t, idx) => {
               const onTransporterAdd = () => {
                 arrayHelpers.insert(idx + 1, initialTransporterData);


### PR DESCRIPTION
# Contexte

Le front initialise un premier transporteur à la création d'un bordereau mais si le bordereau a été crée par API avec une liste de transporteurs vides alors on ne peut plus ajouter de transporteur après la création.

Cette PR permet de faire apparaitre un bouton "Ajouter" lorsqu'aucun transporteur n'est présent sur le bordereau.

# Points de vigilance pour les intégrateurs

# Démo


https://github.com/user-attachments/assets/16896599-2f78-4f07-8ed8-a66f2c104714


# Ticket Favro

[Impossibilité d'ajouter un transporteur après signature du BSDD par l'émetteur ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/95baff048704d6b9e0adbd28?card=tra-16150)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB