### PR TITLE
Hotfix - Affichage des erreurs d'import dans les logs

### DIFF
--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -158,7 +158,7 @@ export async function processStream({
       }
     }
   } catch (err) {
-    logger.error(`Error processing import ${importId}`, { importId, err });
+    logger.error(`Error processing import ${importId}`, err);
     errorStream.write({ errors: INTERNAL_ERROR });
   } finally {
     errorStream.end();


### PR DESCRIPTION
# Contexte

Pour que winston parse correctement l'erreur elle doit être passée directement
