### PR TITLE
[TRA-16314] Hotfix - Correction de la documentation sur le BSDA

### DIFF
--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -113,9 +113,6 @@ input BsdaInput {
 
   "Courtier"
   broker: BsdaBrokerInput
-    @deprecated(
-      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier sur son profil Trackdéchets"
-    )
 
   "Dénomination du déchet"
   waste: BsdaWasteInput
@@ -381,6 +378,9 @@ input BsdaBrokerInput {
   company: CompanyInput
   "Récépissé courtier"
   recepisse: BsdaBrokerRecepisseInput
+    @deprecated(
+      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier sur son profil Trackdéchets"
+    )
 }
 
 input BsdaSignatureInput {

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -358,10 +358,19 @@ input BsdaBrokerRecepisseInput {
   isExempted: Boolean
   "Numéro de récépissé"
   number: String
+    @deprecated(
+      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier"
+    )
   "Département"
   department: String
+    @deprecated(
+      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier"
+    )
   "Date limite de validité"
   validityLimit: DateTime
+    @deprecated(
+      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier"
+    )
 }
 
 input BsdaTransportInput {
@@ -378,9 +387,6 @@ input BsdaBrokerInput {
   company: CompanyInput
   "Récépissé courtier"
   recepisse: BsdaBrokerRecepisseInput
-    @deprecated(
-      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier sur son profil Trackdéchets"
-    )
 }
 
 input BsdaSignatureInput {

--- a/back/src/bsda/typeDefs/bsda.inputs.graphql
+++ b/back/src/bsda/typeDefs/bsda.inputs.graphql
@@ -413,9 +413,6 @@ input BsdaRevisionRequestContentInput {
 
   "Courtier"
   broker: BsdaBrokerInput
-    @deprecated(
-      reason: "Ignoré - Complété par Trackdéchets en fonction des informations renseignées par le courtier sur son profil Trackdéchets"
-    )
 
   "Installation de destination"
   destination: BsdaRevisionRequestDestinationInput


### PR DESCRIPTION
# Contexte

Un utilisateur a remonté un souci avec la doc sur le BSDA. Dans la mutation `createBsda`, ce n'est pas l'input `broker` qui est déprécié, mais `broker.recepisse`.

Visiblement ça leur pose des problèmes de leur côté pour générer les typages.

A noter, GraphiQL ne remonte pas du tout les champs dépréciés!

# Ticket Favro

[Corriger la documentation du BSDA: le courtier n'est pas déprécié](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-16314)
