### PR TITLE
[TRA 16691] Permettre de sélectionner jusqu'à 4 consistances sur un BSDD

### DIFF
--- a/back/src/__tests__/factories.ts
+++ b/back/src/__tests__/factories.ts
@@ -352,7 +352,7 @@ const formdata: Partial<Prisma.FormCreateInput> = {
   },
   wasteAcceptationStatus: null,
   wasteDetailsCode: "05 01 04*",
-  wasteDetailsConsistence: "SOLID" as Consistence,
+  wasteDetailsConsistence: ["SOLID"] as Consistence[],
   wasteDetailsIsDangerous: true,
   wasteDetailsName: "Divers",
   wasteDetailsOnuCode: "2003",
@@ -387,7 +387,7 @@ export const forwardedInData: Partial<Prisma.FormCreateInput> = {
   wasteDetailsOnuCode: "2003",
   wasteDetailsPackagingInfos: [{ type: "CITERNE", quantity: 1 }],
   wasteDetailsQuantity: 1,
-  wasteDetailsConsistence: "SOLID" as Consistence,
+  wasteDetailsConsistence: ["SOLID"] as Consistence[],
   wasteDetailsQuantityType: "ESTIMATED",
   transporters: {
     create: { ...bsddTransporterData, number: 1 }

--- a/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
+++ b/back/src/activity-events/bsdd/__tests__/bsdd.integration.ts
@@ -125,7 +125,7 @@ describe("ActivityEvent.Bsdd", () => {
             ],
             quantity: 1.5,
             quantityType: "REAL",
-            consistence: "SOLID"
+            consistence: ["SOLID"]
           }
         }
       }

--- a/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
+++ b/back/src/bsds/resolvers/queries/__tests__/bsds.bsdd.integration.ts
@@ -170,7 +170,7 @@ describe("Query.bsds workflow", () => {
           isSubjectToADR: false,
           onuCode: null,
           name: "Stylos bille",
-          consistence: "SOLID",
+          consistence: ["SOLID"],
           packagingInfos: [
             {
               type: "BENNE",

--- a/back/src/forms/__tests__/edition.integration.ts
+++ b/back/src/forms/__tests__/edition.integration.ts
@@ -90,7 +90,7 @@ describe("checkEditionRules", () => {
         numberOfPackages: 50,
         quantity: 200,
         quantityType: "ESTIMATED",
-        consistence: "DOUGHY",
+        consistence: ["DOUGHY"],
         pop: !form.wasteDetailsPop,
         isDangerous: !form.wasteDetailsIsDangerous,
         parcelNumbers: [

--- a/back/src/forms/__tests__/edition.test.ts
+++ b/back/src/forms/__tests__/edition.test.ts
@@ -78,13 +78,15 @@ describe("edition", () => {
       numberOfPackages: 1,
       quantity: 1,
       quantityType: "REAL",
-      consistence: "SOLID",
+      consistence: ["SOLID"],
       pop: false,
       isDangerous: true,
       parcelNumbers: [],
       analysisReferences: [],
       landIdentifiers: [],
-      sampleNumber: ""
+      sampleNumber: "",
+      isSubjectToADR: false,
+      nonRoadRegulationMention: ""
     };
 
     const trader: Required<TraderInput> = {
@@ -128,7 +130,8 @@ describe("edition", () => {
       ecoOrganisme,
       temporaryStorageDetail,
       intermediaries: [],
-      transporters: []
+      transporters: [],
+      isDirectSupply: false
     };
     const flatInput = flattenFormInput(input);
     for (const key of Object.keys(flatInput)) {

--- a/back/src/forms/__tests__/form-converter.integration.ts
+++ b/back/src/forms/__tests__/form-converter.integration.ts
@@ -238,7 +238,7 @@ describe("expandFormFromDb", () => {
         numberOfPackages: 1,
         quantity: 1,
         quantityType: "ESTIMATED",
-        consistence: "SOLID",
+        consistence: ["SOLID"],
         pop: false,
         isDangerous: forwardedIn!.wasteDetailsIsDangerous
       },

--- a/back/src/forms/__tests__/sirenify.integration.ts
+++ b/back/src/forms/__tests__/sirenify.integration.ts
@@ -541,7 +541,7 @@ describe("sirenifyFormCreateInput", () => {
       wasteDetailsAnalysisReferences: [],
       wasteDetailsLandIdentifiers: [],
       wasteDetailsName: "",
-      wasteDetailsConsistence: "SOLID",
+      wasteDetailsConsistence: ["SOLID"],
       wasteDetailsSampleNumber: "",
       traderCompanyName: trader.company.name,
       traderCompanySiret: trader.company.siret,

--- a/back/src/forms/__tests__/validation.integration.ts
+++ b/back/src/forms/__tests__/validation.integration.ts
@@ -38,7 +38,7 @@ const formData: Partial<Form> = {
   emitterWorkSiteName: "",
   emitterWorkSiteAddress: "",
   emitterWorkSiteCity: "",
-  emitterWorkSiteinseeCode: "",
+  emitterWorkSitePostalCode: "",
   emitterWorkSiteInfos: "",
   emitterCompanyName: "A company 2",
   emitterCompanySiret: siret1,
@@ -65,7 +65,7 @@ const formData: Partial<Form> = {
   ],
   wasteDetailsQuantity: new Decimal(1.5),
   wasteDetailsQuantityType: "REAL",
-  wasteDetailsConsistence: "SOLID",
+  wasteDetailsConsistence: ["SOLID"],
   wasteDetailsPop: false
 };
 
@@ -1717,7 +1717,7 @@ describe("draftFormSchema", () => {
       emitterWorkSiteName: "",
       emitterWorkSiteAddress: "",
       emitterWorkSiteCity: "",
-      emitterWorkSiteinseeCode: "",
+      emitterWorkSitePostalCode: "",
       emitterWorkSiteInfos: "",
       emitterCompanyName: "A company 2",
       emitterCompanyContact: "Emetteur",
@@ -1731,9 +1731,9 @@ describe("draftFormSchema", () => {
         { type: "FUT", other: null, quantity: 1 },
         { type: "GRV", other: null, quantity: 1 }
       ],
-      wasteDetailsQuantity: 1.5,
+      wasteDetailsQuantity: new Decimal("1.5"),
       wasteDetailsQuantityType: "REAL",
-      wasteDetailsConsistence: "SOLID",
+      wasteDetailsConsistence: ["SOLID"],
       wasteDetailsPop: false
     };
     const isValid = await draftFormSchema.isValid(partialForm);

--- a/back/src/forms/converter.ts
+++ b/back/src/forms/converter.ts
@@ -125,7 +125,10 @@ function flattenWasteDetailsInput(input: {
     wasteDetailsQuantity: chain(input.wasteDetails, w => w.quantity),
     wasteDetailsQuantityType: chain(input.wasteDetails, w => w.quantityType),
     wasteDetailsName: chain(input.wasteDetails, w => w.name),
-    wasteDetailsConsistence: chain(input.wasteDetails, w => w.consistence),
+    wasteDetailsConsistence: undefinedOrDefault(
+      chain(input.wasteDetails, w => w.consistence),
+      []
+    ),
     wasteDetailsPop: undefinedOrDefault(
       chain(input.wasteDetails, w => w.pop),
       false

--- a/back/src/forms/examples/fixtures.ts
+++ b/back/src/forms/examples/fixtures.ts
@@ -111,7 +111,7 @@ const wasteDetailsInput = {
   packagingInfos: [{ type: "CITERNE", quantity: 1 }],
   quantity: 1,
   quantityType: "ESTIMATED",
-  consistence: "LIQUID"
+  consistence: ["LIQUID"]
 };
 
 function signEmissionFormInput() {

--- a/back/src/forms/examples/steps/createForm.ts
+++ b/back/src/forms/examples/steps/createForm.ts
@@ -171,7 +171,7 @@ export function createAppendix1Form(
             isSubjectToADR: false,
             onuCode: null,
             name: "Huiles",
-            consistence: "LIQUID"
+            consistence: ["LIQUID"]
           }
         }
       };

--- a/back/src/forms/pdf/components/BsddPdf.tsx
+++ b/back/src/forms/pdf/components/BsddPdf.tsx
@@ -612,8 +612,9 @@ export function BsddPdf({
                   <input
                     type="checkbox"
                     checked={
-                      form.wasteDetails?.consistence ===
-                        consistenceType.value && renderCheckboxState
+                      form.wasteDetails?.consistence?.includes(
+                        consistenceType.value
+                      ) && renderCheckboxState
                     }
                     readOnly
                   />{" "}

--- a/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/importPaperForm.integration.ts
@@ -99,7 +99,7 @@ describe("mutation / importPaperForm", () => {
           packagingInfos: [{ type: "BENNE" as Packagings, quantity: 1 }],
           isSubjectToADR: true,
           onuCode: "ONU",
-          consistence: Consistence.SOLID
+          consistence: [Consistence.SOLID]
         },
         signingInfo: {
           sentAt: "2019-12-20T00:00:00.000Z" as any,
@@ -424,7 +424,7 @@ describe("mutation / importPaperForm", () => {
         wasteDetailsQuantity: 1.0,
         wasteDetailsQuantityType: QuantityType.ESTIMATED,
         wasteDetailsPackagingInfos: [{ type: "BENNE", quantity: 1 }],
-        wasteDetailsConsistence: Consistence.SOLID,
+        wasteDetailsConsistence: [Consistence.SOLID],
         wasteDetailsPop: false,
         wasteDetailsIsDangerous: true,
         wasteDetailsOnuCode: "ONU",

--- a/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
+++ b/back/src/forms/resolvers/mutations/__tests__/updateForm.integration.ts
@@ -4155,7 +4155,7 @@ describe("Mutation.updateForm", () => {
         variables: {
           updateFormInput: {
             id: form.id,
-            wasteDetails: { consistence: "SOLID" }
+            wasteDetails: { consistence: ["SOLID"] }
           }
         }
       });

--- a/back/src/forms/typeDefs/bsdd.inputs.graphql
+++ b/back/src/forms/typeDefs/bsdd.inputs.graphql
@@ -713,7 +713,7 @@ input WasteDetailsInput {
   quantityType: QuantityType
 
   "Consistance"
-  consistence: Consistence
+  consistence: [Consistence!]
 
   "Contient des Polluants Organiques Persistants (POP) oui / non"
   pop: Boolean

--- a/back/src/forms/typeDefs/bsdd.objects.graphql
+++ b/back/src/forms/typeDefs/bsdd.objects.graphql
@@ -571,7 +571,7 @@ type WasteDetails {
   quantityType: QuantityType
 
   "Consistance"
-  consistence: Consistence
+  consistence: [Consistence!]
 
   "Contient des Polluants Organiques Persistants (POP) oui / non"
   pop: Boolean

--- a/back/src/forms/validation.ts
+++ b/back/src/forms/validation.ts
@@ -971,9 +971,15 @@ const baseWasteDetailsSchemaFn: FactorySchemaOf<
     wasteDetailsParcelNumbers: yup.array().of(parcelInfos as any),
     wasteDetailsAnalysisReferences: yup.array().of(yup.string()) as any,
     wasteDetailsLandIdentifiers: yup.array().of(yup.string()) as any,
-    wasteDetailsConsistence: yup
-      .mixed<Consistence>()
-      .requiredIf(!isDraft, "La consistance du déchet doit être précisée"),
+    wasteDetailsConsistence: (isDraft
+      ? yup
+          .array()
+          .of(yup.mixed<Consistence>().oneOf(Object.values(Consistence)))
+          .nullable()
+      : yup
+          .array()
+          .of(yup.mixed<Consistence>().oneOf(Object.values(Consistence)))
+          .min(1, "Au moins une consistance doit être sélectionnée")) as any,
     wasteDetailsPackagingInfos: yup
       .array()
       .of(packagingInfoFn({ isDraft }) as any)

--- a/back/src/scripts/bin/bsdTemplates/emptyPdfData.ts
+++ b/back/src/scripts/bin/bsdTemplates/emptyPdfData.ts
@@ -305,7 +305,7 @@ export const emptyBsdd = {
   wasteDetailsOnuCode: "",
   wasteDetailsQuantity: 1,
   wasteDetailsQuantityType: "ESTIMATED",
-  wasteDetailsConsistence: "LIQUID",
+  wasteDetailsConsistence: ["LIQUID"],
   wasteDetailsPackagingInfos: [{ type: "GRV", other: null, quantity: 1 }],
   wasteDetailsPop: false,
   wasteDetailsSampleNumber: null,

--- a/front/src/Apps/Dashboard/Validation/BSDD/FormWasteSummary.tsx
+++ b/front/src/Apps/Dashboard/Validation/BSDD/FormWasteSummary.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Consistence, Form, Maybe, QuantityType } from "@td/codegen-ui";
+import { Form, QuantityType } from "@td/codegen-ui";
 import {
   DataList,
   DataListDescription,
@@ -13,6 +13,7 @@ import {
 import { isDefined } from "../../../../common/helper";
 import { getFormWasteDetailsADRMention } from "@td/constants";
 import { WASTE_NAME_LABEL } from "../../../common/wordings/wordingsCommon";
+import { getConsistenceLabel } from "../../../common/consistenceLabel";
 
 interface FormWasteSummaryProps {
   form: Form;
@@ -59,22 +60,6 @@ export function FormWasteSummary({ form }: FormWasteSummaryProps) {
     </DataList>
   );
 }
-
-const getConsistenceLabel = (consistence: Maybe<Consistence> | undefined) => {
-  switch (consistence) {
-    case Consistence.Liquid:
-      return "Liquide";
-    case Consistence.Solid:
-      return "Solide";
-    case Consistence.Doughy:
-      return "Pâteux";
-    case Consistence.Gaseous:
-      return "Gaseux";
-
-    default:
-      return "Non soumis";
-  }
-};
 
 const getWasteQuantityAndIsEstimated = (
   form

--- a/front/src/Apps/common/consistenceLabel.ts
+++ b/front/src/Apps/common/consistenceLabel.ts
@@ -1,0 +1,25 @@
+import { Consistence, Maybe } from "@td/codegen-ui";
+
+export const getConsistenceLabel = (
+  consistence: Maybe<Consistence[]> | undefined
+) => {
+  if (!consistence || !consistence.length) {
+    return "Non soumis";
+  }
+  return consistence
+    .map(c => {
+      switch (c) {
+        case Consistence.Liquid:
+          return "Liquide";
+        case Consistence.Solid:
+          return "Solide";
+        case Consistence.Doughy:
+          return "Pâteux";
+        case Consistence.Gaseous:
+          return "Gaseux";
+        default:
+          return "";
+      }
+    })
+    .join(", ");
+};

--- a/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
+++ b/front/src/dashboard/detail/bsdd/BSDDetailContent.tsx
@@ -41,7 +41,6 @@ import {
 import routes from "../../../Apps/routes";
 
 import {
-  getVerboseConsistence,
   getVerboseAcceptationStatus,
   getVerboseQuantityType
 } from "../common/utils";
@@ -79,6 +78,7 @@ import { isDefined } from "../../../common/helper";
 import { BSD_DETAILS_QTY_TOOLTIP } from "../../../Apps/common/wordings/dashboard/wordingsDashboard";
 import { CITERNE_NOT_WASHED_OUT_REASON } from "../../../Apps/common/utils/citerneBsddSummary";
 import { useMyCompany } from "../../../Apps/common/hooks/useMyCompany";
+import { getConsistenceLabel } from "../../../Apps/common/consistenceLabel";
 
 type CompanyProps = {
   company?: FormCompany | null;
@@ -813,7 +813,7 @@ export default function BSDDetailContent({
                 />
               )}
               <dt>Consistance</dt>{" "}
-              <dd>{getVerboseConsistence(form.wasteDetails?.consistence)}</dd>
+              <dd>{getConsistenceLabel(form.wasteDetails?.consistence)}</dd>
               <DetailRow
                 value={form.wasteDetails?.parcelNumbers
                   ?.map(

--- a/front/src/dashboard/detail/common/utils.tsx
+++ b/front/src/dashboard/detail/common/utils.tsx
@@ -6,6 +6,7 @@ import {
   QuantityType
 } from "@td/codegen-ui";
 
+// only works for single consistence, do not use with BSDD
 export const getVerboseConsistence = (
   consistence: Consistence | null | undefined | ""
 ): string => {

--- a/front/src/form/bsdd/WasteInfo.tsx
+++ b/front/src/form/bsdd/WasteInfo.tsx
@@ -28,6 +28,7 @@ import {
   bsddPackagingTypes,
   emptyBsddPackaging
 } from "../../Apps/Forms/Components/PackagingList/helpers";
+import { Consistence } from "@td/codegen-ui";
 
 const SOIL_CODES = [
   "17 05 03*",
@@ -221,36 +222,51 @@ export default function WasteInfo({ disabled }) {
 
       <div className="form__row">
         <fieldset>
-          <legend>Consistance</legend>
-          <div className="tw-flex">
-            <Field
-              name="wasteDetails.consistence"
-              id="SOLID"
-              label="Solide"
-              component={RadioButton}
-              disabled={disabled}
-            />
-            <Field
-              name="wasteDetails.consistence"
-              id="LIQUID"
-              label="Liquide"
-              component={RadioButton}
-              disabled={disabled}
-            />
-            <Field
-              name="wasteDetails.consistence"
-              id="GASEOUS"
-              label="Gazeux"
-              component={RadioButton}
-              disabled={disabled}
-            />
-            <Field
-              name="wasteDetails.consistence"
-              id="DOUGHY"
-              label="Pâteux"
-              component={RadioButton}
-              disabled={disabled}
-            />
+          <h4 className="fr-h4 fr-mt-0 fr-mb-1w">Consistance</h4>
+          <div className="fr-text--xs fr-mb-1w">
+            Sélectionnez une ou plusieurs consistances.
+          </div>
+          <div className="tw-flex tw-flex-row tw-gap-4">
+            <label>
+              <Field
+                disabled={disabled}
+                type="checkbox"
+                name="wasteDetails.consistence"
+                value={Consistence.Solid}
+                className="td-checkbox"
+              />
+              Solide
+            </label>
+            <label>
+              <Field
+                disabled={disabled}
+                type="checkbox"
+                name="wasteDetails.consistence"
+                value={Consistence.Liquid}
+                className="td-checkbox"
+              />
+              Liquide
+            </label>
+            <label>
+              <Field
+                disabled={disabled}
+                type="checkbox"
+                name="wasteDetails.consistence"
+                value={Consistence.Gaseous}
+                className="td-checkbox"
+              />
+              Gazeux
+            </label>
+            <label>
+              <Field
+                disabled={disabled}
+                type="checkbox"
+                name="wasteDetails.consistence"
+                value={Consistence.Doughy}
+                className="td-checkbox"
+              />
+              Pâteux
+            </label>
           </div>
         </fieldset>
 
@@ -270,7 +286,7 @@ export default function WasteInfo({ disabled }) {
 
       {values.emitter?.type !== "APPENDIX1" && (
         <>
-          <h4 className="form__section-heading">Quantité en tonnes</h4>
+          <h4 className="fr-h4 fr-mt-2w fr-mb-1w">Quantité en tonnes</h4>
           <div className="form__row">
             <label>
               <Field

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelect.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  Consistence,
   Form,
   InitialForm,
   InitialFormFraction,
@@ -31,6 +32,9 @@ type Appendix2MultiSelectProps = {
   // callback permettant de mettre à jour la liste de contenants
   // du bordereau en fonction des annexes 2 sélectionnées
   updatePackagings: (packagings: PackagingInfoInput[]) => void;
+  // callback permettant de mettre à jour la consistance du bordereau
+  // en fonction des annexes 2 sélectionnées
+  updateConsistence: (consistence: Consistence[]) => void;
 };
 
 // Limite le nombre de bordereaux que l'on peut afficher dans le tableau
@@ -52,7 +56,8 @@ const MAX_APPENDIX_2_COUNT_USE_EFFECT = 100;
 export default function Appendix2MultiSelect({
   appendixForms,
   updateTotalQuantity,
-  updatePackagings
+  updatePackagings,
+  updateConsistence
 }: Appendix2MultiSelectProps) {
   const { values, setFieldValue, getFieldMeta } = useFormikContext<Form>();
   const meta = getFieldMeta<InitialFormFraction[]>("grouping");
@@ -188,7 +193,19 @@ export default function Appendix2MultiSelect({
         })
       )
     );
-  }, [currentlyAnnexedForms, updateTotalQuantity, updatePackagings]);
+    updateConsistence([
+      ...new Set(
+        currentlyAnnexedForms.flatMap(
+          ({ form }) => form.wasteDetails?.consistence ?? []
+        )
+      )
+    ]);
+  }, [
+    currentlyAnnexedForms,
+    updateTotalQuantity,
+    updatePackagings,
+    updateConsistence
+  ]);
 
   // Auto-complète la quantité totale à partir des annexes 2 sélectionnées
   useEffect(() => {
@@ -442,8 +459,8 @@ export default function Appendix2MultiSelect({
               calculateTotalQuantityAndPackagings();
             }}
           >
-            Calculer la quantité totale et le conditionnement à partir de la
-            liste des annexes 2
+            Calculer la quantité totale, le conditionnement et la consistance à
+            partir de la liste des annexes 2
           </Button>
         )}
       </>

--- a/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
+++ b/front/src/form/bsdd/components/appendix/Appendix2MultiSelectWrapper.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from "react";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/client";
 import {
+  Consistence,
   Form,
   PackagingInfo,
   Query,
@@ -27,6 +28,7 @@ const APPENDIX2_FORMS = gql`
         code
         name
         quantity
+        consistence
         packagingInfos {
           type
           other
@@ -84,6 +86,12 @@ function Appendix2MultiSelectWrapper({
     [setFieldValue]
   );
 
+  const updateConsistence = useCallback(
+    (consistence: Consistence[]) =>
+      setFieldValue("wasteDetails.consistence", consistence),
+    [setFieldValue]
+  );
+
   if (loading) {
     return <Loader />;
   }
@@ -105,6 +113,7 @@ function Appendix2MultiSelectWrapper({
         appendixForms={data.appendixForms}
         updateTotalQuantity={updateTotalQuantity}
         updatePackagings={updatePackagings}
+        updateConsistence={updateConsistence}
       />
     );
   }

--- a/front/src/form/bsdd/utils/initial-state.ts
+++ b/front/src/form/bsdd/utils/initial-state.ts
@@ -191,7 +191,7 @@ export function getInitialState(f?: Form | null): FormFormikValues {
         : [emptyBsddPackaging],
       quantity: f?.wasteDetails?.quantity ?? null,
       quantityType: f?.wasteDetails?.quantityType ?? QuantityType.Estimated,
-      consistence: f?.wasteDetails?.consistence ?? Consistence.Solid,
+      consistence: f?.wasteDetails?.consistence ?? [Consistence.Solid],
       pop: f?.wasteDetails?.pop ?? false,
       isDangerous: f?.wasteDetails?.isDangerous ?? false,
       parcelNumbers: f?.wasteDetails?.parcelNumbers ?? [],

--- a/front/src/form/bsdd/utils/schema.ts
+++ b/front/src/form/bsdd/utils/schema.ts
@@ -218,9 +218,8 @@ export const formSchema = object().shape({
       /(REAL|ESTIMATED)/,
       "Le type de quantité (réelle ou estimée) doit être précisé"
     ),
-    consistence: string().oneOf(
-      Object.values(Consistence),
-      "La consistance du déchet doit être précisée"
+    consistence: array().of(
+      mixed<Consistence>().oneOf(Object.values(Consistence))
     )
   }),
   temporaryStorageDetail: object()

--- a/libs/back/prisma/src/migrations/20250805174913_form_consistence_array/migration.sql
+++ b/libs/back/prisma/src/migrations/20250805174913_form_consistence_array/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - Changed the column `wasteDetailsConsistence` on the `Form` table from a scalar field to a list field. Existing scalar values will be converted to single-element arrays.
+
+*/
+
+-- Step 1: Add a temporary array column
+ALTER TABLE "Form" ADD COLUMN "wasteDetailsConsistence_new" "Consistence"[];
+
+-- Step 2: Migrate existing scalar values to arrays
+UPDATE "Form" 
+SET "wasteDetailsConsistence_new" = ARRAY["wasteDetailsConsistence"]
+WHERE "wasteDetailsConsistence" IS NOT NULL;
+
+-- Step 3: Drop the old column
+ALTER TABLE "Form" DROP COLUMN "wasteDetailsConsistence";
+
+-- Step 4: Rename the new column to the original name
+ALTER TABLE "Form" RENAME COLUMN "wasteDetailsConsistence_new" TO "wasteDetailsConsistence";

--- a/libs/back/prisma/src/schema/schema.prisma
+++ b/libs/back/prisma/src/schema/schema.prisma
@@ -490,7 +490,7 @@ model Form {
   wasteDetailsNonRoadRegulationMention  String?
   wasteDetailsQuantity                  Decimal?                   @db.Decimal(65, 30)
   wasteDetailsQuantityType              QuantityType?
-  wasteDetailsConsistence               Consistence?
+  wasteDetailsConsistence               Consistence[]
   wasteDetailsPackagingInfos            Json                       @default("[]")
   wasteDetailsPop                       Boolean                    @default(false)
   wasteDetailsSampleNumber              String?

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,6 @@
         "totp-generator": "^1.0.0",
         "tslib": "^2.3.0",
         "uuid": "^11.0.3",
-        "vite-bundle-visualizer": "^1.2.1",
         "winston": "^3.13.0",
         "world-countries": "4.0.0",
         "xss": "^1.0.10",
@@ -24063,6 +24062,8 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -31995,18 +31996,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/import-from-esm": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
-      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "import-meta-resolve": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.20"
-      }
-    },
     "node_modules/import-in-the-middle": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
@@ -32126,15 +32115,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -46064,7 +46044,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.0.tgz",
       "integrity": "sha512-Qe7w62TyawbDzB4yt32R0+AbIo6m1/sqO7UPzFS8Z/ksL5mrfhA0v4CavfdmFav3D+ub4QeAgsGEe84DoWe/nQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -46092,46 +46072,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.14.0",
         "@rollup/rollup-win32-x64-msvc": "4.14.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
-      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
-      "dependencies": {
-        "open": "^8.4.0",
-        "picomatch": "^4.0.2",
-        "source-map": "^0.7.4",
-        "yargs": "^17.5.1"
-      },
-      "bin": {
-        "rollup-plugin-visualizer": "dist/bin/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "rolldown": "1.x",
-        "rollup": "2.x || 3.x || 4.x"
-      },
-      "peerDependenciesMeta": {
-        "rolldown": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
@@ -50042,23 +49982,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-bundle-visualizer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz",
-      "integrity": "sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "import-from-esm": "^1.3.3",
-        "rollup-plugin-visualizer": "^5.11.0",
-        "tmp": "^0.2.1"
-      },
-      "bin": {
-        "vite-bundle-visualizer": "bin.js"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
       }
     },
     "node_modules/vite-node": {


### PR DESCRIPTION
# Contexte

Modification du champ consistance sur BSDD pour accepter plusieurs valeurs en même temps.

# Points de vigilance pour les intégrateurs

Le champ graphQL wasteDetails.consistence passe du type:
`Consistence` à `[Consistence!]` et attend donc une array de valeurs.

# Démo

### Formulaire

<img width="572" height="446" alt="édition" src="https://github.com/user-attachments/assets/73424206-ff47-4e35-a177-9ab8f6d73232" />

### Aperçu

<img width="376" height="327" alt="aperçu" src="https://github.com/user-attachments/assets/d1fe9bce-c0e2-4cc8-ba1f-968989cb0782" />

### PDF

<img width="187" height="120" alt="pdf" src="https://github.com/user-attachments/assets/414d5654-6981-48f1-a3ca-9c9c40a2b20c" />

### Répercussion sur Annexes 1

Bordereau chapeau :

<img width="1117" height="630" alt="Annexe 1 chapeau" src="https://github.com/user-attachments/assets/3322e142-8a23-40fa-9b43-94c9bfe7cfb2" />

Bordereau Annexé :

<img width="1121" height="476" alt="Annexe 1" src="https://github.com/user-attachments/assets/6c898505-f1b6-4097-9095-b077399fc914" />

### Calcul de la consistance à partir des Annexes 2 :

https://github.com/user-attachments/assets/78df5f3c-39e2-4fa6-9bbb-53e9cd5eff41


# Ticket Favro

[Permettre de sélectionner jusqu'à 4 consistances sur un BSDD initial, de tournée dédiée et Annexe 2](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16691)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB