### PR TITLE
[TRA 14422] - Ne pas afficher les brouillons DASRI aux acteurs tiers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Permettre aux intégrateurs API d'accéder aux délégations registre en lecture [PR 4039](https://github.com/MTES-MCT/trackdechets/pull/4039)
 - Ne pas permettre d'accéder aux brouillons des autres acteurs sur le PAOH [PR 4050](https://github.com/MTES-MCT/trackdechets/pull/4050)
+- Ne pas afficher les brouillons DASRI aux acteurs tiers [PR 4061](https://github.com/MTES-MCT/trackdechets/pull/4061)
 
 #### :bug: Corrections de bugs
 

--- a/back/src/bsdasris/__tests__/factories.ts
+++ b/back/src/bsdasris/__tests__/factories.ts
@@ -11,6 +11,7 @@ import type { BsdasriPackagingsInput } from "@td/codegen-back";
 import getReadableId, { ReadableIdPrefix } from "../../forms/readableId";
 import { distinct } from "../../common/arrays";
 import { computeTotalVolume } from "../converter";
+import { getCanAccessDraftOrgIds } from "../utils";
 const dasriData = () => ({
   status: "INITIAL" as BsdasriStatus,
   id: getReadableId(ReadableIdPrefix.DASRI),
@@ -18,8 +19,10 @@ const dasriData = () => ({
 });
 
 export const bsdasriFactory = async ({
+  userId,
   opt = {}
 }: {
+  userId?: string;
   opt?: Partial<Prisma.BsdasriCreateInput>;
 }) => {
   const dasriParams = {
@@ -59,6 +62,15 @@ export const bsdasriFactory = async ({
     return prisma.bsdasri.update({
       where: { id: created.id },
       data: { groupingEmitterSirets }
+    });
+  }
+
+  if (created.isDraft && userId) {
+    const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(created, userId);
+
+    return prisma.bsdasri.update({
+      where: { id: created.id },
+      data: { canAccessDraftOrgIds }
     });
   }
 

--- a/back/src/bsdasris/edition.ts
+++ b/back/src/bsdasris/edition.ts
@@ -23,6 +23,7 @@ type EditableBsdasriFields = Required<
     | "synthesizedIn"
     | "synthesisEmitterSirets"
     | "groupingEmitterSirets"
+    | "canAccessDraftOrgIds"
     | "transportSignatory"
     | "emissionSignatory"
     | "emitterEmissionSignatureDate"

--- a/back/src/bsdasris/permissions.ts
+++ b/back/src/bsdasris/permissions.ts
@@ -7,15 +7,17 @@ import { ForbiddenError, UserInputError } from "../common/errors";
  * Retrieves organisations allowed to read a BSDASRI
  */
 function readers(bsdasri: Bsdasri): string[] {
-  return [
-    bsdasri.emitterCompanySiret,
-    bsdasri.transporterCompanySiret,
-    bsdasri.transporterCompanyVatNumber,
-    bsdasri.destinationCompanySiret,
-    bsdasri.ecoOrganismeSiret,
-    ...bsdasri.synthesisEmitterSirets,
-    ...bsdasri.groupingEmitterSirets
-  ].filter(Boolean);
+  return bsdasri.isDraft
+    ? [...bsdasri.canAccessDraftOrgIds]
+    : [
+        bsdasri.emitterCompanySiret,
+        bsdasri.transporterCompanySiret,
+        bsdasri.transporterCompanyVatNumber,
+        bsdasri.destinationCompanySiret,
+        bsdasri.ecoOrganismeSiret,
+        ...bsdasri.synthesisEmitterSirets,
+        ...bsdasri.groupingEmitterSirets
+      ].filter(Boolean);
 }
 
 /**
@@ -25,6 +27,9 @@ function readers(bsdasri: Bsdasri): string[] {
  * a user is not removing his own company from the BSDASRI
  */
 function contributors(bsdasri: Bsdasri, input?: BsdasriInput) {
+  if (bsdasri.isDraft) {
+    return [...bsdasri.canAccessDraftOrgIds];
+  }
   const updateEmitterCompanySiret = input?.emitter?.company?.siret;
   const updateTransporterCompanySiret = input?.transporter?.company?.siret;
   const updateTransporterCompanyVatNumber =

--- a/back/src/bsdasris/repository/bsdasri/create.ts
+++ b/back/src/bsdasris/repository/bsdasri/create.ts
@@ -39,10 +39,10 @@ export function buildCreateBsdasri(deps: RepositoryFnDeps): CreateBsdasriFn {
     }
 
     // For drafts, only the owner's sirets that appear on the bsd have access
-    const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(
-      bsdasri,
-      user.id
-    );
+    let canAccessDraftOrgIds: string[] = [];
+    if (bsdasri.isDraft) {
+      canAccessDraftOrgIds = await getCanAccessDraftOrgIds(bsdasri, user.id);
+    }
 
     const updatedBsdasri = await prisma.bsdasri.update({
       where: { id: bsdasri.id },

--- a/back/src/bsdasris/repository/bsdasri/create.ts
+++ b/back/src/bsdasris/repository/bsdasri/create.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../common/repository/types";
 import { enqueueCreatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdasriEventTypes } from "./eventTypes";
+import { getCanAccessDraftOrgIds } from "../../utils";
 
 export type CreateBsdasriFn = (
   data: Prisma.BsdasriCreateInput,
@@ -20,30 +21,41 @@ export function buildCreateBsdasri(deps: RepositoryFnDeps): CreateBsdasriFn {
       include: { synthesizing: true, grouping: true }
     });
     // denormalize synthesis emitter sirets
+    let synthesisEmitterSirets: string[] = [];
     if (bsdasri.type === BsdasriType.SYNTHESIS) {
-      const synthesisEmitterSirets = [
+      synthesisEmitterSirets = [
         ...new Set(
           bsdasri.synthesizing.map(associated => associated.emitterCompanySiret)
         )
       ].filter(Boolean);
-
-      await prisma.bsdasri.update({
-        where: { id: bsdasri.id },
-        data: { synthesisEmitterSirets }
-      });
     }
 
     // denormalize grouped emitter sirets
+    let groupingEmitterSirets: string[] = [];
     if (bsdasri.type === BsdasriType.GROUPING) {
-      const groupingEmitterSirets = [
+      groupingEmitterSirets = [
         ...new Set(bsdasri.grouping.map(grouped => grouped.emitterCompanySiret))
       ].filter(Boolean);
-
-      await prisma.bsdasri.update({
-        where: { id: bsdasri.id },
-        data: { groupingEmitterSirets }
-      });
     }
+
+    // For drafts, only the owner's sirets that appear on the bsd have access
+    const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(
+      bsdasri,
+      user.id
+    );
+
+    const updatedBsdasri = await prisma.bsdasri.update({
+      where: { id: bsdasri.id },
+      data: {
+        ...(canAccessDraftOrgIds.length ? { canAccessDraftOrgIds } : {}),
+        ...(bsdasri.type === BsdasriType.SYNTHESIS
+          ? { synthesisEmitterSirets }
+          : {}),
+        ...(bsdasri.type === BsdasriType.GROUPING
+          ? { groupingEmitterSirets }
+          : {})
+      }
+    });
 
     await prisma.event.create({
       data: {
@@ -56,6 +68,6 @@ export function buildCreateBsdasri(deps: RepositoryFnDeps): CreateBsdasriFn {
     });
     prisma.addAfterCommitCallback(() => enqueueCreatedBsdToIndex(bsdasri.id));
 
-    return bsdasri;
+    return updatedBsdasri;
   };
 }

--- a/back/src/bsdasris/repository/bsdasri/update.ts
+++ b/back/src/bsdasris/repository/bsdasri/update.ts
@@ -6,6 +6,7 @@ import {
 import { enqueueUpdatedBsdToIndex } from "../../../queue/producers/elastic";
 import { bsdasriEventTypes } from "./eventTypes";
 import { objectDiff } from "../../../forms/workflow/diff";
+import { getCanAccessDraftOrgIds } from "../../utils";
 
 export type UpdateBsdasriFn = (
   where: Prisma.BsdasriWhereUniqueInput,
@@ -57,6 +58,22 @@ export function buildUpdateBsdasri(deps: RepositoryFnDeps): UpdateBsdasriFn {
       await prisma.bsdasri.update({
         where: { id: bsdasri.id },
         data: { groupingEmitterSirets }
+      });
+    }
+
+    if (bsdasri.isDraft) {
+      const canAccessDraftOrgIds = await getCanAccessDraftOrgIds(
+        bsdasri,
+        user.id
+      );
+      await prisma.bsdasri.update({
+        where: { id: bsdasri.id },
+        data: {
+          canAccessDraftOrgIds
+        },
+        select: {
+          id: true
+        }
       });
     }
 

--- a/back/src/bsdasris/resolvers/mutations/__tests__/publishBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/publishBsdasri.integration.ts
@@ -52,6 +52,7 @@ describe("Mutation.publishBsdasri", () => {
     const { company: destination } = await userWithCompanyFactory("MEMBER");
 
     const dasri = await bsdasriFactory({
+      userId: user.id,
       opt: {
         isDraft: true,
         ...initialData(company),
@@ -110,6 +111,7 @@ describe("Mutation.publishBsdasri", () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const { company: destination } = await userWithCompanyFactory("MEMBER");
     const dasri = await bsdasriFactory({
+      userId: user.id,
       opt: {
         isDraft: true,
         ...initialData(company),

--- a/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
+++ b/back/src/bsdasris/resolvers/mutations/__tests__/updateBsdasri.integration.ts
@@ -175,6 +175,7 @@ describe("Mutation.updateBsdasri", () => {
     async draftStatus => {
       const { user, company } = await userWithCompanyFactory("MEMBER");
       const dasri = await bsdasriFactory({
+        userId: user.id,
         opt: {
           status: BsdasriStatus.INITIAL,
           isDraft: draftStatus === "draft",
@@ -197,7 +198,6 @@ describe("Mutation.updateBsdasri", () => {
           }
         }
       );
-
       expect(data.updateBsdasri.emitter!.company!.mail).toBe("test@test.test");
       expect(data.updateBsdasri.type).toBe("SIMPLE");
       // check input is sirenified
@@ -274,6 +274,7 @@ describe("Mutation.updateBsdasri", () => {
   it("should update transporter recepisse with data pulled from db", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const dasri = await bsdasriFactory({
+      userId: user.id,
       opt: {
         status: BsdasriStatus.INITIAL,
         isDraft: true,
@@ -316,6 +317,7 @@ describe("Mutation.updateBsdasri", () => {
   it("should empty transporter recepisse if transporter has no receipt data", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
     const dasri = await bsdasriFactory({
+      userId: user.id,
       opt: {
         status: BsdasriStatus.INITIAL,
         isDraft: true,
@@ -358,6 +360,7 @@ describe("Mutation.updateBsdasri", () => {
     });
 
     const dasri = await bsdasriFactory({
+      userId: user.id,
       opt: {
         status: BsdasriStatus.INITIAL,
         isDraft: true,

--- a/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/duplicateBsdasri.ts
@@ -103,6 +103,7 @@ async function duplicateBsdasri(user: Express.User, bsdasri: Bsdasri) {
     identificationNumbers,
     synthesisEmitterSirets,
     groupingEmitterSirets,
+    canAccessDraftOrgIds,
     ...fieldsToCopy
   } = bsdasri;
 

--- a/back/src/bsdasris/utils.ts
+++ b/back/src/bsdasris/utils.ts
@@ -1,5 +1,32 @@
 import { DASRI_WASTE_CODES_MAPPING } from "@td/constants";
+import { getUserCompanies } from "../users/database";
+import { Bsdasri } from "@prisma/client";
 
 export function getWasteDescription(wasteCode: string) {
   return DASRI_WASTE_CODES_MAPPING[wasteCode] ?? "";
 }
+
+export const getCanAccessDraftOrgIds = async (
+  bsdasri: Bsdasri,
+  userId: string
+): Promise<string[]> => {
+  const canAccessDraftOrgIds: string[] = [];
+  if (bsdasri.isDraft) {
+    const userCompanies = await getUserCompanies(userId);
+    const userOrgIds = userCompanies.map(company => company.orgId);
+    const bsdasriOrgIds = [
+      bsdasri.emitterCompanySiret,
+      ...[
+        bsdasri.transporterCompanySiret,
+        bsdasri.transporterCompanyVatNumber
+      ].filter(Boolean),
+      bsdasri.ecoOrganismeSiret,
+      bsdasri.destinationCompanySiret
+    ].filter(Boolean);
+    const userOrgIdsInForm = userOrgIds.filter(orgId =>
+      bsdasriOrgIds.includes(orgId)
+    );
+    canAccessDraftOrgIds.push(...userOrgIdsInForm);
+  }
+  return canAccessDraftOrgIds;
+};

--- a/back/src/bsdasris/utils.ts
+++ b/back/src/bsdasris/utils.ts
@@ -16,10 +16,7 @@ export const getCanAccessDraftOrgIds = async (
     const userOrgIds = userCompanies.map(company => company.orgId);
     const bsdasriOrgIds = [
       bsdasri.emitterCompanySiret,
-      ...[
-        bsdasri.transporterCompanySiret,
-        bsdasri.transporterCompanyVatNumber
-      ].filter(Boolean),
+      ...[bsdasri.transporterCompanySiret, bsdasri.transporterCompanyVatNumber],
       bsdasri.ecoOrganismeSiret,
       bsdasri.destinationCompanySiret
     ].filter(Boolean);

--- a/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
+++ b/back/src/bsds/resolvers/mutations/utils/clone.utils.ts
@@ -375,7 +375,8 @@ export const cloneBsdasri = async (user: Express.User, id: string) => {
     type: bsdasri.type,
     updatedAt: bsdasri.updatedAt,
     wasteAdr: bsdasri.wasteAdr,
-    wasteCode: bsdasri.wasteCode
+    wasteCode: bsdasri.wasteCode,
+    canAccessDraftOrgIds: bsdasri.canAccessDraftOrgIds
   };
 
   const newBsdasri = await create(newBsdasriCreateInput);

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdasri.integration.ts
@@ -228,7 +228,7 @@ describe("Query.bsds.dasris base workflow", () => {
         expect.objectContaining({ node: { id: bsdasriId } })
       ]);
     });
-    it("draft bsdasri should be isDraftFor transporter", async () => {
+    it("draft bsdasri should be hidden for the transporter", async () => {
       const { query } = makeClient(transporter.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -241,11 +241,9 @@ describe("Query.bsds.dasris base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bsdasriId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
-    it("draft bsdasri should be isDraftFor destination", async () => {
+    it("draft bsdasri should be hidden for the destination destination", async () => {
       const { query } = makeClient(destination.user);
       const { data } = await query<Pick<Query, "bsds">, QueryBsdsArgs>(
         GET_BSDS,
@@ -258,9 +256,7 @@ describe("Query.bsds.dasris base workflow", () => {
         }
       );
 
-      expect(data.bsds.edges).toEqual([
-        expect.objectContaining({ node: { id: bsdasriId } })
-      ]);
+      expect(data.bsds.edges).toEqual([]);
     });
   });
 

--- a/libs/back/prisma/src/migrations/20250321211406_bsdasri_draft_access/migration.sql
+++ b/libs/back/prisma/src/migrations/20250321211406_bsdasri_draft_access/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Bsdasri" ADD COLUMN     "canAccessDraftOrgIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "_BsdasriCanAccessDraftOrgIdsIdx" ON "Bsdasri" USING GIN ("canAccessDraftOrgIds");

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -323,7 +323,7 @@ model Company {
 
   delegatorRegistryDelegations RegistryDelegation[] @relation("RegistryDelegationDelegator")
   delegateRegistryDelegations  RegistryDelegation[] @relation("RegistryDelegationDelegate")
-  
+
   registryReportedForChangeAggregates RegistryChangeAggregate[] @relation("RegistryChangeAggregatesReportedFor")
   registryReportedAsChangeAggregates  RegistryChangeAggregate[] @relation("RegistryChangeAggregatesReportedAs")
 
@@ -934,10 +934,10 @@ model User {
   StatusLog             StatusLog[]
   UserResetPasswordHash UserResetPasswordHash[]
 
-  bsdasriEmissionSignatures  Bsdasri[]               @relation("BsdasriEmissionSignature")
-  bsdasriTransportSignatures Bsdasri[]               @relation("BsdasriTransportSignature")
-  bsdasriReceptionSignatures Bsdasri[]               @relation("BsdasriReceptionSignature")
-  bsdasriOperationignatures  Bsdasri[]               @relation("BsdasriOperationSignature")
+  bsdasriEmissionSignatures  Bsdasri[]                 @relation("BsdasriEmissionSignature")
+  bsdasriTransportSignatures Bsdasri[]                 @relation("BsdasriTransportSignature")
+  bsdasriReceptionSignatures Bsdasri[]                 @relation("BsdasriReceptionSignature")
+  bsdasriOperationignatures  Bsdasri[]                 @relation("BsdasriOperationSignature")
   Form                       Form[]
   UserActivationHash         UserActivationHash[]
   CompanyDigest              CompanyDigest[]
@@ -1320,6 +1320,8 @@ model Bsdasri {
   finalOperations              BsdasriFinalOperation[] @relation("FinalOperationToInitialBsdasri")
   FinalOperationToFinalBsdasri BsdasriFinalOperation[] @relation("FinalOperationToFinalBsdasri")
 
+  canAccessDraftOrgIds String[] @default([])
+
   // partial indices _BsdasriIsDraftIdx, _BsdasriIsDeletedIdx see migration82_missing_indices.sql
 
   @@index([emitterCompanySiret], map: "_BsdasriEmitterCompanySiretIdx")
@@ -1329,6 +1331,7 @@ model Bsdasri {
   @@index([ecoOrganismeSiret], map: "_BsdasriEcoOrganismeSiretIdx")
   @@index([synthesizedInId], map: "_BsdasriSynthesizedInIdIdx")
   @@index([groupedInId], map: "_BsdasriGroupedInIdIdx")
+  @@index([canAccessDraftOrgIds], map: "_BsdasriCanAccessDraftOrgIdsIdx", type: Gin)
   @@index([status], map: "_BsdasriStatusIdx")
   @@index([type], map: "_BsdasriTypeIdx")
   @@index([updatedAt], map: "_BsdasriUpdatedAtIdx")

--- a/libs/back/scripts/src/scripts/20250321215658031_bsdasri_draft_restriction.ts
+++ b/libs/back/scripts/src/scripts/20250321215658031_bsdasri_draft_restriction.ts
@@ -1,0 +1,181 @@
+import { MongoClient } from "mongodb";
+import Queue, { JobOptions } from "bull";
+import { Bsdasri, Company, Event, User } from "@prisma/client";
+import { prisma } from "@td/prisma";
+import { logger } from "@td/logger";
+
+type EventLike = Omit<Event, "metadata" | "data"> & {
+  data: any;
+  metadata: any;
+};
+
+type EventCollection = { _id: string } & Omit<EventLike, "id">;
+
+const { MONGO_URL, REDIS_URL, NODE_ENV } = process.env;
+const EVENTS_COLLECTION = "events";
+const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+
+const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
+  }
+});
+
+async function enqueueUpdatedBsdToIndex(
+  bsdId: string,
+  options?: JobOptions
+): Promise<void> {
+  logger.info(`Enqueuing BSD ${bsdId} for indexation`);
+  await indexQueue.add("index_updated", bsdId, options);
+}
+
+async function getUserCompanies(userId: string): Promise<Company[]> {
+  const companyAssociations = await prisma.companyAssociation.findMany({
+    where: { userId },
+    include: { company: true }
+  });
+  return companyAssociations.map(association => association.company);
+}
+
+export async function run() {
+  logger.info("starting BSDASRI draft restriction script");
+  const mongodbClient = new MongoClient(MONGO_URL!);
+
+  const database = mongodbClient.db();
+  const eventsCollection =
+    database.collection<EventCollection>(EVENTS_COLLECTION);
+  let finished = false;
+  let lastId: string | null = null;
+  while (!finished) {
+    let bsdasris: Bsdasri[] = [];
+    try {
+      bsdasris = await prisma.bsdasri.findMany({
+        take: 10,
+        skip: 1, // Skip the cursor
+        ...(lastId
+          ? {
+              cursor: {
+                id: lastId
+              }
+            }
+          : {}),
+        where: {
+          AND: [
+            {
+              isDraft: true
+            },
+            {
+              NOT: {
+                isDeleted: true
+              }
+            }
+          ]
+        },
+
+        orderBy: {
+          id: "asc"
+        }
+      });
+    } catch (error) {
+      logger.error(`failed to fetch bsdasris from cursor ${lastId}`);
+      logger.error(error);
+      break;
+    }
+    logger.info(
+      `got BSDASRIS ${bsdasris.map(bsdasri => bsdasri.id).join(", ")}`
+    );
+    if (bsdasris.length < 10) {
+      finished = true;
+    }
+    if (bsdasris.length === 0) {
+      break;
+    }
+    lastId = bsdasris[bsdasris.length - 1].id;
+    let events: EventCollection[];
+    try {
+      events = await eventsCollection
+        .find({
+          streamId: { $in: bsdasris.map(bsdasri => bsdasri.id) },
+          type: "BsdasriCreated"
+        })
+        .toArray();
+      logger.info(
+        `got events ${events.map(event => event.streamId).join(", ")}`
+      );
+    } catch (error) {
+      logger.error(
+        `failed to fetch events for bsdasris ${bsdasris
+          .map(bsdasri => bsdasri.id)
+          .join(", ")}`
+      );
+      logger.error(error);
+      break;
+    }
+
+    for (const bsdasri of bsdasris) {
+      logger.info(`handling ${bsdasri.id}`);
+      const correspondingEvent = events.find(
+        event => event.streamId === bsdasri.id
+      );
+      let user: User | null = null;
+      if (correspondingEvent?.actor) {
+        logger.info("found creation event");
+        try {
+          user = await prisma.user.findFirst({
+            where: {
+              id: correspondingEvent.actor
+            }
+          });
+        } catch (_) {
+          logger.error(`failed to fetch user ${correspondingEvent.actor}`);
+        }
+      }
+
+      let canAccessDraftOrgIds: string[] = [];
+      const bsdasriOrgIds = [
+        bsdasri.emitterCompanySiret,
+        bsdasri.ecoOrganismeSiret,
+        ...[
+          bsdasri.transporterCompanySiret,
+          bsdasri.transporterCompanyVatNumber
+        ].filter(Boolean),
+        bsdasri.destinationCompanySiret
+      ].filter(Boolean);
+      if (user) {
+        logger.info("treating with user");
+        let userCompanies: Company[] = [];
+        try {
+          userCompanies = await getUserCompanies(user.id as string);
+        } catch (_) {
+          logger.error(`failed to fetch companies of user ${user.id}`);
+        }
+        const userOrgIds = userCompanies.map(company => company.orgId);
+        const userOrgIdsInForm = userOrgIds.filter(orgId =>
+          bsdasriOrgIds.includes(orgId)
+        );
+        canAccessDraftOrgIds.push(...userOrgIdsInForm);
+      } else {
+        logger.info("treating without user");
+        canAccessDraftOrgIds = bsdasriOrgIds.filter(Boolean) as string[];
+      }
+      logger.info(`updating ${bsdasri.id}`);
+      await prisma.bsdasri.update({
+        where: { id: bsdasri.id },
+        data: {
+          canAccessDraftOrgIds
+        },
+        select: {
+          id: true
+        }
+      });
+      enqueueUpdatedBsdToIndex(bsdasri.id);
+      logger.info(`updated ${bsdasri.id}`);
+    }
+  }
+  logger.info("exiting");
+  await mongodbClient.close();
+  logger.info("mongo connection closed");
+}


### PR DESCRIPTION
# Contexte

Comme pour les autres bordereaux ayant reçu ce traitement, on ajoute une colonne à la table BSDASRI pour stocker les SIRETS pouvant voir le bordereau à sa création/mise à jour

⚠️ Besoin d'exécuter un script de migration (`npx nx run @td/scripts:migrate` dans une one-off)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Ne pas permettre d'accéder aux brouillons des autres acteurs sur le DASRI](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14422)

# Checklist

- [x] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB