### PR TITLE
[Hotfix TRA-16635] Meilleur gestion de isSubjectToADR pour les BSDA de réexpédition

### DIFF
--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -106,7 +106,7 @@ export function BsdaPicker({ name, bsdaId }: Props) {
     setFieldValue("waste.code", bsda?.waste?.code ?? initialState!.waste!.code);
     setFieldValue("waste.adr", bsda?.waste?.adr ?? initialState!.waste!.adr);
 
-    // Careful when forwarding legacy BSDAs with isSubjectToADR = null
+    // Attention avec les bordereaux qui réexpédient un BSDA legacy où isSubjectToADR = null
     let isSubjectToADR =
       bsda?.waste?.isSubjectToADR ?? initialState!.waste!.isSubjectToADR;
     if (bsda?.waste?.isSubjectToADR === null) {

--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -23,6 +23,7 @@ import { useParams } from "react-router-dom";
 import { getInitialState } from "../../stepper/initial-state";
 import { getInitialCompany } from "../../../../Apps/common/data/initialState";
 import { mergePackagings } from "../../../../common/packagings";
+import { isDefinedStrict } from "../../../../common/helper";
 
 type Props = { name: string; bsdaId: string };
 
@@ -104,10 +105,22 @@ export function BsdaPicker({ name, bsdaId }: Props) {
     );
     setFieldValue("waste.code", bsda?.waste?.code ?? initialState!.waste!.code);
     setFieldValue("waste.adr", bsda?.waste?.adr ?? initialState!.waste!.adr);
-    setFieldValue(
-      "waste.isSubjectToADR",
-      bsda?.waste?.isSubjectToADR ?? initialState!.waste!.isSubjectToADR
-    );
+
+    // Careful when forwarding legacy BSDAs with isSubjectToADR = null
+    let isSubjectToADR =
+      bsda?.waste?.isSubjectToADR ?? initialState!.waste!.isSubjectToADR;
+    if (bsda?.waste?.isSubjectToADR === null) {
+      if (!isDefinedStrict(bsda?.waste?.adr)) {
+        // Si rien dans la mention ADR, on peut supposer que le déchet n'est pas soumis à l'ADR
+        isSubjectToADR = false;
+      } else {
+        // Si la mention ADR n'est pas vide, on ne peut pas deviner la valeur de isSubjectToADR,
+        // parce que le champ adr peut être égal à "Non soumis" ou équivalent
+        isSubjectToADR = null;
+      }
+    }
+    setFieldValue("waste.isSubjectToADR", isSubjectToADR);
+
     setFieldValue(
       "waste.nonRoadRegulationMention",
       bsda?.waste?.nonRoadRegulationMention ??

--- a/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
+++ b/front/src/form/bsda/components/bsdaPicker/BsdaPicker.tsx
@@ -23,7 +23,7 @@ import { useParams } from "react-router-dom";
 import { getInitialState } from "../../stepper/initial-state";
 import { getInitialCompany } from "../../../../Apps/common/data/initialState";
 import { mergePackagings } from "../../../../common/packagings";
-import { isDefinedStrict } from "../../../../common/helper";
+import { isDefined, isDefinedStrict } from "../../../../common/helper";
 
 type Props = { name: string; bsdaId: string };
 
@@ -109,7 +109,7 @@ export function BsdaPicker({ name, bsdaId }: Props) {
     // Attention avec les bordereaux qui réexpédient un BSDA legacy où isSubjectToADR = null
     let isSubjectToADR =
       bsda?.waste?.isSubjectToADR ?? initialState!.waste!.isSubjectToADR;
-    if (bsda?.waste?.isSubjectToADR === null) {
+    if (!isDefined(bsda?.waste?.isSubjectToADR)) {
       if (!isDefinedStrict(bsda?.waste?.adr)) {
         // Si rien dans la mention ADR, on peut supposer que le déchet n'est pas soumis à l'ADR
         isSubjectToADR = false;


### PR DESCRIPTION
# Contexte

Quand on crée un BSDA de réexpédition, on copie les valeurs du bordereau initial. Sauf que pour les bordereaux legacy pour lesquels `isSubjectToADR = null`, on met la valeur par défaut, à savoir `true`.

Ce qui bloque la suite du workflow si `adr = null` (pas autorisé si `isSubjectToADR = true`). Et on ne peut plus modifier le BSDA à ce stade.

# Ticket Favro

[Champ "Soumis à l'ADR oui/non" manquant sur le BSD initial - Impossible de publier le bordereau de reexpédition ](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16635)
