### PR TITLE
Ajout d'une bannière de consentement au suivi, d'une interface de gestion dans les prefs utilisateur et d'un script de suivi Matomo

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 - Changement de la validation de présence d'entreprise de travaux BSDA [PR 4302](https://github.com/MTES-MCT/trackdechets/pull/4302)
 - Traduction du message d'erreur de date de validité de récépissé [PR 4303](https://github.com/MTES-MCT/trackdechets/pull/4303)
 
+#### :rocket: Nouvelles fonctionnalités
+
+- Ajout d'une bannière de consentement au suivi, d'une interface de gestion dans les prefs utilisateur et d'un script de suivi Matomo [PR 4318](https://github.com/MTES-MCT/trackdechets/pull/4318)
+
 # [2025.07.1] 01/07/2025
 
 #### :nail_care: Améliorations

--- a/back/src/common/typeDefs/common.objects.graphql
+++ b/back/src/common/typeDefs/common.objects.graphql
@@ -42,4 +42,8 @@ type User {
 
   "Liste des fonctionnalités optionelles activées"
   featureFlags: [String!]!
+
+  trackingConsent: Boolean!
+
+  trackingConsentUntil: DateTime
 }

--- a/back/src/users/resolvers/queries/__tests__/me.integration.ts
+++ b/back/src/users/resolvers/queries/__tests__/me.integration.ts
@@ -11,6 +11,8 @@ const ME = `
     me {
       id
       isAdmin
+      trackingConsent
+      trackingConsentUntil
       companies {
         siret
         userRole
@@ -30,6 +32,21 @@ describe("query me", () => {
     expect(data.me.id).toEqual(user.id);
     expect(data.me.isAdmin).toEqual(false);
   });
+  it.each([true, false])(
+    "should return tracking consent data (%p)",
+    async trackingConsentValue => {
+      const until = new Date();
+
+      const user = await userFactory({
+        trackingConsent: trackingConsentValue,
+        trackingConsentUntil: until
+      });
+      const { query } = makeClient(user);
+      const { data } = await query<Pick<Query, "me">>(ME);
+      expect(data.me.trackingConsent).toEqual(trackingConsentValue);
+      expect(data.me.trackingConsentUntil).toEqual(until.toISOString());
+    }
+  );
 
   it("should return user companies with role and permissions", async () => {
     const { user, company } = await userWithCompanyFactory("MEMBER");

--- a/back/src/users/typeDefs/private/user.mutations.graphql
+++ b/back/src/users/typeDefs/private/user.mutations.graphql
@@ -32,8 +32,10 @@ type Mutation {
   """
   USAGE INTERNE
   Met à jour les informations de l'utilisateur
+
+  Quand trackingConsent est passé, la valeur de trackingConsentUntil est modifiée à 180 jours dans le futur
   """
-  editProfile(name: String, phone: String): User!
+  editProfile(name: String, phone: String, trackingConsent: Boolean): User!
 
   """
   USAGE INTERNE

--- a/e2e/src/plans/bsvhu/createBsvhu.spec.ts
+++ b/e2e/src/plans/bsvhu/createBsvhu.spec.ts
@@ -15,6 +15,7 @@ import {
   verifyOverviewData,
   deleteBsvhu
 } from "../../utils/bsvhu";
+import { addDays } from "date-fns";
 
 test.describe.serial("Cahier de recette de création des BSVHU", async () => {
   // User credentials
@@ -32,7 +33,9 @@ test.describe.serial("Cahier de recette de création des BSVHU", async () => {
     user = await seedUser({
       name: USER_NAME,
       email: USER_EMAIL,
-      password: USER_PASSWORD
+      password: USER_PASSWORD,
+      trackingConsent: false,
+      trackingConsentUntil: addDays(new Date(), 180) // do not display consent banner
     });
   });
 

--- a/front/.env.model
+++ b/front/.env.model
@@ -8,7 +8,8 @@ VITE_NOTIFIER_ENDPOINT=http://notifier.trackdechets.local
 VITE_URL_SCHEME=
 VITE_HOSTNAME=
 
-# Matomo tracker id and url
+# Matomo tracker id (eg. container_abcd123) and url (without scheme: eg matomo.example.com)
+
 # Tracking is disabled when those variables are not provided
 # VITE_MATOMO_TRACKER_SITE_ID=
 # VITE_MATOMO_TRACKER_URL=

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from "./ErrorBoundary";
 import { AuthProvider } from "./common/contexts/AuthContext";
 import { FeatureFlagsProvider } from "./common/contexts/FeatureFlagsContext";
 import { PermissionsProvider } from "./common/contexts/PermissionsContext";
+import { MatomoTracker } from "./common/tracking/Tracking";
 import i18next from "i18next";
 import { z } from "zod";
 import { zodI18nMap } from "zod-i18n-map";
@@ -40,6 +41,7 @@ export default function App() {
             <PermissionsProvider>
               <FeatureFlagsProvider defaultFeatureFlags={{}}>
                 <div className="App">
+                  <MatomoTracker />
                   <RouterProvider router={router} />
                 </div>
               </FeatureFlagsProvider>

--- a/front/src/Apps/Account/AccountInfo/AccountFormChangeTrackingSetting.tsx
+++ b/front/src/Apps/Account/AccountInfo/AccountFormChangeTrackingSetting.tsx
@@ -1,0 +1,110 @@
+import { useMutation } from "@apollo/client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import React, { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { z } from "zod";
+import { DsfrNotificationError } from "../../common/Components/Error/Error";
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+import AccountInfoActionBar from "./AccountInfoActionBar";
+
+import { validationAccountTrackingConsentSchema } from "../accountSchema";
+import { UPDATE_TRACKING_CONSENT } from "../../common/queries/user/userQueries";
+import { useAuth } from "../../../common/contexts/AuthContext";
+
+type ValidationSchema = z.infer<typeof validationAccountTrackingConsentSchema>;
+
+interface FormFields {
+  trackingConsent: boolean;
+}
+
+const labelText = `Aidez Trackdéchets à améliorer son service en permettant le recueil automatique des données d’utilisation.Ces données sont, par exemple, le parcours entre le différents écrans et les champs sélectionnés et l’ordre de remplissage de ceux-ci.`;
+
+export default function AccountFormChangeTrackingSetting() {
+  const [updateTrackingConsent, { loading, error }] = useMutation(
+    UPDATE_TRACKING_CONSENT
+  );
+  const { refreshUser, user } = useAuth();
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  const defaultValues: FormFields = {
+    trackingConsent: Boolean(user?.trackingConsent)
+  };
+
+  const { handleSubmit, reset, formState, setValue, watch } =
+    useForm<ValidationSchema>({
+      defaultValues,
+      resolver: zodResolver(validationAccountTrackingConsentSchema)
+    });
+
+  const onReset = async () => {
+    setIsEditing(false);
+    reset();
+    await refreshUser();
+  };
+
+  const onEditSetting = () => {
+    setIsEditing(true);
+  };
+
+  const trackingConsent = watch("trackingConsent");
+
+  const onSubmit: SubmitHandler<ValidationSchema> = async () => {
+    await updateTrackingConsent({
+      variables: { trackingConsent }
+    });
+    setIsEditing(false);
+  };
+  return (
+    <div>
+      {!isEditing && (
+        <>
+          <AccountInfoActionBar
+            title="Analyse et améliorations"
+            onEditInfo={onEditSetting}
+            onReset={onReset}
+            isEditing={isEditing}
+          />
+
+          <div className="fr-col-md-8 ">
+            <ToggleSwitch
+              label={labelText}
+              checked={trackingConsent}
+              onChange={() => null}
+              style={{ cursor: "not-allowed" }}
+            />
+          </div>
+        </>
+      )}
+
+      {isEditing && (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <AccountInfoActionBar
+            title="Analyse et améliorations"
+            onEditInfo={onEditSetting}
+            onReset={onReset}
+            isEditing={isEditing}
+            isDisabled={formState.isSubmitting}
+          />
+          <div className="fr-col-md-8 ">
+            <ToggleSwitch
+              label={labelText}
+              checked={trackingConsent}
+              onChange={e => setValue("trackingConsent", e)}
+            />
+          </div>
+
+          <AccountInfoActionBar
+            onEditInfo={onEditSetting}
+            onReset={async () => await onReset()}
+            isEditing={isEditing}
+            isDisabled={formState.isSubmitting}
+          />
+
+          {loading && <div>Envoi en cours...</div>}
+          {error && <DsfrNotificationError apolloError={error} />}
+        </form>
+      )}
+    </div>
+  );
+}

--- a/front/src/Apps/Account/AccountInfo/AccountInfo.tsx
+++ b/front/src/Apps/Account/AccountInfo/AccountInfo.tsx
@@ -9,6 +9,7 @@ import { validationAccountParametersSchema } from "../accountSchema";
 import AccountInfoActionBar from "./AccountInfoActionBar";
 import { DsfrNotificationError } from "../../common/Components/Error/Error";
 import AccountFormChangePassword from "./AccountFormChangePassword";
+import AccountFormChangeTrackingSetting from "./AccountFormChangeTrackingSetting";
 
 type Props = {
   readonly me: User;
@@ -37,6 +38,14 @@ const AccountFieldNameFragments = {
     }
   `
 };
+const AccountFieldTrackingConsentFragment = {
+  me: gql`
+    fragment AccountFieldTrackingConsentFragment on User {
+      id
+      trackingConsent
+    }
+  `
+};
 
 AccountInfo.fragments = {
   me: gql`
@@ -44,9 +53,12 @@ AccountInfo.fragments = {
       email
       ...AccountFieldPhoneFragment
       ...AccountFieldNameFragment
+      ...AccountFieldTrackingConsentFragment
     }
+
     ${AccountFieldPhoneFragments.me},
     ${AccountFieldNameFragments.me}
+    ${AccountFieldTrackingConsentFragment.me}
   `
 };
 
@@ -178,6 +190,8 @@ export default function AccountInfo({ me }: Props) {
 
       <hr className="fr-mt-2w" />
       <AccountFormChangePassword />
+      <hr className="fr-mt-2w" />
+      <AccountFormChangeTrackingSetting />
     </>
   );
 }

--- a/front/src/Apps/Account/accountSchema.ts
+++ b/front/src/Apps/Account/accountSchema.ts
@@ -34,3 +34,7 @@ export const validationAccountPasswordSchema = z.object({
   oldPassword: z.string().min(3, "Champ requis"),
   newPassword: z.string()
 });
+
+export const validationAccountTrackingConsentSchema = z.object({
+  trackingConsent: z.boolean()
+});

--- a/front/src/Apps/common/Components/ConsentBanner/ConsentBanner.tsx
+++ b/front/src/Apps/common/Components/ConsentBanner/ConsentBanner.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from "react";
+import { useMutation } from "@apollo/client";
+import { UPDATE_TRACKING_CONSENT } from "../../queries/user/userQueries";
+import { DsfrNotificationError } from "../Error/Error";
+import { useAuth } from "../../../../common/contexts/AuthContext";
+
+export const ConsentBanner = () => {
+  const { refreshUser, user } = useAuth();
+
+  const trackingConsentUntil = user?.trackingConsentUntil;
+  const [updateTrackingConsent, { loading, error }] = useMutation(
+    UPDATE_TRACKING_CONSENT
+  );
+  const handleClick = async (trackingConsent: Boolean) => {
+    setDisplay(false);
+    await updateTrackingConsent({
+      variables: { trackingConsent }
+    });
+    await refreshUser();
+  };
+  const initialDisplay = trackingConsentUntil
+    ? new Date(trackingConsentUntil) < new Date()
+    : true;
+  const [display, setDisplay] = useState(initialDisplay);
+  useEffect(() => {
+    setDisplay(initialDisplay);
+  }, [initialDisplay]);
+  if (!user) return null;
+  if (!display) return null;
+  return (
+    <div className="fr-consent-banner">
+      <h2 className="fr-h6">Analyse et amélioration</h2>
+      <div className="fr-consent-banner__content">
+        <p className="fr-text--sm">
+          Aidez Trackdéchets à améliorer son service en permettant le recueil
+          automatique des données d’utilisation. Ces données sont, par exemple,
+          le parcours entre le différents écrans et les champs sélectionnés et
+          l’ordre de remplissage de ceux-ci. Vous pouvez modifier votre choix
+          dans “Mon compte”.
+        </p>
+      </div>
+      <ul className="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
+        <li>
+          <button
+            className="fr-btn"
+            title="Autoriser tous les cookies"
+            onClick={async () => handleClick(true)}
+            disabled={loading}
+          >
+            Accepter
+          </button>
+        </li>
+        <li>
+          <button
+            className="fr-btn"
+            title="Refuser tous les cookies"
+            onClick={async () => handleClick(false)}
+            disabled={loading}
+          >
+            Refuser
+          </button>
+        </li>
+      </ul>
+      {loading && <div>Envoi en cours...</div>}
+
+      {error && <DsfrNotificationError apolloError={error} />}
+    </div>
+  );
+};

--- a/front/src/Apps/common/Components/layout/Layout.tsx
+++ b/front/src/Apps/common/Components/layout/Layout.tsx
@@ -9,11 +9,12 @@ import sandboxIcon from "./assets/code-sandbox.svg";
 import downtimeIcon from "./assets/code-downtime.svg";
 import PageTitle from "../PageTitle/PageTitle";
 import A11ySkipLinks from "../A11ySkipLinks/A11ySkipLinks";
-
+import { ConsentBanner } from "../ConsentBanner/ConsentBanner";
 interface AuthProps {
   v2banner?: JSX.Element;
   isAuthenticated?: boolean;
 }
+
 const { VITE_WARNING_MESSAGE, VITE_DOWNTIME_MESSAGE, VITE_API_ENDPOINT } =
   import.meta.env;
 
@@ -102,6 +103,7 @@ export default function Layout({
       {isAuthenticated ? <Header /> : <UnauthenticatedHeader />}
       <Outlet />
       <PageTitle />
+      <ConsentBanner />
     </>
   );
 }

--- a/front/src/Apps/common/queries/user/userQueries.ts
+++ b/front/src/Apps/common/queries/user/userQueries.ts
@@ -1,0 +1,10 @@
+import { gql } from "@apollo/client";
+
+export const UPDATE_TRACKING_CONSENT = gql`
+  mutation UpdateTrackingConsent($trackingConsent: Boolean!) {
+    editProfile(trackingConsent: $trackingConsent) {
+      id
+      trackingConsent
+    }
+  }
+`;

--- a/front/src/common/tracking/Tracking.tsx
+++ b/front/src/common/tracking/Tracking.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useAuth } from "../contexts/AuthContext";
+
+declare global {
+  interface Window {
+    _mtm?: Array<Record<string, any>>;
+    _matomoLoaded?: boolean;
+  }
+}
+
+export function MatomoTracker() {
+  const { VITE_MATOMO_TRACKER_SITE_ID, VITE_MATOMO_TRACKER_URL } = import.meta
+    .env;
+  const { user } = useAuth();
+
+  const trackingConsentUntil = user?.trackingConsentUntil;
+  const trackingConsent = user?.trackingConsent;
+
+  useEffect(() => {
+    if (!VITE_MATOMO_TRACKER_SITE_ID || !VITE_MATOMO_TRACKER_URL) {
+      return;
+    }
+
+    const hasConsent =
+      trackingConsent &&
+      (trackingConsentUntil
+        ? new Date(trackingConsentUntil) > new Date()
+        : false);
+
+    if (hasConsent) {
+      if (window._matomoLoaded) return;
+
+      const _mtm = (window._mtm = window._mtm || []);
+      _mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
+
+      const d = document;
+      const g = d.createElement("script");
+      const s = d.getElementsByTagName("script")[0];
+      g.async = true;
+      g.src = `https://${VITE_MATOMO_TRACKER_URL}/js/${VITE_MATOMO_TRACKER_SITE_ID}.js`;
+
+      if (s.parentNode) {
+        s.parentNode.insertBefore(g, s);
+      }
+
+      window._matomoLoaded = true;
+    }
+
+    if (!hasConsent) {
+      // Remove Matomo script when consent is withdrawn
+      if (window._matomoLoaded) {
+        // the process of removing in-memory matomo code is a pita, let's just refesh the page
+        window.location.reload();
+      }
+    }
+  }, [trackingConsentUntil, trackingConsent]);
+
+  return null;
+}

--- a/libs/back/prisma/src/migrations/20250721083713_user_tracking_consent/migration.sql
+++ b/libs/back/prisma/src/migrations/20250721083713_user_tracking_consent/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "trackingConsent" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "trackingConsentUntil" TIMESTAMP(3);

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -911,22 +911,25 @@ model BsddTransporter {
 }
 
 model User {
-  id                    String                  @id @default(cuid()) @db.VarChar(30)
-  email                 String                  @unique(map: "User.email_unique")
-  password              String
-  passwordVersion       Int?
-  name                  String
-  phone                 String?
-  createdAt             DateTime                @default(now()) @db.Timestamptz(6)
-  updatedAt             DateTime                @updatedAt @db.Timestamptz(6)
-  activatedAt           DateTime?               @db.Timestamptz(6)
-  firstAssociationDate  DateTime?               @db.Timestamptz(6)
-  isActive              Boolean?                @default(false)
-  isAdmin               Boolean                 @default(false)
-  governmentAccountId   String?                 @unique
-  governmentAccount     GovernmentAccount?      @relation(fields: [governmentAccountId], references: [id])
-  totpSeed              String?
-  totpActivatedAt       DateTime?               @db.Timestamptz(6)
+  id                   String             @id @default(cuid()) @db.VarChar(30)
+  email                String             @unique(map: "User.email_unique")
+  password             String
+  passwordVersion      Int?
+  name                 String
+  phone                String?
+  createdAt            DateTime           @default(now()) @db.Timestamptz(6)
+  updatedAt            DateTime           @updatedAt @db.Timestamptz(6)
+  activatedAt          DateTime?          @db.Timestamptz(6)
+  firstAssociationDate DateTime?          @db.Timestamptz(6)
+  isActive             Boolean?           @default(false)
+  isAdmin              Boolean            @default(false)
+  governmentAccountId  String?            @unique
+  governmentAccount    GovernmentAccount? @relation(fields: [governmentAccountId], references: [id])
+  totpSeed             String?
+  totpActivatedAt      DateTime?          @db.Timestamptz(6)
+  trackingConsent      Boolean            @default(false)
+  trackingConsentUntil DateTime?
+
   AccessToken           AccessToken[]
   applications          Application[]
   companyAssociations   CompanyAssociation[]


### PR DESCRIPTION
# Contexte

Cette PR implémente le tracking matomo et les préférences utilisateurs quant à ce tracking.
- 2 variables d'environnements front ,VITE_MATOMO_TRACKER_SITE_ID et VITE_MATOMO_TRACKER_URL sont requises. EN leur absence, les préférences utilisateurs n'ont aucun effet, il n'y a pas de tracking
- Les préférences sont stockées sur le modèle user (trackingConsent et trackingConsentUntil).
- La requête /me renvoie ces infos, editProfile (pricvée) met à jour la valeur de trackingConsent, et trackingConsentUntil et updaté à date du jour + 180j.
- Une bannière type cookie mais pas cookie parce que c'est pas un cookie et gentiment présenté à l'utilisateur connecté (et uniquement connecté) quand trackingConsentUntil est passé ou null, cad tous les 6 mois (contrainte légale)
- l'utilisateur peut à tout moment, dès qu'il le souhaite, à toute heure et en tout lieu et aussi souvent qu'il le souhaite, mettre à jour ces préférences
- au niveau du front un ingénieux mécanisme déclenche un refresh de la requête /me pour maj les préférences

# Points de vigilance 

Il est important de s'assurer que la révocation du consentement bloque bien l'envoi de requêtes matomo

# Démo

 

https://github.com/user-attachments/assets/50fd8867-3fd8-430c-a4ed-71669d1c7fa7



# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16596
https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16623

# Checklist

- [ ] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB