### PR TITLE
feat(core): amélioration du middleware de logging

### DIFF
--- a/back/src/__tests__/errors.integration.ts
+++ b/back/src/__tests__/errors.integration.ts
@@ -51,7 +51,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       const error = errors[0];
@@ -66,7 +66,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       const error = errors[0];
@@ -89,16 +89,17 @@ describe("Error handling", () => {
       mockFoo.mockResolvedValueOnce("bar");
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       expect(body.singleResult.errors).toBeUndefined();
       expect(body.singleResult.data).toEqual({ foo: "bar" });
     });
 
     test("GRAPHQL_VALIDATION_ERROR should resolves correctly", async () => {
-      const { body } = await server.executeOperation({
-        query: "query { foobar }" // query inconnue
-      });
+      const { body } = await server.executeOperation(
+        { query: "query { foobar }" }, // query inconnue
+        { contextValue: { req: {}, res: { locals: {} } } }
+      );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
       const error = errors[0];
@@ -109,9 +110,10 @@ describe("Error handling", () => {
     });
 
     test("GRAPHQL_PARSE_FAILED error should resolves correctly", async () => {
-      const { body } = await server.executeOperation({
-        query: "query { foo" // missing bracket
-      });
+      const { body } = await server.executeOperation(
+        { query: "query { foo" }, // missing bracket
+        { contextValue: { req: {}, res: { locals: {} } } }
+      );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
       const error = errors[0];
@@ -127,7 +129,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -142,7 +144,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -157,7 +159,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -175,7 +177,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -193,7 +195,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -209,7 +211,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       expect(errors).toHaveLength(1);
@@ -227,7 +229,7 @@ describe("Error handling", () => {
           query: BAR,
           variables
         },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       const error = errors[0];
@@ -252,7 +254,7 @@ describe("Error handling", () => {
       });
       const { body } = await server.executeOperation(
         { query: FOO },
-        { contextValue: { req: {} } }
+        { contextValue: { req: {}, res: { locals: {} } } }
       );
       const errors = body.singleResult.errors;
       const error = errors[0];

--- a/back/src/__tests__/testClient.ts
+++ b/back/src/__tests__/testClient.ts
@@ -34,7 +34,7 @@ function makeClient(user?: (User & { auth?: AuthType }) | null) {
               }
             }
           },
-          res: {},
+          res: { locals: {} },
           dataloaders: getServerDataloaders(),
           ...(user && { user: { auth: AuthType.Session, ...user } })
         } as any

--- a/back/src/types.ts
+++ b/back/src/types.ts
@@ -1,13 +1,14 @@
 import { Request, Response } from "express";
+import "express-session";
+import type { GraphQLError } from "graphql";
 import { createEventsDataLoaders } from "./activity-events/dataloader";
+import { createBsdaDataLoaders } from "./bsda/dataloader";
+import { createBspaohDataLoaders } from "./bspaoh/dataloader";
+import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
 import { GqlInfo } from "./common/plugins/gqlInfosPlugin";
 import { createCompanyDataLoaders } from "./companies/dataloaders";
 import { createFormDataLoaders } from "./forms/dataloader";
-import { createBsdaDataLoaders } from "./bsda/dataloader";
-import { createBsvhuDataLoaders } from "./bsvhu/dataloader";
-import { createBspaohDataLoaders } from "./bspaoh/dataloader";
 import { createUserDataLoaders } from "./users/dataloaders";
-import "express-session";
 
 export type AppDataloaders = ReturnType<typeof createUserDataLoaders> &
   ReturnType<typeof createCompanyDataLoaders> &
@@ -118,5 +119,9 @@ declare module "express-session" {
 declare module "express" {
   interface Request {
     gqlInfos?: GqlInfo[];
+  }
+  interface Locals {
+    hasUndisplayedError?: boolean;
+    gqlErrors?: GraphQLError[];
   }
 }


### PR DESCRIPTION
# Contexte

L'idée principale de ce changement est que lorsqu'une erreur est retournée en graphql, elle apparaisse comme un log d'erreur ou de warning et non un log d'info.
- erreur quand c'est une erreur serveur pour l'utilisateur (erreur privée)
- warning quand c'est une erreur affichable à l'utilisateur

Ca permettra de mieux identifier les retours en erreur, les dénombrer, et naviguer dedans.

En plus de ca, pour les queries gql, j'ajoute le nom de la query/mutation appelée dans le titre du log pour une meilleure visibilité, et éviter d'avoir juste des "POST /" partout