### PR TITLE
[TRA-16018] Le nombre de conditionnements du BSDA apparaît dans le registre V2

### DIFF
--- a/back/src/bsda/__tests__/registryV2.integration.ts
+++ b/back/src/bsda/__tests__/registryV2.integration.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@td/prisma";
+import { toIncomingWasteV2 } from "../registryV2";
+import { bsdaFactory } from "./factories";
+import { RegistryV2Bsda, RegistryV2BsdaInclude } from "../../registryV2/types";
+import { resetDatabase } from "../../../integration-tests/helper";
+
+describe("registryV2", () => {
+  afterEach(resetDatabase);
+
+  it("quantity should return the total number of packagings", async () => {
+    // Given
+    const bsda = await bsdaFactory({
+      opt: {
+        packagings: [
+          { quantity: 3, type: "PALETTE_FILME" },
+          { quantity: 7, type: "DEPOT_BAG" }
+        ]
+      }
+    });
+    const dbBsda = await prisma.bsda.findFirst({
+      where: { id: bsda.id },
+      include: RegistryV2BsdaInclude
+    });
+
+    // When
+    const incomingWaste = toIncomingWasteV2(dbBsda as RegistryV2Bsda);
+
+    // Then
+    expect(incomingWaste.quantity).toBe(10);
+  });
+
+  it("quantity should be null if no packaging", async () => {
+    // Given
+    const bsda = await bsdaFactory({
+      opt: {
+        packagings: []
+      }
+    });
+    const dbBsda = await prisma.bsda.findFirst({
+      where: { id: bsda.id },
+      include: RegistryV2BsdaInclude
+    });
+
+    // When
+    const incomingWaste = toIncomingWasteV2(dbBsda as RegistryV2Bsda);
+
+    // Then
+    expect(incomingWaste.quantity).toBeNull();
+  });
+});

--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -2,6 +2,7 @@ import {
   IncomingWasteV2,
   ManagedWasteV2,
   OutgoingWasteV2,
+  PackagingInfo,
   TransportedWasteV2
 } from "@td/codegen-back";
 import {
@@ -29,6 +30,17 @@ import {
 import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
 import { logger } from "@td/logger";
+
+const getQuantity = (packagings: Prisma.JsonValue) => {
+  if (!packagings || !(packagings as PackagingInfo[])?.length) {
+    return null;
+  }
+
+  return (packagings as PackagingInfo[])?.reduce(
+    (totalQuantity, p) => totalQuantity + (p.quantity ?? 0),
+    0
+  );
+};
 
 const getInitialEmitterData = (bsda: RegistryV2Bsda) => {
   const initialEmitter: Record<string, string | null> = {
@@ -233,7 +245,7 @@ export const toIncomingWasteV2 = (
     weight: bsda.weightValue
       ? bsda.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
-    quantity: null,
+    quantity: getQuantity(bsda.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     initialEmitterCompanyName,
     initialEmitterCompanySiret,
@@ -501,7 +513,7 @@ export const toOutgoingWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsda.wastePop,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsda.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsda.weightValue
       ? bsda.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
@@ -786,7 +798,7 @@ export const toTransportedWasteV2 = (
     weight: bsda.weightValue
       ? bsda.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
-    quantity: null,
+    quantity: getQuantity(bsda.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weightIsEstimate: bsda.weightIsEstimate,
     volume: null,
@@ -1041,7 +1053,7 @@ export const toManagedWasteV2 = (
     wasteCodeBale: null,
     wastePop: bsda.wastePop,
     wasteIsDangerous: true,
-    quantity: null,
+    quantity: getQuantity(bsda.packagings),
     wasteContainsElectricOrHybridVehicles: null,
     weight: bsda.weightValue
       ? bsda.weightValue.dividedBy(1000).toDecimalPlaces(6).toNumber()


### PR DESCRIPTION
# Contexte

Le colonne "Nombre d'unité(s)" renvoie systématiquement null pour le BSDA, j'ai mis le bon résultat (semblable au BSDD et VHU).

# Ticket Favro

[Remonter le nombre total de conditionnements dans la colonne Nombre d'unités (BSDA)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6b1f768da50a90c584e548a?card=tra-16018)
