### PR TITLE
[TRA-16173] Fix de recette: ajout du CAP dans la BSDCard + dans ES pour les recherches

### DIFF
--- a/back/src/bsdasris/elastic.ts
+++ b/back/src/bsdasris/elastic.ts
@@ -256,7 +256,7 @@ export function toBsdElastic(bsdasri: BsdasriForElastic): BsdElastic {
     destinationCompanySiret: bsdasri.destinationCompanySiret ?? "",
     destinationCompanyAddress: bsdasri.destinationCompanyAddress ?? "",
     destinationCustomInfo: bsdasri.destinationCustomInfo ?? "",
-    destinationCap: "",
+    destinationCap: bsdasri.destinationCap ?? "",
 
     brokerCompanyName: bsdasri.brokerCompanyName ?? "",
     brokerCompanySiret: bsdasri.brokerCompanySiret ?? "",

--- a/front/src/Apps/common/queries/fragments/bsdasri.ts
+++ b/front/src/Apps/common/queries/fragments/bsdasri.ts
@@ -124,6 +124,7 @@ export const dashboardDasriFragment = gql`
       }
     }
     destination {
+      cap
       company {
         ...DashboardCompanyFragment
       }


### PR DESCRIPTION
# Contexte

2 corrections:
- Ajout du CAP dans les BSDCard
- Ajout du CAP à ES pour pouvoir faire des recherches dans ES par n° de CAP

# Ticket Favro

[Permettre l'ajout d'un CAP sur le DASRI initial et de regroupement](https://favro.com/widget/ab14a4f0460a99a9d64d4945/38dfd6ba6ec61b84095d067b?card=tra-16173)