### PR TITLE
[tra-16483]Mettre au DSFR les champs de révision de l'adresse de chantier d'un BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/BsdaRequestRevisionCancelationInput.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/BsdaRequestRevisionCancelationInput.tsx
@@ -35,7 +35,6 @@ export function BsdaRequestRevisionCancelationInput({ bsda, onChange }: Props) {
         inputTitle="cancellation"
         disabled={!canBeCancelled}
         onChange={onChange}
-        showCheckedHint={false}
         helperText={
           canBeCancelled ? CANCELATION_MSG : CANCELATION_NOT_POSSIBLE_MSG
         }

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsda/request/BsdaRequestRevision.tsx
@@ -16,7 +16,7 @@ import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { z } from "zod";
 import { removeEmptyKeys } from "../../../../../../common/helper";
-import WorkSiteAddress from "../../../../../../form/common/components/work-site/WorkSiteAddress";
+import DsfrfWorkSiteAddress from "../../../../../../form/common/components/dsfr-work-site/DsfrfWorkSiteAddress";
 import { Loader } from "../../../../../common/Components";
 import RhfOperationModeSelect from "../../../../../common/Components/OperationModeSelect/RhfOperationModeSelect";
 import { CREATE_BSDA_REVISION_REQUEST } from "../../../../../common/queries/reviews/BsdaReviewQuery";
@@ -403,7 +403,7 @@ export function BsdaRequestRevision({ bsda }: Props) {
                 defaultValue={initialBsdaReview.emitter?.pickupSite}
               >
                 <div className="form__row">
-                  <WorkSiteAddress
+                  <DsfrfWorkSiteAddress
                     address={formValues?.emitter?.pickupSite?.address}
                     city={formValues?.emitter?.pickupSite?.city}
                     postalCode={formValues?.emitter?.pickupSite?.postalCode}

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdasri/BsdasriRequestRevisionCancelationInput.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdasri/BsdasriRequestRevisionCancelationInput.tsx
@@ -41,7 +41,6 @@ export function BsdasriRequestRevisionCancelationInput({
         disabled={!canBeCancelled}
         inputTitle="cancellation"
         onChange={onChange}
-        showCheckedHint={false}
         helperText={
           canBeCancelled ? CANCELATION_MSG : CANCELATION_NOT_POSSIBLE_MSG
         }

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/BsddRequestRevisionCancelationInput.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/bsdd/BsddRequestRevisionCancelationInput.tsx
@@ -47,7 +47,6 @@ export function BsddRequestRevisionCancelationInput({ bsdd, onChange }: Props) {
         disabled={!canBeCancelled}
         inputTitle="cancellation"
         onChange={onChange}
-        showCheckedHint={false}
         helperText={
           isAppendix1
             ? CANCELATION_NOT_POSSIBLE_FOR_APPENDIX1_MSG

--- a/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/ReviewableField/RhfReviewableField.tsx
+++ b/front/src/Apps/Dashboard/Components/RevisionRequestList/common/Components/ReviewableField/RhfReviewableField.tsx
@@ -77,7 +77,6 @@ const RhfReviewableField = ({
         label={<LabelContent labelText={title} value={value} suffix={suffix} />}
         inputTitle="terms" // todo: change
         defaultChecked={false}
-        showCheckedHint={false}
         helperText={hint}
         onChange={handleIsEditingChange}
         disabled={disabled}

--- a/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
+++ b/front/src/form/common/components/dsfr-work-site/DsfrfWorkSiteAddress.tsx
@@ -97,7 +97,8 @@ export default function DsfrfWorkSiteAddress({
   onAddressSelection,
   designation,
   disabled = false,
-  placeholder = "Recherchez une adresse puis sélectionnez un des choix qui apparait..."
+  placeholder = "Recherchez une adresse puis sélectionnez un des choix qui apparait...",
+  titleForRevision = ""
 }: {
   address?: string | null;
   city?: string | null;
@@ -111,6 +112,7 @@ export default function DsfrfWorkSiteAddress({
     postcode: string | null | undefined;
     label: string;
   }) => void;
+  titleForRevision?: string;
 }) {
   const [state, dispatch] = useReducer(
     reducer,
@@ -175,7 +177,9 @@ export default function DsfrfWorkSiteAddress({
 
   return (
     <div className="form__row">
-      <label className="fr-label fr-mb-1w">Adresse {designation}</label>
+      <label className="fr-label fr-mb-1w">
+        {!titleForRevision ? `Adresse ${designation}` : titleForRevision}
+      </label>
 
       <SearchInput
         id="eco-search"
@@ -190,7 +194,6 @@ export default function DsfrfWorkSiteAddress({
       <ToggleSwitch
         inputTitle="showAdressFields"
         defaultChecked={false}
-        showCheckedHint={false}
         className="fr-mb-2w"
         onChange={e => {
           setShowAdressFields(e);


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->
<img width="1019" alt="Screenshot 2025-06-04 at 14 47 05" src="https://github.com/user-attachments/assets/f329dedc-45fb-4061-8a22-1ce5a1bf1a77" />

# Ticket Favro

[tra-16483](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16483)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB