### PR TITLE
[HOTFIX BSDA] signature transporteur: passage de la date de prise en charge dans takenOverAt

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaTransport.tsx
@@ -118,8 +118,9 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
     transport: {
       mode: signingTransporter?.transport?.mode ?? TransportMode.Road,
       plates: signingTransporter?.transport?.plates ?? [],
-      takenOverAt:
-        signingTransporter?.transport?.takenOverAt ?? new Date().toISOString()
+      takenOverAt: signingTransporter?.transport?.takenOverAt
+        ? datetimeToYYYYMMDD(new Date(signingTransporter.transport.takenOverAt))
+        : new Date().toISOString()
     },
     signature: {
       author: "",
@@ -145,8 +146,11 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
       transport: {
         mode: signingTransporter.transport?.mode ?? TransportMode.Road,
         plates: signingTransporter.transport?.plates ?? [],
-        takenOverAt:
-          signingTransporter.transport?.takenOverAt ?? new Date().toISOString()
+        takenOverAt: signingTransporter?.transport?.takenOverAt
+          ? datetimeToYYYYMMDD(
+              new Date(signingTransporter.transport.takenOverAt)
+            )
+          : new Date().toISOString()
       },
       signature: {
         author: "",
@@ -309,7 +313,7 @@ const SignBsdaTransport = ({ bsdaId, onClose }) => {
                     type: "date",
                     min: datetimeToYYYYMMDD(subMonths(TODAY, 2)),
                     max: datetimeToYYYYMMDD(TODAY),
-                    ...register("signature.date")
+                    ...register("transport.takenOverAt")
                   }}
                 />
               </div>


### PR DESCRIPTION
# Contexte

La date remplie dans "date de prise en charge" était envoyée dans la date de signature au lieu de la date de prise en charge du transporteur. Ce qui est étonnant c'est que dans la version précédente de la modale, il y avait un champ "date de signature", qui avait ce fonctionnement (mais je vois pas trop quel était l'intérêt) :

<img width="479" alt="Capture d’écran 2025-06-17 à 23 49 12" src="https://github.com/user-attachments/assets/80d4dd2b-d890-4eb2-94c5-33181b03c768" />

Je suppose donc que le champ a changé de wording, mais gardé son fonctionnement, ce qui rendait le truc incohérent.

J'ai aussi rajouté un formatage de la date qui est mise dans takenOverAt pour qu'elle soit affichée dans l'input.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

Pas de ticket

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB