### PR TITLE
[tra-15808]Investiguer les GET_BSDS abusifs

### DIFF
--- a/front/src/Apps/Dashboard/dashboardUtils.tsx
+++ b/front/src/Apps/Dashboard/dashboardUtils.tsx
@@ -57,7 +57,6 @@ import {
   IconBSPaohThin
 } from "../common/Components/Icons/Icons";
 import { getOperationCodesFromSearchString } from "./dashboardServices";
-import { BsdCurrentTab } from "../common/types/commonTypes";
 import { BsdSubType, BsdType, BsdWhere, OrderBy } from "@td/codegen-ui";
 import { getOptionsFromValues } from "../common/Components/SelectWithSubOptions/SelectWithSubOptions.utils";
 
@@ -638,54 +637,4 @@ export const getRevisionPath = bsd => {
     default:
       break;
   }
-};
-
-export const getBsdCurrentTab = ({
-  isDraftTab,
-  isActTab,
-  isFollowTab,
-  isArchivesTab,
-  isToCollectTab,
-  isCollectedTab,
-  isReturnTab,
-  isPendingRevisionForTab,
-  isEmittedRevisionForTab,
-  isReceivedRevisionForTab,
-  isReviewedRevisionForTab
-}): BsdCurrentTab => {
-  if (isDraftTab) {
-    return "draftTab";
-  }
-  if (isActTab) {
-    return "actTab";
-  }
-  if (isFollowTab) {
-    return "followTab";
-  }
-  if (isArchivesTab) {
-    return "archivesTab";
-  }
-  if (isToCollectTab) {
-    return "toCollectTab";
-  }
-  if (isCollectedTab) {
-    return "collectedTab";
-  }
-  if (isReturnTab) {
-    return "returnTab";
-  }
-  if (isPendingRevisionForTab) {
-    return "pendingRevisionForTab";
-  }
-  if (isEmittedRevisionForTab) {
-    return "emittedRevisionForTab";
-  }
-  if (isReceivedRevisionForTab) {
-    return "receivedRevisionForTab";
-  }
-  if (isReviewedRevisionForTab) {
-    return "reviewedRevisionForTab";
-  }
-  // default tab
-  return "allBsdsTab";
 };

--- a/front/src/Pages/Dashboard.utils.tsx
+++ b/front/src/Pages/Dashboard.utils.tsx
@@ -18,38 +18,24 @@ import {
 } from "../Apps/common/wordings/dashboard/wordingsDashboard";
 import { BsdWhere, OrderType, QueryBsdsArgs } from "@td/codegen-ui";
 import { filterList, filterPredicates } from "../Apps/Dashboard/dashboardUtils";
+import { BsdCurrentTab } from "../Apps/common/types/commonTypes";
 
-export type Tabs = {
-  isActTab;
-  isDraftTab;
-  isFollowTab;
-  isArchivesTab;
-  isToCollectTab;
-  isCollectedTab;
-  isAllBsdsTab;
-  isPendingRevisionForTab;
-  isEmittedRevisionForTab;
-  isReceivedRevisionForTab;
-  isReviewedRevisionForTab;
-  isReturnTab;
-};
-
-export const getRoutePredicate = (props: Tabs & { siret }) => {
-  const {
-    siret,
-    isActTab,
-    isDraftTab,
-    isFollowTab,
-    isArchivesTab,
-    isToCollectTab,
-    isCollectedTab,
-    isAllBsdsTab,
-    isPendingRevisionForTab,
-    isEmittedRevisionForTab,
-    isReceivedRevisionForTab,
-    isReviewedRevisionForTab,
-    isReturnTab
-  } = props;
+export const getRoutePredicate = (
+  bsdCurrentTab: BsdCurrentTab,
+  siret: string
+) => {
+  const isActTab = bsdCurrentTab === "actTab";
+  const isDraftTab = bsdCurrentTab === "draftTab";
+  const isFollowTab = bsdCurrentTab === "followTab";
+  const isArchivesTab = bsdCurrentTab === "archivesTab";
+  const isToCollectTab = bsdCurrentTab === "toCollectTab";
+  const isCollectedTab = bsdCurrentTab === "collectedTab";
+  const isAllBsdsTab = bsdCurrentTab === "allBsdsTab";
+  const isPendingRevisionForTab = bsdCurrentTab === "pendingRevisionForTab";
+  const isEmittedRevisionForTab = bsdCurrentTab === "emittedRevisionForTab";
+  const isReceivedRevisionForTab = bsdCurrentTab === "receivedRevisionForTab";
+  const isReviewedRevisionForTab = bsdCurrentTab === "reviewedRevisionForTab";
+  const isReturnTab = bsdCurrentTab === "returnTab";
 
   if (isActTab) {
     return {
@@ -116,18 +102,18 @@ export const getRoutePredicate = (props: Tabs & { siret }) => {
   }
 };
 
-export const getBlankslateTitle = (tabs: Tabs): string | undefined => {
-  const {
-    isActTab,
-    isDraftTab,
-    isFollowTab,
-    isArchivesTab,
-    isPendingRevisionForTab,
-    isEmittedRevisionForTab,
-    isReceivedRevisionForTab,
-    isReviewedRevisionForTab,
-    isReturnTab
-  } = tabs;
+export const getBlankslateTitle = (
+  bsdCurrentTab: BsdCurrentTab
+): string | undefined => {
+  const isActTab = bsdCurrentTab === "actTab";
+  const isDraftTab = bsdCurrentTab === "draftTab";
+  const isFollowTab = bsdCurrentTab === "followTab";
+  const isArchivesTab = bsdCurrentTab === "archivesTab";
+  const isPendingRevisionForTab = bsdCurrentTab === "pendingRevisionForTab";
+  const isEmittedRevisionForTab = bsdCurrentTab === "emittedRevisionForTab";
+  const isReceivedRevisionForTab = bsdCurrentTab === "receivedRevisionForTab";
+  const isReviewedRevisionForTab = bsdCurrentTab === "reviewedRevisionForTab";
+  const isReturnTab = bsdCurrentTab === "returnTab";
 
   if (isActTab) {
     return blankstate_action_title;
@@ -155,17 +141,17 @@ export const getBlankslateTitle = (tabs: Tabs): string | undefined => {
   return blankstate_default_title;
 };
 
-export const getBlankslateDescription = ({
-  isActTab,
-  isDraftTab,
-  isFollowTab,
-  isArchivesTab,
-  isPendingRevisionForTab,
-  isEmittedRevisionForTab,
-  isReceivedRevisionForTab,
-  isReviewedRevisionForTab,
-  isReturnTab
-}: Tabs) => {
+export const getBlankslateDescription = (bsdCurrentTab: BsdCurrentTab) => {
+  const isActTab = bsdCurrentTab === "actTab";
+  const isDraftTab = bsdCurrentTab === "draftTab";
+  const isFollowTab = bsdCurrentTab === "followTab";
+  const isArchivesTab = bsdCurrentTab === "archivesTab";
+  const isPendingRevisionForTab = bsdCurrentTab === "pendingRevisionForTab";
+  const isEmittedRevisionForTab = bsdCurrentTab === "emittedRevisionForTab";
+  const isReceivedRevisionForTab = bsdCurrentTab === "receivedRevisionForTab";
+  const isReviewedRevisionForTab = bsdCurrentTab === "reviewedRevisionForTab";
+  const isReturnTab = bsdCurrentTab === "returnTab";
+
   if (isActTab) {
     return blankstate_action_desc;
   }


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->
Ne pas hésiter à le tester si vous avez un moment

J'ai réduis le nombre de useQuery similaires dans les hooks `useNotificationQueries` et `useShowTransportTabs` pour que ça ne fasse qu'une seule requête. J'ai une requête `gql` qui appelle plusieurs fois `bsds` avec des `alias` ce qui fait que Apollo Client exécute 1 seul appel réseau, même s’il y a plusieurs requêtes internes.

j'ai simplifié la logique autour du `bsdCurrentTab`

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[tra-15808](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-15808)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB