### PR TITLE
[TRA-16544] Permettre à Cyclévia de faire le BSD de regroupement, avec des BSD initiaux sur lequel il est visé comme EO

### DIFF
--- a/.env.model
+++ b/.env.model
@@ -244,3 +244,6 @@ OVERRIDE_V20250101="2024-12-27T00:00:00.000Z"
 
 # For testing purposes, optional and defaulted to "2025-02-12"
 OVERRIDE_V20250201="2025-01-15T00:00:00.000Z"
+
+# EcoOrganismes should not be able to create Appendix2 forms, but we make exceptions
+APPENDIX2_EO_EXCEPTIONS=["90377711800022"]

--- a/back/src/forms/helpers/ecoOrganismes.ts
+++ b/back/src/forms/helpers/ecoOrganismes.ts
@@ -1,0 +1,8 @@
+const appendix2EoExceptions = JSON.parse(
+  process.env.APPENDIX2_EO_EXCEPTIONS ?? "[]"
+) as string[];
+
+// Si l'éco-organisme est autorisé à créer une annexe 2
+export const isEOAllowedToCreateAppendix2 = (siret: string): boolean => {
+  return appendix2EoExceptions.includes(siret);
+};

--- a/back/src/forms/resolvers/mutations/createForm.ts
+++ b/back/src/forms/resolvers/mutations/createForm.ts
@@ -36,6 +36,8 @@ const createFormResolver = async (
   { createFormInput }: MutationCreateFormArgs,
   context: GraphQLContext
 ) => {
+  console.log(">> createFormResolver");
+  console.log("createFormInput", createFormInput);
   const user = checkIsAuthenticated(context);
 
   const sirenifiedFormInput = await sirenifyFormInput(createFormInput, user);


### PR DESCRIPTION
# Contexte

On veut permettre à Cyclévia de faire le BSD de regroupement, avec des BSD initiaux sur lequel il est visé comme EO (uniquement via API).

J'ai écrit 2-3 tests pour montrer que c'est déjà possible (pour tous les EO, apparemment).

# Ticket Favro

[Permettre à Cyclévia de faire le BSD de regroupement, avec des BSD initiaux sur lequel il est visé comme EO](https://favro.com/widget/ab14a4f0460a99a9d64d4945/38dfd6ba6ec61b84095d067b?card=tra-16544)
