### PR TITLE
[TRA-8921] Un transporteur étranger ne peut plus créer de DASRI de synthèse

### DIFF
--- a/back/src/bsdasris/permissions.ts
+++ b/back/src/bsdasris/permissions.ts
@@ -2,6 +2,7 @@ import { Bsdasri, BsdasriStatus, User } from "@prisma/client";
 import type { BsdasriInput } from "@td/codegen-back";
 import { Permission, checkUserPermissions } from "../permissions";
 import { ForbiddenError, UserInputError } from "../common/errors";
+import { isForeignVat } from "@td/constants";
 
 /**
  * Retrieves organisations allowed to read a BSDASRI
@@ -112,6 +113,12 @@ export async function checkCanCreateSynthesis(
   user: User,
   bsdasriInput: BsdasriInput
 ) {
+  if (isForeignVat(bsdasriInput?.transporter?.company?.vatNumber)) {
+    throw new UserInputError(
+      "Un transporteur étranger ne peut pas créer de BSDASRI de synthèse"
+    );
+  }
+
   const authorizedOrgIds = [
     bsdasriInput?.transporter?.company?.siret,
     bsdasriInput?.transporter?.company?.vatNumber

--- a/front/src/form/bsdasri/steps/Type.tsx
+++ b/front/src/form/bsdasri/steps/Type.tsx
@@ -12,6 +12,7 @@ import {
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import Tooltip from "../../../Apps/common/Components/Tooltip/Tooltip";
+import { isForeignVat } from "../../../../../libs/shared/constants/src";
 
 type Props = { disabled: boolean };
 
@@ -63,13 +64,16 @@ const TRANSPORTER_OPTIONS = [
 const ALL_OPTIONS = [...COMMON_OPTIONS, ...TRANSPORTER_OPTIONS];
 
 const getTypeOptions = (data, isUpdating) => {
-  // Only tranporters can create synthesis dasris
   if (isUpdating) {
     return ALL_OPTIONS;
   }
-  return data?.companyInfos?.companyTypes?.includes(CompanyType.Transporter)
-    ? ALL_OPTIONS
-    : COMMON_OPTIONS;
+
+  // Only FR tranporters can create synthesis dasris
+  const isFrenchTransporter =
+    data?.companyInfos?.companyTypes?.includes(CompanyType.Transporter) &&
+    !isForeignVat(data?.companyInfos?.vatNumber);
+
+  return isFrenchTransporter ? ALL_OPTIONS : COMMON_OPTIONS;
 };
 
 export function Type({ disabled }: Props) {


### PR DESCRIPTION
# Démo

[demo_transporteur_etranger.webm](https://github.com/user-attachments/assets/f6d63e36-fe41-4cc8-adf4-d277c1c65748)

# Ticket Favro

[ETQ transporteur étranger, je ne dois pas avoir la possibilité de sélectionner "de synthèse" lorsque je crée un DASRI](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-8921)
