### PR TITLE
[TRA-16220] ETQ utilisateur de l'import registre par API, je souhaite recevoir en retour les déclarations par statut (ajoutées, modifiées, ignorées, annulées) 

### DIFF
--- a/back/src/registryV2/resolvers/mutations/__tests__/addToIncomingWasteRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToIncomingWasteRegistry.integration.ts
@@ -21,6 +21,10 @@ const ADD_TO_INCOMING_WASTE_REGISTRY = gql`
         publicId
         message
       }
+      inserted
+      edited
+      cancelled
+      skipped
     }
   }
 `;
@@ -216,5 +220,50 @@ describe("Registry - addToIncomingWasteRegistry", () => {
       where: { publicId: line.publicId, isLatest: true }
     });
     expect(result.wasteCodeBale).toBe("A1070");
+  });
+
+  it("should return public identifiers by status (inserted, edited, sipped, cancelled)", async () => {
+    const { user, company } = await userWithCompanyFactory();
+
+    const { mutate } = makeClient(user);
+
+    const lines = Array.from({ length: 3 }).map(_ =>
+      getCorrectLine(company.orgId)
+    );
+
+    // Insert lines
+    const res1 = await mutate<Pick<Mutation, "addToIncomingWasteRegistry">>(
+      ADD_TO_INCOMING_WASTE_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.data.addToIncomingWasteRegistry).toMatchObject({
+      inserted: lines.map(l => l.publicId),
+      edited: [],
+      cancelled: [],
+      skipped: []
+    });
+
+    // Edit, cancel and add already existing line that should be skipped
+    const res2 = await mutate<Pick<Mutation, "addToIncomingWasteRegistry">>(
+      ADD_TO_INCOMING_WASTE_REGISTRY,
+      {
+        variables: {
+          lines: [
+            { ...lines[0], reason: "EDIT" },
+            { ...lines[1], reason: "CANCEL" },
+            lines[2]
+          ]
+        }
+      }
+    );
+
+    expect(res2.errors).toBeUndefined();
+
+    expect(res2.data.addToIncomingWasteRegistry).toMatchObject({
+      inserted: [],
+      edited: [lines[0].publicId],
+      cancelled: [lines[1].publicId],
+      skipped: [lines[2].publicId]
+    });
   });
 });

--- a/back/src/registryV2/resolvers/mutations/__tests__/addToManagedRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToManagedRegistry.integration.ts
@@ -21,6 +21,10 @@ const ADD_TO_MANAGED_REGISTRY = gql`
         publicId
         message
       }
+      inserted
+      edited
+      cancelled
+      skipped
     }
   }
 `;
@@ -227,5 +231,50 @@ describe("Registry - addToManagedRegistry", () => {
       where: { publicId: line.publicId, isLatest: true }
     });
     expect(result.wasteCodeBale).toBe("A1070");
+  });
+
+  it("should return public identifiers by status (inserted, edited, sipped, cancelled)", async () => {
+    const { user, company } = await userWithCompanyFactory();
+
+    const { mutate } = makeClient(user);
+
+    const lines = Array.from({ length: 3 }).map(_ =>
+      getCorrectLine(company.orgId)
+    );
+
+    // Insert lines
+    const res1 = await mutate<Pick<Mutation, "addToManagedRegistry">>(
+      ADD_TO_MANAGED_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.data.addToManagedRegistry).toMatchObject({
+      inserted: lines.map(l => l.publicId),
+      edited: [],
+      cancelled: [],
+      skipped: []
+    });
+
+    // Edit, cancel and add already existing line that should be skipped
+    const res2 = await mutate<Pick<Mutation, "addToManagedRegistry">>(
+      ADD_TO_MANAGED_REGISTRY,
+      {
+        variables: {
+          lines: [
+            { ...lines[0], reason: "EDIT" },
+            { ...lines[1], reason: "CANCEL" },
+            lines[2]
+          ]
+        }
+      }
+    );
+
+    expect(res2.errors).toBeUndefined();
+
+    expect(res2.data.addToManagedRegistry).toMatchObject({
+      inserted: [],
+      edited: [lines[0].publicId],
+      cancelled: [lines[1].publicId],
+      skipped: [lines[2].publicId]
+    });
   });
 });

--- a/back/src/registryV2/resolvers/mutations/__tests__/addToOutgoingTexsRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToOutgoingTexsRegistry.integration.ts
@@ -21,6 +21,10 @@ const ADD_TO_OUTGOING_TEXS_REGISTRY = gql`
         publicId
         message
       }
+      inserted
+      edited
+      cancelled
+      skipped
     }
   }
 `;
@@ -225,5 +229,50 @@ describe("Registry - addToOutgoingTexsRegistry", () => {
       where: { publicId: line.publicId, isLatest: true }
     });
     expect(result.wasteCodeBale).toBe("A1070");
+  });
+
+  it("should return public identifiers by status (inserted, edited, sipped, cancelled)", async () => {
+    const { user, company } = await userWithCompanyFactory();
+
+    const { mutate } = makeClient(user);
+
+    const lines = Array.from({ length: 3 }).map(_ =>
+      getCorrectLine(company.orgId)
+    );
+
+    // Insert lines
+    const res1 = await mutate<Pick<Mutation, "addToOutgoingTexsRegistry">>(
+      ADD_TO_OUTGOING_TEXS_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.data.addToOutgoingTexsRegistry).toMatchObject({
+      inserted: lines.map(l => l.publicId),
+      edited: [],
+      cancelled: [],
+      skipped: []
+    });
+
+    // Edit, cancel and add already existing line that should be skipped
+    const res2 = await mutate<Pick<Mutation, "addToOutgoingTexsRegistry">>(
+      ADD_TO_OUTGOING_TEXS_REGISTRY,
+      {
+        variables: {
+          lines: [
+            { ...lines[0], reason: "EDIT" },
+            { ...lines[1], reason: "CANCEL" },
+            lines[2]
+          ]
+        }
+      }
+    );
+
+    expect(res2.errors).toBeUndefined();
+
+    expect(res2.data.addToOutgoingTexsRegistry).toMatchObject({
+      inserted: [],
+      edited: [lines[0].publicId],
+      cancelled: [lines[1].publicId],
+      skipped: [lines[2].publicId]
+    });
   });
 });

--- a/back/src/registryV2/resolvers/mutations/__tests__/addToOutgoingWasteRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToOutgoingWasteRegistry.integration.ts
@@ -21,6 +21,10 @@ const ADD_TO_OUTGOING_WASTE_REGISTRY = gql`
         publicId
         message
       }
+      inserted
+      edited
+      cancelled
+      skipped
     }
   }
 `;
@@ -211,5 +215,50 @@ describe("Registry - addToOutgoingWasteRegistry", () => {
       where: { publicId: line.publicId, isLatest: true }
     });
     expect(result.wasteCodeBale).toBe("A1070");
+  });
+
+  it("should return public identifiers by status (inserted, edited, sipped, cancelled)", async () => {
+    const { user, company } = await userWithCompanyFactory();
+
+    const { mutate } = makeClient(user);
+
+    const lines = Array.from({ length: 3 }).map(_ =>
+      getCorrectLine(company.orgId)
+    );
+
+    // Insert lines
+    const res1 = await mutate<Pick<Mutation, "addToOutgoingWasteRegistry">>(
+      ADD_TO_OUTGOING_WASTE_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.data.addToOutgoingWasteRegistry).toMatchObject({
+      inserted: lines.map(l => l.publicId),
+      edited: [],
+      cancelled: [],
+      skipped: []
+    });
+
+    // Edit, cancel and add already existing line that should be skipped
+    const res2 = await mutate<Pick<Mutation, "addToOutgoingWasteRegistry">>(
+      ADD_TO_OUTGOING_WASTE_REGISTRY,
+      {
+        variables: {
+          lines: [
+            { ...lines[0], reason: "EDIT" },
+            { ...lines[1], reason: "CANCEL" },
+            lines[2]
+          ]
+        }
+      }
+    );
+
+    expect(res2.errors).toBeUndefined();
+
+    expect(res2.data.addToOutgoingWasteRegistry).toMatchObject({
+      inserted: [],
+      edited: [lines[0].publicId],
+      cancelled: [lines[1].publicId],
+      skipped: [lines[2].publicId]
+    });
   });
 });

--- a/back/src/registryV2/resolvers/mutations/__tests__/addToSsdRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToSsdRegistry.integration.ts
@@ -21,6 +21,10 @@ const ADD_TO_SSD_REGISTRY = gql`
         publicId
         message
       }
+      inserted
+      edited
+      cancelled
+      skipped
     }
   }
 `;
@@ -153,5 +157,52 @@ describe("Registry - addToSsdRegistry", () => {
       where: { publicId: line.publicId, isLatest: true }
     });
     expect(result.wasteCodeBale).toBe("A1070");
+  });
+
+  it("should return public identifiers by status (inserted, edited, sipped, cancelled)", async () => {
+    const { user, company } = await userWithCompanyFactory("ADMIN", {
+      companyTypes: { set: ["RECOVERY_FACILITY"] }
+    });
+
+    const { mutate } = makeClient(user);
+
+    const lines = Array.from({ length: 3 }).map(_ =>
+      getCorrectLine(company.orgId)
+    );
+
+    // Insert lines
+    const res1 = await mutate<Pick<Mutation, "addToSsdRegistry">>(
+      ADD_TO_SSD_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.data.addToSsdRegistry).toMatchObject({
+      inserted: lines.map(l => l.publicId),
+      edited: [],
+      cancelled: [],
+      skipped: []
+    });
+
+    // Edit, cancel and add already existing line that should be skipped
+    const res2 = await mutate<Pick<Mutation, "addToSsdRegistry">>(
+      ADD_TO_SSD_REGISTRY,
+      {
+        variables: {
+          lines: [
+            { ...lines[0], reason: "EDIT" },
+            { ...lines[1], reason: "CANCEL" },
+            lines[2]
+          ]
+        }
+      }
+    );
+
+    expect(res2.errors).toBeUndefined();
+
+    expect(res2.data.addToSsdRegistry).toMatchObject({
+      inserted: [],
+      edited: [lines[0].publicId],
+      cancelled: [lines[1].publicId],
+      skipped: [lines[2].publicId]
+    });
   });
 });

--- a/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
+++ b/back/src/registryV2/resolvers/mutations/genericAddToRegistry.ts
@@ -15,6 +15,7 @@ import { Permission, checkUserPermissions } from "../../../permissions";
 import { getDelegatorsByDelegateForEachCompanies } from "../../../registryDelegation/database";
 import { GraphQLContext } from "../../../types";
 import { getUserCompanies } from "../../../users/database";
+import { AddRegistryLinesResponse } from "@td/codegen-back";
 
 const LINES_LIMIT = 1_000;
 
@@ -29,7 +30,7 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
   importType: ImportType,
   lines: T[],
   context: GraphQLContext
-) {
+): Promise<AddRegistryLinesResponse> {
   const options = importOptions[importType];
 
   const user = checkIsAuthenticated(context);
@@ -55,6 +56,13 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
 
   const { safeParseAsync, saveLine } = options;
   const errors = new Map<string, ZodIssue[]>();
+
+  // Payload permettant de renvoyer les identifiants des enregistrements
+  // par statut (insertion, modification, annulation, etc)
+  const identifiers: Pick<
+    AddRegistryLinesResponse,
+    "inserted" | "cancelled" | "edited" | "skipped"
+  > = { inserted: [], cancelled: [], edited: [], skipped: [] };
   const changesByCompany = new Map<
     string,
     { [reportAsSiret: string]: RegistryChanges }
@@ -91,6 +99,21 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
         line: { ...result.data, createdById: user.id },
         importId: null
       });
+
+      switch (result.data.reason) {
+        case "MODIFIER":
+          identifiers.edited.push(result.data.publicId);
+          break;
+        case "ANNULER":
+          identifiers.cancelled.push(result.data.publicId);
+          break;
+        case "IGNORER":
+          identifiers.skipped.push(result.data.publicId);
+          break;
+        default:
+          identifiers.inserted.push(result.data.publicId);
+          break;
+      }
     } else {
       errors.set(line.publicId, result.error.issues);
     }
@@ -118,6 +141,7 @@ export async function genericAddToRegistry<T extends UnparsedLine>(
         message,
         code
       }))
-    }))
+    })),
+    ...identifiers
   };
 }

--- a/back/src/registryV2/typeDefs/registryV2.objects.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.objects.graphql
@@ -1640,6 +1640,14 @@ type AddRegistryLinesStats {
 type AddRegistryLinesResponse {
   stats: AddRegistryLinesStats!
   errors: [RegistryLineError!]
+  # Liste des identifiants (`publicId`) des déclarations qui ont été insérées
+  inserted: [ID!]!
+  # Liste des identifiants (`publicId`) des déclarations qui ont été modifiées
+  edited: [ID!]!
+  # Liste des identifiants (`publicId`) des déclarations qui ont été annulées
+  cancelled: [ID!]!
+  # Liste des identifiants (`publicId`) des déclarations qui ont été ignorées
+  skipped: [ID!]!
 }
 
 type RegistryLookup {


### PR DESCRIPTION

# Contexte

Demande intégrateur sur le forum

https://forum.trackdechets.beta.gouv.fr/t/migration-rndts-lignes-inserees-vs-ignorees/1748

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB