### PR TITLE
HOTFIX - Skip du sirenify transporter après signature

### DIFF
--- a/back/src/bsda/validation/sirenify.ts
+++ b/back/src/bsda/validation/sirenify.ts
@@ -71,8 +71,7 @@ const sirenifyBsdaAccessors = (
     (_, idx) =>
       ({
         siret: bsda.transporters![idx].transporterCompanySiret,
-        // FIXME skip conditionnaly based on transporter signatures
-        skip: false,
+        skip: bsda.transporters![idx].transporterTransportSignatureDate != null,
         setter: (input, companyInput) => {
           const transporter = input.transporters![idx];
           if (companyInput.name) {

--- a/back/src/bsffs/validation/bsff/sirenify.ts
+++ b/back/src/bsffs/validation/bsff/sirenify.ts
@@ -29,8 +29,7 @@ const sirenifyBsffAccessors = (
   },
   ...(bsff.transporters ?? []).map((_, idx) => ({
     siret: bsff.transporters![idx].transporterCompanySiret,
-    // FIXME skip conditionnaly based on transporter signatures
-    skip: false,
+    skip: bsff.transporters![idx].transporterTransportSignatureDate != null,
     setter: (input, companyInput: CompanyInput) => {
       const transporter = input.transporters[idx];
       transporter.transporterCompanyName = companyInput.name;


### PR DESCRIPTION
# Contexte

On a des bordereaux ou les transporteurs ont signés, mais sont désormais fermés. Ca pose problème car ca bloque les signatures suivantes.
Cf ce ticket: https://trackdechets.zammad.com/#ticket/zoom/48706

Passage du correctif en hotfix

# Ticket Favro

[Titre](https://trackdechets.zammad.com/#ticket/zoom/48706)
