### PR TITLE
[TRA 16756] Résolution d'une erreur à la récupération d'une BsdaRevisionRequest fraîchemnt supprimée

### DIFF
--- a/back/src/bsda/resolvers/BsdaRevisionRequest.ts
+++ b/back/src/bsda/resolvers/BsdaRevisionRequest.ts
@@ -19,10 +19,12 @@ const bsdaRevisionRequestResolvers: BsdaRevisionRequestResolvers = {
   content: parent => {
     return expandBsdaRevisionRequestContent(parent as any);
   },
-  authoringCompany: async parent => {
-    const authoringCompany = await prisma.bsdaRevisionRequest
-      .findUnique({ where: { id: parent.id } })
-      .authoringCompany();
+  authoringCompany: async (
+    parent: BsdaRevisionRequest & PrismaBsdaRevisionRequest
+  ) => {
+    const authoringCompany = await prisma.company.findUnique({
+      where: { id: parent.authoringCompanyId }
+    });
 
     if (!authoringCompany) {
       throw new Error(


### PR DESCRIPTION
# Contexte

Investigation menée par @GaelFerrand :

> Ce qui se passe (à priori):
> - Tu annules la révision, envoi de la requête au back
> - Le back supprime l'objet en base de données, et planifie une ré-indexation du BSDA dans Elastic Search
> - Le back répond Ok au front
> - Le front veut immédiatement mettre à jour le BSDA et demande le BSDA au back
> - Le back voit toujours la révision dans Elastic Search pluisque la réindexation planifiée n'est pas encore passée
> - Le back veut récupérer la révision en base de données pour récupérer l'authoringCompany, mais la révision n'existe plus en base
> - Le back remonte une erreur uniquement pour le champ authoringCompany (donc la requête fonctionne, elle retourne le BSDA, sauf une erreur pour un champ, d'où l'erreur subliminale)

Le problème est que le resolver essaie de récupérer authoringCompany en passant par l'objet BsdaRevisionRequest qui n'est plus en DB. Donc Pour éviter ce cas, j'ai changé la requête pour aller directement récupérer la company via son id (ce qui est plus optimal de toute façon).

# Points de vigilance pour les intégrateurs

X

# Démo

https://github.com/user-attachments/assets/66f8ce53-400c-4308-8a53-a01d5fdc9404

# Ticket Favro

[Lorsque j'annule une révision émise sur un BSDA, j'ai une erreur serveur qui apparaît](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16756)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB