### PR TITLE
[tra-16741_tra-16612]fix recette bsda qty refusée

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaOperation.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaOperation.tsx
@@ -12,7 +12,7 @@ import {
   QueryBsdaArgs
 } from "@td/codegen-ui";
 import { subMonths } from "date-fns";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { z } from "zod";
 import { datetimeToYYYYMMDD } from "../../../../common/datetime";
@@ -114,7 +114,7 @@ const SignBsdaOperation = ({ bsdaId, onClose }) => {
   >(SIGN_BsDA);
 
   const title = "Signer le traitement";
-  const TODAY = new Date();
+  const TODAY = useMemo(() => new Date(), []);
 
   const initialState = {
     date: datetimeToYYYYMMDDHHSS(TODAY),
@@ -148,13 +148,10 @@ const SignBsdaOperation = ({ bsdaId, onClose }) => {
   };
 
   const operationCode = watch("destination.operation.code");
-  const operationDate = watch("destination.operation.date");
 
   useEffect(() => {
-    if (!operationDate) {
-      setValue("destination.operation.date", datetimeToYYYYMMDD(TODAY));
-    }
-  }, [TODAY, operationDate, setValue]);
+    setValue("destination.operation.date", datetimeToYYYYMMDD(TODAY));
+  }, [TODAY, setValue]);
 
   const onSubmit = async data => {
     const { author, date, ...update } = data;

--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
@@ -233,8 +233,9 @@ const SignBsdaReception = ({ bsdaId, onClose }) => {
   useEffect(() => {
     if (initialState) {
       reset(initialState);
+      setValue("destination.reception.date", datetimeToYYYYMMDD(TODAY));
     }
-  }, [initialState, reset]);
+  }, [initialState, reset, TODAY, setValue]);
 
   useEffect(() => {
     if (["ACCEPTED", "RECEIVED"].includes(acceptationStatus)) {

--- a/front/src/form/bsda/stepper/initial-state.ts
+++ b/front/src/form/bsda/stepper/initial-state.ts
@@ -108,6 +108,10 @@ export function getInitialState(bsda?: Bsda | null): BsdaFormikValues {
       operation: {
         description: bsda?.destination?.operation?.description ?? "",
         nextDestination: bsda?.destination?.operation?.nextDestination ?? null
+      },
+      reception: {
+        refusedWeight: bsda?.destination?.reception?.refusedWeight ?? null,
+        weight: bsda?.destination?.reception?.weight ?? null
       }
     },
     grouping: bsda?.grouping?.map(g => g.id) ?? [],


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
- init de la date de reception et la date de traitement à la date du jour
- ajout dans l'input de creation d'un bsda les infos de réception (poids refusé, poids réceptionné) pour avoir la bonne info pour l'affichage des bordereaux groupés et de réexpédition

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[tra-16741](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16741)
[tra-16612](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16612)


# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB