### PR TITLE
Display dasri transporter email as mandatory

### DIFF
--- a/back/src/bsdasris/validation/rules.ts
+++ b/back/src/bsdasris/validation/rules.ts
@@ -471,7 +471,6 @@ export const bsdasriEditionRules: BsdasriEditionRules = {
   },
   destinationCompanyMail: {
     sealed: { from: "RECEPTION" },
-    // required: { from: "EMISSION" },
     readableFieldName: "L'adresse e-mail du destinataire",
     path: ["destination", "company", "mail"]
   },

--- a/front/src/form/bsdasri/steps/Transporter.tsx
+++ b/front/src/form/bsdasri/steps/Transporter.tsx
@@ -61,7 +61,7 @@ export default function Transporter({ status, stepName }) {
             disabled={disabled}
             name="transporter.company"
             heading="Entreprise de transport"
-            optionalMail={true}
+            optionalMail={false}
             allowForeignCompanies={true}
             registeredOnlyCompanies={true}
           />
@@ -212,7 +212,7 @@ function CurrentCompanyWidget({ disabled = false }) {
         </div>
         <div className="form__row">
           <label>
-            Mail (optionnel)
+            Mail
             <Field
               type="email"
               name={`transporter.company.mail`}


### PR DESCRIPTION
# Contexte

Le mail transporteur dasri était affiché comme optionnel alors qu'il est requis à partir de la signature TRANSPORT.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16662

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB