### PR TITLE
[TRA 16457] Passage des limites de date à -18 mois sur les registres

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Supression de la fourniture d'identité pour le RNDTS [PR 4202](https://github.com/MTES-MCT/trackdechets/pull/4202/)
+- Passer à J-18 mois la limite de l'ensemble des dates liées aux déclarations [PR 4194](https://github.com/MTES-MCT/trackdechets/pull/4194)
 
 #### :rocket: Nouvelles fonctionnalités
 

--- a/back/src/registryV2/typeDefs/registryV2.inputs.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.inputs.graphql
@@ -90,7 +90,7 @@ input SsdLineInput {
 
   La date d'utilisation ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
   - être antérieure ou égale à la date de traitement
   Une seule date d'utilisation ou d'expédition doit obligatoirement être renseignée.
 
@@ -106,7 +106,7 @@ input SsdLineInput {
 
   La date d'expédition ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
   - être antérieure ou égale à la date de traitement
 
   Une seule date d'utilisation ou d'expédition doit obligatoirement être renseignée.
@@ -244,7 +244,7 @@ input SsdLineInput {
 
   La date de traitement ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
   - être postérieure à la date d'utilisation ou d'expédition
 
   Valeurs acceptées :
@@ -259,7 +259,7 @@ input SsdLineInput {
 
   La date de fin de traitement ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
   - être antérieure à la date de traitement
 
   Valeurs acceptées :
@@ -542,7 +542,7 @@ input IncomingWasteLineInput {
 
   La date de réception ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   - Format ISO-8601 : YYYY-MM-DD ou YYYY-MM-DDThh:mm:ss.sssZ
@@ -1721,7 +1721,7 @@ input IncomingTexsLineInput {
 
   La date de réception ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :
@@ -3099,7 +3099,7 @@ input OutgoingTexsLineInput {
 
   La date d'expédition ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :
   - 2000-01-01T00:00:00.000Z
@@ -4239,7 +4239,7 @@ input OutgoingWasteLineInput {
 
   La date d'expédition ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :
@@ -5531,7 +5531,7 @@ input TransportedLineInput {
 
   La date d'enlèvement ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :
@@ -6147,7 +6147,7 @@ input ManagedLineInput {
 
   La date ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :
@@ -6164,7 +6164,7 @@ input ManagedLineInput {
 
   La date ne peut pas :
   - être dans le futur
-  - être antérieure à J-1 an
+  - être antérieure à J-18 mois
 
   Valeurs :
   Formats Date acceptés, avec [ANNEE-MOIS-JOUR] :

--- a/front/src/form/registry/builder/FormTab.tsx
+++ b/front/src/form/registry/builder/FormTab.tsx
@@ -6,10 +6,12 @@ import { clsx } from "clsx";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Tooltip } from "@codegouvfr/react-dsfr/Tooltip";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { sub } from "date-fns";
 
 import type { FormShapeFieldWithState } from "./types";
 import { formatError } from "./error";
 import "./FormTab.scss";
+import { MIN_DATE_FOR_REGISTRY } from "@td/constants";
 
 type Props = { fields: FormShapeFieldWithState[]; methods: UseFormReturn<any> };
 
@@ -54,6 +56,9 @@ export function FormTab({ fields, methods }: Props) {
                 nativeInputProps={{
                   type: field.type,
                   ...(field.type === "date" && {
+                    min: sub(new Date(), MIN_DATE_FOR_REGISTRY)
+                      .toISOString()
+                      .split("T")[0],
                     max: new Date().toISOString().split("T")[0]
                   }),
                   ...methods.register(field.name)

--- a/libs/back/registry/src/shared/schemas.ts
+++ b/libs/back/registry/src/shared/schemas.ts
@@ -6,7 +6,8 @@ import {
   isSiret,
   TdOperationCodeEnum,
   WASTE_CODES_BALE,
-  WasteCodeEnum
+  WasteCodeEnum,
+  MIN_DATE_FOR_REGISTRY
 } from "@td/constants";
 import { sub } from "date-fns";
 import { z } from "zod";
@@ -235,8 +236,8 @@ export const volumeSchema = z
 export const dateSchema = z.coerce
   .date()
   .min(
-    sub(new Date(), { years: 1 }),
-    "La date ne peut pas être antérieure à J-1 an"
+    sub(new Date(), MIN_DATE_FOR_REGISTRY),
+    "La date ne peut pas être antérieure à J-18 mois"
   )
   .refine(date => date <= new Date(), "La date ne peut pas être dans le futur"); // Dont use max() as the date must be dynamic
 
@@ -268,8 +269,8 @@ export const nullishDateSchema = z
     z
       .date()
       .min(
-        sub(new Date(), { years: 1 }),
-        "La date ne peut pas être antérieure à J-1 an"
+        sub(new Date(), MIN_DATE_FOR_REGISTRY),
+        "La date ne peut pas être antérieure à J-18 mois"
       )
       .refine(
         date => date <= new Date(),

--- a/libs/shared/constants/src/VALIDATION.ts
+++ b/libs/shared/constants/src/VALIDATION.ts
@@ -11,3 +11,8 @@ export function isValidWebsite(s: string): boolean {
     return false;
   }
 }
+
+export const MIN_DATE_FOR_REGISTRY = {
+  years: 1,
+  months: 6
+};


### PR DESCRIPTION
# Contexte

- Assouplissement des dates limites à -18 mois
- Ajout d'une limite sur les sélecteurs de date de l'IHM
- Partage des dates limites entre back et front pour éviter les incohérences

<img width="371" alt="Capture d’écran 2025-05-14 à 17 24 49" src="https://github.com/user-attachments/assets/781af3b9-3584-41db-b968-caf9bd7af507" />


# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Passer à J-18 mois la limite de l'ensemble des dates liées aux déclarations](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16457)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB