### PR TITLE
Migrate SEALED bsdds from an ecoorganisme to another

### DIFF
--- a/libs/back/scripts/src/scripts/20250811131420157_update-ecoorganisme-siret-sealed.ts
+++ b/libs/back/scripts/src/scripts/20250811131420157_update-ecoorganisme-siret-sealed.ts
@@ -1,0 +1,61 @@
+import { logger } from "@td/logger";
+import { prisma } from "@td/prisma";
+import Queue, { JobOptions } from "bull";
+
+const { REDIS_URL, NODE_ENV } = process.env;
+const INDEX_QUEUE_NAME = `queue_index_elastic_${NODE_ENV}`;
+
+const indexQueue = new Queue<string>(INDEX_QUEUE_NAME, REDIS_URL!, {
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "fixed", delay: 100 },
+    removeOnComplete: 10_000,
+    timeout: 10000
+  }
+});
+
+async function enqueueUpdatedBsdToIndex(
+  bsdId: string,
+  options?: JobOptions
+): Promise<void> {
+  logger.info(`Enqueuing BSD ${bsdId} for indexation`);
+  await indexQueue.add("index_updated", bsdId, options);
+}
+
+const SIRET_COREPILE = "42248908800068";
+const SIRET_ECOSYSTEM = "83033936200022";
+const NAME_ECOSYSTEM = "ECOSYSTEM";
+
+export class UpdateEcorganisme {
+  async run() {
+    const bsds = await prisma.form.findMany({
+      where: {
+        ecoOrganismeSiret: SIRET_COREPILE,
+        status: "SEALED",
+        isDeleted: false
+      },
+      select: { readableId: true, id: true }
+    });
+    for (const bsd of bsds) {
+      // no need to update denormalized fields
+
+      logger.info(`Processing ${bsd.readableId}`);
+
+      await prisma.form.update({
+        where: { id: bsd.id },
+        data: {
+          ecoOrganismeSiret: SIRET_ECOSYSTEM,
+          ecoOrganismeName: NAME_ECOSYSTEM
+        }
+      });
+      // ~ 370 bordereaux en prod
+      await enqueueUpdatedBsdToIndex(bsd.readableId);
+    }
+
+    logger.info(`${bsds.length} processed bsdds`);
+  }
+}
+
+export async function run() {
+  await new UpdateEcorganisme().run();
+}


### PR DESCRIPTION
# Contexte

2e passe sur les bsdds corepile


Migrer les bsdds:

    avec corepile comme eco-organisme
    en statut SEALED
    non supprimé
    vers l'écoorg ECOSYSTEM.


# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16918

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB