### PR TITLE
[TRA-16302] Hotfix: correction des délimiters dans les templates Registre V2, "," > ";"

### DIFF
--- a/libs/back/registry/src/scripts/generateModels.ts
+++ b/libs/back/registry/src/scripts/generateModels.ts
@@ -81,7 +81,7 @@ async function generateCsvModel({
     }
   });
 
-  const csvStream = format({ headers: false, writeBOM: true }); // UTF-8 BOM to help tools like Excel recognize UTF-8 encoding
+  const csvStream = format({ headers: false, writeBOM: true, delimiter: ";" }); // UTF-8 BOM to help tools like Excel recognize UTF-8 encoding
   csvStream.pipe(writableStream);
 
   csvStream.write(headers);


### PR DESCRIPTION
# Contexte

On a un  bug en production: les templates Registre V2 qu'on propose dans la doc utilisent des "," comme séparateurs alors qu'on attend des ";".

# Ticket Favro

[Appliquer comme séparateur le point-virgule dans les templates de registre RNDTS ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-16302)
