### PR TITLE
[TRA 16842] Ajout d'un mode lecture seule à l'IHM

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2025.07.1] 29/07/2025
+
+#### :rocket: Nouvelles fonctionnalités
+
+- Ajout d'un mode lecture seule à l'interface d'édition des déclarations RNDTS (IHM) [PR 4234](https://github.com/MTES-MCT/trackdechets/pull/4234)
+
 # [2025.06.1] 03/06/2025
 
 #### :nail_care: Améliorations

--- a/apps/doc/docusaurus.config.js
+++ b/apps/doc/docusaurus.config.js
@@ -185,7 +185,7 @@ module.exports = {
       "docusaurus-graphql-plugin",
       {
         id: "registryV2",
-        schema: "../../back/src/{scalars,common,registryV2}/typeDefs/*.graphql",
+        schema: "../../back/src/{scalars,common,users,companies,registryV2}/typeDefs/*.graphql",
         routeBasePath: "/reference/api-reference/registreV2"
       }
     ],

--- a/back/src/registryV2/resolvers/RegistryCompany.ts
+++ b/back/src/registryV2/resolvers/RegistryCompany.ts
@@ -1,0 +1,14 @@
+import { Company } from "@prisma/client";
+import type { RegistryCompanyResolvers } from "@td/codegen-back";
+import { getUserRole, grants, toGraphQLPermission } from "../../permissions";
+import { GraphQLContext } from "../../types";
+
+export const RegistryCompany: RegistryCompanyResolvers<
+  GraphQLContext,
+  Company
+> = {
+  userPermissions: async (parent, _, context) => {
+    const role = await getUserRole(context.user!.id, parent.orgId);
+    return role ? grants[role].map(toGraphQLPermission) : [];
+  }
+};

--- a/back/src/registryV2/resolvers/RegistryExhaustiveExport.ts
+++ b/back/src/registryV2/resolvers/RegistryExhaustiveExport.ts
@@ -1,11 +1,21 @@
-import { Prisma } from "@prisma/client";
+import { Company, Prisma } from "@prisma/client";
 import type { RegistryExhaustiveExportResolvers } from "@td/codegen-back";
 import { GraphQLContext } from "../../types";
 
-export const RegistryExhaustiveExport: RegistryExhaustiveExportResolvers<
-  GraphQLContext,
-  Prisma.RegistryExhaustiveExportGetPayload<{ include: { createdBy: true } }>
-> = {
+type ParentType = Prisma.RegistryExhaustiveExportGetPayload<{
+  include: { createdBy: true };
+}>;
+
+export const RegistryExhaustiveExport: Omit<
+  RegistryExhaustiveExportResolvers<GraphQLContext, ParentType>,
+  "companies"
+> & {
+  companies: (
+    parent: ParentType,
+    args: unknown,
+    context: GraphQLContext
+  ) => Promise<Company[]>;
+} = {
   companies: async (parent, _, context) => {
     const res = await Promise.all(
       parent.sirets?.map(siret => context.dataloaders.companies.load(siret))

--- a/back/src/registryV2/resolvers/RegistryImportAssociation.ts
+++ b/back/src/registryV2/resolvers/RegistryImportAssociation.ts
@@ -1,25 +1,29 @@
 import { prisma } from "@td/prisma";
 import type { RegistryImportAssociationResolvers } from "@td/codegen-back";
+import {
+  type Company,
+  type RegistryImportAssociation as PrismaRegistryImportAssociation
+} from "@prisma/client";
 
-export const RegistryImportAssociation: RegistryImportAssociationResolvers = {
+export const RegistryImportAssociation: Omit<
+  RegistryImportAssociationResolvers,
+  "reportedFor" | "reportedAs"
+> & {
+  reportedFor: (parent: PrismaRegistryImportAssociation) => Promise<Company>;
+  reportedAs: (parent: PrismaRegistryImportAssociation) => Promise<Company>;
+} = {
   reportedFor: async parent => {
     const company = await prisma.company.findUniqueOrThrow({
       where: { siret: parent.reportedFor as string }
     });
 
-    return {
-      siret: company.orgId,
-      name: company.givenName || company.name
-    };
+    return company;
   },
   reportedAs: async parent => {
     const company = await prisma.company.findUniqueOrThrow({
       where: { siret: parent.reportedAs as string }
     });
 
-    return {
-      siret: company.orgId,
-      name: company.givenName || company.name
-    };
+    return company;
   }
 };

--- a/back/src/registryV2/resolvers/RegistryLookup.ts
+++ b/back/src/registryV2/resolvers/RegistryLookup.ts
@@ -1,0 +1,69 @@
+import { Company, Prisma } from "@prisma/client";
+import type {
+  OutgoingWasteLine,
+  IncomingTexsLine,
+  IncomingWasteLine,
+  RegistryLookupResolvers,
+  SsdLine,
+  OutgoingTexsLine,
+  ManagedLine,
+  TransportedLine
+} from "@td/codegen-back";
+import { GraphQLContext } from "../../types";
+import { getTypeFromLookup } from "./queries/utils/registryLookup.util";
+
+type ParentType = Prisma.RegistryLookupGetPayload<{
+  include: {
+    registrySsd: true;
+    registryIncomingWaste: true;
+    registryIncomingTexs: true;
+    registryOutgoingWaste: true;
+    registryOutgoingTexs: true;
+    registryTransported: true;
+    registryManaged: true;
+  };
+}>;
+
+export const RegistryLookup: Omit<
+  RegistryLookupResolvers<GraphQLContext, ParentType>,
+  "reportFor" | "reportAs"
+> & {
+  reportFor: (
+    parent: ParentType,
+    args: unknown,
+    context: GraphQLContext
+  ) => Promise<Company | null>;
+  reportAs: (
+    parent: ParentType,
+    args: unknown,
+    context: GraphQLContext
+  ) => Promise<Company | null>;
+} = {
+  publicId: parent => parent.readableId,
+  type: parent => getTypeFromLookup(parent),
+  ssd: parent => (parent.registrySsd as SsdLine) ?? undefined,
+  incomingWaste: parent =>
+    (parent.registryIncomingWaste as IncomingWasteLine) ?? null,
+  incomingTexs: parent =>
+    (parent.registryIncomingTexs as IncomingTexsLine) ?? null,
+  outgoingWaste: parent =>
+    (parent.registryOutgoingWaste as OutgoingWasteLine) ?? null,
+  outgoingTexs: parent =>
+    (parent.registryOutgoingTexs as OutgoingTexsLine) ?? null,
+  managedWaste: parent => (parent.registryManaged as ManagedLine) ?? null,
+  transportedWaste: parent =>
+    (parent.registryTransported as TransportedLine) ?? null,
+  reportFor: async (parent, _, context) => {
+    const company = await context.dataloaders.companies.load(parent.siret);
+    return company;
+  },
+  reportAs: async (parent, _, context) => {
+    if (!parent.reportAsSiret) {
+      return null;
+    }
+    const company = await context.dataloaders.companies.load(
+      parent.reportAsSiret
+    );
+    return company;
+  }
+};

--- a/back/src/registryV2/resolvers/RegistryV2Export.ts
+++ b/back/src/registryV2/resolvers/RegistryV2Export.ts
@@ -1,11 +1,26 @@
-import { Prisma } from "@prisma/client";
+import { Company, Prisma } from "@prisma/client";
 import type { RegistryV2ExportResolvers } from "@td/codegen-back";
 import { GraphQLContext } from "../../types";
 
-export const RegistryV2Export: RegistryV2ExportResolvers<
-  GraphQLContext,
-  Prisma.RegistryExportGetPayload<{ include: { createdBy: true } }>
-> = {
+type ParentType = Prisma.RegistryExportGetPayload<{
+  include: { createdBy: true };
+}>;
+
+export const RegistryV2Export: Omit<
+  RegistryV2ExportResolvers<GraphQLContext, ParentType>,
+  "delegate" | "companies"
+> & {
+  delegate: (
+    parent: ParentType,
+    args: unknown,
+    context: GraphQLContext
+  ) => Promise<Company | null>;
+  companies: (
+    parent: ParentType,
+    args: unknown,
+    context: GraphQLContext
+  ) => Promise<Company[]>;
+} = {
   registryType: parent => parent.registryType,
   declarationType: parent => parent.declarationType ?? "ALL",
   delegate: async (parent, _, context) => {

--- a/back/src/registryV2/resolvers/index.ts
+++ b/back/src/registryV2/resolvers/index.ts
@@ -3,10 +3,15 @@ import { Mutation } from "./Mutation";
 import { RegistryV2Export } from "./RegistryV2Export";
 import { RegistryImportAssociation } from "./RegistryImportAssociation";
 import { RegistryExhaustiveExport } from "./RegistryExhaustiveExport";
+import { RegistryLookup } from "./RegistryLookup";
+import { RegistryCompany } from "./RegistryCompany";
+
 export default {
   Query,
   Mutation,
   RegistryV2Export,
   RegistryImportAssociation,
-  RegistryExhaustiveExport
+  RegistryExhaustiveExport,
+  RegistryLookup,
+  RegistryCompany
 };

--- a/back/src/registryV2/typeDefs/registryV2.objects.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.objects.graphql
@@ -61,6 +61,8 @@ type RegistryCompany {
   siret: String
   "SIRET ou num de TVA de l'établissement"
   orgId: String
+  "Liste des permissions de l'utilisateur authentifié au sein de cet établissement"
+  userPermissions: [UserPermission!]!
 }
 
 type RegistryImportConnection {
@@ -137,21 +139,41 @@ type CancelRegistryV2LineResponse {
   publicIds: [ID!]!
 }
 
+"""
+Permet de récupérer l'ensemble des déclarations au registre RNDTS.
+"""
 type RegistryLookup {
+  "publicId de la déclaration associée"
   publicId: ID!
+  "type de registre dans lequel apparaît cette déclaration"
   type: RegistryImportType!
+  "SIRET de l'établissement visé par la déclaration (reportForSiret)"
   siret: String!
+  "SIRET de l'établissement qui a fait la déclaration (reportAsSiret), null si c'est le même que l'établissement visé"
   reportAsSiret: String
+  "Date de l'action déclarée"
   date: DateTime!
+  "Date de la déclaration"
   declaredAt: DateTime!
+  "Code de déchets"
   wasteCode: String
-
+  "établissement qui a fait la déclaration"
+  reportFor: RegistryCompany
+  "établissement qui a fait la déclaration"
+  reportAs: RegistryCompany
+  "Déclaration SSD: contient la ligne de registre si il s'agit d'une déclaration SSD"
   ssd: SsdLine
+  "Déclaration de réception de déchets: contient la ligne de registre si il s'agit d'une déclaration de réception de déchets"
   incomingWaste: IncomingWasteLine
+  "Déclaration de réception de terres et sédiments: contient la ligne de registre si il s'agit d'une déclaration de réception de terres et sédiments"
   incomingTexs: IncomingTexsLine
+  "Déclaration d'expédition de déchets: contient la ligne de registre si il s'agit d'une déclaration d'expédition de déchets"
   outgoingWaste: OutgoingWasteLine
+  "Déclaration d'expédition de terres et sédiments: contient la ligne de registre si il s'agit d'une déclaration d'expédition de terres et sédiments"
   outgoingTexs: OutgoingTexsLine
+  "Déclaration de gestion de déchets: contient la ligne de registre si il s'agit d'une déclaration de gestion de déchets"
   managedWaste: ManagedLine
+  "Déclaration de transport de déchets: contient la ligne de registre si il s'agit d'une déclaration de transport de déchets"
   transportedWaste: TransportedLine
 }
 

--- a/front/src/dashboard/registry/MyImports.tsx
+++ b/front/src/dashboard/registry/MyImports.tsx
@@ -100,7 +100,12 @@ export function MyImports() {
       importData.node.associations
         .map(
           association =>
-            `${association.reportedFor.name} - ${association.reportedFor.siret}`
+            `${
+              association.reportedFor.givenName &&
+              association.reportedFor.givenName !== ""
+                ? association.reportedFor.givenName
+                : association.reportedFor.name
+            } - ${association.reportedFor.siret}`
         )
         .slice(0, 3)
         .concat(

--- a/front/src/dashboard/registry/companyImport/FileImportsTable.tsx
+++ b/front/src/dashboard/registry/companyImport/FileImportsTable.tsx
@@ -60,7 +60,12 @@ export function FileImportsTable({ siret }: Props) {
         a => !!a.reportedAs.siret && a.reportedAs.siret !== a.reportedFor.siret
       );
       const reportedBy = reportedByAssociation
-        ? `${importData.node.createdBy.name} - ${reportedByAssociation.reportedAs.name} (${reportedByAssociation.reportedAs.siret})`
+        ? `${importData.node.createdBy.name} - ${
+            reportedByAssociation.reportedAs.givenName &&
+            reportedByAssociation.reportedAs.givenName !== ""
+              ? reportedByAssociation.reportedAs.givenName
+              : reportedByAssociation.reportedAs.name
+          } (${reportedByAssociation.reportedAs.siret})`
         : importData.node.createdBy.name;
       return [
         format(new Date(importData.node.createdAt), "dd/MM/yyyy HH'h'mm"),

--- a/front/src/dashboard/registry/myLines/MyLines.tsx
+++ b/front/src/dashboard/registry/myLines/MyLines.tsx
@@ -209,17 +209,17 @@ export function MyLines() {
                         state: { background: location }
                       });
                     }
+                  },
+                  {
+                    title: "Annuler",
+                    isButton: true,
+                    handleClick: () => {
+                      setPublicIdToDelete(lookup.publicId);
+                      deleteConfirmationModal.open();
+                    }
                   }
                 ]
-              : []),
-            {
-              title: "Annuler",
-              isButton: true,
-              handleClick: () => {
-                setPublicIdToDelete(lookup.publicId);
-                deleteConfirmationModal.open();
-              }
-            }
+              : [])
           ]}
           isDisabled={false}
         />

--- a/front/src/dashboard/registry/myLines/MyLines.tsx
+++ b/front/src/dashboard/registry/myLines/MyLines.tsx
@@ -4,7 +4,12 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import Select from "@codegouvfr/react-dsfr/Select";
-import { Mutation, Query, RegistryImportType } from "@td/codegen-ui";
+import {
+  Mutation,
+  Query,
+  RegistryImportType,
+  UserPermission
+} from "@td/codegen-ui";
 import { format } from "date-fns";
 import React, { useEffect, useMemo, useState } from "react";
 import { generatePath, useLocation, useNavigate } from "react-router-dom";
@@ -144,47 +149,83 @@ export function MyLines() {
     debouncedOnApplyFilters(publicId);
   }, [debouncedOnApplyFilters, publicId]);
 
-  const tableData = lookupNodes?.map(lookup => [
-    format(new Date(lookup.declaredAt), "dd/MM/yyyy HH'h'mm"),
-    TYPES[lookup.type],
-    lookup.publicId,
-    lookup.reportAsSiret ?? lookup.siret,
-    format(new Date(lookup.date), "dd/MM/yyyy"),
-    lookup.wasteCode ?? "",
-    <div className="tw-px-2 line-actions-dropdown-container">
-      <DropdownMenu
-        className="line-actions-dropdown"
-        menuTitle={`Menu d'action de la déclaration ${lookup.publicId}`}
-        ButtonElement={ActionButton}
-        alignRight
-        links={[
-          {
-            title: "Modifier",
-            isButton: true,
-            handleClick: () => {
-              const path = generatePath(TYPES_ROUTES[lookup.type]);
-              const queryString = new URLSearchParams({
-                siret: lookup.siret,
-                publicId: lookup.publicId
-              }).toString();
-              navigate(`${path}?${queryString}`, {
-                state: { background: location }
-              });
+  const tableData = lookupNodes?.map(lookup => {
+    let companyText = lookup.reportAsSiret ?? lookup.siret;
+    let canEdit = false;
+    if (lookup.reportAs) {
+      companyText = `${lookup.reportAs.givenName ?? lookup.reportAs.name} - ${
+        lookup.reportAs.siret
+      }`;
+      const permissions = lookup.reportAs.userPermissions;
+      canEdit = permissions.includes(UserPermission.RegistryCanImport);
+    } else if (lookup.reportFor) {
+      companyText = `${lookup.reportFor.givenName ?? lookup.reportFor.name} - ${
+        lookup.reportFor.siret
+      }`;
+      const permissions = lookup.reportFor.userPermissions;
+      canEdit = permissions.includes(UserPermission.RegistryCanImport);
+    }
+    return [
+      format(new Date(lookup.declaredAt), "dd/MM/yyyy HH'h'mm"),
+      TYPES[lookup.type],
+      lookup.publicId,
+      companyText,
+      format(new Date(lookup.date), "dd/MM/yyyy"),
+      lookup.wasteCode ?? "",
+      <div className="tw-px-2 line-actions-dropdown-container">
+        <DropdownMenu
+          className="line-actions-dropdown"
+          menuTitle={`Menu d'action de la déclaration ${lookup.publicId}`}
+          ButtonElement={ActionButton}
+          alignRight
+          links={[
+            {
+              title: "Afficher",
+              isButton: true,
+              handleClick: () => {
+                const path = generatePath(TYPES_ROUTES[lookup.type]);
+                const queryString = new URLSearchParams({
+                  siret: lookup.siret,
+                  publicId: lookup.publicId,
+                  readonly: "1"
+                }).toString();
+                navigate(`${path}?${queryString}`, {
+                  state: { background: location }
+                });
+              }
+            },
+            ...(canEdit
+              ? [
+                  {
+                    title: "Modifier",
+                    isButton: true,
+                    handleClick: () => {
+                      const path = generatePath(TYPES_ROUTES[lookup.type]);
+                      const queryString = new URLSearchParams({
+                        siret: lookup.siret,
+                        publicId: lookup.publicId
+                      }).toString();
+                      navigate(`${path}?${queryString}`, {
+                        state: { background: location }
+                      });
+                    }
+                  }
+                ]
+              : []),
+            {
+              title: "Annuler",
+              isButton: true,
+              handleClick: () => {
+                setPublicIdToDelete(lookup.publicId);
+                deleteConfirmationModal.open();
+              }
             }
-          },
-          {
-            title: "Annuler",
-            isButton: true,
-            handleClick: () => {
-              setPublicIdToDelete(lookup.publicId);
-              deleteConfirmationModal.open();
-            }
-          }
-        ]}
-        isDisabled={false}
-      />
-    </div>
-  ]);
+          ]}
+          isDisabled={false}
+        />
+      </div>
+    ];
+  });
 
   return (
     <>

--- a/front/src/dashboard/registry/shared.tsx
+++ b/front/src/dashboard/registry/shared.tsx
@@ -37,10 +37,12 @@ export const GET_REGISTRY_IMPORTS = gql`
           }
           associations {
             reportedFor {
-              siret
+              givenName
               name
+              siret
             }
             reportedAs {
+              givenName
               siret
               name
             }
@@ -85,6 +87,18 @@ export const GET_REGISTRY_LOOKUPS = gql`
           reportAsSiret
           date
           wasteCode
+          reportFor {
+            givenName
+            name
+            siret
+            userPermissions
+          }
+          reportAs {
+            givenName
+            name
+            siret
+            userPermissions
+          }
         }
         cursor
       }

--- a/front/src/form/registry/builder/FormBuilder.tsx
+++ b/front/src/form/registry/builder/FormBuilder.tsx
@@ -4,8 +4,8 @@ import { Tabs } from "@codegouvfr/react-dsfr/Tabs";
 import { RegistryImportType, RegistryLineReason } from "@td/codegen-ui";
 import React, { useState } from "react";
 import { type UseFormReturn, FormProvider } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
-
+import { useLocation, useNavigate } from "react-router-dom";
+import cn from "classnames";
 import { getRegistryNameFromImportType } from "../../../dashboard/registry/shared";
 import { getTabsWithState } from "./error";
 import "./FormBuilder.scss";
@@ -46,6 +46,9 @@ export function FormBuilder({
   disabledFieldNames
 }: Props) {
   const [selectedTabId, setSelectedTabId] = useState<string>(shape[0].tabId);
+  const { search } = useLocation();
+  const queryParams = new URLSearchParams(search);
+  const readOnly = queryParams.get("readonly") === "1";
   const navigate = useNavigate();
   const { errors } = methods.formState;
   const shapeWithState = getTabsWithState(shape, errors, disabledFieldNames);
@@ -76,16 +79,32 @@ export function FormBuilder({
   return (
     <div id="formBuilder" className="registryFormBuilder">
       <h3 className="fr-h3 fr-mb-1v">
-        {reason === RegistryLineReason.Edit
+        {readOnly
+          ? "Afficher "
+          : reason === RegistryLineReason.Edit
           ? "Modifier "
-          : reason === RegistryLineReason.Cancel
-          ? "Annuler "
           : "Créer "}
         une déclaration
       </h3>
-      <div className="fr-hint-text fr-mb-2w fr-text--md">
+      <div
+        className={cn(
+          "fr-hint-text",
+          readOnly ? "fr-mb-1w" : "fr-mb-2w",
+          "fr-text--md"
+        )}
+      >
         {getRegistryNameFromImportType(registryType)}
       </div>
+      {readOnly && (
+        <div>
+          <Alert
+            description="La vue Affichage ne permet pas d'effectuer ou enregistrer des modifications sur les déclarations"
+            severity="info"
+            className="fr-mb-2w fr-pb-1w"
+            small
+          />
+        </div>
+      )}
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)}>
           <Tabs
@@ -154,13 +173,15 @@ export function FormBuilder({
                       Fermer
                     </Button>
 
-                    <Button type="submit" disabled={loading}>
-                      {reason === RegistryLineReason.Edit
-                        ? "Modifier la déclaration"
-                        : reason === RegistryLineReason.Cancel
-                        ? "Annuler la déclaration"
-                        : "Créer la déclaration"}
-                    </Button>
+                    {!readOnly && (
+                      <Button type="submit" disabled={loading}>
+                        {reason === RegistryLineReason.Edit
+                          ? "Modifier la déclaration"
+                          : reason === RegistryLineReason.Cancel
+                          ? "Annuler la déclaration"
+                          : "Créer la déclaration"}
+                      </Button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/front/src/form/registry/incomingWaste/RegistryIncomingWasteForm.tsx
+++ b/front/src/form/registry/incomingWaste/RegistryIncomingWasteForm.tsx
@@ -141,7 +141,6 @@ export function RegistryIncomingWasteForm({ onClose }: Props) {
 
   async function onSubmit(data: FormValues) {
     const { transporter, ...rest } = data;
-    console.log(data);
     // Flatten transporter array back into individual fields
     const flattenedData = {
       ...rest,

--- a/front/src/form/registry/outgoingWaste/RegistryOutgoingWasteForm.tsx
+++ b/front/src/form/registry/outgoingWaste/RegistryOutgoingWasteForm.tsx
@@ -140,7 +140,6 @@ export function RegistryOutgoingWasteForm({ onClose }: Props) {
 
   async function onSubmit(data: FormValues) {
     const { transporter, ...rest } = data;
-    console.log(data);
     // Flatten transporter array back into individual fields
     const flattenedData = {
       ...rest,
@@ -178,9 +177,7 @@ export function RegistryOutgoingWasteForm({ onClose }: Props) {
         onClose();
       }
     } catch (error) {
-      console.log(error);
       if (error instanceof ApolloError) {
-        console.log("AQUI");
         // Handle GraphQL errors
         methods.setError("root.serverError", {
           type: "server",
@@ -189,7 +186,6 @@ export function RegistryOutgoingWasteForm({ onClose }: Props) {
             "Une erreur inconnue est survenue, merci de réessayer dans quelques instants. Si le problème persiste vous pouvez contacter le support"
         });
       } else {
-        console.log("AQUI 2");
         methods.setError("root.serverError", {
           type: "server",
           message:


### PR DESCRIPTION
# Contexte

- Ajout d'un mode "Lecture seule" sur la modale d'édition de déclarations de l'IHM
  - titre différent
  - message en haut signalant que l'enregistrement de modifications est impossible
  - masquage du bouton d'enregistrement
- Accès de ce mode via le dropdown de la liste des déclarations, via "Afficher"
- Masquage des options "Modifier" et "Annuler" pour les profils lecteur

# Points de vigilance pour les intégrateurs

- Ajout d'une array `userPermissions` sur le type `RegistryCompany`. Cette array contient les permissions de l'utilisateur authentifié sur l'entreprise en question. Celà permet d'en déduire facilement quelles sont les permissions de l'utilisateur sur la déclaration portant cette RegistryCompany.

# Démo


https://github.com/user-attachments/assets/4aade6f1-bef7-4eb2-aee6-7f954af4fd0e



# Ticket Favro

[Si l'utilisateur est Lecteur pour l'établissement sélectionné, afficher uniquement Consulter comme action, et retirer le bouton Modifier la déclaration dans l'affichage de la déclaration](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16482)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB