### PR TITLE
[tra-16255] fix focustrap to propagate click event

### DIFF
--- a/front/src/dashboard/registry/RegistryCompanySwitcher.tsx
+++ b/front/src/dashboard/registry/RegistryCompanySwitcher.tsx
@@ -145,7 +145,12 @@ export function RegistryCompanySwitcher({
         onOpenChange={setComboboxOpen}
       >
         {({ close }) => (
-          <FocusTrap active={isOpen}>
+          <FocusTrap
+            active={isOpen}
+            focusTrapOptions={{
+              allowOutsideClick: true
+            }}
+          >
             <div
               className="tw-bg-white tw-inset-x-0 tw-z-10 tw-px-2 tw-h-full tw-flex tw-flex-col"
               tabIndex={0}


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Correction régression du clic sur le selecteur d'entreprise qui ne se refermait plus

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/36dae634-c2cb-46a9-a2ab-387d5dcdfd04


# Ticket Favro

[tra-16255](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16255)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB