### PR TITLE
[TRA-165XX] Résolution de problèmes divers et améliorations de l'IHM

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Résolution d'un bug d'affichage des codes déchets secondaires (SSD) dans la modification de déclarations RNDTS qui pouvait faire crasher l'application [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
+- Assouplissement des règles de validation SSD: Le mode de traitement devient facultatif (car inutile) dans le cas d'un code R12 ou R13 [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
 
 # [2025.06.1] 03/06/2025
 
@@ -43,9 +44,6 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :boom: Breaking Change
 
 - BSDD: le champ `wasteDetailsIsSubjectToADR` est maintenant obligatoire via API [PR 4183](https://github.com/MTES-MCT/trackdechets/pull/4183)
-
-#### :boom: Breaking Change
-
 - Suppression de la query formsRegister (dépréciée depuis plusieurs années) [PR 4214](https://github.com/MTES-MCT/trackdechets/pull/4214)
 
 # [2025.05.1] 03/05/2025

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 
 - Résolution d'un bug d'affichage des codes déchets secondaires (SSD) dans la modification de déclarations RNDTS qui pouvait faire crasher l'application [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
 - Assouplissement des règles de validation SSD: Le mode de traitement devient facultatif (car inutile) dans le cas d'un code R12 ou R13 [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
+- Assouplissement de la règle de validation numéro GISTRID/numéro de notification sur les déclarations [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
 
 # [2025.06.1] 03/06/2025
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,11 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Ajout d'un icône éco-organisme sur le composant de groupement de dasris [PR 4235](https://github.com/MTES-MCT/trackdechets/pull/4235/)
+- Diverses améliorations d'affichage sur la modification des déclarations RNDTS [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
+
+#### :bug: Corrections de bugs
+
+- Résolution d'un bug d'affichage des codes déchets secondaires (SSD) dans la modification de déclarations RNDTS qui pouvait faire crasher l'application [PR 4240](https://github.com/MTES-MCT/trackdechets/pull/4240)
 
 # [2025.06.1] 03/06/2025
 

--- a/back/src/queue/jobs/__tests__/processRegistryImport.integration.ts
+++ b/back/src/queue/jobs/__tests__/processRegistryImport.integration.ts
@@ -46,6 +46,7 @@ const getCorrectLine = (siret: string, reportAsSiret?: string) => {
     destinationCompanyPostalCode: "75001",
     destinationCompanyCountryCode: "FR",
     operationCode: "R 5",
+    operationMode: "RECYCLAGE",
     qualificationCode: "Recyclage",
     administrativeActReference: "Arrêté du 24 août 2016"
   };

--- a/back/src/registryV2/typeDefs/registryV2.inputs.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.inputs.graphql
@@ -947,8 +947,8 @@ input IncomingWasteLineInput {
   Il est attendu un numéro de notification ou de déclaration si l'expéditeur du déchet est une entreprise UE ou hors UE puisqu'il s'aagit d'un import.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   ttdImportNumber: String
@@ -2188,8 +2188,8 @@ input IncomingTexsLineInput {
   Il est attendu un numéro de notification ou de déclaration si l'expéditeur du déchet est une entreprise UE ou hors UE puisqu'il s'aagit d'un import.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   ttdImportNumber: String
@@ -3483,8 +3483,8 @@ input OutgoingTexsLineInput {
   Le numéro de notification (GISTRID) prévue à l'annexe I-B du règlement (CE) 1013/2006 ou le numéro de déclaration Annexe 7 prévu à l'annexe 1-B du règlement N°1013/2006.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   gistridNumber: String
@@ -4541,8 +4541,8 @@ input OutgoingWasteLineInput {
   Obligatoire si réponse le Type de destinataire est ENTREPRISE_UE ou ENTREPRISE_HORS_UE.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   gistridNumber: String
@@ -5885,8 +5885,8 @@ input TransportedLineInput {
   À utiliser lors d'un transport TTD.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   gistridNumber: String
@@ -6686,8 +6686,8 @@ input ManagedLineInput {
   Obligatoire si le Type de destinataire est ENTREPRISE_UE ou ENTREPRISE_HORS_UE.
 
   Valeurs :
-  - Format n° de notification : PP AAAA DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
-  - Format n° de déclaration : A7E AAAA DDDRRR (A7E: Annexe 7 Export, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de notification : PP(P) (AAAA) DDDRRR (PP: code pays, AAAA: année, DDD: département, RRR: numéro d'ordre)
+  - Format n° de déclaration : A7E|A7I (AAAA) DDDRRR (A7E: Annexe 7 Export/Import, AAAA: année, DDD: département, RRR: numéro d'ordre)
   - De 12 à 15 caractères
   """
   gistridNumber: String

--- a/back/src/registryV2/typeDefs/registryV2.inputs.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.inputs.graphql
@@ -295,7 +295,7 @@ input SsdLineInput {
   - VALORISATION_ENERGETIQUE
   - AUTRES_VALORISATIONS
   """
-  operationMode: OperationMode!
+  operationMode: OperationMode
 
   """
   **Référence de l'acte administratif**

--- a/back/src/registryV2/typeDefs/registryV2.objects.imports.graphql
+++ b/back/src/registryV2/typeDefs/registryV2.objects.imports.graphql
@@ -88,7 +88,7 @@ type SsdLine {
   """
   Mode de traitement
   """
-  operationMode: OperationMode!
+  operationMode: OperationMode
 
   """
   Référence de l'acte administratif

--- a/front/src/Apps/common/Components/Combobox/Combobox.tsx
+++ b/front/src/Apps/common/Components/Combobox/Combobox.tsx
@@ -119,7 +119,7 @@ export function ComboBox({
     const spaceBelow = viewportHeight - triggerOrParentRect.bottom;
     const spaceAbove = triggerOrParentRect.top;
     // Consider a minimum height for the dropdown before flipping
-    const minDropdownHeightThreshold = 50;
+    const minDropdownHeightThreshold = 300;
 
     let positionAbove = false;
     // Decide to position above if space below is insufficient (< threshold + margin)

--- a/front/src/form/registry/common/CompanySelector.tsx
+++ b/front/src/form/registry/common/CompanySelector.tsx
@@ -37,10 +37,7 @@ export function CompanySelector({
   methods,
   disabled
 }: Props) {
-  const companyType = methods.watch(
-    `${prefix}CompanyType`,
-    required ? "ETABLISSEMENT_FR" : ""
-  );
+  const companyType = methods.watch(`${prefix}CompanyType`, "");
   const companyStatusDiffusion: StatutDiffusionEtablissement | undefined =
     methods.watch(`${prefix}CompanyStatusDiffusion`);
 
@@ -83,7 +80,7 @@ export function CompanySelector({
       <div className="fr-grid-row fr-grid-row--gutters">
         <div className="fr-col-8 fr-mb-2w">
           <Select
-            label={capitalize(label)}
+            label={`${capitalize(label)}${required ? "" : " (optionnel)"}`}
             nativeSelectProps={{
               ...typeSelectMethods,
               onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/front/src/form/registry/common/EcoOrganismes.tsx
+++ b/front/src/form/registry/common/EcoOrganismes.tsx
@@ -50,8 +50,7 @@ export function EcoOrganismes({ methods, disabled, reducedMargin }: Props) {
         disabled={disabled}
         shortMode={true}
         reducedMargin={reducedMargin}
-        title="Éco-organisme (optionnel)"
-        toggleLabel="Présence d'un éco-organisme"
+        label="éco-organisme"
       />
 
       {selectedSiret && !isKnownEcoOrganisme && (

--- a/front/src/form/registry/common/FrenchCompanySelector.tsx
+++ b/front/src/form/registry/common/FrenchCompanySelector.tsx
@@ -122,13 +122,6 @@ export function InlineFrenchCompanySelector({
               small
             />
           )}
-          {errors?.[`${prefix}CompanyAddress`] && (
-            <Alert
-              description={formatError(errors[`${prefix}CompanyAddress`])}
-              severity="error"
-              small
-            />
-          )}
           {unknownCompanyError && (
             <Alert
               title="L'établissement mentionné n'existe pas dans la base SIRENE"

--- a/front/src/form/registry/common/Operation.tsx
+++ b/front/src/form/registry/common/Operation.tsx
@@ -13,6 +13,7 @@ type InlineProps = {
   disabled?: boolean;
   showNoTraceability?: boolean;
   showNextOperationCode?: boolean;
+  isPlannedOperation?: boolean;
 };
 
 type Props = InlineProps & {
@@ -37,7 +38,8 @@ export function Operation({
   operationCodes,
   operationModes,
   showNoTraceability,
-  showNextOperationCode
+  showNextOperationCode,
+  isPlannedOperation
 }: Props) {
   return (
     <div className="fr-col">
@@ -49,6 +51,7 @@ export function Operation({
         operationModes={operationModes}
         showNoTraceability={showNoTraceability}
         showNextOperationCode={showNextOperationCode}
+        isPlannedOperation={isPlannedOperation}
       />
     </div>
   );
@@ -60,7 +63,8 @@ export function InlineOperation({
   operationCodes,
   operationModes,
   showNoTraceability,
-  showNextOperationCode
+  showNextOperationCode,
+  isPlannedOperation
 }: InlineProps) {
   const { errors } = methods.formState;
   const selectedOperationCode = methods.watch("operationCode");
@@ -123,7 +127,11 @@ export function InlineOperation({
         <div className={"fr-grid-row fr-grid-row--gutters"}>
           <div className={"fr-col-4"} key={"operationCode"}>
             <Select
-              label={"Code de traitement réalisé"}
+              label={
+                isPlannedOperation
+                  ? "Code de traitement prévu"
+                  : "Code de traitement réalisé"
+              }
               nativeSelectProps={{
                 ...methods.register("operationCode"),
                 defaultValue: ""
@@ -144,7 +152,11 @@ export function InlineOperation({
           </div>
           <div className={"fr-col-4"}>
             <Select
-              label={`Mode de traitement`}
+              label={
+                isPlannedOperation
+                  ? "Mode de traitement prévu (optionnel)"
+                  : "Mode de traitement réalisé"
+              }
               nativeSelectProps={{
                 ...methods.register("operationMode"),
                 defaultValue: ""

--- a/front/src/form/registry/common/OptionalCompanySelector.tsx
+++ b/front/src/form/registry/common/OptionalCompanySelector.tsx
@@ -10,10 +10,11 @@ import {
 import Input from "@codegouvfr/react-dsfr/Input";
 import { formatError } from "../builder/error";
 import { InlineAddress } from "./Address";
+import { capitalize } from "../../../common/helper";
 
-type BlockProps = InlineFrenchCompanySelectorProps & {
+type BlockProps = Omit<InlineFrenchCompanySelectorProps, "title"> & {
   reducedMargin?: boolean;
-  toggleLabel?: string;
+  label: string;
   recepisseName?: string;
 };
 
@@ -23,15 +24,14 @@ export function OptionalCompanySelector({
   disabled,
   shortMode,
   reducedMargin,
-  title,
-  toggleLabel,
+  label,
   recepisseName,
   onCompanySelected
 }: BlockProps) {
   const fieldName = shortMode ? `${prefix}Siret` : `${prefix}CompanyOrgId`;
   const selectedCompanyOrgId = methods.getValues(fieldName);
   const [isCompanyEnabled, setIsCompanyEnabled] = useState(
-    toggleLabel ? (selectedCompanyOrgId ? true : false) : true
+    selectedCompanyOrgId ? true : false
   );
   const companyStatusDiffusion: StatutDiffusionEtablissement | undefined =
     methods.watch(`${prefix}CompanyStatusDiffusion`);
@@ -59,23 +59,21 @@ export function OptionalCompanySelector({
         "company-selector-reduced-margin": reducedMargin
       })}
     >
-      {title && <h5 className="fr-h5">{title}</h5>}
-      {toggleLabel && (
-        <div>
-          <div className={"fr-grid-row fr-grid-row--gutters"}>
-            <div className={"fr-col-12"}>
-              <ToggleSwitch
-                label={toggleLabel}
-                inputTitle={toggleLabel}
-                showCheckedHint={false}
-                checked={isCompanyEnabled}
-                onChange={checked => setIsCompanyEnabled(checked)}
-                disabled={disabled}
-              />
-            </div>
+      {label && <h5 className="fr-h5">{capitalize(label)} (optionnel)</h5>}
+      <div>
+        <div className={"fr-grid-row fr-grid-row--gutters"}>
+          <div className={"fr-col-12"}>
+            <ToggleSwitch
+              label={`Présence d'un ${label}`}
+              inputTitle={`Présence d'un ${label}`}
+              showCheckedHint={false}
+              checked={isCompanyEnabled}
+              onChange={checked => setIsCompanyEnabled(checked)}
+              disabled={disabled}
+            />
           </div>
         </div>
-      )}
+      </div>
       {isCompanyEnabled && (
         <InlineFrenchCompanySelector
           prefix={prefix}

--- a/front/src/form/registry/common/TransporterTags.tsx
+++ b/front/src/form/registry/common/TransporterTags.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { type UseFormReturn } from "react-hook-form";
+import { FieldError, type UseFormReturn } from "react-hook-form";
 import { formatError } from "../builder/error";
 import TagsInput from "../../../Apps/Forms/Components/TagsInput/TagsInput";
 
@@ -22,9 +22,17 @@ export function TransporterTags({
 }: Props) {
   const { errors } = methods.formState;
   const fieldName = `${prefix}Plates`;
-  const error = errors?.[fieldName];
+  const errorArray = errors?.[fieldName];
+  const errorsUnique = errorArray
+    ? [
+        ...new Set(
+          (errorArray as unknown as FieldError[])
+            ?.map(error => error.message)
+            .filter(Boolean)
+        )
+      ]
+    : [];
   const tags = methods.watch(fieldName);
-
   return (
     <div className="fr-col">
       <div className="fr-mb-2w">
@@ -39,7 +47,7 @@ export function TransporterTags({
                 tags.splice(idx, 1);
                 methods.setValue(fieldName, [...tags]);
               }}
-              errorMessage={formatError(error)}
+              errorMessage={errorsUnique.join(", ")}
               hintText={infoText}
               disabled={disabled}
             />

--- a/front/src/form/registry/common/TransporterTags.tsx
+++ b/front/src/form/registry/common/TransporterTags.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { FieldError, type UseFormReturn } from "react-hook-form";
-import { formatError } from "../builder/error";
 import TagsInput from "../../../Apps/Forms/Components/TagsInput/TagsInput";
 
 type Props = {

--- a/front/src/form/registry/common/WasteCodeSelector.tsx
+++ b/front/src/form/registry/common/WasteCodeSelector.tsx
@@ -37,7 +37,8 @@ export function WasteCodeSelector({
   if (!name) {
     console.error('WasteCodeSelector: "name" prop is required');
   }
-
+  const splitName = useMemo(() => name.split("."), [name]);
+  const isArrayField = splitName.length > 1;
   const [search, setSearch] = useState("");
   const [showSearch, setShowSearch] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -130,12 +131,26 @@ export function WasteCodeSelector({
             ...methods.register(name)
           }}
           disabled={disabled}
-          state={errors?.[name] && "error"}
-          stateRelatedMessage={formatError(errors?.[name])}
+          state={
+            (isArrayField
+              ? errors?.[splitName[0]]?.[splitName[1]]?.value
+              : errors?.[name]) && "error"
+          }
+          stateRelatedMessage={formatError(
+            isArrayField
+              ? errors?.[splitName[0]]?.[splitName[1]]?.value
+              : errors?.[name]
+          )}
         />
       </div>
-      <div className="fr-col-2">
-        <div className={clsx({ "fr-mb-9v": !!errors?.[name] })}>
+      <div className="fr-col-2" style={{ paddingTop: "44px" }}>
+        <div
+          className={clsx({
+            "fr-mb-9v": !!(isArrayField
+              ? errors?.[splitName[0]]?.[splitName[1]]?.value
+              : errors?.[name])
+          })}
+        >
           <Button
             onClick={() => setShowSearch(!showSearch)}
             priority="secondary"
@@ -161,7 +176,10 @@ export function WasteCodeSelector({
         searchFields
       ) : (
         <div
-          className="fr-col-12 fr-grid-row fr-grid-row--gutters fr-grid-row--bottom"
+          className="fr-col-12 fr-grid-row fr-grid-row--gutters fr-grid-row--bottom tw-relative"
+          style={{
+            alignItems: "flex-start"
+          }}
           ref={comboboxRef}
         >
           {searchFields}

--- a/front/src/form/registry/incomingTexs/RegistryIncomingTexsForm.tsx
+++ b/front/src/form/registry/incomingTexs/RegistryIncomingTexsForm.tsx
@@ -124,6 +124,7 @@ export function RegistryIncomingTexsForm({ onClose }: Props) {
       }
     }
   );
+
   const isUpcycled = methods.watch("isUpcycled");
   useEffect(() => {
     if (isUpcycled) {
@@ -137,6 +138,7 @@ export function RegistryIncomingTexsForm({ onClose }: Props) {
       methods.setValue("destinationParcelCoordinates", []);
     }
   }, [isUpcycled, methods]);
+
   const isDirectSupply = methods.watch("isDirectSupply");
   useEffect(() => {
     if (isDirectSupply) {
@@ -148,6 +150,7 @@ export function RegistryIncomingTexsForm({ onClose }: Props) {
       methods.setValue("transporter", []);
     }
   }, [isDirectSupply, methods]);
+
   const wasteCode = methods.watch("wasteCode");
   useEffect(() => {
     if (wasteCode && wasteCode.includes("*")) {
@@ -159,6 +162,17 @@ export function RegistryIncomingTexsForm({ onClose }: Props) {
       );
     }
   }, [wasteCode, methods]);
+
+  const operationCode = methods.watch("operationCode");
+  useEffect(() => {
+    if (operationCode && operationCode.startsWith("D")) {
+      setDisabledFieldNames(prev => [...prev, "isUpcycled"]);
+    } else {
+      setDisabledFieldNames(prev =>
+        prev.filter(field => field !== "isUpcycled")
+      );
+    }
+  }, [operationCode, methods]);
 
   const [addToIncomingTexsRegistry, { loading }] = useMutation<
     Pick<Mutation, "addToIncomingTexsRegistry">

--- a/front/src/form/registry/incomingTexs/shape.ts
+++ b/front/src/form/registry/incomingTexs/shape.ts
@@ -150,7 +150,7 @@ export const incomingTexsFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "initialEmitter",
-          label: "producteur initial (optionnel)",
+          label: "producteur initial",
           required: false
         },
         validation: {
@@ -302,9 +302,8 @@ export const incomingTexsFormShape: FormShape = [
         props: {
           prefix: "brokerCompany",
           shortMode: true,
-          title: "Courtier (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un courtier",
+          label: "courtier",
           recepisseName: "brokerRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.brokerReceipt?.receiptNumber) {
@@ -332,9 +331,8 @@ export const incomingTexsFormShape: FormShape = [
         props: {
           prefix: "traderCompany",
           shortMode: true,
-          title: "Négociant (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un négociant",
+          label: "négociant",
           recepisseName: "traderRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.traderReceipt?.receiptNumber) {
@@ -423,7 +421,7 @@ export const incomingTexsFormShape: FormShape = [
         shape: "generic",
         type: "checkbox",
         label: Labels.isDirectSupply,
-        required: false,
+        required: true,
         validation: {
           isDirectSupply: booleanString
         }

--- a/front/src/form/registry/incomingTexs/shape.ts
+++ b/front/src/form/registry/incomingTexs/shape.ts
@@ -139,6 +139,16 @@ export const incomingTexsFormShape: FormShape = [
           volume: optionalNumber,
           weightIsEstimate: booleanString
         }
+      },
+      {
+        name: "wasteDap",
+        shape: "generic",
+        label: Labels.wasteDap,
+        validation: {
+          wasteDap: optionalString
+        },
+        type: "text",
+        style: { className: "fr-col-4" }
       }
     ]
   },

--- a/front/src/form/registry/incomingWaste/shape.ts
+++ b/front/src/form/registry/incomingWaste/shape.ts
@@ -158,8 +158,8 @@ export const incomingWasteFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "initialEmitter",
-          label: "producteur initial (optionnel)",
-          required: true
+          label: "producteur initial",
+          required: false
         },
         validation: {
           initialEmitterCompanyType: optionalString,
@@ -263,9 +263,8 @@ export const incomingWasteFormShape: FormShape = [
         props: {
           prefix: "brokerCompany",
           shortMode: true,
-          title: "Courtier (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un courtier",
+          label: "courtier",
           recepisseName: "brokerRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.brokerReceipt?.receiptNumber) {
@@ -293,9 +292,8 @@ export const incomingWasteFormShape: FormShape = [
         props: {
           prefix: "traderCompany",
           shortMode: true,
-          title: "Négociant (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un négociant",
+          label: "négociant",
           recepisseName: "traderRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.traderReceipt?.receiptNumber) {
@@ -378,7 +376,7 @@ export const incomingWasteFormShape: FormShape = [
         shape: "generic",
         type: "checkbox",
         label: Labels.isDirectSupply,
-        required: false,
+        required: true,
         validation: {
           isDirectSupply: booleanString
         }

--- a/front/src/form/registry/managed/RegistryManagedForm.tsx
+++ b/front/src/form/registry/managed/RegistryManagedForm.tsx
@@ -126,6 +126,7 @@ export function RegistryManagedForm({ onClose }: Props) {
       }
     }
   );
+
   const isUpcycled = methods.watch("isUpcycled");
   useEffect(() => {
     if (isUpcycled) {
@@ -139,6 +140,7 @@ export function RegistryManagedForm({ onClose }: Props) {
       methods.setValue("destinationParcelCoordinates", []);
     }
   }, [isUpcycled, methods]);
+
   const isDirectSupply = methods.watch("isDirectSupply");
   useEffect(() => {
     if (isDirectSupply) {
@@ -150,6 +152,7 @@ export function RegistryManagedForm({ onClose }: Props) {
       );
     }
   }, [isDirectSupply, methods]);
+
   const wasteCode = methods.watch("wasteCode");
   useEffect(() => {
     if (wasteCode && wasteCode.includes("*")) {
@@ -161,6 +164,17 @@ export function RegistryManagedForm({ onClose }: Props) {
       );
     }
   }, [wasteCode, methods]);
+
+  const operationCode = methods.watch("operationCode");
+  useEffect(() => {
+    if (operationCode && operationCode.startsWith("D")) {
+      setDisabledFieldNames(prev => [...prev, "isUpcycled"]);
+    } else {
+      setDisabledFieldNames(prev =>
+        prev.filter(field => field !== "isUpcycled")
+      );
+    }
+  }, [operationCode, methods]);
 
   const [addToManagedRegistry, { loading }] = useMutation<
     Pick<Mutation, "addToManagedRegistry">

--- a/front/src/form/registry/managed/shape.ts
+++ b/front/src/form/registry/managed/shape.ts
@@ -169,8 +169,8 @@ export const managedFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "initialEmitter",
-          label: "producteur initial (optionnel)",
-          required: true
+          label: "producteur initial",
+          required: false
         },
         validation: {
           initialEmitterCompanyType: optionalString,
@@ -286,8 +286,9 @@ export const managedFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "tempStorer",
-          label: "installation de Tri Transit Regroupement (optionnel)",
-          excludeTypes: ["COMMUNES", "PERSONNE_PHYSIQUE"]
+          label: "installation de Tri Transit Regroupement",
+          excludeTypes: ["COMMUNES", "PERSONNE_PHYSIQUE"],
+          required: false
         },
         validation: {
           tempStorerCompanyType: optionalString,
@@ -464,7 +465,7 @@ export const managedFormShape: FormShape = [
         shape: "generic",
         type: "checkbox",
         label: Labels.isDirectSupply,
-        required: false,
+        required: true,
         validation: {
           isDirectSupply: booleanString
         }

--- a/front/src/form/registry/outgoingTexs/RegistryOutgoingTexsForm.tsx
+++ b/front/src/form/registry/outgoingTexs/RegistryOutgoingTexsForm.tsx
@@ -125,6 +125,7 @@ export function RegistryOutgoingTexsForm({ onClose }: Props) {
       }
     }
   );
+
   const isUpcycled = methods.watch("isUpcycled");
   useEffect(() => {
     if (isUpcycled) {
@@ -138,6 +139,7 @@ export function RegistryOutgoingTexsForm({ onClose }: Props) {
       methods.setValue("destinationParcelCoordinates", []);
     }
   }, [isUpcycled, methods]);
+
   const isDirectSupply = methods.watch("isDirectSupply");
   useEffect(() => {
     if (isDirectSupply) {
@@ -149,6 +151,7 @@ export function RegistryOutgoingTexsForm({ onClose }: Props) {
       methods.setValue("transporter", []);
     }
   }, [isDirectSupply, methods]);
+
   const wasteCode = methods.watch("wasteCode");
   useEffect(() => {
     if (wasteCode && wasteCode.includes("*")) {
@@ -160,6 +163,17 @@ export function RegistryOutgoingTexsForm({ onClose }: Props) {
       );
     }
   }, [wasteCode, methods]);
+
+  const operationCode = methods.watch("operationCode");
+  useEffect(() => {
+    if (operationCode && operationCode.startsWith("D")) {
+      setDisabledFieldNames(prev => [...prev, "isUpcycled"]);
+    } else {
+      setDisabledFieldNames(prev =>
+        prev.filter(field => field !== "isUpcycled")
+      );
+    }
+  }, [operationCode, methods]);
 
   const [addToOutgoingTexsRegistry, { loading }] = useMutation<
     Pick<Mutation, "addToOutgoingTexsRegistry">

--- a/front/src/form/registry/outgoingTexs/shape.ts
+++ b/front/src/form/registry/outgoingTexs/shape.ts
@@ -314,7 +314,8 @@ export const outgoingTexsFormShape: FormShape = [
         props: {
           operationCodes: INCOMING_TEXS_PROCESSING_OPERATIONS_CODES,
           showNoTraceability: false,
-          showNextOperationCode: false
+          showNextOperationCode: false,
+          isPlannedOperation: true
         },
         names: ["operationCode", "operationMode"],
         validation: {

--- a/front/src/form/registry/outgoingTexs/shape.ts
+++ b/front/src/form/registry/outgoingTexs/shape.ts
@@ -138,6 +138,16 @@ export const outgoingTexsFormShape: FormShape = [
           volume: optionalNumber,
           weightIsEstimate: booleanString
         }
+      },
+      {
+        name: "wasteDap",
+        shape: "generic",
+        label: Labels.wasteDap,
+        validation: {
+          wasteDap: optionalString
+        },
+        type: "text",
+        style: { className: "fr-col-4" }
       }
     ]
   },

--- a/front/src/form/registry/outgoingTexs/shape.ts
+++ b/front/src/form/registry/outgoingTexs/shape.ts
@@ -149,8 +149,8 @@ export const outgoingTexsFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "initialEmitter",
-          label: "producteur initial (optionnel)",
-          required: true
+          label: "producteur initial",
+          required: false
         },
         validation: {
           initialEmitterCompanyType: optionalString,
@@ -250,9 +250,8 @@ export const outgoingTexsFormShape: FormShape = [
         props: {
           prefix: "brokerCompany",
           shortMode: true,
-          title: "Courtier (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un courtier",
+          label: "courtier",
           recepisseName: "brokerRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.brokerReceipt?.receiptNumber) {
@@ -280,9 +279,8 @@ export const outgoingTexsFormShape: FormShape = [
         props: {
           prefix: "traderCompany",
           shortMode: true,
-          title: "Négociant (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un négociant",
+          label: "négociant",
           recepisseName: "traderRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.traderReceipt?.receiptNumber) {
@@ -441,7 +439,7 @@ export const outgoingTexsFormShape: FormShape = [
         shape: "generic",
         type: "checkbox",
         label: Labels.isDirectSupply,
-        required: false,
+        required: true,
         validation: {
           isDirectSupply: booleanString
         }

--- a/front/src/form/registry/outgoingWaste/shape.ts
+++ b/front/src/form/registry/outgoingWaste/shape.ts
@@ -147,8 +147,8 @@ export const outgoingWasteFormShape: FormShape = [
         Component: CompanySelector,
         props: {
           prefix: "initialEmitter",
-          label: "producteur initial (optionnel)",
-          required: true
+          label: "producteur initial",
+          required: false
         },
         validation: {
           initialEmitterCompanyType: optionalString,
@@ -224,9 +224,8 @@ export const outgoingWasteFormShape: FormShape = [
         props: {
           prefix: "brokerCompany",
           shortMode: true,
-          title: "Courtier (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un courtier",
+          label: "courtier",
           recepisseName: "brokerRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.brokerReceipt?.receiptNumber) {
@@ -254,9 +253,8 @@ export const outgoingWasteFormShape: FormShape = [
         props: {
           prefix: "traderCompany",
           shortMode: true,
-          title: "Négociant (optionnel)",
           reducedMargin: true,
-          toggleLabel: "Présence d'un négociant",
+          label: "négociant",
           recepisseName: "traderRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.traderReceipt?.receiptNumber) {
@@ -387,7 +385,7 @@ export const outgoingWasteFormShape: FormShape = [
         shape: "generic",
         type: "checkbox",
         label: Labels.isDirectSupply,
-        required: false,
+        required: true,
         validation: {
           isDirectSupply: booleanString
         }

--- a/front/src/form/registry/outgoingWaste/shape.ts
+++ b/front/src/form/registry/outgoingWaste/shape.ts
@@ -288,7 +288,8 @@ export const outgoingWasteFormShape: FormShape = [
         props: {
           operationCodes: INCOMING_WASTE_PROCESSING_OPERATIONS_CODES,
           showNoTraceability: false,
-          showNextOperationCode: false
+          showNextOperationCode: false,
+          isPlannedOperation: true
         },
         names: ["operationCode", "operationMode"],
         validation: {

--- a/front/src/form/registry/queries.ts
+++ b/front/src/form/registry/queries.ts
@@ -306,6 +306,7 @@ export const GET_INCOMING_TEXS_REGISTRY_LOOKUP = gql`
         weightValue
         weightIsEstimate
         volume
+        wasteDap
         parcelInseeCodes
         parcelNumbers
         parcelCoordinates
@@ -438,6 +439,7 @@ export const GET_OUTGOING_TEXS_REGISTRY_LOOKUP = gql`
         weightValue
         weightIsEstimate
         volume
+        wasteDap
 
         initialEmitterCompanyType
         initialEmitterCompanyOrgId

--- a/front/src/form/registry/ssd/RegistrySsdForm.tsx
+++ b/front/src/form/registry/ssd/RegistrySsdForm.tsx
@@ -166,53 +166,53 @@ export function RegistrySsdForm({ onClose }: Props) {
   }, [useDate, reportForCompanySiret, methods]);
 
   async function onSubmit(data: SsdLineInput) {
-try {
-    const { secondaryWasteCodes, secondaryWasteDescriptions, ...rest } = data;
+    try {
+      const { secondaryWasteCodes, secondaryWasteDescriptions, ...rest } = data;
 
-    if (secondaryWasteCodes && secondaryWasteDescriptions) {
-      let hasError = false;
-      secondaryWasteCodes.forEach((code, index) => {
-        console.log(code, secondaryWasteDescriptions[index]);
-        if (index === 0) {
-          if (code && !secondaryWasteDescriptions[index]) {
-            methods.setError("secondaryWasteDescriptions.0.value", {
-              message: "La description est requise si le code est renseigné"
-            });
-            hasError = true;
+      if (secondaryWasteCodes && secondaryWasteDescriptions) {
+        let hasError = false;
+        secondaryWasteCodes.forEach((code, index) => {
+          console.log(code, secondaryWasteDescriptions[index]);
+          if (index === 0) {
+            if (code && !secondaryWasteDescriptions[index]) {
+              methods.setError("secondaryWasteDescriptions.0.value", {
+                message: "La description est requise si le code est renseigné"
+              });
+              hasError = true;
+            }
+          } else {
+            if (!code) {
+              methods.setError(`secondaryWasteCodes.${index}.value`, {
+                message:
+                  "Le code est requis, supprimez la ligne si elle n'est pas utile"
+              });
+              hasError = true;
+            }
+            if (code && !secondaryWasteDescriptions[index]) {
+              methods.setError(`secondaryWasteDescriptions.${index}.value`, {
+                message: "La description est requise si le code est renseigné"
+              });
+              hasError = true;
+            }
           }
-        } else {
-          if (!code) {
-            methods.setError(`secondaryWasteCodes.${index}.value`, {
-              message:
-                "Le code est requis, supprimez la ligne si elle n'est pas utile"
-            });
-            hasError = true;
-          }
-          if (code && !secondaryWasteDescriptions[index]) {
-            methods.setError(`secondaryWasteDescriptions.${index}.value`, {
-              message: "La description est requise si le code est renseigné"
-            });
-            hasError = true;
-          }
+        });
+        if (hasError) {
+          return;
+        }
+      }
+
+      const result = await addToSsdRegistry({
+        variables: {
+          lines: [
+            {
+              ...rest,
+              secondaryWasteCodes: secondaryWasteCodes?.filter(Boolean) ?? [],
+              secondaryWasteDescriptions:
+                secondaryWasteDescriptions?.filter(Boolean) ?? []
+            }
+          ]
         }
       });
-      if (hasError) {
-        return;
-      }
-    }
-
-    const result = await addToSsdRegistry({
-      variables: {
-        lines: [
-          {
-            ...rest,
-            secondaryWasteCodes: secondaryWasteCodes?.filter(Boolean) ?? [],
-            secondaryWasteDescriptions:
-              secondaryWasteDescriptions?.filter(Boolean) ?? []
-          }
-        ]
-      }
-    });
 
       const shouldCloseModal = handleMutationResponse(
         result.data?.addToSsdRegistry,

--- a/front/src/form/registry/ssd/RegistrySsdForm.tsx
+++ b/front/src/form/registry/ssd/RegistrySsdForm.tsx
@@ -172,7 +172,6 @@ export function RegistrySsdForm({ onClose }: Props) {
       if (secondaryWasteCodes && secondaryWasteDescriptions) {
         let hasError = false;
         secondaryWasteCodes.forEach((code, index) => {
-          console.log(code, secondaryWasteDescriptions[index]);
           if (index === 0) {
             if (code && !secondaryWasteDescriptions[index]) {
               methods.setError("secondaryWasteDescriptions.0.value", {

--- a/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
+++ b/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
@@ -48,7 +48,6 @@ export function SecondaryWasteCodes({ methods }: Props) {
   }, [codeFields, addLine]);
 
   const { errors } = methods.formState;
-  console.log("errors", errors);
   return (
     <div className="fr-col">
       {codeFields.map(({ id }, index) => (

--- a/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
+++ b/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
@@ -32,8 +32,8 @@ export function SecondaryWasteCodes({ methods }: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const addLine = useCallback(() => {
-    appendCode("");
-    appendDescription("");
+    appendCode({ value: "" });
+    appendDescription({ value: "" });
   }, [appendCode, appendDescription]);
 
   function removeLine(index: number) {
@@ -48,38 +48,41 @@ export function SecondaryWasteCodes({ methods }: Props) {
   }, [codeFields, addLine]);
 
   const { errors } = methods.formState;
-
+  console.log("errors", errors);
   return (
     <div className="fr-col">
-      {codeFields.map((code, index) => (
+      {codeFields.map(({ id }, index) => (
         <div
           className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom tw-relative"
+          style={{
+            alignItems: "flex-start"
+          }}
           ref={containerRef}
           key={index}
         >
           <WasteCodeSelector
             methods={methods}
-            key={code.id}
-            name={`secondaryWasteCodes.${index}`}
+            key={id}
+            name={`secondaryWasteCodes.${index}.value`}
             label="Code déchet secondaire (optionnel)"
             containerRef={containerRef}
           />
           <div className="fr-col-4">
             <Input
-              label="Dénomination"
+              label="Dénomination secondaire"
               key={descriptionFields[index].id}
               nativeInputProps={{
                 type: "text",
-                ...methods.register(`secondaryWasteDescriptions.${index}`)
+                ...methods.register(`secondaryWasteDescriptions.${index}.value`)
               }}
-              state={errors?.secondaryWasteDescriptions && "error"}
+              state={errors?.secondaryWasteDescriptions?.[index] && "error"}
               stateRelatedMessage={formatError(
-                errors?.secondaryWasteDescriptions
+                errors?.secondaryWasteDescriptions?.[index]?.value
               )}
             />
           </div>
 
-          <div className="fr-col-2">
+          <div className="fr-col-2" style={{ paddingTop: "36px" }}>
             <Button
               className="fr-mr-1w"
               nativeButtonProps={{ type: "button" }}

--- a/front/src/form/registry/ssd/shape.ts
+++ b/front/src/form/registry/ssd/shape.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   ADMINISTRATIVE_ACT_REFERENCES,
   ADMINISTRATIVE_ACT_EXPLANATIONS,
@@ -13,7 +14,6 @@ import { SecondaryWasteCodes } from "./SecondaryWasteCodes";
 import {
   nonEmptyString,
   optionalString,
-  filteredArray,
   nonEmptyNumber,
   optionalNumber,
   booleanString
@@ -93,8 +93,12 @@ export const ssdFormShape: FormShape = [
         shape: "custom",
         names: ["secondaryWasteCodes", "secondaryWasteDescriptions"],
         validation: {
-          secondaryWasteCodes: filteredArray,
-          secondaryWasteDescriptions: filteredArray
+          secondaryWasteCodes: z
+            .array(z.object({ value: optionalString }))
+            .transform(arr => arr.map(({ value }) => value)),
+          secondaryWasteDescriptions: z
+            .array(z.object({ value: optionalString }))
+            .transform(arr => arr.map(({ value }) => value))
         }
       }
     ]

--- a/front/src/form/registry/ssd/shape.ts
+++ b/front/src/form/registry/ssd/shape.ts
@@ -194,7 +194,7 @@ export const ssdFormShape: FormShape = [
         names: ["operationCode", "operationMode"],
         validation: {
           operationCode: nonEmptyString,
-          operationMode: nonEmptyString
+          operationMode: optionalString
         },
         shape: "custom"
       },

--- a/front/src/form/registry/ssd/shape.ts
+++ b/front/src/form/registry/ssd/shape.ts
@@ -227,7 +227,8 @@ export const ssdFormShape: FormShape = [
         props: {
           prefix: "destination",
           label: "destination",
-          excludeTypes: ["PERSONNE_PHYSIQUE", "COMMUNES"]
+          excludeTypes: ["PERSONNE_PHYSIQUE", "COMMUNES"],
+          required: true
         },
         validation: {
           destinationCompanyType: optionalString,

--- a/front/src/form/registry/transported/shape.ts
+++ b/front/src/form/registry/transported/shape.ts
@@ -274,9 +274,8 @@ export const transportedFormShape: FormShape = [
         props: {
           prefix: "brokerCompany",
           shortMode: true,
-          title: "Courtier (optionnel)",
+          label: "courtier",
           reducedMargin: true,
-          toggleLabel: "Présence d'un courtier",
           recepisseName: "brokerRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.brokerReceipt?.receiptNumber) {
@@ -304,9 +303,8 @@ export const transportedFormShape: FormShape = [
         props: {
           prefix: "traderCompany",
           shortMode: true,
-          title: "Négociant (optionnel)",
+          label: "négociant",
           reducedMargin: true,
-          toggleLabel: "Présence d'un négociant",
           recepisseName: "traderRecepisseNumber",
           onCompanySelected: (company, setValue) => {
             if (company.traderReceipt?.receiptNumber) {

--- a/libs/back/registry/src/shared/__tests__/schemas.test.ts
+++ b/libs/back/registry/src/shared/__tests__/schemas.test.ts
@@ -218,16 +218,32 @@ describe("Schemas", () => {
   });
 
   test("ttdNumberSchema", () => {
-    expect(() => ttdNumberSchema.parse("AA1234567890")).not.toThrow();
-    expect(() => ttdNumberSchema.parse("FR 2023 077002")).not.toThrow();
-    expect(() => ttdNumberSchema.parse("AA 1234 567890")).not.toThrow();
-    expect(() => ttdNumberSchema.parse("AAA 1234567890")).toThrow();
-    expect(() => ttdNumberSchema.parse("AA 12345 678901")).toThrow();
+    expect(() => ttdNumberSchema.parse("A7E123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("A7I 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("A7I12123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("A7E 12 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("A7E 1234123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("A7E 1234 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR12123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR 12 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR 1234123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FR 1234 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ12123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ 12 123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ 1234123456")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ 1234 123456")).not.toThrow();
 
-    expect(() => ttdNumberSchema.parse("A7E 2024 063125")).not.toThrow();
-    expect(() => ttdNumberSchema.parse("A7E2024063125")).not.toThrow();
+    expect(() => ttdNumberSchema.parse("F123456")).toThrow();
+    expect(() => ttdNumberSchema.parse("FRZA123456")).toThrow();
+    expect(() => ttdNumberSchema.parse("12345678")).toThrow();
+    expect(() => ttdNumberSchema.parse("FR 1234 1234")).toThrow();
+    expect(() => ttdNumberSchema.parse("FRZ 12 1234567")).toThrow();
+    expect(() => ttdNumberSchema.parse("AAAA 1234567890")).toThrow();
     expect(() => ttdNumberSchema.parse("A7E 2024 0631256")).toThrow();
-    expect(() => ttdNumberSchema.parse("A7E 2024 06312")).toThrow();
   });
 
   test("parcelNumbersSchema", () => {

--- a/libs/back/registry/src/shared/__tests__/schemas.test.ts
+++ b/libs/back/registry/src/shared/__tests__/schemas.test.ts
@@ -237,10 +237,11 @@ describe("Schemas", () => {
     expect(() => ttdNumberSchema.parse("FRZ 1234123456")).not.toThrow();
     expect(() => ttdNumberSchema.parse("FRZ 1234 123456")).not.toThrow();
 
+    expect(() => ttdNumberSchema.parse("ABCDEF")).toThrow();
     expect(() => ttdNumberSchema.parse("F123456")).toThrow();
+    expect(() => ttdNumberSchema.parse("FR123")).toThrow();
     expect(() => ttdNumberSchema.parse("FRZA123456")).toThrow();
     expect(() => ttdNumberSchema.parse("12345678")).toThrow();
-    expect(() => ttdNumberSchema.parse("FR 1234 1234")).toThrow();
     expect(() => ttdNumberSchema.parse("FRZ 12 1234567")).toThrow();
     expect(() => ttdNumberSchema.parse("AAAA 1234567890")).toThrow();
     expect(() => ttdNumberSchema.parse("A7E 2024 0631256")).toThrow();

--- a/libs/back/registry/src/shared/__tests__/schemas.test.ts
+++ b/libs/back/registry/src/shared/__tests__/schemas.test.ts
@@ -242,7 +242,6 @@ describe("Schemas", () => {
     expect(() => ttdNumberSchema.parse("FR123")).toThrow();
     expect(() => ttdNumberSchema.parse("FRZA123456")).toThrow();
     expect(() => ttdNumberSchema.parse("12345678")).toThrow();
-    expect(() => ttdNumberSchema.parse("FRZ 12 1234567")).toThrow();
     expect(() => ttdNumberSchema.parse("AAAA 1234567890")).toThrow();
     expect(() => ttdNumberSchema.parse("A7E 2024 0631256")).toThrow();
   });

--- a/libs/back/registry/src/shared/schemas.ts
+++ b/libs/back/registry/src/shared/schemas.ts
@@ -477,8 +477,8 @@ const transportPlatesArraySchema = z.array(
   z
     .string()
     .trim()
-    .min(4, "Une plaque d'immatriculation doit faire au moins 4 cacatères")
-    .max(12, "Une plaque d'immatriculation ne peut pas dépasser 12 cacatères")
+    .min(4, "Une plaque d'immatriculation doit faire au moins 4 caractères")
+    .max(12, "Une plaque d'immatriculation ne peut pas dépasser 12 caractères")
 );
 
 export const transportPlatesSchema = z.union([

--- a/libs/back/registry/src/shared/schemas.ts
+++ b/libs/back/registry/src/shared/schemas.ts
@@ -329,11 +329,16 @@ export const municipalitiesNamesSchema = z.union([
   municipalitiesNamesArraySchema
 ]);
 
+/*
+  les contraintes de format sont les suivantes:
+  [2 à 3 lettres][espace (facultatif)][1 à 4 chiffres (facultatif)][espace (facultatif)][6 chiffres]
+*/
+
 export const ttdNumberSchema = z
   .string()
   .transform(v => v.replace(/\s+/g, ""))
   .refine(
-    v => /^[A-Z]{2}[0-9]{10}$/.test(v) || /^A7[EI][0-9]{10}$/.test(v),
+    v => /^(?:[A-Z]{2,3}|A7[EI])[0-9]{0,4}[0-9]{6}$/.test(v),
     "Le numéro de notification ou de déclaration de transfert transfrontalier de déchet ne respecte pas le format attendu"
   )
   .nullish();

--- a/libs/back/registry/src/ssd/validation/index.ts
+++ b/libs/back/registry/src/ssd/validation/index.ts
@@ -1,3 +1,4 @@
+import { refineRequiredOperationMode } from "../../shared/refinement";
 import { transformReportForInfos } from "../../shared/transform";
 import { registryErrorMap } from "../../zodErrors";
 import {
@@ -15,6 +16,7 @@ export function safeParseAsyncSsd(line: unknown) {
     .superRefine(refineDates)
     .superRefine(refineDestination)
     .superRefine(refineSecondaryWasteCodes)
+    .superRefine(refineRequiredOperationMode)
     .transform(transformAndRefineReason)
     .transform(transformReportForInfos)
     .transform(transformDestination)


### PR DESCRIPTION
# Contexte

## Company Selector

Par défaut, le sélecteur du company selector n'affiche plus "établissement français" mais l'option vide. De plus, pour être cohérent avec les autres composants, le wording "(optionnel)" n'est pas passé en dur mais dépend du paramètre `required`

[Ne pas afficher par défaut le Company selector tant que le type d'acteur Établissement français n'a pas été sélectionné ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16561)

<img width="858" alt="Capture d’écran 2025-06-06 à 21 14 57" src="https://github.com/user-attachments/assets/b2a362f1-a8bd-404a-a4d0-bd21b61539a5" />

### Erreur sur Company Selector vide

Suppression de l'erreur d'adresse sur le company selector, que j'avais mis lorsque l'on avait des adresses manquantes sur les adresses de test, afin de ne pas avoir un bloquage sans raison évidente. Ne devrait plus être nécessaire maintenant

[Seul le message d'erreur "Le SIRET doit être saisi pour un établissement français" doit s'afficher quand je valide une modification, que l'acteur est obligatoire et que j'ai sélectionné Type d'acteur français](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16626)

<img width="1139" alt="Capture d’écran 2025-06-06 à 21 30 51" src="https://github.com/user-attachments/assets/fd58a95f-d6c9-46af-9c1f-58653d772296" />

## Approvisionnement direct

Passage de `required` à true sur isDirectSupply

[Retirer la mention (optionnel) à la suite d'Approvisionnement direct sur l'ensemble des registres (hors transporteur et SSD)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16568)

<img width="649" alt="Capture d’écran 2025-06-06 à 21 15 37" src="https://github.com/user-attachments/assets/bd305245-5c2d-4741-8492-93630d51550a" />

## Code réalisé/prévu

Différenciation du wording "réalisé"/"prévu" sur les codes/modes d'opération

[Remplacer "réalisé" par "prévu" et ajouter la mention "optionnelle" au mode de traitement pour les registres sortants (déchets et TEXS)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16567)

<img width="753" alt="Capture d’écran 2025-06-06 à 21 16 58" src="https://github.com/user-attachments/assets/db4c14fb-c251-4dc6-b10c-e070e18eea47" />

## Champ Terres valorisées

Désactivation du champ "isUpcycled" (terre valorisée) si le code d'opération commence par un D

[Griser le champs Terres valorisées si un code de traitement commence par un D sur les registres TEXS entrants, sortants et de gestion](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16563)

<img width="742" alt="Capture d’écran 2025-06-06 à 21 17 56" src="https://github.com/user-attachments/assets/b4452a49-19af-4198-81cc-6cbe6fb356b2" />

## Codes/Descriptions de déchets secondaires

Résolution de problèmes d'affichage de la liste des codes secondaires (SSD) :

- bug qui faisait crash l'app lors de l'ajout/suppression de lignes de codes secondaires (problème de gestion de la fieldArray) -> résolu en utilisant des objet `{ value: "xxx"}` à la place de strings directement qui ne sont pas bien supportés par fieldArray. 
- erreurs qui ne remontaient pas correctement (à cause des chemins nested liés à la fieldArray)
- mauvais alignement des champs à l'affichage d'erreurs
- Combobox de sélection des codes déchets qui apparaissait en tout petit en base de l'écran -> s'affiche au dessus du champs si pas assez d'espace en dessous

[Remonter l'erreur sur l'absence d'un code déchet secondaire si une dénomination secondaire a été renseignée (SSD)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16506)

https://github.com/user-attachments/assets/3d474ef4-3126-4443-996c-f079b8420574

## Champ plaques d'immatriculation

Résolution de problème d'affichage d'erreurs sur le champs de plaques transporteur -> transformation du'une array d'erreur en message unique séparé par des virgules

[Sur le registre transporté, afficher le détail de l'erreur lorsque le format de plaque d'immatriculation ne respecte pas les conditions](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16595)

https://github.com/user-attachments/assets/47343d29-6c9d-4a2b-88c0-f6d151da257a

## Date de fin de traitement SSD

Correction de l'affichage de `processingEndDate` sur SSD, la date n'était pas correctement parsée en front pour être utilisable par l'Input

[Enregistrer la date de fin de traitement sur le registre SSD](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16602)

<img width="765" alt="Capture d’écran 2025-06-06 à 21 22 29" src="https://github.com/user-attachments/assets/acce6c60-ca0a-4712-8914-2d0aeb752990" />

## SSD: Mode de traitement optionnel pour code R12/R13

Dans le cas de code de traitement non final (R12 ou R13), le sélecteur de mode était grisé dans l'IHM, car le mode de traitement est inutile. Cependant le mode de traitement était encore obligatoire sur la validation backend, ce qui rendait la création de déclaration R12/R13 impossible. J'ai donc enlevé le caractère obligatoire au niveau du type GraphQL (OperationMode! -> OperationMode) et ajouté le même refinement que pour les autres déclarations (`refineRequiredOperationMode`) afin de rendre le mode obligatoire sur les autres codes.

[Sur le registre SSD, ne pas rendre obligatoire la sélection d'un mode de traitement lorsque R12 ou R13 a été sélectionné](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16601)

https://github.com/user-attachments/assets/29340eac-61c9-443c-ba40-eab2513ae9d2

## Assouplissement de la validation numéro GISTRID/numéro de notification

La règle de validation de ces numéros était un peu trop stricte et ne prenait pas en compte les cas d'usage réel. En effet, le format attendu était PP NNNNNNNNNN (2 lettres puis 10 chiffres), mais le code pays peut faire 3 lettres, et la séquence de chiffres peut en contenir de 6 à 10.

[Assouplir le format du champ Numéro de notification ou de déclaration GISTRID](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16630)

## TEXS entrant/sortant: ajout du champ DAP

Le champ DAP était manquant sur les modales d'édition de l'IHM. Il n'est maintenant plus manquant.

<img width="792" alt="Capture d’écran 2025-06-13 à 02 19 58" src="https://github.com/user-attachments/assets/365333f2-872f-4dce-86f7-a1ec4839ee95" />


La validation

# Points de vigilance pour les intégrateurs

- Le mode de traitement sur SSD devient facultatif lorsque le ode de traitement est R12 ou R13
- La règle de validation des numéros GISTRID/Numéro de notification ou de déclaration d'import s'assouplit afin de correspondre à la régulation et aux cas d'usage


# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB