### PR TITLE
[Hotfix] Correctif pour les courriers de vérification de demande d'admin

### DIFF
--- a/back/src/common/post/index.ts
+++ b/back/src/common/post/index.ts
@@ -121,8 +121,9 @@ export async function sendAdminRequestVerificationCodeLetter(
     source_file_type: "html",
     variables: {
       code,
-      company,
-      user
+      company_name: company.name,
+      company_siret: company.siret,
+      user_name: user.name
     }
   });
 }

--- a/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
+++ b/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
@@ -272,18 +272,18 @@
             <p>
               <b
                 >Objet : Demande de vérification pour l’accès administrateur de
-                l’établissement {{ company.name}} - {{ company.siret }}</b
+                l’établissement {{ company_name}} - {{ company_siret }}</b
               >
             </p>
             <br />
 
-            <p>À l’attention de {{ user.name }},</p>
+            <p>À l’attention de {{ user_name }},</p>
             <br />
 
             <p>Madame, Monsieur,</p>
             <p>
               À la suite de votre demande pour obtenir les droits administrateur
-              au sein de l’établissement {{ company.name}} - {{ company.siret
+              au sein de l’établissement {{ company_name}} - {{ company_siret
               }}, nous vous adressons ce courrier à titre de vérification. Les
               administrateurs actuels de l'établissement concerné étant inactifs
               ou indisponibles, nous souhaitons nous assurer de la légitimité de


### PR DESCRIPTION
# Contexte

Apparamment les courriers sont mal paramétrés puisqu'il manque le nom & le siret de l'entreprise:

![image](https://github.com/user-attachments/assets/836e9628-b02c-409b-bef3-ea026c354b27)

Je ne suis pas sûr de la cause de cette erreur. Dans MySendingBox, je vois bien les variables et elles sont correctes:

![image](https://github.com/user-attachments/assets/11e90fb1-4c18-4f17-860c-97f788acf46b)

Si je me fie à la doc de MySendInBox, les variables nestées ne sont pas supportées:

![image](https://github.com/user-attachments/assets/bced1f7f-41c8-4b3c-a02a-5790b3fa8959)

Pourtant `{{ user.name }}` marche bien? Donc est-ce une fausse piste?

C'est pénible à débugguer parce qu'en local (ou en recette) on n'envoie pas vraiment les courriers, on se content de les logguer; mais le template est loggué sans que les variables soient remplacées...


# Ticket Favro

[[Hotfix] Correctif pour les courriers de vérification de demande d'admin](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-16278)
