### PR TITLE
[TRA-16566] Ajout de limites de caractères quand manquants

### DIFF
--- a/libs/back/registry/src/incomingTexs/validation/schema.ts
+++ b/libs/back/registry/src/incomingTexs/validation/schema.ts
@@ -82,7 +82,14 @@ const inputIncomingTexsSchema = z.object({
   emitterCompanyPostalCode: actorPostalCodeSchema.nullish(),
   emitterCompanyCity: actorCitySchema.nullish(),
   emitterCompanyCountryCode: actorCountryCodeSchema.nullish(),
-  emitterPickupSiteName: z.string().trim().nullish(),
+  emitterPickupSiteName: z
+    .string()
+    .trim()
+    .max(
+      300,
+      "Le nom du site de collecte ne peut pas faire plus de 300 caractères"
+    )
+    .nullish(),
   emitterPickupSiteAddress: actorAddressSchema.nullish(),
   emitterPickupSitePostalCode: actorPostalCodeSchema.nullish(),
   emitterPickupSiteCity: actorCitySchema.nullish(),

--- a/libs/back/registry/src/outgoingTexs/validation/schema.ts
+++ b/libs/back/registry/src/outgoingTexs/validation/schema.ts
@@ -44,7 +44,14 @@ const inputOutgoingTexsSchema = z.object({
   publicId: publicIdSchema,
   reportAsCompanySiret: reportAsCompanySiretSchema,
   reportForCompanySiret: siretSchema,
-  reportForPickupSiteName: z.string().trim().nullish(),
+  reportForPickupSiteName: z
+    .string()
+    .trim()
+    .max(
+      300,
+      "La référence du chantier ne peut pas faire plus de 300 caractères"
+    )
+    .nullish(),
   reportForPickupSiteAddress: actorAddressSchema.nullish(),
   reportForPickupSitePostalCode: actorPostalCodeSchema.nullish(),
   reportForPickupSiteCity: actorCitySchema.nullish(),

--- a/libs/back/registry/src/outgoingWaste/validation/schema.ts
+++ b/libs/back/registry/src/outgoingWaste/validation/schema.ts
@@ -38,7 +38,14 @@ const inputOutgoingWasteSchema = z.object({
   publicId: publicIdSchema,
   reportAsCompanySiret: reportAsCompanySiretSchema,
   reportForCompanySiret: siretSchema,
-  reportForPickupSiteName: z.string().trim().nullish(),
+  reportForPickupSiteName: z
+    .string()
+    .trim()
+    .max(
+      300,
+      "La référence du chantier ne peut pas faire plus de 300 caractères"
+    )
+    .nullish(),
   reportForPickupSiteAddress: actorAddressSchema.nullish(),
   reportForPickupSitePostalCode: actorPostalCodeSchema.nullish(),
   reportForPickupSiteCity: actorCitySchema.nullish(),

--- a/libs/back/registry/src/shared/schemas.ts
+++ b/libs/back/registry/src/shared/schemas.ts
@@ -187,6 +187,7 @@ export const getOperationModeSchema = (
 const numberAsStringSchema = z
   .string()
   .trim()
+  .max(50, "Le nombre ne peut pas dépasser 50 caractères")
   .nullish()
   .transform(val => (val ? Number(val.replace(",", ".")) : undefined));
 

--- a/libs/back/registry/src/transported/validation/schema.ts
+++ b/libs/back/registry/src/transported/validation/schema.ts
@@ -40,8 +40,17 @@ const inputTransportedSchema = z.object({
   reportForTransportIsWaste: booleanSchema,
   reportForRecepisseIsExempted: booleanSchema.nullish(),
   reportForRecepisseNumber: transportRecepisseNumberSchema.nullish(),
-  reportForTransportAdr: z.string().nullish(),
-  reportForTransportOtherTmdCode: z.string().nullish(),
+  reportForTransportAdr: z
+    .string()
+    .max(300, "La mention ADR ne peut pas faire plus de 300 caractères")
+    .nullish(),
+  reportForTransportOtherTmdCode: z
+    .string()
+    .max(
+      300,
+      "La mention RID, ADN, IMDG ne peut pas faire plus de 300 caractères"
+    )
+    .nullish(),
   reportForTransportPlates: transportPlatesSchema,
   wasteDescription: wasteDescriptionSchema,
   wasteCode: getWasteCodeSchema().nullish(),


### PR DESCRIPTION
# Contexte

Appliquer une limite de nombre de caractères sur l'ensemble des champs texte qui n'en ont pas 

# Points de vigilance pour les intégrateurs

Pas de vigilance particulière, changement transparent d'un point de vue user. Ca évite simplement un usage abusif sur les quelques champs qui n'avaient pas de maximum de longueur

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16566)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB