### PR TITLE
HOTFIX / Gestion des version ES

### DIFF
--- a/back/integration-tests/helper.ts
+++ b/back/integration-tests/helper.ts
@@ -87,9 +87,13 @@ export async function resetDatabase() {
 }
 
 export async function refreshElasticSearch() {
-  // Wait for all indexation jobs to finish
-  const activeJobs = await indexQueue.getActive();
-  await Promise.all(activeJobs.map(job => job.finished()));
+  try {
+    // Wait for all indexation jobs to finish
+    const activeJobs = await indexQueue.getActive();
+    await Promise.all(activeJobs.map(job => job.finished()));
+  } catch (_) {
+    // Do nothing. But we make sure the jobs don't fail the test suite
+  }
 
   return elasticSearch.indices.refresh(
     {

--- a/back/src/bsda/elastic.ts
+++ b/back/src/bsda/elastic.ts
@@ -428,7 +428,13 @@ export function toBsdElastic(bsda: BsdaForElastic): BsdElastic {
   };
 }
 
-export function indexBsda(bsda: BsdaForElastic, ctx?: GraphQLContext) {
+export function indexBsda(
+  bsda: BsdaForElastic,
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
+) {
   return indexBsd(toBsdElastic(bsda), ctx);
 }
 

--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -280,7 +280,13 @@ export function toBsdElastic(bsdasri: BsdasriForElastic): BsdElastic {
   };
 }
 
-export function indexBsdasri(bsdasri: BsdasriForElastic, ctx?: GraphQLContext) {
+export function indexBsdasri(
+  bsdasri: BsdasriForElastic,
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
+) {
   return indexBsd(toBsdElastic(bsdasri), ctx);
 }
 /**

--- a/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
+++ b/back/src/bsdasris/resolvers/mutations/createSynthesisBsdasri.ts
@@ -6,7 +6,6 @@ import getReadableId, { ReadableIdPrefix } from "../../../forms/readableId";
 import { checkIsAuthenticated } from "../../../common/permissions";
 import { validateBsdasri } from "../../validation";
 import { getEligibleDasrisForSynthesis, aggregatePackagings } from "./utils";
-import { getBsdasriForElastic, indexBsdasri } from "../../elastic";
 import { BsdasriType } from "@prisma/client";
 import { getBsdasriRepository } from "../../repository";
 import { sirenify } from "../../sirenify";
@@ -91,7 +90,6 @@ const createSynthesisBsdasri = async (
     synthesizing: { connect: synthesizedBsdasrisId }
   });
   const expandeBsdasri = expandBsdasriFromDB(newDasri);
-  await indexBsdasri(await getBsdasriForElastic(newDasri), context);
 
   return expandeBsdasri;
 };

--- a/back/src/bsffs/elastic.ts
+++ b/back/src/bsffs/elastic.ts
@@ -346,7 +346,13 @@ export function toBsdElastic(bsff: BsffForElastic): BsdElastic {
   return bsd;
 }
 
-export async function indexBsff(bsff: BsffForElastic, ctx?: GraphQLContext) {
+export async function indexBsff(
+  bsff: BsffForElastic,
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
+) {
   return indexBsd(toBsdElastic(bsff), ctx);
 }
 

--- a/back/src/bspaoh/elastic.ts
+++ b/back/src/bspaoh/elastic.ts
@@ -256,7 +256,10 @@ export function toBsdElastic(bspaoh: BspaohForElastic): BsdElastic {
 
 export function indexBspaoh(
   bspaoh: BspaohWithTransporters,
-  ctx?: GraphQLContext
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
 ) {
   return indexBsd(toBsdElastic(bspaoh), ctx);
 }

--- a/back/src/bsvhu/elastic.ts
+++ b/back/src/bsvhu/elastic.ts
@@ -303,7 +303,13 @@ export function toBsdElastic(bsvhu: BsvhuForElastic): BsdElastic {
   };
 }
 
-export function indexBsvhu(bsvhu: BsvhuForElastic, ctx?: GraphQLContext) {
+export function indexBsvhu(
+  bsvhu: BsvhuForElastic,
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
+) {
   return indexBsd(toBsdElastic(bsvhu), ctx);
 }
 

--- a/back/src/common/elastic.ts
+++ b/back/src/common/elastic.ts
@@ -365,6 +365,12 @@ function refresh(ctx?: GraphQLContext): Partial<RequestParams.Index> {
     : { refresh: false };
 }
 
+/**
+ * Set optimistic concurrency control parameters if seqNo and primaryTerm are provided.
+ * This is used to ensure that the document is not modified by another process
+ * before the current operation completes.
+ * cf https://www.elastic.co/guide/en/elasticsearch/reference/8.18/optimistic-concurrency-control.html
+ */
 function optimisticConcurrency(ctx?: { seqNo?: number; primaryTerm?: number }) {
   return ctx?.seqNo && ctx?.primaryTerm
     ? {

--- a/back/src/forms/elastic.ts
+++ b/back/src/forms/elastic.ts
@@ -231,7 +231,10 @@ export function toBsdElastic(form: FormForElastic): BsdElastic {
 
 export async function indexForm(
   form: FormForElastic,
-  ctx?: GraphQLContext
+  ctx?: {
+    gqlCtx?: GraphQLContext;
+    optimisticCtx?: { seqNo: number; primaryTerm: number };
+  }
 ): Promise<BsdElastic> {
   // prevent unwanted cascaded reindexation
   if (form.isDeleted) {

--- a/libs/back/registry/src/import.ts
+++ b/libs/back/registry/src/import.ts
@@ -215,6 +215,15 @@ function formatErrorMessage(error: Error) {
     };
   }
 
+  // Cannot unzip file or file is not a valid zip
+  if (message.includes("invalid signature: 0x")) {
+    return {
+      hidden: false,
+      message:
+        "Type de fichier invalide. Vérifiez que le fichier est bien au format XLSX (XLS n'est pas supporté) ou CSV."
+    };
+  }
+
   return { hidden: true, message: INTERNAL_ERROR };
 }
 


### PR DESCRIPTION
- plus de version manuelle dans ES
- on se base sur les versions auto incrémentées maintenant que tout passe par la queue
- avant de récupérer un bordereau on fetch le seq_no ES qu'on passe au moment de l'update
- s'il est outdated au moment de l'écriture ca fail le job avec une 409 conflict
- les jobs sont retry 3x avec 1sec de delay, ca permet de laisser à ES le temps de se refresh (défaut à 1sec entre les refresh)

J'ai glissé dans ce hotfix un nouveau message d'erreur pour le registre. Ca renvoie un message explicite dans le cas ou on passe un fichier XLS (format binaire, non supporté) et non XLSX (format zip)