### PR TITLE
[TRA 16007] - Ne pas permettre d'accéder aux brouillons des autres acteurs sur le PAOH

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Permettre aux intégrateurs API d'accéder aux délégations registre en lecture [PR 4039](https://github.com/MTES-MCT/trackdechets/pull/4039)
+- Ne pas permettre d'accéder aux brouillons des autres acteurs sur le PAOH [PR 4050](https://github.com/MTES-MCT/trackdechets/pull/4050)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bspaoh.integration.ts
@@ -256,7 +256,7 @@ describe("Query.bsds.bspaohs base workflow", () => {
       ]);
     });
 
-    it("draft bspaoh should be isDraftFor transporter", async () => {
+    it("draft bspaoh should not be isDraftFor transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -268,13 +268,10 @@ describe("Query.bsds.bspaohs base workflow", () => {
           }
         }
       );
-
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bspaohId } })
-      ]);
+      expect(data.bsds.edges.length).toEqual(0);
     });
 
-    it("draft bspaoh should be isDraftFor destination", async () => {
+    it("draft bspaoh should not be isDraftFor destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -287,9 +284,7 @@ describe("Query.bsds.bspaohs base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bspaohId } })
-      ]);
+      expect(data.bsds.edges.length).toEqual(0);
     });
   });
 

--- a/back/src/bspaoh/elastic.ts
+++ b/back/src/bspaoh/elastic.ts
@@ -51,11 +51,22 @@ function getWhere(bspaoh: Bspaoh, transporter): Pick<BsdElastic, WhereKeys> {
     isCollectedFor: []
   };
 
-  const bsdSirets: Record<string, string | null | undefined> = {
+  let bsdSirets: Record<string, string | null | undefined> = {
     emitterCompanySiret: bspaoh.emitterCompanySiret,
     destinationCompanySiret: bspaoh.destinationCompanySiret,
     transporterCompanySiret: getTransporterCompanyOrgId(transporter)
   };
+
+  // Drafts only appear in the dashboard for companies the bspaoh owner belongs to
+  if (bspaoh.status === BspaohStatus.DRAFT) {
+    const draftFormSiretsEntries = Object.entries(bsdSirets).filter(
+      ([, siret]) => siret && bspaoh.canAccessDraftSirets.includes(siret)
+    );
+    bsdSirets = Object.fromEntries(draftFormSiretsEntries) as Record<
+      string,
+      string | null | undefined
+    >;
+  }
 
   const siretsFilters = new Map<string, keyof typeof where>(
     Object.entries(bsdSirets)


### PR DESCRIPTION
# Contexte

La propriété canAccessDraftSirets existe déjà sur le BSPAOH, donc la seule chose à faire pour changer l'affichage des BSPAOH était de modifier l'indexation elastic pour le prendre en compte.

⚠️ Après déploiement, exécuter `FORCE_LOGGER_CONSOLE=true npx nx run back:reindex-partial-in-place -- -f BSPAOH` dans une one-off pour réindexer les BSPAOH

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/e8d4c0a7-b980-4b5a-a685-c65100dabf2d



# Ticket Favro

[Ne pas permettre d'accéder aux brouillons des autres acteurs sur le PAOH](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16007)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB