### PR TITLE
[TRA 16437 - Hotfix] Pagination de la liste des déclarations

### DIFF
--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -1263,9 +1263,9 @@ const bsdaToLookupCreateInputs = (
       wasteType: RegistryExportWasteType.DD,
       wasteCode: bsda.wasteCode,
       ...generateDateInfos(
-        bsda.destinationReceptionDate ?? bsda.destinationOperationSignatureDate
+        bsda.destinationReceptionDate ?? bsda.destinationOperationSignatureDate,
+        bsda.createdAt
       ),
-      declaredAt: bsda.createdAt,
       bsdaId: bsda.id
     });
   }
@@ -1289,9 +1289,9 @@ const bsdaToLookupCreateInputs = (
         wasteCode: bsda.wasteCode,
         ...generateDateInfos(
           transporter.transporterTransportTakenOverAt ??
-            transporter.transporterTransportSignatureDate!
+            transporter.transporterTransportSignatureDate!,
+          bsda.createdAt
         ),
-        declaredAt: bsda.createdAt,
         bsdaId: bsda.id
       });
     });
@@ -1316,9 +1316,9 @@ const bsdaToLookupCreateInputs = (
         wasteCode: bsda.wasteCode,
         ...generateDateInfos(
           transporter.transporterTransportTakenOverAt ??
-            transporter.transporterTransportSignatureDate!
+            transporter.transporterTransportSignatureDate!,
+          bsda.createdAt
         ),
-        declaredAt: bsda.createdAt,
         bsdaId: bsda.id
       });
     });
@@ -1346,9 +1346,9 @@ const bsdaToLookupCreateInputs = (
       wasteCode: bsda.wasteCode,
       ...generateDateInfos(
         transporter.transporterTransportTakenOverAt ??
-          transporter.transporterTransportSignatureDate!
+          transporter.transporterTransportSignatureDate!,
+        bsda.createdAt
       ),
-      declaredAt: bsda.createdAt,
       bsdaId: bsda.id
     });
   });

--- a/back/src/bsdasris/registryV2.ts
+++ b/back/src/bsdasris/registryV2.ts
@@ -634,9 +634,9 @@ const bsdasriToLookupCreateInputs = (
       wasteCode: bsdasri.wasteCode,
       ...generateDateInfos(
         bsdasri.destinationReceptionDate ??
-          bsdasri.destinationReceptionSignatureDate
+          bsdasri.destinationReceptionSignatureDate,
+        bsdasri.createdAt
       ),
-      declaredAt: bsdasri.createdAt,
       bsdasriId: bsdasri.id
     });
   }
@@ -659,9 +659,9 @@ const bsdasriToLookupCreateInputs = (
         wasteCode: bsdasri.wasteCode,
         ...generateDateInfos(
           bsdasri.transporterTakenOverAt ??
-            bsdasri.transporterTransportSignatureDate!
+            bsdasri.transporterTransportSignatureDate!,
+          bsdasri.createdAt
         ),
-        declaredAt: bsdasri.createdAt,
         bsdasriId: bsdasri.id
       });
     });
@@ -677,9 +677,9 @@ const bsdasriToLookupCreateInputs = (
         wasteCode: bsdasri.wasteCode,
         ...generateDateInfos(
           bsdasri.transporterTakenOverAt ??
-            bsdasri.transporterTransportSignatureDate!
+            bsdasri.transporterTransportSignatureDate!,
+          bsdasri.createdAt
         ),
-        declaredAt: bsdasri.createdAt,
         bsdasriId: bsdasri.id
       });
     }

--- a/back/src/bsdasris/registryV2.ts
+++ b/back/src/bsdasris/registryV2.ts
@@ -712,7 +712,7 @@ export const updateRegistryLookup = async (
   });
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("BSDASRI");
   await prisma.registryLookup.deleteMany({
     where: {
@@ -731,7 +731,25 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalBsdasriForLookup[]) => {
+    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
+    for (const bsdasri of items) {
+      const createInputs = bsdasriToLookupCreateInputs(bsdasri);
+      createArray = createArray.concat(createInputs);
+    }
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.bsdasri.findMany({
       where: {
         isDeleted: false,
@@ -745,17 +763,18 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalBsdasriForLookupSelect
     });
-    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
-    for (const bsdasri of items) {
-      const createInputs = bsdasriToLookupCreateInputs(bsdasri);
-      createArray = createArray.concat(createInputs);
-    }
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
 
     if (items.length < pageSize) {
       done = true;
@@ -763,6 +782,12 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -1033,9 +1033,9 @@ const bsffToLookupCreateInputs = (
       wasteType: RegistryExportWasteType.DD,
       wasteCode: bsff.wasteCode,
       ...generateDateInfos(
-        bsff.destinationReceptionDate ?? bsff.destinationReceptionSignatureDate
+        bsff.destinationReceptionDate ?? bsff.destinationReceptionSignatureDate,
+        bsff.createdAt
       ),
-      declaredAt: bsff.createdAt,
       bsffId: bsff.id
     });
   }
@@ -1058,9 +1058,9 @@ const bsffToLookupCreateInputs = (
         wasteCode: bsff.wasteCode,
         ...generateDateInfos(
           transporter.transporterTransportTakenOverAt ??
-            transporter.transporterTransportSignatureDate!
+            transporter.transporterTransportSignatureDate!,
+          bsff.createdAt
         ),
-        declaredAt: bsff.createdAt,
         bsffId: bsff.id
       });
     });
@@ -1088,9 +1088,9 @@ const bsffToLookupCreateInputs = (
       wasteCode: bsff.wasteCode,
       ...generateDateInfos(
         transporter.transporterTransportTakenOverAt ??
-          transporter.transporterTransportSignatureDate
+          transporter.transporterTransportSignatureDate,
+        bsff.createdAt
       ),
-      declaredAt: bsff.createdAt,
       bsffId: bsff.id
     });
   });

--- a/back/src/bsffs/registryV2.ts
+++ b/back/src/bsffs/registryV2.ts
@@ -1120,7 +1120,7 @@ export const updateRegistryLookup = async (
   });
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("BSFF");
   await prisma.registryLookup.deleteMany({
     where: {
@@ -1139,7 +1139,25 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalBsffForLookup[]) => {
+    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
+    for (const bsff of items) {
+      const createInputs = bsffToLookupCreateInputs(bsff);
+      createArray = createArray.concat(createInputs);
+    }
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.bsff.findMany({
       where: {
         isDeleted: false,
@@ -1153,23 +1171,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalBsffForLookupSelect
     });
-    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
-    for (const bsff of items) {
-      const createInputs = bsffToLookupCreateInputs(bsff);
-      createArray = createArray.concat(createInputs);
-    }
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/back/src/bspaoh/registryV2.ts
+++ b/back/src/bspaoh/registryV2.ts
@@ -588,9 +588,9 @@ const bspaohToLookupCreateInputs = (
       wasteCode: bspaoh.wasteCode,
       ...generateDateInfos(
         bspaoh.destinationReceptionDate ??
-          bspaoh.destinationReceptionSignatureDate
+          bspaoh.destinationReceptionSignatureDate,
+        bspaoh.createdAt
       ),
-      declaredAt: bspaoh.createdAt,
       bspaohId: bspaoh.id
     });
   }
@@ -608,9 +608,9 @@ const bspaohToLookupCreateInputs = (
       wasteCode: bspaoh.wasteCode,
       ...generateDateInfos(
         transporter.transporterTakenOverAt ??
-          transporter.transporterTransportSignatureDate
+          transporter.transporterTransportSignatureDate,
+        bspaoh.createdAt
       ),
-      declaredAt: bspaoh.createdAt,
       bspaohId: bspaoh.id
     });
   }
@@ -627,9 +627,9 @@ const bspaohToLookupCreateInputs = (
         wasteCode: bspaoh.wasteCode,
         ...generateDateInfos(
           transporter.transporterTakenOverAt ??
-            transporter.transporterTransportSignatureDate
+            transporter.transporterTransportSignatureDate,
+          bspaoh.createdAt
         ),
-        declaredAt: bspaoh.createdAt,
         bspaohId: bspaoh.id
       });
     }

--- a/back/src/bspaoh/registryV2.ts
+++ b/back/src/bspaoh/registryV2.ts
@@ -661,7 +661,7 @@ export const updateRegistryLookup = async (
   });
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("BSPAOH");
   await prisma.registryLookup.deleteMany({
     where: {
@@ -678,10 +678,29 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       }
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalBspaohForLookup[]) => {
+    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
+    for (const bspaoh of items) {
+      const createInputs = bspaohToLookupCreateInputs(bspaoh);
+      createArray = createArray.concat(createInputs);
+    }
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.bspaoh.findMany({
       where: {
         isDeleted: false,
@@ -697,23 +716,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalBspaohForLookupSelect
     });
-    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
-    for (const bspaoh of items) {
-      const createInputs = bspaohToLookupCreateInputs(bspaoh);
-      createArray = createArray.concat(createInputs);
-    }
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -826,7 +826,7 @@ export const updateRegistryLookup = async (
   });
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("BSVHU");
   await prisma.registryLookup.deleteMany({
     where: {
@@ -841,10 +841,29 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       isDraft: false
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalBsvhuForLookup[]) => {
+    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
+    for (const bsvhu of items) {
+      const createInputs = bsvhuToLookupCreateInputs(bsvhu);
+      createArray = createArray.concat(createInputs);
+    }
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.bsvhu.findMany({
       where: {
         isDeleted: false,
@@ -858,23 +877,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalBsvhuForLookupSelect
     });
-    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
-    for (const bsvhu of items) {
-      const createInputs = bsvhuToLookupCreateInputs(bsvhu);
-      createArray = createArray.concat(createInputs);
-    }
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/back/src/bsvhu/registryV2.ts
+++ b/back/src/bsvhu/registryV2.ts
@@ -718,9 +718,9 @@ const bsvhuToLookupCreateInputs = (
       wasteCode: bsvhu.wasteCode,
       ...generateDateInfos(
         bsvhu.destinationReceptionDate ??
-          bsvhu.destinationOperationSignatureDate
+          bsvhu.destinationOperationSignatureDate,
+        bsvhu.createdAt
       ),
-      declaredAt: bsvhu.createdAt,
       bsvhuId: bsvhu.id
     });
   }
@@ -743,9 +743,9 @@ const bsvhuToLookupCreateInputs = (
         wasteCode: bsvhu.wasteCode,
         ...generateDateInfos(
           bsvhu.transporterTransportTakenOverAt ??
-            bsvhu.transporterTransportSignatureDate!
+            bsvhu.transporterTransportSignatureDate!,
+          bsvhu.createdAt
         ),
-        declaredAt: bsvhu.createdAt,
         bsvhuId: bsvhu.id
       });
     });
@@ -762,9 +762,9 @@ const bsvhuToLookupCreateInputs = (
         wasteCode: bsvhu.wasteCode,
         ...generateDateInfos(
           bsvhu.transporterTransportTakenOverAt ??
-            bsvhu.transporterTransportSignatureDate!
+            bsvhu.transporterTransportSignatureDate!,
+          bsvhu.createdAt
         ),
-        declaredAt: bsvhu.createdAt,
         bsvhuId: bsvhu.id
       });
     }
@@ -792,9 +792,9 @@ const bsvhuToLookupCreateInputs = (
         wasteCode: bsvhu.wasteCode,
         ...generateDateInfos(
           bsvhu.transporterTransportTakenOverAt ??
-            bsvhu.transporterTransportSignatureDate!
+            bsvhu.transporterTransportSignatureDate!,
+          bsvhu.createdAt
         ),
-        declaredAt: bsvhu.createdAt,
         bsvhuId: bsvhu.id
       });
     });

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -1235,6 +1235,7 @@ export const toManagedWasteV2 = (
 
 const minimalBsddForLookupSelect = {
   id: true,
+  createdAt: true,
   readableId: true,
   receivedAt: true,
   sentAt: true,
@@ -1282,7 +1283,7 @@ const bsddToLookupCreateInputs = (
       declarationType: RegistryExportDeclarationType.BSD,
       wasteType: getWasteType(form),
       wasteCode: form.wasteDetailsCode,
-      ...generateDateInfos(form.receivedAt),
+      ...generateDateInfos(form.receivedAt, form.createdAt),
       bsddId: form.id
     });
   }
@@ -1303,7 +1304,7 @@ const bsddToLookupCreateInputs = (
         declarationType: RegistryExportDeclarationType.BSD,
         wasteType: getWasteType(form),
         wasteCode: form.wasteDetailsCode,
-        ...generateDateInfos(form.takenOverAt ?? form.sentAt!),
+        ...generateDateInfos(form.takenOverAt ?? form.sentAt!, form.createdAt),
         bsddId: form.id
       });
     });
@@ -1329,7 +1330,7 @@ const bsddToLookupCreateInputs = (
         declarationType: RegistryExportDeclarationType.BSD,
         wasteType: getWasteType(form),
         wasteCode: form.wasteDetailsCode,
-        ...generateDateInfos(form.takenOverAt ?? form.sentAt!),
+        ...generateDateInfos(form.takenOverAt ?? form.sentAt!, form.createdAt),
         bsddId: form.id
       });
     });
@@ -1355,7 +1356,7 @@ const bsddToLookupCreateInputs = (
       declarationType: RegistryExportDeclarationType.BSD,
       wasteType: getWasteType(form),
       wasteCode: form.wasteDetailsCode,
-      ...generateDateInfos(transporter.takenOverAt),
+      ...generateDateInfos(transporter.takenOverAt, form.createdAt),
       bsddId: form.id
     });
   });

--- a/back/src/forms/registryV2.ts
+++ b/back/src/forms/registryV2.ts
@@ -1386,8 +1386,9 @@ export const updateRegistryLookup = async (
   });
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("BSDD");
+
   await prisma.registryLookup.deleteMany({
     where: {
       bsddId: { not: null }
@@ -1407,7 +1408,27 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalBsddForLookup[]) => {
+    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
+    for (const bsdd of items) {
+      const createInputs = bsddToLookupCreateInputs(bsdd);
+      createArray = createArray.concat(createInputs);
+    }
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.form.findMany({
       where: {
         isDeleted: false,
@@ -1423,23 +1444,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalBsddForLookupSelect
     });
-    let createArray: Prisma.RegistryLookupUncheckedCreateInput[] = [];
-    for (const bsdd of items) {
-      const createInputs = bsddToLookupCreateInputs(bsdd);
-      createArray = createArray.concat(createInputs);
-    }
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/back/src/registryV2/resolvers/queries/registryLookups.ts
+++ b/back/src/registryV2/resolvers/queries/registryLookups.ts
@@ -1,13 +1,14 @@
 import { GraphQLContext } from "../../../types";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { prisma } from "@td/prisma";
+import { Prisma } from "@prisma/client";
 import {
   IncomingTexsLine,
   IncomingWasteLine,
   ManagedLine,
   OutgoingTexsLine,
   OutgoingWasteLine,
-  QueryRegistryLookupArgs,
+  QueryRegistryLookupsArgs,
   SsdLine,
   TransportedLine
 } from "@td/codegen-back";
@@ -17,10 +18,11 @@ import {
   getTypeFilter,
   getTypeFromLookup
 } from "./utils/registryLookup.util";
+import { getRelativeConnection } from "../../../common/pagination";
 
 export async function registryLookups(
   _,
-  { siret, type, publicId }: QueryRegistryLookupArgs,
+  { siret, type, publicId, ...gqlPaginationArgs }: QueryRegistryLookupsArgs,
   context: GraphQLContext
 ) {
   const user = checkIsAuthenticated(context);
@@ -35,43 +37,108 @@ export async function registryLookups(
     `Vous n'êtes pas autorisé à lire des données du registre`
   );
 
-  const lookups = await prisma.registryLookup.findMany({
-    where: {
-      siret,
-      ...(reportAsSiretsFilter.length > 0 && {
-        reportAsSiret: { in: reportAsSiretsFilter }
+  // const lookups = await prisma.registryLookup.findMany({
+  //   where: {
+  //     siret,
+  //     ...(reportAsSiretsFilter.length > 0 && {
+  //       reportAsSiret: { in: reportAsSiretsFilter }
+  //     }),
+  //     declarationType: "REGISTRY",
+  //     ...getTypeFilter(type),
+  //     ...(publicId && {
+  //       readableId: {
+  //         contains: publicId,
+  //         mode: "insensitive"
+  //       }
+  //     })
+  //   },
+  //   orderBy: { declaredAt: "desc" },
+  //   take: 10,
+  //   include: {
+  //     registrySsd: true,
+  //     registryIncomingWaste: true,
+  //     registryIncomingTexs: true,
+  //     registryOutgoingWaste: true,
+  //     registryOutgoingTexs: true,
+  //     registryTransported: true,
+  //     registryManaged: true
+  //   }
+  // });
+  // return lookups.map(lookup => ({
+  //   ...lookup,
+  //   publicId: lookup.readableId,
+  //   type: type ?? getTypeFromLookup(lookup),
+  //   ssd: (lookup.registrySsd as SsdLine) ?? null,
+  //   incomingWaste: (lookup.registryIncomingWaste as IncomingWasteLine) ?? null,
+  //   incomingTexs: (lookup.registryIncomingTexs as IncomingTexsLine) ?? null,
+  //   outgoingWaste: (lookup.registryOutgoingWaste as OutgoingWasteLine) ?? null,
+  //   outgoingTexs: (lookup.registryOutgoingTexs as OutgoingTexsLine) ?? null,
+  //   managedWaste: (lookup.registryManaged as ManagedLine) ?? null,
+  //   transportedWaste: (lookup.registryTransported as TransportedLine) ?? null
+  // }));
+
+  return getRelativeConnection(
+    {
+      findMany: prismaPaginationArgs => {
+        const { cursor, ...rest } = prismaPaginationArgs;
+        return prisma.registryLookup.findMany({
+          where: {
+            siret,
+            ...(reportAsSiretsFilter.length > 0 && {
+              reportAsSiret: { in: reportAsSiretsFilter }
+            }),
+            declarationType: "REGISTRY",
+            ...getTypeFilter(type),
+            ...(publicId && {
+              readableId: {
+                contains: publicId,
+                mode: "insensitive"
+              }
+            })
+          },
+          ...rest,
+          ...(cursor && { cursor: { declaredAtId: cursor.declaredAtId } }),
+          orderBy: { declaredAtId: "desc" },
+          include: {
+            registrySsd: true,
+            registryIncomingWaste: true,
+            registryIncomingTexs: true,
+            registryOutgoingWaste: true,
+            registryOutgoingTexs: true,
+            registryTransported: true,
+            registryManaged: true
+          }
+        });
+      },
+      formatNode: (
+        lookup: Prisma.RegistryLookupGetPayload<{
+          include: {
+            registrySsd: true;
+            registryIncomingWaste: true;
+            registryIncomingTexs: true;
+            registryOutgoingWaste: true;
+            registryOutgoingTexs: true;
+            registryTransported: true;
+            registryManaged: true;
+          };
+        }>
+      ) => ({
+        ...lookup,
+        publicId: lookup.readableId,
+        type: type ?? getTypeFromLookup(lookup),
+        ssd: (lookup.registrySsd as SsdLine) ?? null,
+        incomingWaste:
+          (lookup.registryIncomingWaste as IncomingWasteLine) ?? null,
+        incomingTexs: (lookup.registryIncomingTexs as IncomingTexsLine) ?? null,
+        outgoingWaste:
+          (lookup.registryOutgoingWaste as OutgoingWasteLine) ?? null,
+        outgoingTexs: (lookup.registryOutgoingTexs as OutgoingTexsLine) ?? null,
+        managedWaste: (lookup.registryManaged as ManagedLine) ?? null,
+        transportedWaste:
+          (lookup.registryTransported as TransportedLine) ?? null
       }),
-      declarationType: "REGISTRY",
-      ...getTypeFilter(type),
-      ...(publicId && {
-        readableId: {
-          contains: publicId,
-          mode: "insensitive"
-        }
-      })
+      ...gqlPaginationArgs
     },
-    orderBy: { declaredAt: "desc" },
-    take: 10,
-    include: {
-      registrySsd: true,
-      registryIncomingWaste: true,
-      registryIncomingTexs: true,
-      registryOutgoingWaste: true,
-      registryOutgoingTexs: true,
-      registryTransported: true,
-      registryManaged: true
-    }
-  });
-  return lookups.map(lookup => ({
-    ...lookup,
-    publicId: lookup.readableId,
-    type: type ?? getTypeFromLookup(lookup),
-    ssd: (lookup.registrySsd as SsdLine) ?? null,
-    incomingWaste: (lookup.registryIncomingWaste as IncomingWasteLine) ?? null,
-    incomingTexs: (lookup.registryIncomingTexs as IncomingTexsLine) ?? null,
-    outgoingWaste: (lookup.registryOutgoingWaste as OutgoingWasteLine) ?? null,
-    outgoingTexs: (lookup.registryOutgoingTexs as OutgoingTexsLine) ?? null,
-    managedWaste: (lookup.registryManaged as ManagedLine) ?? null,
-    transportedWaste: (lookup.registryTransported as TransportedLine) ?? null
-  }));
+    "declaredAtId"
+  );
 }

--- a/back/src/registryV2/resolvers/queries/registryLookups.ts
+++ b/back/src/registryV2/resolvers/queries/registryLookups.ts
@@ -37,46 +37,6 @@ export async function registryLookups(
     `Vous n'êtes pas autorisé à lire des données du registre`
   );
 
-  // const lookups = await prisma.registryLookup.findMany({
-  //   where: {
-  //     siret,
-  //     ...(reportAsSiretsFilter.length > 0 && {
-  //       reportAsSiret: { in: reportAsSiretsFilter }
-  //     }),
-  //     declarationType: "REGISTRY",
-  //     ...getTypeFilter(type),
-  //     ...(publicId && {
-  //       readableId: {
-  //         contains: publicId,
-  //         mode: "insensitive"
-  //       }
-  //     })
-  //   },
-  //   orderBy: { declaredAt: "desc" },
-  //   take: 10,
-  //   include: {
-  //     registrySsd: true,
-  //     registryIncomingWaste: true,
-  //     registryIncomingTexs: true,
-  //     registryOutgoingWaste: true,
-  //     registryOutgoingTexs: true,
-  //     registryTransported: true,
-  //     registryManaged: true
-  //   }
-  // });
-  // return lookups.map(lookup => ({
-  //   ...lookup,
-  //   publicId: lookup.readableId,
-  //   type: type ?? getTypeFromLookup(lookup),
-  //   ssd: (lookup.registrySsd as SsdLine) ?? null,
-  //   incomingWaste: (lookup.registryIncomingWaste as IncomingWasteLine) ?? null,
-  //   incomingTexs: (lookup.registryIncomingTexs as IncomingTexsLine) ?? null,
-  //   outgoingWaste: (lookup.registryOutgoingWaste as OutgoingWasteLine) ?? null,
-  //   outgoingTexs: (lookup.registryOutgoingTexs as OutgoingTexsLine) ?? null,
-  //   managedWaste: (lookup.registryManaged as ManagedLine) ?? null,
-  //   transportedWaste: (lookup.registryTransported as TransportedLine) ?? null
-  // }));
-
   return getRelativeConnection(
     {
       findMany: prismaPaginationArgs => {

--- a/back/src/registryV2/resolvers/queries/utils/registryLookup.util.ts
+++ b/back/src/registryV2/resolvers/queries/utils/registryLookup.util.ts
@@ -9,7 +9,7 @@ import { getUserCompanies } from "../../../../users/database";
 import { UserInputError } from "../../../../common/errors";
 import { getDelegatorsByDelegateForEachCompanies } from "../../../../registryDelegation/database";
 
-export function getTypeFilter(type: RegistryImportType | null) {
+export function getTypeFilter(type: RegistryImportType | null | undefined) {
   switch (type) {
     case "INCOMING_TEXS":
       return {

--- a/back/src/registryV2/typeDefs/registryV2.objects.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.objects.graphql
@@ -130,3 +130,13 @@ type RegistryLookup {
   managedWaste: ManagedLine
   transportedWaste: TransportedLine
 }
+
+type RegistryLookupConnection {
+  pageInfo: PageInfo!
+  edges: [RegistryLookupEdge!]!
+}
+
+type RegistryLookupEdge {
+  cursor: String!
+  node: RegistryLookup!
+}

--- a/back/src/registryV2/typeDefs/registryV2.queries.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.queries.graphql
@@ -76,5 +76,18 @@ type Query {
     type: RegistryImportType
     "Identifiant unique de la déclaration, supporte un match partiel"
     publicId: String
-  ): [RegistryLookup!]
+    """
+    (Optionnel) PAGINATION
+    Cursor de la page à récupérer (endCursor de la page précédente)
+    """
+    after: String
+
+    before: String
+    """
+    (Optionnel) PAGINATION
+    Nombre d'éléments à récupérer
+    """
+    first: Int
+    last: Int
+  ): RegistryLookupConnection!
 }

--- a/back/src/scripts/bin/rebuildRegistryLookup.ts
+++ b/back/src/scripts/bin/rebuildRegistryLookup.ts
@@ -184,7 +184,12 @@ const runIntegrityTest = async () => {
   const pageSize = args.includes("--page-size")
     ? parseInt(args[args.indexOf("--page-size") + 1])
     : 500;
+
+  const threads = args.includes("--threads")
+    ? parseInt(args[args.indexOf("--threads") + 1])
+    : 4;
   console.log("pageSize", pageSize);
+  console.log("threads", threads);
   try {
     if (integrityTest) {
       await runIntegrityTest();
@@ -194,79 +199,79 @@ const runIntegrityTest = async () => {
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("SSD")
     ) {
-      await ssdLookupUtils.rebuildLookup(pageSize);
+      await ssdLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_WASTE")
     ) {
-      await incomingWasteLookupUtils.rebuildLookup(pageSize);
+      await incomingWasteLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("INCOMING_TEXS")
     ) {
-      await incomingTexsLookupUtils.rebuildLookup(pageSize);
+      await incomingTexsLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("OUTGOING_WASTE")
     ) {
-      await outgoingWasteLookupUtils.rebuildLookup(pageSize);
+      await outgoingWasteLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("OUTGOING_TEXS")
     ) {
-      await outgoingTexsLookupUtils.rebuildLookup(pageSize);
+      await outgoingTexsLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("TRANSPORTED")
     ) {
-      await transportedLookupUtils.rebuildLookup(pageSize);
+      await transportedLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("MANAGED")
     ) {
-      await managedLookupUtils.rebuildLookup(pageSize);
+      await managedLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDD")
     ) {
-      await bsddLookupUtils.rebuildLookup(pageSize);
+      await bsddLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDA")
     ) {
-      await bsdaLookupUtils.rebuildLookup(pageSize);
+      await bsdaLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSDASRI")
     ) {
-      await bsdasriLookupUtils.rebuildLookup(pageSize);
+      await bsdasriLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSFF")
     ) {
-      await bsffLookupUtils.rebuildLookup(pageSize);
+      await bsffLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSPAOH")
     ) {
-      await bspaohLookupUtils.rebuildLookup(pageSize);
+      await bspaohLookupUtils.rebuildLookup(pageSize, threads);
     }
     if (
       bsdOrRegistryTypesToIndex.length === 0 ||
       bsdOrRegistryTypesToIndex.includes("BSVHU")
     ) {
-      await bsvhuLookupUtils.rebuildLookup(pageSize);
+      await bsvhuLookupUtils.rebuildLookup(pageSize, threads);
     }
   } catch (error) {
     console.error("Error in rebuildRegistryLookup script, exiting", error);

--- a/front/src/Apps/common/Components/CursorPagination/CursorPagination.tsx
+++ b/front/src/Apps/common/Components/CursorPagination/CursorPagination.tsx
@@ -8,10 +8,12 @@ const Link = ({
   children: React.ReactNode;
   [key: string]: any;
 }) => {
-  return rest["aria-disabled"] === true ? (
+  return rest.disabled === true ? (
     <a {...rest}>{children}</a>
   ) : (
-    <button {...rest}>{children}</button>
+    <button type="button" {...rest}>
+      {children}
+    </button>
   );
 };
 
@@ -42,13 +44,12 @@ const CursorPagination = ({
         <li>
           <Link
             className="fr-link fr-pagination__link fr-pagination__link--first"
-            onClick={event => {
-              event.preventDefault();
-              if (!contentLoading) {
+            onClick={() => {
+              if (hasPreviousPage && !contentLoading) {
                 onFirstClick();
               }
             }}
-            aria-disabled={!hasPreviousPage || contentLoading}
+            disabled={!hasPreviousPage || contentLoading}
             title="Première page"
           >
             Première page
@@ -57,37 +58,26 @@ const CursorPagination = ({
         <li>
           <Link
             className="fr-link fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-            onClick={event => {
-              event.preventDefault();
-              if (!contentLoading) {
+            onClick={() => {
+              if (hasPreviousPage && !contentLoading) {
                 onPreviousClick();
               }
             }}
-            aria-disabled={!hasPreviousPage || contentLoading}
+            disabled={!hasPreviousPage || contentLoading}
             title="Page précédente"
           >
             Page précédente
           </Link>
         </li>
-        {/* <li>
-          <Link
-            className="fr-link fr-pagination__link"
-            title={`Page ${currentPage}`}
-            aria-current="page"
-          >
-            {currentPage}
-          </Link>
-        </li> */}
         <li>
           <Link
             className="fr-link fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-            onClick={event => {
-              event.preventDefault();
-              if (!contentLoading) {
+            onClick={() => {
+              if (hasNextPage && !contentLoading) {
                 onNextClick();
               }
             }}
-            aria-disabled={!hasNextPage || contentLoading}
+            disabled={!hasNextPage || contentLoading}
             title="Page suivante"
           >
             Page suivante
@@ -96,13 +86,12 @@ const CursorPagination = ({
         <li>
           <Link
             className="fr-link fr-pagination__link fr-pagination__link--last"
-            onClick={event => {
-              event.preventDefault();
-              if (!contentLoading) {
+            onClick={() => {
+              if (hasNextPage && !contentLoading) {
                 onLastClick();
               }
             }}
-            aria-disabled={!hasNextPage || contentLoading}
+            disabled={!hasNextPage || contentLoading}
             title="Dernière page"
           >
             Dernière page

--- a/front/src/Apps/common/Components/CursorPagination/CursorPagination.tsx
+++ b/front/src/Apps/common/Components/CursorPagination/CursorPagination.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import cn from "classnames";
+
+const Link = ({
+  children,
+  ...rest
+}: {
+  children: React.ReactNode;
+  [key: string]: any;
+}) => {
+  return rest["aria-disabled"] === true ? (
+    <a {...rest}>{children}</a>
+  ) : (
+    <button {...rest}>{children}</button>
+  );
+};
+
+const CursorPagination = ({
+  id,
+  className,
+  onFirstClick,
+  onLastClick,
+  onNextClick,
+  onPreviousClick,
+  hasNextPage,
+  hasPreviousPage,
+  contentLoading
+}: {
+  id?: string;
+  className?: string;
+  onFirstClick: () => void;
+  onLastClick: () => void;
+  onNextClick: () => void;
+  onPreviousClick: () => void;
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+  contentLoading: boolean;
+}) => {
+  return (
+    <nav id={id} role="navigation" className={cn("fr-pagination", className)}>
+      <ul className={"fr-pagination__list"}>
+        <li>
+          <Link
+            className="fr-link fr-pagination__link fr-pagination__link--first"
+            onClick={event => {
+              event.preventDefault();
+              if (!contentLoading) {
+                onFirstClick();
+              }
+            }}
+            aria-disabled={!hasPreviousPage || contentLoading}
+            title="Première page"
+          >
+            Première page
+          </Link>
+        </li>
+        <li>
+          <Link
+            className="fr-link fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
+            onClick={event => {
+              event.preventDefault();
+              if (!contentLoading) {
+                onPreviousClick();
+              }
+            }}
+            aria-disabled={!hasPreviousPage || contentLoading}
+            title="Page précédente"
+          >
+            Page précédente
+          </Link>
+        </li>
+        {/* <li>
+          <Link
+            className="fr-link fr-pagination__link"
+            title={`Page ${currentPage}`}
+            aria-current="page"
+          >
+            {currentPage}
+          </Link>
+        </li> */}
+        <li>
+          <Link
+            className="fr-link fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
+            onClick={event => {
+              event.preventDefault();
+              if (!contentLoading) {
+                onNextClick();
+              }
+            }}
+            aria-disabled={!hasNextPage || contentLoading}
+            title="Page suivante"
+          >
+            Page suivante
+          </Link>
+        </li>
+        <li>
+          <Link
+            className="fr-link fr-pagination__link fr-pagination__link--last"
+            onClick={event => {
+              event.preventDefault();
+              if (!contentLoading) {
+                onLastClick();
+              }
+            }}
+            aria-disabled={!hasNextPage || contentLoading}
+            title="Dernière page"
+          >
+            Dernière page
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default CursorPagination;

--- a/front/src/dashboard/registry/MyExports.tsx
+++ b/front/src/dashboard/registry/MyExports.tsx
@@ -324,25 +324,6 @@ export function MyExports() {
             <InlineLoader />
           )}
         </div>
-
-        {/* <div className="tw-p-6">
-          {!exportsLoading ? (
-            <Table
-              bordered
-              caption="Exports récents"
-              className={styles.fullWidthTable}
-              data={tableData}
-              headers={[
-                "Date",
-                "Établissements",
-                "Type de registre",
-                "Type de déclaration",
-                "Période",
-                "Fichier"
-              ]}
-            />
-          ) : <InlineLoader />}
-        </div> */}
         <div className="tw-flex tw-justify-center">
           <Pagination
             showFirstLast

--- a/front/src/dashboard/registry/shared.tsx
+++ b/front/src/dashboard/registry/shared.tsx
@@ -56,15 +56,38 @@ export const GET_REGISTRY_LOOKUPS = gql`
     $siret: String!
     $type: RegistryImportType
     $publicId: String
+    $first: Int
+    $last: Int
+    $after: String
+    $before: String
   ) {
-    registryLookups(siret: $siret, type: $type, publicId: $publicId) {
-      declaredAt
-      publicId
-      type
-      siret
-      reportAsSiret
-      date
-      wasteCode
+    registryLookups(
+      siret: $siret
+      type: $type
+      publicId: $publicId
+      first: $first
+      last: $last
+      after: $after
+      before: $before
+    ) {
+      pageInfo {
+        startCursor
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        node {
+          declaredAt
+          publicId
+          type
+          siret
+          reportAsSiret
+          date
+          wasteCode
+        }
+        cursor
+      }
     }
   }
 `;

--- a/libs/back/prisma/src/migrations/20250507184104_add_registry_lookup_declared_at_id/migration.sql
+++ b/libs/back/prisma/src/migrations/20250507184104_add_registry_lookup_declared_at_id/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[declaredAtId]` on the table `RegistryLookup` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "RegistryLookup" ADD COLUMN     "declaredAtId" UUID;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_RegistryLookupDeclaredAtIdIdx" ON "RegistryLookup"("declaredAtId" DESC);

--- a/libs/back/prisma/src/schema/registry.prisma
+++ b/libs/back/prisma/src/schema/registry.prisma
@@ -904,7 +904,8 @@ model RegistryLookup {
     // should be a UUIDv7 using date as time source
     // to allow cursor based queries that required a unique key that should
     // also be the sort order
-    dateId             String                        @db.Uuid
+    dateId             String                        @default(uuid(7)) @db.Uuid
+    declaredAtId       String?                       @default(uuid(7)) @db.Uuid
 
     // foreign keys to registry models
     registrySsdId String?
@@ -947,6 +948,8 @@ model RegistryLookup {
     @@id([id, exportRegistryType, siret], name: "idExportTypeAndSiret")
     // UUIDv7 unique index used for sorting/pagination on exports
     @@unique([dateId(sort: Asc)], map: "_RegistryLookupDateIdIdx")
+    // UUIDv7 unique index used for sorting/pagination on Lookup lists
+    @@unique([declaredAtId(sort: Desc)], map: "_RegistryLookupDeclaredAtIdIdx")
     // array of elements so gin index
     @@index([reportAsSiret], map: "_RegistryLookupReportAsSiretIdx")
     // multi-column index because those columns are mandatory for any export

--- a/libs/back/registry/src/incomingTexs/registry.ts
+++ b/libs/back/registry/src/incomingTexs/registry.ts
@@ -267,8 +267,9 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("INCOMING_TEXS");
+
   await prisma.registryLookup.deleteMany({
     where: {
       registryIncomingTexsId: { not: null }
@@ -276,16 +277,37 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   });
   logger.logDelete();
 
+  // First, get total count for progress calculation
   const total = await prisma.registryIncomingTexs.count({
     where: {
       isCancelled: false,
       isLatest: true
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalRegistryForLookup[]) => {
+    const createArray = items.map(
+      (registryIncomingTexs: MinimalRegistryForLookup) =>
+        registryToLookupCreateInput(registryIncomingTexs)
+    );
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.registryIncomingTexs.findMany({
       where: {
         isCancelled: false,
@@ -299,22 +321,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const createArray = items.map(
-      (registryIncomingTexs: MinimalRegistryForLookup) =>
-        registryToLookupCreateInput(registryIncomingTexs)
-    );
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/libs/back/registry/src/incomingTexs/registry.ts
+++ b/libs/back/registry/src/incomingTexs/registry.ts
@@ -216,8 +216,10 @@ const registryToLookupCreateInput = (
     declarationType: RegistryExportDeclarationType.REGISTRY,
     wasteType: RegistryExportWasteType.TEXS,
     wasteCode: registryIncomingTexs.wasteCode,
-    ...generateDateInfos(registryIncomingTexs.receptionDate),
-    declaredAt: registryIncomingTexs.createdAt,
+    ...generateDateInfos(
+      registryIncomingTexs.receptionDate,
+      registryIncomingTexs.createdAt
+    ),
     registryIncomingTexsId: registryIncomingTexs.id
   };
 };
@@ -244,8 +246,10 @@ export const updateRegistryLookup = async (
         id: registryIncomingTexs.id,
         reportAsSiret: registryIncomingTexs.reportAsCompanySiret,
         wasteCode: registryIncomingTexs.wasteCode,
-        ...generateDateInfos(registryIncomingTexs.receptionDate),
-        declaredAt: registryIncomingTexs.createdAt,
+        ...generateDateInfos(
+          registryIncomingTexs.receptionDate,
+          registryIncomingTexs.createdAt
+        ),
         registryIncomingTexsId: registryIncomingTexs.id
       },
       create: registryToLookupCreateInput(registryIncomingTexs),

--- a/libs/back/registry/src/incomingWaste/registry.ts
+++ b/libs/back/registry/src/incomingWaste/registry.ts
@@ -229,8 +229,10 @@ const registryToLookupCreateInput = (
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryIncomingWaste.wasteCode,
-    ...generateDateInfos(registryIncomingWaste.receptionDate),
-    declaredAt: registryIncomingWaste.createdAt,
+    ...generateDateInfos(
+      registryIncomingWaste.receptionDate,
+      registryIncomingWaste.createdAt
+    ),
     registryIncomingWasteId: registryIncomingWaste.id
   };
 };
@@ -260,8 +262,10 @@ export const updateRegistryLookup = async (
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryIncomingWaste.wasteCode,
-        ...generateDateInfos(registryIncomingWaste.receptionDate),
-        declaredAt: registryIncomingWaste.createdAt,
+        ...generateDateInfos(
+          registryIncomingWaste.receptionDate,
+          registryIncomingWaste.createdAt
+        ),
         registryIncomingWasteId: registryIncomingWaste.id
       },
       create: registryToLookupCreateInput(registryIncomingWaste),

--- a/libs/back/registry/src/incomingWaste/registry.ts
+++ b/libs/back/registry/src/incomingWaste/registry.ts
@@ -285,8 +285,9 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("INCOMING_WASTE");
+
   await prisma.registryLookup.deleteMany({
     where: {
       registryIncomingWasteId: { not: null }
@@ -294,16 +295,37 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   });
   logger.logDelete();
 
+  // First, get total count for progress calculation
   const total = await prisma.registryIncomingWaste.count({
     where: {
       isCancelled: false,
       isLatest: true
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalRegistryForLookup[]) => {
+    const createArray = items.map(
+      (registryIncomingWaste: MinimalRegistryForLookup) =>
+        registryToLookupCreateInput(registryIncomingWaste)
+    );
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.registryIncomingWaste.findMany({
       where: {
         isCancelled: false,
@@ -317,22 +339,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const createArray = items.map(
-      (registryIncomingWaste: MinimalRegistryForLookup) =>
-        registryToLookupCreateInput(registryIncomingWaste)
-    );
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/libs/back/registry/src/lookup/utils.ts
+++ b/libs/back/registry/src/lookup/utils.ts
@@ -5,13 +5,17 @@ import { ITXClientDenyList } from "@prisma/client/runtime/library";
 import { clearLine, cursorTo } from "readline";
 import { performance } from "perf_hooks";
 
-export const generateDateInfos = (date: Date) => ({
+export const generateDateInfos = (date: Date, declaredAt: Date) => ({
   date,
+  declaredAt,
   // generate a uuid v7 id
   // using the date as timestamp, so we can sort by this dateId
   // and be in date order with uniqueness
   dateId: uuidv7({
     msecs: date.getTime()
+  }),
+  declaredAtId: uuidv7({
+    msecs: declaredAt.getTime()
   })
 });
 

--- a/libs/back/registry/src/managed/registry.ts
+++ b/libs/back/registry/src/managed/registry.ts
@@ -315,7 +315,7 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("MANAGED");
 
   await prisma.registryLookup.deleteMany({
@@ -325,16 +325,36 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   });
   logger.logDelete();
 
+  // First, get total count for progress calculation
   const total = await prisma.registryManaged.count({
     where: {
       isCancelled: false,
       isLatest: true
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalRegistryForLookup[]) => {
+    const createArray = items.map((registryManaged: MinimalRegistryForLookup) =>
+      registryToLookupCreateInput(registryManaged)
+    );
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.registryManaged.findMany({
       where: {
         isCancelled: false,
@@ -348,21 +368,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const createArray = items.map((registryManaged: MinimalRegistryForLookup) =>
-      registryToLookupCreateInput(registryManaged)
-    );
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/libs/back/registry/src/managed/registry.ts
+++ b/libs/back/registry/src/managed/registry.ts
@@ -257,8 +257,10 @@ const registryToLookupCreateInput = (
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryManaged.wasteCode,
-    ...generateDateInfos(registryManaged.managingStartDate),
-    declaredAt: registryManaged.createdAt,
+    ...generateDateInfos(
+      registryManaged.managingStartDate,
+      registryManaged.createdAt
+    ),
     registryManagedId: registryManaged.id
   };
 };
@@ -290,8 +292,10 @@ export const updateRegistryLookup = async (
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryManagedWaste.wasteCode,
-        ...generateDateInfos(registryManagedWaste.managingStartDate),
-        declaredAt: registryManagedWaste.createdAt,
+        ...generateDateInfos(
+          registryManagedWaste.managingStartDate,
+          registryManagedWaste.createdAt
+        ),
         registryManagedId: registryManagedWaste.id
       },
       create: registryToLookupCreateInput(registryManagedWaste),

--- a/libs/back/registry/src/outgoingTexs/registry.ts
+++ b/libs/back/registry/src/outgoingTexs/registry.ts
@@ -245,8 +245,10 @@ const registryToLookupCreateInput = (
     declarationType: RegistryExportDeclarationType.REGISTRY,
     wasteType: RegistryExportWasteType.TEXS,
     wasteCode: registryOutgoingTexs.wasteCode,
-    ...generateDateInfos(registryOutgoingTexs.dispatchDate),
-    declaredAt: registryOutgoingTexs.createdAt,
+    ...generateDateInfos(
+      registryOutgoingTexs.dispatchDate,
+      registryOutgoingTexs.createdAt
+    ),
     registryOutgoingTexsId: registryOutgoingTexs.id
   };
 };
@@ -273,8 +275,10 @@ export const updateRegistryLookup = async (
         id: registryOutgoingTexs.id,
         reportAsSiret: registryOutgoingTexs.reportAsCompanySiret,
         wasteCode: registryOutgoingTexs.wasteCode,
-        ...generateDateInfos(registryOutgoingTexs.dispatchDate),
-        declaredAt: registryOutgoingTexs.createdAt,
+        ...generateDateInfos(
+          registryOutgoingTexs.dispatchDate,
+          registryOutgoingTexs.createdAt
+        ),
         registryOutgoingTexsId: registryOutgoingTexs.id
       },
       create: registryToLookupCreateInput(registryOutgoingTexs),

--- a/libs/back/registry/src/outgoingTexs/registry.ts
+++ b/libs/back/registry/src/outgoingTexs/registry.ts
@@ -298,8 +298,9 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("OUTGOING_TEXS");
+
   await prisma.registryLookup.deleteMany({
     where: {
       registryOutgoingTexsId: { not: null }
@@ -307,16 +308,37 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   });
   logger.logDelete();
 
+  // First, get total count for progress calculation
   const total = await prisma.registryOutgoingTexs.count({
     where: {
       isCancelled: false,
       isLatest: true
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalRegistryForLookup[]) => {
+    const createArray = items.map(
+      (registryOutgoingTexs: MinimalRegistryForLookup) =>
+        registryToLookupCreateInput(registryOutgoingTexs)
+    );
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.registryOutgoingTexs.findMany({
       where: {
         isCancelled: false,
@@ -330,22 +352,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const createArray = items.map(
-      (registryOutgoingTexs: MinimalRegistryForLookup) =>
-        registryToLookupCreateInput(registryOutgoingTexs)
-    );
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/libs/back/registry/src/outgoingWaste/registry.ts
+++ b/libs/back/registry/src/outgoingWaste/registry.ts
@@ -259,8 +259,10 @@ const registryToLookupCreateInput = (
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryOutgoingWaste.wasteCode,
-    ...generateDateInfos(registryOutgoingWaste.dispatchDate),
-    declaredAt: registryOutgoingWaste.createdAt,
+    ...generateDateInfos(
+      registryOutgoingWaste.dispatchDate,
+      registryOutgoingWaste.createdAt
+    ),
     registryOutgoingWasteId: registryOutgoingWaste.id
   };
 };
@@ -290,8 +292,10 @@ export const updateRegistryLookup = async (
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryOutgoingWaste.wasteCode,
-        ...generateDateInfos(registryOutgoingWaste.dispatchDate),
-        declaredAt: registryOutgoingWaste.createdAt,
+        ...generateDateInfos(
+          registryOutgoingWaste.dispatchDate,
+          registryOutgoingWaste.createdAt
+        ),
         registryOutgoingWasteId: registryOutgoingWaste.id
       },
       create: registryToLookupCreateInput(registryOutgoingWaste),

--- a/libs/back/registry/src/outgoingWaste/registry.ts
+++ b/libs/back/registry/src/outgoingWaste/registry.ts
@@ -315,8 +315,9 @@ export const updateRegistryLookup = async (
   }
 };
 
-export const rebuildRegistryLookup = async (pageSize = 100) => {
+export const rebuildRegistryLookup = async (pageSize = 100, threads = 4) => {
   const logger = createRegistryLogger("OUTGOING_WASTE");
+
   await prisma.registryLookup.deleteMany({
     where: {
       registryOutgoingWasteId: { not: null }
@@ -324,16 +325,37 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
   });
   logger.logDelete();
 
+  // First, get total count for progress calculation
   const total = await prisma.registryOutgoingWaste.count({
     where: {
       isCancelled: false,
       isLatest: true
     }
   });
+
   let done = false;
   let cursorId: string | null = null;
   let processedCount = 0;
+  let operationId = 0;
+  const pendingWrites = new Map<number, Promise<void>>();
+
+  const processWrite = async (items: MinimalRegistryForLookup[]) => {
+    const createArray = items.map(
+      (registryOutgoingWaste: MinimalRegistryForLookup) =>
+        registryToLookupCreateInput(registryOutgoingWaste)
+    );
+
+    await prisma.registryLookup.createMany({
+      data: createArray,
+      skipDuplicates: true
+    });
+
+    processedCount += items.length;
+    logger.logProgress(processedCount, total);
+  };
+
   while (!done) {
+    // Sequential read
     const items = await prisma.registryOutgoingWaste.findMany({
       where: {
         isCancelled: false,
@@ -347,22 +369,31 @@ export const rebuildRegistryLookup = async (pageSize = 100) => {
       },
       select: minimalRegistryForLookupSelect
     });
-    const createArray = items.map(
-      (registryOutgoingWaste: MinimalRegistryForLookup) =>
-        registryToLookupCreateInput(registryOutgoingWaste)
-    );
-    await prisma.registryLookup.createMany({
-      data: createArray,
-      skipDuplicates: true
+
+    // Start the write operation
+    const currentOperationId = operationId++;
+    const writePromise = processWrite(items).finally(() => {
+      pendingWrites.delete(currentOperationId);
     });
-    processedCount += items.length;
-    logger.logProgress(processedCount, total);
+    pendingWrites.set(currentOperationId, writePromise);
+
+    // If we've reached max concurrency, wait for one write to complete
+    if (pendingWrites.size >= threads) {
+      await Promise.race(pendingWrites.values());
+    }
+
     if (items.length < pageSize) {
       done = true;
       break;
     }
     cursorId = items[items.length - 1].id;
   }
+
+  // Wait for any remaining writes to complete
+  if (pendingWrites.size > 0) {
+    await Promise.all(pendingWrites.values());
+  }
+
   logger.logCompletion(processedCount);
 };
 

--- a/libs/back/registry/src/ssd/registry.ts
+++ b/libs/back/registry/src/ssd/registry.ts
@@ -77,9 +77,9 @@ const registryToLookupCreateInput = (
     wasteType: RegistryExportWasteType.DND,
     wasteCode: registrySsd.wasteCode,
     ...generateDateInfos(
-      (registrySsd.useDate ?? registrySsd.dispatchDate) as Date
+      (registrySsd.useDate ?? registrySsd.dispatchDate) as Date,
+      registrySsd.createdAt
     ),
-    declaredAt: registrySsd.createdAt,
     registrySsdId: registrySsd.id
   };
 };
@@ -107,9 +107,9 @@ export const updateRegistryLookup = async (
         reportAsSiret: registrySsd.reportAsCompanySiret,
         wasteCode: registrySsd.wasteCode,
         ...generateDateInfos(
-          (registrySsd.useDate ?? registrySsd.dispatchDate) as Date
+          (registrySsd.useDate ?? registrySsd.dispatchDate) as Date,
+          registrySsd.createdAt
         ),
-        declaredAt: registrySsd.createdAt,
         registrySsdId: registrySsd.id
       },
       create: registryToLookupCreateInput(registrySsd),

--- a/libs/back/registry/src/transported/registry.ts
+++ b/libs/back/registry/src/transported/registry.ts
@@ -170,8 +170,10 @@ const registryToLookupCreateInput = (
       ? RegistryExportWasteType.DD
       : RegistryExportWasteType.DND,
     wasteCode: registryTransported.wasteCode,
-    ...generateDateInfos(registryTransported.collectionDate),
-    declaredAt: registryTransported.createdAt,
+    ...generateDateInfos(
+      registryTransported.collectionDate,
+      registryTransported.createdAt
+    ),
     registryTransportedId: registryTransported.id
   };
 };
@@ -201,8 +203,10 @@ export const updateRegistryLookup = async (
           ? RegistryExportWasteType.DD
           : RegistryExportWasteType.DND,
         wasteCode: registryTransported.wasteCode,
-        ...generateDateInfos(registryTransported.collectionDate),
-        declaredAt: registryTransported.createdAt,
+        ...generateDateInfos(
+          registryTransported.collectionDate,
+          registryTransported.createdAt
+        ),
         registryTransportedId: registryTransported.id
       },
       create: registryToLookupCreateInput(registryTransported),


### PR DESCRIPTION
# Contexte

Ajout d'une pagination relative par curseur à la liste des déclarations. Pour celà, ajout d'une nouvelle colonne declaredAtId qui est un UUID v7 créé à partir de declaredAt, et utilisé comme curseur pour paginer.

L'ajout de cette colonne nécessitant une réindexationn des registres, passer en hotfix permet d'avoir un plus grand contrôle sur le timing.

Cette PR ajoute aussi un peu de parallélisation aux routines de réindexation, qui vont lire les registres et bordereaux de façon séquentielle, et créer une queue de queries d'écritures qui sont donc exécutées en parallèle. Vu que ce ne sont que des créations, ça ne pose pas de problème, et permet de multi-threader au niveau de la db.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo


https://github.com/user-attachments/assets/a6548f67-dae1-4f7b-8623-c17f64bb5d1f



# Ticket Favro

[Augmenter la limite des déclarations affichées sur la page Mes déclarations / Afficher un message informatif](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16437)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB