### PR TITLE
HOTFIX - résolution de problème d'écriture concurrente sur RegistryLookup

### DIFF
--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -5,13 +5,11 @@ import {
   TransportedWasteV2
 } from "@td/codegen-back";
 import {
-  PrismaClient,
   RegistryExportType,
   RegistryExportDeclarationType,
   RegistryExportWasteType,
   Prisma
 } from "@prisma/client";
-import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { getTransporterCompanyOrgId } from "@td/constants";
 import {
   emptyIncomingWasteV2,
@@ -1348,36 +1346,54 @@ const bsdaToLookupCreateInputs = (
   return res;
 };
 
-const performRegistryLookupUpdate = async (
-  bsda: MinimalBsdaForLookup,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-): Promise<void> => {
-  await deleteRegistryLookup(bsda.id, tx);
-  const lookupInputs = bsdaToLookupCreateInputs(bsda);
-  if (lookupInputs.length > 0) {
-    try {
-      await tx.registryLookup.createMany({
-        data: lookupInputs
-      });
-    } catch (error) {
-      logger.error(`Error creating registry lookup for bsda ${bsda.id}`);
-      logger.error(lookupInputs);
-      throw error;
-    }
-  }
-};
-
 export const updateRegistryLookup = async (
-  bsda: MinimalBsdaForLookup,
-  tx?: Omit<PrismaClient, ITXClientDenyList>
+  bsda: MinimalBsdaForLookup
 ): Promise<void> => {
-  if (!tx) {
-    await prisma.$transaction(async transaction => {
-      await performRegistryLookupUpdate(bsda, transaction);
-    });
-  } else {
-    await performRegistryLookupUpdate(bsda, tx);
-  }
+  await prisma.$transaction(async tx => {
+    /*
+    Acquire an advisory lock on the bsda id
+    This ensures that only one transaction can proceed with the delete and create
+    operations at a time, preventing conflicts and inconsistencies.
+    Example of problems :
+    tx1: delete(id1) -------------------- create(id1, OUTGOING, siret1, wasteCode1) -> succeeds
+    tx2: ----------- delete(id1) -------------------- create(id1, OUTGOING, siret1, wasteCode2) -> fails
+    --> the second update would fail because of the unique constraint on (id, OUTGOING, siret1)
+    leading to an outdated lookup table
+
+    tx1: delete(id1) -------------------- create(id1, OUTGOING, siret1) -> succeeds
+    tx2: ----------- delete(id1) -------------------- create(id1, OUTGOING, siret2) -> succeeds
+    --> the second update would succeed, but without deleting the row created in the first tx,
+    leading to an inconsistency.
+
+    Without proper locking, the transaction doesn't prevent other transactions from
+    deleting and creating the same rows in parallel, it only prevents the deletion to happen if the subsequent creation fails.
+
+    Using a "select for update" lock would prevent most problems (if the lines already exist at the time the lock is acquired)
+    since it would wait for the lock to be released before proceeding with the delete and create.
+    But if the lines don't exist when the select for update is called, then nothing is locked
+    and we end up with the same problems.
+
+    Using an advisory lock allows us to define a lock that will prevent other transactions for operations
+    on the same id, even if there isn't any rows for this id yet.
+    They will have to wait for the lock to be released (at the end of the tx) before proceeding with the delete and create.
+  */
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${bsda.id}, 0))`;
+
+    // Now proceed with delete and create
+    await deleteRegistryLookup(bsda.id, tx);
+    const lookupInputs = bsdaToLookupCreateInputs(bsda);
+    if (lookupInputs.length > 0) {
+      try {
+        await tx.registryLookup.createMany({
+          data: lookupInputs
+        });
+      } catch (error) {
+        logger.error(`Error creating registry lookup for bsda ${bsda.id}`);
+        logger.error(lookupInputs);
+        throw error;
+      }
+    }
+  });
 };
 
 export const rebuildRegistryLookup = async () => {

--- a/back/src/bsdasris/registryV2.ts
+++ b/back/src/bsdasris/registryV2.ts
@@ -6,12 +6,10 @@ import {
 import { getTransporterCompanyOrgId } from "@td/constants";
 import {
   Prisma,
-  PrismaClient,
   RegistryExportDeclarationType,
   RegistryExportType,
   RegistryExportWasteType
 } from "@prisma/client";
-import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import {
   emptyIncomingWasteV2,
   emptyOutgoingWasteV2,
@@ -681,36 +679,29 @@ const bsdasriToLookupCreateInputs = (
   return res;
 };
 
-const performRegistryLookupUpdate = async (
-  bsdasri: MinimalBsdasriForLookup,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-): Promise<void> => {
-  await deleteRegistryLookup(bsdasri.id, tx);
-  const lookupInputs = bsdasriToLookupCreateInputs(bsdasri);
-  if (lookupInputs.length > 0) {
-    try {
-      await tx.registryLookup.createMany({
-        data: lookupInputs
-      });
-    } catch (error) {
-      logger.error(`Error creating registry lookup for bsdasri ${bsdasri.id}`);
-      logger.error(lookupInputs);
-      throw error;
-    }
-  }
-};
-
 export const updateRegistryLookup = async (
-  bsdasri: MinimalBsdasriForLookup,
-  tx?: Omit<PrismaClient, ITXClientDenyList>
+  bsdasri: MinimalBsdasriForLookup
 ): Promise<void> => {
-  if (!tx) {
-    await prisma.$transaction(async transaction => {
-      await performRegistryLookupUpdate(bsdasri, transaction);
-    });
-  } else {
-    await performRegistryLookupUpdate(bsdasri, tx);
-  }
+  await prisma.$transaction(async tx => {
+    // acquire an advisory lock on the bsdasri id
+    // see more explanation in bsda/registryV2.ts
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${bsdasri.id}, 0))`;
+    await deleteRegistryLookup(bsdasri.id, tx);
+    const lookupInputs = bsdasriToLookupCreateInputs(bsdasri);
+    if (lookupInputs.length > 0) {
+      try {
+        await tx.registryLookup.createMany({
+          data: lookupInputs
+        });
+      } catch (error) {
+        logger.error(
+          `Error creating registry lookup for bsdasri ${bsdasri.id}`
+        );
+        logger.error(lookupInputs);
+        throw error;
+      }
+    }
+  });
 };
 
 export const rebuildRegistryLookup = async () => {

--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -9,14 +9,12 @@ import {
   BsffType,
   OperationMode,
   Prisma,
-  PrismaClient,
   RegistryExportDeclarationType,
   RegistryExportType,
   RegistryExportWasteType,
   WasteAcceptationStatus
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { getTransporterCompanyOrgId } from "@td/constants";
 import {
   emptyIncomingWasteV2,
@@ -1091,36 +1089,27 @@ const bsffToLookupCreateInputs = (
   return res;
 };
 
-const performRegistryLookupUpdate = async (
-  bsff: MinimalBsffForLookup,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-): Promise<void> => {
-  await deleteRegistryLookup(bsff.id, tx);
-  const lookupInputs = bsffToLookupCreateInputs(bsff);
-  if (lookupInputs.length > 0) {
-    try {
-      await tx.registryLookup.createMany({
-        data: lookupInputs
-      });
-    } catch (error) {
-      logger.error(`Error creating registry lookup for bsff ${bsff.id}`);
-      logger.error(lookupInputs);
-      throw error;
-    }
-  }
-};
-
 export const updateRegistryLookup = async (
-  bsff: MinimalBsffForLookup,
-  tx?: Omit<PrismaClient, ITXClientDenyList>
+  bsff: MinimalBsffForLookup
 ): Promise<void> => {
-  if (!tx) {
-    await prisma.$transaction(async transaction => {
-      await performRegistryLookupUpdate(bsff, transaction);
-    });
-  } else {
-    await performRegistryLookupUpdate(bsff, tx);
-  }
+  await prisma.$transaction(async tx => {
+    // acquire an advisory lock on the bsff id
+    // see more explanation in bsda/registryV2.ts
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${bsff.id}, 0))`;
+    await deleteRegistryLookup(bsff.id, tx);
+    const lookupInputs = bsffToLookupCreateInputs(bsff);
+    if (lookupInputs.length > 0) {
+      try {
+        await tx.registryLookup.createMany({
+          data: lookupInputs
+        });
+      } catch (error) {
+        logger.error(`Error creating registry lookup for bsff ${bsff.id}`);
+        logger.error(lookupInputs);
+        throw error;
+      }
+    }
+  });
 };
 
 export const rebuildRegistryLookup = async () => {

--- a/back/src/bspaoh/registryV2.ts
+++ b/back/src/bspaoh/registryV2.ts
@@ -1,13 +1,11 @@
 import Decimal from "decimal.js";
 import {
   Prisma,
-  PrismaClient,
   RegistryExportDeclarationType,
   RegistryExportType,
   RegistryExportWasteType
 } from "@prisma/client";
 import { prisma } from "@td/prisma";
-import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import {
   IncomingWasteV2,
   OutgoingWasteV2,
@@ -631,36 +629,28 @@ const bspaohToLookupCreateInputs = (
   return res;
 };
 
-const performRegistryLookupUpdate = async (
-  bspaoh: MinimalBspaohForLookup,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-): Promise<void> => {
-  await deleteRegistryLookup(bspaoh.id, tx);
-  const lookupInputs = bspaohToLookupCreateInputs(bspaoh);
-  if (lookupInputs.length > 0) {
-    try {
-      await tx.registryLookup.createMany({
-        data: lookupInputs
-      });
-    } catch (error) {
-      logger.error(`Error creating registry lookup for bspaoh ${bspaoh.id}`);
-      logger.error(lookupInputs);
-      throw error;
-    }
-  }
-};
-
 export const updateRegistryLookup = async (
-  bspaoh: MinimalBspaohForLookup,
-  tx?: Omit<PrismaClient, ITXClientDenyList>
+  bspaoh: MinimalBspaohForLookup
 ): Promise<void> => {
-  if (!tx) {
-    await prisma.$transaction(async transaction => {
-      await performRegistryLookupUpdate(bspaoh, transaction);
-    });
-  } else {
-    await performRegistryLookupUpdate(bspaoh, tx);
-  }
+  await prisma.$transaction(async tx => {
+    // acquire an advisory lock on the bspaoh id
+    // see more explanation in bsda/registryV2.ts
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${bspaoh.id}, 0))`;
+
+    await deleteRegistryLookup(bspaoh.id, tx);
+    const lookupInputs = bspaohToLookupCreateInputs(bspaoh);
+    if (lookupInputs.length > 0) {
+      try {
+        await tx.registryLookup.createMany({
+          data: lookupInputs
+        });
+      } catch (error) {
+        logger.error(`Error creating registry lookup for bspaoh ${bspaoh.id}`);
+        logger.error(lookupInputs);
+        throw error;
+      }
+    }
+  });
 };
 
 export const rebuildRegistryLookup = async () => {

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -6,7 +6,6 @@ import {
   TransportedWasteV2
 } from "@td/codegen-back";
 import {
-  PrismaClient,
   RegistryExportType,
   RegistryExportDeclarationType,
   RegistryExportWasteType,
@@ -22,7 +21,6 @@ import {
 import { formToBsddV2, BsddV2 } from "./compat";
 import { getBsddSubType } from "../common/subTypes";
 import { splitAddress } from "../common/addresses";
-import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { deleteRegistryLookup, generateDateInfos } from "@td/registry";
 import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
@@ -1360,36 +1358,27 @@ const bsddToLookupCreateInputs = (
   return res;
 };
 
-const performRegistryLookupUpdate = async (
-  form: MinimalBsddForLookup,
-  tx: Omit<PrismaClient, ITXClientDenyList>
-): Promise<void> => {
-  await deleteRegistryLookup(form.id, tx);
-  const lookupInputs = bsddToLookupCreateInputs(form);
-  if (lookupInputs.length > 0) {
-    try {
-      await tx.registryLookup.createMany({
-        data: lookupInputs
-      });
-    } catch (error) {
-      logger.error(`Error creating registry lookup for bsdd ${form.id}`);
-      logger.error(lookupInputs);
-      throw error;
-    }
-  }
-};
-
 export const updateRegistryLookup = async (
-  form: MinimalBsddForLookup,
-  tx?: Omit<PrismaClient, ITXClientDenyList>
+  form: MinimalBsddForLookup
 ): Promise<void> => {
-  if (!tx) {
-    await prisma.$transaction(async transaction => {
-      await performRegistryLookupUpdate(form, transaction);
-    });
-  } else {
-    await performRegistryLookupUpdate(form, tx);
-  }
+  await prisma.$transaction(async tx => {
+    // acquire an advisory lock on the bsdd id
+    // see more explanation in bsda/registryV2.ts
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${form.id}, 0))`;
+    await deleteRegistryLookup(form.id, tx);
+    const lookupInputs = bsddToLookupCreateInputs(form);
+    if (lookupInputs.length > 0) {
+      try {
+        await tx.registryLookup.createMany({
+          data: lookupInputs
+        });
+      } catch (error) {
+        logger.error(`Error creating registry lookup for bsdd ${form.id}`);
+        logger.error(lookupInputs);
+        throw error;
+      }
+    }
+  });
 };
 
 export const rebuildRegistryLookup = async () => {


### PR DESCRIPTION
# Contexte

Ajout d'un advisory lock sur les transactions d'update de Registrylookup

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB