### PR TITLE
[TRA-16613] La quantité refusée des BSDA s'affiche dans le registre

### DIFF
--- a/back/src/bsda/registryV2.ts
+++ b/back/src/bsda/registryV2.ts
@@ -36,6 +36,7 @@ import {
 import { prisma } from "@td/prisma";
 import { isFinalOperationCode } from "../common/operationCodes";
 import { logger } from "@td/logger";
+import { bsdaWasteQuantities } from "./utils";
 
 const getQuantity = (packagings: Prisma.JsonValue) => {
   if (!packagings || !(packagings as PackagingInfo[])?.length) {
@@ -226,6 +227,10 @@ export const toIncomingWasteV2 = (
     country: emitterCompanyCountry
   } = splitAddress(bsda.emitterCompanyAddress);
 
+  const wasteQuantities = bsdaWasteQuantities(bsda);
+  const quantityAccepted = wasteQuantities?.quantityAccepted ?? null;
+  const quantityRefused = wasteQuantities?.quantityRefused ?? null;
+
   return {
     ...emptyIncomingWasteV2,
     id: bsda.id,
@@ -332,13 +337,12 @@ export const toIncomingWasteV2 = (
           .toDecimalPlaces(6)
           .toNumber()
       : null,
-    destinationReceptionRefusedWeight: bsda.destinationReceptionRefusedWeight
-      ? bsda.destinationReceptionRefusedWeight
-          .dividedBy(1000)
-          .toDecimalPlaces(6)
-          .toNumber()
+    destinationReceptionRefusedWeight: quantityRefused
+      ? quantityRefused.dividedBy(1000).toDecimalPlaces(6).toNumber()
       : null,
-    destinationReceptionAcceptedWeight: null,
+    destinationReceptionAcceptedWeight: quantityAccepted
+      ? quantityAccepted.dividedBy(1000).toDecimalPlaces(6).toNumber()
+      : null,
     destinationReceptionWeightIsEstimate: false,
     destinationReceptionVolume: null,
     destinationPlannedOperationCode: bsda.destinationPlannedOperationCode,


### PR DESCRIPTION
# Ticket Favro

[Remonter la "Quantité refusée" et "Quantité acceptée / traitée" dans les registres entrants, sortants, transport, gestion et exhaustif](https://favro.com/widget/ab14a4f0460a99a9d64d4945/86ca51bec3a3fc5ca60933af?card=tra-16613)