### PR TITLE
[HOTFIX TRA 16682] résolution de problèmes d'export registre pour délégataires

### DIFF
--- a/front/src/dashboard/registry/ExportModal.tsx
+++ b/front/src/dashboard/registry/ExportModal.tsx
@@ -459,7 +459,7 @@ export function ExportModal({ isOpen, onClose }: Props) {
         if (registryDelegationsData?.registryDelegations.edges.length === 1) {
           const tmpSiret =
             registryDelegationsData.registryDelegations.edges[0].node.delegate
-              .siret;
+              .orgId;
           if (tmpSiret) {
             delegateSiret = tmpSiret;
           }
@@ -529,9 +529,12 @@ export function ExportModal({ isOpen, onClose }: Props) {
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="fr-mb-8v">
             <RegistryCompanySwitcher
-              onCompanySelect={(orgId, isDelegation) => {
-                setValue("companyOrgId", orgId);
+              setIsDelegation={isDelegation => {
                 setValue("isDelegation", isDelegation);
+                setValue("delegateSiret", null);
+              }}
+              onCompanySelect={orgId => {
+                setValue("companyOrgId", orgId);
                 setValue("delegateSiret", null);
               }}
               wrapperClassName={"tw-relative"}

--- a/front/src/dashboard/registry/RegistryCompanySwitcher.tsx
+++ b/front/src/dashboard/registry/RegistryCompanySwitcher.tsx
@@ -14,11 +14,7 @@ import { GET_REGISTRY_COMPANIES } from "./shared";
 import FocusTrap from "focus-trap-react";
 import styles from "./RegistryCompanySwitcher.module.scss";
 type Props = {
-  onCompanySelect: (
-    orgId: string,
-    isDelegation: boolean,
-    company?: RegistryCompanyInfos
-  ) => void;
+  onCompanySelect: (orgId: string, company?: RegistryCompanyInfos) => void;
   setIsDelegation?: (isDelegation: boolean) => void;
   wrapperClassName?: string;
   allOption?: {
@@ -80,11 +76,11 @@ export function RegistryCompanySwitcher({
       const { name, givenName, siret } = selected.company;
       setSelectedItem(`${givenName || name || ""} ${siret || ""}`);
       setIsDelegation?.(!!isDelegation);
-      onCompanySelect(orgId, !!isDelegation, selected?.company);
+      onCompanySelect(orgId, selected?.company);
     } else if (selected.all) {
       setSelectedItem(allOption?.name ?? "");
       setIsDelegation?.(!!isDelegation);
-      onCompanySelect(orgId, !!isDelegation);
+      onCompanySelect(orgId);
     }
   };
 
@@ -113,7 +109,7 @@ export function RegistryCompanySwitcher({
         }
         if (firstNode) {
           if (!defaultSiret) {
-            onCompanySelect(firstNode.orgId, firstNodeIsDelegation);
+            onCompanySelect(firstNode.orgId);
           }
           setIsDelegation?.(!!firstNodeIsDelegation);
           setSelectedItem(

--- a/front/src/form/registry/common/ReportFor.tsx
+++ b/front/src/form/registry/common/ReportFor.tsx
@@ -24,7 +24,6 @@ type Props = {
   disabled?: boolean;
   onCompanySelect?: (
     orgId: string,
-    isDelegation: boolean,
     setValue: UseFormSetValue<any>,
     company?: RegistryCompanyInfos
   ) => void;
@@ -81,14 +80,9 @@ export function ReportFor({
               defaultSiret={field.value}
               disabled={disabled}
               setIsDelegation={setIsDelegation}
-              onCompanySelect={(siret, isDelegation, company) => {
+              onCompanySelect={(siret, company) => {
                 field.onChange(siret);
-                onCompanySelect?.(
-                  siret,
-                  isDelegation,
-                  methods.setValue,
-                  company
-                );
+                onCompanySelect?.(siret, methods.setValue, company);
               }}
             />
           )}

--- a/front/src/form/registry/transported/shape.ts
+++ b/front/src/form/registry/transported/shape.ts
@@ -42,7 +42,6 @@ export const transportedFormShape: FormShape = [
           reportAsLabel: "SIRET du déclarant",
           onCompanySelect: (
             _,
-            __,
             setValue: UseFormSetValue<any>,
             company?: RegistryCompanyInfos
           ) => {


### PR DESCRIPTION
# Contexte

C'est en gros le même problème que résolu ici: https://github.com/MTES-MCT/trackdechets/pull/4259
La séléction de délégataire ne se faisait pas correctement suite à quelques changements de fonctionnement du sélecteur d'entreprises pour le registre. J'ai donc fait les changements nécessaires pour régler le problème. Au passage il y a l'ajout de la gestion d'erreur unifiée qui a été faite sur tous les registres mais qui avait été oubliée (fichier pas enregistré :/) sur le registre TEXS sortant.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Le délégataire ne peut pas exporter un registre réglementaire : Vous n'êtes pas autorisé à lire les données de ce registre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16682)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB