### PR TITLE
[FIX TRA 16506] Affichage des erreurs et descriptions sur codes secondaires SSD

### DIFF
--- a/front/src/form/registry/common/WasteCodeSelector.tsx
+++ b/front/src/form/registry/common/WasteCodeSelector.tsx
@@ -23,6 +23,7 @@ type Props = {
   disabled?: boolean;
   whiteList?: string[];
   blackList?: string[];
+  displayDescription?: boolean;
 };
 
 export function WasteCodeSelector({
@@ -32,7 +33,8 @@ export function WasteCodeSelector({
   containerRef,
   disabled,
   whiteList,
-  blackList
+  blackList,
+  displayDescription = true
 }: Props) {
   if (!name) {
     console.error('WasteCodeSelector: "name" prop is required');
@@ -162,7 +164,7 @@ export function WasteCodeSelector({
           </Button>
         </div>
       </div>
-      {description && (
+      {displayDescription && description && (
         <div className="fr-col-12">
           <Alert description={capitalize(description)} severity="info" small />
         </div>

--- a/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
+++ b/front/src/form/registry/ssd/SecondaryWasteCodes.tsx
@@ -4,6 +4,9 @@ import { WasteCodeSelector } from "../common/WasteCodeSelector";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { formatError } from "../builder/error";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import { ALL_WASTES } from "@td/constants";
+import { capitalize } from "../../../common/helper";
 
 type Props = {
   name: string;
@@ -50,55 +53,84 @@ export function SecondaryWasteCodes({ methods }: Props) {
   const { errors } = methods.formState;
   return (
     <div className="fr-col">
-      {codeFields.map(({ id }, index) => (
-        <div
-          className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom tw-relative"
-          style={{
-            alignItems: "flex-start"
-          }}
-          ref={containerRef}
-          key={index}
-        >
-          <WasteCodeSelector
-            methods={methods}
-            key={id}
-            name={`secondaryWasteCodes.${index}.value`}
-            label="Code déchet secondaire (optionnel)"
-            containerRef={containerRef}
-          />
-          <div className="fr-col-4">
-            <Input
-              label="Dénomination secondaire"
-              key={descriptionFields[index].id}
-              nativeInputProps={{
-                type: "text",
-                ...methods.register(`secondaryWasteDescriptions.${index}.value`)
-              }}
-              state={errors?.secondaryWasteDescriptions?.[index] && "error"}
-              stateRelatedMessage={formatError(
-                errors?.secondaryWasteDescriptions?.[index]?.value
-              )}
+      {codeFields.map(({ id }, index) => {
+        const description = ALL_WASTES.find(
+          waste =>
+            waste.code ===
+            methods.getValues(`secondaryWasteCodes.${index}.value`)
+        )?.description;
+        return (
+          <div
+            className="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom tw-relative"
+            style={{
+              alignItems: "flex-start"
+            }}
+            ref={containerRef}
+            key={index}
+          >
+            <WasteCodeSelector
+              methods={methods}
+              key={id}
+              name={`secondaryWasteCodes.${index}.value`}
+              label="Code déchet secondaire (optionnel)"
+              containerRef={containerRef}
+              displayDescription={false}
             />
-          </div>
+            <div className="fr-col-4">
+              <Input
+                label="Dénomination secondaire"
+                key={descriptionFields[index].id}
+                nativeInputProps={{
+                  type: "text",
+                  ...methods.register(
+                    `secondaryWasteDescriptions.${index}.value`
+                  )
+                }}
+                state={errors?.secondaryWasteDescriptions?.[index] && "error"}
+                stateRelatedMessage={formatError(
+                  errors?.secondaryWasteDescriptions?.[index]?.value
+                )}
+              />
+            </div>
 
-          <div className="fr-col-2" style={{ paddingTop: "36px" }}>
-            <Button
-              className="fr-mr-1w"
-              nativeButtonProps={{ type: "button" }}
-              iconId="fr-icon-add-line"
-              onClick={addLine}
-              title="Label button"
-            />
-            <Button
-              className="fr-mt-1w"
-              nativeButtonProps={{ type: "button" }}
-              iconId="fr-icon-delete-line"
-              onClick={() => removeLine(index)}
-              title="Label button"
+            <div className="fr-col-2" style={{ paddingTop: "36px" }}>
+              <Button
+                className="fr-mr-1w"
+                nativeButtonProps={{ type: "button" }}
+                iconId="fr-icon-add-line"
+                onClick={addLine}
+                title="Label button"
+              />
+              <Button
+                className="fr-mt-1w"
+                nativeButtonProps={{ type: "button" }}
+                iconId="fr-icon-delete-line"
+                onClick={() => removeLine(index)}
+                title="Label button"
+              />
+            </div>
+            {description && (
+              <div className="fr-col-12">
+                <Alert
+                  description={capitalize(description)}
+                  severity="info"
+                  small
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+      {errors?.secondaryWasteCodes &&
+        !Array.isArray(errors?.secondaryWasteCodes) && (
+          <div className="fr-col-12 fr-mt-2w">
+            <Alert
+              description={formatError(errors.secondaryWasteCodes)}
+              severity="error"
+              small
             />
           </div>
-        </div>
-      ))}
+        )}
     </div>
   );
 }


### PR DESCRIPTION
# Contexte

Affichage de la description sous le code déchet secondaire sans couper le composant en 2
<img width="1178" alt="Capture d’écran 2025-06-30 à 19 20 30" src="https://github.com/user-attachments/assets/b56fc2b0-76d2-49f0-a2e5-17cdbcd53568" />

Affichage de l'erreur lorsqu'il y a mismatch entre nombre de codes et descriptions
<img width="1152" alt="Capture d’écran 2025-06-30 à 19 23 42" src="https://github.com/user-attachments/assets/020abb8d-414f-4ab5-8e4f-dc197237d005" />


# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Remonter l'erreur sur l'absence d'un code déchet secondaire si une dénomination secondaire a été renseignée (SSD)](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16506)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB