### PR TITLE
Fix dasri with intermediaries signature

### DIFF
--- a/front/src/Apps/common/queries/dashboard/detailQueries.ts
+++ b/front/src/Apps/common/queries/dashboard/detailQueries.ts
@@ -34,16 +34,3 @@ export const GET_DETAIL_DASRI_WITH_METADATA = gql`
   }
   ${fullDasriFragment}
 `;
-
-export const GET_DASRI_METADATA = gql`
-  query Bsdasri($id: ID!) {
-    bsdasri(id: $id) {
-      metadata {
-        errors {
-          message
-          requiredFor
-        }
-      }
-    }
-  }
-`;

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/PartialForms.tsx
@@ -302,12 +302,16 @@ export function OperationSignatureForm() {
   );
 }
 
-export const removeSections = (input, signatureType: SignatureType) => {
+export const removeBsdasriSectionsBeforeSignature = (
+  input,
+  signatureType: SignatureType
+) => {
   const emitterKey = "emitter";
   const wasteKey = "waste";
   const ecoOrganismeKey = "ecoOrganisme";
   const transporterKey = "transporter";
   const destinationKey = "destination";
+  const intermediariesKey = "intermediaries";
   const receptionKey = "reception";
   const operationKey = "operation";
   const wholeCompanyKey = "company";
@@ -331,7 +335,9 @@ export const removeSections = (input, signatureType: SignatureType) => {
     groupingKey,
     synthesizingKey,
     synthesizedInKey,
-    transporterTransportVolumeKey
+    transporterTransportVolumeKey,
+
+    intermediariesKey
   ];
   const mapping = {
     [BsdasriSignatureType.Emission]: [

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasri.tsx
@@ -36,7 +36,7 @@ import {
   SynthesisTransportSignatureForm,
   ReceptionSignatureForm,
   OperationSignatureForm,
-  removeSections
+  removeBsdasriSectionsBeforeSignature
 } from "./PartialForms";
 import routes from "../../../../../Apps/routes";
 
@@ -192,7 +192,7 @@ export function RouteSignBsdasri({
             variables: {
               id: id,
               input: {
-                ...removeSections(rest, UIsignatureType)
+                ...removeBsdasriSectionsBeforeSignature(rest, UIsignatureType)
               }
             }
           });

--- a/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
+++ b/front/src/dashboard/components/BSDList/BSDasri/WorkflowAction/RouteSignBsdasriSecretCode.tsx
@@ -32,7 +32,7 @@ import {
 import EmptyDetail from "../../../../detail/common/EmptyDetailView";
 import { Formik, Field, Form } from "formik";
 import routes from "../../../../../Apps/routes";
-import { removeSections } from "./PartialForms";
+import { removeBsdasriSectionsBeforeSignature } from "./PartialForms";
 import {
   SIGN_BSDASRI_EMISSION_WITH_SECRET_CODE,
   UPDATE_BSDASRI
@@ -120,7 +120,10 @@ export function RouteBSDasrisSignEmissionSecretCode() {
             variables: {
               id: id,
               input: {
-                ...removeSections(rest, BsdasriSignatureType.Emission)
+                ...removeBsdasriSectionsBeforeSignature(
+                  rest,
+                  BsdasriSignatureType.Emission
+                )
               }
             }
           });


### PR DESCRIPTION
# Contexte

Fix de cahier de recette

Dans les modales de signature dasri, on renvoie un udpate + un sign. Le payload doit de l'update doit être nettoyé pour éviter de renvoyer certains champ. Les intermédiaires étaient partiellement renvoyés, causant un bug de signature

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16841

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB