### PR TITLE
[hotfix][tra-16240]Ne pas permettre de valider une révision si pas de changement dans les conditionnements

### DIFF
--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/Packagings/packagings.ts
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/Packagings/packagings.ts
@@ -8,7 +8,7 @@ import {
 } from "@td/codegen-ui";
 import { Decimal } from "decimal.js";
 import { BsdTypename } from "../../../../../../common/types/bsdTypes";
-import { isEqual } from "lodash";
+import { packagingsEqual } from "@td/constants";
 
 export const PACKAGINGS_BSD_NAMES = {
   [BsdTypename.Bsdasri]: {
@@ -120,33 +120,16 @@ export const resetPackagingIfUnchanged = (
   packagingsNewValue,
   deleteObjCallback
 ) => {
+  if (!packagingsNewValue?.length) {
+    return data;
+  }
+
   packagingsInitalValue = packagingsInitalValue.map(packaging => {
     const { __typename, ...newData } = packaging;
     return newData;
   });
 
-  const sortedPackagingsInitalValue = Object.keys(packagingsInitalValue)
-    .sort((a, b) => {
-      const typeA = a[0]["type"];
-      const typeB = b[0]["type"];
-      return typeA.localeCompare(typeB);
-    })
-    .reduce((acc, key) => {
-      acc[key] = packagingsInitalValue[key]; // Ajoute chaque propriété triée à l'objet résultat
-      return acc;
-    }, {});
-
-  const sortedPackagingsNewValue = Object.keys(packagingsNewValue)
-    .sort((a, b) => {
-      const typeA = a[0]["type"];
-      const typeB = b[0]["type"];
-      return typeA.localeCompare(typeB);
-    })
-    .reduce((acc, key) => {
-      acc[key] = packagingsNewValue[key];
-      return acc;
-    }, {});
-  if (isEqual(sortedPackagingsInitalValue, sortedPackagingsNewValue)) {
+  if (packagingsEqual(packagingsInitalValue, packagingsNewValue)) {
     deleteObjCallback();
   }
   return data;


### PR DESCRIPTION

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Bug détecté par @benoitguigal régression sur les revisions contenant 2 conditionnement ou plus

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/b971a21b-b918-4edc-9054-9e20bdd5ab64


# Ticket Favro

[Ticket ayant créé la régression](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16240)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB