### PR TITLE
Fix/ Droits S3 des modèles de registre

### DIFF
--- a/libs/back/registry/src/scripts/generateModels.ts
+++ b/libs/back/registry/src/scripts/generateModels.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { PutObjectCommand, ObjectCannedACL } from "@aws-sdk/client-s3";
 import { format } from "@fast-csv/format";
 import * as Excel from "exceljs";
 import { Writable } from "node:stream";
@@ -114,7 +114,8 @@ async function writeToS3({
     Key: name,
     Body: buffer,
     ContentType: contentType,
-    ContentEncoding: "utf-8"
+    ContentEncoding: "utf-8",
+    ACL: ObjectCannedACL.public_read
   };
 
   const command = new PutObjectCommand(params);


### PR DESCRIPTION
Lorsque le fichier est uploadé on souhaite qu'ils le soit avec les bons droits.
Quand on run `npx nx run  @td/registry:models` en recette ca met à jour les fichiers. Mais ca les mettait en "private" par défaut. Avec cette modif ils se mettront automatiquement en public read et seront accessibles au téléchargement depuis la FAQ.
