### PR TITLE
Hotfix - Fix import & companies

### DIFF
--- a/back/src/companies/resolvers/mutations/createCompany.ts
+++ b/back/src/companies/resolvers/mutations/createCompany.ts
@@ -105,8 +105,15 @@ const createCompanyResolver: MutationResolvers["createCompany"] = async (
     throw new UserInputError(CLOSED_COMPANY_ERROR);
   }
 
-  if (isAnonymousCompany(companyInfo) && !companyInfo.isRegistered) {
-    throw new AnonymousCompanyError();
+  if (isAnonymousCompany(companyInfo)) {
+    const anonymousCompany = await prisma.anonymousCompany.findUnique({
+      where: {
+        orgId: companyInfo.orgId
+      }
+    });
+    if (!anonymousCompany) {
+      throw new AnonymousCompanyError();
+    }
   }
 
   const companyCreateInput: Prisma.CompanyCreateInput = {

--- a/back/src/companies/resolvers/queries/__tests__/companyPrivateInfos.integration.ts
+++ b/back/src/companies/resolvers/queries/__tests__/companyPrivateInfos.integration.ts
@@ -527,9 +527,7 @@ describe("query { companyPrivateInfos(clue: <SIRET>) }", () => {
     );
 
     // Then
-    expect(errors).not.toBeUndefined();
-    expect(errors[0].message).toBe("Cet établissement est fermé");
-    expect(errors[0].extensions?.code).toBe("BAD_USER_INPUT");
+    expect(errors).toBeUndefined();
   });
 
   it("Hidden company in INSEE and not registered", async () => {

--- a/back/src/companies/resolvers/queries/companyInfos.ts
+++ b/back/src/companies/resolvers/queries/companyInfos.ts
@@ -25,10 +25,6 @@ export async function getCompanyInfos(
   }
   const searchResult = await searchCompany(siretOrVat);
 
-  if (isClosedCompany(searchResult)) {
-    throw new ClosedCompanyError();
-  }
-
   return {
     orgId: searchResult.orgId,
     siret: searchResult.siret,
@@ -78,9 +74,12 @@ const companyInfosResolvers: QueryResolvers["companyInfos"] = async (
       }
     );
   }
-  const companyInfos = (await getCompanyInfos(
-    !!args.siret ? args.siret : args.clue!
-  )) as CompanyPublic;
+  const companyInfos = await getCompanyInfos(args.siret ?? args.clue!);
+
+  if (isClosedCompany(companyInfos)) {
+    throw new ClosedCompanyError();
+  }
+
   if (!["P", "N"].includes(companyInfos.statutDiffusionEtablissement!)) {
     return companyInfos;
   } else {

--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -1,11 +1,7 @@
 import { AuthType } from "../auth";
 import { UserInputError } from "../common/errors";
 import { searchCompany } from "../companies/search";
-import type {
-  CompanySearchResult,
-  CompanyInput,
-  StatutDiffusionEtablissement
-} from "@td/codegen-back";
+import type { CompanySearchResult, CompanyInput } from "@td/codegen-back";
 import { logger } from "@td/logger";
 import { escapeRegExp } from "../utils";
 import { SireneSearchResult } from "./sirene/types";
@@ -168,10 +164,7 @@ export function nextBuildSirenify<T>(
         continue;
       }
       const company = companySearchResult as CompanySearchResult;
-      if (
-        company.statutDiffusionEtablissement ===
-        ("P" as StatutDiffusionEtablissement)
-      ) {
+      if (company.statutDiffusionEtablissement === "P") {
         continue;
       }
       if (company.etatAdministratif === "F") {

--- a/front/src/Apps/common/queries/company/query.ts
+++ b/front/src/Apps/common/queries/company/query.ts
@@ -135,7 +135,9 @@ export const SEARCH_COMPANIES = gql`
  * Only query the necessary parts
  */
 export const FAVORITES = (favType: FavoriteType) => {
-  let favFragmentString = commonCompanySearchString;
+  let favFragmentString = commonCompanySearchString.concat(
+    commonCompanyTypesSearchString
+  );
   switch (favType) {
     case FavoriteType.Broker:
       favFragmentString = favFragmentString.concat(

--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -1,8 +1,15 @@
 import { logger } from "@td/logger";
-import { Readable, Writable } from "node:stream";
+import { pipeline, Readable, Writable } from "node:stream";
 import { SafeParseReturnType } from "zod";
 
+import {
+  getSumOfChanges,
+  incrementLocalChangesForCompany,
+  RegistryChanges,
+  saveCompaniesChanges
+} from "./changeAggregates";
 import { endImport, startImport, updateImportStats } from "./database";
+import { getCsvErrorStream, getXlsxErrorStream } from "./errors";
 import {
   importOptions,
   ImportType,
@@ -11,14 +18,12 @@ import {
   PERMISSION_ERROR,
   UNAUTHORIZED_ERROR
 } from "./options";
-import { getTransformCsvStream, getTransformXlsxStream } from "./transformers";
-import { getCsvErrorStream, getXlsxErrorStream } from "./errors";
 import {
-  RegistryChanges,
-  getSumOfChanges,
-  incrementLocalChangesForCompany,
-  saveCompaniesChanges
-} from "./changeAggregates";
+  getTransformCsvStream,
+  getTransformXlsxStream,
+  RegistryImportHeaderError
+} from "./transformers";
+import { Utf8ValidationError, Utf8ValidatorTransform } from "./utf8Transformer";
 
 export async function processStream({
   importId,
@@ -58,6 +63,8 @@ export async function processStream({
       : getXlsxErrorStream(options);
   errorStream.pipe(outputErrorStream);
 
+  const utf8Validator = new Utf8ValidatorTransform();
+
   const transformStream =
     fileType === "CSV"
       ? getTransformCsvStream(options)
@@ -72,12 +79,8 @@ export async function processStream({
     const parsedLinesStream: AsyncIterable<{
       rawLine: Record<string, string>;
       result: SafeParseReturnType<unknown, ParsedLine>;
-    }> = inputStream.pipe(transformStream).on("error", error => {
-      globalErrorNumber++;
-
-      if (errorStream.writable) {
-        errorStream.write({ errors: formatErrorMessage(error.message) });
-      }
+    }> = pipeline(inputStream, utf8Validator, transformStream, _ => {
+      // Ignoring error as it will be handled in the catch block
     });
 
     for await (const { rawLine, result } of parsedLinesStream) {
@@ -157,9 +160,17 @@ export async function processStream({
         });
       }
     }
-  } catch (err) {
-    logger.error(`Error processing import ${importId}`, err);
-    errorStream.write({ errors: INTERNAL_ERROR });
+  } catch (error) {
+    globalErrorNumber++;
+
+    const { message, hidden } = formatErrorMessage(error);
+    if (errorStream.writable) {
+      errorStream.write({ errors: message });
+    }
+
+    if (hidden) {
+      logger.error(`Error processing import ${importId}`, error);
+    }
   } finally {
     errorStream.end();
 
@@ -182,13 +193,27 @@ export async function processStream({
   return stats;
 }
 
-function formatErrorMessage(message: string) {
-  // CSV parsing error when the content is unreadable
-  if (message.includes("Parse Error:")) {
-    return "Erreur de format du fichier. Il ne correspond pas au format attendu et n'a pas pu être lu. Vérifiez que le fichier est bien au format CSV ou XLSX";
+function formatErrorMessage(error: Error) {
+  const { message } = error;
+
+  if (error instanceof Utf8ValidationError) {
+    return { hidden: false, message: error.message };
   }
 
-  return message;
+  if (error instanceof RegistryImportHeaderError) {
+    return { hidden: false, message };
+  }
+
+  // CSV parsing error when the content is unreadable
+  if (message.includes("Parse Error:")) {
+    return {
+      hidden: false,
+      message:
+        "Erreur de format du fichier. Il ne correspond pas au format attendu et n'a pas pu être lu. Vérifiez que le fichier est bien au format CSV ou XLSX"
+    };
+  }
+
+  return { hidden: true, message: INTERNAL_ERROR };
 }
 
 export function isAuthorized({

--- a/libs/back/registry/src/transformers.ts
+++ b/libs/back/registry/src/transformers.ts
@@ -7,6 +7,14 @@ import { PassThrough, Readable } from "node:stream";
 import { CSV_DELIMITER, ERROR_HEADER, ImportOptions } from "./options";
 import { format } from "date-fns";
 
+export class RegistryImportHeaderError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = "RegistryImportHeaderError";
+  }
+}
+
 export function getTransformCsvStream(options: ImportOptions) {
   const parseStream = parse({
     headers: rawHeaders => {
@@ -65,7 +73,7 @@ export function getTransformCsvStream(options: ImportOptions) {
       if (errors.length > 0) {
         // Destroy the stream to stop the parsing process without flushing it
         parseStream.destroy(
-          new Error(
+          new RegistryImportHeaderError(
             [
               "Les en-têtes de colonnes ne correspondent pas au modèle. Assurez-vous que vous utilisez le bon modèle. Le détail des colonnes en erreur est précisé ci-dessous:",
               ...errors
@@ -138,7 +146,7 @@ export function getTransformXlsxStream(options: ImportOptions) {
           }
 
           if (errors.length > 0) {
-            throw new Error(
+            throw new RegistryImportHeaderError(
               [
                 "Les en-têtes de colonnes ne correspondent pas au modèle. Assurez-vous que vous utilisez le bon modèle. Le détail des colonnes en erreur est précisé ci-dessous:",
                 ...errors

--- a/libs/back/registry/src/utf8Transformer.ts
+++ b/libs/back/registry/src/utf8Transformer.ts
@@ -1,0 +1,87 @@
+import { Transform, TransformCallback } from "node:stream";
+
+// Custom Error for UTF-8 Validation
+export class Utf8ValidationError extends Error {
+  constructor() {
+    super(
+      "Le fichier ne semble pas être encodé en UTF-8. Veuillez vérifier l'encodage du fichier."
+    );
+    this.name = "Utf8ValidationError";
+  }
+}
+
+const UTF8_CHECK_BYTES_THRESHOLD = 1024; // Check up to the first 1KB
+
+export class Utf8ValidatorTransform extends Transform {
+  private buffer: Buffer[] = [];
+  private totalBytesBuffered = 0;
+  private validationPerformed = false;
+
+  // Using TextDecoder to validate UTF-8 encoding
+  private readonly decoder = new TextDecoder("utf-8", { fatal: true });
+
+  constructor(options?: import("stream").TransformOptions) {
+    super(options);
+  }
+
+  _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback
+  ): void {
+    if (this.validationPerformed) {
+      this.push(chunk);
+      return callback();
+    }
+
+    this.buffer.push(chunk);
+    this.totalBytesBuffered += chunk.length;
+
+    if (this.totalBytesBuffered >= UTF8_CHECK_BYTES_THRESHOLD) {
+      this.performValidation(callback);
+    } else {
+      // Not enough bytes yet, wait for more or for _flush
+      callback();
+    }
+  }
+
+  _flush(callback: TransformCallback): void {
+    if (!this.validationPerformed) {
+      this.performValidation(callback);
+    } else {
+      callback();
+    }
+  }
+
+  private performValidation(callback: TransformCallback): void {
+    const bufferConcat = Buffer.concat(this.buffer);
+
+    if (this.validationPerformed) {
+      if (this.buffer.length > 0) {
+        this.push(bufferConcat);
+        this.buffer = [];
+      }
+      return callback();
+    }
+
+    this.validationPerformed = true;
+
+    // If no bytes were ever buffered, empty stream is considered valid.
+    if (bufferConcat.length === 0) {
+      return callback();
+    }
+
+    try {
+      // This throws if the buffer is not valid UTF-8
+      this.decoder.decode(bufferConcat);
+
+      this.push(bufferConcat);
+      this.buffer = [];
+      this.totalBytesBuffered = 0;
+      callback();
+    } catch (_) {
+      // Emit error via the callback, pipeline() will forward it
+      callback(new Utf8ValidationError());
+    }
+  }
+}


### PR DESCRIPTION
- amélioration des erreurs sur les imports de registre
  - ne pas indiquer "erreur inconnue" si ce n'est pas le cas
  - gérer le cas des fichiers qui ne sont pas encodés en utf-8
- correction sur la query des favorites qui ne chargeait pas les sous types de profil, causant un problème au moment de la création des bspaoh
- correction sur la création d'une entreprise avec une entreprise anonyme. Elle ne peut jamais être déjà isRegistered, il faut vérifier si elle est registered dans les entreprises anonymes
- correction pour que companyPrivateInfos puisse retourner une entreprise fermée. C'est utile particulièrement pour l'impersonation