### PR TITLE
HOTFIX - Permettre aux établissements identifiés comme systèmes d'individuels d'être désignés comme producteurs sur un BSDD et BSDA

### DIFF
--- a/back/src/bsda/validation/refinements.ts
+++ b/back/src/bsda/validation/refinements.ts
@@ -271,7 +271,7 @@ async function checkEmitterIsNotEcoOrganisme(
   if (!siret) return null;
 
   const ecoOrganisme = await prisma.ecoOrganisme.findFirst({
-    where: { siret },
+    where: { siret, handleBsda: true },
     select: { id: true }
   });
 

--- a/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/createForm.integration.ts
@@ -641,7 +641,10 @@ describe("Mutation.createForm", () => {
 
   it("should not allow to create a form with an eco-organisme as emitter", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");
-    const ecoOrganisme = await ecoOrganismeFactory({ siret: siretify() });
+    const ecoOrganisme = await ecoOrganismeFactory({
+      siret: siretify(),
+      handle: { handleBsdd: true }
+    });
 
     const { mutate } = makeClient(user);
     const { errors } = await mutate<
@@ -668,6 +671,40 @@ describe("Mutation.createForm", () => {
     expect(errors[0].message).toContain(
       "L'émetteur ne peut pas être un éco-organisme."
     );
+  });
+
+  // tra-16203 - Permettre aux établissements identifiés comme systèmes d'individuels VHU d'être désignés
+  // comme producteurs sur un BSDD et BSDA
+  it("should allow to create a form with an eco-organisme that do not handle BSDD as emitter", async () => {
+    const { user, company } = await userWithCompanyFactory("MEMBER");
+    const ecoOrganisme = await ecoOrganismeFactory({
+      siret: siretify(),
+      // système individuel VHU
+      handle: { handleBsvhu: true }
+    });
+
+    const { mutate } = makeClient(user);
+    const { errors } = await mutate<
+      Pick<Mutation, "createForm">,
+      MutationCreateFormArgs
+    >(CREATE_FORM, {
+      variables: {
+        createFormInput: {
+          emitter: {
+            company: {
+              siret: ecoOrganisme.siret
+            }
+          },
+          transporter: {
+            company: {
+              siret: company.siret
+            }
+          }
+        }
+      }
+    });
+
+    expect(errors).toBeUndefined();
   });
 
   it("should be possible to create a form and connect existing bsddTransporters", async () => {

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -465,7 +465,7 @@ const emitterSchemaFn: FactorySchemaOf<FormValidationContext, Emitter> = ({
           if (!value) return true;
 
           const ecoOrganisme = await prisma.ecoOrganisme.findFirst({
-            where: { siret: value },
+            where: { siret: value, handleBsdd: true },
             select: { id: true }
           });
 


### PR DESCRIPTION
Un constructeur auto identifié comme système individuel et assimilé à un éco-organisme VHU ne pouvait plus être identifié en tant qu'émetteur sur un BSDD ou BSDA.

# Ticket Favro

[Permettre aux établissements identifiés comme systèmes d'individuels d'être désignés comme producteurs sur un BSDD et BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16203)

