### PR TITLE
Hotfix: synthesis dasri update

### DIFF
--- a/back/src/bsdasris/validation/refinements.ts
+++ b/back/src/bsdasris/validation/refinements.ts
@@ -92,9 +92,14 @@ export const validateRecipientIsCollectorForGroupingCodes: (
 
 export const validateSynthesisTransporterAcceptation: (
   validationContext: BsdasriValidationContext
-) => Refinement<ParsedZodBsdasri> = () => {
+) => Refinement<ParsedZodBsdasri> = validationContext => {
   return async (bsdasri, { addIssue }) => {
     if (bsdasri.type !== BsdasriType.SYNTHESIS) {
+      return;
+    }
+    const currentSignatureType = validationContext.currentSignatureType;
+
+    if (currentSignatureType !== "TRANSPORT") {
       return;
     }
 


### PR DESCRIPTION
# Contexte

Suite refacto validation, le champ d'acceptation transporteur était contrôlé trop précocement et empêchait la mise à jour d'un dasri de synthèse.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16645

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB