### PR TITLE
[TRA-15971] Après signature de la réception, un VHU reste dans l'onglet "Pour action" du destinataire

### DIFF
--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -157,6 +157,11 @@ export function getWhere(bsvhu: BsvhuForElastic): Pick<BsdElastic, WhereKeys> {
       break;
     }
 
+    case BsvhuStatus.RECEIVED: {
+      setTab(siretsFilters, "destinationCompanySiret", "isForActionFor");
+      break;
+    }
+
     case BsvhuStatus.REFUSED:
     case BsvhuStatus.PROCESSED: {
       for (const fieldName of siretsFilters.keys()) {

--- a/back/src/scripts/bin/reindexReceivedVHUs.ts
+++ b/back/src/scripts/bin/reindexReceivedVHUs.ts
@@ -1,0 +1,41 @@
+import { prisma } from "@td/prisma";
+import { reindex } from "../../bsds/indexation/reindexBsdHelpers";
+import { BsvhuStatus } from "@prisma/client";
+
+// Environ 100 VHUs concernés en production
+// Commande: npx tsx --tsconfig back/tsconfig.lib.json back/src/scripts/bin/reindexReceivedVHUs.ts
+
+(async function () {
+  console.log(
+    ">> Lancement du script de réindexation des VHU au statut RECEIVED"
+  );
+
+  const where = {
+    status: BsvhuStatus.RECEIVED
+  };
+
+  const vhusCount = await prisma.bsvhu.count({
+    where
+  });
+
+  console.log(`${vhusCount} VHUs trouvés avec le statut RECEIVED`);
+
+  const vhus = await prisma.bsvhu.findMany({
+    where,
+    select: {
+      id: true
+    }
+  });
+
+  await Promise.allSettled(
+    vhus.map(async vhu => {
+      try {
+        await reindex(vhu.id, success => success);
+      } catch (_) {
+        throw new Error(`Erreur pour le VHU ${vhu.id}`);
+      }
+    })
+  );
+
+  console.log("Terminé!");
+})().then(() => process.exit());


### PR DESCRIPTION
# Contexte

Petit souci d'indexation dans ES, on a oublié le cas `RECEIVED`.

# :warning: MEP :warning: 

Penser à exécuter le script de correction des VHUs cassés: 
`npx tsx --tsconfig back/tsconfig.lib.json back/src/scripts/bin/reindexReceivedVHUs.ts`

# Démo

[Screencast from 2025-03-21 14-00-49.webm](https://github.com/user-attachments/assets/3e053404-36d3-4372-8e20-c7fc86e0951f)

# Ticket Favro

[Le bordereau va dans l'onglet Suivis après la signature de la réception, alors qu'il devrait rester dans Pour action (signature traitement)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/8e2d603068ea234852fa70d0?card=tra-15971)
