### PR TITLE
HOTFIX/ Recherche de form.delete()

### DIFF
--- a/libs/back/prisma/src/index.ts
+++ b/libs/back/prisma/src/index.ts
@@ -16,6 +16,18 @@ export const prisma = new PrismaClient({
   log: process.env.NODE_ENV !== "test" ? ["info", "warn", "error"] : []
 });
 
+// TODO: temporary addition to track Form delete operations
+prisma.$use(async (params, next) => {
+  if (
+    params.model === "Form" &&
+    (params.action === "delete" || params.action === "deleteMany")
+  ) {
+    console.trace(`!!! Delete Form detected`);
+    console.log("!!! With params", params);
+  }
+  return next(params);
+});
+
 if (NODE_ENV === "production") {
   collectMetrics(prisma);
 }


### PR DESCRIPTION
On voit des delete de form passer en DB sans qu'on puisse les localiser.
Tentative d'identification temporaire avec ce snippet