### PR TITLE
[TRA-15895] La date de prise en charge par le transporteur apparaît sur le PDF du BSVHU

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsvhu/SignVhuTransport.tsx
@@ -11,7 +11,7 @@ import {
   MutationUpdateBsvhuArgs,
   TransportMode
 } from "@td/codegen-ui";
-import { subMonths } from "date-fns";
+import { format, subMonths } from "date-fns";
 import React from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { generatePath, Link, useLocation, useParams } from "react-router-dom";
@@ -179,7 +179,11 @@ const SignVhuTransport = ({ bsvhuId, onClose }) => {
                     id: bsvhuId,
                     input: {
                       transporter: {
-                        transport: { mode: mode as TransportMode, plates }
+                        transport: {
+                          mode: mode as TransportMode,
+                          plates,
+                          takenOverAt: date
+                        }
                       }
                     }
                   }
@@ -189,7 +193,7 @@ const SignVhuTransport = ({ bsvhuId, onClose }) => {
                     id: bsvhu.id,
                     input: {
                       author,
-                      date,
+                      date: format(new Date(), "yyyy-MM-dd"),
                       type: SignatureTypeInput.Transport
                     }
                   }


### PR DESCRIPTION
# Contexte

On a un bug dans le PDF et dans l'aperçu, lié à une confusion entre 2 champs du VHU: 
- `transporter.takenOverAt`: la date à laquelle le transporteur a effectué l'enlèvement (date choisie par le transporteur dans le formulaire)
- `transporter.signature.date`: la date à laquelle le transporteur a signé l'enlèvement (`Date.now()` au moment de la signature du formulaire par le transporteur)

J'ai l'impression que le formulaire front est cassé, et qu'il envoie le `takenOverAt` dans le champ signature.date. Donc dans la DB:
- Le champ `transporterTransportTakenOverAt` est vide
- Le champ `transporterTransportSignatureDate` contient le `takenOverAt`

Question: que faire pour les VHU cassés?

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Compléter la date de prise en charge transporteur sur le PDF d'un BSVHU](https://favro.com/widget/ab14a4f0460a99a9d64d4945/8e2d603068ea234852fa70d0?card=tra-15895)
