### PR TITLE
[TRA-16612] Changes weight on bsda grouping

### DIFF
--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -216,7 +216,7 @@ function PickerTable({
             <TableHeaderCell>Numéro</TableHeaderCell>
             <TableHeaderCell>Code déchet</TableHeaderCell>
             <TableHeaderCell>Nom du matériau</TableHeaderCell>
-            <TableHeaderCell>Poids reçu (tonnes)</TableHeaderCell>
+            <TableHeaderCell>Quantité acceptée (en t)</TableHeaderCell>
             <TableHeaderCell>Émetteur</TableHeaderCell>
             <TableHeaderCell>CAP final</TableHeaderCell>
             <TableHeaderCell>Exutoire</TableHeaderCell>
@@ -254,7 +254,10 @@ function PickerTable({
                 <TableCell>{bsda.id}</TableCell>
                 <TableCell>{bsda.waste?.code}</TableCell>
                 <TableCell>{bsda.waste?.materialName ?? "inconnu"}</TableCell>
-                <TableCell>{bsda.destination?.reception?.weight}</TableCell>
+                <TableCell>
+                  {bsda.destination?.reception?.acceptedWeight ??
+                    bsda.destination?.reception?.weight}
+                </TableCell>
                 <TableCell>{bsda.emitter?.company?.name}</TableCell>
                 <TableCell>
                   {bsda.destination?.operation?.nextDestination?.cap ??

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.test.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.test.tsx
@@ -199,9 +199,9 @@ describe("<Appendix2MultiSelect />", () => {
     expect(headers[3]).toHaveTextContent("Émetteur initial");
     //expect(headers[4]).toHaveTextContent("Date de l'acceptation");
     expect(headers[4]).toHaveTextContent("Opération réalisée");
-    expect(headers[5]).toHaveTextContent("Qté acceptée (en T)");
-    expect(headers[6]).toHaveTextContent("Qté restante (en T)");
-    expect(headers[7]).toHaveTextContent("Qté à regrouper (en T)");
+    expect(headers[5]).toHaveTextContent("Quantité acceptée (en t)");
+    expect(headers[6]).toHaveTextContent("Quantité restante (en t)");
+    expect(headers[7]).toHaveTextContent("Quantité à regrouper (en t)");
 
     const rows = screen.getAllByRole("row");
 

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -258,8 +258,8 @@ export default function Appendix2MultiSelect({
             {form.readableId}
           </div>,
           <div>
-            <p>{form.wasteDetails?.code}</p>
-            <p
+            <div>{form.wasteDetails?.code}</div>
+            <div
               style={{
                 maxHeight: "25px",
                 overflow: "hidden",
@@ -268,7 +268,7 @@ export default function Appendix2MultiSelect({
               aria-describedby={form.readableId}
             >
               {form.wasteDetails?.name}
-            </p>
+            </div>
             <span
               className="fr-tooltip fr-placement"
               id={form.readableId}
@@ -358,9 +358,9 @@ export default function Appendix2MultiSelect({
       "Code déchet",
       "Émetteur initial",
       "Opération réalisée",
-      "Qté acceptée (en T)",
-      "Qté restante (en T)",
-      "Qté à regrouper (en T)"
+      "Quantité acceptée (en t)",
+      "Quantité restante (en t)",
+      "Quantité à regrouper (en t)"
     ];
 
     return (


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Remplacer la quantité reçue par la quantité acceptée dans les tableaux de groupement / réexpédition 

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

![image](https://github.com/user-attachments/assets/9fc3323c-54a7-4a21-9507-8a5e2bcddb33)


# Ticket Favro

[Remplacer la quantité reçue par la quantité acceptée dans les tableaux de groupement / réexpédition ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16612)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB