### PR TITLE
Cacher l'IHM en sandbox

### DIFF
--- a/front/src/Apps/common/Components/layout/Header.tsx
+++ b/front/src/Apps/common/Components/layout/Header.tsx
@@ -73,7 +73,11 @@ const MenuLink = ({ entry }) => {
   );
 };
 
-function DashboardSubNav({ currentCompany, canViewNewRegistry }) {
+function DashboardSubNav({
+  currentCompany,
+  canViewNewRegistry,
+  canViewRegistryIHM
+}) {
   const { permissions, role } = usePermissions();
 
   const location = useLocation();
@@ -150,6 +154,15 @@ function DashboardSubNav({ currentCompany, canViewNewRegistry }) {
     location.pathname
   );
 
+  const matchRegistryLines = matchPath(
+    {
+      path: routes.registry_new.lines,
+      caseSensitive: false,
+      end: false
+    },
+    location.pathname
+  );
+
   const matchReviewsTab = !!matchReviewsReviewed || !!matchReviewsToReview;
   const matchTransportTab =
     !!matchTransportCollected || !!matchTransportToCollect;
@@ -159,7 +172,8 @@ function DashboardSubNav({ currentCompany, canViewNewRegistry }) {
   const matchRegistryV2Tab =
     !!matchRegistryImport ||
     !!matchRegistryCompanyImports ||
-    !!matchRegistryExport;
+    !!matchRegistryExport ||
+    !!matchRegistryLines;
 
   const { showTransportTabs } = useShowTransportTabs(
     currentCompany.companyTypes,
@@ -383,6 +397,17 @@ function DashboardSubNav({ currentCompany, canViewNewRegistry }) {
                   }}
                 />
               </li>
+              {canViewRegistryIHM && (
+                <li>
+                  <MenuLink
+                    entry={{
+                      navlink: true,
+                      caption: "Déclarations",
+                      href: routes.registry_new.lines
+                    }}
+                  />
+                </li>
+              )}
             </ul>
           </div>
         </li>
@@ -396,7 +421,11 @@ function DashboardSubNav({ currentCompany, canViewNewRegistry }) {
  * Navigation subset to be included in the moble slidning panel nav
  * Contains main navigation items from the desktop top level nav (Dashboard, Account etc.)
  */
-function MobileSubNav({ currentCompany, canViewNewRegistry }) {
+function MobileSubNav({
+  currentCompany,
+  canViewNewRegistry,
+  canViewRegistryIHM
+}) {
   const location = useLocation();
 
   const matchAccount = matchPath(
@@ -417,6 +446,7 @@ function MobileSubNav({ currentCompany, canViewNewRegistry }) {
       <DashboardSubNav
         currentCompany={currentCompany}
         canViewNewRegistry={canViewNewRegistry}
+        canViewRegistryIHM={canViewRegistryIHM}
       />
     );
   }
@@ -670,6 +700,9 @@ export default function Header() {
         )
     );
 
+  const canViewRegistryIHM =
+    import.meta.env.VITE_FLAG_REGISTRY_V2_IHM === "true";
+
   const menuEntries = getDesktopMenuEntries(
     isAuthenticated,
     isAdmin,
@@ -799,6 +832,7 @@ export default function Header() {
         <MobileSubNav
           currentCompany={currentCompany}
           canViewNewRegistry={canViewNewRegistry}
+          canViewRegistryIHM={canViewRegistryIHM}
         />
       </div>
 

--- a/front/src/dashboard/registry/RegistryMenu.tsx
+++ b/front/src/dashboard/registry/RegistryMenu.tsx
@@ -5,7 +5,11 @@ import { NavLink } from "react-router-dom";
 import SideBar from "../../Apps/common/Components/SideBar/SideBar";
 import routes from "../../Apps/routes";
 
-export const RegistryMenuContent = () => (
+export const RegistryMenuContent = ({
+  canViewRegistryIHM
+}: {
+  canViewRegistryIHM: boolean;
+}) => (
   <div>
     <Accordion defaultExpanded label="Registre national" className="fr-mt-4w">
       <ul>
@@ -33,18 +37,20 @@ export const RegistryMenuContent = () => (
             Imports par établissement
           </NavLink>
         </li>
-        <li className="tw-mb-1">
-          <NavLink
-            to={routes.registry_new.lines}
-            className={({ isActive }) =>
-              isActive
-                ? "sidebarv2__item sidebarv2__item--indented sidebarv2__item--active"
-                : "sidebarv2__item sidebarv2__item--indented"
-            }
-          >
-            Déclarations
-          </NavLink>
-        </li>
+        {canViewRegistryIHM && (
+          <li className="tw-mb-1">
+            <NavLink
+              to={routes.registry_new.lines}
+              className={({ isActive }) =>
+                isActive
+                  ? "sidebarv2__item sidebarv2__item--indented sidebarv2__item--active"
+                  : "sidebarv2__item sidebarv2__item--indented"
+              }
+            >
+              Déclarations
+            </NavLink>
+          </li>
+        )}
       </ul>
     </Accordion>
     <Accordion defaultExpanded label="Exports">
@@ -81,9 +87,12 @@ export const RegistryMenuContent = () => (
 );
 
 export default function RegistryMenu() {
+  const canViewRegistryIHM =
+    import.meta.env.VITE_FLAG_REGISTRY_V2_IHM === "true";
+
   return (
     <SideBar>
-      <RegistryMenuContent />
+      <RegistryMenuContent canViewRegistryIHM={canViewRegistryIHM} />
     </SideBar>
   );
 }


### PR DESCRIPTION
# Contexte

- Ajout d'une variable d'env permettant de cacher la partie "Déclarations" (l'IHM) en sandbox temps qu'il n'est pas prêt.
- Ajout du lien vers la page Déclarations dans la navigation mobile

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB