### PR TITLE
FIX Scalingo - Réduction du nombre de fichiers dans le bundle

### DIFF
--- a/front/src/Apps/common/Components/layout/LayoutContainer.tsx
+++ b/front/src/Apps/common/Components/layout/LayoutContainer.tsx
@@ -1,37 +1,50 @@
-import React, { Suspense } from "react";
+import React, { lazy, Suspense } from "react";
 import { Route, Routes, Navigate } from "react-router-dom";
 import Loader from "../Loader/Loaders";
 import Layout from "./Layout";
 import routes from "../../../routes";
 import { useQuery, gql } from "@apollo/client";
 import { Query } from "@td/codegen-ui";
-
 import ResendActivationEmail from "../../../../login/ResendActivationEmail";
 import Login from "../../../../login/Login";
 import SurveyBanner from "../SurveyBanner/SurveyBanner";
 import { RequireAuth, Redirect } from "../../../utils/routerUtils";
 import { Oauth2Dialog, OidcDialog } from "../../../../oauth/AuthDialog";
 
-import Admin from "../../../../admin/Admin";
-import DashboardRoutes from "../../../Dashboard/DashboardRoutes";
-import CompaniesRoutes from "../../../Companies/CompaniesRoutes";
-import RegistryRoutes from "../../../../dashboard/registry/RegistryRoutes";
-import Account from "../../../Account/Account";
-import FormContainer from "../../../../form/bsdd/FormContainer";
+const Admin = lazy(() => import("../../../../admin/Admin"));
+const DashboardRoutes = lazy(
+  () => import("../../../Dashboard/DashboardRoutes")
+);
+const CompaniesRoutes = lazy(
+  () => import("../../../Companies/CompaniesRoutes")
+);
+const RegistryRoutes = lazy(
+  () => import("../../../../dashboard/registry/RegistryRoutes")
+);
+const Account = lazy(() => import("../../../Account/Account"));
+const FormContainer = lazy(() => import("../../../../form/bsdd/FormContainer"));
 
-import BsffFormContainer from "../../../../form/bsff/FormContainer";
-import BsdasriFormContainer from "../../../../form/bsdasri/FormContainer";
-import BsdaFormContainer from "../../../../form/bsda/FormContainer";
+const BsffFormContainer = lazy(
+  () => import("../../../../form/bsff/FormContainer")
+);
+const BsdasriFormContainer = lazy(
+  () => import("../../../../form/bsdasri/FormContainer")
+);
+const BsdaFormContainer = lazy(
+  () => import("../../../../form/bsda/FormContainer")
+);
 
-import WasteSelector from "../../../../login/WasteSelector";
+const WasteSelector = lazy(() => import("../../../../login/WasteSelector"));
 
-import Invite from "../../../../login/Invite";
-import UserActivation from "../../../../login/UserActivation";
-import PasswordResetRequest from "../../../../login/PasswordResetRequest";
-import PasswordReset from "../../../../login/PasswordReset";
-import Signup from "../../../../login/Signup";
-import Company from "../../../../Pages/Company/Company";
-import WasteTree from "../search/WasteTree";
+const Invite = lazy(() => import("../../../../login/Invite"));
+const UserActivation = lazy(() => import("../../../../login/UserActivation"));
+const PasswordResetRequest = lazy(
+  () => import("../../../../login/PasswordResetRequest")
+);
+const PasswordReset = lazy(() => import("../../../../login/PasswordReset"));
+const Signup = lazy(() => import("../../../../login/Signup"));
+const Company = lazy(() => import("../../../../Pages/Company/Company"));
+const WasteTree = lazy(() => import("../search/WasteTree"));
 
 const BANNER_MESSAGES = [
   <>

--- a/front/src/Apps/common/Components/layout/LayoutContainer.tsx
+++ b/front/src/Apps/common/Components/layout/LayoutContainer.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from "react";
+import React, { Suspense } from "react";
 import { Route, Routes, Navigate } from "react-router-dom";
 import Loader from "../Loader/Loaders";
 import Layout from "./Layout";
@@ -12,40 +12,26 @@ import SurveyBanner from "../SurveyBanner/SurveyBanner";
 import { RequireAuth, Redirect } from "../../../utils/routerUtils";
 import { Oauth2Dialog, OidcDialog } from "../../../../oauth/AuthDialog";
 
-const Admin = lazy(() => import("../../../../admin/Admin"));
-const DashboardRoutes = lazy(
-  () => import("../../../Dashboard/DashboardRoutes")
-);
-const CompaniesRoutes = lazy(
-  () => import("../../../Companies/CompaniesRoutes")
-);
-const RegistryRoutes = lazy(
-  () => import("../../../../dashboard/registry/RegistryRoutes")
-);
-const Account = lazy(() => import("../../../Account/Account"));
-const FormContainer = lazy(() => import("../../../../form/bsdd/FormContainer"));
+import Admin from"../../../../admin/Admin";
+import DashboardRoutes from "../../../Dashboard/DashboardRoutes";
+import CompaniesRoutes from "../../../Companies/CompaniesRoutes";
+import RegistryRoutes from "../../../../dashboard/registry/RegistryRoutes";
+import Account from "../../../Account/Account";
+import FormContainer from "../../../../form/bsdd/FormContainer";
 
-const BsffFormContainer = lazy(
-  () => import("../../../../form/bsff/FormContainer")
-);
-const BsdasriFormContainer = lazy(
-  () => import("../../../../form/bsdasri/FormContainer")
-);
-const BsdaFormContainer = lazy(
-  () => import("../../../../form/bsda/FormContainer")
-);
+import BsffFormContainer from "../../../../form/bsff/FormContainer";
+import BsdasriFormContainer from "../../../../form/bsdasri/FormContainer";
+import BsdaFormContainer from "../../../../form/bsda/FormContainer";
 
-const WasteSelector = lazy(() => import("../../../../login/WasteSelector"));
+import WasteSelector from "../../../../login/WasteSelector";
 
-const Invite = lazy(() => import("../../../../login/Invite"));
-const UserActivation = lazy(() => import("../../../../login/UserActivation"));
-const PasswordResetRequest = lazy(
-  () => import("../../../../login/PasswordResetRequest")
-);
-const PasswordReset = lazy(() => import("../../../../login/PasswordReset"));
-const Signup = lazy(() => import("../../../../login/Signup"));
-const Company = lazy(() => import("../../../../Pages/Company/Company"));
-const WasteTree = lazy(() => import("../search/WasteTree"));
+import Invite from "../../../../login/Invite";
+import UserActivation from "../../../../login/UserActivation";
+import PasswordResetRequest from "../../../../login/PasswordResetRequest";
+import PasswordReset from "../../../../login/PasswordReset";
+import Signup from "../../../../login/Signup";
+import Company from "../../../../Pages/Company/Company";
+import WasteTree from "../search/WasteTree";
 
 const BANNER_MESSAGES = [
   <>

--- a/front/src/Apps/common/Components/layout/LayoutContainer.tsx
+++ b/front/src/Apps/common/Components/layout/LayoutContainer.tsx
@@ -12,7 +12,7 @@ import SurveyBanner from "../SurveyBanner/SurveyBanner";
 import { RequireAuth, Redirect } from "../../../utils/routerUtils";
 import { Oauth2Dialog, OidcDialog } from "../../../../oauth/AuthDialog";
 
-import Admin from"../../../../admin/Admin";
+import Admin from "../../../../admin/Admin";
 import DashboardRoutes from "../../../Dashboard/DashboardRoutes";
 import CompaniesRoutes from "../../../Companies/CompaniesRoutes";
 import RegistryRoutes from "../../../../dashboard/registry/RegistryRoutes";

--- a/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/TransporterInfoEdit.tsx
+++ b/front/src/dashboard/components/BSDList/BSDa/WorkflowAction/TransporterInfoEdit.tsx
@@ -1,15 +1,13 @@
 import { useMutation } from "@apollo/client";
 import { Field, Form, Formik } from "formik";
-import React, { useState, lazy } from "react";
+import React, { useState } from "react";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import { IconPaperWrite } from "../../../../../Apps/common/Components/Icons/Icons";
 import TdModal from "../../../../../Apps/common/Components/Modal/Modal";
 import Tooltip from "../../../../../Apps/common/Components/Tooltip/Tooltip";
 import { UPDATE_BSDA } from "../../../../../Apps/common/queries/bsda/queries";
 import { Bsda, Mutation, MutationUpdateBsdaArgs } from "@td/codegen-ui";
-const TagsInput = lazy(
-  () => import("../../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../../common/components/tags-input/TagsInput";
 type Props = {
   bsda: Bsda;
   isModalOpenFromParent?: boolean;

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/UpdateBsdasriTransporterPlates.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/UpdateBsdasriTransporterPlates.tsx
@@ -8,7 +8,7 @@ import { UPDATE_BSDASRI } from "../../../../../Apps/common/queries/bsdasri/queri
 
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import Tooltip from "../../../../../Apps/common/Components/Tooltip/Tooltip";
-import TagsInput from "../../../../../common/components/tags-input/TagsInput"
+import TagsInput from "../../../../../common/components/tags-input/TagsInput";
 
 export function UpdateBsdasriTransporterPlates({
   bsdasri,

--- a/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/UpdateBsdasriTransporterPlates.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/BSDasriActions/UpdateBsdasriTransporterPlates.tsx
@@ -1,5 +1,5 @@
 import { Form, Formik } from "formik";
-import React, { useState, lazy } from "react";
+import React, { useState } from "react";
 import { IconPaperWrite } from "../../../../../Apps/common/Components/Icons/Icons";
 import { useMutation } from "@apollo/client";
 import { Mutation, MutationUpdateBsdasriArgs, Bsdasri } from "@td/codegen-ui";
@@ -8,9 +8,7 @@ import { UPDATE_BSDASRI } from "../../../../../Apps/common/queries/bsdasri/queri
 
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import Tooltip from "../../../../../Apps/common/Components/Tooltip/Tooltip";
-const TagsInput = lazy(
-  () => import("../../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../../common/components/tags-input/TagsInput"
 
 export function UpdateBsdasriTransporterPlates({
   bsdasri,

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, useEffect } from "react";
+import React, { useEffect } from "react";
 import { RedErrorMessage } from "../../../../../common/components";
 import {
   BsdasriSignatureType,
@@ -21,9 +21,8 @@ import TransporterRecepisseWrapper from "../../../../../form/common/components/c
 import { subMonths } from "date-fns";
 import OperationModeSelect from "../../../../../common/components/OperationModeSelect";
 import Tooltip from "../../../../../Apps/common/Components/Tooltip/Tooltip";
-const TagsInput = lazy(
-  () => import("../../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../../common/components/tags-input/TagsInput";
+
 export function EmitterSignatureForm() {
   return (
     <>

--- a/front/src/dashboard/components/BSDList/BSFF/BsffActions/UpdateTransporterPlates.tsx
+++ b/front/src/dashboard/components/BSDList/BSFF/BsffActions/UpdateTransporterPlates.tsx
@@ -1,5 +1,5 @@
 import { Form, Formik } from "formik";
-import React, { useState, lazy } from "react";
+import React, { useState } from "react";
 import { IconPaperWrite } from "../../../../../Apps/common/Components/Icons/Icons";
 import { useMutation } from "@apollo/client";
 import { Mutation, MutationUpdateBsffArgs } from "@td/codegen-ui";
@@ -8,9 +8,7 @@ import { UPDATE_BSFF_FORM } from "../../../../../Apps/common/queries/bsff/querie
 import { BsffFragment } from "../types";
 import { NotificationError } from "../../../../../Apps/common/Components/Error/Error";
 import Tooltip from "../../../../../Apps/common/Components/Tooltip/Tooltip";
-const TagsInput = lazy(
-  () => import("../../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../../common/components/tags-input/TagsInput";
 
 export function UpdateTransporterPlates({
   bsff,

--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
-import React, { lazy, ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader } from "../../../Apps/common/Components";
 import { IStepContainerProps } from "../../common/stepper/Step";
@@ -36,10 +36,7 @@ import {
 } from "../../../Apps/Forms/Components/query";
 import { isForeignVat } from "@td/constants";
 import { cleanPackagings } from "../../../Apps/Forms/Components/PackagingList/helpers";
-
-const GenericStepList = lazy(
-  () => import("../../common/stepper/GenericStepList")
-);
+import GenericStepList from "../../common/stepper/GenericStepList";
 
 interface Props {
   children: (bsda: Bsda | undefined) => ReactElement;

--- a/front/src/form/bsda/stepper/steps/Transport.tsx
+++ b/front/src/form/bsda/stepper/steps/Transport.tsx
@@ -1,13 +1,10 @@
-import React, { lazy } from "react";
+import React from "react";
 import { Field } from "formik";
 import { FieldTransportModeSelect } from "../../../../common/components";
 import Tooltip from "../../../../Apps/common/Components/Tooltip/Tooltip";
 import DateInput from "../../../common/components/custom-inputs/DateInput";
 import { subMonths } from "date-fns";
-
-const TagsInput = lazy(
-  () => import("../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../common/components/tags-input/TagsInput";
 
 type Props = { disabled: boolean; required?: boolean };
 

--- a/front/src/form/bsda/stepper/steps/WasteInfo.tsx
+++ b/front/src/form/bsda/stepper/steps/WasteInfo.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, useContext } from "react";
+import React, { useContext } from "react";
 import { useParams } from "react-router-dom";
 import { Field, useFormikContext } from "formik";
 import NumberInput from "../../../common/components/custom-inputs/NumberInput";
@@ -12,9 +12,7 @@ import EstimatedQuantityTooltip from "../../../../common/components/EstimatedQua
 import FormikPackagingList from "../../../../Apps/Forms/Components/PackagingList/FormikPackagingList";
 import { bsdaPackagingTypes } from "../../../../Apps/Forms/Components/PackagingList/helpers";
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
-const TagsInput = lazy(
-  () => import("../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../common/components/tags-input/TagsInput";
 
 export function WasteInfo({ disabled }) {
   const bsdaContext = useContext(BsdaContext);

--- a/front/src/form/bsdasri/BsdasriStepList.tsx
+++ b/front/src/form/bsdasri/BsdasriStepList.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from "@apollo/client";
 import toast from "react-hot-toast";
 import omitDeep from "omit-deep-lodash";
-import React, { lazy, ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader } from "../../Apps/common/Components";
 import { getComputedState } from "../../Apps/Dashboard/Creation/getComputedState";
@@ -28,8 +28,8 @@ import {
   UPDATE_BSDASRI
 } from "../../Apps/common/queries/bsdasri/queries";
 import { TOAST_DURATION } from "../../common/config";
+import GenericStepList from "../common/stepper/GenericStepList";
 
-const GenericStepList = lazy(() => import("../common/stepper/GenericStepList"));
 interface Props {
   children: (dasriForm: Bsdasri | undefined) => ReactElement;
   formId?: string;

--- a/front/src/form/bsdasri/steps/Transport.tsx
+++ b/front/src/form/bsdasri/steps/Transport.tsx
@@ -1,5 +1,5 @@
 import { Field, useFormikContext } from "formik";
-import React, { lazy } from "react";
+import React from "react";
 import classNames from "classnames";
 import Tooltip from "../../../Apps/common/Components/Tooltip/Tooltip";
 import WeightWidget from "../components/Weight";
@@ -11,9 +11,7 @@ import { BsdasriStatus, Bsdasri, BsdasriType } from "@td/codegen-ui";
 import Acceptation from "../components/acceptation/Acceptation";
 import { customInfoToolTip } from "./Emitter";
 import { subMonths } from "date-fns";
-const TagsInput = lazy(
-  () => import("../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../common/components/tags-input/TagsInput";
 
 export default function Transport({ status, editionDisabled = false }) {
   function handleTransportMode(e) {

--- a/front/src/form/bsdd/StepList.tsx
+++ b/front/src/form/bsdd/StepList.tsx
@@ -12,7 +12,7 @@ import {
   QueryFormArgs,
   TransportMode
 } from "@td/codegen-ui";
-import React, { ReactElement, useMemo, lazy } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   CreateOrUpdateTransporterInput,
@@ -34,7 +34,8 @@ import {
   UPDATE_FORM
 } from "../../Apps/common/queries/bsdd/queries";
 import { cleanPackagings } from "../../Apps/Forms/Components/PackagingList/helpers";
-const GenericStepList = lazy(() => import("../common/stepper/GenericStepList"));
+import GenericStepList from "../common/stepper/GenericStepList";
+
 interface Props {
   children: (form: Form | undefined) => ReactElement;
   formId?: string;

--- a/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
+++ b/front/src/form/bsdd/components/parcel-number/ParcelNumber.tsx
@@ -5,14 +5,12 @@ import {
   FieldProps,
   useFormikContext
 } from "formik";
-import React, { useMemo, lazy } from "react";
+import React, { useMemo } from "react";
 import TdSwitch from "../../../../common/components/Switch";
 import { Form, ParcelNumber } from "@td/codegen-ui";
 import Tooltip from "../../../../Apps/common/Components/Tooltip/Tooltip";
 import { IconDelete1 } from "../../../../Apps/common/Components/Icons/Icons";
-const TagsInput = lazy(
-  () => import("../../../../common/components/tags-input/TagsInput")
-);
+import TagsInput from "../../../../common/components/tags-input/TagsInput";
 
 const newParcelNumber = {
   city: "",

--- a/front/src/form/bsff/BsffStepList.tsx
+++ b/front/src/form/bsff/BsffStepList.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
-import React, { ReactElement, useMemo, lazy } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader } from "../../Apps/common/Components";
 import { IStepContainerProps } from "../common/stepper/Step";
@@ -34,8 +34,8 @@ import {
   UPDATE_BSFF_TRANSPORTER
 } from "../../Apps/Forms/Components/query";
 import { isForeignVat } from "@td/constants";
+import GenericStepList from "../common/stepper/GenericStepList";
 
-const GenericStepList = lazy(() => import("../common/stepper/GenericStepList"));
 interface Props {
   children: (bsff: Bsff | undefined) => ReactElement;
   formId?: string;

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -12,7 +12,34 @@ export default defineConfig({
     commonjsOptions: {
       transformMixedEsModules: true
     },
-    sourcemap: true
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("Dashboard")) {
+            return "Dashboard";
+          }
+          if (id.includes("Companies")) {
+            return "Companies";
+          }
+          if (id.includes("registry")) {
+            return "registry";
+          }
+          if (id.includes("form")) {
+            return "form";
+          }
+          if (id.includes("common/components")) {
+            return "components";
+          }
+          if (id.includes("login")) {
+            return "login";
+          }
+          if (id.includes("admin")) {
+            return "admin";
+          }
+        }
+      }
+    }
   },
   cacheDir: "../node_modules/.vite/front",
   plugins: [


### PR DESCRIPTION
# Contexte

Le front est trop code splitté pour Scalingo qui limite à 50 requetes dans sa queue max. Le dashboard charge 98 fichiers.
Test tentant de faire des bundle définis à la main et en gardant le lazy loading. Faudra tester voir comment ca se comporte, je ne sais pas si les splits proposés sont les plus malins / intéressants...

# Démo

![image](https://github.com/user-attachments/assets/713896ef-be44-4006-98c3-740454b3c807)


# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB