### PR TITLE
[TRA-16897] Corrige l'affichage des tabs sur le registre

### DIFF
--- a/front/src/form/registry/builder/FormBuilder.tsx
+++ b/front/src/form/registry/builder/FormBuilder.tsx
@@ -10,7 +10,7 @@ import { getRegistryNameFromImportType } from "../../../dashboard/registry/share
 import { getTabsWithState } from "./error";
 import "./FormBuilder.scss";
 import { FormTab } from "./FormTab";
-import type { FormShape } from "./types";
+import type { FormShape, FormShapeWithState } from "./types";
 
 type Props = {
   registryType: RegistryImportType;
@@ -64,7 +64,11 @@ export function FormBuilder({
     }
   };
 
-  const scrollTabIntoView = (tabs, prevTabId, tabId) => {
+  const scrollTabIntoView = (
+    tabs: FormShapeWithState,
+    prevTabId: string,
+    tabId: string
+  ) => {
     const prevTabIndex = tabs.findIndex(tab => tab.tabId === prevTabId);
     const tabIndex = tabs.findIndex(tab => tab.tabId === tabId);
 
@@ -85,7 +89,8 @@ export function FormBuilder({
 
       elementToScroll?.scrollIntoView({
         behavior: "smooth",
-        inline: "nearest"
+        inline: "nearest",
+        block: "nearest"
       });
     }
   };


### PR DESCRIPTION
# Contexte

<!--
  Résumé succinct et à jour du ticket Favro
-->

Adapter l’affichage des onglets avec des marges à gauche ou droite selon la sélection sur les déclarations

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Adapter l’affichage des onglets avec des marges à gauche ou droite selon la sélection sur les déclarations](https://favro.com/organization/ab14a4f0460a99a9d64d4945/2c84e07578945e0ee8fb61f3?card=tra-16897)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB