### PR TITLE
[TRA-15993] Mise à jour des modes d'opération

### DIFF
--- a/back/src/common/__tests__/operationModes.test.ts
+++ b/back/src/common/__tests__/operationModes.test.ts
@@ -1,59 +1,27 @@
 import { OperationMode } from "@prisma/client";
-import { getOperationModesFromOperationCode } from "../operationModes";
-import { trim } from "../strings";
+import {
+  CODES_AND_EXPECTED_OPERATION_MODES,
+  getOperationModesFromOperationCode
+} from "../operationModes";
+
+const addSpaceAfterFirstCharacter = (input: string): string => {
+  return input[0] + " " + input.slice(1);
+};
 
 const test = (code: string, expectedModes: OperationMode[]) => {
-  // With spaces
+  // Without spaces
   const mode = getOperationModesFromOperationCode(code);
   expect(mode).toEqual(expectedModes);
 
-  // Without spaces
-  const modeTrimmed = getOperationModesFromOperationCode(trim(code));
-  expect(modeTrimmed).toEqual(expectedModes);
+  // With spaces
+  const modeWithSpace = getOperationModesFromOperationCode(
+    addSpaceAfterFirstCharacter(code)
+  );
+  expect(modeWithSpace).toEqual(expectedModes);
 };
 
 describe("getOperationModesFromOperationCode", () => {
-  it.each([
-    "D 1",
-    "D 2",
-    "D 3",
-    "D 4",
-    "D 5",
-    "D 6",
-    "D 7",
-    "D 8",
-
-    "D 9 F",
-    "D 10",
-    "D 11",
-    "D 12"
-  ])("Code %p > [ELIMINATION]", code => {
-    test(code, [OperationMode.ELIMINATION]);
-  });
-
-  it.each(["D 13", "D 14", "D 15", "R 12", "R 13", "D 9"])(
-    "Regroupement code %p > []",
-    code => {
-      test(code, []);
-    }
-  );
-
-  it.each(["R 0"])("Code %p > [REUTILISATION]", code => {
-    test(code, [OperationMode.REUTILISATION]);
-  });
-
-  it.each(["R 1"])("Code %p > [ENERGY_RECOVERY]", code => {
-    test(code, [OperationMode.VALORISATION_ENERGETIQUE]);
-  });
-
-  it.each(["R 2", "R 3", "R 4", "R 5", "R 7", "R 9", "R 11"])(
-    "Code %p > [REUSE, RECYCLING]",
-    code => {
-      test(code, [OperationMode.REUTILISATION, OperationMode.RECYCLAGE]);
-    }
-  );
-
-  it.each(["R 6", "R 8", "R 10"])("Code %p > [RECYCLING]", code => {
-    test(code, [OperationMode.RECYCLAGE]);
+  it.each(Object.keys(CODES_AND_EXPECTED_OPERATION_MODES))("Code %p", code => {
+    test(code, CODES_AND_EXPECTED_OPERATION_MODES[code]);
   });
 });

--- a/back/src/common/operationModes.ts
+++ b/back/src/common/operationModes.ts
@@ -1,6 +1,69 @@
 import { OperationMode } from "@prisma/client";
 import { trim } from "./strings";
 
+/**
+ * Documentation: https://app.gitbook.com/o/-LxvsGVFUcY-b40HZcJs/s/bOGR2l18BC74rMQs4CWK/~/changes/2/general/codes-de-traitement
+ */
+export const CODES_AND_EXPECTED_OPERATION_MODES = {
+  // Opérations d'élimination
+  D1: [OperationMode.ELIMINATION],
+  D2: [OperationMode.ELIMINATION],
+  D3: [OperationMode.ELIMINATION],
+  D4: [OperationMode.ELIMINATION],
+  D5: [OperationMode.ELIMINATION],
+  // "D6": Interdit en France
+  D7: [OperationMode.ELIMINATION],
+  D8: [OperationMode.ELIMINATION],
+  D9: [],
+  D9F: [OperationMode.ELIMINATION],
+  D10: [OperationMode.ELIMINATION],
+  D11: [OperationMode.ELIMINATION],
+  D12: [OperationMode.ELIMINATION],
+  D13: [],
+  D14: [],
+  D15: [],
+
+  // Opérations de valorisation
+  R0: [OperationMode.REUTILISATION],
+  R1: [OperationMode.VALORISATION_ENERGETIQUE],
+  R2: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R3: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R4: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R5: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R6: [OperationMode.RECYCLAGE, OperationMode.AUTRES_VALORISATIONS],
+  R7: [OperationMode.RECYCLAGE, OperationMode.AUTRES_VALORISATIONS],
+  R8: [OperationMode.RECYCLAGE, OperationMode.AUTRES_VALORISATIONS],
+  R9: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R10: [OperationMode.AUTRES_VALORISATIONS],
+  R11: [
+    OperationMode.REUTILISATION,
+    OperationMode.RECYCLAGE,
+    OperationMode.AUTRES_VALORISATIONS
+  ],
+  R12: [],
+  R13: []
+};
+
 export const getOperationModesFromOperationCode = (
   operationCode: string
 ): OperationMode[] => {
@@ -10,45 +73,7 @@ export const getOperationModesFromOperationCode = (
   // In some places we use "X 0", in some other "X0"
   const trimmed = trim(operationCode);
 
-  if (
-    [
-      "D1",
-      "D2",
-      "D3",
-      "D4",
-      "D5",
-      "D6",
-      "D7",
-      "D8",
-      // "D9" traitement non final
-      "D9F",
-      "D10",
-      "D11",
-      "D12"
-    ].includes(trimmed)
-  ) {
-    return [OperationMode.ELIMINATION];
-  }
-
-  if (trimmed === "R0") {
-    return [OperationMode.REUTILISATION];
-  }
-
-  if (trimmed === "R1") {
-    return [OperationMode.VALORISATION_ENERGETIQUE];
-  }
-
-  if (["R2", "R3", "R4", "R5", "R7", "R9", "R11"].includes(trimmed)) {
-    return [OperationMode.REUTILISATION, OperationMode.RECYCLAGE];
-  }
-
-  if (["R6", "R8", "R10"].includes(trimmed)) {
-    return [OperationMode.RECYCLAGE];
-  }
-
-  // Regroupements: D13, D14, D15, R12, R13
-  // D9 traitement non final
-  return [];
+  return CODES_AND_EXPECTED_OPERATION_MODES[trimmed] || [];
 };
 
 export const getOperationModeLabel = (operationMode: OperationMode) => {
@@ -61,5 +86,7 @@ export const getOperationModeLabel = (operationMode: OperationMode) => {
       return "Réutilisation";
     case OperationMode.VALORISATION_ENERGETIQUE:
       return "Valorisation énergétique";
+    case OperationMode.AUTRES_VALORISATIONS:
+      return "Autres valorisations";
   }
 };

--- a/front/src/Apps/common/operationModes.test.ts
+++ b/front/src/Apps/common/operationModes.test.ts
@@ -1,60 +1,27 @@
 import { OperationMode } from "@td/codegen-ui";
-import { getOperationModesFromOperationCode } from "./operationModes";
+import {
+  getOperationModesFromOperationCode,
+  CODES_AND_EXPECTED_OPERATION_MODES
+} from "./operationModes";
+
+const addSpaceAfterFirstCharacter = (input: string): string => {
+  return input[0] + " " + input.slice(1);
+};
 
 const test = (code: string, expectedModes: OperationMode[]) => {
-  // With spaces
+  // Without spaces
   const mode = getOperationModesFromOperationCode(code);
   expect(mode).toEqual(expectedModes);
 
-  // Without spaces
-  const modeTrimmed = getOperationModesFromOperationCode(
-    code.replace(/ /g, "").toString()
+  // With spaces
+  const modeWithSpace = getOperationModesFromOperationCode(
+    addSpaceAfterFirstCharacter(code)
   );
-  expect(modeTrimmed).toEqual(expectedModes);
+  expect(modeWithSpace).toEqual(expectedModes);
 };
 
 describe("getOperationModesFromOperationCode", () => {
-  it.each([
-    "D 1",
-    "D 2",
-    "D 3",
-    "D 4",
-    "D 5",
-    "D 6",
-    "D 7",
-    "D 8",
-
-    "D 9 F",
-    "D 10",
-    "D 11",
-    "D 12"
-  ])("Code %p > [ELIMINATION]", code => {
-    test(code, [OperationMode.Elimination]);
-  });
-
-  it.each(["D 13", "D 14", "D 15", "R 12", "R 13", "D 9"])(
-    "Regroupement code %p > []",
-    code => {
-      test(code, []);
-    }
-  );
-
-  it.each(["R 0"])("Code %p > [REUTILISATION]", code => {
-    test(code, [OperationMode.Reutilisation]);
-  });
-
-  it.each(["R 1"])("Code %p > [ENERGY_RECOVERY]", code => {
-    test(code, [OperationMode.ValorisationEnergetique]);
-  });
-
-  it.each(["R 2", "R 3", "R 4", "R 5", "R 7", "R 9", "R 11"])(
-    "Code %p > [REUSE, RECYCLING]",
-    code => {
-      test(code, [OperationMode.Reutilisation, OperationMode.Recyclage]);
-    }
-  );
-
-  it.each(["R 6", "R 8", "R 10"])("Code %p > [RECYCLING]", code => {
-    test(code, [OperationMode.Recyclage]);
+  it.each(Object.keys(CODES_AND_EXPECTED_OPERATION_MODES))("Code %p", code => {
+    test(code, CODES_AND_EXPECTED_OPERATION_MODES[code]);
   });
 });

--- a/front/src/Apps/common/operationModes.ts
+++ b/front/src/Apps/common/operationModes.ts
@@ -1,5 +1,68 @@
 import { OperationMode } from "@td/codegen-ui";
 
+/**
+ * Documentation: https://app.gitbook.com/o/-LxvsGVFUcY-b40HZcJs/s/bOGR2l18BC74rMQs4CWK/~/changes/2/general/codes-de-traitement
+ */
+export const CODES_AND_EXPECTED_OPERATION_MODES = {
+  // Opérations d'élimination
+  D1: [OperationMode.Elimination],
+  D2: [OperationMode.Elimination],
+  D3: [OperationMode.Elimination],
+  D4: [OperationMode.Elimination],
+  D5: [OperationMode.Elimination],
+  // "D6": Interdit en France
+  D7: [OperationMode.Elimination],
+  D8: [OperationMode.Elimination],
+  D9: [],
+  D9F: [OperationMode.Elimination],
+  D10: [OperationMode.Elimination],
+  D11: [OperationMode.Elimination],
+  D12: [OperationMode.Elimination],
+  D13: [],
+  D14: [],
+  D15: [],
+
+  // Opérations de valorisation
+  R0: [OperationMode.Reutilisation],
+  R1: [OperationMode.ValorisationEnergetique],
+  R2: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R3: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R4: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R5: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R6: [OperationMode.Recyclage, OperationMode.AutresValorisations],
+  R7: [OperationMode.Recyclage, OperationMode.AutresValorisations],
+  R8: [OperationMode.Recyclage, OperationMode.AutresValorisations],
+  R9: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R10: [OperationMode.AutresValorisations],
+  R11: [
+    OperationMode.Reutilisation,
+    OperationMode.Recyclage,
+    OperationMode.AutresValorisations
+  ],
+  R12: [],
+  R13: []
+};
+
 export const getOperationModesFromOperationCode = (
   operationCode: string
 ): OperationMode[] => {
@@ -9,44 +72,7 @@ export const getOperationModesFromOperationCode = (
   // In some places we use "X 0", in some other "X0"
   const trimmed = operationCode.replace(/ /g, "").toString();
 
-  if (
-    [
-      "D1",
-      "D2",
-      "D3",
-      "D4",
-      "D5",
-      "D6",
-      "D7",
-      "D8",
-      // "D9", non final
-      "D9F",
-      "D10",
-      "D11",
-      "D12"
-    ].includes(trimmed)
-  ) {
-    return [OperationMode.Elimination];
-  }
-
-  if (trimmed === "R0") {
-    return [OperationMode.Reutilisation];
-  }
-
-  if (trimmed === "R1") {
-    return [OperationMode.ValorisationEnergetique];
-  }
-
-  if (["R2", "R3", "R4", "R5", "R7", "R9", "R11"].includes(trimmed)) {
-    return [OperationMode.Reutilisation, OperationMode.Recyclage];
-  }
-
-  if (["R6", "R8", "R10"].includes(trimmed)) {
-    return [OperationMode.Recyclage];
-  }
-
-  // Regroupements: D13, D14, D15, R12, R13 and D9
-  return [];
+  return CODES_AND_EXPECTED_OPERATION_MODES[trimmed] || [];
 };
 
 export const getOperationModeLabel = (operationMode: OperationMode) => {
@@ -59,5 +85,7 @@ export const getOperationModeLabel = (operationMode: OperationMode) => {
       return "Réutilisation";
     case OperationMode.ValorisationEnergetique:
       return "Valorisation énergétique";
+    case OperationMode.AutresValorisations:
+      return "Autres valorisations";
   }
 };

--- a/front/src/common/components/OperationModeSelect.tsx
+++ b/front/src/common/components/OperationModeSelect.tsx
@@ -40,7 +40,7 @@ const OperationModeSelect = ({ operationCode, name }) => {
       <fieldset>
         <legend>
           Mode de traitement{" "}
-          <Tooltip title="Le mode de traitement correspond à un des 4 choix de la hiérarchie des modes de traitement, il s'impose de lui même ou doit être précisé selon l'opération réalisée" />
+          <Tooltip title="Le mode de traitement correspond à l'un des choix de la hiérarchie des modes de traitement. Selon l'opération réalisée, il s'impose de lui-même ou doit être précisé." />
         </legend>
         <div className="tw-flex">
           {modes.map(mode => (


### PR DESCRIPTION
# Contexte

Petite mise à jour des modes d'opération: on ajoute "Autres valorisations" aux codes de traitements R 2, R 3, R 4, R 5, R 6, R 7, R 8, R 9, R 10, R 11.

J'en ai profité pour refactorer un peu le bouzin.

# Démo

![demo_modes](https://github.com/user-attachments/assets/d3ae7ce3-1d6c-4f97-8a72-0ca0860cf641)

# Ticket Favro

[Ajouter comme hiérarchie de mode de traitement "Autres valorisations" aux codes de traitements R 2, R 3, R 4, R 5, R 6, R 7, R 8, R 9, R 10, R 11 (front et back)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15993)
