### PR TITLE
[TRA-16364] On ne peut plus ajouter un conditionnement sur un BSDD de tournée dédiée

### DIFF
--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -164,6 +164,12 @@ const createFormResolver = async (
     transporters
   };
 
+  // Do not take into account the packaging infos. Those a specified in the grouped BSDs,
+  // not the parent one. Deleting the info here helps avoid any breaking change.
+  if (form.emitterType === "APPENDIX1") {
+    delete formCreateInput.wasteDetailsPackagingInfos;
+  }
+
   if (temporaryStorageDetail) {
     if (formContent.recipient?.isTempStorage !== true) {
       // The user is trying to set a temporary storage without


### PR DESCRIPTION
# Contexte

Quand on crée un bordereau de tournée dédiée via l'interface, on ne peut pas choisir de conditionnement. MAIS quand on le fait via API, on peut choisir un conditionnement! 

Or tant que le bordereau est en brouillon, on peut renseigner le conditionnement "à moitié", comme par exemple, choisir conditionnement AUTRES et laisser une description vide (normal, tant qu'un bordereau est en brouillon, on tolère tout).

Cependant, si on essaie de valider pareil bordereau via l'UI, on se prend une erreur ("la description doit être précisée pour le conditionnement 'AUTRE'"), qu'on ne peut pas corriger puisque l'UI ne le permet pas.

# Points de vigilance pour les intégrateurs

RAS. Les packagings seront ignorés (pas de breaking change).

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Ne pas permettre d'ajouter un conditionnement sur un BSDD de tournée dédiée](https://favro.com/widget/ab14a4f0460a99a9d64d4945/86ca51bec3a3fc5ca60933af?card=tra-16364)