### PR TITLE
[TRA-16388] Hotfix: Correction du code de vérification des différentiels sur les BSFF

### DIFF
--- a/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
+++ b/back/src/bsffs/resolvers/mutations/__tests__/updateBsffPackaging.integration.ts
@@ -16,7 +16,7 @@ import {
 import { prisma } from "@td/prisma";
 import { resetDatabase } from "../../../../../integration-tests/helper";
 
-const UPDATE_BSFF_PACKAGING = gql`
+export const UPDATE_BSFF_PACKAGING = gql`
   mutation UpdateBsffPackaging($id: ID!, $input: UpdateBsffPackagingInput!) {
     updateBsffPackaging(id: $id, input: $input) {
       id

--- a/back/src/bsffs/validation/bsff/index.ts
+++ b/back/src/bsffs/validation/bsff/index.ts
@@ -78,7 +78,7 @@ export async function mergeInputAndParseBsffAsync(
         other: p.other,
         volume: p.volume,
         numero: p.numero,
-        emissionNumero: p.numero,
+        emissionNumero: p.emissionNumero,
         weight: p.weight
       }))
     },


### PR DESCRIPTION
# Contexte

On a un bug en prod où un utilisateur n'arrive pas à réceptionner des BSFF. Le cas est complexe et j'ai du mal à la reproduire, mais en essayant j'ai trouvé une coquille.

Quand on met à jour un BSFF, on a un bout de code qui regarde ce qui a changé. Ce bout de code ne comparait pas correctement les changements sur le champ emissionNumero et inventait des différences là où il n'y en a pas.

A voir si ce fix débloque nos utilisateurs.

# Ticket Favro

[[Hotfix] Correction du code de vérification des différentiels sur les BSFF](https://favro.com/widget/ab14a4f0460a99a9d64d4945/75bf894e4c9b3d42b4cb02ca?card=tra-16388)