### PR TITLE
[TRA-16008] Le champ wasteDetailsIsSubjectToADR devient obligatoire sur le BSDD

### DIFF
--- a/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsSealed.integration.ts
@@ -551,7 +551,7 @@ describe("Mutation.markAsSealed", () => {
 
   it(
     "should be required to provide onuCode for dangerous wastes" +
-      " when `wasteDetailsIsSubjectToADR` is not speified ",
+      " when `wasteDetailsIsSubjectToADR` is not specified ",
     async () => {
       const { user, company: emitterCompany } = await userWithCompanyFactory(
         "MEMBER"
@@ -560,6 +560,7 @@ describe("Mutation.markAsSealed", () => {
       const form = await formFactory({
         ownerId: user.id,
         opt: {
+          createdAt: new Date("2023-01-01"),
           status: "DRAFT",
           emitterCompanySiret: emitterCompany.siret,
           recipientCompanySiret: recipientCompany.siret,
@@ -835,6 +836,7 @@ describe("Mutation.markAsSealed", () => {
             ownerId: user.id,
             opt: {
               status: "DRAFT",
+              createdAt: new Date("2023-01-01"),
               emitterCompanySiret: emitterCompany.siret,
               recipientCompanySiret: recipientCompany.siret,
               wasteDetailsIsSubjectToADR: null,
@@ -868,6 +870,7 @@ describe("Mutation.markAsSealed", () => {
             ownerId: user.id,
             opt: {
               status: "DRAFT",
+              createdAt: new Date("2023-01-04T00:00:00.000Z"),
               emitterCompanySiret: emitterCompany.siret,
               recipientCompanySiret: recipientCompany.siret,
               wasteDetailsIsSubjectToADR: null,
@@ -908,6 +911,7 @@ describe("Mutation.markAsSealed", () => {
           ownerId: user.id,
           opt: {
             status: "DRAFT",
+            createdAt: new Date("2023-01-04T00:00:00.000Z"),
             emitterCompanySiret: emitterCompany.siret,
             recipientCompanySiret: recipientCompany.siret,
             wasteDetailsIsSubjectToADR: null,
@@ -927,6 +931,73 @@ describe("Mutation.markAsSealed", () => {
 
         // Then
         expect(errors).toBeUndefined();
+      });
+
+      it("[legacy] if waste has been created before MEP_2025_05_2, wasteDetailsIsDangerous can be null", async () => {
+        // Given
+        const { user, company: emitterCompany } = await userWithCompanyFactory(
+          "MEMBER"
+        );
+        const recipientCompany = await destinationFactory();
+        const form = await formFactory({
+          ownerId: user.id,
+          opt: {
+            status: "DRAFT",
+            createdAt: new Date("2024-05-26T00:00:00.000Z"),
+            emitterCompanySiret: emitterCompany.siret,
+            recipientCompanySiret: recipientCompany.siret,
+            wasteDetailsIsSubjectToADR: null,
+            wasteDetailsCode: "01 01 01",
+            wasteDetailsIsDangerous: undefined, // Not possible!
+            wasteDetailsOnuCode: "Some ADR mention"
+          }
+        });
+
+        // When
+        const { mutate } = makeClient(user);
+        const { errors } = await mutate(MARK_AS_SEALED, {
+          variables: {
+            id: form.id
+          }
+        });
+
+        // Then
+        expect(errors).toBeUndefined();
+      });
+
+      it("if waste has been created past MEP_2025_05_2, wasteDetailsIsDangerous cannot be null", async () => {
+        // Given
+        const { user, company: emitterCompany } = await userWithCompanyFactory(
+          "MEMBER"
+        );
+        const recipientCompany = await destinationFactory();
+        const form = await formFactory({
+          ownerId: user.id,
+          opt: {
+            status: "DRAFT",
+            createdAt: new Date("2024-05-27T00:00:00.000Z"),
+            emitterCompanySiret: emitterCompany.siret,
+            recipientCompanySiret: recipientCompany.siret,
+            wasteDetailsIsSubjectToADR: null,
+            wasteDetailsCode: "01 01 01",
+            wasteDetailsIsDangerous: undefined, // Not possible!
+            wasteDetailsOnuCode: "Some ADR mention"
+          }
+        });
+
+        // When
+        const { mutate } = makeClient(user);
+        const { errors } = await mutate(MARK_AS_SEALED, {
+          variables: {
+            id: form.id
+          }
+        });
+
+        // Then
+        expect(errors).not.toBeUndefined();
+        expect(errors[0].message).toContain(
+          "Erreur(s): Vous devez préciser si le bordereau est soumis à l'ADR ou non (champ wasteDetailsIsSubjectToADR)"
+        );
       });
     });
   });

--- a/back/src/forms/resolvers/mutations/duplicateForm.ts
+++ b/back/src/forms/resolvers/mutations/duplicateForm.ts
@@ -148,7 +148,7 @@ async function getDuplicateFormInput(
     wasteDetailsIsSubjectToADR:
       form.wasteDetailsIsDangerous || form.wasteDetailsPop
         ? true
-        : form.wasteDetailsIsSubjectToADR,
+        : form.wasteDetailsIsSubjectToADR || false,
     wasteDetailsOnuCode: form.wasteDetailsOnuCode,
     traderCompanyName: trader?.name ?? form.traderCompanyName,
     traderCompanySiret: form.traderCompanySiret,

--- a/back/src/forms/resolvers/mutations/markAsSealed.ts
+++ b/back/src/forms/resolvers/mutations/markAsSealed.ts
@@ -38,7 +38,8 @@ const markAsSealedResolver: MutationResolvers["markAsSealed"] = async (
 
   const transporter = await getFirstTransporter(form);
   // validate form data
-  await checkCanBeSealed({ ...form, ...transporter });
+  // TODO: fix bug (conflicting fields:  [ 'id', 'createdAt', 'updatedAt', 'takenOverAt', 'takenOverBy' ])
+  await checkCanBeSealed({ ...transporter, ...form });
 
   const transporterAfterTempStorage = form.forwardedIn
     ? getFirstTransporterSync(form.forwardedIn)

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -239,6 +239,8 @@ type ProcessedInfo = Pick<
   | "nextDestinationNotificationNumber"
 >;
 
+export const MEP_2025_05_2 = new Date("2025-05-27");
+
 export type Form = Emitter &
   Recipient &
   WasteDetails &
@@ -903,8 +905,21 @@ const baseWasteDetailsSchemaFn: FactorySchemaOf<
         const {
           wasteDetailsIsDangerous,
           wasteDetailsIsSubjectToADR,
-          wasteDetailsOnuCode
+          wasteDetailsOnuCode,
+          createdAt
         } = ctx.parent;
+
+        // Field becomes required after MEP_2025_05_2. Be careful and don't break BSDs created before
+        if (
+          !isDefined(createdAt) ||
+          new Date(createdAt).getTime() >= MEP_2025_05_2.getTime()
+        ) {
+          if (!isDefined(wasteDetailsIsSubjectToADR)) {
+            return new yup.ValidationError(
+              `Vous devez préciser si le bordereau est soumis à l'ADR ou non (champ wasteDetailsIsSubjectToADR).`
+            );
+          }
+        }
 
         // New method: using the switch wasteDetailsIsSubjectToADR
         if (isDefined(wasteDetailsIsSubjectToADR)) {


### PR DESCRIPTION
# Contexte

Le champ `wasteDetailsIsSubjectToADR` devient obligatoire sur le BSDD (à compter de la MEP). Il est déjà envoyé systématiquement par le front, c'est donc un changement surtout côté API (breaking change annoncé).

# Points de vigilance pour les intégrateurs

:warning: ATTENTION :warning: 

Le champ `wasteDetailsIsSubjectToADR` est désormais obligatoire sur les BSDD! 

Les BSDD créés avant la MEP ne seront pas impactés.

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[ÉTAPE 4 (BSDD) - Rendre le champ wasteDetailsIsSubjectToADR obligatoire via API](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6b1f768da50a90c584e548a?card=tra-16008)
