### PR TITLE
Hotfix IHM transporteurs + erreur de permissions

### DIFF
--- a/front/src/form/registry/builder/FormBuilder.scss
+++ b/front/src/form/registry/builder/FormBuilder.scss
@@ -50,6 +50,12 @@
       var(--border-default-grey),
       var(--border-default-grey)
     );
+    .error-container {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      // gap: 16px;
+    }
   }
   .fr-tabs {
     box-shadow: none;

--- a/front/src/form/registry/builder/FormBuilder.tsx
+++ b/front/src/form/registry/builder/FormBuilder.tsx
@@ -108,53 +108,60 @@ export function FormBuilder({
             )}
           </Tabs>
 
-          {errors.root?.serverError && (
-            <Alert
-              title="Erreur interne"
-              description="Une erreur inconnue est survenue, merci de réessayer dans quelques instants. Si le problème persiste vous pouvez contacter le support"
-              severity="error"
-              className="fr-my-2w"
-            />
-          )}
           <div className="fr-modal__footer fr-py-3w fr-mt-0">
-            <div className="fr-btns-group fr-btns-group--inline">
-              <div>
-                <div>
-                  <Button
-                    onClick={onPrevTab}
-                    priority="tertiary"
-                    disabled={selectedTabId === firstTabId}
-                    type="button"
-                  >
-                    Précédent
-                  </Button>
-
-                  <Button
-                    onClick={onNextTab}
-                    priority="tertiary"
-                    disabled={selectedTabId === lastTabId}
-                    type="button"
-                  >
-                    Suivant
-                  </Button>
+            <div className="error-container">
+              {errors.root?.serverError && (
+                <div tabIndex={-1}>
+                  <Alert
+                    title="Erreur interne"
+                    description={
+                      errors.root.serverError.message ??
+                      "Une erreur inconnue est survenue, merci de réessayer dans quelques instants. Si le problème persiste vous pouvez contacter le support"
+                    }
+                    severity="error"
+                    className="fr-mb-2w"
+                  />
                 </div>
-
+              )}
+              <div className="fr-btns-group fr-btns-group--inline">
                 <div>
-                  <Button
-                    priority="secondary"
-                    type="button"
-                    onClick={() => navigate(-1)}
-                  >
-                    Fermer
-                  </Button>
+                  <div>
+                    <Button
+                      onClick={onPrevTab}
+                      priority="tertiary"
+                      disabled={selectedTabId === firstTabId}
+                      type="button"
+                    >
+                      Précédent
+                    </Button>
 
-                  <Button type="submit" disabled={loading}>
-                    {reason === RegistryLineReason.Edit
-                      ? "Modifier la déclaration"
-                      : reason === RegistryLineReason.Cancel
-                      ? "Annuler la déclaration"
-                      : "Créer la déclaration"}
-                  </Button>
+                    <Button
+                      onClick={onNextTab}
+                      priority="tertiary"
+                      disabled={selectedTabId === lastTabId}
+                      type="button"
+                    >
+                      Suivant
+                    </Button>
+                  </div>
+
+                  <div>
+                    <Button
+                      priority="secondary"
+                      type="button"
+                      onClick={() => navigate(-1)}
+                    >
+                      Fermer
+                    </Button>
+
+                    <Button type="submit" disabled={loading}>
+                      {reason === RegistryLineReason.Edit
+                        ? "Modifier la déclaration"
+                        : reason === RegistryLineReason.Cancel
+                        ? "Annuler la déclaration"
+                        : "Créer la déclaration"}
+                    </Button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/front/src/form/registry/incomingTexs/RegistryIncomingTexsForm.tsx
+++ b/front/src/form/registry/incomingTexs/RegistryIncomingTexsForm.tsx
@@ -93,7 +93,10 @@ export function RegistryIncomingTexsForm({ onClose }: Props) {
 
           const transporters = Object.values(transportersObj).filter(
             partialTransporter => {
-              if (partialTransporter.TransportMode) {
+              if (
+                partialTransporter.TransportMode ||
+                partialTransporter.CompanyType
+              ) {
                 return true;
               }
               return false;

--- a/front/src/form/registry/incomingWaste/RegistryIncomingWasteForm.tsx
+++ b/front/src/form/registry/incomingWaste/RegistryIncomingWasteForm.tsx
@@ -87,7 +87,10 @@ export function RegistryIncomingWasteForm({ onClose }: Props) {
 
           const transporters = Object.values(transportersObj).filter(
             partialTransporter => {
-              if (partialTransporter.TransportMode) {
+              if (
+                partialTransporter.TransportMode ||
+                partialTransporter.CompanyType
+              ) {
                 return true;
               }
               return false;

--- a/front/src/form/registry/managed/RegistryManagedForm.tsx
+++ b/front/src/form/registry/managed/RegistryManagedForm.tsx
@@ -92,7 +92,10 @@ export function RegistryManagedForm({ onClose }: Props) {
 
           const transporters = Object.values(transportersObj).filter(
             partialTransporter => {
-              if (partialTransporter.TransportMode) {
+              if (
+                partialTransporter.TransportMode ||
+                partialTransporter.CompanyType
+              ) {
                 return true;
               }
               return false;

--- a/front/src/form/registry/outgoingTexs/RegistryOutgoingTexsForm.tsx
+++ b/front/src/form/registry/outgoingTexs/RegistryOutgoingTexsForm.tsx
@@ -93,7 +93,10 @@ export function RegistryOutgoingTexsForm({ onClose }: Props) {
 
           const transporters = Object.values(transportersObj).filter(
             partialTransporter => {
-              if (partialTransporter.TransportMode) {
+              if (
+                partialTransporter.TransportMode ||
+                partialTransporter.CompanyType
+              ) {
                 return true;
               }
               return false;

--- a/libs/back/registry/src/shared/refinement.ts
+++ b/libs/back/registry/src/shared/refinement.ts
@@ -38,6 +38,14 @@ export function refineTransporterInfos<T>({
         path: [typeKey]
       });
     }
+    if (!item[modeKey] && item[typeKey]) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Le mode de transport doit être renseigné si les informations du transporteur le sont",
+        path: [modeKey]
+      });
+    }
 
     if (!item[typeKey]) {
       return;


### PR DESCRIPTION
# Contexte

- Ajout d'une règle de validation qui empêche de remplir des infos sur un transporteur si le mode de transport n'est pas renseigné
- Ajout de la possibilité d'affichage du transporteur dans l'IHM si transportMode est manquant (pour legacy + erreurs d'avant fix)
- ajout d'un message d'erreur explicite en cas d'impossibilité d'édition car permissions insuffisantes
- déplacement du message d'erreur "global" dans le footer pour en améliorer l'apparence (border de la tab qui était coupée)

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB