### PR TITLE
[TRA 16585] Auth: modification de signup/signin pour éviter l'énumération

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Traduction du message d'erreur de date de validité de récépissé [PR 4303](https://github.com/MTES-MCT/trackdechets/pull/4303)
 - Changements divers sur formulaires de déclaration [PR 4310](https://github.com/MTES-MCT/trackdechets/pull/4310)
 
+#### :bug: Corrections de bugs
+
+- Modification de signup/signin pour éviter l'énumération [PR 4306](https://github.com/MTES-MCT/trackdechets/pull/4306)
+
 # [2025.07.1] 01/07/2025
 
 #### :nail_care: Améliorations

--- a/back/src/__tests__/auth.integration.ts
+++ b/back/src/__tests__/auth.integration.ts
@@ -7,6 +7,7 @@ import { app, sess } from "../server";
 import { getUid, hashToken } from "../utils";
 import { userFactory, userWithAccessTokenFactory } from "./factories";
 import { TOTP } from "totp-generator";
+import { clearUserLoginNeedsCaptcha } from "../common/redis/captcha";
 
 const { UI_HOST } = process.env;
 
@@ -20,7 +21,9 @@ const cookieRegExp = new RegExp(
 );
 
 describe("POST /login", () => {
-  afterEach(() => resetDatabase());
+  beforeEach(() => clearUserLoginNeedsCaptcha("user_1@td.io"));
+
+  afterEach(async () => resetDatabase());
 
   it("create a persistent session if login form is valid", async () => {
     const user = await userFactory();

--- a/back/src/auth/auth.ts
+++ b/back/src/auth/auth.ts
@@ -134,12 +134,6 @@ passport.use(
         });
       }
 
-      if (!user.isActive) {
-        return done(null, false, {
-          ...getLoginError(username).NOT_ACTIVATED
-        });
-      }
-
       const needsTotp = !!user.totpActivatedAt && !!user.totpSeed;
 
       const passwordValid = await compare(password, user.password);
@@ -147,6 +141,11 @@ passport.use(
       if (passwordValid) {
         await clearUserLoginNeedsCaptcha(user.email);
 
+        if (!user.isActive) {
+          return done(null, false, {
+            ...getLoginError(username).NOT_ACTIVATED
+          });
+        }
         if (needsTotp) {
           // we redirect to the totp page without logging the user in.
           // We store their email in a short-lived session to be retrieved on the 2nd factor page

--- a/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
@@ -53,7 +53,7 @@ describe("Mutation.signup", () => {
       }
     });
 
-    expect(data.signup).toEqual(user);
+    expect(data.signup).toEqual(true);
 
     const newUser = await prisma.user.findUniqueOrThrow({
       where: { email: user.email }
@@ -73,10 +73,10 @@ describe("Mutation.signup", () => {
     );
   });
 
-  it("should throw BAD_USER_INPUT if email already exist", async () => {
+  it("should return the same result if email already exist", async () => {
     const alreadyExistingUser = await userFactory();
 
-    const { errors } = await mutate(SIGNUP, {
+    const { data } = await mutate(SIGNUP, {
       variables: {
         userInfos: {
           email: alreadyExistingUser.email,
@@ -86,23 +86,7 @@ describe("Mutation.signup", () => {
         }
       }
     });
-    expect(errors[0].extensions?.code).toEqual(ErrorCode.BAD_USER_INPUT);
-  });
-
-  it("should throw BAD_USER_INPUT if email already exist regarldess of the email casing", async () => {
-    const alreadyExistingUser = await userFactory();
-
-    const { errors } = await mutate(SIGNUP, {
-      variables: {
-        userInfos: {
-          email: alreadyExistingUser.email.toUpperCase(),
-          password: "newUserPassword",
-          name: alreadyExistingUser.name,
-          phone: alreadyExistingUser.phone
-        }
-      }
-    });
-    expect(errors[0].extensions?.code).toEqual(ErrorCode.BAD_USER_INPUT);
+    expect(data.signup).toEqual(true);
   });
 
   it("should throw BAD_USER_INPUT if email is not valid", async () => {
@@ -166,7 +150,7 @@ describe("Mutation.signup", () => {
     expect(errors[0].extensions?.code).toEqual(ErrorCode.BAD_USER_INPUT);
   });
 
-  it("should throw BAD_USER_INPUT if password is to long", async () => {
+  it("should throw BAD_USER_INPUT if password is too long", async () => {
     const user = {
       email: "bademail",
       name: "New User",

--- a/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.integration.ts
@@ -15,11 +15,7 @@ jest.mock("../../../../mailer/mailing");
 
 const SIGNUP = `
   mutation SignUp($userInfos: SignupInput!) {
-    signup(userInfos: $userInfos) {
-      email
-      name
-      phone
-    }
+    signup(userInfos: $userInfos)
   }
 `;
 
@@ -76,16 +72,17 @@ describe("Mutation.signup", () => {
   it("should return the same result if email already exist", async () => {
     const alreadyExistingUser = await userFactory();
 
-    const { data } = await mutate(SIGNUP, {
+    const { data, errors } = await mutate(SIGNUP, {
       variables: {
         userInfos: {
           email: alreadyExistingUser.email,
-          password: "newUserPassword",
+          password: "newUserPassword&",
           name: alreadyExistingUser.name,
           phone: alreadyExistingUser.phone
         }
       }
     });
+    console.log(errors);
     expect(data.signup).toEqual(true);
   });
 

--- a/back/src/users/resolvers/mutations/__tests__/signup.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.test.ts
@@ -18,7 +18,7 @@ jest.mock("@td/prisma", () => ({
     user: {
       create: jest.fn(() => Promise.resolve(userInfos)),
       update: jest.fn(() => Promise.resolve(userInfos)),
-      findUnique: jest.fn(() => Promise.resolve(userInfos)),
+      findUnique: jest.fn(() => Promise.resolve(null)),
       findFirst: jest.fn(() => Promise.resolve(null)),
       findMany: jest.fn(() => Promise.resolve([])),
       count: jest.fn(() => Promise.resolve(0))

--- a/back/src/users/resolvers/mutations/__tests__/signup.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.test.ts
@@ -49,9 +49,9 @@ describe("signup", () => {
   });
 
   test("should create user", async () => {
-    const user = await signup({ userInfos });
+    const res = await signup({ userInfos });
 
-    expect(user.id).toBe("new_user");
+    expect(res).toBe(true);
   });
 
   test("should create activation hash", async () => {

--- a/back/src/users/resolvers/mutations/__tests__/signup.test.ts
+++ b/back/src/users/resolvers/mutations/__tests__/signup.test.ts
@@ -18,6 +18,7 @@ jest.mock("@td/prisma", () => ({
     user: {
       create: jest.fn(() => Promise.resolve(userInfos)),
       update: jest.fn(() => Promise.resolve(userInfos)),
+      findUnique: jest.fn(() => Promise.resolve(userInfos)),
       findFirst: jest.fn(() => Promise.resolve(null)),
       findMany: jest.fn(() => Promise.resolve([])),
       count: jest.fn(() => Promise.resolve(0))

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -3,7 +3,7 @@ type Mutation {
   USAGE INTERNE
   Permet de créer un nouvel utilisateur
   """
-  signup(userInfos: SignupInput!): User!
+  signup(userInfos: SignupInput!): Boolean!
 
   """
   USAGE INTERNE

--- a/front/src/login/mutations.ts
+++ b/front/src/login/mutations.ts
@@ -2,9 +2,7 @@ import { gql } from "@apollo/client";
 
 export const SIGNUP = gql`
   mutation Signup($userInfos: SignupInput!) {
-    signup(userInfos: $userInfos) {
-      id
-    }
+    signup(userInfos: $userInfos)
   }
 `;
 

--- a/libs/back/mail/src/templates/index.ts
+++ b/libs/back/mail/src/templates/index.ts
@@ -20,6 +20,12 @@ export const onSignup: MailTemplate<{ activationHash: string }> = {
   templateId: templateIds.LAYOUT
 };
 
+export const onSignupExistingUser: MailTemplate = {
+  subject: "Vous avez déjà un compte sur Trackdéchets",
+  body: mustacheRenderer("confirmation-de-compte-existant.html"),
+  templateId: templateIds.LAYOUT
+};
+
 export const inviteUserToJoin: MailTemplate<{
   hash: string;
   companyName: string;

--- a/libs/back/mail/src/templates/mustache/confirmation-de-compte-existant.html
+++ b/libs/back/mail/src/templates/mustache/confirmation-de-compte-existant.html
@@ -1,0 +1,14 @@
+<p>
+  Vous avez récemment tenté de créer un compte sur Trackdéchets avec cette
+  adresse e-mail. Nous tenons à vous informer qu’un compte existe déjà avec
+  cette adresse. Vous pouvez donc vous connecter directement en utilisant votre
+  e-mail.
+</p>
+<p>
+  Si vous avez oublié votre mot de passe, n’hésitez pas à utiliser la fonction
+  "Mot de passe oublié" pour le réinitialiser.
+</p>
+<p>
+  Si vous n’êtes pas à l’origine de cette demande, nous vous recommandons de
+  changer votre mot de passe par précaution.
+</p>


### PR DESCRIPTION
# Contexte

### Signup

Modification de l'endpoint de signup qui renvoyait un résultat différent si l'utilisateur existe déjà ou non.

Il renvoit maintenant un résultat identique, avec un timing aléatoire permettant d'éviter une timing attack (puisqu'il y a création d'un utilisateur et envoi de mail à la création d'un utilisateur, et un retour direct si l'utilisateur existe déjà, il est possible de déduire du temps de réponse serveur si un utilisateur est créé ou non).

De plus, un email signalant qu'une tentative de signup a été faite avec son mail est envoyé.

### Signin

Modification de l'ordre des vérifications au signin pour éviter de leak l'information qu'un compte est en cours de vérification si on essaie de se signin avec le bon mail mais mauvais mot de passe.

# Points de vigilance pour les intégrateurs

Les endpoints sont privés donc pas d'impact.

# Démo


https://github.com/user-attachments/assets/5b8acd2c-10ca-470d-ab47-72a95567b8dc



# Ticket Favro

[Yogosha - Énumération des adresses mail présentes sur l'application](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16585)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB