### PR TITLE
[tra-16395] - Bordereaux suite et récursivité

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - BSDA: le nombre total de conditionnements remonte désormais dans la colonne "Nombre d'unités" du registre [PR 4209](https://github.com/MTES-MCT/trackdechets/pull/4209)
+- BSDD: l'application de la récursivité sur les statuts des bordereaux se fait également sur les bordereaux suite pour les bordereaux ayant un entreposage provisoire [PR 4261](https://github.com/MTES-MCT/trackdechets/pull/4261)
 
 #### :boom: Breaking Change
 

--- a/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/markAsProcessed.integration.ts
@@ -1546,7 +1546,7 @@ describe("mutation.markAsProcessed", () => {
     expect(updatedGroupedForm2.status).toEqual("PROCESSED");
   });
 
-  it("should mark appendix2 forms as processed  despite rogue decimal digits", async () => {
+  it("should mark appendix2 forms as processed despite rogue decimal digits", async () => {
     const { user, company } = await userWithCompanyFactory("ADMIN");
 
     const groupedForm1 = await formFactory({
@@ -1616,9 +1616,11 @@ describe("mutation.markAsProcessed", () => {
     expect(updatedGroupedForm1.status).toEqual("PROCESSED");
 
     const updatedGroupedForm2 = await prisma.form.findUniqueOrThrow({
-      where: { id: groupedForm2.id }
+      where: { id: groupedForm2.id },
+      include: { forwardedIn: true }
     });
     expect(updatedGroupedForm2.status).toEqual("PROCESSED");
+    expect(updatedGroupedForm2.forwardedIn?.status).toEqual("PROCESSED");
   });
 
   it.each([0.1, 1])(

--- a/back/src/forms/updateAppendix2.ts
+++ b/back/src/forms/updateAppendix2.ts
@@ -107,16 +107,21 @@ export async function updateAppendix2Fn(args: UpdateAppendix2FnArgs) {
     ? Status.GROUPED
     : Status.AWAITING_GROUP;
 
-  const { update: updateForm, findGroupedFormsById } = getFormRepository(user);
+  const { updateMany: updateManyForms, findGroupedFormsById } =
+    getFormRepository(user);
 
   if (
     nextStatus !== form.status ||
     !quantityGrouped.equals(new Decimal(form.quantityGrouped))
   ) {
-    await updateForm(
-      { id: form.id },
-      { quantityGrouped: quantityGrouped.toNumber(), status: nextStatus }
+    await updateManyForms(
+      [form.id, ...(form.forwardedIn ? [form.forwardedIn.id] : [])],
+      {
+        status: nextStatus,
+        quantityGrouped: quantityGrouped.toNumber()
+      }
     );
+
     if (
       form.emitterType === EmitterType.APPENDIX2 &&
       nextStatus === "PROCESSED"


### PR DESCRIPTION
# Contexte

Appliquer la récursivité sur les statuts des bordereaux sur la deuxième partie des bordereaux avec entreposage provisoire 

Seul le bordereau initial avait son statut updaté. Le bordereau suite doit connaitre la même transformation.

# Points de vigilance pour les intégrateurs

# Démo

![image](https://github.com/user-attachments/assets/64ab2cb2-d5a1-47ea-9122-0b3a80626570)

# Ticket Favro

[Titre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16395)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB