### PR TITLE
[Hotfix TRA-16639] Un BSDD d'entreposage provisoire devrait pouvoir forward un BSD legacy avec wasteDetailsIsSubjectToADR = null

### DIFF
--- a/back/src/common/subTypes.ts
+++ b/back/src/common/subTypes.ts
@@ -40,7 +40,7 @@ interface BsddForSubType {
 export const getBsddSubType = (bsdd: BsddForSubType): BsdSubType => {
   if (
     bsdd.forwardedInId ||
-    bsdd.id.endsWith("-suite") ||
+    bsdd.id?.endsWith("-suite") ||
     bsdd.readableId?.endsWith("-suite")
   ) {
     return "TEMP_STORED";

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -82,6 +82,7 @@ import {
   ERROR_TRANSPORTER_PLATES_INCORRECT_LENGTH,
   ERROR_TRANSPORTER_PLATES_INCORRECT_FORMAT
 } from "../common/validation/messages";
+import { getBsddSubType } from "../common/subTypes";
 
 // set yup default error messages
 configureYup();
@@ -908,6 +909,12 @@ const baseWasteDetailsSchemaFn: FactorySchemaOf<
           wasteDetailsOnuCode,
           createdAt
         } = ctx.parent;
+
+        // User must be able to forward a legacy BSD without wasteDetailsIsSubjectToADR
+        const bsdSubType = getBsddSubType(ctx.parent);
+        if (bsdSubType === "TEMP_STORED") {
+          return true;
+        }
 
         // Field becomes required after MEP_2025_05_2. Be careful and don't break BSDs created before
         if (


### PR DESCRIPTION
# Contexte

Petit oubli avec le breaking change qui rend le champ `wasteDetailsIsSubjectToADR` obligatoire: un BSD d'entreposage provisoire devrait fonctionner si le BSDD initial a `wasteDetailsIsSubjectToADR = null`.

# Ticket Favro

[Impossible de générer un BSD suite : "Vous devez préciser si le bordereau est soumis à l’ADR ou non (champ wasteDetailsIsSubjectToADR)."](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16639)
