### PR TITLE
[TRA-15999, TRA-16001] Correctifs sur le BSDA en cas d'entreposage provisoire

### DIFF
--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -105,6 +105,15 @@ export function BsdaPicker({ name, bsdaId }: Props) {
     setFieldValue("waste.code", bsda?.waste?.code ?? initialState!.waste!.code);
     setFieldValue("waste.adr", bsda?.waste?.adr ?? initialState!.waste!.adr);
     setFieldValue(
+      "waste.isSubjectToADR",
+      bsda?.waste?.isSubjectToADR ?? initialState!.waste!.isSubjectToADR
+    );
+    setFieldValue(
+      "waste.nonRoadRegulationMention",
+      bsda?.waste?.nonRoadRegulationMention ??
+        initialState!.waste!.nonRoadRegulationMention
+    );
+    setFieldValue(
       "waste.familyCode",
       bsda?.waste?.familyCode ?? initialState!.waste!.familyCode
     );


### PR DESCRIPTION
# Contexte

En cas d'entreposage provisoire, j'avais oublié de ramener le switch ADR et les mentions RID, ADN etc. dans le nouveau BSD créé.

# Ticket Favro

[ÉTAPE 1 - Distinguer la mention ADR de la "Mention au titre des règlements RID, ADN, IMDG (optionnel)" (créer un nouveau champ)](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6b1f768da50a90c584e548a?card=tra-16001)