### PR TITLE
[TRA-16759] Accepter les numéros de parcelles à 4 chiffres 

### DIFF
--- a/libs/back/registry/src/shared/__tests__/schemas.test.ts
+++ b/libs/back/registry/src/shared/__tests__/schemas.test.ts
@@ -252,6 +252,9 @@ describe("Schemas", () => {
     expect(() => parcelNumbersSchema.parse("1-AA-1")).not.toThrow();
     expect(() => parcelNumbersSchema.parse("123-AA-1234")).not.toThrow();
     expect(() => parcelNumbersSchema.parse("12-AA-12")).not.toThrow();
+    expect(() => parcelNumbersSchema.parse("1234-AA-12")).not.toThrow();
+    expect(() => parcelNumbersSchema.parse("123-12-12")).not.toThrow();
+    expect(() => parcelNumbersSchema.parse("1234-A2-12")).not.toThrow();
     expect(() =>
       parcelNumbersSchema.parse("123-AA-1234,123-AA-1234")
     ).not.toThrow();

--- a/libs/back/registry/src/shared/schemas.ts
+++ b/libs/back/registry/src/shared/schemas.ts
@@ -349,7 +349,7 @@ const parcelNumbersArraySchema = z.array(
     .string()
     .transform(v => v.replace(/\s+/g, ""))
     .refine(
-      v => /^\d{1,3}-[A-Z]{1,2}-\d{1,4}$/.test(v),
+      v => /^\d{1,4}-[A-Z0-9]{1,2}-\d{1,4}$/.test(v),
       "Le numéro de parcelle ne respecte pas le format attendu"
     )
 );


### PR DESCRIPTION
# Contexte

- Accepter les numéros de parcelles à 4 chiffres 
- autoriser également les chiffres au lieu des lettres au milieu (cf TRA-16759)

# Points de vigilance pour les intégrateurs

# Démo

# Ticket Favro

[Titre](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16759)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB