### PR TITLE
FIX: affichage des fichiers sur le registre géré

### DIFF
--- a/front/src/form/registry/queries.ts
+++ b/front/src/form/registry/queries.ts
@@ -781,6 +781,11 @@ export const GET_MANAGED_REGISTRY_LOOKUP = gql`
         transporter5CompanyPostalCode
         transporter5CompanyCity
         transporter5CompanyCountryCode
+
+        texsAnalysisFiles {
+          id
+          originalFileName
+        }
       }
     }
   }


### PR DESCRIPTION
Les fichiers n'étaient pas récupérés pour le registre géré