### PR TITLE
Hotfix/ Registry & file type

### DIFF
--- a/front/src/dashboard/registry/ImportModal.tsx
+++ b/front/src/dashboard/registry/ImportModal.tsx
@@ -233,7 +233,7 @@ function Step2({ getValues, goToNextStep, setRegistryImportId }: StepProps) {
 
       const form = new FormData();
       Object.keys(fields).forEach(key => form.append(key, fields[key]));
-      form.append("Content-Type", file.type);
+      form.append("Content-Type", getContentType(file));
       form.append("file", file);
 
       const uploadResponse = await fetch(signedUrl, {
@@ -454,4 +454,15 @@ function Step3({ registryImportId }) {
       )}
     </div>
   );
+}
+
+function getContentType(file: File): string {
+  // file.type is not reliable for CSV files
+  // Some browsers may detect CSV files as application/vnd.ms-excel instead of text/csv because of Windows file type mappings.
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  if (extension === "csv") {
+    return "text/csv";
+  }
+
+  return file.type;
 }


### PR DESCRIPTION
Fix pour les problèmes de "Invalid signature 0x..." rencontrés.
Sur windows, en fonction des navigateurs (chrome & edge, pas firefox de ce que j'ai lu) les fichiers CSV sont souvent envoyés avec un mime type excel.
Résultat, notre import tente de lire un CSV comme un excel. Il tente donc de le dézipper, et unzip throw une "Invalid signature" erreur quand il se rend compte que le fichier n'est pas du tout un zip.

On ne parvenait pas à reproduire car sur macosx le problème de semble pas exister.

Ex de ticket: https://trackdechets.zammad.com/#ticket/zoom/47311