### PR TITLE
Résoud problème de signature réception BSDA

### DIFF
--- a/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
+++ b/front/src/Apps/Dashboard/Validation/Bsda/SignBsdaReception.tsx
@@ -73,7 +73,6 @@ const schema = z
           ),
           weight: z.coerce.number().nonnegative().nullish(),
           refusedWeight: z.coerce.number().nonnegative().nullish(),
-          acceptedWeight: z.coerce.number().nonnegative().nullish(),
           refusalReason: z.string().nullish(),
           date: z.coerce
             .date({
@@ -436,20 +435,11 @@ const SignBsdaReception = ({ bsdaId, onClose }) => {
                           label="Poids total net en tonnes"
                           disabled
                           className="fr-col-12"
-                          state={
-                            formState.errors?.destination?.reception
-                              ?.acceptedWeight && "error"
-                          }
-                          stateRelatedMessage={
-                            (formState.errors?.destination?.reception
-                              ?.acceptedWeight?.message as string) ?? ""
-                          }
                           nativeInputProps={{
                             value: acceptedWeight,
                             inputMode: "decimal",
                             step: "0.000001",
-                            type: "number",
-                            ...register("destination.reception.acceptedWeight")
+                            type: "number"
                           }}
                         />
                         <p

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "react-aria": "3.25.0",
         "react-datepicker": "^4.25.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.0.0",
         "react-hot-toast": "2.4.1",
         "react-multi-select-component": "^4.3.4",
         "react-qr-code": "^2.0.18",
@@ -42963,7 +42964,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
       "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "react-aria": "3.25.0",
     "react-datepicker": "^4.25.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.0.0",
     "react-hot-toast": "2.4.1",
     "react-multi-select-component": "^4.3.4",
     "react-qr-code": "^2.0.18",


### PR DESCRIPTION
# Contexte

Probablement en raison d'un changement de version de React Hook Form, le champ disabled acceptedWeight est transmis à la backend alors qu'il n'est pas censé être passé à la backend. on retire ce champ du form puisque ça ne sert à rien pour éviter qu'il soit transmis lors de l'update.

J'ajoute aussi react-hook-form aux dépendances car il était importé via un autre package, ce qui est un peu bancal.

# Points de vigilance pour les intégrateurs

<!--
  Si la PR introduit des breaking changes ou des modifications 
  côté API, mettre ici un bref résumé technique type TL;DR à 
  l'attention des intégrateurs
-->

# Démo

<!-- 
  Vidéo de préférence
-->

# Ticket Favro

[Titre](lien)

# Checklist

- [ ] Mettre à jour la documentation
- [ ] Mettre à jour le change log
- [ ] Documenter les manipulations à faire lors de la mise en production (sur le ticket Favro de release)
- [ ] Informer le data engineer de tout changement de schéma DB