### PR TITLE
FIX Content-Type sur imports registre corrompu

### DIFF
--- a/back/src/queue/jobs/__tests__/processRegistryImport.integration.ts
+++ b/back/src/queue/jobs/__tests__/processRegistryImport.integration.ts
@@ -605,5 +605,101 @@ describe("Process registry import job", () => {
       expect(result.numberOfEdits).toBe(0);
       expect(result.numberOfErrors).toBe(0);
     });
+
+    it("should handle corrupted Content-Type from Scaleway S3 with multipart/form-data", async () => {
+      const fileKey = "corrupted-content-type.csv";
+      const { company, user } = await userWithCompanyFactory("ADMIN", {
+        companyTypes: { set: ["RECOVERY_FACILITY"] }
+      });
+
+      // Create a test file with normal content
+      const { s3Stream, upload } = getUploadWithWritableStream({
+        bucketName: process.env.S3_REGISTRY_IMPORTS_BUCKET,
+        key: fileKey,
+        // Simulate corrupted Content-Type from Scaleway S3
+        contentType:
+          "text/csv,multipart/form-data; boundary=----WebKitFormBoundaryUTF8sK2AkLXvM6Fr"
+      });
+
+      s3Stream.write(Object.values(SSD_HEADERS).join(";") + "\n");
+      s3Stream.end(
+        Object.values(getCorrectLine(company.orgId)).join(";") + "\n"
+      );
+
+      await upload.done();
+
+      const registryImport = await prisma.registryImport.create({
+        data: {
+          s3FileKey: fileKey,
+          originalFileName: "corrupted-content-type.csv",
+          type: "SSD",
+          status: "PENDING",
+          createdById: user.id
+        }
+      });
+
+      // This should not throw an error and should successfully parse the file
+      await processRegistryImportJob({
+        data: {
+          importId: registryImport.id,
+          importType: registryImport.type,
+          s3FileKey: registryImport.s3FileKey
+        }
+      } as Job<RegistryImportJobArgs>);
+
+      const result = await prisma.registryImport.findUniqueOrThrow({
+        where: { id: registryImport.id }
+      });
+
+      expect(result.status).toBe("SUCCESSFUL");
+      expect(result.numberOfInsertions).toBe(1);
+      expect(result.numberOfCancellations).toBe(0);
+      expect(result.numberOfEdits).toBe(0);
+      expect(result.numberOfErrors).toBe(0);
+    });
+
+    it("should handle corrupted Content-Type for Excel files", async () => {
+      const fileKey = "corrupted-content-type.xlsx";
+      const user = await userFactory({});
+
+      // Create a minimal S3 object with corrupted Excel Content-Type
+      const { s3Stream, upload } = getUploadWithWritableStream({
+        bucketName: process.env.S3_REGISTRY_IMPORTS_BUCKET,
+        key: fileKey,
+        // Simulate corrupted Content-Type for Excel file from Scaleway S3
+        contentType:
+          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,multipart/form-data; boundary=----WebKitFormBoundaryABC123"
+      });
+
+      // We just need to create the S3 object to test the Content-Type parsing
+      // The actual Excel processing isn't the focus here
+      s3Stream.write("dummy content");
+      s3Stream.end();
+
+      await upload.done();
+
+      const registryImport = await prisma.registryImport.create({
+        data: {
+          s3FileKey: fileKey,
+          originalFileName: "corrupted-content-type.xlsx",
+          type: "SSD",
+          status: "PENDING",
+          createdById: user.id
+        }
+      });
+
+      // This should properly detect the file type despite the corrupted Content-Type
+      // Note: This test will fail later during Excel parsing due to invalid content,
+      // but the file type detection should work correctly
+      await expect(
+        processRegistryImportJob({
+          data: {
+            importId: registryImport.id,
+            importType: registryImport.type,
+            s3FileKey: registryImport.s3FileKey
+          }
+        } as Job<RegistryImportJobArgs>)
+      ).rejects.not.toThrow(/Unknown file type/);
+    });
   });
 });

--- a/back/src/queue/jobs/processRegistryImport.ts
+++ b/back/src/queue/jobs/processRegistryImport.ts
@@ -127,11 +127,16 @@ function getFileType(mimeType: string | undefined) {
     return undefined;
   }
 
-  if (allowedCsvMimeTypes.includes(mimeType)) {
+  // Handle corrupted Content-Type from S3 that may include multipart/form-data
+  // e.g., "text/csv,multipart/form-data; boundary=..."
+  // Extract the first MIME type before any comma
+  const cleanMimeType = mimeType.split(",")[0].trim();
+
+  if (allowedCsvMimeTypes.includes(cleanMimeType)) {
     return "CSV";
   }
 
-  if (allowedExcelMimeTypes.includes(mimeType)) {
+  if (allowedExcelMimeTypes.includes(cleanMimeType)) {
     return "XLSX";
   }
 


### PR DESCRIPTION
# Contexte

Le process d'import registre échoue avec ces erreurs:
```
[
	"Error: Unknown file type for file \"fichier_import.xlsx\",
	import \"xxx\".
	Received content type
	\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,multipart/form-data; boundary=----WebKitFormBoundaryUTF8sK2AkLXvM6Fr\".
	\n    at Queue.processRegistryImportJob (/app/dist/apps/queues-runner/back/src/queue/jobs/processRegistryImport.js:54:11)\n
	at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
]

[
	"Error: Unknown file type for file \"fichier_import.csv\",
	import \"xxx\".
	Received content type
	\"text/csv,multipart/form-data; boundary=---------------------------165118693413497368032229547973\".
	\n    at Queue.processRegistryImportJob (/app/dist/apps/queues-runner/back/src/queue/jobs/processRegistryImport.js:54:11)
	\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
]
```

Scaleway devrait utiliser le content type du form lors de l'upload, mais il a l'air de faire un mix entre le content type du form et celui des headers (multipart...), et ce changement a l'air récent. Le fix consiste à ignorer la fin du content type renvoyé par scaleway pour utiliser uniquement la première partie, qui correspond au type envoyé dans le form.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB