### PR TITLE
[tra-16246]Reprendre la liste des numéros de scellés du bordereau lors d'une révision

### DIFF
--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -11,7 +11,7 @@ import {
   MutationCreateBsdaRevisionRequestArgs
 } from "@td/codegen-ui";
 import { BSDA_WASTES } from "@td/constants";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { z } from "zod";
@@ -83,6 +83,13 @@ export function BsdaRequestRevision({ bsda }: Props) {
     reset();
     navigate(-1);
   };
+
+  useEffect(() => {
+    if (bsda?.waste?.sealNumbers) {
+      setSealNumbersTags([...bsda.waste.sealNumbers]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Hacky fonction implémentée en hotfix dans tra-15573
   // La bonne solution à mon sens (benoît) serait d'initialiser


### PR DESCRIPTION

# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[tra-16246](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16246)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB