### PR TITLE
[TRA-16172] Corriger le fonctionnement du filtre `hasNextStep` sur la query forms

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Permettre aux intégrateurs API d'accéder aux délégations registre en lecture [PR 4039](https://github.com/MTES-MCT/trackdechets/pull/4039)
 
+#### :bug: Corrections de bugs
+
+- Corriger le fonctionnement du filtre `hasNextStep` sur la query `forms`[PR 4051](https://github.com/MTES-MCT/trackdechets/pull/4051)
+
 #### :memo: Documentation
 
 - Mettre à jour la doc "Utiliser le playground" de la documentation développeur [PR 4034](https://github.com/MTES-MCT/trackdechets/pull/4034)

--- a/back/src/forms/resolvers/queries/forms.ts
+++ b/back/src/forms/resolvers/queries/forms.ts
@@ -87,6 +87,13 @@ function getHasNextStepFilter(siret: string, hasNextStep?: boolean | null) {
     OR: [
       // nextStep = markAsSealed
       { status: Status.DRAFT },
+      // Le bordereau est scellé, en attente de la signature émetteur
+      { status: Status.SEALED, emitterCompanySiret: siret },
+      // Le bordereau est signé par l'émetteur, en attente de la signature du 1er transporteur
+      {
+        status: Status.SIGNED_BY_PRODUCER,
+        transporters: { some: { transporterCompanySiret: siret, number: 1 } }
+      },
       {
         AND: [
           // BSD avec acheminement direct du producteur à l'installation de destination


### PR DESCRIPTION
Lorsque `hasNextStep` était `true`, on ne renvoyait pas les bordereaux en attente de signature par l'émetteur ou par le transporteur. 

Problème remonté via le forum : https://forum.trackdechets.beta.gouv.fr/t/filtrage-query-forms-filtre-hasnextstep/1714

# Ticket Favro

[Corriger le fonctionnement du filtre `hasNextStep` sur la query forms](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16172)

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB