### PR TITLE
[TRA 16660] Company Profile: résolution de soucis de validation 

### DIFF
--- a/back/src/companies/resolvers/mutations/createWorkerCertification.ts
+++ b/back/src/companies/resolvers/mutations/createWorkerCertification.ts
@@ -30,7 +30,10 @@ export const workerCertificationSchema = yup.object({
   }),
   validityLimit: yup
     .date()
-    .min(todayAtMidnight())
+    .min(
+      todayAtMidnight(),
+      "La date de validité de la certification Amiante doit être dans le futur"
+    )
     .when("hasSubSectionThree", {
       is: true,
       then: schema => schema.required(),

--- a/front/src/Apps/Companies/CompanyInfo/CompanyProfileForm.tsx
+++ b/front/src/Apps/Companies/CompanyInfo/CompanyProfileForm.tsx
@@ -434,9 +434,15 @@ const CompanyProfileForm = ({ company }: CompanyProfileFormProps) => {
             data.workerCertification?.hasSubSectionFour ?? false,
           hasSubSectionThree:
             data.workerCertification?.hasSubSectionThree ?? false,
-          certificationNumber: data.workerCertification?.certificationNumber,
-          validityLimit: data.workerCertification?.validityLimit,
-          organisation: data.workerCertification?.organisation
+          certificationNumber: data.workerCertification?.hasSubSectionThree
+            ? data.workerCertification?.certificationNumber
+            : null,
+          validityLimit: data.workerCertification?.hasSubSectionThree
+            ? data.workerCertification?.validityLimit
+            : null,
+          organisation: data.workerCertification?.hasSubSectionThree
+            ? data.workerCertification?.organisation
+            : null
         };
 
         if (company.workerCertification) {


### PR DESCRIPTION
# Contexte

Il y avait 2 problèmes avec la validation des certificats Amiante sur le profil établissement:
- en cas de déselection de la sous-section 3, les infos renseignées dans les champs certificationNumber/validityLimit/organisation étaient quand même envoyés, ce qui n'a pas de sens et causait des problèmes avec la validation GraphQL sur la date
- en cas de date invalide (dans le passé) l'erreur était en anglais

# Points de vigilance pour les intégrateurs

Aucun

# Démo


https://github.com/user-attachments/assets/f7f97976-e71c-436b-a08d-4bf482abb2ee



# Ticket Favro

[Permettre d'enregistrer la création / modification d'un type de profil Entreprise de travaux amiante, si SS4 uniquement a été coché et ne pas vérifier les informations de la SS3](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16660)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB