### PR TITLE
Rendre le champ emitterWastePackagings requis à la signature émetteur au lieu de la publication

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Améliorations et rework de la liste de déclarations + IHM [PR 4113](https://github.com/MTES-MCT/trackdechets/pull/4113)
+- Le champ emitterWastePackagings (détail du conditionnement émis) n'est plus obligatoire à la publication d'un dasri [PR 4140](https://github.com/MTES-MCT/trackdechets/pull/4140)
 
 #### :rocket: Nouvelles fonctionnalités
 

--- a/back/src/bsdasris/validation.ts
+++ b/back/src/bsdasris/validation.ts
@@ -274,15 +274,14 @@ export const emissionSchema: FactorySchemaOf<
 
     emitterWastePackagings: yup
       .array()
-      .requiredIf(
-        context.emissionSignature,
-        `Le détail du conditionnement émis est obligatoire.`
-      )
       .of(packagingInfo(true))
       .test(
         "packaging-info-required",
         "Le détail du conditionnement émis est obligatoire",
         function (value) {
+          if (this.parent.isDraft) {
+            return true;
+          }
           return !!context.emissionSignature ? !!value && !!value.length : true;
         }
       )
@@ -719,6 +718,7 @@ export type BsdasriValidationContext = {
   isSynthesis?: boolean;
   isDraft?: boolean;
 };
+
 export function validateBsdasri(
   dasri: Partial<Prisma.BsdasriCreateInput>,
   context: BsdasriValidationContext


### PR DESCRIPTION
# Contexte

Aujourd'hui, parfois ce sont les destinations qui créent le bordereau, mais parfois ce sont les producteurs. Avec la modification de l'accessibilité d'un bordereau au statut Brouillons ([seul l'établissement créateur du bordereau y aura accès](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-14422)), les destinations ont peur que les producteurs ne se chargent plus de la création du bordereau à cause du conditionnement à renseigner qui peut être complexe. 



➡️ Ainsi, on souhaite rendre le champ emitterWastePackagings requis à la signature émetteur plutôt qu'à la publication, afin que la destination puisse l'ajouter après publication.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

 

https://github.com/user-attachments/assets/2c513c8f-f389-463c-bd2a-785ddd7f2dd3


 

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16185

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB