### PR TITLE
[TRA 16389] - Fix problème d'indexation des bordereaux suite

### DIFF
--- a/back/src/queue/jobs/indexBsd.ts
+++ b/back/src/queue/jobs/indexBsd.ts
@@ -46,6 +46,12 @@ export async function indexBsdJob(
     const rawForm = await getFormForElastic({ readableId: bsdId });
     const elasticBsdd = await indexForm(rawForm);
     await bsddLookupUtils.update(rawForm);
+    if (rawForm.forwardedIn) {
+      await bsddLookupUtils.update({
+        ...rawForm.forwardedIn,
+        intermediaries: []
+      });
+    }
     return { ...elasticBsdd, siretsBeforeUpdate };
   }
 


### PR DESCRIPTION
# Contexte

Les bordereaux suite sont indexés en même temps que le bordereau initial pour elastic, or je ne faisais que l'indexation du bordereau initial pour les registres. J'ajoute donc une indexation registre du bsd suite.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB