### PR TITLE
[tra-16242]Test1-Corriger le notifier pour ne pas spamer le tableau de bord des utilisateurs d'un même établissement

### DIFF
--- a/front/src/Pages/Dashboard.tsx
+++ b/front/src/Pages/Dashboard.tsx
@@ -42,6 +42,7 @@ import { useNotifier } from "../dashboard/components/BSDList/useNotifier";
 import { NotificationError } from "../Apps/common/Components/Error/Error";
 
 import "./dashboard.scss";
+import { debounce } from "../common/helper";
 
 const DashboardPage = () => {
   const { permissions } = usePermissions();
@@ -143,6 +144,11 @@ const DashboardPage = () => {
     [lazyFetchBsds]
   );
 
+  const debouncedFetchBsds = useMemo(
+    () => debounce(fetchBsds, 1000),
+    [fetchBsds]
+  );
+
   const handleFiltersSubmit = filterValues => {
     // Transform the filters into a GQL query
     const variables = filtersToQueryBsdsArgs(filterValues, bsdsVariables);
@@ -153,7 +159,7 @@ const DashboardPage = () => {
 
   // Be notified if someone else modifies bsds
   useNotifier(siret!, () => {
-    fetchBsds(siret, bsdsVariables, tabs);
+    debouncedFetchBsds(siret, bsdsVariables, tabs);
   });
 
   useEffect(() => {


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Je n'ai pas réussi à reproduire le bug en local, je créé une annexe 2 je regroupe 500 bordereaux mais je n'ai pas le clignotement du tableau de bord comme en recette.
Je propose cette PR mais je ne pourrais tester qu'en recette pour voir si ça corrige. Si quelqu'un arrive a reproduire en local, je suis preneuse.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Bug

https://github.com/user-attachments/assets/3b2942bf-af06-4d2c-949e-5da2318bffe4



# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[tra-16242](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16242)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB