### PR TITLE
chore : upgrade getsentry/action-release to v3

### DIFF
--- a/.github/workflows/deploy-recette.yml
+++ b/.github/workflows/deploy-recette.yml
@@ -27,7 +27,7 @@ jobs:
         run: npx nx run-many -t build
 
       - name: Create a Sentry Release
-        uses: getsentry/action-release@v1.1.6
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: betagouv

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         run: npx nx run-many -t build
 
       - name: Create a Sentry Release
-        uses: getsentry/action-release@v1.1.6
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: betagouv


### PR DESCRIPTION
Erreur dans le pipeline de deploy recette

<img width="857" alt="Capture d’écran 2025-04-08 à 15 40 27" src="https://github.com/user-attachments/assets/282afdb7-f652-48a5-8738-d1bd86523d4f" />
