### PR TITLE
[Hotfix TRA-16634] Pouvoir renseigner un poids en kg lors de la signature du BSDA par l'entreprise de travaux

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaWork.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaWork.tsx
@@ -406,7 +406,7 @@ const SignBsdaWork = ({ bsdaId, onClose }) => {
                     label="Poids total en tonnes"
                     nativeInputProps={{
                       inputMode: "decimal",
-                      step: "0.1",
+                      step: "0.001",
                       type: "number",
                       ...register("weight.value")
                     }}


### PR DESCRIPTION
# Contexte

Lors de la refont au DSFR, le champ numérique a été implémenté avec une précision de 0.1, on veut pouvoir aller jusqu'au kg, donc 0.001.

# Ticket Favro

[[HOTFIX] Pouvoir renseigner un poids inférieur à 0,1T lors de la signature du BSDA par l'entreprise de travaux. ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/86ca51bec3a3fc5ca60933af?card=tra-16634)