### PR TITLE
[TRA 16092] Résoud problème de dates sur l'export exhaustif

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Les changements importants de Trackdéchets sont documentés dans ce fichier.
 Le format est basé sur [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 et le projet suit un schéma de versionning inspiré de [Calendar Versioning](https://calver.org/).
 
+# [2025.08.1] 26/08/2025
+
+#### :bug: Corrections de bugs
+
+- Résolution d'un problème de dates sur l'export exhaustif [PR 4344](https://github.com/MTES-MCT/trackdechets/pull/4344)
+
 # [2025.07.2] 29/07/2025
 
 #### :nail_care: Améliorations

--- a/back/src/common/where.ts
+++ b/back/src/common/where.ts
@@ -371,7 +371,8 @@ export function toElasticStringListQuery(
 
 export function toElasticDateQuery(
   fieldName: string,
-  dateFilter: DateFilter | null | undefined
+  dateFilter: DateFilter | null | undefined,
+  rounding = true
 ): estypes.QueryContainer | undefined {
   if (!dateFilter) {
     return undefined;
@@ -405,16 +406,32 @@ export function toElasticDateQuery(
     range: {
       [fieldName]: {
         ...(dateFilter._gt
-          ? { gt: `${new Date(dateFilter._gt).getTime()}||/d` }
+          ? {
+              gt: `${new Date(dateFilter._gt).getTime()}${
+                rounding ? "||/d" : ""
+              }`
+            }
           : {}),
         ...(dateFilter._gte
-          ? { gte: `${new Date(dateFilter._gte).getTime()}||/d` }
+          ? {
+              gte: `${new Date(dateFilter._gte).getTime()}${
+                rounding ? "||/d" : ""
+              }`
+            }
           : {}),
         ...(dateFilter._lt
-          ? { lt: `${new Date(dateFilter._lt).getTime()}||/d` }
+          ? {
+              lt: `${new Date(dateFilter._lt).getTime()}${
+                rounding ? "||/d" : ""
+              }`
+            }
           : {}),
         ...(dateFilter._lte
-          ? { lte: `${new Date(dateFilter._lte).getTime()}||/d` }
+          ? {
+              lte: `${new Date(dateFilter._lte).getTime()}${
+                rounding ? "||/d" : ""
+              }`
+            }
           : {})
       }
     }

--- a/back/src/registryV2/elastic.ts
+++ b/back/src/registryV2/elastic.ts
@@ -118,5 +118,5 @@ export function dateFilterToElasticFilter(
   fieldName: keyof BsdElastic,
   dateFilter: DateFilter
 ): estypes.QueryContainer {
-  return toElasticDateQuery(fieldName, dateFilter) ?? {};
+  return toElasticDateQuery(fieldName, dateFilter, false) ?? {};
 }

--- a/front/src/dashboard/registry/RegistryExhaustiveExportModalContext.tsx
+++ b/front/src/dashboard/registry/RegistryExhaustiveExportModalContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useState } from "react";
 import { useMutation } from "@apollo/client";
-import { format, startOfYear, endOfDay, startOfDay } from "date-fns";
+import { format, startOfYear } from "date-fns";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 
@@ -77,6 +77,28 @@ const getDefaultValues = (asAdmin: boolean) => ({
   format: RegistryExportFormat.Csv
 });
 
+const getUTCStartOfDay = (dateStr: string) => {
+  const date = new Date(dateStr);
+  return new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  ).toISOString();
+};
+
+const getUTCEndOfDay = (dateStr: string) => {
+  const date = new Date(dateStr);
+  return new Date(
+    Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      23,
+      59,
+      59,
+      999
+    )
+  ).toISOString();
+};
+
 export const RegistryExhaustiveExportModalProvider: React.FC<{
   children: React.ReactNode;
   asAdmin?: boolean;
@@ -128,10 +150,8 @@ export const RegistryExhaustiveExportModalProvider: React.FC<{
       const { companyOrgId, format, startDate, endDate } = input;
       const siret = companyOrgId === "all" ? null : companyOrgId;
       // push the dates to the extremities of days so we include the days entered in the inputs
-      const startOfDayStartDate = startOfDay(new Date(startDate)).toISOString();
-      const endOfDayEndDate = endDate
-        ? endOfDay(new Date(endDate)).toISOString()
-        : null;
+      const startOfDayStartDate = getUTCStartOfDay(startDate);
+      const endOfDayEndDate = endDate ? getUTCEndOfDay(endDate) : null;
 
       await generateExport({
         variables: {

--- a/front/src/dashboard/registry/RegistryExhaustiveExportModalContext.tsx
+++ b/front/src/dashboard/registry/RegistryExhaustiveExportModalContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useState } from "react";
 import { useMutation } from "@apollo/client";
-import { format, startOfYear } from "date-fns";
+import { format, startOfYear, endOfDay, startOfDay } from "date-fns";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 
@@ -77,28 +77,6 @@ const getDefaultValues = (asAdmin: boolean) => ({
   format: RegistryExportFormat.Csv
 });
 
-const getUTCStartOfDay = (dateStr: string) => {
-  const date = new Date(dateStr);
-  return new Date(
-    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
-  ).toISOString();
-};
-
-const getUTCEndOfDay = (dateStr: string) => {
-  const date = new Date(dateStr);
-  return new Date(
-    Date.UTC(
-      date.getFullYear(),
-      date.getMonth(),
-      date.getDate(),
-      23,
-      59,
-      59,
-      999
-    )
-  ).toISOString();
-};
-
 export const RegistryExhaustiveExportModalProvider: React.FC<{
   children: React.ReactNode;
   asAdmin?: boolean;
@@ -150,8 +128,10 @@ export const RegistryExhaustiveExportModalProvider: React.FC<{
       const { companyOrgId, format, startDate, endDate } = input;
       const siret = companyOrgId === "all" ? null : companyOrgId;
       // push the dates to the extremities of days so we include the days entered in the inputs
-      const startOfDayStartDate = getUTCStartOfDay(startDate);
-      const endOfDayEndDate = endDate ? getUTCEndOfDay(endDate) : null;
+      const startOfDayStartDate = startOfDay(new Date(startDate)).toISOString();
+      const endOfDayEndDate = endDate
+        ? endOfDay(new Date(endDate)).toISOString()
+        : null;
 
       await generateExport({
         variables: {


### PR DESCRIPTION
# Contexte

Certains acteurs voyaient des bordereaux en dehors de leur plage de date demandée apparaître dans leur export.
Ce problème était dû au fait que le formatage de dates pour elastic fait un arrondi (à la borne inférieure), et la frontend définit la date de début par rapport au fuseau horaire de l'utilisateur. Donc 00:00 le 01/01 en UTC ISOstring donne 2024-12-31T23:00:00.000Z, ce qui une fois arrondi à la borne inférieure pour elastic donnait une recherche à partir de 00:00 le 31/12.

Etant donné qu'il est possible via API de passer une heure précise pour le début et la fin du range d'export, j'ai choisi de résoudre le problème en enlevant l'arrondi du formatage de query elastic, pour obtenir la même précision dans la query que dans la requête.

A noter que le ticket fait mention de dates d'expédition mais qu'il s'agit d'un quiproquo, car se sont bien les dates de dernière mise à jour qui servent à filtrer et classer les bordereaux.

# Points de vigilance pour les intégrateurs

Les dates de sélection de l'export exhaustif (dateFilter) ne sont plus arrondies à l'inférieur et ont donc la précision attendue.

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Registre exhaustif - L’export généré ne respecte pas les dates d’expédition complétées par l’utilisateur](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16092)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB