### PR TITLE
FIX/Signature sur un BSDA avec un transporteur en sommeil

### DIFF
--- a/back/src/bsda/validation/refinements.ts
+++ b/back/src/bsda/validation/refinements.ts
@@ -339,7 +339,10 @@ export const checkCompanies = async (
           transporter.transporterRecepisseIsExempted ?? false
       },
       zodContext,
-      !sealedFields.includes("transporters")
+      // Transporters are sealed when all transporters have signed
+      // If one of the transporter has already signed, we should not block if he is sleeping
+      transporter.transporterTransportSignatureDate == null ||
+        !sealedFields.includes("transporters")
     );
     await isRegisteredVatNumberRefinement(
       transporter.transporterCompanyVatNumber,


### PR DESCRIPTION
# Contexte

Si le transporteur est en sommeil mais qu'il a signé, il faut permettre à l'exutoire de signer la fin du bordereau
cf: https://trackdechets.zammad.com/#ticket/zoom/48706

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB