### PR TITLE
[tra-16692]Appliquer la même gestion que sur le VHU pour la remontée des erreurs sur les modales de signatures BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
@@ -62,20 +62,31 @@ const schema = z.object({
     phone: z.string().nullish(),
     mail: z.string().nullish()
   }),
-  transport: z.object({
-    takenOverAt: z.coerce
-      .date()
-      .nullish()
-      .transform(v => v?.toISOString()),
-    mode: z.string().nullish(),
-    plates: z.preprocess(
-      (val: string) => (typeof val === "string" ? val.split(",") : val ?? []),
-      z
-        .string()
-        .array()
-        .max(2, { message: "Un maximum de 2 plaques est accepté" })
-    )
-  }),
+  transport: z
+    .object({
+      takenOverAt: z.coerce
+        .date()
+        .nullish()
+        .transform(v => v?.toISOString()),
+      mode: z.string().nullish(),
+      plates: z.preprocess(
+        val => (Array.isArray(val) ? val : [val]).filter(Boolean),
+        z
+          .string()
+          .array()
+
+          .max(2, "2 plaques d'immatriculation maximum")
+      )
+    })
+    .superRefine((val, ctx) => {
+      if (val.mode === "ROAD" && !val.plates?.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["plates"],
+          message: `Ce champ est requis pour le transport routier`
+        });
+      }
+    }),
   recepisse: z
     .object({
       isExempted: z.boolean().nullish()
@@ -134,7 +145,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
     }
   });
 
-  const { handleSubmit, reset, register } = methods;
+  const { handleSubmit, reset, register, formState } = methods;
 
   // mettre à jour les valeurs quand signingTransporter est dispo
   useEffect(() => {
@@ -316,9 +327,15 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
               <div className="fr-col-8 fr-mb-2w">
                 <Input
                   label="Nom et prénom"
+                  state={
+                    formState.errors.signature?.author ? "error" : "default"
+                  }
                   nativeInputProps={{
                     ...register("signature.author")
                   }}
+                  stateRelatedMessage={
+                    formState.errors.signature?.author?.message
+                  }
                 />
               </div>
               <div className="fr-mb-8w">

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInput.tsx
@@ -71,6 +71,8 @@ const TagsInput = ({
             Ajouter
           </Button>
         }
+        state={errorMessage ? "error" : "default"}
+        stateRelatedMessage={errorMessage}
       />
       <div style={{ display: "flex", flexWrap: "wrap", gap: 5 }}>
         {tags?.map((plate, idx) => (
@@ -92,7 +94,6 @@ const TagsInput = ({
           </div>
         ))}
       </div>
-      {errorMessage && <p className="fr-error-text fr-mt-0">{errorMessage}</p>}
     </>
   );
 };

--- a/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.tsx
+++ b/front/src/Apps/Forms/Components/TagsInput/TagsInputWrapper.tsx
@@ -56,6 +56,8 @@ export const RhfTagsInputWrapper = ({
 
   const { error } = getFieldState(fieldName);
 
+  const errorMessage = !tags.length ? error?.message : "";
+
   return (
     <TagsInput
       label={label}
@@ -67,7 +69,7 @@ export const RhfTagsInputWrapper = ({
         tags.splice(idx, 1);
         setValue(fieldName, [...tags]);
       }}
-      errorMessage={error?.message}
+      errorMessage={errorMessage}
       hintText={hintText}
       disabled={disabled}
     />


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

https://github.com/user-attachments/assets/a29a86fb-561d-47df-b429-d92c2e95f40b


# Ticket Favro

[tra-16692](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16692)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB