### PR TITLE
Registre - Insertion d'une ligne précedemment annulée

### DIFF
--- a/back/src/registryV2/resolvers/mutations/__tests__/addToIncomingTexsRegistry.integration.ts
+++ b/back/src/registryV2/resolvers/mutations/__tests__/addToIncomingTexsRegistry.integration.ts
@@ -418,4 +418,41 @@ describe("Registry - addToIncomingTexsRegistry", () => {
       skipped: [expect.objectContaining({ publicId: lines[2].publicId })]
     });
   });
+
+  it("should allow re-creating a line that was cancelled without passing a reason", async () => {
+    const { user, company } = await userWithCompanyFactory();
+
+    const { mutate } = makeClient(user);
+
+    const lines = [getCorrectLine(company.orgId)];
+
+    // Insert line
+    const res1 = await mutate<Pick<Mutation, "addToIncomingTexsRegistry">>(
+      ADD_TO_INCOMING_TEXS_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res1.errors).toBeUndefined();
+    expect(res1.data.addToIncomingTexsRegistry.stats.insertions).toBe(1);
+
+    // Cancel already existing line
+    const res2 = await mutate<Pick<Mutation, "addToIncomingTexsRegistry">>(
+      ADD_TO_INCOMING_TEXS_REGISTRY,
+      {
+        variables: {
+          lines: [{ ...lines[0], reason: "CANCEL" }]
+        }
+      }
+    );
+    expect(res2.errors).toBeUndefined();
+    expect(res2.data.addToIncomingTexsRegistry.stats.cancellations).toBe(1);
+
+    // Now re-create the line without passing a reason
+    const res3 = await mutate<Pick<Mutation, "addToIncomingTexsRegistry">>(
+      ADD_TO_INCOMING_TEXS_REGISTRY,
+      { variables: { lines } }
+    );
+    expect(res3.errors).toBeUndefined();
+    expect(res3.data.addToIncomingTexsRegistry.stats.insertions).toBe(0); // It's not an insertion
+    expect(res3.data.addToIncomingTexsRegistry.stats.edits).toBe(1); // It's an edit, even if no reason was passed in
+  });
 });

--- a/libs/back/registry/src/incomingTexs/validation/transform.ts
+++ b/libs/back/registry/src/incomingTexs/validation/transform.ts
@@ -17,7 +17,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodIncomingTexsItem>(
     incomingTexsItem,
-    incomingTexsItemInDb?.id,
+    incomingTexsItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/incomingWaste/validation/transform.ts
+++ b/libs/back/registry/src/incomingWaste/validation/transform.ts
@@ -17,7 +17,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodIncomingWasteItem>(
     incomingWasteItem,
-    incomingWasteItemInDb?.id,
+    incomingWasteItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/managed/validation/transform.ts
+++ b/libs/back/registry/src/managed/validation/transform.ts
@@ -18,7 +18,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodManagedItem>(
     transportedItem,
-    transportedItemInDb?.id,
+    transportedItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/outgoingTexs/validation/transform.ts
+++ b/libs/back/registry/src/outgoingTexs/validation/transform.ts
@@ -17,7 +17,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodOutgoingTexsItem>(
     outgoingTexsItem,
-    outgoingTexsItemInDb?.id,
+    outgoingTexsItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/outgoingWaste/validation/transform.ts
+++ b/libs/back/registry/src/outgoingWaste/validation/transform.ts
@@ -17,7 +17,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodOutgoingWasteItem>(
     outgoingWasteItem,
-    outgoingWasteItemInDb?.id,
+    outgoingWasteItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/ssd/validation/transform.ts
+++ b/libs/back/registry/src/ssd/validation/transform.ts
@@ -18,7 +18,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodSsdItem>(
     ssdItem,
-    ssdItemInDb?.id,
+    ssdItemInDb,
     ctx
   );
 }

--- a/libs/back/registry/src/transported/validation/transform.ts
+++ b/libs/back/registry/src/transported/validation/transform.ts
@@ -19,7 +19,7 @@ export async function transformAndRefineReason(
 
   return transformAndRefineItemReason<ParsedZodTransportedItem>(
     transportedItem,
-    transportedItemInDb?.id,
+    transportedItemInDb,
     ctx
   );
 }


### PR DESCRIPTION
On autorise à ré-importer une ligne annulée sans passer de motif.
Si la ligne est annulée et qu'on a pas de motif on set automatiquement ce motif à "MODIFIER".
A noter que la ligne est comptabilisée comme une modification et pas une insertion