### PR TITLE
[FIX TRA 16491/16657] ajouts/changements de wording

### DIFF
--- a/front/src/form/registry/common/Labels.tsx
+++ b/front/src/form/registry/common/Labels.tsx
@@ -77,5 +77,6 @@ export const InfoLabels = {
   weighingHour:
     "À renseigner pour les installations soumises à contrôle par vidéo",
   sisIdentifier:
-    "À renseigner lorsque les terres ont été extraites d'un terrain placé en secteur d'information sur les sols au titre de l'article L. 125-6"
+    "À renseigner lorsque les terres ont été extraites d'un terrain placé en secteur d'information sur les sols au titre de l'article L. 125-6",
+  gistrid: "Doit être renseigné dans le cadre d'un transfert transfrontalier"
 };

--- a/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
+++ b/front/src/form/registry/common/ParcelsVisualizer/ParcelsVisualizer.tsx
@@ -417,7 +417,7 @@ export function ParcelsVisualizer({
                     onClick={async () => {
                       if (!inseeCode) {
                         setClientError({
-                          text: "Impossible d'afficher la parcelle, veuillez renseigner le code INSEE",
+                          text: "Affichage de la parcelle impossible : veuillez renseigner le code INSEE",
                           severity: "error",
                           field: "inseeCode"
                         });
@@ -425,7 +425,7 @@ export function ParcelsVisualizer({
                       }
                       if (!parcelNumber) {
                         setClientError({
-                          text: "Impossible d'afficher la parcelle, veuillez renseigner le numéro de parcelle",
+                          text: "Affichage de la parcelle impossible : veuillez renseigner le numéro de parcelle",
                           severity: "error",
                           field: "parcelNumber"
                         });
@@ -438,7 +438,7 @@ export function ParcelsVisualizer({
                       );
                       if (!res) {
                         setClientError({
-                          text: "Impossible d'afficher la parcelle, etes vous sûr que le numéro de parcelle est correct ?",
+                          text: "Affichage de la parcelle impossible : les informations renseignées semblent incorrectes",
                           severity: "warning",
                           field: null
                         });
@@ -456,7 +456,7 @@ export function ParcelsVisualizer({
                     onClick={async () => {
                       if (!inseeCode) {
                         setClientError({
-                          text: "Impossible d'afficher la parcelle, veuillez renseigner le code INSEE",
+                          text: "Ajout de la parcelle impossible : veuillez renseigner le code INSEE",
                           severity: "error",
                           field: "inseeCode"
                         });
@@ -464,7 +464,7 @@ export function ParcelsVisualizer({
                       }
                       if (!parcelNumber) {
                         setClientError({
-                          text: "Impossible d'afficher la parcelle, veuillez renseigner le numéro de parcelle",
+                          text: "Ajout de la parcelle impossible : veuillez renseigner le numéro de parcelle",
                           severity: "error",
                           field: "parcelNumber"
                         });
@@ -485,7 +485,7 @@ export function ParcelsVisualizer({
                         setClientError(null);
                       } else {
                         setClientError({
-                          text: "Impossible d'ajouter la parcelle, etes vous sûr que le numéro de parcelle est correct ?",
+                          text: "Ajout de la parcelle impossible : les informations renseignées semblent incorrectes",
                           severity: "warning",
                           field: null
                         });
@@ -525,7 +525,7 @@ export function ParcelsVisualizer({
                     onClick={() => {
                       if (!coordinates) {
                         setClientError({
-                          text: "Impossible d'afficher le point, veuillez renseigner les coordonnées GPS",
+                          text: "Affichage du point impossible : veuillez renseigner les coordonnées GPS",
                           severity: "error",
                           field: "coordinates"
                         });
@@ -534,7 +534,7 @@ export function ParcelsVisualizer({
                       const res = displayCoordinates(coordinates, map);
                       if (!res) {
                         setClientError({
-                          text: "Impossible d'afficher le point, etes vous sûr que les coordonnées GPS sont correctes ?",
+                          text: "Affichage du point impossible : les informations renseignées semblent incorrectes",
                           severity: "warning",
                           field: null
                         });
@@ -550,6 +550,14 @@ export function ParcelsVisualizer({
                     priority="secondary"
                     disabled={disabled}
                     onClick={() => {
+                      if (!coordinates) {
+                        setClientError({
+                          text: "Ajout du point impossible : veuillez renseigner les coordonnées GPS",
+                          severity: "error",
+                          field: "coordinates"
+                        });
+                        return;
+                      }
                       const lonLat = lonLatFromCoordinatesString(coordinates);
                       if (lonLat) {
                         const res = addPointToMap(
@@ -559,7 +567,7 @@ export function ParcelsVisualizer({
                         );
                         if (!res) {
                           setClientError({
-                            text: "Impossible d'ajouter le point, etes vous sûr que les coordonnées GPS sont correctes ?",
+                            text: "Ajout du point impossible : les informations renseignées semblent incorrectes",
                             severity: "warning",
                             field: null
                           });
@@ -572,7 +580,7 @@ export function ParcelsVisualizer({
                         setClientError(null);
                       } else {
                         setClientError({
-                          text: "Impossible d'ajouter le point, etes vous sûr que les coordonnées GPS sont correctes ?",
+                          text: "Ajout du point impossible : les informations renseignées semblent incorrectes",
                           severity: "warning",
                           field: null
                         });

--- a/front/src/form/registry/incomingTexs/shape.ts
+++ b/front/src/form/registry/incomingTexs/shape.ts
@@ -227,7 +227,8 @@ export const incomingTexsFormShape: FormShape = [
         shape: "generic",
         title: "Transfert transfrontalier de déchets",
         label: Labels.ttdImportNumber,
-        required: false,
+        infoLabel: InfoLabels.gistrid,
+        required: true,
         validation: {
           ttdImportNumber: optionalString
         },

--- a/front/src/form/registry/incomingWaste/shape.ts
+++ b/front/src/form/registry/incomingWaste/shape.ts
@@ -352,7 +352,8 @@ export const incomingWasteFormShape: FormShape = [
         name: "ttdImportNumber",
         shape: "generic",
         label: Labels.ttdImportNumber,
-        required: false,
+        infoLabel: InfoLabels.gistrid,
+        required: true,
         validation: {
           ttdImportNumber: optionalString
         },

--- a/front/src/form/registry/managed/shape.ts
+++ b/front/src/form/registry/managed/shape.ts
@@ -374,6 +374,7 @@ export const managedFormShape: FormShape = [
         shape: "generic",
         title: "Transfert transfrontalier de déchets",
         label: Labels.gistridNumber,
+        infoLabel: InfoLabels.gistrid,
         required: true,
         validation: {
           gistridNumber: optionalString

--- a/front/src/form/registry/outgoingTexs/shape.ts
+++ b/front/src/form/registry/outgoingTexs/shape.ts
@@ -353,6 +353,7 @@ export const outgoingTexsFormShape: FormShape = [
         name: "gistridNumber",
         shape: "generic",
         label: Labels.gistridNumber,
+        infoLabel: InfoLabels.gistrid,
         required: true,
         validation: {
           gistridNumber: optionalString

--- a/front/src/form/registry/outgoingWaste/shape.ts
+++ b/front/src/form/registry/outgoingWaste/shape.ts
@@ -304,6 +304,7 @@ export const outgoingWasteFormShape: FormShape = [
         name: "gistridNumber",
         shape: "generic",
         label: Labels.gistridNumber,
+        infoLabel: InfoLabels.gistrid,
         required: true,
         validation: {
           gistridNumber: optionalString

--- a/front/src/form/registry/transported/shape.ts
+++ b/front/src/form/registry/transported/shape.ts
@@ -235,6 +235,7 @@ export const transportedFormShape: FormShape = [
         shape: "generic",
         title: "Transfert transfrontalier de déchets",
         label: Labels.gistridNumber,
+        infoLabel: InfoLabels.gistrid,
         required: true,
         validation: {
           gistridNumber: optionalString


### PR DESCRIPTION
# Contexte

- Ajout de labels d'info sur les champs GISTRID/transfert transfrontalier et suppression de la mention "optionnel" en passant le flag "required" à true
- Changement du wording des erreurs sur le sélecteur de parcelles

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB