### PR TITLE
[TRA-13446] Correction de l'affichage dans le PDF BSDD

### DIFF
--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -507,7 +507,7 @@ export function BsddPdf({
 
             {form.emitter?.type === EmitterType.APPENDIX1 && (
               <p>
-                <i>Liste des producteurs initiaux en annexe</i>
+                <i>LISTE DES PRODUCTEURS INITIAUX EN ANNEXE</i>
               </p>
             )}
 


### PR DESCRIPTION
# Contexte

Emmanuel voulait un truc plus visible

# Démo

![image](https://github.com/user-attachments/assets/5894d324-cb54-46fe-b544-a7527a23383e)

# Ticket Favro

[Sur le PDF du BSD de tournée dédiée, ajouter au dessus du 1.2 Point de collecte/chantier, "Liste des producteurs initiaux en annexe" ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-13446)
