### PR TITLE
[TRA-13257] Ne pas fuiter de token vers sentry

### DIFF
--- a/front/src/setupSentry.ts
+++ b/front/src/setupSentry.ts
@@ -21,6 +21,35 @@ if (import.meta.env.VITE_SENTRY_DSN) {
       // Happens after a new release, when trying to load files that don't exist anymore
       // https://rollbar.com/blog/javascript-chunk-load-error
       /Loading chunk [0-9]+ failed/
-    ]
+    ],
+    beforeSend(event) {
+      const removeKeys = [
+        "token",
+        "access_token",
+        "secret",
+        "password",
+        "hash"
+      ];
+
+      // Remove sensitive info from request URL
+      if (event.request?.url) {
+        const url = new URL(event.request.url);
+        removeKeys.forEach(key => {
+          url.searchParams.delete(key);
+        });
+        event.request.url = url.toString();
+      }
+
+      // Also remove from tags or extra data if needed
+      if (event.tags?.url) {
+        const tagUrl = new URL(event.tags.url as string);
+        removeKeys.forEach(key => {
+          tagUrl.searchParams.delete(key);
+        });
+        event.tags.url = tagUrl.toString();
+      }
+
+      return event;
+    }
   });
 }


### PR DESCRIPTION
# Contexte

Point de sécu remonté il y a longtemps dans le programme YesWeHack
Si sur la page de reset password on a une erreur il ne faut pas envoyer le hash qui apparait dans l'URL à sentry.

J'ai élargi un peu le cleanup par rapport à la carte, au cas ou.

# Points de vigilance pour les intégrateurs
RAS

# Démo
RAS

# Ticket Favro

[Titre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-13257)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB