### PR TITLE
[Hotfix] Les BSDA legacy avec isSubjectToADR = null devraient pouvoir poursuivre leur workflow

### DIFF
--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -37,6 +37,7 @@ import {
 import { isForeignVat } from "@td/constants";
 import { cleanPackagings } from "../../../Apps/Forms/Components/PackagingList/helpers";
 import GenericStepList from "../../common/stepper/GenericStepList";
+import { isDefinedStrict } from "../../../common/helper";
 
 interface Props {
   children: (bsda: Bsda | undefined) => ReactElement;
@@ -197,6 +198,17 @@ export default function BsdaStepsList(props: Props) {
       transporters: transporterIds,
       packagings: cleanPackagings(packagings ?? [])
     };
+
+    // Careful. Legacy BSDAs have a `waste.isSubjectToADR` field
+    // set to null, but the toggle is automatically set to true.
+    const initialBsda = bsdaQuery.data?.bsda;
+    if (
+      initialBsda?.waste?.isSubjectToADR === null &&
+      bsdaInput.waste?.isSubjectToADR === true &&
+      !isDefinedStrict(bsdaInput.waste?.adr)
+    ) {
+      bsdaInput.waste.isSubjectToADR = null;
+    }
 
     saveBsda(bsdaInput)
       .then(_ => {


### PR DESCRIPTION
# Contexte

Petit fix pour les BSDA legacy qui avaient isSubjectToADR = null (le toggle met automatiquement la valeur à true, même s'il n'est plus possible de modifier la valeur).

# Ticket Favro

[ÉTAPE 2 - Permettre au créateur du BSDA de déclarer que son déchet est Soumis à l'ADR Oui / Non, et rendre la mention ADR obligatoire si Oui ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/b6b1f768da50a90c584e548a?card=tra-15999)
