### PR TITLE
[TRA-16736] Mise en forme de l'erreur remontée lors de la signature d'un BSDA sans récepissé de transport

### DIFF
--- a/back/src/bsda/validation/rules.ts
+++ b/back/src/bsda/validation/rules.ts
@@ -254,7 +254,7 @@ export const bsdaTransporterEditionRules: BsdaTransporterEditionRules = {
       from: transporterSignature,
       when: requireTransporterRecepisse,
       customErrorMessage:
-        "L'établissement doit renseigner son récépissé dans Trackdéchets"
+        "L'établissement doit renseigner son récépissé dans Trackdéchets."
     }
   },
   transporterRecepisseDepartment: {
@@ -264,7 +264,7 @@ export const bsdaTransporterEditionRules: BsdaTransporterEditionRules = {
       from: transporterSignature,
       when: requireTransporterRecepisse,
       customErrorMessage:
-        "L'établissement doit renseigner son récépissé dans Trackdéchets"
+        "L'établissement doit renseigner son récépissé dans Trackdéchets."
     }
   },
   transporterRecepisseValidityLimit: {
@@ -274,7 +274,7 @@ export const bsdaTransporterEditionRules: BsdaTransporterEditionRules = {
       from: transporterSignature,
       when: requireTransporterRecepisse,
       customErrorMessage:
-        "L'établissement doit renseigner son récépissé dans Trackdéchets"
+        "L'établissement doit renseigner son récépissé dans Trackdéchets."
     }
   },
   transporterTransportMode: {

--- a/front/src/Apps/common/Components/Error/Error.tsx
+++ b/front/src/Apps/common/Components/Error/Error.tsx
@@ -65,13 +65,29 @@ export function NotificationError({ apolloError, className, message }: Props) {
 }
 
 export function DsfrNotificationError({ apolloError, message }: Props) {
+  // Format error so that \n are transformed into divs with confortable spacing
+  // Note: css `white-space: pre-line;` would achieve the same but we would have
+  // no control on the spacing between lines.
+  const formatError = error => {
+    const errors = error.message.split("\n");
+    return (
+      <>
+        {errors.map(e => (
+          <div className="fr-mt-1w">{e}</div>
+        ))}
+      </>
+    );
+  };
+
   return (
     <ErrorProvider apolloError={apolloError}>
       {({ error, idx }) => (
         <Alert
           key={`${idx}-${error.message}`}
           title="Erreur"
-          description={message ? message(apolloError) : error.message}
+          description={
+            message ? message(apolloError) : formatError(apolloError)
+          }
           severity="error"
         />
       )}


### PR DESCRIPTION
# Contexte

L'erreur remontait comme un gros pavé illisible:

![image](https://github.com/user-attachments/assets/40949438-4552-4efd-bd98-ef1185edd9a4)

On aère un peu tout ça:

![image](https://github.com/user-attachments/assets/84cadcea-9265-4e39-b664-61d0786a0870)

# Ticket Favro

[Revoir l'erreur qui s'affiche lorsque le transporteur n'a pas de récépissé sur BSDA ](https://favro.com/widget/ab14a4f0460a99a9d64d4945/38dfd6ba6ec61b84095d067b?card=tra-16736)
