### PR TITLE
[TRA 16897] Adapter l’affichage des onglets avec des marges à gauche ou droite selon la sélection sur les déclarations

### DIFF
--- a/front/src/form/registry/builder/FormBuilder.tsx
+++ b/front/src/form/registry/builder/FormBuilder.tsx
@@ -56,21 +56,54 @@ export function FormBuilder({
   const lastTabId = tabIds[tabIds.length - 1];
   const firstTabId = tabIds[0];
   const reason = methods.watch("reason");
+
   const scrollToTop = () => {
     const element = document.getElementById("formBuilder");
     if (element) {
       element.scroll({ top: 0 });
     }
   };
+
+  const scrollTabIntoView = (tabs, prevTabId, tabId) => {
+    const prevTabIndex = tabs.findIndex(tab => tab.tabId === prevTabId);
+    const tabIndex = tabs.findIndex(tab => tab.tabId === tabId);
+
+    const maxTabIndex = tabs.length - 1;
+    const forwardMoveIndex =
+      tabIndex + 1 > maxTabIndex ? maxTabIndex : tabIndex + 1;
+    const backwardMoveIndex = tabIndex - 1 < 0 ? 0 : tabIndex - 1;
+
+    // we want to scroll to the tab + or - 1 depending on the direction of the change
+    const futureTabIndex =
+      tabIndex > prevTabIndex ? forwardMoveIndex : backwardMoveIndex;
+
+    const tabElements = document
+      .getElementById("formBuilder")
+      ?.querySelectorAll("[class^='fr-tabs__tab']");
+    if (tabElements && tabElements[futureTabIndex]) {
+      const elementToScroll = tabElements[futureTabIndex].parentElement;
+
+      elementToScroll?.scrollIntoView({
+        behavior: "smooth",
+        inline: "nearest"
+      });
+    }
+  };
+
   const onTabChange = (tabId: string) => {
+    scrollTabIntoView(shapeWithState, selectedTabId, tabId);
     setSelectedTabId(tabId);
     scrollToTop();
   };
   const onPrevTab = () => {
-    setSelectedTabId(getPrevTab(tabIds, selectedTabId));
+    const prevTabId = getPrevTab(tabIds, selectedTabId);
+    scrollTabIntoView(shapeWithState, selectedTabId, prevTabId);
+    setSelectedTabId(prevTabId);
     scrollToTop();
   };
   const onNextTab = () => {
+    const nextTabId = getNextTab(tabIds, selectedTabId);
+    scrollTabIntoView(shapeWithState, selectedTabId, nextTabId);
     setSelectedTabId(getNextTab(tabIds, selectedTabId));
     scrollToTop();
   };


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Adapter l’affichage des onglets avec des marges à gauche ou droite selon la sélection sur les déclarations

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->


https://github.com/user-attachments/assets/ea3a48b6-6a37-4866-b86d-8c41c8ae90b3



# Ticket Favro

[Adapter l’affichage des onglets avec des marges à gauche ou droite selon la sélection sur les déclarations](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16897)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB