### PR TITLE
[TRA-15994] Ajout du lien FAQ manquant pour le changement d'admin

### DIFF
--- a/front/src/Apps/Companies/CompanyManage/CompanyAdminRequest/CompanyAdminRequest.tsx
+++ b/front/src/Apps/Companies/CompanyManage/CompanyAdminRequest/CompanyAdminRequest.tsx
@@ -40,7 +40,7 @@ export const CompanyAdminRequest = () => {
             assurer de la relation entre le demandeur et l'établissement.
             Retrouvez les{" "}
             <a
-              href="TODO"
+              href="https://faq.trackdechets.fr/inscription-et-gestion-de-compte/gerer-son-compte/modifier-les-informations-de-son-compte#option-3-si-ladministrateur-est-inactif-et-que-loption-2-ne-fonctionne-pas"
               target="_blank"
               rel="noopener noreferrer"
               className="fr-link force-external-link-content force-underline-link"


### PR DESCRIPTION
# Contexte

Il manquait un petit lien de bon aloi.

# Ticket Favro

[Rendre autonomes les utilisateurs dans la récupération du compte administrateur de leur établissement](https://favro.com/widget/ab14a4f0460a99a9d64d4945/8e2d603068ea234852fa70d0?card=tra-15994)