### PR TITLE
[TRA-12187] Il n'est plus possible de sélectionner des dates dans le passé pour les récépissés d'établissements

### DIFF
--- a/back/src/companies/resolvers/mutations/__tests__/createBrokerReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createBrokerReceipt.integration.ts
@@ -4,6 +4,7 @@ import { AuthType } from "../../../../auth";
 import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import type { Mutation } from "@td/codegen-back";
+import { addDays } from "date-fns";
 
 describe("{ mutation { createBrokerReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -11,7 +12,7 @@ describe("{ mutation { createBrokerReceipt } }", () => {
   it("should create a broker receipt !", async () => {
     const receipt = {
       receiptNumber: "receiptNumber",
-      validityLimit: "2021-03-31T00:00:00.000Z",
+      validityLimit: "2050-03-31T00:00:00.000Z",
       department: "07"
     };
 
@@ -38,5 +39,36 @@ describe("{ mutation { createBrokerReceipt } }", () => {
     expect(await prisma.brokerReceipt.count()).toEqual(1);
 
     expect(data.createBrokerReceipt).toEqual(receipt);
+  });
+
+  it("should throw if validityDate is in the past", async () => {
+    // Given
+    const receipt = {
+      receiptNumber: "receiptNumber",
+      validityLimit: addDays(new Date(), -1).toISOString(),
+      department: "07"
+    };
+
+    const user = await userFactory();
+    const createBrokerReceipt = `
+      mutation CreateBrokerReceipt($input: CreateBrokerReceiptInput!){
+        createBrokerReceipt(input: $input){
+          receiptNumber
+          validityLimit
+          department
+          }
+      }`;
+
+    // When
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate<Pick<Mutation, "createBrokerReceipt">>(
+      createBrokerReceipt,
+      {
+        variables: { input: receipt }
+      }
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
   });
 });

--- a/back/src/companies/resolvers/mutations/__tests__/createTransporterReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/createTransporterReceipt.integration.ts
@@ -4,6 +4,7 @@ import { AuthType } from "../../../../auth";
 import { userFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import type { Mutation } from "@td/codegen-back";
+import { addDays } from "date-fns";
 
 describe("{ mutation { createTransporterReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -11,7 +12,7 @@ describe("{ mutation { createTransporterReceipt } }", () => {
   it("should create a transporter receipt", async () => {
     const receipt = {
       receiptNumber: "receiptNumber",
-      validityLimit: "2021-03-31T00:00:00.000Z",
+      validityLimit: "2050-03-31T00:00:00.000Z",
       department: "07"
     };
 
@@ -36,5 +37,36 @@ describe("{ mutation { createTransporterReceipt } }", () => {
     expect(await prisma.transporterReceipt.count()).toEqual(1);
 
     expect(data.createTransporterReceipt).toEqual(receipt);
+  });
+
+  it("should throw if validityDate is in the past", async () => {
+    // Given
+    const receipt = {
+      receiptNumber: "receiptNumber",
+      validityLimit: addDays(new Date(), -1).toISOString(),
+      department: "07"
+    };
+
+    const user = await userFactory();
+
+    const mutation = `
+      mutation {
+        createTransporterReceipt(
+          input: {
+            receiptNumber: "${receipt.receiptNumber}"
+            validityLimit: "${receipt.validityLimit}"
+            department: "${receipt.department}"
+          }
+          ) { receiptNumber, validityLimit, department }
+        }`;
+
+    // When
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate<Pick<Mutation, "createTransporterReceipt">>(
+      mutation
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
   });
 });

--- a/back/src/companies/resolvers/mutations/__tests__/updateBrokerReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateBrokerReceipt.integration.ts
@@ -4,6 +4,7 @@ import { AuthType } from "../../../../auth";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import type { Mutation } from "@td/codegen-back";
+import { addDays } from "date-fns";
 
 describe("{ mutation { updateBrokerReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -11,7 +12,7 @@ describe("{ mutation { updateBrokerReceipt } }", () => {
   test("admin can update a broker receipt", async () => {
     const receipt = {
       receiptNumber: "receiptNumber",
-      validityLimit: "2021-03-31T00:00:00.000Z",
+      validityLimit: "2050-03-31T00:00:00.000Z",
       department: "07"
     };
 
@@ -24,7 +25,7 @@ describe("{ mutation { updateBrokerReceipt } }", () => {
 
     const update = {
       receiptNumber: "receiptNumber2",
-      validityLimit: "2021-04-30T00:00:00.000Z",
+      validityLimit: "2051-04-30T00:00:00.000Z",
       department: "13"
     };
 
@@ -55,5 +56,48 @@ describe("{ mutation { updateBrokerReceipt } }", () => {
     expect(updated.receiptNumber).toEqual(update.receiptNumber);
     expect(updated.validityLimit.toISOString()).toEqual(update.validityLimit);
     expect(updated.department).toEqual(update.department);
+  });
+
+  test("should throw if validityLimit is in the past", async () => {
+    // Given
+    const receipt = {
+      receiptNumber: "receiptNumber",
+      validityLimit: new Date().toISOString(),
+      department: "07"
+    };
+
+    const createdReceipt = await prisma.brokerReceipt.create({ data: receipt });
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await prisma.company.update({
+      data: { brokerReceipt: { connect: { id: createdReceipt.id } } },
+      where: { id: company.id }
+    });
+
+    const update = {
+      receiptNumber: "receiptNumber2",
+      validityLimit: addDays(new Date(), -1).toISOString(),
+      department: "13"
+    };
+
+    const mutation = `
+      mutation {
+        updateBrokerReceipt(
+          input: {
+            id: "${createdReceipt.id}"
+            receiptNumber: "${update.receiptNumber}"
+            validityLimit: "${update.validityLimit}"
+            department: "${update.department}"
+          }
+          ) { receiptNumber, validityLimit, department }
+        }`;
+
+    // When
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate<Pick<Mutation, "updateBrokerReceipt">>(
+      mutation
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
   });
 });

--- a/back/src/companies/resolvers/mutations/__tests__/updateTraderReceipt.integration.ts
+++ b/back/src/companies/resolvers/mutations/__tests__/updateTraderReceipt.integration.ts
@@ -4,6 +4,7 @@ import { AuthType } from "../../../../auth";
 import { userWithCompanyFactory } from "../../../../__tests__/factories";
 import makeClient from "../../../../__tests__/testClient";
 import type { Mutation } from "@td/codegen-back";
+import { addDays } from "date-fns";
 
 describe("{ mutation { updateTraderReceipt } }", () => {
   afterEach(() => resetDatabase());
@@ -11,7 +12,7 @@ describe("{ mutation { updateTraderReceipt } }", () => {
   test("admin can update a trader receipt", async () => {
     const receipt = {
       receiptNumber: "receiptNumber",
-      validityLimit: "2021-03-31T00:00:00.000Z",
+      validityLimit: "2050-03-31T00:00:00.000Z",
       department: "07"
     };
 
@@ -24,7 +25,7 @@ describe("{ mutation { updateTraderReceipt } }", () => {
 
     const update = {
       receiptNumber: "receiptNumber2",
-      validityLimit: "2021-04-30T00:00:00.000Z",
+      validityLimit: "2051-04-30T00:00:00.000Z",
       department: "13"
     };
 
@@ -55,5 +56,48 @@ describe("{ mutation { updateTraderReceipt } }", () => {
     expect(updated.receiptNumber).toEqual(update.receiptNumber);
     expect(updated.validityLimit.toISOString()).toEqual(update.validityLimit);
     expect(updated.department).toEqual(update.department);
+  });
+
+  test("should throw if validityDate is in the past", async () => {
+    // Given
+    const receipt = {
+      receiptNumber: "receiptNumber",
+      validityLimit: "2050-03-31T00:00:00.000Z",
+      department: "07"
+    };
+
+    const createdReceipt = await prisma.traderReceipt.create({ data: receipt });
+    const { user, company } = await userWithCompanyFactory("ADMIN");
+    await prisma.company.update({
+      data: { traderReceipt: { connect: { id: createdReceipt.id } } },
+      where: { id: company.id }
+    });
+
+    const update = {
+      receiptNumber: "receiptNumber2",
+      validityLimit: addDays(new Date(), -1).toISOString(),
+      department: "13"
+    };
+
+    const mutation = `
+      mutation {
+        updateTraderReceipt(
+          input: {
+            id: "${createdReceipt.id}"
+            receiptNumber: "${update.receiptNumber}"
+            validityLimit: "${update.validityLimit}"
+            department: "${update.department}"
+          }
+          ) { receiptNumber, validityLimit, department }
+        }`;
+
+    // When
+    const { mutate } = makeClient({ ...user, auth: AuthType.Session });
+    const { errors } = await mutate<Pick<Mutation, "updateTraderReceipt">>(
+      mutation
+    );
+
+    // Then
+    expect(errors).not.toBeUndefined();
   });
 });

--- a/back/src/companies/resolvers/mutations/createWorkerCertification.ts
+++ b/back/src/companies/resolvers/mutations/createWorkerCertification.ts
@@ -5,6 +5,7 @@ import { checkIsAuthenticated } from "../../../common/permissions";
 import { GraphQLContext } from "../../../types";
 import type { MutationCreateWorkerCertificationArgs } from "@td/codegen-back";
 import configureYup from "../../../common/yup/configureYup";
+import { todayAtMidnight } from "../../../utils";
 
 configureYup();
 
@@ -27,11 +28,14 @@ export const workerCertificationSchema = yup.object({
     then: schema => schema.required(),
     otherwise: schema => schema.nullable()
   }),
-  validityLimit: yup.date().when("hasSubSectionThree", {
-    is: true,
-    then: schema => schema.required(),
-    otherwise: schema => schema.nullable()
-  }),
+  validityLimit: yup
+    .date()
+    .min(todayAtMidnight())
+    .when("hasSubSectionThree", {
+      is: true,
+      then: schema => schema.required(),
+      otherwise: schema => schema.nullable()
+    }),
   organisation: yup
     .string()
     .label("L'organisme")

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -15,9 +15,10 @@ import {
 import { checkVAT } from "jsvat";
 import type { FormCompany } from "@td/codegen-back";
 import countries, { Country } from "world-countries";
+import { todayAtMidnight } from "../utils";
 
 export const receiptSchema = yup.object().shape({
-  validityLimit: yup.date().required()
+  validityLimit: yup.date().min(todayAtMidnight()).required()
 });
 
 export function isCollector(company: Company) {

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/RecepisseForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/RecepisseForm.tsx
@@ -43,6 +43,7 @@ const RecepisseForm = ({
             label="Limite de validité"
             nativeInputProps={{
               type: "date",
+              min: new Date().toISOString().split("T")[0],
               ...inputProps?.validityLimit
             }}
             state={inputErrors?.validityLimit ? "error" : "default"}

--- a/front/src/Apps/Companies/common/Components/CompanyTypeForm/WorkerCertificationForm.tsx
+++ b/front/src/Apps/Companies/common/Components/CompanyTypeForm/WorkerCertificationForm.tsx
@@ -82,6 +82,7 @@ const WorkerCertificationForm = ({
               label="Date de validité"
               nativeInputProps={{
                 type: "date",
+                min: new Date().toISOString().split("T")[0],
                 max: "2999/12/31",
                 ...inputProps?.workerCertification?.validityLimit
               }}


### PR DESCRIPTION
# Démo

https://github.com/user-attachments/assets/b8053e8d-07d4-44da-9acb-695adbf8b2e7


# Ticket Favro

[Ne pas permettre de sélectionner une date antérieure à celle d'aujourd'hui pour les récépissés d'établissements](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-12187)
