### PR TITLE
Get a name for all middlewares

### DIFF
--- a/back/src/common/middlewares/correlationId.ts
+++ b/back/src/common/middlewares/correlationId.ts
@@ -1,0 +1,12 @@
+import { runWithCorrelationId } from "@td/logger";
+import { Request, Response, NextFunction } from "express";
+
+export function correlationIdMiddleware(
+  _req: Request,
+  _res: Response,
+  next: NextFunction
+) {
+  runWithCorrelationId(() => {
+    next();
+  });
+}

--- a/back/src/common/middlewares/namedMiddleware.ts
+++ b/back/src/common/middlewares/namedMiddleware.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction, RequestHandler } from "express";
+import { trace } from "@opentelemetry/api";
+
+// Wrap third-party middleware to provide names
+export function namedMiddleware(name: string, middlewareFn: RequestHandler) {
+  const wrapper = function (req: Request, res: Response, next: NextFunction) {
+    const currentSpan = trace.getActiveSpan();
+    if (currentSpan) {
+      currentSpan.updateName(`middleware.${name}`);
+    }
+    return middlewareFn(req, res, next);
+  };
+
+  Object.defineProperty(wrapper, "name", { value: name });
+  return wrapper;
+}


### PR DESCRIPTION
On avait des middlewares joués en double, et d'autres en "anonymous", pour lesquels c'était dur de savoir à quoi ils se référaient. Voici le contenu d'une requête et l'ordre des middlewares:

```
middleware - query ---- vient de Express https://github.com/expressjs/express/blob/4.x/lib/middleware/query.js
middleware - expressInit ---- vient de Express https://github.com/expressjs/express/blob/4.x/lib/middleware/init.js
middleware - correlationIdMiddleware ---- était anonymous, nommé désormais
middleware - corsMiddleware
middleware - rateLimit
middleware - helmetMiddleware
middleware - urlencodedParser
middleware - jsonParser
middleware - graphqlBodyParser
middleware - graphqlBatchLimiter
middleware - logging
middleware - timeoutLongRequests
middleware - session
middleware - initialize
middleware - authenticate
router - /
router - /
router - /
middleware - impersonateMiddleware
middleware - passportBearerMiddleware
middleware - checkBlacklist
middleware - checkGqlPath
middleware - apolloExpress ---- était anonymous. c'est le expressMiddleware d'Apollo. On avait 2 middlewares en plus juste au dessus: cors & json. Mais inutile de les rejouer pour gql puisqu'ils sont joués à la racine de toute manière
```