### PR TITLE
[TRA-16354] Mise à jour des logos & du CSS dans les courriers 

### DIFF
--- a/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
+++ b/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
@@ -180,7 +180,7 @@
       }
 
       .content {
-        margin-top: 40px;
+        margin-top: 100px;
         font-size: 14px;
       }
 

--- a/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
+++ b/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
@@ -227,6 +227,18 @@
       .steps {
         list-style-type: decimal;
       }
+
+      .footer {
+        text-align: center;
+        width: 100%;
+        position: absolute;
+        bottom: 12px;
+      }
+
+      .footer-img {
+        display: inline-block;
+        vertical-align: middle;
+      }
     </style>
   </head>
 
@@ -253,13 +265,8 @@
           <img
             class="marianne"
             width="150px"
-            alt="Ministère de la Transition Écologique"
-            src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/mte.svg"
-          />
-          <img
-            width="100px"
-            src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/trackdechets.png"
-            alt="Trackdéchets logo"
+            alt="Ministère de la transition écologique, de la biodiversité, de la forêt, de la mer et de la pêche"
+            src="https://medias.trackdechets.beta.gouv.fr/mte_large.png"
           />
           <h3 class="ui header m-no-bottom">{{ expediteur.nom }}</h3>
           <p>
@@ -334,6 +341,20 @@
           </article>
         </div>
       </div>
+      <section class="footer">
+        <img
+          class="footer-img"
+          width="200px"
+          src="https://medias.trackdechets.beta.gouv.fr/brgm_large.png"
+          alt="BRGM, géosciences pour une Terre durable"
+        />
+        <img
+          class="footer-img"
+          width="100px"
+          src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/trackdechets.png"
+          alt="Trackdéchets logo"
+        />
+      </section>
     </section>
   </body>
 </html>

--- a/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
+++ b/back/src/common/post/templates/adminRequestVerificationCodeLetter.html
@@ -233,11 +233,16 @@
         width: 100%;
         position: absolute;
         bottom: 12px;
+        height: 70px;
       }
 
       .footer-img {
         display: inline-block;
         vertical-align: middle;
+        max-width: 120px;
+        max-height: 70px;
+        height: auto;
+        width: auto;
       }
     </style>
   </head>

--- a/back/src/common/post/templates/verificationCodeLetter.html
+++ b/back/src/common/post/templates/verificationCodeLetter.html
@@ -227,6 +227,18 @@
       .steps {
         list-style-type: decimal;
       }
+
+      .footer {
+        text-align: center;
+        width: 100%;
+        position: absolute;
+        bottom: 12px;
+      }
+
+      .footer-img {
+        display: inline-block;
+        vertical-align: middle;
+      }
     </style>
   </head>
 
@@ -253,13 +265,8 @@
           <img
             class="marianne"
             width="150px"
-            alt="Ministère de la Transition Écologique"
-            src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/mte.svg"
-          />
-          <img
-            width="100px"
-            src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/trackdechets.png"
-            alt="Trackdéchets logo"
+            alt="Ministère de la transition écologique, de la biodiversité, de la forêt, de la mer et de la pêche"
+            src="https://medias.trackdechets.beta.gouv.fr/mte_large.png"
           />
           <h3 class="ui header m-no-bottom">{{ expediteur.nom }}</h3>
           <p>
@@ -307,14 +314,22 @@
             <p>L'équipe Trackdéchets</p>
           </article>
         </div>
-
-        <div class="footer">
-          <p>
-            Trackdéchets est un service numérique de l'Etat incubé à la Fabrique
-            Numérique du Ministère de la Transition écologique.
-          </p>
-        </div>
       </div>
+
+      <section class="footer">
+        <img
+          class="footer-img"
+          width="200px"
+          src="https://medias.trackdechets.beta.gouv.fr/brgm_large.png"
+          alt="BRGM, géosciences pour une Terre durable"
+        />
+        <img
+          class="footer-img"
+          width="100px"
+          src="https://raw.githubusercontent.com/MTES-MCT/trackdechets-website/master/src/components/assets/trackdechets.png"
+          alt="Trackdéchets logo"
+        />
+      </section>
     </section>
   </body>
 </html>

--- a/back/src/common/post/templates/verificationCodeLetter.html
+++ b/back/src/common/post/templates/verificationCodeLetter.html
@@ -233,11 +233,16 @@
         width: 100%;
         position: absolute;
         bottom: 12px;
+        height: 70px;
       }
 
       .footer-img {
         display: inline-block;
         vertical-align: middle;
+        max-width: 120px;
+        max-height: 70px;
+        height: auto;
+        width: auto;
       }
     </style>
   </head>


### PR DESCRIPTION
# Contexte

On change le logo du MTE, on ajoute le logo du BRGM, et on modifie un peu le CSS.

# Démo

### Courrier de vérification d'entreprise

![image](https://github.com/user-attachments/assets/9fb653ad-cd37-462c-8792-ea6c3747e31e)

### Courrier de demande de droits d'admin

![image](https://github.com/user-attachments/assets/d242a8f8-c2a2-4bba-8815-c9c703008037)

# Ticket Favro

[Mettre à jour le logo du MTE, modifier l'emplacement du logo de TD et supprimer la mention en bas de page du courrier qui est envoyé via Mysendingbox (code de vérification ET demande droits administrateur) ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-16254)
