### PR TITLE
HOTFIX/ No Utf8Validator for Excel

### DIFF
--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -1,5 +1,5 @@
 import { logger } from "@td/logger";
-import { pipeline, Readable, Writable } from "node:stream";
+import { PassThrough, pipeline, Readable, Writable } from "node:stream";
 import { SafeParseReturnType } from "zod";
 
 import {
@@ -63,7 +63,9 @@ export async function processStream({
       : getXlsxErrorStream(options);
   errorStream.pipe(outputErrorStream);
 
-  const utf8Validator = new Utf8ValidatorTransform();
+  // Only apply utf8 validation on CSV files
+  const utf8Validator =
+    fileType === "CSV" ? new Utf8ValidatorTransform() : new PassThrough();
 
   const transformStream =
     fileType === "CSV"


### PR DESCRIPTION
Il ne faut pas jouer le UTF8Validator sur les excel. Les premiers bytes ne correspondent pas pas au contenu