### PR TITLE
[tra-16521] BSDD - pas de sélection d'entreprise fermée

### DIFF
--- a/back/src/companies/sirenify.ts
+++ b/back/src/companies/sirenify.ts
@@ -46,11 +46,6 @@ export default function buildSirenify<T>(
   companyInputAccessors: (input: T) => CompanyInputAccessor<T>[]
 ): SirenifyFn<T> {
   return async (input, user) => {
-    if (user?.auth === AuthType.Session) {
-      // data sent from TD UI is considered to be sane
-      return input;
-    }
-
     // by pass some users
     for (const r of SIRENIFY_BYPASS_USER_EMAILS) {
       if (user && user.email?.match(r)) {

--- a/front/src/form/common/components/company/CompanyResult.module.scss
+++ b/front/src/form/common/components/company/CompanyResult.module.scss
@@ -11,7 +11,7 @@
   padding: 10px;
   display: flex;
   align-items: center;
-  
+
   &.clickable {
     cursor: pointer;
   }

--- a/front/src/form/common/components/company/CompanyResult.module.scss
+++ b/front/src/form/common/components/company/CompanyResult.module.scss
@@ -9,9 +9,12 @@
 
   margin: 10px 0;
   padding: 10px;
-  cursor: pointer;
   display: flex;
   align-items: center;
+  
+  &.clickable {
+    cursor: pointer;
+  }
 
   .content {
     flex: 1;
@@ -27,7 +30,7 @@
     font-size: 1.5em;
   }
 
-  &:hover .icon,
+  &.clickable:hover .icon,
   &.isSelected .icon {
     color: #03bd5b;
   }

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -76,11 +76,13 @@ export function CompanyResult<T extends CompanyResultBase>({
   onSelect,
   onUnselect
 }: CompanyResultProp<T>) {
+  const isClosedCompany = item.etatAdministratif === "F";
   return (
     <li
       key={item.orgId!}
       className={classNames(styles.resultsItem, {
-        [styles.isSelected]: isSelected(item, selectedItem)
+        [styles.isSelected]: isSelected(item, selectedItem),
+        [styles.clickable]: !isClosedCompany
       })}
       onClick={() =>
         isSelected(item, selectedItem) ? onUnselect?.() : onSelect(item)
@@ -96,7 +98,7 @@ export function CompanyResult<T extends CompanyResultBase>({
               <IconTrackDechetsCheck />
             </div>
           )}
-          {item.etatAdministratif === "F" && (
+          {isClosedCompany && (
             <div className="tw-ml-1 tw-text-red-600">Etablissement fermé</div>
           )}
         </h6>

--- a/front/src/form/common/components/company/CompanyResults.tsx
+++ b/front/src/form/common/components/company/CompanyResults.tsx
@@ -26,6 +26,7 @@ export type CompanyResultBase = Pick<
   | "isRegistered"
   | "vatNumber"
   | "codePaysEtrangerEtablissement"
+  | "etatAdministratif"
 >;
 
 export function isSelected<T extends CompanyResultBase>(
@@ -94,6 +95,9 @@ export function CompanyResult<T extends CompanyResultBase>({
             <div className="tw-ml-1">
               <IconTrackDechetsCheck />
             </div>
+          )}
+          {item.etatAdministratif === "F" && (
+            <div className="tw-ml-1 tw-text-red-600">Etablissement fermé</div>
           )}
         </h6>
         <p>

--- a/front/src/form/common/components/company/CompanySelector.tsx
+++ b/front/src/form/common/components/company/CompanySelector.tsx
@@ -69,6 +69,7 @@ interface CompanySelectorProps {
   // whether the company is optional
   optional?: boolean;
   initialAutoSelectFirstCompany?: boolean;
+  allowClosedCompanies?: boolean;
 }
 
 export default function CompanySelector({
@@ -83,7 +84,8 @@ export default function CompanySelector({
   isBsdaTransporter = false,
   optional = false,
   initialAutoSelectFirstCompany = true,
-  onCompanyPrivateInfos = undefined
+  onCompanyPrivateInfos = undefined,
+  allowClosedCompanies = false
 }: CompanySelectorProps) {
   // siret is the current active company
   const { siret } = useParams<{ siret: string }>();
@@ -251,6 +253,10 @@ export default function CompanySelector({
         return;
       }
 
+      if (!allowClosedCompanies && company.etatAdministratif === "F") {
+        return;
+      }
+
       // Side effects
       const notVoidCompany = Object.keys(company).length !== 0; // unselect returns emtpy object {}
       setMustBeRegistered(
@@ -300,7 +306,8 @@ export default function CompanySelector({
       setMustBeRegistered,
       disabled,
       field.name,
-      registeredOnlyCompanies
+      registeredOnlyCompanies,
+      allowClosedCompanies
     ]
   );
 


### PR DESCRIPTION
# Contexte

On empêche dans l'UI de sélectionner une entreprise fermée.
Et on revalide les données qui proviennent de l'UI dans le sirenify côté back

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

![image](https://github.com/user-attachments/assets/682a4bcf-ef6b-465d-ad1a-f6c624931025)

# Ticket Favro

[Titre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16521)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB