### PR TITLE
[TRA 16609] Erreurs de dates de récépissé en français

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :nail_care: Améliorations
 
 - Changement de la validation de présence d'entreprise de travaux BSDA [PR 4302](https://github.com/MTES-MCT/trackdechets/pull/4302)
+- Traduction du message d'erreur de date de validité de récépissé [PR 4303](https://github.com/MTES-MCT/trackdechets/pull/4303)
 
 # [2025.07.1] 01/07/2025
 

--- a/back/src/companies/validation.ts
+++ b/back/src/companies/validation.ts
@@ -18,7 +18,13 @@ import countries, { Country } from "world-countries";
 import { todayAtMidnight } from "../utils";
 
 export const receiptSchema = yup.object().shape({
-  validityLimit: yup.date().min(todayAtMidnight()).required()
+  validityLimit: yup
+    .date()
+    .min(
+      todayAtMidnight(),
+      "La limite de validité du récépissé doit être dans le futur"
+    )
+    .required()
 });
 
 export function isCollector(company: Company) {


### PR DESCRIPTION
# Contexte

Les messages d'erreur lorsque l'utilisateur entre une date de limite de validité pour le récépissé étaient en anglais (message standard d'erreur yup). J'ajoute un message en français.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<img width="1153" alt="Capture d’écran 2025-07-03 à 02 54 04" src="https://github.com/user-attachments/assets/6310d8dd-7408-48b4-82d0-28222364bc41" />


# Ticket Favro

[Remonter les messages d'erreur en français sur les dates limites de récépissé dans les profils Courtier et Négociant](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16609)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB