### PR TITLE
[TRA 16895] Ajout du chemin manquant sur erreur d'import registre

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ et le projet suit un schéma de versionning inspiré de [Calendar Versioning](ht
 #### :bug: Corrections de bugs
 
 - Résolution d'un problème de dates sur l'export exhaustif [PR 4344](https://github.com/MTES-MCT/trackdechets/pull/4344)
+- Ajout du chemin manquant sur erreur d'import registre [PR 4347](https://github.com/MTES-MCT/trackdechets/pull/4347)
 
 # [2025.07.2] 29/07/2025
 

--- a/libs/back/registry/src/shared/refinement.ts
+++ b/libs/back/registry/src/shared/refinement.ts
@@ -241,7 +241,8 @@ export function refineActorInfos<T>({
           context.addIssue({
             code: z.ZodIssueCode.custom,
             message:
-              "Le numéro d'identification doit contenir le nom et prénom pour une personne physique"
+              "Le numéro d'identification doit contenir le nom et prénom pour une personne physique",
+            path: [orgIdKey]
           });
         }
         break;


### PR DESCRIPTION
# Contexte

Une erreur registre remontait sans chemin : "undefined : Le numéro d'identification doit contenir le nom et prénom pour une personne physique". On rajoute donc le chemin de la colonne concernée.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<img width="618" height="146" alt="Capture d’écran 2025-08-05 à 15 36 01" src="https://github.com/user-attachments/assets/374289a7-5400-4964-92cc-50df53d05e0a" />

# Ticket Favro

[Revoir le message d'erreur "undefined : Le numéro d'identification doit contenir le nom et prénom pour une personne physique"](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16895)

# Checklist

- [x] Mettre à jour la documentation
- [x] Mettre à jour le change log
- [x] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [x] Informer le data engineer de tout changement de schéma DB