### PR TITLE
[Hotfix TRA-16652] On devrait pouvoir ajouter une étape d'entreposage provisoire sur un BSDA legacy avec wasteIsSubjectToADR = null

### DIFF
--- a/front/src/form/bsda/stepper/BsdaStepList.tsx
+++ b/front/src/form/bsda/stepper/BsdaStepList.tsx
@@ -203,9 +203,12 @@ export default function BsdaStepsList(props: Props) {
     // set to null, but the toggle is automatically set to true.
     const initialBsda = bsdaQuery.data?.bsda;
     if (
+      // If legacy BSDA...
       initialBsda?.waste?.isSubjectToADR === null &&
+      // ...and the user did not change the toggle (nor the ADR value)
       bsdaInput.waste?.isSubjectToADR === true &&
-      !isDefinedStrict(bsdaInput.waste?.adr)
+      (!isDefinedStrict(bsdaInput.waste?.adr) ||
+        bsdaInput.waste?.adr === initialBsda.waste?.adr)
     ) {
       bsdaInput.waste.isSubjectToADR = null;
     }


### PR DESCRIPTION
# Ticket Favro

[Impossible d'ajouter/enlever une étape d'entreposage provisoire sur un BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16652)