### PR TITLE
[TRA 16366] - Info sur le sélecteur de date modale d'export registres

### DIFF
--- a/front/src/dashboard/registry/ExportModal.tsx
+++ b/front/src/dashboard/registry/ExportModal.tsx
@@ -266,6 +266,19 @@ const getDefaultValues = () => ({
   wasteCodes: []
 });
 
+const getDateDescription = (registryType: RegistryV2ExportType) => {
+  switch (registryType) {
+    case RegistryV2ExportType.Ssd:
+      return "La date d'utilisation ou d'expédition est prise en compte.";
+    case RegistryV2ExportType.Incoming:
+      return "La date de réception est prise en compte.";
+    case RegistryV2ExportType.Outgoing:
+    case RegistryV2ExportType.Transported:
+    case RegistryV2ExportType.Managed:
+      return "La date d'expédition est prise en compte. ";
+  }
+};
+
 export function ExportModal({ isOpen, onClose }: Props) {
   // const [companies, setCompanies] = useState<ExportCompany[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -706,7 +719,7 @@ export function ExportModal({ isOpen, onClose }: Props) {
               </Button>
             ))}
           </div>
-          <div className="fr-container--fluid fr-mb-8v">
+          <div className="fr-container--fluid fr-mb-2v">
             <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom">
               <div className="fr-col-6">
                 <Input
@@ -738,6 +751,13 @@ export function ExportModal({ isOpen, onClose }: Props) {
                 />
               </div>
             </div>
+          </div>
+          <div className="fr-mb-8v">
+            <Alert
+              description={getDateDescription(registryType)}
+              severity="info"
+              small
+            />
           </div>
           <div className="fr-container--fluid fr-mb-8v">
             <Select

--- a/front/src/dashboard/registry/ExportModal.tsx
+++ b/front/src/dashboard/registry/ExportModal.tsx
@@ -266,7 +266,7 @@ const getDefaultValues = () => ({
   wasteCodes: []
 });
 
-const getDateDescription = (registryType: RegistryV2ExportType) => {
+const getDateDescription = (registryType: RegistryV2ExportType): string => {
   switch (registryType) {
     case RegistryV2ExportType.Ssd:
       return "La date d'utilisation ou d'expédition est prise en compte.";
@@ -277,6 +277,7 @@ const getDateDescription = (registryType: RegistryV2ExportType) => {
     case RegistryV2ExportType.Managed:
       return "La date d'expédition est prise en compte. ";
   }
+  return "";
 };
 
 export function ExportModal({ isOpen, onClose }: Props) {


### PR DESCRIPTION
# Contexte

Ajout d'un petit bandeau d'info sous le sélecteur de date de la modale d'export de registres V2, spécifiant quelle date est utilisée pour le filtrage par date, selon le type de registre exporté.


https://github.com/user-attachments/assets/7e70c101-f348-45a8-ba5a-1ca16ed1f537



# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Afficher Date d'expédition ou Date de réception](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16366)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB