### PR TITLE
[HOTFIX] - changement de l'indexation DD/DND des registres

### DIFF
--- a/libs/back/registry/src/incomingWaste/registry.ts
+++ b/libs/back/registry/src/incomingWaste/registry.ts
@@ -12,6 +12,19 @@ import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { IncomingWasteV2 } from "@td/codegen-back";
 import { isDangerous } from "@td/constants";
 
+const getWasteIsDangerous = (
+  incomingWaste: Pick<
+    RegistryIncomingWaste,
+    "wasteIsDangerous" | "wastePop" | "wasteCode"
+  >
+) => {
+  return (
+    !!incomingWaste.wasteIsDangerous ||
+    !!incomingWaste.wastePop ||
+    isDangerous(incomingWaste.wasteCode)
+  );
+};
+
 export const toIncomingWaste = (
   incomingWaste: RegistryIncomingWaste
 ): IncomingWasteV2 => {
@@ -35,10 +48,7 @@ export const toIncomingWaste = (
     wasteCode: incomingWaste.wasteCode,
     wasteCodeBale: incomingWaste.wasteCodeBale,
     wastePop: incomingWaste.wastePop,
-    wasteIsDangerous:
-      !!incomingWaste.wasteIsDangerous ||
-      !!incomingWaste.wastePop ||
-      isDangerous(incomingWaste.wasteCode),
+    wasteIsDangerous: getWasteIsDangerous(incomingWaste),
     weight: null,
     quantity: null,
     wasteContainsElectricOrHybridVehicles: null,
@@ -191,6 +201,7 @@ const minimalRegistryForLookupSelect = {
   reportForCompanySiret: true,
   reportAsCompanySiret: true,
   wasteIsDangerous: true,
+  wastePop: true,
   wasteCode: true,
   receptionDate: true
 };
@@ -209,7 +220,7 @@ const registryToLookupCreateInput = (
     reportAsSiret: registryIncomingWaste.reportAsCompanySiret,
     exportRegistryType: RegistryExportType.INCOMING,
     declarationType: RegistryExportDeclarationType.REGISTRY,
-    wasteType: registryIncomingWaste.wasteIsDangerous
+    wasteType: getWasteIsDangerous(registryIncomingWaste)
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryIncomingWaste.wasteCode,
@@ -239,7 +250,7 @@ export const updateRegistryLookup = async (
         // the id changes because a new Registry entry is created on each update
         id: registryIncomingWaste.id,
         reportAsSiret: registryIncomingWaste.reportAsCompanySiret,
-        wasteType: registryIncomingWaste.wasteIsDangerous
+        wasteType: getWasteIsDangerous(registryIncomingWaste)
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryIncomingWaste.wasteCode,

--- a/libs/back/registry/src/transported/registry.ts
+++ b/libs/back/registry/src/transported/registry.ts
@@ -12,6 +12,19 @@ import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import type { TransportedWasteV2 } from "@td/codegen-back";
 import { isDangerous } from "@td/constants";
 
+const getWasteIsDangerous = (
+  transportedWaste: Pick<
+    RegistryTransported,
+    "wasteIsDangerous" | "wastePop" | "wasteCode"
+  >
+) => {
+  return (
+    !!transportedWaste.wasteIsDangerous ||
+    !!transportedWaste.wastePop ||
+    isDangerous(transportedWaste.wasteCode)
+  );
+};
+
 export const toTransportedWaste = (
   transportedWaste: RegistryTransported
 ): TransportedWasteV2 => {
@@ -34,10 +47,7 @@ export const toTransportedWaste = (
     wasteCode: transportedWaste.wasteCode,
     wasteCodeBale: transportedWaste.wasteCodeBale,
     wastePop: transportedWaste.wastePop,
-    wasteIsDangerous:
-      !!transportedWaste.wasteIsDangerous ||
-      !!transportedWaste.wastePop ||
-      isDangerous(transportedWaste.wasteCode),
+    wasteIsDangerous: getWasteIsDangerous(transportedWaste),
     weight: transportedWaste.weightValue,
     quantity: null,
     wasteContainsElectricOrHybridVehicles: null,
@@ -133,6 +143,7 @@ const minimalRegistryForLookupSelect = {
   reportAsCompanySiret: true,
   wasteIsDangerous: true,
   wasteCode: true,
+  wastePop: true,
   collectionDate: true
 };
 
@@ -150,7 +161,7 @@ const registryToLookupCreateInput = (
     reportAsSiret: registryTransported.reportAsCompanySiret,
     exportRegistryType: RegistryExportType.TRANSPORTED,
     declarationType: RegistryExportDeclarationType.REGISTRY,
-    wasteType: registryTransported.wasteIsDangerous
+    wasteType: getWasteIsDangerous(registryTransported)
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryTransported.wasteCode,
@@ -180,7 +191,7 @@ export const updateRegistryLookup = async (
         // the id changes because a new Registry entry is created on each update
         id: registryTransported.id,
         reportAsSiret: registryTransported.reportAsCompanySiret,
-        wasteType: registryTransported.wasteIsDangerous
+        wasteType: getWasteIsDangerous(registryTransported)
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryTransported.wasteCode,


### PR DESCRIPTION
# Contexte

Les registres waste importés n'apparaissent parfois pas lors de l'utilisation de filtres DD/DND parce que l'indexation n'utilisait que wasteIsDangerous pour la classification. J'ai donc uniformisé la façon dont ce champ est calculé entre le mapping et l'indexation.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB