### PR TITLE
[HOTFIX TRA-16640] Correction de l'état initial des modales de signature BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
@@ -124,7 +124,7 @@ const SignBsdaReception = ({ bsdaId, onClose }) => {
   } as ZodBsdaReception;
 
   const methods = useForm<ZodBsdaReception>({
-    defaultValues: initialState,
+    values: initialState,
     resolver: async (data, context, options) => {
       return zodResolver(schema)(data, context, options);
     }

--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
@@ -128,7 +128,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
   };
 
   const methods = useForm<ZodBdsaTransport>({
-    defaultValues: initialState,
+    values: initialState,
     resolver: async (data, context, options) => {
       return zodResolver(schema)(data, context, options);
     }


### PR DESCRIPTION
# Contexte

Le problème remonté était que les plaques d'immatriculation ne remontaient pas sur la modale de signature transporteur BSDA (après passage au DSFR).

Le problème sous-jacent était que l'état initial était défini avec defaultValues, qui prend les premières valeurs reçues et ne met pas à jour l'état interne du formulaire lorsque l'objet passé dans defaultValues change. Or au moment de la création du formulaire, les infos du BSDA ne sont pas encore chargées. Donc une fois les infos récupérées, elles ne sont pas mises dans le formulaires. L'utilisation de values à la place de defaultValues résout ce problème (et est cohérent avec l'utilisation faite dans d'autres modales de signature).

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Le champ "immatriculation" prérempli disparaît à la signature chauffeur sur le BSDA](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16640)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB