### PR TITLE
[TRA-16695] Passage du statut du BSDA à Refusé en cas de refus à la signature réception

### DIFF
--- a/back/src/bsda/machine.ts
+++ b/back/src/bsda/machine.ts
@@ -79,9 +79,15 @@ export const machine = createMachine<Record<string, never>, Event>(
       [BsdaStatus.SENT]: {
         on: {
           TRANSPORT: { target: BsdaStatus.SENT }, // multi-modal
-          RECEPTION: {
-            target: BsdaStatus.RECEIVED
-          },
+          RECEPTION: [
+            {
+              target: BsdaStatus.REFUSED,
+              cond: "isBsdaRefused"
+            },
+            {
+              target: BsdaStatus.RECEIVED
+            }
+          ],
           OPERATION: [
             {
               target: BsdaStatus.REFUSED,


### PR DESCRIPTION
# Contexte

Le refus d'un BSDA se fait maintenant à la signature réception, mais la machine d'état ne reflétait pas cette possibilité pour mettre le statut refusé et classer le BSDA dans Archivés.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Un BSDA refusé à la signature par l'installation de destination devrait passer au statut "Refusé" et basculer dans l'onglet Archives](https://favro.com/organization/ab14a4f0460a99a9d64d4945/b64d96be58e6a57fe4d5c049?card=tra-16695)

# Checklist

- [x] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB