### PR TITLE
[TRA-16484,TRA-16473,TRA-16464,TRA-16454] Améliorations de registre

### DIFF
--- a/front/src/dashboard/registry/companyImport/CompanyImports.tsx
+++ b/front/src/dashboard/registry/companyImport/CompanyImports.tsx
@@ -19,11 +19,11 @@ export function CompanyImports() {
           tabs={[
             {
               tabId: "API",
-              label: "Déclaration par API"
+              label: "Déclaration par API ou via formulaire"
             },
             {
               tabId: "FILE",
-              label: "Déclaration par fichiers"
+              label: "Déclaration par fichier"
             }
           ]}
           onTabChange={setSelectedTabId}

--- a/front/src/form/registry/common/Address.tsx
+++ b/front/src/form/registry/common/Address.tsx
@@ -90,7 +90,7 @@ export function InlineAddress({
         <NonScrollableInput
           label="Code postal"
           nativeInputProps={{
-            type: "number",
+            type: "text",
             disabled,
             ...methods.register(`${prefix}PostalCode`)
           }}

--- a/front/src/form/registry/common/WasteCodeSelector.tsx
+++ b/front/src/form/registry/common/WasteCodeSelector.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useRef, useState } from "react";
-import { ALL_WASTES_TREE } from "@td/constants";
+import { ALL_WASTES, ALL_WASTES_TREE } from "@td/constants";
 import type { UseFormReturn } from "react-hook-form";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { formatError } from "../builder/error";
 import { ComboBox } from "../../../Apps/common/Components/Combobox/Combobox";
 import clsx from "clsx";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 
 type WasteCode = {
   code: string;
@@ -114,6 +115,10 @@ export function WasteCodeSelector({
     );
   }
 
+  const description = ALL_WASTES.find(
+    waste => waste.code === methods.getValues(name)
+  )?.description;
+
   const searchFields = (
     <>
       <div className="fr-col-4 fr-col-md-4">
@@ -121,7 +126,7 @@ export function WasteCodeSelector({
           label={label ?? "Code déchet"}
           nativeInputProps={{
             type: "text",
-            ...methods.register(name!)
+            ...methods.register(name)
           }}
           disabled={disabled}
           state={errors?.[name] && "error"}
@@ -141,6 +146,11 @@ export function WasteCodeSelector({
           </Button>
         </div>
       </div>
+      {description && (
+        <div className="fr-col-12">
+          <Alert description={description} severity="info" small />
+        </div>
+      )}
     </>
   );
 
@@ -150,7 +160,7 @@ export function WasteCodeSelector({
         searchFields
       ) : (
         <div
-          className="fr-col-12 fr-grid-row fr-grid-row--gutters fr-grid-row--bottom tw-relative"
+          className="fr-col-12 fr-grid-row fr-grid-row--gutters fr-grid-row--bottom"
           ref={comboboxRef}
         >
           {searchFields}

--- a/libs/back/registry/src/shared/refinement.ts
+++ b/libs/back/registry/src/shared/refinement.ts
@@ -43,7 +43,16 @@ export function refineTransporterInfos<T>({
       return;
     }
 
-    if (!item[recepisseIsExemptedKey] && !item[recepisseNumberKey]) {
+    const isForeignTransporter = [
+      "ENTREPRISE_UE",
+      "ENTREPRISE_HORS_UE"
+    ].includes(item[typeKey]);
+
+    if (
+      !item[recepisseIsExemptedKey] &&
+      !isForeignTransporter &&
+      !item[recepisseNumberKey]
+    ) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message:
@@ -55,7 +64,7 @@ export function refineTransporterInfos<T>({
     // When the declaration comes from abroad and the transporter is not french,
     // we often have partial or no information about the transporter. So we just skip the actor infos check.
     if (
-      ["ENTREPRISE_UE", "ENTREPRISE_HORS_UE"].includes(item[typeKey]) &&
+      isForeignTransporter &&
       ttdImportNumberKey &&
       item[ttdImportNumberKey]
     ) {


### PR DESCRIPTION
# Contexte

Plusieurs petites améliorations registre
- Rendre optionnel le Numéro de récépissé pour tous les transporteurs (1 à 5) pour tous les registres si le type de transporteur est : ENTREPRISE_UE, ENTREPRISE_HORS_UE
- Renommer les onglets "Déclaration par API" > "Déclarations par API ou via formulaire" et "Déclaration par fichier" > "Déclarations par fichier"
- Permettre de renseigner un code postal avec des caractères alphanumériques pour les adresses à l'étranger via l'IHM (espaces, lettres, tirets, etc.)
- Afficher l'intitulé du déchet sous le code déchet sélectionné sur le formulaire des déclarations

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB