### PR TITLE
[TRA-16338] Correction de la réception & traitement des BSDA dans le cas d'un COLLECTION_2710

### DIFF
--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -36,6 +36,16 @@ export const machine = createMachine<Record<string, never>, Event>(
             target: BsdaStatus.SENT,
             cond: "isPrivateIndividualWithNoWorkerBsda"
           },
+          RECEPTION: [
+            {
+              target: BsdaStatus.RECEIVED,
+              cond: "isCollectedBy2710AndGroupingOrReshipmentOperation"
+            },
+            {
+              target: BsdaStatus.RECEIVED,
+              cond: "isCollectedBy2710"
+            }
+          ],
           OPERATION: [
             {
               target: BsdaStatus.AWAITING_CHILD,

--- a/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/duplicateBsda.integration.ts
@@ -114,6 +114,8 @@ async function createBsda(opt: Partial<Prisma.BsdaCreateInput> = {}) {
       workerWorkSignatureAuthor: "John",
       destinationOperationSignatureDate: new Date(),
       destinationOperationSignatureAuthor: "John",
+      destinationReceptionSignatureDate: new Date(),
+      destinationReceptionSignatureAuthor: "John",
       ...opt
     },
     transporterOpt: {

--- a/back/src/bsda/resolvers/mutations/__tests__/signBsda.integration.ts
+++ b/back/src/bsda/resolvers/mutations/__tests__/signBsda.integration.ts
@@ -1435,6 +1435,68 @@ describe("Mutation.Bsda.sign", () => {
       expect(data.signBsda.id).toBeTruthy();
     });
 
+    it("destination should be able to sign reception + operation for COLLECTION_2710", async () => {
+      // Given
+      const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
+      const bsda = await bsdaFactory({
+        opt: {
+          status: "INITIAL",
+          type: "COLLECTION_2710",
+          destinationCompanySiret: company.siret,
+          workerCompanyName: null,
+          workerCompanySiret: null
+        },
+        transporterOpt: {
+          transporterCompanyName: null,
+          transporterCompanySiret: null
+        }
+      });
+
+      // il n'y a pas de transporteur sur les bordereaux de collecte
+      // en déchetterie
+      await prisma.bsda.update({
+        where: { id: bsda.id },
+        data: { transporters: { deleteMany: {} } }
+      });
+
+      // When: sign reception
+      const { mutate } = makeClient(user);
+      const { errors: receptionErrors, data: receptionData } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "RECEPTION",
+            author: user.name
+          }
+        }
+      });
+
+      // Then
+      expect(receptionErrors).toBeUndefined();
+      expect(receptionData.signBsda.status).toBe("RECEIVED");
+
+      // When: sign operation
+      const { errors: operationErrors, data: operationData } = await mutate<
+        Pick<Mutation, "signBsda">,
+        MutationSignBsdaArgs
+      >(SIGN_BSDA, {
+        variables: {
+          id: bsda.id,
+          input: {
+            type: "OPERATION",
+            author: user.name
+          }
+        }
+      });
+
+      // Then
+      expect(operationErrors).toBeUndefined();
+      expect(operationData.signBsda.status).toBe("PROCESSED");
+    });
+
     it("should disallow destination to sign operation when required data is missing", async () => {
       const { user, company } = await userWithCompanyFactory(UserRole.ADMIN);
 

--- a/back/src/bsda/resolvers/mutations/duplicate.ts
+++ b/back/src/bsda/resolvers/mutations/duplicate.ts
@@ -45,6 +45,8 @@ export default async function duplicate(
     destinationOperationSignatureAuthor,
     destinationOperationSignatureDate,
     destinationOperationDate,
+    destinationReceptionSignatureAuthor,
+    destinationReceptionSignatureDate,
     wasteSealNumbers,
     packagings,
     weightValue,

--- a/back/src/bsda/resolvers/mutations/sign.ts
+++ b/back/src/bsda/resolvers/mutations/sign.ts
@@ -452,7 +452,11 @@ function checkSignatureTypeSpecificRules(
   bsda: Bsda,
   input: BsdaSignatureInput
 ) {
-  if (bsda.type === BsdaType.COLLECTION_2710 && input.type !== "OPERATION") {
+  if (
+    bsda.type === BsdaType.COLLECTION_2710 &&
+    input.type !== "RECEPTION" &&
+    input.type !== "OPERATION"
+  ) {
     throw new UserInputError(
       "Ce type de bordereau ne peut être signé qu'à la réception par la déchetterie."
     );
@@ -464,12 +468,6 @@ function checkSignatureTypeSpecificRules(
   ) {
     throw new UserInputError(
       "Ce type de bordereau ne peut pas être signé par une entreprise de travaux."
-    );
-  }
-
-  if (bsda.type === BsdaType.COLLECTION_2710 && input.type !== "OPERATION") {
-    throw new UserInputError(
-      "Ce type de bordereau ne peut être signé qu'à la réception par la déchetterie."
     );
   }
 }


### PR DESCRIPTION
# Contexte

Deux petits bugfix:
- dans le cas d'un BSDA COLLECTION_2710, on peut réceptionner et traiter le bordereau 
- on ne duplique plus les date & auteur de signature de réception d'un bordereau

# Ticket Favro

[Mettre la modale de signature de la réception et acceptation au DSFR d'un BSDA - FRONT](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16338)
